### PR TITLE
feat: add transaction construction to daemon

### DIFF
--- a/applications/tari_dan_wallet_daemon/src/handlers/transaction.rs
+++ b/applications/tari_dan_wallet_daemon/src/handlers/transaction.rs
@@ -1,6 +1,6 @@
 //   Copyright 2023 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
-use std::{collections::HashSet, time::Duration};
+use std::{collections::HashSet, convert::TryFrom, time::Duration};
 
 use anyhow::anyhow;
 use futures::{future, future::Either};
@@ -8,9 +8,10 @@ use log::*;
 use tari_dan_common_types::{optional::Optional, ShardId};
 use tari_dan_wallet_sdk::apis::{jwt::JrpcPermission, key_manager};
 use tari_engine_types::{instruction::Instruction, substate::SubstateAddress};
-use tari_template_lib::{models::Amount, prelude::NonFungibleAddress};
+use tari_template_lib::{args, models::Amount, prelude::NonFungibleAddress};
 use tari_transaction::Transaction;
 use tari_wallet_daemon_client::types::{
+    CallInstructionRequest,
     TransactionGetRequest,
     TransactionGetResponse,
     TransactionGetResultRequest,
@@ -29,6 +30,43 @@ use crate::{
 };
 
 const LOG_TARGET: &str = "tari::dan_wallet_daemon::handlers::transaction";
+
+pub async fn handle_submit_instruction(
+    context: &HandlerContext,
+    token: Option<String>,
+    req: CallInstructionRequest,
+) -> Result<TransactionSubmitResponse, anyhow::Error> {
+    let mut instructions = vec![req.instruction];
+    if let Some(dump_account) = req.dump_outputs_into {
+        instructions.push(Instruction::PutLastInstructionOutputOnWorkspace {
+            key: b"bucket".to_vec(),
+        });
+        instructions.push(Instruction::CallMethod {
+            component_address: dump_account.address.as_component_address().unwrap(),
+            method: "deposit".to_string(),
+            args: args![Variable("bucket")],
+        });
+    }
+    let request = TransactionSubmitRequest {
+        signing_key_index: None,
+        fee_instructions: vec![Instruction::CallMethod {
+            component_address: req.fee_account.address.as_component_address().unwrap(),
+            method: "pay_fee".to_string(),
+            args: args![Amount::try_from(req.fee)?],
+        }],
+        instructions,
+        inputs: req.inputs,
+        override_inputs: req.override_inputs.unwrap_or_default(),
+        new_outputs: req.new_outputs.unwrap_or(0),
+        specific_non_fungible_outputs: req.specific_non_fungible_outputs,
+        new_resources: req.new_resources,
+        new_non_fungible_outputs: req.new_non_fungible_outputs,
+        new_non_fungible_index_outputs: req.new_non_fungible_index_outputs,
+        is_dry_run: req.is_dry_run,
+        proof_ids: vec![],
+    };
+    handle_submit(context, token, request).await
+}
 
 pub async fn handle_submit(
     context: &HandlerContext,

--- a/applications/tari_dan_wallet_daemon/src/jrpc_server.rs
+++ b/applications/tari_dan_wallet_daemon/src/jrpc_server.rs
@@ -99,6 +99,7 @@ async fn handler(
             _ => Ok(value.method_not_found(&value.method)),
         },
         Some(("transactions", method)) => match method {
+            "submit_instruction" => call_handler(context, value, token, transaction::handle_submit_instruction).await,
             "submit" => call_handler(context, value, token, transaction::handle_submit).await,
             "get" => call_handler(context, value, token, transaction::handle_get).await,
             "get_result" => call_handler(context, value, token, transaction::handle_get_result).await,

--- a/clients/wallet_daemon_client/src/types.rs
+++ b/clients/wallet_daemon_client/src/types.rs
@@ -48,6 +48,23 @@ use crate::{
 };
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct CallInstructionRequest {
+    pub instruction: Instruction,
+    pub fee_account: Account,
+    pub dump_outputs_into: Option<Account>,
+    pub fee: u64,
+    pub inputs: Vec<VersionedSubstateAddress>,
+    pub override_inputs: Option<bool>,
+    pub new_outputs: Option<u8>,
+    pub specific_non_fungible_outputs: Vec<(ResourceAddress, NonFungibleId)>,
+    pub new_resources: Vec<(TemplateAddress, String)>,
+    pub new_non_fungible_outputs: Vec<(ResourceAddress, u8)>,
+    pub new_non_fungible_index_outputs: Vec<(ResourceAddress, u64)>,
+    pub is_dry_run: bool,
+    pub proof_ids: Vec<ConfidentialProofId>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct TransactionSubmitRequest {
     pub signing_key_index: Option<u64>,
     pub fee_instructions: Vec<Instruction>,

--- a/clients/wallet_daemon_client/src/types.rs
+++ b/clients/wallet_daemon_client/src/types.rs
@@ -50,8 +50,8 @@ use crate::{
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct CallInstructionRequest {
     pub instruction: Instruction,
-    pub fee_account: Account,
-    pub dump_outputs_into: Option<Account>,
+    pub fee_account: ComponentAddressOrName,
+    pub dump_outputs_into: Option<ComponentAddressOrName>,
     pub fee: u64,
     pub inputs: Vec<VersionedSubstateAddress>,
     pub override_inputs: Option<bool>,


### PR DESCRIPTION
Description
---
Now you can call transaction over the jrpc (instruction `transactions.call_instruction` (any name suggestions are welcome), the boilerplate (account
```
let fee_account_name = "fee_account_name";

let instruction = {
  CallFunction: {
    template_address: [
      1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30,
      31, 32,
    ],
    function: "function_name",
    args: [],
  }
};

jsonRpc("transactions.call_instruction", [
  instruction,
  fee_account_name,
  null, // dump_outputs_into
  1000, // fee
  [],   // inputs
  null, // override_inputs
  null, // new_outputs
  [],   // specific_non_fungible_outputs
  [],   // new_resources
  [],   // new_non_fungible_outputs
  [],   // new_non_fungible_index_outputs
  true, // is_dry_run
  [],   // proof_ids
]);
```


What process can a PR reviewer use to test or verify this change?
---
Use the code above with appropriate `template_address`, `function_name`, `args`, and `fee_account_name` (has to be valid). All other fields are default values. 

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify