### PR TITLE
refactor(consensus)!: use validator address for proposed_by in block

### DIFF
--- a/applications/tari_dan_app_utilities/src/base_layer_scanner.rs
+++ b/applications/tari_dan_app_utilities/src/base_layer_scanner.rs
@@ -29,7 +29,7 @@ use tari_base_node_client::{
     BaseNodeClient,
     BaseNodeClientError,
 };
-use tari_common_types::types::{Commitment, FixedHash, FixedHashSizeError};
+use tari_common_types::types::{Commitment, FixedHash, FixedHashSizeError, PublicKey};
 use tari_core::transactions::transaction_components::{
     CodeTemplateRegistration,
     SideChainFeature,
@@ -69,7 +69,7 @@ pub fn spawn(
     template_manager: TemplateManagerHandle,
     shutdown: ShutdownSignal,
     consensus_constants: ConsensusConstants,
-    shard_store: SqliteStateStore,
+    shard_store: SqliteStateStore<PublicKey>,
     scan_base_layer: bool,
     base_layer_scanning_interval: Duration,
 ) -> JoinHandle<anyhow::Result<()>> {
@@ -102,7 +102,7 @@ pub struct BaseLayerScanner {
     template_manager: TemplateManagerHandle,
     shutdown: ShutdownSignal,
     consensus_constants: ConsensusConstants,
-    state_store: SqliteStateStore,
+    state_store: SqliteStateStore<PublicKey>,
     scan_base_layer: bool,
     base_layer_scanning_interval: Duration,
     has_attempted_scan: bool,
@@ -116,7 +116,7 @@ impl BaseLayerScanner {
         template_manager: TemplateManagerHandle,
         shutdown: ShutdownSignal,
         consensus_constants: ConsensusConstants,
-        state_store: SqliteStateStore,
+        state_store: SqliteStateStore<PublicKey>,
         scan_base_layer: bool,
         base_layer_scanning_interval: Duration,
     ) -> Self {
@@ -375,7 +375,7 @@ impl BaseLayerScanner {
         let epoch = self.epoch_manager.current_epoch().await?;
         self.state_store
             .with_write_tx(|tx| {
-                let genesis = Block::genesis(epoch);
+                let genesis = Block::<PublicKey>::genesis(epoch);
 
                 SubstateRecord {
                     address,

--- a/applications/tari_dan_wallet_web_ui/.gitignore
+++ b/applications/tari_dan_wallet_web_ui/.gitignore
@@ -8,7 +8,8 @@ pnpm-debug.log*
 lerna-debug.log*
 
 node_modules
-dist
+dist/*
+!dist/.gitkeep
 dist-ssr
 *.local
 

--- a/applications/tari_validator_node/src/consensus/mod.rs
+++ b/applications/tari_validator_node/src/consensus/mod.rs
@@ -3,6 +3,7 @@
 
 use std::sync::Arc;
 
+use tari_common_types::types::PublicKey;
 use tari_comms::{types::CommsPublicKey, NodeIdentity};
 use tari_consensus::{
     hotstuff::{HotstuffEvent, HotstuffWorker},
@@ -37,11 +38,11 @@ mod spec;
 mod state_manager;
 
 pub async fn spawn(
-    store: SqliteStateStore,
+    store: SqliteStateStore<PublicKey>,
     node_identity: Arc<NodeIdentity>,
     epoch_manager: EpochManagerHandle,
     rx_new_transactions: mpsc::Receiver<ExecutedTransaction>,
-    rx_hs_message: mpsc::Receiver<(CommsPublicKey, HotstuffMessage)>,
+    rx_hs_message: mpsc::Receiver<(CommsPublicKey, HotstuffMessage<PublicKey>)>,
     outbound_messaging: OutboundMessaging,
     shutdown_signal: ShutdownSignal,
 ) -> (JoinHandle<Result<(), anyhow::Error>>, EventSubscription<HotstuffEvent>) {
@@ -89,8 +90,8 @@ pub async fn spawn(
 }
 
 struct ConsensusWorker {
-    rx_broadcast: mpsc::Receiver<(Committee<CommsPublicKey>, HotstuffMessage)>,
-    rx_leader: mpsc::Receiver<(CommsPublicKey, HotstuffMessage)>,
+    rx_broadcast: mpsc::Receiver<(Committee<CommsPublicKey>, HotstuffMessage<CommsPublicKey>)>,
+    rx_leader: mpsc::Receiver<(CommsPublicKey, HotstuffMessage<CommsPublicKey>)>,
     rx_mempool: mpsc::Receiver<Transaction>,
     outbound_messaging: OutboundMessaging,
 }

--- a/applications/tari_validator_node/src/consensus/spec.rs
+++ b/applications/tari_validator_node/src/consensus/spec.rs
@@ -19,6 +19,6 @@ impl ConsensusSpec for TariConsensusSpec {
     type EpochManager = EpochManagerHandle;
     type LeaderStrategy = RoundRobinLeaderStrategy;
     type StateManager = TariStateManager;
-    type StateStore = SqliteStateStore;
+    type StateStore = SqliteStateStore<Self::Addr>;
     type VoteSignatureService = TariSignatureService;
 }

--- a/applications/tari_validator_node/src/consensus/state_manager.rs
+++ b/applications/tari_validator_node/src/consensus/state_manager.rs
@@ -24,7 +24,7 @@ impl<TStateStore: StateStore> StateManager<TStateStore> for TariStateManager {
     fn commit_transaction(
         &self,
         tx: &mut TStateStore::WriteTransaction<'_>,
-        block: &Block,
+        block: &Block<TStateStore::Addr>,
         transaction: &ExecutedTransaction,
     ) -> Result<(), Self::Error> {
         let Some(diff) = transaction.result().finalize.result.accept() else {

--- a/applications/tari_validator_node/src/dry_run_transaction_processor.rs
+++ b/applications/tari_validator_node/src/dry_run_transaction_processor.rs
@@ -21,6 +21,7 @@
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use log::info;
+use tari_common_types::types::PublicKey;
 use tari_comms::protocol::rpc::RpcStatus;
 use tari_dan_app_utilities::{
     template_manager::implementation::TemplateManager,
@@ -68,7 +69,8 @@ pub enum DryRunTransactionProcessorError {
 
 #[derive(Clone, Debug)]
 pub struct DryRunTransactionProcessor {
-    substate_resolver: TariSubstateResolver<SqliteStateStore, EpochManagerHandle, TariCommsValidatorNodeClientFactory>,
+    substate_resolver:
+        TariSubstateResolver<SqliteStateStore<PublicKey>, EpochManagerHandle, TariCommsValidatorNodeClientFactory>,
     epoch_manager: EpochManagerHandle,
     payload_processor: TariDanTransactionProcessor<TemplateManager>,
 }
@@ -78,7 +80,7 @@ impl DryRunTransactionProcessor {
         epoch_manager: EpochManagerHandle,
         payload_processor: TariDanTransactionProcessor<TemplateManager>,
         substate_resolver: TariSubstateResolver<
-            SqliteStateStore,
+            SqliteStateStore<PublicKey>,
             EpochManagerHandle,
             TariCommsValidatorNodeClientFactory,
         >,

--- a/applications/tari_validator_node/src/json_rpc/handlers.rs
+++ b/applications/tari_validator_node/src/json_rpc/handlers.rs
@@ -32,6 +32,7 @@ use log::*;
 use serde::Serialize;
 use serde_json::{self as json, json};
 use tari_base_node_client::{grpc::GrpcBaseNodeClient, BaseNodeClient};
+use tari_common_types::types::PublicKey;
 use tari_comms::{
     multiaddr::Multiaddr,
     peer_manager::{NodeId, PeerFeatures},
@@ -102,7 +103,7 @@ pub struct JsonRpcHandlers {
     epoch_manager: EpochManagerHandle,
     comms: CommsNode,
     base_node_client: GrpcBaseNodeClient,
-    state_store: SqliteStateStore,
+    state_store: SqliteStateStore<PublicKey>,
     dry_run_transaction_processor: DryRunTransactionProcessor,
     config: ValidatorNodeConfig,
 }

--- a/applications/tari_validator_node/src/p2p/rpc/mod.rs
+++ b/applications/tari_validator_node/src/p2p/rpc/mod.rs
@@ -23,6 +23,7 @@
 mod service_impl;
 
 pub use service_impl::ValidatorNodeRpcServiceImpl;
+use tari_common_types::types::PublicKey;
 use tari_dan_p2p::PeerProvider;
 use tari_state_store_sqlite::SqliteStateStore;
 use tari_validator_node_rpc::rpc_service::ValidatorNodeRpcServer;
@@ -31,7 +32,7 @@ use crate::p2p::services::mempool::MempoolHandle;
 
 pub fn create_tari_validator_node_rpc_service<TPeerProvider>(
     peer_provider: TPeerProvider,
-    shard_store_store: SqliteStateStore,
+    shard_store_store: SqliteStateStore<PublicKey>,
     mempool: MempoolHandle,
 ) -> ValidatorNodeRpcServer<ValidatorNodeRpcServiceImpl<TPeerProvider>>
 where

--- a/applications/tari_validator_node/src/p2p/rpc/service_impl.rs
+++ b/applications/tari_validator_node/src/p2p/rpc/service_impl.rs
@@ -23,6 +23,7 @@
 use std::convert::{TryFrom, TryInto};
 
 use log::*;
+use tari_common_types::types::PublicKey;
 use tari_comms::protocol::rpc::{Request, Response, RpcStatus, Streaming};
 use tari_dan_common_types::{optional::Optional, NodeAddressable, ShardId};
 use tari_dan_p2p::PeerProvider;
@@ -55,12 +56,16 @@ use crate::p2p::services::mempool::MempoolHandle;
 
 pub struct ValidatorNodeRpcServiceImpl<TPeerProvider> {
     peer_provider: TPeerProvider,
-    shard_state_store: SqliteStateStore,
+    shard_state_store: SqliteStateStore<PublicKey>,
     mempool: MempoolHandle,
 }
 
 impl<TPeerProvider: PeerProvider> ValidatorNodeRpcServiceImpl<TPeerProvider> {
-    pub fn new(peer_provider: TPeerProvider, shard_state_store: SqliteStateStore, mempool: MempoolHandle) -> Self {
+    pub fn new(
+        peer_provider: TPeerProvider,
+        shard_state_store: SqliteStateStore<PublicKey>,
+        mempool: MempoolHandle,
+    ) -> Self {
         Self {
             peer_provider,
             shard_state_store,

--- a/applications/tari_validator_node/src/p2p/services/committee_state_sync.rs
+++ b/applications/tari_validator_node/src/p2p/services/committee_state_sync.rs
@@ -5,6 +5,7 @@ use std::{convert::TryInto, ops::RangeInclusive};
 
 use futures::StreamExt;
 use log::info;
+use tari_common_types::types::PublicKey;
 use tari_comms::{
     protocol::rpc::{RpcError, RpcStatus},
     types::CommsPublicKey,
@@ -29,7 +30,7 @@ const LOG_TARGET: &str = "tari::dan::committee_state_sync";
 pub struct CommitteeStateSync {
     epoch_manager: EpochManagerHandle,
     validator_node_client_factory: TariCommsValidatorNodeClientFactory,
-    shard_store: SqliteStateStore,
+    shard_store: SqliteStateStore<PublicKey>,
     global_db: GlobalDb<SqliteGlobalDbAdapter>,
     node_public_key: CommsPublicKey,
 }
@@ -38,7 +39,7 @@ impl CommitteeStateSync {
     pub fn new(
         epoch_manager: EpochManagerHandle,
         validator_node_client_factory: TariCommsValidatorNodeClientFactory,
-        shard_store: SqliteStateStore,
+        shard_store: SqliteStateStore<PublicKey>,
         global_db: GlobalDb<SqliteGlobalDbAdapter>,
         node_public_key: CommsPublicKey,
     ) -> Self {

--- a/applications/tari_validator_node/src/p2p/services/mempool/initializer.rs
+++ b/applications/tari_validator_node/src/p2p/services/mempool/initializer.rs
@@ -22,6 +22,7 @@
 
 use std::sync::Arc;
 
+use tari_common_types::types::PublicKey;
 use tari_comms::NodeIdentity;
 use tari_dan_app_utilities::transaction_executor::{TransactionExecutor, TransactionProcessorError};
 use tari_dan_storage::consensus_models::ExecutedTransaction;
@@ -47,7 +48,7 @@ pub fn spawn<TExecutor, TValidator, TSubstateResolver>(
     transaction_executor: TExecutor,
     substate_resolver: TSubstateResolver,
     validator: TValidator,
-    state_store: SqliteStateStore,
+    state_store: SqliteStateStore<PublicKey>,
 ) -> (MempoolHandle, JoinHandle<anyhow::Result<()>>)
 where
     TValidator: Validator<Transaction, Error = MempoolError> + Send + Sync + 'static,

--- a/applications/tari_validator_node/src/p2p/services/mempool/service.rs
+++ b/applications/tari_validator_node/src/p2p/services/mempool/service.rs
@@ -24,6 +24,7 @@ use std::{collections::HashSet, fmt::Display, iter, sync::Arc};
 
 use futures::{future::BoxFuture, stream::FuturesUnordered, FutureExt, StreamExt};
 use log::*;
+use tari_common_types::types::PublicKey;
 use tari_comms::NodeIdentity;
 use tari_dan_app_utilities::transaction_executor::{TransactionExecutor, TransactionProcessorError};
 use tari_dan_common_types::{Epoch, ShardId};
@@ -68,7 +69,7 @@ pub struct MempoolService<TValidator, TExecutor, TSubstateResolver> {
     validator: TValidator,
     transaction_executor: TExecutor,
     substate_resolver: TSubstateResolver,
-    state_store: SqliteStateStore,
+    state_store: SqliteStateStore<PublicKey>,
 }
 
 impl<TValidator, TExecutor, TSubstateResolver> MempoolService<TValidator, TExecutor, TSubstateResolver>
@@ -87,7 +88,7 @@ where
         transaction_executor: TExecutor,
         substate_resolver: TSubstateResolver,
         validator: TValidator,
-        state_store: SqliteStateStore,
+        state_store: SqliteStateStore<PublicKey>,
     ) -> Self {
         Self {
             transactions: Default::default(),

--- a/applications/tari_validator_node/src/p2p/services/messaging/mod.rs
+++ b/applications/tari_validator_node/src/p2p/services/messaging/mod.rs
@@ -56,14 +56,14 @@ pub fn spawn(
 
 #[derive(Debug, Clone)]
 pub struct DanMessageSenders {
-    pub tx_consensus_message: mpsc::Sender<(CommsPublicKey, HotstuffMessage)>,
+    pub tx_consensus_message: mpsc::Sender<(CommsPublicKey, HotstuffMessage<CommsPublicKey>)>,
     pub tx_new_transaction_message: mpsc::Sender<Transaction>,
     pub tx_network_announce: mpsc::Sender<(CommsPublicKey, NetworkAnnounce<CommsPublicKey>)>,
 }
 
 #[derive(Debug)]
 pub struct DanMessageReceivers {
-    pub rx_consensus_message: mpsc::Receiver<(CommsPublicKey, HotstuffMessage)>,
+    pub rx_consensus_message: mpsc::Receiver<(CommsPublicKey, HotstuffMessage<CommsPublicKey>)>,
     pub rx_new_transaction_message: mpsc::Receiver<Transaction>,
     pub rx_network_announce: mpsc::Receiver<(CommsPublicKey, NetworkAnnounce<CommsPublicKey>)>,
 }

--- a/dan_layer/common_types/src/node_addressable.rs
+++ b/dan_layer/common_types/src/node_addressable.rs
@@ -12,6 +12,8 @@ use tari_utilities::ByteArray;
 pub trait NodeAddressable: Eq + Hash + Clone + Debug + Send + Sync + Display {
     fn zero() -> Self;
     fn as_bytes(&self) -> &[u8];
+
+    fn from_bytes(bytes: &[u8]) -> Option<Self>;
 }
 
 impl NodeAddressable for String {
@@ -22,15 +24,9 @@ impl NodeAddressable for String {
     fn as_bytes(&self) -> &[u8] {
         self.as_bytes()
     }
-}
 
-impl NodeAddressable for &str {
-    fn zero() -> Self {
-        ""
-    }
-
-    fn as_bytes(&self) -> &[u8] {
-        str::as_bytes(self)
+    fn from_bytes(bytes: &[u8]) -> Option<Self> {
+        String::from_utf8(bytes.to_vec()).ok()
     }
 }
 
@@ -41,5 +37,9 @@ impl NodeAddressable for PublicKey {
 
     fn as_bytes(&self) -> &[u8] {
         <PublicKey as ByteArray>::as_bytes(self)
+    }
+
+    fn from_bytes(bytes: &[u8]) -> Option<Self> {
+        ByteArray::from_bytes(bytes).ok()
     }
 }

--- a/dan_layer/consensus/src/hotstuff/common.rs
+++ b/dan_layer/consensus/src/hotstuff/common.rs
@@ -4,15 +4,19 @@
 use std::ops::DerefMut;
 
 use log::*;
+use tari_dan_common_types::committee::Committee;
 use tari_dan_storage::{
     consensus_models::{HighQc, QuorumCertificate},
     StateStoreReadTransaction,
     StateStoreWriteTransaction,
 };
 
-use crate::hotstuff::error::HotStuffError;
+use crate::{hotstuff::error::HotStuffError, messages::HotstuffMessage};
 
 const LOG_TARGET: &str = "tari::dan::consensus::hotstuff";
+
+// To avoid clippy::type_complexity
+pub(super) type CommitteeAndMessage<TAddr> = (Committee<TAddr>, HotstuffMessage<TAddr>);
 
 pub fn update_high_qc<TTx>(tx: &mut TTx, qc: &QuorumCertificate) -> Result<(), HotStuffError>
 where

--- a/dan_layer/consensus/src/hotstuff/on_receive_proposal.rs
+++ b/dan_layer/consensus/src/hotstuff/on_receive_proposal.rs
@@ -60,7 +60,7 @@ pub struct OnReceiveProposalHandler<TConsensusSpec: ConsensusSpec> {
     leader_strategy: TConsensusSpec::LeaderStrategy,
     state_manager: TConsensusSpec::StateManager,
     transaction_pool: TransactionPool<TConsensusSpec::StateStore>,
-    tx_leader: mpsc::Sender<(TConsensusSpec::Addr, HotstuffMessage)>,
+    tx_leader: mpsc::Sender<(TConsensusSpec::Addr, HotstuffMessage<TConsensusSpec::Addr>)>,
     tx_events: broadcast::Sender<HotstuffEvent>,
     on_beat: OnBeat,
 }
@@ -76,7 +76,7 @@ where TConsensusSpec: ConsensusSpec
         leader_strategy: TConsensusSpec::LeaderStrategy,
         state_manager: TConsensusSpec::StateManager,
         transaction_pool: TransactionPool<TConsensusSpec::StateStore>,
-        tx_leader: mpsc::Sender<(TConsensusSpec::Addr, HotstuffMessage)>,
+        tx_leader: mpsc::Sender<(TConsensusSpec::Addr, HotstuffMessage<TConsensusSpec::Addr>)>,
         tx_events: broadcast::Sender<HotstuffEvent>,
         on_beat: OnBeat,
     ) -> Self {
@@ -94,7 +94,11 @@ where TConsensusSpec: ConsensusSpec
         }
     }
 
-    pub async fn handle(&self, from: TConsensusSpec::Addr, message: ProposalMessage) -> Result<(), HotStuffError> {
+    pub async fn handle(
+        &self,
+        from: TConsensusSpec::Addr,
+        message: ProposalMessage<TConsensusSpec::Addr>,
+    ) -> Result<(), HotStuffError> {
         let ProposalMessage { block } = message;
 
         let local_committee = self.epoch_manager.get_local_committee(block.epoch()).await?;
@@ -127,7 +131,7 @@ where TConsensusSpec: ConsensusSpec
         &self,
         from: TConsensusSpec::Addr,
         local_committee: Committee<TConsensusSpec::Addr>,
-        block: Block,
+        block: Block<TConsensusSpec::Addr>,
     ) -> Result<(), HotStuffError> {
         // First save the block in one db transaction
         self.store.with_write_tx(|tx| {
@@ -148,7 +152,7 @@ where TConsensusSpec: ConsensusSpec
     async fn block_has_missing_transaction(
         &self,
         local_committee: &Committee<TConsensusSpec::Addr>,
-        block: &Block,
+        block: &Block<TConsensusSpec::Addr>,
     ) -> Result<bool, HotStuffError> {
         let mut missing_tx_ids = Vec::new();
         let mut awaiting_execution = Vec::new();
@@ -207,7 +211,7 @@ where TConsensusSpec: ConsensusSpec
     async fn process_block(
         &self,
         local_committee: &Committee<<TConsensusSpec as ConsensusSpec>::Addr>,
-        block: &Block,
+        block: &Block<TConsensusSpec::Addr>,
     ) -> Result<(), HotStuffError> {
         let local_committee_shard = self.epoch_manager.get_local_committee_shard(block.epoch()).await?;
         let maybe_decision = self.store.with_write_tx(|tx| {
@@ -238,7 +242,11 @@ where TConsensusSpec: ConsensusSpec
         Ok(())
     }
 
-    async fn handle_foreign_proposal(&self, from: TConsensusSpec::Addr, block: Block) -> Result<(), HotStuffError> {
+    async fn handle_foreign_proposal(
+        &self,
+        from: TConsensusSpec::Addr,
+        block: Block<TConsensusSpec::Addr>,
+    ) -> Result<(), HotStuffError> {
         let vn = self.epoch_manager.get_validator_node(block.epoch(), &from).await?;
         let committee_shard = self
             .epoch_manager
@@ -257,7 +265,7 @@ where TConsensusSpec: ConsensusSpec
     fn on_receive_foreign_block(
         &self,
         tx: &mut <TConsensusSpec::StateStore as StateStore>::WriteTransaction<'_>,
-        block: &Block,
+        block: &Block<TConsensusSpec::Addr>,
         foreign_committee_shard: &CommitteeShard,
     ) -> Result<(), HotStuffError> {
         // Save the QCs if it doesnt exist already, we'll reference the QC in subsequent blocks
@@ -308,7 +316,7 @@ where TConsensusSpec: ConsensusSpec
         local_committee: &Committee<TConsensusSpec::Addr>,
         block_id: &BlockId,
         height: NodeHeight,
-        message: HotstuffMessage,
+        message: HotstuffMessage<TConsensusSpec::Addr>,
     ) -> Result<(), HotStuffError> {
         let leader = self.leader_strategy.get_leader(local_committee, block_id, height);
         self.tx_leader
@@ -340,7 +348,7 @@ where TConsensusSpec: ConsensusSpec
     fn decide_what_to_vote(
         &self,
         tx: &mut <TConsensusSpec::StateStore as StateStore>::WriteTransaction<'_>,
-        block: &Block,
+        block: &Block<TConsensusSpec::Addr>,
         local_committee_shard: &CommitteeShard,
     ) -> Result<Option<QuorumDecision>, HotStuffError> {
         block.as_last_voted().set(tx)?;
@@ -533,7 +541,7 @@ where TConsensusSpec: ConsensusSpec
 
     async fn generate_vote_message(
         &self,
-        block: &Block,
+        block: &Block<TConsensusSpec::Addr>,
         decision: QuorumDecision,
     ) -> Result<VoteMessage, HotStuffError> {
         let merkle_proof = self
@@ -560,7 +568,7 @@ where TConsensusSpec: ConsensusSpec
     fn update_nodes(
         &self,
         tx: &mut <TConsensusSpec::StateStore as StateStore>::WriteTransaction<'_>,
-        block: &Block,
+        block: &Block<TConsensusSpec::Addr>,
         local_committee_shard: &CommitteeShard,
     ) -> Result<(), HotStuffError> {
         update_high_qc(tx, block.justify())?;
@@ -618,7 +626,7 @@ where TConsensusSpec: ConsensusSpec
         &self,
         tx: &mut <TConsensusSpec::StateStore as StateStore>::WriteTransaction<'_>,
         last_executed: &LastExecuted,
-        block: &Block,
+        block: &Block<TConsensusSpec::Addr>,
         local_committee_shard: &CommitteeShard,
     ) -> Result<(), HotStuffError> {
         if last_executed.height < block.height() {
@@ -645,7 +653,7 @@ where TConsensusSpec: ConsensusSpec
     fn execute(
         &self,
         tx: &mut <TConsensusSpec::StateStore as StateStore>::WriteTransaction<'_>,
-        block: &Block,
+        block: &Block<TConsensusSpec::Addr>,
         local_committee_shard: &CommitteeShard,
     ) -> Result<(), HotStuffError> {
         for cmd in block.commands() {
@@ -692,7 +700,7 @@ where TConsensusSpec: ConsensusSpec
         &self,
         tx: &mut <TConsensusSpec::StateStore as StateStore>::ReadTransaction<'_>,
         from: &TConsensusSpec::Addr,
-        candidate_block: &Block,
+        candidate_block: &Block<TConsensusSpec::Addr>,
     ) -> Result<(), ProposalValidationError> {
         self.validate_proposed_block(from, candidate_block)?;
 
@@ -724,7 +732,7 @@ where TConsensusSpec: ConsensusSpec
     fn validate_proposed_block(
         &self,
         from: &TConsensusSpec::Addr,
-        candidate_block: &Block,
+        candidate_block: &Block<TConsensusSpec::Addr>,
     ) -> Result<(), ProposalValidationError> {
         if candidate_block.height() == NodeHeight::zero() || candidate_block.id().is_genesis() {
             return Err(ProposalValidationError::ProposingGenesisBlock {
@@ -754,7 +762,7 @@ where TConsensusSpec: ConsensusSpec
     fn should_vote(
         &self,
         tx: &mut <TConsensusSpec::StateStore as StateStore>::ReadTransaction<'_>,
-        block: &Block,
+        block: &Block<TConsensusSpec::Addr>,
     ) -> Result<bool, HotStuffError> {
         let Some(last_voted) = LastVoted::get(tx, block.epoch()).optional()? else {
             // Never voted, then validated.block.height() > last_voted.height (0)
@@ -800,8 +808,8 @@ where TConsensusSpec: ConsensusSpec
 /// is true as long as either one of two rules holds.
 fn is_safe_block<TTx: StateStoreReadTransaction>(
     tx: &mut TTx,
-    block: &Block,
-    locked_block: &Block,
+    block: &Block<TTx::Addr>,
+    locked_block: &Block<TTx::Addr>,
 ) -> Result<bool, HotStuffError> {
     // Liveness
     if block.justify().block_height() <= locked_block.height() {

--- a/dan_layer/consensus/src/hotstuff/on_receive_request_missing_transactions.rs
+++ b/dan_layer/consensus/src/hotstuff/on_receive_request_missing_transactions.rs
@@ -15,7 +15,7 @@ const LOG_TARGET: &str = "tari::dan::consensus::hotstuff::on_receive_request_mis
 
 pub struct OnReceiveRequestMissingTransactions<TConsensusSpec: ConsensusSpec> {
     store: TConsensusSpec::StateStore,
-    tx_request_missing_tx: mpsc::Sender<(TConsensusSpec::Addr, HotstuffMessage)>,
+    tx_request_missing_tx: mpsc::Sender<(TConsensusSpec::Addr, HotstuffMessage<TConsensusSpec::Addr>)>,
 }
 
 impl<TConsensusSpec> OnReceiveRequestMissingTransactions<TConsensusSpec>
@@ -23,7 +23,7 @@ where TConsensusSpec: ConsensusSpec
 {
     pub fn new(
         store: TConsensusSpec::StateStore,
-        tx_request_missing_tx: mpsc::Sender<(TConsensusSpec::Addr, HotstuffMessage)>,
+        tx_request_missing_tx: mpsc::Sender<(TConsensusSpec::Addr, HotstuffMessage<TConsensusSpec::Addr>)>,
     ) -> Self {
         Self {
             store,

--- a/dan_layer/consensus/src/messages/message.rs
+++ b/dan_layer/consensus/src/messages/message.rs
@@ -9,15 +9,15 @@ use super::{NewViewMessage, ProposalMessage, RequestedTransactionMessage, VoteMe
 use crate::messages::RequestMissingTransactionsMessage;
 
 #[derive(Debug, Clone, Serialize)]
-pub enum HotstuffMessage {
+pub enum HotstuffMessage<TAddr> {
     NewView(NewViewMessage),
-    Proposal(ProposalMessage),
+    Proposal(ProposalMessage<TAddr>),
     Vote(VoteMessage),
     RequestMissingTransactions(RequestMissingTransactionsMessage),
     RequestedTransaction(RequestedTransactionMessage),
 }
 
-impl HotstuffMessage {
+impl<TAddr> HotstuffMessage<TAddr> {
     pub fn epoch(&self) -> Epoch {
         match self {
             Self::NewView(msg) => msg.high_qc.epoch(),

--- a/dan_layer/consensus/src/messages/proposal.rs
+++ b/dan_layer/consensus/src/messages/proposal.rs
@@ -5,6 +5,6 @@ use serde::Serialize;
 use tari_dan_storage::consensus_models::Block;
 
 #[derive(Debug, Clone, Serialize)]
-pub struct ProposalMessage {
-    pub block: Block,
+pub struct ProposalMessage<TAddr> {
+    pub block: Block<TAddr>,
 }

--- a/dan_layer/consensus/src/traits/mod.rs
+++ b/dan_layer/consensus/src/traits/mod.rs
@@ -6,6 +6,7 @@ mod signing_service;
 mod state_manager;
 
 pub use leader_strategy::*;
+use serde::Serialize;
 pub use state_manager::*;
 use tari_dan_common_types::NodeAddressable;
 use tari_dan_storage::StateStore;
@@ -14,9 +15,9 @@ use tari_epoch_manager::EpochManagerReader;
 pub use crate::traits::signing_service::*;
 
 pub trait ConsensusSpec: Send + Sync + 'static {
-    type Addr: NodeAddressable;
+    type Addr: NodeAddressable + Serialize;
 
-    type StateStore: StateStore + Send + Sync + 'static;
+    type StateStore: StateStore<Addr = Self::Addr> + Send + Sync + 'static;
     type EpochManager: EpochManagerReader<Addr = Self::Addr> + Send + Sync + 'static;
     type LeaderStrategy: LeaderStrategy<Self::Addr> + Send + Sync + 'static;
     type VoteSignatureService: VoteSignatureService + Send + Sync + 'static;

--- a/dan_layer/consensus/src/traits/state_manager.rs
+++ b/dan_layer/consensus/src/traits/state_manager.rs
@@ -12,7 +12,7 @@ pub trait StateManager<TStateStore: StateStore> {
     fn commit_transaction(
         &self,
         tx: &mut TStateStore::WriteTransaction<'_>,
-        block: &Block,
+        block: &Block<TStateStore::Addr>,
         transaction: &ExecutedTransaction,
     ) -> Result<(), Self::Error>;
 }

--- a/dan_layer/consensus_tests/src/consensus.rs
+++ b/dan_layer/consensus_tests/src/consensus.rs
@@ -39,7 +39,7 @@ async fn single_transaction() {
         if test.is_transaction_pool_empty() {
             break;
         }
-        let leaf = test.get_validator(&TestAddress("1")).get_leaf_block();
+        let leaf = test.get_validator(&TestAddress::new("1")).get_leaf_block();
         if leaf.height > NodeHeight(4) {
             panic!("Not all transaction committed after {} blocks", leaf.height);
         }
@@ -66,7 +66,7 @@ async fn propose_blocks_with_queued_up_transactions_until_all_committed() {
         if test.is_transaction_pool_empty() {
             break;
         }
-        let leaf = test.get_validator(&TestAddress("1")).get_leaf_block();
+        let leaf = test.get_validator(&TestAddress::new("1")).get_leaf_block();
         if leaf.height > NodeHeight(20) {
             panic!("Not all transaction committed after {} blocks", leaf.height);
         }
@@ -81,10 +81,10 @@ async fn node_requests_missing_transaction_from_local_leader() {
     let mut test = Test::builder().add_committee(0, vec!["1", "2"]).start().await;
     // First get all transactions in the mempool of node "1"
     for _ in 0..10 {
-        test.send_transaction_to(&TestAddress("1"), Decision::Commit, 1, 5)
+        test.send_transaction_to(&TestAddress::new("1"), Decision::Commit, 1, 5)
             .await;
     }
-    test.wait_until_new_pool_count_for_vn(10, TestAddress("1")).await;
+    test.wait_until_new_pool_count_for_vn(10, TestAddress::new("1")).await;
     test.network().start();
     loop {
         test.on_block_committed().await;
@@ -92,14 +92,14 @@ async fn node_requests_missing_transaction_from_local_leader() {
         if test.is_transaction_pool_empty() {
             break;
         }
-        let leaf = test.get_validator(&TestAddress("1")).get_leaf_block();
+        let leaf = test.get_validator(&TestAddress::new("1")).get_leaf_block();
         if leaf.height > NodeHeight(10) {
             panic!("Not all transaction committed after {} blocks", leaf.height);
         }
     }
 
     // Check if we clean the missing transactions table in the DB once the transactions are committed
-    test.get_validator(&TestAddress("2"))
+    test.get_validator(&TestAddress::new("2"))
         .state_store
         .with_read_tx(|tx| {
             let mut block_id = BlockId::genesis();
@@ -131,7 +131,7 @@ async fn propose_blocks_with_new_transactions_until_all_committed() {
         if test.is_transaction_pool_empty() {
             break;
         }
-        let leaf = test.get_validator(&TestAddress("1")).get_leaf_block();
+        let leaf = test.get_validator(&TestAddress::new("1")).get_leaf_block();
         if leaf.height > NodeHeight(20) {
             panic!("Not all transaction committed after {} blocks", leaf.height);
         }
@@ -159,7 +159,7 @@ async fn multi_validator_propose_blocks_with_new_transactions_until_all_committe
         if remaining_txs == 0 && test.is_transaction_pool_empty() {
             break;
         }
-        let leaf = test.get_validator(&TestAddress("1")).get_leaf_block();
+        let leaf = test.get_validator(&TestAddress::new("1")).get_leaf_block();
         if leaf.height > NodeHeight(20) {
             panic!("Not all transaction committed after {} blocks", leaf.height);
         }
@@ -194,9 +194,9 @@ async fn multi_shard_propose_blocks_with_new_transactions_until_all_committed() 
             break;
         }
 
-        let leaf1 = test.get_validator(&TestAddress("1")).get_leaf_block();
-        let leaf2 = test.get_validator(&TestAddress("4")).get_leaf_block();
-        let leaf3 = test.get_validator(&TestAddress("7")).get_leaf_block();
+        let leaf1 = test.get_validator(&TestAddress::new("1")).get_leaf_block();
+        let leaf2 = test.get_validator(&TestAddress::new("4")).get_leaf_block();
+        let leaf3 = test.get_validator(&TestAddress::new("7")).get_leaf_block();
         if leaf1.height > NodeHeight(20) || leaf2.height > NodeHeight(20) || leaf3.height > NodeHeight(20) {
             panic!(
                 "Not all transaction committed after {}/{}/{} blocks",
@@ -239,8 +239,8 @@ async fn foreign_shard_decides_to_abort() {
             break;
         }
 
-        let leaf1 = test.get_validator(&TestAddress("1")).get_leaf_block();
-        let leaf2 = test.get_validator(&TestAddress("2")).get_leaf_block();
+        let leaf1 = test.get_validator(&TestAddress::new("1")).get_leaf_block();
+        let leaf2 = test.get_validator(&TestAddress::new("2")).get_leaf_block();
         if leaf1.height > NodeHeight(6) || leaf2.height > NodeHeight(6) {
             panic!(
                 "Not all transaction committed after {}/{} blocks",

--- a/dan_layer/consensus_tests/src/support/address.rs
+++ b/dan_layer/consensus_tests/src/support/address.rs
@@ -6,16 +6,26 @@ use std::fmt::Display;
 use serde::{Deserialize, Serialize};
 use tari_dan_common_types::NodeAddressable;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
-pub struct TestAddress(pub &'static str);
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct TestAddress(pub String);
+
+impl TestAddress {
+    pub fn new<T: Into<String>>(s: T) -> Self {
+        TestAddress(s.into())
+    }
+}
 
 impl NodeAddressable for TestAddress {
     fn zero() -> Self {
-        TestAddress("")
+        TestAddress::new("")
     }
 
     fn as_bytes(&self) -> &[u8] {
         self.0.as_bytes()
+    }
+
+    fn from_bytes(bytes: &[u8]) -> Option<Self> {
+        std::str::from_utf8(bytes).ok().map(TestAddress::new)
     }
 }
 

--- a/dan_layer/consensus_tests/src/support/epoch_manager.rs
+++ b/dan_layer/consensus_tests/src/support/epoch_manager.rs
@@ -54,10 +54,11 @@ impl TestEpochManager {
         let num_committees = committees.len() as u32;
         for (bucket, committee) in committees {
             for address in &committee.members {
-                state
-                    .validator_shards
-                    .insert(*address, (bucket, random_shard_in_bucket(bucket, num_committees)));
-                state.address_bucket.insert(*address, bucket);
+                state.validator_shards.insert(
+                    address.clone(),
+                    (bucket, random_shard_in_bucket(bucket, num_committees)),
+                );
+                state.address_bucket.insert(address.clone(), bucket);
             }
 
             state.committees.insert(bucket, committee);
@@ -69,7 +70,7 @@ impl TestEpochManager {
             .await
             .validator_shards
             .iter()
-            .map(|(a, (bucket, shard))| (*a, *bucket, *shard))
+            .map(|(a, (bucket, shard))| (a.clone(), *bucket, *shard))
             .collect()
     }
 
@@ -100,7 +101,7 @@ impl EpochManagerReader for TestEpochManager {
         let (bucket, shard_key) = self.state_lock().await.validator_shards[addr];
 
         Ok(ValidatorNode {
-            address: *addr,
+            address: addr.clone(),
             shard_key,
             epoch,
             committee_bucket: Some(bucket),
@@ -182,7 +183,7 @@ impl EpochManagerReader for TestEpochManager {
                 .iter()
                 .filter(|(_, (_, s))| range.contains(s))
                 .map(|(a, _)| a)
-                .copied()
+                .cloned()
                 .collect(),
         ))
     }

--- a/dan_layer/consensus_tests/src/support/spec.rs
+++ b/dan_layer/consensus_tests/src/support/spec.rs
@@ -19,6 +19,6 @@ impl ConsensusSpec for TestConsensusSpec {
     type EpochManager = TestEpochManager;
     type LeaderStrategy = SelectedIndexLeaderStrategy;
     type StateManager = NoopStateManager;
-    type StateStore = SqliteStateStore;
+    type StateStore = SqliteStateStore<Self::Addr>;
     type VoteSignatureService = TestVoteSignatureService;
 }

--- a/dan_layer/consensus_tests/src/support/state_manager.rs
+++ b/dan_layer/consensus_tests/src/support/state_manager.rs
@@ -33,7 +33,7 @@ impl<TStateStore: StateStore> StateManager<TStateStore> for NoopStateManager {
     fn commit_transaction(
         &self,
         _tx: &mut TStateStore::WriteTransaction<'_>,
-        _block: &Block,
+        _block: &Block<TStateStore::Addr>,
         _transaction: &ExecutedTransaction,
     ) -> Result<(), Self::Error> {
         self.0.store(true, std::sync::atomic::Ordering::Relaxed);

--- a/dan_layer/consensus_tests/src/support/validator/builder.rs
+++ b/dan_layer/consensus_tests/src/support/validator/builder.rs
@@ -32,7 +32,7 @@ pub struct ValidatorBuilder {
 impl ValidatorBuilder {
     pub fn new() -> Self {
         Self {
-            address: TestAddress("default"),
+            address: TestAddress::new("default"),
             shard: ShardId::zero(),
             bucket: 0,
             sql_url: ":memory".to_string(),
@@ -88,12 +88,12 @@ impl ValidatorBuilder {
         let (tx_epoch_events, rx_epoch_events) = broadcast::channel(1);
 
         let worker = HotstuffWorker::<TestConsensusSpec>::new(
-            self.address,
+            self.address.clone(),
             rx_new_transactions,
             rx_hs_message,
             store.clone(),
             rx_epoch_events,
-            self.epoch_manager.clone_for(self.address, self.shard),
+            self.epoch_manager.clone_for(self.address.clone(), self.shard),
             self.leader_strategy.clone(),
             signing_service,
             noop_state_manager.clone(),
@@ -109,7 +109,7 @@ impl ValidatorBuilder {
         });
 
         let channels = ValidatorChannels {
-            address: self.address,
+            address: self.address.clone(),
             bucket: self.bucket,
             tx_new_transactions,
             tx_hs_message,
@@ -122,10 +122,10 @@ impl ValidatorBuilder {
         tx_epoch_events.send(EpochManagerEvent::EpochChanged(Epoch(0))).unwrap();
 
         let validator = Validator {
-            address: self.address,
+            address: self.address.clone(),
             shard: self.shard,
             state_store: store,
-            epoch_manager: self.epoch_manager.clone_for(self.address, self.shard),
+            epoch_manager: self.epoch_manager.clone_for(self.address.clone(), self.shard),
             shutdown,
             tx_epoch_events,
             state_manager: noop_state_manager,

--- a/dan_layer/consensus_tests/src/support/validator/instance.rs
+++ b/dan_layer/consensus_tests/src/support/validator/instance.rs
@@ -30,9 +30,9 @@ pub struct ValidatorChannels {
     pub bucket: u32,
 
     pub tx_new_transactions: mpsc::Sender<ExecutedTransaction>,
-    pub tx_hs_message: mpsc::Sender<(TestAddress, HotstuffMessage)>,
-    pub rx_broadcast: mpsc::Receiver<(Committee<TestAddress>, HotstuffMessage)>,
-    pub rx_leader: mpsc::Receiver<(TestAddress, HotstuffMessage)>,
+    pub tx_hs_message: mpsc::Sender<(TestAddress, HotstuffMessage<TestAddress>)>,
+    pub rx_broadcast: mpsc::Receiver<(Committee<TestAddress>, HotstuffMessage<TestAddress>)>,
+    pub rx_leader: mpsc::Receiver<(TestAddress, HotstuffMessage<TestAddress>)>,
     pub rx_mempool: mpsc::Receiver<Transaction>,
 }
 
@@ -40,7 +40,7 @@ pub struct Validator {
     pub address: TestAddress,
     pub shard: ShardId,
 
-    pub state_store: SqliteStateStore,
+    pub state_store: SqliteStateStore<TestAddress>,
     pub epoch_manager: TestEpochManager,
     pub leader_strategy: SelectedIndexLeaderStrategy,
     pub shutdown: Shutdown,

--- a/dan_layer/p2p/src/message.rs
+++ b/dan_layer/p2p/src/message.rs
@@ -10,7 +10,7 @@ use tari_transaction::Transaction;
 #[derive(Debug, Clone, Serialize)]
 pub enum DanMessage<TAddr> {
     // Consensus
-    HotStuffMessage(Box<HotstuffMessage>),
+    HotStuffMessage(Box<HotstuffMessage<TAddr>>),
     // Mempool
     NewTransaction(Box<Transaction>),
     // Network

--- a/dan_layer/state_store_sqlite/src/store.rs
+++ b/dan_layer/state_store_sqlite/src/store.rs
@@ -3,11 +3,14 @@
 
 use std::{
     fmt,
+    marker::PhantomData,
     sync::{Arc, Mutex},
 };
 
 use diesel::{sql_query, Connection, RunQueryDsl, SqliteConnection};
 use diesel_migrations::{embed_migrations, EmbeddedMigrations, MigrationHarness};
+use serde::Serialize;
+use tari_dan_common_types::NodeAddressable;
 use tari_dan_storage::{StateStore, StorageError};
 
 use crate::{
@@ -19,12 +22,12 @@ use crate::{
 
 const _LOG_TARGET: &str = "tari::dan::storage::sqlite::state_store";
 
-#[derive(Clone)]
-pub struct SqliteStateStore {
+pub struct SqliteStateStore<TAddr> {
     connection: Arc<Mutex<SqliteConnection>>,
+    _addr: PhantomData<TAddr>,
 }
 
-impl SqliteStateStore {
+impl<TAddr> SqliteStateStore<TAddr> {
     pub fn connect(url: &str) -> Result<Self, StorageError> {
         let mut connection = SqliteConnection::establish(url).map_err(SqliteStorageError::from)?;
 
@@ -42,20 +45,22 @@ impl SqliteStateStore {
 
         Ok(Self {
             connection: Arc::new(Mutex::new(connection)),
+            _addr: PhantomData,
         })
     }
 }
 
-// we mock the Debug implementation because "SqliteConnection" does not implement the Debug trait
-impl fmt::Debug for SqliteStateStore {
+// Manually implement the Debug implementation because `SqliteConnection` does not implement the Debug trait
+impl<TAddr> fmt::Debug for SqliteStateStore<TAddr> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "SqliteShardStore")
     }
 }
 
-impl StateStore for SqliteStateStore {
-    type ReadTransaction<'a> = SqliteStateStoreReadTransaction<'a>;
-    type WriteTransaction<'a> = SqliteStateStoreWriteTransaction<'a>;
+impl<TAddr: NodeAddressable + Serialize> StateStore for SqliteStateStore<TAddr> {
+    type Addr = TAddr;
+    type ReadTransaction<'a> = SqliteStateStoreReadTransaction<'a, Self::Addr> where TAddr: 'a;
+    type WriteTransaction<'a> = SqliteStateStoreWriteTransaction<'a, Self::Addr> where TAddr: 'a;
 
     fn create_read_tx(&self) -> Result<Self::ReadTransaction<'_>, StorageError> {
         let tx = SqliteTransaction::begin(self.connection.lock().unwrap())?;
@@ -65,5 +70,14 @@ impl StateStore for SqliteStateStore {
     fn create_write_tx(&self) -> Result<Self::WriteTransaction<'_>, StorageError> {
         let tx = SqliteTransaction::begin(self.connection.lock().unwrap())?;
         Ok(SqliteStateStoreWriteTransaction::new(tx))
+    }
+}
+
+impl<TAddr> Clone for SqliteStateStore<TAddr> {
+    fn clone(&self) -> Self {
+        Self {
+            connection: self.connection.clone(),
+            _addr: PhantomData,
+        }
     }
 }

--- a/dan_layer/state_store_sqlite/src/writer.rs
+++ b/dan_layer/state_store_sqlite/src/writer.rs
@@ -8,7 +8,7 @@ use std::{
 
 use diesel::{AsChangeset, ExpressionMethods, OptionalExtension, QueryDsl, RunQueryDsl, SqliteConnection};
 use log::*;
-use tari_dan_common_types::{Epoch, ShardId};
+use tari_dan_common_types::{Epoch, NodeAddressable, ShardId};
 use tari_dan_storage::{
     consensus_models::{
         Block,
@@ -45,12 +45,12 @@ use crate::{
 
 const LOG_TARGET: &str = "tari::dan::storage";
 
-pub struct SqliteStateStoreWriteTransaction<'a> {
+pub struct SqliteStateStoreWriteTransaction<'a, TAddr> {
     /// None indicates if the transaction has been explicitly committed/rolled back
-    transaction: Option<SqliteStateStoreReadTransaction<'a>>,
+    transaction: Option<SqliteStateStoreReadTransaction<'a, TAddr>>,
 }
 
-impl<'a> SqliteStateStoreWriteTransaction<'a> {
+impl<'a, TAddr> SqliteStateStoreWriteTransaction<'a, TAddr> {
     pub fn new(transaction: SqliteTransaction<'a>) -> Self {
         Self {
             transaction: Some(SqliteStateStoreReadTransaction::new(transaction)),
@@ -62,7 +62,9 @@ impl<'a> SqliteStateStoreWriteTransaction<'a> {
     }
 }
 
-impl StateStoreWriteTransaction for SqliteStateStoreWriteTransaction<'_> {
+impl<TAddr: NodeAddressable> StateStoreWriteTransaction for SqliteStateStoreWriteTransaction<'_, TAddr> {
+    type Addr = TAddr;
+
     fn commit(mut self) -> Result<(), StorageError> {
         // Take so that we mark this transaction as complete in the drop impl
         self.transaction.take().unwrap().commit()?;
@@ -75,7 +77,7 @@ impl StateStoreWriteTransaction for SqliteStateStoreWriteTransaction<'_> {
         Ok(())
     }
 
-    fn blocks_insert(&mut self, block: &Block) -> Result<(), StorageError> {
+    fn blocks_insert(&mut self, block: &Block<TAddr>) -> Result<(), StorageError> {
         use crate::schema::blocks;
 
         let insert = (
@@ -84,7 +86,7 @@ impl StateStoreWriteTransaction for SqliteStateStoreWriteTransaction<'_> {
             blocks::height.eq(block.height().as_u64() as i64),
             blocks::epoch.eq(block.epoch().as_u64() as i64),
             blocks::leader_round.eq(block.round() as i64),
-            blocks::proposed_by.eq(serialize_hex(block.proposed_by())),
+            blocks::proposed_by.eq(serialize_hex(block.proposed_by().as_bytes())),
             blocks::commands.eq(serialize_json(block.commands())?),
             blocks::qc_id.eq(serialize_hex(block.justify().id())),
         );
@@ -759,21 +761,21 @@ impl StateStoreWriteTransaction for SqliteStateStoreWriteTransaction<'_> {
     }
 }
 
-impl<'a> Deref for SqliteStateStoreWriteTransaction<'a> {
-    type Target = SqliteStateStoreReadTransaction<'a>;
+impl<'a, TAddr> Deref for SqliteStateStoreWriteTransaction<'a, TAddr> {
+    type Target = SqliteStateStoreReadTransaction<'a, TAddr>;
 
     fn deref(&self) -> &Self::Target {
         self.transaction.as_ref().unwrap()
     }
 }
 
-impl<'a> DerefMut for SqliteStateStoreWriteTransaction<'a> {
+impl<'a, TAddr> DerefMut for SqliteStateStoreWriteTransaction<'a, TAddr> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.transaction.as_mut().unwrap()
     }
 }
 
-impl Drop for SqliteStateStoreWriteTransaction<'_> {
+impl<TAddr> Drop for SqliteStateStoreWriteTransaction<'_, TAddr> {
     fn drop(&mut self) {
         if self.transaction.is_some() {
             warn!(

--- a/dan_layer/storage/src/consensus_models/leaf_block.rs
+++ b/dan_layer/storage/src/consensus_models/leaf_block.rs
@@ -59,7 +59,7 @@ impl LeafBlock {
         tx.leaf_block_set(self)
     }
 
-    pub fn get_block<TTx: StateStoreReadTransaction>(&self, tx: &mut TTx) -> Result<Block, StorageError> {
+    pub fn get_block<TTx: StateStoreReadTransaction>(&self, tx: &mut TTx) -> Result<Block<TTx::Addr>, StorageError> {
         tx.blocks_get(&self.block_id)
     }
 }

--- a/dan_layer/storage/src/consensus_models/locked_block.rs
+++ b/dan_layer/storage/src/consensus_models/locked_block.rs
@@ -22,7 +22,7 @@ impl LockedBlock {
         tx.locked_block_get(epoch)
     }
 
-    pub fn get_block<TTx: StateStoreReadTransaction>(&self, tx: &mut TTx) -> Result<Block, StorageError> {
+    pub fn get_block<TTx: StateStoreReadTransaction>(&self, tx: &mut TTx) -> Result<Block<TTx::Addr>, StorageError> {
         tx.blocks_get(&self.block_id)
     }
 

--- a/dan_layer/storage/src/consensus_models/quorum_certificate.rs
+++ b/dan_layer/storage/src/consensus_models/quorum_certificate.rs
@@ -152,7 +152,10 @@ impl QuorumCertificate {
         tx.quorum_certificates_get(qc_id)
     }
 
-    pub fn get_block<TTx: StateStoreReadTransaction + ?Sized>(&self, tx: &mut TTx) -> Result<Block, StorageError> {
+    pub fn get_block<TTx: StateStoreReadTransaction + ?Sized>(
+        &self,
+        tx: &mut TTx,
+    ) -> Result<Block<TTx::Addr>, StorageError> {
         Block::get(tx, &self.block_id)
     }
 

--- a/dan_layer/validator_node_rpc/src/client.rs
+++ b/dan_layer/validator_node_rpc/src/client.rs
@@ -164,7 +164,7 @@ impl ValidatorNodeRpcClient for TariCommsValidatorNodeRpcClient {
                     })
                     .collect::<Result<_, _>>()?;
                 Result::<_, ValidatorNodeRpcClientError>::Ok(DanPeer {
-                    identity: CommsPublicKey::from_bytes(&p.identity)
+                    identity: ByteArray::from_bytes(&p.identity)
                         .map_err(|_| ValidatorNodeRpcClientError::InvalidResponse(anyhow!("Invalid identity")))?,
                     addresses: addresses.into_iter().zip(claims).collect(),
                 })

--- a/dan_layer/validator_node_rpc/src/conversions/consensus.rs
+++ b/dan_layer/validator_node_rpc/src/conversions/consensus.rs
@@ -26,8 +26,8 @@ use std::{
 };
 
 use anyhow::anyhow;
+use serde::Serialize;
 use tari_bor::{decode_exact, encode};
-use tari_common_types::types::PublicKey;
 use tari_consensus::messages::{
     HotstuffMessage,
     NewViewMessage,
@@ -37,7 +37,7 @@ use tari_consensus::messages::{
     VoteMessage,
 };
 use tari_crypto::tari_utilities::ByteArray;
-use tari_dan_common_types::{Epoch, NodeHeight, ValidatorMetadata};
+use tari_dan_common_types::{Epoch, NodeAddressable, NodeHeight, ValidatorMetadata};
 use tari_dan_storage::consensus_models::{
     BlockId,
     Command,
@@ -52,8 +52,8 @@ use tari_transaction::TransactionId;
 use crate::proto;
 // -------------------------------- HotstuffMessage -------------------------------- //
 
-impl From<HotstuffMessage> for proto::consensus::HotStuffMessage {
-    fn from(source: HotstuffMessage) -> Self {
+impl<TAddr: NodeAddressable> From<HotstuffMessage<TAddr>> for proto::consensus::HotStuffMessage {
+    fn from(source: HotstuffMessage<TAddr>) -> Self {
         let message = match source {
             HotstuffMessage::NewView(msg) => proto::consensus::hot_stuff_message::Message::NewView(msg.into()),
             HotstuffMessage::Proposal(msg) => proto::consensus::hot_stuff_message::Message::Proposal(msg.into()),
@@ -69,7 +69,7 @@ impl From<HotstuffMessage> for proto::consensus::HotStuffMessage {
     }
 }
 
-impl TryFrom<proto::consensus::HotStuffMessage> for HotstuffMessage {
+impl<TAddr: NodeAddressable + Serialize> TryFrom<proto::consensus::HotStuffMessage> for HotstuffMessage<TAddr> {
     type Error = anyhow::Error;
 
     fn try_from(value: proto::consensus::HotStuffMessage) -> Result<Self, Self::Error> {
@@ -110,15 +110,15 @@ impl TryFrom<proto::consensus::NewViewMessage> for NewViewMessage {
 
 //---------------------------------- ProposalMessage --------------------------------------------//
 
-impl From<ProposalMessage> for proto::consensus::ProposalMessage {
-    fn from(value: ProposalMessage) -> Self {
+impl<TAddr: NodeAddressable> From<ProposalMessage<TAddr>> for proto::consensus::ProposalMessage {
+    fn from(value: ProposalMessage<TAddr>) -> Self {
         Self {
             block: Some(value.block.into()),
         }
     }
 }
 
-impl TryFrom<proto::consensus::ProposalMessage> for ProposalMessage {
+impl<TAddr: NodeAddressable + Serialize> TryFrom<proto::consensus::ProposalMessage> for ProposalMessage<TAddr> {
     type Error = anyhow::Error;
 
     fn try_from(value: proto::consensus::ProposalMessage) -> Result<Self, Self::Error> {
@@ -219,8 +219,8 @@ impl TryFrom<proto::consensus::RequestedTransactionMessage> for RequestedTransac
 }
 //---------------------------------- Block --------------------------------------------//
 
-impl From<tari_dan_storage::consensus_models::Block> for proto::consensus::Block {
-    fn from(value: tari_dan_storage::consensus_models::Block) -> Self {
+impl<TAddr: NodeAddressable> From<tari_dan_storage::consensus_models::Block<TAddr>> for proto::consensus::Block {
+    fn from(value: tari_dan_storage::consensus_models::Block<TAddr>) -> Self {
         Self {
             height: value.height().as_u64(),
             epoch: value.epoch().as_u64(),
@@ -234,7 +234,9 @@ impl From<tari_dan_storage::consensus_models::Block> for proto::consensus::Block
     }
 }
 
-impl TryFrom<proto::consensus::Block> for tari_dan_storage::consensus_models::Block {
+impl<TAddr: NodeAddressable + Serialize> TryFrom<proto::consensus::Block>
+    for tari_dan_storage::consensus_models::Block<TAddr>
+{
     type Error = anyhow::Error;
 
     fn try_from(value: proto::consensus::Block) -> Result<Self, Self::Error> {
@@ -247,7 +249,7 @@ impl TryFrom<proto::consensus::Block> for tari_dan_storage::consensus_models::Bl
             NodeHeight(value.height),
             Epoch(value.epoch),
             value.round,
-            value.proposed_by.try_into()?,
+            TAddr::from_bytes(&value.proposed_by).ok_or_else(|| anyhow!("Block conversion: Invalid proposed_by"))?,
             value
                 .commands
                 .into_iter()
@@ -395,7 +397,7 @@ impl TryFrom<proto::consensus::ValidatorMetadata> for ValidatorMetadata {
 
     fn try_from(value: proto::consensus::ValidatorMetadata) -> Result<Self, Self::Error> {
         Ok(ValidatorMetadata {
-            public_key: PublicKey::from_bytes(&value.public_key)?,
+            public_key: ByteArray::from_bytes(&value.public_key)?,
             vn_shard_key: value.vn_shard_key.try_into()?,
             signature: value
                 .signature


### PR DESCRIPTION
Description
---
Add Address generic to Block

Motivation and Context
---
Code is simpler in many cases when the proposer public key is available in the block rather than the shard, which will require extra calls to the epoch manager to fetch the corresponding public key. 

How Has This Been Tested?
---
Existing tests updated

What process can a PR reviewer use to test or verify this change?
---


Breaking Changes
---

- [ ] None
- [x] Requires data directory to be deleted
- [ ] Other - Please specify