### PR TITLE
fix(mempool): return error to caller if tx fails validation

### DIFF
--- a/applications/tari_validator_node/src/p2p/rpc/service_impl.rs
+++ b/applications/tari_validator_node/src/p2p/rpc/service_impl.rs
@@ -78,22 +78,18 @@ where TPeerProvider: PeerProvider + Clone + Send + Sync + 'static
             },
         };
 
-        // TODO: Implement a mempool handle that returns if the transaction was accepted or not
         match self.mempool.submit_transaction(transaction).await {
             Ok(_) => {
                 debug!(target: LOG_TARGET, "Accepted instruction into mempool");
-                return Ok(Response::new(proto::rpc::SubmitTransactionResponse {
+                Ok(Response::new(proto::rpc::SubmitTransactionResponse {
                     result: vec![],
                     status: "Accepted".to_string(),
-                }));
+                }))
             },
-            Err(_err) => {
-                // debug!(target: LOG_TARGET, "Mempool rejected instruction: {}", err);
-                return Ok(Response::new(proto::rpc::SubmitTransactionResponse {
-                    result: vec![],
-                    status: "Mempool has shut down".to_string(),
-                }));
-            },
+            Err(err) => Ok(Response::new(proto::rpc::SubmitTransactionResponse {
+                result: vec![],
+                status: format!("Failed to submit transaction to mempool: {}", err),
+            })),
         }
     }
 

--- a/applications/tari_validator_node/src/p2p/services/mempool/mod.rs
+++ b/applications/tari_validator_node/src/p2p/services/mempool/mod.rs
@@ -44,7 +44,7 @@ pub use validator::{FeeTransactionValidator, TemplateExistsValidator};
 #[derive(Error, Debug)]
 pub enum MempoolError {
     #[error("Epoch Manager Error: {0}")]
-    EpochManagerError(#[from] Box<EpochManagerError>),
+    EpochManagerError(#[from] EpochManagerError),
     #[error("Broadcast failed: {0}")]
     BroadcastFailed(#[from] MessagingError),
     #[error("Invalid template address: {0}")]


### PR DESCRIPTION
Description
---
Returns error to caller if tx fails validation and back to JSON RPC callers

Motivation and Context
---
Wallet daemon can tell that the transaction was rejected at submit time.

How Has This Been Tested?
---
Manually

What process can a PR reviewer use to test or verify this change?
---
Submit transaction before PR #442 and check that an error is returned instead of waiting forever for a result.
`Request failed: code: -32603 message: Mempool rejected transaction: No fee instructions" `

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify