### PR TITLE
fix: cucumber errors for templates and transactions

### DIFF
--- a/applications/tari_validator_node/src/p2p/services/template_manager/manager.rs
+++ b/applications/tari_validator_node/src/p2p/services/template_manager/manager.rs
@@ -154,9 +154,7 @@ impl TemplateManager {
         self.global_db
             .templates(&tx)
             .template_exists(address)
-            .map_err(|_| TemplateManagerError::TemplateNotFound {
-                address: address.clone(),
-            })
+            .map_err(|_| TemplateManagerError::TemplateNotFound { address: *address })
     }
 
     pub fn fetch_template(&self, address: &TemplateAddress) -> Result<Template, TemplateManagerError> {

--- a/applications/tari_validator_node/tests/cucumber.rs
+++ b/applications/tari_validator_node/tests/cucumber.rs
@@ -39,7 +39,7 @@ use tari_validator_node::GrpcBaseNodeClient;
 use tari_validator_node_client::types::{GetIdentityResponse, GetTemplateRequest, TemplateRegistrationResponse};
 use utils::{
     miner::{mine_blocks, register_miner_process},
-    template::send_template_transaction,
+    template::send_call_function_transaction,
     validator_node::spawn_validator_node,
     wallet::spawn_wallet,
 };
@@ -171,11 +171,19 @@ async fn assert_template_is_registered(world: &mut TariWorld, template_name: Str
     assert_eq!(resp.registration_metadata.address, template_address);
 }
 
-#[when(expr = "the validator node {word} calls the function \"{word}\" on the template \"{word}\"")]
-async fn call_template_function(world: &mut TariWorld, vn_name: String, function_name: String, template_name: String) {
-    let resp = send_template_transaction(world, vn_name, template_name, function_name).await;
+#[when(expr = "the validator node {word} calls the function \"{word}\" with {int} outputs on the template \"{word}\"")]
+async fn call_template_function(
+    world: &mut TariWorld,
+    vn_name: String,
+    function_name: String,
+    num_outputs: u8,
+    template_name: String,
+) {
+    let resp = send_call_function_transaction(world, vn_name, template_name, function_name, num_outputs).await;
+    eprintln!("Template function call response: {:?}", resp);
 
-    eprintln!("Template call response: {:?}", resp);
+    // give it some time for hotstuff consensus
+    tokio::time::sleep(Duration::from_secs(2)).await;
 }
 
 #[when(expr = "I wait {int} seconds")]

--- a/applications/tari_validator_node/tests/cucumber.rs
+++ b/applications/tari_validator_node/tests/cucumber.rs
@@ -155,6 +155,9 @@ async fn assert_vn_is_registered(world: &mut TariWorld, vn_name: String) {
 
 #[then(expr = "the template \"{word}\" is listed as registered by the validator node {word}")]
 async fn assert_template_is_registered(world: &mut TariWorld, template_name: String, vn_name: String) {
+    // give it some time for the template tx to be picked up by the VNs
+    tokio::time::sleep(Duration::from_secs(4)).await;
+
     // retrieve the template address
     let template_address = world.templates.get(&template_name).unwrap().address;
 

--- a/applications/tari_validator_node/tests/features/basic.feature
+++ b/applications/tari_validator_node/tests/features/basic.feature
@@ -30,8 +30,7 @@ Feature: Basic scenarios
     Then the template "counter" is listed as registered by the validator node VAL_2
 
     # Call the constructor in the "counter" template
-    # FIXME: The VN does not return a valid response
-    # When the validator node VAL_1 calls the function "new" on the template "counter"
+    When the validator node VAL_1 calls the function "new" with 1 outputs on the template "counter" 
 
     # Uncomment the following lines to stop execution for manual inspection of the nodes
     # When I print the cucumber world

--- a/applications/tari_validator_node/tests/features/basic.feature
+++ b/applications/tari_validator_node/tests/features/basic.feature
@@ -24,11 +24,10 @@ Feature: Basic scenarios
     Then the validator node VAL_2 is listed as registered
 
     # Register the "counter" template
-    # When validator node VAL_1 registers the template "counter"
-    # When miner MINER mines 20 new blocks
-    # Then the template "counter" is listed as registered by the validator node VAL_1
-    # FIXME: In GitHub actions, we get a "Template not found" error in VN2
-    # Then the template "counter" is listed as registered by the validator node VAL_2
+    When validator node VAL_1 registers the template "counter"
+    When miner MINER mines 20 new blocks
+    Then the template "counter" is listed as registered by the validator node VAL_1
+    Then the template "counter" is listed as registered by the validator node VAL_2
 
     # Call the constructor in the "counter" template
     # FIXME: The VN does not return a valid response

--- a/applications/tari_validator_node/tests/utils/template.rs
+++ b/applications/tari_validator_node/tests/utils/template.rs
@@ -21,11 +21,12 @@ pub struct RegisteredTemplate {
     pub address: TemplateAddress,
 }
 
-pub async fn send_template_transaction(
+pub async fn send_call_function_transaction(
     world: &mut TariWorld,
     vn_name: String,
     template_name: String,
     function_name: String,
+    num_outputs: u8,
 ) -> SubmitTransactionResponse {
     let template_address = world.templates.get(&template_name).unwrap().address;
 
@@ -49,7 +50,7 @@ pub async fn send_template_transaction(
         wait_for_result: false,
         wait_for_result_timeout: None,
         inputs: vec![],
-        num_outputs: 0,
+        num_outputs,
         is_dry_run: false,
     };
 


### PR DESCRIPTION
Description
---
* Added a time sleep before checking if a template is registered, to allow VNs to catch up
* Added the `num_outputs` param when calling a template function

Motivation and Context
---
Some steps in cucumber scenarios were commented out because they failed:
* VN2 did not receive the template
* The `submit_transaction` request failed

How Has This Been Tested?
---
The cucumber scenario steps now work
