### PR TITLE
fix: vns should not store transactions for shards outside committee range (see issue #193)

### DIFF
--- a/applications/tari_validator_node/src/bootstrap.rs
+++ b/applications/tari_validator_node/src/bootstrap.rs
@@ -127,7 +127,12 @@ pub async fn spawn_services(
     );
 
     // Mempool
-    let mempool = mempool::spawn(rx_new_transaction_message, outbound_messaging.clone());
+    let mempool = mempool::spawn(
+        rx_new_transaction_message,
+        outbound_messaging.clone(),
+        epoch_manager.clone(),
+        node_identity.clone(),
+    );
 
     // Networking
     let peer_provider = CommsPeerProvider::new(comms.peer_manager());

--- a/applications/tari_validator_node/src/p2p/services/mempool/mod.rs
+++ b/applications/tari_validator_node/src/p2p/services/mempool/mod.rs
@@ -30,13 +30,8 @@ use thiserror::Error;
 
 mod service;
 
-// TODO: write this
 #[derive(Error, Debug)]
 pub enum MempoolError {
-    #[error("Transaction should not processed by current node")]
-    TransactionNotProcessedByCurrentVN,
-    #[error("Transaction already exists in the mempool")]
-    TransactionAlreadyExists,
     #[error("Epoch Manager Error: {0}")]
     EpochManagerError(#[from] Box<EpochManagerError>),
 }

--- a/applications/tari_validator_node/src/p2p/services/mempool/mod.rs
+++ b/applications/tari_validator_node/src/p2p/services/mempool/mod.rs
@@ -25,5 +25,13 @@ pub use initializer::spawn;
 
 mod handle;
 pub use handle::{MempoolHandle, MempoolRequest};
+use thiserror::Error;
 
 mod service;
+
+// TODO: write this
+#[derive(Error, Debug)]
+pub enum MempoolError {
+    #[error("Transaction should not processed by current node")]
+    TransactionNotProcessedByCurrentVN,
+}

--- a/applications/tari_validator_node/src/p2p/services/mempool/mod.rs
+++ b/applications/tari_validator_node/src/p2p/services/mempool/mod.rs
@@ -38,5 +38,5 @@ pub enum MempoolError {
     #[error("Transaction already exists in the mempool")]
     TransactionAlreadyExists,
     #[error("Epoch Manager Error: {0}")]
-    EpochManagerError(#[from] EpochManagerError),
+    EpochManagerError(#[from] Box<EpochManagerError>),
 }

--- a/applications/tari_validator_node/src/p2p/services/mempool/mod.rs
+++ b/applications/tari_validator_node/src/p2p/services/mempool/mod.rs
@@ -25,6 +25,7 @@ pub use initializer::spawn;
 
 mod handle;
 pub use handle::{MempoolHandle, MempoolRequest};
+use tari_dan_core::services::epoch_manager::EpochManagerError;
 use thiserror::Error;
 
 mod service;
@@ -34,4 +35,8 @@ mod service;
 pub enum MempoolError {
     #[error("Transaction should not processed by current node")]
     TransactionNotProcessedByCurrentVN,
+    #[error("Transaction already exists in the mempool")]
+    TransactionAlreadyExists,
+    #[error("Epoch Manager Error: {0}")]
+    EpochManagerError(#[from] EpochManagerError),
 }


### PR DESCRIPTION
Description
---
Validator nodes should only store transactions that contain substates to be processed within its shard range. Moreover, the validator node should only broadcast the transaction for other validator nodes in the same committee. We refactor the code to address these two issues.

Motivation and Context
---
Tackle issue #193 and broadcast transactions only for VNs in the same committee.

Fixes #193 

How Has This Been Tested?
---

