### PR TITLE
feat: add token name to daemon ui

### DIFF
--- a/applications/tari_dan_wallet_cli/src/command/webrtc.rs
+++ b/applications/tari_dan_wallet_cli/src/command/webrtc.rs
@@ -33,6 +33,7 @@ pub enum WebRtcSubcommand {
 pub struct StartArgs {
     pub signaling_server_token: String,
     pub webrtc_permissions_token: String,
+    pub token_name: String,
 }
 
 impl WebRtcSubcommand {
@@ -45,6 +46,7 @@ impl WebRtcSubcommand {
                     .webrtc_start(WebRtcStartRequest {
                         signaling_server_token: args.signaling_server_token,
                         permissions: args.webrtc_permissions_token,
+                        name: args.token_name,
                     })
                     .await?;
             },

--- a/applications/tari_dan_wallet_daemon/src/handlers/webrtc.rs
+++ b/applications/tari_dan_wallet_daemon/src/handlers/webrtc.rs
@@ -64,7 +64,7 @@ pub fn handle_start(
             ),
         )
     })?;
-    let permissions_token = jwt.grant("webrtc".to_string(), auth_token.0).map_err(|e| {
+    let permissions_token = jwt.grant(webrtc_start_request.name, auth_token.0).map_err(|e| {
         JsonRpcResponse::error(
             answer_id,
             JsonRpcError::new(

--- a/applications/tari_dan_wallet_web_ui/src/utils/json_rpc.tsx
+++ b/applications/tari_dan_wallet_web_ui/src/utils/json_rpc.tsx
@@ -20,8 +20,8 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import { Mutex } from "async-mutex";
-import { json } from "react-router-dom";
+import {Mutex} from "async-mutex";
+import {json} from "react-router-dom";
 
 let token: String | null = null;
 let json_id = 0;
@@ -40,8 +40,9 @@ async function internalJsonRpc(method: string, token: any = null, params: any = 
     if (/^\d+(\.\d+){3}:[0-9]+$/.test(text)) {
       address = text;
     }
-  } catch { }
-  let headers: { [key: string]: string } = { "Content-Type": "application/json" };
+  } catch {
+  }
+  let headers: { [key: string]: string } = {"Content-Type": "application/json"};
   if (token) {
     headers["Authorization"] = `Bearer ${token}`
   }
@@ -68,7 +69,7 @@ export async function jsonRpc(method: string, params: any = null) {
     if (token === null) {
       let auth_response = await internalJsonRpc("auth.request", null, [["Admin"], null]);
       let auth_token = auth_response["auth_token"];
-      let accept_response = await internalJsonRpc("auth.accept", null, [auth_token]);
+      let accept_response = await internalJsonRpc("auth.accept", null, [auth_token, "AdminToken"]);
       token = accept_response.permissions_token
     }
   })
@@ -125,7 +126,7 @@ export const transactionsWaitResult = (hash: string, timeoutSecs: number | null)
 // accounts
 export const accountsClaimBurn = (account: string, claimProof: any, fee: number) =>
   // Fees are passed as strings because Amount is tagged
-  jsonRpc("accounts.claim_burn", { account, claim_proof: claimProof, fee: fee });
+  jsonRpc("accounts.claim_burn", {account, claim_proof: claimProof, fee: fee});
 export const accountsCreate = (
   accountName: string | undefined,
   signingKeyIndex: number | undefined,
@@ -158,4 +159,4 @@ export const confidentialFinalize = (proofId: number) => jsonRpc("confidential.f
 export const confidentialCancel = (proofId: number) => jsonRpc("confidential.cancel", [proofId]);
 export const confidentialCreateOutputProof = (amount: number) => jsonRpc("confidential.create_output_proof", [amount]);
 
-export const webrtc = (signalingServerToken: string, permissions: string) => jsonRpc("webrtc.start", [signalingServerToken, permissions]);
+export const webrtc = (signalingServerToken: string, permissions: string, name: string) => jsonRpc("webrtc.start", [signalingServerToken, permissions, name]);

--- a/clients/wallet_daemon_client/src/types.rs
+++ b/clients/wallet_daemon_client/src/types.rs
@@ -457,6 +457,7 @@ pub struct WebRtcStart {
 pub struct WebRtcStartRequest {
     pub signaling_server_token: String,
     pub permissions: String,
+    pub name: String,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]


### PR DESCRIPTION
Description
---
Add token name to UI. User can change the value coming from website.
Webrtc now requires a name as well, because it generates the token for the website.
The tokens generated with previous version of tari-connector will not work.

Motivation and Context
---

How Has This Been Tested?
---
Manualy.

What process can a PR reviewer use to test or verify this change?
---
Make a simple website using tari-connector and generate a token. Paste it to the daemon ui, this will on the 3rd step of accepting show the edit field for the name.
You can then use `tari_dan_wallet_cli --token <permissions token> auth list` to show the names of token.


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify