### PR TITLE
fix(cli): allow dns addresses for json rpc url

### DIFF
--- a/applications/tari_validator_node_cli/src/main.rs
+++ b/applications/tari_validator_node_cli/src/main.rs
@@ -70,6 +70,7 @@ pub fn multiaddr_to_http_url(multiaddr: Multiaddr) -> anyhow::Result<Url> {
     let ip = match ip {
         Protocol::Ip4(ip) => ip.to_string(),
         Protocol::Ip6(ip) => ip.to_string(),
+        Protocol::Dns4(ip) | Protocol::Dns(ip) | Protocol::Dnsaddr(ip) | Protocol::Dns6(ip) => ip.to_string(),
         _ => return Err(anyhow!("Invalid multiaddr")),
     };
 


### PR DESCRIPTION
Description
---
Allow /dnsx multiaddrs

Motivation and Context
---
Allows 
export JRPC_ENDPOINT=/dns4/foo.com/tcp/80 

How Has This Been Tested?
---
Manually
