### PR TITLE
feat: request missing TXs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1600,6 +1600,7 @@ dependencies = [
  "async-trait",
  "env_logger",
  "futures 0.3.28",
+ "itertools 0.11.0",
  "log",
  "rand 0.7.3",
  "serde",
@@ -2061,7 +2062,7 @@ dependencies = [
  "globwalk",
  "humantime",
  "inventory",
- "itertools",
+ "itertools 0.10.5",
  "junit-report",
  "linked-hash-map",
  "once_cell",
@@ -2079,7 +2080,7 @@ checksum = "755eae3e762505d670bbf02db048d512e79118f93f8383ae1bf6235506ed3c94"
 dependencies = [
  "cucumber-expressions",
  "inflections",
- "itertools",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "regex",
@@ -3868,6 +3869,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3981,7 +3991,7 @@ dependencies = [
  "diff",
  "ena",
  "is-terminal",
- "itertools",
+ "itertools 0.10.5",
  "lalrpop-util",
  "petgraph",
  "regex",
@@ -5437,7 +5447,7 @@ checksum = "62941722fb675d463659e49c4f3fe1fe792ff24fe5bbaa9c08cd3b98a1c354f5"
 dependencies = [
  "bytes 1.4.0",
  "heck 0.3.3",
- "itertools",
+ "itertools 0.10.5",
  "lazy_static",
  "log",
  "multimap",
@@ -5456,7 +5466,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9cc1a3263e07e0bf68e96268f37665207b49560d98739662cdfaae215c720fe"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -5469,7 +5479,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -8382,7 +8392,7 @@ dependencies = [
  "digest 0.9.0",
  "fs2",
  "futures 0.3.28",
- "itertools",
+ "itertools 0.10.5",
  "libsqlite3-sys",
  "log",
  "prost 0.9.0",
@@ -10429,7 +10439,7 @@ checksum = "103fa851fff70ea29af380e87c25c48ff7faac5c530c70bd0e65366d4e0c94e4"
 dependencies = [
  "derive_builder 0.12.0",
  "fancy-regex",
- "itertools",
+ "itertools 0.10.5",
  "js-sys",
  "lazy_static",
  "quick-error",

--- a/applications/tari_validator_node/src/consensus/state_manager.rs
+++ b/applications/tari_validator_node/src/consensus/state_manager.rs
@@ -27,7 +27,7 @@ impl<TStateStore: StateStore> StateManager<TStateStore> for TariStateManager {
         block: &Block,
         transaction: &ExecutedTransaction,
     ) -> Result<(), Self::Error> {
-        let Some(diff) =transaction.result().finalize.result.accept() else {
+        let Some(diff) = transaction.result().finalize.result.accept() else {
             // We should only commit accepted transactions, might want to change this API to reflect that
             return Ok(());
         };

--- a/dan_layer/consensus/src/hotstuff/mod.rs
+++ b/dan_layer/consensus/src/hotstuff/mod.rs
@@ -7,6 +7,8 @@ mod on_beat;
 mod on_propose;
 mod on_receive_new_view;
 mod on_receive_proposal;
+mod on_receive_request_missing_transactions;
+mod on_receive_requested_transactions;
 mod on_receive_vote;
 mod worker;
 

--- a/dan_layer/consensus/src/hotstuff/on_receive_proposal.rs
+++ b/dan_layer/consensus/src/hotstuff/on_receive_proposal.rs
@@ -126,7 +126,7 @@ where TConsensusSpec: ConsensusSpec
         let mut missing_tx_ids = Vec::new();
         self.store.with_read_tx(|tx| {
             for tx_id in block.all_transaction_ids() {
-                if ExecutedTransaction::exists(tx, tx_id)? {
+                if !ExecutedTransaction::exists(tx, tx_id)? {
                     missing_tx_ids.push(*tx_id);
                 }
             }
@@ -193,7 +193,7 @@ where TConsensusSpec: ConsensusSpec
                 maybe_decision = self.decide_what_to_vote(tx, block, &local_committee_shard)?;
             }
 
-            self.update_nodes(tx, &block, &local_committee_shard)?;
+            self.update_nodes(tx, block, &local_committee_shard)?;
             Ok::<_, HotStuffError>(maybe_decision)
         })?;
 

--- a/dan_layer/consensus/src/hotstuff/on_receive_request_missing_transactions.rs
+++ b/dan_layer/consensus/src/hotstuff/on_receive_request_missing_transactions.rs
@@ -1,0 +1,58 @@
+//   Copyright 2023 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+use log::*;
+use tari_dan_storage::{StateStore, StateStoreReadTransaction};
+use tokio::sync::mpsc;
+
+use crate::{
+    hotstuff::error::HotStuffError,
+    messages::{HotstuffMessage, RequestMissingTransactionsMessage, RequestedTransactionMessage},
+    traits::{ConsensusSpec, EpochManager},
+};
+
+const LOG_TARGET: &str = "tari::dan::consensus::hotstuff::on_receive_request_missing_transactions";
+
+pub struct OnReceiveRequestMissingTransactions<TConsensusSpec: ConsensusSpec> {
+    store: TConsensusSpec::StateStore,
+    tx_leader: mpsc::Sender<(TConsensusSpec::Addr, HotstuffMessage)>,
+}
+
+impl<TConsensusSpec> OnReceiveRequestMissingTransactions<TConsensusSpec>
+where
+    TConsensusSpec: ConsensusSpec,
+    HotStuffError: From<<TConsensusSpec::EpochManager as EpochManager>::Error>,
+{
+    pub fn new(
+        store: TConsensusSpec::StateStore,
+        tx_leader: mpsc::Sender<(TConsensusSpec::Addr, HotstuffMessage)>,
+    ) -> Self {
+        Self { store, tx_leader }
+    }
+
+    pub async fn handle(
+        &mut self,
+        from: TConsensusSpec::Addr,
+        msg: RequestMissingTransactionsMessage,
+    ) -> Result<(), HotStuffError> {
+        info!(target: LOG_TARGET, "{:?} is requesting missing transactions from block {} with ids {:?}", from,msg.block_id, msg.transactions);
+        let txs = self
+            .store
+            .with_read_tx(|tx| tx.transactions_get_many(&msg.transactions));
+        let txs = txs?;
+        self.tx_leader
+            .send((
+                from,
+                HotstuffMessage::RequestedTransaction(RequestedTransactionMessage {
+                    epoch: msg.epoch,
+                    block_id: msg.block_id,
+                    transactions: txs,
+                }),
+            ))
+            .await
+            .map_err(|_| HotStuffError::InternalChannelClosed {
+                context: "tx_new_transaction in OnReceiveRequestMissingTransactions::handle",
+            })?;
+        Ok(())
+    }
+}

--- a/dan_layer/consensus/src/hotstuff/on_receive_request_missing_transactions.rs
+++ b/dan_layer/consensus/src/hotstuff/on_receive_request_missing_transactions.rs
@@ -15,7 +15,7 @@ const LOG_TARGET: &str = "tari::dan::consensus::hotstuff::on_receive_request_mis
 
 pub struct OnReceiveRequestMissingTransactions<TConsensusSpec: ConsensusSpec> {
     store: TConsensusSpec::StateStore,
-    tx_leader: mpsc::Sender<(TConsensusSpec::Addr, HotstuffMessage)>,
+    tx_request_missing_tx: mpsc::Sender<(TConsensusSpec::Addr, HotstuffMessage)>,
 }
 
 impl<TConsensusSpec> OnReceiveRequestMissingTransactions<TConsensusSpec>
@@ -23,9 +23,12 @@ where TConsensusSpec: ConsensusSpec
 {
     pub fn new(
         store: TConsensusSpec::StateStore,
-        tx_leader: mpsc::Sender<(TConsensusSpec::Addr, HotstuffMessage)>,
+        tx_request_missing_tx: mpsc::Sender<(TConsensusSpec::Addr, HotstuffMessage)>,
     ) -> Self {
-        Self { store, tx_leader }
+        Self {
+            store,
+            tx_request_missing_tx,
+        }
     }
 
     pub async fn handle(
@@ -37,7 +40,7 @@ where TConsensusSpec: ConsensusSpec
         let txs = self
             .store
             .with_read_tx(|tx| ExecutedTransaction::get_many(tx, &msg.transactions))?;
-        self.tx_leader
+        self.tx_request_missing_tx
             .send((
                 from,
                 HotstuffMessage::RequestedTransaction(RequestedTransactionMessage {

--- a/dan_layer/consensus/src/hotstuff/on_receive_requested_transactions.rs
+++ b/dan_layer/consensus/src/hotstuff/on_receive_requested_transactions.rs
@@ -2,30 +2,24 @@
 //   SPDX-License-Identifier: BSD-3-Clause
 
 use log::*;
-use tari_dan_storage::consensus_models::ExecutedTransaction;
+use tari_transaction::Transaction;
 use tokio::sync::mpsc;
 
-use crate::{
-    hotstuff::error::HotStuffError,
-    messages::RequestedTransactionMessage,
-    traits::{ConsensusSpec, EpochManager},
-};
+use crate::{hotstuff::error::HotStuffError, messages::RequestedTransactionMessage, traits::ConsensusSpec};
 
 const LOG_TARGET: &str = "tari::dan::consensus::hotstuff::on_receive_requested_transactions";
 
 pub struct OnReceiveRequestedTransactions<TConsensusSpec: ConsensusSpec> {
-    tx_new_transaction: mpsc::Sender<ExecutedTransaction>,
+    tx_mempool: mpsc::Sender<Transaction>,
     _phantom: std::marker::PhantomData<TConsensusSpec>,
 }
 
 impl<TConsensusSpec> OnReceiveRequestedTransactions<TConsensusSpec>
-where
-    TConsensusSpec: ConsensusSpec,
-    HotStuffError: From<<TConsensusSpec::EpochManager as EpochManager>::Error>,
+where TConsensusSpec: ConsensusSpec
 {
-    pub fn new(tx_new_transaction: mpsc::Sender<ExecutedTransaction>) -> Self {
+    pub fn new(tx_mempool: mpsc::Sender<Transaction>) -> Self {
         Self {
-            tx_new_transaction,
+            tx_mempool,
             _phantom: Default::default(),
         }
     }
@@ -37,7 +31,7 @@ where
     ) -> Result<(), HotStuffError> {
         info!(target: LOG_TARGET, "{:?} sent the requested transactions for block {}", from,msg.block_id);
         for tx in msg.transactions {
-            self.tx_new_transaction
+            self.tx_mempool
                 .send(tx)
                 .await
                 .map_err(|_| HotStuffError::InternalChannelClosed {

--- a/dan_layer/consensus/src/hotstuff/on_receive_requested_transactions.rs
+++ b/dan_layer/consensus/src/hotstuff/on_receive_requested_transactions.rs
@@ -1,0 +1,49 @@
+//   Copyright 2023 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+use log::*;
+use tari_dan_storage::consensus_models::ExecutedTransaction;
+use tokio::sync::mpsc;
+
+use crate::{
+    hotstuff::error::HotStuffError,
+    messages::RequestedTransactionMessage,
+    traits::{ConsensusSpec, EpochManager},
+};
+
+const LOG_TARGET: &str = "tari::dan::consensus::hotstuff::on_receive_requested_transactions";
+
+pub struct OnReceiveRequestedTransactions<TConsensusSpec: ConsensusSpec> {
+    tx_new_transaction: mpsc::Sender<ExecutedTransaction>,
+    _phantom: std::marker::PhantomData<TConsensusSpec>,
+}
+
+impl<TConsensusSpec> OnReceiveRequestedTransactions<TConsensusSpec>
+where
+    TConsensusSpec: ConsensusSpec,
+    HotStuffError: From<<TConsensusSpec::EpochManager as EpochManager>::Error>,
+{
+    pub fn new(tx_new_transaction: mpsc::Sender<ExecutedTransaction>) -> Self {
+        Self {
+            tx_new_transaction,
+            _phantom: Default::default(),
+        }
+    }
+
+    pub async fn handle(
+        &mut self,
+        from: TConsensusSpec::Addr,
+        msg: RequestedTransactionMessage,
+    ) -> Result<(), HotStuffError> {
+        info!(target: LOG_TARGET, "{:?} sent the requested transactions for block {}", from,msg.block_id);
+        for tx in msg.transactions {
+            self.tx_new_transaction
+                .send(tx)
+                .await
+                .map_err(|_| HotStuffError::InternalChannelClosed {
+                    context: "tx_new_transaction in OnReceiveRequestedTransactions::handle",
+                })?;
+        }
+        Ok(())
+    }
+}

--- a/dan_layer/consensus/src/messages/message.rs
+++ b/dan_layer/consensus/src/messages/message.rs
@@ -13,7 +13,7 @@ pub enum HotstuffMessage {
     NewView(NewViewMessage),
     Proposal(ProposalMessage),
     Vote(VoteMessage),
-    RequestMissingTx(RequestMissingTransactionsMessage),
+    RequestMissingTransactions(RequestMissingTransactionsMessage),
     RequestedTransaction(RequestedTransactionMessage),
 }
 
@@ -23,7 +23,7 @@ impl HotstuffMessage {
             Self::NewView(msg) => msg.high_qc.epoch(),
             Self::Proposal(msg) => msg.block.epoch(),
             Self::Vote(msg) => msg.epoch,
-            Self::RequestMissingTx(msg) => msg.epoch,
+            Self::RequestMissingTransactions(msg) => msg.epoch,
             Self::RequestedTransaction(msg) => msg.epoch,
         }
     }
@@ -33,6 +33,8 @@ impl HotstuffMessage {
             Self::NewView(msg) => msg.high_qc.block_id(),
             Self::Proposal(msg) => msg.block.id(),
             Self::Vote(msg) => &msg.block_id,
+            Self::RequestMissingTransactions(msg) => &msg.block_id,
+            Self::RequestedTransaction(msg) => &msg.block_id,
         }
     }
 }

--- a/dan_layer/consensus/src/messages/message.rs
+++ b/dan_layer/consensus/src/messages/message.rs
@@ -5,13 +5,16 @@ use serde::Serialize;
 use tari_dan_common_types::Epoch;
 use tari_dan_storage::consensus_models::BlockId;
 
-use super::{NewViewMessage, ProposalMessage, VoteMessage};
+use super::{NewViewMessage, ProposalMessage, RequestedTransactionMessage, VoteMessage};
+use crate::messages::RequestMissingTransactionsMessage;
 
 #[derive(Debug, Clone, Serialize)]
 pub enum HotstuffMessage {
     NewView(NewViewMessage),
     Proposal(ProposalMessage),
     Vote(VoteMessage),
+    RequestMissingTx(RequestMissingTransactionsMessage),
+    RequestedTransaction(RequestedTransactionMessage),
 }
 
 impl HotstuffMessage {
@@ -20,6 +23,8 @@ impl HotstuffMessage {
             Self::NewView(msg) => msg.high_qc.epoch(),
             Self::Proposal(msg) => msg.block.epoch(),
             Self::Vote(msg) => msg.epoch,
+            Self::RequestMissingTx(msg) => msg.epoch,
+            Self::RequestedTransaction(msg) => msg.epoch,
         }
     }
 

--- a/dan_layer/consensus/src/messages/mod.rs
+++ b/dan_layer/consensus/src/messages/mod.rs
@@ -11,3 +11,9 @@ pub use proposal::*;
 
 mod vote;
 pub use vote::*;
+
+mod request_missing_transaction;
+pub use request_missing_transaction::*;
+
+mod requested_transaction;
+pub use requested_transaction::*;

--- a/dan_layer/consensus/src/messages/request_missing_transaction.rs
+++ b/dan_layer/consensus/src/messages/request_missing_transaction.rs
@@ -3,7 +3,8 @@
 
 use serde::Serialize;
 use tari_dan_common_types::Epoch;
-use tari_dan_storage::consensus_models::{BlockId, TransactionId};
+use tari_dan_storage::consensus_models::BlockId;
+use tari_transaction::TransactionId;
 
 #[derive(Debug, Clone, Serialize)]
 pub struct RequestMissingTransactionsMessage {

--- a/dan_layer/consensus/src/messages/request_missing_transaction.rs
+++ b/dan_layer/consensus/src/messages/request_missing_transaction.rs
@@ -1,0 +1,13 @@
+//   Copyright 2023 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+use serde::Serialize;
+use tari_dan_common_types::Epoch;
+use tari_dan_storage::consensus_models::{BlockId, TransactionId};
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RequestMissingTransactionsMessage {
+    pub epoch: Epoch,
+    pub block_id: BlockId,
+    pub transactions: Vec<TransactionId>,
+}

--- a/dan_layer/consensus/src/messages/requested_transaction.rs
+++ b/dan_layer/consensus/src/messages/requested_transaction.rs
@@ -3,11 +3,12 @@
 
 use serde::Serialize;
 use tari_dan_common_types::Epoch;
-use tari_dan_storage::consensus_models::{BlockId, ExecutedTransaction};
+use tari_dan_storage::consensus_models::BlockId;
+use tari_transaction::Transaction;
 
 #[derive(Debug, Clone, Serialize)]
 pub struct RequestedTransactionMessage {
     pub epoch: Epoch,
     pub block_id: BlockId,
-    pub transactions: Vec<ExecutedTransaction>,
+    pub transactions: Vec<Transaction>,
 }

--- a/dan_layer/consensus/src/messages/requested_transaction.rs
+++ b/dan_layer/consensus/src/messages/requested_transaction.rs
@@ -1,0 +1,13 @@
+//   Copyright 2023 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+use serde::Serialize;
+use tari_dan_common_types::Epoch;
+use tari_dan_storage::consensus_models::{BlockId, ExecutedTransaction};
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RequestedTransactionMessage {
+    pub epoch: Epoch,
+    pub block_id: BlockId,
+    pub transactions: Vec<ExecutedTransaction>,
+}

--- a/dan_layer/consensus_tests/Cargo.toml
+++ b/dan_layer/consensus_tests/Cargo.toml
@@ -30,3 +30,4 @@ tokio = { version = "1", default-features = false, features = ["sync"] }
 rand = "0.7"
 futures = "0.3"
 env_logger = "0.10.0"
+itertools = "0.11.0"

--- a/dan_layer/consensus_tests/src/consensus.rs
+++ b/dan_layer/consensus_tests/src/consensus.rs
@@ -40,6 +40,45 @@ async fn propose_blocks_with_queued_up_transactions_until_all_committed() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn node_requests_missing_transaction_from_local_leader() {
+    let mut test = Test::builder().add_committee(0, vec!["1", "2"]).start().await;
+    // First get all transactions in the mempool of node "1"
+    for _ in 0..10 {
+        test.send_transaction_to(&TestAddress("1"), Decision::Commit, 1, 5)
+            .await;
+    }
+    test.wait_until_new_pool_count_for_vn(10, TestAddress("1")).await;
+    test.network().start();
+    loop {
+        test.on_block_committed().await;
+
+        if test.are_all_transactions_committed() {
+            break;
+        }
+        let leaf = test.get_validator(&TestAddress("1")).get_leaf_block();
+        if leaf.height > NodeHeight(10) {
+            panic!("Not all transaction committed after {} blocks", leaf.height);
+        }
+    }
+
+    // Check if we clean the missing transactions table in the DB once the transactions are committed
+    test.get_validator(&TestAddress("2"))
+        .state_store
+        .with_read_tx(|tx| {
+            let mut block_id = BlockId::genesis();
+            while let Ok(block) = tx.blocks_get_by_parent(&block_id) {
+                assert!(tx.blocks_get_missing_transactions(block.id()).is_err());
+                block_id = *block.id();
+            }
+            Ok::<_, HotStuffError>(())
+        })
+        .unwrap();
+
+    test.assert_all_validators_at_same_height().await;
+    test.assert_clean_shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn propose_blocks_with_new_transactions_until_all_committed() {
     let mut test = Test::builder().add_committee(0, vec!["1"]).start().await;
     let mut remaining_txs = 10;

--- a/dan_layer/consensus_tests/src/consensus.rs
+++ b/dan_layer/consensus_tests/src/consensus.rs
@@ -1,8 +1,13 @@
 //   Copyright 2023 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
+use tari_consensus::hotstuff::HotStuffError;
 use tari_dan_common_types::NodeHeight;
-use tari_dan_storage::consensus_models::Decision;
+use tari_dan_storage::{
+    consensus_models::{BlockId, Decision},
+    StateStore,
+    StateStoreReadTransaction,
+};
 
 use crate::support::{Test, TestAddress};
 
@@ -29,6 +34,46 @@ async fn propose_blocks_with_queued_up_transactions_until_all_committed() {
             panic!("Not all transaction committed after {} blocks", leaf.height);
         }
     }
+
+    test.assert_all_validators_at_same_height().await;
+    test.assert_clean_shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn node_requests_missing_transaction_from_local_leader() {
+    let mut test = Test::builder().add_committee(0, vec!["1", "2"]).start().await;
+    // First get all transactions in the mempool of node "1"
+    for _ in 0..10 {
+        test.send_transaction_to(&TestAddress("1"), Decision::Commit, 1, 5)
+            .await;
+    }
+    test.wait_until_new_pool_count_for_vn(10, TestAddress("1")).await;
+    test.network().start();
+
+    loop {
+        test.on_block_committed().await;
+
+        if test.are_all_transactions_committed() {
+            break;
+        }
+        let leaf = test.get_validator(&TestAddress("1")).get_leaf_block();
+        if leaf.height > NodeHeight(10) {
+            panic!("Not all transaction committed after {} blocks", leaf.height);
+        }
+    }
+
+    // Check if we clean the missing transactions table in the DB once the transactions are committed
+    test.get_validator(&TestAddress("2"))
+        .state_store
+        .with_read_tx(|tx| {
+            let mut block_id = BlockId::genesis();
+            while let Ok(block) = tx.blocks_get_by_parent(&block_id) {
+                assert!(tx.blocks_get_missing_transactions(block.id()).is_err());
+                block_id = block.id().clone();
+            }
+            Ok::<_, HotStuffError>(())
+        })
+        .unwrap();
 
     test.assert_all_validators_at_same_height().await;
     test.assert_clean_shutdown().await;

--- a/dan_layer/consensus_tests/src/support/harness.rs
+++ b/dan_layer/consensus_tests/src/support/harness.rs
@@ -97,7 +97,7 @@ impl Test {
         self.wait_all_for_predicate(format!("new pool count to be {}", count), |v| {
             v.address != vn ||
                 v.state_store
-                    .with_read_tx(|tx| tx.transaction_pool_count(None, None))
+                    .with_read_tx(|tx| tx.transaction_pool_count(Some(TransactionPoolStage::New), None))
                     .unwrap() >=
                     count
         })
@@ -107,7 +107,7 @@ impl Test {
     pub async fn wait_until_new_pool_count(&self, count: usize) {
         self.wait_all_for_predicate(format!("new pool count to be {}", count), |v| {
             v.state_store
-                .with_read_tx(|tx| tx.transaction_pool_count(None, None))
+                .with_read_tx(|tx| tx.transaction_pool_count(Some(TransactionPoolStage::New), None))
                 .unwrap() >=
                 count
         })

--- a/dan_layer/consensus_tests/src/support/harness.rs
+++ b/dan_layer/consensus_tests/src/support/harness.rs
@@ -203,6 +203,8 @@ impl Test {
 pub struct TestBuilder {
     committees: HashMap<u32, Committee<TestAddress>>,
     sql_address: String,
+    default_decision: Decision,
+    default_fee: u64,
 }
 
 impl TestBuilder {
@@ -210,6 +212,8 @@ impl TestBuilder {
         Self {
             committees: HashMap::new(),
             sql_address: ":memory:".to_string(),
+            default_decision: Decision::Commit,
+            default_fee: 1,
         }
     }
 
@@ -257,7 +261,7 @@ impl TestBuilder {
             epoch_manager.add_committee(*bucket, committee.clone()).await;
         }
         let (channels, validators) = self.build_validators(&leader_strategy, &epoch_manager).await;
-        let network = spawn_network(channels);
+        let network = spawn_network(channels, self.default_decision, self.default_fee);
 
         Test {
             validators,

--- a/dan_layer/consensus_tests/src/support/network.rs
+++ b/dan_layer/consensus_tests/src/support/network.rs
@@ -7,23 +7,34 @@ use std::{
 };
 
 use futures::{stream::FuturesUnordered, FutureExt, StreamExt};
+use itertools::Itertools;
 use tari_consensus::messages::HotstuffMessage;
 use tari_dan_common_types::committee::Committee;
-use tari_dan_storage::consensus_models::ExecutedTransaction;
-use tokio::sync::{mpsc, watch};
+use tari_dan_storage::consensus_models::{Decision, ExecutedTransaction};
+use tari_transaction::Transaction;
+use tokio::sync::{
+    mpsc::{self},
+    watch,
+};
 
-use crate::support::{address::TestAddress, ValidatorChannels};
+use crate::support::{address::TestAddress, transaction::build_transaction_from, ValidatorChannels};
 
-pub fn spawn_network(channels: Vec<ValidatorChannels>) -> TestNetwork {
+pub fn spawn_network(channels: Vec<ValidatorChannels>, default_decision: Decision, default_fee: u64) -> TestNetwork {
     let tx_new_transactions = channels
         .iter()
         .map(|c| (c.address, c.tx_new_transactions.clone()))
         .collect();
     let tx_hs_message = channels.iter().map(|c| (c.address, c.tx_hs_message.clone())).collect();
-    let (rx_broadcast, rx_leader) = channels
+    let (rx_broadcast, rx_leader, rx_mempool) = channels
         .into_iter()
-        .map(|c| ((c.address, c.rx_broadcast), (c.address, c.rx_leader)))
-        .unzip();
+        .map(|c| {
+            (
+                (c.address, c.rx_broadcast),
+                (c.address, c.rx_leader),
+                (c.address, c.rx_mempool),
+            )
+        })
+        .multiunzip();
     let (tx_new_transaction, rx_new_transaction) = mpsc::channel(100);
     let (tx_network_status, network_status) = watch::channel(NetworkStatus::Paused);
     let (tx_on_message, rx_on_message) = watch::channel(None);
@@ -36,8 +47,11 @@ pub fn spawn_network(channels: Vec<ValidatorChannels>) -> TestNetwork {
         tx_hs_message,
         rx_broadcast: Some(rx_broadcast),
         rx_leader: Some(rx_leader),
+        rx_mempool: Some(rx_mempool),
         on_message: tx_on_message,
         num_sent_messages: num_sent_messages.clone(),
+        default_decision,
+        default_fee,
     }
     .spawn();
 
@@ -100,9 +114,12 @@ pub struct TestNetworkWorker {
     #[allow(clippy::type_complexity)]
     rx_broadcast: Option<HashMap<TestAddress, mpsc::Receiver<(Committee<TestAddress>, HotstuffMessage)>>>,
     rx_leader: Option<HashMap<TestAddress, mpsc::Receiver<(TestAddress, HotstuffMessage)>>>,
+    rx_mempool: Option<HashMap<TestAddress, mpsc::Receiver<Transaction>>>,
     network_status: watch::Receiver<NetworkStatus>,
     on_message: watch::Sender<Option<HotstuffMessage>>,
     num_sent_messages: Arc<AtomicUsize>,
+    default_decision: Decision,
+    default_fee: u64,
 }
 
 impl TestNetworkWorker {
@@ -113,6 +130,7 @@ impl TestNetworkWorker {
     async fn run(mut self) {
         let mut rx_broadcast = self.rx_broadcast.take().unwrap();
         let mut rx_leader = self.rx_leader.take().unwrap();
+        let mut rx_mempool = self.rx_mempool.take().unwrap();
 
         let mut rx_new_transaction = self.rx_new_transaction.take().unwrap();
         let mut tx_new_transactions = self.tx_new_transactions.clone();
@@ -148,9 +166,15 @@ impl TestNetworkWorker {
                 .map(|(from, rx)| rx.recv().map(|r| (*from, r.unwrap())))
                 .collect::<FuturesUnordered<_>>();
 
+            let mut rx_mempool = rx_mempool
+                .iter_mut()
+                .map(|(from, rx)| rx.recv().map(|r| (*from, r.unwrap())))
+                .collect::<FuturesUnordered<_>>();
+
             tokio::select! {
                 Some((from, (to, msg))) = rx_broadcast.next() => self.handle_broadcast(from, to, msg).await,
-                Some((from, (to, msg))) = rx_leader.next() => self.handle_leader(from,to, msg).await,
+                Some((from, (to, msg))) = rx_leader.next() => self.handle_leader(from, to, msg).await,
+                Some((from, msg)) = rx_mempool.next() => self.handle_mempool(from, msg).await,
 
                 Ok(_) = self.network_status.changed() => {
                     if let NetworkStatus::Started = *self.network_status.borrow() {
@@ -187,5 +211,14 @@ impl TestNetworkWorker {
         self.num_sent_messages
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         self.tx_hs_message.get(&to).unwrap().send((from, msg)).await.unwrap();
+    }
+
+    pub async fn handle_mempool(&mut self, from: TestAddress, msg: Transaction) {
+        self.tx_new_transactions
+            .get(&from)
+            .unwrap()
+            .send(build_transaction_from(msg, self.default_decision, self.default_fee))
+            .await
+            .unwrap();
     }
 }

--- a/dan_layer/consensus_tests/src/support/transaction.rs
+++ b/dan_layer/consensus_tests/src/support/transaction.rs
@@ -11,8 +11,41 @@ use tari_engine_types::{
     resource_container::ResourceContainer,
     substate::SubstateDiff,
 };
+use tari_transaction::Transaction;
 
 use crate::support::helpers::random_shard;
+
+pub fn build_transaction_from(tx: Transaction, decision: Decision, fee: u64) -> ExecutedTransaction {
+    let tx_id = *tx.id();
+    ExecutedTransaction::new(tx, ExecuteResult {
+        finalize: FinalizeResult::new(
+            tx_id.into_array().into(),
+            vec![],
+            vec![],
+            if decision.is_commit() {
+                TransactionResult::Accept(SubstateDiff::new())
+            } else {
+                TransactionResult::Reject(RejectReason::ExecutionFailure("Test failure".to_string()))
+            },
+            FeeCostBreakdown {
+                total_fees_charged: fee.try_into().unwrap(),
+                breakdown: vec![],
+            },
+        ),
+        transaction_failure: None,
+        fee_receipt: Some(FeeReceipt {
+            total_fee_payment: fee.try_into().unwrap(),
+            fee_resource: ResourceContainer::Confidential {
+                address: "resource_0000000000000000000000000000000000000000000000000000000000000000"
+                    .parse()
+                    .unwrap(),
+                commitments: Default::default(),
+                revealed_amount: fee.try_into().unwrap(),
+            },
+            cost_breakdown: vec![],
+        }),
+    })
+}
 
 pub fn build_transaction(decision: Decision, fee: u64, num_shards: usize) -> ExecutedTransaction {
     let k = PrivateKey::default();

--- a/dan_layer/consensus_tests/src/support/validator/builder.rs
+++ b/dan_layer/consensus_tests/src/support/validator/builder.rs
@@ -69,6 +69,7 @@ impl ValidatorBuilder {
         let (tx_new_transactions, rx_new_transactions) = mpsc::channel(100);
         let (tx_hs_message, rx_hs_message) = mpsc::channel(10);
         let (tx_leader, rx_leader) = mpsc::channel(10);
+        let (tx_mempool, rx_mempool) = mpsc::channel(10);
 
         let store = SqliteStateStore::connect(&self.sql_url).unwrap();
         let signing_service = TestVoteSignatureService::new();
@@ -93,7 +94,7 @@ impl ValidatorBuilder {
             tx_broadcast,
             tx_leader,
             tx_events.clone(),
-            tx_new_transactions.clone(),
+            tx_mempool,
             shutdown_signal,
         );
         let handle = tokio::spawn(async move {
@@ -106,6 +107,7 @@ impl ValidatorBuilder {
             tx_hs_message,
             rx_broadcast,
             rx_leader,
+            rx_mempool,
         };
 
         // Fire off initial epoch change event

--- a/dan_layer/consensus_tests/src/support/validator/builder.rs
+++ b/dan_layer/consensus_tests/src/support/validator/builder.rs
@@ -93,6 +93,7 @@ impl ValidatorBuilder {
             tx_broadcast,
             tx_leader,
             tx_events.clone(),
+            tx_new_transactions.clone(),
             shutdown_signal,
         );
         let handle = tokio::spawn(async move {

--- a/dan_layer/consensus_tests/src/support/validator/instance.rs
+++ b/dan_layer/consensus_tests/src/support/validator/instance.rs
@@ -11,6 +11,7 @@ use tari_dan_storage::{
 use tari_epoch_manager::EpochManagerEvent;
 use tari_shutdown::Shutdown;
 use tari_state_store_sqlite::SqliteStateStore;
+use tari_transaction::Transaction;
 use tokio::{
     sync::{broadcast, mpsc},
     task::JoinHandle,
@@ -30,6 +31,7 @@ pub struct ValidatorChannels {
     pub tx_hs_message: mpsc::Sender<(TestAddress, HotstuffMessage)>,
     pub rx_broadcast: mpsc::Receiver<(Committee<TestAddress>, HotstuffMessage)>,
     pub rx_leader: mpsc::Receiver<(TestAddress, HotstuffMessage)>,
+    pub rx_mempool: mpsc::Receiver<Transaction>,
 }
 
 pub struct Validator {

--- a/dan_layer/p2p/src/outbound_service.rs
+++ b/dan_layer/p2p/src/outbound_service.rs
@@ -30,6 +30,8 @@ pub trait OutboundService {
     type Error;
     type Addr: NodeAddressable + Send;
 
+    async fn send_self(&mut self, message: DanMessage<Self::Addr>) -> Result<(), Self::Error>;
+
     async fn send(&mut self, to: Self::Addr, message: DanMessage<Self::Addr>) -> Result<(), Self::Error>;
 
     async fn broadcast(&mut self, committee: &[Self::Addr], message: DanMessage<Self::Addr>)

--- a/dan_layer/state_store_sqlite/migrations/2023-07-12-192955_add_missing_txs/down.sql
+++ b/dan_layer/state_store_sqlite/migrations/2023-07-12-192955_add_missing_txs/down.sql
@@ -1,0 +1,4 @@
+-- This file should undo anything in `up.sql`
+
+DROP TABLE missing_txs
+DROP TABLE missing_txs_in_block

--- a/dan_layer/state_store_sqlite/migrations/2023-07-12-192955_add_missing_txs/up.sql
+++ b/dan_layer/state_store_sqlite/migrations/2023-07-12-192955_add_missing_txs/up.sql
@@ -1,0 +1,16 @@
+-- Your SQL goes here
+CREATE TABLE block_missing_txs
+(
+    id              integer   not NULL PRIMARY KEY AUTOINCREMENT,
+    transaction_ids text      not NULL,
+    created_at      timestamp not NULL DEFAULT CURRENT_TIMESTAMP,
+    block_id        text      not NULL
+);
+
+CREATE TABLE missing_tx
+(
+    id              integer   not NULL primary key AUTOINCREMENT,
+    transaction_id  text      not NULL,
+    created_at      timestamp not NULL DEFAULT CURRENT_TIMESTAMP,
+    block_id        text      not NULL
+);

--- a/dan_layer/state_store_sqlite/src/reader.rs
+++ b/dan_layer/state_store_sqlite/src/reader.rs
@@ -342,6 +342,20 @@ impl StateStoreReadTransaction for SqliteStateStoreReadTransaction<'_> {
         Ok(is_ancestor.count > 0)
     }
 
+    fn blocks_get_missing_transactions(&mut self, block_id: &BlockId) -> Result<Vec<TransactionId>, StorageError> {
+        use crate::schema::block_missing_txs;
+
+        let txs = block_missing_txs::table
+            .select(block_missing_txs::transaction_ids)
+            .filter(block_missing_txs::block_id.eq(serialize_hex(block_id)))
+            .first::<String>(self.connection())
+            .map_err(|e| SqliteStorageError::DieselError {
+                operation: "blocks_get_missing_transactions",
+                source: e,
+            })?;
+        deserialize_json(&txs)
+    }
+
     fn quorum_certificates_get(&mut self, qc_id: &QcId) -> Result<QuorumCertificate, StorageError> {
         use crate::schema::quorum_certificates;
 

--- a/dan_layer/state_store_sqlite/src/schema.rs
+++ b/dan_layer/state_store_sqlite/src/schema.rs
@@ -16,6 +16,24 @@ diesel::table! {
 }
 
 diesel::table! {
+    block_missing_txs(id) {
+        id -> Integer,
+        block_id -> Text,
+        transaction_ids -> Text,
+        created_at -> Timestamp,
+    }
+}
+
+diesel::table! {
+    missing_tx(id) {
+        id -> Integer,
+        transaction_id -> Text,
+        block_id -> Text,
+        created_at -> Timestamp,
+    }
+}
+
+diesel::table! {
     high_qcs (id) {
         id -> Integer,
         epoch -> BigInt,

--- a/dan_layer/state_store_sqlite/src/writer.rs
+++ b/dan_layer/state_store_sqlite/src/writer.rs
@@ -6,7 +6,7 @@ use std::{
     ops::{Deref, DerefMut},
 };
 
-use diesel::{AsChangeset, ExpressionMethods, QueryDsl, RunQueryDsl, SqliteConnection};
+use diesel::{AsChangeset, ExpressionMethods, OptionalExtension, QueryDsl, RunQueryDsl, SqliteConnection};
 use log::*;
 use tari_dan_common_types::{Epoch, ShardId};
 use tari_dan_storage::{
@@ -37,7 +37,7 @@ use tari_transaction::TransactionId;
 use crate::{
     error::SqliteStorageError,
     reader::SqliteStateStoreReadTransaction,
-    serialization::{serialize_hex, serialize_json},
+    serialization::{deserialize_hex_try_from, deserialize_json, serialize_hex, serialize_json},
     sqlite_transaction::SqliteTransaction,
 };
 
@@ -96,6 +96,98 @@ impl StateStoreWriteTransaction for SqliteStateStoreWriteTransaction<'_> {
             })?;
 
         Ok(())
+    }
+
+    fn insert_missing_transactions(
+        &mut self,
+        block_id: &BlockId,
+        transaction_ids: Vec<TransactionId>,
+    ) -> Result<(), StorageError> {
+        use crate::schema::{block_missing_txs, missing_tx};
+
+        let insert = (
+            block_missing_txs::block_id.eq(serialize_hex(block_id)),
+            block_missing_txs::transaction_ids.eq(serialize_json(&transaction_ids)?),
+        );
+
+        diesel::insert_into(block_missing_txs::table)
+            .values(insert)
+            .execute(self.connection())
+            .map_err(|e| SqliteStorageError::DieselError {
+                operation: "insert_missing_txs",
+                source: e,
+            })?;
+
+        for transaction_id in transaction_ids {
+            diesel::insert_into(missing_tx::table)
+                .values((
+                    missing_tx::block_id.eq(serialize_hex(block_id)),
+                    missing_tx::transaction_id.eq(serialize_hex(transaction_id)),
+                ))
+                .execute(self.connection())
+                .map_err(|e| SqliteStorageError::DieselError {
+                    operation: "insert_missing_txs",
+                    source: e,
+                })?;
+        }
+        Ok(())
+    }
+
+    fn remove_missing_transaction(&mut self, transaction_id: TransactionId) -> Result<Option<BlockId>, StorageError> {
+        use crate::schema::{block_missing_txs, missing_tx};
+        let block_id = missing_tx::table
+            .select(missing_tx::block_id)
+            .filter(missing_tx::transaction_id.eq(serialize_hex(transaction_id)))
+            .first::<String>(self.connection())
+            .optional()
+            .map_err(|e| SqliteStorageError::DieselError {
+                operation: "remove_missing_transaction",
+                source: e,
+            })?;
+        if let Some(block_id) = block_id {
+            diesel::delete(missing_tx::table)
+                .filter(missing_tx::transaction_id.eq(serialize_hex(transaction_id)))
+                .execute(self.connection())
+                .map_err(|e| SqliteStorageError::DieselError {
+                    operation: "remove_missing_transaction",
+                    source: e,
+                })?;
+            let missing_transactions = block_missing_txs::table
+                .select(block_missing_txs::transaction_ids)
+                .filter(block_missing_txs::block_id.eq(block_id.clone()))
+                .first::<String>(self.connection())
+                .map_err(|e| SqliteStorageError::DieselError {
+                    operation: "remove_missing_transaction",
+                    source: e,
+                })?;
+
+            let mut missing_transactions = deserialize_json::<Vec<TransactionId>>(&missing_transactions)?;
+
+            missing_transactions.retain(|&transaction| transaction != transaction_id);
+
+            if missing_transactions.is_empty() {
+                diesel::delete(block_missing_txs::table)
+                    .filter(block_missing_txs::block_id.eq(block_id.clone()))
+                    .execute(self.connection())
+                    .map_err(|e| SqliteStorageError::DieselError {
+                        operation: "remove_missing_transaction",
+                        source: e,
+                    })?;
+                Ok(Some(deserialize_hex_try_from(&block_id)?))
+            } else {
+                diesel::update(block_missing_txs::table)
+                    .filter(block_missing_txs::block_id.eq(block_id))
+                    .set(block_missing_txs::transaction_ids.eq(serialize_json(&missing_transactions)?))
+                    .execute(self.connection())
+                    .map_err(|e| SqliteStorageError::DieselError {
+                        operation: "remove_missing_transaction",
+                        source: e,
+                    })?;
+                Ok(None)
+            }
+        } else {
+            Ok(None)
+        }
     }
 
     fn quorum_certificates_insert(&mut self, qc: &QuorumCertificate) -> Result<(), StorageError> {

--- a/dan_layer/storage/src/state_store/mod.rs
+++ b/dan_layer/storage/src/state_store/mod.rs
@@ -94,6 +94,7 @@ pub trait StateStoreReadTransaction {
     fn blocks_exists(&mut self, block_id: &BlockId) -> Result<bool, StorageError>;
     fn blocks_is_ancestor(&mut self, descendant: &BlockId, ancestor: &BlockId) -> Result<bool, StorageError>;
     fn blocks_get_by_parent(&mut self, parent: &BlockId) -> Result<Block, StorageError>;
+    fn blocks_get_missing_transactions(&mut self, block_id: &BlockId) -> Result<Vec<TransactionId>, StorageError>;
 
     fn quorum_certificates_get(&mut self, qc_id: &QcId) -> Result<QuorumCertificate, StorageError>;
 
@@ -170,6 +171,14 @@ pub trait StateStoreWriteTransaction {
         is_ready: Option<bool>,
     ) -> Result<(), StorageError>;
     fn transaction_pool_remove(&mut self, transaction_id: &TransactionId) -> Result<(), StorageError>;
+
+    fn insert_missing_transactions(
+        &mut self,
+        block_id: &BlockId,
+        transaction_ids: Vec<TransactionId>,
+    ) -> Result<(), StorageError>;
+
+    fn remove_missing_transaction(&mut self, transaction_id: TransactionId) -> Result<Option<BlockId>, StorageError>;
 
     // -------------------------------- Votes -------------------------------- //
     fn votes_insert(&mut self, vote: &Vote) -> Result<(), StorageError>;

--- a/dan_layer/validator_node_rpc/proto/consensus.proto
+++ b/dan_layer/validator_node_rpc/proto/consensus.proto
@@ -13,6 +13,8 @@ message HotStuffMessage {
     NewViewMessage new_view = 1;
     ProposalMessage proposal = 2;
     VoteMessage vote = 3;
+    RequestMissingTransactionsMessage request_missing_transactions = 4;
+    RequestedTransactionMessage requested_transaction = 5;
   }
 }
 
@@ -140,4 +142,16 @@ message UpState {
 message DownState {
   bytes deleted_by = 1;
   uint64 fees_accrued = 2;
+}
+
+message RequestMissingTransactionsMessage {
+    uint64 epoch = 1;
+    bytes block_id = 2;
+    repeated bytes transaction_ids = 3;
+}
+
+message RequestedTransactionMessage {
+    uint64 epoch = 1;
+    bytes block_id = 2;
+    repeated tari.dan.transaction.Transaction transactions = 3;
 }


### PR DESCRIPTION
Description
---
Request TXs in a proposal that the VN doesn't know of. It sends all the ids of the missing transactions to the leader. And store the information into two tables. One is to know which transaction belong to which block, and the other one is to know which block is missing which transaction. This way the look ups are fast.

How Has This Been Tested?
---
We have a test `consensus::node_requests_missing_transaction_from_local_leader`. There are two nodes, but only one receives the transactions. The other one receives the block and asks for the transactions.

What process can a PR reviewer use to test or verify this change?
---
You can run the same test.

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify