### PR TITLE
fix: include transaction meta in transaction proto

### DIFF
--- a/applications/tari_validator_node/proto/dan/common.proto
+++ b/applications/tari_validator_node/proto/dan/common.proto
@@ -72,7 +72,7 @@ message MerkleProof {
    uint32 path_bitmap = 3;
 }
 
-message Transaction{
+message Transaction {
   repeated ThaumInput inputs = 1;
   repeated ThaumOutput outputs = 2;
   repeated Instruction instructions = 3;
@@ -81,6 +81,7 @@ message Transaction{
   Signature signature = 6;
   uint64 fee = 7;
   bytes sender_public_key = 8;
+  TransactionMeta meta = 9;
 }
 
 message Instruction {
@@ -113,4 +114,20 @@ message Arg {
   }
   ArgType arg_type = 1;
   bytes data = 2;
+}
+
+message TransactionMeta {
+  repeated bytes involved_shard_ids = 1;
+  // TODO: no idea what to call this ;)
+  repeated SubstateRef involved_substates = 2;
+}
+
+message SubstateRef {
+  SubstateChange change = 1;
+  // claim = 2
+}
+
+enum SubstateChange {
+    Create = 0;
+    Destroy = 1;
 }

--- a/applications/tari_validator_node/proto/dan/validator_node.proto
+++ b/applications/tari_validator_node/proto/dan/validator_node.proto
@@ -112,10 +112,6 @@ message GetIdentityResponse {
   bytes node_id = 3;
 }
 
-
-
-
-
 message SubmitTransactionRequest{
   tari.dan.common.Transaction transaction = 1;
 }

--- a/applications/tari_validator_node/src/p2p/proto/conversions.rs
+++ b/applications/tari_validator_node/src/p2p/proto/conversions.rs
@@ -31,7 +31,7 @@ use chrono::{DateTime, NaiveDateTime, Utc};
 use tari_common_types::types::{PrivateKey, PublicKey, Signature};
 use tari_comms::{peer_manager::IdentitySignature, types::CommsPublicKey};
 use tari_crypto::tari_utilities::ByteArray;
-use tari_dan_common_types::{ShardId, SubstateState};
+use tari_dan_common_types::{ObjectClaim, ShardId, SubstateChange, SubstateState};
 use tari_dan_core::{
     message::{DanMessage, NetworkAnnounce},
     models::{
@@ -561,19 +561,41 @@ impl TryFrom<proto::common::Transaction> for Transaction {
         let instruction_signature = signature.try_into().map_err(|s| anyhow!("{}", s))?;
         let sender_public_key =
             PublicKey::from_bytes(&request.sender_public_key).map_err(|_| anyhow!("invalid sender_public_key"))?;
+        let meta = request.meta.map(TryInto::try_into).transpose()?;
         let transaction = Transaction::new(
-            // TODO
-            0,
+            request.fee,
             instructions,
             instruction_signature,
             sender_public_key,
-            // TODO
-            TransactionMeta::default(),
+            meta.unwrap_or_default(),
         );
 
         Ok(transaction)
     }
 }
+
+impl From<Transaction> for proto::common::Transaction {
+    fn from(transaction: Transaction) -> Self {
+        let fee = transaction.fee();
+        let meta = transaction.meta().clone();
+        let (instructions, signature, sender_public_key) = transaction.destruct();
+
+        proto::common::Transaction {
+            instructions: instructions.into_iter().map(Into::into).collect(),
+            signature: Some(signature.signature().into()),
+            sender_public_key: sender_public_key.to_vec(),
+            fee,
+            meta: Some(meta.into()),
+            // balance_proof: todo!(),
+            // inputs: todo!(),
+            // max_instruction_outputs: todo!(),
+            // outputs: todo!(),
+            ..Default::default()
+        }
+    }
+}
+
+// -------------------------------- Instruction -------------------------------- //
 
 impl TryFrom<proto::common::Instruction> for tari_engine_types::instruction::Instruction {
     type Error = anyhow::Error;
@@ -616,24 +638,6 @@ impl TryFrom<proto::common::Instruction> for tari_engine_types::instruction::Ins
     }
 }
 
-impl From<Transaction> for proto::common::Transaction {
-    fn from(transaction: Transaction) -> Self {
-        let (instructions, signature, sender_public_key) = transaction.destruct();
-
-        proto::common::Transaction {
-            instructions: instructions.into_iter().map(Into::into).collect(),
-            signature: Some(signature.signature().into()),
-            sender_public_key: sender_public_key.to_vec(),
-            // balance_proof: todo!(),
-            // inputs: todo!(),
-            // max_instruction_outputs: todo!(),
-            // outputs: todo!(),
-            // fee: todo!(),
-            ..Default::default()
-        }
-    }
-}
-
 impl From<tari_engine_types::instruction::Instruction> for proto::common::Instruction {
     fn from(instruction: tari_engine_types::instruction::Instruction) -> Self {
         let mut result = proto::common::Instruction::default();
@@ -667,6 +671,8 @@ impl From<tari_engine_types::instruction::Instruction> for proto::common::Instru
     }
 }
 
+// -------------------------------- Arg -------------------------------- //
+
 impl TryFrom<proto::common::Arg> for Arg {
     type Error = anyhow::Error;
 
@@ -698,5 +704,71 @@ impl From<Arg> for proto::common::Arg {
         }
 
         result
+    }
+}
+
+// -------------------------------- TransactionMeta -------------------------------- //
+
+impl TryFrom<proto::common::TransactionMeta> for TransactionMeta {
+    type Error = anyhow::Error;
+
+    fn try_from(val: proto::common::TransactionMeta) -> Result<Self, Self::Error> {
+        if val.involved_shard_ids.len() != val.involved_substates.len() {
+            return Err(anyhow!(
+                "involved_shard_ids and involved_shard_ids must have the same length"
+            ));
+        }
+
+        Ok(TransactionMeta::new(
+            val.involved_shard_ids
+                .into_iter()
+                .map(|s| ShardId::try_from(s).map_err(|e| anyhow!("{}", e)))
+                .zip(val.involved_substates.into_iter().map(|c| {
+                    proto::common::SubstateChange::from_i32(c.change)
+                        .ok_or_else(|| anyhow!("invalid change"))
+                        .and_then(SubstateChange::try_from)
+                }))
+                .map(|(a, b)| {
+                    let a = a?;
+                    let b = b?;
+                    Result::<_, anyhow::Error>::Ok((a, (b, ObjectClaim {})))
+                })
+                .collect::<Result<_, _>>()?,
+        ))
+    }
+}
+
+impl<T: Borrow<TransactionMeta>> From<T> for proto::common::TransactionMeta {
+    fn from(val: T) -> Self {
+        let mut meta = proto::common::TransactionMeta::default();
+        for (k, (ch, _)) in val.borrow().involved_objects_iter() {
+            meta.involved_shard_ids.push(k.as_bytes().to_vec());
+            meta.involved_substates.push(proto::common::SubstateRef {
+                change: proto::common::SubstateChange::from(*ch) as i32,
+            });
+        }
+        meta
+    }
+}
+
+// -------------------------------- SubstateChange -------------------------------- //
+
+impl TryFrom<proto::common::SubstateChange> for SubstateChange {
+    type Error = anyhow::Error;
+
+    fn try_from(val: proto::common::SubstateChange) -> Result<Self, Self::Error> {
+        match val {
+            proto::common::SubstateChange::Create => Ok(SubstateChange::Create),
+            proto::common::SubstateChange::Destroy => Ok(SubstateChange::Destroy),
+        }
+    }
+}
+
+impl From<SubstateChange> for proto::common::SubstateChange {
+    fn from(val: SubstateChange) -> Self {
+        match val {
+            SubstateChange::Create => proto::common::SubstateChange::Create,
+            SubstateChange::Destroy => proto::common::SubstateChange::Destroy,
+        }
     }
 }

--- a/dan_layer/common_types/src/lib.rs
+++ b/dan_layer/common_types/src/lib.rs
@@ -95,7 +95,7 @@ impl Display for ShardId {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Deserialize, Serialize)]
+#[derive(Clone, Debug, Copy, PartialEq, Eq, Hash, Deserialize, Serialize)]
 pub enum SubstateChange {
     Create,
     Destroy,

--- a/dan_layer/engine/src/transaction/mod.rs
+++ b/dan_layer/engine/src/transaction/mod.rs
@@ -80,6 +80,14 @@ pub struct TransactionMeta {
 }
 
 impl TransactionMeta {
+    pub fn new(involved_objects: HashMap<ShardId, (SubstateChange, ObjectClaim)>) -> Self {
+        Self { involved_objects }
+    }
+
+    pub fn involved_objects_iter(&self) -> impl Iterator<Item = (&ShardId, &(SubstateChange, ObjectClaim))> + '_ {
+        self.involved_objects.iter()
+    }
+
     pub fn involved_shards(&self) -> Vec<ShardId> {
         self.involved_objects.keys().copied().collect()
     }


### PR DESCRIPTION
Description
---
Adds proto conversion for TransactionMeta 

Motivation and Context
---
Involved_objects is populated when transmitting the transaction

How Has This Been Tested?
---

