### PR TITLE
fix(walletd): minor improvement to webrtc error handling and walletd webui

### DIFF
--- a/applications/tari_dan_wallet_daemon/src/config.rs
+++ b/applications/tari_dan_wallet_daemon/src/config.rs
@@ -67,7 +67,7 @@ impl Default for WalletDaemonConfig {
             signaling_server_addr: Some(SocketAddr::from(([127u8, 0, 0, 1], 9100))),
             validator_node_endpoint: Some("http://127.0.0.1:18200/json_rpc".to_string()),
             // TODO: Come up with a reasonable default value
-            jwt_duration: Some(Duration::from_secs(5 * 60)),
+            jwt_duration: Some(Duration::from_secs(500 * 60)),
             // TODO: Generate a random secret key at start if not set by hand. Otherwise anyone can generate a JWT token
             // when they know the secret_key.
             jwt_secret_key: Some("secret_key".to_string()),

--- a/applications/tari_dan_wallet_web_ui/src/routes/Wallet/Components/Accounts.tsx
+++ b/applications/tari_dan_wallet_web_ui/src/routes/Wallet/Components/Accounts.tsx
@@ -76,8 +76,8 @@ function Accounts() {
         setState(response);
         setError(undefined);
       })
-      .catch((reason) => {
-        setError(reason);
+      .catch((err) => {
+        setError(err && err.message ? err.message : `Unknown error: ${JSON.stringify(err)}`);
       });
   };
 
@@ -104,9 +104,9 @@ function Accounts() {
         console.log(response);
         loadAccounts();
       })
-      .catch((reason) => {
-        console.log(reason);
-        setError(reason.message);
+      .catch((err) => {
+        console.log(err);
+        setError(err && err.message ? err.message : `Unknown error: ${JSON.stringify(err)}`);
       });
     setClaimBurnFormState({ account: "", claimProof: "", fee: "" });
     setShowClaimBurnDialog(false);
@@ -124,7 +124,7 @@ function Accounts() {
     <>
       {error ? (
           <Alert severity="error">{error}</Alert>
-      ) : ( null ) }
+      ) : null }
       <BoxHeading2>
         {showAccountDialog && (
           <Fade in={showAccountDialog}>

--- a/applications/tari_dan_wallet_web_ui/src/routes/Wallet/Components/Keys.tsx
+++ b/applications/tari_dan_wallet_web_ui/src/routes/Wallet/Components/Keys.tsx
@@ -71,8 +71,8 @@ function Keys() {
       setState(response);
       setError(undefined);
     })
-    .catch((reason) => {
-      setError(reason);
+    .catch((err) => {
+      setError(err && err.message ? err.message : `Unknown error: ${JSON.stringify(err)}`);
     });
   };
   const setActive = (index:number) => {

--- a/clients/tari_indexer_client/src/graphql_client.rs
+++ b/clients/tari_indexer_client/src/graphql_client.rs
@@ -71,10 +71,7 @@ impl IndexerGraphQLClient {
         let resp = req.body(serde_json::to_string(&body)?).send().await?;
         let val = resp.json::<Value>().await?;
         let data = graphql_data(val)?;
-        match serde_json::from_value::<R>(data) {
-            Ok(r) => Ok(r),
-            Err(e) => Err(anyhow!("Failed to deserialize response: {}", e)),
-        }
+        serde_json::from_value::<R>(data).map_err(|e| anyhow!("Failed to deserialize response: {}", e))
     }
 }
 


### PR DESCRIPTION
Description
---
- Fix webui crash when error is shown in webui
- Minor improvements to error handling in webrtc server
- increase default token expiry to 500m

Motivation and Context
---
Was looking through the WebRTC functionality and walletd webui and made some minor improvements as I went.

The webui needs to use token auth (currently displays error).

How Has This Been Tested?
---
Manually

What process can a PR reviewer use to test or verify this change?
---


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify