### PR TITLE
feat: add RejectReason to QuorumCertificate

### DIFF
--- a/applications/tari_validator_node/proto/dan/consensus.proto
+++ b/applications/tari_validator_node/proto/dan/consensus.proto
@@ -28,8 +28,9 @@ message ShardVote {
 
 message QuorumCertificate {
   enum QuorumDecision {
-    QUORUM_DECISION_REJECT = 0;
-    QUORUM_DECISION_ACCEPT = 1;
+    QUORUM_DECISION_ACCEPT = 0;
+    QUORUM_DECISION_REJECT_SHARD_NOT_PLEDGED = 1;
+    QUORUM_DECISION_REJECT_EXECUTION_FAILURE = 2;
   }
   bytes payload_id = 1;
   uint64 payload_height = 2;

--- a/applications/tari_validator_node/src/payload_processor.rs
+++ b/applications/tari_validator_node/src/payload_processor.rs
@@ -34,7 +34,7 @@ use tari_dan_engine::{
     transaction::TransactionProcessor,
 };
 use tari_engine_types::{
-    commit_result::FinalizeResult,
+    commit_result::{FinalizeResult, RejectReason},
     substate::{SubstateAddress, SubstateValue},
 };
 use tari_template_lib::models::{ComponentAddress, ResourceAddress, VaultId};
@@ -84,7 +84,7 @@ where TTemplateProvider: TemplateProvider
         let tx_hash = *transaction.hash();
         let result = match processor.execute(transaction) {
             Ok(result) => result,
-            Err(err) => FinalizeResult::errored(tx_hash, err.to_string()),
+            Err(err) => FinalizeResult::errored(tx_hash, RejectReason::ExecutionFailure(err.to_string())),
         };
         Ok(result)
     }

--- a/applications/tari_validator_node_cli/src/command/transaction.rs
+++ b/applications/tari_validator_node_cli/src/command/transaction.rs
@@ -287,8 +287,8 @@ fn summarize(result: &TransactionFinalizeResult) {
                 println!();
             }
         },
-        TransactionResult::Reject(ref reject) => {
-            println!("❌️ Transaction rejected: {}", reject.reason);
+        TransactionResult::Reject(ref reason) => {
+            println!("❌️ Transaction rejected: {}", reason);
         },
     }
     println!("========= Pledges =========");

--- a/dan_layer/core/src/models/mod.rs
+++ b/dan_layer/core/src/models/mod.rs
@@ -59,7 +59,7 @@ pub use hot_stuff_tree_node::HotStuffTreeNode;
 pub use leaf_node::LeafNode;
 pub use node::Node;
 pub use payload::Payload;
-pub use quorum_certificate::{QuorumCertificate, QuorumDecision};
+pub use quorum_certificate::{QuorumCertificate, QuorumDecision, QuorumRejectReason};
 pub use sidechain_metadata::SidechainMetadata;
 use tari_core::{consensus::ToConsensusBytes, ValidatorNodeMmr};
 use tari_dan_common_types::{serde_with, PayloadId, ShardId, SubstateState};

--- a/dan_layer/core/src/workers/hotstuff_error.rs
+++ b/dan_layer/core/src/workers/hotstuff_error.rs
@@ -20,6 +20,7 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+use tari_engine_types::commit_result::RejectReason;
 use thiserror::Error;
 
 use crate::{
@@ -49,7 +50,7 @@ pub enum HotStuffError {
     #[error("Payload failed to process: {0}")]
     PayloadProcessorError(#[from] PayloadProcessorError),
     #[error("Transaction rejected: {0}")]
-    TransactionRejected(String),
+    TransactionRejected(RejectReason),
     #[error("Storage Error: `{0}`")]
     StorageError(#[from] StorageError),
     #[error("Payload height is too high. Actual: {actual}, expected: {max}")]

--- a/dan_layer/core/src/workers/hotstuff_waiter.rs
+++ b/dan_layer/core/src/workers/hotstuff_waiter.rs
@@ -974,7 +974,7 @@ where
                         info!(target: LOG_TARGET, "Payload execution failure: {}", msg);
                     },
                 }
-                VoteMessage::reject(local_node, local_shard, votes)
+                VoteMessage::reject(local_node, local_shard, votes, reason)
             },
         };
 

--- a/dan_layer/integration_tests/src/test_consensus.rs
+++ b/dan_layer/integration_tests/src/test_consensus.rs
@@ -49,7 +49,7 @@ use tari_dan_core::{
 };
 use tari_dan_engine::transaction::{Transaction, TransactionBuilder};
 use tari_engine_types::{
-    commit_result::{FinalizeResult, RejectResult, TransactionResult},
+    commit_result::{FinalizeResult, RejectReason, TransactionResult},
     instruction::Instruction,
     substate::SubstateDiff,
 };
@@ -104,9 +104,7 @@ impl PayloadProcessor<TariDanPayload> for NullPayloadProcessor {
         Ok(FinalizeResult::new(
             payload.to_id().into_array().into(),
             vec![],
-            TransactionResult::Reject(RejectResult {
-                reason: "NullPayloadProcessor".to_string(),
-            }),
+            TransactionResult::Reject(RejectReason::ExecutionFailure("NullPayloadProcessor".to_string())),
         ))
     }
 }

--- a/dan_layer/template_test_tooling/src/template_test.rs
+++ b/dan_layer/template_test_tooling/src/template_test.rs
@@ -141,7 +141,7 @@ impl TemplateTest<MockRuntimeInterface> {
         let diff = result
             .result
             .accept()
-            .ok_or_else(|| panic!("Transaction was rejected: {}", result.result.reject().unwrap().reason))
+            .ok_or_else(|| panic!("Transaction was rejected: {}", result.result.reject().unwrap()))
             .unwrap();
         // It is convenient to commit the state back to the staged state store in tests.
         self.commit_diff(diff);


### PR DESCRIPTION
Description
---
* Added a new `RejectReason` enum to both `QuorumCertificate` and `VoteMessage`.
* Added a reject reason also to the result of a transaction execution

Motivation and Context
---
Currently only a decision `Accept` or `Reject` is attached to a `QuorumCertificate` (and `VoteMessage`). We want to be able to differentiate different reject reasons:
* Shard was not pledged
* Payload execution failure

Solves https://github.com/tari-project/tari-dan/issues/207

How Has This Been Tested?
---
Unit and integration tests pass
