### PR TITLE
fix: use hex encoding for json

### DIFF
--- a/applications/tari_validator_node/src/comms/broadcast.rs
+++ b/applications/tari_validator_node/src/comms/broadcast.rs
@@ -114,13 +114,13 @@ where
             let svc = next_service.ready().await?;
             match dest {
                 Destination::Peer(pk) => {
-                    logger.log_outbound_message("Peer", ByteArray::as_bytes(&pk).to_vec(), type_str, &msg);
+                    logger.log_outbound_message("Peer", pk.to_vec(), type_str, &msg);
                     svc.call(OutboundMessage::new(NodeId::from_public_key(&pk), bytes))
                         .await?;
                 },
                 Destination::Selected(pks) => {
                     let iter = pks.iter().map(NodeId::from_public_key).map(|n| {
-                        logger.log_outbound_message("Selected", n.as_bytes().to_vec(), type_str, &msg);
+                        logger.log_outbound_message("Selected", n.to_vec(), type_str, &msg);
                         OutboundMessage::new(n, bytes.clone())
                     });
                     svc.call_all(stream::iter(iter))

--- a/dan_layer/core/src/models/mod.rs
+++ b/dan_layer/core/src/models/mod.rs
@@ -59,7 +59,7 @@ pub use node::Node;
 pub use payload::Payload;
 pub use quorum_certificate::{QuorumCertificate, QuorumDecision};
 pub use sidechain_metadata::SidechainMetadata;
-use tari_dan_common_types::{PayloadId, ShardId, SubstateState};
+use tari_dan_common_types::{serde_with, PayloadId, ShardId, SubstateState};
 pub use tari_dan_payload::{CheckpointData, TariDanPayload};
 pub use tree_node_hash::TreeNodeHash;
 pub use validator_node::ValidatorNode;
@@ -210,6 +210,7 @@ pub enum ConsensusWorkerState {
 
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct ValidatorSignature {
+    #[serde(with = "serde_with::hex")]
     pub signer: Vec<u8>,
 }
 

--- a/dan_layer/core/src/models/tree_node_hash.rs
+++ b/dan_layer/core/src/models/tree_node_hash.rs
@@ -28,10 +28,11 @@ use std::{
 use digest::{consts::U32, generic_array};
 use serde::{Deserialize, Serialize};
 use tari_common_types::types::{FixedHash, FixedHashSizeError};
+use tari_dan_common_types::serde_with;
 use tari_utilities::hex::{Hex, HexError};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Deserialize, Serialize)]
-pub struct TreeNodeHash(FixedHash);
+pub struct TreeNodeHash(#[serde(with = "serde_with::hex")] FixedHash);
 
 impl TreeNodeHash {
     pub fn zero() -> Self {
@@ -61,6 +62,12 @@ impl TryFrom<Vec<u8>> for TreeNodeHash {
     fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
         let hash = FixedHash::try_from(value)?;
         Ok(Self(hash))
+    }
+}
+
+impl AsRef<[u8]> for TreeNodeHash {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_slice()
     }
 }
 


### PR DESCRIPTION
Description
---
uses hex encoding for human readable encodings e.g. JSON

Motivation and Context
---
JSON byte arrays are inefficient and make payloads harder to read

How Has This Been Tested?
---
Manually
