### PR TITLE
fix!: max_outputs missing from proto conversion

### DIFF
--- a/applications/tari_validator_node/proto/dan/transaction.proto
+++ b/applications/tari_validator_node/proto/dan/transaction.proto
@@ -68,12 +68,11 @@ message Transaction {
   repeated ThaumInput inputs = 1;
   repeated ThaumOutput outputs = 2;
   repeated Instruction instructions = 3;
-  uint32 max_instruction_outputs = 4;
-  bytes balance_proof = 5;
-  tari.dan.common.Signature signature = 6;
-  uint64 fee = 7;
-  bytes sender_public_key = 8;
-  TransactionMeta meta = 9;
+  bytes balance_proof = 4;
+  tari.dan.common.Signature signature = 5;
+  uint64 fee = 6;
+  bytes sender_public_key = 7;
+  TransactionMeta meta = 8;
 }
 
 message Instruction {

--- a/dan_layer/core/src/storage/error.rs
+++ b/dan_layer/core/src/storage/error.rs
@@ -24,6 +24,7 @@ use std::{io, sync::PoisonError};
 
 use lmdb_zero as lmdb;
 use tari_common_types::types::FixedHashSizeError;
+use tari_dan_common_types::optional::IsNotFoundError;
 use tari_storage::lmdb_store::LMDBError;
 use tari_utilities::ByteArrayError;
 
@@ -77,5 +78,11 @@ pub enum StorageError {
 impl<T> From<PoisonError<T>> for StorageError {
     fn from(_err: PoisonError<T>) -> Self {
         Self::LockError
+    }
+}
+
+impl IsNotFoundError for StorageError {
+    fn is_not_found_error(&self) -> bool {
+        matches!(self, Self::NotFound { .. })
     }
 }


### PR DESCRIPTION
Description
---
- sets num_outputs/max_outputs in TransactionMeta proto conversion

Motivation and Context
---
Transactions would propagate without the max_outputs field

Breaking change: network, proto field numbers changed

How Has This Been Tested?
---
Manually
