### PR TITLE
fix: dont dial local shards if epoch manager has not synced

### DIFF
--- a/applications/tari_validator_node/src/p2p/services/epoch_manager/base_layer_epoch_manager.rs
+++ b/applications/tari_validator_node/src/p2p/services/epoch_manager/base_layer_epoch_manager.rs
@@ -92,7 +92,7 @@ impl BaseLayerEpochManager {
         }
     }
 
-    pub async fn load_initial_state(&mut self) -> Result<(), EpochManagerError> {
+    pub fn load_initial_state(&mut self) -> Result<(), EpochManagerError> {
         let tx = self.global_db.create_transaction()?;
         let metadata = self.global_db.metadata(&tx);
         self.current_epoch = metadata.get_metadata(MetadataKey::CurrentEpoch)?.unwrap_or(Epoch(0));

--- a/applications/tari_validator_node/src/p2p/services/epoch_manager/epoch_manager_service.rs
+++ b/applications/tari_validator_node/src/p2p/services/epoch_manager/epoch_manager_service.rs
@@ -172,7 +172,7 @@ impl EpochManagerService {
 
     pub async fn run(&mut self, mut shutdown: ShutdownSignal) -> Result<(), EpochManagerError> {
         // first, load initial state
-        self.inner.load_initial_state().await?;
+        self.inner.load_initial_state()?;
 
         loop {
             tokio::select! {

--- a/applications/tari_validator_node/tests/utils/validator_node.rs
+++ b/applications/tari_validator_node/tests/utils/validator_node.rs
@@ -126,6 +126,12 @@ pub async fn spawn_validator_node(
     // TODO: it would be better to scan the VN to detect when it has started
     tokio::time::sleep(Duration::from_secs(5)).await;
 
+    // Check if the inner thread panicked
+    if handle.is_finished() {
+        handle.await.unwrap();
+        return;
+    }
+
     // get the public key of the VN
     let public_key = get_vn_identity(json_rpc_port).await;
 


### PR DESCRIPTION
Description
---
Skips dialing local shard peers if the epoch manager has not synced.

Motivation and Context
---
VN crashes if the epoch manager has not synced yet. In general, failures to dial local shard peers on startup is not fatal.

How Has This Been Tested?
---
Manually, starting a new VN.

Updated the cucumber tests to check for panics in the spawned validator task. Cucumbers fail without this fix.
