### PR TITLE
fix: use round robin leader strategy

### DIFF
--- a/applications/tari_validator_node/src/consensus/leader_selection.rs
+++ b/applications/tari_validator_node/src/consensus/leader_selection.rs
@@ -2,7 +2,7 @@
 //    SPDX-License-Identifier: BSD-3-Clause
 
 use tari_consensus::traits::LeaderStrategy;
-use tari_dan_common_types::{committee::Committee, NodeAddressable};
+use tari_dan_common_types::{committee::Committee, NodeAddressable, NodeHeight};
 use tari_dan_storage::consensus_models::BlockId;
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -15,12 +15,26 @@ impl RandomDeterministicLeaderStrategy {
 }
 
 impl<TAddr: NodeAddressable> LeaderStrategy<TAddr> for RandomDeterministicLeaderStrategy {
-    fn calculate_leader(&self, committee: &Committee<TAddr>, block: &BlockId, round: u32) -> u32 {
+    fn calculate_leader(&self, committee: &Committee<TAddr>, block: &BlockId, height: NodeHeight) -> u32 {
         // TODO: Maybe Committee should not be able to be constructed with an empty committee
         assert!(!committee.is_empty(), "Committee was empty in calculate_leader");
         let block_id = block.as_bytes();
         let val = u32::from_le_bytes([block_id[0], block_id[1], block_id[2], block_id[3]]);
         let first = val % committee.members.len() as u32;
-        (first + round) % committee.members.len() as u32
+        (first + height.0 as u32) % committee.members.len() as u32
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct RoundRobinLeaderStrategy;
+impl RoundRobinLeaderStrategy {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl<TAddr: NodeAddressable> LeaderStrategy<TAddr> for RoundRobinLeaderStrategy {
+    fn calculate_leader(&self, committee: &Committee<TAddr>, block: &BlockId, height: NodeHeight) -> u32 {
+        (height.0 % committee.members.len() as u64) as u32
     }
 }

--- a/applications/tari_validator_node/src/consensus/leader_selection.rs
+++ b/applications/tari_validator_node/src/consensus/leader_selection.rs
@@ -8,12 +8,6 @@ use tari_dan_storage::consensus_models::BlockId;
 #[derive(Debug, Clone, Copy, Default)]
 pub struct RandomDeterministicLeaderStrategy;
 
-impl RandomDeterministicLeaderStrategy {
-    pub fn new() -> Self {
-        Self
-    }
-}
-
 impl<TAddr: NodeAddressable> LeaderStrategy<TAddr> for RandomDeterministicLeaderStrategy {
     fn calculate_leader(&self, committee: &Committee<TAddr>, block: &BlockId, height: NodeHeight) -> u32 {
         // TODO: Maybe Committee should not be able to be constructed with an empty committee
@@ -34,7 +28,7 @@ impl RoundRobinLeaderStrategy {
 }
 
 impl<TAddr: NodeAddressable> LeaderStrategy<TAddr> for RoundRobinLeaderStrategy {
-    fn calculate_leader(&self, committee: &Committee<TAddr>, block: &BlockId, height: NodeHeight) -> u32 {
+    fn calculate_leader(&self, committee: &Committee<TAddr>, _block: &BlockId, height: NodeHeight) -> u32 {
         (height.0 % committee.members.len() as u64) as u32
     }
 }

--- a/applications/tari_validator_node/src/consensus/mod.rs
+++ b/applications/tari_validator_node/src/consensus/mod.rs
@@ -22,7 +22,7 @@ use tokio::{
 
 use crate::{
     consensus::{
-        leader_selection::{RandomDeterministicLeaderStrategy, RoundRobinLeaderStrategy},
+        leader_selection::RoundRobinLeaderStrategy,
         signature_service::TariSignatureService,
         spec::TariConsensusSpec,
         state_manager::TariStateManager,

--- a/applications/tari_validator_node/src/consensus/mod.rs
+++ b/applications/tari_validator_node/src/consensus/mod.rs
@@ -22,7 +22,7 @@ use tokio::{
 
 use crate::{
     consensus::{
-        leader_selection::RandomDeterministicLeaderStrategy,
+        leader_selection::{RandomDeterministicLeaderStrategy, RoundRobinLeaderStrategy},
         signature_service::TariSignatureService,
         spec::TariConsensusSpec,
         state_manager::TariStateManager,
@@ -51,7 +51,7 @@ pub async fn spawn(
 
     let validator_addr = node_identity.public_key().clone();
     let signing_service = TariSignatureService::new(node_identity);
-    let leader_strategy = RandomDeterministicLeaderStrategy::new();
+    let leader_strategy = RoundRobinLeaderStrategy::new();
     let transaction_pool = TransactionPool::new();
     let noop_state_manager = TariStateManager::new();
     let (tx_events, _) = broadcast::channel(100);

--- a/applications/tari_validator_node/src/consensus/spec.rs
+++ b/applications/tari_validator_node/src/consensus/spec.rs
@@ -7,7 +7,7 @@ use tari_epoch_manager::base_layer::EpochManagerHandle;
 use tari_state_store_sqlite::SqliteStateStore;
 
 use crate::consensus::{
-    leader_selection::RandomDeterministicLeaderStrategy,
+    leader_selection::{RandomDeterministicLeaderStrategy, RoundRobinLeaderStrategy},
     signature_service::TariSignatureService,
     state_manager::TariStateManager,
 };
@@ -17,7 +17,7 @@ pub struct TariConsensusSpec;
 impl ConsensusSpec for TariConsensusSpec {
     type Addr = CommsPublicKey;
     type EpochManager = EpochManagerHandle;
-    type LeaderStrategy = RandomDeterministicLeaderStrategy;
+    type LeaderStrategy = RoundRobinLeaderStrategy;
     type StateManager = TariStateManager;
     type StateStore = SqliteStateStore;
     type VoteSignatureService = TariSignatureService;

--- a/applications/tari_validator_node/src/consensus/spec.rs
+++ b/applications/tari_validator_node/src/consensus/spec.rs
@@ -7,7 +7,7 @@ use tari_epoch_manager::base_layer::EpochManagerHandle;
 use tari_state_store_sqlite::SqliteStateStore;
 
 use crate::consensus::{
-    leader_selection::{RandomDeterministicLeaderStrategy, RoundRobinLeaderStrategy},
+    leader_selection::RoundRobinLeaderStrategy,
     signature_service::TariSignatureService,
     state_manager::TariStateManager,
 };

--- a/dan_layer/consensus/src/hotstuff/on_receive_proposal.rs
+++ b/dan_layer/consensus/src/hotstuff/on_receive_proposal.rs
@@ -140,6 +140,7 @@ where TConsensusSpec: ConsensusSpec
             self.send_to_leader(
                 local_committee,
                 block.id(),
+                block.height(),
                 HotstuffMessage::RequestMissingTransactions(RequestMissingTransactionsMessage {
                     block_id: *block.id(),
                     epoch: block.epoch(),
@@ -207,7 +208,7 @@ where TConsensusSpec: ConsensusSpec
                 block.parent(),
                 block.height(),
             );
-            self.send_vote_to_leader(local_committee, vote).await?;
+            self.send_vote_to_leader(local_committee, vote, block.height()).await?;
         }
 
         Ok(())
@@ -233,14 +234,15 @@ where TConsensusSpec: ConsensusSpec
         &self,
         local_committee: &Committee<TConsensusSpec::Addr>,
         block_id: &BlockId,
+        height: NodeHeight,
         message: HotstuffMessage,
     ) -> Result<(), HotStuffError> {
-        let leader = self.leader_strategy.get_leader(local_committee, block_id, 0);
+        let leader = self.leader_strategy.get_leader(local_committee, block_id, height);
         self.tx_leader
             .send((leader.clone(), message))
             .await
             .map_err(|_| HotStuffError::InternalChannelClosed {
-                context: "tx_leader in OnReceiveProposalHandler::handle_local_proposal",
+                context: "tx_leader in OnReceiveProposalHandler::send_to_leader",
             })
     }
 
@@ -248,9 +250,17 @@ where TConsensusSpec: ConsensusSpec
         &self,
         local_committee: &Committee<TConsensusSpec::Addr>,
         vote: VoteMessage,
+        height: NodeHeight,
     ) -> Result<(), HotStuffError> {
-        self.send_to_leader(local_committee, &vote.clone().block_id, HotstuffMessage::Vote(vote))
+        let leader = self
+            .leader_strategy
+            .get_leader_for_next_block(local_committee, &vote.block_id, height);
+        self.tx_leader
+            .send((leader.clone(), HotstuffMessage::Vote(vote)))
             .await
+            .map_err(|_| HotStuffError::InternalChannelClosed {
+                context: "tx_leader in OnReceiveProposalHandler::send_vote_to_leader",
+            })
     }
 
     fn decide_what_to_vote(

--- a/dan_layer/consensus/src/hotstuff/on_receive_vote.rs
+++ b/dan_layer/consensus/src/hotstuff/on_receive_vote.rs
@@ -67,17 +67,6 @@ where TConsensusSpec: ConsensusSpec
 
         // Are we the leader for the block being voted for?
         let vn = self.epoch_manager.get_our_validator_node(message.epoch).await?;
-        if !self
-            .leader_strategy
-            .is_leader(&vn.address, &committee, &message.block_id, 0)
-        {
-            return Err(HotStuffError::NotTheLeader {
-                details: format!(
-                    "Not this leader for block {}, vote sent by {}",
-                    message.block_id, vn.address
-                ),
-            });
-        }
 
         let local_committee_shard = self.epoch_manager.get_local_committee_shard(message.epoch).await?;
 
@@ -97,6 +86,19 @@ where TConsensusSpec: ConsensusSpec
 
         let (block, count) = self.store.with_write_tx(|tx| {
             let block = Block::get(tx.deref_mut(), &message.block_id)?;
+            if !self.leader_strategy.is_leader_for_next_block(
+                &vn.address,
+                &committee,
+                &message.block_id,
+                block.height(),
+            ) {
+                return Err(HotStuffError::NotTheLeader {
+                    details: format!(
+                        "Not this leader for block {}, vote sent by {}",
+                        message.block_id, vn.address
+                    ),
+                });
+            }
             Vote {
                 epoch: message.epoch,
                 block_id: message.block_id,
@@ -143,15 +145,15 @@ where TConsensusSpec: ConsensusSpec
 
         let votes = block.get_votes(tx.deref_mut())?;
         let Some(quorum_decision) = Self::calculate_threshold_decision(&votes, &local_committee_shard) else {
-                warn!(
-                    target: LOG_TARGET,
-                    "🔥 Received conflicting votes from replicas for block {} ({} of {}). Waiting for more votes.",
-                    message.block_id,
-                    count,
-                    local_committee_shard.quorum_threshold()
-                );
-                tx.rollback()?;
-                return Ok(())
+            warn!(
+                target: LOG_TARGET,
+                "🔥 Received conflicting votes from replicas for block {} ({} of {}). Waiting for more votes.",
+                message.block_id,
+                count,
+                local_committee_shard.quorum_threshold()
+            );
+            tx.rollback()?;
+            return Ok(());
         };
 
         let signatures = votes.iter().map(|v| v.signature().clone()).collect::<Vec<_>>();

--- a/dan_layer/consensus/src/hotstuff/worker.rs
+++ b/dan_layer/consensus/src/hotstuff/worker.rs
@@ -269,9 +269,13 @@ where
         // Are we the leader?
         let leaf_block = self.state_store.with_read_tx(|tx| LeafBlock::get(tx, epoch))?;
         let local_committee = self.epoch_manager.get_local_committee(epoch).await?;
-        let is_leader = self
-            .leader_strategy
-            .is_leader(&self.validator_addr, &local_committee, &leaf_block.block_id, 0);
+        // TODO: If there were leader failures, the leaf block would be empty and we need to create empty blocks.
+        let is_leader = self.leader_strategy.is_leader_for_next_block(
+            &self.validator_addr,
+            &local_committee,
+            &leaf_block.block_id,
+            leaf_block.height,
+        );
         info!(
             target: LOG_TARGET,
             "🔥 [on_beat] Is leader: {:?}, leaf_block: {}, local_committee: {}",

--- a/dan_layer/consensus/src/traits/leader_strategy.rs
+++ b/dan_layer/consensus/src/traits/leader_strategy.rs
@@ -22,7 +22,6 @@
 
 use tari_dan_common_types::{committee::Committee, NodeAddressable, NodeHeight};
 use tari_dan_storage::consensus_models::BlockId;
-use tari_mmr::sparse_merkle_tree::Node;
 
 pub trait LeaderStrategy<TAddr: NodeAddressable> {
     fn calculate_leader(&self, committee: &Committee<TAddr>, block: &BlockId, height: NodeHeight) -> u32;

--- a/dan_layer/consensus/src/traits/leader_strategy.rs
+++ b/dan_layer/consensus/src/traits/leader_strategy.rs
@@ -20,14 +20,21 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use tari_dan_common_types::{committee::Committee, NodeAddressable};
+use tari_dan_common_types::{committee::Committee, NodeAddressable, NodeHeight};
 use tari_dan_storage::consensus_models::BlockId;
+use tari_mmr::sparse_merkle_tree::Node;
 
 pub trait LeaderStrategy<TAddr: NodeAddressable> {
-    fn calculate_leader(&self, committee: &Committee<TAddr>, block: &BlockId, round: u32) -> u32;
+    fn calculate_leader(&self, committee: &Committee<TAddr>, block: &BlockId, height: NodeHeight) -> u32;
 
-    fn is_leader(&self, validator_addr: &TAddr, committee: &Committee<TAddr>, block: &BlockId, round: u32) -> bool {
-        let position = self.calculate_leader(committee, block, round);
+    fn is_leader(
+        &self,
+        validator_addr: &TAddr,
+        committee: &Committee<TAddr>,
+        block: &BlockId,
+        height: NodeHeight,
+    ) -> bool {
+        let position = self.calculate_leader(committee, block, height);
         if let Some(vn) = committee.members.get(position as usize) {
             vn == validator_addr
         } else {
@@ -35,8 +42,27 @@ pub trait LeaderStrategy<TAddr: NodeAddressable> {
         }
     }
 
-    fn get_leader<'b>(&self, committee: &'b Committee<TAddr>, block: &BlockId, round: u32) -> &'b TAddr {
-        let index = self.calculate_leader(committee, block, round);
+    fn is_leader_for_next_block(
+        &self,
+        validator_addr: &TAddr,
+        committee: &Committee<TAddr>,
+        block: &BlockId,
+        height: NodeHeight,
+    ) -> bool {
+        self.is_leader(validator_addr, committee, block, height + NodeHeight(1))
+    }
+
+    fn get_leader<'b>(&self, committee: &'b Committee<TAddr>, block: &BlockId, height: NodeHeight) -> &'b TAddr {
+        let index = self.calculate_leader(committee, block, height);
         committee.members.get(index as usize).unwrap()
+    }
+
+    fn get_leader_for_next_block<'b>(
+        &self,
+        committee: &'b Committee<TAddr>,
+        block: &BlockId,
+        height: NodeHeight,
+    ) -> &'b TAddr {
+        self.get_leader(committee, block, height + NodeHeight(1))
     }
 }


### PR DESCRIPTION
Description
---
Change from random leaders (determined by blockid) to round robin through the committee using the block height

Motivation and Context
---
This is how hotstuff is usually done, but for more motivation it means that every leader has a fair opportunity to get fees, and leaders cannot be censored in any way.

It also is a step towards implementing leader failure, which will be in another PR

How Has This Been Tested?
---
Tested manually with dan testing

What process can a PR reviewer use to test or verify this change?
---
Run a chain and see that the blocks are proposed in a round robin fashion

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify