### PR TITLE
fix: commit substates in one db transaction after all shards have decided

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,8 +35,7 @@ report
 *.sqlite3
 keys.json
 node_modules
-/integration_tests/temp
-/integration_tests/cucumber_output
+temp/
 
 # ignore output files from windows ISS
 buildtools/Output/

--- a/applications/tari_validator_node/proto/dan/consensus.proto
+++ b/applications/tari_validator_node/proto/dan/consensus.proto
@@ -71,6 +71,7 @@ message TariDanPayload {
 
 message VoteMessage {
   bytes local_node_hash = 1;
+  // TODO: Vote message does not require payload and shard ids - remove them
   bytes payload_id = 2;
   bytes shard_id = 3;
   QuorumDecision decision = 4;

--- a/applications/tari_validator_node/src/lib.rs
+++ b/applications/tari_validator_node/src/lib.rs
@@ -102,11 +102,12 @@ pub struct ShardKey {
 }
 
 pub async fn run_validator_node_with_cli(config: &ApplicationConfig, cli: &Cli) -> Result<(), ExitError> {
-    let _ = initialize_logging(
+    if let Err(e) = initialize_logging(
         &cli.common.log_config_path("validator"),
         include_str!("../log4rs_sample.yml"),
-    )
-    .map_err(|e| error!("{}", e));
+    ) {
+        warn!("{}", e);
+    }
 
     let shutdown = Shutdown::new();
 

--- a/applications/tari_validator_node/src/payload_processor.rs
+++ b/applications/tari_validator_node/src/payload_processor.rs
@@ -133,8 +133,8 @@ fn create_populated_state_store<I: IntoIterator<Item = ObjectPledge>>(
     for input in inputs {
         match input.current_state {
             SubstateState::Up { data, .. } => {
-                log::error!(target: "tari::dan_layer::payload_processor",
-                    "Input data: {} v{}",
+                log::debug!(target: "tari::dan_layer::payload_processor",
+                    "State store input substate: {} v{}",
                     data.substate_value().substate_address(),
                     data.version()
                 );

--- a/applications/tari_validator_node/tests/features/basic.feature
+++ b/applications/tari_validator_node/tests/features/basic.feature
@@ -1,6 +1,5 @@
 # Copyright 2022 The Tari Project
 # SPDX-License-Identifier: BSD-3-Clause
-
 # FIXME: when spawning VN2 the test is flaky
 Feature: Basic scenarios
   @serial
@@ -16,6 +15,7 @@ Feature: Basic scenarios
 
     # The wallet must have some funds before the VN sends transactions
     When miner MINER mines 12 new blocks
+    When wallet WALLET has at least 1000000000 uT
 
     # VN registration
     When validator node VAL_1 sends a registration transaction

--- a/applications/tari_validator_node/tests/log4rs/wallet.yml
+++ b/applications/tari_validator_node/tests/log4rs/wallet.yml
@@ -1,0 +1,69 @@
+# A sample log configuration file for running in release mode. By default, this configuration splits up log messages to
+# three destinations:
+#    * Console: For log messages with level INFO and higher
+#    * log/validator-node/network.log: INFO-level logs related to the comms crate. This file will be quite busy since there
+#      are lots of P2P debug messages, and so this traffic is segregated from the application log messages
+#    * log/validator-node/dan_layer.log: Non-comms related INFO-level messages and higher are logged into this file
+#    * log/validator-node/other.log: Third-party crates' messages will be logged here at an ERROR level
+#
+#  See https://docs.rs/log4rs/0.8.3/log4rs/encode/pattern/index.html for deciphering the log pattern. The log format
+#  used in this sample configuration prints messages as:
+#  timestamp [target] LEVEL message
+refresh_rate: 30 seconds
+appenders:
+  # An appender named "stdout" that writes to stdout
+  stdout:
+    kind: console
+    encoder:
+      pattern: "{d(%H:%M)} {h({l}):5} {m} [{f}:{L}]{n}"
+    filters:
+      - kind: threshold
+        level: trace
+
+root:
+  level: error
+  appenders:
+    - stdout
+
+loggers:
+  tari::application:
+    level: trace
+    appenders:
+      - stdout
+    additive: false
+
+  tari::validator_node:
+    level: trace
+    appenders:
+      - stdout
+    additive: false
+
+  tari::dan:
+    level: trace
+    appenders:
+      - stdout
+    additive: false
+
+  tari::dan_layer:
+    level: trace
+    appenders:
+      - stdout
+    additive: false
+
+  dan:
+    level: trace
+    appenders:
+      - stdout
+    additive: false
+
+  vn:
+    level: trace
+    appenders:
+      - stdout
+    additive: false
+
+  tari_validator_node:
+    level: trace
+    appenders:
+      - stdout
+    additive: false

--- a/applications/tari_validator_node/tests/steps/miner.rs
+++ b/applications/tari_validator_node/tests/steps/miner.rs
@@ -1,0 +1,16 @@
+//   Copyright 2023 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+use cucumber::{given, when};
+
+use crate::{mine_blocks, register_miner_process, TariWorld};
+
+#[given(expr = "a miner {word} connected to base node {word} and wallet {word}")]
+async fn create_miner(world: &mut TariWorld, miner_name: String, bn_name: String, wallet_name: String) {
+    register_miner_process(world, miner_name, bn_name, wallet_name);
+}
+
+#[when(expr = "miner {word} mines {int} new blocks")]
+async fn miner_mines_new_blocks(world: &mut TariWorld, miner_name: String, num_blocks: u64) {
+    mine_blocks(world, miner_name, num_blocks).await;
+}

--- a/applications/tari_validator_node/tests/steps/mod.rs
+++ b/applications/tari_validator_node/tests/steps/mod.rs
@@ -1,0 +1,5 @@
+//   Copyright 2023 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+mod miner;
+mod wallet;

--- a/applications/tari_validator_node/tests/steps/wallet.rs
+++ b/applications/tari_validator_node/tests/steps/wallet.rs
@@ -1,0 +1,45 @@
+//   Copyright 2023 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+use std::time::Duration;
+
+use cucumber::{given, when};
+use tari_app_grpc::tari_rpc::GetBalanceRequest;
+use tokio::time::sleep;
+
+use crate::{spawn_wallet, TariWorld};
+
+#[given(expr = "a wallet {word} connected to base node {word}")]
+async fn start_wallet(world: &mut TariWorld, wallet_name: String, bn_name: String) {
+    spawn_wallet(world, wallet_name, bn_name).await;
+}
+
+#[when(expr = "wallet {word} has at least {int} uT")]
+async fn check_balance(world: &mut TariWorld, wallet_name: String, balance: u64) {
+    let wallet = world
+        .wallets
+        .get(&wallet_name)
+        .unwrap_or_else(|| panic!("Wallet {} not found", wallet_name));
+
+    let mut client = wallet.create_client().await;
+    let mut iterations = 0;
+    loop {
+        let resp = client.get_balance(GetBalanceRequest {}).await.unwrap().into_inner();
+        if resp.available_balance >= balance {
+            break;
+        }
+        eprintln!(
+            "Waiting for wallet {} to have at least {} uT (balance: {} uT, pending: {} uT)",
+            wallet_name, balance, resp.available_balance, resp.pending_incoming_balance
+        );
+        sleep(Duration::from_secs(1)).await;
+
+        if iterations == 20 {
+            panic!(
+                "Wallet {} did not have at least {} uT after 20 seconds  (balance: {} uT, pending: {} uT)",
+                wallet_name, balance, resp.available_balance, resp.pending_incoming_balance
+            );
+        }
+        iterations += 1;
+    }
+}

--- a/applications/tari_validator_node/tests/utils/helpers.rs
+++ b/applications/tari_validator_node/tests/utils/helpers.rs
@@ -1,0 +1,13 @@
+//   Copyright 2023 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+use std::net::TcpListener;
+
+pub fn get_os_assigned_ports() -> (u16, u16) {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let port1 = listener.local_addr().unwrap().port();
+
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let port2 = listener.local_addr().unwrap().port();
+    (port1, port2)
+}

--- a/applications/tari_validator_node/tests/utils/mod.rs
+++ b/applications/tari_validator_node/tests/utils/mod.rs
@@ -21,6 +21,7 @@
 //   USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 pub mod base_node;
+mod helpers;
 pub mod http_server;
 pub mod miner;
 pub mod template;

--- a/applications/tari_validator_node/tests/utils/validator_node_cli.rs
+++ b/applications/tari_validator_node/tests/utils/validator_node_cli.rs
@@ -111,7 +111,7 @@ pub async fn call_method(
     let component_address = world.components.get(&component_name).unwrap();
 
     let instruction = CliInstruction::CallMethod {
-        component_address: FromHex(ComponentAddress::new(*component_address)),
+        component_address: ComponentAddress::new(*component_address).into(),
         // TODO: actually parse the method call for arguments
         method_name: method_call,
         args: vec![],

--- a/applications/tari_validator_node_cli/src/command/transaction.rs
+++ b/applications/tari_validator_node_cli/src/command/transaction.rs
@@ -322,25 +322,27 @@ fn summarize_finalize_result(finalize: &FinalizeResult) {
     match finalize.result {
         TransactionResult::Accept(ref diff) => {
             for (address, substate) in diff.up_iter() {
-                println!("️🌲 UP substate {} (v{})", address, substate.version());
+                println!("️🌲 UP substate {} (v{})", address, substate.version(),);
+                println!("      🧩 Shard: {}", ShardId::from_address(address, substate.version()));
                 match substate.substate_value() {
                     SubstateValue::Component(component) => {
                         println!(
-                            "       ▶ component ({}): {}",
+                            "      ▶ component ({}): {}",
                             component.module_name, component.component_address
                         );
                     },
                     SubstateValue::Resource(resource) => {
-                        println!("       ▶ resource: {}", resource.address());
+                        println!("      ▶ resource: {}", resource.address());
                     },
                     SubstateValue::Vault(vault) => {
-                        println!("       ▶ vault: {} {}", vault.id(), vault.resource_address());
+                        println!("      ▶ vault: {} {}", vault.id(), vault.resource_address());
                     },
                 }
                 println!();
             }
             for (address, version) in diff.down_iter() {
-                println!("🗑️ DOWN substate {} v{}", address, version);
+                println!("🗑️ DOWN substate {} v{}", address, version,);
+                println!("      🧩 Shard: {}", ShardId::from_address(address, *version));
                 println!();
             }
         },

--- a/applications/tari_validator_node_cli/src/command/transaction.rs
+++ b/applications/tari_validator_node_cli/src/command/transaction.rs
@@ -38,11 +38,7 @@ use tari_engine_types::{
     substate::{SubstateAddress, SubstateValue},
     TemplateAddress,
 };
-use tari_template_lib::{
-    arg,
-    args::Arg,
-    models::{Amount, ComponentAddress},
-};
+use tari_template_lib::{arg, args::Arg, models::Amount};
 use tari_transaction_manifest::parse_manifest;
 use tari_utilities::hex::to_hex;
 use tari_validator_node_client::{
@@ -117,7 +113,7 @@ pub enum CliInstruction {
         args: Vec<CliArg>,
     },
     CallMethod {
-        component_address: FromHex<ComponentAddress>,
+        component_address: SubstateAddress,
         method_name: String,
         #[clap(long, short = 'a')]
         args: Vec<CliArg>,
@@ -182,7 +178,9 @@ pub async fn handle_submit(
             method_name,
             args,
         } => Instruction::CallMethod {
-            component_address: component_address.into_inner(),
+            component_address: component_address
+                .as_component_address()
+                .ok_or_else(|| anyhow!("Invalid component address: {}", component_address))?,
             method: method_name,
             args: args.iter().map(|s| s.to_arg()).collect(),
         },

--- a/dan_layer/common_types/src/lib.rs
+++ b/dan_layer/common_types/src/lib.rs
@@ -37,7 +37,7 @@ mod validator_metadata;
 pub use validator_metadata::{vn_mmr_node_hash, ValidatorMetadata};
 
 mod object_pledge;
-pub use object_pledge::ObjectPledge;
+pub use object_pledge::{ObjectPledge, ObjectPledgeInfo};
 
 mod node_addressable;
 pub use node_addressable::NodeAddressable;

--- a/dan_layer/common_types/src/object_pledge.rs
+++ b/dan_layer/common_types/src/object_pledge.rs
@@ -4,12 +4,20 @@
 use serde::{Deserialize, Serialize};
 use tari_bor::borsh::BorshSerialize;
 
-use crate::{PayloadId, ShardId, SubstateState};
+use crate::{PayloadId, ShardId, SubstateState, TreeNodeHash};
 
 #[derive(Debug, Clone, Deserialize, Serialize, BorshSerialize)]
 pub struct ObjectPledge {
     pub shard_id: ShardId,
     pub current_state: SubstateState,
-    // pub current_state_hash: FixedHash,
     pub pledged_to_payload: PayloadId,
+}
+
+#[derive(Debug, Clone)]
+pub struct ObjectPledgeInfo {
+    pub shard_id: ShardId,
+    pub pledged_to_payload_id: PayloadId,
+    pub completed_by_tree_node_hash: Option<TreeNodeHash>,
+    pub abandoned_by_tree_node_hash: Option<TreeNodeHash>,
+    pub is_active: bool,
 }

--- a/dan_layer/core/src/models/hot_stuff_tree_node.rs
+++ b/dan_layer/core/src/models/hot_stuff_tree_node.rs
@@ -115,7 +115,7 @@ impl<TAddr: NodeAddressable, TPayload: Payload> HotStuffTreeNode<TAddr, TPayload
             .chain(&self.parent)
             .chain(&self.epoch)
             .chain(&self.height)
-            // .chain(&self.justify)
+            .chain(&self.justify)
             .chain(&self.shard)
             .chain(&self.payload_id)
             .chain(&self.payload_height)

--- a/dan_layer/core/src/storage/shard_store.rs
+++ b/dan_layer/core/src/storage/shard_store.rs
@@ -20,12 +20,11 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::collections::HashMap;
-
 use tari_dan_common_types::{
     NodeAddressable,
     NodeHeight,
     ObjectPledge,
+    ObjectPledgeInfo,
     PayloadId,
     QuorumCertificate,
     ShardId,
@@ -126,12 +125,7 @@ pub trait ShardStoreTransaction<TAddr: NodeAddressable, TPayload: Payload> {
         node_hash: TreeNodeHash,
         node_height: NodeHeight,
     ) -> Result<(), StorageError>;
-    fn pledge_object(
-        &mut self,
-        shard: ShardId,
-        payload: PayloadId,
-        current_height: NodeHeight,
-    ) -> Result<ObjectPledge, StorageError>;
+
     fn set_last_executed_height(
         &mut self,
         shard: ShardId,
@@ -141,8 +135,8 @@ pub trait ShardStoreTransaction<TAddr: NodeAddressable, TPayload: Payload> {
     fn get_last_executed_height(&self, shard: ShardId, payload_id: PayloadId) -> Result<NodeHeight, StorageError>;
     fn save_substate_changes(
         &mut self,
-        changes: &HashMap<ShardId, Vec<SubstateState>>,
-        node: &HotStuffTreeNode<TAddr, TPayload>,
+        node: HotStuffTreeNode<TAddr, TPayload>,
+        changes: &[SubstateState],
     ) -> Result<(), StorageError>;
     fn insert_substates(&mut self, substate_data: SubstateShardData) -> Result<(), StorageError>;
     fn get_state_inventory(&self) -> Result<Vec<ShardId>, StorageError>;
@@ -197,6 +191,15 @@ pub trait ShardStoreTransaction<TAddr: NodeAddressable, TPayload: Payload> {
     fn get_payload_result(&self, payload_id: &PayloadId) -> Result<FinalizeResult, StorageError>;
     /// Updates the result for an existing payload
     fn update_payload_result(&self, payload_id: &PayloadId, result: FinalizeResult) -> Result<(), StorageError>;
+
+    // -------------------------------- Pledges -------------------------------- //
+    fn pledge_object(
+        &mut self,
+        shard: ShardId,
+        payload: PayloadId,
+        current_height: NodeHeight,
+    ) -> Result<ObjectPledge, StorageError>;
+    fn get_resolved_pledges_for_payload(&self, payload: PayloadId) -> Result<Vec<ObjectPledgeInfo>, StorageError>;
     fn complete_pledges(
         &self,
         shard: ShardId,

--- a/dan_layer/core/src/workers/hotstuff_error.rs
+++ b/dan_layer/core/src/workers/hotstuff_error.rs
@@ -20,7 +20,7 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use tari_dan_common_types::{Epoch, NodeHeight, PayloadId, ShardId};
+use tari_dan_common_types::{Epoch, NodeHeight, PayloadId, ShardId, SubstateChange};
 use tari_engine_types::commit_result::RejectReason;
 use thiserror::Error;
 use tokio::sync::mpsc;
@@ -66,9 +66,10 @@ pub enum HotStuffError {
     NoCommitteeForShard { shard: ShardId, epoch: Epoch },
     #[error("Cannot vote on a proposal that has been rejected")]
     JustifyIsNotAccepted,
-
     #[error("Received NEWVIEW message without attached payload")]
     ReceivedNewViewWithoutPayload,
+    #[error("Missing pledges: {}", .0.iter().map(|(s, c)| format!("{}: {}", s, c)).collect::<Vec<_>>().join(", "))]
+    MissingPledges(Vec<(ShardId, SubstateChange)>),
 }
 
 impl<T> From<mpsc::error::SendError<T>> for HotStuffError {

--- a/dan_layer/engine_types/src/substate.rs
+++ b/dan_layer/engine_types/src/substate.rs
@@ -257,4 +257,12 @@ impl SubstateDiff {
     pub fn down_iter(&self) -> impl Iterator<Item = &(SubstateAddress, u32)> + '_ {
         self.down_substates.iter()
     }
+
+    pub fn len(&self) -> usize {
+        self.up_substates.len() + self.down_substates.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
 }

--- a/dan_layer/storage_sqlite/migrations/2022-10-03-178235_create_shard_store/up.sql
+++ b/dan_layer/storage_sqlite/migrations/2022-10-03-178235_create_shard_store/up.sql
@@ -130,6 +130,9 @@ create table substates
     destroyed_timestamp     timestamp NULL
 );
 
+-- All shard ids are unique
+create unique index uniq_substates_shard_id on substates (shard_id);
+
 create table shard_pledges
 (
     id                          integer   not NULL primary key AUTOINCREMENT,

--- a/dan_layer/storage_sqlite/src/models/pledge.rs
+++ b/dan_layer/storage_sqlite/src/models/pledge.rs
@@ -1,9 +1,12 @@
 //  Copyright 2022 The Tari Project
 //  SPDX-License-Identifier: BSD-3-Clause
 
-use chrono::NaiveDateTime;
+use std::convert::{TryFrom, TryInto};
 
-use crate::schema::*;
+use chrono::NaiveDateTime;
+use tari_dan_common_types::{ObjectPledgeInfo, ShardId};
+
+use crate::{error::SqliteStorageError, schema::*};
 
 #[derive(Debug, Identifiable, Queryable)]
 pub struct ShardPledge {
@@ -25,4 +28,37 @@ pub struct NewShardPledge {
     pub created_height: i64,
     pub pledged_to_payload_id: Vec<u8>,
     pub is_active: bool,
+}
+
+impl TryFrom<ShardPledge> for ObjectPledgeInfo {
+    type Error = SqliteStorageError;
+
+    fn try_from(value: ShardPledge) -> Result<Self, Self::Error> {
+        Ok(Self {
+            shard_id: ShardId::try_from(value.shard_id)
+                .map_err(|_| SqliteStorageError::MalformedDbData("malformed shard ID in object pledge".to_string()))?,
+            pledged_to_payload_id: value.pledged_to_payload_id.try_into().map_err(|_| {
+                SqliteStorageError::MalformedDbData("malformed payload ID in object pledge".to_string())
+            })?,
+            completed_by_tree_node_hash: value
+                .completed_by_tree_node_hash
+                .map(TryInto::try_into)
+                .transpose()
+                .map_err(|_| {
+                    SqliteStorageError::MalformedDbData(
+                        "malformed completed_by_tree_node_hash in object pledge".to_string(),
+                    )
+                })?,
+            abandoned_by_tree_node_hash: value
+                .abandoned_by_tree_node_hash
+                .map(TryInto::try_into)
+                .transpose()
+                .map_err(|_| {
+                    SqliteStorageError::MalformedDbData(
+                        "malformed abandoned_by_tree_node_hash in object pledge".to_string(),
+                    )
+                })?,
+            is_active: value.is_active,
+        })
+    }
 }

--- a/dan_layer/storage_sqlite/src/sqlite_shard_store_factory.rs
+++ b/dan_layer/storage_sqlite/src/sqlite_shard_store_factory.rs
@@ -21,8 +21,7 @@
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use std::{
-    collections::HashMap,
-    convert::TryFrom,
+    convert::{TryFrom, TryInto},
     fs::create_dir_all,
     path::PathBuf,
     sync::{Arc, Mutex},
@@ -43,6 +42,7 @@ use tari_dan_common_types::{
     Epoch,
     NodeHeight,
     ObjectPledge,
+    ObjectPledgeInfo,
     PayloadId,
     QuorumCertificate,
     ShardId,
@@ -81,7 +81,7 @@ use crate::{
         lock_node_and_height::{LockNodeAndHeight, NewLockNodeAndHeight},
         node::{NewNode, Node},
         payload::{NewPayload, Payload as SqlPayload},
-        pledge::{NewShardPledge, ShardPledge},
+        pledge::{NewShardPledge, ShardPledge as DbShardPledge},
         received_votes::{NewReceivedVote, ReceivedVote},
         substate::{ImportedSubstate, NewSubstate, Substate},
     },
@@ -223,7 +223,7 @@ impl<'a> SqliteShardStoreTransaction<'a> {
         Self { transaction }
     }
 
-    fn create_pledge(&mut self, shard: ShardId, obj: ShardPledge) -> Result<ObjectPledge, StorageError> {
+    fn create_pledge(&mut self, shard: ShardId, obj: DbShardPledge) -> Result<ObjectPledge, StorageError> {
         use crate::schema::substates;
         let current_state: Option<Substate> = substates::table
             .filter(substates::shard_id.eq(shard.as_bytes()))
@@ -750,67 +750,6 @@ impl ShardStoreTransaction<PublicKey, TariDanPayload> for SqliteShardStoreTransa
         Ok(())
     }
 
-    fn pledge_object(
-        &mut self,
-        shard: ShardId,
-        payload: PayloadId,
-        current_height: NodeHeight,
-    ) -> Result<ObjectPledge, StorageError> {
-        use crate::schema::shard_pledges;
-
-        let existing_pledge: Option<ShardPledge> = shard_pledges::table
-            .filter(shard_pledges::shard_id.eq(shard.as_bytes()))
-            .filter(shard_pledges::is_active.eq(true))
-            .order_by(shard_pledges::created_height.desc())
-            .first(self.transaction.connection())
-            .optional()
-            .map_err(|e| StorageError::QueryError {
-                reason: format!("Pledge object error: {}", e),
-            })?;
-
-        if let Some(obj) = existing_pledge {
-            // TODO: write test for this logic
-            // if obj.pledged_until_height.unwrap_or_default() as u64 >= current_height.as_u64() {
-            return self.create_pledge(shard, obj);
-            // }
-        }
-
-        // otherwise save pledge
-        let new_row = NewShardPledge {
-            shard_id: shard.as_bytes().to_vec(),
-            created_height: current_height.as_u64() as i64,
-            pledged_to_payload_id: payload.as_bytes().to_vec(),
-            is_active: true,
-        };
-        let num_affected = diesel::insert_into(shard_pledges::table)
-            .values(new_row)
-            .execute(self.transaction.connection())
-            .map_err(|e| StorageError::QueryError {
-                reason: format!("Pledge insert error: {}", e),
-            })?;
-
-        if num_affected != 1 {
-            return Err(StorageError::QueryError {
-                reason: "Pledge object error: no pledge created".to_string(),
-            });
-        }
-
-        let new_pledge: ShardPledge = shard_pledges::table
-            .filter(
-                shard_pledges::shard_id
-                    .eq(shard.as_bytes())
-                    .and(shard_pledges::is_active.eq(true))
-                    .and(shard_pledges::pledged_to_payload_id.eq(payload.as_bytes())),
-            )
-            .order_by(shard_pledges::id.desc())
-            .first(self.transaction.connection())
-            .map_err(|e| StorageError::QueryError {
-                reason: format!("Pledge object error: {}", e),
-            })?;
-
-        self.create_pledge(shard, new_pledge)
-    }
-
     fn set_last_executed_height(
         &mut self,
         shard: ShardId,
@@ -855,98 +794,93 @@ impl ShardStoreTransaction<PublicKey, TariDanPayload> for SqliteShardStoreTransa
         }
     }
 
-    #[allow(clippy::too_many_lines)]
     fn save_substate_changes(
         &mut self,
-        changes: &HashMap<ShardId, Vec<SubstateState>>,
-        node: &HotStuffTreeNode<PublicKey, TariDanPayload>,
+        node: HotStuffTreeNode<PublicKey, TariDanPayload>,
+        changes: &[SubstateState],
     ) -> Result<(), StorageError> {
         use crate::schema::substates;
 
-        let payload_id = Vec::from(node.payload_id().as_bytes());
-        for (shard_id, st_changes) in changes {
-            let current_state = substates::table
-                .filter(substates::shard_id.eq(shard_id.as_bytes()))
-                .order_by(substates::version.desc())
-                .first::<Substate>(self.transaction.connection())
-                .optional()
-                .map_err(|e| StorageError::QueryError {
-                    reason: format!("Save substate changes error. Could not retrieve current state: {}", e),
-                })?;
+        let current_state = substates::table
+            .filter(substates::shard_id.eq(node.shard().as_bytes()))
+            .first::<Substate>(self.transaction.connection())
+            .optional()
+            .map_err(|e| StorageError::QueryError {
+                reason: format!("Save substate changes error. Could not retrieve current state: {}", e),
+            })?;
 
-            for st_change in st_changes {
-                match st_change {
-                    SubstateState::DoesNotExist => (),
-                    SubstateState::Up { data: d, .. } => {
-                        if let Some(s) = &current_state {
-                            if !s.is_destroyed() {
-                                return Err(StorageError::QueryError {
-                                    reason: "Save substate changes error. Cannot create a substate that has not been \
-                                             destroyed"
-                                        .to_string(),
-                                });
-                            }
-                        }
-
-                        let pretty_data =
-                            serde_json::to_string_pretty(d).map_err(|source| StorageError::SerdeJson {
-                                source,
-                                operation: "save_substate_changes".to_string(),
-                                data: "substate data".to_string(),
-                            })?;
-                        let new_row = NewSubstate {
-                            shard_id: shard_id.as_bytes().to_vec(),
-                            version: d.version().into(),
-                            data: pretty_data,
-                            created_by_payload_id: payload_id.clone(),
-                            created_justify: serde_json::to_string_pretty(node.justify()).unwrap(),
-                            created_height: node.height().as_u64() as i64,
-                            created_node_hash: node.hash().as_bytes().to_vec(),
-                        };
-                        diesel::insert_into(substates::table)
-                            .values(&new_row)
-                            .execute(self.transaction.connection())
-                            .map_err(|e| StorageError::QueryError {
-                                reason: format!("Save substate changes error. Could not insert new substate: {}", e),
-                            })?;
-                    },
-                    SubstateState::Down { .. } => {
-                        if let Some(s) = &current_state {
-                            if s.is_destroyed() {
-                                return Err(StorageError::QueryError {
-                                    reason: "Save substate changes error. Cannot destroy a substate that has already \
-                                             been destroyed"
-                                        .to_string(),
-                                });
-                            }
-
-                            let rows_affected = diesel::update(substates::table.filter(substates::id.eq(s.id)))
-                                .set((
-                                    substates::destroyed_by_payload_id.eq(payload_id.clone()),
-                                    substates::destroyed_justify.eq(json!(node.justify()).to_string()),
-                                    substates::destroyed_height.eq(node.height().as_u64() as i64),
-                                    substates::destroyed_node_hash.eq(node.hash().as_bytes()),
-                                    substates::destroyed_timestamp.eq(now),
-                                ))
-                                .execute(self.transaction.connection())
-                                .map_err(|e| StorageError::QueryError {
-                                    reason: format!("Save substate changes error. Could not destroy substate: {}", e),
-                                })?;
-                            if rows_affected != 1 {
-                                return Err(StorageError::QueryError {
-                                    reason: "Save substate changes error. More or less than 1 row affected".to_string(),
-                                });
-                            }
-                        } else {
+        for st_change in changes {
+            match st_change {
+                SubstateState::DoesNotExist => (),
+                SubstateState::Up { data: d, .. } => {
+                    if let Some(s) = &current_state {
+                        if !s.is_destroyed() {
                             return Err(StorageError::QueryError {
-                                reason: "Save substate changes error. Cannot destroy a substate that does not exist"
+                                reason: "Save substate changes error. Cannot create a substate that has not been \
+                                         destroyed"
                                     .to_string(),
                             });
                         }
-                    },
-                }
+                    }
+
+                    let pretty_data = serde_json::to_string_pretty(d).map_err(|source| StorageError::SerdeJson {
+                        source,
+                        operation: "save_substate_changes".to_string(),
+                        data: "substate data".to_string(),
+                    })?;
+                    let new_row = NewSubstate {
+                        shard_id: node.shard().as_bytes().to_vec(),
+                        version: d.version().into(),
+                        data: pretty_data,
+                        created_by_payload_id: node.payload_id().as_bytes().to_vec(),
+                        created_justify: "".to_string(),
+                        created_node_hash: node.hash().as_bytes().to_vec(),
+                        created_height: node.height().as_u64() as i64,
+                    };
+                    diesel::insert_into(substates::table)
+                        .values(&new_row)
+                        .execute(self.transaction.connection())
+                        .map_err(|e| StorageError::QueryError {
+                            reason: format!("Save substate changes error. Could not insert new substate: {}", e),
+                        })?;
+                },
+                SubstateState::Down { .. } => {
+                    if let Some(s) = &current_state {
+                        if s.is_destroyed() {
+                            return Err(StorageError::QueryError {
+                                reason: "Save substate changes error. Cannot destroy a substate that has already been \
+                                         destroyed"
+                                    .to_string(),
+                            });
+                        }
+
+                        let rows_affected = diesel::update(substates::table.filter(substates::id.eq(s.id)))
+                            .set((
+                                substates::destroyed_by_payload_id.eq(node.payload_id().as_bytes()),
+                                substates::destroyed_justify.eq(serde_json::to_string_pretty(node.justify()).unwrap()),
+                                substates::destroyed_height.eq(node.height().as_u64() as i64),
+                                substates::destroyed_node_hash.eq(node.hash().as_bytes()),
+                                substates::destroyed_timestamp.eq(now),
+                            ))
+                            .execute(self.transaction.connection())
+                            .map_err(|e| StorageError::QueryError {
+                                reason: format!("Save substate changes error. Could not destroy substate: {}", e),
+                            })?;
+                        if rows_affected != 1 {
+                            return Err(StorageError::QueryError {
+                                reason: "Save substate changes error. More or less than 1 row affected".to_string(),
+                            });
+                        }
+                    } else {
+                        return Err(StorageError::QueryError {
+                            reason: "Save substate changes error. Cannot destroy a substate that does not exist"
+                                .to_string(),
+                        });
+                    }
+                },
             }
         }
+
         Ok(())
     }
 
@@ -1386,28 +1320,108 @@ impl ShardStoreTransaction<PublicKey, TariDanPayload> for SqliteShardStoreTransa
         Ok(res.into_iter().map(|transaction| transaction.into()).collect())
     }
 
+    // -------------------------------- Pledges -------------------------------- //
+
+    fn pledge_object(
+        &mut self,
+        shard: ShardId,
+        payload: PayloadId,
+        current_height: NodeHeight,
+    ) -> Result<ObjectPledge, StorageError> {
+        use crate::schema::shard_pledges;
+
+        let existing_pledge: Option<DbShardPledge> = shard_pledges::table
+            .filter(shard_pledges::shard_id.eq(shard.as_bytes()))
+            .filter(shard_pledges::is_active.eq(true))
+            .order_by(shard_pledges::created_height.desc())
+            .first(self.transaction.connection())
+            .optional()
+            .map_err(|e| StorageError::QueryError {
+                reason: format!("Pledge object error: {}", e),
+            })?;
+
+        if let Some(obj) = existing_pledge {
+            // TODO: write test for this logic
+            // if obj.pledged_until_height.unwrap_or_default() as u64 >= current_height.as_u64() {
+            return self.create_pledge(shard, obj);
+            // }
+        }
+
+        // otherwise save pledge
+        let new_row = NewShardPledge {
+            shard_id: shard.as_bytes().to_vec(),
+            created_height: current_height.as_u64() as i64,
+            pledged_to_payload_id: payload.as_bytes().to_vec(),
+            is_active: true,
+        };
+        let num_affected = diesel::insert_into(shard_pledges::table)
+            .values(new_row)
+            .execute(self.transaction.connection())
+            .map_err(|e| StorageError::QueryError {
+                reason: format!("Pledge insert error: {}", e),
+            })?;
+
+        if num_affected != 1 {
+            return Err(StorageError::QueryError {
+                reason: "Pledge object error: no pledge created".to_string(),
+            });
+        }
+
+        let new_pledge: DbShardPledge = shard_pledges::table
+            .filter(
+                shard_pledges::shard_id
+                    .eq(shard.as_bytes())
+                    .and(shard_pledges::is_active.eq(true))
+                    .and(shard_pledges::pledged_to_payload_id.eq(payload.as_bytes())),
+            )
+            .order_by(shard_pledges::id.desc())
+            .first(self.transaction.connection())
+            .map_err(|e| StorageError::QueryError {
+                reason: format!("Pledge object error: {}", e),
+            })?;
+
+        self.create_pledge(shard, new_pledge)
+    }
+
+    fn get_resolved_pledges_for_payload(&self, payload: PayloadId) -> Result<Vec<ObjectPledgeInfo>, StorageError> {
+        use crate::schema::shard_pledges;
+
+        let pledges: Vec<DbShardPledge> = shard_pledges::table
+            .filter(shard_pledges::pledged_to_payload_id.eq(payload.as_bytes()))
+            .filter(
+                shard_pledges::completed_by_tree_node_hash
+                    .is_not_null()
+                    .or(shard_pledges::abandoned_by_tree_node_hash.is_not_null()),
+            )
+            .filter(shard_pledges::is_active.eq(false))
+            .order_by(shard_pledges::created_height.desc())
+            .load(self.transaction.connection())
+            .map_err(|e| StorageError::QueryError {
+                reason: format!("Get resolved pledges for payload error: {}", e),
+            })?;
+
+        pledges
+            .into_iter()
+            .map(TryInto::try_into)
+            .collect::<Result<_, SqliteStorageError>>()
+            .map_err(Into::into)
+    }
+
     fn complete_pledges(
         &self,
         shard: ShardId,
         payload: PayloadId,
         node_hash: &TreeNodeHash,
     ) -> Result<(), StorageError> {
-        use crate::schema::shard_pledges::{
-            completed_by_tree_node_hash,
-            dsl::shard_pledges,
-            is_active,
-            pledged_to_payload_id,
-            shard_id,
-            updated_timestamp,
-        };
-        let rows_affected = diesel::update(shard_pledges)
-            .filter(shard_id.eq(shard.as_bytes()))
-            .filter(pledged_to_payload_id.eq(payload.as_bytes()))
-            .filter(is_active.eq(true))
+        use crate::schema::shard_pledges;
+        let rows_affected = diesel::update(shard_pledges::table)
+            .filter(shard_pledges::shard_id.eq(shard.as_bytes()))
+            .filter(shard_pledges::pledged_to_payload_id.eq(payload.as_bytes()))
+            .filter(shard_pledges::is_active.eq(true))
             .set((
-                is_active.eq(false),
-                completed_by_tree_node_hash.eq(node_hash.as_bytes()),
-                updated_timestamp.eq(now),
+                shard_pledges::is_active.eq(false),
+                shard_pledges::completed_by_tree_node_hash.eq(node_hash.as_bytes()),
+                shard_pledges::updated_timestamp.eq(now),
             ))
             .execute(self.transaction.connection())
             .map_err(|e| StorageError::QueryError {

--- a/dan_layer/template_test_tooling/src/template_test.rs
+++ b/dan_layer/template_test_tooling/src/template_test.rs
@@ -146,8 +146,8 @@ impl TemplateTest<MockRuntimeInterface> {
         let diff = result
             .result
             .accept()
-            .ok_or_else(|| panic!("Transaction was rejected: {}", result.result.reject().unwrap()))
-            .unwrap();
+            .unwrap_or_else(|| panic!("Transaction was rejected: {}", result.result.reject().unwrap()));
+
         // It is convenient to commit the state back to the staged state store in tests.
         self.commit_diff(diff);
 


### PR DESCRIPTION
Description
---
- waits for all shards to decide before committing the state changes in single db transaction

Motivation and Context
---
In a transaction where some shards ACCEPT and some REJECT, the ACCEPT shards would be persisted even though the transaction as a whole is rejected. This PR ensures that either all or none of the changes local to the VN are persisted 

How Has This Been Tested?
---
Manually, token transfer manifest
