### PR TITLE
fix(tari_indexer): replace template manager channel sink with a full mock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6521,6 +6521,7 @@ dependencies = [
  "tari_template_lib",
  "tari_transaction",
  "tari_validator_node",
+ "tari_validator_node_client",
  "thiserror",
  "tokio",
  "tokio-stream",

--- a/applications/tari_indexer/Cargo.toml
+++ b/applications/tari_indexer/Cargo.toml
@@ -24,6 +24,7 @@ tari_storage = { git = "https://github.com/tari-project/tari.git", branch = "dev
 
 tari_dan_app_grpc = { path = "../tari_dan_app_grpc" }
 tari_dan_app_utilities = { path = "../tari_dan_app_utilities" }
+tari_validator_node_client = { path = "../../clients/validator_node_client" }
 tari_dan_common_types = { path = "../../dan_layer/common_types" }
 tari_dan_core = { path = "../../dan_layer/core" }
 tari_dan_engine = { path = "../../dan_layer/engine" }

--- a/applications/tari_indexer/src/p2p/services/mod.rs
+++ b/applications/tari_indexer/src/p2p/services/mod.rs
@@ -20,8 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#![allow(dead_code)]
-
 pub mod comms_peer_provider;
 pub mod epoch_manager;
 pub mod rpc_client;
+pub mod template_manager;

--- a/applications/tari_indexer/src/p2p/services/template_manager/initializer.rs
+++ b/applications/tari_indexer/src/p2p/services/template_manager/initializer.rs
@@ -1,0 +1,35 @@
+//  Copyright 2022. The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use tari_dan_app_utilities::template_manager::TemplateManagerHandle;
+use tari_shutdown::ShutdownSignal;
+use tokio::{sync::mpsc, task::JoinHandle};
+
+use crate::p2p::services::template_manager::service::TemplateManagerService;
+
+pub fn spawn(shutdown: ShutdownSignal) -> (TemplateManagerHandle, JoinHandle<anyhow::Result<()>>) {
+    let (tx_request, rx_request) = mpsc::channel(1);
+    let handle = TemplateManagerHandle::new(tx_request);
+
+    let join_handle = TemplateManagerService::spawn(rx_request, shutdown);
+    (handle, join_handle)
+}

--- a/applications/tari_indexer/src/p2p/services/template_manager/mod.rs
+++ b/applications/tari_indexer/src/p2p/services/template_manager/mod.rs
@@ -1,0 +1,25 @@
+//  Copyright 2022. The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+mod initializer;
+pub use initializer::spawn;
+mod service;

--- a/applications/tari_indexer/src/p2p/services/template_manager/service.rs
+++ b/applications/tari_indexer/src/p2p/services/template_manager/service.rs
@@ -1,0 +1,108 @@
+//  Copyright 2022. The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use log::*;
+use tari_dan_app_utilities::template_manager::{
+    Template,
+    TemplateManagerError,
+    TemplateManagerRequest,
+    TemplateMetadata,
+    TemplateRegistration,
+};
+use tari_shutdown::ShutdownSignal;
+use tari_template_lib::models::TemplateAddress;
+use tari_validator_node_client::types::TemplateAbi;
+use tokio::{
+    sync::{mpsc::Receiver, oneshot},
+    task::JoinHandle,
+};
+
+const LOG_TARGET: &str = "tari::indexer::template_manager";
+
+pub struct TemplateManagerService {
+    rx_request: Receiver<TemplateManagerRequest>,
+}
+
+impl TemplateManagerService {
+    pub fn spawn(
+        rx_request: Receiver<TemplateManagerRequest>,
+        shutdown: ShutdownSignal,
+    ) -> JoinHandle<anyhow::Result<()>> {
+        tokio::spawn(async move {
+            Self { rx_request }.run(shutdown).await?;
+            Ok(())
+        })
+    }
+
+    pub async fn run(mut self, mut shutdown: ShutdownSignal) -> Result<(), TemplateManagerError> {
+        loop {
+            tokio::select! {
+                Some(req) = self.rx_request.recv() => self.handle_request(req).await,
+                _ = shutdown.wait() => {
+                    dbg!("Shutting down template manager");
+                    break;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    async fn handle_request(&mut self, req: TemplateManagerRequest) {
+        #[allow(clippy::enum_glob_use)]
+        use TemplateManagerRequest::*;
+        match req {
+            AddTemplate { template, reply } => {
+                handle(reply, self.handle_add_template(*template).await);
+            },
+            GetTemplate { address, reply } => {
+                handle(reply, self.fetch_template(&address));
+            },
+            GetTemplates { limit, reply } => handle(reply, self.fetch_template_metadata(limit)),
+            LoadTemplateAbi { address, reply } => handle(reply, self.handle_load_template_abi(address)),
+        }
+    }
+
+    async fn handle_add_template(&mut self, _template: TemplateRegistration) -> Result<(), TemplateManagerError> {
+        Ok(())
+    }
+
+    fn fetch_template(&self, address: &TemplateAddress) -> Result<Template, TemplateManagerError> {
+        Err(TemplateManagerError::TemplateNotFound { address: *address })
+    }
+
+    fn fetch_template_metadata(&self, _limit: usize) -> Result<Vec<TemplateMetadata>, TemplateManagerError> {
+        Ok(vec![])
+    }
+
+    fn handle_load_template_abi(&mut self, address: TemplateAddress) -> Result<TemplateAbi, TemplateManagerError> {
+        Err(TemplateManagerError::TemplateNotFound { address })
+    }
+}
+
+fn handle<T>(reply: oneshot::Sender<Result<T, TemplateManagerError>>, result: Result<T, TemplateManagerError>) {
+    if let Err(ref e) = result {
+        error!(target: LOG_TARGET, "Request failed with error: {}", e);
+    }
+    if reply.send(result).is_err() {
+        error!(target: LOG_TARGET, "Requester abandoned request");
+    }
+}

--- a/applications/tari_validator_node/tests/features/indexer.feature
+++ b/applications/tari_validator_node/tests/features/indexer.feature
@@ -54,15 +54,14 @@ Feature: Indexer node
     # Initialize an indexer
     Given an indexer IDX connected to base node BASE
 
-  # FIXME: This indexer is silently breaking, perhaps due to the epoch manager calling the dead channel template manager
     # Get substate of a component (the counter has been increased, so the version is 1)
-#    Then the indexer IDX returns version 1 for substate COUNTER_1/components/Counter
-#
-#    # Get substate of a resource (the nft resource has been mutated by the minting, so the version is 1)
-#    Then the indexer IDX returns version 1 for substate NFT/resources/0
-#
-#    #Get substate of a nft (newly minted and not mutated, so version is 0)
-#    Then the indexer IDX returns version 0 for substate TX2/nfts/0
+    Then the indexer IDX returns version 1 for substate COUNTER_1/components/Counter
+
+    # Get substate of a resource (the nft resource has been mutated by the minting, so the version is 1)
+    Then the indexer IDX returns version 1 for substate NFT/resources/0
+
+    # Get substate of a nft (newly minted and not mutated, so version is 0)
+    Then the indexer IDX returns version 0 for substate TX2/nfts/0
     
-    # When I print the cucumber world
+    # When I print the cucumber world
     # When I wait 5000 seconds

--- a/applications/tari_validator_node/tests/log4rs/cucumber.yml
+++ b/applications/tari_validator_node/tests/log4rs/cucumber.yml
@@ -100,6 +100,13 @@ loggers:
       - dan_layer
     additive: false
 
+  tari::base_layer_scanner:
+    level: debug
+    appenders:
+      - stdout
+      - dan_layer
+    additive: false
+
   tari::dan:
     level: debug
     appenders:


### PR DESCRIPTION
Description
---
* Created a new mock template manager system for the `base_layer_scanner` that handles all needed requests.
* Added some more descriptive error logging for indexers.

Motivation and Context
---
Recent changes in `tari_dan_app_utilities`, mainly related to channel management, broke the indexer `EpochManager` when detecting a new template in the base layer.

How Has This Been Tested?
---
The cucumber scenario for the indexer is working again

