### PR TITLE
feat(jrpc): bind on OS-assigned port if preferred unavailable

### DIFF
--- a/applications/tari_validator_node_cli/src/cli.rs
+++ b/applications/tari_validator_node_cli/src/cli.rs
@@ -31,7 +31,7 @@ use crate::command::Command;
 #[clap(author, version, about, long_about = None)]
 #[clap(propagate_version = true)]
 pub(crate) struct Cli {
-    #[clap(long, alias = "endpoint")]
+    #[clap(long, alias = "endpoint", env = "JRPC_ENDPOINT")]
     pub vn_daemon_jrpc_endpoint: Option<Multiaddr>,
     #[clap(long, short = 'b', alias = "basedir")]
     pub base_dir: Option<PathBuf>,


### PR DESCRIPTION
Description
---
bind on OS-assigned port if preferred unavailable

Motivation and Context
---
Ensures that jrpc is available for any VN even if the port is in use. The cli can call both VNs by using `JRPC_ENDPOINT`
The user may manually specify a JRPC bind address

How Has This Been Tested?
---

