### PR TITLE
fix: allow compile without npm

### DIFF
--- a/applications/tari_validator_node/build.rs
+++ b/applications/tari_validator_node/build.rs
@@ -33,15 +33,20 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("cargo:rerun-if-changed=../tari_validator_node_web_ui/public");
     let npm = if cfg!(windows) { "npm.cmd" } else { "npm" };
 
-    Command::new(npm)
+    if let Err(error) = Command::new(npm)
         .arg("ci")
         .current_dir("../tari_validator_node_web_ui")
         .status()
-        .unwrap();
-    Command::new(npm)
+    {
+        println!("cargo:warning='npm ci' error : {:?}", error);
+    }
+    if let Err(error) = Command::new(npm)
         .args(["run", "build"])
         .current_dir("../tari_validator_node_web_ui")
         .status()
-        .unwrap();
+    {
+        println!("cargo:warning='npm run build' error : {:?}", error);
+        println!("cargo:warning=The web ui will not be included!");
+    }
     Ok(())
 }

--- a/applications/tari_validator_node_web_ui/build/index.html
+++ b/applications/tari_validator_node_web_ui/build/index.html
@@ -1,0 +1,6 @@
+<html>
+  <body>
+    The <b>tari_validator_node_web_ui</b> was not compiled, so the web ui is not included. You have to install node.js
+    and run the compilation again.
+  </body>
+</html>


### PR DESCRIPTION
Description
---
Allow compilation without the npm installed. The compiler returns warning on any error returned by the `npm ci` and `npm run build`. Also prints a warning that the ui will not be present. The default web ui returns page with explanation that the node.js should be installed.

How Has This Been Tested?
---
Manually.

Fixes #121 
