### PR TITLE
fix: remove unnecessary checked_sub and expect

### DIFF
--- a/applications/tari_validator_node/src/p2p/services/epoch_manager/base_layer_epoch_manager.rs
+++ b/applications/tari_validator_node/src/p2p/services/epoch_manager/base_layer_epoch_manager.rs
@@ -500,10 +500,8 @@ impl BaseLayerEpochManager {
         let constants = self.get_base_layer_consensus_constants().await?;
         let expiry = constants.validator_node_registration_expiry();
 
-        let num_blocks_since_last_reg = self
-            .current_epoch
-            .checked_sub(last_registration_epoch)
-            .expect("current epoch was less than the epoch we registered"); // Reorgs are not supported
+        // Note this can be negative in some cases
+        let num_blocks_since_last_reg = self.current_epoch - last_registration_epoch;
 
         // None indicates that we are not registered, or a previous registration has expired
         Ok(expiry.checked_sub(num_blocks_since_last_reg))

--- a/applications/tari_validator_node/src/p2p/services/epoch_manager/base_layer_epoch_manager.rs
+++ b/applications/tari_validator_node/src/p2p/services/epoch_manager/base_layer_epoch_manager.rs
@@ -501,7 +501,7 @@ impl BaseLayerEpochManager {
         let expiry = constants.validator_node_registration_expiry();
 
         // Note this can be negative in some cases
-        let num_blocks_since_last_reg = self.current_epoch - last_registration_epoch;
+        let num_blocks_since_last_reg = self.current_epoch.saturating_sub(last_registration_epoch);
 
         // None indicates that we are not registered, or a previous registration has expired
         Ok(expiry.checked_sub(num_blocks_since_last_reg))


### PR DESCRIPTION
Description
---
removes a checked_sub and expect which caused a panic

Motivation and Context
---
The Validator Node would panic when this checked_sub returns a negative. I'm not sure exactly why it mismatched, but the base layer height was 39, so I assume some kind of edge case or perhaps a sync was happening. Either way, the next line does a checked_sub and it doesn't look necessary to prevent a negative number here.

How Has This Been Tested?
---
Validator Node would crash without this change when using dan_testing

What process can a PR reviewer use to test or verify this change?
---
Not really easy to reproduce

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify