### PR TITLE
feat(consensus): abandon early if shard is rejected

### DIFF
--- a/applications/tari_validator_node/src/p2p/proto/conversions/consensus.rs
+++ b/applications/tari_validator_node/src/p2p/proto/conversions/consensus.rs
@@ -30,7 +30,6 @@ use tari_dan_common_types::{
     ObjectPledge,
     QuorumCertificate,
     QuorumDecision,
-    QuorumRejectReason,
     ShardPledge,
     SubstateState,
     TreeNodeHash,
@@ -176,12 +175,7 @@ impl TryFrom<proto::consensus::QuorumCertificate> for QuorumCertificate {
             value.local_node_height.into(),
             value.shard.try_into()?,
             value.epoch.into(),
-            match value.decision {
-                0 => QuorumDecision::Accept,
-                1 => QuorumDecision::Reject(QuorumRejectReason::ShardNotPledged),
-                2 => QuorumDecision::Reject(QuorumRejectReason::ExecutionFailure),
-                _ => return Err(anyhow!("Invalid decision")),
-            },
+            QuorumDecision::from_u8(value.decision.try_into()?)?,
             value
                 .all_shard_pledges
                 .iter()

--- a/applications/tari_validator_node/src/payload_processor.rs
+++ b/applications/tari_validator_node/src/payload_processor.rs
@@ -94,10 +94,10 @@ where TTemplateProvider: TemplateProvider
         let tx_hash = *transaction.hash();
         match processor.execute(transaction) {
             Ok(result) => Ok(result),
-            Err(TransactionError::WasmExecutionError(WasmExecutionError::Panic { message, .. })) => Ok(
-                FinalizeResult::errored(tx_hash, RejectReason::ExecutionFailure(message)),
-            ),
-            Err(err) => Ok(FinalizeResult::errored(
+            Err(TransactionError::WasmExecutionError(WasmExecutionError::Panic { message, .. })) => {
+                Ok(FinalizeResult::reject(tx_hash, RejectReason::ExecutionFailure(message)))
+            },
+            Err(err) => Ok(FinalizeResult::reject(
                 tx_hash,
                 RejectReason::ExecutionFailure(err.to_string()),
             )),

--- a/applications/tari_validator_node_web_ui/src/routes/VN/Components/Committees.tsx
+++ b/applications/tari_validator_node_web_ui/src/routes/VN/Components/Committees.tsx
@@ -24,6 +24,7 @@ import { useEffect, useState } from "react";
 import { getCommittee, getShardKey } from "../../../utils/json_rpc";
 import Committee from "./Committee";
 import { U256 } from "./helpers";
+import PropTypes from "prop-types";
 
 async function get_all_committees(currentEpoch: number, shardKey: string, publicKey: string) {
   let shardKeyMap: { [id: string]: string } = { [publicKey]: shardKey };
@@ -72,8 +73,8 @@ function Committees({
       });
     }
   }, [currentEpoch, shardKey, publicKey]);
-  if (committees.length === 0) {
-    return <div className="commiittees">Committees are loading</div>;
+  if (!committees) {
+    return <div className="committees">Committees are loading</div>;
   }
   return (
     <div className="section">

--- a/applications/tari_validator_node_web_ui/src/routes/VN/Components/RecentTransactions.tsx
+++ b/applications/tari_validator_node_web_ui/src/routes/VN/Components/RecentTransactions.tsx
@@ -50,7 +50,8 @@ function RecentTransactions() {
   useEffect(() => {
     getRecentTransactions().then((recentTransactions) => {
       setRecentTransacations(
-        recentTransactions.map(({ instructions, meta, payload_id, timestamp }: IRecentTransaction) => ({
+        // Display from newest to oldest by reversing
+        recentTransactions.slice().reverse().map(({ instructions, meta, payload_id, timestamp }: IRecentTransaction) => ({
           id: toHexString(payload_id),
           payload_id: toHexString(payload_id),
           timestamp: timestamp,

--- a/applications/tari_validator_node_web_ui/src/routes/VN/Components/helpers.tsx
+++ b/applications/tari_validator_node_web_ui/src/routes/VN/Components/helpers.tsx
@@ -23,8 +23,11 @@
 class U256 {
   n: string;
   constructor(n: string) {
+    if (!n) {
+      throw new Error("U256 input is null/empty");
+    }
     if (n.length > 64) {
-      throw new Error("Input is bigger than it should");
+      throw new Error("U256 input is larger than 64 characters");
     }
     this.n = n.padStart(64, "0");
   }

--- a/dan_layer/common_types/src/quorum_certificate.rs
+++ b/dan_layer/common_types/src/quorum_certificate.rs
@@ -40,7 +40,7 @@ impl QuorumRejectReason {
             QuorumRejectReason::ExecutionFailure => 2,
             QuorumRejectReason::PreviousQcRejection => 3,
             QuorumRejectReason::ShardPledgedToAnotherPayload => 4,
-            QuorumRejectReason::ShardRejected => 4,
+            QuorumRejectReason::ShardRejected => 5,
         }
     }
 }
@@ -60,7 +60,7 @@ impl QuorumDecision {
             2 => Ok(QuorumDecision::Reject(QuorumRejectReason::ExecutionFailure)),
             3 => Ok(QuorumDecision::Reject(QuorumRejectReason::PreviousQcRejection)),
             4 => Ok(QuorumDecision::Reject(QuorumRejectReason::ShardPledgedToAnotherPayload)),
-            4 => Ok(QuorumDecision::Reject(QuorumRejectReason::ShardRejected)),
+            5 => Ok(QuorumDecision::Reject(QuorumRejectReason::ShardRejected)),
             // TODO: Add error type
             _ => Err(anyhow::anyhow!("Invalid QuorumDecision")),
         }

--- a/dan_layer/common_types/src/quorum_certificate.rs
+++ b/dan_layer/common_types/src/quorum_certificate.rs
@@ -18,12 +18,19 @@ pub enum QuorumDecision {
     Reject(QuorumRejectReason),
 }
 
+impl QuorumDecision {
+    pub fn is_reject(&self) -> bool {
+        matches!(self, QuorumDecision::Reject(_))
+    }
+}
+
 #[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq, BorshSerialize)]
 pub enum QuorumRejectReason {
     ShardNotPledged,
     ExecutionFailure,
     PreviousQcRejection,
     ShardPledgedToAnotherPayload,
+    ShardRejected,
 }
 
 impl QuorumRejectReason {
@@ -33,6 +40,7 @@ impl QuorumRejectReason {
             QuorumRejectReason::ExecutionFailure => 2,
             QuorumRejectReason::PreviousQcRejection => 3,
             QuorumRejectReason::ShardPledgedToAnotherPayload => 4,
+            QuorumRejectReason::ShardRejected => 4,
         }
     }
 }
@@ -52,6 +60,7 @@ impl QuorumDecision {
             2 => Ok(QuorumDecision::Reject(QuorumRejectReason::ExecutionFailure)),
             3 => Ok(QuorumDecision::Reject(QuorumRejectReason::PreviousQcRejection)),
             4 => Ok(QuorumDecision::Reject(QuorumRejectReason::ShardPledgedToAnotherPayload)),
+            4 => Ok(QuorumDecision::Reject(QuorumRejectReason::ShardRejected)),
             // TODO: Add error type
             _ => Err(anyhow::anyhow!("Invalid QuorumDecision")),
         }
@@ -65,6 +74,7 @@ impl<T: Borrow<RejectReason>> From<T> for QuorumRejectReason {
             RejectReason::ExecutionFailure(_) => QuorumRejectReason::ExecutionFailure,
             RejectReason::PreviousQcRejection => QuorumRejectReason::PreviousQcRejection,
             RejectReason::ShardPledgedToAnotherPayload(_) => QuorumRejectReason::ShardPledgedToAnotherPayload,
+            RejectReason::ShardRejected(_) => QuorumRejectReason::ShardRejected,
         }
     }
 }

--- a/dan_layer/core/src/storage/shard_store.rs
+++ b/dan_layer/core/src/storage/shard_store.rs
@@ -210,7 +210,7 @@ pub trait ShardStoreWriteTransaction<TAddr: NodeAddressable, TPayload: Payload> 
     ) -> Result<(), StorageError>;
 
     /// Updates the result for an existing payload
-    fn update_payload_result(&self, payload_id: &PayloadId, result: FinalizeResult) -> Result<(), StorageError>;
+    fn update_payload_result(&mut self, payload_id: &PayloadId, result: FinalizeResult) -> Result<(), StorageError>;
 
     // -------------------------------- Pledges -------------------------------- //
     fn pledge_object(
@@ -220,13 +220,13 @@ pub trait ShardStoreWriteTransaction<TAddr: NodeAddressable, TPayload: Payload> 
         current_height: NodeHeight,
     ) -> Result<ObjectPledge, StorageError>;
     fn complete_pledges(
-        &self,
+        &mut self,
         shard: ShardId,
         payload_id: PayloadId,
         node_hash: &TreeNodeHash,
     ) -> Result<(), StorageError>;
     fn abandon_pledges(
-        &self,
+        &mut self,
         shard: ShardId,
         payload_id: PayloadId,
         node_hash: &TreeNodeHash,

--- a/dan_layer/core/src/workers/hotstuff_waiter.rs
+++ b/dan_layer/core/src/workers/hotstuff_waiter.rs
@@ -729,7 +729,7 @@ where
 
                 // If an active pledge already exists for another payload, we REJECT this payload.
                 if pledge.pledged_to_payload != node.payload_id() {
-                    let finalize_result = FinalizeResult::errored(
+                    let finalize_result = FinalizeResult::reject(
                         node.payload_id().into_array().into(),
                         RejectReason::ShardPledgedToAnotherPayload(format!(
                             "Shard {} is pledged to another payload {}",

--- a/dan_layer/engine_types/src/commit_result.rs
+++ b/dan_layer/engine_types/src/commit_result.rs
@@ -43,7 +43,7 @@ impl FinalizeResult {
         }
     }
 
-    pub fn errored(transaction_hash: Hash, reason: RejectReason) -> Self {
+    pub fn reject(transaction_hash: Hash, reason: RejectReason) -> Self {
         Self::new(transaction_hash, Vec::new(), TransactionResult::Reject(reason))
     }
 
@@ -93,6 +93,7 @@ pub enum RejectReason {
     ExecutionFailure(String),
     PreviousQcRejection,
     ShardPledgedToAnotherPayload(String),
+    ShardRejected(String),
 }
 
 impl std::fmt::Display for RejectReason {
@@ -102,6 +103,7 @@ impl std::fmt::Display for RejectReason {
             RejectReason::ExecutionFailure(msg) => write!(f, "Execution failure: {}", msg),
             RejectReason::PreviousQcRejection => write!(f, "Previous QC was a rejection"),
             RejectReason::ShardPledgedToAnotherPayload(msg) => write!(f, "Shard pledged to another payload: {}", msg),
+            RejectReason::ShardRejected(msg) => write!(f, "Shard was rejected: {}", msg),
         }
     }
 }

--- a/dan_layer/storage_sqlite/src/sqlite_shard_store_factory.rs
+++ b/dan_layer/storage_sqlite/src/sqlite_shard_store_factory.rs
@@ -1284,7 +1284,7 @@ impl ShardStoreWriteTransaction<PublicKey, TariDanPayload> for SqliteShardStoreW
     }
 
     fn update_payload_result(
-        &self,
+        &mut self,
         requested_payload_id: &PayloadId,
         result: FinalizeResult,
     ) -> Result<(), StorageError> {
@@ -1377,7 +1377,7 @@ impl ShardStoreWriteTransaction<PublicKey, TariDanPayload> for SqliteShardStoreW
     }
 
     fn complete_pledges(
-        &self,
+        &mut self,
         shard: ShardId,
         payload: PayloadId,
         node_hash: &TreeNodeHash,
@@ -1408,7 +1408,7 @@ impl ShardStoreWriteTransaction<PublicKey, TariDanPayload> for SqliteShardStoreW
     }
 
     fn abandon_pledges(
-        &self,
+        &mut self,
         shard: ShardId,
         payload_id: PayloadId,
         node_hash: &TreeNodeHash,

--- a/dan_layer/storage_sqlite/src/sqlite_shard_store_factory.rs
+++ b/dan_layer/storage_sqlite/src/sqlite_shard_store_factory.rs
@@ -756,11 +756,15 @@ impl<'a> SqliteShardStoreWriteTransaction<'a> {
         }
     }
 
+    pub fn connection(&self) -> &SqliteConnection {
+        self.transaction.connection()
+    }
+
     fn create_pledge(&mut self, shard: ShardId, obj: DbShardPledge) -> Result<ObjectPledge, StorageError> {
         use crate::schema::substates;
         let current_state: Option<Substate> = substates::table
             .filter(substates::shard_id.eq(shard.as_bytes()))
-            .first(self.transaction.connection())
+            .first(self.connection())
             .optional()
             .map_err(|e| StorageError::QueryError {
                 reason: format!("Create object pledge error: {}", e),
@@ -822,7 +826,7 @@ impl ShardStoreWriteTransaction<PublicKey, TariDanPayload> for SqliteShardStoreW
         };
         match diesel::insert_into(high_qcs::table)
             .values(&new_row)
-            .execute(self.transaction.connection())
+            .execute(self.connection())
         {
             Ok(_) => Ok(()),
             // (shard_id, payload_id, height) is a unique index
@@ -835,7 +839,7 @@ impl ShardStoreWriteTransaction<PublicKey, TariDanPayload> for SqliteShardStoreW
             //     //         high_qcs::qc_json.eq(new_row.qc_json),
             //     //         high_qcs::identity.eq(new_row.identity),
             //     //     ))
-            //     //     .execute(self.transaction.connection())
+            //     //     .execute(self.connection())
             //     //     .map_err(|e| StorageError::QueryError {
             //     //         reason: format!("Update high QC: {}", e),
             //     //     })?;
@@ -886,7 +890,7 @@ impl ShardStoreWriteTransaction<PublicKey, TariDanPayload> for SqliteShardStoreW
 
         match diesel::insert_into(payloads::table)
             .values(&new_row)
-            .execute(self.transaction.connection())
+            .execute(self.connection())
         {
             Ok(_) => {},
             Err(err) => {
@@ -923,7 +927,7 @@ impl ShardStoreWriteTransaction<PublicKey, TariDanPayload> for SqliteShardStoreW
             .filter(leaf_nodes::shard_id.eq(shard_id.as_bytes()))
             .filter(leaf_nodes::payload_id.eq(payload_id.as_bytes()))
             .order_by(leaf_nodes::node_height.desc())
-            .first(self.transaction.connection())
+            .first(self.connection())
             .optional()
             .map_err(|e| StorageError::QueryError {
                 reason: format!("Get leaf node: {}", e),
@@ -940,7 +944,7 @@ impl ShardStoreWriteTransaction<PublicKey, TariDanPayload> for SqliteShardStoreW
                         leaf_nodes::payload_id.eq(payload_id.as_bytes()),
                     ))
                     .filter(leaf_nodes::id.eq(leaf_node.id))
-                    .execute(self.transaction.connection())
+                    .execute(self.connection())
                     .map_err(|e| StorageError::QueryError {
                         reason: format!("Update leaf node: {}", e),
                     })?;
@@ -958,7 +962,7 @@ impl ShardStoreWriteTransaction<PublicKey, TariDanPayload> for SqliteShardStoreW
                 // of possibly updating an existing row
                 diesel::insert_into(leaf_nodes::table)
                     .values(&new_row)
-                    .execute(self.transaction.connection())
+                    .execute(self.connection())
                     .map_err(|e| StorageError::QueryError {
                         reason: format!("Update leaf node error: {}", e),
                     })?;
@@ -1002,7 +1006,7 @@ impl ShardStoreWriteTransaction<PublicKey, TariDanPayload> for SqliteShardStoreW
 
         match diesel::insert_into(nodes::dsl::nodes)
             .values(&new_row)
-            .execute(self.transaction.connection())
+            .execute(self.connection())
         {
             Ok(_) => {},
             Err(err) => match err {
@@ -1041,7 +1045,7 @@ impl ShardStoreWriteTransaction<PublicKey, TariDanPayload> for SqliteShardStoreW
 
         diesel::insert_into(lock_node_and_heights::table)
             .values(&new_row)
-            .execute(self.transaction.connection())
+            .execute(self.connection())
             .map_err(|e| StorageError::QueryError {
                 reason: format!("Set locked error: {}", e),
             })?;
@@ -1064,7 +1068,7 @@ impl ShardStoreWriteTransaction<PublicKey, TariDanPayload> for SqliteShardStoreW
 
         diesel::insert_into(last_executed_heights::table)
             .values(&new_row)
-            .execute(self.transaction.connection())
+            .execute(self.connection())
             .map_err(|e| StorageError::QueryError {
                 reason: format!("Set last executed height error: {}", e),
             })?;
@@ -1080,7 +1084,7 @@ impl ShardStoreWriteTransaction<PublicKey, TariDanPayload> for SqliteShardStoreW
 
         let current_state = substates::table
             .filter(substates::shard_id.eq(node.shard().as_bytes()))
-            .first::<Substate>(self.transaction.connection())
+            .first::<Substate>(self.connection())
             .optional()
             .map_err(|e| StorageError::QueryError {
                 reason: format!("Save substate changes error. Could not retrieve current state: {}", e),
@@ -1112,7 +1116,7 @@ impl ShardStoreWriteTransaction<PublicKey, TariDanPayload> for SqliteShardStoreW
                     };
                     diesel::insert_into(substates::table)
                         .values(&new_row)
-                        .execute(self.transaction.connection())
+                        .execute(self.connection())
                         .map_err(|e| StorageError::QueryError {
                             reason: format!("Save substate changes error. Could not insert new substate: {}", e),
                         })?;
@@ -1135,7 +1139,7 @@ impl ShardStoreWriteTransaction<PublicKey, TariDanPayload> for SqliteShardStoreW
                                 substates::destroyed_node_hash.eq(node.hash().as_bytes()),
                                 substates::destroyed_timestamp.eq(now),
                             ))
-                            .execute(self.transaction.connection())
+                            .execute(self.connection())
                             .map_err(|e| StorageError::QueryError {
                                 reason: format!("Save substate changes error. Could not destroy substate: {}", e),
                             })?;
@@ -1179,7 +1183,7 @@ impl ShardStoreWriteTransaction<PublicKey, TariDanPayload> for SqliteShardStoreW
 
         diesel::insert_into(substates::table)
             .values(&new_row)
-            .execute(self.transaction.connection())
+            .execute(self.connection())
             .map_err(|e| StorageError::QueryError {
                 reason: format!("Insert substates: {}", e),
             })?;
@@ -1203,7 +1207,7 @@ impl ShardStoreWriteTransaction<PublicKey, TariDanPayload> for SqliteShardStoreW
 
         diesel::insert_into(last_voted_heights::table)
             .values(&new_row)
-            .execute(self.transaction.connection())
+            .execute(self.connection())
             .map_err(|e| StorageError::QueryError {
                 reason: format!("Set last voted height: {}", e),
             })?;
@@ -1235,7 +1239,7 @@ impl ShardStoreWriteTransaction<PublicKey, TariDanPayload> for SqliteShardStoreW
 
         match diesel::insert_into(leader_proposals::table)
             .values(&new_row)
-            .execute(self.transaction.connection())
+            .execute(self.connection())
         {
             Ok(_) => Ok(()),
             Err(e) => match e {
@@ -1271,7 +1275,7 @@ impl ShardStoreWriteTransaction<PublicKey, TariDanPayload> for SqliteShardStoreW
 
         diesel::insert_into(received_votes::table)
             .values(&new_row)
-            .execute(self.transaction.connection())
+            .execute(self.connection())
             .map_err(|e| StorageError::QueryError {
                 reason: format!("Save received voted for: {}", e),
             })?;
@@ -1291,7 +1295,7 @@ impl ShardStoreWriteTransaction<PublicKey, TariDanPayload> for SqliteShardStoreW
         diesel::update(payloads::table)
             .filter(payloads::payload_id.eq(requested_payload_id.as_bytes()))
             .set(payloads::result.eq(result_json))
-            .execute(self.transaction.connection())
+            .execute(self.connection())
             .map_err(|source| SqliteStorageError::DieselError {
                 source,
                 operation: "update_payload_result".to_string(),
@@ -1314,7 +1318,7 @@ impl ShardStoreWriteTransaction<PublicKey, TariDanPayload> for SqliteShardStoreW
             .filter(shard_pledges::shard_id.eq(shard.as_bytes()))
             .filter(shard_pledges::is_active.eq(true))
             .order_by(shard_pledges::created_height.desc())
-            .first(self.transaction.connection())
+            .first(self.connection())
             .optional()
             .map_err(|e| StorageError::QueryError {
                 reason: format!("Pledge object error: {}", e),
@@ -1345,7 +1349,7 @@ impl ShardStoreWriteTransaction<PublicKey, TariDanPayload> for SqliteShardStoreW
         };
         let num_affected = diesel::insert_into(shard_pledges::table)
             .values(new_row)
-            .execute(self.transaction.connection())
+            .execute(self.connection())
             .map_err(|e| StorageError::QueryError {
                 reason: format!("Pledge insert error: {}", e),
             })?;
@@ -1364,7 +1368,7 @@ impl ShardStoreWriteTransaction<PublicKey, TariDanPayload> for SqliteShardStoreW
                     .and(shard_pledges::pledged_to_payload_id.eq(payload.as_bytes())),
             )
             .order_by(shard_pledges::id.desc())
-            .first(self.transaction.connection())
+            .first(self.connection())
             .map_err(|e| StorageError::QueryError {
                 reason: format!("Pledge object error: {}", e),
             })?;
@@ -1388,7 +1392,7 @@ impl ShardStoreWriteTransaction<PublicKey, TariDanPayload> for SqliteShardStoreW
                 shard_pledges::completed_by_tree_node_hash.eq(node_hash.as_bytes()),
                 shard_pledges::updated_timestamp.eq(now),
             ))
-            .execute(self.transaction.connection())
+            .execute(self.connection())
             .map_err(|e| StorageError::QueryError {
                 reason: format!("Complete pledges: {}", e),
             })?;
@@ -1419,16 +1423,15 @@ impl ShardStoreWriteTransaction<PublicKey, TariDanPayload> for SqliteShardStoreW
                 shard_pledges::abandoned_by_tree_node_hash.eq(node_hash.as_bytes()),
                 shard_pledges::updated_timestamp.eq(now),
             ))
-            .execute(self.transaction.connection())
+            .execute(self.connection())
             .map_err(|e| StorageError::QueryError {
-                reason: format!("Complete pledges: {}", e),
+                reason: format!("Abandon pledges: {}", e),
             })?;
+
         if rows_affected == 0 {
-            return Err(StorageError::QueryError {
-                reason: format!(
-                    "Abandon pledges: No pledges found to abandon for shard {}, payload_id: {}, is_active: true",
-                    shard, payload_id
-                ),
+            return Err(StorageError::NotFound {
+                item: "Abandon pledges".to_string(),
+                key: format!("payload={}, shard={}", payload_id, shard),
             });
         }
         Ok(())


### PR DESCRIPTION
Description
---
Abandons payload early if any shard has a REJECT QC

Motivation and Context
---
Since we know that at least one foreign shard has QC REJECT, the entire payload will never be able to be committed so no further votes are required, pledges can be released and the entire payload is REJECTED. This decreases TTR (time to result) and excess network traffic from erroneous payloads.

How Has This Been Tested?
---
A multishard payload with ~~one missing pledge (single shard REJECT) and separately a payload with~~ an incorrect method node (all shards REJECT), followed by an ACCEPT with the correct payload
