### PR TITLE
fix: wait for n-f newview messages before propose

### DIFF
--- a/applications/tari_validator_node/src/p2p/services/hotstuff/hotstuff_service.rs
+++ b/applications/tari_validator_node/src/p2p/services/hotstuff/hotstuff_service.rs
@@ -20,6 +20,8 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+use std::fmt::Display;
+
 use log::*;
 use tari_comms::types::CommsPublicKey;
 use tari_dan_common_types::ShardId;
@@ -166,9 +168,10 @@ impl HotstuffService {
             tokio::select! {
                 // Inbound
                 res = self.mempool.next_valid_transaction() => {
-                    let (tx, shard_id) = res?;
-                    debug!(target: LOG_TARGET, "Received new transaction {} for shard {}", tx.hash(), shard_id);
-                    log(self.handle_new_valid_transaction(tx, shard_id).await, "new valid transaction");
+                    if let Some((tx, shard_id)) = log(res, "new valid transaction") {
+                        debug!(target: LOG_TARGET, "Received new transaction {} for shard {}", tx.hash(), shard_id);
+                        log(self.handle_new_valid_transaction(tx, shard_id).await, "new valid transaction");
+                    }
                 }
                 // Outbound
                 Some((to, msg)) = self.rx_leader.recv() => {
@@ -194,8 +197,12 @@ impl HotstuffService {
     }
 }
 
-fn log(result: Result<(), anyhow::Error>, area: &str) {
-    if let Err(e) = result {
-        error!(target: LOG_TARGET, "Error in hotstuff service: {} [{}]", e, area);
+fn log<T, E: Display>(result: Result<T, E>, area: &str) -> Option<T> {
+    match result {
+        Ok(t) => Some(t),
+        Err(e) => {
+            error!(target: LOG_TARGET, "Error in hotstuff service: {} [{}]", e, area);
+            None
+        },
     }
 }

--- a/dan_layer/core/src/models/committee.rs
+++ b/dan_layer/core/src/models/committee.rs
@@ -44,6 +44,7 @@ impl<TAddr: NodeAddressable> Committee<TAddr> {
         &self.members[pos]
     }
 
+    /// Returns n - f where n is the number of committee members and f is the tolerated failure nodes.
     pub fn consensus_threshold(&self) -> usize {
         let len = self.members.len();
         let max_failures = (len - 1) / 3;

--- a/dan_layer/core/src/storage/shard_store.rs
+++ b/dan_layer/core/src/storage/shard_store.rs
@@ -72,7 +72,8 @@ impl From<StorageError> for StoreError {
 pub trait ShardStoreTransaction<TAddr: NodeAddressable, TPayload: Payload> {
     type Error: Display + Into<StoreError>;
     fn commit(&mut self) -> Result<(), Self::Error>;
-    fn update_high_qc(&mut self, shard: ShardId, qc: QuorumCertificate) -> Result<(), Self::Error>;
+    fn count_high_qc_for(&self, shard_id: ShardId) -> Result<usize, Self::Error>;
+    fn update_high_qc(&mut self, from: TAddr, shard: ShardId, qc: QuorumCertificate) -> Result<(), Self::Error>;
     fn set_payload(&mut self, payload: TPayload) -> Result<(), Self::Error>;
     fn get_leaf_node(&self, shard: ShardId) -> Result<(TreeNodeHash, NodeHeight), Self::Error>;
     fn update_leaf_node(&mut self, shard: ShardId, node: TreeNodeHash, height: NodeHeight) -> Result<(), Self::Error>;

--- a/dan_layer/integration_tests/src/test_consensus.rs
+++ b/dan_layer/integration_tests/src/test_consensus.rs
@@ -283,10 +283,14 @@ async fn test_hs_waiter_leader_proposes() {
     dbg!(payload.to_id());
     // Send a new view message
     let new_view_message = HotStuffMessage::new_view(QuorumCertificate::genesis(), *SHARD0, Some(payload));
-
     instance
         .tx_hs_messages
-        .send((node1.clone(), new_view_message))
+        .send((node1.clone(), new_view_message.clone()))
+        .await
+        .unwrap();
+    instance
+        .tx_hs_messages
+        .send((node2.clone(), new_view_message))
         .await
         .unwrap();
 
@@ -316,6 +320,11 @@ async fn test_hs_waiter_replica_sends_vote_for_proposal() {
     instance
         .tx_hs_messages
         .send((node2, new_view_message.clone()))
+        .await
+        .unwrap();
+    instance
+        .tx_hs_messages
+        .send((node1.clone(), new_view_message.clone()))
         .await
         .unwrap();
 
@@ -356,6 +365,11 @@ async fn test_hs_waiter_leader_sends_new_proposal_when_enough_votes_are_received
     instance
         .tx_hs_messages
         .send((node2.clone(), new_view_message.clone()))
+        .await
+        .unwrap();
+    instance
+        .tx_hs_messages
+        .send((node1.clone(), new_view_message.clone()))
         .await
         .unwrap();
 

--- a/dan_layer/storage_sqlite/migrations/2022-11-03-160049_add_identity_to_high_qc/down.sql
+++ b/dan_layer/storage_sqlite/migrations/2022-11-03-160049_add_identity_to_high_qc/down.sql
@@ -1,0 +1,1 @@
+-- This file should undo anything in `up.sql`

--- a/dan_layer/storage_sqlite/migrations/2022-11-03-160049_add_identity_to_high_qc/up.sql
+++ b/dan_layer/storage_sqlite/migrations/2022-11-03-160049_add_identity_to_high_qc/up.sql
@@ -1,0 +1,3 @@
+alter table high_qcs add column identity blob not null ;
+drop index high_qcs_index_shard_id_height;
+create unique index high_qcs_index_shard_id_height on high_qcs (shard_id, height, identity);

--- a/dan_layer/storage_sqlite/src/models/high_qc.rs
+++ b/dan_layer/storage_sqlite/src/models/high_qc.rs
@@ -28,6 +28,7 @@ pub struct HighQc {
     pub shard_id: Vec<u8>,
     pub height: i64,
     pub qc_json: String,
+    pub identity: Vec<u8>,
 }
 
 #[derive(Debug, Insertable)]
@@ -36,4 +37,5 @@ pub struct NewHighQc {
     pub shard_id: Vec<u8>,
     pub height: i64,
     pub qc_json: String,
+    pub identity: Vec<u8>,
 }

--- a/dan_layer/storage_sqlite/src/schema.rs
+++ b/dan_layer/storage_sqlite/src/schema.rs
@@ -6,6 +6,7 @@ diesel::table! {
         shard_id -> Binary,
         height -> BigInt,
         qc_json -> Text,
+        identity -> Binary,
     }
 }
 

--- a/dan_layer/storage_sqlite/src/sqlite_shard_store_factory.rs
+++ b/dan_layer/storage_sqlite/src/sqlite_shard_store_factory.rs
@@ -75,13 +75,13 @@ use crate::{
         substate::{NewSubstate, Substate},
     },
     schema::{
-        high_qcs::{dsl::high_qcs, shard_id},
+        high_qcs::dsl::high_qcs,
         last_executed_heights::dsl::last_executed_heights,
         last_voted_heights::dsl::last_voted_heights,
         leader_proposals::dsl::leader_proposals,
         leaf_nodes::dsl::leaf_nodes,
         lock_node_and_heights::dsl::lock_node_and_heights,
-        nodes::dsl::nodes,
+        nodes,
         payloads::dsl::payloads,
         received_votes::dsl::received_votes,
         substates::{dsl::substates, pledged_to_payload_id},
@@ -225,7 +225,25 @@ impl ShardStoreTransaction<PublicKey, TariDanPayload> for SqliteShardStoreTransa
         Ok(())
     }
 
-    fn update_high_qc(&mut self, shard: ShardId, qc: QuorumCertificate) -> Result<(), Self::Error> {
+    fn count_high_qc_for(&self, shard_id: ShardId) -> Result<usize, Self::Error> {
+        use crate::schema::high_qcs::dsl;
+
+        high_qcs
+            .count()
+            .filter(dsl::shard_id.eq(shard_id.as_bytes()))
+            .get_result(&self.connection)
+            .map(|count: i64| count as usize)
+            .map_err(|e| StorageError::QueryError {
+                reason: format!("Failed to count high_qc: {}", e),
+            })
+    }
+
+    fn update_high_qc(
+        &mut self,
+        identity: PublicKey,
+        shard: ShardId,
+        qc: QuorumCertificate,
+    ) -> Result<(), Self::Error> {
         // update all others for this shard to highest == false
         let shard = Vec::from(shard.0);
 
@@ -233,28 +251,67 @@ impl ShardStoreTransaction<PublicKey, TariDanPayload> for SqliteShardStoreTransa
             shard_id: shard,
             height: qc.local_node_height().as_u64() as i64,
             qc_json: json!(qc).to_string(),
+            identity: identity.to_vec(),
         };
         match diesel::insert_into(high_qcs).values(&new_row).execute(&self.connection) {
             Ok(_) => Ok(()),
+            // (shard_id, height) is a unique index
+            Err(Error::DatabaseError(DatabaseErrorKind::UniqueViolation, _)) => {
+                debug!(target: LOG_TARGET, "High QC already exists");
+                Ok(())
+            },
+            Err(err) => Err(Self::Error::QueryError {
+                reason: format!("update high QC error: {}", err),
+            }),
+        }
+    }
+
+    fn set_payload(&mut self, payload: TariDanPayload) -> Result<(), Self::Error> {
+        let transaction = payload.transaction();
+        let instructions = json!(&transaction.instructions()).to_string();
+
+        let signature = transaction.signature();
+
+        let public_nonce = Vec::from(signature.signature().get_public_nonce().as_bytes());
+        let scalar = Vec::from(signature.signature().get_signature().as_bytes());
+
+        let fee = transaction.fee() as i64;
+        let sender_public_key = Vec::from(transaction.sender_public_key().as_bytes());
+
+        let meta = json!(transaction.meta()).to_string();
+
+        let payload_id = Vec::from(payload.to_id().as_slice());
+
+        let new_row = NewPayload {
+            payload_id,
+            instructions,
+            public_nonce,
+            scalar,
+            fee,
+            sender_public_key,
+            meta,
+        };
+
+        match diesel::insert_into(payloads).values(&new_row).execute(&self.connection) {
+            Ok(_) => {},
             Err(err) => {
                 // It can happen that we get this payload from two shards that we are responsible
                 match err {
                     Error::DatabaseError(kind, _) => {
                         if matches!(kind, DatabaseErrorKind::UniqueViolation) {
-                            debug!(target: LOG_TARGET, "High QC already exists");
-                            Ok(())
-                        } else {
-                            Err(StorageError::QueryError {
-                                reason: format!("Update high qc error: {}", err),
-                            })
+                            debug!(target: LOG_TARGET, "Payload already exists");
+                            return Ok(());
                         }
                     },
-                    _ => Err(Self::Error::QueryError {
-                        reason: format!("update high QC error: {}", err),
-                    }),
+                    _ => {
+                        return Err(Self::Error::QueryError {
+                            reason: format!("Set payload error: {}", err),
+                        })
+                    },
                 }
             },
         }
+        Ok(())
     }
 
     fn get_leaf_node(&self, shard: ShardId) -> Result<(TreeNodeHash, NodeHeight), Self::Error> {
@@ -311,11 +368,10 @@ impl ShardStoreTransaction<PublicKey, TariDanPayload> for SqliteShardStoreTransa
     }
 
     fn get_high_qc_for(&self, shard: ShardId) -> Result<QuorumCertificate, Self::Error> {
-        dbg!("get high qc");
-        use crate::schema::high_qcs::height;
-        let qc: Option<HighQc> = high_qcs
-            .filter(shard_id.eq(Vec::from(shard.0)))
-            .order_by(height.desc())
+        use crate::schema::high_qcs::dsl;
+        let qc: Option<HighQc> = dsl::high_qcs
+            .filter(dsl::shard_id.eq(Vec::from(shard.0)))
+            .order_by(dsl::height.desc())
             .first(&self.connection)
             .optional()
             .map_err(|e| Self::Error::QueryError {
@@ -388,54 +444,6 @@ impl ShardStoreTransaction<PublicKey, TariDanPayload> for SqliteShardStoreTransa
         }
     }
 
-    fn set_payload(&mut self, payload: TariDanPayload) -> Result<(), Self::Error> {
-        let transaction = payload.transaction();
-        let instructions = json!(&transaction.instructions()).to_string();
-
-        let signature = transaction.signature();
-
-        let public_nonce = Vec::from(signature.signature().get_public_nonce().as_bytes());
-        let scalar = Vec::from(signature.signature().get_signature().as_bytes());
-
-        let fee = transaction.fee() as i64;
-        let sender_public_key = Vec::from(transaction.sender_public_key().as_bytes());
-
-        let meta = json!(transaction.meta()).to_string();
-
-        let payload_id = Vec::from(payload.to_id().as_slice());
-
-        let new_row = NewPayload {
-            payload_id,
-            instructions,
-            public_nonce,
-            scalar,
-            fee,
-            sender_public_key,
-            meta,
-        };
-
-        match diesel::insert_into(payloads).values(&new_row).execute(&self.connection) {
-            Ok(_) => {},
-            Err(err) => {
-                // It can happen that we get this payload from two shards that we are responsible
-                match err {
-                    Error::DatabaseError(kind, _) => {
-                        if matches!(kind, DatabaseErrorKind::UniqueViolation) {
-                            debug!(target: LOG_TARGET, "Payload already exists");
-                            return Ok(());
-                        }
-                    },
-                    _ => {
-                        return Err(Self::Error::QueryError {
-                            reason: format!("Set payload error: {}", err),
-                        })
-                    },
-                }
-            },
-        }
-        Ok(())
-    }
-
     fn get_node(&self, hash: &TreeNodeHash) -> Result<HotStuffTreeNode<PublicKey, TariDanPayload>, Self::Error> {
         if hash == &TreeNodeHash::zero() {
             return Ok(HotStuffTreeNode::genesis());
@@ -446,7 +454,7 @@ impl ShardStoreTransaction<PublicKey, TariDanPayload> for SqliteShardStoreTransa
         let hash = Vec::from(hash.as_bytes());
         // TODO: Do we need to add an index to the table to order by `height` and `payload_height`
         // more efficiently ?
-        let node: Option<Node> = nodes
+        let node: Option<Node> = nodes::dsl::nodes
             .filter(node_hash.eq(hash.clone()))
             .first(&self.connection)
             .optional()
@@ -541,7 +549,10 @@ impl ShardStoreTransaction<PublicKey, TariDanPayload> for SqliteShardStoreTransa
             justify,
         };
 
-        match diesel::insert_into(nodes).values(&new_row).execute(&self.connection) {
+        match diesel::insert_into(nodes::dsl::nodes)
+            .values(&new_row)
+            .execute(&self.connection)
+        {
             Ok(_) => {},
             Err(err) => match err {
                 Error::DatabaseError(kind, _) => {


### PR DESCRIPTION
Description
---
- leader waits for $n - f$ newview messages before proposing
- added identity column to highqc to allow for counting NEWVIEWS per shard

Motivation and Context
---
Leader should only propose once $n - f$ newviews are recieved.

How Has This Been Tested?
---
Manually, 2 nodes where the leader does not propose until 2/2 newviews are received
