### PR TITLE
fix: only copy compiled builtin templates to dest if changed

### DIFF
--- a/dan_layer/template_builtin/build.rs
+++ b/dan_layer/template_builtin/build.rs
@@ -51,6 +51,13 @@ fn main() -> Result<(), Box<dyn Error>> {
 
         // copy the wasm binary to the root folder of the template, to be included in source control
         let wasm_dest = template_path.join(wasm_name).with_extension("wasm");
+        if wasm_dest.exists() {
+            let existing_contents = fs::read(&wasm_dest)?;
+            let dest_contents = fs::read(&wasm_path)?;
+            if existing_contents == dest_contents {
+                continue;
+            }
+        }
         fs::copy(wasm_path, wasm_dest)?;
     }
 


### PR DESCRIPTION
Description
---
Skips copying builtin templates if their contents are the same

Motivation and Context
---
Often account.wasm is marked as changed in git unnecessarily because it was written even though contents were exactly the same. This leads to a lot of conflicts. It seems that deterministic builds were in fact working and all we needed to do was not overwrite the file if unchanged.

How Has This Been Tested?
---
Manually: making changes to account template that don't change the generated code (e.g. add a newline) and checking that the output file is not written.

