### PR TITLE
feat: cerberus recovery

### DIFF
--- a/applications/tari_validator_node/proto/dan/network.proto
+++ b/applications/tari_validator_node/proto/dan/network.proto
@@ -1,24 +1,30 @@
 // Copyright 2021. The Tari Project
 //
-// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
-// following conditions are met:
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
 //
-// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
-// disclaimer.
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
 //
-// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
-// following disclaimer in the documentation and/or other materials provided with the distribution.
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
 //
-// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
-// products derived from this software without specific prior written permission.
+// 3. Neither the name of the copyright holder nor the names of its contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
-// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
-// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
-// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 syntax = "proto3";
 
 package tari.dan.network;
@@ -33,9 +39,12 @@ message DanMessage {
     tari.dan.consensus.VoteMessage vote = 2;
     tari.dan.transaction.Transaction new_transaction = 3;
     NetworkAnnounce network_announce = 4;
+    RecoveryMessage recovery_message = 6;
   }
 
-  // Message tag for debugging purposes. This is typically set to some identifier that groups a set of messages together e.g. payload ID, or is not provided at all.
+  // Message tag for debugging purposes. This is typically set to some
+  // identifier that groups a set of messages together e.g. payload ID, or is
+  // not provided at all.
   string message_tag = 5;
 }
 
@@ -49,4 +58,24 @@ message IdentitySignature {
   uint32 version = 1;
   tari.dan.common.Signature signature = 2;
   int64 updated_at = 3;
+}
+
+message RecoveryMessage {
+  oneof message {
+    MissingProposal missing_proposal = 1;
+    ElectionInProgress election_in_progress = 2;
+  }
+}
+
+message MissingProposal {
+  uint64 epoch = 1;
+  bytes shard_id = 2;
+  bytes payload_id = 3;
+  uint64 last_known_height = 4;
+}
+
+message ElectionInProgress {
+  uint64 epoch = 1;
+  bytes shard_id = 2;
+  bytes payload_id = 3;
 }

--- a/applications/tari_validator_node/src/bootstrap.rs
+++ b/applications/tari_validator_node/src/bootstrap.rs
@@ -106,6 +106,7 @@ pub async fn spawn_services(
         rx_vote_message,
         rx_new_transaction_message,
         rx_network_announce,
+        rx_recovery_message,
     } = message_receivers;
 
     // Networking
@@ -170,6 +171,7 @@ pub async fn spawn_services(
         mempool.clone(),
         payload_processor.clone(),
         rx_consensus_message,
+        rx_recovery_message,
         rx_vote_message,
         shutdown.clone(),
     );

--- a/applications/tari_validator_node/src/p2p/proto/conversions/network.rs
+++ b/applications/tari_validator_node/src/p2p/proto/conversions/network.rs
@@ -32,6 +32,7 @@ use tari_crypto::tari_utilities::ByteArray;
 use tari_dan_core::{
     message::{DanMessage, NetworkAnnounce},
     models::TariDanPayload,
+    workers::hotstuff_waiter::RecoveryMessage,
 };
 
 use crate::p2p::proto;
@@ -60,6 +61,12 @@ impl From<DanMessage<TariDanPayload, CommsPublicKey>> for proto::network::DanMes
                 )),
                 message_tag,
             },
+            DanMessage::RecoveryMessage(recovery_msg) => Self {
+                message: Some(proto::network::dan_message::Message::RecoveryMessage(
+                    (*recovery_msg).into(),
+                )),
+                message_tag,
+            },
         }
     }
 }
@@ -79,6 +86,9 @@ impl TryFrom<proto::network::DanMessage> for DanMessage<TariDanPayload, CommsPub
             },
             proto::network::dan_message::Message::NetworkAnnounce(msg) => {
                 Ok(DanMessage::NetworkAnnounce(Box::new(msg.try_into()?)))
+            },
+            proto::network::dan_message::Message::RecoveryMessage(msg) => {
+                Ok(DanMessage::RecoveryMessage(Box::new(msg.try_into()?)))
             },
         }
     }
@@ -141,6 +151,58 @@ impl<T: Borrow<IdentitySignature>> From<T> for proto::network::IdentitySignature
             version: u32::from(sig.version()),
             signature: Some(sig.signature().into()),
             updated_at: sig.updated_at().timestamp(),
+        }
+    }
+}
+
+// -------------------------------- RecoveryMessage -------------------------------- //
+impl TryFrom<proto::network::RecoveryMessage> for RecoveryMessage {
+    type Error = anyhow::Error;
+
+    fn try_from(value: proto::network::RecoveryMessage) -> Result<Self, Self::Error> {
+        let msg_type = value.message.ok_or_else(|| anyhow!("Message type not provided"))?;
+        match msg_type {
+            proto::network::recovery_message::Message::MissingProposal(msg) => Ok(RecoveryMessage::MissingProposal(
+                msg.epoch.into(),
+                msg.shard_id.try_into()?,
+                msg.payload_id.try_into()?,
+                msg.last_known_height.into(),
+            )),
+            proto::network::recovery_message::Message::ElectionInProgress(msg) => {
+                Ok(RecoveryMessage::ElectionInProgress(
+                    msg.epoch.into(),
+                    msg.shard_id.try_into()?,
+                    msg.payload_id.try_into()?,
+                ))
+            },
+        }
+    }
+}
+
+impl From<RecoveryMessage> for proto::network::RecoveryMessage {
+    fn from(value: RecoveryMessage) -> Self {
+        match value {
+            RecoveryMessage::MissingProposal(epoch, shard_id, payload_id, last_known_height) => {
+                proto::network::RecoveryMessage {
+                    message: Some(proto::network::recovery_message::Message::MissingProposal(
+                        proto::network::MissingProposal {
+                            epoch: epoch.0,
+                            shard_id: shard_id.into(),
+                            payload_id: payload_id.as_bytes().into(),
+                            last_known_height: last_known_height.0,
+                        },
+                    )),
+                }
+            },
+            RecoveryMessage::ElectionInProgress(epoch, shard_id, payload_id) => proto::network::RecoveryMessage {
+                message: Some(proto::network::recovery_message::Message::ElectionInProgress(
+                    proto::network::ElectionInProgress {
+                        epoch: epoch.0,
+                        shard_id: shard_id.into(),
+                        payload_id: payload_id.as_bytes().into(),
+                    },
+                )),
+            },
         }
     }
 }

--- a/applications/tari_validator_node/src/p2p/services/hotstuff/initializer.rs
+++ b/applications/tari_validator_node/src/p2p/services/hotstuff/initializer.rs
@@ -25,7 +25,10 @@ use std::sync::Arc;
 use tari_comms::{types::CommsPublicKey, NodeIdentity};
 use tari_dan_core::{
     models::{vote_message::VoteMessage, HotStuffMessage, TariDanPayload},
-    workers::events::{EventSubscription, HotStuffEvent},
+    workers::{
+        events::{EventSubscription, HotStuffEvent},
+        hotstuff_waiter::RecoveryMessage,
+    },
 };
 use tari_dan_storage_sqlite::sqlite_shard_store_factory::SqliteShardStore;
 use tari_shutdown::ShutdownSignal;
@@ -50,6 +53,7 @@ pub fn try_spawn(
     mempool: MempoolHandle,
     payload_processor: TariDanPayloadProcessor<TemplateManager>,
     rx_consensus_message: mpsc::Receiver<(CommsPublicKey, HotStuffMessage<TariDanPayload, CommsPublicKey>)>,
+    rx_recovery_message: mpsc::Receiver<(CommsPublicKey, RecoveryMessage)>,
     rx_vote_message: mpsc::Receiver<(CommsPublicKey, VoteMessage)>,
     shutdown: ShutdownSignal,
 ) -> EventSubscription<HotStuffEvent> {
@@ -61,6 +65,7 @@ pub fn try_spawn(
         payload_processor,
         shard_store,
         rx_consensus_message,
+        rx_recovery_message,
         rx_vote_message,
         shutdown,
     )

--- a/applications/tari_validator_node/src/p2p/services/messaging/dispatcher.rs
+++ b/applications/tari_validator_node/src/p2p/services/messaging/dispatcher.rs
@@ -62,6 +62,9 @@ impl MessageDispatcher {
                     .send((from, *announce))
                     .await
                     .ok(),
+                DanMessage::RecoveryMessage(msg) => {
+                    self.message_senders.tx_recovery_message.send((from, *msg)).await.ok()
+                },
             };
 
             if result.is_none() {

--- a/applications/tari_validator_node/src/p2p/services/messaging/mod.rs
+++ b/applications/tari_validator_node/src/p2p/services/messaging/mod.rs
@@ -37,6 +37,7 @@ use tari_comms::types::CommsPublicKey;
 use tari_dan_core::{
     message::NetworkAnnounce,
     models::{vote_message::VoteMessage, HotStuffMessage, TariDanPayload},
+    workers::hotstuff_waiter::RecoveryMessage,
 };
 use tari_dan_engine::transaction::Transaction;
 use tokio::sync::mpsc;
@@ -62,6 +63,7 @@ pub struct DanMessageSenders {
     pub tx_vote_message: mpsc::Sender<(CommsPublicKey, VoteMessage)>,
     pub tx_new_transaction_message: mpsc::Sender<Transaction>,
     pub tx_network_announce: mpsc::Sender<(CommsPublicKey, NetworkAnnounce<CommsPublicKey>)>,
+    pub tx_recovery_message: mpsc::Sender<(CommsPublicKey, RecoveryMessage)>,
 }
 
 #[derive(Debug)]
@@ -70,6 +72,7 @@ pub struct DanMessageReceivers {
     pub rx_vote_message: mpsc::Receiver<(CommsPublicKey, VoteMessage)>,
     pub rx_new_transaction_message: mpsc::Receiver<Transaction>,
     pub rx_network_announce: mpsc::Receiver<(CommsPublicKey, NetworkAnnounce<CommsPublicKey>)>,
+    pub rx_recovery_message: mpsc::Receiver<(CommsPublicKey, RecoveryMessage)>,
 }
 
 pub fn new_messaging_channel(size: usize) -> (DanMessageSenders, DanMessageReceivers) {
@@ -77,17 +80,20 @@ pub fn new_messaging_channel(size: usize) -> (DanMessageSenders, DanMessageRecei
     let (tx_vote_message, rx_vote_message) = mpsc::channel(size);
     let (tx_new_transaction_message, rx_new_transaction_message) = mpsc::channel(size);
     let (tx_network_announce, rx_network_announce) = mpsc::channel(size);
+    let (tx_recovery_message, rx_recovery_message) = mpsc::channel(size);
     let senders = DanMessageSenders {
         tx_consensus_message,
         tx_vote_message,
         tx_new_transaction_message,
         tx_network_announce,
+        tx_recovery_message,
     };
     let receivers = DanMessageReceivers {
         rx_consensus_message,
         rx_vote_message,
         rx_new_transaction_message,
         rx_network_announce,
+        rx_recovery_message,
     };
 
     (senders, receivers)

--- a/dan_layer/core/src/message.rs
+++ b/dan_layer/core/src/message.rs
@@ -25,7 +25,10 @@ use tari_comms::{multiaddr::Multiaddr, peer_manager::IdentitySignature};
 use tari_dan_common_types::NodeAddressable;
 use tari_dan_engine::transaction::Transaction;
 
-use crate::models::{vote_message::VoteMessage, HotStuffMessage};
+use crate::{
+    models::{vote_message::VoteMessage, HotStuffMessage},
+    workers::hotstuff_waiter::RecoveryMessage,
+};
 
 #[derive(Debug, Clone, Serialize)]
 pub enum DanMessage<TPayload, TAddr> {
@@ -36,6 +39,8 @@ pub enum DanMessage<TPayload, TAddr> {
     NewTransaction(Box<Transaction>),
     // Network
     NetworkAnnounce(Box<NetworkAnnounce<TAddr>>),
+    // Recovery
+    RecoveryMessage(Box<RecoveryMessage>),
 }
 
 impl<TPayload, TAddr: NodeAddressable> DanMessage<TPayload, TAddr> {
@@ -45,6 +50,7 @@ impl<TPayload, TAddr: NodeAddressable> DanMessage<TPayload, TAddr> {
             Self::VoteMessage(_) => "VoteMessage",
             Self::NewTransaction(_) => "NewTransaction",
             Self::NetworkAnnounce(_) => "NetworkAnnounce",
+            Self::RecoveryMessage(_) => "RecoveryMessage",
         }
     }
 
@@ -54,6 +60,7 @@ impl<TPayload, TAddr: NodeAddressable> DanMessage<TPayload, TAddr> {
             Self::VoteMessage(msg) => format!("node_{}", msg.local_node_hash()),
             Self::NewTransaction(tx) => format!("hash_{}", tx.hash()),
             Self::NetworkAnnounce(msg) => format!("pk_{}", msg.identity),
+            Self::RecoveryMessage(msg) => format!("recovery_{:?}", msg),
         }
     }
 }

--- a/dan_layer/core/src/models/vote_message.rs
+++ b/dan_layer/core/src/models/vote_message.rs
@@ -99,21 +99,22 @@ impl VoteMessage {
         let merkle_proof =
             MerkleProof::for_leaf_node(vn_mmr, leaf_index as usize).expect("Merkle proof generation failed");
 
-        let hash = vn_mmr_node_hash(signing_service.public_key(), &shard_id);
-        let root = vn_mmr.get_merkle_root().unwrap();
-        let idx = vn_mmr.find_leaf_index(&*hash).unwrap();
+        // let hash = vn_mmr_node_hash(signing_service.public_key(), &shard_id);
+        // let root = vn_mmr.get_merkle_root().unwrap();
+        // let idx = vn_mmr.find_leaf_index(&*hash).unwrap();
         // TODO: remove
-        if let Err(err) =
-            merkle_proof.verify::<tari_core::ValidatorNodeMmrHasherBlake256>(&root, &*hash, leaf_index as usize)
-        {
-            log::warn!(
-                target: "tari::dan_layer::votemessage",
-                "Merkle proof verification failed for validator node {:?} at index {:?} with error: {}",
-                hash,
-                idx,
-                err
-            );
-        }
+        // if let Err(err) =
+        //     merkle_proof.verify::<tari_core::ValidatorNodeMmrHasherBlake256>(&root, &*hash, leaf_index as usize)
+        // {
+        //     dbg!();
+        //     log::warn!(
+        //         target: "tari::dan_layer::votemessage",
+        //         "Merkle proof verification failed for validator node {:?} at index {:?} with error: {}",
+        //         hash,
+        //         idx,
+        //         err
+        //     );
+        // }
 
         let validator_metadata = ValidatorMetadata::new(
             signing_service.public_key().clone(),

--- a/dan_layer/core/src/services/leader_strategy.rs
+++ b/dan_layer/core/src/services/leader_strategy.rs
@@ -71,6 +71,14 @@ impl<TAddr: NodeAddressable> LeaderStrategy<TAddr> for AlwaysFirstLeader {
     }
 }
 
+pub struct RotatingLeader {}
+
+impl<TAddr: NodeAddressable> LeaderStrategy<TAddr> for RotatingLeader {
+    fn calculate_leader(&self, committee: &Committee<TAddr>, _payload: PayloadId, _shard: ShardId, round: u32) -> u32 {
+        round % (committee.len() as u32)
+    }
+}
+
 pub struct PayloadSpecificLeaderStrategy {}
 
 impl<TAddr: NodeAddressable> LeaderStrategy<TAddr> for PayloadSpecificLeaderStrategy {

--- a/dan_layer/core/src/storage/shard_store.rs
+++ b/dan_layer/core/src/storage/shard_store.rs
@@ -139,6 +139,11 @@ pub trait ShardStoreReadTransaction<TAddr: NodeAddressable, TPayload: Payload> {
         payload_height: NodeHeight,
         shards: &[ShardId],
     ) -> Result<Vec<HotStuffTreeNode<TAddr, TPayload>>, StorageError>;
+    fn get_last_payload_height_for_leader_proposal(
+        &self,
+        payload: PayloadId,
+        shard: ShardId,
+    ) -> Result<NodeHeight, StorageError>;
     fn has_vote_for(&self, from: &TAddr, node_hash: TreeNodeHash) -> Result<bool, StorageError>;
     fn get_received_votes_for(&self, node_hash: TreeNodeHash) -> Result<Vec<VoteMessage>, StorageError>;
     fn get_recent_transactions(&self) -> Result<Vec<RecentTransaction>, StorageError>;

--- a/dan_layer/core/src/workers/hotstuff_waiter.rs
+++ b/dan_layer/core/src/workers/hotstuff_waiter.rs
@@ -26,6 +26,8 @@ use std::{
 };
 
 use log::*;
+use rand::seq::SliceRandom;
+use serde::Serialize;
 use tari_common_types::types::{FixedHash, PublicKey, Signature};
 use tari_core::{ValidatorNodeMmr, ValidatorNodeMmrHasherBlake256};
 use tari_dan_common_types::{
@@ -78,7 +80,21 @@ use crate::{
 };
 
 const LOG_TARGET: &str = "tari::dan_layer::hotstuff_waiter";
-pub const NETWORK_LATENCY: Duration = Duration::from_secs(10);
+pub const NETWORK_LATENCY: Duration = Duration::from_secs(1);
+
+// This is the value that we wait over in the pacemaker. So when it trigger we know what triggered it.
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub enum PacemakerEvents {
+    LocalCommittee(Epoch, ShardId, PayloadId),
+    ForeignCommittee(Epoch, ShardId, PayloadId),
+}
+
+// Messages that are send between replicas in case of leader failure
+#[derive(Debug, Serialize, Clone)]
+pub enum RecoveryMessage {
+    MissingProposal(Epoch, ShardId, PayloadId, NodeHeight),
+    ElectionInProgress(Epoch, ShardId, PayloadId),
+}
 
 pub struct HotStuffWaiter<
     TPayload,
@@ -99,19 +115,25 @@ pub struct HotStuffWaiter<
     /// Received replica hotstuff messages, namely Proposal messages from the leader or
     /// NewView messages from replicas.
     rx_hs_message: Receiver<(TAddr, HotStuffMessage<TPayload, TAddr>)>,
+    /// Received replica recovery message, namely request for missing node, response election in progress.
+    rx_recovery_message: Receiver<(TAddr, RecoveryMessage)>,
     /// Received vote messages
     rx_votes: Receiver<(TAddr, VoteMessage)>,
     /// Hotstuff messages that should be delivered to the leader
     tx_leader: Sender<(TAddr, HotStuffMessage<TPayload, TAddr>)>,
     /// Hotstuff messages that should be delivered to the replicas
     tx_broadcast: Sender<(HotStuffMessage<TPayload, TAddr>, Vec<TAddr>)>,
+    /// Recovery messages that should be delivered to replica that initiated recovery
+    tx_recovery: Sender<(RecoveryMessage, TAddr)>,
+    /// Recovery messages that should be delivered to foreign committee
+    tx_recovery_broadcast: Sender<(RecoveryMessage, Vec<TAddr>)>,
     /// Vote messages that should be delivered to the leader
     tx_vote_message: Sender<(VoteMessage, TAddr)>,
     /// HotstuffEvent channel
     tx_events: broadcast::Sender<HotStuffEvent>,
     /// The pacemaker handle. Provides an interface to request timing leader responses
     #[allow(dead_code)]
-    pacemaker: PacemakerHandle<(PayloadId, ShardId, Committee<TAddr>)>,
+    pacemaker: PacemakerHandle<PacemakerEvents>,
     /// The payload processor. This determines whether a payload proposal results in an accepted or rejected vote.
     payload_processor: TPayloadProcessor,
     /// Store used to persist consensus state.
@@ -124,6 +146,11 @@ pub struct HotStuffWaiter<
     /// Network latency
     #[allow(dead_code)]
     network_latency: Duration,
+    // We store what round is for next leader selection, default is 0.
+    current_leader_round: HashMap<(ShardId, PayloadId), u32>,
+    // We have to store if we are in the middle of an election, so that when someone sends a recovery message, we can
+    // responde that we are voting and he should wait.
+    election_in_progress: HashSet<(ShardId, PayloadId)>,
 }
 
 impl<TPayload, TAddr, TLeaderStrategy, TEpochManager, TPayloadProcessor, TShardStore, TSigningService>
@@ -144,16 +171,20 @@ where
         leader_strategy: TLeaderStrategy,
         rx_new: Receiver<(TPayload, ShardId)>,
         rx_hs_message: Receiver<(TAddr, HotStuffMessage<TPayload, TAddr>)>,
+        rx_recovery_message: Receiver<(TAddr, RecoveryMessage)>,
         rx_votes: Receiver<(TAddr, VoteMessage)>,
         tx_leader: Sender<(TAddr, HotStuffMessage<TPayload, TAddr>)>,
         tx_broadcast: Sender<(HotStuffMessage<TPayload, TAddr>, Vec<TAddr>)>,
+        tx_recovery: Sender<(RecoveryMessage, TAddr)>,
+        tx_recovery_broadcast: Sender<(RecoveryMessage, Vec<TAddr>)>,
         tx_vote_message: Sender<(VoteMessage, TAddr)>,
         tx_events: broadcast::Sender<HotStuffEvent>,
-        pacemaker: PacemakerHandle<(PayloadId, ShardId, Committee<TAddr>)>,
+        pacemaker: PacemakerHandle<PacemakerEvents>,
         payload_processor: TPayloadProcessor,
         shard_store: TShardStore,
         shutdown: ShutdownSignal,
         consensus_constants: ConsensusConstants,
+        network_latency: Duration,
     ) -> JoinHandle<Result<(), HotStuffError>> {
         let waiter = HotStuffWaiter::new(
             signing_service,
@@ -162,15 +193,19 @@ where
             leader_strategy,
             rx_new,
             rx_hs_message,
+            rx_recovery_message,
             rx_votes,
             tx_leader,
             tx_broadcast,
+            tx_recovery,
+            tx_recovery_broadcast,
             tx_vote_message,
             tx_events,
             pacemaker,
             payload_processor,
             shard_store,
             consensus_constants,
+            network_latency,
         );
         tokio::spawn(waiter.run(shutdown))
     }
@@ -182,15 +217,19 @@ where
         leader_strategy: TLeaderStrategy,
         rx_new: Receiver<(TPayload, ShardId)>,
         rx_hs_message: Receiver<(TAddr, HotStuffMessage<TPayload, TAddr>)>,
+        rx_recovery_message: Receiver<(TAddr, RecoveryMessage)>,
         rx_votes: Receiver<(TAddr, VoteMessage)>,
         tx_leader: Sender<(TAddr, HotStuffMessage<TPayload, TAddr>)>,
         tx_broadcast: Sender<(HotStuffMessage<TPayload, TAddr>, Vec<TAddr>)>,
+        tx_recovery: Sender<(RecoveryMessage, TAddr)>,
+        tx_recovery_broadcast: Sender<(RecoveryMessage, Vec<TAddr>)>,
         tx_vote_message: Sender<(VoteMessage, TAddr)>,
         tx_events: broadcast::Sender<HotStuffEvent>,
-        pacemaker: PacemakerHandle<(PayloadId, ShardId, Committee<TAddr>)>,
+        pacemaker: PacemakerHandle<PacemakerEvents>,
         payload_processor: TPayloadProcessor,
         shard_store: TShardStore,
         consensus_constants: ConsensusConstants,
+        network_latency: Duration,
     ) -> Self {
         Self {
             signing_service,
@@ -199,9 +238,12 @@ where
             leader_strategy,
             rx_new,
             rx_hs_message,
+            rx_recovery_message,
             rx_votes,
             tx_leader,
             tx_broadcast,
+            tx_recovery,
+            tx_recovery_broadcast,
             tx_vote_message,
             tx_events,
             pacemaker,
@@ -209,19 +251,30 @@ where
             shard_store,
             consensus_constants,
             newview_message_counts: HashMap::new(),
-            network_latency: NETWORK_LATENCY,
+            network_latency,
+            current_leader_round: HashMap::new(),
+            election_in_progress: HashSet::new(),
         }
     }
 
     /// Step 1: A new payload has been received. The payload is persisted and all nodes send a NEWVIEW to the leader.
-    async fn on_next_sync_view(&self, payload: TPayload, shard: ShardId) -> Result<(), HotStuffError> {
+    async fn on_next_sync_view(&mut self, payload: TPayload, shard: ShardId) -> Result<(), HotStuffError> {
         let epoch = self.epoch_manager.current_epoch().await?;
 
         let payload_id = payload.to_id();
+        let involved_shards = payload.involved_shards();
+        let local_shards = self
+            .epoch_manager
+            .filter_to_local_shards(epoch, &self.public_key, &involved_shards)
+            .await?;
         debug!(target: LOG_TARGET, "on_next_sync_view started: {}", payload_id);
 
         let committee = self.epoch_manager.get_committee(epoch, shard).await?;
-        let leader = self.leader_strategy.get_leader(&committee, payload_id, shard, 0);
+        // Here the current_leader is always zero.
+        let current_leader = self.current_leader_round.entry((shard, payload_id)).or_default();
+        let leader = self
+            .leader_strategy
+            .get_leader(&committee, payload_id, shard, *current_leader);
 
         let new_view = self.shard_store.with_write_tx(|tx| {
             let high_qc = tx
@@ -255,6 +308,33 @@ where
             .send((leader.clone(), new_view))
             .await
             .map_err(|_| HotStuffError::SendError)?;
+        // We store that we are running an election, so we know what to send when other nodes asks.
+        self.election_in_progress.insert((shard, payload_id));
+        // There is a lower timeout for local committee (delta).
+        self.pacemaker
+            .start_timer(
+                PacemakerEvents::LocalCommittee(epoch, shard, payload_id),
+                self.network_latency,
+            )
+            .await
+            .unwrap();
+
+        // We wait for the foreign committee twice as long (2*delta).
+        // We start timer for each involved shard, the pacemaker will take care of the duplicates. Because if we are in
+        // more than one committees this can be called multiple times. We have to take care of the local shards. They
+        // are added separately above.
+        for shard in involved_shards {
+            if !local_shards.contains(&shard) {
+                // This is shard for foreign committee.
+                self.pacemaker
+                    .start_timer(
+                        PacemakerEvents::ForeignCommittee(epoch, shard, payload_id),
+                        self.network_latency * 2,
+                    )
+                    .await
+                    .unwrap();
+            }
+        }
         Ok(())
     }
 
@@ -376,7 +456,7 @@ where
     /// Step 5: A replica receives a Proposal from the leader. The replicas including the leader, validate the proposal
     /// and, once proposals for all shards have been received, send votes for all shards.
     async fn on_receive_proposal(
-        &self,
+        &mut self,
         from: TAddr,
         node: HotStuffTreeNode<TAddr, TPayload>,
     ) -> Result<(), HotStuffError> {
@@ -393,6 +473,23 @@ where
         );
 
         self.validate_proposal(&node)?;
+
+        // We remove the shard from pacemaker, so it will not trigger. We don't have to check if it's local shard or
+        // not, we just remove them both, one of them will not exists, but pacemaker will take care of that.
+        self.pacemaker
+            .stop_timer(PacemakerEvents::LocalCommittee(node.epoch(), node.shard(), payload_id))
+            .await?;
+
+        self.pacemaker
+            .stop_timer(PacemakerEvents::ForeignCommittee(
+                node.epoch(),
+                node.shard(),
+                payload_id,
+            ))
+            .await?;
+
+        // We did receive something from the leader, so he was elected.
+        self.election_in_progress.remove(&(node.shard(), payload_id));
 
         let shard = node.shard();
         let payload;
@@ -469,6 +566,182 @@ where
         self.finalize_payload(&involved_shards, &node).await?;
 
         Ok(())
+    }
+
+    // Pacemaker triggered for the local leader. Replica sends a newview.
+    async fn pacemaker_trigger_local_leader_fail(
+        &mut self,
+        epoch: Epoch,
+        payload_id: PayloadId,
+        shard_id: ShardId,
+    ) -> Result<(), HotStuffError> {
+        let high_qc = self
+            .shard_store
+            .create_read_tx()?
+            .get_high_qc_for(payload_id, shard_id)
+            .optional()?
+            .unwrap_or_else(|| QuorumCertificate::genesis(epoch, payload_id, shard_id));
+
+        // TODO: should we send this? the new leader probably has it
+        let payload = self.shard_store.create_read_tx()?.get_payload(&payload_id).unwrap();
+
+        // We leave the payload empty, this is just new round, so the nodes should have it.
+        let new_view = HotStuffMessage::new_view(high_qc, shard_id, payload);
+        let current_leader = self
+            .current_leader_round
+            .entry((shard_id, payload_id))
+            .and_modify(|round| *round += 1)
+            .or_default();
+        let committee = self.epoch_manager.get_committee(epoch, shard_id).await?;
+        let leader = self
+            .leader_strategy
+            .get_leader(&committee, payload_id, shard_id, *current_leader);
+        self.tx_leader
+            .send((leader.clone(), new_view))
+            .await
+            .map_err(|_| HotStuffError::SendError)?;
+        // Election started
+        self.election_in_progress.insert((shard_id, payload_id));
+        Ok(())
+    }
+
+    async fn pacemaker_trigger_foreign_leader_fail(
+        &self,
+        epoch: Epoch,
+        payload_id: PayloadId,
+        shard_id: ShardId,
+    ) -> Result<(), HotStuffError> {
+        // TODO: We should check if this is triggered second time. If that's the case, then foreign committee didn't
+        // responded to our first recovery request. So they probably can't reach consensus and this transaction should
+        // be thrown away.
+
+        // The foreign leader failed to send a proposal. Let's check what's going on in the
+        // foreign committee. We will asks f+1 nodes, so that at least one of the should be honest, so if the
+        // committee reached a decision, it will sent it back. Now broadcast to these nodes that I didn't
+        // received new proposal from their leader, someone should have it, or the QC was not reached. Send the
+        // last know height (0 in case we haven't received any proposal yet from this committee).
+        let foreign_committee = self.epoch_manager.get_committee(epoch, shard_id).await.unwrap();
+        let how_many_to_ask = foreign_committee.len() / 3 + 1; // f+1
+
+        // We select the subset of the committee by random.
+        let selected_foreing_committee_members: Vec<_> = foreign_committee
+            .members
+            .choose_multiple(&mut rand::thread_rng(), how_many_to_ask)
+            .cloned()
+            .collect();
+        let last_height = self
+            .shard_store
+            .create_read_tx()?
+            .get_last_payload_height_for_leader_proposal(payload_id, shard_id)?;
+        self.tx_recovery_broadcast
+            .send((
+                RecoveryMessage::MissingProposal(epoch, shard_id, payload_id, last_height),
+                selected_foreing_committee_members,
+            ))
+            .await
+            .unwrap();
+        self.pacemaker
+            .start_timer(
+                PacemakerEvents::ForeignCommittee(epoch, shard_id, payload_id),
+                self.network_latency * 2,
+            )
+            .await
+            .unwrap();
+        Ok(())
+    }
+
+    // Sender is asking if we have anything newer that he has from our local leader. That means that he didn't
+    // received response from our leader maybe there is nothing.
+    async fn on_receive_missing_proposal(
+        &self,
+        from: TAddr,
+        epoch: Epoch,
+        shard_id: ShardId,
+        payload_id: PayloadId,
+        last_height: NodeHeight,
+    ) -> Result<(), HotStuffError> {
+        // TODO maybe we should check that `from` is from someone from any committee on this transaction.
+        let leader_proposals =
+            self.shard_store
+                .create_write_tx()?
+                .get_leader_proposals(payload_id, last_height + NodeHeight(1), &[shard_id]);
+        // We know the last payload, so we check if we have higher height
+        if let Ok(result) = leader_proposals {
+            assert!(
+                result.len() <= 1,
+                "We can't have more than one proposal at certain height for one particular shard"
+            );
+            // TODO: I should receive messages only for shard_id where I'm part of the committee.
+            // Do we have such a node? If not, maybe our leader failed. So I don't send anything and this node will
+            // receive its own pacemaker trigger as well.
+            if let Some(node) = result.get(0) {
+                // We use the leader channel, but for the node it doesn't really matter, because it doesn't check where
+                // is the node coming from as long it's valid.
+                self.tx_leader
+                    .send((from, HotStuffMessage::new_proposal(node.clone(), shard_id)))
+                    .await?;
+            } else {
+                // Maybe we are selecting a new leader right now.
+                if self.election_in_progress.contains(&(shard_id, payload_id)) {
+                    self.tx_recovery
+                        .send((RecoveryMessage::ElectionInProgress(epoch, shard_id, payload_id), from))
+                        .await?;
+                }
+                // If we don't send anything, that means the TX is invalid, this will also trigger invalid in all
+                // committees that are asking us for update.
+            }
+        }
+        Ok(())
+    }
+
+    // We are running a pacemaker for the proposal. But the other committee is still having an election. Let's postpone
+    // the pacemaker.
+    async fn on_receive_election_in_progress(
+        &self,
+        _from: TAddr,
+        epoch: Epoch,
+        shard_id: ShardId,
+        payload_id: PayloadId,
+    ) -> Result<(), HotStuffError> {
+        // TODO: if there is a byzantine replica, he can always send election in progress. We should count the election
+        // rounds. Be aware that the election rounds are based on delta time, and this trigger is 2*delta.
+        // We restart the timer.
+        self.pacemaker
+            .stop_timer(PacemakerEvents::ForeignCommittee(epoch, shard_id, payload_id))
+            .await?;
+        self.pacemaker
+            .start_timer(
+                PacemakerEvents::ForeignCommittee(epoch, shard_id, payload_id),
+                self.network_latency * 2,
+            )
+            .await?;
+        Ok(())
+    }
+
+    async fn on_receive_recovery_message(&self, from: TAddr, msg: RecoveryMessage) -> Result<(), HotStuffError> {
+        match msg {
+            RecoveryMessage::MissingProposal(epoch, shard_id, payload_id, last_height) => {
+                self.on_receive_missing_proposal(from, epoch, shard_id, payload_id, last_height)
+                    .await
+            },
+            RecoveryMessage::ElectionInProgress(epoch, shard_id, payload_id) => {
+                self.on_receive_election_in_progress(from, epoch, shard_id, payload_id)
+                    .await
+            },
+        }
+    }
+
+    async fn on_pacemaker_trigger(&mut self, message: PacemakerEvents) -> Result<(), HotStuffError> {
+        match message {
+            PacemakerEvents::LocalCommittee(epoch, shard_id, payload_id) => {
+                self.pacemaker_trigger_local_leader_fail(epoch, payload_id, shard_id)
+                    .await
+            },
+            PacemakerEvents::ForeignCommittee(epoch, shard_id, payload_id) => {
+                self.pacemaker_trigger_foreign_leader_fail(epoch, payload_id, shard_id)
+                    .await
+            },
+        }
     }
 
     /// Checks that all pledges have been resolved (completed/abandoned). If so, atomically commit the changeset for the
@@ -630,6 +903,18 @@ where
         for node in proposed_nodes {
             // Check that this node is a node we need to vote on
             if !local_shards.contains(&node.shard()) {
+                if node.payload_phase() != HotstuffPhase::Decide &&
+                    !(is_all_rejected && node.payload_phase() == HotstuffPhase::PreCommit)
+                {
+                    // If we are not in decide phase, we are going to send a vote, we expect that the vote will be
+                    // propagated to foreign committees and that we will get a proposal from respective foreing leaders.
+                    self.pacemaker
+                        .start_timer(
+                            PacemakerEvents::ForeignCommittee(epoch, node.shard(), payload_id),
+                            self.network_latency * 2,
+                        )
+                        .await?;
+                }
                 continue;
             }
 
@@ -677,6 +962,13 @@ where
 
             let leader = self.get_leader(&node).await?;
             self.tx_vote_message.send((vote_msg, leader)).await?;
+            // We add timer for each local committee.
+            self.pacemaker
+                .start_timer(
+                    PacemakerEvents::LocalCommittee(epoch, node.shard(), payload_id),
+                    self.network_latency,
+                )
+                .await?;
         }
 
         if is_all_rejected {
@@ -1040,9 +1332,16 @@ where
         shard: ShardId,
         committee: &Committee<TAddr>,
     ) -> Result<bool, HotStuffError> {
-        Ok(self
-            .leader_strategy
-            .is_leader(&self.public_key, committee, payload, shard, 0))
+        // TODO: What if the leader doesn't know that he is the leader? e.g. didn't get the message. The leader (index
+        // 0) failed. Now index 1 should be leader, but he doesn't know, so he ignores the newviews (should we ignore
+        // the newviews?)
+        Ok(self.leader_strategy.is_leader(
+            &self.public_key,
+            committee,
+            payload,
+            shard,
+            *self.current_leader_round.get(&(shard, payload)).unwrap_or(&0),
+        ))
     }
 
     async fn validate_from_committee(&self, from: &TAddr, epoch: Epoch, shard: ShardId) -> Result<(), HotStuffError> {
@@ -1439,6 +1738,18 @@ where
                         error!(target: LOG_TARGET, "Error while processing vote (on_receive_vote): {}", e);
                     }
                 },
+                Some((from,msg)) = self.rx_recovery_message.recv() => {
+                    debug!(target:LOG_TARGET, "Received recovery message from {}", from);
+                    if let Err(e) = self.on_receive_recovery_message(from, msg).await {
+                        error!(target: LOG_TARGET, "Error while processing recovery message (on_receive_recovery_message): {}", e);
+                    }
+                },
+                Some(timeout) = self.pacemaker.on_timeout() => {
+                    debug!(target:LOG_TARGET, "Received timeout message for {:?}", timeout);
+                    if let Err(e) = self.on_pacemaker_trigger(timeout).await {
+                        error!(target: LOG_TARGET, "Error while processing timeout message (on_timeout): {}", e);
+                    }
+                }
                 _ = shutdown.wait() => {
                     info!(target: LOG_TARGET, "💤 Shutting down");
                     break;

--- a/dan_layer/integration_tests/src/test_consensus.rs
+++ b/dan_layer/integration_tests/src/test_consensus.rs
@@ -639,13 +639,11 @@ async fn test_local_leader_failure_after_on_receive_proposal() {
         .send((node2.clone(), new_view_message.clone()))
         .await
         .unwrap();
-    dbg!();
     instance1
         .tx_hs_messages
         .send((node1.clone(), new_view_message.clone()))
         .await
         .unwrap();
-    dbg!();
     // Get the node hash from the proposal
     let (proposal_message, _broadcast_group) = instance1.recv_broadcast().await;
 
@@ -805,7 +803,7 @@ async fn get_message_to_leader(
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_leader_fail_only_locally() {
+async fn test_leader_fails_only_locally() {
     // let mut builder = Builder::new();
     // builder.filter_level(log::LevelFilter::Info);
     // builder.init();

--- a/dan_layer/integration_tests/src/test_consensus.rs
+++ b/dan_layer/integration_tests/src/test_consensus.rs
@@ -802,6 +802,7 @@ async fn get_message_to_leader(
     .await
 }
 
+#[allow(clippy::too_many_lines)]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_leader_fails_only_locally() {
     // let mut builder = Builder::new();

--- a/dan_layer/integration_tests/src/test_consensus.rs
+++ b/dan_layer/integration_tests/src/test_consensus.rs
@@ -25,14 +25,27 @@ use std::{collections::HashMap, sync::Arc, time::Duration};
 use lazy_static::lazy_static;
 use rand::rngs::OsRng;
 use tari_common_types::types::{PrivateKey, PublicKey};
-use tari_comms::{multiaddr::Multiaddr, peer_manager::PeerFeatures, NodeIdentity};
+use tari_comms::{
+    multiaddr::Multiaddr,
+    peer_manager::PeerFeatures,
+    protocol::rpc::__macro_reexports::future::join_all,
+    NodeIdentity,
+};
 use tari_core::ValidatorNodeMmr;
-use tari_crypto::keys::PublicKey as PublicKeyT;
-use tari_dan_common_types::{vn_mmr_node_hash, Epoch, QuorumCertificate, QuorumDecision, ShardId};
+use tari_crypto::{
+    keys::PublicKey as PublicKeyT,
+    ristretto::{RistrettoPublicKey, RistrettoSecretKey},
+};
+use tari_dan_common_types::{vn_mmr_node_hash, Epoch, NodeHeight, QuorumCertificate, QuorumDecision, ShardId};
 use tari_dan_core::{
-    models::{vote_message::VoteMessage, HotStuffMessage, Payload, TariDanPayload},
-    services::{epoch_manager::RangeEpochManager, leader_strategy::AlwaysFirstLeader, NodeIdentitySigningService},
+    models::{vote_message::VoteMessage, HotStuffMessage, HotstuffPhase, Payload, TariDanPayload},
+    services::{
+        epoch_manager::{EpochManager, RangeEpochManager},
+        leader_strategy::{AlwaysFirstLeader, RotatingLeader},
+        NodeIdentitySigningService,
+    },
     storage::shard_store::{ShardStore, ShardStoreWriteTransaction},
+    workers::hotstuff_waiter::RecoveryMessage,
 };
 use tari_dan_engine::transaction::{Transaction, TransactionBuilder};
 use tari_engine_types::instruction::Instruction;
@@ -102,6 +115,10 @@ fn create_test_qc(
 lazy_static! {
     static ref SHARD0: ShardId = ShardId::zero();
     static ref SHARD1: ShardId = ShardId([1u8; 32]);
+    static ref SHARD2: ShardId = ShardId([2u8; 32]);
+    static ref SHARD3: ShardId = ShardId([3u8; 32]);
+    static ref NEVER: Duration = Duration::from_secs(86400); // 1 day, can't use MAX, because there is multiplicator in the hotstuff_waitter
+    static ref ONE_SEC: Duration = Duration::from_secs(1);
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -110,7 +127,13 @@ async fn test_receives_new_payload_starts_new_chain() {
     let (node1_pk, node1) = PublicKey::random_keypair(&mut OsRng);
     let registered_vn_keys = vec![node1.clone()];
     let epoch_manager = RangeEpochManager::new(registered_vn_keys, *SHARD0..*SHARD1, vec![node1.clone()]);
-    let mut instance = HsTestHarness::new(node1_pk.clone(), node1.clone(), epoch_manager, AlwaysFirstLeader {});
+    let mut instance = HsTestHarness::new(
+        node1_pk.clone(),
+        node1.clone(),
+        epoch_manager,
+        AlwaysFirstLeader {},
+        *NEVER,
+    );
 
     let new_payload = TariDanPayload::new(Transaction::builder().sign(&node1_pk).clone().build());
     instance.tx_new.send((new_payload, *SHARD0)).await.unwrap();
@@ -126,7 +149,13 @@ async fn test_hs_waiter_leader_proposes() {
     let registered_vn_keys = vec![node1.clone(), node2.clone()];
     let epoch_manager =
         RangeEpochManager::new(registered_vn_keys, *SHARD0..*SHARD1, vec![node1.clone(), node2.clone()]);
-    let mut instance = HsTestHarness::new(node1_pk.clone(), node1.clone(), epoch_manager, AlwaysFirstLeader {});
+    let mut instance = HsTestHarness::new(
+        node1_pk.clone(),
+        node1.clone(),
+        epoch_manager,
+        AlwaysFirstLeader {},
+        *NEVER,
+    );
     // let payload = ("Hello World".to_string(), vec![*SHARD0]);
     let payload = TariDanPayload::new(
         Transaction::builder()
@@ -170,7 +199,13 @@ async fn test_hs_waiter_replica_sends_vote_for_proposal() {
     let registered_vn_keys = vec![node1.clone(), node2.clone()];
     let epoch_manager =
         RangeEpochManager::new(registered_vn_keys, *SHARD0..*SHARD1, vec![node1.clone(), node2.clone()]);
-    let mut instance = HsTestHarness::new(node1_pk.clone(), node1.clone(), epoch_manager, AlwaysFirstLeader {});
+    let mut instance = HsTestHarness::new(
+        node1_pk.clone(),
+        node1.clone(),
+        epoch_manager,
+        AlwaysFirstLeader {},
+        *NEVER,
+    );
     // let payload = ("Hello World".to_string(), vec![*SHARD0]);
     let payload = TariDanPayload::new(
         Transaction::builder()
@@ -233,7 +268,13 @@ async fn test_hs_waiter_leader_sends_new_proposal_when_enough_votes_are_received
 
     let epoch_manager =
         RangeEpochManager::new(registered_vn_keys, *SHARD0..*SHARD1, vec![node1.clone(), node2.clone()]);
-    let mut instance = HsTestHarness::new(node1_pk.clone(), node1.clone(), epoch_manager, AlwaysFirstLeader {});
+    let mut instance = HsTestHarness::new(
+        node1_pk.clone(),
+        node1.clone(),
+        epoch_manager,
+        AlwaysFirstLeader {},
+        *NEVER,
+    );
     let payload = TariDanPayload::new(
         Transaction::builder()
             .add_input(*SHARD0)
@@ -306,7 +347,13 @@ async fn test_hs_waiter_execute_called_at_prepare_phase_only() {
     let (node1_pk, node1) = PublicKey::random_keypair(&mut OsRng);
     let registered_vn_keys = vec![node1.clone()];
     let epoch_manager = RangeEpochManager::new(registered_vn_keys, *SHARD0..*SHARD1, vec![node1.clone()]);
-    let mut instance = HsTestHarness::new(node1_pk.clone(), node1.clone(), epoch_manager, AlwaysFirstLeader {});
+    let mut instance = HsTestHarness::new(
+        node1_pk.clone(),
+        node1.clone(),
+        epoch_manager,
+        AlwaysFirstLeader {},
+        *NEVER,
+    );
     let payload = TariDanPayload::new(
         Transaction::builder()
             .add_input(*SHARD0)
@@ -374,15 +421,22 @@ async fn test_hs_waiter_multishard_votes() {
     let registered_vn_keys = vec![node1.clone(), node2.clone()];
     let epoch_manager = RangeEpochManager::new_with_multiple(registered_vn_keys, &[
         (*SHARD0..*SHARD1, shard0_committee),
-        (*SHARD1..ShardId([2u8; 32]), shard1_committee),
+        (*SHARD1..*SHARD2, shard1_committee),
     ]);
     let mut node1_instance = HsTestHarness::new(
         node1_pk.clone(),
         node1.clone(),
         epoch_manager.clone(),
         AlwaysFirstLeader {},
+        *NEVER,
     );
-    let mut node2_instance = HsTestHarness::new(node2_pk.clone(), node2.clone(), epoch_manager, AlwaysFirstLeader {});
+    let mut node2_instance = HsTestHarness::new(
+        node2_pk.clone(),
+        node2.clone(),
+        epoch_manager,
+        AlwaysFirstLeader {},
+        *NEVER,
+    );
 
     let payload = TariDanPayload::new(
         Transaction::builder()
@@ -468,6 +522,477 @@ async fn test_hs_waiter_multishard_votes() {
 
     node1_instance.assert_shuts_down_safely().await;
     node2_instance.assert_shuts_down_safely().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_local_leader_failure_after_on_next_sync_view() {
+    let (node1_pk, node1) = PublicKey::random_keypair(&mut OsRng);
+    let (node2_pk, node2) = PublicKey::random_keypair(&mut OsRng);
+    let registered_vn_keys = vec![node1.clone(), node2.clone()];
+
+    let epoch_manager =
+        RangeEpochManager::new(registered_vn_keys, *SHARD0..*SHARD1, vec![node1.clone(), node2.clone()]);
+    let mut instance = HsTestHarness::new(
+        node2_pk.clone(),
+        node2.clone(),
+        epoch_manager.clone(),
+        RotatingLeader {},
+        *ONE_SEC,
+    );
+    let payload = TariDanPayload::new(
+        Transaction::builder()
+            .add_input(*SHARD0)
+            // .add_output(*SHARD1)
+            .sign(&node1_pk)
+            .clone()
+            .build(),
+    );
+
+    instance.tx_new.send((payload.clone(), *SHARD0)).await.unwrap();
+    assert!(
+        timeout(Duration::from_secs(1), instance.rx_leader.recv()).await.is_ok(),
+        "node2 should have sent the vote from the new_sync_view"
+    );
+    // In the meantime we can test asking for recovery
+    instance
+        .tx_recovery_messages
+        .send((
+            node1,
+            RecoveryMessage::MissingProposal(
+                epoch_manager.current_epoch().await.unwrap(),
+                *SHARD0,
+                payload.to_id(),
+                NodeHeight(0),
+            ),
+        ))
+        .await
+        .unwrap();
+    // Awaiting recovery response
+    let mut recovery_response = None;
+    assert!(
+        timeout(Duration::from_secs(1), async {
+            recovery_response = instance.rx_recovery.recv().await;
+        })
+        .await
+        .is_ok(),
+        "node2 should send recovery response"
+    );
+    // Let's check if the node sent ElectionInProgress
+    assert!(matches!(
+        recovery_response.unwrap().0,
+        RecoveryMessage::ElectionInProgress(_, _, _)
+    ));
+    let mut vote = None;
+    assert!(
+        timeout(Duration::from_secs(2), async {
+            vote = instance.rx_leader.recv().await;
+        })
+        .await
+        .is_ok(),
+        "node2 should vote again, but this time different leader"
+    );
+    assert_eq!(vote.unwrap().0, node2, "node2 should be next leader in order");
+    instance.assert_shuts_down_safely().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_local_leader_failure_after_on_receive_proposal() {
+    let (node1_pk, node1) = PublicKey::random_keypair(&mut OsRng);
+    let (node2_pk, node2) = PublicKey::random_keypair(&mut OsRng);
+    let registered_vn_keys = vec![node1.clone(), node2.clone()];
+
+    let epoch_manager =
+        RangeEpochManager::new(registered_vn_keys, *SHARD0..*SHARD1, vec![node1.clone(), node2.clone()]);
+    let mut instance1 = HsTestHarness::new(
+        node1_pk.clone(),
+        node1.clone(),
+        epoch_manager.clone(),
+        RotatingLeader {},
+        *ONE_SEC,
+    );
+    let mut instance2 = HsTestHarness::new(
+        node2_pk.clone(),
+        node2.clone(),
+        epoch_manager.clone(),
+        RotatingLeader {},
+        *ONE_SEC,
+    );
+    let payload = TariDanPayload::new(
+        Transaction::builder()
+            .add_input(*SHARD0)
+            .sign(&node1_pk)
+            .clone()
+            .build(),
+    );
+    // Let's call on_next_sync_view on node2, that way it knows later that it already voted for node1
+    instance2.tx_new.send((payload.clone(), *SHARD0)).await.unwrap();
+
+    let qc = create_test_default_qc(
+        vec![(node1.clone(), node1_pk.clone()), (node2.clone(), node2_pk.clone())],
+        vec![node1.clone(), node2.clone()],
+        &payload,
+    );
+    // The node1 receives new views from both node.
+    let new_view_message = HotStuffMessage::new_view(qc, *SHARD0, payload.clone());
+    instance1
+        .tx_hs_messages
+        .send((node2.clone(), new_view_message.clone()))
+        .await
+        .unwrap();
+    dbg!();
+    instance1
+        .tx_hs_messages
+        .send((node1.clone(), new_view_message.clone()))
+        .await
+        .unwrap();
+    dbg!();
+    // Get the node hash from the proposal
+    let (proposal_message, _broadcast_group) = instance1.recv_broadcast().await;
+
+    // Now we send the proposal to node2
+    instance2
+        .tx_hs_messages
+        .send((node1.clone(), proposal_message))
+        .await
+        .expect("Should not error");
+
+    // The node2 should send a vote back to leader
+    assert!(
+        timeout(Duration::from_secs(1), instance2.rx_leader.recv())
+            .await
+            .is_ok(),
+        "node2 should vote for this proposal"
+    );
+
+    // Node2 will not receive a response for it's vote, so it will trigger new election process.
+    let mut vote = None;
+    assert!(
+        timeout(Duration::from_secs(4), async {
+            vote = instance2.rx_leader.recv().await;
+        })
+        .await
+        .is_ok(),
+        "node2 should vote again, but this time different leader"
+    );
+    assert_eq!(vote.unwrap().0, node2, "node2 should be next leader in order");
+    instance1.assert_shuts_down_safely().await;
+    instance2.assert_shuts_down_safely().await;
+}
+
+async fn committee_sends_new_view(
+    payload: TariDanPayload,
+    committee: &[PublicKey],
+    instances: &mut [HsTestHarness],
+    shard: ShardId,
+) -> Option<(
+    HotStuffMessage<TariDanPayload, RistrettoPublicKey>,
+    Vec<RistrettoPublicKey>,
+)> {
+    let mut new_views = Vec::new();
+    for instance in instances.iter_mut() {
+        instance.tx_new.send((payload.clone(), shard)).await.unwrap();
+        let mut new_view = None;
+        assert!(
+            timeout(Duration::from_secs(2), async {
+                new_view = instance.rx_leader.recv().await;
+            })
+            .await
+            .is_ok(),
+            "new view should be sent"
+        );
+        new_views.push(new_view);
+    }
+    // Send these to the leader.
+    for (new_view, public_key) in new_views.iter_mut().zip(committee.iter()) {
+        instances[0]
+            .tx_hs_messages
+            .send((public_key.clone(), new_view.take().unwrap().1))
+            .await
+            .unwrap();
+    }
+    let mut proposal = None;
+    assert!(
+        timeout(Duration::from_secs(1), async {
+            proposal = instances[0].rx_broadcast.recv().await;
+        })
+        .await
+        .is_ok(),
+        "Leader should send proposal"
+    );
+    proposal
+}
+
+async fn get_votes(instances: &mut [HsTestHarness]) -> Vec<(VoteMessage, PublicKey)> {
+    let votes = timeout(
+        Duration::from_secs(1),
+        join_all(
+            instances
+                .iter_mut()
+                .map(|instance| instance.rx_vote_message.recv())
+                .collect::<Vec<_>>(),
+        ),
+    )
+    .await;
+    assert!(votes.is_ok(), "Failed to receive votes");
+    let votes = votes.unwrap();
+    assert!(votes.iter().all(Option::is_some), "Failed to get nodes");
+    votes.into_iter().map(|vote| vote.unwrap()).collect()
+}
+
+async fn send_votes_to_leader(leader_instance: &HsTestHarness, votes: Vec<VoteMessage>, committee: &[PublicKey]) {
+    assert!(
+        timeout(
+            Duration::from_secs(1),
+            join_all(
+                votes
+                    .into_iter()
+                    .zip(committee.iter())
+                    .map(|(vote, public_key)| leader_instance.tx_votes.send((public_key.clone(), vote)))
+                    .collect::<Vec<_>>(),
+            )
+        )
+        .await
+        .is_ok(),
+        "Failed to send votes to the leader"
+    );
+}
+
+async fn send_proposal_to_committee(
+    leader: &RistrettoPublicKey,
+    proposal: &HotStuffMessage<TariDanPayload, RistrettoPublicKey>,
+    instances: &[HsTestHarness],
+) {
+    let mut sends = Vec::new();
+    assert!(
+        timeout(Duration::from_secs(1), async {
+            sends = join_all(
+                instances
+                    .iter()
+                    .map(|instance| instance.tx_hs_messages.send((leader.clone(), proposal.clone())))
+                    .collect::<Vec<_>>(),
+            )
+            .await;
+        })
+        .await
+        .is_ok(),
+        "Failed to send proposal to the committee"
+    );
+    assert!(sends.iter().all(Result::is_ok), "Not all sends succeeded");
+}
+
+// async fn get_recovery_messages(
+//     instances: &mut Vec<HsTestHarness>,
+// ) -> Vec<Option<(RecoveryMessage, Vec<RistrettoPublicKey>)>> {
+//     join_all(
+//         instances
+//             .iter_mut()
+//             .map(|instance| instance.rx_recovery_broadcast.recv())
+//             .collect::<Vec<_>>(),
+//     )
+//     .await
+// }
+
+async fn get_message_to_leader(
+    instances: &mut [HsTestHarness],
+) -> Vec<Option<(RistrettoPublicKey, HotStuffMessage<TariDanPayload, RistrettoPublicKey>)>> {
+    join_all(
+        instances
+            .iter_mut()
+            .map(|instance| instance.rx_leader.recv())
+            .collect::<Vec<_>>(),
+    )
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_leader_fail_only_locally() {
+    // let mut builder = Builder::new();
+    // builder.filter_level(log::LevelFilter::Info);
+    // builder.init();
+    // We create 2 committees
+    // Committee0 will fail only locally
+    let committee0 = (0..4)
+        .map(|_| PublicKey::random_keypair(&mut OsRng))
+        .collect::<Vec<(RistrettoSecretKey, RistrettoPublicKey)>>();
+    // Committee1 will work fine
+    let committee1 = (0..1)
+        .map(|_| PublicKey::random_keypair(&mut OsRng))
+        .collect::<Vec<(RistrettoSecretKey, RistrettoPublicKey)>>();
+    let mut shard0_committee = committee0
+        .iter()
+        .map(|(_, public)| public.clone())
+        .collect::<Vec<RistrettoPublicKey>>();
+    let shard1_committee = committee1
+        .iter()
+        .map(|(_, public)| public.clone())
+        .collect::<Vec<RistrettoPublicKey>>();
+    let payload = TariDanPayload::new(
+        Transaction::builder()
+            .with_inputs(vec![*SHARD0, *SHARD1])
+            .sign(&committee0[0].0)
+            .clone()
+            .build(),
+    );
+    let registered_vn_keys = shard0_committee
+        .iter()
+        .chain(shard1_committee.iter())
+        .cloned()
+        .collect();
+    let epoch_manager = RangeEpochManager::new_with_multiple(registered_vn_keys, &[
+        (*SHARD0..*SHARD1, shard0_committee.clone()),
+        (*SHARD1..*SHARD2, shard1_committee.clone()),
+    ]);
+    let mut committee0_instances = committee0
+        .iter()
+        .map(|(private, public)| {
+            HsTestHarness::new(
+                private.clone(),
+                public.clone(),
+                epoch_manager.clone(),
+                RotatingLeader {},
+                *ONE_SEC,
+            )
+        })
+        .collect::<Vec<HsTestHarness>>();
+    let mut committee1_instances = committee1
+        .iter()
+        .map(|(private, public)| {
+            HsTestHarness::new(
+                private.clone(),
+                public.clone(),
+                epoch_manager.clone(),
+                RotatingLeader {},
+                *NEVER,
+            )
+        })
+        .collect::<Vec<HsTestHarness>>();
+    let prepare_proposal0 =
+        committee_sends_new_view(payload.clone(), &shard0_committee, &mut committee0_instances, *SHARD0)
+            .await
+            .unwrap()
+            .0;
+    assert_eq!(
+        prepare_proposal0.node().unwrap().payload_phase(),
+        HotstuffPhase::Prepare
+    );
+    let prepare_proposal1 =
+        committee_sends_new_view(payload.clone(), &shard1_committee, &mut committee1_instances, *SHARD1)
+            .await
+            .unwrap()
+            .0;
+    assert_eq!(
+        prepare_proposal1.node().unwrap().payload_phase(),
+        HotstuffPhase::Prepare
+    );
+    // Committee0 leader will now send only to foreigners, fails only locally.
+    send_proposal_to_committee(&shard0_committee[0], &prepare_proposal0, &committee1_instances).await;
+    // Now the leader goes offline.
+    shard0_committee.remove(0);
+    committee0_instances.remove(0);
+
+    // Committee1 will act normally.
+    send_proposal_to_committee(&shard1_committee[0], &prepare_proposal1, &committee0_instances).await;
+    send_proposal_to_committee(&shard1_committee[0], &prepare_proposal1, &committee1_instances).await;
+
+    // Committee1 can proceed normally.
+    let votes1 = get_votes(&mut committee1_instances)
+        .await
+        .into_iter()
+        .map(|a| a.0)
+        .collect::<Vec<_>>();
+    send_votes_to_leader(&committee1_instances[0], votes1, &shard1_committee).await;
+    let pre_commit_proposal1 = timeout(Duration::from_secs(1), committee1_instances[0].rx_broadcast.recv()).await;
+    assert!(pre_commit_proposal1.is_ok(), "The leader proposal should be send");
+    let pre_commit_proposal1 = pre_commit_proposal1.unwrap().unwrap().0;
+    assert_eq!(
+        pre_commit_proposal1.node().unwrap().payload_phase(),
+        HotstuffPhase::PreCommit
+    );
+    send_proposal_to_committee(&shard1_committee[0], &pre_commit_proposal1, &committee0_instances).await;
+    send_proposal_to_committee(&shard1_committee[0], &pre_commit_proposal1, &committee1_instances).await;
+
+    // Now the trigger of local leader failure will happen in committe0.
+    let mut to_leader_messages = Vec::new();
+    assert!(
+        timeout(*ONE_SEC * 2, async {
+            to_leader_messages = get_message_to_leader(&mut committee0_instances).await;
+        })
+        .await
+        .is_ok(),
+        "everyone in the committee0 should send a newview message"
+    );
+    // The leader should be rotate to index 1
+    // Send the new view message to the new leader (index 1)
+    join_all(
+        to_leader_messages
+            .into_iter()
+            .zip(shard0_committee.iter())
+            .map(|(msg, public_key)| {
+                let hs_msg = msg.unwrap().1;
+                committee0_instances[0]
+                    .tx_hs_messages
+                    .send((public_key.clone(), hs_msg))
+            })
+            .collect::<Vec<_>>(),
+    )
+    .await;
+
+    let prepare_proposal0 = timeout(Duration::from_secs(1), committee0_instances[0].rx_broadcast.recv()).await;
+    let prepare_proposal0 = prepare_proposal0.unwrap().unwrap().0;
+    assert_eq!(
+        prepare_proposal0.node().unwrap().payload_phase(),
+        HotstuffPhase::Prepare
+    );
+    send_proposal_to_committee(&shard0_committee[0], &prepare_proposal0, &committee0_instances).await;
+    send_proposal_to_committee(&shard0_committee[0], &prepare_proposal0, &committee1_instances).await;
+    // Committe1 should not react for the proposal, because it acted on the previous one for the same height.
+    let votes0 = get_votes(&mut committee0_instances).await;
+    send_votes_to_leader(
+        &committee0_instances[0],
+        votes0.into_iter().map(|vote| vote.0).collect::<Vec<_>>(),
+        &shard0_committee,
+    )
+    .await;
+    let pre_commit_proposal0 = timeout(Duration::from_secs(1), committee0_instances[0].rx_broadcast.recv()).await;
+    assert!(
+        pre_commit_proposal0.is_ok(),
+        "leader of committee0 should send proposal"
+    );
+    let pre_commit_proposal0 = pre_commit_proposal0.unwrap().unwrap().0;
+    assert_eq!(
+        pre_commit_proposal0.node().unwrap().payload_phase(),
+        HotstuffPhase::PreCommit
+    );
+    send_proposal_to_committee(&shard0_committee[0], &pre_commit_proposal0, &committee0_instances).await;
+    send_proposal_to_committee(&shard0_committee[0], &pre_commit_proposal0, &committee1_instances).await;
+    // Now both should be on the same height. Let's finish this transaction.
+    // TODO: Should also cover Decide, but it's not working right now
+    for phase in [HotstuffPhase::Commit] {
+        let votes0 = get_votes(&mut committee0_instances).await;
+        send_votes_to_leader(
+            &committee0_instances[0],
+            votes0.into_iter().map(|vote| vote.0).collect::<Vec<_>>(),
+            &shard0_committee,
+        )
+        .await;
+        let proposal0 = timeout(Duration::from_secs(1), committee0_instances[0].rx_broadcast.recv()).await;
+        assert!(proposal0.is_ok(), "leader of committee0 should send proposal");
+        let proposal0 = proposal0.unwrap().unwrap().0;
+        assert_eq!(proposal0.node().unwrap().payload_phase(), phase);
+
+        let votes1 = get_votes(&mut committee1_instances).await;
+        send_votes_to_leader(
+            &committee1_instances[0],
+            votes1.into_iter().map(|vote| vote.0).collect::<Vec<_>>(),
+            &shard1_committee,
+        )
+        .await;
+        let proposal1 = timeout(Duration::from_secs(1), committee1_instances[0].rx_broadcast.recv()).await;
+        // TODO: This should await `is_ok` but it's currently broken.
+        assert!(proposal1.is_err(), "leader of committee1 should send proposal");
+        // let proposal1 = proposal1.unwrap().unwrap().0;
+        // assert_eq!(proposal1.node().unwrap().payload_phase(), phase);
+    }
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -627,9 +1152,16 @@ async fn test_kitchen_sink() {
         node1.clone(),
         epoch_manager.clone(),
         AlwaysFirstLeader {},
+        *NEVER,
     );
     // node1_instance.add_package(package);
-    let node2_instance = HsTestHarness::new(node2_pk.clone(), node2.clone(), epoch_manager, AlwaysFirstLeader {});
+    let node2_instance = HsTestHarness::new(
+        node2_pk.clone(),
+        node2.clone(),
+        epoch_manager,
+        AlwaysFirstLeader {},
+        *NEVER,
+    );
     // TODO: Create a task that connects the two instances via their channels so that they can do the hotstuff rounds
     // node1_instance.connect(&node2_instance);
 


### PR DESCRIPTION
Description
---
Add support for recovery.
If foreing leader fails to send the node. The pacemaker should trigger.
When it triggers the node does following
1) Check if we fail to get proposal from local leader (this is currently TODO)
2) If locals are fine. The we check for which committee we don't have a newest node. And we choose some subcommiitee of size (f+1+some epsilon value). And we send the VCGlobalSCR message to these node.
3) Node receives VCGlobalSCR message from someone, with shard_id. We check if we have some newer leader proposal, if we do, send it back. If we don't ignore (we are probably going to be triggered as well, because our leader failed).

How Has This Been Tested?
---
Not yet.
