### PR TITLE
fix: db error when starting state sync fixes #225

### DIFF
--- a/applications/tari_validator_node/src/bootstrap.rs
+++ b/applications/tari_validator_node/src/bootstrap.rs
@@ -176,7 +176,7 @@ pub async fn spawn_services(
         shutdown.clone(),
     )?;
 
-    let shard_store_store = SqliteShardStoreFactory::try_create(config.validator_node.data_dir.join("state.db"))?;
+    let shard_store_store = SqliteShardStoreFactory::try_create(config.validator_node.state_db_path())?;
 
     let comms = setup_p2p_rpc(config, comms, peer_provider, shard_store_store, mempool.clone());
     let comms = comms::spawn_comms_using_transport(comms, p2p_config.transport.clone())

--- a/applications/tari_validator_node/src/config.rs
+++ b/applications/tari_validator_node/src/config.rs
@@ -98,6 +98,10 @@ pub struct ValidatorNodeConfig {
 }
 
 impl ValidatorNodeConfig {
+    pub fn state_db_path(&self) -> PathBuf {
+        self.data_dir.join("state.db")
+    }
+
     pub fn set_base_path<P: AsRef<Path>>(&mut self, base_path: P) {
         if !self.shard_key_file.is_absolute() {
             self.shard_key_file = base_path.as_ref().join(&self.shard_key_file);

--- a/applications/tari_validator_node/src/p2p/services/hotstuff/hotstuff_service.rs
+++ b/applications/tari_validator_node/src/p2p/services/hotstuff/hotstuff_service.rs
@@ -72,7 +72,6 @@ pub struct HotstuffService {
     rx_broadcast: Receiver<(HotStuffMessage<TariDanPayload, CommsPublicKey>, Vec<CommsPublicKey>)>,
     /// Outgoing vote messages to be sent to the leader
     rx_vote_message: Receiver<(VoteMessage, CommsPublicKey)>,
-    epoch_manager: EpochManagerHandle,
     shutdown: ShutdownSignal, // waiter: HotstuffWaiter,
 }
 
@@ -106,7 +105,7 @@ impl HotstuffService {
             // TODO: we still need this because The signing service is not generic. Abstracting signatures and public
             // keys may add a lot of type complexity.
             node_public_key.clone(),
-            epoch_manager.clone(),
+            epoch_manager,
             leader_strategy,
             rx_new,
             rx_hotstuff_messages,
@@ -130,7 +129,6 @@ impl HotstuffService {
                 rx_leader,
                 rx_broadcast,
                 rx_vote_message,
-                epoch_manager,
                 shutdown,
             }
             .run(),

--- a/applications/tari_validator_node/src/p2p/services/hotstuff/initializer.rs
+++ b/applications/tari_validator_node/src/p2p/services/hotstuff/initializer.rs
@@ -54,7 +54,7 @@ pub fn try_spawn(
     rx_vote_message: mpsc::Receiver<(CommsPublicKey, VoteMessage)>,
     shutdown: ShutdownSignal,
 ) -> Result<(EventSubscription<HotStuffEvent>, SqliteShardStoreFactory), anyhow::Error> {
-    let db = SqliteShardStoreFactory::try_create(config.data_dir.join("state.db"))?;
+    let db = SqliteShardStoreFactory::try_create(config.state_db_path())?;
 
     let events = HotstuffService::spawn(
         node_identity,


### PR DESCRIPTION
Description
---
Fixes database error in epoch manager cause by incorrect db url for state sync

Motivation and Context
---
Fixes #225 

How Has This Been Tested?
---
Manually


