### PR TITLE
fix: correctly convert quorum decision from protobuf type

### DIFF
--- a/applications/tari_validator_node/src/p2p/proto/conversions/consensus.rs
+++ b/applications/tari_validator_node/src/p2p/proto/conversions/consensus.rs
@@ -176,12 +176,7 @@ impl TryFrom<proto::consensus::QuorumCertificate> for QuorumCertificate {
             value.local_node_height.into(),
             value.shard.try_into()?,
             value.epoch.into(),
-            match value.decision {
-                0 => QuorumDecision::Accept,
-                1 => QuorumDecision::Reject(QuorumRejectReason::ShardNotPledged),
-                2 => QuorumDecision::Reject(QuorumRejectReason::ExecutionFailure),
-                _ => return Err(anyhow!("Invalid decision")),
-            },
+            QuorumDecision::from_u8(value.decision.try_into()?)?,
             value
                 .all_shard_pledges
                 .iter()

--- a/applications/tari_validator_node/src/p2p/proto/conversions/consensus.rs
+++ b/applications/tari_validator_node/src/p2p/proto/conversions/consensus.rs
@@ -30,7 +30,6 @@ use tari_dan_common_types::{
     ObjectPledge,
     QuorumCertificate,
     QuorumDecision,
-    QuorumRejectReason,
     ShardPledge,
     SubstateState,
     TreeNodeHash,


### PR DESCRIPTION
Description
---
correctly convert quorum decision from protobuf type

Motivation and Context
---
Duplicate code was not updated, now using QuorumDecision::from_u8 instead

How Has This Been Tested?
---
Manual test which has ShardPledgedToAnotherPayload failure case 
