### PR TITLE
fix(networking): dials seed peers without blocking service

### DIFF
--- a/applications/tari_validator_node/src/lib.rs
+++ b/applications/tari_validator_node/src/lib.rs
@@ -159,7 +159,9 @@ pub async fn run_validator_node(config: &ApplicationConfig, shutdown_signal: Shu
 async fn run_dan_node(services: Services, shutdown_signal: ShutdownSignal) -> Result<(), ExitError> {
     let node = DanNode::new(services);
     info!(target: LOG_TARGET, "🚀 Validator node started!");
-    node.start(shutdown_signal).await
+    node.start(shutdown_signal)
+        .await
+        .map_err(|e| ExitError::new(ExitCode::UnknownError, e))
 }
 
 async fn create_base_layer_clients(

--- a/applications/tari_validator_node/src/p2p/services/mempool/handle.rs
+++ b/applications/tari_validator_node/src/p2p/services/mempool/handle.rs
@@ -20,11 +20,10 @@
 //   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //   USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use futures::channel::oneshot;
 use tari_dan_common_types::ShardId;
 use tari_dan_engine::transaction::Transaction;
 use tari_template_lib::Hash;
-use tokio::sync::{broadcast, broadcast::error::RecvError, mpsc};
+use tokio::sync::{broadcast, broadcast::error::RecvError, mpsc, oneshot};
 
 use crate::p2p::services::mempool::MempoolError;
 

--- a/applications/tari_validator_node/src/p2p/services/mempool/mod.rs
+++ b/applications/tari_validator_node/src/p2p/services/mempool/mod.rs
@@ -26,11 +26,10 @@ pub use initializer::spawn;
 
 mod handle;
 use async_trait::async_trait;
-use futures::channel::oneshot;
 pub use handle::{MempoolHandle, MempoolRequest};
 use tari_dan_core::services::epoch_manager::EpochManagerError;
 use thiserror::Error;
-use tokio::sync::mpsc::error::SendError;
+use tokio::sync::{mpsc::error::SendError, oneshot};
 
 use crate::p2p::services::{messaging::MessagingError, template_manager::TemplateManagerError};
 
@@ -55,8 +54,8 @@ impl From<SendError<MempoolRequest>> for MempoolError {
     }
 }
 
-impl From<oneshot::Canceled> for MempoolError {
-    fn from(_: oneshot::Canceled) -> Self {
+impl From<oneshot::error::RecvError> for MempoolError {
+    fn from(_: oneshot::error::RecvError) -> Self {
         Self::RequestCancelled
     }
 }


### PR DESCRIPTION
Description
---
Changes networking service to dial seed peers without waiting for results.
Send announce once online (at least one dial succeeds)

Motivation and Context
---
Dialing of seed peers held up the networking service until complete. This PR removes that in favour of dialing without waiting and monitoring the connectivity online state before sending announce.

How Has This Been Tested?
---
Manually and existing cucumber tests
