### PR TITLE
feat: transaction filter

### DIFF
--- a/applications/tari_validator_node_web_ui/src/Components/AlertDialog.tsx
+++ b/applications/tari_validator_node_web_ui/src/Components/AlertDialog.tsx
@@ -1,0 +1,87 @@
+//  Copyright 2022. The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import { useState } from 'react';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import DialogTitle from '@mui/material/DialogTitle';
+
+interface AlertDialogProps {
+  buttonTitle?: string;
+  dialogTitle?: string;
+  dialogDescription?: string;
+  confirmFunction?: any;
+  confirmTitle?: string;
+  cancelTitle?: string;
+}
+
+export function ConfirmDialog({
+  buttonTitle,
+  dialogTitle,
+  dialogDescription,
+  confirmFunction,
+  confirmTitle = 'Confirm',
+  cancelTitle = 'Cancel',
+}: AlertDialogProps) {
+  const [open, setOpen] = useState(false);
+
+  const handleClickOpen = () => {
+    setOpen(true);
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+    confirmFunction();
+  };
+
+  return (
+    <div>
+      <Button variant="outlined" onClick={handleClickOpen}>
+        {buttonTitle}
+      </Button>
+      <Dialog
+        open={open}
+        onClose={handleClose}
+        aria-labelledby="alert-dialog-title"
+        aria-describedby="alert-dialog-description"
+      >
+        <DialogTitle id="alert-dialog-title">{dialogTitle}</DialogTitle>
+        <DialogContent>
+          <DialogContentText id="alert-dialog-description">
+            {dialogDescription}
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button variant="outlined" onClick={handleClose}>
+            {cancelTitle}
+          </Button>
+          <Button variant="contained" onClick={handleClose} autoFocus>
+            {confirmTitle}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </div>
+  );
+}

--- a/applications/tari_validator_node_web_ui/src/Components/HeadingMenu.tsx
+++ b/applications/tari_validator_node_web_ui/src/Components/HeadingMenu.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import Button from '@mui/material/Button';
+import Menu from '@mui/material/Menu';
+import MenuItem from '@mui/material/MenuItem';
+import UnfoldMoreIcon from '@mui/icons-material/UnfoldMore';
+import ListItemText from '@mui/material/ListItemText';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import MenuList from '@mui/material/MenuList';
+import FilterListOutlinedIcon from '@mui/icons-material/FilterListOutlined';
+
+interface MenuItem {
+  title: string;
+  fn: () => void;
+  icon?: any;
+}
+
+interface Props {
+  menuTitle: string;
+  menuItems: MenuItem[];
+}
+
+function HeadingMenu({ menuTitle, menuItems }: Props) {
+  const [anchorEl, setAnchorEl] = React.useState(null);
+
+  function handleClick(event: any) {
+    if (anchorEl !== event.currentTarget) {
+      setAnchorEl(event.currentTarget);
+    }
+  }
+
+  function handleClose() {
+    setAnchorEl(null);
+  }
+
+  return (
+    <div>
+      <Button
+        aria-owns={anchorEl ? 'simple-menu' : undefined}
+        aria-haspopup="true"
+        onClick={handleClick}
+        // onMouseOver={handleClick}
+        startIcon={<UnfoldMoreIcon />}
+        style={{
+          textTransform: 'none',
+          color: '#000000',
+        }}
+      >
+        {menuTitle}
+      </Button>
+      <Menu
+        id="simple-menu"
+        anchorEl={anchorEl}
+        open={Boolean(anchorEl)}
+        onClose={handleClose}
+        MenuListProps={{ onMouseLeave: handleClose }}
+      >
+        <MenuList style={{ outline: 'none' }} className="annoying">
+          {menuItems?.map((item, index) => (
+            <MenuItem key={index} onClick={item.fn}>
+              <ListItemIcon>
+                {item.icon ? (
+                  item.icon
+                ) : (
+                  <FilterListOutlinedIcon fontSize="small" />
+                )}
+              </ListItemIcon>
+              <ListItemText>{item.title}</ListItemText>
+            </MenuItem>
+          ))}
+        </MenuList>
+      </Menu>
+    </div>
+  );
+}
+
+export default HeadingMenu;

--- a/applications/tari_validator_node_web_ui/src/Components/HeadingMenu.tsx
+++ b/applications/tari_validator_node_web_ui/src/Components/HeadingMenu.tsx
@@ -1,3 +1,25 @@
+//  Copyright 2022. The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 import React from 'react';
 import Button from '@mui/material/Button';
 import Menu from '@mui/material/Menu';

--- a/applications/tari_validator_node_web_ui/src/Components/TransactionFilter.tsx
+++ b/applications/tari_validator_node_web_ui/src/Components/TransactionFilter.tsx
@@ -1,0 +1,172 @@
+import React, { useState, useRef, useEffect } from 'react';
+import TextField from '@mui/material/TextField';
+import IconButton from '@mui/material/IconButton';
+import FormControl from '@mui/material/FormControl';
+import InputLabel from '@mui/material/InputLabel';
+import Select from '@mui/material/Select';
+import MenuItem from '@mui/material/MenuItem';
+import InputAdornment from '@mui/material/InputAdornment';
+import SearchIcon from '@mui/icons-material/Search';
+import CloseRoundedIcon from '@mui/icons-material/CloseRounded';
+import { ITableRecentTransaction } from '../routes/VN/Components/RecentTransactions';
+import { getRecentTransactions, getTransaction } from '../utils/json_rpc';
+
+interface ISearchProps {
+  recentTransactions: ITableRecentTransaction[];
+  setRecentTransactions: (
+    recentTransactions: ITableRecentTransaction[]
+  ) => void;
+  setPage: (page: number) => void;
+}
+
+const TransactionFilter: React.FC<ISearchProps> = ({
+  recentTransactions,
+  setRecentTransactions,
+  setPage,
+}) => {
+  const [formState, setFormState] = useState({ searchValue: '' });
+  const [filterBy, setFilterBy] = useState('');
+  const [showClearBtn, setShowClearBtn] = useState(false);
+  const filterInputRef = useRef<any>(null);
+
+  const onSelectChange = (event: any) => {
+    setFilterBy(event.target.value as string);
+  };
+
+  // when search input changes
+  const onTextChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    // e.preventDefault();
+    setFormState({ ...formState, [e.target.name]: e.target.value });
+    setShowClearBtn(true);
+  };
+
+  // when search input changes and formState has been updated
+  useEffect(() => {
+    if (formState.searchValue === '') {
+      requestSearch(formState.searchValue, filterBy);
+      setShowClearBtn(false);
+    }
+    requestSearch(formState.searchValue, filterBy);
+  }, [formState]);
+
+  // once selected filter, focus on input
+  useEffect(() => {
+    if (filterBy !== '') {
+      filterInputRef.current.focus();
+    }
+  }, [filterBy]);
+
+  // search function
+  const requestSearch = (searchedVal: string, filter: string) => {
+    const filteredRows = recentTransactions.filter((row) => {
+      let result;
+      switch (filter) {
+        case 'id':
+          result = row.id.toLowerCase().includes(searchedVal.toLowerCase());
+          break;
+        case 'timestamp':
+          result = row.timestamp.includes(searchedVal);
+          break;
+        case 'template':
+          console.log('filter by template address');
+          break;
+        default:
+          result = row.id.toLowerCase().includes(searchedVal.toLowerCase());
+          break;
+      }
+      return result;
+    });
+
+    // Create a new array that is a copy of the original
+    const updatedTransactions = [...recentTransactions];
+
+    // Set the "show" property of all transactions in the copy to false
+    updatedTransactions.forEach((transaction) => {
+      transaction.show = false;
+    });
+
+    // Loop over the filtered array, find the matching object in the
+    // original array, and set its "show" property to true
+    filteredRows.forEach((filteredRow) => {
+      const index = updatedTransactions.findIndex(
+        (transaction) => transaction.id === filteredRow.id
+      );
+      if (index !== -1) {
+        updatedTransactions[index].show = true;
+      }
+    });
+
+    // Update the state with the modified copy of the original array
+    setRecentTransactions(updatedTransactions);
+
+    // Set paging to first page
+    setPage(0);
+  };
+
+  // search function when enter is pressed
+  const confirmSearch = () => {
+    requestSearch(formState.searchValue, filterBy);
+    if (formState.searchValue !== '') {
+      setShowClearBtn(true);
+    }
+  };
+
+  // clear search
+  const cancelSearch = () => {
+    setFormState({ ...formState, searchValue: '' });
+    setShowClearBtn(false);
+    setFilterBy('');
+  };
+
+  return (
+    <>
+      <div className="flex-container">
+        <FormControl>
+          <InputLabel>Filter By</InputLabel>
+          <Select
+            value={filterBy}
+            label="Filter By"
+            placeholder="Filter By"
+            onChange={onSelectChange}
+            size="medium"
+            name="filterBy"
+            style={{ flexGrow: '1', minWidth: '200px' }}
+          >
+            <MenuItem value={'template'}>Template Address</MenuItem>
+            <MenuItem value={'id'}>Payload ID</MenuItem>
+            <MenuItem value={'timestamp'}>Timestamp</MenuItem>
+          </Select>
+        </FormControl>
+        <TextField
+          value={formState.searchValue}
+          name="searchValue"
+          onChange={onTextChange}
+          style={{ flexGrow: 1 }}
+          inputRef={filterInputRef}
+          placeholder="Search for transactions"
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              confirmSearch();
+            }
+          }}
+          InputProps={{
+            startAdornment: (
+              <InputAdornment position="start">
+                <SearchIcon />
+              </InputAdornment>
+            ),
+            endAdornment: (
+              <InputAdornment position="end">
+                <IconButton>
+                  {showClearBtn && <CloseRoundedIcon onClick={cancelSearch} />}
+                </IconButton>
+              </InputAdornment>
+            ),
+          }}
+        />
+      </div>
+    </>
+  );
+};
+
+export default TransactionFilter;

--- a/applications/tari_validator_node_web_ui/src/Components/TransactionFilter.tsx
+++ b/applications/tari_validator_node_web_ui/src/Components/TransactionFilter.tsx
@@ -1,3 +1,25 @@
+//  Copyright 2022. The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 import React, { useState, useRef, useEffect } from 'react';
 import TextField from '@mui/material/TextField';
 import IconButton from '@mui/material/IconButton';
@@ -9,7 +31,6 @@ import InputAdornment from '@mui/material/InputAdornment';
 import SearchIcon from '@mui/icons-material/Search';
 import CloseRoundedIcon from '@mui/icons-material/CloseRounded';
 import { ITableRecentTransaction } from '../routes/VN/Components/RecentTransactions';
-import { getRecentTransactions, getTransaction } from '../utils/json_rpc';
 
 interface ISearchProps {
   recentTransactions: ITableRecentTransaction[];

--- a/applications/tari_validator_node_web_ui/src/index.css
+++ b/applications/tari_validator_node_web_ui/src/index.css
@@ -24,3 +24,35 @@ body {
 code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New", monospace;
 }
+
+.add-confirm-form {
+  display: flex;
+  flex-direction: column;
+  align-content: center;
+  gap: 10px;
+}
+
+.flex-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: stretch;
+  width: 100%;
+  gap: 10px;
+}
+
+@media screen and (max-width: 767px) {
+  .flex-container > * {
+    width: 100%;
+  }
+}
+
+@media screen and (min-width: 768px) {
+  
+.add-confirm-form {
+  flex-direction: row;
+}
+.flex-container {
+  flex-direction: row;
+}
+}

--- a/applications/tari_validator_node_web_ui/src/routes/Transaction/Components/Output.tsx
+++ b/applications/tari_validator_node_web_ui/src/routes/Transaction/Components/Output.tsx
@@ -95,11 +95,9 @@ function RowData({ row, justify }: any) {
                           />
                         </DataTableCell>
                         <DataTableCell>
-                          {row.proposed_by}
+                          <p>{row.proposed_by}</p>
                         </DataTableCell>
-                        <DataTableCell>
-                          {row.leader_round}
-                        </DataTableCell>
+                        <DataTableCell>{row.leader_round}</DataTableCell>
                       </TableRow>
                     );
                   })
@@ -153,29 +151,32 @@ export default function Output({
 }: {
   shard: string;
   output: any[];
-  current_state: [string,number,string] | undefined;
+  current_state: [string, number, string] | undefined;
 }) {
   return (
-    <div id={shard} className="output">
+    <div id={shard}>
+      <BoxHeading
+        style={{
+          marginBottom: '20px',
+          display: 'flex',
+          alignItems: 'flex-start',
+          justifyContent: 'flex-start',
+          gap: '10px',
+        }}
+      >
+        <CommitOutlinedIcon style={{ color: 'rgba(35, 11, 73, 0.20)' }} />
+        Shard: {shard}
+        <br />
+        Current leader : {current_state ? current_state[0] : 'Unknown'}
+        <br />
+        Leader round : {current_state ? current_state[1] : 'Unknown'}
+        <br />
+        Leader timestamp :{' '}
+        {current_state
+          ? new Date(current_state[2]).toLocaleString()
+          : 'Unknown'}
+      </BoxHeading>
       <TableContainer>
-        <BoxHeading
-          style={{
-            marginBottom: '20px',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'flex-start',
-            gap: '10px',
-          }}
-        >
-          <CommitOutlinedIcon style={{ color: 'rgba(35, 11, 73, 0.20)' }} />
-          Shard: {shard}
-          <br/>
-          Current leader : {current_state?current_state[0]:"Unknown"}
-          <br/>
-          Leader round : {current_state?current_state[1]:"Unknown"}
-          <br/>
-          Leader timestamp : {current_state?new Date(current_state[2]).toLocaleString():"Unknown"}
-        </BoxHeading>
         <Table>
           <TableHead>
             <TableRow>

--- a/applications/tari_validator_node_web_ui/src/routes/VN/Components/Connections.tsx
+++ b/applications/tari_validator_node_web_ui/src/routes/VN/Components/Connections.tsx
@@ -22,7 +22,7 @@
 
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { addPeer, getConnections } from '../../../utils/json_rpc';
-import { toHexString } from './helpers';
+import { toHexString, shortenString } from './helpers';
 import Table from '@mui/material/Table';
 import TableBody from '@mui/material/TableBody';
 import TableCell from '@mui/material/TableCell';
@@ -34,10 +34,11 @@ import {
   BoxHeading2,
 } from '../../../Components/StyledComponents';
 import AddIcon from '@mui/icons-material/Add';
-import CloseIcon from '@mui/icons-material/Close';
 import Button from '@mui/material/Button';
 import { TextField } from '@mui/material';
 import { Form } from 'react-router-dom';
+import Fade from '@mui/material/Fade';
+import CopyToClipboard from '../../../Components/CopyToClipboard';
 
 interface IConnection {
   address: string;
@@ -91,79 +92,83 @@ function Connections() {
   useInterval(fetchConnections, 5000);
 
   return (
-    <TableContainer>
-      <BoxHeading2 style={{ minHeight: '75px' }}>
-        {showPeerDialog ? (
-          <Form
-            onSubmit={onSubmitAddPeer}
-            style={{
-              display: 'flex',
-              alignContent: 'center',
-              gap: '10px',
-            }}
-          >
-            <TextField
-              size="small"
-              name="publicKey"
-              label="Public Key"
-              value={formState.publicKey}
-              onChange={onChange}
-            />
-            <TextField
-              size="small"
-              name="address"
-              label="Address"
-              value={formState.address}
-              onChange={onChange}
-            />
-            <Button startIcon={<AddIcon />} variant="contained" type="submit">
-              Add Peer
-            </Button>
-            <Button
-              startIcon={<CloseIcon />}
-              variant="outlined"
-              onClick={() => showAddPeerDialog(false)}
-            >
-              Cancel
-            </Button>
-          </Form>
-        ) : (
-          <Button
-            variant="outlined"
-            startIcon={<AddIcon />}
-            onClick={() => showAddPeerDialog()}
-          >
-            Add Peer
-          </Button>
+    <>
+      <BoxHeading2>
+        {showPeerDialog && (
+          <Fade in={showPeerDialog}>
+            <Form onSubmit={onSubmitAddPeer} className="flex-container">
+              <TextField
+                name="publicKey"
+                label="Public Key"
+                value={formState.publicKey}
+                onChange={onChange}
+                style={{ flexGrow: 1 }}
+              />
+              <TextField
+                name="address"
+                label="Address"
+                value={formState.address}
+                onChange={onChange}
+                style={{ flexGrow: 1 }}
+              />
+              <Button variant="contained" type="submit">
+                Add Peer
+              </Button>
+              <Button
+                variant="outlined"
+                onClick={() => showAddPeerDialog(false)}
+              >
+                Cancel
+              </Button>
+            </Form>
+          </Fade>
+        )}
+        {!showPeerDialog && (
+          <Fade in={!showPeerDialog}>
+            <div className="flex-container">
+              <Button
+                variant="outlined"
+                startIcon={<AddIcon />}
+                onClick={() => showAddPeerDialog()}
+              >
+                Add Peer
+              </Button>
+            </div>
+          </Fade>
         )}
       </BoxHeading2>
-      <Table>
-        <TableHead>
-          <TableRow>
-            <TableCell>Address</TableCell>
-            <TableCell>Age</TableCell>
-            <TableCell>Direction</TableCell>
-            <TableCell>Node id</TableCell>
-            <TableCell>Public key</TableCell>
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {connections.map(
-            ({ address, age, direction, node_id, public_key }) => (
-              <TableRow key={public_key}>
-                <DataTableCell>{address}</DataTableCell>
-                <DataTableCell>{age}</DataTableCell>
-                <DataTableCell>
-                  {direction ? 'Inbound' : 'Outbound'}
-                </DataTableCell>
-                <DataTableCell>{toHexString(node_id)}</DataTableCell>
-                <DataTableCell>{public_key}</DataTableCell>
-              </TableRow>
-            )
-          )}
-        </TableBody>
-      </Table>
-    </TableContainer>
+      <TableContainer>
+        <Table>
+          <TableHead>
+            <TableRow>
+              <TableCell>Address</TableCell>
+              <TableCell>Age</TableCell>
+              <TableCell>Direction</TableCell>
+              <TableCell>Node id</TableCell>
+              <TableCell>Public key</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {connections.map(
+              ({ address, age, direction, node_id, public_key }) => (
+                <TableRow key={public_key}>
+                  <DataTableCell>{address}</DataTableCell>
+                  <DataTableCell>{age}</DataTableCell>
+                  <DataTableCell>
+                    {direction ? 'Inbound' : 'Outbound'}
+                  </DataTableCell>
+                  <DataTableCell>{toHexString(node_id)}</DataTableCell>
+                  <DataTableCell>
+                    {shortenString(public_key)}
+                    <CopyToClipboard copy={public_key} />
+                  </DataTableCell>
+                </TableRow>
+              )
+            )}
+          </TableBody>
+        </Table>
+      </TableContainer>
+    </>
   );
 }
 

--- a/applications/tari_validator_node_web_ui/src/theme.ts
+++ b/applications/tari_validator_node_web_ui/src/theme.ts
@@ -78,8 +78,10 @@ const theme = createTheme({
     MuiButton: {
       defaultProps: {
         disableRipple: true,
-        style: {
-          borderRadius: '5px',
+        sx: {
+          // borderRadius: '5px',
+          minHeight: '55px',
+          boxShadow: 'none',
         },
       },
     },


### PR DESCRIPTION
Description
---
Added a search / filter box for recent transactions.
Transactions can also be sorted ascending / descending by payload id / timestamp by clicking on the table header.
Filter by template address will not work yet - this needs to be filtered in the backend. Can be added to the switch statement in TransactionFIlter.tsx. 
Small styling updates on connections.
Also added the alert dialog component from the indexer, so the component is available to use here as well.

Motivation and Context
---
Makes finding specific transactions easier.

How Has This Been Tested?
---
Manually

What process can a PR reviewer use to test or verify this change?
---
Search for a recent transaction by selecting a category from the dropdown and then typing in the search input box.

Breaking Changes
---
x

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify