### PR TITLE
chore: update tari deps v0.49.0-pre.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5848,8 +5848,8 @@ checksum = "8ae9980cab1db3fceee2f6c6f643d5d8de2997c58ee8d25fb0cc8a9e9e7348e5"
 
 [[package]]
 name = "tari_app_grpc"
-version = "0.49.0-pre.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.0#a008fe2e5ee66ec12598a5148961047d95e84c57"
+version = "0.49.0-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.1#57781b63cec3f0cf6b3d739408c10a467988c092"
 dependencies = [
  "argon2",
  "base64 0.13.1",
@@ -5859,7 +5859,7 @@ dependencies = [
  "prost 0.9.0",
  "prost-types 0.9.0",
  "rand 0.8.5",
- "tari_common_types 0.49.0-pre.0 (git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.0)",
+ "tari_common_types 0.49.0-pre.1",
  "tari_comms",
  "tari_core",
  "tari_crypto",
@@ -5873,8 +5873,8 @@ dependencies = [
 
 [[package]]
 name = "tari_app_utilities"
-version = "0.49.0-pre.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.0#a008fe2e5ee66ec12598a5148961047d95e84c57"
+version = "0.49.0-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.1#57781b63cec3f0cf6b3d739408c10a467988c092"
 dependencies = [
  "clap 3.2.23",
  "futures 0.3.27",
@@ -5882,8 +5882,8 @@ dependencies = [
  "log",
  "rand 0.7.3",
  "serde",
- "tari_common 0.49.0-pre.0 (git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.0)",
- "tari_common_types 0.49.0-pre.0 (git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.0)",
+ "tari_common 0.49.0-pre.1",
+ "tari_common_types 0.49.0-pre.1",
  "tari_comms",
  "tari_utilities",
  "thiserror",
@@ -5892,8 +5892,8 @@ dependencies = [
 
 [[package]]
 name = "tari_base_node"
-version = "0.49.0-pre.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.0#a008fe2e5ee66ec12598a5148961047d95e84c57"
+version = "0.49.0-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.1#57781b63cec3f0cf6b3d739408c10a467988c092"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5917,8 +5917,8 @@ dependencies = [
  "strum",
  "tari_app_grpc",
  "tari_app_utilities",
- "tari_common 0.49.0-pre.0 (git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.0)",
- "tari_common_types 0.49.0-pre.0 (git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.0)",
+ "tari_common 0.49.0-pre.1",
+ "tari_common_types 0.49.0-pre.1",
  "tari_comms",
  "tari_comms_dht",
  "tari_core",
@@ -5937,7 +5937,7 @@ dependencies = [
 [[package]]
 name = "tari_base_node_grpc_client"
 version = "0.1.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.0#a008fe2e5ee66ec12598a5148961047d95e84c57"
+source = "git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.1#57781b63cec3f0cf6b3d739408c10a467988c092"
 dependencies = [
  "tari_app_grpc",
 ]
@@ -5993,7 +5993,30 @@ dependencies = [
 [[package]]
 name = "tari_common"
 version = "0.49.0-pre.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.0#a008fe2e5ee66ec12598a5148961047d95e84c57"
+source = "git+https://github.com/tari-project/tari.git?branch=development#a008fe2e5ee66ec12598a5148961047d95e84c57"
+dependencies = [
+ "anyhow",
+ "blake2 0.9.2",
+ "config",
+ "dirs-next 1.0.2",
+ "log",
+ "log4rs",
+ "multiaddr 0.14.0",
+ "path-clean",
+ "serde",
+ "serde_json",
+ "serde_yaml 0.9.19",
+ "sha2 0.9.9",
+ "structopt",
+ "tari_crypto",
+ "tempfile",
+ "thiserror",
+]
+
+[[package]]
+name = "tari_common"
+version = "0.49.0-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.1#57781b63cec3f0cf6b3d739408c10a467988c092"
 dependencies = [
  "anyhow",
  "blake2 0.9.2",
@@ -6017,51 +6040,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "tari_common"
-version = "0.49.0-pre.0"
-source = "git+https://github.com/tari-project/tari.git?branch=development#a008fe2e5ee66ec12598a5148961047d95e84c57"
-dependencies = [
- "anyhow",
- "blake2 0.9.2",
- "config",
- "dirs-next 1.0.2",
- "log",
- "log4rs",
- "multiaddr 0.14.0",
- "path-clean",
- "serde",
- "serde_json",
- "serde_yaml 0.9.19",
- "sha2 0.9.9",
- "structopt",
- "tari_crypto",
- "tempfile",
- "thiserror",
-]
-
-[[package]]
 name = "tari_common_sqlite"
-version = "0.49.0-pre.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.0#a008fe2e5ee66ec12598a5148961047d95e84c57"
+version = "0.49.0-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.1#57781b63cec3f0cf6b3d739408c10a467988c092"
 dependencies = [
+ "chrono",
  "diesel",
+ "diesel_migrations",
  "log",
- "thiserror",
-]
-
-[[package]]
-name = "tari_common_types"
-version = "0.49.0-pre.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.0#a008fe2e5ee66ec12598a5148961047d95e84c57"
-dependencies = [
- "borsh",
- "digest 0.9.0",
- "lazy_static",
- "newtype-ops",
- "rand 0.7.3",
  "serde",
- "tari_common 0.49.0-pre.0 (git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.0)",
- "tari_crypto",
  "tari_utilities",
  "thiserror",
  "tokio",
@@ -6078,7 +6065,25 @@ dependencies = [
  "newtype-ops",
  "rand 0.7.3",
  "serde",
- "tari_common 0.49.0-pre.0 (git+https://github.com/tari-project/tari.git?branch=development)",
+ "tari_common 0.49.0-pre.0",
+ "tari_crypto",
+ "tari_utilities",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
+name = "tari_common_types"
+version = "0.49.0-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.1#57781b63cec3f0cf6b3d739408c10a467988c092"
+dependencies = [
+ "borsh",
+ "digest 0.9.0",
+ "lazy_static",
+ "newtype-ops",
+ "rand 0.7.3",
+ "serde",
+ "tari_common 0.49.0-pre.1",
  "tari_crypto",
  "tari_utilities",
  "thiserror",
@@ -6087,8 +6092,8 @@ dependencies = [
 
 [[package]]
 name = "tari_comms"
-version = "0.49.0-pre.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.0#a008fe2e5ee66ec12598a5148961047d95e84c57"
+version = "0.49.0-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.1#57781b63cec3f0cf6b3d739408c10a467988c092"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6114,7 +6119,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "snow",
- "tari_common 0.49.0-pre.0 (git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.0)",
+ "tari_common 0.49.0-pre.1",
  "tari_crypto",
  "tari_metrics",
  "tari_shutdown",
@@ -6132,8 +6137,8 @@ dependencies = [
 
 [[package]]
 name = "tari_comms_dht"
-version = "0.49.0-pre.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.0#a008fe2e5ee66ec12598a5148961047d95e84c57"
+version = "0.49.0-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.1#57781b63cec3f0cf6b3d739408c10a467988c092"
 dependencies = [
  "anyhow",
  "bitflags 1.3.2",
@@ -6151,7 +6156,7 @@ dependencies = [
  "prost-types 0.9.0",
  "rand 0.7.3",
  "serde",
- "tari_common 0.49.0-pre.0 (git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.0)",
+ "tari_common 0.49.0-pre.1",
  "tari_common_sqlite",
  "tari_comms",
  "tari_comms_rpc_macros",
@@ -6179,8 +6184,8 @@ dependencies = [
 
 [[package]]
 name = "tari_comms_rpc_macros"
-version = "0.49.0-pre.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.0#a008fe2e5ee66ec12598a5148961047d95e84c57"
+version = "0.49.0-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.1#57781b63cec3f0cf6b3d739408c10a467988c092"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6189,8 +6194,8 @@ dependencies = [
 
 [[package]]
 name = "tari_console_wallet"
-version = "0.49.0-pre.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.0#a008fe2e5ee66ec12598a5148961047d95e84c57"
+version = "0.49.0-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.1#57781b63cec3f0cf6b3d739408c10a467988c092"
 dependencies = [
  "bitflags 1.3.2",
  "chrono",
@@ -6212,10 +6217,11 @@ dependencies = [
  "strum_macros",
  "tari_app_grpc",
  "tari_app_utilities",
- "tari_common 0.49.0-pre.0 (git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.0)",
- "tari_common_types 0.49.0-pre.0 (git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.0)",
+ "tari_common 0.49.0-pre.1",
+ "tari_common_types 0.49.0-pre.1",
  "tari_comms",
  "tari_comms_dht",
+ "tari_contacts",
  "tari_core",
  "tari_crypto",
  "tari_key_manager",
@@ -6235,9 +6241,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "tari_contacts"
+version = "0.49.0-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.1#57781b63cec3f0cf6b3d739408c10a467988c092"
+dependencies = [
+ "chrono",
+ "diesel",
+ "diesel_migrations",
+ "futures 0.3.27",
+ "libsqlite3-sys",
+ "log",
+ "rand 0.7.3",
+ "tari_common 0.49.0-pre.1",
+ "tari_common_sqlite",
+ "tari_common_types 0.49.0-pre.1",
+ "tari_comms",
+ "tari_crypto",
+ "tari_p2p",
+ "tari_service_framework",
+ "tari_shutdown",
+ "tari_utilities",
+ "thiserror",
+ "tokio",
+ "tower",
+]
+
+[[package]]
 name = "tari_core"
-version = "0.49.0-pre.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.0#a008fe2e5ee66ec12598a5148961047d95e84c57"
+version = "0.49.0-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.1#57781b63cec3f0cf6b3d739408c10a467988c092"
 dependencies = [
  "bincode",
  "bitflags 1.3.2",
@@ -6272,8 +6304,8 @@ dependencies = [
  "serde_repr",
  "sha3",
  "strum_macros",
- "tari_common 0.49.0-pre.0 (git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.0)",
- "tari_common_types 0.49.0-pre.0 (git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.0)",
+ "tari_common 0.49.0-pre.1",
+ "tari_common_types 0.49.0-pre.1",
  "tari_comms",
  "tari_comms_dht",
  "tari_comms_rpc_macros",
@@ -6329,8 +6361,8 @@ dependencies = [
  "anyhow",
  "chrono",
  "prost 0.9.0",
- "tari_common 0.49.0-pre.0 (git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.0)",
- "tari_common_types 0.49.0-pre.0 (git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.0)",
+ "tari_common 0.49.0-pre.1",
+ "tari_common_types 0.49.0-pre.1",
  "tari_comms",
  "tari_crypto",
  "tari_dan_common_types",
@@ -6350,7 +6382,7 @@ dependencies = [
  "log",
  "tari_app_grpc",
  "tari_base_node_grpc_client",
- "tari_common_types 0.49.0-pre.0 (git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.0)",
+ "tari_common_types 0.49.0-pre.1",
  "tari_comms",
  "tari_core",
  "tari_crypto",
@@ -6383,8 +6415,8 @@ dependencies = [
  "rand 0.7.3",
  "serde",
  "tari_bor",
- "tari_common 0.49.0-pre.0 (git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.0)",
- "tari_common_types 0.49.0-pre.0 (git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.0)",
+ "tari_common 0.49.0-pre.1",
+ "tari_common_types 0.49.0-pre.1",
  "tari_core",
  "tari_crypto",
  "tari_engine_types",
@@ -6407,8 +6439,8 @@ dependencies = [
  "prost 0.9.0",
  "rand 0.8.5",
  "serde",
- "tari_common 0.49.0-pre.0 (git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.0)",
- "tari_common_types 0.49.0-pre.0 (git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.0)",
+ "tari_common 0.49.0-pre.1",
+ "tari_common_types 0.49.0-pre.1",
  "tari_comms",
  "tari_comms_dht",
  "tari_core",
@@ -6440,7 +6472,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tari_bor",
- "tari_common_types 0.49.0-pre.0 (git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.0)",
+ "tari_common_types 0.49.0-pre.1",
  "tari_crypto",
  "tari_dan_common_types",
  "tari_engine_types",
@@ -6462,7 +6494,7 @@ name = "tari_dan_storage"
 version = "0.50.0-pre.0"
 dependencies = [
  "serde",
- "tari_common_types 0.49.0-pre.0 (git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.0)",
+ "tari_common_types 0.49.0-pre.1",
  "tari_dan_common_types",
  "thiserror",
  "time 0.3.20",
@@ -6492,7 +6524,7 @@ dependencies = [
  "log",
  "serde",
  "serde_json",
- "tari_common_types 0.49.0-pre.0 (git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.0)",
+ "tari_common_types 0.49.0-pre.1",
  "tari_dan_common_types",
  "tari_dan_core",
  "tari_dan_engine",
@@ -6513,7 +6545,7 @@ dependencies = [
  "lazy_static",
  "log",
  "rand 0.7.3",
- "tari_common_types 0.49.0-pre.0 (git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.0)",
+ "tari_common_types 0.49.0-pre.1",
  "tari_comms",
  "tari_core",
  "tari_crypto",
@@ -6543,7 +6575,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "tari_common_types 0.49.0-pre.0 (git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.0)",
+ "tari_common_types 0.49.0-pre.1",
  "tari_crypto",
  "tari_dan_common_types",
  "tari_dan_engine",
@@ -6579,8 +6611,8 @@ dependencies = [
  "serde",
  "serde_json",
  "tari_bor",
- "tari_common 0.49.0-pre.0 (git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.0)",
- "tari_common_types 0.49.0-pre.0 (git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.0)",
+ "tari_common 0.49.0-pre.1",
+ "tari_common_types 0.49.0-pre.1",
  "tari_crypto",
  "tari_dan_common_types",
  "tari_dan_wallet_sdk",
@@ -6610,7 +6642,7 @@ dependencies = [
  "rand 0.7.3",
  "serde",
  "tari_bor",
- "tari_common_types 0.49.0-pre.0 (git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.0)",
+ "tari_common_types 0.49.0-pre.1",
  "tari_crypto",
  "tari_dan_common_types",
  "tari_dan_wallet_storage_sqlite",
@@ -6638,7 +6670,7 @@ dependencies = [
  "log",
  "serde",
  "serde_json",
- "tari_common_types 0.49.0-pre.0 (git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.0)",
+ "tari_common_types 0.49.0-pre.1",
  "tari_dan_common_types",
  "tari_dan_wallet_sdk",
  "tari_engine_types",
@@ -6656,7 +6688,7 @@ dependencies = [
  "rand 0.7.3",
  "serde",
  "tari_bor",
- "tari_common_types 0.49.0-pre.0 (git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.0)",
+ "tari_common_types 0.49.0-pre.1",
  "tari_crypto",
  "tari_template_abi",
  "tari_template_lib",
@@ -6688,8 +6720,8 @@ dependencies = [
  "tari_app_grpc",
  "tari_app_utilities",
  "tari_base_node_grpc_client",
- "tari_common 0.49.0-pre.0 (git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.0)",
- "tari_common_types 0.49.0-pre.0 (git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.0)",
+ "tari_common 0.49.0-pre.1",
+ "tari_common_types 0.49.0-pre.1",
  "tari_comms",
  "tari_comms_logging",
  "tari_comms_rpc_macros",
@@ -6727,7 +6759,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "tari_common_types 0.49.0-pre.0 (git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.0)",
+ "tari_common_types 0.49.0-pre.1",
  "tari_comms_logging",
  "tari_dan_common_types",
  "tari_engine_types",
@@ -6735,8 +6767,8 @@ dependencies = [
 
 [[package]]
 name = "tari_key_manager"
-version = "0.49.0-pre.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.0#a008fe2e5ee66ec12598a5148961047d95e84c57"
+version = "0.49.0-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.1#57781b63cec3f0cf6b3d739408c10a467988c092"
 dependencies = [
  "argon2",
  "blake2 0.9.2",
@@ -6758,7 +6790,7 @@ dependencies = [
 [[package]]
 name = "tari_metrics"
 version = "0.1.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.0#a008fe2e5ee66ec12598a5148961047d95e84c57"
+source = "git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.1#57781b63cec3f0cf6b3d739408c10a467988c092"
 dependencies = [
  "anyhow",
  "futures 0.3.27",
@@ -6773,15 +6805,15 @@ dependencies = [
 
 [[package]]
 name = "tari_mmr"
-version = "0.49.0-pre.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.0#a008fe2e5ee66ec12598a5148961047d95e84c57"
+version = "0.49.0-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.1#57781b63cec3f0cf6b3d739408c10a467988c092"
 dependencies = [
  "borsh",
  "croaring",
  "digest 0.9.0",
  "log",
  "serde",
- "tari_common 0.49.0-pre.0 (git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.0)",
+ "tari_common 0.49.0-pre.1",
  "tari_crypto",
  "tari_utilities",
  "thiserror",
@@ -6789,8 +6821,8 @@ dependencies = [
 
 [[package]]
 name = "tari_p2p"
-version = "0.49.0-pre.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.0#a008fe2e5ee66ec12598a5148961047d95e84c57"
+version = "0.49.0-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.1#57781b63cec3f0cf6b3d739408c10a467988c092"
 dependencies = [
  "anyhow",
  "fs2",
@@ -6804,7 +6836,7 @@ dependencies = [
  "rustls",
  "semver",
  "serde",
- "tari_common 0.49.0-pre.0 (git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.0)",
+ "tari_common 0.49.0-pre.1",
  "tari_comms",
  "tari_comms_dht",
  "tari_crypto",
@@ -6823,7 +6855,7 @@ dependencies = [
 [[package]]
 name = "tari_script"
 version = "0.12.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.0#a008fe2e5ee66ec12598a5148961047d95e84c57"
+source = "git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.1#57781b63cec3f0cf6b3d739408c10a467988c092"
 dependencies = [
  "blake2 0.9.2",
  "borsh",
@@ -6839,8 +6871,8 @@ dependencies = [
 
 [[package]]
 name = "tari_service_framework"
-version = "0.49.0-pre.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.0#a008fe2e5ee66ec12598a5148961047d95e84c57"
+version = "0.49.0-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.1#57781b63cec3f0cf6b3d739408c10a467988c092"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6854,16 +6886,16 @@ dependencies = [
 
 [[package]]
 name = "tari_shutdown"
-version = "0.49.0-pre.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.0#a008fe2e5ee66ec12598a5148961047d95e84c57"
+version = "0.49.0-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.1#57781b63cec3f0cf6b3d739408c10a467988c092"
 dependencies = [
  "futures 0.3.27",
 ]
 
 [[package]]
 name = "tari_storage"
-version = "0.49.0-pre.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.0#a008fe2e5ee66ec12598a5148961047d95e84c57"
+version = "0.49.0-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.1#57781b63cec3f0cf6b3d739408c10a467988c092"
 dependencies = [
  "bincode",
  "lmdb-zero",
@@ -6916,7 +6948,7 @@ version = "0.50.0-pre.0"
 dependencies = [
  "anyhow",
  "borsh",
- "tari_common_types 0.49.0-pre.0 (git+https://github.com/tari-project/tari.git?branch=development)",
+ "tari_common_types 0.49.0-pre.0",
  "tari_crypto",
  "tari_dan_common_types",
  "tari_dan_engine",
@@ -6930,11 +6962,12 @@ dependencies = [
 
 [[package]]
 name = "tari_test_utils"
-version = "0.49.0-pre.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.0#a008fe2e5ee66ec12598a5148961047d95e84c57"
+version = "0.49.0-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.1#57781b63cec3f0cf6b3d739408c10a467988c092"
 dependencies = [
  "futures 0.3.27",
  "rand 0.7.3",
+ "tari_comms",
  "tari_shutdown",
  "tempfile",
  "tokio",
@@ -6946,7 +6979,7 @@ version = "0.50.0-pre.0"
 dependencies = [
  "rand 0.7.3",
  "serde",
- "tari_common_types 0.49.0-pre.0 (git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.0)",
+ "tari_common_types 0.49.0-pre.1",
  "tari_crypto",
  "tari_dan_common_types",
  "tari_engine_types",
@@ -7016,8 +7049,8 @@ dependencies = [
  "tari_app_utilities",
  "tari_base_node",
  "tari_base_node_grpc_client",
- "tari_common 0.49.0-pre.0 (git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.0)",
- "tari_common_types 0.49.0-pre.0 (git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.0)",
+ "tari_common 0.49.0-pre.1",
+ "tari_common_types 0.49.0-pre.1",
  "tari_comms",
  "tari_comms_dht",
  "tari_comms_logging",
@@ -7072,7 +7105,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "tari_common_types 0.49.0-pre.0 (git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.0)",
+ "tari_common_types 0.49.0-pre.1",
  "tari_crypto",
  "tari_dan_common_types",
  "tari_dan_engine",
@@ -7096,7 +7129,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "tari_common_types 0.49.0-pre.0 (git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.0)",
+ "tari_common_types 0.49.0-pre.1",
  "tari_comms_logging",
  "tari_dan_common_types",
  "tari_dan_core",
@@ -7107,8 +7140,8 @@ dependencies = [
 
 [[package]]
 name = "tari_wallet"
-version = "0.49.0-pre.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.0#a008fe2e5ee66ec12598a5148961047d95e84c57"
+version = "0.49.0-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.1#57781b63cec3f0cf6b3d739408c10a467988c092"
 dependencies = [
  "argon2",
  "async-trait",
@@ -7133,11 +7166,12 @@ dependencies = [
  "sha2 0.9.9",
  "strum",
  "strum_macros",
- "tari_common 0.49.0-pre.0 (git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.0)",
+ "tari_common 0.49.0-pre.1",
  "tari_common_sqlite",
- "tari_common_types 0.49.0-pre.0 (git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.0)",
+ "tari_common_types 0.49.0-pre.1",
  "tari_comms",
  "tari_comms_dht",
+ "tari_contacts",
  "tari_core",
  "tari_crypto",
  "tari_key_manager",
@@ -7160,7 +7194,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "tari_common_types 0.49.0-pre.0 (git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.0)",
+ "tari_common_types 0.49.0-pre.1",
  "tari_comms_logging",
  "tari_dan_common_types",
  "tari_dan_wallet_sdk",
@@ -7173,10 +7207,10 @@ dependencies = [
 [[package]]
 name = "tari_wallet_grpc_client"
 version = "0.1.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.0#a008fe2e5ee66ec12598a5148961047d95e84c57"
+source = "git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.1#57781b63cec3f0cf6b3d739408c10a467988c092"
 dependencies = [
  "tari_app_grpc",
- "tari_common_types 0.49.0-pre.0 (git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.0)",
+ "tari_common_types 0.49.0-pre.1",
  "thiserror",
  "tonic 0.6.2",
 ]

--- a/applications/tari_dan_app_grpc/Cargo.toml
+++ b/applications/tari_dan_app_grpc/Cargo.toml
@@ -8,8 +8,8 @@ version = "0.50.0-pre.0"
 edition = "2018"
 
 [dependencies]
-tari_common_types = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.0", package = "tari_common_types" }
-tari_comms = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.0", package = "tari_comms" }
+tari_common_types = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.1", package = "tari_common_types" }
+tari_comms = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.1", package = "tari_comms" }
 tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.16.8" }
 
 tari_dan_common_types = { path = "../../dan_layer/common_types" }
@@ -24,4 +24,4 @@ prost = "0.9"
 tonic = "0.6.2"
 
 [build-dependencies]
-tari_common = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.0", package = "tari_common", features = ["build"] }
+tari_common = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.1", package = "tari_common", features = ["build"] }

--- a/applications/tari_dan_app_utilities/Cargo.toml
+++ b/applications/tari_dan_app_utilities/Cargo.toml
@@ -6,13 +6,13 @@ edition = "2018"
 license = "BSD-3-Clause"
 
 [dependencies]
-tari_app_grpc = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.0" }
-tari_base_node_grpc_client = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.0" }
-tari_common_types = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.0" }
-tari_comms = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.0" }
-tari_core = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.0", default-features = false, features = ["transactions"] }
+tari_app_grpc = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.1" }
+tari_base_node_grpc_client = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.1" }
+tari_common_types = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.1" }
+tari_comms = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.1" }
+tari_core = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.1", default-features = false, features = ["transactions"] }
 tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.16.8" }
-tari_shutdown = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.0" }
+tari_shutdown = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.1" }
 
 tari_dan_common_types = { path = "../../dan_layer/common_types" }
 tari_dan_core = { path = "../../dan_layer/core" }

--- a/applications/tari_dan_app_utilities/src/base_layer_scanner.rs
+++ b/applications/tari_dan_app_utilities/src/base_layer_scanner.rs
@@ -238,6 +238,7 @@ impl BaseLayerScanner {
         }
     }
 
+    #[allow(clippy::too_many_lines)]
     async fn sync_blockchain(&mut self) -> Result<(), BaseLayerScannerError> {
         let start_scan_height = self.last_scanned_height;
         let mut current_hash = self.last_scanned_hash;
@@ -289,34 +290,44 @@ impl BaseLayerScanner {
 
             for output in utxos.outputs {
                 let output_hash = output.hash();
-                if output.is_burned() {
-                    info!(
-                        target: LOG_TARGET,
-                        "Found burned output: {} with commitment {}",
-                        output_hash,
-                        output.commitment.as_public_key()
-                    );
-                    self.register_burnt_utxo(&output)?;
-                } else {
-                    let sidechain_feature = output.features.sidechain_feature.ok_or_else(|| {
-                        BaseLayerScannerError::InvalidSideChainUtxoResponse(
-                            "Validator node registration output must have a sidechain features".to_string(),
-                        )
-                    })?;
-                    match sidechain_feature {
-                        SideChainFeature::ValidatorNodeRegistration(reg) => {
-                            self.register_validator_node_registration(current_height, reg).await?;
-                        },
-                        SideChainFeature::TemplateRegistration(reg) => {
-                            self.register_code_template_registration(
-                                reg.clone().template_name.into_string(),
-                                (*output_hash).into(),
-                                reg,
-                                &block_info,
-                            )
+                let sidechain_feature = output.features.sidechain_feature.as_ref().ok_or_else(|| {
+                    BaseLayerScannerError::InvalidSideChainUtxoResponse(
+                        "Validator node registration output must have a sidechain features".to_string(),
+                    )
+                })?;
+                match sidechain_feature {
+                    SideChainFeature::ValidatorNodeRegistration(reg) => {
+                        self.register_validator_node_registration(current_height, reg.clone())
                             .await?;
-                        },
-                    }
+                    },
+                    SideChainFeature::TemplateRegistration(reg) => {
+                        self.register_code_template_registration(
+                            reg.template_name.to_string(),
+                            (*output_hash).into(),
+                            reg.clone(),
+                            &block_info,
+                        )
+                        .await?;
+                    },
+                    SideChainFeature::ConfidentialOutput(_data) => {
+                        // Should be checked by the base layer
+                        if !output.is_burned() {
+                            warn!(
+                                target: LOG_TARGET,
+                                "Ignoring confidential output that is not burned: {} with commitment {}",
+                                output_hash,
+                                output.commitment.as_public_key()
+                            );
+                            continue;
+                        }
+                        info!(
+                            target: LOG_TARGET,
+                            "Found burned output: {} with commitment {}",
+                            output_hash,
+                            output.commitment.as_public_key()
+                        );
+                        self.register_burnt_utxo(&output)?;
+                    },
                 }
             }
 

--- a/applications/tari_dan_wallet_cli/Cargo.toml
+++ b/applications/tari_dan_wallet_cli/Cargo.toml
@@ -8,7 +8,7 @@ version = "0.50.0-pre.0"
 edition = "2018"
 
 [dependencies]
-tari_common_types = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.0" }
+tari_common_types = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.1" }
 tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.16.8" }
 tari_dan_common_types = { path = "../../dan_layer/common_types" }
 tari_dan_engine = { path = "../../dan_layer/engine" }

--- a/applications/tari_dan_wallet_daemon/Cargo.toml
+++ b/applications/tari_dan_wallet_daemon/Cargo.toml
@@ -8,10 +8,10 @@ version = "0.50.0-pre.0"
 edition = "2018"
 
 [dependencies]
-tari_common = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.0" }
+tari_common = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.1" }
 tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.16.8" }
-tari_common_types = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.0" }
-tari_shutdown = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.0" }
+tari_common_types = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.1" }
+tari_shutdown = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.1" }
 tari_dan_wallet_sdk = { path = "../../dan_layer/wallet/sdk" }
 tari_dan_wallet_storage_sqlite = { path = "../../dan_layer/wallet/storage_sqlite" }
 tari_transaction = { path = "../../dan_layer/transaction" }

--- a/applications/tari_indexer/Cargo.toml
+++ b/applications/tari_indexer/Cargo.toml
@@ -8,19 +8,19 @@ version = "0.50.0-pre.0"
 edition = "2018"
 
 [dependencies]
-tari_app_grpc = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.0", package = "tari_app_grpc" }
-tari_app_utilities = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.0", package = "tari_app_utilities" }
-tari_base_node_grpc_client = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.0", version = "0.1.0", package = "tari_base_node_grpc_client" }
-tari_common = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.0", package = "tari_common" }
-tari_common_types = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.0", package = "tari_common_types" }
-tari_comms = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.0", package = "tari_comms" }
+tari_app_grpc = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.1", package = "tari_app_grpc" }
+tari_app_utilities = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.1", package = "tari_app_utilities" }
+tari_base_node_grpc_client = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.1", version = "0.1.0", package = "tari_base_node_grpc_client" }
+tari_common = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.1", package = "tari_common" }
+tari_common_types = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.1", package = "tari_common_types" }
+tari_comms = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.1", package = "tari_comms" }
 tari_comms_logging = { path = "../../comms/tari_comms_logging" }
-tari_comms_rpc_macros = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.0", package = "tari_comms_rpc_macros" }
-tari_core = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.0", package = "tari_core", default-features = false, features = ["transactions"] }
+tari_comms_rpc_macros = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.1", package = "tari_comms_rpc_macros" }
+tari_core = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.1", package = "tari_core", default-features = false, features = ["transactions"] }
 tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.16.8" }
-tari_p2p = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.0", package = "tari_p2p" }
-tari_shutdown = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.0", package = "tari_shutdown" }
-tari_storage = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.0", package = "tari_storage" }
+tari_p2p = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.1", package = "tari_p2p" }
+tari_shutdown = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.1", package = "tari_shutdown" }
+tari_storage = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.1", package = "tari_storage" }
 
 tari_dan_app_grpc = { path = "../tari_dan_app_grpc" }
 tari_dan_app_utilities = { path = "../tari_dan_app_utilities" }

--- a/applications/tari_validator_node/Cargo.toml
+++ b/applications/tari_validator_node/Cargo.toml
@@ -8,28 +8,28 @@ version = "0.50.0-pre.0"
 edition = "2018"
 
 [dependencies]
-tari_app_utilities = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.0" }
-tari_app_grpc = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.0" }
-tari_common = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.0" }
-tari_comms = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.0" }
-tari_comms_rpc_macros = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.0" }
+tari_app_utilities = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.1" }
+tari_app_grpc = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.1" }
+tari_common = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.1" }
+tari_comms = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.1" }
+tari_comms_rpc_macros = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.1" }
 tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.16.8" }
-tari_p2p = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.0" }
-tari_shutdown = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.0" }
-tari_storage = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.0" }
-tari_core = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.0", default-features = false, features = ["transactions"] }
+tari_p2p = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.1" }
+tari_shutdown = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.1" }
+tari_storage = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.1" }
+tari_core = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.1", default-features = false, features = ["transactions"] }
 tari_dan_app_grpc = { path = "../tari_dan_app_grpc" }
 tari_dan_app_utilities = { path = "../tari_dan_app_utilities" }
 tari_dan_core = { path = "../../dan_layer/core" }
 tari_dan_storage = { path = "../../dan_layer/storage" }
 tari_dan_storage_sqlite = { path = "../../dan_layer/storage_sqlite" }
 tari_dan_common_types = { path = "../../dan_layer/common_types" }
-tari_common_types = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.0" }
+tari_common_types = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.1" }
 tari_dan_engine = { path = "../../dan_layer/engine" }
 tari_template_builtin = { path = "../../dan_layer/template_builtin" }
 tari_template_lib = { path = "../../dan_layer/template_lib" }
-tari_base_node_grpc_client = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.0" }
-tari_wallet_grpc_client = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.0" }
+tari_base_node_grpc_client = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.1" }
+tari_wallet_grpc_client = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.1" }
 tari_engine_types = { path = "../../dan_layer/engine_types" }
 tari_validator_node_client = { path = "../../clients/validator_node_client" }
 tari_comms_logging = { path = "../../comms/tari_comms_logging" }
@@ -66,17 +66,17 @@ tower-http = { version = "0.3.0", features = ["cors"] }
 tower-layer = "0.3"
 
 [build-dependencies]
-tari_common = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.0", package = "tari_common", features = ["build"] }
+tari_common = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.1", package = "tari_common", features = ["build"] }
 
 [dev-dependencies]
 # FIXME: the newest version failed compilation due to a missing "bool_to_option" unstable feature
 cucumber = { version = "0.13.0" }
 tempfile = "3.3.0"
-tari_test_utils = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.0", package = "tari_test_utils" }
-tari_base_node = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.0", package = "tari_base_node" }
-tari_console_wallet = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.0", package = "tari_console_wallet" }
-tari_comms_dht = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.0", package = "tari_comms_dht" }
-tari_wallet = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.0", package = "tari_wallet" }
+tari_test_utils = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.1", package = "tari_test_utils" }
+tari_base_node = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.1", package = "tari_base_node" }
+tari_console_wallet = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.1", package = "tari_console_wallet" }
+tari_comms_dht = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.1", package = "tari_comms_dht" }
+tari_wallet = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.1", package = "tari_wallet" }
 tari_validator_node_cli = { path = "../tari_validator_node_cli" }
 tari_transaction_manifest = { path = "../../dan_layer/transaction_manifest" }
 tari_indexer = { path = "../tari_indexer" }

--- a/applications/tari_validator_node/tests/templates/fees/Cargo.lock
+++ b/applications/tari_validator_node/tests/templates/fees/Cargo.lock
@@ -3149,8 +3149,8 @@ dependencies = [
 
 [[package]]
 name = "tari_common"
-version = "0.49.0-pre.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.0#a008fe2e5ee66ec12598a5148961047d95e84c57"
+version = "0.49.0-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.1#57781b63cec3f0cf6b3d739408c10a467988c092"
 dependencies = [
  "anyhow",
  "blake2 0.9.2",
@@ -3174,18 +3174,23 @@ dependencies = [
 
 [[package]]
 name = "tari_common_sqlite"
-version = "0.49.0-pre.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.0#a008fe2e5ee66ec12598a5148961047d95e84c57"
+version = "0.49.0-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.1#57781b63cec3f0cf6b3d739408c10a467988c092"
 dependencies = [
+ "chrono",
  "diesel",
+ "diesel_migrations",
  "log",
+ "serde",
+ "tari_utilities",
  "thiserror",
+ "tokio",
 ]
 
 [[package]]
 name = "tari_common_types"
-version = "0.49.0-pre.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.0#a008fe2e5ee66ec12598a5148961047d95e84c57"
+version = "0.49.0-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.1#57781b63cec3f0cf6b3d739408c10a467988c092"
 dependencies = [
  "borsh",
  "digest 0.9.0",
@@ -3202,8 +3207,8 @@ dependencies = [
 
 [[package]]
 name = "tari_comms"
-version = "0.49.0-pre.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.0#a008fe2e5ee66ec12598a5148961047d95e84c57"
+version = "0.49.0-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.1#57781b63cec3f0cf6b3d739408c10a467988c092"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3247,8 +3252,8 @@ dependencies = [
 
 [[package]]
 name = "tari_comms_dht"
-version = "0.49.0-pre.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.0#a008fe2e5ee66ec12598a5148961047d95e84c57"
+version = "0.49.0-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.1#57781b63cec3f0cf6b3d739408c10a467988c092"
 dependencies = [
  "anyhow",
  "bitflags 1.3.2",
@@ -3282,8 +3287,8 @@ dependencies = [
 
 [[package]]
 name = "tari_comms_rpc_macros"
-version = "0.49.0-pre.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.0#a008fe2e5ee66ec12598a5148961047d95e84c57"
+version = "0.49.0-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.1#57781b63cec3f0cf6b3d739408c10a467988c092"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3292,8 +3297,8 @@ dependencies = [
 
 [[package]]
 name = "tari_core"
-version = "0.49.0-pre.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.0#a008fe2e5ee66ec12598a5148961047d95e84c57"
+version = "0.49.0-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.1#57781b63cec3f0cf6b3d739408c10a467988c092"
 dependencies = [
  "bincode",
  "bitflags 1.3.2",
@@ -3449,7 +3454,7 @@ dependencies = [
 [[package]]
 name = "tari_metrics"
 version = "0.1.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.0#a008fe2e5ee66ec12598a5148961047d95e84c57"
+source = "git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.1#57781b63cec3f0cf6b3d739408c10a467988c092"
 dependencies = [
  "once_cell",
  "prometheus",
@@ -3458,8 +3463,8 @@ dependencies = [
 
 [[package]]
 name = "tari_mmr"
-version = "0.49.0-pre.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.0#a008fe2e5ee66ec12598a5148961047d95e84c57"
+version = "0.49.0-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.1#57781b63cec3f0cf6b3d739408c10a467988c092"
 dependencies = [
  "borsh",
  "croaring",
@@ -3474,8 +3479,8 @@ dependencies = [
 
 [[package]]
 name = "tari_p2p"
-version = "0.49.0-pre.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.0#a008fe2e5ee66ec12598a5148961047d95e84c57"
+version = "0.49.0-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.1#57781b63cec3f0cf6b3d739408c10a467988c092"
 dependencies = [
  "anyhow",
  "fs2",
@@ -3505,7 +3510,7 @@ dependencies = [
 [[package]]
 name = "tari_script"
 version = "0.12.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.0#a008fe2e5ee66ec12598a5148961047d95e84c57"
+source = "git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.1#57781b63cec3f0cf6b3d739408c10a467988c092"
 dependencies = [
  "blake2 0.9.2",
  "borsh",
@@ -3521,8 +3526,8 @@ dependencies = [
 
 [[package]]
 name = "tari_service_framework"
-version = "0.49.0-pre.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.0#a008fe2e5ee66ec12598a5148961047d95e84c57"
+version = "0.49.0-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.1#57781b63cec3f0cf6b3d739408c10a467988c092"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3536,16 +3541,16 @@ dependencies = [
 
 [[package]]
 name = "tari_shutdown"
-version = "0.49.0-pre.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.0#a008fe2e5ee66ec12598a5148961047d95e84c57"
+version = "0.49.0-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.1#57781b63cec3f0cf6b3d739408c10a467988c092"
 dependencies = [
  "futures",
 ]
 
 [[package]]
 name = "tari_storage"
-version = "0.49.0-pre.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.0#a008fe2e5ee66ec12598a5148961047d95e84c57"
+version = "0.49.0-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.1#57781b63cec3f0cf6b3d739408c10a467988c092"
 dependencies = [
  "bincode",
  "lmdb-zero",
@@ -3584,11 +3589,12 @@ dependencies = [
 
 [[package]]
 name = "tari_test_utils"
-version = "0.49.0-pre.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.0#a008fe2e5ee66ec12598a5148961047d95e84c57"
+version = "0.49.0-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v0.49.0-pre.1#57781b63cec3f0cf6b3d739408c10a467988c092"
 dependencies = [
  "futures",
  "rand 0.7.3",
+ "tari_comms",
  "tari_shutdown",
  "tempfile",
  "tokio",

--- a/applications/tari_validator_node/tests/templates/fees/Cargo.toml
+++ b/applications/tari_validator_node/tests/templates/fees/Cargo.toml
@@ -26,4 +26,4 @@ tari_dan_engine = { path = "../../../../../dan_layer/engine" }
 tari_dan_common_types = { path = "../../../../../dan_layer/common_types" }
 
 tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.16.8" }
-tari_common_types = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.0", package = "tari_common_types" }
+tari_common_types = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.1", package = "tari_common_types" }

--- a/applications/tari_validator_node_cli/Cargo.toml
+++ b/applications/tari_validator_node_cli/Cargo.toml
@@ -8,7 +8,7 @@ version = "0.50.0-pre.0"
 edition = "2018"
 
 [dependencies]
-tari_common_types = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.0" }
+tari_common_types = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.1" }
 tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.16.8" }
 tari_dan_common_types = { path = "../../dan_layer/common_types" }
 tari_dan_engine = { path = "../../dan_layer/engine" }

--- a/clients/tari_indexer_client/Cargo.toml
+++ b/clients/tari_indexer_client/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 tari_dan_common_types = { path = "../../dan_layer/common_types" }
 tari_engine_types = { path = "../../dan_layer/engine_types" }
-tari_common_types = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.0" }
+tari_common_types = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.1" }
 tari_comms_logging = { path = "../../comms/tari_comms_logging" }
 
 anyhow = "1.0.65"

--- a/clients/validator_node_client/Cargo.toml
+++ b/clients/validator_node_client/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 tari_dan_core = { path = "../../dan_layer/core" }
 tari_dan_common_types = { path = "../../dan_layer/common_types" }
 tari_engine_types = { path = "../../dan_layer/engine_types" }
-tari_common_types = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.0" }
+tari_common_types = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.1" }
 tari_comms_logging = { path = "../../comms/tari_comms_logging" }
 tari_transaction = { path = "../../dan_layer/transaction" }
 

--- a/clients/wallet_daemon_client/Cargo.toml
+++ b/clients/wallet_daemon_client/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 tari_dan_common_types = { path = "../../dan_layer/common_types" }
 tari_engine_types = { path = "../../dan_layer/engine_types" }
-tari_common_types = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.0" }
+tari_common_types = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.1" }
 tari_comms_logging = { path = "../../comms/tari_comms_logging" }
 tari_transaction = { path = "../../dan_layer/transaction" }
 tari_dan_wallet_sdk = { path = "../../dan_layer/wallet/sdk" }

--- a/dan_layer/common_types/Cargo.toml
+++ b/dan_layer/common_types/Cargo.toml
@@ -7,13 +7,13 @@ license = "BSD-3-Clause"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tari_common_types = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.0" }
+tari_common_types = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.1" }
 tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.10" }
-tari_core = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.0", package = "tari_core" }
+tari_core = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.1", package = "tari_core" }
 tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.16.8", features = ["borsh"] }
 tari_engine_types = { path = "../engine_types" }
 tari_bor = { path = "../tari_bor" }
-tari_mmr = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.0" }
+tari_mmr = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.1" }
 
 anyhow = "1.0"
 # TODO: remove once we use borsh for all serialization
@@ -28,7 +28,7 @@ prost-types = "0.9"
 serde = "1.0.126"
 
 [build-dependencies]
-tari_common = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.0", package = "tari_common", features = ["build"] }
+tari_common = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.1", package = "tari_common", features = ["build"] }
 
 [package.metadata.cargo-machete]
 ignored = ["prost", "prost-types"] # false positive, used in OUT_DIR structs

--- a/dan_layer/core/Cargo.toml
+++ b/dan_layer/core/Cargo.toml
@@ -7,15 +7,15 @@ license = "BSD-3-Clause"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tari_comms = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.0", package = "tari_comms" }
-tari_comms_dht = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.0", package = "tari_comms_dht" }
+tari_comms = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.1", package = "tari_comms" }
+tari_comms_dht = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.1", package = "tari_comms_dht" }
 tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.16.8" }
-tari_mmr = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.0", package = "tari_mmr" }
-tari_shutdown = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.0", package = "tari_shutdown" }
-tari_storage = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.0", package = "tari_storage" }
-tari_core = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.0", package = "tari_core" }
+tari_mmr = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.1", package = "tari_mmr" }
+tari_shutdown = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.1", package = "tari_shutdown" }
+tari_storage = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.1", package = "tari_storage" }
+tari_core = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.1", package = "tari_core" }
 tari_dan_common_types = { path = "../common_types" }
-tari_common_types = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.0", package = "tari_common_types" }
+tari_common_types = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.1", package = "tari_common_types" }
 tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.10" }
 tari_dan_engine = { path = "../engine" }
 tari_dan_storage = { path = "../storage" }
@@ -38,7 +38,7 @@ tokio = { version = "1.10", features = ["macros", "time"] }
 tonic = "0.6.2"
 
 [dev-dependencies]
-tari_test_utils = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.0", package = "tari_test_utils" }
+tari_test_utils = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.1", package = "tari_test_utils" }
 
 [build-dependencies]
-tari_common = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.0", package = "tari_common", features = ["build"] }
+tari_common = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.1", package = "tari_common", features = ["build"] }

--- a/dan_layer/engine/Cargo.toml
+++ b/dan_layer/engine/Cargo.toml
@@ -7,11 +7,11 @@ edition = "2018"
 
 [dependencies]
 tari_bor = { path = "../tari_bor" }
-tari_common_types = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.0", package = "tari_common_types" }
+tari_common_types = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.1", package = "tari_common_types" }
 tari_crypto =  { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.16.8" }
 tari_dan_common_types = { path = "../common_types" }
 tari_engine_types = { path = "../engine_types" }
-tari_mmr = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.0", package = "tari_mmr" }
+tari_mmr = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.1", package = "tari_mmr" }
 tari_template_abi = { path = "../template_abi", features = ["std"] }
 tari_template_lib = { path = "../template_lib", default-features = false, features = ["serde"] }
 tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.10" }

--- a/dan_layer/engine_types/Cargo.toml
+++ b/dan_layer/engine_types/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 
 [dependencies]
 tari_bor = { path = "../tari_bor" }
-tari_common_types = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.0" }
+tari_common_types = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.1" }
 tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.16.8", features = ["borsh"] }
 tari_template_abi = { path = "../template_abi", features = ["std"] }
 tari_template_lib = { path = "../template_lib", default-features = false, features = ["serde"] }

--- a/dan_layer/integration_tests/Cargo.toml
+++ b/dan_layer/integration_tests/Cargo.toml
@@ -5,18 +5,18 @@ edition = "2018"
 license = "BSD-3-Clause"
 
 [dependencies]
-tari_common_types = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.0", package = "tari_common_types" }
-tari_comms = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.0", package = "tari_comms" }
+tari_common_types = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.1" }
+tari_comms = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.1" }
 tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.16.8" }
 tari_dan_common_types = { path = "../common_types" }
 tari_dan_core = { path = "../core" }
 tari_dan_engine = { path = "../engine" }
 tari_dan_storage_sqlite = { path = "../storage_sqlite" }
 tari_engine_types = { path = "../engine_types" }
-tari_shutdown = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.0", package = "tari_shutdown" }
+tari_shutdown = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.1" }
 tari_template_lib = { path = "../template_lib" }
 tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.10" }
-tari_core = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.0", package = "tari_core" }
+tari_core = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.1" }
 tari_transaction = { path = "../transaction" }
 
 anyhow = "1.0"

--- a/dan_layer/storage/Cargo.toml
+++ b/dan_layer/storage/Cargo.toml
@@ -7,7 +7,7 @@ license = "BSD-3-Clause"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tari_common_types = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.0", package = "tari_common_types" }
+tari_common_types = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.1", package = "tari_common_types" }
 tari_dan_common_types = { path = "../common_types" }
 
 thiserror = "1"

--- a/dan_layer/storage_lmdb/Cargo.toml
+++ b/dan_layer/storage_lmdb/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 tari_dan_engine = { path = "../engine" }
 tari_dan_common_types = { path = "../common_types" }
-tari_storage = {  git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.0", package = "tari_storage" }
+tari_storage = {  git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.1", package = "tari_storage" }
 
 borsh = "0.9.3"
 lmdb-zero = "0.4.4"

--- a/dan_layer/storage_sqlite/Cargo.toml
+++ b/dan_layer/storage_sqlite/Cargo.toml
@@ -6,7 +6,7 @@ license = "BSD-3-Clause"
 
 [dependencies]
 tari_dan_core = { path = "../core" }
-tari_common_types = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.0", package = "tari_common_types" }
+tari_common_types = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.1", package = "tari_common_types" }
 tari_dan_common_types = { path = "../common_types" }
 tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", tag = "v0.4.10" }
 tari_dan_engine = { path = "../engine" }

--- a/dan_layer/transaction/Cargo.toml
+++ b/dan_layer/transaction/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 
 [dependencies]
-tari_common_types = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.0" }
+tari_common_types = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.1" }
 tari_engine_types = { path = "../engine_types" }
 tari_dan_common_types = { path = "../common_types" }
 tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.16.8", features = ["borsh"] }

--- a/dan_layer/wallet/sdk/Cargo.toml
+++ b/dan_layer/wallet/sdk/Cargo.toml
@@ -8,11 +8,11 @@ edition = "2021"
 license = "BSD-3-Clause"
 
 [dependencies]
-tari_common_types = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.0" }
+tari_common_types = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.1" }
 tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", tag = "v0.16.8", features = ["borsh"] }
 tari_engine_types = { path = "../../engine_types" }
 tari_dan_common_types = { path = "../../common_types" }
-tari_key_manager = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.0" }
+tari_key_manager = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.1" }
 tari_transaction = { path = "../../transaction" }
 tari_validator_node_client = { path = "../../../clients/validator_node_client" }
 tari_template_lib = { path = "../../template_lib", features = ["serde"] }

--- a/dan_layer/wallet/storage_sqlite/Cargo.toml
+++ b/dan_layer/wallet/storage_sqlite/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 license = "BSD-3-Clause"
 
 [dependencies]
-tari_common_types = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.0" }
+tari_common_types = { git = "https://github.com/tari-project/tari.git", tag = "v0.49.0-pre.1" }
 tari_dan_common_types = { path = "../../common_types" }
 tari_dan_wallet_sdk = { path = "../sdk" }
 tari_engine_types = { path = "../../engine_types" }


### PR DESCRIPTION
Description
---
Update tari libs to 0.49.0-pre.1

Motivation and Context
---

Contains claim burn proof changes in the console wallet 

How Has This Been Tested?
---
Ran claim burn cucumber - passes

What process can a PR reviewer use to test or verify this change?
---
CI

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify