### PR TITLE
fix(vn): only return payload result from RPC/JRPC if finalized

### DIFF
--- a/applications/tari_indexer/src/transaction_manager/error.rs
+++ b/applications/tari_indexer/src/transaction_manager/error.rs
@@ -1,10 +1,20 @@
 //   Copyright 2023 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
+use tari_dan_common_types::optional::IsNotFoundError;
+
 #[derive(Debug, Clone, thiserror::Error)]
 pub enum TransactionManagerError {
     #[error("Committee provider error: {0}")]
     CommitteeProviderError(String),
     #[error("Rpc call failed for all ({committee_size}) validators")]
     AllValidatorsFailed { committee_size: usize },
+    #[error("{entity} not found: {key}")]
+    NotFound { entity: &'static str, key: String },
+}
+
+impl IsNotFoundError for TransactionManagerError {
+    fn is_not_found_error(&self) -> bool {
+        matches!(self, Self::NotFound { .. })
+    }
 }

--- a/dan_layer/core/src/services/validator_node_rpc_client.rs
+++ b/dan_layer/core/src/services/validator_node_rpc_client.rs
@@ -25,6 +25,7 @@ use tari_comms::{
     protocol::rpc::{RpcError, RpcStatus},
     types::CommsPublicKey,
 };
+use tari_dan_common_types::optional::IsNotFoundError;
 
 #[derive(Debug, thiserror::Error)]
 pub enum ValidatorNodeClientError {
@@ -40,4 +41,13 @@ pub enum ValidatorNodeClientError {
     RpcStatusError(#[from] RpcStatus),
     #[error("Node sent invalid response: {0}")]
     InvalidResponse(anyhow::Error),
+}
+
+impl IsNotFoundError for ValidatorNodeClientError {
+    fn is_not_found_error(&self) -> bool {
+        match self {
+            ValidatorNodeClientError::RpcStatusError(status) => status.is_not_found(),
+            _ => false,
+        }
+    }
 }

--- a/dan_layer/core/src/storage/shard_store.rs
+++ b/dan_layer/core/src/storage/shard_store.rs
@@ -213,7 +213,7 @@ pub trait ShardStoreWriteTransaction<TAddr: NodeAddressable, TPayload: Payload> 
         payload_id: PayloadId,
         height: NodeHeight,
     ) -> Result<(), StorageError>;
-    fn save_substate_changes(
+    fn commit_substate_changes(
         &mut self,
         node: HotStuffTreeNode<TAddr, TPayload>,
         changes: &[SubstateState],
@@ -245,6 +245,8 @@ pub trait ShardStoreWriteTransaction<TAddr: NodeAddressable, TPayload: Payload> 
 
     /// Updates the result for an existing payload
     fn update_payload_result(&mut self, payload_id: &PayloadId, result: PayloadResult) -> Result<(), StorageError>;
+
+    fn mark_payload_finalized(&mut self, payload_id: &PayloadId) -> Result<(), StorageError>;
 
     // -------------------------------- Pledges -------------------------------- //
     fn pledge_object(

--- a/dan_layer/storage_sqlite/migrations/2023-05-05-125535_add_is_finalized_to_payload/down.sql
+++ b/dan_layer/storage_sqlite/migrations/2023-05-05-125535_add_is_finalized_to_payload/down.sql
@@ -1,0 +1,1 @@
+-- This file should undo anything in `up.sql`

--- a/dan_layer/storage_sqlite/migrations/2023-05-05-125535_add_is_finalized_to_payload/up.sql
+++ b/dan_layer/storage_sqlite/migrations/2023-05-05-125535_add_is_finalized_to_payload/up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE main.payloads
+    ADD COLUMN is_finalized       boolean NOT NULL DEFAULT '0';

--- a/dan_layer/storage_sqlite/src/models/payload.rs
+++ b/dan_layer/storage_sqlite/src/models/payload.rs
@@ -36,6 +36,7 @@ pub struct Payload {
     pub meta: String,
     pub result: Option<String>,
     pub timestamp: NaiveDateTime,
+    pub is_finalized: bool,
 }
 
 #[derive(Debug, Insertable)]

--- a/dan_layer/storage_sqlite/src/schema.rs
+++ b/dan_layer/storage_sqlite/src/schema.rs
@@ -110,6 +110,7 @@ diesel::table! {
         meta -> Text,
         result -> Nullable<Text>,
         timestamp -> Timestamp,
+        is_finalized -> Bool,
     }
 }
 


### PR DESCRIPTION
Description
---
Only returns transaction result on transaction finality.
Increased the pacemaker timeout to 30s

Motivation and Context
---
The wallet awaits the transaction result after submission, which would be returned even before consensus had committed it. This led the wallet to accept the result (it shouldn't do that without validating the commit phase QCs, but this is TODO) and update versions as if it succeeded but if the transaction fails, the accounts/vaults/substates at `version + 1` would not exist.

How Has This Been Tested?
---
Manually

What process can a PR reviewer use to test or verify this change?
---

Submit a transaction that fails. The walletd may see the result before finality.

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify