### PR TITLE
fix: exit validator node process on panic

### DIFF
--- a/applications/tari_validator_node/src/main.rs
+++ b/applications/tari_validator_node/src/main.rs
@@ -36,6 +36,8 @@ async fn main() {
     // Uncomment to enable tokio tracing via tokio-console
     // console_subscriber::init();
 
+    // Setup a panic hook which prints the default rust panic message but also exits the process. This makes a panic in
+    // any thread "crash" the system instead of silently continuing.
     let default_hook = panic::take_hook();
     panic::set_hook(Box::new(move |info| {
         default_hook(info);

--- a/applications/tari_validator_node/src/main.rs
+++ b/applications/tari_validator_node/src/main.rs
@@ -22,7 +22,7 @@
 
 mod cli;
 
-use std::process;
+use std::{panic, process};
 
 use clap::Parser;
 use log::*;
@@ -35,6 +35,12 @@ const LOG_TARGET: &str = "tari::validator_node::app";
 async fn main() {
     // Uncomment to enable tokio tracing via tokio-console
     // console_subscriber::init();
+
+    let default_hook = panic::take_hook();
+    panic::set_hook(Box::new(move |info| {
+        default_hook(info);
+        process::exit(1);
+    }));
 
     if let Err(err) = main_inner().await {
         let exit_code = err.exit_code;

--- a/applications/tari_validator_node/src/main.rs
+++ b/applications/tari_validator_node/src/main.rs
@@ -59,6 +59,7 @@ async fn main_inner() -> Result<(), ExitError> {
     let cfg = load_configuration(config_path, true, &cli)?;
     let config = ApplicationConfig::load_from(&cfg)?;
     println!("Starting validator node on network {}", config.network);
+
     run_validator_node_with_cli(&config, &cli).await?;
 
     Ok(())


### PR DESCRIPTION
Description
---
- Custom panic hook that exits when any panic is encountered
- fixes panic in HTTP ui if the socket is in use by using an OS-assigned port

Motivation and Context
---
A panic may fairly silently occur in a tokio task. Panics should end the process so that the problem is immediately noticed, in a production environment the process may be restarted.

How Has This Been Tested?
---
By running the below, the process exits after 1s
```rust
    tokio::task::spawn(async move {
        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
        panic!("Testing panic hook");
    });
```
