### PR TITLE
fix(walletd): use identical encoding for DH output encrytion key hasher

### DIFF
--- a/dan_layer/engine_types/src/base_layer_hashing.rs
+++ b/dan_layer/engine_types/src/base_layer_hashing.rs
@@ -24,7 +24,11 @@ use std::{io, io::Write};
 
 use borsh::BorshSerialize;
 use digest::Digest;
-use tari_crypto::{hash::blake2::Blake256, hash_domain, hashing::DomainSeparation};
+use tari_crypto::{
+    hash::blake2::Blake256,
+    hash_domain,
+    hashing::{DomainSeparatedHasher, DomainSeparation},
+};
 use tari_template_lib::Hash;
 
 hash_domain!(
@@ -43,8 +47,9 @@ fn confidential_hasher(label: &'static str) -> TariBaseLayerHasher {
     TariBaseLayerHasher::new_with_label::<ConfidentialOutputHashDomain>(label)
 }
 
-pub fn encrypted_data_hasher() -> TariBaseLayerHasher {
-    TariBaseLayerHasher::new_with_label::<WalletOutputEncryptionKeysDomain>("")
+type WalletOutputEncryptionKeysDomainHasher = DomainSeparatedHasher<Blake256, WalletOutputEncryptionKeysDomain>;
+pub fn encrypted_data_hasher() -> WalletOutputEncryptionKeysDomainHasher {
+    WalletOutputEncryptionKeysDomainHasher::new_with_label("")
 }
 
 pub fn ownership_proof_hasher() -> TariBaseLayerHasher {

--- a/dan_layer/wallet/sdk/src/confidential/kdfs.rs
+++ b/dan_layer/wallet/sdk/src/confidential/kdfs.rs
@@ -2,6 +2,7 @@
 //   SPDX-License-Identifier: BSD-3-Clause
 
 use chacha20poly1305::{aead::generic_array::GenericArray, Key};
+use digest::FixedOutput;
 use tari_common_types::types::{PrivateKey, PublicKey};
 use tari_crypto::dhke::DiffieHellmanSharedSecret;
 use tari_engine_types::base_layer_hashing::encrypted_data_hasher;
@@ -17,7 +18,7 @@ pub fn encrypted_data_dh_kdf_aead(private_key: &PrivateKey, public_nonce: &Publi
     let mut aead_key = EncryptedDataKey::from(SafeArray::default());
     // Must match base layer burn
     encrypted_data_hasher()
-        .chain(&shared_secret.as_bytes())
+        .chain(shared_secret.as_bytes())
         .finalize_into(GenericArray::from_mut_slice(aead_key.reveal_mut()));
 
     PrivateKey::from_bytes(aead_key.reveal()).unwrap()


### PR DESCRIPTION
Description
---
fix(walletd): use identical encoding for DH output encrytion key hasher

Motivation and Context
---
We were previously using Borsh encoding to hash the DH key to produce the encrypted data key for burns in the base layer. This changed to SecretKey::as_bytes() encoding. This PR changes the hasher to match the base layer.

I copied the hasher into the codebase, IMO we should be exporting shared hash domains and hashers from a dedicated crate so that it's easier to keep these in sync without adding tari_core as a dependency.

How Has This Been Tested?
---
Claim burn and wallet daemon cucumbers pass.

What process can a PR reviewer use to test or verify this change?
---
Run cucumbers, manually: claim burnt funds

Breaking Changes
---

- [ ] None
- [ ] Requires data directory to be deleted
- [x] Other - This change is breaking for all confidential assets. In future we should consider using a separate DAN level hasher or even a different process for confidential assets and only use the base layer hashers for claim burn