### PR TITLE
fix: use development tari branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5340,7 +5340,7 @@ checksum = "9410d0f6853b1d94f0e519fb95df60f29d2c1eff2d921ffdf01a4c8a3b54f12d"
 [[package]]
 name = "tari_app_grpc"
 version = "0.41.0"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan#5de63d35b923a0e78a4da3bdc56ad1b250b4fb47"
+source = "git+https://github.com/tari-project/tari.git?branch=development#5de63d35b923a0e78a4da3bdc56ad1b250b4fb47"
 dependencies = [
  "argon2",
  "base64 0.13.1",
@@ -5367,7 +5367,7 @@ dependencies = [
 [[package]]
 name = "tari_app_utilities"
 version = "0.41.0"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan#5de63d35b923a0e78a4da3bdc56ad1b250b4fb47"
+source = "git+https://github.com/tari-project/tari.git?branch=development#5de63d35b923a0e78a4da3bdc56ad1b250b4fb47"
 dependencies = [
  "clap 3.2.23",
  "config",
@@ -5390,7 +5390,7 @@ dependencies = [
 [[package]]
 name = "tari_base_node"
 version = "0.41.0"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan#5de63d35b923a0e78a4da3bdc56ad1b250b4fb47"
+source = "git+https://github.com/tari-project/tari.git?branch=development#5de63d35b923a0e78a4da3bdc56ad1b250b4fb47"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5439,7 +5439,7 @@ dependencies = [
 [[package]]
 name = "tari_base_node_grpc_client"
 version = "0.1.0"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan#5de63d35b923a0e78a4da3bdc56ad1b250b4fb47"
+source = "git+https://github.com/tari-project/tari.git?branch=development#5de63d35b923a0e78a4da3bdc56ad1b250b4fb47"
 dependencies = [
  "tari_app_grpc",
 ]
@@ -5495,7 +5495,7 @@ dependencies = [
 [[package]]
 name = "tari_common"
 version = "0.41.0"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan#5de63d35b923a0e78a4da3bdc56ad1b250b4fb47"
+source = "git+https://github.com/tari-project/tari.git?branch=development#5de63d35b923a0e78a4da3bdc56ad1b250b4fb47"
 dependencies = [
  "anyhow",
  "blake2 0.9.2",
@@ -5522,7 +5522,7 @@ dependencies = [
 [[package]]
 name = "tari_common_sqlite"
 version = "0.41.0"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan#5de63d35b923a0e78a4da3bdc56ad1b250b4fb47"
+source = "git+https://github.com/tari-project/tari.git?branch=development#5de63d35b923a0e78a4da3bdc56ad1b250b4fb47"
 dependencies = [
  "diesel",
  "log",
@@ -5532,7 +5532,7 @@ dependencies = [
 [[package]]
 name = "tari_common_types"
 version = "0.41.0"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan#5de63d35b923a0e78a4da3bdc56ad1b250b4fb47"
+source = "git+https://github.com/tari-project/tari.git?branch=development#5de63d35b923a0e78a4da3bdc56ad1b250b4fb47"
 dependencies = [
  "base64 0.13.1",
  "borsh",
@@ -5552,7 +5552,7 @@ dependencies = [
 [[package]]
 name = "tari_comms"
 version = "0.41.0"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan#5de63d35b923a0e78a4da3bdc56ad1b250b4fb47"
+source = "git+https://github.com/tari-project/tari.git?branch=development#5de63d35b923a0e78a4da3bdc56ad1b250b4fb47"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5598,7 +5598,7 @@ dependencies = [
 [[package]]
 name = "tari_comms_dht"
 version = "0.41.0"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan#5de63d35b923a0e78a4da3bdc56ad1b250b4fb47"
+source = "git+https://github.com/tari-project/tari.git?branch=development#5de63d35b923a0e78a4da3bdc56ad1b250b4fb47"
 dependencies = [
  "anyhow",
  "bitflags 1.3.2",
@@ -5645,7 +5645,7 @@ dependencies = [
 [[package]]
 name = "tari_comms_rpc_macros"
 version = "0.41.0"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan#5de63d35b923a0e78a4da3bdc56ad1b250b4fb47"
+source = "git+https://github.com/tari-project/tari.git?branch=development#5de63d35b923a0e78a4da3bdc56ad1b250b4fb47"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5655,7 +5655,7 @@ dependencies = [
 [[package]]
 name = "tari_console_wallet"
 version = "0.41.0"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan#5de63d35b923a0e78a4da3bdc56ad1b250b4fb47"
+source = "git+https://github.com/tari-project/tari.git?branch=development#5de63d35b923a0e78a4da3bdc56ad1b250b4fb47"
 dependencies = [
  "base64 0.13.1",
  "bitflags 1.3.2",
@@ -5702,7 +5702,7 @@ dependencies = [
 [[package]]
 name = "tari_core"
 version = "0.41.0"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan#5de63d35b923a0e78a4da3bdc56ad1b250b4fb47"
+source = "git+https://github.com/tari-project/tari.git?branch=development#5de63d35b923a0e78a4da3bdc56ad1b250b4fb47"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5974,7 +5974,7 @@ dependencies = [
 [[package]]
 name = "tari_key_manager"
 version = "0.41.0"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan#5de63d35b923a0e78a4da3bdc56ad1b250b4fb47"
+source = "git+https://github.com/tari-project/tari.git?branch=development#5de63d35b923a0e78a4da3bdc56ad1b250b4fb47"
 dependencies = [
  "argon2",
  "blake2 0.9.2",
@@ -5998,7 +5998,7 @@ dependencies = [
 [[package]]
 name = "tari_metrics"
 version = "0.1.0"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan#5de63d35b923a0e78a4da3bdc56ad1b250b4fb47"
+source = "git+https://github.com/tari-project/tari.git?branch=development#5de63d35b923a0e78a4da3bdc56ad1b250b4fb47"
 dependencies = [
  "anyhow",
  "futures 0.3.25",
@@ -6014,7 +6014,7 @@ dependencies = [
 [[package]]
 name = "tari_mmr"
 version = "0.41.0"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan#5de63d35b923a0e78a4da3bdc56ad1b250b4fb47"
+source = "git+https://github.com/tari-project/tari.git?branch=development#5de63d35b923a0e78a4da3bdc56ad1b250b4fb47"
 dependencies = [
  "croaring",
  "digest 0.9.0",
@@ -6029,7 +6029,7 @@ dependencies = [
 [[package]]
 name = "tari_p2p"
 version = "0.41.0"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan#5de63d35b923a0e78a4da3bdc56ad1b250b4fb47"
+source = "git+https://github.com/tari-project/tari.git?branch=development#5de63d35b923a0e78a4da3bdc56ad1b250b4fb47"
 dependencies = [
  "anyhow",
  "bytes 0.5.6",
@@ -6066,7 +6066,7 @@ dependencies = [
 [[package]]
 name = "tari_script"
 version = "0.12.0"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan#5de63d35b923a0e78a4da3bdc56ad1b250b4fb47"
+source = "git+https://github.com/tari-project/tari.git?branch=development#5de63d35b923a0e78a4da3bdc56ad1b250b4fb47"
 dependencies = [
  "blake2 0.9.2",
  "borsh",
@@ -6083,7 +6083,7 @@ dependencies = [
 [[package]]
 name = "tari_service_framework"
 version = "0.41.0"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan#5de63d35b923a0e78a4da3bdc56ad1b250b4fb47"
+source = "git+https://github.com/tari-project/tari.git?branch=development#5de63d35b923a0e78a4da3bdc56ad1b250b4fb47"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6098,7 +6098,7 @@ dependencies = [
 [[package]]
 name = "tari_shutdown"
 version = "0.41.0"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan#5de63d35b923a0e78a4da3bdc56ad1b250b4fb47"
+source = "git+https://github.com/tari-project/tari.git?branch=development#5de63d35b923a0e78a4da3bdc56ad1b250b4fb47"
 dependencies = [
  "futures 0.3.25",
 ]
@@ -6106,7 +6106,7 @@ dependencies = [
 [[package]]
 name = "tari_storage"
 version = "0.41.0"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan#5de63d35b923a0e78a4da3bdc56ad1b250b4fb47"
+source = "git+https://github.com/tari-project/tari.git?branch=development#5de63d35b923a0e78a4da3bdc56ad1b250b4fb47"
 dependencies = [
  "bincode",
  "lmdb-zero",
@@ -6162,7 +6162,7 @@ dependencies = [
 [[package]]
 name = "tari_test_utils"
 version = "0.41.0"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan#5de63d35b923a0e78a4da3bdc56ad1b250b4fb47"
+source = "git+https://github.com/tari-project/tari.git?branch=development#5de63d35b923a0e78a4da3bdc56ad1b250b4fb47"
 dependencies = [
  "futures 0.3.25",
  "rand 0.7.3",
@@ -6315,7 +6315,7 @@ dependencies = [
 [[package]]
 name = "tari_wallet"
 version = "0.41.0"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan#5de63d35b923a0e78a4da3bdc56ad1b250b4fb47"
+source = "git+https://github.com/tari-project/tari.git?branch=development#5de63d35b923a0e78a4da3bdc56ad1b250b4fb47"
 dependencies = [
  "argon2",
  "async-trait",
@@ -6366,7 +6366,7 @@ dependencies = [
 [[package]]
 name = "tari_wallet_grpc_client"
 version = "0.1.0"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan#5de63d35b923a0e78a4da3bdc56ad1b250b4fb47"
+source = "git+https://github.com/tari-project/tari.git?branch=development#5de63d35b923a0e78a4da3bdc56ad1b250b4fb47"
 dependencies = [
  "tari_app_grpc",
  "tari_common_types",

--- a/applications/tari_validator_node/Cargo.toml
+++ b/applications/tari_validator_node/Cargo.toml
@@ -8,26 +8,26 @@ version = "0.35.1"
 edition = "2018"
 
 [dependencies]
-tari_app_utilities = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan", package = "tari_app_utilities" }
-tari_app_grpc = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan", package = "tari_app_grpc" }
-tari_common = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan", package = "tari_common" }
-tari_comms = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan", package = "tari_comms" }
-tari_comms_rpc_macros = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan", package = "tari_comms_rpc_macros" }
+tari_app_utilities = { git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_app_utilities" }
+tari_app_grpc = { git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_app_grpc" }
+tari_common = { git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_common" }
+tari_comms = { git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_comms" }
+tari_comms_rpc_macros = { git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_comms_rpc_macros" }
 tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.16.5" }
-tari_mmr = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan", package = "tari_mmr" }
-tari_p2p = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan", package = "tari_p2p" }
-tari_shutdown = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan", package = "tari_shutdown" }
-tari_storage = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan", package = "tari_storage" }
-tari_core = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan", package = "tari_core", default-features = false, features = ["transactions"] }
+tari_mmr = { git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_mmr" }
+tari_p2p = { git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_p2p" }
+tari_shutdown = { git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_shutdown" }
+tari_storage = { git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_storage" }
+tari_core = { git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_core", default-features = false, features = ["transactions"] }
 tari_dan_core = { path = "../../dan_layer/core" }
 tari_dan_storage = { path = "../../dan_layer/storage" }
 tari_dan_storage_sqlite = { path = "../../dan_layer/storage_sqlite" }
 tari_dan_common_types = { path = "../../dan_layer/common_types" }
-tari_common_types = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan", package = "tari_common_types" }
+tari_common_types = { git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_common_types" }
 tari_dan_engine = { path = "../../dan_layer/engine" }
 tari_template_lib = { path = "../../dan_layer/template_lib" }
-tari_base_node_grpc_client = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan", package = "tari_base_node_grpc_client" }
-tari_wallet_grpc_client = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan", package = "tari_wallet_grpc_client" }
+tari_base_node_grpc_client = { git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_base_node_grpc_client" }
+tari_wallet_grpc_client = { git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_wallet_grpc_client" }
 tari_engine_types = { path = "../../dan_layer/engine_types" }
 tari_validator_node_client = { path = "../../clients/validator_node_client" }
 tari_comms_logging = { path = "../../comms/tari_comms_logging" }
@@ -67,17 +67,17 @@ tower-layer = "0.3"
 tower-http = { version = "0.3.0", features = ["cors"] }
 
 [build-dependencies]
-tari_common = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan", package = "tari_common", features = ["build"] }
+tari_common = { git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_common", features = ["build"] }
 
 [dev-dependencies]
 # FIXME: the newest version failed compilation due to a missing "bool_to_option" unstable feature
 cucumber = { version = "0.13.0"}
 tempfile = "3.3.0"
-tari_test_utils = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan", package = "tari_test_utils" }
-tari_base_node = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan", package = "tari_base_node" }
-tari_console_wallet = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan", package = "tari_console_wallet"}
-tari_comms_dht = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan", package = "tari_comms_dht" }
-tari_wallet = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan", package = "tari_wallet" }
+tari_test_utils = { git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_test_utils" }
+tari_base_node = { git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_base_node" }
+tari_console_wallet = { git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_console_wallet"}
+tari_comms_dht = { git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_comms_dht" }
+tari_wallet = { git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_wallet" }
 #env_logger = "0.9.0"
 httpmock = "0.6.7"
 indexmap = "1.9.1"

--- a/applications/tari_validator_node/src/grpc/services/wallet_client.rs
+++ b/applications/tari_validator_node/src/grpc/services/wallet_client.rs
@@ -57,7 +57,7 @@ impl GrpcWalletClient {
         Self { endpoint, client: None }
     }
 
-    pub async fn connection(&mut self) -> Result<&mut Client, DigitalAssetError> {
+    async fn connection(&mut self) -> Result<&mut Client, DigitalAssetError> {
         if self.client.is_none() {
             let url = format!("http://{}", self.endpoint);
             let inner = Client::connect(url).await?;

--- a/applications/tari_validator_node/src/template_registration_signing.rs
+++ b/applications/tari_validator_node/src/template_registration_signing.rs
@@ -34,7 +34,7 @@ pub fn sign_template_registration(private_key: &PrivateKey, binary_hash: Vec<u8>
     // TODO: epoch should be committed to, but this is currently not the case on the base node, so we leave it out for
     //       now so that the transaction passes validation.
     let challenge = construct_challenge(&public_key, &public_nonce, &binary_hash, b"");
-    Signature::sign(private_key.clone(), secret_nonce, &*challenge)
+    Signature::sign_raw(private_key, secret_nonce, &*challenge)
         .expect("Sign cannot fail with 32-byte challenge and a RistrettoPublicKey")
 }
 

--- a/applications/tari_validator_node_cli/Cargo.toml
+++ b/applications/tari_validator_node_cli/Cargo.toml
@@ -8,7 +8,7 @@ version = "0.35.1"
 edition = "2018"
 
 [dependencies]
-tari_common_types = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan" }
+tari_common_types = { git = "https://github.com/tari-project/tari.git", branch = "development" }
 tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.16.5" }
 tari_dan_common_types = { path = "../../dan_layer/common_types" }
 tari_dan_engine = { path = "../../dan_layer/engine" }

--- a/clients/validator_node_client/Cargo.toml
+++ b/clients/validator_node_client/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 tari_dan_common_types = { path = "../../dan_layer/common_types" }
 tari_engine_types = { path = "../../dan_layer/engine_types" }
-tari_common_types = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan" }
+tari_common_types = { git = "https://github.com/tari-project/tari.git", branch = "development" }
 
 anyhow = "1.0.65"
 reqwest = { version = "0.11.11", features = ["json"] }

--- a/dan_layer/common_types/Cargo.toml
+++ b/dan_layer/common_types/Cargo.toml
@@ -7,13 +7,13 @@ license = "BSD-3-Clause"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tari_common = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan", package = "tari_common", features = ["build"] }
-tari_common_types = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan", package = "tari_common_types" }
+tari_common = { git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_common", features = ["build"] }
+tari_common_types = { git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_common_types" }
 tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.10" }
 tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.16.5" }
 tari_engine_types = { path = "../engine_types"}
 tari_bor = { path = "../tari_bor" }
-tari_mmr = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan", package = "tari_mmr" }
+tari_mmr = { git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_mmr" }
 
 anyhow = "1.0"
 # TODO: remove once we use borsh for all serialization
@@ -26,4 +26,4 @@ prost = "0.9"
 prost-types = "0.9"
 
 [build-dependencies]
-tari_common = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan", package = "tari_common", features = ["build"] }
+tari_common = { git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_common", features = ["build"] }

--- a/dan_layer/core/Cargo.toml
+++ b/dan_layer/core/Cargo.toml
@@ -7,19 +7,19 @@ license = "BSD-3-Clause"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tari_common = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan", package = "tari_common" }
-tari_comms = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan", package = "tari_comms" }
-tari_comms_dht = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan", package = "tari_comms_dht" }
-tari_comms_rpc_macros = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan", package = "tari_comms_rpc_macros" }
+tari_common = { git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_common" }
+tari_comms = { git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_comms" }
+tari_comms_dht = { git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_comms_dht" }
+tari_comms_rpc_macros = { git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_comms_rpc_macros" }
 tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.16.5" }
-tari_mmr = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan", package = "tari_mmr" }
-tari_p2p = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan", package = "tari_p2p" }
-tari_service_framework = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan", package = "tari_service_framework" }
-tari_shutdown = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan", package = "tari_shutdown" }
-tari_storage = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan", package = "tari_storage" }
-tari_core = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan", package = "tari_core" }
+tari_mmr = { git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_mmr" }
+tari_p2p = { git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_p2p" }
+tari_service_framework = { git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_service_framework" }
+tari_shutdown = { git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_shutdown" }
+tari_storage = { git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_storage" }
+tari_core = { git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_core" }
 tari_dan_common_types = { path = "../common_types" }
-tari_common_types = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan", package = "tari_common_types" }
+tari_common_types = { git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_common_types" }
 tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.10" }
 tari_dan_engine = { path = "../engine" }
 tari_template_lib = { path = "../template_lib" }
@@ -52,7 +52,7 @@ lazy_static = "1.4.0"
 serde_json = "1.0.64"
 
 [dev-dependencies]
-tari_test_utils = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan", package = "tari_test_utils" }
+tari_test_utils = { git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_test_utils" }
 
 [build-dependencies]
-tari_common = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan", package = "tari_common", features = ["build"] }
+tari_common = { git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_common", features = ["build"] }

--- a/dan_layer/core/src/services/signing_service.rs
+++ b/dan_layer/core/src/services/signing_service.rs
@@ -63,7 +63,7 @@ impl SigningService for NodeIdentitySigningService {
     fn sign(&self, challenge: &[u8]) -> Option<Signature> {
         let (nonce, public_nonce) = create_key_pair();
         let challenge = Self::create_challenge(&public_nonce, self.node_identity.public_key(), challenge);
-        let sig = Signature::sign(self.node_identity.secret_key().clone(), nonce, &*challenge).ok()?;
+        let sig = Signature::sign_raw(self.node_identity.secret_key(), nonce, &*challenge).ok()?;
         Some(sig)
     }
 

--- a/dan_layer/engine/Cargo.toml
+++ b/dan_layer/engine/Cargo.toml
@@ -7,12 +7,12 @@ edition = "2018"
 
 [dependencies]
 tari_bor = { path = "../tari_bor" }
-tari_common = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan", package = "tari_common" }
-tari_common_types = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan", package = "tari_common_types" }
+tari_common = { git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_common" }
+tari_common_types = { git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_common_types" }
 tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.16.5" }
 tari_dan_common_types = { path = "../common_types" }
 tari_engine_types = { path = "../engine_types" }
-tari_mmr = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan", package = "tari_mmr" }
+tari_mmr = { git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_mmr" }
 tari_template_abi = { path = "../template_abi", features = ["std"] }
 tari_template_lib = { path = "../template_lib", default-features = false, features = ["serde"] }
 tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.10" }

--- a/dan_layer/engine_types/Cargo.toml
+++ b/dan_layer/engine_types/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 
 [dependencies]
 tari_bor = { path = "../tari_bor" }
-tari_common_types = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan" }
+tari_common_types = { git = "https://github.com/tari-project/tari.git", branch = "development" }
 tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.16.5" }
 tari_template_abi = { path = "../template_abi", features = ["std"] }
 tari_template_lib = { path = "../template_lib", default-features = false, features = ["serde"] }

--- a/dan_layer/engine_types/src/signature.rs
+++ b/dan_layer/engine_types/src/signature.rs
@@ -29,7 +29,7 @@ impl InstructionSignature {
             .chain(public_key.as_bytes())
             .chain(instructions)
             .result();
-        Self(RistrettoSchnorr::sign(secret_key.clone(), secret_nonce, &challenge).unwrap())
+        Self(RistrettoSchnorr::sign_raw(secret_key, secret_nonce, &challenge).unwrap())
     }
 
     pub fn signature(&self) -> RistrettoSchnorr {

--- a/dan_layer/integration_tests/Cargo.toml
+++ b/dan_layer/integration_tests/Cargo.toml
@@ -5,21 +5,21 @@ edition = "2018"
 license = "BSD-3-Clause"
 
 [dependencies]
-tari_common = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan", package = "tari_common", features = ["build"] }
-tari_common_types = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan", package = "tari_common_types" }
-tari_comms = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan", package = "tari_comms" }
+tari_common = { git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_common", features = ["build"] }
+tari_common_types = { git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_common_types" }
+tari_comms = { git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_comms" }
 tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.16.5" }
 tari_dan_common_types = { path = "../common_types" }
 tari_dan_core = { path = "../core" }
 tari_dan_engine = { path = "../engine" }
 tari_dan_storage_sqlite = { path = "../storage_sqlite" }
 tari_engine_types = { path = "../engine_types" }
-tari_shutdown = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan", package = "tari_shutdown" }
+tari_shutdown = { git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_shutdown" }
 tari_template_lib = { path = "../template_lib" }
-tari_test_utils = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan", package = "tari_test_utils" }
+tari_test_utils = { git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_test_utils" }
 tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.10" }
-tari_mmr = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan", package = "tari_mmr" }
-tari_core = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan", package = "tari_core" }
+tari_mmr = { git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_mmr" }
+tari_core = { git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_core" }
 
 lazy_static = "1.4.0"
 rand = "0.7"

--- a/dan_layer/storage/Cargo.toml
+++ b/dan_layer/storage/Cargo.toml
@@ -7,7 +7,7 @@ license = "BSD-3-Clause"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tari_common_types = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan", package = "tari_common_types" }
+tari_common_types = { git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_common_types" }
 
 thiserror = "1"
 time = "0.3.15"

--- a/dan_layer/storage_lmdb/Cargo.toml
+++ b/dan_layer/storage_lmdb/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 tari_dan_engine = { path = "../engine" }
 tari_dan_common_types = { path = "../common_types" }
-tari_storage = {  git = "https://github.com/tari-project/tari.git", branch = "feature-dan", package = "tari_storage" }
+tari_storage = {  git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_storage" }
 
 borsh = "0.9.3"
 lmdb-zero = "0.4.4"

--- a/dan_layer/storage_sqlite/Cargo.toml
+++ b/dan_layer/storage_sqlite/Cargo.toml
@@ -6,8 +6,8 @@ license = "BSD-3-Clause"
 
 [dependencies]
 tari_dan_core = { path = "../core" }
-tari_common = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan", package = "tari_common" }
-tari_common_types = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan", package = "tari_common_types" }
+tari_common = { git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_common" }
+tari_common_types = { git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_common_types" }
 tari_dan_common_types = { path = "../common_types" }
 tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.10" }
 tari_dan_engine = { path = "../engine" }


### PR DESCRIPTION
Description
---
Uses `development` branch instead of `feature-dan`

Motivation and Context
---
`feature-dan` was merged into `development`

How Has This Been Tested?
---
Manually, with fix from https://github.com/tari-project/tari/pull/4975 
