### PR TITLE
fix: add committee size constant, to remove duplicate code (see #174)

### DIFF
--- a/applications/tari_validator_node/src/bootstrap.rs
+++ b/applications/tari_validator_node/src/bootstrap.rs
@@ -119,6 +119,7 @@ pub async fn spawn_services(
     let epoch_manager = epoch_manager::spawn(
         sqlite_db.clone(),
         base_node_client.clone(),
+        consensus_constants.clone(),
         node_identity.public_key().clone(),
         shutdown.clone(),
         node_identity.clone(),

--- a/applications/tari_validator_node/src/p2p/services/epoch_manager/base_layer_epoch_manager.rs
+++ b/applications/tari_validator_node/src/p2p/services/epoch_manager/base_layer_epoch_manager.rs
@@ -20,7 +20,7 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::{convert::TryInto, ops::Div, sync::Arc};
+use std::{convert::TryInto, sync::Arc};
 
 use tari_comms::{types::CommsPublicKey, NodeIdentity};
 use tari_crypto::tari_utilities::ByteArray;
@@ -247,7 +247,14 @@ impl BaseLayerEpochManager {
         // retrieve the validator nodes for this epoch from database
         let vns = self.get_validator_nodes_per_epoch(epoch)?;
 
-        let half_committee_size = COMMITTEE_SIZE.div(2) + 1; // middle point of COMMITTEE_SIZE = 7
+        let half_committee_size = {
+            let v = COMMITTEE_SIZE / 2;
+            if COMMITTEE_SIZE % 2 > 0 {
+                v + 1
+            } else {
+                v
+            }
+        };
         if vns.len() < half_committee_size * 2 {
             return Ok(vns);
         }

--- a/applications/tari_validator_node/src/p2p/services/epoch_manager/base_layer_epoch_manager.rs
+++ b/applications/tari_validator_node/src/p2p/services/epoch_manager/base_layer_epoch_manager.rs
@@ -20,7 +20,7 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::{convert::TryInto, sync::Arc};
+use std::{convert::TryInto, ops::Div, sync::Arc};
 
 use tari_comms::{types::CommsPublicKey, NodeIdentity};
 use tari_crypto::tari_utilities::ByteArray;
@@ -37,7 +37,7 @@ use tari_dan_storage::global::{DbValidatorNode, MetadataKey};
 use tari_dan_storage_sqlite::SqliteDbFactory;
 use tokio::sync::broadcast;
 
-use super::{get_committee_shard_range, sync_peers::PeerSyncManagerService};
+use super::{get_committee_shard_range, sync_peers::PeerSyncManagerService, COMMITTEE_SIZE};
 use crate::{
     grpc::services::base_node_client::GrpcBaseNodeClient,
     p2p::services::{
@@ -247,7 +247,7 @@ impl BaseLayerEpochManager {
         // retrieve the validator nodes for this epoch from database
         let vns = self.get_validator_nodes_per_epoch(epoch)?;
 
-        let half_committee_size = 4; // total committee = 7
+        let half_committee_size = COMMITTEE_SIZE.div(2) + 1; // total committee = 7
         if vns.len() < half_committee_size * 2 {
             return Ok(vns);
         }

--- a/applications/tari_validator_node/src/p2p/services/epoch_manager/base_layer_epoch_manager.rs
+++ b/applications/tari_validator_node/src/p2p/services/epoch_manager/base_layer_epoch_manager.rs
@@ -247,7 +247,7 @@ impl BaseLayerEpochManager {
         // retrieve the validator nodes for this epoch from database
         let vns = self.get_validator_nodes_per_epoch(epoch)?;
 
-        let half_committee_size = COMMITTEE_SIZE.div(2) + 1; // total committee = 7
+        let half_committee_size = COMMITTEE_SIZE.div(2) + 1; // middle point of COMMITTEE_SIZE = 7
         if vns.len() < half_committee_size * 2 {
             return Ok(vns);
         }

--- a/applications/tari_validator_node/src/p2p/services/epoch_manager/epoch_manager_service.rs
+++ b/applications/tari_validator_node/src/p2p/services/epoch_manager/epoch_manager_service.rs
@@ -25,6 +25,7 @@ use std::sync::Arc;
 use tari_comms::{types::CommsPublicKey, NodeIdentity};
 use tari_dan_common_types::{Epoch, ShardId};
 use tari_dan_core::{
+    consensus_constants::ConsensusConstants,
     models::Committee,
     services::epoch_manager::{EpochManagerError, ShardCommitteeAllocation},
 };
@@ -127,6 +128,7 @@ impl EpochManagerService {
         shutdown: ShutdownSignal,
         db_factory: SqliteDbFactory,
         base_node_client: GrpcBaseNodeClient,
+        consensus_constants: ConsensusConstants,
         node_identity: Arc<NodeIdentity>,
         validator_node_config: ValidatorNodeConfig,
         validator_node_client_factory: TariCommsValidatorNodeClientFactory,
@@ -138,6 +140,7 @@ impl EpochManagerService {
                 inner: BaseLayerEpochManager::new(
                     db_factory,
                     base_node_client,
+                    consensus_constants,
                     id,
                     tx.clone(),
                     node_identity,

--- a/applications/tari_validator_node/src/p2p/services/epoch_manager/initializer.rs
+++ b/applications/tari_validator_node/src/p2p/services/epoch_manager/initializer.rs
@@ -23,6 +23,7 @@
 use std::sync::Arc;
 
 use tari_comms::{types::CommsPublicKey, NodeIdentity};
+use tari_dan_core::consensus_constants::ConsensusConstants;
 use tari_dan_storage_sqlite::SqliteDbFactory;
 use tari_shutdown::ShutdownSignal;
 use tokio::sync::mpsc;
@@ -39,6 +40,7 @@ use crate::{
 pub fn spawn(
     db_factory: SqliteDbFactory,
     base_node_client: GrpcBaseNodeClient,
+    consensus_constants: ConsensusConstants,
     id: CommsPublicKey,
     shutdown: ShutdownSignal,
     node_identity: Arc<NodeIdentity>,
@@ -53,6 +55,7 @@ pub fn spawn(
         shutdown,
         db_factory,
         base_node_client,
+        consensus_constants,
         node_identity,
         validator_node_config,
         validator_node_client_factory,

--- a/applications/tari_validator_node/src/p2p/services/epoch_manager/mod.rs
+++ b/applications/tari_validator_node/src/p2p/services/epoch_manager/mod.rs
@@ -32,10 +32,11 @@ pub use initializer::spawn;
 use tari_dan_common_types::ShardId;
 use tari_dan_core::models::ValidatorNode;
 
+const COMMITTEE_SIZE: usize = 7;
+
 fn get_committee_shard_range(committee_vns: &[ValidatorNode]) -> RangeInclusive<ShardId> {
     // TODO: add this committee_size to ConsensusConstants
-    let committee_size = 7;
-    if committee_vns.len() < committee_size {
+    if committee_vns.len() < COMMITTEE_SIZE {
         let min_shard_id = ShardId::zero();
         let max_shard_id = ShardId([u8::MAX; 32]);
         RangeInclusive::new(min_shard_id, max_shard_id)

--- a/applications/tari_validator_node/src/p2p/services/epoch_manager/mod.rs
+++ b/applications/tari_validator_node/src/p2p/services/epoch_manager/mod.rs
@@ -32,11 +32,9 @@ pub use initializer::spawn;
 use tari_dan_common_types::ShardId;
 use tari_dan_core::models::ValidatorNode;
 
-const COMMITTEE_SIZE: usize = 7;
-
-fn get_committee_shard_range(committee_vns: &[ValidatorNode]) -> RangeInclusive<ShardId> {
+fn get_committee_shard_range(committee_size: usize, committee_vns: &[ValidatorNode]) -> RangeInclusive<ShardId> {
     // TODO: add this committee_size to ConsensusConstants
-    if committee_vns.len() < COMMITTEE_SIZE {
+    if committee_vns.len() < committee_size {
         let min_shard_id = ShardId::zero();
         let max_shard_id = ShardId([u8::MAX; 32]);
         RangeInclusive::new(min_shard_id, max_shard_id)

--- a/dan_layer/core/src/consensus_constants.rs
+++ b/dan_layer/core/src/consensus_constants.rs
@@ -20,8 +20,10 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+#[derive(Clone)]
 pub struct ConsensusConstants {
     pub base_layer_confirmations: u64,
+    pub committee_size: u64,
     pub hotstuff_rounds: u64,
 }
 
@@ -29,6 +31,7 @@ impl ConsensusConstants {
     pub const fn devnet() -> Self {
         Self {
             base_layer_confirmations: 3,
+            committee_size: 7,
             hotstuff_rounds: 4,
         }
     }


### PR DESCRIPTION
Description
---
Address #174. Even though we don't add this constant to `ConsensusConstants`, as it is not used as inner type of `EpochManager`, we remove duplicate instances of the value `committee_size`.

Motivation and Context
---

How Has This Been Tested?
---

