### PR TITLE
fix: negative begin index in committee

### DIFF
--- a/applications/tari_validator_node/src/p2p/services/epoch_manager/base_layer_epoch_manager.rs
+++ b/applications/tari_validator_node/src/p2p/services/epoch_manager/base_layer_epoch_manager.rs
@@ -110,7 +110,7 @@ impl BaseLayerEpochManager {
     #[allow(dead_code)]
     pub fn is_epoch_valid(&self, epoch: Epoch) -> bool {
         let current_epoch = self.current_epoch();
-        current_epoch.0 - 10 <= epoch.0 && epoch.0 <= current_epoch.0 + 10
+        current_epoch.0 <= epoch.0 + 10 && epoch.0 <= current_epoch.0 + 10
     }
 
     #[allow(dead_code)]
@@ -141,8 +141,7 @@ impl BaseLayerEpochManager {
         }
 
         let mid_point = vns.iter().filter(|x| x.shard_key <= shard).count();
-
-        let begin = ((mid_point as i64 - half_committee_size as i64) % vns.len() as i64) as usize;
+        let begin = ((vns.len() as i64 + mid_point as i64 - half_committee_size as i64) % vns.len() as i64) as usize;
         let end = ((mid_point as i64 + half_committee_size as i64) % vns.len() as i64) as usize;
         let mut result = Vec::with_capacity(half_committee_size * 2);
         if mid_point < half_committee_size {


### PR DESCRIPTION
Description
---
Rust modulo on negative numbers is negative, that leads to wrong begin index.
Epoch valid had a similar issue with negative number.

How Has This Been Tested?
---
Manually, by running 17 VNs and checking their committees.
