### PR TITLE
fix: allow web UI to use OS-assigned JRPC address

### DIFF
--- a/applications/tari_validator_node/src/http_ui/server.rs
+++ b/applications/tari_validator_node/src/http_ui/server.rs
@@ -34,7 +34,10 @@ use reqwest::StatusCode;
 
 const LOG_TARGET: &str = "tari::validator_node::http_ui::server";
 
-pub async fn run_http_ui_server(address: SocketAddr, json_rpc_address: Option<String>) -> Result<(), anyhow::Error> {
+pub async fn run_http_ui_server(
+    address: SocketAddr,
+    json_rpc_address: Option<SocketAddr>,
+) -> Result<(), anyhow::Error> {
     let json_rpc_address = Arc::new(json_rpc_address);
     let router = Router::new()
         .route(

--- a/applications/tari_validator_node/src/json_rpc/mod.rs
+++ b/applications/tari_validator_node/src/json_rpc/mod.rs
@@ -26,4 +26,4 @@ pub use handlers::JsonRpcHandlers;
 mod jrpc_errors;
 mod server;
 
-pub use server::run_json_rpc;
+pub use server::spawn_json_rpc;


### PR DESCRIPTION
Description
---
Sends correct listen address for JRPC to web UI, even when OS-assigned

Motivation and Context
---
When the JRPC falls back to an OS-assigned listen address, the web UI uses the configured address which points to some other socket (usually another running VN). This PR fixes this.

How Has This Been Tested?
---
Manually, going to the webui for another VN and clicking register an checking the correct VN registers
