### PR TITLE
feat: template functions on new page

### DIFF
--- a/applications/tari_validator_node_web_ui/src/App.tsx
+++ b/applications/tari_validator_node_web_ui/src/App.tsx
@@ -46,6 +46,7 @@ import ErrorPage from './routes/ErrorPage';
 import Transaction from './routes/Transaction/Transaction';
 import Logo from './Components/Logo';
 import Container from '@mui/material/Container';
+import TemplateFunctions from './routes/VN/Components/TemplateFunctions';
 
 const drawerWidth = 300;
 
@@ -197,6 +198,7 @@ export default function App() {
           <Route path="vns" element={<ValidatorNodes />} />
           <Route path="mempool" element={<Mempool />} />
           <Route path="transaction/:payloadId" element={<Transaction />} />
+          <Route path="template/:address" element={<TemplateFunctions />} />
           <Route path="*" element={<ErrorPage />} />
         </Route>
       </Routes>

--- a/applications/tari_validator_node_web_ui/src/Components/CopyToClipboard.tsx
+++ b/applications/tari_validator_node_web_ui/src/Components/CopyToClipboard.tsx
@@ -21,20 +21,23 @@
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import { useState } from 'react';
-import Snackbar from '@mui/material/Snackbar';
 import IconButton from '@mui/material/IconButton';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import Tooltip from '@mui/material/Tooltip';
 
 interface CopyProps {
   copy: string;
+  floatright?: boolean;
 }
 
-const CopyToClipboard = ({ copy }: CopyProps) => {
+const CopyToClipboard = ({ copy, floatright }: CopyProps) => {
   const [open, setOpen] = useState(false);
   const handleClick = (copyThis: string) => {
     setOpen(true);
     navigator.clipboard.writeText(copyThis);
+    setTimeout(() => {
+      setOpen(false);
+    }, 2000);
   };
 
   return (
@@ -43,12 +46,13 @@ const CopyToClipboard = ({ copy }: CopyProps) => {
         onClick={() => handleClick(copy)}
         size="small"
         aria-label="copy to clipboard"
-        style={{
-          // float: 'right',
-          marginLeft: '10px',
-        }}
+        style={
+          floatright
+            ? { float: 'right', marginLeft: '10px', marginRight: '10px' }
+            : { marginLeft: '10px', marginRight: '10px' }
+        }
       >
-        <Tooltip title={copy} arrow>
+        <Tooltip title={!open ? copy : 'Copied to clipboard'} arrow>
           <ContentCopyIcon
             color="primary"
             style={{
@@ -58,12 +62,6 @@ const CopyToClipboard = ({ copy }: CopyProps) => {
           />
         </Tooltip>
       </IconButton>
-      <Snackbar
-        open={open}
-        onClose={() => setOpen(false)}
-        autoHideDuration={2000}
-        message="Copied to clipboard"
-      />
     </>
   );
 };

--- a/applications/tari_validator_node_web_ui/src/Components/StyledComponents.ts
+++ b/applications/tari_validator_node_web_ui/src/Components/StyledComponents.ts
@@ -26,6 +26,7 @@ import { styled } from '@mui/material/styles';
 import Box from '@mui/material/Box';
 import IconButton from '@mui/material/IconButton';
 import theme from '../theme';
+import Typography from '@mui/material/Typography';
 
 interface IAccordionIconButton {
   open: boolean;
@@ -65,4 +66,15 @@ export const BoxHeading = styled(Box)(({ theme }) => ({
   fontFamily: "'Courier New', Courier, monospace",
   boxShadow: '0px 5px 5px rgba(35, 11, 73, 0.10)',
   margin: '10px 5px',
+}));
+
+export const BoxHeading2 = styled(Box)(({ theme }) => ({
+  padding: theme.spacing(2),
+  borderBottom: '1px solid #f5f5f5',
+}));
+
+export const SubHeading = styled(Typography)(() => ({
+  marginTop: '20px',
+  marginBottom: '20px',
+  textAlign: 'center',
 }));

--- a/applications/tari_validator_node_web_ui/src/index.tsx
+++ b/applications/tari_validator_node_web_ui/src/index.tsx
@@ -37,6 +37,7 @@ import RecentTransactions from './routes/RecentTransactions/RecentTransactions';
 import Templates from './routes/Templates/Templates';
 import ValidatorNodes from './routes/ValidatorNodes/ValidatorNodes';
 import ErrorPage from './routes/ErrorPage';
+import TemplateFunctions from './routes/VN/Components/TemplateFunctions';
 
 const router = createBrowserRouter([
   {
@@ -76,6 +77,10 @@ const router = createBrowserRouter([
         path: 'transaction/:payloadId',
         element: <Transaction />,
         loader: transactionLoader,
+      },
+      {
+        path: 'template/:address',
+        element: <TemplateFunctions />,
       },
     ],
   },

--- a/applications/tari_validator_node_web_ui/src/routes/VN/Components/Connections.tsx
+++ b/applications/tari_validator_node_web_ui/src/routes/VN/Components/Connections.tsx
@@ -20,8 +20,8 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import React, {useCallback, useEffect, useRef, useState} from 'react';
-import {addPeer, getConnections} from '../../../utils/json_rpc';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { addPeer, getConnections } from '../../../utils/json_rpc';
 import { toHexString } from './helpers';
 import Table from '@mui/material/Table';
 import TableBody from '@mui/material/TableBody';
@@ -29,13 +29,15 @@ import TableCell from '@mui/material/TableCell';
 import TableContainer from '@mui/material/TableContainer';
 import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
-import { DataTableCell } from '../../../Components/StyledComponents';
-import IconButton from "@mui/material/IconButton";
+import {
+  DataTableCell,
+  BoxHeading2,
+} from '../../../Components/StyledComponents';
 import AddIcon from '@mui/icons-material/Add';
-import Button from "@mui/material/Button";
-import {TextField} from "@mui/material";
-import Container from "@mui/material/Container";
-import {Form} from "react-router-dom";
+import CloseIcon from '@mui/icons-material/Close';
+import Button from '@mui/material/Button';
+import { TextField } from '@mui/material';
+import { Form } from 'react-router-dom';
 
 interface IConnection {
   address: string;
@@ -67,21 +69,20 @@ const useInterval = (fn: () => Promise<unknown>, ms: number) => {
 function Connections() {
   const [connections, setConnections] = useState<IConnection[]>([]);
   const [showPeerDialog, setShowAddPeerDialog] = useState(false);
-  const [formState, setFormState] = useState({publicKey: "", address: ""});
+  const [formState, setFormState] = useState({ publicKey: '', address: '' });
 
-  const showAddPeerDialog = (setElseToggle: boolean  = !showPeerDialog) => {
-        setShowAddPeerDialog(setElseToggle);
+  const showAddPeerDialog = (setElseToggle: boolean = !showPeerDialog) => {
+    setShowAddPeerDialog(setElseToggle);
   };
 
   const onSubmitAddPeer = () => {
     addPeer(formState.publicKey, [formState.address]);
-    setFormState({publicKey: "", address: ""});
+    setFormState({ publicKey: '', address: '' });
     setShowAddPeerDialog(false);
   };
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setFormState({...formState, [e.target.name]: e.target.value});
+    setFormState({ ...formState, [e.target.name]: e.target.value });
   };
-
 
   let fetchConnections = useCallback(async () => {
     const resp = await getConnections();
@@ -91,18 +92,51 @@ function Connections() {
 
   return (
     <TableContainer>
-      <Button startIcon={<AddIcon />} onClick={() => showAddPeerDialog()}>
-          Add Peer
-      </Button>
+      <BoxHeading2 style={{ minHeight: '75px' }}>
         {showPeerDialog ? (
-              <Form onSubmit={onSubmitAddPeer}>
-                <TextField name="publicKey" label="Public Key" value={formState.publicKey} onChange={onChange} />
-                <TextField name="address" label="Address" value={formState.address} onChange={onChange} />
-                <Button type ="submit">Add Peer</Button>
-                <Button onClick={() => showAddPeerDialog(false)}>Cancel</Button>
-              </Form>
-        ): null
-        }
+          <Form
+            onSubmit={onSubmitAddPeer}
+            style={{
+              display: 'flex',
+              alignContent: 'center',
+              gap: '10px',
+            }}
+          >
+            <TextField
+              size="small"
+              name="publicKey"
+              label="Public Key"
+              value={formState.publicKey}
+              onChange={onChange}
+            />
+            <TextField
+              size="small"
+              name="address"
+              label="Address"
+              value={formState.address}
+              onChange={onChange}
+            />
+            <Button startIcon={<AddIcon />} variant="contained" type="submit">
+              Add Peer
+            </Button>
+            <Button
+              startIcon={<CloseIcon />}
+              variant="outlined"
+              onClick={() => showAddPeerDialog(false)}
+            >
+              Cancel
+            </Button>
+          </Form>
+        ) : (
+          <Button
+            variant="outlined"
+            startIcon={<AddIcon />}
+            onClick={() => showAddPeerDialog()}
+          >
+            Add Peer
+          </Button>
+        )}
+      </BoxHeading2>
       <Table>
         <TableHead>
           <TableRow>

--- a/applications/tari_validator_node_web_ui/src/routes/VN/Components/TemplateFunctions.tsx
+++ b/applications/tari_validator_node_web_ui/src/routes/VN/Components/TemplateFunctions.tsx
@@ -1,0 +1,102 @@
+//  Copyright 2022. The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import { useState, useEffect } from 'react';
+import { useParams, useLocation, useLoaderData } from 'react-router-dom';
+import { ITemplate } from '../../../utils/interfaces';
+import { getTemplate } from '../../../utils/json_rpc';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableContainer from '@mui/material/TableContainer';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
+import {
+  DataTableCell,
+  BoxHeading,
+  BoxHeading2,
+} from '../../../Components/StyledComponents';
+import PageHeading from '../../../Components/PageHeading';
+import Grid from '@mui/material/Grid';
+import { StyledPaper } from '../../../Components/StyledComponents';
+import { fromHexString } from './helpers';
+
+function TemplateFunctions() {
+  const { address } = useParams();
+  const [info, setInfo] = useState<ITemplate>();
+
+  const data = address ? fromHexString(address.replace('0x', '')) : '';
+
+  const load = (address: any) => {
+    getTemplate(address).then((response) => {
+      setInfo(response);
+    });
+  };
+
+  useEffect(() => {
+    load(data);
+  }, []);
+
+  const renderFunctions = (template: ITemplate) => {
+    return (
+      <TableContainer>
+        <BoxHeading2>{template.abi.template_name}</BoxHeading2>
+        <Table>
+          <TableHead>
+            <TableRow>
+              <TableCell>Function</TableCell>
+              <TableCell>Args</TableCell>
+              <TableCell>Returns</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {template.abi.functions.map((fn) => (
+              <TableRow key={fn.name}>
+                <DataTableCell style={{ textAlign: 'left' }}>
+                  {fn.name}
+                </DataTableCell>
+                <DataTableCell>{fn.arguments.join(', ')}</DataTableCell>
+                <DataTableCell>{fn.output}</DataTableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+    );
+  };
+
+  return (
+    <Grid container spacing={5}>
+      <Grid item xs={12} md={12} lg={12}>
+        <PageHeading>Template Functions</PageHeading>
+      </Grid>
+      <Grid item xs={12} md={12} lg={12}>
+        <StyledPaper>
+          <BoxHeading>Address: {address}</BoxHeading>
+          {info ? renderFunctions(info) : ''}
+        </StyledPaper>
+      </Grid>
+    </Grid>
+  );
+}
+
+export default TemplateFunctions;

--- a/applications/tari_validator_node_web_ui/src/routes/VN/Components/Templates.tsx
+++ b/applications/tari_validator_node_web_ui/src/routes/VN/Components/Templates.tsx
@@ -21,8 +21,8 @@
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import { useEffect, useState } from 'react';
-import { ITemplate } from '../../../utils/interfaces';
-import { getTemplate, getTemplates } from '../../../utils/json_rpc';
+import { getTemplates } from '../../../utils/json_rpc';
+import { shortenString } from './helpers';
 import './Templates.css';
 import Table from '@mui/material/Table';
 import TableBody from '@mui/material/TableBody';
@@ -31,25 +31,19 @@ import TableContainer from '@mui/material/TableContainer';
 import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
 import { DataTableCell } from '../../../Components/StyledComponents';
+import { Link } from 'react-router-dom';
+import CopyToClipboard from '../../../Components/CopyToClipboard';
+import IconButton from '@mui/material/IconButton';
+import KeyboardArrowRightIcon from '@mui/icons-material/KeyboardArrowRight';
 
 function Templates() {
   const [templates, setTemplates] = useState([]);
-  const [info, setInfo] = useState<{ [id: string]: ITemplate }>();
-  const [loading, setLoading] = useState<{ [id: string]: Boolean }>();
   useEffect(() => {
     getTemplates(10).then((response) => {
       setTemplates(response.templates);
     });
   }, []);
-  const load = (address: string) => {
-    if (info?.[address] || loading?.[address]) {
-      return;
-    }
-    setLoading({ ...loading, [address]: true });
-    getTemplate(address).then((response) => {
-      setInfo({ ...info, [address]: response });
-    });
-  };
+
   const toHex = (str: Uint8Array) => {
     return (
       '0x' +
@@ -58,31 +52,7 @@ function Templates() {
         .join('')
     );
   };
-  const renderFunctions = (template: ITemplate) => {
-    return (
-      <TableContainer>
-        <div className="caption">{template.abi.template_name}</div>
-        <Table>
-          <TableHead>
-            <TableCell>Function</TableCell>
-            <TableCell>Args</TableCell>
-            <TableCell>Returns</TableCell>
-          </TableHead>
-          <TableBody>
-            {template.abi.functions.map((fn) => (
-              <TableRow>
-                <DataTableCell style={{ textAlign: 'left' }}>
-                  {fn.name}
-                </DataTableCell>
-                <DataTableCell>{fn.arguments.join(', ')}</DataTableCell>
-                <DataTableCell>{fn.output}</DataTableCell>
-              </TableRow>
-            ))}
-          </TableBody>
-        </Table>
-      </TableContainer>
-    );
-  };
+
   return (
     <TableContainer>
       <Table>
@@ -90,31 +60,40 @@ function Templates() {
           <TableRow>
             <TableCell>Address</TableCell>
             <TableCell>Download URL</TableCell>
-            <TableCell>Mined Height</TableCell>
-            <TableCell>Status</TableCell>
+            <TableCell style={{ textAlign: 'center' }}>Mined Height</TableCell>
+            <TableCell style={{ textAlign: 'center' }}>Status</TableCell>
+            <TableCell style={{ textAlign: 'center' }}>Functions</TableCell>
           </TableRow>
         </TableHead>
         <TableBody>
           {templates.map(({ address, binary_sha, height, url }) => (
             <TableRow key={address}>
-              <DataTableCell
-                onMouseOver={() => load(address)}
-                className="tooltip"
-              >
-                <span>{toHex(address)}</span>
-                {info?.[address] !== undefined ? (
-                  <span className="tooltiptext">
-                    {renderFunctions(info[address])}
-                  </span>
-                ) : (
-                  <></>
-                )}
+              <DataTableCell>
+                <Link
+                  to={`/template/${toHex(address)}`}
+                  state={[address]}
+                  style={{ textDecoration: 'none' }}
+                >
+                  {shortenString(toHex(address))}
+                </Link>
+                <CopyToClipboard copy={toHex(address)} />
               </DataTableCell>
               <DataTableCell>
                 <a href={url}>{url}</a>
               </DataTableCell>
-              <DataTableCell>{height}</DataTableCell>
-              <DataTableCell>Active</DataTableCell>
+              <DataTableCell style={{ textAlign: 'center' }}>
+                {height}
+              </DataTableCell>
+              <DataTableCell style={{ textAlign: 'center' }}>
+                Active
+              </DataTableCell>
+              <DataTableCell style={{ textAlign: 'center' }}>
+                <Link to={`/template/${toHex(address)}`} state={[address]}>
+                  <IconButton>
+                    <KeyboardArrowRightIcon color="primary" />
+                  </IconButton>
+                </Link>
+              </DataTableCell>
             </TableRow>
           ))}
         </TableBody>


### PR DESCRIPTION
Description
---
Moved template functions to a separate page.
Also added some general UI improvements, like on the connections "Add peer" buttons.
Changed the copy to clipboard component, so the hover state and confirmation message both display in the tooltip.

Motivation and Context
---
The template functions are currently displaying in a hover, making them difficult to read.

How Has This Been Tested?
---
Manually
