### PR TITLE
fix(wallet_daemon): proper permissions on `wait_result` method

### DIFF
--- a/applications/tari_dan_wallet_daemon/src/handlers/transaction.rs
+++ b/applications/tari_dan_wallet_daemon/src/handlers/transaction.rs
@@ -217,7 +217,7 @@ pub async fn handle_wait_result(
     context
         .wallet_sdk()
         .jwt_api()
-        .check_auth(token, &[JrpcPermission::Admin])?;
+        .check_auth(token, &[JrpcPermission::TransactionGet])?;
     let mut events = context.notifier().subscribe();
     let transaction = context
         .wallet_sdk()


### PR DESCRIPTION
Description
---
Changed the `wait_result` JSON RPC method permission from `Admin` to `TransactionGet`

Motivation and Context
---
In web applications we want to be able to wait for a transaction result using the `wait_result` method in the wallet daemon. Until now this required `Admin` permissions. We should only require `TransactionGet` permissions similar to the `get` and `get_result` methods.

How Has This Been Tested?
---
Manually calling `wait_result` on a transaction using JavaScript

What process can a PR reviewer use to test or verify this change?
---
Call `wait_result` on a transaction, using a token that has the `TransactionGet` permission

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify