### PR TITLE
fix: fix VN merkle root mismatch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2003,6 +2003,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_logger"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
+dependencies = [
+ "atty",
+ "humantime",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
 name = "errno"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5400,6 +5413,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "tari_bor"
+version = "0.1.0"
+dependencies = [
+ "borsh",
+]
+
+[[package]]
 name = "tari_bulletproofs"
 version = "4.3.0"
 source = "git+https://github.com/tari-project/bulletproofs?tag=v4.3.0#02d5cb51d7fdaabf0e2523d45afed8b3d206c402"
@@ -5735,10 +5755,11 @@ name = "tari_dan_common_types"
 version = "0.35.1"
 dependencies = [
  "base64 0.20.0-alpha.1",
- "borsh",
+ "digest 0.9.0",
  "prost",
  "prost-types",
  "serde",
+ "tari_bor",
  "tari_common",
  "tari_common_types",
  "tari_crypto",
@@ -5769,6 +5790,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_json",
+ "tari_bor",
  "tari_common",
  "tari_common_types",
  "tari_comms",
@@ -5799,7 +5821,6 @@ name = "tari_dan_engine"
 version = "0.35.1"
 dependencies = [
  "anyhow",
- "borsh",
  "cargo_toml",
  "d3ne",
  "digest 0.9.0",
@@ -5807,6 +5828,7 @@ dependencies = [
  "rand 0.7.3",
  "serde",
  "serde_json",
+ "tari_bor",
  "tari_common",
  "tari_common_types",
  "tari_crypto",
@@ -5874,6 +5896,7 @@ dependencies = [
 name = "tari_dan_tests"
 version = "0.35.1"
 dependencies = [
+ "env_logger",
  "lazy_static",
  "rand 0.7.3",
  "tari_common",
@@ -5898,9 +5921,9 @@ dependencies = [
 name = "tari_engine_types"
 version = "0.1.0"
 dependencies = [
- "borsh",
  "digest 0.9.0",
  "serde",
+ "tari_bor",
  "tari_common_types",
  "tari_crypto",
  "tari_template_abi",
@@ -6057,18 +6080,18 @@ dependencies = [
 name = "tari_template_abi"
 version = "0.35.1"
 dependencies = [
- "borsh",
+ "tari_bor",
 ]
 
 [[package]]
 name = "tari_template_lib"
 version = "0.35.1"
 dependencies = [
- "borsh",
  "hex",
  "newtype-ops",
  "serde",
  "serde_json",
+ "tari_bor",
  "tari_template_abi",
  "tari_template_macros",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "dan_layer/transaction_manifest",
     "dan_layer/template_test_tooling",
     "dan_layer/integration_tests",
+    "dan_layer/tari_bor",
     "applications/tari_validator_node",
     "applications/tari_validator_node_cli",
 ]

--- a/applications/tari_validator_node/proto/dan/consensus.proto
+++ b/applications/tari_validator_node/proto/dan/consensus.proto
@@ -5,6 +5,7 @@ syntax = "proto3";
 
 package tari.dan.consensus;
 
+import "common.proto";
 import "transaction.proto";
 
 enum HotStuffMessageType {
@@ -58,9 +59,10 @@ message HotStuffTreeNode {
 
 message ValidatorMetadata {
   bytes public_key = 1;
-  bytes signature = 2;
-  bytes merkle_proof = 3;
-  uint64 merkle_leaf_index = 4;
+  bytes shard_id = 2;
+  tari.dan.common.Signature signature = 3;
+  bytes merkle_proof = 4;
+  uint64 merkle_leaf_index = 5;
 }
 
 message TariDanPayload {

--- a/applications/tari_validator_node/proto/dan/consensus.proto
+++ b/applications/tari_validator_node/proto/dan/consensus.proto
@@ -59,7 +59,7 @@ message HotStuffTreeNode {
 
 message ValidatorMetadata {
   bytes public_key = 1;
-  bytes shard_id = 2;
+  bytes vn_shard_key = 2;
   tari.dan.common.Signature signature = 3;
   bytes merkle_proof = 4;
   uint64 merkle_leaf_index = 5;

--- a/applications/tari_validator_node/src/grpc/services/base_node_client.rs
+++ b/applications/tari_validator_node/src/grpc/services/base_node_client.rs
@@ -101,7 +101,7 @@ impl BaseNodeClient for GrpcBaseNodeClient {
         })
     }
 
-    async fn get_validator_nodes(&mut self, height: u64) -> Result<Vec<ValidatorNode>, BaseNodeError> {
+    async fn get_validator_nodes(&mut self, height: u64) -> Result<Vec<ValidatorNode<CommsPublicKey>>, BaseNodeError> {
         let inner = self.connection().await?;
         let request = grpc::GetActiveValidatorNodesRequest { height };
         let mut vns = vec![];

--- a/applications/tari_validator_node/src/p2p/proto/conversions/consensus.rs
+++ b/applications/tari_validator_node/src/p2p/proto/conversions/consensus.rs
@@ -306,7 +306,7 @@ impl From<ValidatorMetadata> for proto::consensus::ValidatorMetadata {
         let merkle_proof = msg.encode_merkle_proof();
         Self {
             public_key: msg.public_key.to_vec(),
-            shard_id: msg.shard_id.as_bytes().to_vec(),
+            vn_shard_key: msg.vn_shard_key.as_bytes().to_vec(),
             signature: Some(msg.signature.into()),
             merkle_proof,
             merkle_leaf_index: msg.merkle_leaf_index,
@@ -320,14 +320,14 @@ impl TryFrom<proto::consensus::ValidatorMetadata> for ValidatorMetadata {
     fn try_from(value: proto::consensus::ValidatorMetadata) -> Result<Self, Self::Error> {
         Ok(ValidatorMetadata {
             public_key: PublicKey::from_bytes(&value.public_key)?,
-            shard_id: value.shard_id.try_into()?,
+            vn_shard_key: value.vn_shard_key.try_into()?,
             signature: value
                 .signature
                 .map(TryFrom::try_from)
                 .transpose()?
                 .ok_or_else(|| anyhow!("ValidatorMetadata missing signature"))?,
             merkle_proof: ValidatorMetadata::decode_merkle_proof(&value.merkle_proof)?,
-            merkle_leaf_index: 0,
+            merkle_leaf_index: value.merkle_leaf_index,
         })
     }
 }

--- a/applications/tari_validator_node/src/p2p/proto/conversions/consensus.rs
+++ b/applications/tari_validator_node/src/p2p/proto/conversions/consensus.rs
@@ -54,7 +54,7 @@ impl From<VoteMessage> for proto::consensus::VoteMessage {
             shard_id: msg.shard().as_bytes().to_vec(),
             decision: i32::from(msg.decision().as_u8()),
             all_shard_nodes: msg.all_shard_nodes().iter().map(|n| n.clone().into()).collect(),
-            validator_metadata: Some(msg.validator_metadata().to_owned().into()),
+            validator_metadata: Some(msg.validator_metadata().clone().into()),
         }
     }
 }
@@ -63,6 +63,9 @@ impl TryFrom<proto::consensus::VoteMessage> for VoteMessage {
     type Error = anyhow::Error;
 
     fn try_from(value: proto::consensus::VoteMessage) -> Result<Self, Self::Error> {
+        let metadata = value
+            .validator_metadata
+            .ok_or_else(|| anyhow!("Validator metadata is missing"))?;
         Ok(VoteMessage::with_validator_metadata(
             TreeNodeHash::try_from(value.local_node_hash)?,
             ShardId::from_bytes(&value.shard_id)?,
@@ -72,17 +75,7 @@ impl TryFrom<proto::consensus::VoteMessage> for VoteMessage {
                 .into_iter()
                 .map(|n| n.try_into())
                 .collect::<Result<Vec<_>, _>>()?,
-            ValidatorMetadata::from_bytes(
-                &value.validator_metadata.as_ref().unwrap().public_key,
-                &value.validator_metadata.as_ref().unwrap().signature,
-                &value.validator_metadata.as_ref().unwrap().merkle_proof,
-                &value
-                    .validator_metadata
-                    .as_ref()
-                    .unwrap()
-                    .merkle_leaf_index
-                    .to_le_bytes(),
-            )?,
+            metadata.try_into()?,
         ))
     }
 }
@@ -308,27 +301,34 @@ impl From<SubstateState> for proto::consensus::SubstateState {
 
 // -------------------------------- ValidatorMetadata -------------------------------- //
 
+impl From<ValidatorMetadata> for proto::consensus::ValidatorMetadata {
+    fn from(msg: ValidatorMetadata) -> Self {
+        let merkle_proof = msg.encode_merkle_proof();
+        Self {
+            public_key: msg.public_key.to_vec(),
+            shard_id: msg.shard_id.as_bytes().to_vec(),
+            signature: Some(msg.signature.into()),
+            merkle_proof,
+            merkle_leaf_index: msg.merkle_leaf_index,
+        }
+    }
+}
+
 impl TryFrom<proto::consensus::ValidatorMetadata> for ValidatorMetadata {
     type Error = anyhow::Error;
 
     fn try_from(value: proto::consensus::ValidatorMetadata) -> Result<Self, Self::Error> {
-        Ok(Self {
-            public_key: value.public_key,
-            signature: value.signature,
-            merkle_proof: value.merkle_proof,
-            merkle_leaf_index: value.merkle_leaf_index,
+        Ok(ValidatorMetadata {
+            public_key: PublicKey::from_bytes(&value.public_key)?,
+            shard_id: value.shard_id.try_into()?,
+            signature: value
+                .signature
+                .map(TryFrom::try_from)
+                .transpose()?
+                .ok_or_else(|| anyhow!("ValidatorMetadata missing signature"))?,
+            merkle_proof: ValidatorMetadata::decode_merkle_proof(&value.merkle_proof)?,
+            merkle_leaf_index: 0,
         })
-    }
-}
-
-impl From<ValidatorMetadata> for proto::consensus::ValidatorMetadata {
-    fn from(value: ValidatorMetadata) -> Self {
-        Self {
-            public_key: value.public_key,
-            signature: value.signature,
-            merkle_proof: value.merkle_proof,
-            merkle_leaf_index: value.merkle_leaf_index,
-        }
     }
 }
 

--- a/applications/tari_validator_node/src/p2p/services/epoch_manager/base_layer_epoch_manager.rs
+++ b/applications/tari_validator_node/src/p2p/services/epoch_manager/base_layer_epoch_manager.rs
@@ -241,6 +241,7 @@ impl BaseLayerEpochManager {
     }
 
     pub async fn get_shard_id(&mut self, epoch: Epoch, public_key: &PublicKey) -> Result<ShardId, EpochManagerError> {
+        // TODO: Cache the assigned shard key for the epoch (ideally the epoch validity range)
         let shard_id = self
             .base_node_client
             .get_shard_key(epoch.to_height(), public_key)

--- a/applications/tari_validator_node/src/p2p/services/epoch_manager/epoch_manager_service.rs
+++ b/applications/tari_validator_node/src/p2p/services/epoch_manager/epoch_manager_service.rs
@@ -65,6 +65,11 @@ pub enum EpochManagerRequest {
     CurrentEpoch {
         reply: Reply<Epoch>,
     },
+    GetShardId {
+        epoch: Epoch,
+        addr: CommsPublicKey,
+        reply: Reply<ShardId>,
+    },
     UpdateEpoch {
         tip_info: BaseLayerMetadata,
         reply: Reply<()>,
@@ -92,7 +97,7 @@ pub enum EpochManagerRequest {
     },
     GetValidatorNodesPerEpoch {
         epoch: Epoch,
-        reply: Reply<Vec<ValidatorNode>>,
+        reply: Reply<Vec<ValidatorNode<CommsPublicKey>>>,
     },
     GetValidatorNodeMmr {
         epoch: Epoch,
@@ -175,6 +180,9 @@ impl EpochManagerService {
     async fn handle_request(&mut self, req: EpochManagerRequest) {
         match req {
             EpochManagerRequest::CurrentEpoch { reply } => handle(reply, Ok(self.inner.current_epoch())),
+            EpochManagerRequest::GetShardId { epoch, addr, reply } => {
+                handle(reply, self.inner.get_shard_id(epoch, &addr).await)
+            },
             EpochManagerRequest::UpdateEpoch { tip_info, reply } => {
                 handle(reply, self.inner.update_epoch(tip_info).await);
             },

--- a/applications/tari_validator_node/src/p2p/services/epoch_manager/epoch_manager_service.rs
+++ b/applications/tari_validator_node/src/p2p/services/epoch_manager/epoch_manager_service.rs
@@ -65,7 +65,7 @@ pub enum EpochManagerRequest {
     CurrentEpoch {
         reply: Reply<Epoch>,
     },
-    GetShardId {
+    GetValidatorShardKey {
         epoch: Epoch,
         addr: CommsPublicKey,
         reply: Reply<ShardId>,
@@ -180,8 +180,8 @@ impl EpochManagerService {
     async fn handle_request(&mut self, req: EpochManagerRequest) {
         match req {
             EpochManagerRequest::CurrentEpoch { reply } => handle(reply, Ok(self.inner.current_epoch())),
-            EpochManagerRequest::GetShardId { epoch, addr, reply } => {
-                handle(reply, self.inner.get_shard_id(epoch, &addr).await)
+            EpochManagerRequest::GetValidatorShardKey { epoch, addr, reply } => {
+                handle(reply, self.inner.get_validator_shard_key(epoch, &addr))
             },
             EpochManagerRequest::UpdateEpoch { tip_info, reply } => {
                 handle(reply, self.inner.update_epoch(tip_info).await);

--- a/applications/tari_validator_node/src/p2p/services/epoch_manager/handle.rs
+++ b/applications/tari_validator_node/src/p2p/services/epoch_manager/handle.rs
@@ -91,10 +91,10 @@ impl EpochManager<CommsPublicKey> for EpochManagerHandle {
         rx.await.map_err(|_| EpochManagerError::ReceiveError)?
     }
 
-    async fn get_shard_id(&self, epoch: Epoch, addr: CommsPublicKey) -> Result<ShardId, EpochManagerError> {
+    async fn get_validator_shard_key(&self, epoch: Epoch, addr: CommsPublicKey) -> Result<ShardId, EpochManagerError> {
         let (tx, rx) = oneshot::channel();
         self.tx_request
-            .send(EpochManagerRequest::GetShardId { epoch, addr, reply: tx })
+            .send(EpochManagerRequest::GetValidatorShardKey { epoch, addr, reply: tx })
             .await
             .map_err(|_| EpochManagerError::SendError)?;
 

--- a/applications/tari_validator_node/src/p2p/services/epoch_manager/handle.rs
+++ b/applications/tari_validator_node/src/p2p/services/epoch_manager/handle.rs
@@ -91,6 +91,16 @@ impl EpochManager<CommsPublicKey> for EpochManagerHandle {
         rx.await.map_err(|_| EpochManagerError::ReceiveError)?
     }
 
+    async fn get_shard_id(&self, epoch: Epoch, addr: CommsPublicKey) -> Result<ShardId, EpochManagerError> {
+        let (tx, rx) = oneshot::channel();
+        self.tx_request
+            .send(EpochManagerRequest::GetShardId { epoch, addr, reply: tx })
+            .await
+            .map_err(|_| EpochManagerError::SendError)?;
+
+        rx.await.map_err(|_| EpochManagerError::ReceiveError)?
+    }
+
     async fn is_epoch_valid(&self, epoch: Epoch) -> Result<bool, EpochManagerError> {
         let (tx, rx) = oneshot::channel();
         self.tx_request
@@ -176,7 +186,10 @@ impl EpochManager<CommsPublicKey> for EpochManagerHandle {
         rx.await.map_err(|_| EpochManagerError::ReceiveError)?
     }
 
-    async fn get_validator_nodes_per_epoch(&self, epoch: Epoch) -> Result<Vec<ValidatorNode>, EpochManagerError> {
+    async fn get_validator_nodes_per_epoch(
+        &self,
+        epoch: Epoch,
+    ) -> Result<Vec<ValidatorNode<CommsPublicKey>>, EpochManagerError> {
         let (tx, rx) = oneshot::channel();
         self.tx_request
             .send(EpochManagerRequest::GetValidatorNodesPerEpoch { epoch, reply: tx })

--- a/applications/tari_validator_node/src/p2p/services/epoch_manager/mod.rs
+++ b/applications/tari_validator_node/src/p2p/services/epoch_manager/mod.rs
@@ -32,7 +32,10 @@ pub use initializer::spawn;
 use tari_dan_common_types::ShardId;
 use tari_dan_core::models::ValidatorNode;
 
-fn get_committee_shard_range(committee_size: usize, committee_vns: &[ValidatorNode]) -> RangeInclusive<ShardId> {
+fn get_committee_shard_range<TAddr>(
+    committee_size: usize,
+    committee_vns: &[ValidatorNode<TAddr>],
+) -> RangeInclusive<ShardId> {
     // TODO: add this committee_size to ConsensusConstants
     if committee_vns.len() < committee_size {
         let min_shard_id = ShardId::zero();

--- a/applications/tari_validator_node/src/p2p/services/epoch_manager/sync_peers.rs
+++ b/applications/tari_validator_node/src/p2p/services/epoch_manager/sync_peers.rs
@@ -23,6 +23,7 @@
 use std::convert::TryFrom;
 
 use futures::StreamExt;
+use tari_comms::types::CommsPublicKey;
 use tari_dan_common_types::{PayloadId, ShardId, SubstateState};
 use tari_dan_core::{
     models::{NodeHeight, QuorumCertificate, SubstateShardData, TreeNodeHash, ValidatorNode},
@@ -59,7 +60,7 @@ impl PeerSyncManagerService {
 
     pub(crate) async fn sync_peers_state(
         &self,
-        committee_vns: Vec<ValidatorNode>,
+        committee_vns: Vec<ValidatorNode<CommsPublicKey>>,
         start_shard_id: ShardId,
         end_shard_id: ShardId,
         vn_shard_key: ShardId,

--- a/applications/tari_validator_node/src/p2p/services/hotstuff/hotstuff_service.rs
+++ b/applications/tari_validator_node/src/p2p/services/hotstuff/hotstuff_service.rs
@@ -33,6 +33,7 @@ use tari_dan_core::{
         epoch_manager::EpochManager,
         infrastructure_services::OutboundService,
         leader_strategy::AlwaysFirstLeader,
+        NodeIdentitySigningService,
     },
     workers::{
         events::{EventSubscription, HotStuffEvent},
@@ -79,7 +80,6 @@ pub struct HotstuffService {
 impl HotstuffService {
     pub fn spawn(
         node_identity: Arc<NodeIdentity>,
-        node_public_key: CommsPublicKey,
         epoch_manager: EpochManagerHandle,
         mempool: MempoolHandle,
         outbound: OutboundMessaging,
@@ -100,8 +100,12 @@ impl HotstuffService {
 
         let consensus_constants = ConsensusConstants::devnet();
 
+        let node_public_key = node_identity.public_key().clone();
+
         HotStuffWaiter::spawn(
-            node_identity,
+            NodeIdentitySigningService::new(node_identity),
+            // TODO: we still need this because The signing service is not generic. Abstracting signatures and public
+            // keys may add a lot of type complexity.
             node_public_key.clone(),
             epoch_manager.clone(),
             leader_strategy,

--- a/applications/tari_validator_node/src/p2p/services/hotstuff/initializer.rs
+++ b/applications/tari_validator_node/src/p2p/services/hotstuff/initializer.rs
@@ -57,8 +57,7 @@ pub fn try_spawn(
     let db = SqliteShardStoreFactory::try_create(config.data_dir.join("state.db"))?;
 
     let events = HotstuffService::spawn(
-        node_identity.clone(),
-        node_identity.public_key().clone(),
+        node_identity,
         epoch_manager,
         mempool,
         outbound,

--- a/applications/tari_validator_node_cli/src/command/manifest.rs
+++ b/applications/tari_validator_node_cli/src/command/manifest.rs
@@ -1,5 +1,5 @@
 //   Copyright 2022 The Tari Project
-//   SPDX-License-Identifier: BSD-3-Claus
+//   SPDX-License-Identifier: BSD-3-clause
 
 use std::{
     collections::HashMap,

--- a/applications/tari_validator_node_cli/src/command/manifest.template.rs
+++ b/applications/tari_validator_node_cli/src/command/manifest.template.rs
@@ -1,5 +1,5 @@
 //   Copyright 2022 The Tari Project
-//   SPDX-License-Identifier: BSD-3-Claus
+//   SPDX-License-Identifier: BSD-3-clause
 
 // TODO: Improve this template
 use template_bc617551fc331bb5ebc12943c1456dbf8fbd0ae4e950b2ffc28a6b89ce040382 as Account;

--- a/applications/tari_validator_node_cli/src/command/transaction.rs
+++ b/applications/tari_validator_node_cli/src/command/transaction.rs
@@ -25,6 +25,7 @@ use std::{
     str::FromStr,
 };
 
+use anyhow::anyhow;
 use clap::{Args, Subcommand};
 use tari_dan_common_types::{ShardId, SubstateChange};
 use tari_dan_engine::transaction::Transaction;
@@ -159,7 +160,7 @@ async fn handle_submit_manifest(
     base_dir: impl AsRef<Path>,
     client: &mut ValidatorNodeClient,
 ) -> Result<(), anyhow::Error> {
-    let contents = std::fs::read_to_string(&args.manifest)?;
+    let contents = std::fs::read_to_string(&args.manifest).map_err(|e| anyhow!("Failed to read manifest: {}", e))?;
     let instructions = parse_manifest(&contents, manifest::parse_globals(args.globals)?)?;
     // TODO: improve output
     println!("Instructions: {:?}", instructions);

--- a/dan_layer/common_types/Cargo.toml
+++ b/dan_layer/common_types/Cargo.toml
@@ -12,9 +12,10 @@ tari_common_types = { git = "https://github.com/tari-project/tari.git", branch =
 tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.7" }
 tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.15.7" }
 tari_engine_types = { path = "../engine_types"}
+tari_bor = { path = "../tari_bor" }
 
 base64 = "0.20.0-alpha.1"
-borsh = "0.9.3"
+digest = "0.9"
 serde = "1.0.126"
 prost = "0.9"
 prost-types = "0.9"

--- a/dan_layer/common_types/src/hashing.rs
+++ b/dan_layer/common_types/src/hashing.rs
@@ -1,3 +1,6 @@
+//   Copyright 2022 The Tari Project
+//   SPDX-License-Identifier: BSD-3-clause
+
 //  Copyright 2022. The Tari Project
 //
 //  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
@@ -24,24 +27,22 @@ use std::{io, io::Write};
 
 use digest::Digest;
 use tari_bor::{encode_into, Encode};
-use tari_crypto::{hash::blake2::Blake256, hash_domain, hashing::DomainSeparation};
-use tari_template_lib::Hash;
+use tari_common_types::types::FixedHash;
+use tari_crypto::{hash::blake2::Blake256, hashing::DomainSeparation};
 
-hash_domain!(TariEngineHashDomain, "tari.dan.engine", 0);
-
-pub fn hasher(label: &'static str) -> TariEngineHasher {
-    TariEngineHasher::new_with_label(label)
+pub fn tari_hasher<D: DomainSeparation>(label: &'static str) -> TariHasher {
+    TariHasher::new_with_label::<D>(label)
 }
 
 #[derive(Debug, Clone)]
-pub struct TariEngineHasher {
+pub struct TariHasher {
     hasher: Blake256,
 }
 
-impl TariEngineHasher {
-    pub fn new_with_label(label: &'static str) -> Self {
+impl TariHasher {
+    pub fn new_with_label<D: DomainSeparation>(label: &'static str) -> Self {
         let mut hasher = Blake256::new();
-        TariEngineHashDomain::add_domain_separation_tag(&mut hasher, label);
+        D::add_domain_separation_tag(&mut hasher, label);
         Self { hasher }
     }
 
@@ -58,11 +59,11 @@ impl TariEngineHasher {
         self
     }
 
-    pub fn digest<T: Encode + ?Sized>(self, data: &T) -> Hash {
+    pub fn digest<T: Encode + ?Sized>(self, data: &T) -> FixedHash {
         self.chain(data).result()
     }
 
-    pub fn result(self) -> Hash {
+    pub fn result(self) -> FixedHash {
         let hash: [u8; 32] = self.hasher.finalize().into();
         hash.into()
     }

--- a/dan_layer/common_types/src/lib.rs
+++ b/dan_layer/common_types/src/lib.rs
@@ -5,6 +5,7 @@ pub mod proto;
 pub mod storage;
 
 mod epoch;
+pub mod hashing;
 pub mod optional;
 pub mod serde_with;
 mod template_id;
@@ -17,8 +18,8 @@ use std::{
 };
 
 use ::serde::{Deserialize, Serialize};
-use borsh::{BorshDeserialize, BorshSerialize};
 pub use epoch::Epoch;
+use tari_bor::{borsh, Decode, Encode};
 use tari_common_types::types::{FixedHash, FixedHashSizeError};
 use tari_engine_types::substate::{Substate, SubstateAddress};
 use tari_utilities::{
@@ -27,7 +28,7 @@ use tari_utilities::{
 };
 pub use template_id::TemplateId;
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize, BorshSerialize)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize, Encode)]
 pub struct ShardId(#[serde(with = "serde_with::hex")] pub [u8; 32]);
 
 impl ShardId {
@@ -94,6 +95,12 @@ impl TryFrom<&[u8]> for ShardId {
     }
 }
 
+impl AsRef<[u8]> for ShardId {
+    fn as_ref(&self) -> &[u8] {
+        self.as_bytes()
+    }
+}
+
 impl PartialOrd for ShardId {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         self.0.partial_cmp(&other.0)
@@ -132,7 +139,7 @@ pub enum SubstateChange {
     Destroy,
 }
 
-#[derive(Debug, Clone, BorshSerialize, BorshDeserialize, Deserialize, Serialize)]
+#[derive(Debug, Clone, Encode, Decode, Deserialize, Serialize)]
 pub enum SubstateState {
     DoesNotExist,
     Up { created_by: PayloadId, data: Substate },
@@ -159,7 +166,7 @@ impl ObjectClaim {
     }
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, BorshSerialize, BorshDeserialize, Deserialize, Serialize)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Encode, Decode, Deserialize, Serialize)]
 pub struct PayloadId {
     #[serde(with = "serde_with::hex")]
     id: [u8; 32],

--- a/dan_layer/core/Cargo.toml
+++ b/dan_layer/core/Cargo.toml
@@ -25,6 +25,7 @@ tari_dan_engine = { path = "../engine" }
 tari_template_lib = { path = "../template_lib" }
 tari_dan_storage = { path = "../storage" }
 tari_engine_types = { path = "../engine_types" }
+tari_bor = { path = "../tari_bor" }
 
 anyhow = "1.0.53"
 async-trait = "0.1.50"

--- a/dan_layer/core/src/lib.rs
+++ b/dan_layer/core/src/lib.rs
@@ -21,7 +21,9 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #![allow(clippy::too_many_arguments)]
 mod digital_assets_error;
+
 pub use digital_assets_error::DigitalAssetError;
+use tari_crypto::hash_domain;
 
 pub mod consensus_constants;
 pub mod message;
@@ -31,3 +33,5 @@ pub mod storage;
 pub mod template_command;
 pub mod types;
 pub mod workers;
+
+hash_domain!(TariDanCoreHashDomain, "tari.dan.core", 0);

--- a/dan_layer/core/src/models/committee.rs
+++ b/dan_layer/core/src/models/committee.rs
@@ -25,7 +25,7 @@ use serde::Serialize;
 use crate::{models::ViewId, services::infrastructure_services::NodeAddressable};
 
 #[derive(Debug, Clone, Serialize)]
-pub struct Committee<TAddr: NodeAddressable> {
+pub struct Committee<TAddr> {
     // TODO: encapsulate
     pub members: Vec<TAddr>,
 }

--- a/dan_layer/core/src/models/hot_stuff_tree_node.rs
+++ b/dan_layer/core/src/models/hot_stuff_tree_node.rs
@@ -102,7 +102,7 @@ impl<TAddr: NodeAddressable, TPayload: Payload> HotStuffTreeNode<TAddr, TPayload
             .chain(self.parent.as_bytes())
             .chain(self.epoch.to_le_bytes())
             .chain(self.height.to_le_bytes())
-            .chain(self.justify.as_bytes())
+            .chain(self.justify.to_hash())
             .chain(self.shard.to_le_bytes())
             .chain(self.payload_id.as_slice())
             .chain(self.payload_height.to_le_bytes())

--- a/dan_layer/core/src/models/mod.rs
+++ b/dan_layer/core/src/models/mod.rs
@@ -22,15 +22,17 @@
 
 use std::{
     cmp::Ordering,
-    convert::{Infallible, TryFrom},
+    convert::TryFrom,
     fmt::{Debug, Display, Formatter},
+    io,
     ops::Add,
 };
 
 use anyhow::anyhow;
 use borsh::BorshSerialize;
+use digest::Digest;
 use serde::{Deserialize, Serialize};
-use tari_common_types::types::{FixedHash, PrivateKey, PublicKey, Signature};
+use tari_common_types::types::{FixedHash, PublicKey, Signature};
 
 mod base_layer_metadata;
 mod base_layer_output;
@@ -62,7 +64,7 @@ pub use node::Node;
 pub use payload::Payload;
 pub use quorum_certificate::{QuorumCertificate, QuorumDecision, QuorumRejectReason};
 pub use sidechain_metadata::SidechainMetadata;
-use tari_core::{consensus::ToConsensusBytes, ValidatorNodeMmr};
+use tari_crypto::hash::blake2::Blake256;
 use tari_dan_common_types::{serde_with, PayloadId, ShardId, SubstateState};
 pub use tari_dan_payload::{CheckpointData, TariDanPayload};
 use tari_mmr::MerkleProof;
@@ -227,80 +229,67 @@ pub enum ConsensusWorkerState {
 
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct ValidatorMetadata {
+    pub public_key: PublicKey,
     #[serde(with = "serde_with::hex")]
-    pub public_key: Vec<u8>,
-    #[serde(with = "serde_with::hex")]
-    pub signature: Vec<u8>,
-    #[serde(with = "serde_with::hex")]
-    pub merkle_proof: Vec<u8>,
+    pub shard_id: ShardId,
+    pub signature: Signature,
+    pub merkle_proof: MerkleProof,
     pub merkle_leaf_index: u64,
 }
 
 impl ValidatorMetadata {
     pub fn new(
-        public_key: &PublicKey,
-        secret_key: &PrivateKey,
-        secret_nonce: PrivateKey,
-        challenge: &[u8],
-        vn_mmr: &ValidatorNodeMmr,
-        vn_mmr_leaf_index: u64,
+        public_key: PublicKey,
+        shard_id: ShardId,
+        signature: Signature,
+        merkle_proof: MerkleProof,
+        merkle_leaf_index: u64,
     ) -> Self {
-        let public_key_bytes = ByteArray::as_bytes(public_key);
-
-        // calculate the signature
-        let signature = Signature::sign(secret_key.clone(), secret_nonce, &*challenge)
-            .expect("Sign cannot fail with 32-byte challenge and a RistrettoPublicKey");
-
-        // construct the merkle proof for the inclusion of the VN's public key in the epoch
-        let leaf_pos = vn_mmr
-            .find_leaf_index(public_key_bytes)
-            .expect("Unexpected Merkle Mountain Range error")
-            .expect("The VN's public key is not listed for the epoch");
-        let merkle_proof =
-            MerkleProof::for_leaf_node(vn_mmr, leaf_pos as usize).expect("Merkle proof generation failed");
-        let merkle_proof_bytes = bincode::serialize(&merkle_proof).expect("Merkle proof serialization failed");
-
         Self {
-            public_key: public_key_bytes.to_vec(),
-            signature: signature.to_consensus_bytes(),
-            merkle_proof: merkle_proof_bytes,
-            merkle_leaf_index: vn_mmr_leaf_index,
+            public_key,
+            shard_id,
+            signature,
+            merkle_proof,
+            merkle_leaf_index,
         }
     }
 
-    // TODO: implement from bytes with correct error
-    pub fn from_bytes(
-        public_key_bytes: &[u8],
-        signature_bytes: &[u8],
-        merkle_proof_bytes: &[u8],
-        merkle_proof_index_bytes: &[u8],
-    ) -> Result<Self, Infallible> {
-        // TODO: handle possible deserialization errors
-        let mut buf = [0u8; 8];
-        buf.copy_from_slice(merkle_proof_index_bytes);
-        let merkle_leaf_index = u64::from_le_bytes(buf);
-
-        Ok(Self {
-            public_key: Vec::from(public_key_bytes),
-            signature: Vec::from(signature_bytes),
-            merkle_proof: Vec::from(merkle_proof_bytes),
-            merkle_leaf_index,
-        })
+    pub fn get_node_hash(&self) -> FixedHash {
+        // Each node is defined as H(V_i || S_i)
+        vn_mmr_node_hash(&self.public_key, &self.shard_id)
     }
 
-    pub fn combine(&self, other: &ValidatorMetadata) -> ValidatorMetadata {
-        other.clone()
+    // TODO: impl Borsh for merkle proof
+    pub fn encode_merkle_proof(&self) -> Vec<u8> {
+        bincode::serialize(&self.merkle_proof).unwrap()
     }
 
+    // TODO: impl Borsh for merkle proof
+    pub fn decode_merkle_proof(bytes: &[u8]) -> Result<MerkleProof, io::Error> {
+        // Map to an io error because borsh uses that
+        bincode::deserialize(bytes).map_err(|e| io::Error::new(io::ErrorKind::Other, e))
+    }
+
+    // TODO: once this type implements borsh we can use the consensus hashing to hash this type directly
     pub fn to_bytes(&self) -> Vec<u8> {
         [
-            self.public_key.clone(),
-            self.signature.clone(),
-            self.merkle_proof.clone(),
+            self.public_key.to_vec(),
+            self.shard_id.as_bytes().to_vec(),
+            self.signature.get_public_nonce().to_vec(),
+            self.signature.get_signature().to_vec(),
+            self.encode_merkle_proof(),
             self.merkle_leaf_index.to_le_bytes().to_vec(),
         ]
         .concat()
     }
+}
+
+pub fn vn_mmr_node_hash<TAddr: NodeAddressable>(public_key: &TAddr, shard_id: &ShardId) -> FixedHash {
+    Blake256::new()
+        .chain(public_key.as_bytes())
+        .chain(shard_id.as_bytes())
+        .finalize()
+        .into()
 }
 
 #[derive(Copy, Clone, Debug)]

--- a/dan_layer/core/src/models/mod.rs
+++ b/dan_layer/core/src/models/mod.rs
@@ -231,7 +231,7 @@ pub enum ConsensusWorkerState {
 pub struct ValidatorMetadata {
     pub public_key: PublicKey,
     #[serde(with = "serde_with::hex")]
-    pub shard_id: ShardId,
+    pub vn_shard_key: ShardId,
     pub signature: Signature,
     pub merkle_proof: MerkleProof,
     pub merkle_leaf_index: u64,
@@ -240,14 +240,14 @@ pub struct ValidatorMetadata {
 impl ValidatorMetadata {
     pub fn new(
         public_key: PublicKey,
-        shard_id: ShardId,
+        vn_shard_key: ShardId,
         signature: Signature,
         merkle_proof: MerkleProof,
         merkle_leaf_index: u64,
     ) -> Self {
         Self {
             public_key,
-            shard_id,
+            vn_shard_key,
             signature,
             merkle_proof,
             merkle_leaf_index,
@@ -256,7 +256,7 @@ impl ValidatorMetadata {
 
     pub fn get_node_hash(&self) -> FixedHash {
         // Each node is defined as H(V_i || S_i)
-        vn_mmr_node_hash(&self.public_key, &self.shard_id)
+        vn_mmr_node_hash(&self.public_key, &self.vn_shard_key)
     }
 
     // TODO: impl Borsh for merkle proof
@@ -274,7 +274,7 @@ impl ValidatorMetadata {
     pub fn to_bytes(&self) -> Vec<u8> {
         [
             self.public_key.to_vec(),
-            self.shard_id.as_bytes().to_vec(),
+            self.vn_shard_key.as_bytes().to_vec(),
             self.signature.get_public_nonce().to_vec(),
             self.signature.get_signature().to_vec(),
             self.encode_merkle_proof(),

--- a/dan_layer/core/src/models/quorum_certificate.rs
+++ b/dan_layer/core/src/models/quorum_certificate.rs
@@ -22,6 +22,7 @@
 
 use digest::Digest;
 use serde::{Deserialize, Serialize};
+use tari_common_types::types::FixedHash;
 use tari_crypto::hash::blake2::Blake256;
 use tari_dan_common_types::{Epoch, PayloadId, ShardId};
 
@@ -127,7 +128,7 @@ impl QuorumCertificate {
         self.validators_metadata.as_slice()
     }
 
-    pub fn as_bytes(&self) -> Vec<u8> {
+    pub fn to_hash(&self) -> FixedHash {
         let mut result = Blake256::new()
             .chain(self.local_node_hash.as_bytes())
             .chain(self.local_node_height.to_le_bytes())
@@ -142,7 +143,7 @@ impl QuorumCertificate {
         // for shard in &self.involved_shards {
         //     result = result.chain((*shard).to_le_bytes());
         // }
-        result.finalize().to_vec()
+        result.finalize().into()
     }
 
     pub fn payload_id(&self) -> PayloadId {

--- a/dan_layer/core/src/models/tree_node_hash.rs
+++ b/dan_layer/core/src/models/tree_node_hash.rs
@@ -26,9 +26,9 @@ use std::{
     io::{self, Write},
 };
 
-use borsh::BorshSerialize;
 use digest::{consts::U32, generic_array};
 use serde::{Deserialize, Serialize};
+use tari_bor::Encode;
 use tari_common_types::types::{FixedHash, FixedHashSizeError};
 use tari_dan_common_types::serde_with;
 use tari_utilities::hex::{Hex, HexError};
@@ -37,9 +37,9 @@ use tari_utilities::hex::{Hex, HexError};
 pub struct TreeNodeHash(#[serde(with = "serde_with::hex")] FixedHash);
 
 // TODO: remove this implementation once the Borsh is on FixedHash
-impl BorshSerialize for TreeNodeHash {
+impl Encode for TreeNodeHash {
     fn serialize<W: Write>(&self, writer: &mut W) -> io::Result<()> {
-        BorshSerialize::serialize(&self.as_bytes(), writer)
+        Encode::serialize(&self.as_bytes(), writer)
     }
 }
 

--- a/dan_layer/core/src/services/base_node_client.rs
+++ b/dan_layer/core/src/services/base_node_client.rs
@@ -22,6 +22,7 @@
 
 use async_trait::async_trait;
 use tari_common_types::types::{FixedHash, PublicKey};
+use tari_comms::types::CommsPublicKey;
 use tari_core::{
     blocks::BlockHeader,
     transactions::transaction_components::{CodeTemplateRegistration, TransactionOutput},
@@ -37,7 +38,7 @@ use crate::{
 pub trait BaseNodeClient: Send + Sync + Clone {
     async fn test_connection(&mut self) -> Result<(), BaseNodeError>;
     async fn get_tip_info(&mut self) -> Result<BaseLayerMetadata, BaseNodeError>;
-    async fn get_validator_nodes(&mut self, height: u64) -> Result<Vec<ValidatorNode>, BaseNodeError>;
+    async fn get_validator_nodes(&mut self, height: u64) -> Result<Vec<ValidatorNode<CommsPublicKey>>, BaseNodeError>;
     async fn get_shard_key(&mut self, height: u64, public_key: &PublicKey) -> Result<Option<ShardId>, BaseNodeError>;
     async fn get_template_registrations(
         &mut self,

--- a/dan_layer/core/src/services/epoch_manager.rs
+++ b/dan_layer/core/src/services/epoch_manager.rs
@@ -76,7 +76,7 @@ pub enum EpochManagerError {
 // TODO: Rename to reflect that it's a read only interface (e.g. EpochReader, EpochQuery)
 pub trait EpochManager<TAddr: NodeAddressable>: Clone {
     async fn current_epoch(&self) -> Result<Epoch, EpochManagerError>;
-    async fn get_shard_id(&self, epoch: Epoch, addr: TAddr) -> Result<ShardId, EpochManagerError>;
+    async fn get_validator_shard_key(&self, epoch: Epoch, addr: TAddr) -> Result<ShardId, EpochManagerError>;
     async fn is_epoch_valid(&self, epoch: Epoch) -> Result<bool, EpochManagerError>;
     async fn get_committees(
         &self,
@@ -168,7 +168,7 @@ impl<TAddr: NodeAddressable> EpochManager<TAddr> for RangeEpochManager<TAddr> {
         Ok(self.current_epoch)
     }
 
-    async fn get_shard_id(&self, epoch: Epoch, addr: TAddr) -> Result<ShardId, EpochManagerError> {
+    async fn get_validator_shard_key(&self, epoch: Epoch, addr: TAddr) -> Result<ShardId, EpochManagerError> {
         self.registered_vns
             .iter()
             .find_map(|(e, vns)| {

--- a/dan_layer/core/src/services/epoch_manager.rs
+++ b/dan_layer/core/src/services/epoch_manager.rs
@@ -23,7 +23,6 @@
 use std::{collections::HashMap, ops::Range};
 
 use async_trait::async_trait;
-use tari_common_types::types::PublicKey;
 use tari_comms::protocol::rpc::{RpcError, RpcStatus};
 use tari_core::ValidatorNodeMmr;
 use tari_dan_common_types::{Epoch, ShardId};
@@ -69,12 +68,15 @@ pub enum EpochManagerError {
     RpcStatus(#[from] RpcStatus),
     #[error("No committee VNs found for shard {shard_id} and epoch {epoch}")]
     NoCommitteeVns { shard_id: ShardId, epoch: Epoch },
+    #[error("This validator node is not registered")]
+    ValidatorNodeNotRegistered,
 }
 
 #[async_trait]
 // TODO: Rename to reflect that it's a read only interface (e.g. EpochReader, EpochQuery)
 pub trait EpochManager<TAddr: NodeAddressable>: Clone {
     async fn current_epoch(&self) -> Result<Epoch, EpochManagerError>;
+    async fn get_shard_id(&self, epoch: Epoch, addr: TAddr) -> Result<ShardId, EpochManagerError>;
     async fn is_epoch_valid(&self, epoch: Epoch) -> Result<bool, EpochManagerError>;
     async fn get_committees(
         &self,
@@ -97,26 +99,27 @@ pub trait EpochManager<TAddr: NodeAddressable>: Clone {
         available_shards: &[ShardId],
     ) -> Result<Vec<ShardId>, EpochManagerError>;
 
-    async fn get_validator_nodes_per_epoch(&self, epoch: Epoch) -> Result<Vec<ValidatorNode>, EpochManagerError>;
+    async fn get_validator_nodes_per_epoch(&self, epoch: Epoch)
+        -> Result<Vec<ValidatorNode<TAddr>>, EpochManagerError>;
     async fn get_validator_node_mmr(&self, epoch: Epoch) -> Result<ValidatorNodeMmr, EpochManagerError>;
     async fn get_validator_node_merkle_root(&self, epoch: Epoch) -> Result<Vec<u8>, EpochManagerError>;
 }
 
 #[derive(Debug, Clone)]
-pub struct RangeEpochManager<TAddr: NodeAddressable> {
+pub struct RangeEpochManager<TAddr> {
     current_epoch: Epoch,
     #[allow(clippy::type_complexity)]
     epochs: HashMap<Epoch, Vec<(Range<ShardId>, Committee<TAddr>)>>,
-    registered_vns: HashMap<Epoch, Vec<ValidatorNode>>,
+    registered_vns: HashMap<Epoch, Vec<ValidatorNode<TAddr>>>,
 }
 
 impl<TAddr: NodeAddressable> RangeEpochManager<TAddr> {
-    pub fn new(vn_keys: Vec<PublicKey>, current: Range<ShardId>, committee: Vec<TAddr>) -> Self {
+    pub fn new(vn_keys: Vec<TAddr>, current: Range<ShardId>, committee: Vec<TAddr>) -> Self {
         let mut epochs = HashMap::new();
         epochs.insert(Epoch(0), vec![(current, Committee::new(committee))]);
 
         let mut registered_vns = HashMap::new();
-        let vns: Vec<ValidatorNode> = vn_keys
+        let vns: Vec<_> = vn_keys
             .into_iter()
             .map(|k| ValidatorNode {
                 shard_key: ShardId::zero(),
@@ -132,7 +135,7 @@ impl<TAddr: NodeAddressable> RangeEpochManager<TAddr> {
         }
     }
 
-    pub fn new_with_multiple(vn_keys: Vec<PublicKey>, ranges: &[(Range<ShardId>, Vec<TAddr>)]) -> Self {
+    pub fn new_with_multiple(vn_keys: Vec<TAddr>, ranges: &[(Range<ShardId>, Vec<TAddr>)]) -> Self {
         let mut epochs = HashMap::new();
         epochs.insert(
             Epoch(0),
@@ -143,7 +146,7 @@ impl<TAddr: NodeAddressable> RangeEpochManager<TAddr> {
                 .collect(),
         );
         let mut registered_vns = HashMap::new();
-        let vns: Vec<ValidatorNode> = vn_keys
+        let vns: Vec<_> = vn_keys
             .into_iter()
             .map(|k| ValidatorNode {
                 shard_key: ShardId::zero(),
@@ -163,6 +166,25 @@ impl<TAddr: NodeAddressable> RangeEpochManager<TAddr> {
 impl<TAddr: NodeAddressable> EpochManager<TAddr> for RangeEpochManager<TAddr> {
     async fn current_epoch(&self) -> Result<Epoch, EpochManagerError> {
         Ok(self.current_epoch)
+    }
+
+    async fn get_shard_id(&self, epoch: Epoch, addr: TAddr) -> Result<ShardId, EpochManagerError> {
+        self.registered_vns
+            .iter()
+            .find_map(|(e, vns)| {
+                if *e == epoch {
+                    vns.iter().find_map(|vn| {
+                        if vn.public_key == addr {
+                            Some(vn.shard_key)
+                        } else {
+                            None
+                        }
+                    })
+                } else {
+                    None
+                }
+            })
+            .ok_or(EpochManagerError::ValidatorNodeNotRegistered)
     }
 
     async fn is_epoch_valid(&self, epoch: Epoch) -> Result<bool, EpochManagerError> {
@@ -239,23 +261,23 @@ impl<TAddr: NodeAddressable> EpochManager<TAddr> for RangeEpochManager<TAddr> {
         Ok(result)
     }
 
-    async fn get_validator_nodes_per_epoch(&self, epoch: Epoch) -> Result<Vec<ValidatorNode>, EpochManagerError> {
+    async fn get_validator_nodes_per_epoch(
+        &self,
+        epoch: Epoch,
+    ) -> Result<Vec<ValidatorNode<TAddr>>, EpochManagerError> {
         let vns = self.registered_vns.get(&epoch).unwrap();
         Ok(vns.clone())
     }
 
     async fn get_validator_node_mmr(&self, epoch: Epoch) -> Result<ValidatorNodeMmr, EpochManagerError> {
-        let mut vn_mmr = ValidatorNodeMmr::new(Vec::new());
-        let public_keys: Vec<Vec<u8>> = self
+        let mut vn_mmr = ValidatorNodeMmr::new(Vec::with_capacity(self.registered_vns.len()));
+        let vns = self
             .registered_vns
             .get(&epoch)
-            .unwrap()
-            .iter()
-            .map(|vn| vn.public_key.as_bytes().to_vec())
-            .collect();
-        for pk in public_keys {
+            .ok_or(EpochManagerError::NoEpochFound(epoch))?;
+        for vn in vns {
             vn_mmr
-                .push(pk)
+                .push(vn.node_hash().to_vec())
                 .expect("Could not build the merkle mountain range of the VN set");
         }
 

--- a/dan_layer/core/src/services/infrastructure_services/node_addressable.rs
+++ b/dan_layer/core/src/services/infrastructure_services/node_addressable.rs
@@ -51,6 +51,10 @@ impl NodeAddressable for &str {
     fn as_bytes(&self) -> &[u8] {
         str::as_bytes(self)
     }
+
+    // fn try_from_bytes(bytes: &[u8]) -> Option<Self> {
+    //     Some(std::str::from_utf8(bytes).ok()?)
+    // }
 }
 
 impl NodeAddressable for CommsPublicKey {
@@ -61,4 +65,8 @@ impl NodeAddressable for CommsPublicKey {
     fn as_bytes(&self) -> &[u8] {
         <CommsPublicKey as ByteArray>::as_bytes(self)
     }
+
+    // fn try_from_bytes(bytes: &[u8]) -> Option<Self> {
+    //     Some(CommsPublicKey::from_bytes(bytes).ok()?)
+    // }
 }

--- a/dan_layer/core/src/services/signing_service.rs
+++ b/dan_layer/core/src/services/signing_service.rs
@@ -22,15 +22,25 @@
 
 use std::sync::Arc;
 
-use tari_comms::NodeIdentity;
+use tari_common_types::types::{FixedHash, PublicKey};
+use tari_comms::{
+    types::{CommsPublicKey, Signature},
+    NodeIdentity,
+};
+use tari_dan_common_types::hashing::tari_hasher;
+use tari_dan_engine::crypto::create_key_pair;
 use tari_utilities::ByteArray;
 
-use crate::{digital_assets_error::DigitalAssetError, models::ValidatorMetadata};
+use crate::TariDanCoreHashDomain;
 
 pub trait SigningService {
-    fn sign(&self, challenge: &[u8]) -> Result<ValidatorMetadata, DigitalAssetError>;
+    fn sign(&self, challenge: &[u8]) -> Option<Signature>;
+    fn verify(&self, signature: &Signature, challenge: &[u8]) -> bool;
+    fn verify_for_public_key(&self, public_key: &PublicKey, signature: &Signature, challenge: &[u8]) -> bool;
+    fn public_key(&self) -> &CommsPublicKey;
 }
 
+#[derive(Debug, Clone)]
 pub struct NodeIdentitySigningService {
     node_identity: Arc<NodeIdentity>,
 }
@@ -39,16 +49,57 @@ impl NodeIdentitySigningService {
     pub fn new(node_identity: Arc<NodeIdentity>) -> Self {
         Self { node_identity }
     }
+
+    fn create_challenge(public_key: &PublicKey, public_nonce: &PublicKey, challenge: &[u8]) -> FixedHash {
+        tari_hasher::<TariDanCoreHashDomain>("signing_service")
+            .chain(&key_to_fixed_bytes(public_key))
+            .chain(&key_to_fixed_bytes(public_nonce))
+            .chain(challenge)
+            .result()
+    }
 }
 
 impl SigningService for NodeIdentitySigningService {
-    fn sign(&self, _challenge: &[u8]) -> Result<ValidatorMetadata, DigitalAssetError> {
-        // TODO better sig
-        Ok(ValidatorMetadata {
-            public_key: Vec::from(self.node_identity.public_key().as_bytes()),
-            signature: Vec::new(),
-            merkle_proof: Vec::new(),
-            merkle_leaf_index: 0,
-        })
+    fn sign(&self, challenge: &[u8]) -> Option<Signature> {
+        let (nonce, public_nonce) = create_key_pair();
+        let challenge = Self::create_challenge(&public_nonce, self.node_identity.public_key(), challenge);
+        let sig = Signature::sign(self.node_identity.secret_key().clone(), nonce, &*challenge).ok()?;
+        Some(sig)
+    }
+
+    fn verify(&self, signature: &Signature, challenge: &[u8]) -> bool {
+        self.verify_for_public_key(self.node_identity.public_key(), signature, challenge)
+    }
+
+    fn verify_for_public_key(&self, public_key: &PublicKey, signature: &Signature, challenge: &[u8]) -> bool {
+        let challenge = Self::create_challenge(signature.get_public_nonce(), public_key, challenge);
+        signature.verify_challenge(public_key, &*challenge)
+    }
+
+    fn public_key(&self) -> &CommsPublicKey {
+        self.node_identity.public_key()
+    }
+}
+
+// TODO: this wont be required when borsh support is added to tari crypto
+fn key_to_fixed_bytes(key: &CommsPublicKey) -> [u8; 32] {
+    let mut buf = [0u8; 32];
+    buf.copy_from_slice(key.as_bytes());
+    buf
+}
+
+#[cfg(test)]
+mod tests {
+    use tari_comms::{peer_manager::PeerFeatures, test_utils::node_identity::build_node_identity};
+
+    use super::*;
+
+    #[test]
+    fn basic() {
+        let node_identity = build_node_identity(PeerFeatures::COMMUNICATION_NODE);
+        let signing_service = NodeIdentitySigningService::new(node_identity);
+        let challenge = b"challenge";
+        let signature = signing_service.sign(challenge).unwrap();
+        assert!(signing_service.verify(&signature, challenge));
     }
 }

--- a/dan_layer/core/src/storage/mocks/global_db.rs
+++ b/dan_layer/core/src/storage/mocks/global_db.rs
@@ -89,6 +89,15 @@ impl GlobalDbAdapter for MockGlobalDbBackupAdapter {
         todo!()
     }
 
+    fn get_validator_node(
+        &self,
+        _tx: &Self::DbTransaction,
+        _epoch: u64,
+        _public_key: &[u8],
+    ) -> Result<DbValidatorNode, Self::Error> {
+        todo!()
+    }
+
     fn insert_epoch(&self, _tx: &Self::DbTransaction, _epoch: DbEpoch) -> Result<(), Self::Error> {
         todo!()
     }

--- a/dan_layer/core/src/workers/hotstuff_error.rs
+++ b/dan_layer/core/src/workers/hotstuff_error.rs
@@ -61,4 +61,8 @@ pub enum HotStuffError {
     ShardHasNoData,
     #[error("Invalid qc error: `{0}`")]
     InvalidQuorumCertificate(String),
+    #[error("Failed to sign QC")]
+    FailedToSignQc,
+    #[error("This validator node is not included in the MMR")]
+    ValidatorNodeNotIncludedInMmr,
 }

--- a/dan_layer/core/src/workers/hotstuff_waiter.rs
+++ b/dan_layer/core/src/workers/hotstuff_waiter.rs
@@ -209,6 +209,7 @@ where
             //  Save the payload, because we will need it when the proposal comes back
             tx.set_payload(payload.clone())?;
             tx.commit()?;
+            // TODO: combine merkle proofs into one before sending
             new_view = HotStuffMessage::new_view(high_qc, shard, Some(payload));
         }
 
@@ -692,9 +693,9 @@ where
             ));
         }
 
-        // TODO: Fix merkle proof verification
         // all merkle proofs for the signers must be valid
         let validator_node_root = self.epoch_manager.get_validator_node_merkle_root(qc.epoch()).await?;
+        // TODO: Combine all validator merkle proofs before sending them
         for md in qc.validators_metadata() {
             md.merkle_proof
                 .verify_leaf::<ValidatorNodeMmrHasherBlake256>(

--- a/dan_layer/core/src/workers/hotstuff_waiter.rs
+++ b/dan_layer/core/src/workers/hotstuff_waiter.rs
@@ -20,19 +20,14 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::{
-    collections::{HashMap, HashSet},
-    sync::Arc,
-};
+use std::collections::{HashMap, HashSet};
 
 use log::*;
 use tari_common_types::types::{PublicKey, Signature};
-use tari_comms::NodeIdentity;
-use tari_core::consensus::FromConsensusBytes;
+use tari_core::ValidatorNodeMmrHasherBlake256;
 use tari_dan_common_types::{optional::Optional, Epoch, PayloadId, ShardId, SubstateState};
 use tari_engine_types::commit_result::{FinalizeResult, RejectReason, TransactionResult};
 use tari_shutdown::ShutdownSignal;
-use tari_utilities::ByteArray;
 use tokio::{
     sync::{
         broadcast,
@@ -63,6 +58,7 @@ use crate::{
         infrastructure_services::NodeAddressable,
         leader_strategy::LeaderStrategy,
         PayloadProcessor,
+        SigningService,
     },
     storage::shard_store::{ShardStoreFactory, ShardStoreTransaction},
     workers::{events::HotStuffEvent, hotstuff_error::HotStuffError},
@@ -70,8 +66,16 @@ use crate::{
 
 const LOG_TARGET: &str = "tari::dan_layer::hotstuff_waiter";
 
-pub struct HotStuffWaiter<TPayload, TAddr, TLeaderStrategy, TEpochManager, TPayloadProcessor, TShardStore> {
-    node_identity: Arc<NodeIdentity>,
+pub struct HotStuffWaiter<
+    TPayload,
+    TAddr,
+    TLeaderStrategy,
+    TEpochManager,
+    TPayloadProcessor,
+    TShardStore,
+    TSigningService,
+> {
+    signing_service: TSigningService,
     public_key: TAddr,
     leader_strategy: TLeaderStrategy,
     /// The epoch manager
@@ -99,8 +103,8 @@ pub struct HotStuffWaiter<TPayload, TAddr, TLeaderStrategy, TEpochManager, TPayl
     consensus_constants: ConsensusConstants,
 }
 
-impl<TPayload, TAddr, TLeaderStrategy, TEpochManager, TPayloadProcessor, TShardStore>
-    HotStuffWaiter<TPayload, TAddr, TLeaderStrategy, TEpochManager, TPayloadProcessor, TShardStore>
+impl<TPayload, TAddr, TLeaderStrategy, TEpochManager, TPayloadProcessor, TShardStore, TSigningService>
+    HotStuffWaiter<TPayload, TAddr, TLeaderStrategy, TEpochManager, TPayloadProcessor, TShardStore, TSigningService>
 where
     TPayload: Payload + 'static,
     TAddr: NodeAddressable + 'static,
@@ -108,9 +112,10 @@ where
     TEpochManager: EpochManager<TAddr> + 'static + Send + Sync,
     TPayloadProcessor: PayloadProcessor<TPayload> + 'static + Send + Sync,
     TShardStore: ShardStoreFactory<Addr = TAddr, Payload = TPayload> + 'static + Send + Sync,
+    TSigningService: SigningService + Sync + Send + 'static,
 {
     pub fn spawn(
-        node_identity: Arc<NodeIdentity>,
+        signing_service: TSigningService,
         public_key: TAddr,
         epoch_manager: TEpochManager,
         leader_strategy: TLeaderStrategy,
@@ -127,7 +132,7 @@ where
         consensus_constants: ConsensusConstants,
     ) -> JoinHandle<Result<(), HotStuffError>> {
         let waiter = HotStuffWaiter::new(
-            node_identity,
+            signing_service,
             public_key,
             epoch_manager,
             leader_strategy,
@@ -146,7 +151,7 @@ where
     }
 
     pub fn new(
-        node_identity: Arc<NodeIdentity>,
+        signing_service: TSigningService,
         public_key: TAddr,
         epoch_manager: TEpochManager,
         leader_strategy: TLeaderStrategy,
@@ -162,7 +167,7 @@ where
         consensus_constants: ConsensusConstants,
     ) -> Self {
         Self {
-            node_identity,
+            signing_service,
             public_key,
             epoch_manager,
             leader_strategy,
@@ -390,12 +395,15 @@ where
             .await?;
 
         let mut votes_to_send = vec![];
-        let vn_mmr = self.epoch_manager.get_validator_node_mmr(node.epoch()).await?;
         let vns = self.epoch_manager.get_validator_nodes_per_epoch(node.epoch()).await?;
         let vn_mmr_leaf_index = vns
             .iter()
-            .position(|vn| vn.public_key == *self.node_identity.public_key())
+            .position(|vn| vn.public_key == self.public_key)
             .expect("The VN is not registered");
+
+        let node_shard_id = self.get_shard_id(node.epoch(), self.public_key.clone()).await?;
+        let vn_mmr = self.epoch_manager.get_validator_node_mmr(node.epoch()).await?;
+
         {
             let mut tx = self.shard_store.create_tx()?;
             tx.save_node(node.clone())?;
@@ -464,12 +472,7 @@ where
                         &finalize_result,
                     )?;
 
-                    vote_msg.set_metadata(
-                        self.node_identity.public_key(),
-                        self.node_identity.secret_key(),
-                        &vn_mmr,
-                        vn_mmr_leaf_index as u64,
-                    );
+                    vote_msg.sign_vote(&self.signing_service, node_shard_id, &vn_mmr, vn_mmr_leaf_index as u64)?;
 
                     votes_to_send.push((vote_msg, local_node.proposed_by().clone()));
                 }
@@ -494,6 +497,11 @@ where
         Ok(())
     }
 
+    async fn get_shard_id(&self, epoch: Epoch, addr: TAddr) -> Result<ShardId, HotStuffError> {
+        let shard_id = self.epoch_manager.get_shard_id(epoch, addr).await?;
+        Ok(shard_id)
+    }
+
     /// Step 6: The leader receives votes from the local shard, and once it has enough ($n - f$) votes, it commits a
     /// high QC and sends the next round of proposals.
     async fn on_receive_vote(&mut self, from: TAddr, msg: VoteMessage) -> Result<(), HotStuffError> {
@@ -515,7 +523,7 @@ where
 
             node = tx.get_node(&msg.local_node_hash())?;
 
-            if node.proposed_by() != &self.public_key {
+            if *node.proposed_by() != self.public_key {
                 return Err(HotStuffError::NotTheLeader);
             }
         }
@@ -646,7 +654,7 @@ where
     ) -> Result<bool, HotStuffError> {
         Ok(self
             .leader_strategy
-            .is_leader(&self.public_key.clone(), committee, payload, shard, 0))
+            .is_leader(&self.public_key, committee, payload, shard, 0))
     }
 
     async fn validate_from_committee(
@@ -664,7 +672,7 @@ where
 
     async fn validate_qc(&self, qc: &QuorumCertificate, min_signers: usize) -> Result<(), HotStuffError> {
         // extract all the pairs of signer-signature present in the QC
-        let signer_signatures = Self::extract_signer_signatures_from_qc(qc)?;
+        let signer_signatures = Self::extract_signer_signatures_from_qc(qc);
 
         // the QC should not have repeated signers
         let signers_set = signer_signatures
@@ -686,19 +694,16 @@ where
 
         // TODO: Fix merkle proof verification
         // all merkle proofs for the signers must be valid
-        // let validator_node_root = self.epoch_manager.get_validator_node_merkle_root(qc.epoch()).await?;
-        // for md in qc.validators_metadata() {
-        //     let merkle_proof: MerkleProof = bincode::deserialize(&md.merkle_proof).map_err(|_| {
-        //         HotStuffError::InvalidQuorumCertificate("could not deserialize merkle proof".to_string())
-        //     })?;
-        //     merkle_proof
-        //         .verify_leaf::<ValidatorNodeMmrHasherBlake256>(
-        //             &validator_node_root,
-        //             &md.public_key,
-        //             md.merkle_leaf_index as usize,
-        //         )
-        //         .map_err(|_| HotStuffError::InvalidQuorumCertificate("invalid merkle proof".to_string()))?;
-        // }
+        let validator_node_root = self.epoch_manager.get_validator_node_merkle_root(qc.epoch()).await?;
+        for md in qc.validators_metadata() {
+            md.merkle_proof
+                .verify_leaf::<ValidatorNodeMmrHasherBlake256>(
+                    &validator_node_root,
+                    &*md.get_node_hash(),
+                    md.merkle_leaf_index as usize,
+                )
+                .map_err(|_| HotStuffError::InvalidQuorumCertificate("invalid merkle proof".to_string()))?;
+        }
 
         // all signers must be included in the epoch commitee for the shard
         let committee = self.epoch_manager.get_committee(qc.epoch(), qc.shard()).await?;
@@ -713,7 +718,7 @@ where
         // all signatures must be valid
         let all_signatures_are_valid = signer_signatures
             .iter()
-            .all(|(public_key, signature)| Self::validate_vote(qc, public_key, signature));
+            .all(|(public_key, signature)| self.validate_vote(qc, public_key, signature));
         if !all_signatures_are_valid {
             return Err(HotStuffError::InvalidQuorumCertificate("invalid signature".to_string()));
         }
@@ -721,30 +726,23 @@ where
         Ok(())
     }
 
-    fn validate_vote(qc: &QuorumCertificate, public_key: &PublicKey, signature: &Signature) -> bool {
+    fn validate_vote(&self, qc: &QuorumCertificate, public_key: &PublicKey, signature: &Signature) -> bool {
         let vote = VoteMessage::new(
             qc.local_node_hash(),
             qc.shard(),
             *qc.decision(),
             qc.all_shard_nodes().to_vec(),
         );
-        let challenge = vote.construct_challenge(public_key, signature.get_public_nonce());
-        signature.verify_challenge(public_key, &*challenge)
+        let challenge = vote.construct_challenge();
+        self.signing_service
+            .verify_for_public_key(public_key, signature, &*challenge)
     }
 
-    fn extract_signer_signatures_from_qc(qc: &QuorumCertificate) -> Result<Vec<(PublicKey, Signature)>, HotStuffError> {
-        let mut signatures: Vec<(PublicKey, Signature)> = vec![];
-
-        for s in qc.validators_metadata() {
-            let public_key = PublicKey::from_bytes(&s.public_key)
-                .map_err(|e| HotStuffError::InvalidQuorumCertificate(e.to_string()))?;
-            let signature = Signature::from_consensus_bytes(&s.signature)
-                .map_err(|e| HotStuffError::InvalidQuorumCertificate(e.to_string()))?;
-
-            signatures.push((public_key, signature));
-        }
-
-        Ok(signatures)
+    fn extract_signer_signatures_from_qc(qc: &QuorumCertificate) -> Vec<(PublicKey, Signature)> {
+        qc.validators_metadata()
+            .iter()
+            .map(|md| (md.public_key.clone(), md.signature.clone()))
+            .collect()
     }
 
     /// Performs the requisite state updates for a given tree node.

--- a/dan_layer/engine/Cargo.toml
+++ b/dan_layer/engine/Cargo.toml
@@ -6,18 +6,18 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+tari_bor = { path = "../tari_bor" }
 tari_common = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan", package = "tari_common" }
 tari_common_types = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan", package = "tari_common_types" }
 tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.15.7" }
 tari_dan_common_types = { path = "../common_types" }
-tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.7" }
+tari_engine_types = { path = "../engine_types" }
 tari_mmr = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan", package = "tari_mmr" }
 tari_template_abi = { path = "../template_abi", features = ["std"] }
 tari_template_lib = { path = "../template_lib", default-features = false, features = ["serde"] }
-tari_engine_types = {path = "../engine_types" }
+tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.7" }
 
 anyhow = "1.0.53"
-borsh = "0.9.3"
 cargo_toml = "0.11.5"
 d3ne = { git = "https://github.com/stringhandler/d3ne-rs.git", branch = "st-fixes2" }
 digest = "0.9.0"

--- a/dan_layer/engine/src/runtime/impl.rs
+++ b/dan_layer/engine/src/runtime/impl.rs
@@ -20,12 +20,12 @@
 //   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //   USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+use tari_bor::decode;
 use tari_engine_types::{
     commit_result::{FinalizeResult, RejectReason, TransactionResult},
     logs::LogEntry,
     substate::{SubstateAddress, SubstateValue},
 };
-use tari_template_abi::decode;
 use tari_template_lib::{
     args::{
         BucketAction,

--- a/dan_layer/engine/src/state_store/memory.rs
+++ b/dan_layer/engine/src/state_store/memory.rs
@@ -25,8 +25,8 @@ use std::{
 };
 
 use anyhow::anyhow;
+use tari_bor::encode;
 use tari_dan_common_types::SubstateState;
-use tari_template_abi::encode;
 use tari_utilities::hex::to_hex;
 
 use crate::state_store::{AtomicDb, StateReader, StateStoreError, StateWriter};
@@ -153,8 +153,8 @@ impl<'a> StateWriter for MemoryTransaction<RwLockWriteGuard<'a, InnerKvMap>> {
 
 #[cfg(test)]
 mod tests {
+    use tari_bor::{borsh, Decode, Encode};
     use tari_dan_common_types::optional::Optional;
-    use tari_template_abi::{Decode, Encode};
 
     use super::*;
 

--- a/dan_layer/engine/src/state_store/mod.rs
+++ b/dan_layer/engine/src/state_store/mod.rs
@@ -24,8 +24,8 @@ pub mod memory;
 
 use std::{error::Error, fmt::Debug, io};
 
+use tari_bor::{decode, encode, Decode, Encode};
 use tari_dan_common_types::optional::IsNotFoundError;
-use tari_template_abi::{decode, encode, Decode, Encode};
 
 // pub trait StateStorage<'a>: AtomicDb<'a, Error = StateStoreError> + Send + Sync {}
 //

--- a/dan_layer/engine/src/wasm/module.rs
+++ b/dan_layer/engine/src/wasm/module.rs
@@ -121,7 +121,7 @@ fn initialize_and_load_template_abi(
 
     // Load ABI from memory
     let data = env.read_memory_with_embedded_len(ptr)?;
-    let decoded = tari_template_abi::decode(&data).map_err(|_| WasmExecutionError::AbiDecodeError)?;
+    let decoded = tari_bor::decode(&data).map_err(|_| WasmExecutionError::AbiDecodeError)?;
     Ok(decoded)
 }
 

--- a/dan_layer/engine/src/wasm/process.rs
+++ b/dan_layer/engine/src/wasm/process.rs
@@ -20,9 +20,9 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use borsh::{BorshDeserialize, BorshSerialize};
+use tari_bor::{decode, encode, encode_into, encode_with_len, Decode, Encode};
 use tari_engine_types::execution_result::ExecutionResult;
-use tari_template_abi::{decode, encode, encode_into, encode_with_len, CallInfo, EngineOp};
+use tari_template_abi::{CallInfo, EngineOp};
 use tari_template_lib::{
     args::{
         Arg,
@@ -67,7 +67,7 @@ impl WasmProcess {
         Ok(Self { module, env, instance })
     }
 
-    fn alloc_and_write<T: BorshSerialize>(&self, val: &T) -> Result<AllocPtr, WasmExecutionError> {
+    fn alloc_and_write<T: Encode>(&self, val: &T) -> Result<AllocPtr, WasmExecutionError> {
         let mut buf = Vec::with_capacity(512);
         encode_into(val, &mut buf).unwrap();
         let ptr = self.env.alloc(buf.len() as u32)?;
@@ -140,8 +140,8 @@ impl WasmProcess {
         f: fn(&WasmEnv<Runtime>, T) -> Result<U, E>,
     ) -> Result<i32, WasmExecutionError>
     where
-        T: BorshDeserialize,
-        U: BorshSerialize,
+        T: Decode,
+        U: Encode,
         WasmExecutionError: From<E>,
     {
         let decoded = decode(&args).map_err(WasmExecutionError::EngineArgDecodeFailed)?;

--- a/dan_layer/engine/tests/templates/account/Cargo.lock
+++ b/dan_layer/engine/tests/templates/account/Cargo.lock
@@ -161,19 +161,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "tari_bor"
+version = "0.1.0"
+dependencies = [
+ "borsh",
+]
+
+[[package]]
 name = "tari_template_abi"
 version = "0.35.1"
 dependencies = [
- "borsh",
+ "tari_bor",
 ]
 
 [[package]]
 name = "tari_template_lib"
 version = "0.35.1"
 dependencies = [
- "borsh",
  "hex",
  "newtype-ops",
+ "tari_bor",
  "tari_template_abi",
  "tari_template_macros",
 ]

--- a/dan_layer/engine/tests/templates/buggy/Cargo.lock
+++ b/dan_layer/engine/tests/templates/buggy/Cargo.lock
@@ -62,6 +62,7 @@ dependencies = [
 name = "buggy"
 version = "0.1.0"
 dependencies = [
+ "tari_bor",
  "tari_template_abi",
  "wee_alloc",
 ]
@@ -161,10 +162,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tari_bor"
+version = "0.1.0"
+dependencies = [
+ "borsh",
+]
+
+[[package]]
 name = "tari_template_abi"
 version = "0.35.1"
 dependencies = [
- "borsh",
+ "tari_bor",
 ]
 
 [[package]]

--- a/dan_layer/engine/tests/templates/buggy/Cargo.toml
+++ b/dan_layer/engine/tests/templates/buggy/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 
 [dependencies]
 tari_template_abi = { path = "../../../../template_abi", default-features = false }
+tari_bor = { path = "../../../../tari_bor", default-features = false }
 wee_alloc = "0.4.5"
 
 [profile.release]

--- a/dan_layer/engine/tests/templates/buggy/src/lib.rs
+++ b/dan_layer/engine/tests/templates/buggy/src/lib.rs
@@ -31,6 +31,7 @@ static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
 #[cfg(any(feature = "call_engine_in_abi", feature = "unexpected_export_function"))]
 #[no_mangle]
 pub extern "C" fn Buggy_abi() -> *mut u8 {
+    use tari_bor::encode_with_len;
     use tari_template_abi::*;
     // Call the engine in the ABI code, you aren't allowed to do that *shakes head*
     #[cfg(feature = "call_engine_in_abi")]

--- a/dan_layer/engine/tests/templates/faucet/Cargo.lock
+++ b/dan_layer/engine/tests/templates/faucet/Cargo.lock
@@ -161,19 +161,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "tari_bor"
+version = "0.1.0"
+dependencies = [
+ "borsh",
+]
+
+[[package]]
 name = "tari_template_abi"
 version = "0.35.1"
 dependencies = [
- "borsh",
+ "tari_bor",
 ]
 
 [[package]]
 name = "tari_template_lib"
 version = "0.35.1"
 dependencies = [
- "borsh",
  "hex",
  "newtype-ops",
+ "tari_bor",
  "tari_template_abi",
  "tari_template_macros",
 ]

--- a/dan_layer/engine/tests/templates/hello_world/Cargo.lock
+++ b/dan_layer/engine/tests/templates/hello_world/Cargo.lock
@@ -161,19 +161,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "tari_bor"
+version = "0.1.0"
+dependencies = [
+ "borsh",
+]
+
+[[package]]
 name = "tari_template_abi"
 version = "0.35.1"
 dependencies = [
- "borsh",
+ "tari_bor",
 ]
 
 [[package]]
 name = "tari_template_lib"
 version = "0.35.1"
 dependencies = [
- "borsh",
  "hex",
  "newtype-ops",
+ "tari_bor",
  "tari_template_abi",
  "tari_template_macros",
 ]

--- a/dan_layer/engine/tests/templates/private_function/Cargo.lock
+++ b/dan_layer/engine/tests/templates/private_function/Cargo.lock
@@ -162,19 +162,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "tari_bor"
+version = "0.1.0"
+dependencies = [
+ "borsh",
+]
+
+[[package]]
 name = "tari_template_abi"
 version = "0.35.1"
 dependencies = [
- "borsh",
+ "tari_bor",
 ]
 
 [[package]]
 name = "tari_template_lib"
 version = "0.35.1"
 dependencies = [
- "borsh",
  "hex",
  "newtype-ops",
+ "tari_bor",
  "tari_template_abi",
  "tari_template_macros",
 ]

--- a/dan_layer/engine/tests/templates/state/Cargo.lock
+++ b/dan_layer/engine/tests/templates/state/Cargo.lock
@@ -161,19 +161,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "tari_bor"
+version = "0.1.0"
+dependencies = [
+ "borsh",
+]
+
+[[package]]
 name = "tari_template_abi"
 version = "0.35.1"
 dependencies = [
- "borsh",
+ "tari_bor",
 ]
 
 [[package]]
 name = "tari_template_lib"
 version = "0.35.1"
 dependencies = [
- "borsh",
  "hex",
  "newtype-ops",
+ "tari_bor",
  "tari_template_abi",
  "tari_template_macros",
 ]

--- a/dan_layer/engine/tests/templates/tuples/Cargo.lock
+++ b/dan_layer/engine/tests/templates/tuples/Cargo.lock
@@ -153,19 +153,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "tari_bor"
+version = "0.1.0"
+dependencies = [
+ "borsh",
+]
+
+[[package]]
 name = "tari_template_abi"
 version = "0.35.1"
 dependencies = [
- "borsh",
+ "tari_bor",
 ]
 
 [[package]]
 name = "tari_template_lib"
 version = "0.35.1"
 dependencies = [
- "borsh",
  "hex",
  "newtype-ops",
+ "tari_bor",
  "tari_template_abi",
  "tari_template_macros",
 ]

--- a/dan_layer/engine_types/Cargo.toml
+++ b/dan_layer/engine_types/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 
 [dependencies]
+tari_bor = { path = "../tari_bor" }
 tari_common_types = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan" }
 tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.15.7" }
 tari_template_abi = { path = "../template_abi", features = ["std"] }
@@ -13,5 +14,4 @@ tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", t
 
 digest = "0.9.0"
 serde = "1.0.126"
-borsh = "0.9.3"
 thiserror = "1"

--- a/dan_layer/engine_types/src/bucket.rs
+++ b/dan_layer/engine_types/src/bucket.rs
@@ -20,7 +20,7 @@
 //   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //   USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use tari_template_abi::{Decode, Encode};
+use tari_bor::{borsh, Decode, Encode};
 use tari_template_lib::models::{Amount, ResourceAddress};
 
 use crate::resource::{Resource, ResourceError};

--- a/dan_layer/engine_types/src/execution_result.rs
+++ b/dan_layer/engine_types/src/execution_result.rs
@@ -23,7 +23,7 @@
 use std::io;
 
 use serde::{Deserialize, Serialize};
-use tari_template_abi::Decode;
+use tari_bor::Decode;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ExecutionResult {
@@ -40,7 +40,7 @@ impl ExecutionResult {
     }
 
     pub fn decode<T: Decode>(&self) -> io::Result<T> {
-        tari_template_abi::decode(&self.raw)
+        tari_bor::decode(&self.raw)
     }
 }
 

--- a/dan_layer/engine_types/src/instruction.rs
+++ b/dan_layer/engine_types/src/instruction.rs
@@ -2,7 +2,7 @@
 //  SPDX-License-Identifier: BSD-3-Clause
 
 use serde::{Deserialize, Serialize};
-use tari_template_abi::Encode;
+use tari_bor::{borsh, Encode};
 use tari_template_lib::{
     args::{Arg, LogLevel},
     models::{ComponentAddress, TemplateAddress},

--- a/dan_layer/engine_types/src/resource.rs
+++ b/dan_layer/engine_types/src/resource.rs
@@ -21,7 +21,7 @@
 //   USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use serde::{Deserialize, Serialize};
-use tari_template_abi::{Decode, Encode};
+use tari_bor::{borsh, Decode, Encode};
 use tari_template_lib::models::{Amount, Metadata, ResourceAddress};
 
 #[derive(Debug, Clone, Encode, Decode, Serialize, Deserialize)]

--- a/dan_layer/engine_types/src/substate.rs
+++ b/dan_layer/engine_types/src/substate.rs
@@ -23,7 +23,7 @@
 use std::fmt::{Display, Formatter};
 
 use serde::{Deserialize, Serialize};
-use tari_template_abi::{decode, encode, Decode, Encode};
+use tari_bor::{borsh, decode, encode, Decode, Encode};
 use tari_template_lib::{
     models::{ComponentAddress, ComponentInstance, ResourceAddress, VaultId},
     Hash,

--- a/dan_layer/engine_types/src/vault.rs
+++ b/dan_layer/engine_types/src/vault.rs
@@ -21,7 +21,7 @@
 //   USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use serde::{Deserialize, Serialize};
-use tari_template_abi::{Decode, Encode};
+use tari_bor::{borsh, Decode, Encode};
 use tari_template_lib::models::{Amount, ResourceAddress, VaultId};
 
 use crate::{

--- a/dan_layer/integration_tests/Cargo.toml
+++ b/dan_layer/integration_tests/Cargo.toml
@@ -24,3 +24,6 @@ tari_core = { git = "https://github.com/tari-project/tari.git", branch = "featur
 lazy_static = "1.4.0"
 rand = "0.7"
 tokio = { version = "1.10", features = ["macros", "time"] }
+
+[dev-dependencies]
+env_logger = "0.9.3"

--- a/dan_layer/integration_tests/src/lib.rs
+++ b/dan_layer/integration_tests/src/lib.rs
@@ -20,7 +20,9 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+#[cfg(test)]
 mod temp_shard_store_factory;
+#[cfg(test)]
 pub use temp_shard_store_factory::TempShardStoreFactory;
 
 #[cfg(test)]

--- a/dan_layer/integration_tests/src/test_consensus.rs
+++ b/dan_layer/integration_tests/src/test_consensus.rs
@@ -39,7 +39,6 @@ use tari_dan_core::{
         QuorumCertificate,
         QuorumDecision,
         TariDanPayload,
-        ValidatorMetadata,
     },
     services::{
         epoch_manager::{EpochManager, RangeEpochManager},
@@ -129,6 +128,7 @@ pub struct HsTestHarness {
     tx_votes: Sender<(PublicKey, VoteMessage)>,
     rx_execute: broadcast::Receiver<(TariDanPayload, HashMap<ShardId, Option<ObjectPledge>>)>,
     hs_waiter: Option<JoinHandle<Result<(), HotStuffError>>>,
+    signing_service: NodeIdentitySigningService,
 }
 
 impl HsTestHarness {
@@ -159,8 +159,9 @@ impl HsTestHarness {
         let public_address = Multiaddr::from_str("/ip4/127.0.0.1/tcp/48000").unwrap();
         let node_identity = NodeIdentity::new(private_key, public_address, PeerFeatures::COMMUNICATION_NODE);
 
+        let signing_service = NodeIdentitySigningService::new(Arc::new(node_identity));
         let hs_waiter = HotStuffWaiter::spawn(
-            Arc::new(node_identity),
+            signing_service.clone(),
             identity.clone(),
             epoch_manager,
             leader,
@@ -187,11 +188,16 @@ impl HsTestHarness {
             tx_votes,
             rx_execute,
             hs_waiter: Some(hs_waiter),
+            signing_service,
         }
     }
 
     fn identity(&self) -> PublicKey {
         self.identity.clone()
+    }
+
+    pub fn signing_service(&self) -> &impl SigningService {
+        &self.signing_service
     }
 
     async fn assert_shuts_down_safely(&mut self) {
@@ -271,16 +277,28 @@ fn create_test_qc(
     let mut vn_mmr = ValidatorNodeMmr::new(Vec::new());
     for pk in &all_vn_keys {
         vn_mmr
-            .push(pk.to_vec())
+            .push(vn_mmr_node_hash(pk, &ShardId::zero()).to_vec())
             .expect("Could not build the merkle mountain range of the VN set");
     }
 
-    let validators_metadata: Vec<ValidatorMetadata> = commitee_keys
-        .iter()
-        .map(|(public_key, secret_key)| {
+    let validators_metadata: Vec<_> = commitee_keys
+        .into_iter()
+        .map(|(public_key, secret)| {
             let mut node_vote = vote.clone();
-            let leaf_index = get_merkle_leaf_index(&all_vn_keys, public_key);
-            node_vote.set_metadata(public_key, secret_key, &vn_mmr, leaf_index as u64);
+            let leaf_index = get_merkle_leaf_index(&all_vn_keys, &public_key);
+            let node_identity = Arc::new(NodeIdentity::new(
+                secret,
+                Multiaddr::empty(),
+                PeerFeatures::COMMUNICATION_NODE,
+            ));
+            node_vote
+                .sign_vote(
+                    &NodeIdentitySigningService::new(node_identity),
+                    ShardId::zero(),
+                    &vn_mmr,
+                    leaf_index as u64,
+                )
+                .unwrap();
             node_vote.validator_metadata().clone()
         })
         .collect();
@@ -429,8 +447,12 @@ async fn test_hs_waiter_leader_sends_new_proposal_when_enough_votes_are_received
 
     // create the VN set mmr
     let mut vn_mmr = ValidatorNodeMmr::new(Vec::new());
-    vn_mmr.push(node1.to_vec()).unwrap();
-    vn_mmr.push(node2.to_vec()).unwrap();
+    vn_mmr
+        .push(vn_mmr_node_hash(&node1, &ShardId::zero()).to_vec())
+        .unwrap();
+    vn_mmr
+        .push(vn_mmr_node_hash(&node2, &ShardId::zero()).to_vec())
+        .unwrap();
 
     let epoch_manager =
         RangeEpochManager::new(registered_vn_keys, *SHARD0..*SHARD1, vec![node1.clone(), node2.clone()]);
@@ -463,16 +485,17 @@ async fn test_hs_waiter_leader_sends_new_proposal_when_enough_votes_are_received
     // Get the node hash from the proposal
     let (proposal_message, _broadcast_group) = instance.recv_broadcast().await;
 
-    // tx_hs_messages
-    //     .send((node1.clone(), proposal_message))
-    //     .await
-    //     .expect("Should not error");
-
     let vote_hash = proposal_message.node().unwrap().hash();
 
     // Create some votes
-    let mut vote = VoteMessage::new(*vote_hash, *SHARD0, QuorumDecision::Accept, Default::default());
-    vote.set_metadata(&node1, &node1_pk, &vn_mmr, 0);
+    let mut vote = VoteMessage::new(
+        *vote_hash,
+        *SHARD0,
+        QuorumDecision::Accept,
+        new_view_message.high_qc().unwrap().all_shard_nodes().to_vec(),
+    );
+    vote.sign_vote(instance.signing_service(), ShardId::zero(), &vn_mmr, 0)
+        .unwrap();
     instance.tx_votes.send((node1, vote.clone())).await.unwrap();
 
     // Should get no proposal
@@ -485,7 +508,8 @@ async fn test_hs_waiter_leader_sends_new_proposal_when_enough_votes_are_received
 
     // Send another vote
     let mut vote = VoteMessage::new(*vote_hash, *SHARD0, QuorumDecision::Accept, Default::default());
-    vote.set_metadata(&node2, &node2_pk, &vn_mmr, 1);
+    vote.sign_vote(instance.signing_service(), ShardId::zero(), &vn_mmr, 1)
+        .unwrap();
     instance.tx_votes.send((node2, vote)).await.unwrap();
 
     // should get a proposal
@@ -750,7 +774,8 @@ async fn test_hs_waiter_cannot_spend_until_it_is_proven_committed() {
 }
 
 use tari_dan_core::{
-    services::{PayloadProcessor, PayloadProcessorError},
+    models::vn_mmr_node_hash,
+    services::{NodeIdentitySigningService, PayloadProcessor, PayloadProcessorError, SigningService},
     workers::hotstuff_error::HotStuffError,
 };
 use tari_template_lib::{args::Arg, Hash};

--- a/dan_layer/storage/src/global/backend_adapter.rs
+++ b/dan_layer/storage/src/global/backend_adapter.rs
@@ -55,6 +55,12 @@ pub trait GlobalDbAdapter: AtomicDb + Send + Sync + Clone {
         epoch: u64,
     ) -> Result<Vec<DbValidatorNode>, Self::Error>;
 
+    fn get_validator_node(
+        &self,
+        tx: &Self::DbTransaction,
+        epoch: u64,
+        public_key: &[u8],
+    ) -> Result<DbValidatorNode, Self::Error>;
     fn insert_epoch(&self, tx: &Self::DbTransaction, epoch: DbEpoch) -> Result<(), Self::Error>;
     fn get_epoch(&self, tx: &Self::DbTransaction, epoch: u64) -> Result<Option<DbEpoch>, Self::Error>;
 }

--- a/dan_layer/storage/src/global/validator_node_db.rs
+++ b/dan_layer/storage/src/global/validator_node_db.rs
@@ -38,7 +38,13 @@ impl<'a, TGlobalDbAdapter: GlobalDbAdapter> ValidatorNodeDb<'a, TGlobalDbAdapter
             .map_err(TGlobalDbAdapter::Error::into)
     }
 
-    pub fn get_validator_nodes_per_epoch(&self, epoch: u64) -> Result<Vec<DbValidatorNode>, TGlobalDbAdapter::Error> {
+    pub fn get(&self, epoch: u64, public_key: &[u8]) -> Result<DbValidatorNode, TGlobalDbAdapter::Error> {
+        self.backend
+            .get_validator_node(self.tx, epoch, public_key)
+            .map_err(TGlobalDbAdapter::Error::into)
+    }
+
+    pub fn get_all_per_epoch(&self, epoch: u64) -> Result<Vec<DbValidatorNode>, TGlobalDbAdapter::Error> {
         self.backend
             .get_validator_nodes_per_epoch(self.tx, epoch)
             .map_err(TGlobalDbAdapter::Error::into)

--- a/dan_layer/storage_sqlite/src/global/models/epoch.rs
+++ b/dan_layer/storage_sqlite/src/global/models/epoch.rs
@@ -26,7 +26,7 @@ use crate::global::schema::*;
 
 #[derive(Queryable)]
 pub struct Epoch {
-    pub epoch: i32,
+    pub epoch: i64,
     pub validator_node_mr: Vec<u8>,
 }
 
@@ -42,14 +42,14 @@ impl From<Epoch> for DbEpoch {
 #[derive(Insertable)]
 #[table_name = "epochs"]
 pub struct NewEpoch {
-    pub epoch: i32,
+    pub epoch: i64,
     pub validator_node_mr: Vec<u8>,
 }
 
 impl From<DbEpoch> for NewEpoch {
     fn from(e: DbEpoch) -> Self {
         Self {
-            epoch: e.epoch as i32,
+            epoch: e.epoch as i64,
             validator_node_mr: e.validator_node_mr,
         }
     }

--- a/dan_layer/storage_sqlite/src/global/models/validator_node.rs
+++ b/dan_layer/storage_sqlite/src/global/models/validator_node.rs
@@ -29,7 +29,7 @@ pub struct ValidatorNode {
     pub id: i32,
     pub public_key: Vec<u8>,
     pub shard_key: Vec<u8>,
-    pub epoch: i32,
+    pub epoch: i64,
 }
 
 impl From<ValidatorNode> for DbValidatorNode {
@@ -47,7 +47,7 @@ impl From<ValidatorNode> for DbValidatorNode {
 pub struct NewValidatorNode {
     pub public_key: Vec<u8>,
     pub shard_key: Vec<u8>,
-    pub epoch: i32,
+    pub epoch: i64,
 }
 
 impl From<DbValidatorNode> for NewValidatorNode {
@@ -55,7 +55,7 @@ impl From<DbValidatorNode> for NewValidatorNode {
         Self {
             shard_key: vn.shard_key,
             public_key: vn.public_key,
-            epoch: vn.epoch as i32,
+            epoch: vn.epoch as i64,
         }
     }
 }

--- a/dan_layer/storage_sqlite/src/global/schema.rs
+++ b/dan_layer/storage_sqlite/src/global/schema.rs
@@ -22,7 +22,7 @@
 
 table! {
     epochs (epoch) {
-        epoch -> Integer,
+        epoch -> BigInt,
         validator_node_mr -> Binary,
     }
 }
@@ -32,7 +32,7 @@ table! {
         id -> Integer,
         public_key -> Binary,
         shard_key -> Binary,
-        epoch -> Integer,
+        epoch -> BigInt,
     }
 }
 

--- a/dan_layer/tari_bor/Cargo.toml
+++ b/dan_layer/tari_bor/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "tari_bor"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+borsh = { version ="0.9.3", default-features = false }
+
+[features]
+default = ["std"]
+std = ["borsh/std"]

--- a/dan_layer/tari_bor/src/lib.rs
+++ b/dan_layer/tari_bor/src/lib.rs
@@ -1,0 +1,49 @@
+//   Copyright 2022 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use borsh::maybestd::{io, vec::Vec};
+// This is to make the borsh macros happy
+pub use borsh::{self, BorshDeserialize as Decode, BorshSerialize as Encode};
+
+pub fn encode_with_len<T: Encode>(val: &T) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(512);
+    buf.extend([0u8; 4]);
+
+    encode_into(val, &mut buf).expect("Vec<u8> Write impl is infallible");
+
+    let len = ((buf.len() - 4) as u32).to_le_bytes();
+    buf[..4].copy_from_slice(&len);
+
+    buf
+}
+
+pub fn encode_into<T: Encode + ?Sized, W: io::Write>(val: &T, writer: &mut W) -> io::Result<()> {
+    val.serialize(writer)
+}
+
+pub fn encode<T: Encode>(val: &T) -> io::Result<Vec<u8>> {
+    let mut buf = Vec::with_capacity(512);
+    encode_into(val, &mut buf)?;
+    Ok(buf)
+}
+
+pub fn decode<T: Decode>(mut input: &[u8]) -> io::Result<T> {
+    let result = T::deserialize(&mut input)?;
+    // assert!(input.is_empty());
+    Ok(result)
+}
+
+pub fn decode_len(input: &[u8]) -> io::Result<usize> {
+    if input.len() < 4 {
+        return Err(io::Error::new(
+            io::ErrorKind::UnexpectedEof,
+            "Not enough bytes to decode length",
+        ));
+    }
+
+    let mut buf = [0u8; 4];
+    buf.copy_from_slice(&input[..4]);
+    let len = u32::from_le_bytes(buf);
+    Ok(len as usize)
+}

--- a/dan_layer/template_abi/Cargo.toml
+++ b/dan_layer/template_abi/Cargo.toml
@@ -3,11 +3,9 @@ name = "tari_template_abi"
 version = "0.35.1"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
-borsh = { version ="0.9.3", default-features = false }
+tari_bor = { path = "../tari_bor", default-features = false }
 
 [features]
 default = ["std"]
-std = ["borsh/std"]
+std = ["tari_bor/std"]

--- a/dan_layer/template_abi/src/abi/mod.rs
+++ b/dan_layer/template_abi/src/abi/mod.rs
@@ -28,15 +28,11 @@ pub use wasm::*;
 mod non_wasm;
 #[cfg(not(target_arch = "wasm32"))]
 pub use non_wasm::*;
+use tari_bor::{decode, decode_len, encode_into, Decode, Encode};
 
 use crate::{
-    decode,
-    decode_len,
-    encode_into,
     ops::EngineOp,
     rust::{fmt, mem, ptr::copy, slice, vec::Vec},
-    Decode,
-    Encode,
 };
 
 pub fn wrap_ptr(mut v: Vec<u8>) -> *mut u8 {

--- a/dan_layer/template_abi/src/call_info.rs
+++ b/dan_layer/template_abi/src/call_info.rs
@@ -20,11 +20,9 @@
 //   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //   USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::{
-    rust::{string::String, vec::Vec},
-    Decode,
-    Encode,
-};
+use tari_bor::{borsh, Decode, Encode};
+
+use crate::rust::{string::String, vec::Vec};
 
 #[derive(Debug, Clone, Encode, Decode)]
 pub struct CallInfo {

--- a/dan_layer/template_abi/src/lib.rs
+++ b/dan_layer/template_abi/src/lib.rs
@@ -27,16 +27,11 @@
 //! This library provides types and encoding that allow low-level communication between the Tari WASM runtime and the
 //! WASM modules.
 
-pub use borsh::{BorshDeserialize as Decode, BorshSerialize as Encode};
-
 mod abi;
 pub use abi::*;
 
 mod call_info;
 pub use call_info::CallInfo;
-
-mod encoding;
-pub use encoding::{decode, decode_len, encode, encode_into, encode_with_len};
 
 mod ops;
 pub use ops::EngineOp;

--- a/dan_layer/template_abi/src/rust.rs
+++ b/dan_layer/template_abi/src/rust.rs
@@ -27,7 +27,7 @@ mod no_std {
     pub use alloc::{string, vec};
     pub use core::{fmt, mem, ptr, slice};
 
-    pub use borsh::maybestd::io;
+    pub use tari_bor::borsh::maybestd::io;
 }
 
 #[cfg(not(feature = "std"))]

--- a/dan_layer/template_abi/src/types.rs
+++ b/dan_layer/template_abi/src/types.rs
@@ -20,11 +20,9 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::{
-    rust::{string::String, vec::Vec},
-    Decode,
-    Encode,
-};
+use tari_bor::{borsh, Decode, Encode};
+
+use crate::rust::{string::String, vec::Vec};
 
 #[derive(Debug, Clone, Encode, Decode)]
 pub struct TemplateDef {

--- a/dan_layer/template_lib/Cargo.toml
+++ b/dan_layer/template_lib/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2021"
 [dependencies]
 tari_template_abi = { path = "../template_abi" }
 tari_template_macros = { path = "../template_macros", optional = true }
+tari_bor = { path = "../tari_bor" }
 
-borsh = "0.9.3"
 newtype-ops = "0.1.4"
 serde = { version = "1.0.143", optional = true }
 hex = { version = "0.4.3"}

--- a/dan_layer/template_lib/src/args/arg.rs
+++ b/dan_layer/template_lib/src/args/arg.rs
@@ -20,7 +20,8 @@
 //   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //   USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use tari_template_abi::{decode, encode, rust::io, Decode, Encode};
+use tari_bor::{borsh, decode, encode, Decode, Encode};
+use tari_template_abi::rust::io;
 
 #[derive(Debug, Clone, PartialEq, Eq, Decode, Encode)]
 #[cfg_attr(

--- a/dan_layer/template_lib/src/args/engine.rs
+++ b/dan_layer/template_lib/src/args/engine.rs
@@ -22,13 +22,8 @@
 
 use std::{fmt::Formatter, str::FromStr};
 
-use tari_template_abi::{
-    decode,
-    encode,
-    rust::{fmt::Display, io},
-    Decode,
-    Encode,
-};
+use tari_bor::{borsh, decode, encode, Decode, Encode};
+use tari_template_abi::rust::{fmt::Display, io};
 
 use crate::{
     models::{Amount, BucketId, ComponentAddress, Metadata, ResourceAddress, VaultRef},

--- a/dan_layer/template_lib/src/args/mod.rs
+++ b/dan_layer/template_lib/src/args/mod.rs
@@ -91,7 +91,7 @@ macro_rules! invoke_args {
     ($($args:expr),+) => {{
         let mut args = Vec::with_capacity($crate::__expr_counter!($($args),+));
         $(
-            $crate::args::__push(&mut args, tari_template_abi::encode(&$args).unwrap());
+            $crate::args::__push(&mut args, tari_bor::encode(&$args).unwrap());
         )+
         args
     }}
@@ -153,17 +153,11 @@ mod tests {
 
         let args = args![Variable("foo"), "bar".to_string()];
         assert_eq!(args[0], Arg::Variable("foo".into()));
-        assert_eq!(
-            args[1],
-            Arg::Literal(tari_template_abi::encode(&"bar".to_string()).unwrap())
-        );
+        assert_eq!(args[1], Arg::Literal(tari_bor::encode(&"bar".to_string()).unwrap()));
 
         let args = args!["foo".to_string(), Variable("bar"), 123u64];
-        assert_eq!(
-            args[0],
-            Arg::Literal(tari_template_abi::encode(&"foo".to_string()).unwrap())
-        );
+        assert_eq!(args[0], Arg::Literal(tari_bor::encode(&"foo".to_string()).unwrap()));
         assert_eq!(args[1], Arg::Variable("bar".into()));
-        assert_eq!(args[2], Arg::Literal(tari_template_abi::encode(&123u64).unwrap()));
+        assert_eq!(args[2], Arg::Literal(tari_bor::encode(&123u64).unwrap()));
     }
 }

--- a/dan_layer/template_lib/src/args/value.rs
+++ b/dan_layer/template_lib/src/args/value.rs
@@ -1,5 +1,5 @@
 //   Copyright 2022 The Tari Project
-//   SPDX-License-Identifier: BSD-3-Claus
+//   SPDX-License-Identifier: BSD-3-clause
 
 use tari_template_abi::{
     rust::{format, io},

--- a/dan_layer/template_lib/src/context.rs
+++ b/dan_layer/template_lib/src/context.rs
@@ -20,7 +20,8 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use tari_template_abi::{decode, CallInfo, Decode, Encode};
+use tari_bor::{borsh, decode, Decode, Encode};
+use tari_template_abi::CallInfo;
 
 use crate::resource::ResourceManager;
 

--- a/dan_layer/template_lib/src/engine.rs
+++ b/dan_layer/template_lib/src/engine.rs
@@ -20,7 +20,8 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use tari_template_abi::{call_engine, decode, encode, Decode, Encode, EngineOp};
+use tari_bor::{decode, encode, Decode, Encode};
+use tari_template_abi::{call_engine, EngineOp};
 
 use crate::{
     args::{ComponentAction, ComponentInvokeArg, ComponentRef, EmitLogArg, InvokeResult, LogLevel},

--- a/dan_layer/template_lib/src/hash.rs
+++ b/dan_layer/template_lib/src/hash.rs
@@ -28,7 +28,7 @@ use std::{
     ops::{Deref, DerefMut},
 };
 
-use tari_template_abi::{Decode, Encode};
+use tari_bor::{Decode, Encode};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]

--- a/dan_layer/template_lib/src/lib.rs
+++ b/dan_layer/template_lib/src/lib.rs
@@ -49,7 +49,7 @@ pub mod prelude;
 #[cfg(feature = "macro")]
 pub use prelude::template;
 // Re-export for macro
-pub use tari_template_abi::encode;
+pub use tari_bor::encode;
 
 #[cfg(target_arch = "wasm32")]
 pub mod workspace;

--- a/dan_layer/template_lib/src/models/amount.rs
+++ b/dan_layer/template_lib/src/models/amount.rs
@@ -23,7 +23,7 @@
 use std::fmt::{Display, Formatter};
 
 use newtype_ops::newtype_ops;
-use tari_template_abi::{Decode, Encode};
+use tari_bor::{borsh, Decode, Encode};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Decode, Encode)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]

--- a/dan_layer/template_lib/src/models/bucket.rs
+++ b/dan_layer/template_lib/src/models/bucket.rs
@@ -20,7 +20,8 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use tari_template_abi::{call_engine, Decode, Encode, EngineOp};
+use tari_bor::{borsh, Decode, Encode};
+use tari_template_abi::{call_engine, EngineOp};
 
 use crate::{
     args::{BucketAction, BucketInvokeArg, BucketRef, InvokeResult},

--- a/dan_layer/template_lib/src/models/component.rs
+++ b/dan_layer/template_lib/src/models/component.rs
@@ -20,7 +20,7 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use tari_template_abi::{Decode, Encode};
+use tari_bor::{borsh, Decode, Encode};
 
 use crate::models::TemplateAddress;
 

--- a/dan_layer/template_lib/src/models/metadata.rs
+++ b/dan_layer/template_lib/src/models/metadata.rs
@@ -23,7 +23,7 @@
 use std::collections::HashMap;
 
 use hex;
-use tari_template_abi::{Decode, Encode};
+use tari_bor::{borsh, Decode, Encode};
 
 #[derive(Clone, Debug, Decode, Encode, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]

--- a/dan_layer/template_lib/src/models/vault.rs
+++ b/dan_layer/template_lib/src/models/vault.rs
@@ -20,7 +20,8 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use tari_template_abi::{call_engine, Decode, Encode, EngineOp};
+use tari_bor::{borsh, Decode, Encode};
+use tari_template_abi::{call_engine, EngineOp};
 
 use crate::{
     args::{InvokeResult, VaultAction, VaultInvokeArg},

--- a/dan_layer/template_lib/src/resource/builder.rs
+++ b/dan_layer/template_lib/src/resource/builder.rs
@@ -20,7 +20,7 @@
 //   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //   USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use tari_template_abi::{encode, Encode};
+use tari_bor::{encode, Encode};
 
 use crate::{
     args::MintResourceArg,

--- a/dan_layer/template_lib/src/resource/mod.rs
+++ b/dan_layer/template_lib/src/resource/mod.rs
@@ -20,7 +20,7 @@
 //   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //   USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use tari_template_abi::{Decode, Encode};
+use tari_bor::{borsh, Decode, Encode};
 
 mod builder;
 pub use builder::ResourceBuilder;

--- a/dan_layer/template_lib/src/template_dependencies.rs
+++ b/dan_layer/template_lib/src/template_dependencies.rs
@@ -22,7 +22,7 @@
 
 //! Public types that are available to all template authors.
 
-pub use borsh;
-pub use tari_template_abi::{call_debug as debug, Decode, Encode};
+pub use tari_bor::{borsh, decode, encode_with_len, Decode, Encode};
+pub use tari_template_abi::call_debug as debug;
 
 pub use crate::{args::LogLevel, engine, get_context as context};

--- a/dan_layer/template_macros/src/template/abi.rs
+++ b/dan_layer/template_macros/src/template/abi.rs
@@ -34,7 +34,8 @@ pub fn generate_abi(ast: &TemplateAst) -> Result<TokenStream> {
     let output = quote! {
         #[no_mangle]
         pub extern "C" fn #abi_function_name() -> *mut u8 {
-            use ::tari_template_abi::{encode_with_len, FunctionDef, TemplateDef, Type, wrap_ptr};
+            use ::tari_template_abi::{FunctionDef, TemplateDef, Type, wrap_ptr};
+            use ::tari_template_lib::template_dependencies::encode_with_len;
 
             let template = TemplateDef {
                 template_name: #template_name_as_str.to_string(),
@@ -118,7 +119,7 @@ mod tests {
     use crate::template::ast::TemplateAst;
 
     #[test]
-    fn test_signatures() {
+    fn test_codegen() {
         let input = TokenStream::from_str(indoc! {"
             mod foo {
                 struct Foo {}
@@ -145,7 +146,8 @@ mod tests {
         assert_code_eq(output, quote! {
             #[no_mangle]
             pub extern "C" fn Foo_abi() -> *mut u8 {
-                use ::tari_template_abi::{encode_with_len, FunctionDef, TemplateDef, Type, wrap_ptr};
+                use ::tari_template_abi::{FunctionDef, TemplateDef, Type, wrap_ptr};
+                use ::tari_template_lib::template_dependencies::encode_with_len;
 
                 let template = TemplateDef {
                     template_name: "Foo".to_string(),

--- a/dan_layer/template_macros/src/template/dispatcher.rs
+++ b/dan_layer/template_macros/src/template/dispatcher.rs
@@ -34,8 +34,8 @@ pub fn generate_dispatcher(ast: &TemplateAst) -> Result<TokenStream> {
     let output = quote! {
         #[no_mangle]
         pub extern "C" fn #dispatcher_function_name(call_info: *mut u8, call_info_len: usize) -> *mut u8 {
-            use ::tari_template_abi::{decode, encode_with_len, CallInfo, wrap_ptr};
-            use ::tari_template_lib::{init_context, panic_hook::register_panic_hook};
+            use ::tari_template_abi::{CallInfo, wrap_ptr};
+            use ::tari_template_lib::{template_dependencies::{decode, encode_with_len},init_context, panic_hook::register_panic_hook};
 
             register_panic_hook();
 

--- a/dan_layer/template_macros/src/template/mod.rs
+++ b/dan_layer/template_macros/src/template/mod.rs
@@ -123,7 +123,8 @@ mod tests {
 
             #[no_mangle]
             pub extern "C" fn State_abi() -> *mut u8 {
-                use ::tari_template_abi::{encode_with_len, FunctionDef, TemplateDef, Type, wrap_ptr};
+                use ::tari_template_abi::{ FunctionDef, TemplateDef, Type, wrap_ptr};
+                use :: tari_template_lib :: template_dependencies :: encode_with_len ;
 
                 let template = TemplateDef {
                     template_name: "State".to_string(),
@@ -152,8 +153,8 @@ mod tests {
 
             #[no_mangle]
             pub extern "C" fn State_main(call_info: *mut u8, call_info_len: usize) -> *mut u8 {
-                use ::tari_template_abi::{decode, encode_with_len, CallInfo, wrap_ptr};
-                use ::tari_template_lib::{init_context, panic_hook::register_panic_hook};
+                use ::tari_template_abi::{CallInfo, wrap_ptr};
+                use ::tari_template_lib::{template_dependencies::{decode, encode_with_len}, init_context, panic_hook::register_panic_hook};
                 register_panic_hook();
 
                 if call_info.is_null() {

--- a/dan_layer/transaction_manifest/src/generator.rs
+++ b/dan_layer/transaction_manifest/src/generator.rs
@@ -1,5 +1,5 @@
 //   Copyright 2022 The Tari Project
-//   SPDX-License-Identifier: BSD-3-Claus
+//   SPDX-License-Identifier: BSD-3-clause
 
 use std::collections::{HashMap, HashSet};
 

--- a/dan_layer/transaction_manifest/src/parser.rs
+++ b/dan_layer/transaction_manifest/src/parser.rs
@@ -1,5 +1,5 @@
 //   Copyright 2022 The Tari Project
-//   SPDX-License-Identifier: BSD-3-Claus
+//   SPDX-License-Identifier: BSD-3-clause
 
 use proc_macro2::{Ident, TokenStream};
 use syn::{

--- a/dan_layer/transaction_manifest/src/value.rs
+++ b/dan_layer/transaction_manifest/src/value.rs
@@ -1,5 +1,5 @@
 //   Copyright 2022 The Tari Project
-//   SPDX-License-Identifier: BSD-3-Claus
+//   SPDX-License-Identifier: BSD-3-clause
 
 use std::str::FromStr;
 

--- a/dan_layer/transaction_manifest/tests/examples/picture_seller.rs
+++ b/dan_layer/transaction_manifest/tests/examples/picture_seller.rs
@@ -1,5 +1,5 @@
 //   Copyright 2022 The Tari Project
-//   SPDX-License-Identifier: BSD-3-Claus
+//   SPDX-License-Identifier: BSD-3-clause
 
 // These mappings can be provided to the parser context or defined inline in the manifest
 // TODO: Account builtin should not have to be explicitly defined


### PR DESCRIPTION
Description
---
- Fixes QC Merkle root mismatch
- add borsh encoding consensus hasher and tari_bor crate, so that it does not have to depend on tari_template_abi
- removed a number of panics
- domain separated hashing
- number of small fixes
- updated integration tests

Motivation and Context
---
Relies on https://github.com/tari-project/tari/pull/4952

Fixes #218 

How Has This Been Tested?
---
Manually
Existing tests updated
