### PR TITLE
refactor: move transaction builder into its own crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6065,6 +6065,7 @@ dependencies = [
  "newtype-ops",
  "prost",
  "prost-types",
+ "rand 0.7.3",
  "serde",
  "tari_bor",
  "tari_common",
@@ -6082,27 +6083,18 @@ dependencies = [
  "anyhow",
  "async-trait",
  "blake2 0.9.2",
- "borsh",
  "chrono",
- "clap 3.2.23",
  "digest 0.9.0",
  "futures 0.3.25",
- "lazy_static",
  "lmdb-zero",
  "log",
- "num-derive",
- "num-traits",
  "prost",
- "prost-types",
  "rand 0.8.5",
  "serde",
- "serde_json",
- "tari_bor",
  "tari_common",
  "tari_common_types",
  "tari_comms",
  "tari_comms_dht",
- "tari_comms_rpc_macros",
  "tari_core",
  "tari_crypto",
  "tari_dan_common_types",
@@ -6110,15 +6102,13 @@ dependencies = [
  "tari_dan_storage",
  "tari_engine_types",
  "tari_mmr",
- "tari_p2p",
- "tari_service_framework",
  "tari_shutdown",
  "tari_storage",
  "tari_test_utils",
+ "tari_transaction",
  "tari_utilities",
  "thiserror",
  "tokio",
- "tokio-stream",
  "tonic",
 ]
 
@@ -6128,21 +6118,18 @@ version = "0.35.1"
 dependencies = [
  "anyhow",
  "cargo_toml",
- "digest 0.9.0",
  "log",
- "rand 0.7.3",
  "serde",
  "serde_json",
  "tari_bor",
- "tari_common",
  "tari_common_types",
- "tari_crypto",
  "tari_dan_common_types",
  "tari_engine_types",
  "tari_mmr",
  "tari_template_abi",
  "tari_template_lib",
  "tari_template_test_tooling",
+ "tari_transaction",
  "tari_transaction_manifest",
  "tari_utilities",
  "tempfile",
@@ -6179,7 +6166,6 @@ dependencies = [
 name = "tari_dan_storage_sqlite"
 version = "0.35.1"
 dependencies = [
- "async-trait",
  "borsh",
  "chrono",
  "diesel",
@@ -6187,18 +6173,16 @@ dependencies = [
  "log",
  "serde",
  "serde_json",
- "tari_common",
  "tari_common_types",
  "tari_dan_common_types",
  "tari_dan_core",
  "tari_dan_engine",
  "tari_dan_storage",
  "tari_engine_types",
+ "tari_transaction",
  "tari_utilities",
  "thiserror",
  "time 0.3.17",
- "tokio",
- "tokio-stream",
 ]
 
 [[package]]
@@ -6209,7 +6193,6 @@ dependencies = [
  "lazy_static",
  "log",
  "rand 0.7.3",
- "tari_common",
  "tari_common_types",
  "tari_comms",
  "tari_core",
@@ -6219,10 +6202,9 @@ dependencies = [
  "tari_dan_engine",
  "tari_dan_storage_sqlite",
  "tari_engine_types",
- "tari_mmr",
  "tari_shutdown",
  "tari_template_lib",
- "tari_test_utils",
+ "tari_transaction",
  "tari_utilities",
  "tempdir",
  "tokio",
@@ -6233,6 +6215,7 @@ name = "tari_engine_types"
 version = "0.1.0"
 dependencies = [
  "digest 0.9.0",
+ "rand 0.7.3",
  "serde",
  "tari_bor",
  "tari_common_types",
@@ -6432,13 +6415,13 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "borsh",
- "log",
  "tari_crypto",
+ "tari_dan_common_types",
  "tari_dan_engine",
  "tari_engine_types",
- "tari_template_abi",
  "tari_template_builtin",
  "tari_template_lib",
+ "tari_transaction",
  "tari_transaction_manifest",
 ]
 
@@ -6455,11 +6438,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "tari_transaction"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "tari_common_types",
+ "tari_crypto",
+ "tari_dan_common_types",
+ "tari_engine_types",
+ "tari_template_lib",
+ "thiserror",
+]
+
+[[package]]
 name = "tari_transaction_manifest"
 version = "0.35.1"
 dependencies = [
  "proc-macro2",
- "quote",
  "syn",
  "tari_engine_types",
  "tari_template_builtin",
@@ -6493,16 +6488,11 @@ dependencies = [
  "async-trait",
  "axum",
  "axum-jrpc",
- "bincode",
- "blake2 0.9.2",
- "borsh",
  "bytes 1.3.0",
  "chrono",
  "clap 3.2.23",
  "config",
  "cucumber",
- "diesel",
- "digest 0.9.0",
  "futures 0.3.25",
  "httpmock",
  "include_dir",
@@ -6537,13 +6527,13 @@ dependencies = [
  "tari_dan_storage",
  "tari_dan_storage_sqlite",
  "tari_engine_types",
- "tari_mmr",
  "tari_p2p",
  "tari_shutdown",
  "tari_storage",
  "tari_template_builtin",
  "tari_template_lib",
  "tari_test_utils",
+ "tari_transaction",
  "tari_transaction_manifest",
  "tari_validator_node_cli",
  "tari_validator_node_client",
@@ -6580,6 +6570,7 @@ dependencies = [
  "tari_engine_types",
  "tari_template_builtin",
  "tari_template_lib",
+ "tari_transaction",
  "tari_transaction_manifest",
  "tari_utilities",
  "tari_validator_node_client",
@@ -6600,6 +6591,7 @@ dependencies = [
  "tari_comms_logging",
  "tari_dan_common_types",
  "tari_engine_types",
+ "tari_transaction",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "dan_layer/template_abi",
     "dan_layer/template_builtin",
     "dan_layer/template_lib",
+    "dan_layer/transaction",
     "dan_layer/template_macros",
     "dan_layer/transaction_manifest",
     "dan_layer/template_test_tooling",

--- a/applications/tari_validator_node/Cargo.toml
+++ b/applications/tari_validator_node/Cargo.toml
@@ -14,7 +14,6 @@ tari_common = { git = "https://github.com/tari-project/tari.git", branch = "deve
 tari_comms = { git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_comms" }
 tari_comms_rpc_macros = { git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_comms_rpc_macros" }
 tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.16.6" }
-tari_mmr = { git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_mmr" }
 tari_p2p = { git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_p2p" }
 tari_shutdown = { git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_shutdown" }
 tari_storage = { git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_storage" }
@@ -32,41 +31,37 @@ tari_wallet_grpc_client = { git = "https://github.com/tari-project/tari.git", br
 tari_engine_types = { path = "../../dan_layer/engine_types" }
 tari_validator_node_client = { path = "../../clients/validator_node_client" }
 tari_comms_logging = { path = "../../comms/tari_comms_logging" }
+tari_transaction = { path = "../../dan_layer/transaction" }
 
 anyhow = "1.0.53"
 async-trait = "0.1.50"
 axum = "0.6.0"
 axum-jrpc = { version = "0.3.2", features = ["anyhow_error"] }
-bincode = "1.3.3"
-blake2 = "0.9.2"
-borsh = { version = "0.9.3", default-features = false }
 bytes = "1"
 chrono = "0.4.22"
 clap = { version = "3.2.5", features = ["env"] }
 config = "0.13.0"
-digest = "0.9.0"
-diesel = { version = "1.4.8", default-features = false, features = ["sqlite"] }
 futures = { version = "^0.3.1" }
-json5 = "0.2.2"
 include_dir = "0.7.2"
+json5 = "0.2.2"
+libsqlite3-sys = { version = "0.22.2", features = ["bundled"] }
+lmdb-zero = "0.4.4"
 log = { version = "0.4.8", features = ["std"] }
 log4rs = { version = "1.1.1", features = ["rolling_file_appender", "compound_policy", "size_trigger", "fixed_window_roller"] }
-lmdb-zero = "0.4.4"
-libsqlite3-sys = { version = "0.22.2", features = ["bundled"] }
 mini-moka = "0.10.0"
 prost = "0.9"
 rand = "0.7"
 reqwest = "0.11.11"
 serde = { version = "1.0.126", features = ["derive"] }
 serde_json = "1.0.64"
-time = "0.3.15"
 thiserror = "^1.0.20"
+time = "0.3.15"
 tokio = { version = "1.10", features = ["macros", "time", "sync", "rt-multi-thread"] }
 tokio-stream = { version = "0.1.7", features = ["sync"] }
 tonic = "0.6.2"
 tower = "0.4"
-tower-layer = "0.3"
 tower-http = { version = "0.3.0", features = ["cors"] }
+tower-layer = "0.3"
 
 [build-dependencies]
 tari_common = { git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_common", features = ["build"] }
@@ -89,3 +84,11 @@ indexmap = "1.9.1"
 [[test]]
 name = "cucumber" # this should be the same as the filename of your test target
 harness = false # allows Cucumber to print output instead of libtest
+
+[package.metadata.cargo-machete]
+ignored = [
+    # We want to bundle this lib
+    "libsqlite3-sys",
+    # Want to enable some log4rs features
+    "log4rs",
+]

--- a/applications/tari_validator_node/src/dry_run_transaction_processor.rs
+++ b/applications/tari_validator_node/src/dry_run_transaction_processor.rs
@@ -44,12 +44,13 @@ use tari_dan_core::{
         StorageError,
     },
 };
-use tari_dan_engine::{runtime::ConsensusContext, transaction::Transaction};
+use tari_dan_engine::runtime::ConsensusContext;
 use tari_dan_storage_sqlite::sqlite_shard_store_factory::SqliteShardStore;
 use tari_engine_types::{
     commit_result::FinalizeResult,
     substate::{Substate, SubstateAddress},
 };
+use tari_transaction::Transaction;
 use thiserror::Error;
 
 use crate::{

--- a/applications/tari_validator_node/src/json_rpc/handlers.rs
+++ b/applications/tari_validator_node/src/json_rpc/handlers.rs
@@ -34,15 +34,15 @@ use serde_json::{self as json, json};
 use tari_comms::{multiaddr::Multiaddr, peer_manager::NodeId, types::CommsPublicKey, CommsNode, NodeIdentity};
 use tari_comms_logging::SqliteMessageLog;
 use tari_crypto::tari_utilities::hex::Hex;
-use tari_dan_common_types::{PayloadId, QuorumCertificate, QuorumDecision, ShardId, SubstateChange};
+use tari_dan_common_types::{PayloadId, QuorumCertificate, QuorumDecision, ShardId};
 use tari_dan_core::{
     services::{epoch_manager::EpochManager, BaseNodeClient},
     storage::shard_store::{ShardStore, ShardStoreReadTransaction},
     workers::events::{EventSubscription, HotStuffEvent},
 };
-use tari_dan_engine::transaction::TransactionBuilder;
 use tari_dan_storage_sqlite::sqlite_shard_store_factory::SqliteShardStore;
 use tari_template_lib::Hash;
+use tari_transaction::{SubstateChange, TransactionBuilder};
 use tari_validator_node_client::types::{
     GetCommitteeRequest,
     GetIdentityResponse,

--- a/applications/tari_validator_node/src/p2p/proto/conversions/transaction.rs
+++ b/applications/tari_validator_node/src/p2p/proto/conversions/transaction.rs
@@ -28,10 +28,10 @@ use std::{
 use anyhow::anyhow;
 use tari_common_types::types::{PublicKey, Signature};
 use tari_crypto::tari_utilities::ByteArray;
-use tari_dan_common_types::{ObjectClaim, ShardId, SubstateChange};
-use tari_dan_engine::transaction::{Transaction, TransactionMeta};
+use tari_dan_common_types::ShardId;
 use tari_engine_types::instruction::Instruction;
 use tari_template_lib::{args::Arg, Hash};
+use tari_transaction::{ObjectClaim, SubstateChange, Transaction, TransactionMeta};
 
 use crate::p2p::proto;
 

--- a/applications/tari_validator_node/src/p2p/rpc/service_impl.rs
+++ b/applications/tari_validator_node/src/p2p/rpc/service_impl.rs
@@ -29,8 +29,8 @@ use tari_dan_core::{
     services::PeerProvider,
     storage::shard_store::{ShardStore, ShardStoreReadTransaction},
 };
-use tari_dan_engine::transaction::Transaction;
 use tari_dan_storage_sqlite::sqlite_shard_store_factory::SqliteShardStore;
+use tari_transaction::Transaction;
 use tokio::{sync::mpsc, task};
 
 use crate::p2p::proto::rpc::{VnStateSyncRequest, VnStateSyncResponse};

--- a/applications/tari_validator_node/src/p2p/services/hotstuff/hotstuff_service.rs
+++ b/applications/tari_validator_node/src/p2p/services/hotstuff/hotstuff_service.rs
@@ -40,9 +40,9 @@ use tari_dan_core::{
         pacemaker_worker::Pacemaker,
     },
 };
-use tari_dan_engine::transaction::Transaction;
 use tari_dan_storage_sqlite::sqlite_shard_store_factory::SqliteShardStore;
 use tari_shutdown::ShutdownSignal;
+use tari_transaction::Transaction;
 use tokio::sync::{
     broadcast,
     mpsc::{channel, Receiver, Sender},

--- a/applications/tari_validator_node/src/p2p/services/mempool/handle.rs
+++ b/applications/tari_validator_node/src/p2p/services/mempool/handle.rs
@@ -21,8 +21,8 @@
 //   USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use tari_dan_common_types::ShardId;
-use tari_dan_engine::transaction::Transaction;
 use tari_template_lib::Hash;
+use tari_transaction::Transaction;
 use tokio::sync::{broadcast, broadcast::error::RecvError, mpsc, oneshot};
 
 use crate::p2p::services::mempool::MempoolError;

--- a/applications/tari_validator_node/src/p2p/services/mempool/initializer.rs
+++ b/applications/tari_validator_node/src/p2p/services/mempool/initializer.rs
@@ -23,7 +23,7 @@
 use std::sync::Arc;
 
 use tari_comms::NodeIdentity;
-use tari_dan_engine::transaction::Transaction;
+use tari_transaction::Transaction;
 use tokio::{
     sync::{broadcast, mpsc},
     task,

--- a/applications/tari_validator_node/src/p2p/services/mempool/service.rs
+++ b/applications/tari_validator_node/src/p2p/services/mempool/service.rs
@@ -32,8 +32,8 @@ use tari_dan_core::{
     message::DanMessage,
     services::{epoch_manager::EpochManager, infrastructure_services::OutboundService},
 };
-use tari_dan_engine::transaction::Transaction;
 use tari_template_lib::Hash;
+use tari_transaction::Transaction;
 use tokio::sync::{broadcast, mpsc};
 
 use super::MempoolError;

--- a/applications/tari_validator_node/src/p2p/services/mempool/validator.rs
+++ b/applications/tari_validator_node/src/p2p/services/mempool/validator.rs
@@ -2,8 +2,8 @@
 //   SPDX-License-Identifier: BSD-3-Clause
 
 use async_trait::async_trait;
-use tari_dan_engine::transaction::Transaction;
 use tari_engine_types::instruction::Instruction;
+use tari_transaction::Transaction;
 
 use crate::p2p::services::{
     mempool::{MempoolError, Validator},

--- a/applications/tari_validator_node/src/p2p/services/messaging/mod.rs
+++ b/applications/tari_validator_node/src/p2p/services/messaging/mod.rs
@@ -39,7 +39,7 @@ use tari_dan_core::{
     models::{vote_message::VoteMessage, HotStuffMessage, TariDanPayload},
     workers::hotstuff_waiter::RecoveryMessage,
 };
-use tari_dan_engine::transaction::Transaction;
+use tari_transaction::Transaction;
 use tokio::sync::mpsc;
 
 use crate::comms::MessageChannel;

--- a/applications/tari_validator_node/src/p2p/services/rpc_client.rs
+++ b/applications/tari_validator_node/src/p2p/services/rpc_client.rs
@@ -33,7 +33,7 @@ use tari_comms::{
 };
 use tari_crypto::tari_utilities::ByteArray;
 use tari_dan_core::services::{DanPeer, ValidatorNodeClientError, ValidatorNodeClientFactory, ValidatorNodeRpcClient};
-use tari_dan_engine::transaction::Transaction;
+use tari_transaction::Transaction;
 use tokio_stream::StreamExt;
 
 use crate::p2p::{

--- a/applications/tari_validator_node/src/payload_processor.rs
+++ b/applications/tari_validator_node/src/payload_processor.rs
@@ -36,7 +36,7 @@ use tari_dan_engine::{
     packager::{LoadedTemplate, Package},
     runtime::{AuthParams, ConsensusContext},
     state_store::{memory::MemoryStateStore, AtomicDb, StateReader, StateStoreError, StateWriter},
-    transaction::{Transaction, TransactionError, TransactionProcessor},
+    transaction::{TransactionError, TransactionProcessor},
     wasm::WasmExecutionError,
 };
 use tari_engine_types::{
@@ -48,6 +48,7 @@ use tari_template_lib::{
     models::{ComponentAddress, TemplateAddress},
     prelude::NonFungibleAddress,
 };
+use tari_transaction::Transaction;
 
 #[derive(Debug, Default, Clone)]
 pub struct TariDanPayloadProcessor<TTemplateProvider> {

--- a/applications/tari_validator_node_cli/Cargo.toml
+++ b/applications/tari_validator_node_cli/Cargo.toml
@@ -13,21 +13,22 @@ tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "
 tari_dan_common_types = { path = "../../dan_layer/common_types" }
 tari_dan_engine = { path = "../../dan_layer/engine" }
 tari_engine_types = { path = "../../dan_layer/engine_types" }
+tari_template_builtin = { path = "../../dan_layer/template_builtin" }
+tari_template_lib = { path = "../../dan_layer/template_lib" }
+tari_transaction = { path = "../../dan_layer/transaction" }
+tari_transaction_manifest = { path = "../../dan_layer/transaction_manifest" }
 tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.10" }
 tari_validator_node_client = { path = "../../clients/validator_node_client" }
-tari_template_lib = { path = "../../dan_layer/template_lib" }
-tari_transaction_manifest = { path = "../../dan_layer/transaction_manifest" }
-tari_template_builtin = { path = "../../dan_layer/template_builtin" }
 
 anyhow = "1.0.65"
 clap = { version = "3.2.22", features = ["derive", "env"] }
 dirs = "4.0.0"
-log = "0.4.17"
 jfs = "0.7.1"
+log = "0.4.17"
 multiaddr = "0.14.0"
 reqwest = { version = "0.11.11", features = ["json"] }
 serde = "1.0.144"
 serde_json = "1.0.85"
-time = "0.3.15"
 thiserror = "1.0.36"
+time = "0.3.15"
 tokio = { version = "1", features = ["macros"] }

--- a/applications/tari_validator_node_cli/src/command/transaction.rs
+++ b/applications/tari_validator_node_cli/src/command/transaction.rs
@@ -30,8 +30,7 @@ use std::{
 use anyhow::anyhow;
 use clap::{Args, Subcommand};
 use tari_common_types::types::FixedHash;
-use tari_dan_common_types::{ShardId, SubstateChange};
-use tari_dan_engine::transaction::Transaction;
+use tari_dan_common_types::ShardId;
 use tari_engine_types::{
     commit_result::{FinalizeResult, TransactionResult},
     execution_result::{ExecutionResult, Type},
@@ -45,6 +44,7 @@ use tari_template_lib::{
     models::{Amount, NonFungibleAddress, NonFungibleId},
     prelude::ResourceAddress,
 };
+use tari_transaction::{SubstateChange, Transaction};
 use tari_transaction_manifest::parse_manifest;
 use tari_utilities::hex::to_hex;
 use tari_validator_node_client::{

--- a/applications/tari_validator_node_cli/src/key_manager.rs
+++ b/applications/tari_validator_node_cli/src/key_manager.rs
@@ -31,8 +31,7 @@ use serde_json as json;
 use serde_json::json;
 use tari_common_types::types::{PrivateKey, PublicKey};
 use tari_crypto::keys::PublicKey as PublicKeyT;
-use tari_dan_common_types::NodeAddressable;
-use tari_dan_engine::crypto::create_key_pair;
+use tari_dan_common_types::{crypto::create_key_pair, NodeAddressable};
 use tari_template_lib::{crypto::RistrettoPublicKeyBytes, models::NonFungibleAddress};
 use tari_utilities::hex::Hex;
 

--- a/clients/validator_node_client/Cargo.toml
+++ b/clients/validator_node_client/Cargo.toml
@@ -10,6 +10,7 @@ tari_dan_common_types = { path = "../../dan_layer/common_types" }
 tari_engine_types = { path = "../../dan_layer/engine_types" }
 tari_common_types = { git = "https://github.com/tari-project/tari.git", branch = "development" }
 tari_comms_logging = { path = "../../comms/tari_comms_logging" }
+tari_transaction = { path = "../../dan_layer/transaction" }
 
 anyhow = "1.0.65"
 reqwest = { version = "0.11.11", features = ["json"] }

--- a/clients/validator_node_client/src/types.rs
+++ b/clients/validator_node_client/src/types.rs
@@ -27,7 +27,6 @@ use tari_dan_common_types::{
     serde_with,
     Epoch,
     ShardId,
-    SubstateChange,
 };
 use tari_engine_types::{
     commit_result::FinalizeResult,
@@ -35,6 +34,7 @@ use tari_engine_types::{
     signature::InstructionSignature,
     TemplateAddress,
 };
+use tari_transaction::SubstateChange;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GetIdentityResponse {

--- a/dan_layer/common_types/Cargo.toml
+++ b/dan_layer/common_types/Cargo.toml
@@ -7,7 +7,6 @@ license = "BSD-3-Clause"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tari_common = { git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_common", features = ["build"] }
 tari_common_types = { git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_common_types" }
 tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.10" }
 tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.16.6", features = ["borsh"] }
@@ -22,9 +21,13 @@ base64 = "0.20.0-alpha.1"
 borsh = "0.9"
 digest = "0.9"
 newtype-ops = "0.1.4"
+rand = "0.7"
 prost = "0.9"
 prost-types = "0.9"
 serde = "1.0.126"
 
 [build-dependencies]
 tari_common = { git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_common", features = ["build"] }
+
+[package.metadata.cargo-machete]
+ignored = ["prost", "prost-types"] # false positive, used in OUT_DIR structs

--- a/dan_layer/common_types/src/crypto.rs
+++ b/dan_layer/common_types/src/crypto.rs
@@ -1,4 +1,4 @@
-//   Copyright 2022 The Tari Project
+//   Copyright 2023 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
 use rand::rngs::OsRng;

--- a/dan_layer/common_types/src/lib.rs
+++ b/dan_layer/common_types/src/lib.rs
@@ -12,6 +12,7 @@ use tari_common_types::types::{FixedHash, FixedHashSizeError};
 use tari_engine_types::substate::{Substate, SubstateAddress};
 use tari_utilities::hex::Hex;
 
+pub mod crypto;
 pub mod proto;
 
 mod epoch;
@@ -43,27 +44,8 @@ mod node_addressable;
 pub use node_addressable::NodeAddressable;
 
 mod shard_id;
+
 pub use shard_id::ShardId;
-
-#[derive(Clone, Debug, Copy, PartialEq, Eq, Hash, Deserialize, Serialize)]
-pub enum SubstateChange {
-    /// An "Up" state
-    Create,
-    /// Substate exists but will not be created/destroyed
-    Exists,
-    /// A "Down" state
-    Destroy,
-}
-
-impl Display for SubstateChange {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        match self {
-            SubstateChange::Create => write!(f, "Create"),
-            SubstateChange::Exists => write!(f, "Exists"),
-            SubstateChange::Destroy => write!(f, "Destroy"),
-        }
-    }
-}
 
 #[derive(Debug, Clone, Encode, Decode, Deserialize, Serialize)]
 pub enum SubstateState {
@@ -85,16 +67,6 @@ impl SubstateState {
             Self::Up { .. } => "Up",
             Self::Down { .. } => "Down",
         }
-    }
-}
-
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
-pub struct ObjectClaim {}
-
-impl ObjectClaim {
-    pub fn is_valid(&self, _payload: PayloadId) -> bool {
-        // TODO: Implement this
-        true
     }
 }
 

--- a/dan_layer/core/Cargo.toml
+++ b/dan_layer/core/Cargo.toml
@@ -7,14 +7,10 @@ license = "BSD-3-Clause"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tari_common = { git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_common" }
 tari_comms = { git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_comms" }
 tari_comms_dht = { git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_comms_dht" }
-tari_comms_rpc_macros = { git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_comms_rpc_macros" }
 tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.16.6" }
 tari_mmr = { git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_mmr" }
-tari_p2p = { git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_p2p" }
-tari_service_framework = { git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_service_framework" }
 tari_shutdown = { git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_shutdown" }
 tari_storage = { git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_storage" }
 tari_core = { git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_core" }
@@ -24,31 +20,22 @@ tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", t
 tari_dan_engine = { path = "../engine" }
 tari_dan_storage = { path = "../storage" }
 tari_engine_types = { path = "../engine_types" }
-tari_bor = { path = "../tari_bor" }
+tari_transaction = { path = "../transaction" }
 
 anyhow = "1.0.53"
 async-trait = "0.1.50"
 blake2 = "0.9.2"
-borsh = "0.9.3"
 chrono = { version = "0.4.19", default-features = false }
-clap = "3.1.8"
 digest = "0.9.0"
 futures = { version = "^0.3.1" }
 lmdb-zero = "0.4.4"
 log = { version = "0.4.8", features = ["std"] }
-num-derive = "0.3.3"
-num-traits = "0.2.15"
 prost = "0.9"
-prost-types = "0.9"
 rand = "0.8.4"
 serde = "1.0.126"
 thiserror = "^1.0.20"
 tokio = { version = "1.10", features = ["macros", "time"] }
-tokio-stream = { version = "0.1.7", features = ["sync"] }
 tonic = "0.6.2"
-lazy_static = "1.4.0"
-
-serde_json = "1.0.64"
 
 [dev-dependencies]
 tari_test_utils = { git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_test_utils" }

--- a/dan_layer/core/src/message.rs
+++ b/dan_layer/core/src/message.rs
@@ -23,7 +23,7 @@
 use serde::Serialize;
 use tari_comms::{multiaddr::Multiaddr, peer_manager::IdentitySignature};
 use tari_dan_common_types::NodeAddressable;
-use tari_dan_engine::transaction::Transaction;
+use tari_transaction::Transaction;
 
 use crate::{
     models::{vote_message::VoteMessage, HotStuffMessage},

--- a/dan_layer/core/src/models/payload.rs
+++ b/dan_layer/core/src/models/payload.rs
@@ -24,8 +24,9 @@ use std::fmt::Debug;
 
 use serde::{Deserialize, Serialize};
 use tari_common_types::types::FixedHash;
-use tari_dan_common_types::{ObjectClaim, PayloadId, ShardId, SubstateChange};
+use tari_dan_common_types::{PayloadId, ShardId};
 use tari_engine_types::commit_result::FinalizeResult;
+use tari_transaction::{ObjectClaim, SubstateChange};
 
 use crate::models::ConsensusHash;
 

--- a/dan_layer/core/src/models/tari_dan_payload.rs
+++ b/dan_layer/core/src/models/tari_dan_payload.rs
@@ -25,9 +25,9 @@ use std::fmt::Debug;
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use tari_common_types::types::FixedHash;
-use tari_dan_common_types::{ObjectClaim, ShardId, SubstateChange};
-use tari_dan_engine::transaction::Transaction;
+use tari_dan_common_types::ShardId;
 use tari_engine_types::commit_result::FinalizeResult;
+use tari_transaction::{ObjectClaim, SubstateChange, Transaction};
 
 use crate::models::{ConsensusHash, Payload};
 

--- a/dan_layer/core/src/services/signing_service.rs
+++ b/dan_layer/core/src/services/signing_service.rs
@@ -27,8 +27,7 @@ use tari_comms::{
     types::{CommsPublicKey, Signature},
     NodeIdentity,
 };
-use tari_dan_common_types::hashing::tari_hasher;
-use tari_dan_engine::crypto::create_key_pair;
+use tari_dan_common_types::{crypto::create_key_pair, hashing::tari_hasher};
 use tari_utilities::ByteArray;
 
 use crate::TariDanCoreHashDomain;

--- a/dan_layer/core/src/services/validator_node_rpc_client.rs
+++ b/dan_layer/core/src/services/validator_node_rpc_client.rs
@@ -28,7 +28,7 @@ use tari_comms::{
 };
 use tari_comms_dht::DhtActorError;
 use tari_dan_common_types::NodeAddressable;
-use tari_dan_engine::transaction::Transaction;
+use tari_transaction::Transaction;
 
 use crate::services::DanPeer;
 

--- a/dan_layer/core/src/workers/hotstuff_error.rs
+++ b/dan_layer/core/src/workers/hotstuff_error.rs
@@ -20,8 +20,9 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use tari_dan_common_types::{Epoch, NodeHeight, PayloadId, ShardId, SubstateChange};
+use tari_dan_common_types::{Epoch, NodeHeight, PayloadId, ShardId};
 use tari_engine_types::{commit_result::RejectReason, substate::SubstateAddress};
+use tari_transaction::SubstateChange;
 use thiserror::Error;
 use tokio::sync::mpsc;
 

--- a/dan_layer/core/src/workers/hotstuff_waiter.rs
+++ b/dan_layer/core/src/workers/hotstuff_waiter.rs
@@ -41,7 +41,6 @@ use tari_dan_common_types::{
     ShardId,
     ShardPledge,
     ShardPledgeCollection,
-    SubstateChange,
     SubstateState,
     TreeNodeHash,
 };
@@ -51,6 +50,7 @@ use tari_engine_types::{
     substate::SubstateDiff,
 };
 use tari_shutdown::ShutdownSignal;
+use tari_transaction::SubstateChange;
 use tokio::{
     sync::{
         broadcast,

--- a/dan_layer/engine/Cargo.toml
+++ b/dan_layer/engine/Cargo.toml
@@ -7,22 +7,19 @@ edition = "2018"
 
 [dependencies]
 tari_bor = { path = "../tari_bor" }
-tari_common = { git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_common" }
 tari_common_types = { git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_common_types" }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.16.6" }
 tari_dan_common_types = { path = "../common_types" }
 tari_engine_types = { path = "../engine_types" }
 tari_mmr = { git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_mmr" }
 tari_template_abi = { path = "../template_abi", features = ["std"] }
 tari_template_lib = { path = "../template_lib", default-features = false, features = ["serde"] }
 tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.10" }
+tari_transaction = { path = "../transaction" }
 
 anyhow = "1.0.53"
 cargo_toml = "0.11.5"
 #d3ne = { git = "https://github.com/stringhandler/d3ne-rs.git", branch = "st-fixes2" }
-digest = "0.9.0"
 log = { version = "0.4.8", features = ["std"] }
-rand = "0.7"
 serde = "1.0.126"
 serde_json = "1.0.81"
 thiserror = "^1.0.20"
@@ -33,3 +30,4 @@ wasmer-middlewares = "2.3.0"
 [dev-dependencies]
 tari_template_test_tooling = { path = "../template_test_tooling" }
 tari_transaction_manifest = { path = "../transaction_manifest" }
+tari_transaction = { path = "../transaction" }

--- a/dan_layer/engine/src/lib.rs
+++ b/dan_layer/engine/src/lib.rs
@@ -1,7 +1,7 @@
 // Copyright 2022 The Tari Project
 // SPDX-License-Identifier: BSD-3-Clause
 
-pub mod crypto;
+// pub mod crypto;
 // pub mod flow;
 pub mod function_definitions;
 pub mod packager;

--- a/dan_layer/engine/src/runtime/error.rs
+++ b/dan_layer/engine/src/runtime/error.rs
@@ -26,9 +26,10 @@ use anyhow::anyhow;
 use tari_dan_common_types::optional::IsNotFoundError;
 use tari_engine_types::{resource_container::ResourceError, substate::SubstateAddress};
 use tari_template_lib::models::{Amount, BucketId, ComponentAddress, NonFungibleId, ResourceAddress, VaultId};
+use tari_transaction::id_provider::MaxIdsExceeded;
 
 use crate::{
-    runtime::{id_provider::MaxIdsExceeded, FunctionIdent, RuntimeModuleError},
+    runtime::{FunctionIdent, RuntimeModuleError},
     state_store::StateStoreError,
 };
 

--- a/dan_layer/engine/src/runtime/impl.rs
+++ b/dan_layer/engine/src/runtime/impl.rs
@@ -542,7 +542,8 @@ impl RuntimeInterface for RuntimeInterfaceImpl {
 
     fn generate_uuid(&self) -> Result<[u8; 32], RuntimeError> {
         self.invoke_on_runtime_call_modules("generate_uuid")?;
-        self.tracker.id_provider().new_uuid()
+        let uuid = self.tracker.id_provider().new_uuid()?;
+        Ok(uuid)
     }
 
     fn set_last_instruction_output(&self, value: Option<Vec<u8>>) -> Result<(), RuntimeError> {

--- a/dan_layer/engine/src/runtime/mod.rs
+++ b/dan_layer/engine/src/runtime/mod.rs
@@ -23,9 +23,6 @@
 mod auth;
 pub use auth::{AuthParams, AuthorizationScope};
 
-mod id_provider;
-pub use id_provider::IdProvider;
-
 mod r#impl;
 pub use r#impl::RuntimeInterfaceImpl;
 

--- a/dan_layer/engine/src/runtime/tests.rs
+++ b/dan_layer/engine/src/runtime/tests.rs
@@ -4,9 +4,10 @@
 use std::collections::HashMap;
 
 use tari_template_lib::{auth::AccessRules, Hash};
+use tari_transaction::id_provider::IdProvider;
 
 use crate::{
-    runtime::{IdProvider, RuntimeState, StateTracker},
+    runtime::{RuntimeState, StateTracker},
     state_store::memory::MemoryStateStore,
 };
 

--- a/dan_layer/engine/src/runtime/tracker.rs
+++ b/dan_layer/engine/src/runtime/tracker.rs
@@ -56,9 +56,10 @@ use tari_template_lib::{
     resource::ResourceType,
     Hash,
 };
+use tari_transaction::id_provider::IdProvider;
 
 use crate::{
-    runtime::{id_provider::IdProvider, working_state::WorkingState, RuntimeError, TransactionCommitError},
+    runtime::{working_state::WorkingState, RuntimeError, TransactionCommitError},
     state_store::{memory::MemoryStateStore, AtomicDb, StateReader},
 };
 

--- a/dan_layer/engine/src/transaction/processor.rs
+++ b/dan_layer/engine/src/transaction/processor.rs
@@ -29,6 +29,7 @@ use tari_template_lib::{
     args::{Arg, WorkspaceAction},
     invoke_args,
 };
+use tari_transaction::{id_provider::IdProvider, Transaction};
 
 use crate::{
     packager::{LoadedTemplate, Package},
@@ -37,7 +38,6 @@ use crate::{
         AuthorizationScope,
         ConsensusContext,
         FunctionIdent,
-        IdProvider,
         Runtime,
         RuntimeInterfaceImpl,
         RuntimeModule,
@@ -46,7 +46,7 @@ use crate::{
     },
     state_store::memory::MemoryStateStore,
     traits::Invokable,
-    transaction::{Transaction, TransactionError},
+    transaction::TransactionError,
     wasm::WasmProcess,
 };
 
@@ -89,7 +89,7 @@ impl TransactionProcessor {
         let auth_scope = AuthorizationScope::new(&initial_proofs);
         let runtime = Runtime::new(Arc::new(runtime_interface));
         let exec_results = transaction
-            .instructions
+            .into_instructions()
             .into_iter()
             .map(|instruction| Self::process_instruction(&package, &runtime, &auth_scope, instruction))
             .collect::<Result<Vec<_>, _>>()?;

--- a/dan_layer/engine_types/Cargo.toml
+++ b/dan_layer/engine_types/Cargo.toml
@@ -12,6 +12,7 @@ tari_template_abi = { path = "../template_abi", features = ["std"] }
 tari_template_lib = { path = "../template_lib", default-features = false, features = ["serde"] }
 tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.10" }
 
+rand = "0.7"
 digest = "0.9.0"
 serde = "1.0.126"
 thiserror = "1"

--- a/dan_layer/engine_types/src/signature.rs
+++ b/dan_layer/engine_types/src/signature.rs
@@ -3,6 +3,7 @@
 
 use std::convert::TryFrom;
 
+use rand::rngs::OsRng;
 use serde::{Deserialize, Serialize};
 use tari_crypto::{
     keys::PublicKey as PublicKeyT,
@@ -16,11 +17,8 @@ use crate::{hashing::hasher, instruction::Instruction};
 pub struct InstructionSignature(RistrettoSchnorr);
 
 impl InstructionSignature {
-    pub fn sign(
-        secret_key: &RistrettoSecretKey,
-        secret_nonce: RistrettoSecretKey,
-        instructions: &[Instruction],
-    ) -> Self {
+    pub fn sign(secret_key: &RistrettoSecretKey, instructions: &[Instruction]) -> Self {
+        let (secret_nonce, _nonce_pk) = RistrettoPublicKey::random_keypair(&mut OsRng);
         let public_key = RistrettoPublicKey::from_secret_key(secret_key);
         let nonce_pk = RistrettoPublicKey::from_secret_key(&secret_nonce);
         // TODO: implement dan encoding for (a wrapper of) PublicKey

--- a/dan_layer/integration_tests/Cargo.toml
+++ b/dan_layer/integration_tests/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2018"
 license = "BSD-3-Clause"
 
 [dependencies]
-tari_common = { git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_common", features = ["build"] }
 tari_common_types = { git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_common_types" }
 tari_comms = { git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_comms" }
 tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.16.6" }
@@ -16,10 +15,9 @@ tari_dan_storage_sqlite = { path = "../storage_sqlite" }
 tari_engine_types = { path = "../engine_types" }
 tari_shutdown = { git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_shutdown" }
 tari_template_lib = { path = "../template_lib" }
-tari_test_utils = { git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_test_utils" }
 tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.10" }
-tari_mmr = { git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_mmr" }
 tari_core = { git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_core" }
+tari_transaction = { path = "../transaction" }
 
 lazy_static = "1.4.0"
 tempdir = "0.3.7"

--- a/dan_layer/integration_tests/src/test_consensus.rs
+++ b/dan_layer/integration_tests/src/test_consensus.rs
@@ -47,9 +47,9 @@ use tari_dan_core::{
     storage::shard_store::{ShardStore, ShardStoreWriteTransaction},
     workers::hotstuff_waiter::RecoveryMessage,
 };
-use tari_dan_engine::transaction::{Transaction, TransactionBuilder};
 use tari_engine_types::instruction::Instruction;
 use tari_template_lib::{args, models::TemplateAddress};
+use tari_transaction::{Transaction, TransactionBuilder};
 use tari_utilities::ByteArray;
 use tokio::time::timeout;
 

--- a/dan_layer/storage_sqlite/Cargo.toml
+++ b/dan_layer/storage_sqlite/Cargo.toml
@@ -6,22 +6,19 @@ license = "BSD-3-Clause"
 
 [dependencies]
 tari_dan_core = { path = "../core" }
-tari_common = { git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_common" }
 tari_common_types = { git = "https://github.com/tari-project/tari.git", branch = "development", package = "tari_common_types" }
 tari_dan_common_types = { path = "../common_types" }
 tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.10" }
 tari_dan_engine = { path = "../engine" }
 tari_dan_storage = { path = "../storage" }
 tari_engine_types = { path = "../engine_types" }
+tari_transaction = { path = "../transaction" }
 
 borsh = "0.9.3"
 diesel = { version = "1.4.8", default-features = false, features = ["sqlite", "chrono"] }
 diesel_migrations = "1.4.0"
 thiserror = "1.0.30"
-async-trait = "0.1.50"
 chrono = "0.4.19"
-tokio = { version = "1.10", features = ["macros", "time"] }
-tokio-stream = { version = "0.1.7", features = ["sync"] }
 log = { version = "0.4.8", features = ["std"] }
 time = "0.3.15"
 serde_json = "1.0.85"

--- a/dan_layer/storage_sqlite/src/sqlite_shard_store_factory.rs
+++ b/dan_layer/storage_sqlite/src/sqlite_shard_store_factory.rs
@@ -69,8 +69,8 @@ use tari_dan_core::{
         StorageError,
     },
 };
-use tari_dan_engine::transaction::{Transaction, TransactionMeta};
 use tari_engine_types::{instruction::Instruction, signature::InstructionSignature};
+use tari_transaction::{Transaction, TransactionMeta};
 use tari_utilities::{
     hex::{to_hex, Hex},
     ByteArray,

--- a/dan_layer/template_builtin/templates/account/Cargo.toml
+++ b/dan_layer/template_builtin/templates/account/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2021"
 tari_template_abi = { path = "../../../template_abi" }
 tari_template_lib = { path = "../../../template_lib" }
 tari_template_macros = { path = "../../../template_macros" }
-log = "*"
 
 [profile.release]
 opt-level = 's'     # Optimize for size.

--- a/dan_layer/template_test_tooling/Cargo.toml
+++ b/dan_layer/template_test_tooling/Cargo.toml
@@ -7,14 +7,12 @@ edition = "2021"
 [dependencies]
 tari_dan_engine = { path = "../engine" }
 tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.16.6" }
-tari_template_abi = { path = "../template_abi", features = ["std"] }
 tari_template_lib = { path = "../template_lib", default-features = false, features = ["serde"] }
 tari_engine_types = { path = "../engine_types" }
 tari_transaction_manifest = { path = "../transaction_manifest" }
 tari_template_builtin = { path = "../template_builtin" }
+tari_transaction = { path = "../transaction" }
+tari_dan_common_types = { path = "../common_types" }
 
 anyhow = "1.0.68"
 borsh = "0.9.3"
-log = { version = "0.4.8", features = ["std"] }
-
-

--- a/dan_layer/template_test_tooling/src/template_test.rs
+++ b/dan_layer/template_test_tooling/src/template_test.rs
@@ -10,13 +10,13 @@ use std::{
 use anyhow::anyhow;
 use borsh::BorshDeserialize;
 use tari_crypto::{ristretto::RistrettoSecretKey, tari_utilities::ByteArray};
+use tari_dan_common_types::crypto::create_key_pair;
 use tari_dan_engine::{
     bootstrap_state,
-    crypto::create_key_pair,
     packager::{LoadedTemplate, Package, TemplateModuleLoader},
     runtime::{AuthParams, ConsensusContext, RuntimeModule},
     state_store::{memory::MemoryStateStore, AtomicDb, StateReader, StateStoreError, StateWriter},
-    transaction::{Transaction, TransactionError, TransactionProcessor},
+    transaction::{TransactionError, TransactionProcessor},
     wasm::{compile::compile_template, LoadedWasmTemplate, WasmModule},
 };
 use tari_engine_types::{
@@ -32,6 +32,7 @@ use tari_template_lib::{
     crypto::RistrettoPublicKeyBytes,
     models::{ComponentAddress, ComponentHeader, NonFungibleAddress, TemplateAddress},
 };
+use tari_transaction::Transaction;
 use tari_transaction_manifest::{parse_manifest, ManifestValue};
 
 use crate::track_calls::TrackCallsModule;

--- a/dan_layer/transaction/Cargo.toml
+++ b/dan_layer/transaction/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "tari_transaction"
+version = "0.1.0"
+edition = "2021"
+
+
+[dependencies]
+#tari_bor = { path = "../tari_bor" }
+tari_common_types = { git = "https://github.com/tari-project/tari.git", branch = "development" }
+tari_engine_types = { path = "../engine_types" }
+tari_dan_common_types = { path = "../common_types" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.16.6", features = ["borsh"] }
+#tari_template_abi = { path = "../template_abi", features = ["std"] }
+tari_template_lib = { path = "../template_lib", default-features = false, features = ["serde"] }
+#tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.10" }
+
+serde = "1.0.126"
+thiserror = "1"

--- a/dan_layer/transaction/src/change.rs
+++ b/dan_layer/transaction/src/change.rs
@@ -1,0 +1,29 @@
+//   Copyright 2023 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+use std::{
+    fmt,
+    fmt::{Display, Formatter},
+};
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Copy, PartialEq, Eq, Hash, Deserialize, Serialize)]
+pub enum SubstateChange {
+    /// An "Up" state
+    Create,
+    /// Substate exists but will not be created/destroyed
+    Exists,
+    /// A "Down" state
+    Destroy,
+}
+
+impl Display for SubstateChange {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            SubstateChange::Create => write!(f, "Create"),
+            SubstateChange::Exists => write!(f, "Exists"),
+            SubstateChange::Destroy => write!(f, "Destroy"),
+        }
+    }
+}

--- a/dan_layer/transaction/src/id_provider.rs
+++ b/dan_layer/transaction/src/id_provider.rs
@@ -1,24 +1,5 @@
-//   Copyright 2022. The Tari Project
-//
-//   Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
-//   following conditions are met:
-//
-//   1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
-//   disclaimer.
-//
-//   2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
-//   following disclaimer in the documentation and/or other materials provided with the distribution.
-//
-//   3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
-//   products derived from this software without specific prior written permission.
-//
-//   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
-//   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-//   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-//   SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
-//   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
-//   USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//   Copyright 2023 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
 
 use std::sync::{atomic::AtomicU32, Arc};
 
@@ -27,8 +8,6 @@ use tari_template_lib::{
     models::{BucketId, ComponentAddress, ResourceAddress, VaultId},
     Hash,
 };
-
-use crate::runtime::RuntimeError;
 
 #[derive(Debug, Clone)]
 pub struct IdProvider {
@@ -97,7 +76,7 @@ impl IdProvider {
         self.bucket_id.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
     }
 
-    pub fn new_uuid(&self) -> Result<[u8; 32], RuntimeError> {
+    pub fn new_uuid(&self) -> Result<[u8; 32], MaxIdsExceeded> {
         let n = self.uuid.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         let id = hasher("uuid_output").chain(&self.transaction_hash).chain(&n).result();
         Ok(id.into_array())

--- a/dan_layer/transaction/src/lib.rs
+++ b/dan_layer/transaction/src/lib.rs
@@ -20,8 +20,13 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-mod error;
-pub use error::TransactionError;
+mod builder;
+mod change;
+pub mod id_provider;
+mod object_claim;
+mod transaction;
 
-mod processor;
-pub use processor::TransactionProcessor;
+pub use builder::TransactionBuilder;
+pub use change::SubstateChange;
+pub use object_claim::ObjectClaim;
+pub use transaction::{Transaction, TransactionMeta};

--- a/dan_layer/transaction/src/object_claim.rs
+++ b/dan_layer/transaction/src/object_claim.rs
@@ -1,0 +1,14 @@
+//   Copyright 2023 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+pub struct ObjectClaim {}
+
+impl ObjectClaim {
+    pub fn is_valid(&self) -> bool {
+        // TODO: Implement this
+        true
+    }
+}

--- a/dan_layer/transaction/src/transaction.rs
+++ b/dan_layer/transaction/src/transaction.rs
@@ -1,0 +1,166 @@
+//   Copyright 2023 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+use tari_common_types::types::PublicKey;
+use tari_dan_common_types::ShardId;
+use tari_engine_types::{hashing::hasher, instruction::Instruction, signature::InstructionSignature};
+use tari_template_lib::{
+    models::{ComponentAddress, TemplateAddress},
+    Hash,
+};
+
+use crate::{change::SubstateChange, ObjectClaim, TransactionBuilder};
+
+#[derive(Debug, Clone)]
+pub struct BalanceProof {}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Transaction {
+    hash: Hash,
+    instructions: Vec<Instruction>,
+    signature: InstructionSignature,
+    _fee: u64,
+    sender_public_key: PublicKey,
+    // Not part of signature. TODO: Should it be?
+    meta: TransactionMeta,
+}
+
+impl Transaction {
+    pub fn builder() -> TransactionBuilder {
+        TransactionBuilder::new()
+    }
+
+    pub fn new(
+        fee: u64,
+        instructions: Vec<Instruction>,
+        signature: InstructionSignature,
+        sender_public_key: PublicKey,
+        meta: TransactionMeta,
+    ) -> Self {
+        let mut s = Self {
+            hash: Hash::default(),
+            instructions,
+            signature,
+            _fee: fee,
+            sender_public_key,
+            meta,
+        };
+        s.hash = s.calculate_hash();
+        s
+    }
+
+    /// Returns the template addresses that are statically known to be executed by this transaction.
+    /// This does not include templates for component invocation as that data is not contained within the transaction.
+    pub fn required_templates(&self) -> Vec<TemplateAddress> {
+        self.instructions
+            .iter()
+            .filter_map(|instruction| match instruction {
+                Instruction::CallFunction {
+                    template_address: package_address,
+                    ..
+                } => Some(*package_address),
+                _ => None,
+            })
+            .collect()
+    }
+
+    pub fn required_components(&self) -> Vec<ComponentAddress> {
+        self.instructions
+            .iter()
+            .filter_map(|instruction| match instruction {
+                Instruction::CallMethod { component_address, .. } => Some(*component_address),
+                _ => None,
+            })
+            .collect()
+    }
+
+    pub fn hash(&self) -> &Hash {
+        &self.hash
+    }
+
+    pub fn fee(&self) -> u64 {
+        self._fee
+    }
+
+    pub fn meta(&self) -> &TransactionMeta {
+        &self.meta
+    }
+
+    pub fn meta_mut(&mut self) -> &mut TransactionMeta {
+        &mut self.meta
+    }
+
+    fn calculate_hash(&self) -> Hash {
+        let mut res = hasher("transaction")
+            .chain(&self.sender_public_key)
+            .chain(self.signature.signature().get_public_nonce())
+            .chain(self.signature.signature().get_signature());
+        for instruction in &self.instructions {
+            res.update(&instruction.hash())
+        }
+        res.result()
+    }
+
+    pub fn instructions(&self) -> &[Instruction] {
+        &self.instructions
+    }
+
+    pub fn into_instructions(self) -> Vec<Instruction> {
+        self.instructions
+    }
+
+    pub fn signature(&self) -> &InstructionSignature {
+        &self.signature
+    }
+
+    pub fn sender_public_key(&self) -> &PublicKey {
+        &self.sender_public_key
+    }
+
+    pub fn destruct(self) -> (Vec<Instruction>, InstructionSignature, PublicKey) {
+        (self.instructions, self.signature, self.sender_public_key)
+    }
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq)]
+pub struct TransactionMeta {
+    involved_objects: HashMap<ShardId, (SubstateChange, ObjectClaim)>,
+    max_outputs: u32,
+}
+
+impl TransactionMeta {
+    pub fn new(involved_objects: HashMap<ShardId, (SubstateChange, ObjectClaim)>, max_outputs: u32) -> Self {
+        Self {
+            involved_objects,
+            max_outputs,
+        }
+    }
+
+    pub fn involved_objects_iter(&self) -> impl Iterator<Item = (&ShardId, &(SubstateChange, ObjectClaim))> + '_ {
+        self.involved_objects.iter()
+    }
+
+    pub fn involved_shards(&self) -> Vec<ShardId> {
+        self.involved_objects.keys().copied().collect()
+    }
+
+    pub(crate) fn involved_objects_mut(&mut self) -> &mut HashMap<ShardId, (SubstateChange, ObjectClaim)> {
+        &mut self.involved_objects
+    }
+
+    pub fn objects_for_shard(&self, shard_id: ShardId) -> Option<(SubstateChange, ObjectClaim)> {
+        self.involved_objects.get(&shard_id).cloned()
+    }
+
+    pub fn set_max_outputs(&mut self, max_outputs: u32) -> &mut Self {
+        self.max_outputs = max_outputs;
+        self
+    }
+
+    pub fn max_outputs(&self) -> u32 {
+        self.max_outputs
+    }
+}

--- a/dan_layer/transaction_manifest/Cargo.toml
+++ b/dan_layer/transaction_manifest/Cargo.toml
@@ -9,6 +9,5 @@ tari_engine_types = { path = "../engine_types" }
 tari_template_builtin = { path = "../template_builtin" }
 
 proc-macro2 = "1.0.42"
-quote = "1.0.20"
 syn = { version = "1.0.98", features = ["full", "extra-traits"] }
 thiserror = "1.0"


### PR DESCRIPTION
Description
---
- moves transaction builder into its own crate
- removes some unused deps using `cargo-machete`

Motivation and Context
---
Previously if you wanted to build a transaction, you'd need to include the engine crate. This PR splits that module out into its own crate.

How Has This Been Tested?
---
Existing tests pass, no lints
