### PR TITLE
fix(networking): fix possible endless propagation for announce messages

### DIFF
--- a/applications/tari_validator_node/src/http_ui/server.rs
+++ b/applications/tari_validator_node/src/http_ui/server.rs
@@ -32,7 +32,7 @@ use include_dir::{include_dir, Dir};
 use log::{error, info};
 use reqwest::StatusCode;
 
-const LOG_TARGET: &str = "tari_validator_node::http_ui::server";
+const LOG_TARGET: &str = "tari::validator_node::http_ui::server";
 
 pub async fn run_http_ui_server(address: SocketAddr, json_rpc_address: Option<String>) -> Result<(), anyhow::Error> {
     let json_rpc_address = Arc::new(json_rpc_address);
@@ -49,17 +49,17 @@ pub async fn run_http_ui_server(address: SocketAddr, json_rpc_address: Option<St
         )
         .fallback(handler);
 
-    info!(target: LOG_TARGET, "🌐 HTTP UI started at {}", address);
+    info!(target: LOG_TARGET, "🕸️ HTTP UI started at {}", address);
     let server = axum::Server::try_bind(&address).or_else(|_| {
         error!(
             target: LOG_TARGET,
-            "🌐 Failed to bind on preferred address {}. Trying OS-assigned", address
+            "🕸️ Failed to bind on preferred address {}. Trying OS-assigned", address
         );
         axum::Server::try_bind(&"127.0.0.1:0".parse().unwrap())
     })?;
 
     let server = server.serve(router.into_make_service());
-    info!(target: LOG_TARGET, "🌐 HTTP UI listening on {}", server.local_addr());
+    info!(target: LOG_TARGET, "🕸️ HTTP UI listening on {}", server.local_addr());
     server.await?;
 
     info!(target: LOG_TARGET, "Stopping HTTP UI");

--- a/applications/tari_validator_node/src/lib.rs
+++ b/applications/tari_validator_node/src/lib.rs
@@ -145,7 +145,6 @@ pub async fn run_validator_node(config: &ApplicationConfig, shutdown_signal: Shu
 
     // Run the http ui
     if let Some(address) = config.validator_node.http_ui_address {
-        info!(target: LOG_TARGET, "🕸️ Started HTTP UI server on {}", address);
         task::spawn(run_http_ui_server(
             address,
             config.validator_node.json_rpc_address.map(|addr| addr.to_string()),

--- a/applications/tari_validator_node/src/p2p/services/comms_peer_provider.rs
+++ b/applications/tari_validator_node/src/p2p/services/comms_peer_provider.rs
@@ -92,10 +92,19 @@ impl PeerProvider for CommsPeerProvider {
         if !self.peer_manager.exists(&peer.identity).await {
             return Err(CommsPeerProviderError::PeerNotFound);
         }
+        let identity_signature = peer.identity_signature;
+        let mut peer = Peer::new(
+            peer.identity,
+            node_id,
+            peer.addresses.into(),
+            PeerFlags::NONE,
+            PeerFeatures::COMMUNICATION_NODE,
+            vec![],
+            String::new(),
+        );
+        peer.identity_signature = identity_signature;
 
-        self.peer_manager
-            .add_or_update_online_peer(&peer.identity, node_id, peer.addresses, PeerFeatures::NONE)
-            .await?;
+        self.peer_manager.add_peer(peer).await?;
 
         Ok(())
     }


### PR DESCRIPTION
Description
---
fixes possible endless propagation for announce messages

Motivation and Context
---

Announce messages could propagate endlessly due to the identity signature not being saved

How Has This Been Tested?
---
Manually with 12 vn nodes
