### PR TITLE
feat: add selecting permissions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7908,6 +7908,7 @@ dependencies = [
  "tari_shutdown",
  "tokio",
  "tower-http",
+ "webrtc",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -266,6 +266,7 @@ dependencies = [
  "num-traits",
  "rusticata-macros",
  "thiserror",
+ "time 0.3.20",
 ]
 
 [[package]]
@@ -2285,6 +2286,7 @@ dependencies = [
  "asn1-rs 0.5.2",
  "displaydoc",
  "nom 7.1.3",
+ "num-bigint",
  "num-traits",
  "rusticata-macros",
 ]
@@ -5587,7 +5589,19 @@ dependencies = [
  "pem",
  "ring",
  "time 0.3.20",
- "x509-parser",
+ "yasna",
+]
+
+[[package]]
+name = "rcgen"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffbe84efe2f38dea12e9bfc1f65377fdf03e53a18cb3b995faedf7934c7e785b"
+dependencies = [
+ "pem",
+ "ring",
+ "time 0.3.20",
+ "x509-parser 0.14.0",
  "yasna",
 ]
 
@@ -9607,9 +9621,9 @@ dependencies = [
 
 [[package]]
 name = "webrtc"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a591ec83ec22b073d63fabb499a587224e8cf4d9e33209d48c03473bcee00d7b"
+checksum = "0507dc2d9a79fe1aa892e8876d3bb9b3d939c654fa8222bbb29b6331baeb08cc"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -9619,7 +9633,7 @@ dependencies = [
  "lazy_static",
  "log",
  "rand 0.8.5",
- "rcgen",
+ "rcgen 0.10.0",
  "regex",
  "ring",
  "rtcp",
@@ -9685,7 +9699,7 @@ dependencies = [
  "p384",
  "rand 0.8.5",
  "rand_core 0.6.4",
- "rcgen",
+ "rcgen 0.9.3",
  "ring",
  "rustls 0.19.1",
  "sec1",
@@ -9699,7 +9713,7 @@ dependencies = [
  "webpki 0.21.4",
  "webrtc-util",
  "x25519-dalek 2.0.0-pre.1",
- "x509-parser",
+ "x509-parser 0.13.2",
 ]
 
 [[package]]
@@ -9741,18 +9755,15 @@ dependencies = [
 
 [[package]]
 name = "webrtc-media"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee2a3c157a040324e5049bcbd644ffc9079e6738fa2cfab2bcff64e5cc4c00d7"
+checksum = "f72e1650a8ae006017d1a5280efb49e2610c19ccc3c0905b03b648aee9554991"
 dependencies = [
  "byteorder",
  "bytes 1.4.0",
- "derive_builder 0.11.2",
- "displaydoc",
  "rand 0.8.5",
  "rtp",
  "thiserror",
- "webrtc-util",
 ]
 
 [[package]]
@@ -10114,6 +10125,24 @@ dependencies = [
  "lazy_static",
  "nom 7.1.3",
  "oid-registry 0.4.0",
+ "rusticata-macros",
+ "thiserror",
+ "time 0.3.20",
+]
+
+[[package]]
+name = "x509-parser"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0ecbeb7b67ce215e40e3cc7f2ff902f94a223acf44995934763467e7b1febc8"
+dependencies = [
+ "asn1-rs 0.5.2",
+ "base64 0.13.1",
+ "data-encoding",
+ "der-parser 8.2.0",
+ "lazy_static",
+ "nom 7.1.3",
+ "oid-registry 0.6.1",
  "ring",
  "rusticata-macros",
  "thiserror",

--- a/applications/tari_dan_wallet_cli/src/command/webrtc.rs
+++ b/applications/tari_dan_wallet_cli/src/command/webrtc.rs
@@ -44,7 +44,7 @@ impl WebRtcSubcommand {
                 let _resp = client
                     .webrtc_start(WebRtcStartRequest {
                         signaling_server_token: args.signaling_server_token,
-                        permissions_token: args.webrtc_permissions_token,
+                        permissions: args.webrtc_permissions_token,
                     })
                     .await?;
             },

--- a/applications/tari_dan_wallet_daemon/src/handlers/webrtc.rs
+++ b/applications/tari_dan_wallet_daemon/src/handlers/webrtc.rs
@@ -10,7 +10,7 @@ use axum_jrpc::{
     JsonRpcResponse,
 };
 use log::*;
-use tari_dan_wallet_sdk::apis::jwt::JrpcPermission;
+use tari_dan_wallet_sdk::apis::jwt::{JrpcPermission, JrpcPermissions};
 use tari_shutdown::ShutdownSignal;
 use tari_wallet_daemon_client::types::{WebRtcStartRequest, WebRtcStartResponse};
 
@@ -43,11 +43,42 @@ pub fn handle_start(
         })?;
     let webrtc_start_request = value.parse_params::<WebRtcStartRequest>()?;
     let shutdown_signal = (*shutdown_signal).clone();
+    let permissions = serde_json::from_str::<JrpcPermissions>(&webrtc_start_request.permissions).map_err(|e| {
+        JsonRpcResponse::error(
+            answer_id,
+            JsonRpcError::new(
+                JsonRpcErrorReason::InternalError,
+                e.to_string(),
+                serde_json::Value::Null,
+            ),
+        )
+    })?;
+    let mut jwt = context.wallet_sdk().jwt_api();
+    let auth_token = jwt.generate_auth_token(permissions).map_err(|e| {
+        JsonRpcResponse::error(
+            answer_id,
+            JsonRpcError::new(
+                JsonRpcErrorReason::InternalError,
+                e.to_string(),
+                serde_json::Value::Null,
+            ),
+        )
+    })?;
+    let permissions_token = jwt.grant(auth_token).map_err(|e| {
+        JsonRpcResponse::error(
+            answer_id,
+            JsonRpcError::new(
+                JsonRpcErrorReason::InternalError,
+                e.to_string(),
+                serde_json::Value::Null,
+            ),
+        )
+    })?;
     tokio::spawn(async move {
         let (preferred_address, signaling_server_address) = addresses;
         if let Err(err) = webrtc_start_session(
             webrtc_start_request.signaling_server_token,
-            webrtc_start_request.permissions_token,
+            permissions_token,
             preferred_address,
             signaling_server_address,
             shutdown_signal,

--- a/applications/tari_dan_wallet_web_ui/src/Components/ConnectorLink/Permissions.tsx
+++ b/applications/tari_dan_wallet_web_ui/src/Components/ConnectorLink/Permissions.tsx
@@ -20,7 +20,7 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import FormControl from '@mui/material/FormControl';
 import FormGroup from '@mui/material/FormGroup';
 import FormControlLabel from '@mui/material/FormControlLabel';
@@ -29,54 +29,28 @@ import Switch from '@mui/material/Switch';
 import Divider from '@mui/material/Divider';
 import Typography from '@mui/material/Typography';
 import './Permissions.css';
+import { TariPermission } from '../../utils/tari_permissions';
 
-export default function Permissions() {
-  const [permissions, setPermissions] = useState([
-    {
-      id: 1,
-      name: 'Choose an identity (account public key) to log in with',
-      checked: true,
-    },
-    {
-      id: 2,
-      name: 'Choose an NFT as a profile picture',
-      checked: true,
-    },
-    {
-      id: 3,
-      name: 'Read all NFTs of a specific contract (in your wallet)',
-      checked: true,
-    },
-    {
-      id: 4,
-      name: 'Generate a proof of ownership of NFT',
-      checked: true,
-    },
-    {
-      id: 5,
-      name: 'Send funds',
-      checked: true,
-    },
-    {
-      id: 6,
-      name: 'Invoke generic method',
-      checked: true,
-    },
-  ]);
+export default function Permissions({ requiredPermissions, optionalPermissions, setOptionalPermissions }: { requiredPermissions: TariPermission[], optionalPermissions: TariPermission[], setOptionalPermissions: any }) {
+  const [permissions, setPermissions] = useState(optionalPermissions.map((permission, index) => {
+    return ({ id: index, name: permission.toString(), checked: true });
+  }));
 
-  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleChange = (index: number) => {
     setPermissions(
       permissions.map((item) => {
-        if (item.name === event.target.name) {
+        if (item.id === index) {
           return {
             ...item,
-            checked: event.target.checked,
+            checked: !item.checked,
           };
         }
         return item;
       })
     );
   };
+
+  useEffect(() => setOptionalPermissions(permissions.map((item) => item.checked)), [permissions]);
 
   return (
     <>
@@ -90,6 +64,27 @@ export default function Permissions() {
       >
         <Divider />
         <FormGroup>
+          {requiredPermissions.map((permissions) => {
+            return (
+              <>
+                <FormControlLabel
+                  control={
+                    <Switch
+                      checked={true}
+                      disabled={true}
+                    />
+                  }
+                  label={permissions.toString()}
+                  labelPlacement="start"
+                  key={permissions.toString()}
+                  className="permissions-switch"
+                />
+                <Divider />
+              </>
+            );
+          })}
+        </FormGroup>
+        <FormGroup>
           {permissions.map(({ checked, name, id }) => {
             return (
               <>
@@ -97,7 +92,7 @@ export default function Permissions() {
                   control={
                     <Switch
                       checked={checked}
-                      onChange={handleChange}
+                      onChange={() => handleChange(id)}
                       name={name}
                       value={name}
                     />

--- a/applications/tari_dan_wallet_web_ui/src/utils/json_rpc.tsx
+++ b/applications/tari_dan_wallet_web_ui/src/utils/json_rpc.tsx
@@ -158,4 +158,4 @@ export const confidentialFinalize = (proofId: number) => jsonRpc("confidential.f
 export const confidentialCancel = (proofId: number) => jsonRpc("confidential.cancel", [proofId]);
 export const confidentialCreateOutputProof = (amount: number) => jsonRpc("confidential.create_output_proof", [amount]);
 
-export const webrtc = (session: string) => jsonRpc("webrtc.start", [session]);
+export const webrtc = (signalingServerToken: string, permissions: string) => jsonRpc("webrtc.start", [signalingServerToken, permissions]);

--- a/applications/tari_dan_wallet_web_ui/src/utils/tari_permissions.tsx
+++ b/applications/tari_dan_wallet_web_ui/src/utils/tari_permissions.tsx
@@ -1,0 +1,378 @@
+//  Copyright 2022. The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import { toHexString } from "./helpers";
+
+export class Hash {
+  private value: number[];
+  constructor(value: number[]) {
+    this.value = value;
+  }
+  toString() {
+    return toHexString(this.value);
+  }
+  toJSON() {
+    return this.value;
+  }
+}
+
+export enum TAG {
+  ComponentAddress = 0,
+  Metadata = 1,
+  NonFungibleAddress = 2,
+  ResourceAddress = 3,
+  VaultId = 4,
+  BucketId = 5,
+}
+
+export class Tagged {
+  private value: any;
+  private tag: number;
+  constructor(tag: number, value: any) {
+    this.tag = tag;
+    this.value = value;
+  }
+  toString() {
+    return this.value.toString();
+  }
+  toJSON() {
+    return { "@@TAGGED@@": [this.tag, this.value] };
+  }
+}
+
+export class ResourceAddress {
+  private tagged: Tagged;
+  constructor(value: any) {
+    this.tagged = new Tagged(value["@@TAGGED@@"][0], new Hash(value["@@TAGGED@@"][1]));
+  }
+  toString() {
+    return `Resource(${this.tagged.toString()})`;
+  }
+  toJSON() {
+    return this.tagged.toJSON();
+  }
+}
+
+export class UnclaimedConfidentialOutputAddress {
+  private hash: Hash;
+  constructor(value: any) {
+    this.hash = new Hash(value);
+  }
+  toString() {
+    return `UnclaimedConfidentialOutput(${this.hash.toString()})`;
+  }
+  toJSON() {
+    return this.hash.toJSON();
+  }
+}
+
+export type u64 = number;
+export type u32 = number;
+export class U256 {
+  private value: number[];
+  constructor(value: any) {
+    this.value = value;
+  }
+  toString() {
+    return toHexString(this.value);
+  }
+  toJSON() {
+    return this.value;
+  }
+}
+
+export type NonFungibleIdType = U256 | number | string;
+
+export class NonFungibleId {
+  private value: NonFungibleIdType;
+  constructor(value: any) {
+    if (value.hasOwnProperty("U256")) {
+      this.value = new U256(value.U256);
+    } else if (value.hasOwnProperty("Uint32")) {
+      this.value = value.Uint32;
+    } else if (value.hasOwnProperty("Uint64")) {
+      this.value = value.Uint64;
+    } else if (value.hasOwnProperty("String")) {
+      this.value = value;
+    } else {
+      throw "unimplemented2";
+    }
+  }
+  toString() {
+    return this.value.toString();
+  }
+  toJSON() {
+    switch (typeof this.value) {
+      case 'string':
+        return { 'string': this.value };
+      case 'number':
+        return { 'Uint64': this.value };
+    }
+    return { 'U256': this.value };
+  }
+}
+
+export class NonFungibleAddressContents {
+  private resource_address: ResourceAddress;
+  private id: NonFungibleId;
+  constructor(value: any) {
+    this.resource_address = new ResourceAddress(value.resource_address);
+    this.id = new NonFungibleId(value.id);
+  }
+  toString() {
+    return `${this.resource_address.toString()}, ${this.id.toString()}`;
+  }
+  toJSON() {
+    return { resource_address: this.resource_address, id: this.id };
+  }
+}
+
+export class NonFungibleAddress {
+  private tagged: Tagged;
+  constructor(value: any) {
+    this.tagged = new Tagged(value["@@TAGGED@@"][0], new NonFungibleAddressContents(value["@@TAGGED@@"][1]));
+  }
+  toString() {
+    return `NonFungible(${this.tagged.toString()})`;
+  }
+  toJSON() {
+    return this.tagged.toJSON();
+  }
+}
+
+export class NonFungibleIndexAddress {
+  private resource_address: ResourceAddress;
+  private index: number;
+  constructor(value: any) {
+    this.resource_address = new ResourceAddress(value.resource_address);
+    this.index = value.index;
+  }
+  toString() {
+    return `NonFungibleIndex(${this.resource_address.toString()}, ${this.index})`;
+  }
+  toJSON() {
+    return { resource_address: this.resource_address, index: this.index };
+  }
+}
+
+export class ComponentAddress {
+  private tagged: Tagged;
+  constructor(value: any) {
+    this.tagged = new Tagged(value["@@TAGGED@@"][0], new Hash(value["@@TAGGED@@"][1]));
+  }
+  toString() {
+    return `Component(${this.tagged.toString()})`;
+  }
+  toJSON() {
+    return this.tagged.toJSON();
+  }
+}
+
+export class VaultId {
+  private tagged: Tagged;
+  constructor(value: any) {
+    this.tagged = new Tagged(value["@@TAGGED@@"][0], new Hash(value["@@TAGGED@@"][1]));
+  }
+  toString() {
+    return `Vault(${this.tagged.toString()})`;
+  }
+  toJSON() {
+    return this.tagged.toJSON();
+  }
+}
+
+export type SubstateAddressType =
+  | ResourceAddress
+  | ComponentAddress
+  | VaultId
+  | UnclaimedConfidentialOutputAddress
+  | NonFungibleAddress
+  | NonFungibleIndexAddress;
+
+export class SubstateAddress {
+  private value: SubstateAddressType;
+  constructor(value: any) {
+    if (value.hasOwnProperty("Component")) {
+      this.value = new ComponentAddress(value.ComponentAddress);
+    } else if (value.hasOwnProperty("Resource")) {
+      this.value = new ResourceAddress(value.Resource);
+    } else if (value.hasOwnProperty("Vault")) {
+      this.value = new VaultId(value.Vault);
+    } else if (value.hasOwnProperty("UnclaimedConfidentialOutput")) {
+      this.value = new UnclaimedConfidentialOutputAddress(value.UnclaimedConfidentialOutput);
+    } else if (value.hasOwnProperty("NonFungible")) {
+      this.value = new NonFungibleAddress(value.NonFungible);
+    } else if (value.hasOwnProperty("NonFungibleIndex")) {
+      this.value = new NonFungibleIndexAddress(value.NonFungibleIndex);
+    } else {
+      throw "unimplemented";
+    }
+  }
+  toString() {
+    return this.value.toString();
+  }
+  toJSON() {
+    if (this.value instanceof ComponentAddress) {
+      return { Component: this.value };
+    } else if (this.value instanceof ResourceAddress) {
+      return { Resource: this.value };
+    } else if (this.value instanceof VaultId) {
+      return { Vault: this.value };
+    } else if (this.value instanceof UnclaimedConfidentialOutputAddress) {
+      return { UnclaimedConfidentialOutput: this.value };
+    } else if (this.value instanceof NonFungibleAddress) {
+      return { NonFungible: this.value };
+    } else if (this.value instanceof NonFungibleIndexAddress) {
+      return { NonFungibleIndex: this.value };
+    }
+    throw "Unknown type";
+  }
+}
+
+export class TariPermissionAccountBalance {
+  private value: SubstateAddress;
+  constructor(value: any) {
+    this.value = new SubstateAddress(value);
+  }
+  toString() {
+    return `AccountBalance(${this.value.toString()})`;
+  }
+  toJSON() {
+    return { AccountBalance: this.value };
+  }
+}
+export class TariPermissionAccountList {
+  private value?: ComponentAddress;
+  constructor(value?: any) {
+    this.value = new ComponentAddress(value["@@TAGGED@@"][1]);
+  }
+  toString() {
+    if (this.value !== null) {
+      return `AccountList(${this.value?.toString()})`;
+    } else {
+      return "AccountList(any)";
+    }
+  }
+  toJSON() {
+    if (this.value === undefined) {
+      return { AccountList: this.value };
+    } else {
+      return { AccountList: null };
+    }
+  }
+}
+export class TariPermissionTransactionSend {
+  private value: SubstateAddress;
+  constructor(value: any) {
+    this.value = new SubstateAddress(value);
+  }
+  toString() {
+    return `TransactionSend(${this.value.toString()})`;
+  }
+  toJSON() {
+    return { TransactionSend: this.value };
+  }
+}
+
+export class TariPermissionGetNft {
+  private value0?: SubstateAddress;
+  private value1?: ResourceAddress;
+  constructor(value0?: SubstateAddress, value1?: ResourceAddress) {
+    this.value0 = value0;
+    this.value1 = value1;
+  }
+  toString() {
+    let svalue0, svalue1;
+    if (this.value0) {
+      svalue0 = this.value0.toString()
+    }
+    else {
+      svalue0 = "any";
+    }
+    if (this.value1) {
+      svalue1 = this.value1.toString()
+    }
+    else {
+      svalue1 = "any";
+    }
+    return `GetNft(${svalue0},${svalue1})`;
+  }
+  toJSON() {
+    return { GetNft: [this.value0, this.value1] };
+  }
+}
+
+export class TariPermissionNftGetOwnershipProof {
+  private value?: ResourceAddress;
+  constructor(value?: ResourceAddress) {
+    this.value = value;
+  }
+  toString() {
+    if (this.value) {
+      return `NftGetOwnershipProof(${this.value?.toString()})`;
+    }
+    else {
+      return `NftGetOwnershipProof(any)`;
+    }
+  }
+  toJSON() {
+    return { NftGetOwnershipProof: this.value };
+  }
+}
+
+export type TariPermission =
+  | TariPermissionNftGetOwnershipProof
+  | TariPermissionAccountBalance
+  | TariPermissionAccountList
+  | TariPermissionTransactionSend
+  | TariPermissionGetNft;
+
+export class TariPermissions {
+  private permissions: TariPermission[];
+
+  constructor() {
+    this.permissions = [];
+  }
+
+  addPermission(permission: TariPermission) {
+    this.permissions.push(permission);
+  }
+
+  toJSON() {
+    return this.permissions;
+  }
+}
+
+export function parse(permission: any) {
+  if (permission.hasOwnProperty("AccountBalance")) {
+    return new TariPermissionAccountBalance(permission.AccountBalance);
+  } else if (permission.hasOwnProperty("AccountList")) {
+    return new TariPermissionAccountList(permission.AccountList);
+  } else if (permission.hasOwnProperty("TransactionSend")) {
+    return new TariPermissionTransactionSend(permission.TransactionSend);
+  } else if (permission.hasOwnProperty("GetNft")) {
+    return new TariPermissionGetNft(permission.GetNft);
+  } else if (permission.hasOwnProperty("NftGetOwnershipProof")) {
+    return new TariPermissionNftGetOwnershipProof(permission.NftGetOwnershipProof);
+  }
+  return null;
+}

--- a/applications/tari_signaling_server/Cargo.toml
+++ b/applications/tari_signaling_server/Cargo.toml
@@ -23,3 +23,4 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
 tower-http = { version = "0.3.5", default-features = false, features = ["cors", "trace"] }
 jsonwebtoken = "8.3.0"
 chrono = "0.4.24"
+webrtc = "0.7.2"

--- a/applications/tari_signaling_server/src/data.rs
+++ b/applications/tari_signaling_server/src/data.rs
@@ -7,12 +7,13 @@ use anyhow::Result;
 use chrono::{Duration, Utc};
 use jsonwebtoken::{decode, encode, DecodingKey, EncodingKey, Header, TokenData, Validation};
 use serde::{Deserialize, Serialize};
+use webrtc::ice_transport::ice_candidate::RTCIceCandidateInit;
 
 pub struct Data {
     pub offers: HashMap<u64, String>,
     pub answers: HashMap<u64, String>,
-    pub offer_ice_candidates: HashMap<u64, Vec<String>>,
-    pub answer_ice_candidates: HashMap<u64, Vec<String>>,
+    pub offer_ice_candidates: HashMap<u64, Vec<RTCIceCandidateInit>>,
+    pub answer_ice_candidates: HashMap<u64, Vec<RTCIceCandidateInit>>,
     pub expiration: Duration,
     pub secret_key: String,
     // The lowest still probably alive id. They will be cleaned up after expiration, which goes in order.
@@ -79,27 +80,27 @@ impl Data {
         self.answers.get(&id).ok_or_else(|| anyhow::Error::msg("Invalid id"))
     }
 
-    pub fn add_offer_ice_candidate(&mut self, id: u64, ice_candidate: String) {
+    pub fn add_offer_ice_candidate(&mut self, id: u64, ice_candidate: RTCIceCandidateInit) {
         self.offer_ice_candidates
             .entry(id)
             .or_insert_with(Vec::new)
             .push(ice_candidate);
     }
 
-    pub fn get_offer_ice_candidates(&self, id: u64) -> Result<&Vec<String>> {
+    pub fn get_offer_ice_candidates(&self, id: u64) -> Result<&Vec<RTCIceCandidateInit>> {
         self.offer_ice_candidates
             .get(&id)
             .ok_or_else(|| anyhow::Error::msg("Invalid id"))
     }
 
-    pub fn add_answer_ice_candidate(&mut self, id: u64, ice_candidate: String) {
+    pub fn add_answer_ice_candidate(&mut self, id: u64, ice_candidate: RTCIceCandidateInit) {
         self.answer_ice_candidates
             .entry(id)
             .or_insert_with(Vec::new)
             .push(ice_candidate);
     }
 
-    pub fn get_answer_ice_candidates(&self, id: u64) -> Result<&Vec<String>> {
+    pub fn get_answer_ice_candidates(&self, id: u64) -> Result<&Vec<RTCIceCandidateInit>> {
         self.answer_ice_candidates
             .get(&id)
             .ok_or_else(|| anyhow::Error::msg("Invalid id"))

--- a/clients/wallet_daemon_client/src/types.rs
+++ b/clients/wallet_daemon_client/src/types.rs
@@ -444,7 +444,7 @@ pub struct WebRtcStart {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct WebRtcStartRequest {
     pub signaling_server_token: String,
-    pub permissions_token: String,
+    pub permissions: String,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/dan_layer/wallet/sdk/src/storage.rs
+++ b/dan_layer/wallet/sdk/src/storage.rs
@@ -167,6 +167,7 @@ pub trait WalletStoreWriter {
     // JWT
     fn jwt_add_empty_token(&mut self) -> Result<u64, WalletStorageError>;
     fn jwt_store_decision(&mut self, id: u64, permissions_token: Option<String>) -> Result<(), WalletStorageError>;
+    fn jwt_is_revoked(&mut self, token: &str) -> Result<bool, WalletStorageError>;
 
     // Key manager
     fn key_manager_insert(&mut self, branch: &str, index: u64) -> Result<(), WalletStorageError>;

--- a/dan_layer/wallet/storage_sqlite/migrations/2023-05-09-120000_add_revokability/down.sql
+++ b/dan_layer/wallet/storage_sqlite/migrations/2023-05-09-120000_add_revokability/down.sql
@@ -1,0 +1,5 @@
+--  // Copyright 2022 The Tari Project
+--  // SPDX-License-Identifier: BSD-3-Clause
+
+ALTER TABLE auth_status
+    DROP COLUMN revoked;

--- a/dan_layer/wallet/storage_sqlite/migrations/2023-05-09-120000_add_revokability/up.sql
+++ b/dan_layer/wallet/storage_sqlite/migrations/2023-05-09-120000_add_revokability/up.sql
@@ -1,0 +1,5 @@
+--  // Copyright 2022 The Tari Project
+--  // SPDX-License-Identifier: BSD-3-Clause
+
+ALTER TABLE auth_status
+    ADD COLUMN revoked BOOLEAN NOT NULL DEFAULT FALSE;

--- a/dan_layer/wallet/storage_sqlite/src/schema.rs
+++ b/dan_layer/wallet/storage_sqlite/src/schema.rs
@@ -11,6 +11,16 @@ table! {
 }
 
 table! {
+    auth_status(id) {
+        id -> Integer,
+        user_decided -> Bool,
+        granted -> Bool,
+        token -> Text,
+        revoked -> Bool,
+    }
+}
+
+table! {
     config (id) {
         id -> Integer,
         key -> Text,
@@ -18,15 +28,6 @@ table! {
         is_encrypted -> Bool,
         created_at -> Timestamp,
         updated_at -> Timestamp,
-    }
-}
-
-table! {
-    auth_status(id) {
-        id -> Integer,
-        user_decided -> Bool,
-        granted -> Bool,
-        token -> Text,
     }
 }
 


### PR DESCRIPTION
Description
---
Add jwt permissions, the web3 developer can set optional and required permission. In the dan wallet you can deselect the optional permissions and grant the token. Then the web3 developer gets the token, which is then sent with every request. The wallet store all tokens. And in the DB there is a flag for revoking the token (no ui yet).

How Has This Been Tested?
---
Manually.

What process can a PR reviewer use to test or verify this change?
---
You can setup danwallet, and create a simple page using [tari-connector](https://github.com/tari-project/tari-connector). This will connect to the signaling server and create an url/qrcode (there is a signaling server jwt and permissions). Pass this to the dan wallet. Authorize that. Next the web3 page can reguest the token by sending "get.token" message. After that you can start using the token for other jrpc (over webrtc) requests.

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify