### PR TITLE
fix(engine)!: use resource addresses derived from tx hash

### DIFF
--- a/applications/tari_dan_wallet_cli/src/command/transaction.rs
+++ b/applications/tari_dan_wallet_cli/src/command/transaction.rs
@@ -425,7 +425,7 @@ pub async fn submit_transaction(
     println!("✅ Transaction {} submitted.", resp.hash);
     println!();
     // TODO: Would be great if we could display the Substate addresses as well as shard ids
-    summarize_request(&request, &resp.inputs, &resp.outputs);
+    summarize_request(&request, &resp.inputs);
 
     println!();
     println!("⏳️ Waiting for transaction result...");
@@ -447,7 +447,7 @@ pub async fn submit_transaction(
     Ok(resp)
 }
 
-fn summarize_request(request: &TransactionSubmitRequest, inputs: &[ShardId], outputs: &[ShardId]) {
+fn summarize_request(request: &TransactionSubmitRequest, inputs: &[ShardId]) {
     if request.is_dry_run {
         println!("NOTE: Dry run is enabled. This transaction will not be processed by the network.");
         println!();
@@ -461,15 +461,6 @@ fn summarize_request(request: &TransactionSubmitRequest, inputs: &[ShardId], out
         }
     }
     println!();
-    println!("Outputs:");
-    if outputs.is_empty() && request.new_outputs == 0 {
-        println!("  None");
-    } else {
-        for shard_id in outputs {
-            println!("- {}", shard_id);
-        }
-        println!("- {} new output(s)", request.new_outputs);
-    }
     println!();
     println!("🌟 Submitting fee instructions:");
     for instruction in &request.fee_instructions {

--- a/applications/tari_dan_wallet_daemon/src/handlers/transaction.rs
+++ b/applications/tari_dan_wallet_daemon/src/handlers/transaction.rs
@@ -149,11 +149,7 @@ pub async fn handle_submit(
         });
     }
 
-    Ok(TransactionSubmitResponse {
-        hash,
-        inputs,
-        outputs: vec![],
-    })
+    Ok(TransactionSubmitResponse { hash, inputs })
 }
 
 pub async fn handle_get(

--- a/applications/tari_validator_node/tests/cucumber.rs
+++ b/applications/tari_validator_node/tests/cucumber.rs
@@ -1010,14 +1010,18 @@ async fn successful_transaction(world: &mut TariWorld) {
             let get_transaction_res = client
                 .get_transaction_result(get_transaction_req)
                 .await
-                .expect(format!("Failed to get transaction with hash {} for vn = {}", hash, vn_ps.name).as_str());
-            let finalized_tx = get_transaction_res.result.expect(
-                format!(
+                .unwrap_or_else(|e| {
+                    panic!(
+                        "Failed to get transaction with hash {} for vn = {}: {}",
+                        hash, vn_ps.name, e
+                    )
+                });
+            let finalized_tx = get_transaction_res.result.unwrap_or_else(|| {
+                panic!(
                     "Transaction result was rejected for tx hash {} and vn = {}",
                     hash, vn_ps.name
                 )
-                .as_str(),
-            );
+            });
             finalized_tx.expect_success();
         }
     }

--- a/applications/tari_validator_node/tests/features/fungible.feature
+++ b/applications/tari_validator_node/tests/features/fungible.feature
@@ -29,7 +29,7 @@ Feature: Fungible tokens
     When I use an account key named K1
 
     # Create a new Faucet component
-    When I call function "mint" on template "faucet" on VN with args "amount_10000" and 3 outputs named "FAUCET" with new resource "test"
+    When I call function "mint" on template "faucet" on VN with args "amount_10000" and outputs named "FAUCET"
 
     # Create two accounts to test sending the tokens
     When I create an account ACC_1 on VN
@@ -37,7 +37,7 @@ Feature: Fungible tokens
 
     # Submit a transaction manifest
 #    When I print the cucumber world
-    When I submit a transaction manifest on VN with inputs "FAUCET, ACC_1" and 3 outputs named "TX1" signed with key ACC_1
+    When I submit a transaction manifest on VN with inputs "FAUCET, ACC_1" and outputs named "TX1" signed with key ACC_1
     ```
     let faucet = global!["FAUCET/components/TestFaucet"];
     let mut acc1 = global!["ACC_1/components/Account"];

--- a/applications/tari_validator_node/tests/features/indexer.feature
+++ b/applications/tari_validator_node/tests/features/indexer.feature
@@ -40,7 +40,7 @@ Feature: Indexer node
     When I create an account ACC1 on VN
 
     # Create a new SparkleNft component and mint an NFT
-    When I call function "new" on template "basic_nft" on VN with 3 outputs named "NFT" with new resource "SPKL"
+    When I call function "new" on template "basic_nft" on VN with outputs named "NFT"
     When I submit a transaction manifest on VN with inputs "NFT, ACC1" and 12 outputs named "TX2" signed with key ACC1
     ```
     // $mint NFT/resources/0 6

--- a/applications/tari_validator_node/tests/features/nft.feature
+++ b/applications/tari_validator_node/tests/features/nft.feature
@@ -31,14 +31,14 @@ Feature: NFTs
     When I use an account key named K1
 
     # Create a new BasicNft component
-    When I call function "new" on template "basic_nft" on VN with 3 outputs named "NFT" with new resource "SPKL"
+    When I call function "new" on template "basic_nft" on VN with outputs named "NFT"
 
     # Create an account to deposit the minted nfts
     When I create an account ACC1 on VN
     When I create an account ACC2 on VN
 
     # Submit a transaction with NFT operations
-    When I submit a transaction manifest on VN with inputs "NFT, ACC1, ACC2" and 6 outputs named "TX1" signed with key ACC1
+    When I submit a transaction manifest on VN with inputs "NFT, ACC1, ACC2" and outputs named "TX1" signed with key ACC1
         ```
             // $mint NFT/resources/0 1
             // $mint_specific NFT/resources/0 str:SpecialNft
@@ -73,4 +73,72 @@ Feature: NFTs
             sparkle_nft.burn(acc_bucket);
         ```
     When I print the cucumber world
+
+  @serial
+  @doit
+  Scenario: Create resource and mint in one transaction
+    # Initialize a base node, wallet, miner and VN
+    Given a base node BASE
+    Given a wallet WALLET connected to base node BASE
+    Given a miner MINER connected to base node BASE and wallet WALLET
+
+    # Initialize a VN
+    Given a validator node VN connected to base node BASE and wallet WALLET
+
+    # The wallet must have some funds before the VN sends transactions
+    When miner MINER mines 7 new blocks
+    When wallet WALLET has at least 10000 T
+
+    # VN registration
+    When validator node VN sends a registration transaction
+
+    # Register the "basic_nft" template
+    When validator node VN registers the template "basic_nft"
+    When miner MINER mines 13 new blocks
+    Then VN has scanned to height 17 within 10 seconds
+    Then the validator node VN is listed as registered
+    Then the template "basic_nft" is listed as registered by the validator node VN
+
+    # Create a new BasicNft component
+    When I call function "with_initial_nft" on template "basic_nft" on VN with args "nft_str:1000" and outputs named "TX1"
+
+    # Create an account to deposit the minted nfts
+    When I create an account ACC1 on VN
+
+    # Submit a transaction with NFT operations
+#    When I submit a transaction manifest on VN with inputs "TX1" named "TX2" signed with key ACC1
+#  ```
+#  // $mint NFT/resources/0 1
+#  // $mint_specific NFT/resources/0 str:SpecialNft
+#  // $mint_specific NFT/resources/0 str:Burn!
+#  // $nft_index NFT/resources/0 0
+#  // $nft_index NFT/resources/0 1
+#  // $nft_index NFT/resources/0 2
+#  let sparkle_nft = global!["NFT/components/SparkleNft"];
+#  let sparkle_res = global!["NFT/resources/0"];
+#  let mut acc1 = global!["ACC1/components/Account"];
+#  let mut acc2 = global!["ACC2/components/Account"];
+#
+#  // mint a new nft with random id
+#  let nft_bucket = sparkle_nft.mint("NFT1", "http://example.com");
+#  acc1.deposit(nft_bucket);
+#
+#  // mint a new nft with specific id
+#  let nft_bucket = sparkle_nft.mint_specific(NonFungibleId("SpecialNft"), "NFT2", "http://example.com");
+#  acc1.deposit(nft_bucket);
+#
+#  // transfer nft between accounts
+#  let acc_bucket = acc1.withdraw_non_fungible(sparkle_res, NonFungibleId("SpecialNft"));
+#  acc2.deposit(acc_bucket);
+#
+#  // mutate a nft
+#  sparkle_nft.inc_brightness(NonFungibleId("SpecialNft"), 10u32);
+#
+#  // burn a nft
+#  let nft_bucket = sparkle_nft.mint_specific(NonFungibleId("Burn!"), "NFT3", "http://example.com");
+#  acc1.deposit(nft_bucket);
+#  let acc_bucket = acc1.withdraw_non_fungible(sparkle_res, NonFungibleId("Burn!"));
+#  sparkle_nft.burn(acc_bucket);
+#  ```
+#    When I print the cucumber world
 

--- a/applications/tari_validator_node/tests/features/transfer.feature
+++ b/applications/tari_validator_node/tests/features/transfer.feature
@@ -34,8 +34,7 @@ Feature: Account transfers
     When I create an account ACCOUNT via the wallet daemon WALLET_D with 1000 free coins
 
     # Create a new Faucet component
-    # When I call function "mint" on template "faucet" on VN with args "amount_10000" and 3 outputs named "FAUCET" with new resource "test"
-    When I call function "mint" on template "faucet" using account ACCOUNT to pay fees via wallet daemon WALLET_D with args "amount_10000" and 3 outputs named "FAUCET"
+    When I call function "mint" on template "faucet" using account ACCOUNT to pay fees via wallet daemon WALLET_D with args "amount_10000" and outputs named "FAUCET"
 
     # Burn some tari in the base layer to have funds for fees in the sender account
     When I burn 10T on wallet WALLET with wallet daemon WALLET_D into commitment COMMITMENT with proof PROOF for ACCOUNT, range proof RANGEPROOF and claim public key CLAIM_PUBKEY

--- a/applications/tari_validator_node/tests/features/wallet_daemon.feature
+++ b/applications/tari_validator_node/tests/features/wallet_daemon.feature
@@ -41,7 +41,7 @@ Feature: Wallet Daemon
         When I check the balance of ACC_2 on wallet daemon WALLET_D the amount is exactly 0
 
         # Create a new Faucet component
-        When I call function "mint" on template "faucet" using account ACC_1 to pay fees via wallet daemon WALLET_D with args "10000" and 3 outputs named "FAUCET"
+        When I call function "mint" on template "faucet" using account ACC_1 to pay fees via wallet daemon WALLET_D with args "10000" and outputs named "FAUCET"
 
         # Submit a transaction manifest
         When I print the cucumber world

--- a/applications/tari_validator_node/tests/steps/validator_node.rs
+++ b/applications/tari_validator_node/tests/steps/validator_node.rs
@@ -79,7 +79,6 @@ async fn when_i_claim_burn(
         .unwrap_or_else(|| panic!("Claim public key {} not found", claim_public_key_name));
 
     let account_shard = ShardId::from_address(&account_address, 0);
-    let account_v1_shard = ShardId::from_address(&account_address, 1);
 
     let transaction = Transaction::builder()
         .claim_burn(ConfidentialClaim {
@@ -91,7 +90,6 @@ async fn when_i_claim_burn(
         })
         .put_last_instruction_output_on_workspace("burn")
         .call_method(component_address, "deposit", args![Workspace("burn")])
-        .with_outputs(vec![account_v1_shard])
         .with_inputs(vec![commitment_shard, account_shard])
         .sign(account_secret)
         .build();

--- a/applications/tari_validator_node/tests/templates/basic_nft/src/lib.rs
+++ b/applications/tari_validator_node/tests/templates/basic_nft/src/lib.rs
@@ -32,13 +32,33 @@ mod sparkle_nft_template {
 
     pub struct SparkleNft {
         resource_address: ResourceAddress,
+        vault: Vault,
     }
 
     impl SparkleNft {
         pub fn new() -> Self {
             let resource_address = ResourceBuilder::non_fungible("SPKL").build();
 
-            Self { resource_address }
+            Self {
+                resource_address,
+                vault: Vault::new_empty(resource_address),
+            }
+        }
+
+        pub fn with_initial_nft(nft: NonFungibleId) -> Self {
+            let empty = Metadata::new();
+            let bucket = ResourceBuilder::non_fungible("SPKL")
+                .with_non_fungibles(Some((nft, (&(), &empty))))
+                .build_bucket();
+
+            Self {
+                resource_address: bucket.resource_address(),
+                vault: Vault::from_bucket(bucket),
+            }
+        }
+
+        pub fn take_initial_nft(&mut self) -> Bucket {
+            self.vault.withdraw(Amount(1))
         }
 
         pub fn mint(&mut self, name: String, url: String) -> Bucket {

--- a/applications/tari_validator_node/tests/utils/wallet_daemon_cli.rs
+++ b/applications/tari_validator_node/tests/utils/wallet_daemon_cli.rs
@@ -594,7 +594,6 @@ pub async fn create_component(
     wallet_daemon_name: String,
     function_call: String,
     args: Vec<String>,
-    _num_outputs: u64,
 ) {
     let mut client = get_auth_wallet_daemon_client(world, &wallet_daemon_name).await;
 

--- a/applications/tari_validator_node_cli/src/command/account.rs
+++ b/applications/tari_validator_node_cli/src/command/account.rs
@@ -80,16 +80,11 @@ pub async fn handle_create(
     let common = CommonSubmitArgs {
         wait_for_result: true,
         wait_for_result_timeout: Some(60),
-        num_outputs: Some(1),
         inputs: vec![],
         version: None,
         dump_outputs_into: None,
         account_template_address: None,
         dry_run: args.is_dry_run,
-        new_resources: vec![],
-        non_fungible_mint_outputs: vec![],
-        new_non_fungible_outputs: vec![],
-        new_non_fungible_index_outputs: vec![],
     };
 
     submit_transaction(vec![instruction], common, base_dir, client).await

--- a/clients/wallet_daemon_client/src/types.rs
+++ b/clients/wallet_daemon_client/src/types.rs
@@ -99,7 +99,6 @@ pub struct TransactionSubmitResponse {
     #[serde(with = "serde_with::hex")]
     pub hash: FixedHash,
     pub inputs: Vec<ShardId>,
-    pub outputs: Vec<ShardId>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/dan_layer/engine/src/runtime/tracker.rs
+++ b/dan_layer/engine/src/runtime/tracker.rs
@@ -159,9 +159,7 @@ impl<TTemplateProvider: TemplateProvider<Template = LoadedTemplate>> StateTracke
         token_symbol: String,
         metadata: Metadata,
     ) -> Result<ResourceAddress, RuntimeError> {
-        let resource_address = self
-            .id_provider
-            .new_resource_address(&self.runtime_state()?.template_address, &token_symbol)?;
+        let resource_address = self.id_provider.new_resource_address()?;
         let resource = Resource::new(resource_type, token_symbol, metadata);
         self.write_with(|state| {
             state.new_resources.insert(resource_address, resource);

--- a/dan_layer/transaction/src/id_provider.rs
+++ b/dan_layer/transaction/src/id_provider.rs
@@ -62,16 +62,8 @@ impl IdProvider {
         Ok(id)
     }
 
-    pub fn new_resource_address(
-        &self,
-        template_address: &TemplateAddress,
-        token_symbol: &str,
-    ) -> Result<ResourceAddress, IdProviderError> {
-        Ok(hasher(EngineHashDomainLabel::ResourceAddress)
-            .chain(&template_address)
-            .chain(&token_symbol)
-            .result()
-            .into())
+    pub fn new_resource_address(&self) -> Result<ResourceAddress, IdProviderError> {
+        Ok(self.new_id()?.into())
     }
 
     pub fn new_component_address(

--- a/dan_layer/transaction_manifest/src/parser.rs
+++ b/dan_layer/transaction_manifest/src/parser.rs
@@ -358,7 +358,7 @@ fn build_arguments(args: Punctuated<Expr, Comma>) -> Result<Vec<ManifestLiteral>
                 } else {
                     Err(syn::Error::new_spanned(
                         func,
-                        "Invalid function call, only Amount is supported",
+                        "Invalid function call, only Amount and NonFungibleId are supported",
                     ))
                 }
             },
@@ -399,7 +399,7 @@ fn handle_special_literals(name: &Ident, args: Punctuated<Expr, Comma>) -> Resul
     } else {
         Err(syn::Error::new_spanned(
             name,
-            "Invalid function call, only Amount is supported",
+            "Invalid function call, only Amount and NonFungibleId are supported",
         ))
     }
 }


### PR DESCRIPTION
Description
---
- uses resource address = `H(tx_hash || n)`
- reverts some of the changes in #450 
- removes the ability to add output shards in the transaction builder

Motivation and Context
---

How Has This Been Tested?
---

What process can a PR reviewer use to test or verify this change?
---


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify