### PR TITLE
fix: stop retriggering redraw

### DIFF
--- a/applications/tari_validator_node_web_ui/src/Components/SearchFilter.tsx
+++ b/applications/tari_validator_node_web_ui/src/Components/SearchFilter.tsx
@@ -101,8 +101,17 @@ const TransactionFilter: React.FC<ISearchProps> = ({
         }
       });
 
-      // Update the state with the modified copy of the original array
-      setStateObject(updatedObject);
+      // Update the state with the modified copy of the original array, but only
+      // when it actually changes, to prevent retriggering redraw
+      let changed = updatedObject.length !== stateObject.length;
+      if (!changed) {
+        for (let i = 0; i < stateObject.length && !changed; ++i) {
+          changed = stateObject[i] !== updatedObject[i];
+        }
+      }
+      if (changed) {
+        setStateObject(updatedObject);
+      }
 
       // Set paging to first page
       setPage(0);


### PR DESCRIPTION
Description
---
Stop retriggering redraw of the `Recent Transactions`.

Motivation and Context
---
I've noticed that I sometimes don't see the recent transactions in the web UI, when running the VN. Starting the react manually with the correct json port was always working. Maybe the axum server handling the http server of the ui is not as fast as when you run the `node` (npm start in the webui folder). But now without redraw it works perfectly.t

How Has This Been Tested?
---
I've manually checked that the component is not being redrawn all the time.

What process can a PR reviewer use to test or verify this change?
---
You can use some kind of react analyzer extension, or manually just adding console.log inside the recent transactions component.


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify