### PR TITLE
fix: dont initially register automatically

### DIFF
--- a/applications/tari_validator_node/src/registration.rs
+++ b/applications/tari_validator_node/src/registration.rs
@@ -160,6 +160,14 @@ async fn handle_epoch_changed(
     node_identity: &NodeIdentity,
     epoch_manager: &EpochManagerHandle,
 ) -> Result<(), AutoRegistrationError> {
+    if epoch_manager.last_registration_epoch().await?.is_none() {
+        info!(
+            target: LOG_TARGET,
+            "📋️ Validator has never registered. Auto-registration will only occur after initial registration."
+        );
+        return Ok(());
+    }
+
     let last_registration_epoch = epoch_manager.last_registration_epoch().await?.unwrap_or(Epoch(0));
 
     // TODO: This need to consider the validator node confirmation period and submit a reregistration which the tip


### PR DESCRIPTION
Description
---
Validator will not register the first time automatically until user has initiated registration via the UI/JRPC

Motivation and Context
---
Potentially controversial: If auto_register = true, the validator would immediately try to register. If a user has this flag on (perhaps unintentionally) but does not intend to spend significant funds on registration, either because they are not ready, dont have funds, they only want the VN to observe the network, or for any other reason. They should have to explicitly initiate a registration via the UI/CLI and thereafter only let auto-registration take care of ensuring the VN stays registered.

How Has This Been Tested?
---
Manually, auto registration happens after initial has been done in web UI
