### PR TITLE
fix: start pacemaker when local leader fail

### DIFF
--- a/dan_layer/core/src/workers/hotstuff_waiter.rs
+++ b/dan_layer/core/src/workers/hotstuff_waiter.rs
@@ -635,7 +635,7 @@ where
         self.pacemaker
             .start_timer(
                 PacemakerEvents::LocalCommittee(epoch, shard_id, payload_id),
-                self.network_latency * 2,
+                self.network_latency * (2 << *current_leader),
             )
             .await
             .unwrap();

--- a/dan_layer/core/src/workers/hotstuff_waiter.rs
+++ b/dan_layer/core/src/workers/hotstuff_waiter.rs
@@ -632,6 +632,13 @@ where
             .send((leader.clone(), new_view))
             .await
             .map_err(|_| HotStuffError::SendError)?;
+        self.pacemaker
+            .start_timer(
+                PacemakerEvents::LocalCommittee(epoch, shard_id, payload_id),
+                self.network_latency * 2,
+            )
+            .await
+            .unwrap();
         // Election started
         self.election_in_progress.insert((shard_id, payload_id));
         Ok(())


### PR DESCRIPTION
Description
---
When the first leader fails. And the local leader failure is triggered, we send a new view, but we don't start a timer. So if the second leader fails we never retrigger new view.

How Has This Been Tested?
---
I will add a test in here, or next PR.