### PR TITLE
fix(consensus): provide substate address and version of missing output pledge

### DIFF
--- a/dan_layer/core/src/workers/hotstuff_error.rs
+++ b/dan_layer/core/src/workers/hotstuff_error.rs
@@ -21,7 +21,7 @@
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use tari_dan_common_types::{Epoch, NodeHeight, PayloadId, ShardId, SubstateChange};
-use tari_engine_types::commit_result::RejectReason;
+use tari_engine_types::{commit_result::RejectReason, substate::SubstateAddress};
 use thiserror::Error;
 use tokio::sync::mpsc;
 
@@ -68,13 +68,19 @@ pub enum HotStuffError {
     JustifyIsNotAccepted,
     #[error("Received NEWVIEW message without attached payload")]
     ReceivedNewViewWithoutPayload,
-    #[error("Missing pledges: {}", .0.iter().map(|(s, c)| format!("{}: {}", s, c)).collect::<Vec<_>>().join(", "))]
-    MissingPledges(Vec<(ShardId, SubstateChange)>),
+    #[error("Missing pledges: {}", .0.iter().map(|(s, c, a, v)| format!("{} ({}): {} v{}", s, c, a, v)).collect::<Vec<_>>().join(", "))]
+    MissingPledges(Vec<(ShardId, SubstateChange, SubstateAddress, u32)>),
     #[error("Shard {shard} already pledged to another payload {pledged_payload}, expected {expected}")]
     ShardPledgedToDifferentPayload {
         shard: ShardId,
         pledged_payload: PayloadId,
         expected: PayloadId,
+    },
+    #[error("Pledge for shard {shard} for payload {pledged_payload} is invalid: {details}")]
+    InvalidPledge {
+        shard: ShardId,
+        pledged_payload: PayloadId,
+        details: String,
     },
 }
 

--- a/dan_layer/core/src/workers/hotstuff_waiter.rs
+++ b/dan_layer/core/src/workers/hotstuff_waiter.rs
@@ -845,10 +845,10 @@ where
                 }) => {
                     // To down a substate it should be pledged as up
                     if !matches!(current_state, SubstateState::Up { .. }) {
-                        missing_pledges.push((shard_id, SubstateChange::Exists));
+                        missing_pledges.push((shard_id, SubstateChange::Exists, *address, *version));
                     }
                 },
-                None => missing_pledges.push((shard_id, SubstateChange::Exists)),
+                None => missing_pledges.push((shard_id, SubstateChange::Exists, *address, *version)),
             }
         }
 
@@ -856,15 +856,34 @@ where
             let shard_id = ShardId::from_address(addr, substate.version());
             match shard_pledges.iter().find(|p| p.pledge.shard_id == shard_id) {
                 Some(ShardPledge {
-                    pledge: ObjectPledge { current_state, .. },
+                    pledge:
+                        ObjectPledge {
+                            current_state,
+                            pledged_to_payload,
+                            ..
+                        },
                     ..
                 }) => {
-                    // To up a substate it should be pledged as down
-                    if !matches!(current_state, SubstateState::DoesNotExist) {
-                        missing_pledges.push((shard_id, SubstateChange::Create));
+                    // To up a substate it should be pledged as never existing
+                    match current_state {
+                        SubstateState::DoesNotExist => {},
+                        SubstateState::Up { created_by, .. } => {
+                            return Err(HotStuffError::InvalidPledge {
+                                shard: shard_id,
+                                pledged_payload: *pledged_to_payload,
+                                details: format!("Pledged substate is already UP'd by payload {}", created_by),
+                            });
+                        },
+                        SubstateState::Down { deleted_by } => {
+                            return Err(HotStuffError::InvalidPledge {
+                                shard: shard_id,
+                                pledged_payload: *pledged_to_payload,
+                                details: format!("Pledged substate is already DOWN'd by payload {}", deleted_by),
+                            });
+                        },
                     }
                 },
-                None => missing_pledges.push((shard_id, SubstateChange::Create)),
+                None => missing_pledges.push((shard_id, SubstateChange::Create, *addr, substate.version())),
             }
         }
 


### PR DESCRIPTION
Description
---
Adds the substate address and version of the missing output pledge

Motivation and Context
---

```
👮 Command failed with error "JSON-RPC error 1: Shards not pledged: Missing pledges: 
bc84e9d9ed0ad5127d4b8baf961b86501e05cacee80c3c12cf68f276790516c8 (Create): component_8bff52c7bf92737fba9b2793c68398848aaa3ad582245445bfe5cf3cc6305e7c v3
```
How Has This Been Tested?
---
Manually
