### PR TITLE
fix(consensus): any execution error will result in REJECT decision

### DIFF
--- a/applications/tari_validator_node/src/payload_processor.rs
+++ b/applications/tari_validator_node/src/payload_processor.rs
@@ -69,8 +69,9 @@ where TTemplateProvider: TemplateProvider
         let state_db = create_populated_state_store(pledges.into_values())?;
         template_addresses.extend(load_template_addresses_for_components(&state_db, &components)?);
 
+        // Execution will fail if more than the max addresses are created
         // let id_provider = IdProvider::new(*transaction.hash(), transaction.meta().max_outputs());
-        // The consensus will fail if not enough ids are pledged
+        // Execution will fail if more than 64 new addresses are created
         let id_provider = IdProvider::new(*transaction.hash(), 64);
         let tracker = StateTracker::new(state_db, id_provider);
         let runtime = RuntimeInterfaceImpl::new(tracker);

--- a/dan_layer/engine/src/transaction/mod.rs
+++ b/dan_layer/engine/src/transaction/mod.rs
@@ -77,6 +77,8 @@ impl Transaction {
         s
     }
 
+    /// Returns the template addresses that are statically known to be executed by this transaction.
+    /// This does not include templates for component invocation as that data is not contained within the transaction.
     pub fn required_templates(&self) -> Vec<TemplateAddress> {
         self.instructions
             .iter()


### PR DESCRIPTION
Description
---
Changes behaviour to reject decision for any payload execution failures

Motivation and Context
---
The payload processor returns a REJECT for the payload, however REJECT results were not persisted causing consensus to fail in an unexpected way and not complete, which led to active pledges being re-used in subsequent payloads (fixed in #280 ).

This also votes to reject for any execution failures, currently this is only possible if the template does not exist which is an invariant at this point (template addresses are checked before the transaction gets to consensus)

How Has This Been Tested?
---
Manually, create a counter component, call an invalid method on the counter component, then check that no pledges are dangling and REJECT consensus is completed