### PR TITLE
fix(consensus): check payload matches on proposed and local pledges, else REJECT

### DIFF
--- a/dan_layer/common_types/src/quorum_certificate.rs
+++ b/dan_layer/common_types/src/quorum_certificate.rs
@@ -23,6 +23,7 @@ pub enum QuorumRejectReason {
     ShardNotPledged,
     ExecutionFailure,
     PreviousQcRejection,
+    ShardPledgedToAnotherPayload,
 }
 
 impl QuorumRejectReason {
@@ -31,6 +32,7 @@ impl QuorumRejectReason {
             QuorumRejectReason::ShardNotPledged => 1,
             QuorumRejectReason::ExecutionFailure => 2,
             QuorumRejectReason::PreviousQcRejection => 3,
+            QuorumRejectReason::ShardPledgedToAnotherPayload => 4,
         }
     }
 }
@@ -49,6 +51,7 @@ impl QuorumDecision {
             1 => Ok(QuorumDecision::Reject(QuorumRejectReason::ShardNotPledged)),
             2 => Ok(QuorumDecision::Reject(QuorumRejectReason::ExecutionFailure)),
             3 => Ok(QuorumDecision::Reject(QuorumRejectReason::PreviousQcRejection)),
+            4 => Ok(QuorumDecision::Reject(QuorumRejectReason::ShardPledgedToAnotherPayload)),
             // TODO: Add error type
             _ => Err(anyhow::anyhow!("Invalid QuorumDecision")),
         }
@@ -61,6 +64,7 @@ impl<T: Borrow<RejectReason>> From<T> for QuorumRejectReason {
             RejectReason::ShardsNotPledged(_) => QuorumRejectReason::ShardNotPledged,
             RejectReason::ExecutionFailure(_) => QuorumRejectReason::ExecutionFailure,
             RejectReason::PreviousQcRejection => QuorumRejectReason::PreviousQcRejection,
+            RejectReason::ShardPledgedToAnotherPayload(_) => QuorumRejectReason::ShardPledgedToAnotherPayload,
         }
     }
 }

--- a/dan_layer/core/src/workers/hotstuff_error.rs
+++ b/dan_layer/core/src/workers/hotstuff_error.rs
@@ -70,7 +70,7 @@ pub enum HotStuffError {
     ReceivedNewViewWithoutPayload,
     #[error("Missing pledges: {}", .0.iter().map(|(s, c)| format!("{}: {}", s, c)).collect::<Vec<_>>().join(", "))]
     MissingPledges(Vec<(ShardId, SubstateChange)>),
-    #[error("Shard was pledged to a different payload")]
+    #[error("Shard {shard} already pledged to another payload {pledged_payload}, expected {expected}")]
     ShardPledgedToDifferentPayload {
         shard: ShardId,
         pledged_payload: PayloadId,
@@ -107,4 +107,6 @@ pub enum ProposalValidationError {
     PayloadHeightIsTooHigh { actual: NodeHeight, max: NodeHeight },
     #[error("Local pledge was not provided in proposal")]
     LocalPledgeIsNone,
+    #[error("Received proposal pledge for a different payload {pledged_payload} for shard {shard}")]
+    PledgePayloadMismatch { shard: ShardId, pledged_payload: PayloadId },
 }

--- a/dan_layer/engine_types/src/commit_result.rs
+++ b/dan_layer/engine_types/src/commit_result.rs
@@ -92,6 +92,7 @@ pub enum RejectReason {
     ShardsNotPledged(String),
     ExecutionFailure(String),
     PreviousQcRejection,
+    ShardPledgedToAnotherPayload(String),
 }
 
 impl std::fmt::Display for RejectReason {
@@ -100,6 +101,7 @@ impl std::fmt::Display for RejectReason {
             RejectReason::ShardsNotPledged(msg) => write!(f, "Shards not pledged: {}", msg),
             RejectReason::ExecutionFailure(msg) => write!(f, "Execution failure: {}", msg),
             RejectReason::PreviousQcRejection => write!(f, "Previous QC was a rejection"),
+            RejectReason::ShardPledgedToAnotherPayload(msg) => write!(f, "Shard pledged to another payload: {}", msg),
         }
     }
 }

--- a/dan_layer/storage_sqlite/src/sqlite_shard_store_factory.rs
+++ b/dan_layer/storage_sqlite/src/sqlite_shard_store_factory.rs
@@ -70,7 +70,10 @@ use tari_dan_core::{
 };
 use tari_dan_engine::transaction::{Transaction, TransactionMeta};
 use tari_engine_types::{commit_result::FinalizeResult, instruction::Instruction, signature::InstructionSignature};
-use tari_utilities::{hex::Hex, ByteArray};
+use tari_utilities::{
+    hex::{to_hex, Hex},
+    ByteArray,
+};
 
 use crate::{
     error::SqliteStorageError,
@@ -1394,11 +1397,20 @@ impl ShardStoreWriteTransaction<PublicKey, TariDanPayload> for SqliteShardStoreW
                 reason: format!("Pledge object error: {}", e),
             })?;
 
-        if let Some(obj) = existing_pledge {
-            // TODO: write test for this logic
-            // if obj.pledged_until_height.unwrap_or_default() as u64 >= current_height.as_u64() {
-            return self.create_pledge(shard, obj);
-            // }
+        if let Some(pledge) = existing_pledge {
+            // Emit a warning in this case, consensus should handle this correctly (by rejecting)
+            if pledge.pledged_to_payload_id != payload.as_bytes() {
+                warn!(
+                    target: LOG_TARGET,
+                    "[pledge_object]: Attempted to create a pledge for shard {}/payload{} that already exists for \
+                     another payload {}",
+                    shard,
+                    payload,
+                    to_hex(&pledge.pledged_to_payload_id)
+                );
+            }
+
+            return self.create_pledge(shard, pledge);
         }
 
         // otherwise save pledge


### PR DESCRIPTION
Description
---
checks payload matches on proposed and local pledges, else REJECT

Motivation and Context
---
If a leader sends a proposal pledged to another payload, fail proposal validation
If a node has locally pledged to another payload, REJECT

How Has This Been Tested?
---
Not explicitly tested (TODO), Previous manual tests still work
