### PR TITLE
fix: add current leader to get_leader fn

### DIFF
--- a/dan_layer/core/src/workers/hotstuff_waiter.rs
+++ b/dan_layer/core/src/workers/hotstuff_waiter.rs
@@ -1626,9 +1626,15 @@ where
     async fn get_leader(&self, node: &HotStuffTreeNode<TAddr, TPayload>) -> Result<TAddr, HotStuffError> {
         let epoch = self.epoch_manager.current_epoch().await?;
         let committee = self.epoch_manager.get_committee(epoch, node.shard()).await?;
-        let leader = self
-            .leader_strategy
-            .get_leader(&committee, node.payload_id(), node.shard(), 0);
+        let leader = self.leader_strategy.get_leader(
+            &committee,
+            node.payload_id(),
+            node.shard(),
+            *self
+                .current_leader_round
+                .get(&(node.shard(), node.payload_id()))
+                .unwrap_or(&0),
+        );
         Ok(leader.clone())
     }
 


### PR DESCRIPTION
Description
---
The current leader was missing in the get_leader fn. So when the nodes voted for it. They send all message to the old leader.

How Has This Been Tested?
---
I'm adding a better test. Will be in next PR.