### PR TITLE
fix(consensus): report error back to cli

### DIFF
--- a/applications/tari_validator_node_cli/src/command/transaction.rs
+++ b/applications/tari_validator_node_cli/src/command/transaction.rs
@@ -209,7 +209,20 @@ async fn submit_transaction(
         .get_active_account()
         .ok_or_else(|| anyhow::anyhow!("No active account. Use `accounts use [public key hex]` to set one."))?;
 
-    let input_refs = extract_input_refs(&instructions, &component_manager)?;
+    // let input_refs = extract_input_refs(&instructions, &component_manager)?;
+    let input_refs: Vec<ShardId> = instructions
+        .iter()
+        .map(|i| match i {
+            Instruction::CallFunction { template_address, .. } => {
+                vec![]
+            },
+            Instruction::CallMethod { component_address, .. } => {
+                vec![ShardId::from_bytes(&component_address.into_array()).expect("Not a valid shardid")]
+            },
+            _ => vec![],
+        })
+        .flatten()
+        .collect();
     let inputs = common
         .inputs
         .into_iter()

--- a/dan_layer/core/src/workers/hotstuff_error.rs
+++ b/dan_layer/core/src/workers/hotstuff_error.rs
@@ -67,4 +67,6 @@ pub enum HotStuffError {
     ValidatorNodeNotIncludedInMmr,
     #[error("No committee for shard {shard} and epoch {epoch}")]
     NoCommitteeForShard { shard: ShardId, epoch: Epoch },
+    #[error("Cannot vote on a proposal that has been rejected")]
+    JustifyIsNotAccepted,
 }

--- a/dan_layer/engine_types/src/commit_result.rs
+++ b/dan_layer/engine_types/src/commit_result.rs
@@ -46,6 +46,10 @@ impl FinalizeResult {
     pub fn errored(transaction_hash: Hash, reason: RejectReason) -> Self {
         Self::new(transaction_hash, Vec::new(), TransactionResult::Reject(reason))
     }
+
+    pub fn is_accept(&self) -> bool {
+        matches!(self.result, TransactionResult::Accept(_))
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]


### PR DESCRIPTION
Description
---
Returns an error to the JSONRPC on failure. 
Also does not vote on rejected QC's

Motivation and Context
---
The main aim here is to return an error to the CLI instead of timing out. I don't think this is foolproof, since there may be multiple proposals that it fails on. I think the result and failure propagation needs a bit more thought in general, but this will help. 

The previous code also failed to vote if there was an error. It would fail to extract the changes, then error out of  `on_receive_proposal` and not vote (I presume). Fixing this bug brought up a different error in that, although the first proposal is executed and rejected, the rest of the proposals were accepted. Hence the check to see if a previous proposal was Accepted before voting. 

I'm in two minds about whether the node should continue a rejected chain all the way up to Commit state (in this case no changes will be made). On the one hand, it makes it uniform and the proposal reaches height 4, the pledging does not need to change. On the other hand, it seems better not to do the extra communication rounds. One problem with exiting early is that nodes who do not receive the Reject QC might elect a new leader. I suppose in that case, the high qc that the new leader receives will be a reject and it will not propose it. IDK, maybe the answer will be more clear once fees are involved, and we'll know whether to charge fees on a rejected QC.

Partial fix of #237 

How Has This Been Tested?
---
locally
