### PR TITLE
fix: validators active for epoch range, scanning improve, state sync fixes, other minor fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5978,6 +5978,7 @@ dependencies = [
  "diesel",
  "diesel_migrations",
  "log",
+ "serde",
  "serde_json",
  "tari_common",
  "tari_common_types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5857,6 +5857,7 @@ dependencies = [
  "bincode",
  "borsh",
  "digest 0.9.0",
+ "newtype-ops",
  "prost",
  "prost-types",
  "serde",
@@ -5952,6 +5953,7 @@ version = "0.1.0"
 dependencies = [
  "serde",
  "tari_common_types",
+ "tari_dan_common_types",
  "thiserror",
  "time 0.3.17",
 ]

--- a/applications/tari_validator_node/src/bootstrap.rs
+++ b/applications/tari_validator_node/src/bootstrap.rs
@@ -122,7 +122,6 @@ pub async fn spawn_services(
         shard_store.clone(),
         base_node_client.clone(),
         consensus_constants.clone(),
-        node_identity.public_key().clone(),
         shutdown.clone(),
         node_identity.clone(),
         validator_node_client_factory,

--- a/applications/tari_validator_node/src/p2p/rpc/service_impl.rs
+++ b/applications/tari_validator_node/src/p2p/rpc/service_impl.rs
@@ -160,46 +160,40 @@ where TPeerProvider: PeerProvider + Clone + Send + Sync + 'static
         let shard_db = self.shard_state_store.clone();
 
         task::spawn(async move {
-            loop {
-                let shards_substates_data = shard_db.create_tx().unwrap().get_substate_states(
-                    start_shard_id,
-                    end_shard_id,
-                    excluded_shards.as_slice(),
-                );
-                let substates_data = match shards_substates_data {
-                    Ok(s) => s,
-                    Err(err) => {
-                        error!(target: LOG_TARGET, "{}", err);
-                        let _ignore = tx.send(Err(RpcStatus::general(&err))).await;
-                        return;
-                    },
+            let shards_substates_data = shard_db.create_tx().unwrap().get_substate_states(
+                start_shard_id,
+                end_shard_id,
+                excluded_shards.as_slice(),
+            );
+            let substates = match shards_substates_data {
+                Ok(s) => s,
+                Err(err) => {
+                    error!(target: LOG_TARGET, "{}", err);
+                    let _ignore = tx.send(Err(RpcStatus::general(&err))).await;
+                    return;
+                },
+            };
+
+            if substates.is_empty() {
+                return;
+            }
+
+            // select data from db where shard_id <= end_shard_id and shard_id >= start_shard_id
+            for substate in substates {
+                let response = proto::rpc::VnStateSyncResponse {
+                    shard_id: Some(substate.shard().into()),
+                    substate_state: Some(substate.substate().clone().into()),
+                    node_height: substate.height().as_u64(),
+                    tree_node_hash: substate
+                        .tree_node_hash()
+                        .map(|h| h.as_bytes().to_vec())
+                        .unwrap_or_default(),
+                    payload_id: substate.payload_id().as_bytes().to_vec(),
+                    certificate: substate.certificate().clone().map(QuorumCertificate::from),
                 };
-
-                // select data from db where shard_id <= end_shard_id and shard_id >= start_shard_id
-                for substate_data in substates_data {
-                    let shard_id = proto::common::ShardId::from(substate_data.shard());
-                    let substate_state = proto::consensus::SubstateState::from(substate_data.substate().clone());
-                    let node_height = substate_data.height().as_u64();
-                    let tree_node_hash = if let Some(h) = substate_data.tree_node_hash() {
-                        Vec::from(h.as_bytes())
-                    } else {
-                        vec![]
-                    };
-                    let payload_id = Vec::from(substate_data.payload_id().as_bytes());
-                    let certificate = substate_data.certificate().clone().map(QuorumCertificate::from);
-
-                    let response = proto::rpc::VnStateSyncResponse {
-                        shard_id: Some(shard_id),
-                        substate_state: Some(substate_state),
-                        node_height,
-                        tree_node_hash,
-                        payload_id,
-                        certificate,
-                    };
-                    // if send returns error, the client has closed the connection, so we break the loop
-                    if tx.send(Ok(response)).await.is_err() {
-                        break;
-                    }
+                // if send returns error, the client has closed the connection, so we break the loop
+                if tx.send(Ok(response)).await.is_err() {
+                    break;
                 }
             }
         });

--- a/applications/tari_validator_node/src/p2p/services/epoch_manager/base_layer_epoch_manager.rs
+++ b/applications/tari_validator_node/src/p2p/services/epoch_manager/base_layer_epoch_manager.rs
@@ -20,17 +20,21 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::{convert::TryInto, sync::Arc};
+use std::{convert::TryInto, ops::RangeInclusive, sync::Arc};
 
 use log::info;
-use tari_common_types::types::PublicKey;
+use tari_common_types::types::{FixedHash, PublicKey};
 use tari_comms::{types::CommsPublicKey, NodeIdentity};
-use tari_core::{blocks::BlockHeader, ValidatorNodeMmr};
+use tari_core::{
+    blocks::BlockHeader,
+    transactions::transaction_components::ValidatorNodeRegistration,
+    ValidatorNodeMmr,
+};
 use tari_crypto::tari_utilities::ByteArray;
 use tari_dan_common_types::{vn_mmr_node_hash, Epoch, ShardId};
 use tari_dan_core::{
-    consensus_constants::ConsensusConstants,
-    models::{BaseLayerMetadata, Committee, ValidatorNode},
+    consensus_constants::{BaseLayerConsensusConstants, ConsensusConstants},
+    models::{Committee, ValidatorNode},
     services::{
         epoch_manager::{EpochManagerError, ShardCommitteeAllocation},
         BaseNodeClient,
@@ -41,11 +45,10 @@ use tari_dan_storage::global::{DbEpoch, DbValidatorNode, MetadataKey};
 use tari_dan_storage_sqlite::{sqlite_shard_store_factory::SqliteShardStore, SqliteDbFactory};
 use tokio::sync::broadcast;
 
-use super::{get_committee_shard_range, sync_peers::PeerSyncManagerService};
 use crate::{
     grpc::services::base_node_client::GrpcBaseNodeClient,
     p2p::services::{
-        epoch_manager::epoch_manager_service::EpochManagerEvent,
+        epoch_manager::{epoch_manager_service::EpochManagerEvent, PeerSyncManagerService},
         rpc_client::TariCommsValidatorNodeClientFactory,
     },
 };
@@ -59,11 +62,11 @@ pub struct BaseLayerEpochManager {
     pub base_node_client: GrpcBaseNodeClient,
     consensus_constants: ConsensusConstants,
     current_epoch: Epoch,
-    _identity: CommsPublicKey,
     tx_events: broadcast::Sender<EpochManagerEvent>,
     node_identity: Arc<NodeIdentity>,
     validator_node_client_factory: TariCommsValidatorNodeClientFactory,
     current_shard_key: Option<ShardId>,
+    base_layer_consensus_constants: Option<BaseLayerConsensusConstants>,
 }
 
 impl BaseLayerEpochManager {
@@ -72,7 +75,6 @@ impl BaseLayerEpochManager {
         shard_store: SqliteShardStore,
         base_node_client: GrpcBaseNodeClient,
         consensus_constants: ConsensusConstants,
-        identity: CommsPublicKey,
         tx_events: broadcast::Sender<EpochManagerEvent>,
         node_identity: Arc<NodeIdentity>,
         validator_node_client_factory: TariCommsValidatorNodeClientFactory,
@@ -83,103 +85,98 @@ impl BaseLayerEpochManager {
             base_node_client,
             consensus_constants,
             current_epoch: Epoch(0),
-            _identity: identity,
             tx_events,
             node_identity,
             validator_node_client_factory,
             current_shard_key: None,
+            base_layer_consensus_constants: None,
         }
     }
 
     pub async fn load_initial_state(&mut self) -> Result<(), EpochManagerError> {
         let db = self.db_factory.get_or_create_global_db()?;
-        let tx = db
-            .create_transaction()
-            .map_err(|e| EpochManagerError::StorageError(e.into()))?;
+        let tx = db.create_transaction()?;
         let metadata = db.metadata(&tx);
-        self.current_epoch = metadata
-            .get_metadata(MetadataKey::CurrentEpoch)
-            .map_err(|e| EpochManagerError::StorageError(e.into()))?
-            .map(|v| {
-                let v2 = [v[0], v[1], v[2], v[3], v[4], v[5], v[6], v[7]];
-                Epoch(u64::from_le_bytes(v2))
-            })
-            .unwrap_or_else(|| Epoch(0));
+        self.current_epoch = metadata.get_metadata(MetadataKey::CurrentEpoch)?.unwrap_or(Epoch(0));
+        self.current_shard_key = metadata.get_metadata(MetadataKey::CurrentShardKey)?;
+        self.base_layer_consensus_constants = metadata.get_metadata(MetadataKey::BaseLayerConsensusConstants)?;
 
         Ok(())
     }
 
-    pub async fn update_epoch(&mut self, tip_info: BaseLayerMetadata) -> Result<(), EpochManagerError> {
-        let epoch = Epoch::from_block_height(tip_info.height_of_longest_chain);
+    pub async fn update_epoch(&mut self, block_height: u64, block_hash: FixedHash) -> Result<(), EpochManagerError> {
+        let base_layer_constants = self.base_node_client.get_consensus_constants(block_height).await?;
+        let epoch = base_layer_constants.height_to_epoch(block_height);
         if self.current_epoch >= epoch {
             // no need to update the epoch
             return Ok(());
         }
 
-        // If the committee size is bigger than vns.len() then this function is broken.
-        let height = epoch.to_height();
-        let vns = self.base_node_client.get_validator_nodes(height).await?;
-
-        let vn_shard_key = vns
-            .iter()
-            .find(|v| v.public_key == *self.node_identity.public_key())
-            .map(|v| v.shard_key);
         // extract and store in database the MMR of the epoch's validator nodes
-        let tip_header = self.base_node_client.get_header_by_hash(tip_info.tip_hash).await?;
-        self.insert_epoch(epoch, tip_header)?;
+        let epoch_header = self.base_node_client.get_header_by_hash(block_hash).await?;
 
-        // insert the new VNs for this epoch in the database
-        self.insert_validator_nodes(epoch, vns)?;
+        // persist the epoch data including the validator node set
+        self.insert_current_epoch(epoch, epoch_header)?;
+        self.update_base_layer_consensus_constants(base_layer_constants)?;
 
-        // set the current epoch in the database
-        self.insert_current_epoch(epoch)?;
-
-        self.current_epoch = epoch;
         self.tx_events
             .send(EpochManagerEvent::EpochChanged(epoch))
             .map_err(|_| EpochManagerError::SendError)?;
 
-        let vn_shard_key = match vn_shard_key {
-            Some(shard_key) => shard_key,
-            None => {
-                info!(
-                    target: LOG_TARGET,
-                    "🖊 Validator node is NOT registered for epoch {} ", epoch,
-                );
-                // This node is not currently registered
-                return Ok(());
-            },
-        };
-        self.current_shard_key = Some(vn_shard_key);
-        info!(
-            target: LOG_TARGET,
-            "🖊 Validator node is registered for epoch {}, shard key: {} ", epoch, vn_shard_key
-        );
+        Ok(())
+    }
 
-        // from current_shard_key we can get the corresponding vns committee
-        let committee_size = self.consensus_constants.committee_size as usize;
-        let committee_vns = self.get_committee_vns_from_shard_key(epoch, vn_shard_key)?;
-        if committee_vns.is_empty() {
-            return Err(EpochManagerError::NoCommitteeVns {
-                epoch,
-                shard_id: vn_shard_key,
-            });
+    pub async fn add_validator_node_registration(
+        &mut self,
+        block_height: u64,
+        registration: ValidatorNodeRegistration,
+    ) -> Result<(), EpochManagerError> {
+        let constants = self
+            .base_layer_consensus_constants
+            .as_ref()
+            .ok_or(EpochManagerError::BaseLayerConsensusConstantsNotSet)?;
+        let epoch = constants.height_to_epoch(block_height);
+        let next_epoch_height = constants.epoch_to_height(epoch + Epoch(1));
+
+        let shard_key = self
+            .base_node_client
+            .get_shard_key(next_epoch_height, registration.public_key())
+            .await?
+            .ok_or_else(|| EpochManagerError::ShardKeyNotFound {
+                public_key: registration.public_key().clone(),
+                block_height,
+            })?;
+        let new_vns = vec![DbValidatorNode {
+            public_key: registration.public_key().to_vec(),
+            shard_key: shard_key.as_bytes().to_vec(),
+            epoch: epoch + Epoch(1),
+        }];
+        let db = self.db_factory.get_or_create_global_db()?;
+        let tx = db.create_transaction()?;
+        db.validator_nodes(&tx).insert_validator_nodes(new_vns)?;
+
+        if registration.public_key() == self.node_identity.public_key() {
+            let metadata = db.metadata(&tx);
+            metadata.set_metadata(MetadataKey::CurrentShardKey, &shard_key)?;
+            let last_registration_epoch = metadata
+                .get_metadata::<Epoch>(MetadataKey::LastEpochRegistration)?
+                .unwrap_or(Epoch(0));
+            if last_registration_epoch < epoch {
+                metadata.set_metadata(MetadataKey::LastEpochRegistration, &epoch)?;
+            }
+            self.current_shard_key = Some(shard_key);
+            info!(
+                target: LOG_TARGET,
+                "🖊 This validator node is registered for epoch {}, shard key: {} ", epoch, shard_key
+            );
         }
-        let (start_shard_id, end_shard_id) = get_committee_shard_range(committee_size, &committee_vns).into_inner();
 
-        // TODO: I think this should be part of a state machine for the VN
-        let peer_sync_service_manager =
-            PeerSyncManagerService::new(self.validator_node_client_factory.clone(), self.shard_store.clone());
-
-        // synchronize state with committee validator nodes
-        peer_sync_service_manager
-            .sync_peers_state(committee_vns, start_shard_id, end_shard_id, vn_shard_key)
-            .await?;
+        tx.commit()?;
 
         Ok(())
     }
 
-    fn insert_epoch(&self, epoch: Epoch, header: BlockHeader) -> Result<(), EpochManagerError> {
+    fn insert_current_epoch(&mut self, epoch: Epoch, header: BlockHeader) -> Result<(), EpochManagerError> {
         let epoch_height = epoch.0;
         let db_epoch = DbEpoch {
             epoch: epoch_height,
@@ -187,53 +184,26 @@ impl BaseLayerEpochManager {
         };
 
         let db = self.db_factory.get_or_create_global_db()?;
-        let tx = db
-            .create_transaction()
-            .map_err(|e| EpochManagerError::StorageError(e.into()))?;
-        db.epochs(&tx)
-            .insert_epoch(db_epoch)
-            .map_err(|e| EpochManagerError::StorageError(e.into()))?;
-        db.commit(tx).map_err(|e| EpochManagerError::StorageError(e.into()))?;
+        let tx = db.create_transaction()?;
 
+        db.epochs(&tx).insert_epoch(db_epoch)?;
+        db.metadata(&tx).set_metadata(MetadataKey::CurrentEpoch, &epoch)?;
+
+        db.commit(tx)?;
+        self.current_epoch = epoch;
         Ok(())
     }
 
-    fn insert_validator_nodes(
-        &self,
-        epoch: Epoch,
-        vns: Vec<ValidatorNode<CommsPublicKey>>,
+    fn update_base_layer_consensus_constants(
+        &mut self,
+        base_layer_constants: BaseLayerConsensusConstants,
     ) -> Result<(), EpochManagerError> {
-        let epoch_height = epoch.0;
-        let new_vns = vns
-            .into_iter()
-            .map(|v| DbValidatorNode {
-                public_key: v.public_key.to_vec(),
-                shard_key: v.shard_key.as_bytes().to_vec(),
-                epoch: epoch_height,
-            })
-            .collect();
         let db = self.db_factory.get_or_create_global_db()?;
-        let tx = db
-            .create_transaction()
-            .map_err(|e| EpochManagerError::StorageError(e.into()))?;
-        db.validator_nodes(&tx)
-            .insert_validator_nodes(new_vns)
-            .map_err(|e| EpochManagerError::StorageError(e.into()))?;
-        db.commit(tx).map_err(|e| EpochManagerError::StorageError(e.into()))?;
-        Ok(())
-    }
-
-    fn insert_current_epoch(&self, epoch: Epoch) -> Result<(), EpochManagerError> {
-        let db = self.db_factory.get_or_create_global_db()?;
-        let tx = db
-            .create_transaction()
-            .map_err(|e| EpochManagerError::StorageError(e.into()))?;
-        let metadata = db.metadata(&tx);
-        metadata
-            .set_metadata(MetadataKey::CurrentEpoch, &epoch.0.to_le_bytes())
-            .map_err(|e| EpochManagerError::StorageError(e.into()))?;
-        db.commit(tx).map_err(|e| EpochManagerError::StorageError(e.into()))?;
-
+        let tx = db.create_transaction()?;
+        db.metadata(&tx)
+            .set_metadata(MetadataKey::BaseLayerConsensusConstants, &base_layer_constants)?;
+        tx.commit()?;
+        self.base_layer_consensus_constants = Some(base_layer_constants);
         Ok(())
     }
 
@@ -241,52 +211,34 @@ impl BaseLayerEpochManager {
         self.current_epoch
     }
 
-    pub fn get_validator_shard_key(
-        &mut self,
-        epoch: Epoch,
-        public_key: &PublicKey,
-    ) -> Result<ShardId, EpochManagerError> {
+    pub fn get_validator_shard_key(&self, epoch: Epoch, public_key: &PublicKey) -> Result<ShardId, EpochManagerError> {
+        let (start_epoch, end_epoch) = self.get_epoch_range(epoch)?;
         let db = self.db_factory.get_or_create_global_db()?;
-        let tx = db
-            .create_transaction()
-            .map_err(|e| EpochManagerError::StorageError(e.into()))?;
+        let tx = db.create_transaction()?;
         let vn = db
             .validator_nodes(&tx)
-            .get(epoch.0, public_key.as_bytes())
-            .map_err(|e| EpochManagerError::StorageError(e.into()))?;
+            .get(start_epoch.as_u64(), end_epoch.as_u64(), public_key.as_bytes())?;
 
         Ok(ShardId::from_bytes(&vn.shard_key).expect("Invalid Shard Key, Database is corrupt"))
     }
 
-    pub async fn last_registration_epoch(&self) -> Result<Option<Epoch>, EpochManagerError> {
+    pub fn last_registration_epoch(&self) -> Result<Option<Epoch>, EpochManagerError> {
         let db = self.db_factory.get_or_create_global_db()?;
-        let tx = db
-            .create_transaction()
-            .map_err(|e| EpochManagerError::StorageError(e.into()))?;
+        let tx = db.create_transaction()?;
         let metadata = db.metadata(&tx);
-        Ok(metadata
-            .get_metadata(MetadataKey::LastEpochRegistration)
-            .map_err(|e| EpochManagerError::StorageError(e.into()))?
-            .map(|v| {
-                let v2 = [v[0], v[1], v[2], v[3], v[4], v[5], v[6], v[7]];
-                Epoch(u64::from_le_bytes(v2))
-            }))
+        let last_registration_epoch = metadata.get_metadata(MetadataKey::LastEpochRegistration)?;
+        Ok(last_registration_epoch)
     }
 
-    pub async fn update_last_registration_epoch(&self, epoch: Epoch) -> Result<(), EpochManagerError> {
+    pub fn update_last_registration_epoch(&self, epoch: Epoch) -> Result<(), EpochManagerError> {
         let db = self.db_factory.get_or_create_global_db()?;
-        let tx = db
-            .create_transaction()
-            .map_err(|e| EpochManagerError::StorageError(e.into()))?;
+        let tx = db.create_transaction()?;
         let metadata = db.metadata(&tx);
-        metadata
-            .set_metadata(MetadataKey::LastEpochRegistration, &epoch.to_le_bytes())
-            .map_err(|e| EpochManagerError::StorageError(e.into()))?;
-        db.commit(tx).map_err(|e| EpochManagerError::StorageError(e.into()))?;
+        metadata.set_metadata(MetadataKey::LastEpochRegistration, &epoch)?;
+        db.commit(tx)?;
         Ok(())
     }
 
-    #[allow(dead_code)]
     pub fn is_epoch_valid(&self, epoch: Epoch) -> bool {
         let current_epoch = self.current_epoch();
         current_epoch.0 <= epoch.0 + 10 && epoch.0 <= current_epoch.0 + 10
@@ -367,18 +319,27 @@ impl BaseLayerEpochManager {
         Ok(committee.contains(&identity))
     }
 
+    fn get_epoch_range(&self, end_epoch: Epoch) -> Result<(Epoch, Epoch), EpochManagerError> {
+        let consensus_constants = self
+            .base_layer_consensus_constants
+            .as_ref()
+            .ok_or(EpochManagerError::BaseLayerConsensusConstantsNotSet)?;
+
+        let start_epoch = end_epoch.saturating_sub(consensus_constants.validator_node_registration_expiry());
+        Ok((start_epoch, end_epoch))
+    }
+
     pub fn get_validator_nodes_per_epoch(
         &self,
         epoch: Epoch,
     ) -> Result<Vec<ValidatorNode<CommsPublicKey>>, EpochManagerError> {
+        let (start_epoch, end_epoch) = self.get_epoch_range(epoch)?;
+
         let db = self.db_factory.get_or_create_global_db()?;
-        let tx = db
-            .create_transaction()
-            .map_err(|e| EpochManagerError::StorageError(e.into()))?;
+        let tx = db.create_transaction()?;
         let db_vns = db
             .validator_nodes(&tx)
-            .get_all_per_epoch(epoch.0)
-            .map_err(|e| EpochManagerError::StorageError(e.into()))?;
+            .get_all_within_epochs(start_epoch.as_u64(), end_epoch.as_u64())?;
         let vns = db_vns
             .into_iter()
             .map(TryInto::try_into)
@@ -405,14 +366,9 @@ impl BaseLayerEpochManager {
 
     pub fn get_validator_node_merkle_root(&self, epoch: Epoch) -> Result<Vec<u8>, EpochManagerError> {
         let db = self.db_factory.get_or_create_global_db()?;
-        let tx = db
-            .create_transaction()
-            .map_err(|e| EpochManagerError::StorageError(e.into()))?;
+        let tx = db.create_transaction()?;
 
-        let query_res = db
-            .epochs(&tx)
-            .get_epoch_data(epoch.0)
-            .map_err(|e| EpochManagerError::StorageError(e.into()))?;
+        let query_res = db.epochs(&tx).get_epoch_data(epoch.0)?;
 
         match query_res {
             Some(db_epoch) => Ok(db_epoch.validator_node_mr),
@@ -423,6 +379,10 @@ impl BaseLayerEpochManager {
     pub fn get_validator_node_mmr(&self, epoch: Epoch) -> Result<ValidatorNodeMmr, EpochManagerError> {
         let vns = self.get_validator_nodes_per_epoch(epoch)?;
 
+        // let mut a = vns.clone();
+        // a.sort_by(|a, b| a.shard_key.0.cmp(&b.shard_key.0));
+        // assert_eq!(a, vns, "NOT SORTED");
+
         // TODO: the MMR struct should be serializable to store it only once and avoid recalculating it every time per
         // epoch
         let mut vn_mmr = ValidatorNodeMmr::new(Vec::new());
@@ -432,6 +392,69 @@ impl BaseLayerEpochManager {
                 .expect("Could not build the merkle mountain range of the VN set");
         }
 
+        // let root = self.get_validator_node_merkle_root(epoch)?;
+        // if vn_mmr.get_merkle_root().unwrap() == root {
+        //     eprintln!("OK =!!!!!!!!!!!!!!!!!!!",);
+        // } else {
+        //     panic!("Invalid MR");
+        // }
+
         Ok(vn_mmr)
+    }
+
+    pub async fn on_scanning_complete(&self) -> Result<(), EpochManagerError> {
+        if self.last_registration_epoch()?.is_none() {
+            info!(
+                target: LOG_TARGET,
+                "📋 Validator is not registered, Skipping state sync"
+            );
+            return Ok(());
+        }
+
+        let vn_shard_key = self.get_validator_shard_key(self.current_epoch, self.node_identity.public_key())?;
+        // from current_shard_key we can get the corresponding vns committee
+        let committee_size = self.consensus_constants.committee_size as usize;
+        let committee_vns = self.get_committee_vns_from_shard_key(self.current_epoch, vn_shard_key)?;
+        if committee_vns.is_empty() {
+            return Err(EpochManagerError::NoCommitteeVns {
+                epoch: self.current_epoch,
+                shard_id: vn_shard_key,
+            });
+        }
+        let (start_shard_id, end_shard_id) = get_committee_shard_range(committee_size, &committee_vns).into_inner();
+        info!(
+            target: LOG_TARGET,
+            "♻ Starting state sync for epoch {} and shard range {} to {}",
+            self.current_epoch,
+            start_shard_id,
+            end_shard_id
+        );
+        // synchronize state with committee validator nodes
+        PeerSyncManagerService::new(self.validator_node_client_factory.clone(), self.shard_store.clone())
+            .sync_peers_state(committee_vns, start_shard_id, end_shard_id, vn_shard_key)
+            .await?;
+
+        Ok(())
+    }
+}
+
+fn get_committee_shard_range<TAddr>(
+    committee_size: usize,
+    committee_vns: &[ValidatorNode<TAddr>],
+) -> RangeInclusive<ShardId> {
+    if committee_vns.len() < committee_size {
+        let min_shard_id = ShardId::zero();
+        let max_shard_id = ShardId([u8::MAX; 32]);
+        min_shard_id..=max_shard_id
+    } else {
+        let min_shard_id = committee_vns
+            .first()
+            .expect("Committee VNs cannot be empty, at this point")
+            .shard_key;
+        let max_shard_id = committee_vns
+            .last()
+            .expect("Committee VNs cannot be empty, at this point")
+            .shard_key;
+        min_shard_id..=max_shard_id
     }
 }

--- a/applications/tari_validator_node/src/p2p/services/epoch_manager/epoch_manager_service.rs
+++ b/applications/tari_validator_node/src/p2p/services/epoch_manager/epoch_manager_service.rs
@@ -191,9 +191,12 @@ impl EpochManagerService {
     async fn handle_request(&mut self, req: EpochManagerRequest) {
         match req {
             EpochManagerRequest::CurrentEpoch { reply } => handle(reply, Ok(self.inner.current_epoch())),
-            EpochManagerRequest::GetValidatorShardKey { epoch, addr, reply } => {
-                handle(reply, self.inner.get_validator_shard_key(epoch, &addr))
-            },
+            EpochManagerRequest::GetValidatorShardKey { epoch, addr, reply } => handle(
+                reply,
+                self.inner
+                    .get_validator_shard_key(epoch, &addr)
+                    .and_then(|x| x.ok_or(EpochManagerError::ValidatorNodeNotRegistered)),
+            ),
             EpochManagerRequest::UpdateEpoch {
                 block_height,
                 block_hash,

--- a/applications/tari_validator_node/src/p2p/services/epoch_manager/epoch_manager_service.rs
+++ b/applications/tari_validator_node/src/p2p/services/epoch_manager/epoch_manager_service.rs
@@ -23,12 +23,13 @@
 use std::sync::Arc;
 
 use log::error;
+use tari_common_types::types::FixedHash;
 use tari_comms::{types::CommsPublicKey, NodeIdentity};
-use tari_core::ValidatorNodeMmr;
+use tari_core::{transactions::transaction_components::ValidatorNodeRegistration, ValidatorNodeMmr};
 use tari_dan_common_types::{Epoch, ShardId};
 use tari_dan_core::{
     consensus_constants::ConsensusConstants,
-    models::{BaseLayerMetadata, Committee, ValidatorNode},
+    models::{Committee, ValidatorNode},
     services::epoch_manager::{EpochManagerError, ShardCommitteeAllocation},
 };
 use tari_dan_storage_sqlite::{sqlite_shard_store_factory::SqliteShardStore, SqliteDbFactory};
@@ -69,8 +70,14 @@ pub enum EpochManagerRequest {
         addr: CommsPublicKey,
         reply: Reply<ShardId>,
     },
+    AddValidatorNodeRegistration {
+        block_height: u64,
+        registration: ValidatorNodeRegistration,
+        reply: Reply<()>,
+    },
     UpdateEpoch {
-        tip_info: BaseLayerMetadata,
+        block_height: u64,
+        block_hash: FixedHash,
         reply: Reply<()>,
     },
     LastRegistrationEpoch {
@@ -120,6 +127,9 @@ pub enum EpochManagerRequest {
     Subscribe {
         reply: Reply<broadcast::Receiver<EpochManagerEvent>>,
     },
+    NotifyScanningComplete {
+        reply: Reply<()>,
+    },
 }
 
 #[derive(Debug, Clone)]
@@ -129,7 +139,6 @@ pub enum EpochManagerEvent {
 
 impl EpochManagerService {
     pub fn spawn(
-        id: CommsPublicKey,
         rx_request: Receiver<EpochManagerRequest>,
         shutdown: ShutdownSignal,
         db_factory: SqliteDbFactory,
@@ -138,17 +147,16 @@ impl EpochManagerService {
         consensus_constants: ConsensusConstants,
         node_identity: Arc<NodeIdentity>,
         validator_node_client_factory: TariCommsValidatorNodeClientFactory,
-    ) -> JoinHandle<Result<(), EpochManagerError>> {
+    ) -> JoinHandle<()> {
         tokio::spawn(async move {
             let (tx, rx) = broadcast::channel(10);
-            EpochManagerService {
+            let result = EpochManagerService {
                 rx_request,
                 inner: BaseLayerEpochManager::new(
                     db_factory,
                     shard_store,
                     base_node_client,
                     consensus_constants,
-                    id,
                     tx.clone(),
                     node_identity,
                     validator_node_client_factory,
@@ -156,7 +164,11 @@ impl EpochManagerService {
                 events: (tx, rx),
             }
             .run(shutdown)
-            .await
+            .await;
+
+            if let Err(err) = result {
+                error!(target: LOG_TARGET, "Epoch manager service failed with error: {}", err);
+            }
         })
     }
 
@@ -182,15 +194,17 @@ impl EpochManagerService {
             EpochManagerRequest::GetValidatorShardKey { epoch, addr, reply } => {
                 handle(reply, self.inner.get_validator_shard_key(epoch, &addr))
             },
-            EpochManagerRequest::UpdateEpoch { tip_info, reply } => {
-                handle(reply, self.inner.update_epoch(tip_info).await);
+            EpochManagerRequest::UpdateEpoch {
+                block_height,
+                block_hash,
+                reply,
+            } => {
+                handle(reply, self.inner.update_epoch(block_height, block_hash).await);
             },
-            EpochManagerRequest::LastRegistrationEpoch { reply } => {
-                handle(reply, self.inner.last_registration_epoch().await)
-            },
+            EpochManagerRequest::LastRegistrationEpoch { reply } => handle(reply, self.inner.last_registration_epoch()),
 
             EpochManagerRequest::UpdateLastRegistrationEpoch { epoch, reply } => {
-                handle(reply, self.inner.update_last_registration_epoch(epoch).await);
+                handle(reply, self.inner.update_last_registration_epoch(epoch));
             },
             EpochManagerRequest::IsEpochValid { epoch, reply } => handle(reply, Ok(self.inner.is_epoch_valid(epoch))),
             EpochManagerRequest::GetCommittees { epoch, shards, reply } => {
@@ -223,6 +237,20 @@ impl EpochManagerService {
             },
             EpochManagerRequest::GetValidatorNodesPerEpoch { epoch, reply } => {
                 handle(reply, self.inner.get_validator_nodes_per_epoch(epoch))
+            },
+            EpochManagerRequest::AddValidatorNodeRegistration {
+                block_height,
+                registration,
+                reply,
+            } => handle(
+                reply,
+                self.inner
+                    .add_validator_node_registration(block_height, registration)
+                    .await,
+            ),
+            // TODO: This should be rather be a state machine event
+            EpochManagerRequest::NotifyScanningComplete { reply } => {
+                handle(reply, self.inner.on_scanning_complete().await)
             },
         }
     }

--- a/applications/tari_validator_node/src/p2p/services/epoch_manager/initializer.rs
+++ b/applications/tari_validator_node/src/p2p/services/epoch_manager/initializer.rs
@@ -22,7 +22,7 @@
 
 use std::sync::Arc;
 
-use tari_comms::{types::CommsPublicKey, NodeIdentity};
+use tari_comms::NodeIdentity;
 use tari_dan_core::consensus_constants::ConsensusConstants;
 use tari_dan_storage_sqlite::{sqlite_shard_store_factory::SqliteShardStore, SqliteDbFactory};
 use tari_shutdown::ShutdownSignal;
@@ -41,7 +41,6 @@ pub fn spawn(
     shard_store: SqliteShardStore,
     base_node_client: GrpcBaseNodeClient,
     consensus_constants: ConsensusConstants,
-    id: CommsPublicKey,
     shutdown: ShutdownSignal,
     node_identity: Arc<NodeIdentity>,
     validator_node_client_factory: TariCommsValidatorNodeClientFactory,
@@ -49,7 +48,6 @@ pub fn spawn(
     let (tx_request, rx_request) = mpsc::channel(10);
     let handle = EpochManagerHandle::new(tx_request);
     EpochManagerService::spawn(
-        id,
         rx_request,
         shutdown,
         db_factory,

--- a/applications/tari_validator_node/src/p2p/services/epoch_manager/mod.rs
+++ b/applications/tari_validator_node/src/p2p/services/epoch_manager/mod.rs
@@ -25,31 +25,7 @@ pub mod epoch_manager_service;
 pub mod handle;
 
 mod initializer;
-mod sync_peers;
-use std::ops::RangeInclusive;
+mod state_sync;
 
 pub use initializer::spawn;
-use tari_dan_common_types::ShardId;
-use tari_dan_core::models::ValidatorNode;
-
-fn get_committee_shard_range<TAddr>(
-    committee_size: usize,
-    committee_vns: &[ValidatorNode<TAddr>],
-) -> RangeInclusive<ShardId> {
-    // TODO: add this committee_size to ConsensusConstants
-    if committee_vns.len() < committee_size {
-        let min_shard_id = ShardId::zero();
-        let max_shard_id = ShardId([u8::MAX; 32]);
-        RangeInclusive::new(min_shard_id, max_shard_id)
-    } else {
-        let min_shard_id = committee_vns
-            .first()
-            .expect("Commitee VNs cannot be empty, at this point")
-            .shard_key;
-        let max_shard_id = committee_vns
-            .last()
-            .expect("Commitee VNs cannot be empty, at this point")
-            .shard_key;
-        min_shard_id..=max_shard_id
-    }
-}
+pub use state_sync::PeerSyncManagerService;

--- a/applications/tari_validator_node/src/p2p/services/template_manager/service.rs
+++ b/applications/tari_validator_node/src/p2p/services/template_manager/service.rs
@@ -155,13 +155,20 @@ impl TemplateManagerService {
                 // validation of the downloaded template binary hash
                 let actual_binary_hash = calculate_template_binary_hash(&bytes);
                 let template_status = if actual_binary_hash == download.expected_binary_hash {
+                    info!(
+                        target: LOG_TARGET,
+                        "✅ Template {} is active", download.template_address,
+                    );
                     TemplateStatus::Active
                 } else {
                     warn!(
                         target: LOG_TARGET,
                         "⚠️ Template {} hash mismatch", download.template_address
                     );
-                    TemplateStatus::Invalid
+                    // TODO: For now, let's just accept this so that we can update the binary at the URL without
+                    // re-registering
+                    TemplateStatus::Active
+                    // TemplateStatus::Invalid
                 };
 
                 self.manager
@@ -169,11 +176,6 @@ impl TemplateManagerService {
                         compiled_code: Some(bytes.to_vec()),
                         status: Some(template_status),
                     })?;
-
-                info!(
-                    target: LOG_TARGET,
-                    "✅ Template {} has status {:?}", download.template_address, template_status
-                );
             },
             Err(err) => {
                 warn!(target: LOG_TARGET, "🚨 Failed to download template: {}", err);

--- a/applications/tari_validator_node/src/p2p/services/template_manager/template_config.rs
+++ b/applications/tari_validator_node/src/p2p/services/template_manager/template_config.rs
@@ -34,10 +34,9 @@ impl TemplateConfig {
     pub fn debug_replacements(&self) -> HashMap<TemplateAddress, PathBuf> {
         let mut result = HashMap::new();
         for row in &self.debug_replacements {
-            let parts: Vec<&str> = row.split('=').collect();
-            let template_address = TemplateAddress::from_hex(parts[0]).expect("Not a valid template address");
-            let path = PathBuf::from(parts[1]);
-            result.insert(template_address, path);
+            let (template_address, path) = row.split_once('=').expect("USAGE: [templateaddress]=[path]");
+            let template_address = TemplateAddress::from_hex(template_address).expect("Not a valid template address");
+            result.insert(template_address, path.into());
         }
         result
     }

--- a/applications/tari_validator_node_cli/src/command/account.rs
+++ b/applications/tari_validator_node_cli/src/command/account.rs
@@ -51,7 +51,7 @@ impl AccountsSubcommand {
                 println!("Accounts:");
                 for (i, account) in account_manager.all().into_iter().enumerate() {
                     if account.is_active {
-                        println!("{}. (active) {}", i, account);
+                        println!("{}. {} (active)", i, account);
                     } else {
                         println!("{}. {}", i, account);
                     }

--- a/applications/tari_validator_node_cli/src/command/manifest.template.rs
+++ b/applications/tari_validator_node_cli/src/command/manifest.template.rs
@@ -1,10 +1,11 @@
 //   Copyright 2022 The Tari Project
 //   SPDX-License-Identifier: BSD-3-clause
 
-// TODO: Improve this template
-use template_bc617551fc331bb5ebc12943c1456dbf8fbd0ae4e950b2ffc28a6b89ce040382 as Account;
+use template_7c793e0e945c10228ceb08bfa7ccd1e673ba609dc7200f6a7721278de6231625 as Account;
 
 fn main() {
-    let mut account = global!["account"];
+    info!("Hello, world!");
+    // Account::new();
+    // let mut account = global!["account"];
     // account.deposit(funds);
 }

--- a/applications/tari_validator_node_cli/src/command/mod.rs
+++ b/applications/tari_validator_node_cli/src/command/mod.rs
@@ -26,7 +26,7 @@ mod account;
 pub use account::AccountsSubcommand;
 
 mod template;
-pub use template::{PublishTemplateArgs, TemplateSubcommand};
+pub use template::TemplateSubcommand;
 
 mod vn;
 pub use vn::VnSubcommand;
@@ -41,12 +41,12 @@ mod transaction;
 pub enum Command {
     #[clap(subcommand)]
     Vn(VnSubcommand),
-    #[clap(subcommand)]
+    #[clap(subcommand, alias = "template")]
     Templates(TemplateSubcommand),
-    #[clap(subcommand)]
+    #[clap(subcommand, alias = "account")]
     Accounts(AccountsSubcommand),
-    #[clap(subcommand)]
+    #[clap(subcommand, alias = "transaction")]
     Transactions(TransactionSubcommand),
-    #[clap(subcommand)]
-    Manifest(ManifestSubcommand),
+    #[clap(subcommand, alias = "manifest")]
+    Manifests(ManifestSubcommand),
 }

--- a/applications/tari_validator_node_cli/src/command/template.rs
+++ b/applications/tari_validator_node_cli/src/command/template.rs
@@ -94,7 +94,6 @@ async fn handle_get(template_address: TemplateAddress, mut client: ValidatorNode
 
 async fn handle_list(mut client: ValidatorNodeClient) -> Result<(), anyhow::Error> {
     let templates = client.get_active_templates(GetTemplatesRequest { limit: 10 }).await?;
-    println!("Templates:");
 
     let mut table = Table::new();
     table

--- a/applications/tari_validator_node_cli/src/command/transaction.rs
+++ b/applications/tari_validator_node_cli/src/command/transaction.rs
@@ -98,10 +98,9 @@ pub struct CommonSubmitArgs {
 
 #[derive(Debug, Args, Clone)]
 pub struct SubmitManifestArgs {
-    #[clap(long, short = 'p')]
     manifest: PathBuf,
     #[clap(long, short = 'g')]
-    globals: Vec<String>,
+    input_variables: Vec<String>,
     #[clap(flatten)]
     common: CommonSubmitArgs,
 }
@@ -191,9 +190,12 @@ async fn handle_submit_manifest(
     client: &mut ValidatorNodeClient,
 ) -> Result<(), anyhow::Error> {
     let contents = std::fs::read_to_string(&args.manifest).map_err(|e| anyhow!("Failed to read manifest: {}", e))?;
-    let instructions = parse_manifest(&contents, manifest::parse_globals(args.globals)?)?;
-    // TODO: improve output
-    println!("Instructions: {:?}", instructions);
+    let instructions = parse_manifest(&contents, manifest::parse_globals(args.input_variables)?)?;
+    println!("🌟 Submitting instructions:");
+    for instruction in &instructions {
+        println!("- {}", instruction);
+    }
+    println!();
     submit_transaction(instructions, args.common, base_dir, client).await
 }
 
@@ -307,11 +309,7 @@ fn summarize_finalize_result(finalize: &FinalizeResult) {
     match finalize.result {
         TransactionResult::Accept(ref diff) => {
             for (address, substate) in diff.up_iter() {
-                println!(
-                    "️🌲 UP substate {} (v{})",
-                    ShardId::from_address(address),
-                    substate.version()
-                );
+                println!("️🌲 UP substate {} (v{})", address, substate.version());
                 match substate.substate_value() {
                     SubstateValue::Component(component) => {
                         println!(
@@ -329,7 +327,7 @@ fn summarize_finalize_result(finalize: &FinalizeResult) {
                 println!();
             }
             for address in diff.down_iter() {
-                println!("🗑️ DOWN substate {}", ShardId::from_address(address));
+                println!("🗑️ DOWN substate {}", address);
                 println!();
             }
         },

--- a/applications/tari_validator_node_cli/src/main.rs
+++ b/applications/tari_validator_node_cli/src/main.rs
@@ -66,7 +66,7 @@ async fn handle_command(command: Command, base_dir: PathBuf, client: ValidatorNo
         Command::Templates(cmd) => cmd.handle(client).await?,
         Command::Accounts(cmd) => cmd.handle(base_dir).await?,
         Command::Transactions(cmd) => cmd.handle(base_dir, client).await?,
-        Command::Manifest(cmd) => cmd.handle()?,
+        Command::Manifests(cmd) => cmd.handle()?,
     }
 
     Ok(())

--- a/dan_layer/common_types/Cargo.toml
+++ b/dan_layer/common_types/Cargo.toml
@@ -21,9 +21,10 @@ bincode = "1.0"
 base64 = "0.20.0-alpha.1"
 borsh = "0.9"
 digest = "0.9"
-serde = "1.0.126"
+newtype-ops = "0.1.4"
 prost = "0.9"
 prost-types = "0.9"
+serde = "1.0.126"
 
 [build-dependencies]
 tari_common = { git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_common", features = ["build"] }

--- a/dan_layer/common_types/src/epoch.rs
+++ b/dan_layer/common_types/src/epoch.rs
@@ -22,6 +22,7 @@
 
 use std::fmt::Display;
 
+use newtype_ops::newtype_ops;
 use serde::{Deserialize, Serialize};
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize, Serialize)]
@@ -36,13 +37,8 @@ impl Epoch {
         self.0.to_le_bytes()
     }
 
-    pub fn to_height(self) -> u64 {
-        self.0 * 10
-    }
-
-    pub fn from_block_height(bh: u64) -> Self {
-        let e = bh / 10;
-        Self(e)
+    pub fn saturating_sub(&self, other: Epoch) -> Epoch {
+        Epoch(self.0.saturating_sub(other.0))
     }
 }
 
@@ -57,3 +53,7 @@ impl Display for Epoch {
         write!(f, "{}", self.0)
     }
 }
+
+newtype_ops! { [Epoch] {add sub mul div} {:=} Self Self }
+newtype_ops! { [Epoch] {add sub mul div} {:=} &Self &Self }
+newtype_ops! { [Epoch] {add sub mul div} {:=} Self &Self }

--- a/dan_layer/core/src/consensus_constants.rs
+++ b/dan_layer/core/src/consensus_constants.rs
@@ -20,6 +20,9 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+use serde::{Deserialize, Serialize};
+use tari_dan_common_types::Epoch;
+
 #[derive(Clone)]
 pub struct ConsensusConstants {
     pub base_layer_confirmations: u64,
@@ -37,14 +40,23 @@ impl ConsensusConstants {
     }
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BaseLayerConsensusConstants {
     pub validator_node_registration_expiry: u64,
     pub epoch_length: u64,
 }
 
 impl BaseLayerConsensusConstants {
-    pub fn get_validator_node_registration_expiry(&self) -> u64 {
-        self.validator_node_registration_expiry
+    pub fn height_to_epoch(&self, height: u64) -> Epoch {
+        Epoch(height / self.epoch_length)
+    }
+
+    pub fn epoch_to_height(&self, epoch: Epoch) -> u64 {
+        epoch.0 * self.epoch_length
+    }
+
+    pub fn validator_node_registration_expiry(&self) -> Epoch {
+        Epoch(self.validator_node_registration_expiry)
     }
 
     pub fn epoch_length(&self) -> u64 {

--- a/dan_layer/core/src/models/vote_message.rs
+++ b/dan_layer/core/src/models/vote_message.rs
@@ -122,6 +122,19 @@ impl VoteMessage {
         let merkle_proof =
             MerkleProof::for_leaf_node(vn_mmr, leaf_pos as usize).expect("Merkle proof generation failed");
 
+        // let hash = vn_mmr_node_hash(signing_service.public_key(), &shard_id);
+        // let root = vn_mmr.get_merkle_root().unwrap();
+        // let idx = vn_mmr.find_leaf_index(&*hash).unwrap();
+        // if let Err(err) = merkle_proof.verify::<ValidatorNodeMmrHasherBlake256>(&root, &*hash, leaf_pos as usize) {
+        //     log::warn!(
+        //         target: "tari::dan_layer::votemessage",
+        //         "Merkle proof verification failed for validator node {:?} at index {:?} with error: {}",
+        //         hash,
+        //         idx,
+        //         err
+        //     );
+        // }
+
         let validator_metadata = ValidatorMetadata::new(
             signing_service.public_key().clone(),
             shard_id,

--- a/dan_layer/core/src/models/vote_message.rs
+++ b/dan_layer/core/src/models/vote_message.rs
@@ -122,18 +122,20 @@ impl VoteMessage {
         let merkle_proof =
             MerkleProof::for_leaf_node(vn_mmr, leaf_pos as usize).expect("Merkle proof generation failed");
 
-        // let hash = vn_mmr_node_hash(signing_service.public_key(), &shard_id);
-        // let root = vn_mmr.get_merkle_root().unwrap();
-        // let idx = vn_mmr.find_leaf_index(&*hash).unwrap();
-        // if let Err(err) = merkle_proof.verify::<ValidatorNodeMmrHasherBlake256>(&root, &*hash, leaf_pos as usize) {
-        //     log::warn!(
-        //         target: "tari::dan_layer::votemessage",
-        //         "Merkle proof verification failed for validator node {:?} at index {:?} with error: {}",
-        //         hash,
-        //         idx,
-        //         err
-        //     );
-        // }
+        let hash = vn_mmr_node_hash(signing_service.public_key(), &shard_id);
+        let root = vn_mmr.get_merkle_root().unwrap();
+        let idx = vn_mmr.find_leaf_index(&*hash).unwrap();
+        if let Err(err) =
+            merkle_proof.verify::<tari_core::ValidatorNodeMmrHasherBlake256>(&root, &*hash, leaf_pos as usize)
+        {
+            log::warn!(
+                target: "tari::dan_layer::votemessage",
+                "Merkle proof verification failed for validator node {:?} at index {:?} with error: {}",
+                hash,
+                idx,
+                err
+            );
+        }
 
         let validator_metadata = ValidatorMetadata::new(
             signing_service.public_key().clone(),

--- a/dan_layer/core/src/services/epoch_manager.rs
+++ b/dan_layer/core/src/services/epoch_manager.rs
@@ -23,6 +23,7 @@
 use std::{collections::HashMap, ops::Range};
 
 use async_trait::async_trait;
+use tari_common_types::types::PublicKey;
 use tari_comms::protocol::rpc::{RpcError, RpcStatus};
 use tari_core::ValidatorNodeMmr;
 use tari_dan_common_types::{Epoch, NodeAddressable, ShardId};
@@ -57,7 +58,7 @@ pub enum EpochManagerError {
     #[error("Unexpected response")]
     UnexpectedResponse,
     #[error("Storage error: {0}")]
-    StorageError(#[from] StorageError),
+    StorageError(StorageError),
     #[error("No validator nodes found for current shard key")]
     ValidatorNodesNotFound,
     #[error("Validator node client error: {0}")]
@@ -70,6 +71,16 @@ pub enum EpochManagerError {
     NoCommitteeVns { shard_id: ShardId, epoch: Epoch },
     #[error("This validator node is not registered")]
     ValidatorNodeNotRegistered,
+    #[error("Base layer consensus constants not set")]
+    BaseLayerConsensusConstantsNotSet,
+    #[error("Base layer could not return shard key for {public_key} at height {block_height}")]
+    ShardKeyNotFound { public_key: PublicKey, block_height: u64 },
+}
+
+impl<T: Into<StorageError>> From<T> for EpochManagerError {
+    fn from(e: T) -> Self {
+        Self::StorageError(e.into())
+    }
 }
 
 #[async_trait]
@@ -103,6 +114,9 @@ pub trait EpochManager<TAddr: NodeAddressable>: Clone {
         -> Result<Vec<ValidatorNode<TAddr>>, EpochManagerError>;
     async fn get_validator_node_mmr(&self, epoch: Epoch) -> Result<ValidatorNodeMmr, EpochManagerError>;
     async fn get_validator_node_merkle_root(&self, epoch: Epoch) -> Result<Vec<u8>, EpochManagerError>;
+
+    // TODO: Should be part of VN state machine
+    async fn notify_scanning_complete(&self) -> Result<(), EpochManagerError>;
 }
 
 #[derive(Debug, Clone)]
@@ -287,5 +301,9 @@ impl<TAddr: NodeAddressable> EpochManager<TAddr> for RangeEpochManager<TAddr> {
     async fn get_validator_node_merkle_root(&self, epoch: Epoch) -> Result<Vec<u8>, EpochManagerError> {
         let vn_mmr = self.get_validator_node_mmr(epoch).await?;
         Ok(vn_mmr.get_merkle_root().unwrap())
+    }
+
+    async fn notify_scanning_complete(&self) -> Result<(), EpochManagerError> {
+        Ok(())
     }
 }

--- a/dan_layer/core/src/storage/mocks/global_db.rs
+++ b/dan_layer/core/src/storage/mocks/global_db.rs
@@ -20,6 +20,7 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+use serde::{de::DeserializeOwned, Serialize};
 use tari_dan_storage::{
     global::{DbEpoch, DbTemplate, DbTemplateUpdate, DbValidatorNode, GlobalDbAdapter, MetadataKey},
     AtomicDb,
@@ -44,11 +45,20 @@ impl AtomicDb for MockGlobalDbBackupAdapter {
 }
 
 impl GlobalDbAdapter for MockGlobalDbBackupAdapter {
-    fn get_metadata(&self, _tx: &Self::DbTransaction<'_>, _key: &MetadataKey) -> Result<Option<Vec<u8>>, Self::Error> {
+    fn get_metadata<T: DeserializeOwned>(
+        &self,
+        _tx: &Self::DbTransaction<'_>,
+        _key: &MetadataKey,
+    ) -> Result<Option<T>, Self::Error> {
         todo!()
     }
 
-    fn set_metadata(&self, _tx: &Self::DbTransaction<'_>, _key: MetadataKey, _value: &[u8]) -> Result<(), Self::Error> {
+    fn set_metadata<T: Serialize>(
+        &self,
+        _tx: &Self::DbTransaction<'_>,
+        _key: MetadataKey,
+        _value: &T,
+    ) -> Result<(), Self::Error> {
         todo!()
     }
 
@@ -81,10 +91,11 @@ impl GlobalDbAdapter for MockGlobalDbBackupAdapter {
         todo!()
     }
 
-    fn get_validator_nodes_per_epoch(
+    fn get_validator_nodes_within_epochs(
         &self,
         _tx: &Self::DbTransaction<'_>,
-        _epoch: u64,
+        _start_epoch: u64,
+        _end_epoch: u64,
     ) -> Result<Vec<DbValidatorNode>, Self::Error> {
         todo!()
     }
@@ -92,7 +103,8 @@ impl GlobalDbAdapter for MockGlobalDbBackupAdapter {
     fn get_validator_node(
         &self,
         _tx: &Self::DbTransaction<'_>,
-        _epoch: u64,
+        _start_epoch: u64,
+        _end_epoch: u64,
         _public_key: &[u8],
     ) -> Result<DbValidatorNode, Self::Error> {
         todo!()

--- a/dan_layer/core/src/workers/hotstuff_error.rs
+++ b/dan_layer/core/src/workers/hotstuff_error.rs
@@ -20,7 +20,7 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use tari_dan_common_types::{Epoch, NodeHeight, ShardId};
+use tari_dan_common_types::{Epoch, NodeHeight, PayloadId, ShardId};
 use tari_engine_types::commit_result::RejectReason;
 use thiserror::Error;
 
@@ -41,8 +41,11 @@ pub enum HotStuffError {
     StoreError(#[from] StoreError),
     #[error("Claim is not valid")]
     ClaimIsNotValid,
-    #[error("Node payload does not match justify payload")]
-    NodePayloadDoesNotMatchJustifyPayload,
+    #[error("Node payload {node_payload} does not match justify payload {justify_payload}")]
+    NodePayloadDoesNotMatchJustifyPayload {
+        node_payload: PayloadId,
+        justify_payload: PayloadId,
+    },
     #[error("Send error")]
     SendError,
     #[error("Not the leader")]
@@ -67,4 +70,11 @@ pub enum HotStuffError {
     ValidatorNodeNotIncludedInMmr,
     #[error("No committee for shard {shard} and epoch {epoch}")]
     NoCommitteeForShard { shard: ShardId, epoch: Epoch },
+    #[error(
+        "Node payload height ({node_payload_height}) does not match justify payload height ({justify_payload_height})"
+    )]
+    NodePayloadHeightIncorrect {
+        node_payload_height: NodeHeight,
+        justify_payload_height: NodeHeight,
+    },
 }

--- a/dan_layer/core/src/workers/hotstuff_waiter.rs
+++ b/dan_layer/core/src/workers/hotstuff_waiter.rs
@@ -24,7 +24,6 @@ use std::collections::{HashMap, HashSet};
 
 use log::*;
 use tari_common_types::types::{PublicKey, Signature};
-use tari_core::ValidatorNodeMmrHasherBlake256;
 use tari_dan_common_types::{
     optional::Optional,
     Epoch,
@@ -210,7 +209,7 @@ where
             //  Save the payload, because we will need it when the proposal comes back
             tx.set_payload(payload.clone())?;
             tx.commit()?;
-            // TODO: combine merkle proofs into one before sending
+
             new_view = HotStuffMessage::new_view(high_qc, shard, Some(payload));
         }
 
@@ -408,17 +407,37 @@ where
             .get_validator_shard_key(node.epoch(), self.public_key.clone())
             .await?;
         let vn_mmr = self.epoch_manager.get_validator_node_mmr(node.epoch()).await?;
+        // let mr = self.epoch_manager.get_validator_node_merkle_root(node.epoch()).await?;
+        // if vn_mmr.get_merkle_root().unwrap() != mr {
+        //     error!(target: LOG_TARGET, "🔥 Merkle root mismatch for epoch {}", node.epoch());
+        // }
 
         {
             let mut tx = self.shard_store.create_tx()?;
             tx.save_node(node.clone())?;
             let v_height = tx.get_last_voted_height(shard)?;
             // TODO: can also use the QC and committee to justify this....
+            if node.height() <= v_height {
+                error!(
+                    target: LOG_TARGET,
+                    "Received a proposal that is not valid: node_height {} <= v_height {}",
+                    node.height(),
+                    v_height
+                );
+                tx.commit()?;
+                return Ok(());
+            }
             let (locked_node, locked_height) = tx.get_locked_node_hash_and_height(shard)?;
-            if node.height() <= v_height ||
-                (node.parent() != &locked_node && node.justify().local_node_height() <= locked_height)
-            {
-                error!(target: LOG_TARGET, "Received a proposal that is not valid");
+            if node.parent() != &locked_node && node.justify().local_node_height() <= locked_height {
+                error!(
+                    target: LOG_TARGET,
+                    "Received a proposal that is not valid: node.parent() {} != locked_node {} && \
+                     node.local_node_height {} <= locked_height {}",
+                    node.parent(),
+                    locked_node,
+                    node.justify().local_node_height(),
+                    locked_height
+                );
                 tx.commit()?;
                 return Ok(());
             }
@@ -698,19 +717,19 @@ where
         }
 
         // all merkle proofs for the signers must be valid
-        let validator_node_root = self.epoch_manager.get_validator_node_merkle_root(qc.epoch()).await?;
-        // TODO: Combine all validator merkle proofs before sending them
-        for md in qc.validators_metadata() {
-            md.merkle_proof
-                .verify_leaf::<ValidatorNodeMmrHasherBlake256>(
-                    &validator_node_root,
-                    &*md.get_node_hash(),
-                    md.merkle_leaf_index as usize,
-                )
-                .map_err(|_| HotStuffError::InvalidQuorumCertificate("invalid merkle proof".to_string()))?;
-        }
+        // let validator_node_root = self.epoch_manager.get_validator_node_merkle_root(qc.epoch()).await?;
+        // // TODO: Combine all validator merkle proofs before sending them
+        // for md in qc.validators_metadata() {
+        //     md.merkle_proof
+        //         .verify_leaf::<ValidatorNodeMmrHasherBlake256>(
+        //             &validator_node_root,
+        //             &*md.get_node_hash(),
+        //             md.merkle_leaf_index as usize,
+        //         )
+        //         .map_err(|e| HotStuffError::InvalidQuorumCertificate(format!("invalid merkle proof: {}", e)))?;
+        // }
 
-        // all signers must be included in the epoch commitee for the shard
+        // all signers must be included in the epoch committee for the shard
         let committee = self.epoch_manager.get_committee(qc.epoch(), qc.shard()).await?;
         let commitee_set = committee.members.iter().map(|m| m.as_bytes()).collect::<HashSet<_>>();
         let all_signers_are_in_committee = signers_set.iter().all(|s| commitee_set.contains(s));
@@ -848,21 +867,32 @@ where
     }
 
     fn validate_proposal(&self, node: &HotStuffTreeNode<TAddr, TPayload>) -> Result<(), HotStuffError> {
-        if node.payload_height() == NodeHeight(0) ||
-            (node.payload_id() == node.justify().payload_id() &&
-                node.payload_height() == node.justify().payload_height() + NodeHeight(1))
-        {
-            let max_node_height = NodeHeight(self.consensus_constants.hotstuff_rounds - 1);
-            if node.payload_height() > max_node_height {
-                return Err(HotStuffError::PayloadHeightIsTooHigh {
-                    actual: node.payload_height(),
-                    max: max_node_height,
-                });
-            }
-            Ok(())
-        } else {
-            Err(HotStuffError::NodePayloadDoesNotMatchJustifyPayload)
+        if node.payload_height() == NodeHeight(0) {
+            return Ok(());
         }
+
+        if node.payload_id() != node.justify().payload_id() {
+            return Err(HotStuffError::NodePayloadDoesNotMatchJustifyPayload {
+                node_payload: node.payload_id(),
+                justify_payload: node.justify().payload_id(),
+            });
+        }
+
+        if node.payload_height() != node.justify().payload_height() + NodeHeight(1) {
+            return Err(HotStuffError::NodePayloadHeightIncorrect {
+                node_payload_height: node.payload_height(),
+                justify_payload_height: node.justify().payload_height() + NodeHeight(1),
+            });
+        }
+
+        let max_node_height = NodeHeight(self.consensus_constants.hotstuff_rounds - 1);
+        if node.payload_height() > max_node_height {
+            return Err(HotStuffError::PayloadHeightIsTooHigh {
+                actual: node.payload_height(),
+                max: max_node_height,
+            });
+        }
+        Ok(())
     }
 
     fn validate_pledges(

--- a/dan_layer/engine_types/src/instruction.rs
+++ b/dan_layer/engine_types/src/instruction.rs
@@ -1,6 +1,8 @@
 //  Copyright 2022 The Tari Project
 //  SPDX-License-Identifier: BSD-3-Clause
 
+use std::fmt::{Display, Formatter};
+
 use serde::{Deserialize, Serialize};
 use tari_bor::{borsh, Encode};
 use tari_template_lib::{
@@ -36,5 +38,36 @@ pub enum Instruction {
 impl Instruction {
     pub fn hash(&self) -> Hash {
         hasher("instruction").chain(self).result()
+    }
+}
+
+impl Display for Instruction {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::CallFunction {
+                template_address,
+                function,
+                args,
+            } => write!(
+                f,
+                "CallFunction {{ template_address: {}, function: {}, args: {:?} }}",
+                template_address, function, args
+            ),
+            Self::CallMethod {
+                component_address,
+                method,
+                args,
+            } => write!(
+                f,
+                "CallMethod {{ component_address: {}, method: {}, args: {:?} }}",
+                component_address, method, args
+            ),
+            Self::PutLastInstructionOutputOnWorkspace { key } => {
+                write!(f, "PutLastInstructionOutputOnWorkspace {{ key: {:?} }}", key)
+            },
+            Self::EmitLog { level, message } => {
+                write!(f, "EmitLog {{ level: {:?}, message: {:?} }}", level, message)
+            },
+        }
     }
 }

--- a/dan_layer/engine_types/src/substate.rs
+++ b/dan_layer/engine_types/src/substate.rs
@@ -106,9 +106,9 @@ impl SubstateAddress {
 impl Display for SubstateAddress {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            SubstateAddress::Component(addr) => write!(f, "Component({})", addr),
-            SubstateAddress::Resource(addr) => write!(f, "Resource({})", addr),
-            SubstateAddress::Vault(addr) => write!(f, "Vault({})", addr),
+            SubstateAddress::Component(addr) => write!(f, "component_{}", addr),
+            SubstateAddress::Resource(addr) => write!(f, "resource_{}", addr),
+            SubstateAddress::Vault(addr) => write!(f, "vault_{}", addr),
         }
     }
 }

--- a/dan_layer/integration_tests/src/temp_shard_store_factory.rs
+++ b/dan_layer/integration_tests/src/temp_shard_store_factory.rs
@@ -43,8 +43,7 @@ impl TempShardStoreFactory {
     }
 }
 
-impl Default for TempShardStoreFactory {g st
-
+impl Default for TempShardStoreFactory {
     fn default() -> Self {
         Self::new()
     }

--- a/dan_layer/integration_tests/src/temp_shard_store_factory.rs
+++ b/dan_layer/integration_tests/src/temp_shard_store_factory.rs
@@ -43,7 +43,8 @@ impl TempShardStoreFactory {
     }
 }
 
-impl Default for TempShardStoreFactory {
+impl Default for TempShardStoreFactory {g st
+
     fn default() -> Self {
         Self::new()
     }

--- a/dan_layer/storage/Cargo.toml
+++ b/dan_layer/storage/Cargo.toml
@@ -8,6 +8,7 @@ license = "BSD-3-Clause"
 
 [dependencies]
 tari_common_types = { git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_common_types" }
+tari_dan_common_types = { path = "../common_types" }
 
 thiserror = "1"
 time = "0.3.15"

--- a/dan_layer/storage/src/global/metadata_db.rs
+++ b/dan_layer/storage/src/global/metadata_db.rs
@@ -55,6 +55,7 @@ pub enum MetadataKey {
     CurrentEpoch,
     CurrentShardKey,
     LastEpochRegistration,
+    LastSyncedEpoch,
 }
 
 impl MetadataKey {
@@ -68,6 +69,7 @@ impl MetadataKey {
             MetadataKey::CurrentEpoch => b"current_epoch",
             MetadataKey::LastEpochRegistration => b"last_registered_epoch",
             MetadataKey::CurrentShardKey => b"current_shard_key",
+            MetadataKey::LastSyncedEpoch => b"last_synced_epoch",
         }
     }
 }

--- a/dan_layer/storage/src/global/metadata_db.rs
+++ b/dan_layer/storage/src/global/metadata_db.rs
@@ -20,6 +20,8 @@
 //   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //   USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+use serde::{de::DeserializeOwned, Serialize};
+
 use crate::global::GlobalDbAdapter;
 
 pub struct MetadataDb<'a, TGlobalDbAdapter: GlobalDbAdapter> {
@@ -32,12 +34,12 @@ impl<'a, TGlobalDbAdapter: GlobalDbAdapter> MetadataDb<'a, TGlobalDbAdapter> {
         Self { backend, tx }
     }
 
-    pub fn set_metadata(&self, key: MetadataKey, value: &[u8]) -> Result<(), TGlobalDbAdapter::Error> {
+    pub fn set_metadata<T: Serialize>(&self, key: MetadataKey, value: &T) -> Result<(), TGlobalDbAdapter::Error> {
         self.backend.set_metadata(self.tx, key, value)?;
         Ok(())
     }
 
-    pub fn get_metadata(&self, key: MetadataKey) -> Result<Option<Vec<u8>>, TGlobalDbAdapter::Error> {
+    pub fn get_metadata<T: DeserializeOwned>(&self, key: MetadataKey) -> Result<Option<T>, TGlobalDbAdapter::Error> {
         let data = self.backend.get_metadata(self.tx, &key)?;
         Ok(data)
     }
@@ -48,7 +50,10 @@ pub enum MetadataKey {
     BaseLayerScannerLastScannedTip,
     BaseLayerScannerLastScannedBlockHeight,
     BaseLayerScannerLastScannedBlockHash,
+    BaseLayerScannerNextBlockHash,
+    BaseLayerConsensusConstants,
     CurrentEpoch,
+    CurrentShardKey,
     LastEpochRegistration,
 }
 
@@ -58,8 +63,11 @@ impl MetadataKey {
             MetadataKey::BaseLayerScannerLastScannedTip => b"base_layer_scanner.last_scanned_tip",
             MetadataKey::BaseLayerScannerLastScannedBlockHash => b"base_layer_scanner.last_scanned_block_hash",
             MetadataKey::BaseLayerScannerLastScannedBlockHeight => b"base_layer_scanner.last_scanned_block_height",
+            MetadataKey::BaseLayerScannerNextBlockHash => b"base_layer_scanner.next_block_hash",
+            MetadataKey::BaseLayerConsensusConstants => b"base_layer.consensus_constants",
             MetadataKey::CurrentEpoch => b"current_epoch",
             MetadataKey::LastEpochRegistration => b"last_registered_epoch",
+            MetadataKey::CurrentShardKey => b"current_shard_key",
         }
     }
 }

--- a/dan_layer/storage/src/global/validator_node_db.rs
+++ b/dan_layer/storage/src/global/validator_node_db.rs
@@ -20,6 +20,8 @@
 //   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //   USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+use tari_dan_common_types::Epoch;
+
 use crate::global::GlobalDbAdapter;
 
 pub struct ValidatorNodeDb<'a, TGlobalDbAdapter: GlobalDbAdapter> {
@@ -38,15 +40,24 @@ impl<'a, TGlobalDbAdapter: GlobalDbAdapter> ValidatorNodeDb<'a, TGlobalDbAdapter
             .map_err(TGlobalDbAdapter::Error::into)
     }
 
-    pub fn get(&self, epoch: u64, public_key: &[u8]) -> Result<DbValidatorNode, TGlobalDbAdapter::Error> {
+    pub fn get(
+        &self,
+        start_epoch: u64,
+        end_epoch: u64,
+        public_key: &[u8],
+    ) -> Result<DbValidatorNode, TGlobalDbAdapter::Error> {
         self.backend
-            .get_validator_node(self.tx, epoch, public_key)
+            .get_validator_node(self.tx, start_epoch, end_epoch, public_key)
             .map_err(TGlobalDbAdapter::Error::into)
     }
 
-    pub fn get_all_per_epoch(&self, epoch: u64) -> Result<Vec<DbValidatorNode>, TGlobalDbAdapter::Error> {
+    pub fn get_all_within_epochs(
+        &self,
+        start_epoch: u64,
+        end_epoch: u64,
+    ) -> Result<Vec<DbValidatorNode>, TGlobalDbAdapter::Error> {
         self.backend
-            .get_validator_nodes_per_epoch(self.tx, epoch)
+            .get_validator_nodes_within_epochs(self.tx, start_epoch, end_epoch)
             .map_err(TGlobalDbAdapter::Error::into)
     }
 }
@@ -55,5 +66,5 @@ impl<'a, TGlobalDbAdapter: GlobalDbAdapter> ValidatorNodeDb<'a, TGlobalDbAdapter
 pub struct DbValidatorNode {
     pub public_key: Vec<u8>,
     pub shard_key: Vec<u8>,
-    pub epoch: u64,
+    pub epoch: Epoch,
 }

--- a/dan_layer/storage_sqlite/Cargo.toml
+++ b/dan_layer/storage_sqlite/Cargo.toml
@@ -24,3 +24,4 @@ tokio-stream = { version = "0.1.7", features = ["sync"] }
 log = { version = "0.4.8", features = ["std"] }
 time = "0.3.15"
 serde_json = "1.0.85"
+serde = "1.0"

--- a/dan_layer/storage_sqlite/src/error.rs
+++ b/dan_layer/storage_sqlite/src/error.rs
@@ -51,6 +51,8 @@ pub enum SqliteStorageError {
     ConversionError { reason: String },
     #[error("Malformed metadata for key '{key}'")]
     MalformedMetadata { key: String },
+    #[error("Serialization failed")]
+    SerializationFailed(#[from] serde_json::Error),
 }
 
 impl From<SqliteStorageError> for StorageError {

--- a/dan_layer/storage_sqlite/src/error.rs
+++ b/dan_layer/storage_sqlite/src/error.rs
@@ -21,6 +21,7 @@
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 use diesel;
 use tari_common_types::types::FixedHashSizeError;
+use tari_dan_common_types::optional::IsNotFoundError;
 use tari_dan_core::{models::ModelError, storage::StorageError};
 use thiserror::Error;
 
@@ -77,5 +78,11 @@ impl From<SqliteStorageError> for StorageError {
 impl From<FixedHashSizeError> for SqliteStorageError {
     fn from(_: FixedHashSizeError) -> Self {
         SqliteStorageError::MalformedHashData
+    }
+}
+
+impl IsNotFoundError for SqliteStorageError {
+    fn is_not_found_error(&self) -> bool {
+        matches!(self, SqliteStorageError::DieselError { source, .. } if matches!(source, diesel::result::Error::NotFound))
     }
 }

--- a/dan_layer/storage_sqlite/src/global/backend_adapter.rs
+++ b/dan_layer/storage_sqlite/src/global/backend_adapter.rs
@@ -276,7 +276,7 @@ impl GlobalDbAdapter for SqliteGlobalDbAdapter {
             .first::<ValidatorNode>(tx.connection())
             .map_err(|source| SqliteStorageError::DieselError {
                 source,
-                operation: "get::validator_nodes_per_epoch".to_string(),
+                operation: "get::validator_node".to_string(),
             })?;
 
         Ok(vn.into())
@@ -294,10 +294,12 @@ impl GlobalDbAdapter for SqliteGlobalDbAdapter {
             .filter(validator_nodes::epoch.ge(start_epoch as i64))
             .filter(validator_nodes::epoch.le(end_epoch as i64))
             .load::<ValidatorNode>(tx.connection())
+            .optional()
             .map_err(|source| SqliteStorageError::DieselError {
                 source,
-                operation: format!("get::validator_nodes_per_epoch({}, {})", start_epoch, end_epoch),
+                operation: format!("get::get_validator_nodes_within_epochs({}, {})", start_epoch, end_epoch),
             })?;
+        let sqlite_vns = sqlite_vns.unwrap_or_default();
 
         // TODO: Perhaps we should overwrite duplicate validator node entries for the epoch validity period
         let mut db_vns = Vec::with_capacity(sqlite_vns.len());

--- a/dan_layer/storage_sqlite/src/global/models/validator_node.rs
+++ b/dan_layer/storage_sqlite/src/global/models/validator_node.rs
@@ -20,6 +20,7 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+use tari_dan_common_types::Epoch;
 use tari_dan_storage::global::DbValidatorNode;
 
 use crate::global::schema::*;
@@ -37,7 +38,7 @@ impl From<ValidatorNode> for DbValidatorNode {
         Self {
             shard_key: vn.shard_key,
             public_key: vn.public_key,
-            epoch: vn.epoch as u64,
+            epoch: Epoch(vn.epoch as u64),
         }
     }
 }
@@ -55,7 +56,7 @@ impl From<DbValidatorNode> for NewValidatorNode {
         Self {
             shard_key: vn.shard_key,
             public_key: vn.public_key,
-            epoch: vn.epoch as i64,
+            epoch: vn.epoch.as_u64() as i64,
         }
     }
 }

--- a/dan_layer/storage_sqlite/src/sqlite_shard_store_factory.rs
+++ b/dan_layer/storage_sqlite/src/sqlite_shard_store_factory.rs
@@ -945,7 +945,7 @@ impl ShardStoreTransaction<PublicKey, TariDanPayload> for SqliteShardStoreTransa
         end_shard_id: ShardId,
         excluded_shards: &[ShardId],
     ) -> Result<Vec<SubstateShardData>, StorageError> {
-        use crate::schema::substates::shard_id;
+        use crate::schema::substates;
         let excluded_shards = excluded_shards
             .iter()
             .map(|sh| Vec::from(sh.as_bytes()))
@@ -953,10 +953,11 @@ impl ShardStoreTransaction<PublicKey, TariDanPayload> for SqliteShardStoreTransa
 
         let substate_states: Option<Vec<crate::models::substate::Substate>> = substates
             .filter(
-                shard_id
+                substates::shard_id
                     .gt(Vec::from(start_shard_id.as_bytes()))
-                    .and(shard_id.lt(Vec::from(end_shard_id.as_bytes())))
-                    .and(shard_id.ne_all(excluded_shards)),
+                    .and(substates::shard_id.lt(Vec::from(end_shard_id.as_bytes())))
+                    .and(substates::shard_id.ne_all(excluded_shards))
+                    .and(substates::data.is_not_null()),
             )
             .get_results(self.transaction.connection())
             .optional()

--- a/dan_layer/storage_sqlite/src/sqlite_shard_store_factory.rs
+++ b/dan_layer/storage_sqlite/src/sqlite_shard_store_factory.rs
@@ -957,7 +957,7 @@ impl ShardStoreTransaction<PublicKey, TariDanPayload> for SqliteShardStoreTransa
                     .gt(Vec::from(start_shard_id.as_bytes()))
                     .and(substates::shard_id.lt(Vec::from(end_shard_id.as_bytes())))
                     .and(substates::shard_id.ne_all(excluded_shards))
-                    .and(substates::data.is_not_null()),
+                    .and(substates::is_draft.eq(false)),
             )
             .get_results(self.transaction.connection())
             .optional()

--- a/dan_layer/template_lib/src/models/mod.rs
+++ b/dan_layer/template_lib/src/models/mod.rs
@@ -39,5 +39,7 @@ mod package;
 pub use package::TemplateAddress;
 
 mod vault;
-
 pub use vault::{Vault, VaultId, VaultRef};
+
+mod substate_address;
+pub use substate_address::SubstateAddress;

--- a/dan_layer/template_lib/src/models/substate_address.rs
+++ b/dan_layer/template_lib/src/models/substate_address.rs
@@ -1,0 +1,13 @@
+//   Copyright 2022 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+use tari_bor::{borsh, Decode, Encode};
+
+use crate::models::{ComponentAddress, ResourceAddress, VaultId};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Encode, Decode)]
+pub enum SubstateAddress {
+    Component(ComponentAddress),
+    Resource(ResourceAddress),
+    Vault(VaultId),
+}

--- a/dan_layer/template_lib/src/prelude.rs
+++ b/dan_layer/template_lib/src/prelude.rs
@@ -26,6 +26,6 @@ pub use tari_template_macros::template;
 pub use crate::{
     chain_time::ChainTime,
     component::ComponentManager,
-    models::{Amount, Bucket, BucketId, ResourceAddress, Vault},
+    models::{Amount, Bucket, BucketId, ResourceAddress, SubstateAddress, Vault},
     resource::{ResourceBuilder, ResourceManager, ResourceType},
 };

--- a/dan_layer/transaction_manifest/src/parser.rs
+++ b/dan_layer/transaction_manifest/src/parser.rs
@@ -282,7 +282,7 @@ impl ManifestParser {
 
 fn assignment_from_macro(var_name: Ident, mac: &Ident, tokens: TokenStream) -> Result<ManifestIntent, syn::Error> {
     match mac.to_string().as_str() {
-        "global" => Ok(ManifestIntent::AssignInput(AssignInputStmt {
+        "global" | "var" => Ok(ManifestIntent::AssignInput(AssignInputStmt {
             variable_name: var_name,
             global_variable_name: parse2(tokens)?,
         })),


### PR DESCRIPTION
Description
---
- cli: minor cosmetic and usage improvements
- Add validators and epochs as blockchain is scanned
- Improve instruction output
- Display  substate addresses in [type]_[id] format
- get and set metadata allow backend to define serialization
- Don't retrieve empty data in get_substate_states
- Allow var! macro in template manifest
- Allow SubstateAddress to be used in templates
- MMR check in hotstuff commented out for now

Motivation and Context
---
Trying to get MR to work and came across a few other issues. 
PRing these changes for now since they allow the VN to work and will carry on with Merkle root fixes from there.

State sync starts and syncs

How Has This Been Tested?
---
Manually, existing tests
