### PR TITLE
fix: wallet daemon reads wrong directory in cucumber

### DIFF
--- a/applications/tari_validator_node/tests/utils/wallet_daemon.rs
+++ b/applications/tari_validator_node/tests/utils/wallet_daemon.rs
@@ -67,6 +67,7 @@ pub async fn spawn_wallet_daemon(world: &mut TariWorld, wallet_daemon_name: Stri
         dan_wallet_daemon: WalletDaemonConfig::default(),
     };
 
+    config.common.base_path = base_dir.clone();
     config.dan_wallet_daemon.listen_addr = Some(listen_addr);
     config.dan_wallet_daemon.signaling_server_addr = Some(signaling_server_addr);
     config.dan_wallet_daemon.validator_node_endpoint = Some(validator_node_endpoint);


### PR DESCRIPTION
Description
---
Fixed the wallet daemon cucumber config so it reads and writes in a temporal data folder instead of the _home_ folder of the user. This caused the cucumber test execution to be inconsistent between machines.

Motivation and Context
---
Recently some errors start appearing when running cucumber in local machines (not in Github CI), related to the wallet daemon having conflicts when reading or writing to database.

The error messages are of the type:
```
ERROR Error checking pending transactions: Accounts API error: Store error: General database failure for operation
accounts_get_many: no such column: accounts.balance
[applications\tari_dan_wallet_daemon\src\services\account_monitor.rs
```

How Has This Been Tested?
---
The execution error do not appear anymore in local machines.

What process can a PR reviewer use to test or verify this change?
---
This can only be verified if you experience the problem in your local machine, with this fix the problem should not happen anymore.

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify