### PR TITLE
fix: submit component as input for call-method instruction

### DIFF
--- a/applications/tari_validator_node/src/json_rpc/handlers.rs
+++ b/applications/tari_validator_node/src/json_rpc/handlers.rs
@@ -129,6 +129,7 @@ impl JsonRpcHandlers {
 
         let mut builder = TransactionBuilder::new();
         builder
+            .with_inputs(transaction.inputs)
             .with_instructions(transaction.instructions)
             .with_new_components(transaction.num_new_components)
             .signature(transaction.signature)

--- a/applications/tari_validator_node_cli/src/command/transaction.rs
+++ b/applications/tari_validator_node_cli/src/command/transaction.rs
@@ -74,6 +74,7 @@ async fn handle_submit(
     base_dir: impl AsRef<Path>,
     client: &mut ValidatorNodeClient,
 ) -> Result<(), anyhow::Error> {
+    let mut inputs = vec![];
     let instruction = match args.instruction {
         CliInstruction::CallFunction {
             template_address,
@@ -91,6 +92,7 @@ async fn handle_submit(
             component_address,
             method_name,
         } => {
+            inputs.push(component_address.into_inner().into_array().into());
             Instruction::CallMethod {
                 template_address: template_address.into_inner(),
                 component_address: component_address.into_inner(),
@@ -115,6 +117,7 @@ async fn handle_submit(
         signature: transaction.signature().clone(),
         fee: transaction.fee(),
         sender_public_key: transaction.sender_public_key().clone(),
+        inputs,
         // TODO:
         num_new_components: 1,
         wait_for_result: args.wait_for_result,

--- a/applications/tari_validator_node_cli/src/from_hex.rs
+++ b/applications/tari_validator_node_cli/src/from_hex.rs
@@ -24,7 +24,7 @@ use std::{convert::TryFrom, str::FromStr};
 
 use tari_utilities::hex::from_hex;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct FromHex<T>(pub T);
 
 impl<T> FromHex<T> {

--- a/clients/validator_node_client/src/types.rs
+++ b/clients/validator_node_client/src/types.rs
@@ -124,6 +124,7 @@ pub struct SubmitTransactionRequest {
     pub fee: u64,
     pub sender_public_key: PublicKey,
     pub num_new_components: u8,
+    pub inputs: Vec<ShardId>,
     /// Set to true to wait for the transaction to complete before returning
     #[serde(default)]
     pub wait_for_result: bool,

--- a/dan_layer/engine/src/transaction/builder.rs
+++ b/dan_layer/engine/src/transaction/builder.rs
@@ -98,6 +98,13 @@ impl TransactionBuilder {
         self
     }
 
+    pub fn with_inputs(&mut self, inputs: Vec<ShardId>) -> &mut Self {
+        for input in inputs {
+            self.add_input_object(input);
+        }
+        self
+    }
+
     // pub fn add_outputs(&mut self, max_outputs: u8) -> &mut Self {
     //     self.max_outputs += max_outputs;
     //     self


### PR DESCRIPTION
Description
---
submit component as input for call-method instruction

Motivation and Context
---
Component is used as a input for the transaction. This allows it to be loaded for template execution.

How Has This Been Tested?
---
`vncli transactions submit -w call-method [template] [component] increase`
