### PR TITLE
feat(engine): add resource_type() method to Buckets

### DIFF
--- a/dan_layer/engine/src/runtime/impl.rs
+++ b/dan_layer/engine/src/runtime/impl.rs
@@ -344,10 +344,18 @@ impl RuntimeInterface for RuntimeInterfaceImpl {
             BucketAction::GetResourceAddress => {
                 let bucket_id = bucket_ref.bucket_id().ok_or_else(|| RuntimeError::InvalidArgument {
                     argument: "bucket_ref",
-                    reason: "Create bucket action requires a bucket id".to_string(),
+                    reason: "GetResourceAddress action requires a bucket id".to_string(),
                 })?;
                 let bucket = self.tracker.get_bucket(bucket_id)?;
                 Ok(InvokeResult::encode(bucket.resource_address())?)
+            },
+            BucketAction::GetResourceType => {
+                let bucket_id = bucket_ref.bucket_id().ok_or_else(|| RuntimeError::InvalidArgument {
+                    argument: "bucket_ref",
+                    reason: "GetResourceType action requires a bucket id".to_string(),
+                })?;
+                let bucket = self.tracker.get_bucket(bucket_id)?;
+                Ok(InvokeResult::encode(&bucket.resource_type())?)
             },
             BucketAction::GetAmount => {
                 let bucket_id = bucket_ref.bucket_id().ok_or_else(|| RuntimeError::InvalidArgument {

--- a/dan_layer/engine/tests/templates/nft/basic_nft/src/lib.rs
+++ b/dan_layer/engine/tests/templates/nft/basic_nft/src/lib.rs
@@ -111,6 +111,11 @@ mod sparkle_nft_template {
         }
 
         pub fn burn(&mut self, mut bucket: Bucket) {
+            // this check is actually not needed, but with it we cover the "bucket.resource_type" method
+            assert!(
+                bucket.resource_type() == ResourceType::NonFungible,
+                "The resource is not a NFT"
+            );
             assert!(
                 bucket.resource_address() == self.address,
                 "Cannot burn bucket not from this collection"

--- a/dan_layer/engine/tests/templates/nft/marketplace/src/lib.rs
+++ b/dan_layer/engine/tests/templates/nft/marketplace/src/lib.rs
@@ -81,10 +81,19 @@ mod marketplace {
             }
         }
 
-        // TODO: how to ensure the bucket contains a single NFT item? Passing both the address and id seems a bit too unconvenient
         // returns a badge used to cancel the sell order in the future
         //      the badge will contain a immutable metadata with a reference to the nft being sold
         pub fn start_auction(&mut self, nft_bucket: Bucket, seller_address: ComponentAddress, payment_resource_address: ResourceAddress, min_price: Option<Amount>, buy_price: Option<Amount>, epoch_period: u64) -> Bucket {
+            assert!(
+                nft_bucket.resource_type() == ResourceType::NonFungible,
+                "The resource is not a NFT"
+            );
+
+            assert!(
+                nft_bucket.amount() == Amount(1),
+                "Can only start an auction of a single NFT"
+            );
+            
             assert!(
                 epoch_period > 0,
                 "Invalid auction period"
@@ -115,7 +124,6 @@ mod marketplace {
         //  - ignoring it (throws panic) if lower than the current highest
         //  - setting it up as the new highest bid 
         //  - performs the payment to the seller + the nft to the buyer if the buy price was met
-        // TODO: we need to handle the payment change (or just check that the payment is within a valid range)
         pub fn bid(&mut self, bidder_account_address: ComponentAddress, nft_address: ResourceAddress, payment: Bucket) {
             let mut auction = self.auctions.get_mut(nft_address)
                 .expect("Auction does not exist");

--- a/dan_layer/template_lib/src/args/engine.rs
+++ b/dan_layer/template_lib/src/args/engine.rs
@@ -258,6 +258,7 @@ impl BucketRef {
 pub enum BucketAction {
     Create,
     GetResourceAddress,
+    GetResourceType,
     GetAmount,
     Take,
     Burn,

--- a/dan_layer/template_lib/src/models/bucket.rs
+++ b/dan_layer/template_lib/src/models/bucket.rs
@@ -26,6 +26,7 @@ use tari_template_abi::{call_engine, EngineOp};
 use crate::{
     args::{BucketAction, BucketInvokeArg, BucketRef, InvokeResult},
     models::{Amount, ResourceAddress},
+    prelude::ResourceType,
 };
 
 pub type BucketId = u32;
@@ -52,7 +53,18 @@ impl Bucket {
         });
 
         resp.decode()
-            .expect("Bucket GetResource returned invalid resource address")
+            .expect("Bucket GetResourceAddress returned invalid resource address")
+    }
+
+    pub fn resource_type(&self) -> ResourceType {
+        let resp: InvokeResult = call_engine(EngineOp::BucketInvoke, &BucketInvokeArg {
+            bucket_ref: BucketRef::Ref(self.id),
+            action: BucketAction::GetResourceType,
+            args: invoke_args![],
+        });
+
+        resp.decode()
+            .expect("Bucket GetResourceType returned invalid resource type")
     }
 
     pub fn take(&mut self, amount: Amount) -> Self {


### PR DESCRIPTION
Description
---
* Added a new method in Buckets: `resource_type()` that indicates if the containing resources are fungible or non-fungible. A new engine operation (`GetResourceType`) was needed.
* Updated the code of the `basic_nft` and `marketplace` examples with the new check

Motivation and Context
---
The NFT marketplace showcases that we need a way to check the type of resource (`Fungible` or `NonFungible`) of an incoming bucket.

How Has This Been Tested?
---
The NFT marketplace example still does not compile, so added to the existing `basic_nft` unit test for _burning_ a check if the incoming bucket is an NFT.
