### PR TITLE
chore(template_lib): derive Ord/PartialOrd for NonFungibleAddress type

### DIFF
--- a/dan_layer/template_lib/src/models/non_fungible.rs
+++ b/dan_layer/template_lib/src/models/non_fungible.rs
@@ -167,10 +167,10 @@ impl Display for NonFungibleId {
 
 const TAG: u64 = BinaryTag::NonFungibleAddress.as_u64();
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct NonFungibleAddress(BorTag<NonFungibleAddressContents, TAG>);
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct NonFungibleAddressContents {
     resource_address: ResourceAddress,
     id: NonFungibleId,


### PR DESCRIPTION
Description
---
Derive `PartialOrd` and `Ord` on `NonFungibleAddress`

Motivation and Context
---
For [atomic swap](https://github.com/mrnaveira/tari-atomic-swap) matchmaking we need to store a map of liquidity providers with their positions, inside a template. We want to use the liquidity provider public key (in the form of a NFT) as the key in the map.

Following the motivation of https://github.com/tari-project/tari-dan/pull/567, it's desirable to use `BTreeMap` instead of `HashMap` for deterministic serialization. That's why we need to derive `PartialOrd` and `Ord` on the key type of the map (`NonFungibleAddress`)

How Has This Been Tested?
---
Existing tests pass

What process can a PR reviewer use to test or verify this change?
---
Run tests

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify