### PR TITLE
fix: re-add pledge validation

### DIFF
--- a/applications/tari_validator_node/proto/dan/consensus.proto
+++ b/applications/tari_validator_node/proto/dan/consensus.proto
@@ -71,6 +71,7 @@ message TariDanPayload {
 
 message VoteMessage {
   bytes local_node_hash = 1;
+  // TODO: Vote message does not require payload and shard ids - remove them
   bytes payload_id = 2;
   bytes shard_id = 3;
   QuorumDecision decision = 4;

--- a/applications/tari_validator_node/src/payload_processor.rs
+++ b/applications/tari_validator_node/src/payload_processor.rs
@@ -133,8 +133,8 @@ fn create_populated_state_store<I: IntoIterator<Item = ObjectPledge>>(
     for input in inputs {
         match input.current_state {
             SubstateState::Up { data, .. } => {
-                log::error!(target: "tari::dan_layer::payload_processor",
-                    "Input data: {} v{}",
+                log::debug!(target: "tari::dan_layer::payload_processor",
+                    "State store input substate: {} v{}",
                     data.substate_value().substate_address(),
                     data.version()
                 );

--- a/applications/tari_validator_node_cli/src/command/transaction.rs
+++ b/applications/tari_validator_node_cli/src/command/transaction.rs
@@ -322,25 +322,27 @@ fn summarize_finalize_result(finalize: &FinalizeResult) {
     match finalize.result {
         TransactionResult::Accept(ref diff) => {
             for (address, substate) in diff.up_iter() {
-                println!("️🌲 UP substate {} (v{})", address, substate.version());
+                println!("️🌲 UP substate {} (v{})", address, substate.version(),);
+                println!("      🧩 Shard: {}", ShardId::from_address(address, substate.version()));
                 match substate.substate_value() {
                     SubstateValue::Component(component) => {
                         println!(
-                            "       ▶ component ({}): {}",
+                            "      ▶ component ({}): {}",
                             component.module_name, component.component_address
                         );
                     },
                     SubstateValue::Resource(resource) => {
-                        println!("       ▶ resource: {}", resource.address());
+                        println!("      ▶ resource: {}", resource.address());
                     },
                     SubstateValue::Vault(vault) => {
-                        println!("       ▶ vault: {} {}", vault.id(), vault.resource_address());
+                        println!("      ▶ vault: {} {}", vault.id(), vault.resource_address());
                     },
                 }
                 println!();
             }
             for (address, version) in diff.down_iter() {
-                println!("🗑️ DOWN substate {} v{}", address, version);
+                println!("🗑️ DOWN substate {} v{}", address, version,);
+                println!("      🧩 Shard: {}", ShardId::from_address(address, *version));
                 println!();
             }
         },

--- a/applications/tari_validator_node_cli/src/command/transaction.rs
+++ b/applications/tari_validator_node_cli/src/command/transaction.rs
@@ -38,11 +38,7 @@ use tari_engine_types::{
     substate::{SubstateAddress, SubstateValue},
     TemplateAddress,
 };
-use tari_template_lib::{
-    arg,
-    args::Arg,
-    models::{Amount, ComponentAddress},
-};
+use tari_template_lib::{arg, args::Arg, models::Amount};
 use tari_transaction_manifest::parse_manifest;
 use tari_utilities::hex::to_hex;
 use tari_validator_node_client::{
@@ -117,7 +113,7 @@ pub enum CliInstruction {
         args: Vec<CliArg>,
     },
     CallMethod {
-        component_address: FromHex<ComponentAddress>,
+        component_address: SubstateAddress,
         method_name: String,
         #[clap(long, short = 'a')]
         args: Vec<CliArg>,
@@ -182,7 +178,9 @@ pub async fn handle_submit(
             method_name,
             args,
         } => Instruction::CallMethod {
-            component_address: component_address.into_inner(),
+            component_address: component_address
+                .as_component_address()
+                .ok_or_else(|| anyhow!("Invalid component address: {}", component_address))?,
             method: method_name,
             args: args.iter().map(|s| s.to_arg()).collect(),
         },

--- a/dan_layer/core/src/models/hot_stuff_tree_node.rs
+++ b/dan_layer/core/src/models/hot_stuff_tree_node.rs
@@ -115,7 +115,7 @@ impl<TAddr: NodeAddressable, TPayload: Payload> HotStuffTreeNode<TAddr, TPayload
             .chain(&self.parent)
             .chain(&self.epoch)
             .chain(&self.height)
-            // .chain(&self.justify)
+            .chain(&self.justify)
             .chain(&self.shard)
             .chain(&self.payload_id)
             .chain(&self.payload_height)

--- a/dan_layer/core/src/workers/hotstuff_error.rs
+++ b/dan_layer/core/src/workers/hotstuff_error.rs
@@ -20,7 +20,7 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use tari_dan_common_types::{Epoch, NodeHeight, PayloadId, ShardId};
+use tari_dan_common_types::{Epoch, NodeHeight, PayloadId, ShardId, SubstateChange};
 use tari_engine_types::commit_result::RejectReason;
 use thiserror::Error;
 use tokio::sync::mpsc;
@@ -66,9 +66,10 @@ pub enum HotStuffError {
     NoCommitteeForShard { shard: ShardId, epoch: Epoch },
     #[error("Cannot vote on a proposal that has been rejected")]
     JustifyIsNotAccepted,
-
     #[error("Received NEWVIEW message without attached payload")]
     ReceivedNewViewWithoutPayload,
+    #[error("Missing pledges: {}", .0.iter().map(|(s, c)| format!("{}: {}", s, c)).collect::<Vec<_>>().join(", "))]
+    MissingPledges(Vec<(ShardId, SubstateChange)>),
 }
 
 impl<T> From<mpsc::error::SendError<T>> for HotStuffError {


### PR DESCRIPTION
Description
---
- adds validate_pledges back 
- bugfix: commits all decided nodes

Motivation and Context
---
Pledges received from the leader are validated against the local execution change set.

In multi-shard executions, only one of the state changes for a shard is persisted. This change collects the decided nodes and persists all of them. 

How Has This Been Tested?
---
Manually, creating account and faucet components and depositing faucet coins in the account
