### PR TITLE
feat: return QC to client for submit-transaction calls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6511,6 +6511,7 @@ dependencies = [
  "serde_json",
  "tari_common_types",
  "tari_dan_common_types",
+ "tari_dan_core",
  "tari_engine_types",
 ]
 

--- a/applications/tari_validator_node/src/json_rpc/handlers.rs
+++ b/applications/tari_validator_node/src/json_rpc/handlers.rs
@@ -54,6 +54,7 @@ use tari_validator_node_client::types::{
     TemplateMetadata,
     TemplateRegistrationRequest,
     TemplateRegistrationResponse,
+    TransactionFinalizeResult,
 };
 use tokio::sync::{broadcast, broadcast::error::RecvError};
 
@@ -150,7 +151,7 @@ impl JsonRpcHandlers {
             .map_err(internal_error(answer_id))?;
 
         if transaction.wait_for_result {
-            return wait_for_result(answer_id, hash, subscription, Duration::from_secs(30)).await;
+            return wait_for_transaction_result(answer_id, hash, subscription, Duration::from_secs(30)).await;
         }
 
         Ok(JsonRpcResponse::success(answer_id, SubmitTransactionResponse {
@@ -429,7 +430,7 @@ struct GetConnectionsResponse {
     connections: Vec<Connection>,
 }
 
-async fn wait_for_result(
+async fn wait_for_transaction_result(
     answer_id: i64,
     hash: Hash,
     mut subscription: broadcast::Receiver<HotStuffEvent>,
@@ -438,31 +439,20 @@ async fn wait_for_result(
     loop {
         match tokio::time::timeout(timeout, subscription.recv()).await {
             Ok(res) => match res {
-                Ok(HotStuffEvent::OnAccept(payload_id, result)) => {
-                    if payload_id.as_slice() != hash.as_ref() {
+                Ok(HotStuffEvent::OnFinalized(qc, result)) => {
+                    if qc.payload_id().as_slice() != hash.as_ref() {
                         continue;
                     }
 
                     let response = SubmitTransactionResponse {
                         hash: hash.into_array().into(),
-                        result: Some(result),
+                        result: Some(TransactionFinalizeResult {
+                            finalize: result,
+                            qc: *qc,
+                        }),
                     };
-                    dbg!(&response);
+
                     return Ok(JsonRpcResponse::success(answer_id, response));
-                },
-                Ok(HotStuffEvent::OnReject(payload_id, reject)) => {
-                    if payload_id.as_slice() != hash.as_ref() {
-                        continue;
-                    }
-                    return Err(JsonRpcResponse::error(
-                        answer_id,
-                        JsonRpcError::new(
-                            // TODO: define error code
-                            JsonRpcErrorReason::ApplicationError(1),
-                            reject.reason,
-                            json!(null),
-                        ),
-                    ));
                 },
                 Ok(HotStuffEvent::Failed(err)) => {
                     // May not be our tx that failed

--- a/applications/tari_validator_node_cli/src/command/transaction.rs
+++ b/applications/tari_validator_node_cli/src/command/transaction.rs
@@ -26,7 +26,7 @@ use clap::{Args, Subcommand};
 use tari_dan_common_types::ShardId;
 use tari_dan_engine::transaction::Transaction;
 use tari_engine_types::{
-    commit_result::{FinalizeResult, TransactionResult},
+    commit_result::TransactionResult,
     execution_result::Type,
     instruction::Instruction,
     substate::SubstateValue,
@@ -34,7 +34,10 @@ use tari_engine_types::{
 };
 use tari_template_lib::{args::Arg, models::ComponentAddress};
 use tari_utilities::hex::to_hex;
-use tari_validator_node_client::{types::SubmitTransactionRequest, ValidatorNodeClient};
+use tari_validator_node_client::{
+    types::{SubmitTransactionRequest, TransactionFinalizeResult},
+    ValidatorNodeClient,
+};
 
 use crate::{account_manager::AccountFileManager, from_hex::FromHex};
 
@@ -223,12 +226,19 @@ async fn handle_submit(
     Ok(())
 }
 
-fn summarize(result: &FinalizeResult) {
-    match result.result {
+fn summarize(result: &TransactionFinalizeResult) {
+    println!("✅️ Transaction finalized",);
+    println!();
+    println!("Epoch: {}", result.qc.epoch());
+    println!("Payload height: {}", result.qc.payload_height());
+    println!("Signed by: {} validator nodes", result.qc.signature().len());
+    println!();
+    println!("========= Substates =========");
+    match result.finalize.result {
         TransactionResult::Accept(ref diff) => {
             for (address, substate) in diff.up_iter() {
                 println!(
-                    "️🌲 New substate {} (v{})",
+                    "️🌲 UP substate {} (v{})",
                     ShardId::from_address(address),
                     substate.version()
                 );
@@ -249,7 +259,7 @@ fn summarize(result: &FinalizeResult) {
                 println!();
             }
             for address in diff.down_iter() {
-                println!("🗑️ Destroyed substate {}", ShardId::from_address(address));
+                println!("🗑️ DOWN substate {}", ShardId::from_address(address));
                 println!();
             }
         },
@@ -258,7 +268,7 @@ fn summarize(result: &FinalizeResult) {
         },
     }
     println!("========= Return Values =========");
-    for result in &result.execution_results {
+    for result in &result.finalize.execution_results {
         match result.return_type {
             Type::Unit => {},
             Type::Bool => {
@@ -305,7 +315,7 @@ fn summarize(result: &FinalizeResult) {
 
     println!();
     println!("========= LOGS =========");
-    for log in &result.logs {
+    for log in &result.finalize.logs {
         println!("{}", log);
     }
 }

--- a/clients/validator_node_client/Cargo.toml
+++ b/clients/validator_node_client/Cargo.toml
@@ -10,6 +10,10 @@ tari_dan_common_types = { path = "../../dan_layer/common_types" }
 tari_engine_types = { path = "../../dan_layer/engine_types" }
 tari_common_types = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan" }
 
+# TODO: I don't like that the whole of core with services/workers/storage is compiled in. Currently used for the QuorumCertificate type.
+#       We should split core up into core/models, core/services or workers, core/storage crates.
+tari_dan_core = { path = "../../dan_layer/core"}
+
 anyhow = "1.0.65"
 reqwest = { version = "0.11.11", features = ["json"] }
 serde = "1.0.144"

--- a/clients/validator_node_client/src/types.rs
+++ b/clients/validator_node_client/src/types.rs
@@ -23,6 +23,7 @@
 use serde::{Deserialize, Serialize};
 use tari_common_types::types::{FixedHash, PublicKey};
 use tari_dan_common_types::{serde_with, Epoch, ShardId};
+use tari_dan_core::models::QuorumCertificate;
 use tari_engine_types::{
     commit_result::FinalizeResult,
     instruction::Instruction,
@@ -137,8 +138,14 @@ pub struct SubmitTransactionRequest {
 pub struct SubmitTransactionResponse {
     #[serde(with = "serde_with::hex")]
     pub hash: FixedHash,
+    pub result: Option<TransactionFinalizeResult>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TransactionFinalizeResult {
     // TODO: we should not return the whole state but only the addresses and perhaps a hash of the state
-    pub result: Option<FinalizeResult>,
+    pub finalize: FinalizeResult,
+    pub qc: QuorumCertificate,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/dan_layer/common_types/src/epoch.rs
+++ b/dan_layer/common_types/src/epoch.rs
@@ -20,6 +20,8 @@
 //   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //   USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+use std::fmt::Display;
+
 use serde::{Deserialize, Serialize};
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize, Serialize)]
@@ -43,5 +45,11 @@ impl Epoch {
 impl From<u64> for Epoch {
     fn from(e: u64) -> Self {
         Self(e)
+    }
+}
+
+impl Display for Epoch {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
     }
 }

--- a/dan_layer/core/src/workers/events.rs
+++ b/dan_layer/core/src/workers/events.rs
@@ -20,9 +20,10 @@
 //   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //   USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use tari_dan_common_types::PayloadId;
-use tari_engine_types::commit_result::{FinalizeResult, RejectResult};
+use tari_engine_types::commit_result::FinalizeResult;
 use tokio::sync::broadcast;
+
+use crate::models::QuorumCertificate;
 
 /// Wraps a broadcast sender, allowing a subscription (Receiver) to be obtained but removing the ability to send an
 /// event.
@@ -46,7 +47,6 @@ impl<T> Clone for EventSubscription<T> {
 
 #[derive(Debug, Clone)]
 pub enum HotStuffEvent {
-    OnAccept(PayloadId, FinalizeResult),
-    OnReject(PayloadId, RejectResult),
+    OnFinalized(Box<QuorumCertificate>, FinalizeResult),
     Failed(String),
 }


### PR DESCRIPTION
Description
---
Return QC back to client when submitting the transaction

Motivation and Context
---
Allows client to validate finalization

How Has This Been Tested?
---
Manually (cli)
