### PR TITLE
feat(walletd): add naming to the JWT tokens

### DIFF
--- a/applications/tari_dan_wallet_cli/src/command/auth.rs
+++ b/applications/tari_dan_wallet_cli/src/command/auth.rs
@@ -89,7 +89,6 @@ impl AuthSubcommand {
                 }
             },
             Grant(args) => {
-                println!("Grant {:?}", args);
                 let resp = client
                     .auth_accept(AuthLoginAcceptRequest {
                         auth_token: args.auth_token,

--- a/applications/tari_dan_wallet_cli/src/command/auth.rs
+++ b/applications/tari_dan_wallet_cli/src/command/auth.rs
@@ -25,7 +25,13 @@ use std::time::Duration;
 use clap::{Args, Subcommand};
 use tari_dan_wallet_sdk::apis::jwt::JrpcPermissions;
 use tari_wallet_daemon_client::{
-    types::{AuthLoginAcceptRequest, AuthLoginDenyRequest, AuthLoginRequest, AuthRevokeTokenRequest},
+    types::{
+        AuthGetAllJwtRequest,
+        AuthLoginAcceptRequest,
+        AuthLoginDenyRequest,
+        AuthLoginRequest,
+        AuthRevokeTokenRequest,
+    },
     WalletDaemonClient,
 };
 
@@ -35,6 +41,7 @@ pub enum AuthSubcommand {
     Grant(GrantArgs),
     Deny(DenyArgs),
     Revoke(RevokeArgs),
+    List,
 }
 
 // TODO: Add permissions
@@ -50,6 +57,7 @@ pub struct RequestArgs {
 #[derive(Debug, Args, Clone)]
 pub struct GrantArgs {
     auth_token: String,
+    name: String,
 }
 
 #[derive(Debug, Args, Clone)]
@@ -81,9 +89,11 @@ impl AuthSubcommand {
                 }
             },
             Grant(args) => {
+                println!("Grant {:?}", args);
                 let resp = client
                     .auth_accept(AuthLoginAcceptRequest {
                         auth_token: args.auth_token,
+                        name: args.name,
                     })
                     .await?;
                 println!("Access granted. Your JRPC token : {}", resp.permissions_token);
@@ -103,6 +113,12 @@ impl AuthSubcommand {
                     })
                     .await?;
                 println!("Token revoked!");
+            },
+            List => {
+                let tokens = client.auth_get_all_jwt(AuthGetAllJwtRequest {}).await?;
+                for (id, name) in &tokens.jwt {
+                    println!("Id {id} name {name}");
+                }
             },
         }
         Ok(())

--- a/applications/tari_dan_wallet_daemon/src/handlers/rpc.rs
+++ b/applications/tari_dan_wallet_daemon/src/handlers/rpc.rs
@@ -3,6 +3,8 @@
 
 use tari_dan_wallet_sdk::apis::jwt::JrpcPermission;
 use tari_wallet_daemon_client::types::{
+    AuthGetAllJwtRequest,
+    AuthGetAllJwtResponse,
     AuthLoginAcceptRequest,
     AuthLoginAcceptResponse,
     AuthLoginDenyRequest,
@@ -44,8 +46,7 @@ pub async fn handle_login_accept(
     auth_accept_request: AuthLoginAcceptRequest,
 ) -> Result<AuthLoginAcceptResponse, anyhow::Error> {
     let jwt = context.wallet_sdk().jwt_api();
-
-    let permissions_token = jwt.grant(auth_accept_request.auth_token)?;
+    let permissions_token = jwt.grant(auth_accept_request.name, auth_accept_request.auth_token)?;
     Ok(AuthLoginAcceptResponse { permissions_token })
 }
 
@@ -68,4 +69,15 @@ pub async fn handle_revoke(
     jwt.check_auth(token, &[JrpcPermission::Admin])?;
     jwt.revoke(revoke_request.permission_token.as_str())?;
     Ok(AuthRevokeTokenResponse {})
+}
+
+pub async fn handle_get_all_jwt(
+    context: &HandlerContext,
+    token: Option<String>,
+    _request: AuthGetAllJwtRequest,
+) -> Result<AuthGetAllJwtResponse, anyhow::Error> {
+    let jwt = context.wallet_sdk().jwt_api();
+    jwt.check_auth(token, &[JrpcPermission::Admin])?;
+    let tokens = jwt.get_tokens()?;
+    Ok(AuthGetAllJwtResponse { jwt: tokens })
 }

--- a/applications/tari_dan_wallet_daemon/src/handlers/webrtc.rs
+++ b/applications/tari_dan_wallet_daemon/src/handlers/webrtc.rs
@@ -64,7 +64,7 @@ pub fn handle_start(
             ),
         )
     })?;
-    let permissions_token = jwt.grant(auth_token.0).map_err(|e| {
+    let permissions_token = jwt.grant("webrtc".to_string(), auth_token.0).map_err(|e| {
         JsonRpcResponse::error(
             answer_id,
             JsonRpcError::new(

--- a/applications/tari_dan_wallet_daemon/src/jrpc_server.rs
+++ b/applications/tari_dan_wallet_daemon/src/jrpc_server.rs
@@ -86,6 +86,7 @@ async fn handler(
             "accept" => call_handler(context, value, token, rpc::handle_login_accept).await,
             "deny" => call_handler(context, value, token, rpc::handle_login_deny).await,
             "revoke" => call_handler(context, value, token, rpc::handle_revoke).await,
+            "get_all_jwt" => call_handler(context, value, token, rpc::handle_get_all_jwt).await,
             _ => Ok(value.method_not_found(&value.method)),
         },
         Some(("webrtc", "start")) => webrtc::handle_start(context, value, token, shutdown_signal, addresses),

--- a/applications/tari_validator_node/tests/utils/wallet_daemon_cli.rs
+++ b/applications/tari_validator_node/tests/utils/wallet_daemon_cli.rs
@@ -717,7 +717,13 @@ pub(crate) async fn get_auth_wallet_daemon_client(world: &TariWorld, wallet_daem
         })
         .await
         .unwrap();
-    let auth_response = client.auth_accept(AuthLoginAcceptRequest { auth_token }).await.unwrap();
+    let auth_response = client
+        .auth_accept(AuthLoginAcceptRequest {
+            auth_token,
+            name: "Testing Token".to_string(),
+        })
+        .await
+        .unwrap();
     client.set_auth_token(auth_response.permissions_token);
     client
 }

--- a/clients/wallet_daemon_client/src/lib.rs
+++ b/clients/wallet_daemon_client/src/lib.rs
@@ -78,6 +78,8 @@ use crate::{
         AccountsInvokeResponse,
         AccountsListRequest,
         AccountsListResponse,
+        AuthGetAllJwtRequest,
+        AuthGetAllJwtResponse,
         AuthRevokeTokenRequest,
         AuthRevokeTokenResponse,
         ConfidentialCreateOutputProofRequest,
@@ -379,6 +381,13 @@ impl WalletDaemonClient {
         req: T,
     ) -> Result<AuthRevokeTokenResponse, WalletDaemonClientError> {
         self.send_request("auth.revoke", req.borrow()).await
+    }
+
+    pub async fn auth_get_all_jwt<T: Borrow<AuthGetAllJwtRequest>>(
+        &mut self,
+        req: T,
+    ) -> Result<AuthGetAllJwtResponse, WalletDaemonClientError> {
+        self.send_request("auth.get_all_jwt", req.borrow()).await
     }
 
     pub async fn webrtc_start<T: Borrow<WebRtcStartRequest>>(

--- a/clients/wallet_daemon_client/src/types.rs
+++ b/clients/wallet_daemon_client/src/types.rs
@@ -476,6 +476,7 @@ pub struct AuthLoginResponse {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct AuthLoginAcceptRequest {
     pub auth_token: String,
+    pub name: String,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -498,3 +499,11 @@ pub struct AuthRevokeTokenRequest {
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct AuthRevokeTokenResponse {}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct AuthGetAllJwtRequest {}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct AuthGetAllJwtResponse {
+    pub jwt: Vec<(i32, String)>,
+}

--- a/dan_layer/wallet/sdk/src/apis/jwt.rs
+++ b/dan_layer/wallet/sdk/src/apis/jwt.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 use tari_engine_types::substate::SubstateAddress;
 use tari_template_lib::prelude::{ComponentAddress, ResourceAddress};
 
-use crate::storage::{WalletStorageError, WalletStore, WalletStoreWriter};
+use crate::storage::{WalletStorageError, WalletStore, WalletStoreReader, WalletStoreWriter};
 
 pub struct JwtApi<'a, TStore> {
     store: &'a TStore,
@@ -102,6 +102,7 @@ impl JrpcPermissions {
 #[derive(Debug, Serialize, Deserialize)]
 struct Claims {
     id: u64,
+    name: String,
     permissions: JrpcPermissions,
     exp: usize,
 }
@@ -161,19 +162,29 @@ impl<'a, TStore: WalletStore> JwtApi<'a, TStore> {
         Ok(auth_token_data.claims)
     }
 
-    fn get_permissions(&self, token: &str) -> Result<JrpcPermissions, JwtApiError> {
-        let token_data = decode::<Claims>(
+    fn get_token_claims(&self, token: &str) -> Result<Claims, JwtApiError> {
+        let claims = decode::<Claims>(
             token,
             &DecodingKey::from_secret(self.jwt_secret_key.as_ref()),
             &Validation::default(),
-        )?;
-        Ok(token_data.claims.permissions)
+        )
+        .map(|token_data| token_data.claims)?;
+        Ok(claims)
     }
 
-    pub fn grant(&self, auth_token: String) -> Result<String, JwtApiError> {
+    fn get_permissions(&self, token: &str) -> Result<JrpcPermissions, JwtApiError> {
+        self.get_token_claims(token).map(|claims| claims.permissions)
+    }
+
+    fn get_name(&self, token: &str) -> Result<String, JwtApiError> {
+        self.get_token_claims(token).map(|claims| claims.name)
+    }
+
+    pub fn grant(&self, name: String, auth_token: String) -> Result<String, JwtApiError> {
         let auth_claims = self.check_auth_token(auth_token.as_ref())?;
         let my_claims = Claims {
             id: auth_claims.id,
+            name,
             permissions: auth_claims.permissions,
             exp: auth_claims.exp,
         };
@@ -221,6 +232,18 @@ impl<'a, TStore: WalletStore> JwtApi<'a, TStore> {
         tx.jwt_revoke(token)?;
         tx.commit()?;
         Ok(())
+    }
+
+    pub fn get_tokens(&self) -> Result<Vec<(i32, String)>, JwtApiError> {
+        let mut tx = self.store.create_read_tx()?;
+        let tokens = tx.jwt_get_all()?;
+        let mut res = Vec::new();
+        for (id, token) in &tokens {
+            if let Ok(name) = self.get_name(token.as_str()) {
+                res.push((*id, name));
+            }
+        }
+        Ok(res)
     }
 }
 

--- a/dan_layer/wallet/sdk/src/storage.rs
+++ b/dan_layer/wallet/sdk/src/storage.rs
@@ -110,6 +110,8 @@ pub trait WalletStoreReader {
     fn key_manager_get_last_index(&mut self, branch: &str) -> Result<u64, WalletStorageError>;
     // Config
     fn config_get<T: serde::de::DeserializeOwned>(&mut self, key: &str) -> Result<Config<T>, WalletStorageError>;
+    // JWT
+    fn jwt_get_all(&mut self) -> Result<Vec<(i32, String)>, WalletStorageError>;
     // Transactions
     fn transaction_get(&mut self, hash: FixedHash) -> Result<WalletTransaction, WalletStorageError>;
     fn transactions_fetch_all_by_status(

--- a/dan_layer/wallet/storage_sqlite/src/reader.rs
+++ b/dan_layer/wallet/storage_sqlite/src/reader.rs
@@ -26,11 +26,7 @@ use tari_engine_types::substate::{InvalidSubstateAddressFormat, SubstateAddress}
 use tari_template_lib::models::ResourceAddress;
 use tari_utilities::hex::Hex;
 
-use crate::{
-    diesel::ExpressionMethods,
-    models,
-    serialization::deserialize_json,
-};
+use crate::{diesel::ExpressionMethods, models, serialization::deserialize_json};
 
 const LOG_TARGET: &str = "tari::dan::wallet_sdk::storage_sqlite::reader";
 

--- a/dan_layer/wallet/storage_sqlite/src/reader.rs
+++ b/dan_layer/wallet/storage_sqlite/src/reader.rs
@@ -26,7 +26,11 @@ use tari_engine_types::substate::{InvalidSubstateAddressFormat, SubstateAddress}
 use tari_template_lib::models::ResourceAddress;
 use tari_utilities::hex::Hex;
 
-use crate::{diesel::ExpressionMethods, models, serialization::deserialize_json};
+use crate::{
+    diesel::ExpressionMethods,
+    models,
+    serialization::deserialize_json,
+};
 
 const LOG_TARGET: &str = "tari::dan::wallet_sdk::storage_sqlite::reader";
 
@@ -148,6 +152,17 @@ impl WalletStoreReader for ReadTransaction<'_> {
             created_at: 0,
             updated_at: 0,
         })
+    }
+
+    // -------------------------------- JWT -------------------------------- //
+    fn jwt_get_all(&mut self) -> Result<Vec<(i32, String)>, WalletStorageError> {
+        use crate::schema::auth_status;
+        let res = auth_status::table
+            .select((auth_status::id, auth_status::token))
+            .filter(auth_status::granted.eq(true))
+            .get_results::<(i32, String)>(self.connection())
+            .map_err(|e| WalletStorageError::general("jwt_get_all", e))?;
+        Ok(res)
     }
 
     // -------------------------------- Transactions -------------------------------- //


### PR DESCRIPTION
Description
---
Add names to the jwt (the user needs to see which token is which).
Add jwt method for listing of the (still valid) tokens.

Motivation and Context
---
Adding a name to the token makes it much easier for user to revoke it. Currently the name comes from user when it calls the `auth.accept`. So we do need a change in the UI for this. Or we can provide the name from the `tari-connector`. But I suggest we can provide the name and still be replaced by the user in the acceptance dialog in the dan wallet ui.

How Has This Been Tested?
---

1. Request a token
`cargo run --bin tari_dan_wallet_cli -- auth request Admin`
Outputs `Auth token <auth_token>`
2. Grant the permissions
`cargo run --bin tari_dan_wallet_cli -- auth grant <auth_token> <name>`
Outputs `Access granted. Your JRPC token : <permission_token>`
3. List the tokens:
`cargo run --bin tari_dan_wallet_cli -- --token <permissions_token> auth list`
Outputs `Id 1 name <name>`

What process can a PR reviewer use to test or verify this change?
---
Use the same step I used for testing.

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify