### PR TITLE
fix: fix database is locked failures in global db

### DIFF
--- a/applications/tari_validator_node/src/bootstrap.rs
+++ b/applications/tari_validator_node/src/bootstrap.rs
@@ -38,11 +38,7 @@ use tari_dan_core::{
     workers::events::{EventSubscription, HotStuffEvent},
 };
 use tari_dan_storage::global::GlobalDb;
-use tari_dan_storage_sqlite::{
-    global::SqliteGlobalDbAdapter,
-    sqlite_shard_store_factory::SqliteShardStore,
-    SqliteDbFactory,
-};
+use tari_dan_storage_sqlite::{global::SqliteGlobalDbAdapter, sqlite_shard_store_factory::SqliteShardStore};
 use tari_shutdown::ShutdownSignal;
 
 use crate::{
@@ -79,7 +75,6 @@ pub async fn spawn_services(
     shutdown: ShutdownSignal,
     node_identity: Arc<NodeIdentity>,
     global_db: GlobalDb<SqliteGlobalDbAdapter>,
-    sqlite_db: SqliteDbFactory,
     consensus_constants: ConsensusConstants,
 ) -> Result<Services, anyhow::Error> {
     let mut p2p_config = config.validator_node.p2p.clone();
@@ -118,7 +113,7 @@ pub async fn spawn_services(
     // Epoch manager
     let validator_node_client_factory = TariCommsValidatorNodeClientFactory::new(comms.connectivity());
     let epoch_manager = epoch_manager::spawn(
-        sqlite_db.clone(),
+        global_db.clone(),
         shard_store.clone(),
         base_node_client.clone(),
         consensus_constants.clone(),
@@ -147,13 +142,13 @@ pub async fn spawn_services(
 
     // Template manager
 
-    let template_manager = TemplateManager::new(sqlite_db.clone(), config.validator_node.templates.clone());
+    let template_manager = TemplateManager::new(global_db.clone(), config.validator_node.templates.clone());
     let template_manager_service = template_manager::spawn(template_manager.clone(), shutdown.clone());
 
     // Base Node scanner
     base_layer_scanner::spawn(
         config.validator_node.clone(),
-        global_db.clone(),
+        global_db,
         base_node_client.clone(),
         epoch_manager.clone(),
         template_manager_service.clone(),

--- a/applications/tari_validator_node/src/lib.rs
+++ b/applications/tari_validator_node/src/lib.rs
@@ -136,7 +136,6 @@ pub async fn run_validator_node_with_cli(config: &ApplicationConfig, cli: &Cli) 
         shutdown.to_signal(),
         node_identity.clone(),
         global_db,
-        db_factory,
         ConsensusConstants::devnet(), // TODO: change this eventually
     )
     .await?;

--- a/applications/tari_validator_node/src/p2p/services/epoch_manager/epoch_manager_service.rs
+++ b/applications/tari_validator_node/src/p2p/services/epoch_manager/epoch_manager_service.rs
@@ -32,7 +32,8 @@ use tari_dan_core::{
     models::{Committee, ValidatorNode},
     services::epoch_manager::{EpochManagerError, ShardCommitteeAllocation},
 };
-use tari_dan_storage_sqlite::{sqlite_shard_store_factory::SqliteShardStore, SqliteDbFactory};
+use tari_dan_storage::global::GlobalDb;
+use tari_dan_storage_sqlite::{global::SqliteGlobalDbAdapter, sqlite_shard_store_factory::SqliteShardStore};
 use tari_shutdown::ShutdownSignal;
 use tokio::{
     sync::{broadcast, mpsc::Receiver, oneshot},
@@ -141,7 +142,7 @@ impl EpochManagerService {
     pub fn spawn(
         rx_request: Receiver<EpochManagerRequest>,
         shutdown: ShutdownSignal,
-        db_factory: SqliteDbFactory,
+        global_db: GlobalDb<SqliteGlobalDbAdapter>,
         shard_store: SqliteShardStore,
         base_node_client: GrpcBaseNodeClient,
         consensus_constants: ConsensusConstants,
@@ -153,7 +154,7 @@ impl EpochManagerService {
             let result = EpochManagerService {
                 rx_request,
                 inner: BaseLayerEpochManager::new(
-                    db_factory,
+                    global_db,
                     shard_store,
                     base_node_client,
                     consensus_constants,

--- a/applications/tari_validator_node/src/p2p/services/epoch_manager/initializer.rs
+++ b/applications/tari_validator_node/src/p2p/services/epoch_manager/initializer.rs
@@ -24,7 +24,8 @@ use std::sync::Arc;
 
 use tari_comms::NodeIdentity;
 use tari_dan_core::consensus_constants::ConsensusConstants;
-use tari_dan_storage_sqlite::{sqlite_shard_store_factory::SqliteShardStore, SqliteDbFactory};
+use tari_dan_storage::global::GlobalDb;
+use tari_dan_storage_sqlite::{global::SqliteGlobalDbAdapter, sqlite_shard_store_factory::SqliteShardStore};
 use tari_shutdown::ShutdownSignal;
 use tokio::sync::mpsc;
 
@@ -37,7 +38,7 @@ use crate::{
 };
 
 pub fn spawn(
-    db_factory: SqliteDbFactory,
+    global_db: GlobalDb<SqliteGlobalDbAdapter>,
     shard_store: SqliteShardStore,
     base_node_client: GrpcBaseNodeClient,
     consensus_constants: ConsensusConstants,
@@ -50,7 +51,7 @@ pub fn spawn(
     EpochManagerService::spawn(
         rx_request,
         shutdown,
-        db_factory,
+        global_db,
         shard_store,
         base_node_client,
         consensus_constants,

--- a/dan_layer/storage_sqlite/src/global/backend_adapter.rs
+++ b/dan_layer/storage_sqlite/src/global/backend_adapter.rs
@@ -23,6 +23,7 @@
 use std::{
     collections::HashMap,
     convert::{TryFrom, TryInto},
+    fmt::{Debug, Formatter},
     sync::{Arc, Mutex},
 };
 
@@ -352,5 +353,13 @@ impl GlobalDbAdapter for SqliteGlobalDbAdapter {
             Some(e) => Ok(Some(e.into())),
             None => Ok(None),
         }
+    }
+}
+
+impl Debug for SqliteGlobalDbAdapter {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SqliteGlobalDbAdapter")
+            .field("db", &"Arc<Mutex<SqliteConnection>>")
+            .finish()
     }
 }


### PR DESCRIPTION
Description
---
fixes database is locked failures in global db

Motivation and Context
---
Some operations fail due to the sqlite global db being locked. This PR uses a single shared connection for all SQLite global db operations.

How Has This Been Tested?
---
Existing tests, manually no "database is locked" errors in logs
