### PR TITLE
fix: state sync regression

### DIFF
--- a/dan_layer/core/src/storage/error.rs
+++ b/dan_layer/core/src/storage/error.rs
@@ -65,12 +65,6 @@ pub enum StorageError {
     General { details: String },
     #[error("Lock error")]
     LockError,
-    #[error("Error converting to or from json during:{operation}: {source}")]
-    SerdeJson {
-        source: serde_json::Error,
-        operation: String,
-        data: String,
-    },
     #[error("Error converting substate type:{substate_type}")]
     InvalidSubStateType { substate_type: String },
 }


### PR DESCRIPTION
Description
---
Fixed regression that affected state sync due to mistaken empty field

Motivation and Context
---
Regression caused (by me) due to created_justify now being set.

Removed the SerdeJson error variant as JSON is internal to the SQLite implementation. It's used for system visibility during development and never for production, so any errors de/encoding to/from json should just crash the node.

How Has This Been Tested?
---
Manually, new VN syncs from remote VN
