### PR TITLE
feat: add jwt expiration from cli

### DIFF
--- a/applications/tari_dan_wallet_cli/src/command/auth.rs
+++ b/applications/tari_dan_wallet_cli/src/command/auth.rs
@@ -20,6 +20,8 @@
 //   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //   USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+use std::time::Duration;
+
 use clap::{Args, Subcommand};
 use tari_dan_wallet_sdk::apis::jwt::JrpcPermissions;
 use tari_wallet_daemon_client::{
@@ -41,6 +43,7 @@ pub enum AuthSubcommand {
 #[derive(Debug, Args, Clone)]
 pub struct RequestArgs {
     permissions: JrpcPermissions,
+    validity_in_seconds: Option<u64>,
 }
 
 // TODO: We have to implement some wallet password for granting access. Only granting and denying access will need
@@ -68,6 +71,7 @@ impl AuthSubcommand {
                     let resp = client
                         .auth_request(AuthLoginRequest {
                             permissions: args.permissions,
+                            duration: args.validity_in_seconds.map(|value| Duration::from_secs(value)),
                         })
                         .await?;
                     println!("Auth token {}", resp.auth_token);

--- a/applications/tari_dan_wallet_cli/src/command/auth.rs
+++ b/applications/tari_dan_wallet_cli/src/command/auth.rs
@@ -71,7 +71,7 @@ impl AuthSubcommand {
                     let resp = client
                         .auth_request(AuthLoginRequest {
                             permissions: args.permissions,
-                            duration: args.validity_in_seconds.map(|value| Duration::from_secs(value)),
+                            duration: args.validity_in_seconds.map(Duration::from_secs),
                         })
                         .await?;
                     println!("Auth token {}", resp.auth_token);

--- a/applications/tari_dan_wallet_daemon/src/handlers/rpc.rs
+++ b/applications/tari_dan_wallet_daemon/src/handlers/rpc.rs
@@ -27,9 +27,10 @@ pub async fn handle_login_request(
 ) -> Result<AuthLoginResponse, anyhow::Error> {
     let jwt = context.wallet_sdk().jwt_api();
 
-    let auth_token = jwt.generate_auth_token(auth_request.permissions)?;
+    let (auth_token, valid_till) = jwt.generate_auth_token(auth_request.permissions, auth_request.duration)?;
     context.notifier().notify(AuthLoginRequestEvent {
         auth_token: auth_token.clone(),
+        valid_till,
     });
     Ok(AuthLoginResponse { auth_token })
 }

--- a/applications/tari_dan_wallet_daemon/src/services/events.rs
+++ b/applications/tari_dan_wallet_daemon/src/services/events.rs
@@ -1,6 +1,8 @@
 //   Copyright 2023 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
+use std::time::SystemTime;
+
 use tari_common_types::types::{FixedHash, PublicKey};
 use tari_dan_common_types::QuorumCertificate;
 use tari_dan_wallet_sdk::models::TransactionStatus;
@@ -79,4 +81,5 @@ pub struct TransactionInvalidEvent {
 #[derive(Debug, Clone)]
 pub struct AuthLoginRequestEvent {
     pub auth_token: String,
+    pub valid_till: SystemTime,
 }

--- a/applications/tari_validator_node/tests/utils/wallet_daemon_cli.rs
+++ b/applications/tari_validator_node/tests/utils/wallet_daemon_cli.rs
@@ -663,6 +663,7 @@ pub(crate) async fn get_auth_wallet_daemon_client(world: &TariWorld, wallet_daem
     let AuthLoginResponse { auth_token } = client
         .auth_request(AuthLoginRequest {
             permissions: JrpcPermissions(vec![JrpcPermission::Admin]),
+            duration: None,
         })
         .await
         .unwrap();

--- a/clients/wallet_daemon_client/src/types.rs
+++ b/clients/wallet_daemon_client/src/types.rs
@@ -20,6 +20,8 @@
 //   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //   USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+use std::time::Duration;
+
 use serde::{Deserialize, Serialize};
 use tari_common_types::types::{FixedHash, PublicKey};
 use tari_dan_common_types::{QuorumCertificate, ShardId};
@@ -453,6 +455,7 @@ pub struct WebRtcStartResponse {}
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct AuthLoginRequest {
     pub permissions: JrpcPermissions,
+    pub duration: Option<Duration>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]


### PR DESCRIPTION
Description
---
Now you can specify the validity duration of the token via cli. Also now the `permissions token` that will be granted will have the same expiration datetime. This way the generated permissions token will not rely on when the user accepts. And if we somehow accepts twice the same request, it will generated the same token. If no value is provided then the default value from daemon is used (currently that's 5 minutes).

Motivation and Context
---
Sometimes there is a need for specifying the time.

How Has This Been Tested?
---
Manually.

What process can a PR reviewer use to test or verify this change?
---
`cargo run --bin tari_dan_wallet_cli -- auth request Admin 1` - this means one second validity.
You can generate a token with validity one second and then try to use it (keep in mind that JWT library allows for 1 minute threshold. So if you have validity one sec, in reality it's 61 seconds.


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify