### PR TITLE
fix(consensus): only store state for local shard

### DIFF
--- a/applications/tari_validator_node_cli/src/command/manifest.rs
+++ b/applications/tari_validator_node_cli/src/command/manifest.rs
@@ -13,7 +13,9 @@ use tari_transaction_manifest::ManifestValue;
 
 #[derive(Debug, Subcommand, Clone)]
 pub enum ManifestSubcommand {
+    /// Creates a new manifest template
     New(NewArgs),
+    /// Parses the manifest for errors
     Check(CheckArgs),
 }
 

--- a/dan_layer/storage_sqlite/src/sqlite_shard_store_factory.rs
+++ b/dan_layer/storage_sqlite/src/sqlite_shard_store_factory.rs
@@ -804,7 +804,8 @@ impl ShardStoreTransaction<PublicKey, TariDanPayload> for SqliteShardStoreTransa
     ) -> Result<(), StorageError> {
         use crate::schema::substates::{data, is_draft, justify, node_height, shard_id, substate_type, tree_node_hash};
         let payload_id = Vec::from(node.payload_id().as_slice());
-        for (sid, st_changes) in changes {
+        // Only save this node's shard state
+        for (sid, st_changes) in changes.iter().filter(|(s, _)| *s == &node.shard()) {
             let shard = Vec::from(sid.as_bytes());
 
             for st_change in st_changes {


### PR DESCRIPTION
Only store the state for shards that are local to the node (instead of foreign committee data as well
