### PR TITLE
chore(tari_dan_storage): set exact `tari_utilities` version

### DIFF
--- a/dan_layer/storage/Cargo.toml
+++ b/dan_layer/storage/Cargo.toml
@@ -16,7 +16,7 @@ tari_transaction = { path = "../transaction" }
 tari_core = { git = "https://github.com/tari-project/tari.git", tag = "v0.51.0-pre.4" }
 tari_mmr = { git = "https://github.com/tari-project/tari.git", tag = "v0.51.0-pre.4" }
 tari_crypto = "0.17"
-tari_utilities = "*"
+tari_utilities = "0.4.10"
 
 anyhow = "1.0"
 chrono = "0.4.23"


### PR DESCRIPTION
Description
---
Set the exact version for the `tari_utilities` dependency on the `tari_dan_storage` crate

Motivation and Context
---
When importing (directly or indirectly) the `tari_dan_storage` package from external Rust applications, the project does not compile due to version incompatibilities with the latest `tari_utilities` dependency. The same happens after running `cargo clean` on the `tari-dan` project.

How Has This Been Tested?
---
External projects that have the `tari_dan_storage` dependency do compile now

What process can a PR reviewer use to test or verify this change?
---
Compile an external project that depends on `tari_dan_storage`

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify