### PR TITLE
fix: auth call in dan wallet ui

### DIFF
--- a/applications/tari_dan_wallet_web_ui/src/utils/json_rpc.tsx
+++ b/applications/tari_dan_wallet_web_ui/src/utils/json_rpc.tsx
@@ -66,7 +66,7 @@ async function internalJsonRpc(method: string, token: any = null, params: any = 
 export async function jsonRpc(method: string, params: any = null) {
   await mutex_token.runExclusive(async () => {
     if (token === null) {
-      let auth_response = await internalJsonRpc("auth.request", null, [["Admin"]]);
+      let auth_response = await internalJsonRpc("auth.request", null, [["Admin"], null]);
       let auth_token = auth_response["auth_token"];
       let accept_response = await internalJsonRpc("auth.accept", null, [auth_token]);
       token = accept_response.permissions_token


### PR DESCRIPTION
Description
---
The `auth.request` has two params now.

How Has This Been Tested?
---
Manually.

What process can a PR reviewer use to test or verify this change?
---
Run the dan wallet ui

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify