### PR TITLE
fix: enable auto-registration by default

### DIFF
--- a/applications/tari_validator_node/src/config.rs
+++ b/applications/tari_validator_node/src/config.rs
@@ -141,7 +141,7 @@ impl Default for ValidatorNodeConfig {
             grpc_address: Some("/ip4/127.0.0.1/tcp/18144".parse().unwrap()),
             json_rpc_address: Some("127.0.0.1:18200".parse().unwrap()),
             http_ui_address: Some("127.0.0.1:5000".parse().unwrap()),
-            auto_register: false,
+            auto_register: true,
             templates: TemplateConfig::default(),
         }
     }


### PR DESCRIPTION
Description
---
enables auto-registration by default

Motivation and Context
---
Since the user has to initiate the initial registration, auto_registration = true seems like a sensible default.

How Has This Been Tested?
---
Manually
