### PR TITLE
refactor: represent tariswap fee as a per-mil amount

### DIFF
--- a/dan_layer/engine/tests/tariswap.rs
+++ b/dan_layer/engine/tests/tariswap.rs
@@ -19,7 +19,7 @@ struct TariSwapTest {
     account_proof: NonFungibleAddress,
 }
 
-fn setup(fee: f64) -> TariSwapTest {
+fn setup(fee: u16) -> TariSwapTest {
     let mut template_test = TemplateTest::new(vec!["tests/templates/tariswap", "tests/templates/faucet"]);
 
     // create the token pair for the swap pool
@@ -60,7 +60,7 @@ fn create_tariswap_component(
     template_test: &mut TemplateTest,
     a_resource: ResourceAddress,
     b_resource: ResourceAddress,
-    fee: f64,
+    fee: u16,
 ) -> (ComponentAddress, ResourceAddress) {
     let module_name = "TariSwapPool";
     let tariswap_template = template_test.get_template_address(module_name);
@@ -187,7 +187,7 @@ fn add_liquidity(test: &mut TariSwapTest, a_amount: Amount, b_amount: Amount) {
                 Instruction::CallMethod {
                     component_address: test.account_address,
                     method: "deposit".to_string(),
-                    args: args![Variable("lp_bucket"),],
+                    args: args![Variable("lp_bucket")],
                 },
             ],
             // proof needed to withdraw
@@ -335,7 +335,7 @@ fn assert_remove_liquidity(
 #[test]
 fn tariswap() {
     // init the test
-    let fee = 5.0; // 5% market fee
+    let fee = 50; // 5% market fee
     let mut test = setup(fee);
 
     // save the resource addreses to keep the compiler happy

--- a/dan_layer/engine/tests/templates/tariswap/src/lib.rs
+++ b/dan_layer/engine/tests/templates/tariswap/src/lib.rs
@@ -31,20 +31,21 @@ mod tariswap {
     pub struct TariSwapPool {
         pools: HashMap<ResourceAddress, Vault>,
         lp_resource: ResourceAddress,
-        fee: f64,
+        fee: u16,
     }
 
     impl TariSwapPool {
 
         // Initialises a new pool component for for the pool A - B
-        pub fn new(a_addr: ResourceAddress, b_addr: ResourceAddress, fee: f64) -> Self {
+        // the fees is represented as a per-mil quantity (e.g. "1" represents "0.1%")
+        pub fn new(a_addr: ResourceAddress, b_addr: ResourceAddress, fee: u16) -> Self {
             // check that the the resource pair is correct
             assert!(a_addr != b_addr, "The resources of the pair must be different");
             Self::check_resource_is_fungible(a_addr);
             Self::check_resource_is_fungible(b_addr);
 
             // the fee represents a percentage, so it must be between 0 and 100
-            let valid_fee_range = 0.0..100.0;
+            let valid_fee_range = 0..1000;
             assert!(valid_fee_range.contains(&fee), "Invalid fee {}", fee);
 
             // create the vaults to store the funds
@@ -79,9 +80,8 @@ mod tariswap {
 
             // apply the fee to the input bucket
             // so the user will get a lesser amout of tokens than the theoritical (for the gain of the LP holders)
-            let input_bucket_balance = input_bucket.amount().value() as f64;
-            let effective_input_balance = input_bucket_balance - (input_bucket_balance * self.fee) / 100.0;
-            let effective_input_balance = effective_input_balance.ceil() as i64;
+            let input_bucket_balance = input_bucket.amount().value();
+            let effective_input_balance = input_bucket_balance - (input_bucket_balance * (self.fee as i64)) / 1000;
             let effective_input_balance = Amount::new(effective_input_balance);
 
             // recalculate the new vault balances for the swap
@@ -189,7 +189,7 @@ mod tariswap {
             ResourceManager::get(self.lp_resource).total_supply()
         }
 
-        pub fn fee(&self) -> f64 {
+        pub fn fee(&self) -> u16 {
             self.fee
         }
 


### PR DESCRIPTION
Description
---
* Changed the `fee` parameter in the `tariswap` template constructor to be an integer (per-mil amount) instead of a float
* Updated the corresponding unit test accordingly

Motivation and Context
---
On https://github.com/tari-project/tari-dan/pull/517 we introduced a new template example `tariswap`, that implements a decentralised exchange that allows adding/removing liquidity and token swaps.

The template works on unit tests, but presents a problem when trying to initialize it (calling the `new` function) via wallet/VN CLI's or through a `tari-connector` web page. The `fee` parameter in the constructor is defined as a float number which is currently not supported in clients, so this PR refactors it to be a integer (a per-mil amount) instead.

The goal is to enable `tariswap` to work manually as soon as possible. We might consider adding float number support for clients in the future.

How Has This Been Tested?
---
* The existing unit test has been updated and passes
* Manually we can initialize now components of the template via wallet/VN CLI's or through a `tari-connector` web page.

What process can a PR reviewer use to test or verify this change?
---
Run the unit test or manually initialize a new component of the Tariswap template (calling the `new` function)

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify