### PR TITLE
fix(cli): update multiple component versions in component manager

### DIFF
--- a/applications/tari_validator_node_cli/src/component_manager.rs
+++ b/applications/tari_validator_node_cli/src/component_manager.rs
@@ -79,6 +79,9 @@ impl ComponentManager {
         for (addr, substate) in diff.up_iter() {
             match addr {
                 addr @ SubstateAddress::Component(_) => {
+                    if let Some((addr, version)) = component.take() {
+                        self.add_root_substate(addr, version, children.drain(..).collect())?;
+                    }
                     component = Some((addr, substate.version()));
                 },
                 addr @ SubstateAddress::Resource(_) |


### PR DESCRIPTION
Description
---
Persists all component addresses from transaction results

Motivation and Context
---
A transaction with multiple UPd components would only persist the last component address in the cli component store. This PR fixes that.

How Has This Been Tested?
---
Manually, transaction that modifies multiple components.
