### PR TITLE
fix: add all_shard_nodes to signature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5757,6 +5757,7 @@ dependencies = [
  "async-trait",
  "bincode",
  "blake2 0.9.2",
+ "borsh",
  "chrono",
  "clap 3.2.23",
  "digest 0.9.0",

--- a/dan_layer/common_types/src/lib.rs
+++ b/dan_layer/common_types/src/lib.rs
@@ -23,7 +23,7 @@ use tari_engine_types::substate::{Substate, SubstateAddress};
 use tari_utilities::{byte_array::ByteArray, hex::Hex};
 pub use template_id::TemplateId;
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize, BorshSerialize)]
 pub struct ShardId(#[serde(with = "serde_with::hex")] pub [u8; 32]);
 
 impl ShardId {

--- a/dan_layer/core/Cargo.toml
+++ b/dan_layer/core/Cargo.toml
@@ -29,6 +29,7 @@ tari_engine_types = { path = "../engine_types" }
 anyhow = "1.0.53"
 async-trait = "0.1.50"
 blake2 = "0.9.2"
+borsh = "0.9.3"
 bincode = "1.0"
 chrono = { version = "0.4.19", default-features = false }
 clap = "3.1.8"

--- a/dan_layer/core/src/models/mod.rs
+++ b/dan_layer/core/src/models/mod.rs
@@ -28,6 +28,7 @@ use std::{
 };
 
 use anyhow::anyhow;
+use borsh::BorshSerialize;
 use serde::{Deserialize, Serialize};
 use tari_common_types::types::{FixedHash, PrivateKey, PublicKey, Signature};
 
@@ -73,7 +74,7 @@ pub use view_id::ViewId;
 
 use crate::services::infrastructure_services::NodeAddressable;
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Deserialize, Serialize)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Deserialize, Serialize, BorshSerialize)]
 pub struct NodeHeight(pub u64);
 
 impl NodeHeight {
@@ -112,7 +113,7 @@ impl Display for NodeHeight {
     }
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize, BorshSerialize)]
 pub struct ObjectPledge {
     pub shard_id: ShardId,
     pub current_state: SubstateState,
@@ -317,7 +318,7 @@ impl From<u64> for ChainHeight {
     }
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize, BorshSerialize)]
 pub struct ShardVote {
     pub shard_id: ShardId,
     pub node_hash: TreeNodeHash,

--- a/dan_layer/core/src/models/tree_node_hash.rs
+++ b/dan_layer/core/src/models/tree_node_hash.rs
@@ -23,8 +23,10 @@
 use std::{
     convert::TryFrom,
     fmt::{Display, Formatter},
+    io::{self, Write},
 };
 
+use borsh::BorshSerialize;
 use digest::{consts::U32, generic_array};
 use serde::{Deserialize, Serialize};
 use tari_common_types::types::{FixedHash, FixedHashSizeError};
@@ -33,6 +35,13 @@ use tari_utilities::hex::{Hex, HexError};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Deserialize, Serialize)]
 pub struct TreeNodeHash(#[serde(with = "serde_with::hex")] FixedHash);
+
+// TODO: remove this implementation once the Borsh is on FixedHash
+impl BorshSerialize for TreeNodeHash {
+    fn serialize<W: Write>(&self, writer: &mut W) -> io::Result<()> {
+        BorshSerialize::serialize(&self.as_bytes(), writer)
+    }
+}
 
 impl TreeNodeHash {
     pub fn zero() -> Self {


### PR DESCRIPTION
Description
---
Add `all_shard_nodes` to VoteMessage signature. There should be a little clean up once with switch from `Consensus` to `Borsh` .