### PR TITLE
fix(base-layer-scanner): takes confirmations into account when detecting chain progress

### DIFF
--- a/dan_layer/storage/src/global/metadata_db.rs
+++ b/dan_layer/storage/src/global/metadata_db.rs
@@ -45,6 +45,7 @@ impl<'a, TGlobalDbAdapter: GlobalDbAdapter> MetadataDb<'a, TGlobalDbAdapter> {
 
 #[derive(Debug, Clone, Copy)]
 pub enum MetadataKey {
+    BaseLayerScannerLastScannedTip,
     BaseLayerScannerLastScannedBlockHeight,
     BaseLayerScannerLastScannedBlockHash,
     CurrentEpoch,
@@ -54,6 +55,7 @@ pub enum MetadataKey {
 impl MetadataKey {
     pub fn as_key_bytes(self) -> &'static [u8] {
         match self {
+            MetadataKey::BaseLayerScannerLastScannedTip => b"base_layer_scanner.last_scanned_tip",
             MetadataKey::BaseLayerScannerLastScannedBlockHash => b"base_layer_scanner.last_scanned_block_hash",
             MetadataKey::BaseLayerScannerLastScannedBlockHeight => b"base_layer_scanner.last_scanned_block_height",
             MetadataKey::CurrentEpoch => b"current_epoch",


### PR DESCRIPTION
Description
---
takes confirmations into account when detecting chain progress

Motivation and Context
---
Base layer scanner would try sync when there was no chain progress due to confirmations offset.

How Has This Been Tested?
---
Manually
