### PR TITLE
fix: compare addresses properly

### DIFF
--- a/applications/tari_validator_node/src/p2p/services/networking/service.rs
+++ b/applications/tari_validator_node/src/p2p/services/networking/service.rs
@@ -205,8 +205,9 @@ impl Networking {
                 //     .unwrap_or(true)
                 // {
 
-                // If there was an update, we forward the announce to other peers
-                if existing_peer.addresses != peer.addresses {
+                // If there was an update, we forward the announce to other peers, we compare everything but
+                // unverified_data
+                if existing_peer != peer {
                     self.peer_provider.update_peer(peer).await?;
 
                     // TODO: should not forward announce to sending peer

--- a/dan_layer/core/src/services/peer_service.rs
+++ b/dan_layer/core/src/services/peer_service.rs
@@ -49,6 +49,22 @@ pub struct DanPeer<TAddr> {
     pub addresses: Vec<(Multiaddr, PeerIdentityClaim)>,
 }
 
+impl<TAddr: PartialEq> PartialEq for DanPeer<TAddr> {
+    fn eq(&self, other: &Self) -> bool {
+        // Compare everything but self.addresses[].1.unverified_data
+        self.identity == other.identity &&
+            self.addresses.len() == other.addresses.len() &&
+            self.addresses.iter().zip(other.addresses.iter()).all(
+                |((multiadd, peer_identity_claim), (other_multiadd, other_peer_identity_claim))| {
+                    multiadd == other_multiadd &&
+                        peer_identity_claim.addresses == other_peer_identity_claim.addresses &&
+                        peer_identity_claim.features == other_peer_identity_claim.features &&
+                        peer_identity_claim.signature == other_peer_identity_claim.signature
+                },
+            )
+    }
+}
+
 impl DanPeer<CommsPublicKey> {
     pub fn is_valid(&self) -> bool {
         self.addresses.iter().all(|(addr, claim)| {


### PR DESCRIPTION
Description
---
Compare the peer addresses differently. Because comparing everything lead to infinity network announcement going around.
Now I compare everything but the unverified data. Because that is filled during conversion [here](https://github.com/tari-project/tari/blob/development/comms/core/src/peer_manager/peer_identity_claim.rs#L105)

How Has This Been Tested?
---
Manually, starting a network with 4 VNs that works.

What process can a PR reviewer use to test or verify this change?
---


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify