### PR TITLE
feat(cli): adds submit-call-function command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1181,6 +1181,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
 name = "dirs-next"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1188,6 +1197,17 @@ checksum = "cf36e65a80337bea855cd4ef9b8401ffce06a7baedf2e85ec467b1ac3f6e82b6"
 dependencies = [
  "cfg-if",
  "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
 ]
 
 [[package]]
@@ -4434,6 +4454,7 @@ version = "0.35.1"
 dependencies = [
  "anyhow",
  "clap 3.2.22",
+ "dirs",
  "log",
  "multiaddr",
  "reqwest",
@@ -4445,6 +4466,7 @@ dependencies = [
  "tari_utilities",
  "tari_validator_node_client",
  "thiserror",
+ "time 0.3.15",
  "tokio",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4460,6 +4460,8 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "tari_common_types",
+ "tari_crypto",
  "tari_dan_common_types",
  "tari_dan_engine",
  "tari_engine_types",

--- a/applications/tari_validator_node/src/json_rpc/handlers.rs
+++ b/applications/tari_validator_node/src/json_rpc/handlers.rs
@@ -30,7 +30,6 @@ use axum_jrpc::{
 };
 use serde::Serialize;
 use serde_json::{self as json, json};
-use tari_common_types::types::FixedHash;
 use tari_comms::{multiaddr::Multiaddr, peer_manager::NodeId, types::CommsPublicKey, CommsNode, NodeIdentity};
 use tari_dan_common_types::serde_with;
 use tari_dan_core::services::{epoch_manager::EpochManager, BaseNodeClient};
@@ -39,6 +38,7 @@ use tari_validator_node_client::types::{
     GetCommitteeRequest,
     GetShardKey,
     SubmitTransactionRequest,
+    SubmitTransactionResponse,
     TemplateRegistrationRequest,
     TemplateRegistrationResponse,
 };
@@ -246,13 +246,6 @@ impl JsonRpcHandlers {
 struct GetIdentityResponse {
     #[serde(with = "serde_with::hex")]
     node_id: NodeId,
-    #[serde(with = "serde_with::hex")]
     public_key: CommsPublicKey,
     public_address: Multiaddr,
-}
-
-#[derive(Serialize, Debug)]
-struct SubmitTransactionResponse {
-    #[serde(with = "serde_with::hex")]
-    hash: FixedHash,
 }

--- a/applications/tari_validator_node_cli/Cargo.toml
+++ b/applications/tari_validator_node_cli/Cargo.toml
@@ -8,18 +8,20 @@ version = "0.35.1"
 edition = "2018"
 
 [dependencies]
-tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.7" }
-tari_dan_engine = { path = "../../dan_layer/engine" }
 tari_dan_common_types = { path = "../../dan_layer/common_types" }
+tari_dan_engine = { path = "../../dan_layer/engine" }
 tari_engine_types = { path = "../../dan_layer/engine_types" }
+tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.7" }
 tari_validator_node_client = { path = "../../clients/validator_node_client" }
 
 anyhow = "1.0.65"
 clap = { version = "3.2.22", features = ["derive"] }
+dirs = "4.0.0"
 log = "0.4.17"
 multiaddr = "0.14.0"
 reqwest = { version = "0.11.11", features = ["json"] }
 serde = "1.0.144"
 serde_json = "1.0.85"
+time = "0.3.15"
 thiserror = "1.0.36"
 tokio = { version = "1", features = ["macros"] }

--- a/applications/tari_validator_node_cli/Cargo.toml
+++ b/applications/tari_validator_node_cli/Cargo.toml
@@ -8,6 +8,8 @@ version = "0.35.1"
 edition = "2018"
 
 [dependencies]
+tari_common_types = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.15.6" }
 tari_dan_common_types = { path = "../../dan_layer/common_types" }
 tari_dan_engine = { path = "../../dan_layer/engine" }
 tari_engine_types = { path = "../../dan_layer/engine_types" }

--- a/applications/tari_validator_node_cli/src/account_manager.rs
+++ b/applications/tari_validator_node_cli/src/account_manager.rs
@@ -1,0 +1,142 @@
+//   Copyright 2022. The Tari Project
+//
+//   Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//   following conditions are met:
+//
+//   1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//   disclaimer.
+//
+//   2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//   following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//   3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//   products derived from this software without specific prior written permission.
+//
+//   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//   SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//   USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use std::{
+    fmt::{Display, Formatter},
+    fs,
+    path::{Path, PathBuf},
+};
+
+use anyhow::anyhow;
+use serde_json as json;
+use serde_json::json;
+use tari_common_types::types::{PrivateKey, PublicKey};
+use tari_crypto::keys::PublicKey as PublicKeyT;
+use tari_dan_engine::crypto::create_key_pair;
+use tari_utilities::hex::Hex;
+
+#[derive(Debug)]
+pub struct AccountFileManager {
+    pub accounts_path: PathBuf,
+}
+
+impl AccountFileManager {
+    pub fn init(base_path: PathBuf) -> anyhow::Result<Self> {
+        let accounts_path = base_path.join("accounts");
+        fs::create_dir_all(&accounts_path)?;
+        Ok(Self { accounts_path })
+    }
+
+    pub fn create_account(&self) -> anyhow::Result<Account> {
+        let (k, p) = create_key_pair();
+        let is_active = self.count() == 0;
+        fs::write(
+            self.accounts_path.join(format!("{}.json", p)),
+            json!({"key": k.to_hex()}).to_string(),
+        )?;
+        if is_active {
+            self.set_active_account(&p.to_hex())?;
+        }
+        Ok(Account {
+            secret_key: k,
+            public_key: p,
+            is_active,
+        })
+    }
+
+    pub fn count(&self) -> usize {
+        match fs::read_dir(&self.accounts_path) {
+            Ok(r) => r.count(),
+            Err(_) => 0,
+        }
+    }
+
+    pub fn all(&self) -> Vec<Account> {
+        let active_account = read_active_account(&self.accounts_path);
+        let dir = match fs::read_dir(&self.accounts_path) {
+            Ok(r) => r,
+            Err(_) => return vec![],
+        };
+        dir.filter_map(|entry| {
+            let entry = entry.ok()?;
+            let key = read_account_key(&entry.path()).ok()?;
+            let public_key = PublicKey::from_secret_key(&key);
+            Some(Account {
+                secret_key: key,
+                is_active: active_account
+                    .as_ref()
+                    .map(|a| a.public_key == public_key)
+                    .unwrap_or(false),
+                public_key,
+            })
+        })
+        .collect()
+    }
+
+    pub fn get_active_account(&self) -> Option<Account> {
+        read_active_account(&self.accounts_path)
+    }
+
+    pub fn set_active_account(&self, name: &str) -> anyhow::Result<()> {
+        if !self.accounts_path.join(format!("{}.json", name)).exists() {
+            return Err(anyhow!("Account does not exist"));
+        }
+        fs::write(self.accounts_path.join("active_account"), name)?;
+        Ok(())
+    }
+}
+
+fn read_active_account<P: AsRef<Path>>(base_dir: P) -> Option<Account> {
+    let active_account = fs::read_to_string(base_dir.as_ref().join("active_account")).ok()?;
+    read_account_key(base_dir.as_ref().join(format!("{}.json", active_account)))
+        .ok()
+        .and_then(|key| {
+            Some(Account {
+                public_key: PublicKey::from_secret_key(&key),
+                secret_key: key,
+                is_active: true,
+            })
+        })
+}
+
+fn read_account_key<P: AsRef<Path>>(path: P) -> anyhow::Result<PrivateKey> {
+    let file = fs::read_to_string(path)?;
+    let val = json::from_str::<json::Value>(&file)?;
+    let key = val
+        .get("key")
+        .and_then(|k| k.as_str())
+        .ok_or_else(|| anyhow!("No key"))?;
+    Ok(PrivateKey::from_hex(key)?)
+}
+
+#[derive(Debug, Clone)]
+pub struct Account {
+    pub secret_key: PrivateKey,
+    pub public_key: PublicKey,
+    pub is_active: bool,
+}
+
+impl Display for Account {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.public_key.to_hex())
+    }
+}

--- a/applications/tari_validator_node_cli/src/command/account.rs
+++ b/applications/tari_validator_node_cli/src/command/account.rs
@@ -1,0 +1,94 @@
+//   Copyright 2022. The Tari Project
+//
+//   Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//   following conditions are met:
+//
+//   1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//   disclaimer.
+//
+//   2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//   following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//   3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//   products derived from this software without specific prior written permission.
+//
+//   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//   SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//   USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use std::{fs, path::Path};
+
+use clap::Subcommand;
+use serde_json::json;
+use tari_dan_engine::crypto::create_key_pair;
+use tari_utilities::hex::Hex;
+
+#[derive(Debug, Subcommand, Clone)]
+pub enum AccountsSubcommand {
+    #[clap(alias = "create")]
+    New,
+    List,
+    Use {
+        name: String,
+    },
+}
+
+impl AccountsSubcommand {
+    pub async fn handle<P: AsRef<Path>>(self, base_dir: P) -> anyhow::Result<()> {
+        let accounts_path = base_dir.as_ref().join("accounts");
+        fs::create_dir_all(&accounts_path)?;
+
+        #[allow(clippy::enum_glob_use)]
+        use AccountsSubcommand::*;
+        match self {
+            New => {
+                let (k, p) = create_key_pair();
+                fs::write(
+                    accounts_path.join(format!("{}.json", p)),
+                    json!({"key": k.to_hex()}).to_string(),
+                )?;
+
+                println!("New account {} created", p.to_hex());
+            },
+            List => {
+                println!("Accounts:");
+                let accounts = fs::read_dir(&accounts_path)?.filter_map(|entry| {
+                    let entry = entry.ok()?;
+                    let name = entry.path().file_stem()?.to_str()?.to_string();
+                    Some(name)
+                });
+                let active_account = read_active_account(&base_dir);
+                for (i, name) in accounts.enumerate() {
+                    if active_account.as_ref() == Some(&name) {
+                        println!("{}. (active) {}", i, name);
+                    } else {
+                        println!("{}. {}", i, name);
+                    }
+                }
+            },
+            Use { name } => {
+                let path = accounts_path.join(format!("{}.json", name));
+                if !path.exists() {
+                    return Err(anyhow::anyhow!("Account {} does not exist", name));
+                }
+                write_active_account(base_dir, &name)?;
+                println!("Account {} is now active", name);
+            },
+        }
+        Ok(())
+    }
+}
+
+fn read_active_account<P: AsRef<Path>>(base_dir: P) -> Option<String> {
+    let active_account = fs::read_to_string(base_dir.as_ref().join("active_account")).ok()?;
+    Some(active_account)
+}
+
+fn write_active_account<P: AsRef<Path>>(base_dir: P, name: &str) -> anyhow::Result<()> {
+    fs::write(base_dir.as_ref().join("active_account"), name)?;
+    Ok(())
+}

--- a/applications/tari_validator_node_cli/src/command/mod.rs
+++ b/applications/tari_validator_node_cli/src/command/mod.rs
@@ -20,27 +20,25 @@
 //   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //   USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::path::PathBuf;
+use clap::Subcommand;
 
-use clap::Parser;
-use multiaddr::Multiaddr;
+mod account;
+pub use account::AccountsSubcommand;
 
-use crate::command::Command;
+mod template;
+pub use template::{PublishTemplateArgs, TemplateSubcommand};
 
-#[derive(Parser, Debug)]
-#[clap(author, version, about, long_about = None)]
-#[clap(propagate_version = true)]
-pub(crate) struct Cli {
-    #[clap(long, alias = "endpoint")]
-    pub vn_daemon_jrpc_endpoint: Option<Multiaddr>,
-    #[clap(long, short = 'b', alias = "basedir")]
-    pub base_dir: Option<PathBuf>,
+mod vn;
+
+pub use vn::VnSubcommand;
+
+#[allow(clippy::large_enum_variant)]
+#[derive(Debug, Subcommand, Clone)]
+pub enum Command {
     #[clap(subcommand)]
-    pub command: Command,
-}
-
-impl Cli {
-    pub fn init() -> Self {
-        Self::parse()
-    }
+    Vn(VnSubcommand),
+    #[clap(subcommand)]
+    Templates(TemplateSubcommand),
+    #[clap(subcommand)]
+    Accounts(AccountsSubcommand),
 }

--- a/applications/tari_validator_node_cli/src/command/mod.rs
+++ b/applications/tari_validator_node_cli/src/command/mod.rs
@@ -29,8 +29,11 @@ mod template;
 pub use template::{PublishTemplateArgs, TemplateSubcommand};
 
 mod vn;
-
 pub use vn::VnSubcommand;
+
+use crate::command::transaction::TransactionSubcommand;
+
+mod transaction;
 
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Subcommand, Clone)]
@@ -41,4 +44,6 @@ pub enum Command {
     Templates(TemplateSubcommand),
     #[clap(subcommand)]
     Accounts(AccountsSubcommand),
+    #[clap(subcommand)]
+    Transactions(TransactionSubcommand),
 }

--- a/applications/tari_validator_node_cli/src/command/template.rs
+++ b/applications/tari_validator_node_cli/src/command/template.rs
@@ -1,0 +1,128 @@
+//   Copyright 2022. The Tari Project
+//
+//   Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//   following conditions are met:
+//
+//   1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//   disclaimer.
+//
+//   2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//   following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//   3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//   products derived from this software without specific prior written permission.
+//
+//   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//   SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//   USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use std::{convert::TryFrom, path::PathBuf};
+
+use clap::{Args, Subcommand};
+use tari_dan_engine::wasm::compile::compile_template;
+use tari_engine_types::{hashing::hasher, TemplateAddress};
+use tari_validator_node_client::{types::TemplateRegistrationRequest, ValidatorNodeClient};
+
+use crate::Prompt;
+
+#[derive(Debug, Subcommand, Clone)]
+pub enum TemplateSubcommand {
+    Publish(PublishTemplateArgs),
+}
+
+#[derive(Debug, Args, Clone)]
+pub struct PublishTemplateArgs {
+    #[clap(long, short = 'p', alias = "path")]
+    pub template_code_path: PathBuf,
+
+    #[clap(long, alias = "template-name")]
+    pub template_name: Option<String>,
+
+    #[clap(long, alias = "template-version")]
+    pub template_version: Option<u16>,
+
+    #[clap(long, alias = "binary-url")]
+    pub binary_url: Option<String>,
+}
+
+impl TemplateSubcommand {
+    pub async fn handle(self, client: ValidatorNodeClient) -> Result<(), anyhow::Error> {
+        match self {
+            TemplateSubcommand::Publish(args) => handle_publish(args, client).await?,
+        }
+        Ok(())
+    }
+}
+
+async fn handle_publish(args: PublishTemplateArgs, mut client: ValidatorNodeClient) -> anyhow::Result<()> {
+    // retrieve the root folder of the template
+    let root_folder = args.template_code_path;
+    println!("Template code path {}", root_folder.display());
+    println!("⏳️ Compiling template...");
+
+    // compile the code and retrieve the binary content of the wasm
+    let wasm_module = compile_template(root_folder.as_path(), &[]).unwrap();
+    let wasm_code = wasm_module.code();
+    println!(
+        "✅ Template compilation successful (WASM file size: {} bytes)",
+        wasm_code.len()
+    );
+    println!();
+
+    // calculate the hash of the WASM binary
+    let binary_sha = hasher("template").chain(&wasm_code).result();
+
+    // get the local path of the compiled wasm
+    // note that the file name will be the same as the root folder name
+    let file_name = root_folder.file_name().unwrap().to_str().unwrap();
+    let mut wasm_path = root_folder.clone();
+    wasm_path.push(format!("target/wasm32-unknown-unknown/release/{}.wasm", file_name));
+
+    // ask the template name (skip if already passed as a CLI argument)
+    let template_name = Prompt::new("Choose an user-friendly name for the template (max 32 characters):")
+        .with_value(args.template_name)
+        .ask()?;
+
+    // ask the template version (skip if already passed as a CLI argument)
+    let template_version: u16 = Prompt::new("Template version:")
+        .with_default(0)
+        .with_value(args.template_version)
+        .ask_parsed()?;
+
+    // TODO: ask repository info
+    let repo_url = String::new();
+    let commit_hash = vec![];
+
+    // Show the wasm file path and ask to upload it to the web
+    let binary_url = match args.binary_url {
+        Some(value) => value,
+        None => {
+            println!("Compiled template WASM file location: {}", wasm_path.display());
+            println!("Please upload the file to a public web location and then paste the URL");
+            Prompt::new("WASM public URL (max 255 characters):").ask()?
+        },
+    };
+
+    // build and send the template registration request
+    let request = TemplateRegistrationRequest {
+        template_name,
+        template_version,
+        repo_url,
+        commit_hash,
+        binary_sha: binary_sha.to_vec(),
+        binary_url,
+    };
+    let resp = client.register_template(request).await?;
+    println!("✅ Template registration submitted");
+    println!();
+    println!(
+        "The template address will be {}",
+        TemplateAddress::try_from(resp.template_address.as_slice()).unwrap()
+    );
+
+    Ok(())
+}

--- a/applications/tari_validator_node_cli/src/command/transaction.rs
+++ b/applications/tari_validator_node_cli/src/command/transaction.rs
@@ -1,0 +1,87 @@
+//   Copyright 2022. The Tari Project
+//
+//   Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//   following conditions are met:
+//
+//   1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//   disclaimer.
+//
+//   2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//   following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//   3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//   products derived from this software without specific prior written permission.
+//
+//   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//   SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//   USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use std::path::Path;
+
+use clap::{Args, Subcommand};
+use tari_dan_engine::transaction::Transaction;
+use tari_engine_types::{instruction::Instruction, TemplateAddress};
+use tari_validator_node_client::{types::SubmitTransactionRequest, ValidatorNodeClient};
+
+use crate::{account_manager::AccountFileManager, from_hex::FromHex};
+
+#[derive(Debug, Subcommand, Clone)]
+pub enum TransactionSubcommand {
+    SubmitCallFunction(SubmitCallFunctionArgs),
+}
+
+#[derive(Debug, Args, Clone)]
+pub struct SubmitCallFunctionArgs {
+    template_address: FromHex<TemplateAddress>,
+    function_name: String,
+    // #[clap(long, short = 'f')]
+    // pub function_name: String,
+    // #[clap(long, short = 'a')]
+    // pub function_args: Vec<Arg>,
+}
+
+impl TransactionSubcommand {
+    pub async fn handle<P: AsRef<Path>>(
+        self,
+        base_dir: P,
+        mut client: ValidatorNodeClient,
+    ) -> Result<(), anyhow::Error> {
+        match self {
+            TransactionSubcommand::SubmitCallFunction(args) => {
+                let account_manager = AccountFileManager::init(base_dir.as_ref().to_path_buf())?;
+                let account = account_manager.get_active_account().ok_or_else(|| {
+                    anyhow::anyhow!("No active account. Use `accounts use [public key hex]` to set one.")
+                })?;
+
+                // TODO: this is a little clunky
+                let mut builder = Transaction::builder();
+                builder
+                    .add_instruction(Instruction::CallFunction {
+                        template_address: args.template_address.into_inner(),
+                        function: args.function_name,
+                        // TODO
+                        args: vec![],
+                    })
+                    .sign(&account.secret_key)
+                    .fee(1);
+                let transaction = builder.build();
+
+                let request = SubmitTransactionRequest {
+                    instructions: transaction.instructions().to_vec(),
+                    signature: transaction.signature().clone(),
+                    fee: transaction.fee(),
+                    sender_public_key: transaction.sender_public_key().clone(),
+                    // TODO:
+                    num_new_components: 1,
+                };
+                let resp = client.submit_transaction(request).await?;
+                println!("✅ Transaction submitted (hash: {})", resp.hash);
+            },
+        }
+        Ok(())
+    }
+}

--- a/applications/tari_validator_node_cli/src/command/vn.rs
+++ b/applications/tari_validator_node_cli/src/command/vn.rs
@@ -20,40 +20,22 @@
 //   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //   USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::path::PathBuf;
-
-use clap::{Args, Subcommand};
-
-#[allow(clippy::large_enum_variant)]
-#[derive(Debug, Subcommand, Clone)]
-pub enum Command {
-    #[clap(subcommand)]
-    Vn(VnSubcommand),
-    #[clap(subcommand)]
-    Templates(TemplateSubcommand),
-}
+use clap::Subcommand;
+use tari_validator_node_client::ValidatorNodeClient;
 
 #[derive(Debug, Subcommand, Clone)]
 pub enum VnSubcommand {
     Register,
 }
 
-#[derive(Debug, Subcommand, Clone)]
-pub enum TemplateSubcommand {
-    Publish(PublishTemplateArgs),
-}
-
-#[derive(Debug, Args, Clone)]
-pub struct PublishTemplateArgs {
-    #[clap(long, short = 'p', alias = "path")]
-    pub template_code_path: PathBuf,
-
-    #[clap(long, alias = "template-name")]
-    pub template_name: Option<String>,
-
-    #[clap(long, alias = "template-version")]
-    pub template_version: Option<u16>,
-
-    #[clap(long, alias = "binary-url")]
-    pub binary_url: Option<String>,
+impl VnSubcommand {
+    pub async fn handle(self, mut client: ValidatorNodeClient) -> Result<(), anyhow::Error> {
+        match self {
+            VnSubcommand::Register => {
+                let tx_id = client.register_validator_node().await?;
+                println!("✅ Validator node registration submitted (tx_id: {})", tx_id);
+            },
+        }
+        Ok(())
+    }
 }

--- a/applications/tari_validator_node_cli/src/main.rs
+++ b/applications/tari_validator_node_cli/src/main.rs
@@ -24,15 +24,12 @@ mod cli;
 mod command;
 mod prompt;
 
-use std::{convert::TryFrom, error::Error};
+use std::{error::Error, path::PathBuf};
 
 use anyhow::anyhow;
-use command::{PublishTemplateArgs, TemplateSubcommand, VnSubcommand};
 use multiaddr::{Multiaddr, Protocol};
 use reqwest::Url;
-use tari_dan_engine::wasm::compile::compile_template;
-use tari_engine_types::{hashing::hasher, TemplateAddress};
-use tari_validator_node_client::{types::TemplateRegistrationRequest, ValidatorNodeClient};
+use tari_validator_node_client::ValidatorNodeClient;
 
 use crate::{cli::Cli, command::Command, prompt::Prompt};
 
@@ -44,11 +41,24 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .vn_daemon_jrpc_endpoint
         .unwrap_or_else(|| "/ip4/127.0.0.1/tcp/18200".parse().unwrap());
     let endpoint = multiaddr_to_http_url(endpoint)?;
+    let base_dir = cli
+        .base_dir
+        .unwrap_or_else(|| dirs::home_dir().unwrap().join(".tari/vncli"));
 
     log::info!("🌍️ Connecting to {}", endpoint);
     let client = ValidatorNodeClient::connect(endpoint)?;
 
-    handle_command(cli.command, client).await?;
+    handle_command(cli.command, base_dir, client).await?;
+
+    Ok(())
+}
+
+async fn handle_command(command: Command, base_dir: PathBuf, client: ValidatorNodeClient) -> anyhow::Result<()> {
+    match command {
+        Command::Vn(cmd) => cmd.handle(client).await?,
+        Command::Templates(cmd) => cmd.handle(client).await?,
+        Command::Accounts(cmd) => cmd.handle(base_dir).await?,
+    }
 
     Ok(())
 }
@@ -71,89 +81,4 @@ fn multiaddr_to_http_url(multiaddr: Multiaddr) -> anyhow::Result<Url> {
 
     let url = Url::parse(&format!("http://{}:{}", ip, port))?;
     Ok(url)
-}
-
-async fn handle_command(command: Command, client: ValidatorNodeClient) -> anyhow::Result<()> {
-    match command {
-        Command::Vn(VnSubcommand::Register) => handle_register_node(client).await?,
-        Command::Templates(TemplateSubcommand::Publish(args)) => handle_register_template(args, client).await?,
-    }
-
-    Ok(())
-}
-
-async fn handle_register_node(mut client: ValidatorNodeClient) -> anyhow::Result<()> {
-    let tx_id = client.register_validator_node().await?;
-    println!("✅ Validator node registration submitted (tx_id: {})", tx_id);
-
-    Ok(())
-}
-
-async fn handle_register_template(args: PublishTemplateArgs, mut client: ValidatorNodeClient) -> anyhow::Result<()> {
-    // retrieve the root folder of the template
-    let root_folder = args.template_code_path;
-    println!("Template code path {}", root_folder.display());
-    println!("⏳️ Compiling template...");
-
-    // compile the code and retrieve the binary content of the wasm
-    let wasm_module = compile_template(root_folder.as_path(), &[]).unwrap();
-    let wasm_code = wasm_module.code();
-    println!(
-        "✅ Template compilation successful (WASM file size: {} bytes)",
-        wasm_code.len()
-    );
-    println!();
-
-    // calculate the hash of the WASM binary
-    let binary_sha = hasher("template").chain(&wasm_code).result();
-
-    // get the local path of the compiled wasm
-    // note that the file name will be the same as the root folder name
-    let file_name = root_folder.file_name().unwrap().to_str().unwrap();
-    let mut wasm_path = root_folder.clone();
-    wasm_path.push(format!("target/wasm32-unknown-unknown/release/{}.wasm", file_name));
-
-    // ask the template name (skip if already passed as a CLI argument)
-    let template_name = Prompt::new("Choose an user-friendly name for the template (max 32 characters):")
-        .with_value(args.template_name)
-        .ask()?;
-
-    // ask the template version (skip if already passed as a CLI argument)
-    let template_version: u16 = Prompt::new("Template version:")
-        .with_default(0)
-        .with_value(args.template_version)
-        .ask_parsed()?;
-
-    // TODO: ask repository info
-    let repo_url = String::new();
-    let commit_hash = vec![];
-
-    // Show the wasm file path and ask to upload it to the web
-    let binary_url = match args.binary_url {
-        Some(value) => value,
-        None => {
-            println!("Compiled template WASM file location: {}", wasm_path.display());
-            println!("Please upload the file to a public web location and then paste the URL");
-            Prompt::new("WASM public URL (max 255 characters):").ask()?
-        },
-    };
-
-    // build and send the template registration request
-    let request = TemplateRegistrationRequest {
-        template_name,
-        template_version,
-        repo_url,
-        commit_hash,
-        binary_sha: binary_sha.to_vec(),
-        binary_url,
-    };
-    let resp = client.register_template(request).await?;
-    println!("✅ Template registration submitted");
-    println!();
-    println!(
-        "The template address will be {}",
-        TemplateAddress::try_from(resp.template_address.as_slice()).unwrap()
-    );
-
-    Ok(())
 }

--- a/applications/tari_validator_node_cli/src/main.rs
+++ b/applications/tari_validator_node_cli/src/main.rs
@@ -20,8 +20,10 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+mod account_manager;
 mod cli;
 mod command;
+mod from_hex;
 mod prompt;
 
 use std::{error::Error, path::PathBuf};
@@ -58,6 +60,7 @@ async fn handle_command(command: Command, base_dir: PathBuf, client: ValidatorNo
         Command::Vn(cmd) => cmd.handle(client).await?,
         Command::Templates(cmd) => cmd.handle(client).await?,
         Command::Accounts(cmd) => cmd.handle(base_dir).await?,
+        Command::Transactions(cmd) => cmd.handle(base_dir, client).await?,
     }
 
     Ok(())

--- a/clients/validator_node_client/src/types.rs
+++ b/clients/validator_node_client/src/types.rs
@@ -21,7 +21,7 @@
 //   USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use serde::{Deserialize, Serialize};
-use tari_common_types::types::PublicKey;
+use tari_common_types::types::{FixedHash, PublicKey};
 use tari_dan_common_types::{serde_with, Epoch, ShardId};
 use tari_engine_types::{instruction::Instruction, signature::InstructionSignature};
 
@@ -73,9 +73,16 @@ pub struct SubmitTransactionRequest {
     pub num_new_components: u8,
 }
 
+// #[derive(Debug, Clone, Serialize, Deserialize)]
+// pub struct SubmitTransactionResponse {
+//     // TODO: Return hash type
+//     pub hash: Vec<u8>,
+// }
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SubmitTransactionResponse {
-    pub hash: Vec<u8>,
+    #[serde(with = "serde_with::hex")]
+    pub hash: FixedHash,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/dan_layer/core/src/workers/tests/mod.rs
+++ b/dan_layer/core/src/workers/tests/mod.rs
@@ -663,8 +663,8 @@ async fn test_kitchen_sink() {
     // This tells us which shards are involved in the transaction
     // Because there are no inputs, we need to say that there are 2 components
     // being created, so that two shards are involved, not just one.
-    builder.with_new_components(2);
-    let transaction = builder.sign(&secret_key).build();
+    builder.with_new_components(2).sign(&secret_key);
+    let transaction = builder.build();
 
     let involved_shards = transaction.meta().involved_shards();
     let s1;

--- a/dan_layer/engine/src/transaction/builder.rs
+++ b/dan_layer/engine/src/transaction/builder.rs
@@ -84,7 +84,7 @@ impl TransactionBuilder {
         self
     }
 
-    pub fn sign(mut self, secret_key: &PrivateKey) -> Self {
+    pub fn sign(&mut self, secret_key: &PrivateKey) -> &mut Self {
         let (nonce, _nonce_pk) = create_key_pair();
         self.signature = Some(InstructionSignature::sign(secret_key, nonce, &self.instructions));
         self.sender_public_key = Some(PublicKey::from_secret_key(secret_key));

--- a/dan_layer/engine/src/transaction/mod.rs
+++ b/dan_layer/engine/src/transaction/mod.rs
@@ -81,6 +81,10 @@ pub struct Transaction {
 }
 
 impl Transaction {
+    pub fn builder() -> TransactionBuilder {
+        TransactionBuilder::new()
+    }
+
     pub fn required_templates(&self) -> Vec<TemplateAddress> {
         self.instructions
             .iter()

--- a/dan_layer/template_lib/src/hash.rs
+++ b/dan_layer/template_lib/src/hash.rs
@@ -65,15 +65,22 @@ impl From<[u8; 32]> for Hash {
 }
 
 impl TryFrom<&[u8]> for Hash {
-    type Error = String;
+    type Error = HashParseError;
 
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         if value.len() != 32 {
-            return Err("Hash must be 32 bytes".to_string());
+            return Err(HashParseError);
         }
         let mut hash = [0u8; 32];
         hash.copy_from_slice(value);
         Ok(Hash(hash))
+    }
+}
+impl TryFrom<Vec<u8>> for Hash {
+    type Error = HashParseError;
+
+    fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
+        Hash::try_from(value.as_slice())
     }
 }
 

--- a/dan_layer/template_test_tooling/src/template_test.rs
+++ b/dan_layer/template_test_tooling/src/template_test.rs
@@ -11,7 +11,7 @@ use tari_dan_engine::{
     packager::{LoadedTemplate, Package, TemplateModuleLoader},
     runtime::{FinalizeResult, RuntimeInterface},
     state_store::memory::MemoryStateStore,
-    transaction::{TransactionBuilder, TransactionProcessor},
+    transaction::{Transaction, TransactionProcessor},
     wasm::{compile::compile_template, LoadedWasmTemplate},
 };
 use tari_engine_types::{hashing::hasher, instruction::Instruction};
@@ -112,11 +112,12 @@ impl<R: RuntimeInterface + Clone + 'static> TemplateTest<R> {
     }
 
     pub fn execute(&self, instructions: Vec<Instruction>) -> FinalizeResult {
-        let mut builder = TransactionBuilder::new();
+        let mut builder = Transaction::builder();
         for instruction in instructions {
             builder.add_instruction(instruction);
         }
-        let transaction = builder.sign(&self.secret_key).build();
+        builder.sign(&self.secret_key);
+        let transaction = builder.build();
 
         self.processor.execute(transaction).unwrap()
     }


### PR DESCRIPTION
Based on #89 
Description
---
Adds `transactions submit-call-function` command

Motivation and Context
---
Allow submission of basic transaction via cli
```
vnctl accounts use 84751fcd094d6afb8de79adea2e1894dcd691709339316d55aec98677707567a
// Or vnctl accounts create 
 vnctl  transactions submit-call-function B8C4D666223A869E12827CDE3A01B0E1D2FA5611BBC1CF8611285D6A4691FBF9 new
✅ Transaction submitted (hash: 1cb481f7a5f9067fa2bbf3f3e413183333d78bb1b24c75d9ba4d1b55edda40b9)
```

How Has This Been Tested?
---
Manually
