### PR TITLE
feat(walletd): scan vaults belonging to accounts, scan destination accounts when sending

### DIFF
--- a/applications/tari_dan_app_grpc/src/conversions/transaction.rs
+++ b/applications/tari_dan_app_grpc/src/conversions/transaction.rs
@@ -144,6 +144,10 @@ impl TryFrom<proto::transaction::Instruction> for tari_engine_types::instruction
                     withdraw_proof: request.claim_burn_withdraw_proof.map(TryInto::try_into).transpose()?,
                 }),
             },
+            101 => Instruction::CreateFreeTestCoins {
+                amount: request.create_free_test_coins_amount,
+                private_key: request.create_free_test_coins_private_key,
+            },
             _ => return Err(anyhow!("invalid instruction_type")),
         };
 
@@ -193,7 +197,11 @@ impl From<Instruction> for proto::transaction::Instruction {
                 result.claim_burn_public_key = claim.public_key.to_vec();
                 result.claim_burn_withdraw_proof = claim.withdraw_proof.map(Into::into);
             },
+            // TODO: debugging feature should not be the default. Perhaps a better way to create faucet coins is to mint
+            //       a faucet vault in the genesis state for dev networks and use faucet builtin template to withdraw
+            //       funds.
             Instruction::CreateFreeTestCoins { amount, private_key } => {
+                result.instruction_type = 101;
                 result.create_free_test_coins_amount = amount;
                 result.create_free_test_coins_private_key = private_key;
             },

--- a/applications/tari_dan_wallet_cli/src/command/account.rs
+++ b/applications/tari_dan_wallet_cli/src/command/account.rs
@@ -325,10 +325,15 @@ async fn handle_list(client: &mut WalletDaemonClient) -> Result<(), anyhow::Erro
 
     let mut table = Table::new();
     table.enable_row_count();
-    table.set_titles(vec!["Name", "Address", "Public Key"]);
+    table.set_titles(vec!["Name", "Address", "Public Key", "Default"]);
     println!("Accounts:");
     for AccountInfo { account, public_key } in resp.accounts {
-        table.add_row(table_row!(account.name, account.address, public_key));
+        table.add_row(table_row!(
+            account.name,
+            account.address,
+            public_key,
+            if account.is_default { "✅" } else { "" }
+        ));
     }
     table.print_stdout();
     Ok(())

--- a/applications/tari_dan_wallet_cli/src/command/account.rs
+++ b/applications/tari_dan_wallet_cli/src/command/account.rs
@@ -227,6 +227,7 @@ async fn handle_get_balances(args: GetBalancesArgs, client: &mut WalletDaemonCli
     let resp = client
         .get_account_balances(AccountsGetBalancesRequest {
             account: args.account_name,
+            refresh: true,
         })
         .await?;
 

--- a/applications/tari_dan_wallet_daemon/src/handlers/accounts.rs
+++ b/applications/tari_dan_wallet_daemon/src/handlers/accounts.rs
@@ -236,6 +236,12 @@ pub async fn handle_get_balances(
     let account = get_account_or_default(req.account, sdk)?;
     sdk.jwt_api()
         .check_auth(token, &[JrpcPermission::AccountBalance(account.clone().address)])?;
+    if req.refresh {
+        context
+            .account_monitor()
+            .refresh_account(account.address.clone())
+            .await?;
+    }
     let vaults = sdk.accounts_api().get_vaults_by_account(&account.address)?;
     let outputs_api = sdk.confidential_outputs_api();
 

--- a/applications/tari_dan_wallet_daemon/src/handlers/accounts.rs
+++ b/applications/tari_dan_wallet_daemon/src/handlers/accounts.rs
@@ -14,7 +14,7 @@ use tari_crypto::{
 };
 use tari_dan_common_types::{optional::Optional, ShardId};
 use tari_dan_wallet_sdk::{
-    apis::{jwt::JrpcPermission, key_manager},
+    apis::{jwt::JrpcPermission, key_manager, substate::ValidatorScanResult},
     confidential::{get_commitment_factory, ConfidentialProofStatement},
     models::{ConfidentialOutputModel, OutputStatus, VersionedSubstateAddress},
 };
@@ -570,9 +570,12 @@ pub async fn handle_claim_burn(
     );
 
     // We have to unmask the commitment to allow us to reveal funds for the fee payment
-    let (_, output) = sdk
+    let ValidatorScanResult { substate: output, .. } = sdk
         .substate_api()
-        .scan_from_vn(&commitment_substate_address.address)
+        .scan_from_vn(
+            &commitment_substate_address.address,
+            Some(commitment_substate_address.version),
+        )
         .await?;
     let output = output.into_unclaimed_confidential_output().unwrap();
     let unmasked_output = sdk.confidential_crypto_api().unblind_output(

--- a/applications/tari_dan_wallet_daemon/src/handlers/accounts.rs
+++ b/applications/tari_dan_wallet_daemon/src/handlers/accounts.rs
@@ -116,8 +116,14 @@ pub async fn handle_create(
         .find(|(addr, _)| addr.is_component())
         .ok_or_else(|| anyhow!("Create account transaction accepted but no component address was returned"))?;
 
-    sdk.accounts_api()
-        .add_account(req.account_name.as_deref(), addr, key_index, req.is_default)?;
+    let is_first_account = sdk.accounts_api().count()? == 0;
+
+    sdk.accounts_api().add_account(
+        req.account_name.as_deref(),
+        addr,
+        key_index,
+        req.is_default || is_first_account,
+    )?;
 
     Ok(AccountsCreateResponse {
         address: addr.clone(),

--- a/applications/tari_dan_wallet_daemon/src/handlers/context.rs
+++ b/applications/tari_dan_wallet_daemon/src/handlers/context.rs
@@ -4,17 +4,29 @@
 use tari_dan_wallet_sdk::DanWalletSdk;
 use tari_dan_wallet_storage_sqlite::SqliteWalletStore;
 
-use crate::{notify::Notify, services::WalletEvent};
+use crate::{
+    notify::Notify,
+    services::{AccountMonitorHandle, WalletEvent},
+};
 
 #[derive(Debug, Clone)]
 pub struct HandlerContext {
     wallet_sdk: DanWalletSdk<SqliteWalletStore>,
     notifier: Notify<WalletEvent>,
+    account_monitor: AccountMonitorHandle,
 }
 
 impl HandlerContext {
-    pub fn new(wallet_sdk: DanWalletSdk<SqliteWalletStore>, notifier: Notify<WalletEvent>) -> Self {
-        Self { wallet_sdk, notifier }
+    pub fn new(
+        wallet_sdk: DanWalletSdk<SqliteWalletStore>,
+        notifier: Notify<WalletEvent>,
+        account_monitor: AccountMonitorHandle,
+    ) -> Self {
+        Self {
+            wallet_sdk,
+            notifier,
+            account_monitor,
+        }
     }
 
     pub fn notifier(&self) -> &Notify<WalletEvent> {
@@ -23,5 +35,9 @@ impl HandlerContext {
 
     pub fn wallet_sdk(&self) -> &DanWalletSdk<SqliteWalletStore> {
         &self.wallet_sdk
+    }
+
+    pub fn account_monitor(&self) -> &AccountMonitorHandle {
+        &self.account_monitor
     }
 }

--- a/applications/tari_dan_wallet_daemon/src/handlers/transaction.rs
+++ b/applications/tari_dan_wallet_daemon/src/handlers/transaction.rs
@@ -49,9 +49,8 @@ pub async fn handle_submit(
         // If we are not overriding inputs, we will use inputs that we know about in the local substate address db
         let mut substates = get_referenced_component_addresses(&req.instructions);
         substates.extend(get_referenced_component_addresses(&req.fee_instructions));
-        let loaded_dependent_substates = sdk
-            .substate_api()
-            .load_dependent_substates(&substates.iter().collect::<Vec<_>>())?;
+        let substates = substates.iter().collect::<Vec<_>>();
+        let loaded_dependent_substates = sdk.substate_api().locate_dependent_substates(&substates).await?;
         vec![req.inputs, loaded_dependent_substates].concat()
     };
 

--- a/applications/tari_dan_wallet_daemon/src/handlers/webrtc.rs
+++ b/applications/tari_dan_wallet_daemon/src/handlers/webrtc.rs
@@ -21,7 +21,7 @@ pub fn handle_start(
     value: JsonRpcExtractor,
     token: Option<String>,
     shutdown_signal: Arc<ShutdownSignal>,
-    addresses: Arc<(SocketAddr, SocketAddr)>,
+    addresses: (SocketAddr, SocketAddr),
 ) -> JrpcResult {
     let answer_id = value.get_answer_id();
     context
@@ -40,8 +40,8 @@ pub fn handle_start(
         })?;
     let webrtc_start_request = value.parse_params::<WebRtcStartRequest>()?;
     let shutdown_signal = (*shutdown_signal).clone();
-    let (preferred_address, signaling_server_address) = *addresses.clone();
     tokio::spawn(async move {
+        let (preferred_address, signaling_server_address) = addresses;
         webrtc_start_session(
             webrtc_start_request.signaling_server_token,
             webrtc_start_request.permissions_token,

--- a/applications/tari_dan_wallet_daemon/src/jrpc_server.rs
+++ b/applications/tari_dan_wallet_daemon/src/jrpc_server.rs
@@ -57,7 +57,7 @@ pub async fn listen(
         // TODO: Get these traces to work
         .layer(TraceLayer::new_for_http())
         .layer(Extension(Arc::new(context)))
-        .layer(Extension(Arc::new((preferred_address,signaling_server_address))))
+        .layer(Extension((preferred_address,signaling_server_address)))
         .layer(Extension(Arc::new(shutdown_signal.clone())))
         .layer(CorsLayer::permissive())
         .layer(axum::middleware::from_fn(extract_token));
@@ -74,7 +74,7 @@ pub async fn listen(
 
 async fn handler(
     Extension(context): Extension<Arc<HandlerContext>>,
-    Extension(addresses): Extension<Arc<(SocketAddr, SocketAddr)>>,
+    Extension(addresses): Extension<(SocketAddr, SocketAddr)>,
     Extension(shutdown_signal): Extension<Arc<ShutdownSignal>>,
     Extension(token): Extension<Option<String>>,
     value: JsonRpcExtractor,

--- a/applications/tari_dan_wallet_daemon/src/services/account_monitor.rs
+++ b/applications/tari_dan_wallet_daemon/src/services/account_monitor.rs
@@ -1,7 +1,7 @@
 //   Copyright 2023 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use std::time::Duration;
+use std::{collections::HashMap, time::Duration};
 
 use log::*;
 use tari_dan_common_types::optional::Optional;
@@ -9,13 +9,14 @@ use tari_dan_wallet_sdk::{
     apis::{
         accounts::AccountsApiError,
         confidential_outputs::ConfidentialOutputsApiError,
-        substate::SubstateApiError,
+        substate::{SubstateApiError, ValidatorScanResult},
         transaction::TransactionApiError,
     },
     storage::WalletStore,
     DanWalletSdk,
 };
 use tari_engine_types::{
+    indexed_value::{IndexedValue, ValueVisitorError},
     substate::{SubstateAddress, SubstateDiff, SubstateValue},
     vault::Vault,
 };
@@ -63,7 +64,7 @@ where TStore: WalletStore + Clone + Send + Sync + 'static
                     self.on_poll().await;
                 }
 
-                  Ok(event) = events_subscription.recv() => {
+                Ok(event) = events_subscription.recv() => {
                     if let Err(e) = self.on_event(event).await {
                         error!(target: LOG_TARGET, "Error handling event: {}", e);
                     }
@@ -79,41 +80,15 @@ where TStore: WalletStore + Clone + Send + Sync + 'static
     }
 
     async fn refresh_all_accounts(&self) -> Result<(), AccountMonitorError> {
-        let substate_api = self.wallet_sdk.substate_api();
         let accounts_api = self.wallet_sdk.accounts_api();
         // TODO: There could be more than 100 accounts
         let accounts = accounts_api.get_many(0, 100)?;
-        let mut is_updated = false;
         for account in accounts {
             info!(
                 target: LOG_TARGET,
-                "👁️‍🗨️ Checking balance for account '{}' {}", account.name, account.address
+                "👁️‍🗨️ Refreshing account '{}' {}", account.name, account.address
             );
-            let account_children = substate_api.load_dependent_substates(&[&account.address])?;
-            // TODO: Support detecting new vaults
-            let known_child_vaults = account_children
-                .iter()
-                .filter(|s| s.address.is_vault())
-                .collect::<Vec<_>>();
-            for vault in known_child_vaults {
-                let substate = substate_api.scan_from_vn(&vault.address).await.optional()?;
-                let Some((versioned_addr, substate)) = substate else {
-                    warn!(target: LOG_TARGET, "Account {} does not exist according to validator node", account.address);
-                    continue;
-                };
-                if versioned_addr.version == vault.version {
-                    debug!(target: LOG_TARGET, "Vault {} is up to date", versioned_addr.address);
-                    continue;
-                }
-
-                let SubstateValue::Vault(vault) = substate else {
-                    error!(target: LOG_TARGET, "Substate {} is not a vault. This should be impossible.", vault.address);
-                    continue;
-                };
-
-                is_updated = true;
-                self.refresh_vault(&account.address, &vault)?;
-            }
+            let is_updated = self.refresh_account(&account.address).await?;
 
             if is_updated {
                 self.notify.notify(AccountChangedEvent {
@@ -129,15 +104,85 @@ where TStore: WalletStore + Clone + Send + Sync + 'static
         Ok(())
     }
 
+    async fn refresh_account(&self, account_address: &SubstateAddress) -> Result<bool, AccountMonitorError> {
+        let substate_api = self.wallet_sdk.substate_api();
+        let mut is_updated = false;
+        let account_substate = substate_api.get_substate(account_address)?;
+        let ValidatorScanResult {
+            address: versioned_account_address,
+            substate: account_value,
+            created_by_tx,
+        } = substate_api
+            .scan_from_vn(
+                &account_substate.address.address,
+                Some(account_substate.address.version),
+            )
+            .await?;
+
+        substate_api.save_root(created_by_tx, versioned_account_address.clone())?;
+
+        let vaults_value = IndexedValue::from_raw(&account_value.component().unwrap().state.state)?;
+        let known_child_vaults = substate_api
+            .load_dependent_substates(&[&account_substate.address.address])?
+            .into_iter()
+            .filter(|s| s.address.is_vault())
+            .map(|s| (s.address, s.version))
+            .collect::<HashMap<_, _>>();
+        for vault in vaults_value.vault_ids() {
+            let vault_addr = SubstateAddress::Vault(*vault);
+            let maybe_vault_version = known_child_vaults.get(&vault_addr).copied();
+            let scan_result = substate_api
+                .scan_from_vn(&vault_addr, maybe_vault_version)
+                .await
+                .optional()?;
+            let Some(ValidatorScanResult { address: versioned_addr, substate, created_by_tx}) = scan_result else {
+                warn!(target: LOG_TARGET, "Vault {} for account {} does not exist according to validator node", vault_addr, versioned_account_address);
+                continue;
+            };
+
+            if let Some(vault_version) = maybe_vault_version {
+                if versioned_addr.version == vault_version {
+                    debug!(target: LOG_TARGET, "Vault {} is up to date", versioned_addr.address);
+                    continue;
+                }
+            }
+
+            let SubstateValue::Vault(vault) = substate else {
+                error!(target: LOG_TARGET, "Substate {} is not a vault. This should be impossible.", vault_addr);
+                continue;
+            };
+
+            is_updated = true;
+
+            substate_api.save_child(created_by_tx, versioned_account_address.address.clone(), versioned_addr)?;
+            self.refresh_vault(&versioned_account_address.address, &vault)?;
+        }
+
+        Ok(is_updated)
+    }
+
     fn refresh_vault(&self, account_addr: &SubstateAddress, vault: &Vault) -> Result<(), AccountMonitorError> {
+        let accounts_api = self.wallet_sdk.accounts_api();
+
         let balance = vault.balance();
         let vault_addr = SubstateAddress::Vault(*vault.vault_id());
-        self.wallet_sdk
-            .accounts_api()
-            .update_vault_balance(&vault_addr, balance)?;
+        if accounts_api.has_vault(&vault_addr)? {
+            accounts_api.update_vault_balance(&vault_addr, balance)?;
+        } else {
+            accounts_api.add_vault(
+                account_addr.clone(),
+                vault_addr.clone(),
+                *vault.resource_address(),
+                vault.resource_type(),
+                // TODO: fetch the token symbol from the resource
+                None,
+            )?;
+
+            accounts_api.update_vault_balance(&vault_addr, balance)?;
+        }
         info!(
             target: LOG_TARGET,
-            "👁️‍🗨️ vault {} in account {} has new balance {}",
+            "🔒️ vault {} in account {} has new balance {}",
             vault.vault_id(),
             account_addr,
             balance
@@ -145,7 +190,7 @@ where TStore: WalletStore + Clone + Send + Sync + 'static
         if let Some(outputs) = vault.get_confidential_outputs() {
             info!(
                 target: LOG_TARGET,
-                "👁️‍🗨️ vault {} in account {} has {} confidential outputs",
+                "🔒️ vault {} in account {} has {} confidential outputs",
                 vault.vault_id(),
                 account_addr,
                 outputs.len()
@@ -158,6 +203,7 @@ where TStore: WalletStore + Clone + Send + Sync + 'static
     }
 
     async fn process_result(&self, diff: &SubstateDiff) -> Result<(), AccountMonitorError> {
+        let substate_api = self.wallet_sdk.substate_api();
         let vaults = diff.up_iter().filter(|(a, _)| a.is_vault()).collect::<Vec<_>>();
         for (vault_addr, substate) in vaults {
             let SubstateValue::Vault(vault) = substate.substate_value() else {
@@ -166,7 +212,7 @@ where TStore: WalletStore + Clone + Send + Sync + 'static
             };
 
             // Try and get the account address from the vault
-            let maybe_vault_substate = self.wallet_sdk.substate_api().get_substate(vault_addr).optional()?;
+            let maybe_vault_substate = substate_api.get_substate(vault_addr).optional()?;
             let Some(vault_substate) = maybe_vault_substate else{
                 // This should be impossible.
                 error!(target: LOG_TARGET, "👁️‍🗨️ Vault {} is not a known substate.", vault_addr);
@@ -195,14 +241,16 @@ where TStore: WalletStore + Clone + Send + Sync + 'static
             }
 
             // Add the vault if it does not exist
-            if !self.wallet_sdk.accounts_api().has_vault(&vault_addr)? {
-                let scan_result = self
-                    .wallet_sdk
-                    .substate_api()
-                    .scan_from_vn(&(*vault.resource_address()).into())
-                    .await;
+            if !self.wallet_sdk.accounts_api().has_vault(vault_addr)? {
+                let resx_addr = SubstateAddress::Resource(*vault.resource_address());
+                let version = substate_api
+                    .get_substate(&resx_addr)
+                    .optional()?
+                    .map(|s| s.address.version)
+                    .unwrap_or(0);
+                let scan_result = substate_api.scan_from_vn(&resx_addr, Some(version)).await;
                 let maybe_resource = match scan_result {
-                    Ok((_, resource)) => {
+                    Ok(ValidatorScanResult { substate: resource, .. }) => {
                         let resx = resource.into_resource().ok_or_else(|| {
                             AccountMonitorError::UnexpectedSubstate(format!(
                                 "Expected {} to be a resource.",
@@ -261,20 +309,6 @@ where TStore: WalletStore + Clone + Send + Sync + 'static
     }
 }
 
-// fn extract_vault_ids(account_state: &[u8]) -> Vec<VaultId> {
-//     use std::collections::HashMap;
-//
-//     use tari_bor::{borsh, decode_exact, Decode};
-//     // HACK: This is brittle, the account structure could change
-//     #[derive(Decode)]
-//     struct AccountDecode {
-//         vaults: HashMap<ResourceAddress, tari_template_lib::models::Vault>,
-//     }
-//
-//     let account = decode_exact::<AccountDecode>(account_state).unwrap();
-//     account.vaults.values().map(|v| v.vault_id()).collect()
-// }
-
 #[derive(Debug, thiserror::Error)]
 pub enum AccountMonitorError {
     #[error("Transaction API error: {0}")]
@@ -287,4 +321,6 @@ pub enum AccountMonitorError {
     ConfidentialOutputs(#[from] ConfidentialOutputsApiError),
     #[error("Unexpected substate: {0}")]
     UnexpectedSubstate(String),
+    #[error("Failed to decode binary value: {0}")]
+    DecodeValueFailed(#[from] ValueVisitorError),
 }

--- a/applications/tari_dan_wallet_daemon/src/services/mod.rs
+++ b/applications/tari_dan_wallet_daemon/src/services/mod.rs
@@ -5,33 +5,45 @@ mod events;
 pub use events::*;
 
 mod account_monitor;
+pub use account_monitor::AccountMonitorHandle;
+
 mod transaction_service;
 
 // -------------------------------- Spawn -------------------------------- //
-use std::future::Future;
 
 use anyhow::anyhow;
-use futures::future;
+use futures::{future, future::BoxFuture, FutureExt};
 use tari_dan_wallet_sdk::{storage::WalletStore, DanWalletSdk};
 use tari_shutdown::ShutdownSignal;
-use tokio::task::JoinHandle;
+use tokio::{sync::oneshot, task::JoinHandle};
 use transaction_service::TransactionService;
 
 use crate::{notify::Notify, services::account_monitor::AccountMonitor};
+
+pub(self) type Reply<T> = oneshot::Sender<T>;
 
 pub fn spawn_services<TStore>(
     shutdown_signal: ShutdownSignal,
     notify: Notify<WalletEvent>,
     wallet_sdk: DanWalletSdk<TStore>,
-) -> impl Future<Output = Result<(), anyhow::Error>>
+) -> Services
 where
     TStore: WalletStore + Clone + Send + Sync + 'static,
 {
-    let transaction_service_handle =
+    let transaction_service_join_handle =
         tokio::spawn(TransactionService::new(notify.clone(), wallet_sdk.clone(), shutdown_signal.clone()).run());
-    let account_monitor_handle = tokio::spawn(AccountMonitor::new(notify, wallet_sdk, shutdown_signal).run());
+    let (account_monitor, account_monitor_handle) = AccountMonitor::new(notify, wallet_sdk, shutdown_signal);
+    let account_monitor_join_handle = tokio::spawn(account_monitor.run());
 
-    try_select_any([transaction_service_handle, account_monitor_handle])
+    Services {
+        account_monitor_handle,
+        services_fut: try_select_any([transaction_service_join_handle, account_monitor_join_handle]).boxed(),
+    }
+}
+
+pub struct Services {
+    pub services_fut: BoxFuture<'static, Result<(), anyhow::Error>>,
+    pub account_monitor_handle: AccountMonitorHandle,
 }
 
 async fn try_select_any<I>(handles: I) -> Result<(), anyhow::Error>

--- a/applications/tari_validator_node/src/json_rpc/handlers.rs
+++ b/applications/tari_validator_node/src/json_rpc/handlers.rs
@@ -390,18 +390,20 @@ impl JsonRpcHandlers {
         let shard_id = ShardId::from_address(&data.address, data.version);
         match tx.get_substate_states(&[shard_id]) {
             Ok(substates) => {
-                let (value, status) = if substates.is_empty() {
-                    (None, SubstateStatus::DoesNotExist)
+                let (value, tx_hash, status) = if substates.is_empty() {
+                    (None, None, SubstateStatus::DoesNotExist)
                 } else if substates[0].destroyed_height().is_some() {
-                    (None, SubstateStatus::Down)
+                    (None, None, SubstateStatus::Down)
                 } else {
                     (
                         Some(substates[0].substate().substate_value().clone()),
+                        Some(substates[0].created_payload_id().into_array().into()),
                         SubstateStatus::Up,
                     )
                 };
                 Ok(JsonRpcResponse::success(answer_id, GetSubstateResponse {
                     status,
+                    created_by_tx: tx_hash,
                     value,
                 }))
             },

--- a/applications/tari_validator_node/src/p2p/services/template_manager/service.rs
+++ b/applications/tari_validator_node/src/p2p/services/template_manager/service.rs
@@ -131,7 +131,10 @@ impl TemplateManagerService {
     }
 
     fn handle_load_template_abi(&mut self, address: TemplateAddress) -> Result<TemplateAbi, TemplateManagerError> {
-        let loaded = self.manager.get_template_module(&address)?;
+        let loaded = self
+            .manager
+            .get_template_module(&address)?
+            .ok_or(TemplateManagerError::TemplateNotFound { address })?;
         Ok(TemplateAbi {
             template_name: loaded.template_def().template_name.clone(),
             functions: loaded

--- a/clients/validator_node_client/src/types.rs
+++ b/clients/validator_node_client/src/types.rs
@@ -263,6 +263,7 @@ pub struct GetSubstateRequest {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GetSubstateResponse {
     pub value: Option<SubstateValue>,
+    pub created_by_tx: Option<FixedHash>,
     pub status: SubstateStatus,
 }
 

--- a/clients/wallet_daemon_client/src/types.rs
+++ b/clients/wallet_daemon_client/src/types.rs
@@ -214,6 +214,7 @@ pub struct AccountsListResponse {
 pub struct AccountsGetBalancesRequest {
     #[serde(deserialize_with = "opt_string_or_struct")]
     pub account: Option<ComponentAddressOrName>,
+    pub refresh: bool,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/dan_layer/common_types/src/services/template_provider.rs
+++ b/dan_layer/common_types/src/services/template_provider.rs
@@ -7,5 +7,5 @@ pub trait TemplateProvider: Send + Sync + 'static {
     type Template;
     type Error: std::error::Error + Sync + Send + 'static;
 
-    fn get_template_module(&self, id: &TemplateAddress) -> Result<Self::Template, Self::Error>;
+    fn get_template_module(&self, id: &TemplateAddress) -> Result<Option<Self::Template>, Self::Error>;
 }

--- a/dan_layer/engine/src/flow/workers/call_method_worker.rs
+++ b/dan_layer/engine/src/flow/workers/call_method_worker.rs
@@ -57,6 +57,7 @@ impl<TTemplateProvider: TemplateProvider<Template = LoadedTemplate>> Worker<Flow
         let function_definition = context
             .template_provider
             .get_template_module(&template_address)?
+            .ok_or_else(|| anyhow::anyhow!("could not find template {}", template_address))?
             .template_def()
             .functions
             .iter()

--- a/dan_layer/engine/src/packager/package.rs
+++ b/dan_layer/engine/src/packager/package.rs
@@ -19,12 +19,11 @@
 //  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-use std::collections::HashMap;
+use std::{collections::HashMap, convert::Infallible};
 
 use tari_dan_common_types::services::template_provider::TemplateProvider;
 use tari_template_abi::TemplateDef;
 use tari_template_lib::models::TemplateAddress;
-use thiserror::Error;
 
 use crate::packager::template::LoadedTemplate;
 
@@ -79,17 +78,14 @@ impl PackageBuilder {
     }
 }
 
-#[derive(Debug, Clone, Error)]
-pub enum PackageError {
-    #[error("Template not found")]
-    TemplateNotFound,
-}
-
 impl TemplateProvider for Package {
-    type Error = PackageError;
+    type Error = Infallible;
     type Template = LoadedTemplate;
 
-    fn get_template_module(&self, id: &tari_engine_types::TemplateAddress) -> Result<Self::Template, Self::Error> {
-        self.templates.get(id).cloned().ok_or(PackageError::TemplateNotFound)
+    fn get_template_module(
+        &self,
+        id: &tari_engine_types::TemplateAddress,
+    ) -> Result<Option<Self::Template>, Self::Error> {
+        Ok(self.templates.get(id).cloned())
     }
 }

--- a/dan_layer/engine/src/runtime/error.rs
+++ b/dan_layer/engine/src/runtime/error.rs
@@ -32,6 +32,7 @@ use tari_template_lib::models::{
     ComponentAddress,
     NonFungibleId,
     ResourceAddress,
+    TemplateAddress,
     UnclaimedConfidentialOutputAddress,
     VaultId,
 };
@@ -111,14 +112,16 @@ pub enum RuntimeError {
     ConfidentialOutputAlreadyClaimed {
         address: UnclaimedConfidentialOutputAddress,
     },
-    #[error("Template not found with name '{template_name}'")]
-    TemplateNotFound { template_name: String },
+    #[error("Template {template_address} not found")]
+    TemplateNotFound { template_address: TemplateAddress },
     #[error("Insufficient fees paid: required {required_fee}, paid {fees_paid}")]
     InsufficientFeesPaid { required_fee: Amount, fees_paid: Amount },
     #[error("No checkpoint")]
     NoCheckpoint,
     #[error("Component address must be sequential. Index before {index} was not found")]
     ComponentAddressMustBeSequential { index: u32 },
+    #[error("Failed to load template '{address}': {details}")]
+    FailedToLoadTemplate { address: TemplateAddress, details: String },
 }
 
 impl RuntimeError {

--- a/dan_layer/engine/src/runtime/tracker.rs
+++ b/dan_layer/engine/src/runtime/tracker.rs
@@ -133,8 +133,12 @@ impl<TTemplateProvider: TemplateProvider<Template = LoadedTemplate>> StateTracke
         Ok(self
             .template_provider
             .get_template_module(&runtime_state.template_address)
-            .map_err(|_e| RuntimeError::TemplateNotFound {
-                template_name: runtime_state.template_address.to_string(),
+            .map_err(|e| RuntimeError::FailedToLoadTemplate {
+                address: runtime_state.template_address,
+                details: e.to_string(),
+            })?
+            .ok_or(RuntimeError::TemplateNotFound {
+                template_address: runtime_state.template_address,
             })?
             .template_def()
             .clone())

--- a/dan_layer/engine/src/transaction/error.rs
+++ b/dan_layer/engine/src/transaction/error.rs
@@ -39,4 +39,6 @@ pub enum TransactionError {
     FlowEngineError(#[from] crate::flow::FlowEngineError),
     #[error("Recursion limit exceeded")]
     RecursionLimitExceeded,
+    #[error("Failed to load template '{address}': {details}")]
+    FailedToLoadTemplate { address: TemplateAddress, details: String },
 }

--- a/dan_layer/engine_types/src/indexed_value.rs
+++ b/dan_layer/engine_types/src/indexed_value.rs
@@ -11,6 +11,8 @@ use tari_template_lib::{
     Hash,
 };
 
+use crate::substate::SubstateAddress;
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 pub struct IndexedValue {
     buckets: Vec<BucketId>,
@@ -35,6 +37,51 @@ impl IndexedValue {
             vault_ids: visitor.vault_ids,
             metadata: visitor.metadata,
         })
+    }
+
+    pub fn contains_substate(&self, addr: &SubstateAddress) -> bool {
+        match addr {
+            SubstateAddress::Component(addr) => self.component_addresses.contains(addr),
+            SubstateAddress::Resource(addr) => self.resource_addresses.contains(addr),
+            SubstateAddress::NonFungible(addr) => self.non_fungible_addresses.contains(addr),
+            SubstateAddress::Vault(addr) => self.vault_ids.contains(addr),
+            SubstateAddress::UnclaimedConfidentialOutput(_) => false,
+            // TODO: should we index this value?
+            SubstateAddress::NonFungibleIndex(_) => false,
+        }
+    }
+
+    pub fn owned_substates(&self) -> impl Iterator<Item = SubstateAddress> + '_ {
+        self.component_addresses
+            .iter()
+            .map(|a| (*a).into())
+            .chain(self.resource_addresses.iter().map(|a| (*a).into()))
+            .chain(self.non_fungible_addresses.iter().map(|a| a.clone().into()))
+            .chain(self.vault_ids.iter().map(|a| (*a).into()))
+    }
+
+    pub fn buckets(&self) -> &[BucketId] {
+        &self.buckets
+    }
+
+    pub fn component_addresses(&self) -> &[ComponentAddress] {
+        &self.component_addresses
+    }
+
+    pub fn resource_addresses(&self) -> &[ResourceAddress] {
+        &self.resource_addresses
+    }
+
+    pub fn non_fungible_addresses(&self) -> &[NonFungibleAddress] {
+        &self.non_fungible_addresses
+    }
+
+    pub fn vault_ids(&self) -> &[VaultId] {
+        &self.vault_ids
+    }
+
+    pub fn metadata(&self) -> &[Metadata] {
+        &self.metadata
     }
 }
 

--- a/dan_layer/wallet/sdk/src/apis/accounts.rs
+++ b/dan_layer/wallet/sdk/src/apis/accounts.rs
@@ -130,7 +130,7 @@ impl<'a, TStore: WalletStore> AccountsApi<'a, TStore> {
         Ok(vault)
     }
 
-    pub fn has_vault(&self, vault_addr: &&SubstateAddress) -> Result<bool, AccountsApiError> {
+    pub fn has_vault(&self, vault_addr: &SubstateAddress) -> Result<bool, AccountsApiError> {
         let mut tx = self.store.create_read_tx()?;
         // TODO: consider optimising
         let exists = tx.vaults_get(vault_addr).optional()?.is_some();

--- a/dan_layer/wallet/sdk/src/apis/transaction.rs
+++ b/dan_layer/wallet/sdk/src/apis/transaction.rs
@@ -211,20 +211,13 @@ impl<'a, TStore: WalletStore> TransactionApi<'a, TStore> {
         tx_hash: FixedHash,
         diff: &SubstateDiff,
     ) -> Result<(), TransactionApiError> {
-        for (addr, version) in diff.down_iter() {
+        for (addr, _) in diff.down_iter() {
             if addr.is_layer1_commitment() {
                 info!(target: LOG_TARGET, "Layer 1 commitment {} downed", addr);
                 continue;
             }
 
-            if tx
-                .substates_remove(&VersionedSubstateAddress {
-                    address: addr.clone(),
-                    version: *version,
-                })
-                .optional()?
-                .is_none()
-            {
+            if tx.substates_remove(addr).optional()?.is_none() {
                 warn!(target: LOG_TARGET, "Downed substate {} not found", addr);
             }
         }

--- a/dan_layer/wallet/sdk/src/models/substate.rs
+++ b/dan_layer/wallet/sdk/src/models/substate.rs
@@ -6,7 +6,7 @@ use std::{fmt::Display, str::FromStr};
 use serde::{Deserialize, Serialize};
 use tari_common_types::types::FixedHash;
 use tari_dan_common_types::serde_with;
-use tari_engine_types::substate::SubstateAddress;
+use tari_engine_types::{substate::SubstateAddress, TemplateAddress};
 
 #[derive(Debug, Clone)]
 pub struct SubstateModel {
@@ -14,6 +14,7 @@ pub struct SubstateModel {
     pub address: VersionedSubstateAddress,
     pub parent_address: Option<SubstateAddress>,
     pub transaction_hash: FixedHash,
+    pub template_address: Option<TemplateAddress>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/dan_layer/wallet/sdk/src/storage.rs
+++ b/dan_layer/wallet/sdk/src/storage.rs
@@ -193,12 +193,12 @@ pub trait WalletStoreWriter {
     ) -> Result<(), WalletStorageError>;
 
     // Substates
-    fn substates_insert_parent(
+    fn substates_insert_root(
         &mut self,
         tx_hash: FixedHash,
         address: VersionedSubstateAddress,
-        module_name: String,
-        template_addr: TemplateAddress,
+        module_name: Option<String>,
+        template_addr: Option<TemplateAddress>,
     ) -> Result<(), WalletStorageError>;
     fn substates_insert_child(
         &mut self,

--- a/dan_layer/wallet/sdk/src/storage.rs
+++ b/dan_layer/wallet/sdk/src/storage.rs
@@ -76,7 +76,7 @@ pub enum WalletStorageError {
         item: &'static str,
         details: String,
     },
-    #[error("{entity} not found with key {key}")]
+    #[error("[{operation}] {entity} not found with key {key}")]
     NotFound {
         operation: &'static str,
         entity: String,
@@ -206,8 +206,7 @@ pub trait WalletStoreWriter {
         parent: SubstateAddress,
         address: VersionedSubstateAddress,
     ) -> Result<(), WalletStorageError>;
-
-    fn substates_remove(&mut self, substate: &VersionedSubstateAddress) -> Result<SubstateModel, WalletStorageError>;
+    fn substates_remove(&mut self, substate: &SubstateAddress) -> Result<SubstateModel, WalletStorageError>;
 
     // Accounts
     fn accounts_set_default(&mut self, address: &SubstateAddress) -> Result<(), WalletStorageError>;

--- a/dan_layer/wallet/storage_sqlite/src/models/substate.rs
+++ b/dan_layer/wallet/storage_sqlite/src/models/substate.rs
@@ -8,6 +8,7 @@ use tari_dan_wallet_sdk::{
     models::{SubstateModel, VersionedSubstateAddress},
     storage::WalletStorageError,
 };
+use tari_template_lib::Hash;
 use tari_utilities::hex::Hex;
 
 use crate::schema::substates;
@@ -36,11 +37,21 @@ impl Substate {
             parent_address: self.parent_address.as_ref().map(|s| s.parse().unwrap()),
             transaction_hash: FixedHash::from_hex(&self.transaction_hash).map_err(|e| {
                 WalletStorageError::DecodingError {
-                    operation: "substate_get",
+                    operation: "try_to_record",
                     item: "transaction_hash",
                     details: e.to_string(),
                 }
             })?,
+            template_address: self
+                .template_address
+                .as_ref()
+                .map(|s| Hash::from_hex(s))
+                .transpose()
+                .map_err(|e| WalletStorageError::DecodingError {
+                    operation: "try_to_record",
+                    item: "template_address",
+                    details: e.to_string(),
+                })?,
         })
     }
 }

--- a/dan_layer/wallet/storage_sqlite/tests/substates.rs
+++ b/dan_layer/wallet/storage_sqlite/tests/substates.rs
@@ -10,7 +10,7 @@ use tari_dan_wallet_sdk::{
     storage::{WalletStore, WalletStoreReader, WalletStoreWriter},
 };
 use tari_dan_wallet_storage_sqlite::SqliteWalletStore;
-use tari_engine_types::{substate::SubstateAddress, TemplateAddress};
+use tari_engine_types::substate::SubstateAddress;
 
 #[test]
 fn get_and_insert_substates() {
@@ -27,14 +27,14 @@ fn get_and_insert_substates() {
     let address =
         SubstateAddress::from_str("component_1f019e4d434cbf2b99c0af89ee212f422af86de7280a169d2e392dfb66ab34d4")
             .unwrap();
-    tx.substates_insert_parent(
+    tx.substates_insert_root(
         hash,
         VersionedSubstateAddress {
             address: address.clone(),
             version: 0,
         },
-        "".to_string(),
-        TemplateAddress::default(),
+        None,
+        None,
     )
     .unwrap();
 


### PR DESCRIPTION
Description
---
feat(walletd): inspect component state to determine related substates
feat(walletd): detect and track newly created account vaults
fix(vn): missing conversion code for `CreateFreeTestCoins` instruction
feat(walletd): refresh account before checking balance

Motivation and Context
---
Previously, sending funds between accounts with walletd had these problems:
- if the destination account was unknown, an error would occur because we require the Account version
- if sending to an account results in a new vault being created, the destination wallet would not "see" the received funds.

Both of these are rectified by periodically scanning for the latest account state, extracting the vault ids and obtaining their balance.

How Has This Been Tested?
---
Manually

What process can a PR reviewer use to test or verify this change?
---
Start 2 separate wallet daemons - set `--jrpc-endpoint 127.0.0.1:9999` on daemon2 and open a shell with `export JRPC_ENDPOINT=/ip4/127.0.0.1/tcp/9999` so that the cli will use this endpoint.

Daemon1: 

```shell
$ cargo run --bin tari_dan_wallet_cli --  accounts create --name primary 
$ cargo run --bin tari_dan_wallet_cli --  accounts create-free-test-coins primary
```

Daemon2:
```shell
$ cargo run --bin tari_dan_wallet_cli --  accounts create --name primary 
```

Daemon1: 
```shell
$ cargo run --bin tari_dan_wallet_cli --  transactions send -n1 110 resource_0101010101010101010101010101010101010101010101010101010101010101 <dest_account> primary
```

Daemon2:
```shell
$ cargo run --bin tari_dan_wallet_cli --  accounts get-balances primary
```

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify