### PR TITLE
fix: reduces number of executes per transaction

### DIFF
--- a/applications/tari_validator_node/build.rs
+++ b/applications/tari_validator_node/build.rs
@@ -29,6 +29,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .emit_rerun_if_changed_directives()
         .compile()
         .unwrap();
+
     println!("cargo:rerun-if-changed=../tari_validator_node_web_ui/src");
     println!("cargo:rerun-if-changed=../tari_validator_node_web_ui/public");
     let npm = if cfg!(windows) { "npm.cmd" } else { "npm" };

--- a/applications/tari_validator_node/proto/dan/consensus.proto
+++ b/applications/tari_validator_node/proto/dan/consensus.proto
@@ -8,8 +8,8 @@ package tari.dan.consensus;
 import "transaction.proto";
 
 enum HotStuffMessageType {
-  HOT_STUFF_MESSAGE_TYPE_NEW_VIEW = 0;
-  HOT_STUFF_MESSAGE_TYPE_GENERIC = 1;
+  NEW_VIEW = 0;
+  PROPOSAL = 1;
 }
 
 message HotStuffMessage {

--- a/applications/tari_validator_node/src/p2p/services/epoch_manager/handle.rs
+++ b/applications/tari_validator_node/src/p2p/services/epoch_manager/handle.rs
@@ -153,6 +153,8 @@ impl EpochManager<CommsPublicKey> for EpochManagerHandle {
         rx.await.map_err(|_| EpochManagerError::ReceiveError)?
     }
 
+    /// Filters out from the available_shards, returning the ShardIds for committees for each available_shard that
+    /// `for_addr` is part of.
     async fn filter_to_local_shards(
         &self,
         epoch: Epoch,

--- a/dan_layer/common_types/src/lib.rs
+++ b/dan_layer/common_types/src/lib.rs
@@ -140,6 +140,7 @@ pub struct ObjectClaim {}
 
 impl ObjectClaim {
     pub fn is_valid(&self, _payload: PayloadId) -> bool {
+        // TODO: Implement this
         true
     }
 }

--- a/dan_layer/core/src/models/hot_stuff_message.rs
+++ b/dan_layer/core/src/models/hot_stuff_message.rs
@@ -93,9 +93,9 @@ impl<TPayload: Payload, TAddr: NodeAddressable> HotStuffMessage<TPayload, TAddr>
         }
     }
 
-    pub fn generic(node: HotStuffTreeNode<TAddr, TPayload>, shard: ShardId) -> Self {
+    pub fn new_proposal(node: HotStuffTreeNode<TAddr, TPayload>, shard: ShardId) -> Self {
         Self {
-            message_type: HotStuffMessageType::Generic,
+            message_type: HotStuffMessageType::Proposal,
             shard: Some(shard),
             node: Some(node),
             ..Default::default()

--- a/dan_layer/core/src/models/hot_stuff_tree_node.rs
+++ b/dan_layer/core/src/models/hot_stuff_tree_node.rs
@@ -37,16 +37,16 @@ pub struct HotStuffTreeNode<TAddr, TPayload> {
     parent: TreeNodeHash,
     shard: ShardId,
     height: NodeHeight,
-    // The payload that the node is proposing
+    /// The payload that the node is proposing
     payload_id: PayloadId,
     payload: Option<TPayload>,
-    // How far in the consensus this payload is. It should be 4 in order to be committed.
+    /// How far in the consensus this payload is. It should be 4 in order to be committed.
     payload_height: NodeHeight,
     local_pledge: Option<ObjectPledge>,
     epoch: Epoch,
+    justify: QuorumCertificate,
     // Mostly used for debugging
     proposed_by: TAddr,
-    justify: QuorumCertificate,
 }
 
 impl<TAddr: NodeAddressable, TPayload: Payload> HotStuffTreeNode<TAddr, TPayload> {
@@ -113,8 +113,7 @@ impl<TAddr: NodeAddressable, TPayload: Payload> HotStuffTreeNode<TAddr, TPayload
         //     acc.extend_from_slice(substate.as_bytes())
         // }));
 
-        let result = result.finalize_fixed();
-        result.into()
+        result.finalize_fixed().into()
     }
 
     pub fn hash(&self) -> &TreeNodeHash {
@@ -137,10 +136,12 @@ impl<TAddr: NodeAddressable, TPayload: Payload> HotStuffTreeNode<TAddr, TPayload
         self.payload.as_ref()
     }
 
+    /// The payload height corresponds to the round number.
     pub fn payload_height(&self) -> NodeHeight {
         self.payload_height
     }
 
+    /// The quorum certificate for this node
     pub fn justify(&self) -> &QuorumCertificate {
         &self.justify
     }

--- a/dan_layer/core/src/models/leaf_node.rs
+++ b/dan_layer/core/src/models/leaf_node.rs
@@ -1,4 +1,4 @@
-//  Copyright 2022. The Tari Project
+//  Copyright 2022, The Tari Project
 //
 //  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
 //  following conditions are met:
@@ -20,42 +20,31 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use thiserror::Error;
+use crate::models::{NodeHeight, TreeNodeHash};
 
-use crate::{
-    models::NodeHeight,
-    services::{epoch_manager::EpochManagerError, PayloadProcessorError},
-    storage::{shard_store::StoreError, StorageError},
-};
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LeafNode {
+    hash: TreeNodeHash,
+    height: NodeHeight,
+}
 
-#[derive(Error, Debug)]
-pub enum HotStuffError {
-    #[error("Epoch manager error: {0}")]
-    EpochManagerError(#[from] EpochManagerError),
-    #[error("Received message from a node that is not in the committee")]
-    ReceivedMessageFromNonCommitteeMember,
-    #[error("Update leaf node error: `{0}`")]
-    UpdateLeafNode(String),
-    #[error("Store error: {0}")]
-    StoreError(#[from] StoreError),
-    #[error("Claim is not valid")]
-    ClaimIsNotValid,
-    #[error("Node payload does not match justify payload")]
-    NodePayloadDoesNotMatchJustifyPayload,
-    #[error("Send error")]
-    SendError,
-    #[error("Not the leader")]
-    NotTheLeader,
-    #[error("Payload failed to process: {0}")]
-    PayloadProcessorError(#[from] PayloadProcessorError),
-    #[error("Transaction rejected: {0}")]
-    TransactionRejected(String),
-    #[error("Storage Error: `{0}`")]
-    StorageError(#[from] StorageError),
-    #[error("Payload height is too high. Actual: {actual}, expected: {max}")]
-    PayloadHeightIsTooHigh { actual: NodeHeight, max: NodeHeight },
-    #[error("Received generic message without node")]
-    RecvProposalMessageWithoutNode,
-    #[error("Shard has no data, when it was expected to")]
-    ShardHasNoData,
+impl LeafNode {
+    pub fn genesis() -> Self {
+        Self {
+            hash: TreeNodeHash::zero(),
+            height: NodeHeight(0),
+        }
+    }
+
+    pub fn new(hash: TreeNodeHash, height: NodeHeight) -> Self {
+        Self { hash, height }
+    }
+
+    pub fn hash(&self) -> &TreeNodeHash {
+        &self.hash
+    }
+
+    pub fn height(&self) -> NodeHeight {
+        self.height
+    }
 }

--- a/dan_layer/core/src/models/mod.rs
+++ b/dan_layer/core/src/models/mod.rs
@@ -38,6 +38,7 @@ pub mod domain_events;
 mod error;
 mod hot_stuff_message;
 mod hot_stuff_tree_node;
+mod leaf_node;
 mod node;
 mod payload;
 mod quorum_certificate;
@@ -55,6 +56,7 @@ pub use committee::Committee;
 pub use error::ModelError;
 pub use hot_stuff_message::HotStuffMessage;
 pub use hot_stuff_tree_node::HotStuffTreeNode;
+pub use leaf_node::LeafNode;
 pub use node::Node;
 pub use payload::Payload;
 pub use quorum_certificate::{QuorumCertificate, QuorumDecision};
@@ -109,6 +111,7 @@ impl Display for NodeHeight {
 pub struct ObjectPledge {
     pub shard_id: ShardId,
     pub current_state: SubstateState,
+    // pub current_state_hash: FixedHash,
     pub pledged_to_payload: PayloadId,
     pub pledged_until: NodeHeight,
 }
@@ -142,7 +145,7 @@ impl AsRef<[u8]> for TokenId {
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize)]
 pub enum HotStuffMessageType {
     NewView,
-    Generic,
+    Proposal,
 }
 
 impl Default for HotStuffMessageType {
@@ -155,7 +158,7 @@ impl HotStuffMessageType {
     pub fn as_u8(&self) -> u8 {
         match self {
             HotStuffMessageType::NewView => 0,
-            HotStuffMessageType::Generic => 1,
+            HotStuffMessageType::Proposal => 1,
         }
     }
 }
@@ -166,7 +169,7 @@ impl TryFrom<u8> for HotStuffMessageType {
     fn try_from(value: u8) -> Result<Self, Self::Error> {
         match value {
             0 => Ok(HotStuffMessageType::NewView),
-            1 => Ok(HotStuffMessageType::Generic),
+            1 => Ok(HotStuffMessageType::Proposal),
             _ => Err("Not a value message type".to_string()),
         }
     }
@@ -178,7 +181,7 @@ impl TryFrom<i32> for HotStuffMessageType {
     fn try_from(value: i32) -> Result<Self, Self::Error> {
         match value {
             0 => Ok(HotStuffMessageType::NewView),
-            1 => Ok(HotStuffMessageType::Generic),
+            1 => Ok(HotStuffMessageType::Proposal),
             _ => Err(anyhow!("Not a value message type")),
         }
     }

--- a/dan_layer/core/src/models/quorum_certificate.rs
+++ b/dan_layer/core/src/models/quorum_certificate.rs
@@ -143,6 +143,7 @@ impl QuorumCertificate {
         self.payload_height
     }
 
+    /// The locally stable hash of the node
     pub fn local_node_hash(&self) -> TreeNodeHash {
         self.local_node_hash
     }

--- a/dan_layer/core/src/services/epoch_manager.rs
+++ b/dan_layer/core/src/services/epoch_manager.rs
@@ -84,7 +84,8 @@ pub trait EpochManager<TAddr: NodeAddressable>: Clone {
         shard: ShardId,
         identity: TAddr,
     ) -> Result<bool, EpochManagerError>;
-    // TODO: Get a better name
+    /// Filters out from the available_shards, returning the ShardIds for committees for each available_shard that
+    /// `for_addr` is part of.
     async fn filter_to_local_shards(
         &self,
         epoch: Epoch,

--- a/dan_layer/core/src/storage/shard_store.rs
+++ b/dan_layer/core/src/storage/shard_store.rs
@@ -29,6 +29,7 @@ use crate::{
     models::{
         vote_message::VoteMessage,
         HotStuffTreeNode,
+        LeafNode,
         NodeHeight,
         ObjectPledge,
         Payload,
@@ -75,7 +76,8 @@ pub trait ShardStoreTransaction<TAddr: NodeAddressable, TPayload: Payload> {
     fn count_high_qc_for(&self, shard_id: ShardId) -> Result<usize, Self::Error>;
     fn update_high_qc(&mut self, from: TAddr, shard: ShardId, qc: QuorumCertificate) -> Result<(), Self::Error>;
     fn set_payload(&mut self, payload: TPayload) -> Result<(), Self::Error>;
-    fn get_leaf_node(&self, shard: ShardId) -> Result<(TreeNodeHash, NodeHeight), Self::Error>;
+    /// Returns the current leaf node for the shard, or the genesis node, height are returned.
+    fn get_leaf_node(&self, shard: ShardId) -> Result<LeafNode, Self::Error>;
     fn update_leaf_node(&mut self, shard: ShardId, node: TreeNodeHash, height: NodeHeight) -> Result<(), Self::Error>;
     fn get_high_qc_for(&self, shard: ShardId) -> Result<QuorumCertificate, Self::Error>;
     fn get_payload(&self, payload_id: &PayloadId) -> Result<TPayload, Self::Error>;

--- a/dan_layer/engine/src/runtime/tracker.rs
+++ b/dan_layer/engine/src/runtime/tracker.rs
@@ -124,7 +124,7 @@ impl StateTracker {
     pub fn mint_resource(&self, mint_arg: MintResourceArg) -> Result<ResourceAddress, RuntimeError> {
         let resource_address = self.id_provider.new_resource_address()?;
         debug!(target: LOG_TARGET, "New resource minted: {}", resource_address);
-        dbg!(&resource_address);
+        dbg!(resource_address.to_string());
         match mint_arg {
             MintResourceArg::Fungible { amount, metadata } => {
                 self.check_amount(amount)?;

--- a/dan_layer/integration_tests/src/test_consensus.rs
+++ b/dan_layer/integration_tests/src/test_consensus.rs
@@ -459,9 +459,7 @@ async fn test_hs_waiter_execute_called_when_consensus_reached() {
     instance.tx_hs_messages.send((node1.clone(), proposal3)).await.unwrap();
     let (vote, _) = instance.recv_vote_message().await;
 
-    // Execute again at h=1
-    let (executed_payload, _) = instance.recv_execute().await;
-    assert_eq!(executed_payload, payload);
+    instance.assert_no_execute().await;
 
     // loopback the vote
     instance.tx_votes.send((node1.clone(), vote.clone())).await.unwrap();


### PR DESCRIPTION
Description
---
- executes payload at payload_height 0
- extracts changes from QC for parent nodes
- adds more code comments and reorders functions in step order
- get_leaf_node returns `LeafNode` type

Motivation and Context
---
Nodes should execute at the first round of consensus (node 0) not every round.

We still execute when deciding on the vote and again before committing. I think we need to persist the pending changeset (committed to in the QC) and retrieve it later when we commit (Pending -> Commit). 

How Has This Been Tested?
---
Manually
