### PR TITLE
feat: jwt token to the wallet daemon jrpc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7521,6 +7521,7 @@ dependencies = [
  "config",
  "dirs",
  "futures 0.3.27",
+ "jsonwebtoken",
  "libsqlite3-sys",
  "log",
  "log4rs",

--- a/applications/tari_dan_wallet_daemon/Cargo.toml
+++ b/applications/tari_dan_wallet_daemon/Cargo.toml
@@ -27,12 +27,13 @@ tari_bor = { path = "../../dan_layer/tari_bor" }
 
 anyhow = "1.0.69"
 base64 = "0.20.0-alpha.1"
-axum = "0.6"
+axum = { version = "0.6", features = ["headers"] }
 axum-jrpc = { version = "0.3.2", features = ["anyhow_error"] }
 clap = { version = "3.2.22", features = ["derive", "env"] }
 config = "0.13.0"
 dirs = "4.0.0"
 futures = "0.3.26"
+jsonwebtoken = "8.3.0"
 log = "0.4.17"
 multiaddr = "0.17.0"
 serde = "1.0.152"

--- a/applications/tari_dan_wallet_daemon/src/config.rs
+++ b/applications/tari_dan_wallet_daemon/src/config.rs
@@ -20,7 +20,7 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::net::SocketAddr;
+use std::{net::SocketAddr, time::Duration};
 
 use config::Config;
 use serde::{Deserialize, Serialize};
@@ -53,6 +53,10 @@ pub struct WalletDaemonConfig {
     pub signaling_server_addr: Option<SocketAddr>,
     /// The validator nodes jrpc endpoint url
     pub validator_node_endpoint: Option<String>,
+    /// Expiration duration of the JWT token
+    pub jwt_expiration: Option<Duration>,
+    /// Secret key for the JWT token.
+    pub secret_key: Option<String>,
 }
 
 impl Default for WalletDaemonConfig {
@@ -62,6 +66,11 @@ impl Default for WalletDaemonConfig {
             listen_addr: Some(SocketAddr::from(([127u8, 0, 0, 1], 9000))),
             signaling_server_addr: Some(SocketAddr::from(([127u8, 0, 0, 1], 9100))),
             validator_node_endpoint: Some("http://127.0.0.1:18200/json_rpc".to_string()),
+            // TODO: Come up with a reasonable default value
+            jwt_expiration: Some(Duration::from_secs(5 * 60)),
+            // TODO: Generate a random secret key at start if not set by hand. Otherwise anyone can generate a JWT token
+            // when they know the secret_key.
+            secret_key: Some("secret_key".to_string()),
         }
     }
 }

--- a/applications/tari_dan_wallet_daemon/src/handlers/context.rs
+++ b/applications/tari_dan_wallet_daemon/src/handlers/context.rs
@@ -4,17 +4,22 @@
 use tari_dan_wallet_sdk::DanWalletSdk;
 use tari_dan_wallet_storage_sqlite::SqliteWalletStore;
 
-use crate::{notify::Notify, services::WalletEvent};
+use crate::{jwt::Jwt, notify::Notify, services::WalletEvent};
 
 #[derive(Debug, Clone)]
 pub struct HandlerContext {
     wallet_sdk: DanWalletSdk<SqliteWalletStore>,
     notifier: Notify<WalletEvent>,
+    jwt: Jwt,
 }
 
 impl HandlerContext {
-    pub fn new(wallet_sdk: DanWalletSdk<SqliteWalletStore>, notifier: Notify<WalletEvent>) -> Self {
-        Self { wallet_sdk, notifier }
+    pub fn new(wallet_sdk: DanWalletSdk<SqliteWalletStore>, notifier: Notify<WalletEvent>, jwt: Jwt) -> Self {
+        Self {
+            wallet_sdk,
+            notifier,
+            jwt,
+        }
     }
 
     pub fn notifier(&self) -> &Notify<WalletEvent> {
@@ -23,5 +28,9 @@ impl HandlerContext {
 
     pub fn wallet_sdk(&self) -> &DanWalletSdk<SqliteWalletStore> {
         &self.wallet_sdk
+    }
+
+    pub fn jwt(&self) -> &Jwt {
+        &self.jwt
     }
 }

--- a/applications/tari_dan_wallet_daemon/src/handlers/rpc.rs
+++ b/applications/tari_dan_wallet_daemon/src/handlers/rpc.rs
@@ -9,3 +9,11 @@ pub async fn handle_discover(
 ) -> Result<serde_json::Value, anyhow::Error> {
     Ok(serde_json::from_str(include_str!("../../openrpc.json"))?)
 }
+
+pub async fn handle_init(
+    context: &HandlerContext,
+    _value: serde_json::Value,
+) -> Result<serde_json::Value, anyhow::Error> {
+    let token = context.jwt().generate()?;
+    Ok(serde_json::to_value(token)?)
+}

--- a/applications/tari_dan_wallet_daemon/src/jrpc_server.rs
+++ b/applications/tari_dan_wallet_daemon/src/jrpc_server.rs
@@ -3,7 +3,14 @@
 
 use std::{net::SocketAddr, sync::Arc};
 
-use axum::{extract::Extension, routing::post, Router};
+use axum::{
+    extract::Extension,
+    http::{Request, StatusCode},
+    middleware::Next,
+    response::Response,
+    routing::post,
+    Router,
+};
 use axum_jrpc::{
     error::{JsonRpcError, JsonRpcErrorReason},
     JrpcResult,
@@ -25,6 +32,21 @@ use crate::{
 
 const LOG_TARGET: &str = "tari::dan_wallet_daemon::json_rpc";
 
+// We need to extract the token, because the first call is without any token. So we don't have to have two handlers.
+async fn extract_token<B>(mut request: Request<B>, next: Next<B>) -> Result<Response, StatusCode> {
+    let mut token_ext = None;
+    if let Some(token) = request.headers().get("authorization") {
+        if let Ok(token) = token.to_str() {
+            if let Some(token) = token.strip_prefix("Bearer ") {
+                token_ext = Some(token.to_string());
+            }
+        }
+    }
+    request.extensions_mut().insert::<Option<String>>(token_ext);
+    let response = next.run(request).await;
+    Ok(response)
+}
+
 pub async fn listen(
     preferred_address: SocketAddr,
     signaling_server_address: SocketAddr,
@@ -39,7 +61,8 @@ pub async fn listen(
         .layer(Extension(Arc::new(context)))
         .layer(Extension(Arc::new((preferred_address,signaling_server_address))))
         .layer(Extension(Arc::new(shutdown_signal.clone())))
-        .layer(CorsLayer::permissive());
+        .layer(CorsLayer::permissive())
+        .layer(axum::middleware::from_fn(extract_token));
 
     let server = axum::Server::try_bind(&preferred_address)?;
     let server = server.serve(router.into_make_service());
@@ -55,9 +78,32 @@ async fn handler(
     Extension(context): Extension<Arc<HandlerContext>>,
     Extension(addresses): Extension<Arc<(SocketAddr, SocketAddr)>>,
     Extension(shutdown_signal): Extension<Arc<ShutdownSignal>>,
+    Extension(token): Extension<Option<String>>,
     value: JsonRpcExtractor,
 ) -> JrpcResult {
     info!(target: LOG_TARGET, "🌐 JSON-RPC request: {}", value.method);
+    if value.method == "auth.login" {
+        return call_handler(context, value, rpc::handle_init).await;
+    }
+
+    // Now we check if there is a token present in this request.
+    let token = token.ok_or_else(|| {
+        JsonRpcResponse::error(
+            value.get_answer_id(),
+            JsonRpcError::new(
+                JsonRpcErrorReason::ApplicationError(401),
+                "You need to call 'auth.login' first".to_string(),
+                json!({}),
+            ),
+        )
+    })?;
+    // If so, it is valid (and not expired)?
+    context.jwt().check(&token).map_err(|e| {
+        JsonRpcResponse::error(
+            value.get_answer_id(),
+            JsonRpcError::new(JsonRpcErrorReason::ApplicationError(401), e.to_string(), json!({})),
+        )
+    })?;
 
     match value.method.as_str().split_once('.') {
         Some(("rpc", "discover")) => call_handler(context, value, rpc::handle_discover).await,
@@ -95,13 +141,19 @@ async fn handler(
         },
         Some(("webrtc", "start")) => {
             let answer_id = value.get_answer_id();
-            let token = value.parse_params::<String>()?;
+            let signaling_server_token = value.parse_params::<String>()?;
             let shutdown_signal = (*shutdown_signal).clone();
             let (preferred_address, signaling_server_address) = *addresses.clone();
             tokio::spawn(async move {
-                webrtc_start_session(token, preferred_address, signaling_server_address, shutdown_signal)
-                    .await
-                    .unwrap();
+                webrtc_start_session(
+                    signaling_server_token,
+                    token,
+                    preferred_address,
+                    signaling_server_address,
+                    shutdown_signal,
+                )
+                .await
+                .unwrap();
             });
             Ok(JsonRpcResponse::success(answer_id, "started"))
         },

--- a/applications/tari_dan_wallet_daemon/src/jwt.rs
+++ b/applications/tari_dan_wallet_daemon/src/jwt.rs
@@ -1,0 +1,49 @@
+//   Copyright 2022 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use anyhow::Result;
+use jsonwebtoken::{decode, encode, DecodingKey, EncodingKey, Header, Validation};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone)]
+pub struct Jwt {
+    pub expiration: Duration,
+    pub secret_key: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct Claims {
+    exp: usize,
+}
+
+impl Jwt {
+    pub fn new(expiration: Duration, secret_key: String) -> Self {
+        Jwt { expiration, secret_key }
+    }
+
+    pub fn generate(&self) -> Result<String> {
+        let my_claims = Claims {
+            exp: (SystemTime::now() + self.expiration)
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_secs() as usize,
+        };
+        encode(
+            &Header::default(),
+            &my_claims,
+            &EncodingKey::from_secret(self.secret_key.as_ref()),
+        )
+        .map_err(anyhow::Error::new)
+    }
+
+    pub fn check(&self, token: &str) -> Result<()> {
+        decode::<Claims>(
+            token,
+            &DecodingKey::from_secret(self.secret_key.as_ref()),
+            &Validation::default(),
+        )?;
+        Ok(())
+    }
+}

--- a/applications/tari_dan_wallet_daemon/src/lib.rs
+++ b/applications/tari_dan_wallet_daemon/src/lib.rs
@@ -24,6 +24,7 @@ pub mod cli;
 pub mod config;
 mod handlers;
 mod jrpc_server;
+mod jwt;
 mod notify;
 mod services;
 mod webrtc;
@@ -34,7 +35,7 @@ use tari_dan_wallet_sdk::{apis::key_manager, DanWalletSdk, WalletSdkConfig};
 use tari_dan_wallet_storage_sqlite::SqliteWalletStore;
 use tari_shutdown::ShutdownSignal;
 
-use crate::{config::ApplicationConfig, handlers::HandlerContext, notify::Notify, services::spawn_services};
+use crate::{config::ApplicationConfig, handlers::HandlerContext, jwt::Jwt, notify::Notify, services::spawn_services};
 
 const _LOG_TARGET: &str = "tari::dan_wallet_daemon::main";
 
@@ -71,7 +72,11 @@ pub async fn run_tari_dan_wallet_daemon(
 
     let address = config.dan_wallet_daemon.listen_addr.unwrap();
     let signaling_server_address = config.dan_wallet_daemon.signaling_server_addr.unwrap();
-    let handlers = HandlerContext::new(wallet_sdk.clone(), notify);
+    let jwt = Jwt::new(
+        config.dan_wallet_daemon.jwt_expiration.unwrap(),
+        config.dan_wallet_daemon.secret_key.unwrap(),
+    );
+    let handlers = HandlerContext::new(wallet_sdk.clone(), notify, jwt);
     let listen_fut = jrpc_server::listen(address, signaling_server_address, handlers, shutdown_signal);
 
     // Wait for shutdown, or for any service to error

--- a/applications/tari_dan_wallet_web_ui/package-lock.json
+++ b/applications/tari_dan_wallet_web_ui/package-lock.json
@@ -13,6 +13,7 @@
         "@mui/icons-material": "^5.11.11",
         "@mui/material": "^5.11.14",
         "@mui/x-data-grid": "^6.0.2",
+        "async-mutex": "^0.4.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.9.0"
@@ -1127,6 +1128,14 @@
         "node": ">=4"
       }
     },
+    "node_modules/async-mutex": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.4.0.tgz",
+      "integrity": "sha512-eJFZ1YhRR8UN8eBLoNzcDPcy/jqjsg6I1AP+KvWQX80BqOSW1oJPJXDylPUEeMr2ZQvHgnQ//Lp6f3RQ1zI7HA==",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/babel-plugin-macros": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
@@ -1682,6 +1691,11 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/typescript": {
       "version": "4.9.5",

--- a/applications/tari_dan_wallet_web_ui/package.json
+++ b/applications/tari_dan_wallet_web_ui/package.json
@@ -14,6 +14,7 @@
     "@mui/icons-material": "^5.11.11",
     "@mui/material": "^5.11.14",
     "@mui/x-data-grid": "^6.0.2",
+    "async-mutex": "^0.4.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.9.0"

--- a/applications/tari_dan_wallet_web_ui/src/utils/json_rpc.tsx
+++ b/applications/tari_dan_wallet_web_ui/src/utils/json_rpc.tsx
@@ -20,24 +20,32 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import { Mutex } from "async-mutex";
 import { json } from "react-router-dom";
 
-export async function jsonRpc(method: string, params: any = null) {
-  let id = 0;
-  id += 1;
+let token: String | null = null;
+let json_id = 0;
+const mutex_token = new Mutex();
+const mutex_id = new Mutex();
+
+async function internalJsonRpc(method: string, token: any = null, params: any = null) {
+  let id;
+  await mutex_id.runExclusive(() => {
+    id = json_id;
+    json_id += 1;
+  })
   let address = "localhost:9000";
   try {
     let text = await (await fetch("json_rpc_address")).text();
     if (/^\d+(\.\d+){3}:[0-9]+$/.test(text)) {
       address = text;
     }
-  } catch {}
-  console.log(JSON.stringify({
-    method: method,
-    jsonrpc: "2.0",
-    id: id,
-    params: params,
-  }));
+  } catch { }
+  let headers: { [key: string]: string } = { "Content-Type": "application/json" };
+  if (token) {
+    headers["Authorization"] = `Bearer ${token}`
+  }
+
   let response = await fetch(`http://${address}`, {
     method: "POST",
     body: JSON.stringify({
@@ -46,9 +54,7 @@ export async function jsonRpc(method: string, params: any = null) {
       id: id,
       params: params,
     }),
-    headers: {
-      "Content-Type": "application/json",
-    },
+    headers: headers
   });
   let json = await response.json();
   if (json.error) {
@@ -58,8 +64,21 @@ export async function jsonRpc(method: string, params: any = null) {
   return json.result;
 }
 
+export async function jsonRpc(method: string, params: any = null) {
+  await mutex_token.runExclusive(async () => {
+    if (token === null) {
+      token = await internalJsonRpc("auth.login");
+    }
+  })
+  // This will fail if the token is expired
+  return internalJsonRpc(method, token, params)
+}
+
 
 // The 'any' types are structs I don't define them here, but we can add them later.
+
+// auth
+export const authLogin = () => jsonRpc("auth.login");
 
 // rpc
 export const rpcDiscover = () => jsonRpc("rpc.discover");

--- a/applications/tari_signaling_server/src/jrpc_server.rs
+++ b/applications/tari_signaling_server/src/jrpc_server.rs
@@ -142,14 +142,14 @@ async fn handler(
         }
     } else {
         result = match value.method() {
-            "get.jwt" => {
+            "auth.login" => {
                 info!(target: LOG_TARGET, "Generating new JWT token");
                 data.generate_jwt()
             },
             _ => {
                 error!(
                     target: LOG_TARGET,
-                    "Without bearer token there is only one method available \"get.jwt\""
+                    "Without bearer token there is only one method available \"auth.login\""
                 );
                 return Ok(JsonRpcResponse::error(
                     answer_id,

--- a/applications/tari_web_extension/static/inject.js
+++ b/applications/tari_web_extension/static/inject.js
@@ -9,7 +9,7 @@ class SignaligServer {
   }
 
   async initToken() {
-    this.token = await this.#getToken()
+    this.token = await this.#authLogin()
     window.tari_token = this.token;
   }
 
@@ -45,8 +45,8 @@ class SignaligServer {
     return json.result;
   }
 
-  async #getToken() {
-    return await this.#jsonRpc("get.jwt");
+  async #authLogin() {
+    return await this.#jsonRpc("auth.login");
   }
 
   async storeIceCandidate(ice_candidate) {

--- a/clients/wallet_daemon_client/src/types.rs
+++ b/clients/wallet_daemon_client/src/types.rs
@@ -130,6 +130,9 @@ pub struct TransactionClaimBurnResponse {
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct AuthLoginRequest {}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct KeysListRequest {}
 
 #[derive(Debug, Clone, Deserialize, Serialize)]


### PR DESCRIPTION
Description
---
Add jwt token to wallet daemon.
When starting the webrtc, you need to get the token, the webrtc calls then use this token for the jrpc server calls.
Currently the token is free to get (no real auth is going on). The expiration and secret key are set in config.

How Has This Been Tested?
---
Not yet.

What process can a PR reviewer use to test or verify this change?
---
Can be tested by setting up the extension (including the signaling server).

Breaking Changes
---
This will require dan wallet web ui to be updated.

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify