### PR TITLE
chore: add template type to command line args

### DIFF
--- a/applications/tari_validator_node_cli/src/command/template.rs
+++ b/applications/tari_validator_node_cli/src/command/template.rs
@@ -55,6 +55,9 @@ pub struct PublishTemplateArgs {
     #[clap(long, alias = "template-version")]
     pub template_version: Option<u16>,
 
+    #[clap(long, alias = "template-type")]
+    pub template_type: Option<String>,
+
     #[clap(long, short = 'u', alias = "binary-url", alias = "url")]
     pub binary_url: Option<String>,
 }
@@ -191,6 +194,7 @@ async fn handle_publish(args: PublishTemplateArgs, mut client: ValidatorNodeClie
 
     let template_type = Prompt::new("Choose a template type (wasm, flow):")
         .with_default("wasm")
+        .with_value(args.template_type)
         .ask()?;
 
     // TODO: ask repository info


### PR DESCRIPTION
Description
---
Add template type to command line arguments. So the validator_node_cli can be run without human interaction.

How Has This Been Tested?
---
Manually.

What process can a PR reviewer use to test or verify this change?
---
Run tari_validator_node_cli with e.g. `--template-type wasm` when publishing template

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify