### PR TITLE
fix(consensus): fixes panic when generating a merkle proof

### DIFF
--- a/dan_layer/core/src/models/vote_message.rs
+++ b/dan_layer/core/src/models/vote_message.rs
@@ -92,28 +92,11 @@ impl VoteMessage {
         let challenge = self.construct_challenge();
         let signature = signing_service.sign(&*challenge).ok_or(HotStuffError::FailedToSignQc)?;
         // construct the merkle proof for the inclusion of the VN's public key in the epoch
-        let leaf_index = vn_mmr
-            .find_leaf_index(&*vn_mmr_node_hash(signing_service.public_key(), &shard_id))
-            .expect("Unexpected Merkle Mountain Range error")
-            .ok_or(HotStuffError::ValidatorNodeNotIncludedInMmr)?;
-        let merkle_proof =
-            MerkleProof::for_leaf_node(vn_mmr, leaf_index as usize).expect("Merkle proof generation failed");
-
         let hash = vn_mmr_node_hash(signing_service.public_key(), &shard_id);
-        let root = vn_mmr.get_merkle_root().unwrap();
-        let idx = vn_mmr.find_leaf_index(&*hash).unwrap();
-        // TODO: remove
-        if let Err(err) =
-            merkle_proof.verify::<tari_core::ValidatorNodeMmrHasherBlake256>(&root, &*hash, leaf_index as usize)
-        {
-            log::warn!(
-                target: "tari::dan_layer::votemessage",
-                "Merkle proof verification failed for validator node {:?} at index {:?} with error: {}",
-                hash,
-                idx,
-                err
-            );
-        }
+        let leaf_index = vn_mmr
+            .find_leaf_index(&*hash)?
+            .ok_or(HotStuffError::ValidatorNodeNotIncludedInMmr)?;
+        let merkle_proof = MerkleProof::for_leaf_node(vn_mmr, leaf_index as usize)?;
 
         let validator_metadata = ValidatorMetadata::new(
             signing_service.public_key().clone(),

--- a/dan_layer/core/src/workers/hotstuff_error.rs
+++ b/dan_layer/core/src/workers/hotstuff_error.rs
@@ -76,6 +76,10 @@ pub enum HotStuffError {
         pledged_payload: PayloadId,
         expected: PayloadId,
     },
+    #[error("Merkle proof error: {0}")]
+    MerkleProofError(#[from] tari_mmr::MerkleProofError),
+    #[error("Merkle mountain range error: {0}")]
+    MerkleMountainRangeError(#[from] tari_mmr::error::MerkleMountainRangeError),
 }
 
 impl<T> From<mpsc::error::SendError<T>> for HotStuffError {


### PR DESCRIPTION
Description
---
Removed panics when generating the VN Merkle Proof. 

Motivation and Context
---
The panic may occur due to incorrect API usage. For debugging purposes, I previously added a call `verify` after generating the proof, but I should have used `verify_leaf`. Removed the debugging code. 

To investigate: A panic inside the MerkleProof::check_roots was encountered.

How Has This Been Tested?
---
N/A temporary debug code removed
