### PR TITLE
fix: dont dial local shards if epoch manager has not synced

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,7 @@ version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
 dependencies = [
- "gimli 0.27.1",
+ "gimli 0.27.2",
 ]
 
 [[package]]
@@ -75,9 +75,9 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf6ccdb167abbf410dcb915cabd428929d7f6a04980b54a11f26a39f1c7f7107"
+checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -113,9 +113,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
+checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
 
 [[package]]
 name = "arc-swap"
@@ -318,9 +318,9 @@ checksum = "7a40729d2133846d9ed0ea60a8b9541bccddab49cd30f0715a1da672fe9a2524"
 
 [[package]]
 name = "async-trait"
-version = "0.1.63"
+version = "0.1.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eff18d764974428cf3a9328e23fc5c986f5fbed46e6cd4cdf42544df5d297ec1"
+checksum = "1cd7fce9ba8c3c042128ce72d8b2ddbf3a05747efb67ea0313c635e10bda47a2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -352,14 +352,14 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "axum"
-version = "0.6.3"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678c5130a507ae3a7c797f9a17393c14849300b8440eac47cdb90a5bdcb3a543"
+checksum = "4e246206a63c9830e118d12c894f56a82033da1a2361f5544deeee3df85c99d9"
 dependencies = [
  "async-trait",
  "axum-core",
  "bitflags 1.3.2",
- "bytes 1.3.0",
+ "bytes 1.4.0",
  "futures-util",
  "http",
  "http-body",
@@ -390,7 +390,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1cae3e661676ffbacb30f1a824089a8c9150e71017f7e1e38f2aa32009188d34"
 dependencies = [
  "async-trait",
- "bytes 1.3.0",
+ "bytes 1.4.0",
  "futures-util",
  "http",
  "http-body",
@@ -702,9 +702,9 @@ checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
 
 [[package]]
 name = "bstr"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b45ea9b00a7b3f2988e9a65ad3917e62123c38dba709b666506207be96d1790b"
+checksum = "b7f0778972c64420fdedc63f09919c8a88bda7b25135357fd25a5d9f3257e832"
 dependencies = [
  "memchr",
  "serde",
@@ -773,9 +773,9 @@ checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
 name = "bytes"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
+checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 dependencies = [
  "serde",
 ]
@@ -866,9 +866,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.78"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
 
 [[package]]
 name = "cexpr"
@@ -1061,7 +1061,7 @@ version = "3.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
 dependencies = [
- "heck 0.4.0",
+ "heck 0.4.1",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -1378,7 +1378,7 @@ dependencies = [
  "crossterm_winapi 0.9.0",
  "futures-core",
  "libc",
- "mio 0.8.5",
+ "mio 0.8.6",
  "parking_lot 0.12.1",
  "signal-hook",
  "signal-hook-mio",
@@ -1394,7 +1394,7 @@ dependencies = [
  "bitflags 1.3.2",
  "crossterm_winapi 0.9.0",
  "libc",
- "mio 0.8.5",
+ "mio 0.8.6",
  "parking_lot 0.12.1",
  "signal-hook",
  "signal-hook-mio",
@@ -1489,7 +1489,7 @@ dependencies = [
  "cucumber-expressions",
  "derive_more",
  "either",
- "futures 0.3.25",
+ "futures 0.3.26",
  "gherkin",
  "globwalk",
  "inventory",
@@ -1577,9 +1577,9 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.0.0-pre.5"
+version = "4.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67bc65846be335cb20f4e52d49a437b773a2c1fdb42b19fc84e79e6f6771536f"
+checksum = "8da00a7a9a4eb92a0a0f8e75660926d48f0d0f3c537e455c457bcdaa1e16b1ac"
 dependencies = [
  "cfg-if",
  "fiat-crypto",
@@ -1604,9 +1604,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.87"
+version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b61a7545f753a88bcbe0a70de1fcc0221e10bfc752f576754fa91e663db1622e"
+checksum = "90d59d9acd2a682b4e40605a242f6670eaa58c5957471cbf85e8aa6a0b97a5e8"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -1616,9 +1616,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.87"
+version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f464457d494b5ed6905c63b0c4704842aba319084a0a3561cdc1359536b53200"
+checksum = "ebfa40bda659dd5c864e65f4c9a2b0aff19bea56b017b9b77c73d3766a453a38"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -1631,15 +1631,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.87"
+version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c7119ce3a3701ed81aca8410b9acf6fc399d2629d057b87e2efa4e63a3aaea"
+checksum = "457ce6757c5c70dc6ecdbda6925b958aae7f959bda7d8fb9bde889e34a09dc03"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.87"
+version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65e07508b90551e610910fa648a1878991d367064997a596135b86df30daf07e"
+checksum = "ebf883b7aacd7b2aeb2a7b338648ee19f57c140d4ee8e52c68979c6b2f7f2263"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1658,12 +1658,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.14.2"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0dd3cd20dc6b5a876612a6e5accfe7f3dd883db6d07acfbf14c128f61550dfa"
+checksum = "c0808e1bd8671fb44a113a14e13497557533369847788fa2ae912b6ebfce9fa8"
 dependencies = [
- "darling_core 0.14.2",
- "darling_macro 0.14.2",
+ "darling_core 0.14.3",
+ "darling_macro 0.14.3",
 ]
 
 [[package]]
@@ -1682,9 +1682,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.14.2"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a784d2ccaf7c98501746bf0be29b2022ba41fd62a2e622af997a03e9f972859f"
+checksum = "001d80444f28e193f30c2f293455da62dcf9a6b29918a4253152ae2b1de592cb"
 dependencies = [
  "fnv",
  "ident_case",
@@ -1707,11 +1707,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.14.2"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7618812407e9402654622dd402b0a89dff9ba93badd6540781526117b92aab7e"
+checksum = "b36230598a2d5de7ec1c6f51f72d8a99a9208daff41de2084d06e3fd3ea56685"
 dependencies = [
- "darling_core 0.14.2",
+ "darling_core 0.14.3",
  "quote",
  "syn",
 ]
@@ -1726,7 +1726,7 @@ dependencies = [
  "hashbrown 0.12.3",
  "lock_api",
  "once_cell",
- "parking_lot_core 0.9.6",
+ "parking_lot_core 0.9.7",
 ]
 
 [[package]]
@@ -1809,7 +1809,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f91d4cfa921f1c05904dc3c57b4a32c38aed3340cce209f3a6fd1478babafc4"
 dependencies = [
- "darling 0.14.2",
+ "darling 0.14.3",
  "proc-macro2",
  "quote",
  "syn",
@@ -2002,9 +2002,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "ena"
@@ -2023,9 +2023,9 @@ checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.31"
+version = "0.8.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
+checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
 dependencies = [
  "cfg-if",
 ]
@@ -2042,7 +2042,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21cdad81446a7f7dc43f6a77409efeb9733d2fa65553efef6018ef257c959b73"
 dependencies = [
- "heck 0.4.0",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn",
@@ -2083,7 +2083,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03e7b551eba279bf0fa88b83a46330168c1560a52a94f5126f892f0b364ab3e0"
 dependencies = [
- "darling 0.14.2",
+ "darling 0.14.3",
  "proc-macro2",
  "quote",
  "syn",
@@ -2178,22 +2178,22 @@ checksum = "95765f67b4b18863968b4a1bd5bb576f732b29a4a28c7cd84c09fa3e2875f33c"
 
 [[package]]
 name = "fastrand"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
 dependencies = [
  "instant",
 ]
 
 [[package]]
 name = "fd-lock"
-version = "3.0.9"
+version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28c0190ff0bd3b28bfdd4d0cf9f92faa12880fb0b8ae2054723dd6c76a4efd42"
+checksum = "8ef1a30ae415c3a691a4f41afddc2dbcd6d70baf338368d85ebc1e8ed92cedb9"
 dependencies = [
  "cfg-if",
  "rustix",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -2284,9 +2284,9 @@ checksum = "3a471a38ef8ed83cd6e40aa59c1ffe17db6855c18e3604d9c4ed8c08ebc28678"
 
 [[package]]
 name = "futures"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38390104763dc37a5145a53c29c63c1290b5d316d6086ec32c293f6736051bb0"
+checksum = "13e2792b0ff0340399d58445b88fd9770e3489eff258a4cbc1523418f12abf84"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2299,9 +2299,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ba265a92256105f45b719605a571ffe2d1f0fea3807304b522c1d778f79eed"
+checksum = "2e5317663a9089767a1ec00a487df42e0ca174b61b4483213ac24448e4664df5"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2309,15 +2309,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04909a7a7e4633ae6c4a9ab280aeb86da1236243a77b694a49eacd659a4bd3ac"
+checksum = "ec90ff4d0fe1f57d600049061dc6bb68ed03c7d2fbd697274c41805dcb3f8608"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7acc85df6714c176ab5edf386123fafe217be88c0840ec11f199441134a074e2"
+checksum = "e8de0a35a6ab97ec8869e32a2473f4b1324459e14c29275d14b10cb1fd19b50e"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -2326,9 +2326,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00f5fb52a06bdcadeb54e8d3671f8888a39697dcb0b81b23b55174030427f4eb"
+checksum = "bfb8371b6fb2aeb2d280374607aeabfc99d95c72edfe51692e42d3d7f0d08531"
 
 [[package]]
 name = "futures-lite"
@@ -2347,9 +2347,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d"
+checksum = "95a73af87da33b5acf53acfebdc339fe592ecf5357ac7c0a7734ab9d8c876a70"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2358,21 +2358,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39c15cf1a4aa79df40f1bb462fb39676d0ad9e366c2a33b590d7c66f4f81fcf9"
+checksum = "f310820bb3e8cfd46c80db4d7fb8353e15dfff853a127158425f31e0be6c8364"
 
 [[package]]
 name = "futures-task"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffb393ac5d9a6eaa9d3fdf37ae2776656b706e200c8e16b1bdb227f5198e6ea"
+checksum = "dcf79a1bf610b10f42aea489289c5a2c478a786509693b80cd39c44ccd936366"
 
 [[package]]
 name = "futures-util"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "197676987abd2f9cadff84926f410af1c183608d36641465df73ae8211dc65d6"
+checksum = "9c1d6de3acfef38d2be4b1f543f553131788603495be83da675e180c8d6b7bd1"
 dependencies = [
  "futures 0.1.31",
  "futures-channel",
@@ -2470,9 +2470,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.27.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "221996f774192f0f718773def8201c4ae31f02616a54ccfc2d358bb0e5cefdec"
+checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
 
 [[package]]
 name = "git2"
@@ -2535,7 +2535,7 @@ version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f9f29bc9dda355256b2916cf526ab02ce0aeaaaf2bad60d65ef3f12f11dd0f4"
 dependencies = [
- "bytes 1.3.0",
+ "bytes 1.4.0",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -2544,7 +2544,7 @@ dependencies = [
  "indexmap",
  "slab",
  "tokio",
- "tokio-util 0.7.4",
+ "tokio-util 0.7.7",
  "tracing",
 ]
 
@@ -2572,7 +2572,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
- "ahash 0.8.2",
+ "ahash 0.8.3",
 ]
 
 [[package]]
@@ -2593,7 +2593,7 @@ checksum = "f3e372db8e5c0d213e0cd0b9be18be2aca3d44cf2fe30a9d46a65581cd454584"
 dependencies = [
  "base64 0.13.1",
  "bitflags 1.3.2",
- "bytes 1.3.0",
+ "bytes 1.4.0",
  "headers-core",
  "http",
  "httpdate",
@@ -2621,9 +2621,9 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
@@ -2664,7 +2664,7 @@ version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
 dependencies = [
- "bytes 1.3.0",
+ "bytes 1.4.0",
  "fnv",
  "itoa",
 ]
@@ -2675,7 +2675,7 @@ version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
 dependencies = [
- "bytes 1.3.0",
+ "bytes 1.4.0",
  "http",
  "pin-project-lite",
 ]
@@ -2734,11 +2734,11 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.23"
+version = "0.14.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "034711faac9d2166cb1baf1a2fb0b60b1f277f8492fd72176c17f3515e1abd3c"
+checksum = "5e011372fa0b68db8350aa7a248930ecc7839bf46d8485577d69f117a75f164c"
 dependencies = [
- "bytes 1.3.0",
+ "bytes 1.4.0",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -2774,7 +2774,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
- "bytes 1.3.0",
+ "bytes 1.4.0",
  "hyper",
  "native-tls",
  "tokio",
@@ -2906,9 +2906,9 @@ dependencies = [
 
 [[package]]
 name = "indoc"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da2d6f23ffea9d7e76c53eee25dfb67bcd8fde7f1198b0855350698c9f07c780"
+checksum = "bfa799dd5ed20a7e349f3b4639aa80d74549c81716d9ec4f994c9b5815598306"
 
 [[package]]
 name = "inflections"
@@ -2952,12 +2952,12 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7d6c6f8c91b4b9ed43484ad1a938e393caf35960fce7f82a040497207bd8e9e"
+checksum = "1abeb7a0dd0f8181267ff8adc397075586500b81b28a73e8a0208b00fc170fb3"
 dependencies = [
  "libc",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -3023,9 +3023,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.60"
+version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
+checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -3489,14 +3489,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
+checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
 dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -3813,11 +3813,11 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 dependencies = [
- "parking_lot_core 0.9.6",
+ "parking_lot_core 0.9.7",
 ]
 
 [[package]]
@@ -3930,7 +3930,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.6",
+ "parking_lot_core 0.9.7",
 ]
 
 [[package]]
@@ -3949,15 +3949,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.6"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba1ef8814b5c993410bb3adfad7a5ed269563e4a2f90c41f5d85be7fb47133bf"
+checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -4039,9 +4039,9 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pest"
-version = "2.5.3"
+version = "2.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4257b4a04d91f7e9e6290be5d3da4804dd5784fafde3a497d73eb2b4a158c30a"
+checksum = "028accff104c4e513bad663bbcd2ad7cfd5304144404c31ed0a77ac103d00660"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -4049,9 +4049,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.5.3"
+version = "2.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "241cda393b0cdd65e62e07e12454f1f25d57017dcc514b1514cd3c4645e3a0a6"
+checksum = "2ac3922aac69a40733080f53c1ce7f91dcf57e1a5f6c52f421fadec7fbdc4b69"
 dependencies = [
  "pest",
  "pest_generator",
@@ -4059,9 +4059,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.5.3"
+version = "2.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46b53634d8c8196302953c74d5352f33d0c512a9499bd2ce468fc9f4128fa27c"
+checksum = "d06646e185566b5961b4058dd107e0a7f56e77c3f484549fb119867773c0f202"
 dependencies = [
  "pest",
  "pest_meta",
@@ -4072,9 +4072,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.5.3"
+version = "2.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ef4f1332a8d4678b41966bb4cc1d0676880e84183a1ecc3f4b69f03e99c7a51"
+checksum = "e6f60b2ba541577e2a0c307c8f39d1439108120eb7903adeb6497fa880c59616"
 dependencies = [
  "once_cell",
  "pest",
@@ -4083,9 +4083,9 @@ dependencies = [
 
 [[package]]
 name = "petgraph"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5014253a1331579ce62aa67443b4a658c5e7dd03d4bc6d302b94474888143"
+checksum = "4dd7d28ee937e54fe3080c91faa1c3a46c06de6252988a7f4592ba2310ef22a4"
 dependencies = [
  "fixedbitset",
  "indexmap",
@@ -4346,9 +4346,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.50"
+version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ef7d57beacfaf2d8aee5937dab7b7f28de3cb8b1828479bb5de2a7106f2bae2"
+checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
 dependencies = [
  "unicode-ident",
 ]
@@ -4374,7 +4374,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "444879275cb4fd84958b1a1d5420d15e6fcf7c235fe47f053c9c2a80aceb6001"
 dependencies = [
- "bytes 1.3.0",
+ "bytes 1.4.0",
  "prost-derive",
 ]
 
@@ -4384,7 +4384,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62941722fb675d463659e49c4f3fe1fe792ff24fe5bbaa9c08cd3b98a1c354f5"
 dependencies = [
- "bytes 1.3.0",
+ "bytes 1.4.0",
  "heck 0.3.3",
  "itertools",
  "lazy_static",
@@ -4417,7 +4417,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "534b7a0e836e3c482d2693070f982e39e7611da9695d4d1f5a4b186b51faef0a"
 dependencies = [
- "bytes 1.3.0",
+ "bytes 1.4.0",
  "prost",
 ]
 
@@ -4715,9 +4715,9 @@ dependencies = [
 
 [[package]]
 name = "rend"
-version = "0.3.6"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79af64b4b6362ffba04eef3a4e10829718a4896dac19daa741851c86781edf95"
+checksum = "581008d2099240d37fb08d77ad713bcaec2c4d89d50b5b21a8bb1996bbab68ab"
 dependencies = [
  "bytecheck",
 ]
@@ -4729,7 +4729,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21eed90ec8570952d53b772ecf8f206aa1ec9a3d76b2521c56c42973f2d91ee9"
 dependencies = [
  "base64 0.21.0",
- "bytes 1.3.0",
+ "bytes 1.4.0",
  "encoding_rs",
  "futures-core",
  "futures-util",
@@ -4787,9 +4787,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv"
-version = "0.7.39"
+version = "0.7.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cec2b3485b07d96ddfd3134767b8a447b45ea4eb91448d0a35180ec0ffd5ed15"
+checksum = "c30f1d45d9aa61cbc8cd1eb87705470892289bb2d01943e7803b873a57404dc3"
 dependencies = [
  "bytecheck",
  "hashbrown 0.12.3",
@@ -4801,9 +4801,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv_derive"
-version = "0.7.39"
+version = "0.7.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eaedadc88b53e36dd32d940ed21ae4d850d5916f2581526921f553a72ac34c4"
+checksum = "ff26ed6c7c4dfc2aa9480b86a60e3c7233543a270a680e10758a507c5a4ce476"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4890,16 +4890,16 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.36.7"
+version = "0.36.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4fdebc4b395b7fbb9ab11e462e20ed9051e7b16e42d24042c776eca0ac81b03"
+checksum = "f43abb88211988493c1abb44a70efa56ff0ce98f233b7b276146f1f3f7ba9644"
 dependencies = [
  "bitflags 1.3.2",
  "errno",
  "io-lifetimes",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -5071,9 +5071,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.8.0"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645926f31b250a2dca3c232496c2d898d91036e45ca0e97e0e2390c54e11be36"
+checksum = "a332be01508d814fed64bf28f798a146d73792121129962fdf335bb3c49a4254"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
@@ -5131,9 +5131,9 @@ dependencies = [
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.8"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "718dc5fff5b36f99093fc49b280cfc96ce6fc824317783bff5a1fed0c7a64819"
+checksum = "416bda436f9aab92e02c8e10d49a15ddd339cea90b6e340fe51ed97abb548294"
 dependencies = [
  "serde",
 ]
@@ -5151,9 +5151,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.91"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
+checksum = "cad406b69c91885b5107daf2c29572f6c8cdb3c66826821e286c533490c0bc76"
 dependencies = [
  "itoa",
  "ryu",
@@ -5282,9 +5282,9 @@ checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
 name = "signal-hook"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a253b5e89e2698464fc26b545c9edceb338e18a89effeeecfea192c3025be29d"
+checksum = "732768f1176d21d09e076c23a93123d40bba92d50c4058da34d45c8de8e682b9"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -5298,15 +5298,15 @@ checksum = "29ad2e15f37ec9a6cc544097b78a1ec90001e9f71b81338ca39f430adaca99af"
 dependencies = [
  "libc",
  "mio 0.7.14",
- "mio 0.8.5",
+ "mio 0.8.6",
  "signal-hook",
 ]
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
 dependencies = [
  "libc",
 ]
@@ -5372,14 +5372,14 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "snow"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "774d05a3edae07ce6d68ea6984f3c05e9bba8927e3dd591e3b479e5b03213d0d"
+checksum = "12ba5f4d4ff12bdb6a169ed51b7c48c0e0ac4b0b4b31012b2571e97d78d3201d"
 dependencies = [
  "aes-gcm",
  "blake2 0.10.6",
  "chacha20poly1305 0.9.1",
- "curve25519-dalek 4.0.0-pre.5",
+ "curve25519-dalek 4.0.0-rc.0",
  "rand_core 0.6.4",
  "rustc_version",
  "sha2 0.10.6",
@@ -5537,9 +5537,9 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20518fe4a4c9acf048008599e464deb21beeae3d3578418951a189c235a7a9a8"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "synstructure"
@@ -5594,22 +5594,20 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.5"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9410d0f6853b1d94f0e519fb95df60f29d2c1eff2d921ffdf01a4c8a3b54f12d"
+checksum = "8ae9980cab1db3fceee2f6c6f643d5d8de2997c58ee8d25fb0cc8a9e9e7348e5"
 
 [[package]]
 name = "tari_app_grpc"
-version = "0.44.1"
-source = "git+https://github.com/tari-project/tari.git?branch=development#5f7f04b599ab49765466fb7e0faa37e2dfec4afe"
+version = "0.45.0"
+source = "git+https://github.com/tari-project/tari.git?branch=development#9900d5db3eacf463b479ad242391c9a2e0a38db8"
 dependencies = [
  "argon2",
  "base64 0.13.1",
  "borsh",
  "chrono",
- "digest 0.9.0",
  "log",
- "num-traits",
  "prost",
  "prost-types",
  "rand 0.8.5",
@@ -5627,22 +5625,18 @@ dependencies = [
 
 [[package]]
 name = "tari_app_utilities"
-version = "0.44.1"
-source = "git+https://github.com/tari-project/tari.git?branch=development#5f7f04b599ab49765466fb7e0faa37e2dfec4afe"
+version = "0.45.0"
+source = "git+https://github.com/tari-project/tari.git?branch=development#9900d5db3eacf463b479ad242391c9a2e0a38db8"
 dependencies = [
  "clap 3.2.23",
- "config",
- "dirs-next 1.0.2",
- "futures 0.3.25",
+ "futures 0.3.26",
  "json5 0.2.8",
  "log",
  "rand 0.7.3",
  "serde",
- "structopt",
  "tari_common",
  "tari_common_types",
  "tari_comms",
- "tari_crypto",
  "tari_utilities",
  "thiserror",
  "tokio",
@@ -5650,8 +5644,8 @@ dependencies = [
 
 [[package]]
 name = "tari_base_node"
-version = "0.44.1"
-source = "git+https://github.com/tari-project/tari.git?branch=development#5f7f04b599ab49765466fb7e0faa37e2dfec4afe"
+version = "0.45.0"
+source = "git+https://github.com/tari-project/tari.git?branch=development#9900d5db3eacf463b479ad242391c9a2e0a38db8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5663,19 +5657,15 @@ dependencies = [
  "crossterm 0.23.2",
  "derive_more",
  "either",
- "futures 0.3.25",
+ "futures 0.3.26",
  "log",
  "log-mdc",
  "nom 7.1.3",
- "num_cpus",
  "qrcode",
- "regex",
  "rustyline",
  "rustyline-derive",
  "serde",
- "serde_json",
  "strum",
- "strum_macros",
  "tari_app_grpc",
  "tari_app_utilities",
  "tari_common",
@@ -5685,7 +5675,6 @@ dependencies = [
  "tari_core",
  "tari_crypto",
  "tari_metrics",
- "tari_mmr",
  "tari_p2p",
  "tari_service_framework",
  "tari_shutdown",
@@ -5694,13 +5683,12 @@ dependencies = [
  "thiserror",
  "tokio",
  "tonic",
- "tracing",
 ]
 
 [[package]]
 name = "tari_base_node_grpc_client"
 version = "0.1.0"
-source = "git+https://github.com/tari-project/tari.git?branch=development#5f7f04b599ab49765466fb7e0faa37e2dfec4afe"
+source = "git+https://github.com/tari-project/tari.git?branch=development#9900d5db3eacf463b479ad242391c9a2e0a38db8"
 dependencies = [
  "tari_app_grpc",
 ]
@@ -5755,13 +5743,12 @@ dependencies = [
 
 [[package]]
 name = "tari_common"
-version = "0.44.1"
-source = "git+https://github.com/tari-project/tari.git?branch=development#5f7f04b599ab49765466fb7e0faa37e2dfec4afe"
+version = "0.45.0"
+source = "git+https://github.com/tari-project/tari.git?branch=development#9900d5db3eacf463b479ad242391c9a2e0a38db8"
 dependencies = [
  "anyhow",
  "blake2 0.9.2",
  "config",
- "derivative",
  "dirs-next 1.0.2",
  "git2",
  "log",
@@ -5772,7 +5759,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.9.9",
- "sha3",
  "structopt",
  "tari_crypto",
  "tempfile",
@@ -5782,8 +5768,8 @@ dependencies = [
 
 [[package]]
 name = "tari_common_sqlite"
-version = "0.44.1"
-source = "git+https://github.com/tari-project/tari.git?branch=development#5f7f04b599ab49765466fb7e0faa37e2dfec4afe"
+version = "0.45.0"
+source = "git+https://github.com/tari-project/tari.git?branch=development#9900d5db3eacf463b479ad242391c9a2e0a38db8"
 dependencies = [
  "diesel",
  "log",
@@ -5792,10 +5778,9 @@ dependencies = [
 
 [[package]]
 name = "tari_common_types"
-version = "0.44.1"
-source = "git+https://github.com/tari-project/tari.git?branch=development#5f7f04b599ab49765466fb7e0faa37e2dfec4afe"
+version = "0.45.0"
+source = "git+https://github.com/tari-project/tari.git?branch=development#9900d5db3eacf463b479ad242391c9a2e0a38db8"
 dependencies = [
- "base64 0.13.1",
  "borsh",
  "digest 0.9.0",
  "lazy_static",
@@ -5807,25 +5792,24 @@ dependencies = [
  "tari_utilities",
  "thiserror",
  "tokio",
- "zeroize",
 ]
 
 [[package]]
 name = "tari_comms"
-version = "0.44.1"
-source = "git+https://github.com/tari-project/tari.git?branch=development#5f7f04b599ab49765466fb7e0faa37e2dfec4afe"
+version = "0.45.0"
+source = "git+https://github.com/tari-project/tari.git?branch=development#9900d5db3eacf463b479ad242391c9a2e0a38db8"
 dependencies = [
  "anyhow",
  "async-trait",
  "bitflags 1.3.2",
  "blake2 0.10.6",
- "bytes 1.3.0",
+ "bytes 1.4.0",
  "chrono",
  "cidr",
  "data-encoding",
  "derivative",
  "digest 0.9.0",
- "futures 0.3.25",
+ "futures 0.3.26",
  "lazy_static",
  "lmdb-zero",
  "log",
@@ -5835,7 +5819,6 @@ dependencies = [
  "once_cell",
  "pin-project 1.0.12",
  "prost",
- "prost-types",
  "rand 0.7.3",
  "serde",
  "serde_derive",
@@ -5858,8 +5841,8 @@ dependencies = [
 
 [[package]]
 name = "tari_comms_dht"
-version = "0.44.1"
-source = "git+https://github.com/tari-project/tari.git?branch=development#5f7f04b599ab49765466fb7e0faa37e2dfec4afe"
+version = "0.45.0"
+source = "git+https://github.com/tari-project/tari.git?branch=development#9900d5db3eacf463b479ad242391c9a2e0a38db8"
 dependencies = [
  "anyhow",
  "bitflags 1.3.2",
@@ -5869,7 +5852,7 @@ dependencies = [
  "diesel",
  "diesel_migrations",
  "digest 0.9.0",
- "futures 0.3.25",
+ "futures 0.3.26",
  "log",
  "log-mdc",
  "pin-project 0.4.30",
@@ -5877,7 +5860,6 @@ dependencies = [
  "prost-types",
  "rand 0.7.3",
  "serde",
- "serde_derive",
  "tari_common",
  "tari_common_sqlite",
  "tari_comms",
@@ -5906,8 +5888,8 @@ dependencies = [
 
 [[package]]
 name = "tari_comms_rpc_macros"
-version = "0.44.1"
-source = "git+https://github.com/tari-project/tari.git?branch=development#5f7f04b599ab49765466fb7e0faa37e2dfec4afe"
+version = "0.45.0"
+source = "git+https://github.com/tari-project/tari.git?branch=development#9900d5db3eacf463b479ad242391c9a2e0a38db8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5916,17 +5898,16 @@ dependencies = [
 
 [[package]]
 name = "tari_console_wallet"
-version = "0.44.1"
-source = "git+https://github.com/tari-project/tari.git?branch=development#5f7f04b599ab49765466fb7e0faa37e2dfec4afe"
+version = "0.45.0"
+source = "git+https://github.com/tari-project/tari.git?branch=development#9900d5db3eacf463b479ad242391c9a2e0a38db8"
 dependencies = [
- "base64 0.13.1",
  "bitflags 1.3.2",
  "chrono",
  "clap 3.2.23",
  "config",
  "crossterm 0.25.0",
  "digest 0.9.0",
- "futures 0.3.25",
+ "futures 0.3.26",
  "log",
  "qrcode",
  "rand 0.7.3",
@@ -5955,7 +5936,6 @@ dependencies = [
  "thiserror",
  "tokio",
  "tonic",
- "tracing",
  "tui",
  "unicode-segmentation",
  "unicode-width",
@@ -5965,10 +5945,9 @@ dependencies = [
 
 [[package]]
 name = "tari_core"
-version = "0.44.1"
-source = "git+https://github.com/tari-project/tari.git?branch=development#5f7f04b599ab49765466fb7e0faa37e2dfec4afe"
+version = "0.45.0"
+source = "git+https://github.com/tari-project/tari.git?branch=development#9900d5db3eacf463b479ad242391c9a2e0a38db8"
 dependencies = [
- "async-trait",
  "bincode",
  "bitflags 1.3.2",
  "blake2 0.9.2",
@@ -5981,7 +5960,7 @@ dependencies = [
  "derivative",
  "digest 0.9.0",
  "fs2",
- "futures 0.3.25",
+ "futures 0.3.26",
  "hex",
  "integer-encoding",
  "lmdb-zero",
@@ -6020,7 +5999,6 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
- "tracing-attributes",
  "uint",
  "zeroize",
 ]
@@ -6085,7 +6063,7 @@ dependencies = [
  "blake2 0.9.2",
  "chrono",
  "digest 0.9.0",
- "futures 0.3.25",
+ "futures 0.3.26",
  "lmdb-zero",
  "log",
  "prost",
@@ -6229,8 +6207,8 @@ dependencies = [
 
 [[package]]
 name = "tari_key_manager"
-version = "0.44.1"
-source = "git+https://github.com/tari-project/tari.git?branch=development#5f7f04b599ab49765466fb7e0faa37e2dfec4afe"
+version = "0.45.0"
+source = "git+https://github.com/tari-project/tari.git?branch=development#9900d5db3eacf463b479ad242391c9a2e0a38db8"
 dependencies = [
  "argon2",
  "blake2 0.9.2",
@@ -6240,8 +6218,6 @@ dependencies = [
  "digest 0.9.0",
  "rand 0.7.3",
  "serde",
- "serde_derive",
- "serde_json",
  "strum",
  "strum_macros",
  "subtle",
@@ -6254,10 +6230,10 @@ dependencies = [
 [[package]]
 name = "tari_metrics"
 version = "0.1.0"
-source = "git+https://github.com/tari-project/tari.git?branch=development#5f7f04b599ab49765466fb7e0faa37e2dfec4afe"
+source = "git+https://github.com/tari-project/tari.git?branch=development#9900d5db3eacf463b479ad242391c9a2e0a38db8"
 dependencies = [
  "anyhow",
- "futures 0.3.25",
+ "futures 0.3.26",
  "log",
  "once_cell",
  "prometheus",
@@ -6269,8 +6245,8 @@ dependencies = [
 
 [[package]]
 name = "tari_mmr"
-version = "0.44.1"
-source = "git+https://github.com/tari-project/tari.git?branch=development#5f7f04b599ab49765466fb7e0faa37e2dfec4afe"
+version = "0.45.0"
+source = "git+https://github.com/tari-project/tari.git?branch=development#9900d5db3eacf463b479ad242391c9a2e0a38db8"
 dependencies = [
  "croaring",
  "digest 0.9.0",
@@ -6284,14 +6260,12 @@ dependencies = [
 
 [[package]]
 name = "tari_p2p"
-version = "0.44.1"
-source = "git+https://github.com/tari-project/tari.git?branch=development#5f7f04b599ab49765466fb7e0faa37e2dfec4afe"
+version = "0.45.0"
+source = "git+https://github.com/tari-project/tari.git?branch=development#9900d5db3eacf463b479ad242391c9a2e0a38db8"
 dependencies = [
  "anyhow",
- "bytes 0.5.6",
- "chrono",
  "fs2",
- "futures 0.3.25",
+ "futures 0.3.26",
  "lmdb-zero",
  "log",
  "pgp",
@@ -6301,7 +6275,6 @@ dependencies = [
  "rustls",
  "semver",
  "serde",
- "serde_derive",
  "tari_common",
  "tari_comms",
  "tari_comms_dht",
@@ -6314,7 +6287,6 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tower",
- "tower-service",
  "trust-dns-client",
  "webpki 0.21.4",
 ]
@@ -6322,7 +6294,7 @@ dependencies = [
 [[package]]
 name = "tari_script"
 version = "0.12.0"
-source = "git+https://github.com/tari-project/tari.git?branch=development#5f7f04b599ab49765466fb7e0faa37e2dfec4afe"
+source = "git+https://github.com/tari-project/tari.git?branch=development#9900d5db3eacf463b479ad242391c9a2e0a38db8"
 dependencies = [
  "blake2 0.9.2",
  "borsh",
@@ -6338,12 +6310,12 @@ dependencies = [
 
 [[package]]
 name = "tari_service_framework"
-version = "0.44.1"
-source = "git+https://github.com/tari-project/tari.git?branch=development#5f7f04b599ab49765466fb7e0faa37e2dfec4afe"
+version = "0.45.0"
+source = "git+https://github.com/tari-project/tari.git?branch=development#9900d5db3eacf463b479ad242391c9a2e0a38db8"
 dependencies = [
  "anyhow",
  "async-trait",
- "futures 0.3.25",
+ "futures 0.3.26",
  "log",
  "tari_shutdown",
  "thiserror",
@@ -6353,22 +6325,21 @@ dependencies = [
 
 [[package]]
 name = "tari_shutdown"
-version = "0.44.1"
-source = "git+https://github.com/tari-project/tari.git?branch=development#5f7f04b599ab49765466fb7e0faa37e2dfec4afe"
+version = "0.45.0"
+source = "git+https://github.com/tari-project/tari.git?branch=development#9900d5db3eacf463b479ad242391c9a2e0a38db8"
 dependencies = [
- "futures 0.3.25",
+ "futures 0.3.26",
 ]
 
 [[package]]
 name = "tari_storage"
-version = "0.44.1"
-source = "git+https://github.com/tari-project/tari.git?branch=development#5f7f04b599ab49765466fb7e0faa37e2dfec4afe"
+version = "0.45.0"
+source = "git+https://github.com/tari-project/tari.git?branch=development#9900d5db3eacf463b479ad242391c9a2e0a38db8"
 dependencies = [
  "bincode",
  "lmdb-zero",
  "log",
  "serde",
- "serde_derive",
  "thiserror",
 ]
 
@@ -6428,10 +6399,10 @@ dependencies = [
 
 [[package]]
 name = "tari_test_utils"
-version = "0.44.1"
-source = "git+https://github.com/tari-project/tari.git?branch=development#5f7f04b599ab49765466fb7e0faa37e2dfec4afe"
+version = "0.45.0"
+source = "git+https://github.com/tari-project/tari.git?branch=development#9900d5db3eacf463b479ad242391c9a2e0a38db8"
 dependencies = [
- "futures 0.3.25",
+ "futures 0.3.26",
  "rand 0.7.3",
  "tari_shutdown",
  "tempfile",
@@ -6489,12 +6460,12 @@ dependencies = [
  "async-trait",
  "axum",
  "axum-jrpc",
- "bytes 1.3.0",
+ "bytes 1.4.0",
  "chrono",
  "clap 3.2.23",
  "config",
  "cucumber",
- "futures 0.3.25",
+ "futures 0.3.26",
  "httpmock",
  "include_dir",
  "indexmap",
@@ -6597,8 +6568,8 @@ dependencies = [
 
 [[package]]
 name = "tari_wallet"
-version = "0.44.1"
-source = "git+https://github.com/tari-project/tari.git?branch=development#5f7f04b599ab49765466fb7e0faa37e2dfec4afe"
+version = "0.45.0"
+source = "git+https://github.com/tari-project/tari.git?branch=development#9900d5db3eacf463b479ad242391c9a2e0a38db8"
 dependencies = [
  "argon2",
  "async-trait",
@@ -6612,12 +6583,10 @@ dependencies = [
  "diesel_migrations",
  "digest 0.9.0",
  "fs2",
- "futures 0.3.25",
+ "futures 0.3.26",
  "itertools",
  "libsqlite3-sys",
- "lmdb-zero",
  "log",
- "log4rs",
  "prost",
  "rand 0.7.3",
  "serde",
@@ -6637,7 +6606,6 @@ dependencies = [
  "tari_script",
  "tari_service_framework",
  "tari_shutdown",
- "tari_storage",
  "tari_utilities",
  "tempfile",
  "thiserror",
@@ -6649,7 +6617,7 @@ dependencies = [
 [[package]]
 name = "tari_wallet_grpc_client"
 version = "0.1.0"
-source = "git+https://github.com/tari-project/tari.git?branch=development#5f7f04b599ab49765466fb7e0faa37e2dfec4afe"
+source = "git+https://github.com/tari-project/tari.git?branch=development#9900d5db3eacf463b479ad242391c9a2e0a38db8"
 dependencies = [
  "tari_app_grpc",
  "tari_common_types",
@@ -6758,10 +6726,11 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.4"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
 dependencies = [
+ "cfg-if",
  "once_cell",
 ]
 
@@ -6812,21 +6781,21 @@ dependencies = [
 
 [[package]]
 name = "tinyvec_macros"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.24.2"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a12a59981d9e3c38d216785b0c37399f6e415e8d0712047620f189371b0bb"
+checksum = "c8e00990ebabbe4c14c08aca901caed183ecd5c09562a12c824bb53d3c3fd3af"
 dependencies = [
  "autocfg",
- "bytes 1.3.0",
+ "bytes 1.4.0",
  "libc",
  "memchr",
- "mio 0.8.5",
+ "mio 0.8.6",
  "num_cpus",
  "pin-project-lite",
  "signal-hook-registry",
@@ -6858,9 +6827,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-native-tls"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
  "tokio",
@@ -6886,7 +6855,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
- "tokio-util 0.7.4",
+ "tokio-util 0.7.7",
 ]
 
 [[package]]
@@ -6895,7 +6864,7 @@ version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36943ee01a6d67977dd3f84a5a1d2efeb4ada3a1ae771cadfaa535d9d9fc6507"
 dependencies = [
- "bytes 1.3.0",
+ "bytes 1.4.0",
  "futures-core",
  "futures-io",
  "futures-sink",
@@ -6906,11 +6875,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.4"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bb2e075f03b3d66d8d8785356224ba688d2906a371015e225beeb65ca92c740"
+checksum = "5427d89453009325de0d8f342c9490009f76e999cb7672d77e46267448f7e6b2"
 dependencies = [
- "bytes 1.3.0",
+ "bytes 1.4.0",
  "futures-core",
  "futures-sink",
  "pin-project-lite",
@@ -6936,7 +6905,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "base64 0.13.1",
- "bytes 1.3.0",
+ "bytes 1.4.0",
  "futures-core",
  "futures-util",
  "h2",
@@ -6985,7 +6954,7 @@ dependencies = [
  "rand 0.8.5",
  "slab",
  "tokio",
- "tokio-util 0.7.4",
+ "tokio-util 0.7.7",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -6998,7 +6967,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f873044bf02dd1e8239e9c1293ea39dad76dc594ec16185d0a1bf31d8dc8d858"
 dependencies = [
  "bitflags 1.3.2",
- "bytes 1.3.0",
+ "bytes 1.4.0",
  "futures-core",
  "futures-util",
  "http",
@@ -7230,9 +7199,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a"
+checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
 name = "unicode-width"
@@ -7391,7 +7360,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed7b8be92646fc3d18b06147664ebc5f48d222686cb11a8755e561a735aacc6d"
 dependencies = [
- "bytes 1.3.0",
+ "bytes 1.4.0",
  "futures-channel",
  "futures-util",
  "headers",
@@ -7409,7 +7378,7 @@ dependencies = [
  "serde_urlencoded",
  "tokio",
  "tokio-stream",
- "tokio-util 0.7.4",
+ "tokio-util 0.7.7",
  "tower-service",
  "tracing",
 ]
@@ -7434,9 +7403,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
+checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -7444,9 +7413,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
+checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
 dependencies = [
  "bumpalo",
  "log",
@@ -7459,9 +7428,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23639446165ca5a5de86ae1d8896b737ae80319560fbaa4c2887b7da6e7ebd7d"
+checksum = "f219e0d211ba40266969f6dbdd90636da12f75bee4fc9d6c23d1260dadb51454"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -7471,9 +7440,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
+checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -7481,9 +7450,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
+checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7494,15 +7463,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
+checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
 
 [[package]]
 name = "wasm-encoder"
-version = "0.22.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef126be0e14bdf355ac1a8b41afc89195289e5c7179f80118e3abddb472f0810"
+checksum = "704553b4d614a47080b4a457a976b3c16174b19ce95b931b847561b590dd09ba"
 dependencies = [
  "leb128",
 ]
@@ -7758,9 +7727,9 @@ checksum = "718ed7c55c2add6548cca3ddd6383d738cd73b892df400e96b9aa876f0141d7a"
 
 [[package]]
 name = "wast"
-version = "52.0.1"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829fb867c8e82d21557a2c6c5b3ed8e8f7cdd534ea782b9ecf68bede5607fe4b"
+checksum = "f0d3df4a63b10958fe98ab9d7e9a57a7bc900209d2b4edd10535bfb0703e6516"
 dependencies = [
  "leb128",
  "memchr",
@@ -7770,18 +7739,18 @@ dependencies = [
 
 [[package]]
 name = "wat"
-version = "1.0.55"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3493e7c82d8e9a75e69ecbfe6f324ca1c4e2ae89f67ccbb22f92282e2e27bb23"
+checksum = "3e9a7c7d177696d0548178c36e377d49eba54170e885801d4270e2d44e82ac84"
 dependencies = [
  "wast",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.60"
+version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcda906d8be16e728fd5adc5b729afad4e444e106ab28cd1c7256e54fa61510f"
+checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -7876,6 +7845,30 @@ name = "windows-sys"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc 0.42.1",
+ "windows_i686_gnu 0.42.1",
+ "windows_i686_msvc 0.42.1",
+ "windows_x86_64_gnu 0.42.1",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc 0.42.1",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc 0.42.1",
@@ -7993,7 +7986,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5d9ba232399af1783a58d8eb26f6b5006fbefe2dc9ef36bd283324792d03ea5"
 dependencies = [
- "futures 0.3.25",
+ "futures 0.3.26",
  "log",
  "nohash-hasher",
  "parking_lot 0.12.1",

--- a/applications/tari_validator_node/src/grpc/services/base_node_client.rs
+++ b/applications/tari_validator_node/src/grpc/services/base_node_client.rs
@@ -73,6 +73,9 @@ impl GrpcBaseNodeClient {
         let consensus_constants = BaseLayerConsensusConstants {
             validator_node_registration_expiry: result.validator_node_validity_period,
             epoch_length: result.epoch_length,
+            validator_node_registration_min_deposit_amount: result
+                .validator_node_registration_min_deposit_amount
+                .into(),
         };
         Ok(consensus_constants)
     }

--- a/applications/tari_validator_node/src/grpc/services/wallet_client.rs
+++ b/applications/tari_validator_node/src/grpc/services/wallet_client.rs
@@ -27,6 +27,8 @@ use tari_app_grpc::tari_rpc::{
     BuildInfo,
     CreateTemplateRegistrationRequest,
     CreateTemplateRegistrationResponse,
+    GetBalanceRequest,
+    GetBalanceResponse,
     RegisterValidatorNodeRequest,
     RegisterValidatorNodeResponse,
     TemplateRegistration,
@@ -66,6 +68,12 @@ impl GrpcWalletClient {
         self.client
             .as_mut()
             .ok_or_else(|| DigitalAssetError::FatalError("no connection".into()))
+    }
+
+    pub async fn get_balance(&mut self) -> Result<GetBalanceResponse, DigitalAssetError> {
+        let inner = self.connection().await?;
+        let resp = inner.get_balance(GetBalanceRequest {}).await?;
+        Ok(resp.into_inner())
     }
 
     pub async fn register_validator_node(

--- a/applications/tari_validator_node/src/p2p/services/epoch_manager/base_layer_epoch_manager.rs
+++ b/applications/tari_validator_node/src/p2p/services/epoch_manager/base_layer_epoch_manager.rs
@@ -125,7 +125,9 @@ impl BaseLayerEpochManager {
         Ok(())
     }
 
-    async fn get_base_layer_consensus_constants(&mut self) -> Result<&BaseLayerConsensusConstants, EpochManagerError> {
+    pub async fn get_base_layer_consensus_constants(
+        &mut self,
+    ) -> Result<&BaseLayerConsensusConstants, EpochManagerError> {
         if let Some(ref constants) = self.base_layer_consensus_constants {
             return Ok(constants);
         }

--- a/applications/tari_validator_node/src/p2p/services/epoch_manager/base_layer_epoch_manager.rs
+++ b/applications/tari_validator_node/src/p2p/services/epoch_manager/base_layer_epoch_manager.rs
@@ -471,6 +471,24 @@ impl BaseLayerEpochManager {
 
         Ok(())
     }
+
+    pub async fn remaining_registration_epochs(&mut self) -> Result<Option<Epoch>, EpochManagerError> {
+        let last_registration_epoch = match self.last_registration_epoch()? {
+            Some(epoch) => epoch,
+            None => return Ok(None),
+        };
+
+        let constants = self.get_base_layer_consensus_constants().await?;
+        let expiry = constants.validator_node_registration_expiry();
+
+        let num_blocks_since_last_reg = self
+            .current_epoch
+            .checked_sub(last_registration_epoch)
+            .expect("current epoch was less than the epoch we registered"); // Reorgs are not supported
+
+        // None indicates that we are not registered, or a previous registration has expired
+        Ok(expiry.checked_sub(num_blocks_since_last_reg))
+    }
 }
 
 fn get_committee_shard_range<TAddr>(

--- a/applications/tari_validator_node/src/p2p/services/epoch_manager/epoch_manager_service.rs
+++ b/applications/tari_validator_node/src/p2p/services/epoch_manager/epoch_manager_service.rs
@@ -28,7 +28,7 @@ use tari_comms::{types::CommsPublicKey, NodeIdentity};
 use tari_core::{transactions::transaction_components::ValidatorNodeRegistration, ValidatorNodeMmr};
 use tari_dan_common_types::{Epoch, ShardId};
 use tari_dan_core::{
-    consensus_constants::ConsensusConstants,
+    consensus_constants::{BaseLayerConsensusConstants, ConsensusConstants},
     models::{Committee, ValidatorNode},
     services::epoch_manager::{EpochManagerError, ShardCommitteeAllocation},
 };
@@ -133,6 +133,9 @@ pub enum EpochManagerRequest {
     },
     RemainingRegistrationEpochs {
         reply: Reply<Option<Epoch>>,
+    },
+    GetBaseLayerConsensusConstants {
+        reply: Reply<BaseLayerConsensusConstants>,
     },
 }
 
@@ -258,6 +261,9 @@ impl EpochManagerService {
             },
             EpochManagerRequest::RemainingRegistrationEpochs { reply } => {
                 handle(reply, self.inner.remaining_registration_epochs().await)
+            },
+            EpochManagerRequest::GetBaseLayerConsensusConstants { reply } => {
+                handle(reply, self.inner.get_base_layer_consensus_constants().await.cloned())
             },
         }
     }

--- a/applications/tari_validator_node/src/p2p/services/epoch_manager/epoch_manager_service.rs
+++ b/applications/tari_validator_node/src/p2p/services/epoch_manager/epoch_manager_service.rs
@@ -131,6 +131,9 @@ pub enum EpochManagerRequest {
     NotifyScanningComplete {
         reply: Reply<()>,
     },
+    RemainingRegistrationEpochs {
+        reply: Reply<Option<Epoch>>,
+    },
 }
 
 #[derive(Debug, Clone)]
@@ -252,6 +255,9 @@ impl EpochManagerService {
             // TODO: This should be rather be a state machine event
             EpochManagerRequest::NotifyScanningComplete { reply } => {
                 handle(reply, self.inner.on_scanning_complete().await)
+            },
+            EpochManagerRequest::RemainingRegistrationEpochs { reply } => {
+                handle(reply, self.inner.remaining_registration_epochs().await)
             },
         }
     }

--- a/applications/tari_validator_node/src/p2p/services/epoch_manager/handle.rs
+++ b/applications/tari_validator_node/src/p2p/services/epoch_manager/handle.rs
@@ -26,6 +26,7 @@ use tari_comms::types::CommsPublicKey;
 use tari_core::{transactions::transaction_components::ValidatorNodeRegistration, ValidatorNodeMmr};
 use tari_dan_common_types::{Epoch, ShardId};
 use tari_dan_core::{
+    consensus_constants::BaseLayerConsensusConstants,
     models::{Committee, ValidatorNode},
     services::epoch_manager::{EpochManager, EpochManagerError, ShardCommitteeAllocation},
 };
@@ -51,6 +52,15 @@ impl EpochManagerHandle {
                 block_hash,
                 reply: tx,
             })
+            .await
+            .map_err(|_| EpochManagerError::SendError)?;
+        rx.await.map_err(|_| EpochManagerError::ReceiveError)?
+    }
+
+    pub async fn get_base_layer_consensus_constants(&self) -> Result<BaseLayerConsensusConstants, EpochManagerError> {
+        let (tx, rx) = oneshot::channel();
+        self.tx_request
+            .send(EpochManagerRequest::GetBaseLayerConsensusConstants { reply: tx })
             .await
             .map_err(|_| EpochManagerError::SendError)?;
         rx.await.map_err(|_| EpochManagerError::ReceiveError)?

--- a/applications/tari_validator_node/src/p2p/services/epoch_manager/handle.rs
+++ b/applications/tari_validator_node/src/p2p/services/epoch_manager/handle.rs
@@ -75,6 +75,16 @@ impl EpochManagerHandle {
         rx.await.map_err(|_| EpochManagerError::ReceiveError)?
     }
 
+    /// Returns the number of epochs remaining for the current registration if registered, otherwise None
+    pub async fn remaining_registration_epochs(&self) -> Result<Option<Epoch>, EpochManagerError> {
+        let (tx, rx) = oneshot::channel();
+        self.tx_request
+            .send(EpochManagerRequest::RemainingRegistrationEpochs { reply: tx })
+            .await
+            .map_err(|_| EpochManagerError::SendError)?;
+        rx.await.map_err(|_| EpochManagerError::ReceiveError)?
+    }
+
     pub async fn add_validator_node_registration(
         &self,
         block_height: u64,

--- a/applications/tari_validator_node/src/registration.rs
+++ b/applications/tari_validator_node/src/registration.rs
@@ -44,7 +44,6 @@ use tari_wallet_grpc_client::WalletClientError;
 use tokio::{task, task::JoinHandle, time};
 
 use crate::{
-    grpc::services::base_node_client::GrpcBaseNodeClient,
     p2p::services::epoch_manager::{epoch_manager_service::EpochManagerEvent, handle::EpochManagerHandle},
     ApplicationConfig,
     GrpcWalletClient,
@@ -68,8 +67,6 @@ pub enum AutoRegistrationError {
     SqliteStorageError(#[from] SqliteStorageError),
     #[error("Base node error: {0}")]
     BaseNodeError(#[from] BaseNodeError),
-    #[error("Math Overflow error")]
-    MathOverflow,
 }
 
 pub async fn register(
@@ -77,6 +74,17 @@ pub async fn register(
     node_identity: &NodeIdentity,
     epoch_manager: &EpochManagerHandle,
 ) -> Result<RegisterValidatorNodeResponse, AutoRegistrationError> {
+    let balance = wallet_client.get_balance().await?;
+    // TODO: Get the required amount for registration (currently 0)
+    if balance.available_balance == 0 {
+        return Err(AutoRegistrationError::RegistrationFailed {
+            details: format!(
+                "Wallet does not have sufficient balance to pay for registration. Available funds: {}",
+                balance.available_balance
+            ),
+        });
+    }
+
     let mut attempts = 1;
 
     loop {
@@ -143,8 +151,11 @@ async fn start(
         tokio::select! {
             Ok(event) = rx.recv() => {
                 match event {
-                    EpochManagerEvent::EpochChanged(current_epoch) =>
-                        handle_epoch_changed(current_epoch, &config, &node_identity, &epoch_manager, ).await?,
+                    EpochManagerEvent::EpochChanged(_) => {
+                        if let Err(err) = handle_epoch_changed(&config, &node_identity, &epoch_manager).await {
+                            error!(target: LOG_TARGET, "Auto-registration failed with error: {}", err);
+                        }
+                    }
                 }
             },
             _ = shutdown.wait() => break
@@ -155,39 +166,20 @@ async fn start(
 }
 
 async fn handle_epoch_changed(
-    current_epoch: Epoch,
     config: &ApplicationConfig,
     node_identity: &NodeIdentity,
     epoch_manager: &EpochManagerHandle,
 ) -> Result<(), AutoRegistrationError> {
-    let last_registration_epoch = epoch_manager.last_registration_epoch().await?.unwrap_or(Epoch(0));
+    if epoch_manager.last_registration_epoch().await?.is_none() {
+        info!(
+            target: LOG_TARGET,
+            "📋️ Validator has never registered. Auto-registration will only occur after initial registration."
+        );
+        return Ok(());
+    }
 
-    // TODO: This need to consider the validator node confirmation period and submit a reregistration which the tip
-    //       has progressed to the last valid epoch for this node
-
-    let mut base_node_client =
-        GrpcBaseNodeClient::new(config.validator_node.base_node_grpc_address.unwrap_or_else(|| {
-            let port = grpc_default_port(ApplicationType::BaseNode, config.network);
-            ([127, 0, 0, 1], port).into()
-        }));
-
-    // TODO: This logic probably need to move into the epoch manager because it is aware of the base layer consensus
-    //       constants
-    // e.g. if epoch_manager.epochs_until_next_registration() <= 1 { ... }
-    let current_block_height = current_epoch.as_u64() * 10 + 1;
-    let validator_node_registration_expiry = base_node_client
-        .get_consensus_constants(current_block_height)
-        .await
-        .map_err(AutoRegistrationError::BaseNodeError)?
-        .validator_node_registration_expiry()
-        .as_u64() *
-        10;
-
-    let last_registration_height = last_registration_epoch.as_u64() * 10 + 1;
-    let num_blocks_since_last_reg = current_block_height
-        .checked_sub(last_registration_height)
-        .ok_or(AutoRegistrationError::MathOverflow)?;
-    if num_blocks_since_last_reg >= validator_node_registration_expiry {
+    let remaining_epochs = epoch_manager.remaining_registration_epochs().await?.unwrap_or(Epoch(0));
+    if remaining_epochs.is_zero() {
         let wallet_client = GrpcWalletClient::new(config.validator_node.wallet_grpc_address.unwrap_or_else(|| {
             let port = grpc_default_port(ApplicationType::ConsoleWallet, config.network);
             SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), port)
@@ -195,5 +187,6 @@ async fn handle_epoch_changed(
 
         register(wallet_client, node_identity, epoch_manager).await?;
     }
+
     Ok(())
 }

--- a/applications/tari_validator_node/src/registration.rs
+++ b/applications/tari_validator_node/src/registration.rs
@@ -75,8 +75,8 @@ pub async fn register(
     epoch_manager: &EpochManagerHandle,
 ) -> Result<RegisterValidatorNodeResponse, AutoRegistrationError> {
     let balance = wallet_client.get_balance().await?;
-    // TODO: Get the required amount for registration (currently 0)
-    if balance.available_balance == 0 {
+    let constants = epoch_manager.get_base_layer_consensus_constants().await?;
+    if balance.available_balance == constants.validator_node_registration_min_deposit_amount().as_u64() {
         return Err(AutoRegistrationError::RegistrationFailed {
             details: format!(
                 "Wallet does not have sufficient balance to pay for registration. Available funds: {}",

--- a/applications/tari_validator_node/src/registration.rs
+++ b/applications/tari_validator_node/src/registration.rs
@@ -170,14 +170,6 @@ async fn handle_epoch_changed(
     node_identity: &NodeIdentity,
     epoch_manager: &EpochManagerHandle,
 ) -> Result<(), AutoRegistrationError> {
-    if epoch_manager.last_registration_epoch().await?.is_none() {
-        info!(
-            target: LOG_TARGET,
-            "📋️ Validator has never registered. Auto-registration will only occur after initial registration."
-        );
-        return Ok(());
-    }
-
     let remaining_epochs = epoch_manager.remaining_registration_epochs().await?.unwrap_or(Epoch(0));
     if remaining_epochs.is_zero() {
         let wallet_client = GrpcWalletClient::new(config.validator_node.wallet_grpc_address.unwrap_or_else(|| {

--- a/dan_layer/common_types/src/epoch.rs
+++ b/dan_layer/common_types/src/epoch.rs
@@ -34,12 +34,20 @@ impl Epoch {
         self.0
     }
 
+    pub fn is_zero(&self) -> bool {
+        self.0 == 0
+    }
+
     pub fn to_le_bytes(self) -> [u8; 8] {
         self.0.to_le_bytes()
     }
 
     pub fn saturating_sub(&self, other: Epoch) -> Epoch {
         Epoch(self.0.saturating_sub(other.0))
+    }
+
+    pub fn checked_sub(&self, other: Self) -> Option<Epoch> {
+        self.0.checked_sub(other.0).map(Epoch)
     }
 }
 

--- a/dan_layer/core/src/consensus_constants.rs
+++ b/dan_layer/core/src/consensus_constants.rs
@@ -21,6 +21,7 @@
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use serde::{Deserialize, Serialize};
+use tari_core::transactions::tari_amount::MicroTari;
 use tari_dan_common_types::{Epoch, NodeHeight};
 
 #[derive(Clone)]
@@ -48,6 +49,7 @@ impl ConsensusConstants {
 pub struct BaseLayerConsensusConstants {
     pub validator_node_registration_expiry: u64,
     pub epoch_length: u64,
+    pub validator_node_registration_min_deposit_amount: MicroTari,
 }
 
 impl BaseLayerConsensusConstants {
@@ -61,6 +63,10 @@ impl BaseLayerConsensusConstants {
 
     pub fn validator_node_registration_expiry(&self) -> Epoch {
         Epoch(self.validator_node_registration_expiry)
+    }
+
+    pub fn validator_node_registration_min_deposit_amount(&self) -> MicroTari {
+        self.validator_node_registration_min_deposit_amount
     }
 
     pub fn epoch_length(&self) -> u64 {

--- a/dan_layer/core/src/workers/hotstuff_waiter.rs
+++ b/dan_layer/core/src/workers/hotstuff_waiter.rs
@@ -49,6 +49,7 @@ use tari_engine_types::{
     commit_result::{FinalizeResult, RejectReason, TransactionResult},
     substate::SubstateDiff,
 };
+use tari_mmr::common::LeafIndex;
 use tari_shutdown::ShutdownSignal;
 use tari_transaction::SubstateChange;
 use tokio::{
@@ -1448,7 +1449,7 @@ where
                 .verify_leaf::<ValidatorNodeMmrHasherBlake256>(
                     &validator_node_root,
                     &*md.get_node_hash(),
-                    md.merkle_leaf_index as usize,
+                    LeafIndex(md.merkle_leaf_index as usize),
                 )
                 .map_err(|e| HotStuffError::InvalidQuorumCertificate(format!("invalid merkle proof: {}", e)))?;
         }


### PR DESCRIPTION
Description
---
no auto-register when wallet has insufficient funds
Use correct consensus constants when checking for reregistration

Motivation and Context
---
Validator node will error when no funds are available. This PR checks the wallet balance before attempting to submit a transaction.

Depends on: https://github.com/tari-project/tari/pull/5181 and https://github.com/tari-project/tari/pull/5183

How Has This Been Tested?
---
Manually on fresh VN, cucumber tests also test this
