### PR TITLE
fix(cli): create key-pair automatically if one doesnt exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,12 +90,6 @@ Once the template is registered on the base layer and sufficiently mined, you sh
 ### Calling a function
 With the templated registered we can invoke a function by using the `validator_node_cli`.
 
-First we must create an account
-
-```
-cargo run --bin tari_validator_node_cli -- accounts create
-```
-
 Next we can get a list of templates
 
 ```

--- a/applications/tari_validator_node/tests/utils/validator_node_cli.rs
+++ b/applications/tari_validator_node/tests/utils/validator_node_cli.rs
@@ -10,12 +10,12 @@ use tari_template_lib::{
 };
 use tari_transaction_manifest::parse_manifest;
 use tari_validator_node_cli::{
-    account_manager::AccountFileManager,
     command::{
         handle_submit,
         transaction::{submit_transaction, CliArg, CliInstruction, CommonSubmitArgs, SubmitArgs},
     },
     from_hex::FromHex,
+    key_manager::KeyManager,
 };
 use tari_validator_node_client::{types::SubmitTransactionResponse, ValidatorNodeClient};
 use tempfile::tempdir;
@@ -28,8 +28,8 @@ pub async fn create_dan_wallet(world: &mut TariWorld) {
 
     // initialize the account public/private keys
     let path = PathBuf::from(data_dir);
-    let account_manager = AccountFileManager::init(path).unwrap();
-    account_manager.create_account().unwrap();
+    let account_manager = KeyManager::init(path).unwrap();
+    account_manager.create().unwrap();
 }
 
 pub async fn create_account(world: &mut TariWorld, account_name: String, validator_node_name: String) {

--- a/applications/tari_validator_node_cli/src/command/key.rs
+++ b/applications/tari_validator_node_cli/src/command/key.rs
@@ -24,10 +24,10 @@ use std::path::Path;
 
 use clap::Subcommand;
 
-use crate::account_manager::AccountFileManager;
+use crate::key_manager::KeyManager;
 
 #[derive(Debug, Subcommand, Clone)]
-pub enum AccountsSubcommand {
+pub enum KeysSubcommand {
     #[clap(alias = "create")]
     New,
     List,
@@ -36,30 +36,30 @@ pub enum AccountsSubcommand {
     },
 }
 
-impl AccountsSubcommand {
+impl KeysSubcommand {
     pub async fn handle<P: AsRef<Path>>(self, base_dir: P) -> anyhow::Result<()> {
-        let account_manager = AccountFileManager::init(base_dir.as_ref().to_path_buf())?;
+        let key_manager = KeyManager::init(base_dir)?;
 
         #[allow(clippy::enum_glob_use)]
-        use AccountsSubcommand::*;
+        use KeysSubcommand::*;
         match self {
             New => {
-                let account = account_manager.create_account()?;
-                println!("New account {} created", account);
+                let key = key_manager.create()?;
+                println!("New key pair {} created", key);
             },
             List => {
-                println!("Accounts:");
-                for (i, account) in account_manager.all().into_iter().enumerate() {
-                    if account.is_active {
-                        println!("{}. {} (active)", i, account);
+                println!("Key pairs:");
+                for (i, key) in key_manager.all().into_iter().enumerate() {
+                    if key.is_active {
+                        println!("{}. {} (active)", i, key);
                     } else {
-                        println!("{}. {}", i, account);
+                        println!("{}. {}", i, key);
                     }
                 }
             },
             Use { name } => {
-                account_manager.set_active_account(&name)?;
-                println!("Account {} is now active", name);
+                key_manager.set_active_key(&name)?;
+                println!("Key {} is now active", name);
             },
         }
         Ok(())

--- a/applications/tari_validator_node_cli/src/command/mod.rs
+++ b/applications/tari_validator_node_cli/src/command/mod.rs
@@ -22,8 +22,8 @@
 
 use clap::Subcommand;
 
-mod account;
-pub use account::AccountsSubcommand;
+mod key;
+pub use key::KeysSubcommand;
 
 mod template;
 pub use template::TemplateSubcommand;
@@ -43,8 +43,8 @@ pub enum Command {
     Vn(VnSubcommand),
     #[clap(subcommand, alias = "template")]
     Templates(TemplateSubcommand),
-    #[clap(subcommand, alias = "account")]
-    Accounts(AccountsSubcommand),
+    #[clap(subcommand, alias = "key")]
+    Keys(KeysSubcommand),
     #[clap(subcommand, alias = "transaction")]
     Transactions(TransactionSubcommand),
     #[clap(subcommand, alias = "manifest")]

--- a/applications/tari_validator_node_cli/src/command/template.rs
+++ b/applications/tari_validator_node_cli/src/command/template.rs
@@ -119,7 +119,7 @@ async fn handle_publish(args: PublishTemplateArgs, mut client: ValidatorNodeClie
     println!("⏳️ Compiling template...");
 
     // compile the code and retrieve the binary content of the wasm
-    let wasm_module = compile_template(root_folder.as_path(), &[]).unwrap();
+    let wasm_module = compile_template(root_folder.as_path(), &[])?;
     let wasm_code = wasm_module.code();
     println!(
         "✅ Template compilation successful (WASM file size: {} bytes)",
@@ -175,7 +175,7 @@ async fn handle_publish(args: PublishTemplateArgs, mut client: ValidatorNodeClie
     println!();
     println!(
         "The template address will be {}",
-        TemplateAddress::try_from(resp.template_address.as_slice()).unwrap()
+        TemplateAddress::try_from(resp.template_address.as_slice())?
     );
 
     Ok(())

--- a/applications/tari_validator_node_cli/src/command/transaction.rs
+++ b/applications/tari_validator_node_cli/src/command/transaction.rs
@@ -47,10 +47,10 @@ use tari_validator_node_client::{
 };
 
 use crate::{
-    account_manager::AccountFileManager,
     command::manifest,
     component_manager::ComponentManager,
     from_hex::FromHex,
+    key_manager::KeyManager,
     versioned_substate_address::VersionedSubstateAddress,
 };
 
@@ -206,10 +206,10 @@ pub async fn submit_transaction(
     client: &mut ValidatorNodeClient,
 ) -> Result<Option<SubmitTransactionResponse>, anyhow::Error> {
     let component_manager = ComponentManager::init(base_dir.as_ref())?;
-    let account_manager = AccountFileManager::init(base_dir.as_ref().to_path_buf())?;
-    let account = account_manager
-        .get_active_account()
-        .ok_or_else(|| anyhow::anyhow!("No active account. Use `accounts use [public key hex]` to set one."))?;
+    let key_manager = KeyManager::init(base_dir)?;
+    let key = key_manager
+        .get_active_key()
+        .ok_or_else(|| anyhow::anyhow!("No active key. Use `keys use [public key hex]` to set one."))?;
 
     let inputs = if common.inputs.is_empty() {
         load_inputs(&instructions, &component_manager)?
@@ -238,7 +238,7 @@ pub async fn submit_transaction(
         .with_new_outputs(common.num_outputs.unwrap_or(0))
         .with_outputs(outputs)
         .with_fee(1)
-        .sign(&account.secret_key);
+        .sign(&key.secret_key);
 
     let transaction = builder.build();
 

--- a/applications/tari_validator_node_cli/src/lib.rs
+++ b/applications/tari_validator_node_cli/src/lib.rs
@@ -20,10 +20,10 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-pub mod account_manager;
 pub mod cli;
 pub mod command;
 pub mod from_hex;
+pub mod key_manager;
 pub mod prompt;
 #[macro_use]
 pub mod table;

--- a/applications/tari_validator_node_cli/src/main.rs
+++ b/applications/tari_validator_node_cli/src/main.rs
@@ -25,7 +25,7 @@ use std::{error::Error, path::PathBuf};
 use anyhow::anyhow;
 use multiaddr::{Multiaddr, Protocol};
 use reqwest::Url;
-use tari_validator_node_cli::{cli::Cli, command::Command};
+use tari_validator_node_cli::{cli::Cli, command::Command, key_manager::KeyManager};
 use tari_validator_node_client::ValidatorNodeClient;
 
 #[tokio::main(flavor = "current_thread")]
@@ -39,6 +39,12 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let base_dir = cli
         .base_dir
         .unwrap_or_else(|| dirs::home_dir().unwrap().join(".tari/vncli"));
+
+    // Create a key
+    let key_manager = KeyManager::init(&base_dir)?;
+    if key_manager.count() == 0 {
+        key_manager.create()?;
+    }
 
     log::info!("🌍️ Connecting to {}", endpoint);
     let client = ValidatorNodeClient::connect(endpoint)?;
@@ -54,7 +60,7 @@ async fn handle_command(command: Command, base_dir: PathBuf, client: ValidatorNo
     match command {
         Command::Vn(cmd) => cmd.handle(client).await?,
         Command::Templates(cmd) => cmd.handle(client).await?,
-        Command::Accounts(cmd) => cmd.handle(base_dir).await?,
+        Command::Keys(cmd) => cmd.handle(base_dir).await?,
         Command::Transactions(cmd) => cmd.handle(base_dir, client).await?,
         Command::Manifests(cmd) => cmd.handle()?,
     }


### PR DESCRIPTION
Description
---
- renames accounts command to keys
- create a new key automatically if one doesnt exist

Motivation and Context
---
accounts command was misnamed as it creates a keypair. Avoid having to explicitly create a keypair.

How Has This Been Tested?
---
Manually: Running the cli without previously creating a key
