### PR TITLE
fix: use detach HSflag for tor

### DIFF
--- a/applications/tari_validator_node/src/bootstrap.rs
+++ b/applications/tari_validator_node/src/bootstrap.rs
@@ -40,7 +40,6 @@ use tari_dan_storage_sqlite::{
     sqlite_shard_store_factory::SqliteShardStoreFactory,
     SqliteDbFactory,
 };
-use tari_p2p::initialization::spawn_comms_using_transport;
 use tari_shutdown::ShutdownSignal;
 
 use crate::{
@@ -164,7 +163,7 @@ pub async fn spawn_services(
     let shard_store_store = SqliteShardStoreFactory::try_create(config.validator_node.data_dir.join("state.db"))?;
 
     let comms = setup_p2p_rpc(config, comms, message_senders, peer_provider, shard_store_store);
-    let comms = spawn_comms_using_transport(comms, p2p_config.transport.clone())
+    let comms = comms::spawn_comms_using_transport(comms, p2p_config.transport.clone())
         .await
         .map_err(|e| ExitError::new(ExitCode::ConfigError, format!("Could not spawn using transport: {}", e)))?;
 

--- a/applications/tari_validator_node/src/comms/mod.rs
+++ b/applications/tari_validator_node/src/comms/mod.rs
@@ -27,4 +27,4 @@ pub use destination::Destination;
 
 mod initializer;
 
-pub use initializer::{initialize, MessageChannel};
+pub use initializer::{initialize, spawn_comms_using_transport, MessageChannel};


### PR DESCRIPTION
Description
---
Adds the DETACH hidden service flag for the tor transport on DAN layer

Motivation and Context
---
Currently we're starting and stopping the VNs a lot, each time the hidden service is recreated because it is associated with the control port session. DETACH allows the onion address to remain registered when the vn is offline. This causes a failed assertion when the VN attempts to reregister the onion, however the onion still works and the assertion is ignored.

How Has This Been Tested?
---

