### PR TITLE
feat(templates): hide private methods/functions

### DIFF
--- a/dan_layer/engine/tests/templates/buggy/Cargo.lock
+++ b/dan_layer/engine/tests/templates/buggy/Cargo.lock
@@ -162,7 +162,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_abi"
-version = "0.1.0"
+version = "0.35.1"
 dependencies = [
  "borsh",
 ]

--- a/dan_layer/engine/tests/templates/hello_world/Cargo.lock
+++ b/dan_layer/engine/tests/templates/hello_world/Cargo.lock
@@ -151,14 +151,14 @@ dependencies = [
 
 [[package]]
 name = "tari_template_abi"
-version = "0.1.0"
+version = "0.35.1"
 dependencies = [
  "borsh",
 ]
 
 [[package]]
 name = "tari_template_lib"
-version = "0.1.0"
+version = "0.35.1"
 dependencies = [
  "borsh",
  "tari_template_abi",
@@ -166,7 +166,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_macros"
-version = "0.1.0"
+version = "0.35.1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/dan_layer/engine/tests/templates/private_function/Cargo.lock
+++ b/dan_layer/engine/tests/templates/private_function/Cargo.lock
@@ -86,15 +86,24 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.126"
+version = "0.2.131"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
+checksum = "04c3b4822ccebfa39c02fc03d1534441b22ead323fa0f48bb7ddd8e6ba076a40"
 
 [[package]]
 name = "once_cell"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
+
+[[package]]
+name = "private_function"
+version = "0.1.0"
+dependencies = [
+ "tari_template_abi",
+ "tari_template_lib",
+ "tari_template_macros",
+]
 
 [[package]]
 name = "proc-macro-crate"
@@ -116,33 +125,24 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bcdf212e9776fbcb2d23ab029360416bb1706b1aea2d1a5ba002727cbcab804"
+checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "serde"
-version = "1.0.140"
+version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc855a42c7967b7c369eb5860f7164ef1f6f81c20c7cc1141f2a604e18723b03"
-
-[[package]]
-name = "state"
-version = "0.1.0"
-dependencies = [
- "tari_template_abi",
- "tari_template_lib",
- "tari_template_macros",
-]
+checksum = "53e8e5d5b70924f74ff5c6d64d9a5acd91422117c60f48c4e07855238a254553"
 
 [[package]]
 name = "syn"
-version = "1.0.98"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c50aef8a904de4c23c788f104b7dddc7d6f79c647c7c8ce4cc8f73eb0ca773dd"
+checksum = "58dbef6ec655055e20b86b15a8cc6d439cca19b667537ac6a1369572d151ab13"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -184,9 +184,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15c61ba63f9235225a22310255a29b806b907c9b8c964bcbd0a2c70f3f2deea7"
+checksum = "c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf"
 
 [[package]]
 name = "version_check"

--- a/dan_layer/engine/tests/templates/private_function/Cargo.toml
+++ b/dan_layer/engine/tests/templates/private_function/Cargo.toml
@@ -1,0 +1,22 @@
+[workspace]
+[package]
+name = "private_function"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+tari_template_abi = { path = "../../../../template_abi", default-features = false }
+tari_template_lib = { path = "../../../../template_lib" }
+tari_template_macros = { path = "../../../../template_macros" }
+
+[profile.release]
+opt-level = 's'     # Optimize for size.
+lto = true          # Enable Link Time Optimization.
+codegen-units = 1   # Reduce number of codegen units to increase optimizations.
+panic = 'abort'     # Abort on panic.
+strip = "debuginfo" # Strip debug info.
+
+[lib]
+crate-type = ["cdylib", "lib"]

--- a/dan_layer/engine/tests/templates/private_function/src/lib.rs
+++ b/dan_layer/engine/tests/templates/private_function/src/lib.rs
@@ -1,0 +1,53 @@
+//  Copyright 2022. The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use tari_template_macros::template;
+
+#[template]
+mod private_function {
+    pub struct PrivateCounter {
+        pub value: u32,
+    }
+
+    impl PrivateCounter {
+        pub fn new() -> Self {
+            Self { value: 0 }
+        }
+
+        pub fn get(&self) -> u32 {
+            self.value
+        }
+
+        pub fn increase(&mut self) {
+            self.some_private_method();
+        }
+
+        fn some_private_method(&mut self) {
+            let new_value = Self::some_private_function(self.value);
+            self.value = new_value;
+        }
+
+        fn some_private_function(value: u32) -> u32 {
+            value + 1
+        }
+    }
+}

--- a/dan_layer/engine/tests/test.rs
+++ b/dan_layer/engine/tests/test.rs
@@ -137,3 +137,25 @@ fn test_dodgy_template() {
         PackageError::WasmModuleError(WasmExecutionError::UnexpectedAbiFunction { .. })
     ));
 }
+
+#[test]
+fn test_private_function() {
+    // instantiate the counter
+    let template_test = TemplateTest::new(vec!["tests/templates/private_function"]);
+
+    // check that the private method and function are not exported
+    let functions = template_test
+        .get_module("PrivateCounter")
+        .template_def()
+        .functions
+        .iter()
+        .map(|f| f.name.as_str())
+        .collect::<Vec<_>>();
+    assert_eq!(functions, vec!["new", "get", "increase"]);
+
+    // check that public methods can still internally call private ones
+    let component: ComponentId = template_test.call_function("PrivateCounter", "new", args![]);
+    template_test.call_method::<()>(component, "increase", args![]);
+    let value: u32 = template_test.call_method(component, "get", args![]);
+    assert_eq!(value, 1);
+}

--- a/dan_layer/template_macros/src/ast.rs
+++ b/dan_layer/template_macros/src/ast.rs
@@ -89,6 +89,7 @@ impl TemplateAst {
             .items
             .iter()
             .map(Self::get_function_from_item)
+            .filter(|f| f.is_public)
             .collect()
     }
 
@@ -100,6 +101,7 @@ impl TemplateAst {
                 output_type: Self::get_output_type_token(&m.sig.output),
                 statements: Self::get_statements(m),
                 is_constructor: Self::is_constructor(&m.sig),
+                is_public: Self::is_public_function(m),
             },
             _ => todo!(),
         }
@@ -152,6 +154,10 @@ impl TemplateAst {
             },
         }
     }
+
+    fn is_public_function(item: &ImplItemMethod) -> bool {
+        matches!(item.vis, syn::Visibility::Public(_))
+    }
 }
 
 pub struct FunctionAst {
@@ -160,6 +166,7 @@ pub struct FunctionAst {
     pub output_type: Option<TypeAst>,
     pub statements: Vec<Stmt>,
     pub is_constructor: bool,
+    pub is_public: bool,
 }
 
 pub enum TypeAst {

--- a/dan_layer/template_macros/src/template/abi.rs
+++ b/dan_layer/template_macros/src/template/abi.rs
@@ -124,7 +124,8 @@ mod tests {
                     }
                     pub fn no_return_function() {}
                     pub fn constructor() -> Self {}
-                    pub fn method(&self){}  
+                    pub fn method(&self){}
+                    fn private_function() {}
                 } 
             }
         "})


### PR DESCRIPTION
Description
---
Modified the template macro AST to filter private methods/functions:
* This makes both the `abi` and the `dispatcher` sections of the wasm to not include them, so they are not exposed or directly callable in any way.
* As the user-defined implementation is copied verbatim and treated as a black box inside the wasm, public methods and functions can still internally access the private ones.

Motivation and Context
---
Private methods and functions (i.e. those that do not have the `pub` modifier) should not be callable or exposed directly. But public methods and functions should still be able to call them internally.

How Has This Been Tested?
---
* New template test example (`private_functions`) and corresponding unit test.
* Modified the template ABI test by adding a private function.

