### PR TITLE
fix(base-layer-scanner): improvements to base layer scanning and template manager

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,12 +121,9 @@ checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
 
 [[package]]
 name = "arrayvec"
-version = "0.4.12"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd9fd44efafa8690358b7408d253adf110036b88f55672a933f01d616ad9b1b9"
-dependencies = [
- "nodrop",
-]
+checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
 name = "async-stream"
@@ -191,7 +188,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "itoa 1.0.3",
+ "itoa",
  "matchit",
  "memchr",
  "mime",
@@ -702,6 +699,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "codespan-reporting"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+dependencies = [
+ "termcolor",
+ "unicode-width",
+]
+
+[[package]]
 name = "config"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -981,6 +988,50 @@ dependencies = [
  "rand_core 0.6.4",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "cxx"
+version = "1.0.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f39818dcfc97d45b03953c1292efc4e80954e1583c4aa770bac1383e2310a4"
+dependencies = [
+ "cc",
+ "cxxbridge-flags",
+ "cxxbridge-macro",
+ "link-cplusplus",
+]
+
+[[package]]
+name = "cxx-build"
+version = "1.0.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e580d70777c116df50c390d1211993f62d40302881e54d4b79727acb83d0199"
+dependencies = [
+ "cc",
+ "codespan-reporting",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "scratch",
+ "syn",
+]
+
+[[package]]
+name = "cxxbridge-flags"
+version = "1.0.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56a46460b88d1cec95112c8c363f0e2c39afdb237f60583b0b36343bf627ea9c"
+
+[[package]]
+name = "cxxbridge-macro"
+version = "1.0.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "747b608fecf06b0d72d440f27acc99288207324b793be2c17991839f3d4995ea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1581,7 +1632,7 @@ checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
 dependencies = [
  "bytes 1.2.1",
  "fnv",
- "itoa 1.0.3",
+ "itoa",
 ]
 
 [[package]]
@@ -1634,7 +1685,7 @@ dependencies = [
  "http-body",
  "httparse",
  "httpdate",
- "itoa 1.0.3",
+ "itoa",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -1670,15 +1721,26 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.50"
+version = "0.1.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd911b35d940d2bd0bea0f9100068e5b97b51a1cbe13d13382f132e0365257a0"
+checksum = "f5a6ef98976b22b3b7f2f3a806f858cb862044cfa66805aa3ad84cb3d3b785ed"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
+ "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
  "winapi",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fde6edd6cef363e9359ed3c98ba64590ba9eecba2293eb5a723ab32aee8926aa"
+dependencies = [
+ "cxx",
+ "cxx-build",
 ]
 
 [[package]]
@@ -1768,15 +1830,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.4.8"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
-
-[[package]]
-name = "itoa"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
+checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
 
 [[package]]
 name = "js-sys"
@@ -1835,9 +1891,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.134"
+version = "0.2.135"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "329c933548736bc49fd575ee68c89e8be4d260064184389a5b77517cddd99ffb"
+checksum = "68783febc7782c6c5cb401fbda4de5a9898be1762314da0bb2c10ced61f18b0c"
 
 [[package]]
 name = "libgit2-sys"
@@ -1908,6 +1964,15 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "link-cplusplus"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9272ab7b96c9046fbc5bc56c06c117cb639fe2d509df0c421cad82d2915cf369"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -2230,12 +2295,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nodrop"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
-
-[[package]]
 name = "nohash-hasher"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2285,12 +2344,12 @@ dependencies = [
 
 [[package]]
 name = "num-format"
-version = "0.4.0"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bafe4179722c2894288ee77a9f044f02811c86af699344c498b0840c698a2465"
+checksum = "54b862ff8df690cf089058c98b183676a7ed0f974cc08b426800093227cbff3b"
 dependencies = [
  "arrayvec",
- "itoa 0.4.8",
+ "itoa",
 ]
 
 [[package]]
@@ -3192,6 +3251,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
+name = "scratch"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8132065adcfd6e02db789d9285a0deb2f3fcb04002865ab67d5fb103533898"
+
+[[package]]
 name = "sct"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3313,11 +3378,11 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.85"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e55a28e3aaef9d5ce0506d0a14dbba8054ddc7e499ef522dd8b26859ec9d4a44"
+checksum = "41feea4228a6f1cd09ec7a3593a682276702cd67b5273544757dae23c096f074"
 dependencies = [
- "itoa 1.0.3",
+ "itoa",
  "ryu",
  "serde",
 ]
@@ -3340,7 +3405,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
  "form_urlencoded",
- "itoa 1.0.3",
+ "itoa",
  "ryu",
  "serde",
 ]
@@ -3612,9 +3677,9 @@ checksum = "171758edb47aa306a78dfa4ab9aeb5167405bd4e3dc2b64e88f6a84bbe98bd63"
 
 [[package]]
 name = "syn"
-version = "1.0.101"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e90cde112c4b9690b8cbe810cba9ddd8bc1d7472e2cae317b69e9438c1cba7d2"
+checksum = "3fcd952facd492f9be3ef0d0b7032a6e442ee9b361d4acc2b1d0c4aaa5f613a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3648,7 +3713,7 @@ checksum = "c02424087780c9b71cc96799eaeddff35af2bc513278cda5c99fc1f5d026d3c1"
 [[package]]
 name = "tari_app_grpc"
 version = "0.38.5"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan#788889bb6dcd8c80f08488a62e50619fdf07696d"
+source = "git+https://github.com/sdbondi/tari.git?branch=base-node-return-utxo-info-for-template-reg#0877915130b98dbfc5d13d1116f1e2de3614366b"
 dependencies = [
  "argon2",
  "base64 0.13.0",
@@ -3674,7 +3739,7 @@ dependencies = [
 [[package]]
 name = "tari_app_utilities"
 version = "0.38.5"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan#788889bb6dcd8c80f08488a62e50619fdf07696d"
+source = "git+https://github.com/sdbondi/tari.git?branch=base-node-return-utxo-info-for-template-reg#0877915130b98dbfc5d13d1116f1e2de3614366b"
 dependencies = [
  "clap 3.2.22",
  "config",
@@ -3697,7 +3762,7 @@ dependencies = [
 [[package]]
 name = "tari_base_node_grpc_client"
 version = "0.1.0"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan#788889bb6dcd8c80f08488a62e50619fdf07696d"
+source = "git+https://github.com/sdbondi/tari.git?branch=base-node-return-utxo-info-for-template-reg#0877915130b98dbfc5d13d1116f1e2de3614366b"
 dependencies = [
  "tari_app_grpc",
 ]
@@ -3746,7 +3811,7 @@ dependencies = [
 [[package]]
 name = "tari_common"
 version = "0.38.5"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan#788889bb6dcd8c80f08488a62e50619fdf07696d"
+source = "git+https://github.com/sdbondi/tari.git?branch=base-node-return-utxo-info-for-template-reg#0877915130b98dbfc5d13d1116f1e2de3614366b"
 dependencies = [
  "anyhow",
  "blake2 0.9.2",
@@ -3774,7 +3839,17 @@ dependencies = [
 [[package]]
 name = "tari_common_sqlite"
 version = "0.38.5"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan#788889bb6dcd8c80f08488a62e50619fdf07696d"
+source = "git+https://github.com/sdbondi/tari.git?branch=base-node-return-utxo-info-for-template-reg#0877915130b98dbfc5d13d1116f1e2de3614366b"
+dependencies = [
+ "diesel",
+ "log",
+ "thiserror",
+]
+
+[[package]]
+name = "tari_common_sqlite"
+version = "0.38.5"
+source = "git+https://github.com/tari-project/tari.git?branch=feature-dan#64002e9c442f7a3b69343d580254e4e93ad69dd4"
 dependencies = [
  "diesel",
  "log",
@@ -3784,7 +3859,7 @@ dependencies = [
 [[package]]
 name = "tari_common_types"
 version = "0.38.5"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan#788889bb6dcd8c80f08488a62e50619fdf07696d"
+source = "git+https://github.com/sdbondi/tari.git?branch=base-node-return-utxo-info-for-template-reg#0877915130b98dbfc5d13d1116f1e2de3614366b"
 dependencies = [
  "base64 0.13.0",
  "digest 0.9.0",
@@ -3801,7 +3876,7 @@ dependencies = [
 [[package]]
 name = "tari_comms"
 version = "0.38.5"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan#788889bb6dcd8c80f08488a62e50619fdf07696d"
+source = "git+https://github.com/sdbondi/tari.git?branch=base-node-return-utxo-info-for-template-reg#0877915130b98dbfc5d13d1116f1e2de3614366b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3847,7 +3922,7 @@ dependencies = [
 [[package]]
 name = "tari_comms_dht"
 version = "0.38.5"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan#788889bb6dcd8c80f08488a62e50619fdf07696d"
+source = "git+https://github.com/sdbondi/tari.git?branch=base-node-return-utxo-info-for-template-reg#0877915130b98dbfc5d13d1116f1e2de3614366b"
 dependencies = [
  "anyhow",
  "bitflags 1.3.2",
@@ -3867,7 +3942,43 @@ dependencies = [
  "serde",
  "serde_derive",
  "tari_common",
- "tari_common_sqlite",
+ "tari_common_sqlite 0.38.5 (git+https://github.com/sdbondi/tari.git?branch=base-node-return-utxo-info-for-template-reg)",
+ "tari_comms",
+ "tari_comms_rpc_macros",
+ "tari_crypto",
+ "tari_shutdown",
+ "tari_storage",
+ "tari_utilities",
+ "thiserror",
+ "tokio",
+ "tower",
+ "zeroize",
+]
+
+[[package]]
+name = "tari_comms_dht"
+version = "0.38.5"
+source = "git+https://github.com/tari-project/tari.git?branch=feature-dan#64002e9c442f7a3b69343d580254e4e93ad69dd4"
+dependencies = [
+ "anyhow",
+ "bitflags 1.3.2",
+ "chacha20 0.7.3",
+ "chacha20poly1305",
+ "chrono",
+ "diesel",
+ "diesel_migrations",
+ "digest 0.9.0",
+ "futures",
+ "log",
+ "log-mdc",
+ "pin-project 0.4.30",
+ "prost",
+ "prost-types",
+ "rand 0.7.3",
+ "serde",
+ "serde_derive",
+ "tari_common",
+ "tari_common_sqlite 0.38.5 (git+https://github.com/tari-project/tari.git?branch=feature-dan)",
  "tari_comms",
  "tari_comms_rpc_macros",
  "tari_crypto",
@@ -3883,7 +3994,7 @@ dependencies = [
 [[package]]
 name = "tari_comms_rpc_macros"
 version = "0.38.5"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan#788889bb6dcd8c80f08488a62e50619fdf07696d"
+source = "git+https://github.com/sdbondi/tari.git?branch=base-node-return-utxo-info-for-template-reg#0877915130b98dbfc5d13d1116f1e2de3614366b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3893,7 +4004,7 @@ dependencies = [
 [[package]]
 name = "tari_core"
 version = "0.38.5"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan#788889bb6dcd8c80f08488a62e50619fdf07696d"
+source = "git+https://github.com/sdbondi/tari.git?branch=base-node-return-utxo-info-for-template-reg#0877915130b98dbfc5d13d1116f1e2de3614366b"
 dependencies = [
  "async-trait",
  "bincode",
@@ -3931,17 +4042,17 @@ dependencies = [
  "tari_common",
  "tari_common_types",
  "tari_comms",
- "tari_comms_dht",
+ "tari_comms_dht 0.38.5 (git+https://github.com/sdbondi/tari.git?branch=base-node-return-utxo-info-for-template-reg)",
  "tari_comms_rpc_macros",
  "tari_crypto",
  "tari_metrics",
  "tari_mmr",
  "tari_p2p",
  "tari_script",
- "tari_service_framework",
+ "tari_service_framework 0.38.5 (git+https://github.com/sdbondi/tari.git?branch=base-node-return-utxo-info-for-template-reg)",
  "tari_shutdown",
  "tari_storage",
- "tari_test_utils",
+ "tari_test_utils 0.38.5 (git+https://github.com/sdbondi/tari.git?branch=base-node-return-utxo-info-for-template-reg)",
  "tari_utilities",
  "thiserror",
  "tokio",
@@ -4014,7 +4125,7 @@ dependencies = [
  "tari_common",
  "tari_common_types",
  "tari_comms",
- "tari_comms_dht",
+ "tari_comms_dht 0.38.5 (git+https://github.com/tari-project/tari.git?branch=feature-dan)",
  "tari_comms_rpc_macros",
  "tari_core",
  "tari_crypto",
@@ -4024,11 +4135,11 @@ dependencies = [
  "tari_engine_types",
  "tari_mmr",
  "tari_p2p",
- "tari_service_framework",
+ "tari_service_framework 0.38.5 (git+https://github.com/tari-project/tari.git?branch=feature-dan)",
  "tari_shutdown",
  "tari_storage",
  "tari_template_lib",
- "tari_test_utils",
+ "tari_test_utils 0.38.5 (git+https://github.com/tari-project/tari.git?branch=feature-dan)",
  "tari_utilities",
  "thiserror",
  "tokio",
@@ -4069,8 +4180,10 @@ name = "tari_dan_storage"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "serde",
  "tari_common_types",
  "thiserror",
+ "time 0.3.15",
 ]
 
 [[package]]
@@ -4103,6 +4216,7 @@ dependencies = [
  "tari_engine_types",
  "tari_utilities",
  "thiserror",
+ "time 0.3.15",
  "tokio",
  "tokio-stream",
 ]
@@ -4123,7 +4237,7 @@ dependencies = [
 [[package]]
 name = "tari_metrics"
 version = "0.1.0"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan#788889bb6dcd8c80f08488a62e50619fdf07696d"
+source = "git+https://github.com/sdbondi/tari.git?branch=base-node-return-utxo-info-for-template-reg#0877915130b98dbfc5d13d1116f1e2de3614366b"
 dependencies = [
  "once_cell",
  "prometheus",
@@ -4133,7 +4247,7 @@ dependencies = [
 [[package]]
 name = "tari_mmr"
 version = "0.38.5"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan#788889bb6dcd8c80f08488a62e50619fdf07696d"
+source = "git+https://github.com/sdbondi/tari.git?branch=base-node-return-utxo-info-for-template-reg#0877915130b98dbfc5d13d1116f1e2de3614366b"
 dependencies = [
  "croaring",
  "digest 0.9.0",
@@ -4148,7 +4262,7 @@ dependencies = [
 [[package]]
 name = "tari_p2p"
 version = "0.38.5"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan#788889bb6dcd8c80f08488a62e50619fdf07696d"
+source = "git+https://github.com/sdbondi/tari.git?branch=base-node-return-utxo-info-for-template-reg#0877915130b98dbfc5d13d1116f1e2de3614366b"
 dependencies = [
  "anyhow",
  "bytes 0.5.6",
@@ -4164,9 +4278,9 @@ dependencies = [
  "serde_derive",
  "tari_common",
  "tari_comms",
- "tari_comms_dht",
+ "tari_comms_dht 0.38.5 (git+https://github.com/sdbondi/tari.git?branch=base-node-return-utxo-info-for-template-reg)",
  "tari_crypto",
- "tari_service_framework",
+ "tari_service_framework 0.38.5 (git+https://github.com/sdbondi/tari.git?branch=base-node-return-utxo-info-for-template-reg)",
  "tari_shutdown",
  "tari_storage",
  "tari_utilities",
@@ -4182,7 +4296,7 @@ dependencies = [
 [[package]]
 name = "tari_script"
 version = "0.12.0"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan#788889bb6dcd8c80f08488a62e50619fdf07696d"
+source = "git+https://github.com/sdbondi/tari.git?branch=base-node-return-utxo-info-for-template-reg#0877915130b98dbfc5d13d1116f1e2de3614366b"
 dependencies = [
  "blake2 0.9.2",
  "digest 0.9.0",
@@ -4198,7 +4312,22 @@ dependencies = [
 [[package]]
 name = "tari_service_framework"
 version = "0.38.5"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan#788889bb6dcd8c80f08488a62e50619fdf07696d"
+source = "git+https://github.com/sdbondi/tari.git?branch=base-node-return-utxo-info-for-template-reg#0877915130b98dbfc5d13d1116f1e2de3614366b"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "futures",
+ "log",
+ "tari_shutdown",
+ "thiserror",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
+name = "tari_service_framework"
+version = "0.38.5"
+source = "git+https://github.com/tari-project/tari.git?branch=feature-dan#64002e9c442f7a3b69343d580254e4e93ad69dd4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4213,7 +4342,7 @@ dependencies = [
 [[package]]
 name = "tari_shutdown"
 version = "0.38.5"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan#788889bb6dcd8c80f08488a62e50619fdf07696d"
+source = "git+https://github.com/sdbondi/tari.git?branch=base-node-return-utxo-info-for-template-reg#0877915130b98dbfc5d13d1116f1e2de3614366b"
 dependencies = [
  "futures",
 ]
@@ -4221,7 +4350,7 @@ dependencies = [
 [[package]]
 name = "tari_storage"
 version = "0.38.5"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan#788889bb6dcd8c80f08488a62e50619fdf07696d"
+source = "git+https://github.com/sdbondi/tari.git?branch=base-node-return-utxo-info-for-template-reg#0877915130b98dbfc5d13d1116f1e2de3614366b"
 dependencies = [
  "bincode",
  "lmdb-zero",
@@ -4276,7 +4405,19 @@ dependencies = [
 [[package]]
 name = "tari_test_utils"
 version = "0.38.5"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan#788889bb6dcd8c80f08488a62e50619fdf07696d"
+source = "git+https://github.com/sdbondi/tari.git?branch=base-node-return-utxo-info-for-template-reg#0877915130b98dbfc5d13d1116f1e2de3614366b"
+dependencies = [
+ "futures",
+ "rand 0.7.3",
+ "tari_shutdown",
+ "tempfile",
+ "tokio",
+]
+
+[[package]]
+name = "tari_test_utils"
+version = "0.38.5"
+source = "git+https://github.com/tari-project/tari.git?branch=feature-dan#64002e9c442f7a3b69343d580254e4e93ad69dd4"
 dependencies = [
  "futures",
  "rand 0.7.3",
@@ -4310,6 +4451,7 @@ dependencies = [
  "axum-jrpc",
  "blake2 0.9.2",
  "borsh",
+ "bytes 1.2.1",
  "chrono",
  "clap 3.2.22",
  "config",
@@ -4345,9 +4487,10 @@ dependencies = [
  "tari_shutdown",
  "tari_storage",
  "tari_template_lib",
- "tari_test_utils",
+ "tari_test_utils 0.38.5 (git+https://github.com/tari-project/tari.git?branch=feature-dan)",
  "tari_wallet_grpc_client",
  "thiserror",
+ "time 0.3.15",
  "tokio",
  "tokio-stream",
  "tonic",
@@ -4378,7 +4521,7 @@ dependencies = [
 [[package]]
 name = "tari_wallet_grpc_client"
 version = "0.1.0"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan#788889bb6dcd8c80f08488a62e50619fdf07696d"
+source = "git+https://github.com/sdbondi/tari.git?branch=base-node-return-utxo-info-for-template-reg#0877915130b98dbfc5d13d1116f1e2de3614366b"
 dependencies = [
  "tari_app_grpc",
  "tari_common_types",
@@ -4696,9 +4839,9 @@ dependencies = [
 
 [[package]]
 name = "tower-layer"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "343bc9466d3fe6b0f960ef45960509f84480bf4fd96f92901afe7ff3df9d3a62"
+checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
 
 [[package]]
 name = "tower-service"
@@ -4708,9 +4851,9 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.36"
+version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fce9567bd60a67d08a16488756721ba392f24f29006402881e43b19aac64307"
+checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if",
  "log",
@@ -4721,9 +4864,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11c75893af559bc8e10716548bdef5cb2b983f8e637db9d0e15126b61b484ee2"
+checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4732,9 +4875,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.29"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aeea4303076558a00714b823f9ad67d58a3bbda1df83d8827d21193156e22f7"
+checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
 dependencies = [
  "once_cell",
 ]
@@ -4855,9 +4998,9 @@ checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcc811dc4066ac62f84f11307873c4850cb653bfa9b1719cee2bd2204a4bc5dd"
+checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
 
 [[package]]
 name = "unicode-normalization"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3713,7 +3713,7 @@ checksum = "c02424087780c9b71cc96799eaeddff35af2bc513278cda5c99fc1f5d026d3c1"
 [[package]]
 name = "tari_app_grpc"
 version = "0.38.5"
-source = "git+https://github.com/sdbondi/tari.git?branch=base-node-return-utxo-info-for-template-reg#0877915130b98dbfc5d13d1116f1e2de3614366b"
+source = "git+https://github.com/tari-project/tari.git?branch=feature-dan#9e81c7b6257773ddca970982adb89a1e0d548e2b"
 dependencies = [
  "argon2",
  "base64 0.13.0",
@@ -3739,7 +3739,7 @@ dependencies = [
 [[package]]
 name = "tari_app_utilities"
 version = "0.38.5"
-source = "git+https://github.com/sdbondi/tari.git?branch=base-node-return-utxo-info-for-template-reg#0877915130b98dbfc5d13d1116f1e2de3614366b"
+source = "git+https://github.com/tari-project/tari.git?branch=feature-dan#9e81c7b6257773ddca970982adb89a1e0d548e2b"
 dependencies = [
  "clap 3.2.22",
  "config",
@@ -3762,7 +3762,7 @@ dependencies = [
 [[package]]
 name = "tari_base_node_grpc_client"
 version = "0.1.0"
-source = "git+https://github.com/sdbondi/tari.git?branch=base-node-return-utxo-info-for-template-reg#0877915130b98dbfc5d13d1116f1e2de3614366b"
+source = "git+https://github.com/tari-project/tari.git?branch=feature-dan#9e81c7b6257773ddca970982adb89a1e0d548e2b"
 dependencies = [
  "tari_app_grpc",
 ]
@@ -3811,7 +3811,7 @@ dependencies = [
 [[package]]
 name = "tari_common"
 version = "0.38.5"
-source = "git+https://github.com/sdbondi/tari.git?branch=base-node-return-utxo-info-for-template-reg#0877915130b98dbfc5d13d1116f1e2de3614366b"
+source = "git+https://github.com/tari-project/tari.git?branch=feature-dan#9e81c7b6257773ddca970982adb89a1e0d548e2b"
 dependencies = [
  "anyhow",
  "blake2 0.9.2",
@@ -3839,16 +3839,6 @@ dependencies = [
 [[package]]
 name = "tari_common_sqlite"
 version = "0.38.5"
-source = "git+https://github.com/sdbondi/tari.git?branch=base-node-return-utxo-info-for-template-reg#0877915130b98dbfc5d13d1116f1e2de3614366b"
-dependencies = [
- "diesel",
- "log",
- "thiserror",
-]
-
-[[package]]
-name = "tari_common_sqlite"
-version = "0.38.5"
 source = "git+https://github.com/tari-project/tari.git?branch=feature-dan#64002e9c442f7a3b69343d580254e4e93ad69dd4"
 dependencies = [
  "diesel",
@@ -3859,7 +3849,7 @@ dependencies = [
 [[package]]
 name = "tari_common_types"
 version = "0.38.5"
-source = "git+https://github.com/sdbondi/tari.git?branch=base-node-return-utxo-info-for-template-reg#0877915130b98dbfc5d13d1116f1e2de3614366b"
+source = "git+https://github.com/tari-project/tari.git?branch=feature-dan#9e81c7b6257773ddca970982adb89a1e0d548e2b"
 dependencies = [
  "base64 0.13.0",
  "digest 0.9.0",
@@ -3876,7 +3866,7 @@ dependencies = [
 [[package]]
 name = "tari_comms"
 version = "0.38.5"
-source = "git+https://github.com/sdbondi/tari.git?branch=base-node-return-utxo-info-for-template-reg#0877915130b98dbfc5d13d1116f1e2de3614366b"
+source = "git+https://github.com/tari-project/tari.git?branch=feature-dan#9e81c7b6257773ddca970982adb89a1e0d548e2b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3922,42 +3912,6 @@ dependencies = [
 [[package]]
 name = "tari_comms_dht"
 version = "0.38.5"
-source = "git+https://github.com/sdbondi/tari.git?branch=base-node-return-utxo-info-for-template-reg#0877915130b98dbfc5d13d1116f1e2de3614366b"
-dependencies = [
- "anyhow",
- "bitflags 1.3.2",
- "chacha20 0.7.3",
- "chacha20poly1305",
- "chrono",
- "diesel",
- "diesel_migrations",
- "digest 0.9.0",
- "futures",
- "log",
- "log-mdc",
- "pin-project 0.4.30",
- "prost",
- "prost-types",
- "rand 0.7.3",
- "serde",
- "serde_derive",
- "tari_common",
- "tari_common_sqlite 0.38.5 (git+https://github.com/sdbondi/tari.git?branch=base-node-return-utxo-info-for-template-reg)",
- "tari_comms",
- "tari_comms_rpc_macros",
- "tari_crypto",
- "tari_shutdown",
- "tari_storage",
- "tari_utilities",
- "thiserror",
- "tokio",
- "tower",
- "zeroize",
-]
-
-[[package]]
-name = "tari_comms_dht"
-version = "0.38.5"
 source = "git+https://github.com/tari-project/tari.git?branch=feature-dan#64002e9c442f7a3b69343d580254e4e93ad69dd4"
 dependencies = [
  "anyhow",
@@ -3978,7 +3932,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "tari_common",
- "tari_common_sqlite 0.38.5 (git+https://github.com/tari-project/tari.git?branch=feature-dan)",
+ "tari_common_sqlite",
  "tari_comms",
  "tari_comms_rpc_macros",
  "tari_crypto",
@@ -3994,7 +3948,7 @@ dependencies = [
 [[package]]
 name = "tari_comms_rpc_macros"
 version = "0.38.5"
-source = "git+https://github.com/sdbondi/tari.git?branch=base-node-return-utxo-info-for-template-reg#0877915130b98dbfc5d13d1116f1e2de3614366b"
+source = "git+https://github.com/tari-project/tari.git?branch=feature-dan#9e81c7b6257773ddca970982adb89a1e0d548e2b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4004,7 +3958,7 @@ dependencies = [
 [[package]]
 name = "tari_core"
 version = "0.38.5"
-source = "git+https://github.com/sdbondi/tari.git?branch=base-node-return-utxo-info-for-template-reg#0877915130b98dbfc5d13d1116f1e2de3614366b"
+source = "git+https://github.com/tari-project/tari.git?branch=feature-dan#9e81c7b6257773ddca970982adb89a1e0d548e2b"
 dependencies = [
  "async-trait",
  "bincode",
@@ -4042,17 +3996,17 @@ dependencies = [
  "tari_common",
  "tari_common_types",
  "tari_comms",
- "tari_comms_dht 0.38.5 (git+https://github.com/sdbondi/tari.git?branch=base-node-return-utxo-info-for-template-reg)",
+ "tari_comms_dht",
  "tari_comms_rpc_macros",
  "tari_crypto",
  "tari_metrics",
  "tari_mmr",
  "tari_p2p",
  "tari_script",
- "tari_service_framework 0.38.5 (git+https://github.com/sdbondi/tari.git?branch=base-node-return-utxo-info-for-template-reg)",
+ "tari_service_framework",
  "tari_shutdown",
  "tari_storage",
- "tari_test_utils 0.38.5 (git+https://github.com/sdbondi/tari.git?branch=base-node-return-utxo-info-for-template-reg)",
+ "tari_test_utils",
  "tari_utilities",
  "thiserror",
  "tokio",
@@ -4125,7 +4079,7 @@ dependencies = [
  "tari_common",
  "tari_common_types",
  "tari_comms",
- "tari_comms_dht 0.38.5 (git+https://github.com/tari-project/tari.git?branch=feature-dan)",
+ "tari_comms_dht",
  "tari_comms_rpc_macros",
  "tari_core",
  "tari_crypto",
@@ -4135,11 +4089,11 @@ dependencies = [
  "tari_engine_types",
  "tari_mmr",
  "tari_p2p",
- "tari_service_framework 0.38.5 (git+https://github.com/tari-project/tari.git?branch=feature-dan)",
+ "tari_service_framework",
  "tari_shutdown",
  "tari_storage",
  "tari_template_lib",
- "tari_test_utils 0.38.5 (git+https://github.com/tari-project/tari.git?branch=feature-dan)",
+ "tari_test_utils",
  "tari_utilities",
  "thiserror",
  "tokio",
@@ -4237,7 +4191,7 @@ dependencies = [
 [[package]]
 name = "tari_metrics"
 version = "0.1.0"
-source = "git+https://github.com/sdbondi/tari.git?branch=base-node-return-utxo-info-for-template-reg#0877915130b98dbfc5d13d1116f1e2de3614366b"
+source = "git+https://github.com/tari-project/tari.git?branch=feature-dan#9e81c7b6257773ddca970982adb89a1e0d548e2b"
 dependencies = [
  "once_cell",
  "prometheus",
@@ -4247,7 +4201,7 @@ dependencies = [
 [[package]]
 name = "tari_mmr"
 version = "0.38.5"
-source = "git+https://github.com/sdbondi/tari.git?branch=base-node-return-utxo-info-for-template-reg#0877915130b98dbfc5d13d1116f1e2de3614366b"
+source = "git+https://github.com/tari-project/tari.git?branch=feature-dan#9e81c7b6257773ddca970982adb89a1e0d548e2b"
 dependencies = [
  "croaring",
  "digest 0.9.0",
@@ -4262,7 +4216,7 @@ dependencies = [
 [[package]]
 name = "tari_p2p"
 version = "0.38.5"
-source = "git+https://github.com/sdbondi/tari.git?branch=base-node-return-utxo-info-for-template-reg#0877915130b98dbfc5d13d1116f1e2de3614366b"
+source = "git+https://github.com/tari-project/tari.git?branch=feature-dan#9e81c7b6257773ddca970982adb89a1e0d548e2b"
 dependencies = [
  "anyhow",
  "bytes 0.5.6",
@@ -4278,9 +4232,9 @@ dependencies = [
  "serde_derive",
  "tari_common",
  "tari_comms",
- "tari_comms_dht 0.38.5 (git+https://github.com/sdbondi/tari.git?branch=base-node-return-utxo-info-for-template-reg)",
+ "tari_comms_dht",
  "tari_crypto",
- "tari_service_framework 0.38.5 (git+https://github.com/sdbondi/tari.git?branch=base-node-return-utxo-info-for-template-reg)",
+ "tari_service_framework",
  "tari_shutdown",
  "tari_storage",
  "tari_utilities",
@@ -4296,7 +4250,7 @@ dependencies = [
 [[package]]
 name = "tari_script"
 version = "0.12.0"
-source = "git+https://github.com/sdbondi/tari.git?branch=base-node-return-utxo-info-for-template-reg#0877915130b98dbfc5d13d1116f1e2de3614366b"
+source = "git+https://github.com/tari-project/tari.git?branch=feature-dan#9e81c7b6257773ddca970982adb89a1e0d548e2b"
 dependencies = [
  "blake2 0.9.2",
  "digest 0.9.0",
@@ -4307,21 +4261,6 @@ dependencies = [
  "tari_crypto",
  "tari_utilities",
  "thiserror",
-]
-
-[[package]]
-name = "tari_service_framework"
-version = "0.38.5"
-source = "git+https://github.com/sdbondi/tari.git?branch=base-node-return-utxo-info-for-template-reg#0877915130b98dbfc5d13d1116f1e2de3614366b"
-dependencies = [
- "anyhow",
- "async-trait",
- "futures",
- "log",
- "tari_shutdown",
- "thiserror",
- "tokio",
- "tower-service",
 ]
 
 [[package]]
@@ -4342,7 +4281,7 @@ dependencies = [
 [[package]]
 name = "tari_shutdown"
 version = "0.38.5"
-source = "git+https://github.com/sdbondi/tari.git?branch=base-node-return-utxo-info-for-template-reg#0877915130b98dbfc5d13d1116f1e2de3614366b"
+source = "git+https://github.com/tari-project/tari.git?branch=feature-dan#9e81c7b6257773ddca970982adb89a1e0d548e2b"
 dependencies = [
  "futures",
 ]
@@ -4350,7 +4289,7 @@ dependencies = [
 [[package]]
 name = "tari_storage"
 version = "0.38.5"
-source = "git+https://github.com/sdbondi/tari.git?branch=base-node-return-utxo-info-for-template-reg#0877915130b98dbfc5d13d1116f1e2de3614366b"
+source = "git+https://github.com/tari-project/tari.git?branch=feature-dan#9e81c7b6257773ddca970982adb89a1e0d548e2b"
 dependencies = [
  "bincode",
  "lmdb-zero",
@@ -4400,18 +4339,6 @@ dependencies = [
  "tari_engine_types",
  "tari_template_abi",
  "tari_template_lib",
-]
-
-[[package]]
-name = "tari_test_utils"
-version = "0.38.5"
-source = "git+https://github.com/sdbondi/tari.git?branch=base-node-return-utxo-info-for-template-reg#0877915130b98dbfc5d13d1116f1e2de3614366b"
-dependencies = [
- "futures",
- "rand 0.7.3",
- "tari_shutdown",
- "tempfile",
- "tokio",
 ]
 
 [[package]]
@@ -4487,7 +4414,7 @@ dependencies = [
  "tari_shutdown",
  "tari_storage",
  "tari_template_lib",
- "tari_test_utils 0.38.5 (git+https://github.com/tari-project/tari.git?branch=feature-dan)",
+ "tari_test_utils",
  "tari_wallet_grpc_client",
  "thiserror",
  "time 0.3.15",
@@ -4521,7 +4448,7 @@ dependencies = [
 [[package]]
 name = "tari_wallet_grpc_client"
 version = "0.1.0"
-source = "git+https://github.com/sdbondi/tari.git?branch=base-node-return-utxo-info-for-template-reg#0877915130b98dbfc5d13d1116f1e2de3614366b"
+source = "git+https://github.com/tari-project/tari.git?branch=feature-dan#9e81c7b6257773ddca970982adb89a1e0d548e2b"
 dependencies = [
  "tari_app_grpc",
  "tari_common_types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,35 @@ panic = 'abort'
 # Temporarily lock pgp to commit (master branch at time of writing) because the currently release crate locks zeroize to =1.3
 liblmdb-sys = { git = "https://github.com/tari-project/lmdb-rs", tag = "0.7.6-tari.1" }
 
+# Uncomment and replace myfork and mybranch with the name of your fork and the branch you want to temporarily use
+#[patch."https://github.com/tari-project/tari.git"]
+#tari_app_grpc = { git = "https://github.com/myfork/tari.git", branch = "mybranch" }
+#tari_app_utilities = { git = "https://github.com/myfork/tari.git", branch = "mybranch" }
+#tari_base_node_grpc_client = { git = "https://github.com/myfork/tari.git", branch = "mybranch" }
+#tari_common = { git = "https://github.com/myfork/tari.git", branch = "mybranch" }
+#tari_common_types = { git = "https://github.com/myfork/tari.git", branch = "mybranch" }
+#tari_comms = { git = "https://github.com/myfork/tari.git", branch = "mybranch" }
+#tari_comms_rpc_macros = { git = "https://github.com/myfork/tari.git", branch = "mybranch" }
+#tari_core = { git = "https://github.com/myfork/tari.git", branch = "mybranch" }
+#tari_mmr = { git = "https://github.com/myfork/tari.git", branch = "mybranch" }
+#tari_p2p = { git = "https://github.com/myfork/tari.git", branch = "mybranch" }
+#tari_shutdown = { git = "https://github.com/myfork/tari.git", branch = "mybranch" }
+#tari_storage = { git = "https://github.com/myfork/tari.git", branch = "mybranch" }
+#tari_wallet_grpc_client = { git = "https://github.com/myfork/tari.git", branch = "mybranch" }
+
+# TODO: Remove this once the PR is merged
+[patch."https://github.com/tari-project/tari.git"]
+tari_app_utilities = { git = "https://github.com/sdbondi/tari.git", branch = "base-node-return-utxo-info-for-template-reg" }
+tari_common = { git = "https://github.com/sdbondi/tari.git", branch = "base-node-return-utxo-info-for-template-reg" }
+tari_common_types = { git = "https://github.com/sdbondi/tari.git", branch = "base-node-return-utxo-info-for-template-reg" }
+tari_comms = { git = "https://github.com/sdbondi/tari.git", branch = "base-node-return-utxo-info-for-template-reg" }
+tari_comms_rpc_macros = { git = "https://github.com/sdbondi/tari.git", branch = "base-node-return-utxo-info-for-template-reg" }
+tari_core = { git = "https://github.com/sdbondi/tari.git", branch = "base-node-return-utxo-info-for-template-reg" }
+tari_mmr = { git = "https://github.com/sdbondi/tari.git", branch = "base-node-return-utxo-info-for-template-reg" }
+tari_p2p = { git = "https://github.com/sdbondi/tari.git", branch = "base-node-return-utxo-info-for-template-reg" }
+tari_shutdown = { git = "https://github.com/sdbondi/tari.git", branch = "base-node-return-utxo-info-for-template-reg" }
+tari_storage = { git = "https://github.com/sdbondi/tari.git", branch = "base-node-return-utxo-info-for-template-reg" }
+
+tari_app_grpc = { git = "https://github.com/sdbondi/tari.git", branch = "base-node-return-utxo-info-for-template-reg" }
+tari_base_node_grpc_client = { git = "https://github.com/sdbondi/tari.git", branch = "base-node-return-utxo-info-for-template-reg" }
+tari_wallet_grpc_client = { git = "https://github.com/sdbondi/tari.git", branch = "base-node-return-utxo-info-for-template-reg" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,20 +38,3 @@ liblmdb-sys = { git = "https://github.com/tari-project/lmdb-rs", tag = "0.7.6-ta
 #tari_shutdown = { git = "https://github.com/myfork/tari.git", branch = "mybranch" }
 #tari_storage = { git = "https://github.com/myfork/tari.git", branch = "mybranch" }
 #tari_wallet_grpc_client = { git = "https://github.com/myfork/tari.git", branch = "mybranch" }
-
-# TODO: Remove this once the PR is merged
-[patch."https://github.com/tari-project/tari.git"]
-tari_app_utilities = { git = "https://github.com/sdbondi/tari.git", branch = "base-node-return-utxo-info-for-template-reg" }
-tari_common = { git = "https://github.com/sdbondi/tari.git", branch = "base-node-return-utxo-info-for-template-reg" }
-tari_common_types = { git = "https://github.com/sdbondi/tari.git", branch = "base-node-return-utxo-info-for-template-reg" }
-tari_comms = { git = "https://github.com/sdbondi/tari.git", branch = "base-node-return-utxo-info-for-template-reg" }
-tari_comms_rpc_macros = { git = "https://github.com/sdbondi/tari.git", branch = "base-node-return-utxo-info-for-template-reg" }
-tari_core = { git = "https://github.com/sdbondi/tari.git", branch = "base-node-return-utxo-info-for-template-reg" }
-tari_mmr = { git = "https://github.com/sdbondi/tari.git", branch = "base-node-return-utxo-info-for-template-reg" }
-tari_p2p = { git = "https://github.com/sdbondi/tari.git", branch = "base-node-return-utxo-info-for-template-reg" }
-tari_shutdown = { git = "https://github.com/sdbondi/tari.git", branch = "base-node-return-utxo-info-for-template-reg" }
-tari_storage = { git = "https://github.com/sdbondi/tari.git", branch = "base-node-return-utxo-info-for-template-reg" }
-
-tari_app_grpc = { git = "https://github.com/sdbondi/tari.git", branch = "base-node-return-utxo-info-for-template-reg" }
-tari_base_node_grpc_client = { git = "https://github.com/sdbondi/tari.git", branch = "base-node-return-utxo-info-for-template-reg" }
-tari_wallet_grpc_client = { git = "https://github.com/sdbondi/tari.git", branch = "base-node-return-utxo-info-for-template-reg" }

--- a/applications/tari_validator_node/Cargo.toml
+++ b/applications/tari_validator_node/Cargo.toml
@@ -36,6 +36,7 @@ axum = "0.5.15"
 axum-jrpc = { version = "0.2.1", features = ["anyhow_error"] }
 blake2 = "0.9.2"
 borsh = { version = "0.9.3", default-features = false }
+bytes = "1"
 chrono = "0.4.22"
 clap = { version = "3.2.5", features = ["env"] }
 config = "0.13.0"
@@ -51,6 +52,7 @@ rand = "0.7"
 reqwest = "0.11.11"
 serde = { version = "1.0.126", features = ["derive"] }
 serde_json = "1.0.64"
+time = "0.3.15"
 thiserror = "^1.0.20"
 tokio = { version = "1.10", features = ["macros", "time", "sync", "rt-multi-thread"] }
 tokio-stream = { version = "0.1.7", features = ["sync"] }
@@ -64,3 +66,4 @@ tari_test_utils = { git = "https://github.com/tari-project/tari.git", branch = "
 
 [build-dependencies]
 tari_common = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan", package = "tari_common", features = ["build"] }
+

--- a/applications/tari_validator_node/src/base_layer_scanner.rs
+++ b/applications/tari_validator_node/src/base_layer_scanner.rs
@@ -20,26 +20,32 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::{convert::TryInto, time::Duration};
+use std::convert::TryInto;
 
 use log::*;
 use tari_common_types::types::{FixedHash, FixedHashSizeError};
-use tari_core::transactions::transaction_components::CodeTemplateRegistration;
+use tari_core::transactions::transaction_components::{
+    CodeTemplateRegistration,
+    SideChainFeature,
+    ValidatorNodeRegistration,
+};
 use tari_crypto::tari_utilities::ByteArray;
+use tari_dan_common_types::optional::Optional;
 use tari_dan_core::{
     models::BaseLayerMetadata,
-    services::{base_node_error::BaseNodeError, epoch_manager::EpochManagerError, BaseNodeClient},
+    services::{base_node_error::BaseNodeError, epoch_manager::EpochManagerError, BaseNodeClient, BlockInfo},
     DigitalAssetError,
 };
 use tari_dan_storage::global::{GlobalDb, MetadataKey};
 use tari_dan_storage_sqlite::{error::SqliteStorageError, global::SqliteGlobalDbAdapter};
 use tari_shutdown::ShutdownSignal;
+use tari_template_lib::models::TemplateAddress;
 use tokio::{task, time};
 
 use crate::{
     p2p::services::{
         epoch_manager::handle::EpochManagerHandle,
-        template_manager::{handle::TemplateManagerHandle, TemplateManagerError},
+        template_manager::{TemplateManagerError, TemplateManagerHandle, TemplateRegistration},
     },
     GrpcBaseNodeClient,
     ValidatorNodeConfig,
@@ -66,7 +72,7 @@ pub fn spawn(
         );
 
         if let Err(err) = base_layer_scanner.start().await {
-            error!(target: LOG_TARGET, "Base layer scanner failed with error: {}", err);
+            error!(target: LOG_TARGET, "Base layer scanner failed to initialize: {}", err);
         }
     });
 }
@@ -113,54 +119,20 @@ impl BaseLayerScanner {
         }
 
         self.load_initial_state()?;
+        // Scan on startup
+        if let Err(err) = self.scan_blockchain().await {
+            error!(target: LOG_TARGET, "Base layer scanner failed with error: {}", err);
+        }
 
         loop {
-            // fetch the new base layer info since the previous scan
-            let tip = self.base_node_client.get_tip_info().await?;
-            if tip.height_of_longest_chain > self.last_scanned_height {
-                // let new_blocks = self
-                //     .base_node_client
-                //     .get_blocks(self.last_scanned_hash, tip.height_of_longest_chain)
-                //     .await?;
-                for height in self.last_scanned_height + 1..=tip.height_of_longest_chain {
-                    self.process_block(height).await?;
-                }
-                self.set_last_scanned_block(&tip)?;
-            } else {
-                tokio::select! {
-                   _ = time::sleep(Duration::from_secs(self.config.base_layer_scanning_interval_in_seconds)) => {},
-                   _ = &mut self.shutdown => break
-                }
+            tokio::select! {
+                _ = time::sleep(self.config.base_layer_scanning_interval) => {
+                    if let Err(err) = self.scan_blockchain().await {
+                        error!(target: LOG_TARGET, "Base layer scanner failed with error: {}", err);
+                    }
+                },
+                _ = self.shutdown.wait() => break
             }
-        }
-
-        Ok(())
-    }
-
-    // TODO: Use hashes instead of height to avoid reorg problems
-    async fn process_block(&mut self, height: u64) -> Result<(), BaseLayerScannerError> {
-        let template_registrations = self.scan_for_new_templates(height).await?;
-
-        // both epoch and template tasks are I/O bound,
-        // so they can be ran concurrently as they do not block CPU between them
-        let epoch_task = self.epoch_manager.update_epoch(height);
-        let template_task = self.template_manager.add_templates(template_registrations);
-
-        // wait for all tasks to finish
-        let (epoch_result, template_result) = tokio::join!(epoch_task, template_task);
-
-        if let Err(err) = epoch_result {
-            error!(
-                target: LOG_TARGET,
-                "🚨 Epoch manager failed to update epoch at height {}: {}", height, err
-            );
-        }
-
-        if let Err(err) = template_result {
-            error!(
-                target: LOG_TARGET,
-                "🚨 Template manager failed to add templates at height {}: {}", height, err
-            );
         }
 
         Ok(())
@@ -194,41 +166,180 @@ impl BaseLayerScanner {
         Ok(())
     }
 
-    async fn scan_for_new_templates(
-        &mut self,
-        height: u64,
-    ) -> Result<Vec<CodeTemplateRegistration>, BaseLayerScannerError> {
-        info!(
-            target: LOG_TARGET,
-            "🔍 Scanning base layer (from height: {}) for new templates", self.last_scanned_height
-        );
-
-        let template_registrations = self.base_node_client.get_template_registrations(height).await?;
-        if !template_registrations.is_empty() {
-            info!(
-                target: LOG_TARGET,
-                "📁 {} new template(s) found",
-                template_registrations.len()
-            );
+    async fn scan_blockchain(&mut self) -> Result<(), BaseLayerScannerError> {
+        // fetch the new base layer info since the previous scan
+        let tip = self.base_node_client.get_tip_info().await?;
+        match self.get_blockchain_progression(&tip).await? {
+            BlockchainProgression::Progressed => {
+                info!(
+                    target: LOG_TARGET,
+                    "⛓️ Blockchain has progressed to height {}. We last scanned {}. Scanning for new side-chain UTXOs.",
+                    tip.height_of_longest_chain,
+                    self.last_scanned_height
+                );
+                self.sync_blockchain().await?;
+            },
+            BlockchainProgression::Reorged => {
+                warn!(
+                    target: LOG_TARGET,
+                    "⚠️ Base layer reorg detected. Rescanning from genesis."
+                );
+                // TODO: we need to figure out where the fork happened, and delete data after the fork.
+                self.last_scanned_hash = None;
+                self.last_scanned_height = 0;
+                self.sync_blockchain().await?;
+            },
+            BlockchainProgression::NoProgress => {
+                debug!(target: LOG_TARGET, "No new blocks to scan.");
+            },
         }
 
-        Ok(template_registrations)
+        Ok(())
     }
 
-    fn set_last_scanned_block(&mut self, tip: &BaseLayerMetadata) -> Result<(), BaseLayerScannerError> {
+    async fn get_blockchain_progression(
+        &mut self,
+        tip: &BaseLayerMetadata,
+    ) -> Result<BlockchainProgression, BaseLayerScannerError> {
+        match self.last_scanned_hash {
+            Some(hash) if hash == tip.tip_hash => Ok(BlockchainProgression::NoProgress),
+            Some(hash) => {
+                let header = self.base_node_client.get_header_by_hash(hash).await.optional()?;
+                if header.is_some() {
+                    Ok(BlockchainProgression::Progressed)
+                } else {
+                    Ok(BlockchainProgression::Reorged)
+                }
+            },
+            None => Ok(BlockchainProgression::Progressed),
+        }
+    }
+
+    async fn sync_blockchain(&mut self) -> Result<(), BaseLayerScannerError> {
+        let start_scan_height = self.last_scanned_height;
+        let mut current_hash = self.last_scanned_hash;
+        // TODO: we need to scan ending a few blocks back to mitigate for reorgs
+        let tip = self.base_node_client.get_tip_info().await?;
+        if tip.height_of_longest_chain == 0 {
+            return Ok(());
+        }
+        let end_height = tip.height_of_longest_chain;
+
+        for current_height in start_scan_height..=end_height {
+            let utxos = self
+                .base_node_client
+                .get_sidechain_utxos(current_hash, 1)
+                .await?
+                .pop()
+                .ok_or_else(|| {
+                    BaseLayerScannerError::InvalidSideChainUtxoResponse(format!(
+                        "Base layer returned empty response for height {}",
+                        current_height
+                    ))
+                })?;
+            let block_info = utxos.block_info;
+            // TODO: Because we dont know the next hash when we're done scanning to the tip, we need to load the
+            //       previous scanned block again to get it.  This isn't ideal, but won't be an issue when we scan a few
+            //       blocks back.
+            if self.last_scanned_hash.map(|h| h == block_info.hash).unwrap_or(false) {
+                if let Some(hash) = block_info.next_block_hash {
+                    current_hash = Some(hash);
+                    continue;
+                }
+                break;
+            }
+            info!(
+                target: LOG_TARGET,
+                "⛓️ Scanning base layer block {} of {}", block_info.height, end_height
+            );
+            for output in utxos.outputs {
+                let output_hash = output.hash();
+                let sidechain_feature = output.features.sidechain_feature.ok_or_else(|| {
+                    BaseLayerScannerError::InvalidSideChainUtxoResponse(
+                        "Validator node registration output must have a sidechain features".to_string(),
+                    )
+                })?;
+                match sidechain_feature {
+                    SideChainFeature::ValidatorNodeRegistration(reg) => {
+                        self.register_validator_node_registration(current_height, reg).await?;
+                    },
+                    SideChainFeature::TemplateRegistration(reg) => {
+                        self.register_code_template_registration((*output_hash).into(), reg, &block_info)
+                            .await?;
+                    },
+                }
+            }
+
+            self.set_last_scanned_block(block_info.height, block_info.hash)?;
+            match block_info.next_block_hash {
+                Some(next_hash) => {
+                    current_hash = Some(next_hash);
+                },
+                None => {
+                    info!(
+                        target: LOG_TARGET,
+                        "⛓️ No more blocks to scan. Last scanned block height: {}", block_info.height
+                    );
+                    if block_info.height != end_height {
+                        return Err(BaseLayerScannerError::InvalidSideChainUtxoResponse(format!(
+                            "Expected to scan to height {}, but got to height {}",
+                            end_height, block_info.height
+                        )));
+                    }
+                    break;
+                },
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn register_validator_node_registration(
+        &mut self,
+        height: u64,
+        _registration: ValidatorNodeRegistration,
+    ) -> Result<(), BaseLayerScannerError> {
+        // TODO: add to VN registry
+        info!(
+            target: LOG_TARGET,
+            "⛓️ Validator node registration UTXO found at height {}", height,
+        );
+        self.epoch_manager.update_epoch(height).await?;
+        Ok(())
+    }
+
+    async fn register_code_template_registration(
+        &mut self,
+        template_address: TemplateAddress,
+        registration: CodeTemplateRegistration,
+        block_info: &BlockInfo,
+    ) -> Result<(), BaseLayerScannerError> {
+        info!(
+            target: LOG_TARGET,
+            "🌠 new template found with address {} at height {}", template_address, block_info.height
+        );
+        let template = TemplateRegistration {
+            template_address,
+            registration,
+            mined_height: block_info.height,
+            mined_hash: block_info.hash,
+        };
+        self.template_manager.add_template(template).await?;
+
+        Ok(())
+    }
+
+    fn set_last_scanned_block(&mut self, height: u64, hash: FixedHash) -> Result<(), BaseLayerScannerError> {
         let tx = self.global_db.create_transaction()?;
         let metadata = self.global_db.metadata(&tx);
-        metadata.set_metadata(
-            MetadataKey::BaseLayerScannerLastScannedBlockHash,
-            tip.tip_hash.as_bytes(),
-        )?;
+        metadata.set_metadata(MetadataKey::BaseLayerScannerLastScannedBlockHash, hash.as_bytes())?;
         metadata.set_metadata(
             MetadataKey::BaseLayerScannerLastScannedBlockHeight,
-            &tip.height_of_longest_chain.to_le_bytes(),
+            &height.to_le_bytes(),
         )?;
         self.global_db.commit(tx)?;
-        self.last_scanned_hash = Some(tip.tip_hash);
-        self.last_scanned_height = tip.height_of_longest_chain;
+        self.last_scanned_hash = Some(hash);
+        self.last_scanned_height = height;
         Ok(())
     }
 }
@@ -249,4 +360,15 @@ pub enum BaseLayerScannerError {
     TemplateManagerError(#[from] TemplateManagerError),
     #[error("Base node client error: {0}")]
     BaseNodeError(#[from] BaseNodeError),
+    #[error("Invalid side chain utxo response: {0}")]
+    InvalidSideChainUtxoResponse(String),
+}
+
+enum BlockchainProgression {
+    /// The blockchain has progressed since the last scan
+    Progressed,
+    /// Reorg was detected
+    Reorged,
+    /// The blockchain has not progressed since the last scan
+    NoProgress,
 }

--- a/applications/tari_validator_node/src/bootstrap.rs
+++ b/applications/tari_validator_node/src/bootstrap.rs
@@ -48,7 +48,7 @@ use crate::{
             networking,
             networking::NetworkingHandle,
             template_manager,
-            template_manager::manager::TemplateManager,
+            template_manager::TemplateManager,
         },
     },
     payload_processor::TariDanPayloadProcessor,

--- a/applications/tari_validator_node/src/config.rs
+++ b/applications/tari_validator_node/src/config.rs
@@ -23,12 +23,13 @@
 use std::{
     net::{IpAddr, Ipv4Addr, SocketAddr},
     path::{Path, PathBuf},
+    time::Duration,
 };
 
 use config::Config;
 use serde::{Deserialize, Serialize};
 use tari_common::{
-    configuration::{CommonConfig, Network},
+    configuration::{serializers, CommonConfig, Network},
     ConfigurationError,
     DefaultConfigLoader,
     SubConfigPath,
@@ -77,7 +78,8 @@ pub struct ValidatorNodeConfig {
     /// If set to false, there will be no base layer scanning at all
     pub scan_base_layer: bool,
     /// How often do we want to scan the base layer for changes
-    pub base_layer_scanning_interval_in_seconds: u64,
+    #[serde(with = "serializers::seconds")]
+    pub base_layer_scanning_interval: Duration,
     /// If set to true, it will constantly scan for new assets on the base layer
     pub scan_for_assets: bool,
     /// How often do we want to scan the base layer for changes
@@ -138,7 +140,7 @@ impl Default for ValidatorNodeConfig {
             base_node_grpc_address: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 18142),
             wallet_grpc_address: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 18143),
             scan_base_layer: true,
-            base_layer_scanning_interval_in_seconds: 10,
+            base_layer_scanning_interval: Duration::from_secs(10),
             data_dir: PathBuf::from("data/validator_node"),
             p2p,
             grpc_address: Some("/ip4/127.0.0.1/tcp/18144".parse().unwrap()),

--- a/applications/tari_validator_node/src/default_service_specification.rs
+++ b/applications/tari_validator_node/src/default_service_specification.rs
@@ -39,7 +39,7 @@ use crate::{
         comms_peer_provider::CommsPeerProvider,
         messaging::OutboundMessaging,
         rpc_client::TariCommsValidatorNodeClientFactory,
-        template_manager::manager::TemplateManager,
+        template_manager::TemplateManager,
     },
     payload_processor::TariDanPayloadProcessor,
 };

--- a/applications/tari_validator_node/src/grpc/services/wallet_client.rs
+++ b/applications/tari_validator_node/src/grpc/services/wallet_client.rs
@@ -55,18 +55,6 @@ pub struct GrpcWalletClient {
     client: Option<Client>,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
-pub struct TemplateRegistrationRequest {
-    template_name: String,
-    template_version: u16,
-    repo_url: String,
-    #[serde(with = "serde_with::base64")]
-    commit_hash: Vec<u8>,
-    #[serde(with = "serde_with::base64")]
-    binary_sha: Vec<u8>,
-    binary_url: String,
-}
-
 impl GrpcWalletClient {
     pub fn new(endpoint: SocketAddr) -> GrpcWalletClient {
         Self { endpoint, client: None }
@@ -135,3 +123,22 @@ impl GrpcWalletClient {
 
 #[async_trait]
 impl WalletClient for GrpcWalletClient {}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct TemplateRegistrationRequest {
+    template_name: String,
+    template_version: u16,
+    repo_url: String,
+    #[serde(with = "serde_with::base64")]
+    commit_hash: Vec<u8>,
+    #[serde(with = "serde_with::base64")]
+    binary_sha: Vec<u8>,
+    binary_url: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct TemplateRegistrationResponse {
+    #[serde(with = "serde_with::base64")]
+    pub template_address: Vec<u8>,
+    pub transaction_id: u64,
+}

--- a/applications/tari_validator_node/src/p2p/services/epoch_manager/base_layer_epoch_manager.rs
+++ b/applications/tari_validator_node/src/p2p/services/epoch_manager/base_layer_epoch_manager.rs
@@ -57,7 +57,7 @@ impl BaseLayerEpochManager {
 
     pub async fn update_epoch(&mut self, tip: u64) -> Result<(), EpochManagerError> {
         let epoch = Epoch(tip / 10);
-        if self.current_epoch.0 >= epoch.0 {
+        if self.current_epoch >= epoch {
             // no need to update the epoch
             return Ok(());
         }

--- a/applications/tari_validator_node/src/p2p/services/hotstuff/hotstuff_service.rs
+++ b/applications/tari_validator_node/src/p2p/services/hotstuff/hotstuff_service.rs
@@ -42,7 +42,7 @@ use crate::{
         epoch_manager::handle::EpochManagerHandle,
         mempool::MempoolHandle,
         messaging::OutboundMessaging,
-        template_manager::manager::TemplateManager,
+        template_manager::TemplateManager,
     },
     payload_processor::TariDanPayloadProcessor,
 };

--- a/applications/tari_validator_node/src/p2p/services/hotstuff/initializer.rs
+++ b/applications/tari_validator_node/src/p2p/services/hotstuff/initializer.rs
@@ -36,7 +36,7 @@ use crate::{
         hotstuff::hotstuff_service::HotstuffService,
         mempool::MempoolHandle,
         messaging::OutboundMessaging,
-        template_manager::manager::TemplateManager,
+        template_manager::TemplateManager,
     },
     payload_processor::TariDanPayloadProcessor,
 };

--- a/applications/tari_validator_node/src/p2p/services/template_manager/downloader.rs
+++ b/applications/tari_validator_node/src/p2p/services/template_manager/downloader.rs
@@ -1,0 +1,99 @@
+//   Copyright 2022. The Tari Project
+//
+//   Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//   following conditions are met:
+//
+//   1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//   disclaimer.
+//
+//   2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//   following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//   3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//   products derived from this software without specific prior written permission.
+//
+//   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//   SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//   USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use bytes::Bytes;
+use futures::{future::BoxFuture, stream::FuturesUnordered};
+use prost::bytes;
+use tari_template_lib::models::TemplateAddress;
+use tokio::{sync::mpsc, task};
+use tokio_stream::StreamExt;
+
+pub struct DownloadRequest {
+    pub address: TemplateAddress,
+    pub url: String,
+}
+
+pub(super) struct TemplateDownloadWorker {
+    download_queue: mpsc::Receiver<DownloadRequest>,
+    pending_downloads: FuturesUnordered<BoxFuture<'static, DownloadResult>>,
+    completed_downloads: mpsc::Sender<DownloadResult>,
+}
+
+impl TemplateDownloadWorker {
+    pub fn new(
+        download_queue: mpsc::Receiver<DownloadRequest>,
+        completed_downloads: mpsc::Sender<DownloadResult>,
+    ) -> Self {
+        Self {
+            download_queue,
+            pending_downloads: FuturesUnordered::new(),
+            completed_downloads,
+        }
+    }
+
+    pub fn spawn(self) {
+        task::spawn(self.run());
+    }
+
+    pub async fn run(mut self) {
+        loop {
+            tokio::select! {
+                maybe_req = self.download_queue.recv() => {
+                    match maybe_req {
+                        Some(req)  => {
+                            self.pending_downloads.push(Box::pin(download(req)));
+                        },
+                        None => break,
+                    }
+                },
+                Some(result) = self.pending_downloads.next() => {
+                    self.completed_downloads.send(result).await.unwrap();
+                }
+            }
+        }
+    }
+}
+
+async fn download(req: DownloadRequest) -> DownloadResult {
+    async fn inner(req: DownloadRequest) -> Result<Bytes, TemplateDownloadError> {
+        let resp = reqwest::get(&req.url).await?;
+        let bytes = resp.bytes().await?;
+        Ok(bytes)
+    }
+
+    DownloadResult {
+        template_address: req.address,
+        result: inner(req).await,
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum TemplateDownloadError {
+    #[error("Failed to download template: {0}")]
+    DownloadFailed(#[from] reqwest::Error),
+}
+
+#[derive(Debug)]
+pub struct DownloadResult {
+    pub template_address: TemplateAddress,
+    pub result: Result<Bytes, TemplateDownloadError>,
+}

--- a/applications/tari_validator_node/src/p2p/services/template_manager/mod.rs
+++ b/applications/tari_validator_node/src/p2p/services/template_manager/mod.rs
@@ -20,37 +20,16 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-pub mod handle;
+mod downloader;
+mod handle;
+pub use handle::{TemplateManagerHandle, TemplateRegistration};
+
 mod initializer;
-pub mod manager;
-pub mod template_manager_service;
-
 pub use initializer::spawn;
-use tari_dan_common_types::optional::IsNotFoundError;
-use tari_dan_core::storage::StorageError;
-use tari_dan_storage_sqlite::error::SqliteStorageError;
-use tari_template_lib::models::TemplateAddress;
-use thiserror::Error;
 
-#[derive(Error, Debug)]
-pub enum TemplateManagerError {
-    #[error("There was an error sending to a channel")]
-    SendError,
-    #[error("Could not fetch the template code from the web")]
-    TemplateCodeFetchError,
-    #[error("The hash of the template code does not match the metadata")]
-    #[allow(dead_code)]
-    TemplateCodeHashMismatch,
-    #[error("Storage error: {0}")]
-    StorageError(#[from] StorageError),
-    #[error("Storage error: {0}")]
-    SqliteStorageError(#[from] SqliteStorageError),
-    #[error("Template not found: {address}")]
-    TemplateNotFound { address: TemplateAddress },
-}
+mod manager;
+pub use manager::{Template, TemplateManager};
+mod service;
 
-impl IsNotFoundError for TemplateManagerError {
-    fn is_not_found_error(&self) -> bool {
-        matches!(self, Self::TemplateNotFound { .. })
-    }
-}
+mod error;
+pub use error::TemplateManagerError;

--- a/applications/tari_validator_node/src/p2p/services/template_manager/service.rs
+++ b/applications/tari_validator_node/src/p2p/services/template_manager/service.rs
@@ -21,16 +21,18 @@
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use log::*;
-use tari_core::transactions::transaction_components::CodeTemplateRegistration;
+use tari_dan_storage::global::{DbTemplateUpdate, TemplateStatus};
 use tari_dan_storage_sqlite::SqliteDbFactory;
 use tari_shutdown::ShutdownSignal;
 use tari_template_lib::models::TemplateAddress;
 use tokio::{
-    sync::{mpsc::Receiver, oneshot},
+    sync::{mpsc, mpsc::Receiver, oneshot},
     task::JoinHandle,
 };
 
 use crate::p2p::services::template_manager::{
+    downloader::{DownloadRequest, DownloadResult},
+    handle::TemplateRegistration,
     manager::{Template, TemplateManager},
     TemplateManagerError,
 };
@@ -39,13 +41,15 @@ const LOG_TARGET: &str = "tari::validator_node::template_manager";
 
 pub struct TemplateManagerService {
     rx_request: Receiver<TemplateManagerRequest>,
-    inner: TemplateManager,
+    manager: TemplateManager,
+    completed_downloads: mpsc::Receiver<DownloadResult>,
+    download_queue: mpsc::Sender<DownloadRequest>,
 }
 
 #[derive(Debug)]
 pub enum TemplateManagerRequest {
-    AddTemplates {
-        templates: Vec<CodeTemplateRegistration>,
+    AddTemplate {
+        template: Box<TemplateRegistration>,
         reply: oneshot::Sender<Result<(), TemplateManagerError>>,
     },
     GetTemplate {
@@ -58,22 +62,30 @@ impl TemplateManagerService {
     pub fn spawn(
         rx_request: Receiver<TemplateManagerRequest>,
         sqlite_db_factory: SqliteDbFactory,
+        download_queue: mpsc::Sender<DownloadRequest>,
+        completed_downloads: mpsc::Receiver<DownloadResult>,
         shutdown: ShutdownSignal,
     ) -> JoinHandle<Result<(), TemplateManagerError>> {
-        tokio::spawn(async move {
-            TemplateManagerService {
+        tokio::spawn(
+            Self {
                 rx_request,
-                inner: TemplateManager::new(sqlite_db_factory),
+                manager: TemplateManager::new(sqlite_db_factory),
+                download_queue,
+                completed_downloads,
             }
-            .run(shutdown)
-            .await
-        })
+            .run(shutdown),
+        )
     }
 
-    pub async fn run(&mut self, mut shutdown: ShutdownSignal) -> Result<(), TemplateManagerError> {
+    pub async fn run(mut self, mut shutdown: ShutdownSignal) -> Result<(), TemplateManagerError> {
         loop {
             tokio::select! {
                 Some(req) = self.rx_request.recv() => self.handle_request(req).await,
+                Some(download) = self.completed_downloads.recv() => {
+                    if let Err(err) = self.handle_completed_download(download) {
+                        error!(target: LOG_TARGET, "Error handling completed download: {}", err);
+                    }
+                },
 
                 _ = shutdown.wait() => {
                     dbg!("Shutting down epoch manager");
@@ -88,13 +100,51 @@ impl TemplateManagerService {
         #[allow(clippy::enum_glob_use)]
         use TemplateManagerRequest::*;
         match req {
-            AddTemplates { templates, reply } => {
-                handle(reply, self.inner.add_templates(templates).await);
+            AddTemplate { template, reply } => {
+                handle(reply, self.handle_add_template(*template).await);
             },
             GetTemplate { address, reply } => {
-                handle(reply, self.inner.fetch_template(&address));
+                handle(reply, self.manager.fetch_template(&address));
             },
         }
+    }
+
+    fn handle_completed_download(&mut self, download: DownloadResult) -> Result<(), TemplateManagerError> {
+        match download.result {
+            Ok(bytes) => {
+                // TODO: Validate binary against hash
+                info!(target: LOG_TARGET, "✅ Template downloaded successfully");
+                self.manager
+                    .update_template(download.template_address, DbTemplateUpdate {
+                        compiled_code: Some(bytes.to_vec()),
+                        status: Some(TemplateStatus::Active),
+                    })?;
+            },
+            Err(err) => {
+                warn!(target: LOG_TARGET, "🚨 Failed to download template: {}", err);
+                self.manager
+                    .update_template(download.template_address, DbTemplateUpdate {
+                        status: Some(TemplateStatus::DownloadFailed),
+                        ..Default::default()
+                    })?;
+            },
+        }
+        Ok(())
+    }
+
+    async fn handle_add_template(&mut self, template: TemplateRegistration) -> Result<(), TemplateManagerError> {
+        let address = template.template_address;
+        let url = template.registration.binary_url.to_string();
+        self.manager.add_template(template)?;
+        // We could queue this up much later, at which point we'd update to pending
+        self.manager.update_template(address, DbTemplateUpdate {
+            status: Some(TemplateStatus::Pending),
+            ..Default::default()
+        })?;
+
+        let _ignore = self.download_queue.send(DownloadRequest { address, url }).await;
+        info!(target: LOG_TARGET, "⏳️️ Template {} queued for download", address);
+        Ok(())
     }
 }
 

--- a/applications/tari_validator_node/src/p2p/services/template_manager/service.rs
+++ b/applications/tari_validator_node/src/p2p/services/template_manager/service.rs
@@ -113,7 +113,10 @@ impl TemplateManagerService {
         match download.result {
             Ok(bytes) => {
                 // TODO: Validate binary against hash
-                info!(target: LOG_TARGET, "✅ Template downloaded successfully");
+                info!(
+                    target: LOG_TARGET,
+                    "✅ Template {} downloaded successfully", download.template_address
+                );
                 self.manager
                     .update_template(download.template_address, DbTemplateUpdate {
                         compiled_code: Some(bytes.to_vec()),

--- a/applications/tari_validator_node_cli/src/main.rs
+++ b/applications/tari_validator_node_cli/src/main.rs
@@ -107,13 +107,13 @@ async fn handle_register_template(args: PublishTemplateArgs, mut client: Validat
     let wasm_module = compile_template(root_folder.as_path(), &[]).unwrap();
     let wasm_code = wasm_module.code();
     println!(
-        "✅ Template compilation succesful (WASM file size: {} bytes)",
+        "✅ Template compilation successful (WASM file size: {} bytes)",
         wasm_code.len()
     );
+    println!();
 
     // calculate the hash of the WASM binary
     let binary_sha = hasher("template").chain(&wasm_code).result();
-    println!("Template binary hash: {}", binary_sha);
 
     // get the local path of the compiled wasm
     // note that the file name will be the same as the root folder name

--- a/applications/tari_validator_node_cli/src/prompt.rs
+++ b/applications/tari_validator_node_cli/src/prompt.rs
@@ -27,6 +27,7 @@ use thiserror::Error;
 pub struct Prompt {
     label: String,
     default: Option<String>,
+    value: Option<String>,
 }
 
 impl Prompt {
@@ -34,15 +35,24 @@ impl Prompt {
         Self {
             label: label.into(),
             default: None,
+            value: None,
         }
     }
 
-    pub fn with_default<T: Into<String>>(mut self, default: T) -> Self {
-        self.default = Some(default.into());
+    pub fn with_default<T: ToString>(mut self, default: T) -> Self {
+        self.default = Some(default.to_string());
+        self
+    }
+
+    pub fn with_value<T: ToString>(mut self, value: Option<T>) -> Self {
+        self.value = value.map(|r| r.to_string());
         self
     }
 
     pub fn ask(self) -> Result<String, CommandError> {
+        if let Some(response) = self.value {
+            return Ok(response);
+        }
         loop {
             match self.default.as_ref().filter(|s| !s.is_empty()) {
                 Some(default) => {

--- a/dan_layer/core/src/models/mod.rs
+++ b/dan_layer/core/src/models/mod.rs
@@ -92,7 +92,7 @@ impl PartialOrd for NodeHeight {
     }
 }
 
-#[derive(Copy, Clone, Debug, Deserialize, PartialEq, Eq, Hash, Serialize)]
+#[derive(Copy, Clone, Debug, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
 pub struct Epoch(pub u64);
 
 impl Epoch {

--- a/dan_layer/core/src/services/base_node_client.rs
+++ b/dan_layer/core/src/services/base_node_client.rs
@@ -21,9 +21,12 @@
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use async_trait::async_trait;
-use tari_common_types::types::PublicKey;
+use tari_common_types::types::{FixedHash, PublicKey};
 use tari_comms::types::CommsPublicKey;
-use tari_core::transactions::transaction_components::CodeTemplateRegistration;
+use tari_core::{
+    blocks::BlockHeader,
+    transactions::transaction_components::{CodeTemplateRegistration, TransactionOutput},
+};
 use tari_dan_common_types::ShardId;
 
 use crate::{
@@ -37,6 +40,28 @@ pub trait BaseNodeClient: Send + Sync + Clone {
     async fn get_validator_nodes(&mut self, height: u64) -> Result<Vec<ValidatorNode>, BaseNodeError>;
     async fn get_committee(&mut self, height: u64, shard_key: &[u8; 32]) -> Result<Vec<CommsPublicKey>, BaseNodeError>;
     async fn get_shard_key(&mut self, height: u64, public_key: &PublicKey) -> Result<Option<ShardId>, BaseNodeError>;
-    async fn get_template_registrations(&mut self, height: u64)
-        -> Result<Vec<CodeTemplateRegistration>, BaseNodeError>;
+    async fn get_template_registrations(
+        &mut self,
+        start_hash: Option<FixedHash>,
+        count: u64,
+    ) -> Result<Vec<CodeTemplateRegistration>, BaseNodeError>;
+    async fn get_header_by_hash(&mut self, block_hash: FixedHash) -> Result<BlockHeader, BaseNodeError>;
+    async fn get_sidechain_utxos(
+        &mut self,
+        start_hash: Option<FixedHash>,
+        count: u64,
+    ) -> Result<Vec<SideChainUtxos>, BaseNodeError>;
+}
+
+#[derive(Debug, Clone)]
+pub struct SideChainUtxos {
+    pub block_info: BlockInfo,
+    pub outputs: Vec<TransactionOutput>,
+}
+
+#[derive(Debug, Clone)]
+pub struct BlockInfo {
+    pub hash: FixedHash,
+    pub height: u64,
+    pub next_block_hash: Option<FixedHash>,
 }

--- a/dan_layer/core/src/services/base_node_error.rs
+++ b/dan_layer/core/src/services/base_node_error.rs
@@ -21,6 +21,7 @@
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use tari_common_types::types::FixedHashSizeError;
+use tari_dan_common_types::optional::IsNotFoundError;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -36,4 +37,14 @@ pub enum BaseNodeError {
     InvalidPeerMessage(String),
     #[error("Hash size error: {0}")]
     HashSizeError(#[from] FixedHashSizeError),
+}
+
+impl IsNotFoundError for BaseNodeError {
+    fn is_not_found_error(&self) -> bool {
+        if let Self::GrpcStatus(status) = self {
+            status.code() == tonic::Code::NotFound
+        } else {
+            false
+        }
+    }
 }

--- a/dan_layer/core/src/services/mod.rs
+++ b/dan_layer/core/src/services/mod.rs
@@ -30,7 +30,7 @@ mod signing_service;
 mod wallet_client;
 
 pub use asset_proxy::{AssetProxy, ConcreteAssetProxy};
-pub use base_node_client::BaseNodeClient;
+pub use base_node_client::{BaseNodeClient, BlockInfo, SideChainUtxos};
 pub use events_publisher::{EventsPublisher, LoggingEventsPublisher};
 pub use payload_processor::{PayloadProcessor, PayloadProcessorError};
 pub use peer_service::{DanPeer, PeerProvider};

--- a/dan_layer/core/src/storage/mocks/global_db.rs
+++ b/dan_layer/core/src/storage/mocks/global_db.rs
@@ -21,7 +21,7 @@
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use tari_dan_storage::{
-    global::{DbTemplate, DbValidatorNode, GlobalDbAdapter, MetadataKey},
+    global::{DbTemplate, DbTemplateUpdate, DbValidatorNode, GlobalDbAdapter, MetadataKey},
     AtomicDb,
 };
 
@@ -57,6 +57,15 @@ impl GlobalDbAdapter for MockGlobalDbBackupAdapter {
     }
 
     fn insert_template(&self, _tx: &Self::DbTransaction, _template: DbTemplate) -> Result<(), Self::Error> {
+        todo!()
+    }
+
+    fn update_template(
+        &self,
+        _tx: &Self::DbTransaction,
+        _key: &[u8],
+        _template: DbTemplateUpdate,
+    ) -> Result<(), Self::Error> {
         todo!()
     }
 

--- a/dan_layer/engine_types/src/lib.rs
+++ b/dan_layer/engine_types/src/lib.rs
@@ -4,3 +4,6 @@
 pub mod hashing;
 pub mod instruction;
 pub mod signature;
+
+mod template;
+pub use template::TemplateAddress;

--- a/dan_layer/engine_types/src/template.rs
+++ b/dan_layer/engine_types/src/template.rs
@@ -1,0 +1,24 @@
+//   Copyright 2022. The Tari Project
+//
+//   Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//   following conditions are met:
+//
+//   1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//   disclaimer.
+//
+//   2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//   following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//   3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//   products derived from this software without specific prior written permission.
+//
+//   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//   SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//   USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+/// Package (template) identifier
+pub type TemplateAddress = tari_template_lib::Hash;

--- a/dan_layer/storage/Cargo.toml
+++ b/dan_layer/storage/Cargo.toml
@@ -11,3 +11,5 @@ tari_common_types = { git = "https://github.com/tari-project/tari.git", branch =
 
 anyhow = "1"
 thiserror = "1"
+time = "0.3.15"
+serde = "1.0"

--- a/dan_layer/storage/src/global/backend_adapter.rs
+++ b/dan_layer/storage/src/global/backend_adapter.rs
@@ -23,7 +23,10 @@
 use super::validator_node_db::DbValidatorNode;
 use crate::{
     atomic::AtomicDb,
-    global::{metadata_db::MetadataKey, template_db::DbTemplate},
+    global::{
+        metadata_db::MetadataKey,
+        template_db::{DbTemplate, DbTemplateUpdate},
+    },
 };
 
 pub trait GlobalDbAdapter: AtomicDb + Send + Sync + Clone {
@@ -32,6 +35,12 @@ pub trait GlobalDbAdapter: AtomicDb + Send + Sync + Clone {
 
     fn get_template(&self, tx: &Self::DbTransaction, key: &[u8]) -> Result<Option<DbTemplate>, Self::Error>;
     fn insert_template(&self, tx: &Self::DbTransaction, template: DbTemplate) -> Result<(), Self::Error>;
+    fn update_template(
+        &self,
+        tx: &Self::DbTransaction,
+        key: &[u8],
+        template: DbTemplateUpdate,
+    ) -> Result<(), Self::Error>;
 
     fn insert_validator_nodes(
         &self,

--- a/dan_layer/storage/src/global/mod.rs
+++ b/dan_layer/storage/src/global/mod.rs
@@ -29,7 +29,7 @@ mod metadata_db;
 pub use metadata_db::{MetadataDb, MetadataKey};
 
 mod template_db;
-pub use template_db::{DbTemplate, TemplateDb};
+pub use template_db::{DbTemplate, DbTemplateUpdate, TemplateDb, TemplateStatus};
 
 mod validator_node_db;
 pub use validator_node_db::{DbValidatorNode, ValidatorNodeDb};

--- a/dan_layer/storage_sqlite/Cargo.toml
+++ b/dan_layer/storage_sqlite/Cargo.toml
@@ -22,4 +22,5 @@ async-trait = "0.1.50"
 tokio = { version = "1.10", features = ["macros", "time"] }
 tokio-stream = { version = "0.1.7", features = ["sync"] }
 log = { version = "0.4.8", features = ["std"] }
+time = "0.3.15"
 serde_json = "1.0.85"

--- a/dan_layer/storage_sqlite/global_db_migrations/2022-10-11-121711_add_status_to_templates/down.sql
+++ b/dan_layer/storage_sqlite/global_db_migrations/2022-10-11-121711_add_status_to_templates/down.sql
@@ -1,0 +1,1 @@
+-- This file should undo anything in `up.sql`

--- a/dan_layer/storage_sqlite/global_db_migrations/2022-10-11-121711_add_status_to_templates/up.sql
+++ b/dan_layer/storage_sqlite/global_db_migrations/2022-10-11-121711_add_status_to_templates/up.sql
@@ -1,0 +1,9 @@
+ALTER TABLE templates
+    ADD COLUMN status VARCHAR(20) NOT NULL DEFAULT 'New';
+
+ALTER TABLE templates
+    ADD COLUMN wasm_path VARCHAR(255) NULL;
+
+ALTER TABLE templates
+    ADD COLUMN added_at INT(11) NOT NULL DEFAULT 0;
+

--- a/dan_layer/storage_sqlite/src/global/backend_adapter.rs
+++ b/dan_layer/storage_sqlite/src/global/backend_adapter.rs
@@ -24,7 +24,7 @@ use std::convert::TryInto;
 
 use diesel::{prelude::*, Connection, RunQueryDsl, SqliteConnection};
 use tari_dan_storage::{
-    global::{DbTemplate, DbValidatorNode, GlobalDbAdapter, MetadataKey},
+    global::{DbTemplate, DbTemplateUpdate, DbValidatorNode, GlobalDbAdapter, MetadataKey},
     AtomicDb,
 };
 
@@ -32,7 +32,7 @@ use super::models::validator_node::{NewValidatorNode, ValidatorNode};
 use crate::{
     error::SqliteStorageError,
     global::{
-        models::{MetadataModel, NewTemplateModel, TemplateModel},
+        models::{MetadataModel, NewTemplateModel, TemplateModel, TemplateUpdateModel},
         schema::templates,
     },
     SqliteTransaction,
@@ -129,9 +129,9 @@ impl GlobalDbAdapter for SqliteGlobalDbAdapter {
 
     fn get_template(&self, tx: &Self::DbTransaction, key: &[u8]) -> Result<Option<DbTemplate>, Self::Error> {
         use crate::global::schema::templates::dsl;
-        let template = dsl::templates
+        let template: Option<TemplateModel> = dsl::templates
             .filter(templates::template_address.eq(key))
-            .first::<TemplateModel>(tx.connection())
+            .first(tx.connection())
             .optional()
             .map_err(|source| SqliteStorageError::DieselError {
                 source,
@@ -144,6 +144,8 @@ impl GlobalDbAdapter for SqliteGlobalDbAdapter {
                 url: t.url,
                 height: t.height as u64,
                 compiled_code: t.compiled_code,
+                status: t.status.parse().expect("DB status corrupted"),
+                added_at: time::OffsetDateTime::from_unix_timestamp(t.added_at).expect("added_at timestamp corrupted"),
             })),
             None => Ok(None),
         }
@@ -155,6 +157,10 @@ impl GlobalDbAdapter for SqliteGlobalDbAdapter {
             url: item.url.to_string(),
             height: item.height as i32,
             compiled_code: item.compiled_code.clone(),
+            status: item.status.as_str().to_string(),
+            // TODO
+            wasm_path: None,
+            added_at: item.added_at.unix_timestamp(),
         };
         diesel::insert_into(templates::table)
             .values(new_template)
@@ -162,6 +168,29 @@ impl GlobalDbAdapter for SqliteGlobalDbAdapter {
             .map_err(|source| SqliteStorageError::DieselError {
                 source,
                 operation: "insert_template".to_string(),
+            })?;
+
+        Ok(())
+    }
+
+    fn update_template(
+        &self,
+        tx: &Self::DbTransaction,
+        key: &[u8],
+        template: DbTemplateUpdate,
+    ) -> Result<(), Self::Error> {
+        let model = TemplateUpdateModel {
+            compiled_code: template.compiled_code,
+            status: template.status.map(|s| s.as_str().to_string()),
+            wasm_path: None,
+        };
+        diesel::update(templates::table)
+            .filter(templates::template_address.eq(key))
+            .set(model)
+            .execute(tx.connection())
+            .map_err(|source| SqliteStorageError::DieselError {
+                source,
+                operation: "update_template".to_string(),
             })?;
 
         Ok(())

--- a/dan_layer/storage_sqlite/src/global/schema.rs
+++ b/dan_layer/storage_sqlite/src/global/schema.rs
@@ -43,6 +43,9 @@ table! {
         url -> Text,
         height -> Integer,
         compiled_code -> Binary,
+        status -> Text,
+        wasm_path -> Nullable<Text>,
+        added_at -> BigInt,
     }
 }
 

--- a/dan_layer/storage_sqlite/src/schema.rs
+++ b/dan_layer/storage_sqlite/src/schema.rs
@@ -1,3 +1,25 @@
+// Copyright 2022. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 table! {
     high_qcs (id) {
         id -> Integer,


### PR DESCRIPTION
Description
---
- Fetches "sidechain" UTXOs from base layer and extracts template and validator node data
- Add status to templates to indicate download result
- Adds basic download queue for templates
- cli: template publish command shows template address

Motivation and Context
---
- We can remove base layer indexing of templates in the chain database, since we "scan" each block for sidechain utxos. All validators are interested in all side chain UTXOs (Template Reg, and VN Reg).
- Download would stall progress of other services
- Some basic failure management for downloads

How Has This Been Tested?
---
Manually
