### PR TITLE
fix(wallet): add fee support to the remaining transaction commands

### DIFF
--- a/applications/tari_dan_wallet_daemon/src/services/account_monitor.rs
+++ b/applications/tari_dan_wallet_daemon/src/services/account_monitor.rs
@@ -253,6 +253,7 @@ where TStore: WalletStore + Clone + Send + Sync + 'static
                     self.process_result(diff).await?;
                 }
             },
+            WalletEvent::TransactionInvalid(_) => {},
             WalletEvent::AccountChanged(_) => {},
         }
         Ok(())

--- a/applications/tari_dan_wallet_daemon/src/services/events.rs
+++ b/applications/tari_dan_wallet_daemon/src/services/events.rs
@@ -14,6 +14,7 @@ use tari_template_lib::models::Amount;
 pub enum WalletEvent {
     TransactionSubmitted(TransactionSubmittedEvent),
     TransactionFinalized(TransactionFinalizedEvent),
+    TransactionInvalid(TransactionInvalidEvent),
     AccountChanged(AccountChangedEvent),
 }
 
@@ -35,6 +36,12 @@ impl From<AccountChangedEvent> for WalletEvent {
     }
 }
 
+impl From<TransactionInvalidEvent> for WalletEvent {
+    fn from(value: TransactionInvalidEvent) -> Self {
+        Self::TransactionInvalid(value)
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct TransactionSubmittedEvent {
     pub hash: FixedHash,
@@ -53,4 +60,11 @@ pub struct TransactionFinalizedEvent {
 #[derive(Debug, Clone)]
 pub struct AccountChangedEvent {
     pub account_address: SubstateAddress,
+}
+
+#[derive(Debug, Clone)]
+pub struct TransactionInvalidEvent {
+    pub hash: FixedHash,
+    pub status: TransactionStatus,
+    pub final_fee: Amount,
 }

--- a/applications/tari_dan_wallet_daemon/src/services/transaction_service.rs
+++ b/applications/tari_dan_wallet_daemon/src/services/transaction_service.rs
@@ -19,7 +19,7 @@ use tokio::{
 
 use crate::{
     notify::Notify,
-    services::{TransactionFinalizedEvent, WalletEvent},
+    services::{TransactionFinalizedEvent, TransactionInvalidEvent, WalletEvent},
 };
 
 const LOG_TARGET: &str = "tari::dan_wallet_daemon::transaction_service";
@@ -133,14 +133,24 @@ where TStore: WalletStore + Clone + Send + Sync + 'static
                         transaction.transaction.hash(),
                         transaction.status,
                     );
-                    notify.notify(TransactionFinalizedEvent {
-                        hash: transaction.transaction.hash().into_array().into(),
-                        finalize: transaction.result.unwrap(),
-                        transaction_failure: transaction.transaction_failure,
-                        final_fee: transaction.final_fee.unwrap_or_default(),
-                        qcs: transaction.qcs,
-                        status: transaction.status,
-                    });
+
+                    match transaction.finalize {
+                        Some(finalize) => {
+                            notify.notify(TransactionFinalizedEvent {
+                                hash: transaction.transaction.hash().into_array().into(),
+                                finalize,
+                                transaction_failure: transaction.transaction_failure,
+                                final_fee: transaction.final_fee.unwrap_or_default(),
+                                qcs: transaction.qcs,
+                                status: transaction.status,
+                            });
+                        },
+                        None => notify.notify(TransactionInvalidEvent {
+                            hash: transaction.transaction.hash().into_array().into(),
+                            status: transaction.status,
+                            final_fee: transaction.final_fee.unwrap_or_default(),
+                        }),
+                    }
                 },
                 None => {
                     debug!(
@@ -159,7 +169,9 @@ where TStore: WalletStore + Clone + Send + Sync + 'static
             WalletEvent::TransactionSubmitted(_) => {
                 let _ = self.trigger_poll.send(());
             },
-            WalletEvent::TransactionFinalized(_) | WalletEvent::AccountChanged(_) => {},
+            WalletEvent::TransactionInvalid(_) |
+            WalletEvent::TransactionFinalized(_) |
+            WalletEvent::AccountChanged(_) => {},
         }
         Ok(())
     }

--- a/clients/wallet_daemon_client/src/types.rs
+++ b/clients/wallet_daemon_client/src/types.rs
@@ -112,6 +112,7 @@ pub struct TransactionWaitResultResponse {
     pub result: Option<FinalizeResult>,
     pub qcs: Vec<QuorumCertificate>,
     pub status: TransactionStatus,
+    pub final_fee: Amount,
     pub timed_out: bool,
 }
 

--- a/dan_layer/wallet/sdk/src/models/wallet_transaction.rs
+++ b/dan_layer/wallet/sdk/src/models/wallet_transaction.rs
@@ -1,7 +1,7 @@
 //   Copyright 2023 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use std::str::FromStr;
+use std::{fmt::Display, str::FromStr};
 
 use anyhow::anyhow;
 use serde::{Deserialize, Serialize};
@@ -14,7 +14,7 @@ use tari_transaction::Transaction;
 pub struct WalletTransaction {
     pub transaction: Transaction,
     pub status: TransactionStatus,
-    pub result: Option<FinalizeResult>,
+    pub finalize: Option<FinalizeResult>,
     pub transaction_failure: Option<RejectReason>,
     pub final_fee: Option<Amount>,
     pub qcs: Vec<QuorumCertificate>,
@@ -29,6 +29,7 @@ pub enum TransactionStatus {
     Pending,
     Accepted,
     Rejected,
+    InvalidTransaction,
 }
 
 impl TransactionStatus {
@@ -39,6 +40,7 @@ impl TransactionStatus {
             TransactionStatus::Pending => "Pending",
             TransactionStatus::Accepted => "Accepted",
             TransactionStatus::Rejected => "Rejected",
+            TransactionStatus::InvalidTransaction => "InvalidTransaction",
         }
     }
 }
@@ -53,7 +55,14 @@ impl FromStr for TransactionStatus {
             "Pending" => Ok(TransactionStatus::Pending),
             "Accepted" => Ok(TransactionStatus::Accepted),
             "Rejected" => Ok(TransactionStatus::Rejected),
+            "InvalidTransaction" => Ok(TransactionStatus::InvalidTransaction),
             _ => Err(anyhow!("Invalid TransactionStatus: {}", s)),
         }
+    }
+}
+
+impl Display for TransactionStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_key_str())
     }
 }

--- a/dan_layer/wallet/storage_sqlite/src/models/transaction.rs
+++ b/dan_layer/wallet/storage_sqlite/src/models/transaction.rs
@@ -54,7 +54,7 @@ impl Transaction {
                 item: "status",
                 details: e.to_string(),
             })?,
-            result: self.result.map(|r| deserialize_json(&r)).transpose()?,
+            finalize: self.result.map(|r| deserialize_json(&r)).transpose()?,
             transaction_failure: self.transaction_failure.map(|r| deserialize_json(&r)).transpose()?,
             final_fee: self.final_fee.map(|f| f.into()),
             qcs: self.qcs.map(|q| deserialize_json(&q)).transpose()?.unwrap_or_default(),


### PR DESCRIPTION
Description
---
- fix(wallet): add fee support to the remaining transaction commands
- fix(wallet): handle case where transaction is not found after submission.

Motivation and Context
---

Some commands were missing fee instructions. 

When a transaction is submitted that fails validation, the wallet continuously gets a 404 error and never can resolve the transaction. This PR resolves this by marking the transaction with a new status 'TransactionInvalid'

How Has This Been Tested?
---
Manually

What process can a PR reviewer use to test or verify this change?
---
fix1: test submitting a transaction via wallet cli
fix2:  Comment out the fee instruction from some commands and submit the instruction


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify