### PR TITLE
fix: json error on transaction page

### DIFF
--- a/applications/tari_validator_node_web_ui/src/routes/Transaction/Components/Output.tsx
+++ b/applications/tari_validator_node_web_ui/src/routes/Transaction/Components/Output.tsx
@@ -95,7 +95,10 @@ function RowData({ row, justify }: any) {
                           />
                         </DataTableCell>
                         <DataTableCell>
-                          <p>{row.proposed_by}</p>
+                          {shortenString(toHexString(row.proposed_by))}
+                          <CopyToClipboard
+                            copy={toHexString(row.proposed_by)}
+                          />
                         </DataTableCell>
                         <DataTableCell>{row.leader_round}</DataTableCell>
                       </TableRow>
@@ -135,7 +138,7 @@ function RowData({ row, justify }: any) {
         >
           <Collapse in={open} timeout="auto" unmountOnExit>
             <CodeBlock style={{ marginBottom: '10px' }}>
-              {row.justify ? renderJson(JSON.parse(row.justify)) : ''}
+              {justify && renderJson(justify)}
             </CodeBlock>
           </Collapse>
         </DataTableCell>


### PR DESCRIPTION
Description
---
Fix for error on transaction page.
It works on the mock server, but please test if this fixes the error on a live server.

Motivation and Context
---
Clicking on a recent transaction gave the following error:
"Cannot convert undefined or null to object"

How Has This Been Tested?
---
Manually

What process can a PR reviewer use to test or verify this change?
---
From the homepage, click on any recent transaction.
Also click on the dropdown below "Justify" on the transaction page.

Breaking Changes
---
x

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify