### PR TITLE
feat: add a remove pending timeout unit test to pacemaker

### DIFF
--- a/dan_layer/core/src/workers/pacemaker_worker.rs
+++ b/dan_layer/core/src/workers/pacemaker_worker.rs
@@ -301,15 +301,13 @@ mod tests {
         let (_, rx_signal) = channel::<PacemakerTimer<u8>>(10);
         let (tx_waiter_status, _) = channel::<u8>(10);
 
-        let mut pacemaker = Box::new(Pacemaker::new(rx_signal, tx_waiter_status));
+        let mut pacemaker = Pacemaker::new(rx_signal, tx_waiter_status);
 
         // loop over start wait messages
         for i in 0..100 {
             pacemaker.handle_signal(PacemakerTimer::Start(i, Duration::from_millis(2000)));
             assert_eq!(pacemaker.pending_timeouts.len(), i as usize + 1);
         }
-
-        tokio::time::sleep(Duration::from_millis(1)).await;
 
         // stop waiting messages that are indexed by even numbers, and check that the corresponding
         // pending timeouts are removed from the pending_timeouts hash map
@@ -320,7 +318,6 @@ mod tests {
 
         // assert that timeouts occur and they are removed from pending_timeouts hash map,
         // for each odd number in 0..100
-        tokio::time::sleep(Duration::from_millis(100)).await;
         for i in (0..100).filter(|i| i % 2 == 1) {
             pacemaker.handle_timeout(i, true).await;
             assert_eq!(pacemaker.pending_timeouts.len(), 50 - (i / 2) as usize - 1);

--- a/dan_layer/core/src/workers/pacemaker_worker.rs
+++ b/dan_layer/core/src/workers/pacemaker_worker.rs
@@ -34,6 +34,7 @@ use super::hotstuff_error::HotStuffError;
 
 const LOG_TARGET: &str = "tari::dan_layer::pacemaker_worker";
 
+#[derive(Debug)]
 pub enum PacemakerTimer<T> {
     Start(T, Duration),
     Stop(T),
@@ -95,53 +96,61 @@ where T: Clone + Debug + PartialEq + Eq + Hash + Send + Sync + 'static
         }
     }
 
+    fn handle_signal(&mut self, signal: PacemakerTimer<T>) {
+        match signal {
+            PacemakerTimer::Stop(wait_over) => {
+                self.handle_stop_signal(wait_over);
+            },
+            PacemakerTimer::Start(wait_over, duration_timeout) => {
+                info!(
+                    target: LOG_TARGET,
+                    "Received start wait signal for value: {:?}", wait_over
+                );
+                if self.pending_timeouts.contains_key(&wait_over) {
+                    info!(
+                        target: LOG_TARGET,
+                        "Already received an existing wait timer for value = {:?}", wait_over
+                    );
+                } else {
+                    let (tx, rx_stop_signal) = oneshot::channel();
+                    self.pending_timeouts.insert(wait_over.clone(), tx);
+                    self.waiting_futures.push(Box::pin(async move {
+                        tokio::select! {
+                            _ = tokio::time::sleep(duration_timeout) => {
+                                info!("The wait signal for value = {:?} has timeout", wait_over);
+                                (wait_over, true)
+                            },
+                            _ = rx_stop_signal => {
+                                info!("The wait signal for wait_over = {:?} has been shut down", wait_over);
+                                (wait_over, false)
+                            }
+                        }
+                    }));
+                }
+            },
+        }
+    }
+
+    async fn handle_timeout(&mut self, wait_over: T, has_timed_out: bool) {
+        if has_timed_out {
+            // at this point it is safe to remove the wait_over from pending_timeouts
+            // so that this data structure doesn't grow every time.
+            // When the signal was triggered it was removed in the handle_stop_signal.
+            self.pending_timeouts.remove(&wait_over);
+            // send status to the other side of the channel
+            let send_status = self.tx_waiter_status.send(wait_over);
+            if send_status.await.is_err() {
+                error!(target: LOG_TARGET, "Hotstuff waiter has shut down");
+            }
+        }
+    }
+
     pub async fn run(mut self, mut shutdown: ShutdownSignal) -> Result<(), HotStuffError> {
         loop {
             tokio::select! {
-                Some(signal) = self.rx_signal.recv() => {
-                    match signal {
-                        PacemakerTimer::Stop(wait_over) => {
-                            self.handle_stop_signal(wait_over);
-                        }
-                        PacemakerTimer::Start(wait_over, duration_timeout) => {
-                        info!(
-                            target: LOG_TARGET,
-                            "Received start wait signal for value: {:?}", wait_over
-                        );
-                        if self.pending_timeouts.contains_key(&wait_over) {
-                            info!(target: LOG_TARGET, "Already received an existing wait timer for value = {:?}", wait_over);
-                        } else {
-                            let (tx, rx_stop_signal) = oneshot::channel();
-                            self.pending_timeouts.insert(wait_over.clone(), tx);
-                            self.waiting_futures.push(Box::pin(async move {
-                                    tokio::select! {
-                                        _ = tokio::time::sleep(duration_timeout) => {
-                                            info!("The wait signal for value = {:?} has timeout", wait_over);
-                                            (wait_over, true)
-                                        },
-                                        _ = rx_stop_signal => {
-                                            info!("The wait signal for wait_over = {:?} has been shut down", wait_over);
-                                            (wait_over, false)
-                                        }
-                                    }
-                                }
-                            ));
-                        }
-                    }
-                }
-                },
+                Some(signal) = self.rx_signal.recv() => { self.handle_signal(signal) },
                 Some((wait_over, has_timed_out)) = self.waiting_futures.next() => {
-                    // at this point it is safe to remove the wait_over from pending_timeouts
-                    // so that this data structure doesn't grow every time
-                    if has_timed_out {
-                        // When the signal was triggered it was removed in the handle_stop_signal.
-                        self.pending_timeouts.remove(&wait_over);
-                        // send status to the other side of the channel
-                        let send_status = self.tx_waiter_status.send(wait_over);
-                        if send_status.await.is_err() {
-                            error!(target: LOG_TARGET, "Hotstuff waiter has shut down");
-                        }
-                    }
+                    self.handle_timeout(wait_over, has_timed_out).await
                 },
                 _ = shutdown.wait() => {
                     info!("Shutting down pacemaker service..");
@@ -285,6 +294,37 @@ mod tests {
         assert!(tokio::time::timeout(Duration::from_millis(100), handle.on_timeout())
             .await
             .is_err());
+    }
+
+    #[tokio::test]
+    async fn test_remove_pending_timeouts() {
+        let (_, rx_signal) = channel::<PacemakerTimer<u8>>(10);
+        let (tx_waiter_status, _) = channel::<u8>(10);
+
+        let mut pacemaker = Box::new(Pacemaker::new(rx_signal, tx_waiter_status));
+
+        // loop over start wait messages
+        for i in 0..100 {
+            pacemaker.handle_signal(PacemakerTimer::Start(i, Duration::from_millis(2000)));
+            assert_eq!(pacemaker.pending_timeouts.len(), i as usize + 1);
+        }
+
+        tokio::time::sleep(Duration::from_millis(1)).await;
+
+        // stop waiting messages that are indexed by even numbers, and check that the corresponding
+        // pending timeouts are removed from the pending_timeouts hash map
+        for i in (0..100).filter(|i| i % 2 == 0) {
+            pacemaker.handle_signal(PacemakerTimer::Stop(i));
+            assert_eq!(pacemaker.pending_timeouts.len(), 100 - (i / 2) as usize - 1);
+        }
+
+        // assert that timeouts occur and they are removed from pending_timeouts hash map,
+        // for each odd number in 0..100
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        for i in (0..100).filter(|i| i % 2 == 1) {
+            pacemaker.handle_timeout(i, true).await;
+            assert_eq!(pacemaker.pending_timeouts.len(), 50 - (i / 2) as usize - 1);
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
Description
---
We test that pending timeouts are being removed correctly, within the internal state of a `Pacemaker` struct. Ideally, this test would make use of raw/smart pointers while `Pacemaker` run on the background (within a spawned thread) as a service. But this turns out to be complex, as we don't know which new memory address is the data pointing to. For this reason, we encapsulated most of the logic of the `run` function into proper segments, so that we can test these in a unit test environment.

Motivation and Context
---
Related to a previous bug, that we had before.

How Has This Been Tested?
---
Add a specific unit test.

