### PR TITLE
feat!: merge the mmr proofs into one

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7365,6 +7365,7 @@ version = "0.50.0-pre.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "bincode",
  "blake2 0.9.2",
  "chrono",
  "digest 0.9.0",

--- a/dan_layer/common_types/src/quorum_certificate.rs
+++ b/dan_layer/common_types/src/quorum_certificate.rs
@@ -1,13 +1,15 @@
 //   Copyright 2022 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use std::borrow::Borrow;
+use std::{borrow::Borrow, io};
 
 use digest::Digest;
 use serde::{Deserialize, Serialize};
 use tari_common_types::types::FixedHash;
+use tari_core::ValidatorNodeBmtHasherBlake256;
 use tari_crypto::hash::blake2::Blake256;
 use tari_engine_types::commit_result::RejectReason;
+use tari_mmr::{Hash, MergedBalancedBinaryMerkleProof};
 
 use crate::{
     Epoch,
@@ -109,6 +111,8 @@ pub struct QuorumCertificate<TAddr> {
     decision: QuorumDecision,
     all_shard_pledges: ShardPledgeCollection,
     validators_metadata: Vec<ValidatorMetadata>,
+    merged_proof: Option<MergedBalancedBinaryMerkleProof<ValidatorNodeBmtHasherBlake256>>,
+    leaves_hashes: Vec<Hash>,
 }
 
 impl<TAddr: Clone> QuorumCertificate<TAddr> {
@@ -131,6 +135,8 @@ impl<TAddr: NodeAddressable> QuorumCertificate<TAddr> {
         decision: QuorumDecision,
         all_shard_pledges: ShardPledgeCollection,
         validators_metadata: Vec<ValidatorMetadata>,
+        merged_proof: Option<MergedBalancedBinaryMerkleProof<ValidatorNodeBmtHasherBlake256>>,
+        leaves_hashes: Vec<Hash>,
     ) -> Self {
         Self {
             payload_id: payload,
@@ -143,6 +149,8 @@ impl<TAddr: NodeAddressable> QuorumCertificate<TAddr> {
             decision,
             all_shard_pledges,
             validators_metadata,
+            merged_proof,
+            leaves_hashes,
         }
     }
 
@@ -158,6 +166,8 @@ impl<TAddr: NodeAddressable> QuorumCertificate<TAddr> {
             decision: QuorumDecision::Accept,
             all_shard_pledges: ShardPledgeCollection::empty(),
             validators_metadata: vec![],
+            merged_proof: None,
+            leaves_hashes: vec![],
         }
     }
 
@@ -177,6 +187,27 @@ impl<TAddr: NodeAddressable> QuorumCertificate<TAddr> {
         &self.proposed_by
     }
 
+    pub fn merged_proof(&self) -> Option<MergedBalancedBinaryMerkleProof<ValidatorNodeBmtHasherBlake256>> {
+        self.merged_proof.clone()
+    }
+
+    // TODO: impl CBOR for merged merkle proof
+    pub fn encode_merged_merkle_proof(&self) -> Vec<u8> {
+        bincode::serialize(&self.merged_proof).unwrap()
+    }
+
+    // TODO: impl CBOR for merkle proof
+    pub fn decode_merged_merkle_proof(
+        bytes: &[u8],
+    ) -> Result<Option<MergedBalancedBinaryMerkleProof<ValidatorNodeBmtHasherBlake256>>, io::Error> {
+        // Map to an io error because borsh uses that
+        bincode::deserialize(bytes).map_err(|e| io::Error::new(io::ErrorKind::Other, e))
+    }
+
+    pub fn leave_hashes(&self) -> Vec<Hash> {
+        self.leaves_hashes.clone()
+    }
+
     pub fn validators_metadata(&self) -> &[ValidatorMetadata] {
         self.validators_metadata.as_slice()
     }
@@ -186,16 +217,15 @@ impl<TAddr: NodeAddressable> QuorumCertificate<TAddr> {
     }
 
     pub fn to_hash(&self) -> FixedHash {
-        let mut result = Blake256::new()
+        let result = Blake256::new()
             .chain(self.local_node_hash.as_bytes())
             .chain(self.local_node_height.to_le_bytes())
             .chain(self.shard.as_bytes())
-            .chain((self.validators_metadata.len() as u64).to_le_bytes());
+            .chain((self.validators_metadata.len() as u64).to_le_bytes())
+            .chain(bincode::serialize(&self.merged_proof).unwrap())
+            .chain(bincode::serialize(&self.leaves_hashes).unwrap());
         // TODO: add all fields
 
-        for vm in &self.validators_metadata {
-            result = result.chain(vm.encode_merkle_proof());
-        }
         // result = result.chain((self.involved_shards.len() as u32).to_le_bytes());
         // for shard in &self.involved_shards {
         //     result = result.chain((*shard).to_le_bytes());

--- a/dan_layer/common_types/src/quorum_certificate.rs
+++ b/dan_layer/common_types/src/quorum_certificate.rs
@@ -10,7 +10,7 @@ use tari_engine_types::{
     commit_result::RejectReason,
     hashing::{hasher, EngineHashDomainLabel},
 };
-use tari_mmr::{Hash, MergedBalancedBinaryMerkleProof};
+use tari_mmr::MergedBalancedBinaryMerkleProof;
 
 use crate::{
     Epoch,
@@ -113,7 +113,7 @@ pub struct QuorumCertificate<TAddr> {
     all_shard_pledges: ShardPledgeCollection,
     validators_metadata: Vec<ValidatorMetadata>,
     merged_proof: Option<MergedBalancedBinaryMerkleProof<ValidatorNodeBmtHasherBlake256>>,
-    leaves_hashes: Vec<Hash>,
+    leaves_hashes: Vec<FixedHash>,
 }
 
 impl<TAddr: Clone> QuorumCertificate<TAddr> {
@@ -137,7 +137,7 @@ impl<TAddr: NodeAddressable> QuorumCertificate<TAddr> {
         all_shard_pledges: ShardPledgeCollection,
         validators_metadata: Vec<ValidatorMetadata>,
         merged_proof: Option<MergedBalancedBinaryMerkleProof<ValidatorNodeBmtHasherBlake256>>,
-        leaves_hashes: Vec<Hash>,
+        leaves_hashes: Vec<FixedHash>,
     ) -> Self {
         Self {
             payload_id: payload,
@@ -205,7 +205,7 @@ impl<TAddr: NodeAddressable> QuorumCertificate<TAddr> {
         bincode::deserialize(bytes).map_err(|e| io::Error::new(io::ErrorKind::Other, e))
     }
 
-    pub fn leave_hashes(&self) -> Vec<Hash> {
+    pub fn leave_hashes(&self) -> Vec<FixedHash> {
         self.leaves_hashes.clone()
     }
 

--- a/dan_layer/common_types/src/validator_metadata.rs
+++ b/dan_layer/common_types/src/validator_metadata.rs
@@ -1,12 +1,9 @@
 //   Copyright 2022 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use std::io;
-
 use digest::Digest;
 use serde::{Deserialize, Serialize};
 use tari_common_types::types::{FixedHash, PublicKey, Signature};
-use tari_core::ValidatorNodeBmtHasherBlake256;
 use tari_crypto::hash::blake2::Blake256;
 use tari_engine_types::serde_with;
 use tari_mmr::BalancedBinaryMerkleProof;
@@ -19,43 +16,20 @@ pub struct ValidatorMetadata {
     #[serde(with = "serde_with::hex")]
     pub vn_shard_key: ShardId,
     pub signature: Signature,
-    pub merkle_proof: BalancedBinaryMerkleProof<ValidatorNodeBmtHasherBlake256>,
-    pub merkle_leaf_index: u64,
 }
 
 impl ValidatorMetadata {
-    pub fn new(
-        public_key: PublicKey,
-        vn_shard_key: ShardId,
-        signature: Signature,
-        merkle_proof: BalancedBinaryMerkleProof<ValidatorNodeBmtHasherBlake256>,
-        merkle_leaf_index: u64,
-    ) -> Self {
+    pub fn new(public_key: PublicKey, vn_shard_key: ShardId, signature: Signature) -> Self {
         Self {
             public_key,
             vn_shard_key,
             signature,
-            merkle_proof,
-            merkle_leaf_index,
         }
     }
 
     pub fn get_node_hash(&self) -> FixedHash {
         // Each node is defined as H(V_i || S_i)
         vn_bmt_node_hash(&self.public_key, &self.vn_shard_key)
-    }
-
-    // TODO: impl CBOR for merkle proof
-    pub fn encode_merkle_proof(&self) -> Vec<u8> {
-        bincode::serialize(&self.merkle_proof).unwrap()
-    }
-
-    // TODO: impl CBOR for merkle proof
-    pub fn decode_merkle_proof(
-        bytes: &[u8],
-    ) -> Result<BalancedBinaryMerkleProof<ValidatorNodeBmtHasherBlake256>, io::Error> {
-        // Map to an io error because borsh uses that
-        bincode::deserialize(bytes).map_err(|e| io::Error::new(io::ErrorKind::Other, e))
     }
 }
 

--- a/dan_layer/common_types/src/validator_metadata.rs
+++ b/dan_layer/common_types/src/validator_metadata.rs
@@ -6,7 +6,6 @@ use serde::{Deserialize, Serialize};
 use tari_common_types::types::{FixedHash, PublicKey, Signature};
 use tari_crypto::hash::blake2::Blake256;
 use tari_engine_types::serde_with;
-use tari_mmr::BalancedBinaryMerkleProof;
 
 use crate::{NodeAddressable, ShardId};
 

--- a/dan_layer/core/Cargo.toml
+++ b/dan_layer/core/Cargo.toml
@@ -24,6 +24,7 @@ tari_transaction = { path = "../transaction" }
 
 anyhow = "1.0.53"
 async-trait = "0.1.50"
+bincode = "1.0"
 blake2 = "0.9.2"
 chrono = { version = "0.4.19", default-features = false }
 digest = "0.9.0"

--- a/dan_layer/core/src/models/vote_message.rs
+++ b/dan_layer/core/src/models/vote_message.rs
@@ -182,6 +182,6 @@ impl VoteMessage {
     }
 
     pub fn node_hash(&self) -> FixedHash {
-        self.node_hash.clone()
+        self.node_hash
     }
 }

--- a/dan_layer/core/src/workers/hotstuff_error.rs
+++ b/dan_layer/core/src/workers/hotstuff_error.rs
@@ -22,6 +22,7 @@
 
 use tari_dan_common_types::{Epoch, NodeHeight, PayloadId, ShardId};
 use tari_engine_types::{commit_result::RejectReason, substate::SubstateAddress};
+use tari_mmr::BalancedBinaryMerkleProofError;
 use tari_transaction::SubstateChange;
 use thiserror::Error;
 use tokio::sync::mpsc;
@@ -93,6 +94,10 @@ pub enum HotStuffError {
     NodeIsNotInvolvedInPayload { payload_id: PayloadId },
     #[error("MathOverflow")]
     MathOverflow,
+    #[error("Merkle proof is missing")]
+    MerkleProofMissing,
+    #[error("Merkle proof error: {0}")]
+    BalancedBinaryMerkleProofError(#[from] BalancedBinaryMerkleProofError),
 }
 
 impl<T> From<mpsc::error::SendError<T>> for HotStuffError {

--- a/dan_layer/core/src/workers/hotstuff_waiter.rs
+++ b/dan_layer/core/src/workers/hotstuff_waiter.rs
@@ -1504,9 +1504,11 @@ where
             // Check the proof only for non-genesis blocks
             let res = qc
                 .merged_proof()
-                .unwrap()
-                .verify_consume(&validator_node_root, qc.leave_hashes());
-            let res = res.unwrap();
+                .ok_or(HotStuffError::MerkleProofMissing)?
+                .verify_consume(
+                    &validator_node_root,
+                    qc.leave_hashes().iter().map(|hash| hash.to_vec()).collect(),
+                )?;
             if !res {
                 return Err(HotStuffError::InvalidQuorumCertificate(
                     "invalid merkle proof".to_string(),

--- a/dan_layer/engine_types/src/hashing.rs
+++ b/dan_layer/engine_types/src/hashing.rs
@@ -115,6 +115,7 @@ pub enum EngineHashDomainLabel {
     ResourceAddress,
     ComponentAddress,
     RandomBytes,
+    QuorumCertificate,
 }
 
 impl EngineHashDomainLabel {
@@ -135,6 +136,7 @@ impl EngineHashDomainLabel {
             Self::ResourceAddress => "ResourceAddress",
             Self::ComponentAddress => "ComponentAddress",
             Self::RandomBytes => "RandomBytes",
+            Self::QuorumCertificate => "QuorumCertificate",
         }
     }
 }

--- a/dan_layer/integration_tests/src/test_consensus.rs
+++ b/dan_layer/integration_tests/src/test_consensus.rs
@@ -111,6 +111,8 @@ fn create_test_qc(
         *qc.decision(),
         qc.all_shard_pledges().clone(),
         validators_metadata,
+        None,
+        vec![],
     )
 }
 

--- a/dan_layer/validator_node_rpc/proto/consensus.proto
+++ b/dan_layer/validator_node_rpc/proto/consensus.proto
@@ -43,6 +43,8 @@ message QuorumCertificate {
   repeated ShardPledge all_shard_pledges = 8;
   repeated ValidatorMetadata validators_metadata = 9;
   bytes proposed_by = 10;
+  bytes merged_merkle_proof = 11;
+  repeated bytes leaves_hashes = 12;
 }
 
 message HotStuffTreeNode {
@@ -63,8 +65,6 @@ message ValidatorMetadata {
   bytes public_key = 1;
   bytes vn_shard_key = 2;
   tari.dan.common.Signature signature = 3;
-  bytes merkle_proof = 4;
-  uint64 merkle_leaf_index = 5;
 }
 
 message TariDanPayload {
@@ -76,6 +76,8 @@ message VoteMessage {
   QuorumDecision decision = 2;
   repeated ShardPledge all_shard_pledges = 3;
   ValidatorMetadata validator_metadata = 4;
+  bytes merkle_proof = 5;
+  bytes node_hash = 6;
 }
 
 enum QuorumDecision {

--- a/dan_layer/validator_node_rpc/src/conversions/consensus.rs
+++ b/dan_layer/validator_node_rpc/src/conversions/consensus.rs
@@ -201,7 +201,7 @@ impl TryFrom<proto::consensus::QuorumCertificate> for QuorumCertificate<PublicKe
             value
                 .leaves_hashes
                 .into_iter()
-                .map(|hash| FixedHash::try_from(hash))
+                .map(FixedHash::try_from)
                 .collect::<Result<_, _>>()?,
         ))
     }

--- a/dan_layer/validator_node_rpc/src/conversions/consensus.rs
+++ b/dan_layer/validator_node_rpc/src/conversions/consensus.rs
@@ -49,6 +49,8 @@ impl From<VoteMessage> for proto::consensus::VoteMessage {
             decision: i32::from(msg.decision().as_u8()),
             all_shard_pledges: msg.all_shard_pledges().iter().map(|n| n.clone().into()).collect(),
             validator_metadata: Some(msg.validator_metadata().clone().into()),
+            merkle_proof: msg.encode_merkle_proof(),
+            node_hash: msg.node_hash(),
         }
     }
 }
@@ -69,6 +71,8 @@ impl TryFrom<proto::consensus::VoteMessage> for VoteMessage {
                 .map(|n| n.try_into())
                 .collect::<Result<_, _>>()?,
             metadata.try_into()?,
+            VoteMessage::decode_merkle_proof(&value.merkle_proof)?,
+            value.node_hash,
         ))
     }
 }
@@ -149,6 +153,7 @@ impl From<HotStuffTreeNode<CommsPublicKey, TariDanPayload>> for proto::consensus
 
 impl From<QuorumCertificate<PublicKey>> for proto::consensus::QuorumCertificate {
     fn from(source: QuorumCertificate<PublicKey>) -> Self {
+        let merged_merkle_proof = source.encode_merged_merkle_proof();
         Self {
             payload_id: source.payload_id().as_bytes().to_vec(),
             payload_height: source.payload_height().as_u64(),
@@ -163,6 +168,8 @@ impl From<QuorumCertificate<PublicKey>> for proto::consensus::QuorumCertificate 
             proposed_by: source.proposed_by().as_bytes().to_vec(),
             all_shard_pledges: source.all_shard_pledges().iter().map(|p| p.clone().into()).collect(),
             validators_metadata: source.validators_metadata().iter().map(|p| p.clone().into()).collect(),
+            merged_merkle_proof,
+            leaves_hashes: source.leave_hashes(),
         }
     }
 }
@@ -190,6 +197,8 @@ impl TryFrom<proto::consensus::QuorumCertificate> for QuorumCertificate<PublicKe
                 .iter()
                 .map(|v| v.clone().try_into())
                 .collect::<Result<_, _>>()?,
+            QuorumCertificate::<PublicKey>::decode_merged_merkle_proof(&value.merged_merkle_proof)?,
+            value.leaves_hashes,
         ))
     }
 }
@@ -308,13 +317,10 @@ impl From<SubstateState> for proto::consensus::SubstateState {
 
 impl From<ValidatorMetadata> for proto::consensus::ValidatorMetadata {
     fn from(msg: ValidatorMetadata) -> Self {
-        let merkle_proof = msg.encode_merkle_proof();
         Self {
             public_key: msg.public_key.to_vec(),
             vn_shard_key: msg.vn_shard_key.as_bytes().to_vec(),
             signature: Some(msg.signature.into()),
-            merkle_proof,
-            merkle_leaf_index: msg.merkle_leaf_index,
         }
     }
 }
@@ -331,8 +337,6 @@ impl TryFrom<proto::consensus::ValidatorMetadata> for ValidatorMetadata {
                 .map(TryFrom::try_from)
                 .transpose()?
                 .ok_or_else(|| anyhow!("ValidatorMetadata missing signature"))?,
-            merkle_proof: ValidatorMetadata::decode_merkle_proof(&value.merkle_proof)?,
-            merkle_leaf_index: value.merkle_leaf_index,
         })
     }
 }


### PR DESCRIPTION
Description
---
Merge proof into one. This moves the mmr proof from the `ValidatorMetadata` to the `QuorumCertificate` / `VoteMessage`.

Motivation and Context
---
This will make the proof much smaller. Also the time to prove will be faster.

How Has This Been Tested?
---
Using script that creates many VN nodes and running TXs

What process can a PR reviewer use to test or verify this change?
---
Create more than one node and run some TXs

Breaking Changes
---

- [ ] None
- [ ] Requires data directory to be deleted
- [x] Other - Please specify
  - This will change the Votes and QCs. So the second layer needs to be restarted.