### PR TITLE
refactor(engine-types): move transaction receipt into own module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7851,7 +7851,6 @@ dependencies = [
  "async-trait",
  "axum",
  "axum-jrpc",
- "ciborium",
  "clap 3.2.25",
  "config",
  "diesel",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7800,7 +7800,6 @@ version = "0.50.0-pre.0"
 dependencies = [
  "base64 0.21.2",
  "borsh",
- "ciborium",
  "digest 0.9.0",
  "hex",
  "lazy_static",

--- a/applications/tari_indexer/Cargo.toml
+++ b/applications/tari_indexer/Cargo.toml
@@ -42,7 +42,6 @@ axum = "0.6.0"
 async-graphql = "5.0.7"
 async-graphql-axum = "5.0.7"
 axum-jrpc = { version = "0.3.2", features = ["anyhow_error"] }
-ciborium = { version = "0.2.1", default-features = false }
 clap = { version = "3.2.22", features = ["derive", "env"] }
 config = "0.13.0"
 diesel = { version = "2", default-features = false, features = ["sqlite", "chrono"] }

--- a/applications/tari_validator_node/src/consensus/mod.rs
+++ b/applications/tari_validator_node/src/consensus/mod.rs
@@ -53,7 +53,7 @@ pub async fn spawn(
     let signing_service = TariSignatureService::new(node_identity);
     let leader_strategy = RoundRobinLeaderStrategy::new();
     let transaction_pool = TransactionPool::new();
-    let noop_state_manager = TariStateManager::new();
+    let state_manager = TariStateManager::new();
     let (tx_events, _) = broadcast::channel(100);
 
     let epoch_events = epoch_manager.subscribe().await.unwrap();
@@ -67,7 +67,7 @@ pub async fn spawn(
         epoch_manager,
         leader_strategy,
         signing_service,
-        noop_state_manager,
+        state_manager,
         transaction_pool,
         tx_broadcast,
         tx_leader,

--- a/dan_layer/engine/src/runtime/error.rs
+++ b/dan_layer/engine/src/runtime/error.rs
@@ -26,9 +26,9 @@ use anyhow::anyhow;
 use tari_bor::BorError;
 use tari_dan_common_types::optional::IsNotFoundError;
 use tari_engine_types::{
-    commit_result::TransactionReceiptAddress,
     resource_container::ResourceError,
     substate::SubstateAddress,
+    transaction_receipt::TransactionReceiptAddress,
 };
 use tari_template_lib::models::{
     Amount,

--- a/dan_layer/engine/src/runtime/tracker.rs
+++ b/dan_layer/engine/src/runtime/tracker.rs
@@ -32,7 +32,7 @@ use log::debug;
 use tari_dan_common_types::{optional::Optional, services::template_provider::TemplateProvider};
 use tari_engine_types::{
     bucket::Bucket,
-    commit_result::{RejectReason, TransactionReceipt, TransactionResult},
+    commit_result::{RejectReason, TransactionResult},
     component::{ComponentBody, ComponentHeader},
     confidential::UnclaimedConfidentialOutput,
     events::Event,
@@ -43,6 +43,7 @@ use tari_engine_types::{
     resource::Resource,
     resource_container::ResourceContainer,
     substate::{Substate, SubstateAddress, SubstateDiff, SubstateValue},
+    transaction_receipt::TransactionReceipt,
     vault::Vault,
     TemplateAddress,
 };

--- a/dan_layer/engine_types/Cargo.toml
+++ b/dan_layer/engine_types/Cargo.toml
@@ -16,7 +16,6 @@ tari_template_lib = { path = "../template_lib" }
 tari_utilities = "0.4.10"
 
 borsh = "0.9.3"
-ciborium = { version = "0.2.1", default-features = false }
 base64 = "0.21.0"
 rand = "0.7"
 digest = "0.9.0"

--- a/dan_layer/engine_types/src/commit_result.rs
+++ b/dan_layer/engine_types/src/commit_result.rs
@@ -22,9 +22,8 @@
 
 use std::fmt::{self, Display, Formatter};
 
-use ciborium::tag::Required;
 use serde::{Deserialize, Serialize};
-use tari_template_lib::{models::BinaryTag, Hash, HashParseError};
+use tari_template_lib::Hash;
 
 use crate::{
     events::Event,
@@ -34,46 +33,6 @@ use crate::{
     serde_with,
     substate::SubstateDiff,
 };
-
-const TAG: u64 = BinaryTag::TransactionReceipt.as_u64();
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
-pub struct TransactionReceiptAddress(Required<Hash, TAG>);
-
-impl TransactionReceiptAddress {
-    pub const fn new(address: Hash) -> Self {
-        Self(Required(address))
-    }
-
-    pub fn hash(&self) -> &Hash {
-        &self.0 .0
-    }
-
-    pub fn from_hex(hex: &str) -> Result<Self, HashParseError> {
-        let hash = Hash::from_hex(hex)?;
-        Ok(Self::new(hash))
-    }
-}
-
-impl<T: Into<Hash>> From<T> for TransactionReceiptAddress {
-    fn from(address: T) -> Self {
-        Self::new(address.into())
-    }
-}
-
-impl Display for TransactionReceiptAddress {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "txreceipt_{}", self.0 .0)
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct TransactionReceipt {
-    pub transaction_hash: Hash,
-    pub events: Vec<Event>,
-    pub logs: Vec<LogEntry>,
-    pub fee_receipt: Option<FeeReceipt>,
-}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ExecuteResult {

--- a/dan_layer/engine_types/src/indexed_value.rs
+++ b/dan_layer/engine_types/src/indexed_value.rs
@@ -11,7 +11,7 @@ use tari_template_lib::{
     Hash,
 };
 
-use crate::{commit_result::TransactionReceiptAddress, serde_with, substate::SubstateAddress};
+use crate::{serde_with, substate::SubstateAddress, transaction_receipt::TransactionReceiptAddress};
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 pub struct IndexedValue {

--- a/dan_layer/engine_types/src/lib.rs
+++ b/dan_layer/engine_types/src/lib.rs
@@ -20,8 +20,8 @@ pub mod resource;
 pub mod resource_container;
 pub mod serde_with;
 pub mod substate;
+pub mod transaction_receipt;
 pub mod vault;
 
 mod template;
-
 pub use template::{calculate_template_binary_hash, TemplateAddress};

--- a/dan_layer/engine_types/src/substate.rs
+++ b/dan_layer/engine_types/src/substate.rs
@@ -41,7 +41,6 @@ use tari_template_lib::{
 };
 
 use crate::{
-    commit_result::{TransactionReceipt, TransactionReceiptAddress},
     component::ComponentHeader,
     confidential::UnclaimedConfidentialOutput,
     hashing::{hasher, EngineHashDomainLabel},
@@ -49,6 +48,7 @@ use crate::{
     non_fungible_index::NonFungibleIndex,
     resource::Resource,
     serde_with,
+    transaction_receipt::{TransactionReceipt, TransactionReceiptAddress},
     vault::Vault,
 };
 

--- a/dan_layer/engine_types/src/transaction_receipt.rs
+++ b/dan_layer/engine_types/src/transaction_receipt.rs
@@ -1,0 +1,53 @@
+//    Copyright 2023 The Tari Project
+//    SPDX-License-Identifier: BSD-3-Clause
+
+use std::{
+    fmt,
+    fmt::{Display, Formatter},
+};
+
+use serde::{Deserialize, Serialize};
+use tari_bor::BorTag;
+use tari_template_lib::{models::BinaryTag, Hash, HashParseError};
+
+use crate::{events::Event, fees::FeeReceipt, logs::LogEntry};
+
+const TAG: u64 = BinaryTag::TransactionReceipt.as_u64();
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct TransactionReceiptAddress(BorTag<Hash, TAG>);
+
+impl TransactionReceiptAddress {
+    pub const fn new(address: Hash) -> Self {
+        Self(BorTag::new(address))
+    }
+
+    pub fn hash(&self) -> &Hash {
+        self.0.inner()
+    }
+
+    pub fn from_hex(hex: &str) -> Result<Self, HashParseError> {
+        let hash = Hash::from_hex(hex)?;
+        Ok(Self::new(hash))
+    }
+}
+
+impl<T: Into<Hash>> From<T> for TransactionReceiptAddress {
+    fn from(address: T) -> Self {
+        Self::new(address.into())
+    }
+}
+
+impl Display for TransactionReceiptAddress {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "txreceipt_{}", self.hash())
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TransactionReceipt {
+    pub transaction_hash: Hash,
+    pub events: Vec<Event>,
+    pub logs: Vec<LogEntry>,
+    pub fee_receipt: Option<FeeReceipt>,
+}

--- a/dan_layer/wallet/sdk/src/apis/substate.rs
+++ b/dan_layer/wallet/sdk/src/apis/substate.rs
@@ -6,9 +6,9 @@ use std::collections::HashMap;
 use log::*;
 use tari_dan_common_types::optional::{IsNotFoundError, Optional};
 use tari_engine_types::{
-    commit_result::TransactionReceiptAddress,
     indexed_value::{IndexedValue, IndexedValueVisitorError},
     substate::{SubstateAddress, SubstateValue},
+    transaction_receipt::TransactionReceiptAddress,
 };
 use tari_transaction::TransactionId;
 


### PR DESCRIPTION
Description
---
Move transactions receipt out of commit result and into its own module
Remove ciborium dependency, tari_bor::BorTag is used for tags
Remove ciborium dependency from indexer

Motivation and Context
---
Some cleanup for transaction receipt, which was placed in the commit result module
A new type for ciborium::Required type called BorTag is used throughout the codebase, updated in tx receipt for consistency.
tari_bor should be used for all substate en/decoding

How Has This Been Tested?
---
Lints

What process can a PR reviewer use to test or verify this change?
---
CI

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify