### PR TITLE
fix: correct cargo manifest key for git revisions (ciborium)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1280,9 +1280,9 @@ dependencies = [
 [[package]]
 name = "ciborium"
 version = "0.2.0"
-source = "git+https://github.com/enarx/ciborium.git#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
+source = "git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
 dependencies = [
- "ciborium-io 0.2.0 (git+https://github.com/enarx/ciborium.git)",
+ "ciborium-io 0.2.0 (git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56)",
  "ciborium-ll",
  "serde",
 ]
@@ -1296,14 +1296,14 @@ checksum = "346de753af073cc87b52b2083a506b38ac176a44cfb05497b622e27be899b369"
 [[package]]
 name = "ciborium-io"
 version = "0.2.0"
-source = "git+https://github.com/enarx/ciborium.git#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
+source = "git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
 
 [[package]]
 name = "ciborium-ll"
 version = "0.2.0"
-source = "git+https://github.com/enarx/ciborium.git#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
+source = "git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
 dependencies = [
- "ciborium-io 0.2.0 (git+https://github.com/enarx/ciborium.git)",
+ "ciborium-io 0.2.0 (git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56)",
  "half",
 ]
 

--- a/applications/tari_indexer/Cargo.toml
+++ b/applications/tari_indexer/Cargo.toml
@@ -43,7 +43,7 @@ async-graphql-axum = "5.0.7"
 axum-jrpc = { version = "0.3.2", features = ["anyhow_error"] }
 chrono = "0.4.22"
 #ciborium = { version = "0.2.0" }
-ciborium = { git = "https://github.com/enarx/ciborium.git", ref = "ac38b3dddeadf81f93cc8e58689ea92dc46a8e56", default-features = false }
+ciborium = { git = "https://github.com/enarx/ciborium.git", rev = "ac38b3dddeadf81f93cc8e58689ea92dc46a8e56", default-features = false }
 ciborium-io = { version = "0.2.0" }
 clap = { version = "3.2.22", features = ["derive", "env"] }
 config = "0.13.0"

--- a/dan_layer/engine/tests/templates/caller_context/Cargo.lock
+++ b/dan_layer/engine/tests/templates/caller_context/Cargo.lock
@@ -144,9 +144,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "ciborium"
 version = "0.2.0"
-source = "git+https://github.com/enarx/ciborium.git#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
+source = "git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
 dependencies = [
- "ciborium-io 0.2.0 (git+https://github.com/enarx/ciborium.git)",
+ "ciborium-io 0.2.0 (git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56)",
  "ciborium-ll",
  "serde",
 ]
@@ -160,14 +160,14 @@ checksum = "346de753af073cc87b52b2083a506b38ac176a44cfb05497b622e27be899b369"
 [[package]]
 name = "ciborium-io"
 version = "0.2.0"
-source = "git+https://github.com/enarx/ciborium.git#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
+source = "git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
 
 [[package]]
 name = "ciborium-ll"
 version = "0.2.0"
-source = "git+https://github.com/enarx/ciborium.git#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
+source = "git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
 dependencies = [
- "ciborium-io 0.2.0 (git+https://github.com/enarx/ciborium.git)",
+ "ciborium-io 0.2.0 (git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56)",
  "half",
 ]
 

--- a/dan_layer/engine/tests/templates/confidential/faucet/Cargo.lock
+++ b/dan_layer/engine/tests/templates/confidential/faucet/Cargo.lock
@@ -134,9 +134,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "ciborium"
 version = "0.2.0"
-source = "git+https://github.com/enarx/ciborium.git#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
+source = "git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
 dependencies = [
- "ciborium-io 0.2.0 (git+https://github.com/enarx/ciborium.git)",
+ "ciborium-io 0.2.0 (git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56)",
  "ciborium-ll",
  "serde",
 ]
@@ -150,14 +150,14 @@ checksum = "346de753af073cc87b52b2083a506b38ac176a44cfb05497b622e27be899b369"
 [[package]]
 name = "ciborium-io"
 version = "0.2.0"
-source = "git+https://github.com/enarx/ciborium.git#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
+source = "git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
 
 [[package]]
 name = "ciborium-ll"
 version = "0.2.0"
-source = "git+https://github.com/enarx/ciborium.git#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
+source = "git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
 dependencies = [
- "ciborium-io 0.2.0 (git+https://github.com/enarx/ciborium.git)",
+ "ciborium-io 0.2.0 (git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56)",
  "half",
 ]
 

--- a/dan_layer/engine/tests/templates/confidential/utilities/Cargo.lock
+++ b/dan_layer/engine/tests/templates/confidential/utilities/Cargo.lock
@@ -134,9 +134,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "ciborium"
 version = "0.2.0"
-source = "git+https://github.com/enarx/ciborium.git#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
+source = "git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
 dependencies = [
- "ciborium-io 0.2.0 (git+https://github.com/enarx/ciborium.git)",
+ "ciborium-io 0.2.0 (git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56)",
  "ciborium-ll",
  "serde",
 ]
@@ -150,14 +150,14 @@ checksum = "346de753af073cc87b52b2083a506b38ac176a44cfb05497b622e27be899b369"
 [[package]]
 name = "ciborium-io"
 version = "0.2.0"
-source = "git+https://github.com/enarx/ciborium.git#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
+source = "git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
 
 [[package]]
 name = "ciborium-ll"
 version = "0.2.0"
-source = "git+https://github.com/enarx/ciborium.git#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
+source = "git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
 dependencies = [
- "ciborium-io 0.2.0 (git+https://github.com/enarx/ciborium.git)",
+ "ciborium-io 0.2.0 (git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56)",
  "half",
 ]
 

--- a/dan_layer/engine/tests/templates/consensus/Cargo.lock
+++ b/dan_layer/engine/tests/templates/consensus/Cargo.lock
@@ -134,9 +134,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "ciborium"
 version = "0.2.0"
-source = "git+https://github.com/enarx/ciborium.git#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
+source = "git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
 dependencies = [
- "ciborium-io 0.2.0 (git+https://github.com/enarx/ciborium.git)",
+ "ciborium-io 0.2.0 (git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56)",
  "ciborium-ll",
  "serde",
 ]
@@ -150,14 +150,14 @@ checksum = "346de753af073cc87b52b2083a506b38ac176a44cfb05497b622e27be899b369"
 [[package]]
 name = "ciborium-io"
 version = "0.2.0"
-source = "git+https://github.com/enarx/ciborium.git#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
+source = "git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
 
 [[package]]
 name = "ciborium-ll"
 version = "0.2.0"
-source = "git+https://github.com/enarx/ciborium.git#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
+source = "git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
 dependencies = [
- "ciborium-io 0.2.0 (git+https://github.com/enarx/ciborium.git)",
+ "ciborium-io 0.2.0 (git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56)",
  "half",
 ]
 

--- a/dan_layer/engine/tests/templates/errors/Cargo.lock
+++ b/dan_layer/engine/tests/templates/errors/Cargo.lock
@@ -143,9 +143,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "ciborium"
 version = "0.2.0"
-source = "git+https://github.com/enarx/ciborium.git#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
+source = "git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
 dependencies = [
- "ciborium-io 0.2.0 (git+https://github.com/enarx/ciborium.git)",
+ "ciborium-io 0.2.0 (git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56)",
  "ciborium-ll",
  "serde",
 ]
@@ -159,14 +159,14 @@ checksum = "346de753af073cc87b52b2083a506b38ac176a44cfb05497b622e27be899b369"
 [[package]]
 name = "ciborium-io"
 version = "0.2.0"
-source = "git+https://github.com/enarx/ciborium.git#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
+source = "git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
 
 [[package]]
 name = "ciborium-ll"
 version = "0.2.0"
-source = "git+https://github.com/enarx/ciborium.git#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
+source = "git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
 dependencies = [
- "ciborium-io 0.2.0 (git+https://github.com/enarx/ciborium.git)",
+ "ciborium-io 0.2.0 (git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56)",
  "half",
 ]
 

--- a/dan_layer/engine/tests/templates/faucet/Cargo.lock
+++ b/dan_layer/engine/tests/templates/faucet/Cargo.lock
@@ -134,9 +134,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "ciborium"
 version = "0.2.0"
-source = "git+https://github.com/enarx/ciborium.git#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
+source = "git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
 dependencies = [
- "ciborium-io 0.2.0 (git+https://github.com/enarx/ciborium.git)",
+ "ciborium-io 0.2.0 (git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56)",
  "ciborium-ll",
  "serde",
 ]
@@ -150,14 +150,14 @@ checksum = "346de753af073cc87b52b2083a506b38ac176a44cfb05497b622e27be899b369"
 [[package]]
 name = "ciborium-io"
 version = "0.2.0"
-source = "git+https://github.com/enarx/ciborium.git#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
+source = "git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
 
 [[package]]
 name = "ciborium-ll"
 version = "0.2.0"
-source = "git+https://github.com/enarx/ciborium.git#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
+source = "git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
 dependencies = [
- "ciborium-io 0.2.0 (git+https://github.com/enarx/ciborium.git)",
+ "ciborium-io 0.2.0 (git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56)",
  "half",
 ]
 

--- a/dan_layer/engine/tests/templates/hello_world/Cargo.lock
+++ b/dan_layer/engine/tests/templates/hello_world/Cargo.lock
@@ -134,9 +134,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "ciborium"
 version = "0.2.0"
-source = "git+https://github.com/enarx/ciborium.git#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
+source = "git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
 dependencies = [
- "ciborium-io 0.2.0 (git+https://github.com/enarx/ciborium.git)",
+ "ciborium-io 0.2.0 (git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56)",
  "ciborium-ll",
  "serde",
 ]
@@ -150,14 +150,14 @@ checksum = "346de753af073cc87b52b2083a506b38ac176a44cfb05497b622e27be899b369"
 [[package]]
 name = "ciborium-io"
 version = "0.2.0"
-source = "git+https://github.com/enarx/ciborium.git#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
+source = "git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
 
 [[package]]
 name = "ciborium-ll"
 version = "0.2.0"
-source = "git+https://github.com/enarx/ciborium.git#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
+source = "git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
 dependencies = [
- "ciborium-io 0.2.0 (git+https://github.com/enarx/ciborium.git)",
+ "ciborium-io 0.2.0 (git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56)",
  "half",
 ]
 

--- a/dan_layer/engine/tests/templates/nft/airdrop/Cargo.lock
+++ b/dan_layer/engine/tests/templates/nft/airdrop/Cargo.lock
@@ -143,9 +143,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "ciborium"
 version = "0.2.0"
-source = "git+https://github.com/enarx/ciborium.git#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
+source = "git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
 dependencies = [
- "ciborium-io 0.2.0 (git+https://github.com/enarx/ciborium.git)",
+ "ciborium-io 0.2.0 (git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56)",
  "ciborium-ll",
  "serde",
 ]
@@ -159,14 +159,14 @@ checksum = "346de753af073cc87b52b2083a506b38ac176a44cfb05497b622e27be899b369"
 [[package]]
 name = "ciborium-io"
 version = "0.2.0"
-source = "git+https://github.com/enarx/ciborium.git#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
+source = "git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
 
 [[package]]
 name = "ciborium-ll"
 version = "0.2.0"
-source = "git+https://github.com/enarx/ciborium.git#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
+source = "git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
 dependencies = [
- "ciborium-io 0.2.0 (git+https://github.com/enarx/ciborium.git)",
+ "ciborium-io 0.2.0 (git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56)",
  "half",
 ]
 

--- a/dan_layer/engine/tests/templates/nft/basic_nft/Cargo.lock
+++ b/dan_layer/engine/tests/templates/nft/basic_nft/Cargo.lock
@@ -143,9 +143,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "ciborium"
 version = "0.2.0"
-source = "git+https://github.com/enarx/ciborium.git#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
+source = "git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
 dependencies = [
- "ciborium-io 0.2.0 (git+https://github.com/enarx/ciborium.git)",
+ "ciborium-io 0.2.0 (git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56)",
  "ciborium-ll",
  "serde",
 ]
@@ -159,14 +159,14 @@ checksum = "346de753af073cc87b52b2083a506b38ac176a44cfb05497b622e27be899b369"
 [[package]]
 name = "ciborium-io"
 version = "0.2.0"
-source = "git+https://github.com/enarx/ciborium.git#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
+source = "git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
 
 [[package]]
 name = "ciborium-ll"
 version = "0.2.0"
-source = "git+https://github.com/enarx/ciborium.git#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
+source = "git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
 dependencies = [
- "ciborium-io 0.2.0 (git+https://github.com/enarx/ciborium.git)",
+ "ciborium-io 0.2.0 (git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56)",
  "half",
 ]
 

--- a/dan_layer/engine/tests/templates/nft/emoji_id/Cargo.lock
+++ b/dan_layer/engine/tests/templates/nft/emoji_id/Cargo.lock
@@ -134,9 +134,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "ciborium"
 version = "0.2.0"
-source = "git+https://github.com/enarx/ciborium.git#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
+source = "git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
 dependencies = [
- "ciborium-io 0.2.0 (git+https://github.com/enarx/ciborium.git)",
+ "ciborium-io 0.2.0 (git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56)",
  "ciborium-ll",
  "serde",
 ]
@@ -150,14 +150,14 @@ checksum = "346de753af073cc87b52b2083a506b38ac176a44cfb05497b622e27be899b369"
 [[package]]
 name = "ciborium-io"
 version = "0.2.0"
-source = "git+https://github.com/enarx/ciborium.git#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
+source = "git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
 
 [[package]]
 name = "ciborium-ll"
 version = "0.2.0"
-source = "git+https://github.com/enarx/ciborium.git#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
+source = "git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
 dependencies = [
- "ciborium-io 0.2.0 (git+https://github.com/enarx/ciborium.git)",
+ "ciborium-io 0.2.0 (git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56)",
  "half",
 ]
 

--- a/dan_layer/engine/tests/templates/nft/nft_list/Cargo.lock
+++ b/dan_layer/engine/tests/templates/nft/nft_list/Cargo.lock
@@ -134,9 +134,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "ciborium"
 version = "0.2.0"
-source = "git+https://github.com/enarx/ciborium.git#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
+source = "git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
 dependencies = [
- "ciborium-io 0.2.0 (git+https://github.com/enarx/ciborium.git)",
+ "ciborium-io 0.2.0 (git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56)",
  "ciborium-ll",
  "serde",
 ]
@@ -150,14 +150,14 @@ checksum = "346de753af073cc87b52b2083a506b38ac176a44cfb05497b622e27be899b369"
 [[package]]
 name = "ciborium-io"
 version = "0.2.0"
-source = "git+https://github.com/enarx/ciborium.git#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
+source = "git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
 
 [[package]]
 name = "ciborium-ll"
 version = "0.2.0"
-source = "git+https://github.com/enarx/ciborium.git#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
+source = "git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
 dependencies = [
- "ciborium-io 0.2.0 (git+https://github.com/enarx/ciborium.git)",
+ "ciborium-io 0.2.0 (git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56)",
  "half",
 ]
 

--- a/dan_layer/engine/tests/templates/nft/tickets/Cargo.lock
+++ b/dan_layer/engine/tests/templates/nft/tickets/Cargo.lock
@@ -134,9 +134,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "ciborium"
 version = "0.2.0"
-source = "git+https://github.com/enarx/ciborium.git#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
+source = "git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
 dependencies = [
- "ciborium-io 0.2.0 (git+https://github.com/enarx/ciborium.git)",
+ "ciborium-io 0.2.0 (git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56)",
  "ciborium-ll",
  "serde",
 ]
@@ -150,14 +150,14 @@ checksum = "346de753af073cc87b52b2083a506b38ac176a44cfb05497b622e27be899b369"
 [[package]]
 name = "ciborium-io"
 version = "0.2.0"
-source = "git+https://github.com/enarx/ciborium.git#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
+source = "git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
 
 [[package]]
 name = "ciborium-ll"
 version = "0.2.0"
-source = "git+https://github.com/enarx/ciborium.git#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
+source = "git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
 dependencies = [
- "ciborium-io 0.2.0 (git+https://github.com/enarx/ciborium.git)",
+ "ciborium-io 0.2.0 (git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56)",
  "half",
 ]
 

--- a/dan_layer/engine/tests/templates/private_function/Cargo.lock
+++ b/dan_layer/engine/tests/templates/private_function/Cargo.lock
@@ -134,9 +134,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "ciborium"
 version = "0.2.0"
-source = "git+https://github.com/enarx/ciborium.git#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
+source = "git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
 dependencies = [
- "ciborium-io 0.2.0 (git+https://github.com/enarx/ciborium.git)",
+ "ciborium-io 0.2.0 (git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56)",
  "ciborium-ll",
  "serde",
 ]
@@ -150,14 +150,14 @@ checksum = "346de753af073cc87b52b2083a506b38ac176a44cfb05497b622e27be899b369"
 [[package]]
 name = "ciborium-io"
 version = "0.2.0"
-source = "git+https://github.com/enarx/ciborium.git#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
+source = "git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
 
 [[package]]
 name = "ciborium-ll"
 version = "0.2.0"
-source = "git+https://github.com/enarx/ciborium.git#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
+source = "git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
 dependencies = [
- "ciborium-io 0.2.0 (git+https://github.com/enarx/ciborium.git)",
+ "ciborium-io 0.2.0 (git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56)",
  "half",
 ]
 

--- a/dan_layer/engine/tests/templates/random/Cargo.lock
+++ b/dan_layer/engine/tests/templates/random/Cargo.lock
@@ -134,9 +134,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "ciborium"
 version = "0.2.0"
-source = "git+https://github.com/enarx/ciborium.git#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
+source = "git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
 dependencies = [
- "ciborium-io 0.2.0 (git+https://github.com/enarx/ciborium.git)",
+ "ciborium-io 0.2.0 (git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56)",
  "ciborium-ll",
  "serde",
 ]
@@ -150,14 +150,14 @@ checksum = "346de753af073cc87b52b2083a506b38ac176a44cfb05497b622e27be899b369"
 [[package]]
 name = "ciborium-io"
 version = "0.2.0"
-source = "git+https://github.com/enarx/ciborium.git#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
+source = "git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
 
 [[package]]
 name = "ciborium-ll"
 version = "0.2.0"
-source = "git+https://github.com/enarx/ciborium.git#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
+source = "git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
 dependencies = [
- "ciborium-io 0.2.0 (git+https://github.com/enarx/ciborium.git)",
+ "ciborium-io 0.2.0 (git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56)",
  "half",
 ]
 

--- a/dan_layer/engine/tests/templates/state/Cargo.lock
+++ b/dan_layer/engine/tests/templates/state/Cargo.lock
@@ -134,9 +134,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "ciborium"
 version = "0.2.0"
-source = "git+https://github.com/enarx/ciborium.git#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
+source = "git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
 dependencies = [
- "ciborium-io 0.2.0 (git+https://github.com/enarx/ciborium.git)",
+ "ciborium-io 0.2.0 (git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56)",
  "ciborium-ll",
  "serde",
 ]
@@ -150,14 +150,14 @@ checksum = "346de753af073cc87b52b2083a506b38ac176a44cfb05497b622e27be899b369"
 [[package]]
 name = "ciborium-io"
 version = "0.2.0"
-source = "git+https://github.com/enarx/ciborium.git#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
+source = "git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
 
 [[package]]
 name = "ciborium-ll"
 version = "0.2.0"
-source = "git+https://github.com/enarx/ciborium.git#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
+source = "git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
 dependencies = [
- "ciborium-io 0.2.0 (git+https://github.com/enarx/ciborium.git)",
+ "ciborium-io 0.2.0 (git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56)",
  "half",
 ]
 

--- a/dan_layer/engine/tests/templates/tuples/Cargo.lock
+++ b/dan_layer/engine/tests/templates/tuples/Cargo.lock
@@ -134,9 +134,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "ciborium"
 version = "0.2.0"
-source = "git+https://github.com/enarx/ciborium.git#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
+source = "git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
 dependencies = [
- "ciborium-io 0.2.0 (git+https://github.com/enarx/ciborium.git)",
+ "ciborium-io 0.2.0 (git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56)",
  "ciborium-ll",
  "serde",
 ]
@@ -150,14 +150,14 @@ checksum = "346de753af073cc87b52b2083a506b38ac176a44cfb05497b622e27be899b369"
 [[package]]
 name = "ciborium-io"
 version = "0.2.0"
-source = "git+https://github.com/enarx/ciborium.git#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
+source = "git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
 
 [[package]]
 name = "ciborium-ll"
 version = "0.2.0"
-source = "git+https://github.com/enarx/ciborium.git#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
+source = "git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
 dependencies = [
- "ciborium-io 0.2.0 (git+https://github.com/enarx/ciborium.git)",
+ "ciborium-io 0.2.0 (git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56)",
  "half",
 ]
 

--- a/dan_layer/tari_bor/Cargo.toml
+++ b/dan_layer/tari_bor/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 # Remove once https://github.com/enarx/ciborium/pull/77 is released
-ciborium = { git = "https://github.com/enarx/ciborium.git", ref = "ac38b3dddeadf81f93cc8e58689ea92dc46a8e56", default-features = false }
+ciborium = { git = "https://github.com/enarx/ciborium.git", rev = "ac38b3dddeadf81f93cc8e58689ea92dc46a8e56", default-features = false }
 #ciborium = { version = "0.2.0", default-features = false }
 ciborium-io = { version = "0.2.0", default-features = false }
 serde = { version = "1.0.143", default-features = false, features = ["alloc", "derive"] }

--- a/dan_layer/template_builtin/templates/account/Cargo.lock
+++ b/dan_layer/template_builtin/templates/account/Cargo.lock
@@ -144,9 +144,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "ciborium"
 version = "0.2.0"
-source = "git+https://github.com/enarx/ciborium.git#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
+source = "git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
 dependencies = [
- "ciborium-io 0.2.0 (git+https://github.com/enarx/ciborium.git)",
+ "ciborium-io 0.2.0 (git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56)",
  "ciborium-ll",
  "serde",
 ]
@@ -160,14 +160,14 @@ checksum = "346de753af073cc87b52b2083a506b38ac176a44cfb05497b622e27be899b369"
 [[package]]
 name = "ciborium-io"
 version = "0.2.0"
-source = "git+https://github.com/enarx/ciborium.git#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
+source = "git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
 
 [[package]]
 name = "ciborium-ll"
 version = "0.2.0"
-source = "git+https://github.com/enarx/ciborium.git#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
+source = "git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
 dependencies = [
- "ciborium-io 0.2.0 (git+https://github.com/enarx/ciborium.git)",
+ "ciborium-io 0.2.0 (git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56)",
  "half",
 ]
 

--- a/dan_layer/template_lib/Cargo.toml
+++ b/dan_layer/template_lib/Cargo.toml
@@ -9,7 +9,7 @@ tari_template_macros = { path = "../template_macros", optional = true }
 tari_bor = { path = "../tari_bor" }
 tari_crypto = "0.16.10"
 
-ciborium = { git = "https://github.com/enarx/ciborium.git", ref = "ac38b3dddeadf81f93cc8e58689ea92dc46a8e56", default-features = false }
+ciborium = { git = "https://github.com/enarx/ciborium.git", rev = "ac38b3dddeadf81f93cc8e58689ea92dc46a8e56", default-features = false }
 #ciborium = { version = "0.2.0", default-features = false }
 newtype-ops = "0.1.4"
 serde = { version = "1.0.143", default-features = false, features = ["derive", "alloc"] }

--- a/dan_layer/template_test_tooling/templates/faucet/Cargo.lock
+++ b/dan_layer/template_test_tooling/templates/faucet/Cargo.lock
@@ -134,9 +134,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "ciborium"
 version = "0.2.0"
-source = "git+https://github.com/enarx/ciborium.git#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
+source = "git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
 dependencies = [
- "ciborium-io 0.2.0 (git+https://github.com/enarx/ciborium.git)",
+ "ciborium-io 0.2.0 (git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56)",
  "ciborium-ll",
  "serde",
 ]
@@ -150,14 +150,14 @@ checksum = "346de753af073cc87b52b2083a506b38ac176a44cfb05497b622e27be899b369"
 [[package]]
 name = "ciborium-io"
 version = "0.2.0"
-source = "git+https://github.com/enarx/ciborium.git#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
+source = "git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
 
 [[package]]
 name = "ciborium-ll"
 version = "0.2.0"
-source = "git+https://github.com/enarx/ciborium.git#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
+source = "git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56#ac38b3dddeadf81f93cc8e58689ea92dc46a8e56"
 dependencies = [
- "ciborium-io 0.2.0 (git+https://github.com/enarx/ciborium.git)",
+ "ciborium-io 0.2.0 (git+https://github.com/enarx/ciborium.git?rev=ac38b3dddeadf81f93cc8e58689ea92dc46a8e56)",
  "half",
 ]
 


### PR DESCRIPTION
Description
---

Fixed typo in `ciborium` git dependency, replaced "ref" with "rev".

Motivation and Context
---
"ref" was disregarded, "rev" is correct.

How Has This Been Tested?
---

What process can a PR reviewer use to test or verify this change?
---


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify