### PR TITLE
fix: check pledges against changes being made

### DIFF
--- a/applications/tari_validator_node/proto/dan/consensus.proto
+++ b/applications/tari_validator_node/proto/dan/consensus.proto
@@ -23,7 +23,7 @@ message HotStuffMessage {
 message ShardVote {
   bytes shard_id = 1;
   bytes node_hash = 2;
-  repeated ObjectPledge pledges = 3;
+  ObjectPledge pledge = 3;
 }
 
 message QuorumCertificate {
@@ -48,7 +48,7 @@ message HotStuffTreeNode {
   uint64 height = 3;
   bytes shard = 4;
   uint64 payload_height = 5;
-  repeated ObjectPledge local_pledges = 6;
+  ObjectPledge local_pledge = 6;
   uint64 epoch = 7;
   bytes proposed_by = 8;
   QuorumCertificate justify = 9;

--- a/applications/tari_validator_node/src/json_rpc/handlers.rs
+++ b/applications/tari_validator_node/src/json_rpc/handlers.rs
@@ -33,6 +33,7 @@ use serde::Serialize;
 use serde_json::{self as json, json};
 use tari_comms::{multiaddr::Multiaddr, peer_manager::NodeId, types::CommsPublicKey, CommsNode, NodeIdentity};
 use tari_crypto::tari_utilities::hex::Hex;
+use tari_dan_common_types::SubstateChange;
 use tari_dan_core::{
     services::{epoch_manager::EpochManager, BaseNodeClient},
     storage::shard_store::{ShardStoreFactory, ShardStoreTransaction},
@@ -129,7 +130,32 @@ impl JsonRpcHandlers {
 
         let mut builder = TransactionBuilder::new();
         builder
-            .with_input_refs(transaction.inputs)
+            .with_input_refs(
+                transaction
+                    .inputs
+                    .iter()
+                    .filter_map(|i| {
+                        if i.1.eq(&SubstateChange::Exists) {
+                            Some(i.0)
+                        } else {
+                            None
+                        }
+                    })
+                    .collect(),
+            )
+            .with_inputs(
+                transaction
+                    .inputs
+                    .iter()
+                    .filter_map(|i| {
+                        if i.1.ne(&SubstateChange::Exists) {
+                            Some(i.0)
+                        } else {
+                            None
+                        }
+                    })
+                    .collect(),
+            )
             .with_instructions(transaction.instructions)
             .with_num_outputs(transaction.num_outputs)
             .signature(transaction.signature)

--- a/applications/tari_validator_node/src/p2p/proto/conversions/consensus.rs
+++ b/applications/tari_validator_node/src/p2p/proto/conversions/consensus.rs
@@ -117,11 +117,7 @@ impl TryFrom<proto::consensus::HotStuffTreeNode> for HotStuffTreeNode<CommsPubli
             value.payload_id.try_into()?,
             value.payload.map(|a| a.try_into().unwrap()),
             value.payload_height.into(),
-            value
-                .local_pledges
-                .iter()
-                .map(|lp| lp.clone().try_into())
-                .collect::<Result<_, _>>()?,
+            value.local_pledge.map(|lp| lp.try_into()).transpose()?,
             value.epoch.into(),
             PublicKey::from_bytes(value.proposed_by.as_slice())?,
             value
@@ -142,7 +138,7 @@ impl From<HotStuffTreeNode<CommsPublicKey, TariDanPayload>> for proto::consensus
             shard: source.shard().as_bytes().to_vec(),
             payload_id: source.payload_id().as_bytes().to_vec(),
             payload_height: source.payload_height().as_u64(),
-            local_pledges: source.local_pledges().iter().map(|p| p.clone().into()).collect(),
+            local_pledge: source.local_pledge().map(|p| p.clone().into()),
             epoch: source.epoch().as_u64(),
             proposed_by: source.proposed_by().as_bytes().to_vec(),
             justify: Some(source.justify().clone().into()),
@@ -208,7 +204,7 @@ impl From<ShardVote> for proto::consensus::ShardVote {
         Self {
             shard_id: s.shard_id.into(),
             node_hash: s.node_hash.into(),
-            pledges: s.pledges.into_iter().map(Into::into).collect(),
+            pledge: s.pledge.map(Into::into),
         }
     }
 }
@@ -220,11 +216,7 @@ impl TryFrom<proto::consensus::ShardVote> for ShardVote {
         Ok(Self {
             shard_id: value.shard_id.try_into()?,
             node_hash: value.node_hash.try_into()?,
-            pledges: value
-                .pledges
-                .iter()
-                .map(|p| p.clone().try_into())
-                .collect::<Result<_, _>>()?,
+            pledge: value.pledge.map(|p| p.try_into()).transpose()?,
         })
     }
 }

--- a/applications/tari_validator_node/src/payload_processor.rs
+++ b/applications/tari_validator_node/src/payload_processor.rs
@@ -56,7 +56,7 @@ where TTemplateProvider: TemplateProvider
     fn process_payload(
         &self,
         payload: TariDanPayload,
-        pledges: HashMap<ShardId, Vec<ObjectPledge>>,
+        pledges: HashMap<ShardId, Option<ObjectPledge>>,
     ) -> Result<FinalizeResult, PayloadProcessorError> {
         let transaction = payload.into_payload();
         let template_addresses = transaction.required_templates();

--- a/applications/tari_validator_node_cli/src/command/transaction.rs
+++ b/applications/tari_validator_node_cli/src/command/transaction.rs
@@ -23,7 +23,7 @@
 use std::{convert::TryFrom, path::Path, str::FromStr};
 
 use clap::{Args, Subcommand};
-use tari_dan_common_types::ShardId;
+use tari_dan_common_types::{ShardId, SubstateChange};
 use tari_dan_engine::transaction::Transaction;
 use tari_engine_types::{
     commit_result::{FinalizeResult, TransactionResult},
@@ -159,6 +159,7 @@ async fn handle_submit(
     base_dir: impl AsRef<Path>,
     client: &mut ValidatorNodeClient,
 ) -> Result<(), anyhow::Error> {
+    let mut input_refs = vec![];
     let mut inputs = vec![];
     let instruction = match args.instruction {
         CliInstruction::CallFunction {
@@ -176,7 +177,8 @@ async fn handle_submit(
             method_name,
             args,
         } => {
-            inputs.push(component_address.into_inner().into_array().into());
+            input_refs.push(component_address.into_inner().into_array().into());
+            // inputs.push(component_address.into_inner().into_array().into());
             Instruction::CallMethod {
                 template_address: template_address.into_inner(),
                 component_address: component_address.into_inner(),
@@ -193,7 +195,8 @@ async fn handle_submit(
     // TODO: this is a little clunky
     let mut builder = Transaction::builder();
     builder
-        .with_input_refs(inputs.clone())
+        .with_input_refs(input_refs.clone())
+        .with_inputs(inputs.clone())
         .with_num_outputs(args.num_outputs.unwrap_or(0))
         .add_instruction(instruction)
         .sign(&account.secret_key)
@@ -201,21 +204,30 @@ async fn handle_submit(
     let transaction = builder.build();
     let tx_hash = *transaction.hash();
 
+    let mut input_data: Vec<(ShardId, SubstateChange)> =
+        input_refs.iter().map(|i| (*i, SubstateChange::Exists)).collect();
+    input_data.extend(inputs.iter().map(|i| (*i, SubstateChange::Destroy)));
     let request = SubmitTransactionRequest {
         instructions: transaction.instructions().to_vec(),
         signature: transaction.signature().clone(),
         fee: transaction.fee(),
         sender_public_key: transaction.sender_public_key().clone(),
-        inputs,
+        inputs: input_data,
         num_outputs: args.num_outputs.unwrap_or(0),
         wait_for_result: args.wait_for_result,
     };
 
+    if request.inputs.is_empty() && request.num_outputs == 0 {
+        println!("No inputs or outputs. This transaction will not be processed by the network.");
+        return Ok(());
+    }
     println!("✅ Transaction {} submitted.", tx_hash);
     if args.wait_for_result {
         println!("⏳️ Waiting for transaction result...");
         println!();
     }
+
+    dbg!(&request);
     let resp = client.submit_transaction(request).await?;
     if let Some(result) = resp.result {
         summarize(&result);

--- a/applications/tari_validator_node_cli/src/command/transaction.rs
+++ b/applications/tari_validator_node_cli/src/command/transaction.rs
@@ -163,7 +163,7 @@ async fn handle_submit(
     client: &mut ValidatorNodeClient,
 ) -> Result<(), anyhow::Error> {
     let mut input_refs = vec![];
-    let mut inputs = vec![];
+    let inputs = vec![];
     let instruction = match args.instruction {
         CliInstruction::CallFunction {
             template_address,

--- a/applications/tari_validator_node_cli/src/command/transaction.rs
+++ b/applications/tari_validator_node_cli/src/command/transaction.rs
@@ -230,7 +230,7 @@ async fn handle_submit(
         println!();
     }
 
-    dbg!(&request);
+    // dbg!(&request);
     let resp = client.submit_transaction(request).await?;
     if let Some(result) = resp.result {
         summarize(&result);

--- a/clients/validator_node_client/src/types.rs
+++ b/clients/validator_node_client/src/types.rs
@@ -22,7 +22,7 @@
 
 use serde::{Deserialize, Serialize};
 use tari_common_types::types::{FixedHash, PublicKey};
-use tari_dan_common_types::{serde_with, Epoch, ShardId};
+use tari_dan_common_types::{serde_with, Epoch, ShardId, SubstateChange};
 use tari_engine_types::{
     commit_result::FinalizeResult,
     instruction::Instruction,
@@ -126,7 +126,7 @@ pub struct SubmitTransactionRequest {
     pub signature: InstructionSignature,
     pub fee: u64,
     pub sender_public_key: PublicKey,
-    pub inputs: Vec<ShardId>,
+    pub inputs: Vec<(ShardId, SubstateChange)>,
     pub num_outputs: u8,
     /// Set to true to wait for the transaction to complete before returning
     #[serde(default)]

--- a/dan_layer/core/src/models/hot_stuff_tree_node.rs
+++ b/dan_layer/core/src/models/hot_stuff_tree_node.rs
@@ -42,7 +42,7 @@ pub struct HotStuffTreeNode<TAddr, TPayload> {
     payload: Option<TPayload>,
     // How far in the consensus this payload is. It should be 4 in order to be committed.
     payload_height: NodeHeight,
-    local_pledges: Vec<ObjectPledge>,
+    local_pledge: Option<ObjectPledge>,
     epoch: Epoch,
     // Mostly used for debugging
     proposed_by: TAddr,
@@ -57,7 +57,7 @@ impl<TAddr: NodeAddressable, TPayload: Payload> HotStuffTreeNode<TAddr, TPayload
         payload_id: PayloadId,
         payload: Option<TPayload>,
         payload_height: NodeHeight,
-        local_pledges: Vec<ObjectPledge>,
+        local_pledge: Option<ObjectPledge>,
         epoch: Epoch,
         proposed_by: TAddr,
         justify: QuorumCertificate,
@@ -72,7 +72,7 @@ impl<TAddr: NodeAddressable, TPayload: Payload> HotStuffTreeNode<TAddr, TPayload
             height,
             justify,
             payload_height,
-            local_pledges,
+            local_pledge,
             proposed_by,
         };
         s.hash = s.calculate_hash();
@@ -91,7 +91,7 @@ impl<TAddr: NodeAddressable, TPayload: Payload> HotStuffTreeNode<TAddr, TPayload
             epoch: Epoch(0),
             proposed_by: TAddr::zero(),
             justify: QuorumCertificate::genesis(),
-            local_pledges: vec![],
+            local_pledge: None,
         };
         s.hash = s.calculate_hash();
         s
@@ -157,8 +157,8 @@ impl<TAddr: NodeAddressable, TPayload: Payload> HotStuffTreeNode<TAddr, TPayload
         self.height
     }
 
-    pub fn local_pledges(&self) -> &[ObjectPledge] {
-        self.local_pledges.as_slice()
+    pub fn local_pledge(&self) -> Option<&ObjectPledge> {
+        self.local_pledge.as_ref()
     }
 }
 

--- a/dan_layer/core/src/models/mod.rs
+++ b/dan_layer/core/src/models/mod.rs
@@ -258,7 +258,7 @@ impl From<u64> for ChainHeight {
 pub struct ShardVote {
     pub shard_id: ShardId,
     pub node_hash: TreeNodeHash,
-    pub pledges: Vec<ObjectPledge>,
+    pub pledge: Option<ObjectPledge>,
 }
 
 #[derive(Debug, Serialize)]

--- a/dan_layer/core/src/models/vote_message.rs
+++ b/dan_layer/core/src/models/vote_message.rs
@@ -96,17 +96,14 @@ impl VoteMessage {
         for ShardVote {
             shard_id,
             node_hash,
-            pledges,
+            pledge,
         } in &self.all_shard_nodes
         {
             result = result
                 .chain(shard_id.0)
                 .chain(node_hash.as_bytes())
-                .chain((pledges.len() as u32).to_le_bytes());
-
-            for p in pledges {
-                result = result.chain(p.shard_id.0)
-            }
+                // TODO: borsh serialize pledge
+                .chain(pledge.as_ref().map(|p| p.shard_id.0).unwrap_or_default());
         }
         result.finalize_fixed().into()
     }

--- a/dan_layer/core/src/services/payload_processor.rs
+++ b/dan_layer/core/src/services/payload_processor.rs
@@ -32,7 +32,7 @@ pub trait PayloadProcessor<TPayload: Payload> {
     fn process_payload(
         &self,
         payload: TPayload,
-        pledges: HashMap<ShardId, Vec<ObjectPledge>>,
+        pledges: HashMap<ShardId, Option<ObjectPledge>>,
     ) -> Result<FinalizeResult, PayloadProcessorError>;
 }
 

--- a/dan_layer/core/src/storage/shard_store.rs
+++ b/dan_layer/core/src/storage/shard_store.rs
@@ -97,7 +97,7 @@ pub trait ShardStoreTransaction<TAddr: NodeAddressable, TPayload: Payload> {
     fn get_last_executed_height(&self, shard: ShardId) -> Result<NodeHeight, Self::Error>;
     fn save_substate_changes(
         &mut self,
-        changes: &HashMap<ShardId, SubstateState>,
+        changes: &HashMap<ShardId, Vec<SubstateState>>,
         node: &HotStuffTreeNode<TAddr, TPayload>,
     ) -> Result<(), Self::Error>;
     fn get_state_inventory(&self, start_shard: ShardId, end_shard: ShardId) -> Result<Vec<ShardId>, Self::Error>;

--- a/dan_layer/storage_sqlite/src/sqlite_shard_store_factory.rs
+++ b/dan_layer/storage_sqlite/src/sqlite_shard_store_factory.rs
@@ -207,7 +207,6 @@ impl SqliteShardStoreTransaction {
             pledged_to_payload: PayloadId::try_from(obj.pledged_to_payload_id.unwrap_or_default())?,
             pledged_until: NodeHeight(obj.pledged_until_height.unwrap_or_default() as u64),
         };
-        dbg!(&pledge);
         Ok(pledge)
     }
 }
@@ -467,7 +466,7 @@ impl ShardStoreTransaction<PublicKey, TariDanPayload> for SqliteShardStoreTransa
                 .payload_height
                 .try_into()
                 .map_err(|_| Self::Error::InvalidIntegerCast)?;
-            let local_pledges: Vec<ObjectPledge> =
+            let local_pledge: Option<ObjectPledge> =
                 serde_json::from_str(&node.local_pledges).map_err(|source| StorageError::SerdeJson {
                     source,
                     operation: "get_node".to_string(),
@@ -493,7 +492,7 @@ impl ShardStoreTransaction<PublicKey, TariDanPayload> for SqliteShardStoreTransa
                 payload,
                 None,
                 NodeHeight(payload_hgt),
-                local_pledges,
+                local_pledge,
                 Epoch(epoch),
                 proposed_by,
                 justify,
@@ -520,7 +519,7 @@ impl ShardStoreTransaction<PublicKey, TariDanPayload> for SqliteShardStoreTransa
         let payload_id = Vec::from(node.payload_id().as_bytes());
         let payload_height = node.payload_height().as_u64() as i64;
 
-        let local_pledges = json!(&node.local_pledges()).to_string();
+        let local_pledges = json!(&node.local_pledge()).to_string();
 
         let epoch = node.epoch().as_u64() as i64;
         let proposed_by = Vec::from(node.proposed_by().as_bytes());


### PR DESCRIPTION
Description
---
Validate the changes made after running the WASM to make sure that all the shards have pledged it correctly.
Also fixes a bug where the DOWN and the UP of a component were not created.

Motivation and Context
---
This is a critical check that all committees are prepared to make the changes to the involved shards when the data is finally committed. 

Note that there are quite a few ugly implementation details here. The substate change map is inelegant by using a `match` instead of an `if` because of the inner data in the Substate. There are already a number of changes in this PR and I'm worried that it will cause conflicts with other PRs. I'll return to clean up that code after this and the other changes are merged

How Has This Been Tested?
---
Manually. Calling the Counter::increase method now creates a DOWN and an UP row in the sqlite db
