### PR TITLE
feat(engine): basic transaction commit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
     "dan_layer/template_lib",
     "dan_layer/template_macros",
     "applications/tari_validator_node",
-
+    "applications/tari_validator_node_grpc",
 ]
 #
 

--- a/dan_layer/engine/src/instruction/mod.rs
+++ b/dan_layer/engine/src/instruction/mod.rs
@@ -38,6 +38,13 @@ use tari_template_lib::{
 };
 
 #[derive(Debug, Clone)]
+pub struct Transaction {
+    pub instructions: Vec<Instruction>,
+    pub signature: InstructionSignature,
+    pub sender_public_key: PublicKey,
+}
+
+#[derive(Debug, Clone)]
 pub enum Instruction {
     CallFunction {
         package_address: PackageAddress,
@@ -54,11 +61,4 @@ pub enum Instruction {
     PutLastInstructionOutputOnWorkspace {
         key: Vec<u8>,
     },
-}
-
-#[derive(Debug, Clone)]
-pub struct Transaction {
-    pub instructions: Vec<Instruction>,
-    pub signature: InstructionSignature,
-    pub sender_public_key: PublicKey,
 }

--- a/dan_layer/engine/src/instruction/mod.rs
+++ b/dan_layer/engine/src/instruction/mod.rs
@@ -21,7 +21,9 @@
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 mod builder;
+
 pub use builder::TransactionBuilder;
+use tari_common_types::types::PublicKey;
 
 mod error;
 
@@ -34,8 +36,6 @@ use tari_template_lib::{
     args::Arg,
     models::{ComponentAddress, PackageAddress},
 };
-use tari_common_types::types::PublicKey;
-
 
 #[derive(Debug, Clone)]
 pub enum Instruction {

--- a/dan_layer/engine/src/lib.rs
+++ b/dan_layer/engine/src/lib.rs
@@ -9,7 +9,7 @@ pub mod state;
 pub mod wasm;
 
 pub mod crypto;
-mod hashing;
+pub mod hashing;
 pub mod instruction;
 pub mod packager;
 // mod resource;

--- a/dan_layer/engine/src/models/vault.rs
+++ b/dan_layer/engine/src/models/vault.rs
@@ -44,6 +44,10 @@ impl Vault {
         self.resource.withdraw(amount)
     }
 
+    pub fn balance(&self) -> Amount {
+        self.resource.amount()
+    }
+
     pub fn resource_address(&self) -> ResourceAddress {
         self.resource.address()
     }

--- a/dan_layer/engine/src/runtime/commit_result.rs
+++ b/dan_layer/engine/src/runtime/commit_result.rs
@@ -20,37 +20,28 @@
 //   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //   USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::{
-    fmt::Display,
-    time::{Duration, SystemTime, UNIX_EPOCH},
+use tari_template_lib::Hash;
+
+use crate::{
+    runtime::{logs::LogEntry, TransactionCommitError},
+    wasm::ExecutionResult,
 };
 
-use tari_template_lib::args::LogLevel;
-
-#[derive(Debug, Clone)]
-pub struct LogEntry {
-    pub timestamp: u64,
-    pub message: String,
-    pub level: LogLevel,
+#[derive(Debug)]
+pub struct CommitResult {
+    pub transaction_hash: Hash,
+    pub logs: Vec<LogEntry>,
+    pub execution_results: Vec<ExecutionResult>,
+    pub result: Result<(), TransactionCommitError>,
 }
 
-impl LogEntry {
-    pub fn new(level: LogLevel, message: String) -> Self {
-        let now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            // If the errors, the clock has been set before the UNIX_EPOCH
-            .unwrap_or_else(|_| Duration::from_secs(0))
-            .as_secs();
+impl CommitResult {
+    pub fn new(transaction_hash: Hash, logs: Vec<LogEntry>, result: Result<(), TransactionCommitError>) -> Self {
         Self {
-            timestamp: now,
-            message,
-            level,
+            transaction_hash,
+            logs,
+            execution_results: Vec::new(),
+            result,
         }
-    }
-}
-
-impl Display for LogEntry {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{} {} {}", self.timestamp, self.level, self.message)
     }
 }

--- a/dan_layer/engine/src/runtime/error.rs
+++ b/dan_layer/engine/src/runtime/error.rs
@@ -1,0 +1,82 @@
+//   Copyright 2022. The Tari Project
+//
+//   Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//   following conditions are met:
+//
+//   1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//   disclaimer.
+//
+//   2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//   following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//   3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//   products derived from this software without specific prior written permission.
+//
+//   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//   SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//   USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use std::{fmt::Display, io};
+
+use anyhow::anyhow;
+use tari_template_lib::models::{Amount, BucketId, ComponentAddress, ResourceAddress, VaultId};
+
+use crate::{models::ResourceError, state_store::StateStoreError};
+
+#[derive(Debug, thiserror::Error)]
+pub enum RuntimeError {
+    #[error("Encoding error: {0}")]
+    EncodingError(#[from] io::Error),
+    #[error("State DB error: {0}")]
+    StateDbError(#[from] anyhow::Error),
+    #[error("State storage error: {0}")]
+    StateStoreError(#[from] StateStoreError),
+    #[error("Component not found with address '{address}'")]
+    ComponentNotFound { address: ComponentAddress },
+    #[error("Invalid argument {argument}: {reason}")]
+    InvalidArgument { argument: &'static str, reason: String },
+    #[error("Invalid amount '{amount}': {reason}")]
+    InvalidAmount { amount: Amount, reason: String },
+    #[error("Illegal runtime state")]
+    IllegalRuntimeState,
+    #[error("Vault not found with id ({}, {})", vault_id.0, vault_id.1)]
+    VaultNotFound { vault_id: VaultId },
+    #[error("Bucket not found with id {bucket_id}")]
+    BucketNotFound { bucket_id: BucketId },
+    #[error("Resource not found with address {resource_address}")]
+    ResourceNotFound { resource_address: ResourceAddress },
+    #[error(transparent)]
+    ResourceError(#[from] ResourceError),
+    #[error("Bucket {bucket_id} was dropped but was not empty")]
+    BucketNotEmpty { bucket_id: BucketId },
+    #[error("Named argument {key} was not found")]
+    ItemNotOnWorkspace { key: String },
+    #[error("Attempted to take the last output but there was no previous instruction output")]
+    NoLastInstructionOutput,
+    #[error("Workspace already has an item with key '{key}'")]
+    WorkspaceItemKeyExists { key: String },
+    #[error(transparent)]
+    TransactionCommitError(#[from] TransactionCommitError),
+}
+
+impl RuntimeError {
+    pub fn state_db_error<T: Display>(err: T) -> Self {
+        RuntimeError::StateDbError(anyhow!("{}", err))
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum TransactionCommitError {
+    #[error("{count} dangling buckets remain after transaction execution")]
+    DanglingBuckets { count: usize },
+    #[error("{count} dangling items in workspace after transaction execution")]
+    WorkspaceNotEmpty { count: usize },
+    #[error(transparent)]
+    StateStoreError(#[from] StateStoreError),
+    #[error("Failed to obtain a state store transaction: {0}")]
+    StateStoreTransactionError(anyhow::Error),
+}

--- a/dan_layer/engine/src/runtime/impl.rs
+++ b/dan_layer/engine/src/runtime/impl.rs
@@ -177,6 +177,26 @@ impl RuntimeInterface for RuntimeInterfaceImpl {
                 let bucket = self.tracker.new_bucket(resource);
                 Ok(InvokeResult::encode(&bucket)?)
             },
+            VaultAction::GetBalance => {
+                let vault_id = vault_ref.vault_id().ok_or_else(|| RuntimeError::InvalidArgument {
+                    argument: "vault_ref",
+                    reason: "GetBalance vault action requires a vault id".to_string(),
+                })?;
+
+                let balance = self.tracker.borrow_vault_mut(&vault_id, |vault| vault.balance())?;
+                Ok(InvokeResult::encode(&balance)?)
+            },
+            VaultAction::GetResourceAddress => {
+                let vault_id = vault_ref.vault_id().ok_or_else(|| RuntimeError::InvalidArgument {
+                    argument: "vault_ref",
+                    reason: "vault action requires a vault id".to_string(),
+                })?;
+
+                let address = self
+                    .tracker
+                    .borrow_vault_mut(&vault_id, |vault| vault.resource_address())?;
+                Ok(InvokeResult::encode(&address)?)
+            },
         }
     }
 

--- a/dan_layer/engine/src/runtime/impl.rs
+++ b/dan_layer/engine/src/runtime/impl.rs
@@ -38,6 +38,7 @@ use tari_template_lib::{
 };
 
 use crate::runtime::{
+    commit_result::CommitResult,
     logs::LogEntry,
     tracker::{RuntimeState, StateTracker},
     RuntimeError,
@@ -153,9 +154,8 @@ impl RuntimeInterface for RuntimeInterfaceImpl {
                         })?;
 
                 let bucket = self.tracker.take_bucket(bucket_id)?;
-                let mut vault = self.tracker.get_vault(&vault_id)?;
-                vault.deposit(bucket)?;
-                self.tracker.set_vault(&vault_id, vault)?;
+                self.tracker
+                    .borrow_vault_mut(&vault_id, |vault| vault.deposit(bucket))??;
                 Ok(InvokeResult::empty())
             },
             VaultAction::WithdrawFungible => {
@@ -170,10 +170,11 @@ impl RuntimeInterface for RuntimeInterfaceImpl {
                             argument: "amount",
                             reason: "Argument not provided or failed to decode".to_string(),
                         })?;
-                let mut vault = self.tracker.get_vault(&vault_id)?;
-                let resource = vault.withdraw(amount)?;
+
+                let resource = self
+                    .tracker
+                    .borrow_vault_mut(&vault_id, |vault| vault.withdraw(amount))??;
                 let bucket = self.tracker.new_bucket(resource);
-                self.tracker.set_vault(&vault_id, vault)?;
                 Ok(InvokeResult::encode(&bucket)?)
             },
         }
@@ -274,5 +275,13 @@ impl RuntimeInterface for RuntimeInterfaceImpl {
     fn set_last_instruction_output(&self, value: Option<Vec<u8>>) -> Result<(), RuntimeError> {
         self.tracker.set_last_instruction_output(value);
         Ok(())
+    }
+
+    fn commit(&self) -> Result<CommitResult, RuntimeError> {
+        let result = self.tracker.commit();
+        let logs = self.tracker.take_logs();
+        let commit = CommitResult::new(self.tracker.transaction_hash(), logs, result);
+
+        Ok(commit)
     }
 }

--- a/dan_layer/engine/src/runtime/tracker.rs
+++ b/dan_layer/engine/src/runtime/tracker.rs
@@ -21,7 +21,7 @@
 //   USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use std::{
-    collections::HashMap,
+    collections::{hash_map::Entry, HashMap},
     mem,
     sync::{Arc, RwLock},
 };
@@ -213,14 +213,14 @@ impl StateTracker {
 
     pub fn set_component(&self, updated_component: ComponentInstance) -> Result<(), RuntimeError> {
         self.write_with(|state| {
-            // TODO: Load from state store?
-            let component = state
-                .new_components
-                .get_mut(&updated_component.component_address)
-                .ok_or(RuntimeError::ComponentNotFound {
-                    address: updated_component.component_address,
-                })?;
-            *component = updated_component;
+            match state.new_components.entry(updated_component.component_address) {
+                Entry::Occupied(mut entry) => {
+                    entry.insert(updated_component);
+                },
+                Entry::Vacant(entry) => {
+                    entry.insert(updated_component);
+                },
+            }
             Ok(())
         })
     }

--- a/dan_layer/engine/tests/test.rs
+++ b/dan_layer/engine/tests/test.rs
@@ -166,7 +166,10 @@ fn test_erc20() {
             args: args![Workspace(b"foo_bucket")],
         },
     ]);
-    eprintln!("{:?}", result);
+    for log in result.logs {
+        eprintln!("LOG: {}", log);
+    }
+    eprintln!("{:?}", result.execution_results);
 
     // TODO: commit and test the final state
 }

--- a/dan_layer/engine/tests/tooling/mock_runtime_interface.rs
+++ b/dan_layer/engine/tests/tooling/mock_runtime_interface.rs
@@ -23,7 +23,8 @@
 use std::sync::{Arc, RwLock};
 
 use tari_dan_engine::{
-    runtime::{IdProvider, RuntimeError, RuntimeInterface, RuntimeState},
+    hashing::hasher,
+    runtime::{CommitResult, IdProvider, RuntimeError, RuntimeInterface, RuntimeState},
     state_store::{memory::MemoryStateStore, AtomicDb, StateReader, StateWriter},
 };
 use tari_template_lib::{
@@ -183,5 +184,9 @@ impl RuntimeInterface for MockRuntimeInterface {
     fn set_last_instruction_output(&self, _value: Option<Vec<u8>>) -> Result<(), RuntimeError> {
         self.add_call("set_last_instruction_output");
         Ok(())
+    }
+
+    fn commit(&self) -> Result<CommitResult, RuntimeError> {
+        Ok(CommitResult::new(hasher("tx").result(), vec![], Ok(())))
     }
 }

--- a/dan_layer/engine/tests/tooling/template_test.rs
+++ b/dan_layer/engine/tests/tooling/template_test.rs
@@ -28,9 +28,9 @@ use tari_dan_engine::{
     crypto::create_key_pair,
     instruction::{Instruction, InstructionProcessor, TransactionBuilder},
     packager::Package,
-    runtime::RuntimeInterface,
+    runtime::{CommitResult, RuntimeInterface},
     state_store::memory::MemoryStateStore,
-    wasm::{compile::compile_template, ExecutionResult, LoadedWasmModule},
+    wasm::{compile::compile_template, LoadedWasmModule},
 };
 use tari_template_lib::{
     args::Arg,
@@ -105,7 +105,7 @@ impl<R: RuntimeInterface + Clone + 'static> TemplateTest<R> {
             args,
         }]);
 
-        result[0].decode::<T>().unwrap()
+        result.execution_results[0].decode::<T>().unwrap()
     }
 
     pub fn call_method<T>(&self, component_address: ComponentAddress, method_name: &str, args: Vec<Arg>) -> T
@@ -117,10 +117,10 @@ impl<R: RuntimeInterface + Clone + 'static> TemplateTest<R> {
             args,
         }]);
 
-        result[0].decode::<T>().unwrap()
+        result.execution_results[0].decode::<T>().unwrap()
     }
 
-    pub fn execute(&self, instructions: Vec<Instruction>) -> Vec<ExecutionResult> {
+    pub fn execute(&self, instructions: Vec<Instruction>) -> CommitResult {
         let mut builder = TransactionBuilder::new();
         for instruction in instructions {
             builder.add_instruction(instruction);

--- a/dan_layer/template_lib/src/args/arg.rs
+++ b/dan_layer/template_lib/src/args/arg.rs
@@ -20,7 +20,7 @@
 //   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //   USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use tari_template_abi::{Decode, Encode};
+use tari_template_abi::{decode, encode, rust::io, Decode, Encode};
 
 #[derive(Debug, Clone, PartialEq, Eq, Decode, Encode)]
 pub enum Arg {
@@ -35,5 +35,13 @@ impl Arg {
 
     pub fn from_workspace<T: Into<Vec<u8>>>(key: T) -> Self {
         Arg::FromWorkspace(key.into())
+    }
+
+    pub fn from_bytes(bytes: &[u8]) -> io::Result<Self> {
+        decode(bytes)
+    }
+
+    pub fn to_bytes(&self) -> Vec<u8> {
+        encode(self).unwrap()
     }
 }

--- a/dan_layer/template_lib/src/args/engine.rs
+++ b/dan_layer/template_lib/src/args/engine.rs
@@ -20,7 +20,13 @@
 //   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //   USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use tari_template_abi::{decode, encode, rust::io, Decode, Encode};
+use tari_template_abi::{
+    decode,
+    encode,
+    rust::{fmt::Display, io},
+    Decode,
+    Encode,
+};
 
 use crate::{
     models::{Amount, BucketId, ComponentAddress, Metadata, ResourceAddress, VaultRef},
@@ -39,6 +45,17 @@ pub enum LogLevel {
     Warn,
     Info,
     Debug,
+}
+
+impl Display for LogLevel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LogLevel::Error => write!(f, "ERROR"),
+            LogLevel::Warn => write!(f, "WARN"),
+            LogLevel::Info => write!(f, "INFO"),
+            LogLevel::Debug => write!(f, "DEBUG"),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Encode, Decode)]

--- a/dan_layer/template_lib/src/args/engine.rs
+++ b/dan_layer/template_lib/src/args/engine.rs
@@ -154,6 +154,8 @@ pub enum VaultAction {
     Create,
     Deposit,
     WithdrawFungible,
+    GetBalance,
+    GetResourceAddress,
 }
 
 #[derive(Clone, Debug, Decode, Encode)]

--- a/dan_layer/template_lib/src/models/vault.rs
+++ b/dan_layer/template_lib/src/models/vault.rs
@@ -104,7 +104,8 @@ impl<T: ResourceDefinition> Vault<T> {
         .expect("VaultInvoke returned null");
     }
 
-    pub fn withdraw(&mut self, amount: Amount) -> Bucket<T> {
+    pub fn withdraw<A: Into<Amount>>(&mut self, amount: A) -> Bucket<T> {
+        let amount = amount.into();
         assert!(
             amount.is_positive() && !amount.is_zero(),
             "Amount must be non-zero and positive"
@@ -117,6 +118,29 @@ impl<T: ResourceDefinition> Vault<T> {
         .expect("VaultInvoke returned null");
 
         resp.decode().expect("failed to decode Bucket")
+    }
+
+    pub fn balance(&self) -> Amount {
+        let resp: InvokeResult = call_engine(EngineOp::VaultInvoke, &VaultInvokeArg {
+            vault_ref: VaultRef::Ref(self.vault_id()),
+            action: VaultAction::GetBalance,
+            args: args![],
+        })
+        .expect("VaultInvoke returned null");
+
+        resp.decode().expect("failed to decode Amount")
+    }
+
+    pub fn resource_address(&self) -> ResourceAddress {
+        let resp: InvokeResult = call_engine(EngineOp::VaultInvoke, &VaultInvokeArg {
+            vault_ref: VaultRef::Ref(self.vault_id()),
+            action: VaultAction::GetResourceAddress,
+            args: invoke_args![],
+        })
+        .expect("GetResourceAddress returned null");
+
+        resp.decode()
+            .expect("GetResourceAddress returned invalid resource address")
     }
 
     pub fn vault_id(&self) -> VaultId {

--- a/dan_layer/template_lib/src/resource/builder.rs
+++ b/dan_layer/template_lib/src/resource/builder.rs
@@ -63,8 +63,8 @@ impl<T: ResourceDefinition> FungibleResourceBuilder<T> {
         self
     }
 
-    pub fn initial_supply(mut self, initial_supply: Amount) -> Self {
-        self.initial_supply = initial_supply;
+    pub fn initial_supply<A: Into<Amount>>(mut self, initial_supply: A) -> Self {
+        self.initial_supply = initial_supply.into();
         self
     }
 


### PR DESCRIPTION
Description
---
- returns CommitResult from executed transactions
- read from state store to obtain vaults not created within the current transaction

Motivation and Context
---
Very basic, but exposes some of the problems that need solving:
1. how to load state that was not created within the current transaction
   - should be known/loaded before the transaction executes (component id is in the instruction so seems possible)
2. how do we validate that the component contents contain valid e.g. vault ids when the engine only sees an opaque blob that does not contain this information?
   - an implementor may put whatever data e.g fake/someone else's vault id into the component 

How Has This Been Tested?
---
ERC 20 test runs multiple transactions with common state
