### PR TITLE
feat(vn-cli): add 'peers connect' command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6778,6 +6778,7 @@ name = "tari_validator_node_client"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "multiaddr 0.14.0",
  "reqwest",
  "serde",
  "serde_json",

--- a/applications/tari_validator_node/src/json_rpc/handlers.rs
+++ b/applications/tari_validator_node/src/json_rpc/handlers.rs
@@ -31,7 +31,13 @@ use axum_jrpc::{
 use log::*;
 use serde::Serialize;
 use serde_json::{self as json, json};
-use tari_comms::{multiaddr::Multiaddr, peer_manager::NodeId, types::CommsPublicKey, CommsNode, NodeIdentity};
+use tari_comms::{
+    multiaddr::Multiaddr,
+    peer_manager::{NodeId, PeerFeatures},
+    types::CommsPublicKey,
+    CommsNode,
+    NodeIdentity,
+};
 use tari_comms_logging::SqliteMessageLog;
 use tari_crypto::tari_utilities::hex::Hex;
 use tari_dan_common_types::{optional::Optional, PayloadId, QuorumCertificate, QuorumDecision, ShardId};
@@ -43,6 +49,8 @@ use tari_dan_core::{
 use tari_dan_storage_sqlite::sqlite_shard_store_factory::SqliteShardStore;
 use tari_template_lib::Hash;
 use tari_validator_node_client::types::{
+    AddPeerRequest,
+    AddPeerResponse,
     GetCommitteeRequest,
     GetIdentityResponse,
     GetRecentTransactionsResponse,
@@ -495,6 +503,44 @@ impl JsonRpcHandlers {
                 ),
             )),
         }
+    }
+
+    pub async fn add_peer(&self, value: JsonRpcExtractor) -> JrpcResult {
+        let answer_id = value.get_answer_id();
+        let AddPeerRequest {
+            public_key,
+            addresses,
+            wait_for_dial,
+        } = value.parse_params()?;
+
+        let connectivity = self.comms.connectivity();
+        let peer_manager = self.comms.peer_manager();
+
+        let node_id = NodeId::from_public_key(&public_key);
+
+        peer_manager
+            .add_or_update_online_peer(
+                &public_key,
+                node_id.clone(),
+                addresses,
+                PeerFeatures::COMMUNICATION_NODE,
+            )
+            .await
+            .map_err(internal_error(answer_id))?;
+        if wait_for_dial {
+            let _conn = connectivity
+                .dial_peer(node_id)
+                .await
+                .map_err(internal_error(answer_id))?;
+        } else {
+            // Dial without waiting
+            connectivity
+                .request_many_dials(Some(node_id))
+                .await
+                .map_err(internal_error(answer_id))?;
+        }
+
+        Ok(JsonRpcResponse::success(answer_id, AddPeerResponse {}))
     }
 
     pub async fn get_comms_stats(&self, value: JsonRpcExtractor) -> JrpcResult {

--- a/applications/tari_validator_node/src/json_rpc/server.rs
+++ b/applications/tari_validator_node/src/json_rpc/server.rs
@@ -78,6 +78,7 @@ async fn handler(Extension(handlers): Extension<Arc<JsonRpcHandlers>>, value: Js
         "get_committee" => handlers.get_committee(value).await,
         "get_all_vns" => handlers.get_all_vns(value).await,
         // Comms
+        "add_peer" => handlers.add_peer(value).await,
         "get_comms_stats" => handlers.get_comms_stats(value).await,
         "get_connections" => handlers.get_connections(value).await,
         // Debug

--- a/applications/tari_validator_node_cli/src/main.rs
+++ b/applications/tari_validator_node_cli/src/main.rs
@@ -64,6 +64,7 @@ async fn handle_command(command: Command, base_dir: PathBuf, client: ValidatorNo
         Command::Transactions(cmd) => cmd.handle(base_dir, client).await?,
         Command::Accounts(cmd) => cmd.handle(base_dir, client).await?,
         Command::Manifests(cmd) => cmd.handle()?,
+        Command::Peers(cmd) => cmd.handle(client).await?,
         Command::Debug(cmd) => cmd.handle(client).await?,
     }
 

--- a/applications/tari_validator_node_web_ui/src/routes/VN/Components/Connections.tsx
+++ b/applications/tari_validator_node_web_ui/src/routes/VN/Components/Connections.tsx
@@ -20,8 +20,8 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import { useEffect, useState } from 'react';
-import { getConnections } from '../../../utils/json_rpc';
+import React, {useCallback, useEffect, useRef, useState} from 'react';
+import {addPeer, getConnections} from '../../../utils/json_rpc';
 import { toHexString } from './helpers';
 import Table from '@mui/material/Table';
 import TableBody from '@mui/material/TableBody';
@@ -30,6 +30,12 @@ import TableContainer from '@mui/material/TableContainer';
 import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
 import { DataTableCell } from '../../../Components/StyledComponents';
+import IconButton from "@mui/material/IconButton";
+import AddIcon from '@mui/icons-material/Add';
+import Button from "@mui/material/Button";
+import {TextField} from "@mui/material";
+import Container from "@mui/material/Container";
+import {Form} from "react-router-dom";
 
 interface IConnection {
   address: string;
@@ -39,16 +45,64 @@ interface IConnection {
   public_key: string;
 }
 
+const useInterval = (fn: () => Promise<unknown>, ms: number) => {
+  const timeout = useRef<number>();
+  const mountedRef = useRef(false);
+  const run = useCallback(async () => {
+    await fn();
+    if (mountedRef.current) {
+      timeout.current = window.setTimeout(run, ms);
+    }
+  }, [fn, ms]);
+  useEffect(() => {
+    mountedRef.current = true;
+    run();
+    return () => {
+      mountedRef.current = false;
+      window.clearTimeout(timeout.current);
+    };
+  }, [run]);
+};
+
 function Connections() {
   const [connections, setConnections] = useState<IConnection[]>([]);
-  useEffect(() => {
-    getConnections().then((response) => {
-      setConnections(response.connections);
-    });
+  const [showPeerDialog, setShowAddPeerDialog] = useState(false);
+  const [formState, setFormState] = useState({publicKey: "", address: ""});
+
+  const showAddPeerDialog = (setElseToggle: boolean  = !showPeerDialog) => {
+        setShowAddPeerDialog(setElseToggle);
+  };
+
+  const onSubmitAddPeer = () => {
+    addPeer(formState.publicKey, [formState.address]);
+    setFormState({publicKey: "", address: ""});
+    setShowAddPeerDialog(false);
+  };
+  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setFormState({...formState, [e.target.name]: e.target.value});
+  };
+
+
+  let fetchConnections = useCallback(async () => {
+    const resp = await getConnections();
+    setConnections(resp.connections);
   }, []);
+  useInterval(fetchConnections, 5000);
 
   return (
     <TableContainer>
+      <Button startIcon={<AddIcon />} onClick={() => showAddPeerDialog()}>
+          Add Peer
+      </Button>
+        {showPeerDialog ? (
+              <Form onSubmit={onSubmitAddPeer}>
+                <TextField name="publicKey" label="Public Key" value={formState.publicKey} onChange={onChange} />
+                <TextField name="address" label="Address" value={formState.address} onChange={onChange} />
+                <Button type ="submit">Add Peer</Button>
+                <Button onClick={() => showAddPeerDialog(false)}>Cancel</Button>
+              </Form>
+        ): null
+        }
       <Table>
         <TableHead>
           <TableRow>

--- a/applications/tari_validator_node_web_ui/src/utils/json_rpc.tsx
+++ b/applications/tari_validator_node_web_ui/src/utils/json_rpc.tsx
@@ -25,7 +25,7 @@ import { fromHexString, toHexString } from '../routes/VN/Components/helpers';
 async function jsonRpc(method: string, params: any = null) {
   let id = 0;
   id += 1;
-  let address = 'localhost:3333';
+  let address = 'localhost:18200';
   try {
     let text = await (await fetch('json_rpc_address')).text();
     if (/^\d+(\.\d+){3}:[0-9]+$/.test(text)) {
@@ -74,6 +74,9 @@ async function getAllVns(epoch: number) {
 async function getConnections() {
   return await jsonRpc('get_connections');
 }
+async function addPeer(public_key: string, addresses: string[]) {
+  return await jsonRpc('add_peer', {public_key, addresses, wait_for_dial: false});
+}
 async function registerValidatorNode() {
   return await jsonRpc('register_validator_node');
 }
@@ -102,6 +105,7 @@ export {
   getCommittee,
   getCommsStats,
   getConnections,
+  addPeer,
   getEpochManagerStats,
   getIdentity,
   getMempoolStats,

--- a/clients/validator_node_client/Cargo.toml
+++ b/clients/validator_node_client/Cargo.toml
@@ -15,5 +15,6 @@ tari_transaction = { path = "../../dan_layer/transaction" }
 
 anyhow = "1.0.65"
 reqwest = { version = "0.11.11", features = ["json"] }
+multiaddr = "0.14"
 serde = "1.0.144"
 serde_json = "1.0.85"

--- a/clients/validator_node_client/src/lib.rs
+++ b/clients/validator_node_client/src/lib.rs
@@ -38,6 +38,8 @@ use types::{
 };
 
 use crate::types::{
+    AddPeerRequest,
+    AddPeerResponse,
     GetIdentityResponse,
     GetTemplateRequest,
     GetTemplateResponse,
@@ -137,6 +139,10 @@ impl ValidatorNodeClient {
         request: SubmitTransactionRequest,
     ) -> Result<SubmitTransactionResponse, anyhow::Error> {
         self.send_request("submit_transaction", request).await
+    }
+
+    pub async fn add_peer(&mut self, request: AddPeerRequest) -> Result<AddPeerResponse, anyhow::Error> {
+        self.send_request("add_peer", request).await
     }
 
     pub async fn get_message_logs(&mut self, message_tag: &str) -> Result<Vec<LoggedMessage>, anyhow::Error> {

--- a/clients/validator_node_client/src/types.rs
+++ b/clients/validator_node_client/src/types.rs
@@ -20,6 +20,7 @@
 //   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //   USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+use multiaddr::Multiaddr;
 use serde::{Deserialize, Serialize};
 use tari_common_types::types::{FixedHash, PublicKey};
 use tari_dan_common_types::{
@@ -217,3 +218,13 @@ pub struct GetShardKey {
     pub height: u64,
     pub public_key: PublicKey,
 }
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AddPeerRequest {
+    pub public_key: PublicKey,
+    pub addresses: Vec<Multiaddr>,
+    pub wait_for_dial: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AddPeerResponse {}


### PR DESCRIPTION
Description
---
- adds "add_peer" JSON-rpc call
- adds 'peers connect' command to vn cli
- adds example usage to Web UI

Motivation and Context
---
Allow us to manually dial a peer. Web UI is a TODO but the basics are there

How Has This Been Tested?
---
Manually
