### PR TITLE
fix: rust-analyzer problem

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,6 +13,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "account"
+version = "0.1.0"
+dependencies = [
+ "tari_template_abi",
+ "tari_template_lib",
+]
+
+[[package]]
+name = "account_nfts"
+version = "0.1.0"
+dependencies = [
+ "tari_template_abi",
+ "tari_template_lib",
+]
+
+[[package]]
 name = "addr2line"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,8 @@ members = [
     "dan_layer/tari_bor",
     "dan_layer/template_abi",
     "dan_layer/template_builtin",
+    "dan_layer/template_builtin/templates/account",
+    "dan_layer/template_builtin/templates/account_nfts",
     "dan_layer/template_lib",
     "dan_layer/template_macros",
     "dan_layer/template_test_tooling",

--- a/dan_layer/template_builtin/templates/account/Cargo.toml
+++ b/dan_layer/template_builtin/templates/account/Cargo.toml
@@ -1,4 +1,3 @@
-[workspace]
 [package]
 name = "account"
 version = "0.1.0"

--- a/dan_layer/template_builtin/templates/account_nfts/Cargo.toml
+++ b/dan_layer/template_builtin/templates/account_nfts/Cargo.toml
@@ -1,4 +1,3 @@
-[workspace]
 [package]
 name = "account_nfts"
 version = "0.1.0"


### PR DESCRIPTION
Description
---
Remove the `workspace` from built-in templates `Cargo.toml` files and add them to the root `Cargo.toml` file. 

Motivation and Context
---
I was getting frustrated that rust-analyzer in vscode was not working.

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify