### PR TITLE
feat: add search for templates

### DIFF
--- a/applications/tari_validator_node_web_ui/src/Components/HeadingMenu.tsx
+++ b/applications/tari_validator_node_web_ui/src/Components/HeadingMenu.tsx
@@ -20,7 +20,7 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import React from 'react';
+import { useState } from 'react';
 import Button from '@mui/material/Button';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
@@ -29,6 +29,9 @@ import ListItemText from '@mui/material/ListItemText';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import MenuList from '@mui/material/MenuList';
 import FilterListOutlinedIcon from '@mui/icons-material/FilterListOutlined';
+import IconButton from '@mui/material/IconButton';
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
+import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
 
 interface MenuItem {
   title: string;
@@ -39,10 +42,21 @@ interface MenuItem {
 interface Props {
   menuTitle: string;
   menuItems: MenuItem[];
+  showArrow?: boolean;
+  lastSort?: any;
+  columnName?: string;
+  sortFunction?: any;
 }
 
-function HeadingMenu({ menuTitle, menuItems }: Props) {
-  const [anchorEl, setAnchorEl] = React.useState(null);
+function HeadingMenu({
+  menuTitle,
+  menuItems,
+  showArrow,
+  lastSort,
+  columnName,
+  sortFunction,
+}: Props) {
+  const [anchorEl, setAnchorEl] = useState(null);
 
   function handleClick(event: any) {
     if (anchorEl !== event.currentTarget) {
@@ -55,42 +69,61 @@ function HeadingMenu({ menuTitle, menuItems }: Props) {
   }
 
   return (
-    <div>
-      <Button
-        aria-owns={anchorEl ? 'simple-menu' : undefined}
-        aria-haspopup="true"
-        onClick={handleClick}
-        // onMouseOver={handleClick}
-        startIcon={<UnfoldMoreIcon />}
-        style={{
-          textTransform: 'none',
-          color: '#000000',
-        }}
-      >
-        {menuTitle}
-      </Button>
-      <Menu
-        id="simple-menu"
-        anchorEl={anchorEl}
-        open={Boolean(anchorEl)}
-        onClose={handleClose}
-        MenuListProps={{ onMouseLeave: handleClose }}
-      >
-        <MenuList style={{ outline: 'none' }} className="annoying">
-          {menuItems?.map((item, index) => (
-            <MenuItem key={index} onClick={item.fn}>
-              <ListItemIcon>
-                {item.icon ? (
-                  item.icon
-                ) : (
-                  <FilterListOutlinedIcon fontSize="small" />
-                )}
-              </ListItemIcon>
-              <ListItemText>{item.title}</ListItemText>
-            </MenuItem>
-          ))}
-        </MenuList>
-      </Menu>
+    <div className="heading-menu">
+      <>
+        <Button
+          aria-owns={anchorEl ? 'simple-menu' : undefined}
+          aria-haspopup="true"
+          onClick={handleClick}
+          // onMouseOver={handleClick}
+          startIcon={<UnfoldMoreIcon />}
+          style={{
+            textTransform: 'none',
+            color: '#000000',
+          }}
+        >
+          {menuTitle}
+        </Button>
+        <Menu
+          id="simple-menu"
+          anchorEl={anchorEl}
+          open={Boolean(anchorEl)}
+          onClose={handleClose}
+          MenuListProps={{ onMouseLeave: handleClose }}
+        >
+          <MenuList style={{ outline: 'none' }} className="annoying">
+            {menuItems?.map((item, index) => (
+              <MenuItem key={index} onClick={item.fn}>
+                <ListItemIcon>
+                  {item.icon ? (
+                    item.icon
+                  ) : (
+                    <FilterListOutlinedIcon fontSize="small" />
+                  )}
+                </ListItemIcon>
+                <ListItemText>{item.title}</ListItemText>
+              </MenuItem>
+            ))}
+          </MenuList>
+        </Menu>
+      </>
+      {showArrow && (
+        <IconButton>
+          {lastSort.column === columnName ? (
+            lastSort.order === 1 ? (
+              <KeyboardArrowUpIcon
+                onClick={() => sortFunction(columnName, -1)}
+              />
+            ) : (
+              <KeyboardArrowDownIcon
+                onClick={() => sortFunction(columnName, 1)}
+              />
+            )
+          ) : (
+            ''
+          )}
+        </IconButton>
+      )}
     </div>
   );
 }

--- a/applications/tari_validator_node_web_ui/src/index.css
+++ b/applications/tari_validator_node_web_ui/src/index.css
@@ -41,6 +41,13 @@ code {
   gap: 10px;
 }
 
+.heading-menu {
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  gap: 5px;
+}
+
 @media screen and (max-width: 767px) {
   .flex-container > * {
     width: 100%;

--- a/applications/tari_validator_node_web_ui/src/routes/VN/Components/RecentTransactions.tsx
+++ b/applications/tari_validator_node_web_ui/src/routes/VN/Components/RecentTransactions.tsx
@@ -43,8 +43,7 @@ import Collapse from '@mui/material/Collapse';
 import TablePagination from '@mui/material/TablePagination';
 import Typography from '@mui/material/Typography';
 import HeadingMenu from '../../../Components/HeadingMenu';
-import IconButton from '@mui/material/IconButton';
-import TransactionFilter from '../../../Components/TransactionFilter';
+import SearchFilter from '../../../Components/SearchFilter';
 import Fade from '@mui/material/Fade';
 
 interface IRecentTransaction {
@@ -180,22 +179,6 @@ function RecentTransactions() {
     setPage(0);
   };
 
-  const ascendingTimestamp = () => {
-    sort('timestamp', 1);
-  };
-
-  const descendingTimestamp = () => {
-    sort('timestamp', -1);
-  };
-
-  const ascendingPayloadId = () => {
-    sort('payload_id', 1);
-  };
-
-  const descendingPayloadId = () => {
-    sort('payload_id', -1);
-  };
-
   useEffect(() => {
     getRecentTransactions().then((resp) => {
       setRecentTransactions(
@@ -242,10 +225,25 @@ function RecentTransactions() {
   return (
     <>
       <BoxHeading2>
-        <TransactionFilter
-          recentTransactions={recentTransactions}
-          setRecentTransactions={setRecentTransactions}
+        <SearchFilter
+          stateObject={recentTransactions}
+          setStateObject={setRecentTransactions}
           setPage={setPage}
+          filterItems={[
+            {
+              title: 'Payload Id',
+              value: 'id',
+              filterFn: (value: string, row: ITableRecentTransaction) =>
+                row.id.toLowerCase().includes(value.toLowerCase()),
+            },
+            {
+              title: 'Timestamp',
+              value: 'timestamp',
+              filterFn: (value: string, row: ITableRecentTransaction) =>
+                row.timestamp.includes(value),
+            },
+          ]}
+          placeholder="Search for Transactions"
         />
       </BoxHeading2>
       <TableContainer>
@@ -253,78 +251,46 @@ function RecentTransactions() {
           <TableHead>
             <TableRow>
               <TableCell>
-                <div
-                  style={{
-                    display: 'flex',
-                    justifyContent: 'flex-start',
-                    alignItems: 'center',
-                    gap: '5px',
-                  }}
-                >
-                  <HeadingMenu
-                    menuTitle="Payload ID"
-                    menuItems={[
-                      {
-                        title: 'Sort Ascending',
-                        fn: ascendingPayloadId,
-                        icon: <KeyboardArrowUpIcon />,
-                      },
-                      {
-                        title: 'Sort Descending',
-                        fn: descendingPayloadId,
-                        icon: <KeyboardArrowDownIcon />,
-                      },
-                    ]}
-                  />
-                  <IconButton>
-                    {lastSort.column === 'payload_id' ? (
-                      lastSort.order === 1 ? (
-                        <KeyboardArrowUpIcon onClick={descendingPayloadId} />
-                      ) : (
-                        <KeyboardArrowDownIcon onClick={ascendingPayloadId} />
-                      )
-                    ) : (
-                      ''
-                    )}
-                  </IconButton>
-                </div>
+                <HeadingMenu
+                  menuTitle="Payload ID"
+                  menuItems={[
+                    {
+                      title: 'Sort Ascending',
+                      fn: () => sort('id', 1),
+                      icon: <KeyboardArrowUpIcon />,
+                    },
+                    {
+                      title: 'Sort Descending',
+                      fn: () => sort('id', -1),
+                      icon: <KeyboardArrowDownIcon />,
+                    },
+                  ]}
+                  showArrow
+                  lastSort={lastSort}
+                  columnName="id"
+                  sortFunction={sort}
+                />
               </TableCell>
               <TableCell>
-                <div
-                  style={{
-                    display: 'flex',
-                    justifyContent: 'flex-start',
-                    alignItems: 'center',
-                    gap: '5px',
-                  }}
-                >
-                  <HeadingMenu
-                    menuTitle="Timestamp"
-                    menuItems={[
-                      {
-                        title: 'Sort Ascending',
-                        fn: ascendingTimestamp,
-                        icon: <KeyboardArrowUpIcon />,
-                      },
-                      {
-                        title: 'Sort Descending',
-                        fn: descendingTimestamp,
-                        icon: <KeyboardArrowDownIcon />,
-                      },
-                    ]}
-                  />
-                  <IconButton>
-                    {lastSort.column === 'timestamp' ? (
-                      lastSort.order === 1 ? (
-                        <KeyboardArrowUpIcon onClick={descendingTimestamp} />
-                      ) : (
-                        <KeyboardArrowDownIcon onClick={ascendingTimestamp} />
-                      )
-                    ) : (
-                      ''
-                    )}
-                  </IconButton>
-                </div>
+                <HeadingMenu
+                  menuTitle="Timestamp"
+                  menuItems={[
+                    {
+                      title: 'Sort Ascending',
+                      fn: () => sort('timestamp', 1),
+                      icon: <KeyboardArrowUpIcon />,
+                    },
+                    {
+                      title: 'Sort Descending',
+                      fn: () => sort('timestamp', -1),
+                      icon: <KeyboardArrowDownIcon />,
+                    },
+                  ]}
+                  showArrow
+                  lastSort={lastSort}
+                  columnName="timestamp"
+                  sortFunction={sort}
+                />
               </TableCell>
               <TableCell style={{ textAlign: 'center' }}>Meta</TableCell>
               <TableCell style={{ textAlign: 'center' }}>

--- a/applications/tari_validator_node_web_ui/src/routes/VN/Components/helpers.tsx
+++ b/applications/tari_validator_node_web_ui/src/routes/VN/Components/helpers.tsx
@@ -103,6 +103,8 @@ function compare(a: any, b: any) {
 }
 
 function toHexString(byteArray: number[]) {
+  if (!Array.isArray(byteArray))
+    throw new Error('Expected input to be an array');
   return Array.from(byteArray, function (byte) {
     return ('0' + (byte & 0xff).toString(16)).slice(-2);
   }).join('');
@@ -117,6 +119,8 @@ function fromHexString(hexString: string) {
 }
 
 function shortenString(string: string, start: number = 8, end: number = 8) {
+  if (typeof string !== 'string')
+    throw new Error('Expected input to be a string');
   return string.substring(0, start) + '...' + string.slice(-end);
 }
 


### PR DESCRIPTION
Description
---
Added search and filter functionality for the templates component.
Templates are also now sorted by height descending by default.
Made the search / filter and the heading menu components more generic, so we can reuse them in other places on the site.

Motivation and Context
---
Adds the ability to search for templates.

How Has This Been Tested?
---
Manually

What process can a PR reviewer use to test or verify this change?
---
There's a new search box above the templates component. Search for templates via address or height.

Breaking Changes
---
x

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify