### PR TITLE
fix: invalid URL format on wallet daemon cucumber utils

### DIFF
--- a/applications/tari_validator_node/tests/log4rs/cucumber.yml
+++ b/applications/tari_validator_node/tests/log4rs/cucumber.yml
@@ -125,6 +125,13 @@ loggers:
       - stdout
       - dan_layer
     additive: false
+
+  tari::dan::wallet_sdk:
+    level: debug
+    appenders:
+      - stdout
+      - dan_layer
+    additive: false
   
   tari::indexer:
     level: debug

--- a/applications/tari_validator_node/tests/utils/wallet_daemon.rs
+++ b/applications/tari_validator_node/tests/utils/wallet_daemon.rs
@@ -60,7 +60,7 @@ pub async fn spawn_wallet_daemon(world: &mut TariWorld, wallet_daemon_name: Stri
 
     let listen_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), json_rpc_port);
     let signaling_server_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), signaling_server_port);
-    let validator_node_endpoint = format!("/ip4/127.0.0.1/tcp/{}", validator_node_jrpc_port);
+    let validator_node_endpoint = format!("http://127.0.0.1:{}/json_rpc", validator_node_jrpc_port);
 
     let mut config = ApplicationConfig {
         common: CommonConfig::default(),


### PR DESCRIPTION
Description
---
* Adapted the VN URL format to the expected one in the cucumber util
* Added wallet daemon log target to the cucumber log configuration, to make it easier to debug problems in the future

Motivation and Context
---
Recent changes broke the wallet daemon util in the cucumber tests, as the VN URL format is now different.

How Has This Been Tested?
---
The previously broken integration test now passes

What process can a PR reviewer use to test or verify this change?
---
Run the integration tests

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify