### PR TITLE
refactor: clean up non-fungible substate address

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6140,6 +6140,7 @@ dependencies = [
  "tari_template_abi",
  "tari_template_lib",
  "tari_template_test_tooling",
+ "tari_transaction_manifest",
  "tari_utilities",
  "tempfile",
  "thiserror",

--- a/applications/tari_validator_node/tests/utils/validator_node_cli.rs
+++ b/applications/tari_validator_node/tests/utils/validator_node_cli.rs
@@ -148,7 +148,7 @@ fn add_substate_addresses(world: &mut TariWorld, outputs_name: String, diff: &Su
                 });
                 counters[2] += 1;
             },
-            SubstateAddress::NonFungible(_, _) => {
+            SubstateAddress::NonFungible(_) => {
                 outputs.insert(format!("nfts/{}", counters[3]), VersionedSubstateAddress {
                     address: addr.clone(),
                     version: data.version(),

--- a/applications/tari_validator_node_cli/src/command/transaction.rs
+++ b/applications/tari_validator_node_cli/src/command/transaction.rs
@@ -41,7 +41,7 @@ use tari_engine_types::{
 use tari_template_lib::{
     arg,
     args::Arg,
-    models::{Amount, NonFungibleId},
+    models::{Amount, NonFungibleAddress, NonFungibleId},
     prelude::ResourceAddress,
 };
 use tari_transaction_manifest::parse_manifest;
@@ -237,7 +237,7 @@ pub async fn submit_transaction(
         common
             .non_fungible_mint_outputs
             .into_iter()
-            .map(|m| ShardId::from_address(&SubstateAddress::NonFungible(m.resource_address, m.non_fungible_id), 0)),
+            .map(|m| ShardId::from_address(&m.to_substate_address(), 0)),
     );
 
     // Convert to shard id
@@ -597,8 +597,17 @@ impl CliArg {
 
 #[derive(Debug, Clone)]
 pub struct SpecificNonFungibleMintOutput {
-    pub resource_address: ResourceAddress,
-    pub non_fungible_id: NonFungibleId,
+    resource_address: ResourceAddress,
+    non_fungible_id: NonFungibleId,
+}
+
+impl SpecificNonFungibleMintOutput {
+    pub fn to_substate_address(&self) -> SubstateAddress {
+        SubstateAddress::NonFungible(NonFungibleAddress::new(
+            self.resource_address,
+            self.non_fungible_id.clone(),
+        ))
+    }
 }
 
 impl FromStr for SpecificNonFungibleMintOutput {

--- a/applications/tari_validator_node_cli/src/component_manager.rs
+++ b/applications/tari_validator_node_cli/src/component_manager.rs
@@ -87,7 +87,7 @@ impl ComponentManager {
                 },
                 addr @ SubstateAddress::Resource(_) |
                 addr @ SubstateAddress::Vault(_) |
-                addr @ SubstateAddress::NonFungible(_, _) => {
+                addr @ SubstateAddress::NonFungible(_) => {
                     children.push(VersionedSubstateAddress {
                         address: addr.clone(),
                         version: substate.version(),

--- a/dan_layer/engine/Cargo.toml
+++ b/dan_layer/engine/Cargo.toml
@@ -32,3 +32,4 @@ wasmer-middlewares = "2.3.0"
 
 [dev-dependencies]
 tari_template_test_tooling = { path = "../template_test_tooling" }
+tari_transaction_manifest = { path = "../transaction_manifest" }

--- a/dan_layer/engine/src/runtime/impl.rs
+++ b/dan_layer/engine/src/runtime/impl.rs
@@ -198,7 +198,9 @@ impl RuntimeInterface for RuntimeInterfaceImpl {
                             reason: "GetNonFungible resource action requires a resource address".to_string(),
                         })?;
                 let arg: ResourceGetNonFungibleArg = args.get(0)?;
-                let nf_container = self.tracker.get_non_fungible(&resource_address, &arg.id)?;
+                let nf_container = self
+                    .tracker
+                    .get_non_fungible(&NonFungibleAddress::new(resource_address, arg.id.clone()))?;
                 if nf_container.is_burnt() {
                     return Err(RuntimeError::InvalidOpNonFungibleBurnt {
                         op: "GetNonFungible",
@@ -219,7 +221,8 @@ impl RuntimeInterface for RuntimeInterfaceImpl {
                             reason: "UpdateNonFungibleData resource action requires a resource address".to_string(),
                         })?;
                 let arg: ResourceUpdateNonFungibleDataArg = args.get(0)?;
-                self.tracker.set_non_fungible_data(resource_address, arg.id, arg.data)?;
+                self.tracker
+                    .set_non_fungible_data(&NonFungibleAddress::new(resource_address, arg.id), arg.data)?;
 
                 Ok(InvokeResult::unit())
             },
@@ -420,9 +423,7 @@ impl RuntimeInterface for RuntimeInterfaceImpl {
     ) -> Result<InvokeResult, RuntimeError> {
         match action {
             NonFungibleAction::GetData => {
-                let container = self
-                    .tracker
-                    .get_non_fungible(nf_addr.resource_address(), nf_addr.id())?;
+                let container = self.tracker.get_non_fungible(&nf_addr)?;
                 let contents = container
                     .contents()
                     .ok_or_else(|| RuntimeError::InvalidOpNonFungibleBurnt {
@@ -434,9 +435,7 @@ impl RuntimeInterface for RuntimeInterfaceImpl {
                 Ok(InvokeResult::raw(contents.data().to_vec()))
             },
             NonFungibleAction::GetMutableData => {
-                let container = self
-                    .tracker
-                    .get_non_fungible(nf_addr.resource_address(), nf_addr.id())?;
+                let container = self.tracker.get_non_fungible(&nf_addr)?;
                 let contents = container
                     .contents()
                     .ok_or_else(|| RuntimeError::InvalidOpNonFungibleBurnt {

--- a/dan_layer/engine/src/transaction/builder.rs
+++ b/dan_layer/engine/src/transaction/builder.rs
@@ -7,7 +7,7 @@ use tari_common_types::types::{PrivateKey, PublicKey};
 use tari_crypto::{keys::PublicKey as PublicKeyTrait, ristretto::RistrettoPublicKey};
 use tari_dan_common_types::{ObjectClaim, ShardId, SubstateChange};
 use tari_engine_types::{instruction::Instruction, signature::InstructionSignature, substate::SubstateAddress};
-use tari_template_lib::models::{NonFungibleId, ResourceAddress};
+use tari_template_lib::models::{NonFungibleAddress, NonFungibleId, ResourceAddress};
 
 use super::Transaction;
 use crate::{crypto::create_key_pair, runtime::IdProvider, transaction::TransactionMeta};
@@ -142,7 +142,8 @@ impl TransactionBuilder {
             new_nft_outputs.extend((0..count).map({
                 |_| {
                     let new_hash = id_provider.new_uuid().expect("id provider provides num_outputs IDs");
-                    let new_addr = SubstateAddress::NonFungible(resource_addr, NonFungibleId::from_u256(new_hash));
+                    let address = NonFungibleAddress::new(resource_addr, NonFungibleId::from_u256(new_hash));
+                    let new_addr = SubstateAddress::NonFungible(address);
                     (
                         ShardId::from_hash(&new_addr.to_canonical_hash(), 0),
                         (SubstateChange::Create, ObjectClaim {}),

--- a/dan_layer/engine/tests/test.rs
+++ b/dan_layer/engine/tests/test.rs
@@ -19,8 +19,7 @@
 //   SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
 //   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //   USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-use std::mem::size_of;
+use std::{iter, mem::size_of};
 
 use tari_bor::{borsh, Decode, Encode};
 use tari_dan_engine::{
@@ -28,12 +27,14 @@ use tari_dan_engine::{
     transaction::TransactionError,
     wasm::{compile::compile_template, WasmExecutionError},
 };
-use tari_engine_types::{instruction::Instruction, substate::SubstateAddress};
+use tari_engine_types::{commit_result::FinalizeResult, instruction::Instruction, substate::SubstateAddress};
 use tari_template_lib::{
     args,
-    models::{Amount, ComponentAddress},
+    models::{Amount, ComponentAddress, NonFungibleAddress},
+    prelude::{NonFungibleId, ResourceAddress},
 };
 use tari_template_test_tooling::{MockRuntimeInterface, SubstateType, TemplateTest};
+use tari_transaction_manifest::ManifestValue;
 
 #[test]
 fn test_hello_world() {
@@ -521,12 +522,14 @@ mod basic_nft {
 
         let substate_addr = template_test.get_previous_output_address(SubstateType::NonFungible);
         let nft_addr = substate_addr.as_non_fungible_address().unwrap();
-
         let vars = [
             ("account", account_address.into()),
             ("nft", nft_component.into()),
             ("nft_resx", (*nft_addr.resource_address()).into()),
-            ("nft_id", substate_addr.clone().into()),
+            (
+                "nft_id",
+                ManifestValue::NonFungibleId(substate_addr.as_non_fungible_address().unwrap().id().clone()),
+            ),
         ];
 
         template_test
@@ -616,7 +619,7 @@ mod basic_nft {
         let nfts = diff
             .up_iter()
             .filter_map(|(a, _)| match a {
-                SubstateAddress::NonFungible(_, id) => Some(id),
+                SubstateAddress::NonFungible(address) => Some(address.id()),
                 _ => None,
             })
             .collect::<Vec<_>>();
@@ -722,10 +725,6 @@ mod basic_nft {
 }
 
 mod emoji_id {
-    use std::iter;
-
-    use tari_engine_types::commit_result::FinalizeResult;
-    use tari_template_lib::prelude::ResourceAddress;
 
     use super::*;
 
@@ -897,7 +896,6 @@ mod emoji_id {
 }
 
 mod tickets {
-    use tari_template_lib::prelude::NonFungibleId;
 
     use super::*;
 
@@ -998,14 +996,13 @@ mod tickets {
             template_test.call_method(account_address, "get_non_fungible_ids", args![ticket_resource]);
         assert_eq!(ticket_ids.len(), 1);
         let ticket_id = ticket_ids.first().unwrap().clone();
-        let ticket_substate_addr = SubstateAddress::NonFungible(ticket_resource, ticket_id);
 
         let vars = [
             ("account", account_address.into()),
             ("ticket_seller", ticket_seller.into()),
             // TODO: it's weird that the "redeem_ticket" method accepts a NonFungibleId, but we are passing a
             // SubstateAddress variable
-            ("ticket_addr", ticket_substate_addr.clone().into()),
+            ("ticket_addr", ManifestValue::NonFungibleId(ticket_id.clone())),
         ];
 
         template_test
@@ -1026,6 +1023,7 @@ mod tickets {
             pub is_redeemed: bool,
         }
 
+        let ticket_substate_addr = SubstateAddress::NonFungible(NonFungibleAddress::new(ticket_resource, ticket_id));
         let ticket_nft = template_test
             .read_only_state_store()
             .get_substate(&ticket_substate_addr)

--- a/dan_layer/template_lib/src/models/non_fungible.rs
+++ b/dan_layer/template_lib/src/models/non_fungible.rs
@@ -162,7 +162,7 @@ impl Display for NonFungibleId {
     }
 }
 
-#[derive(Debug, Clone, Encode, Decode)]
+#[derive(Debug, Clone, Encode, Decode, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct NonFungibleAddress {
     resource_address: ResourceAddress,
@@ -180,6 +180,12 @@ impl NonFungibleAddress {
 
     pub fn id(&self) -> &NonFungibleId {
         &self.id
+    }
+}
+
+impl Display for NonFungibleAddress {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} {}", self.resource_address, self.id)
     }
 }
 

--- a/dan_layer/template_test_tooling/src/template_test.rs
+++ b/dan_layer/template_test_tooling/src/template_test.rs
@@ -250,7 +250,7 @@ impl SubstateType {
             (SubstateType::Component, SubstateAddress::Component(_)) => true,
             (SubstateType::Resource, SubstateAddress::Resource(_)) => true,
             (SubstateType::Vault, SubstateAddress::Vault(_)) => true,
-            (SubstateType::NonFungible, SubstateAddress::NonFungible(_, _)) => true,
+            (SubstateType::NonFungible, SubstateAddress::NonFungible(_)) => true,
             _ => false,
         }
     }

--- a/dan_layer/transaction_manifest/src/generator.rs
+++ b/dan_layer/transaction_manifest/src/generator.rs
@@ -141,7 +141,7 @@ impl ManifestInstructionGenerator {
                                 SubstateAddress::Component(addr) => Ok(arg!(*addr)),
                                 SubstateAddress::Resource(addr) => Ok(arg!(*addr)),
                                 SubstateAddress::Vault(addr) => Ok(arg!(*addr)),
-                                SubstateAddress::NonFungible(_, id) => Ok(arg!(*id)),
+                                SubstateAddress::NonFungible(addr) => Ok(arg!(addr)),
                             },
                             ManifestValue::Literal(lit) => lit_to_arg(lit),
                             ManifestValue::NonFungibleId(id) => Ok(arg!(id.clone())),

--- a/dan_layer/transaction_manifest/src/value.rs
+++ b/dan_layer/transaction_manifest/src/value.rs
@@ -29,6 +29,13 @@ impl<T: Into<SubstateAddress>> From<T> for ManifestValue {
     }
 }
 
+// https://github.com/rust-lang/rfcs/issues/2758 :/
+// impl From<NonFungibleId> for ManifestValue {
+//     fn from(id: NonFungibleId) -> Self {
+//         ManifestValue::NonFungibleId(id)
+//     }
+// }
+
 impl FromStr for ManifestValue {
     type Err = ManifestParseError;
 


### PR DESCRIPTION
Description
---
clean up non-fungible substate address

Motivation and Context
---
Non-fungible addresses were inconsistent with other substate addresses.

How Has This Been Tested?
---
Existing tests pass
