### PR TITLE
fix(template)!: remove extra unused version field

### DIFF
--- a/dan_layer/engine/src/runtime/tests.rs
+++ b/dan_layer/engine/src/runtime/tests.rs
@@ -23,7 +23,6 @@ mod tracker {
         });
         let addr = tracker.new_component("test".to_string(), vec![1, 2, 3]).unwrap();
         let component = tracker.get_component(&addr).unwrap();
-        assert_eq!(component.version, 0);
         assert_eq!(component.module_name, "test");
         assert_eq!(component.state.state, vec![1, 2, 3]);
     }

--- a/dan_layer/engine/src/runtime/tracker.rs
+++ b/dan_layer/engine/src/runtime/tracker.rs
@@ -234,7 +234,6 @@ impl StateTracker {
         let component = ComponentHeader {
             component_address,
             template_address: runtime_state.template_address,
-            version: 0,
             module_name,
             state: component,
         };

--- a/dan_layer/template_lib/src/models/component.rs
+++ b/dan_layer/template_lib/src/models/component.rs
@@ -76,7 +76,6 @@ pub struct ComponentHeader {
     pub component_address: ComponentAddress,
     pub template_address: TemplateAddress,
     pub module_name: String,
-    pub version: u32,
     // TODO: Split the state from the header
     pub state: ComponentBody,
 }


### PR DESCRIPTION
Description
---
removes extra unused version field from component header

Motivation and Context
---
Version is contained within the substate value, not on the template-level objects.

How Has This Been Tested?
---
Code compiles
