### PR TITLE
feat(engine): add decoded json field on instruction results

### DIFF
--- a/applications/tari_validator_node/src/p2p/services/mempool/validators/input_refs.rs
+++ b/applications/tari_validator_node/src/p2p/services/mempool/validators/input_refs.rs
@@ -22,8 +22,8 @@ impl Validator<ExecutedTransaction> for InputRefsValidator {
 
     async fn validate(&self, executed: &ExecutedTransaction) -> Result<(), Self::Error> {
         let Some(diff) = executed.result().finalize.result.accept() else {
-                return Ok(());
-            };
+            return Ok(());
+        };
 
         let is_input_refs_downed = diff
             .down_iter()

--- a/applications/tari_validator_node_cli/src/cli_range.rs
+++ b/applications/tari_validator_node_cli/src/cli_range.rs
@@ -39,14 +39,13 @@ impl FromStr for CliRange<u64> {
 }
 
 fn parse_range(s: &str) -> Result<ParsedRange<'_>, anyhow::Error> {
-    let Some((start, end)) = s
-        .split_once("..") else {
+    let Some((start, end)) = s.split_once("..") else {
         // If the user enters just a value, we treat it as a V..=V range
-        return Ok(ParsedRange{
+        return Ok(ParsedRange {
             start: Some(s),
             end: Some(s),
             inclusive: true,
-        })
+        });
     };
 
     let inclusive = end.starts_with('=');

--- a/dan_layer/engine/src/json_encoder.rs
+++ b/dan_layer/engine/src/json_encoder.rs
@@ -1,0 +1,129 @@
+//  Copyright 2023. The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use serde_json as json;
+use tari_bor as cbor;
+
+#[derive(Debug, thiserror::Error)]
+pub enum JsonEncodingError {
+    #[error("Could not decode the CBOR value: {0}")]
+    BinaryEncoding(#[from] tari_bor::BorError),
+    #[error("Serde error: {0}")]
+    Serde(#[from] json::Error),
+    #[error("Unexpected error: {0}")]
+    Unexpected(String),
+}
+
+pub fn cbor_to_json(raw: &[u8]) -> Result<json::Value, JsonEncodingError> {
+    let decoded_cbor: cbor::Value = tari_bor::decode(raw)?;
+    let decoded_cbor = fix_invalid_object_keys(&decoded_cbor);
+    let result = serde_json::to_value(decoded_cbor)?;
+
+    Ok(result)
+}
+
+/// In JSON, all object keys must be string values.
+/// But ciborium sometimes will use other types (e.g. Tags) as keys,
+/// so in that case we transform the object into an array so it can be safely converted to JSON
+/// AND we need to to it recursively
+pub fn fix_invalid_object_keys(value: &cbor::Value) -> cbor::Value {
+    match value {
+        cbor::Value::Tag(tag, content) => {
+            let fixed_content = fix_invalid_object_keys(content);
+            cbor::Value::Tag(*tag, Box::new(fixed_content))
+        },
+        cbor::Value::Array(arr) => {
+            let fixed_items = arr.iter().map(fix_invalid_object_keys).collect();
+            cbor::Value::Array(fixed_items)
+        },
+        cbor::Value::Map(map) => {
+            let has_invalid_keys = map.iter().any(|(k, _)| !k.is_text());
+
+            if has_invalid_keys {
+                let map_entries_as_arrays = map
+                    .iter()
+                    .map(|(k, v)| {
+                        let fixed_key = fix_invalid_object_keys(k);
+                        let fixed_value = fix_invalid_object_keys(v);
+                        cbor::Value::Array(vec![fixed_key, fixed_value])
+                    })
+                    .collect();
+                return cbor::Value::Array(map_entries_as_arrays);
+            }
+
+            let fixed_entries = map
+                .iter()
+                .map(|(k, v)| {
+                    let fixed_value = fix_invalid_object_keys(v);
+                    (k.to_owned(), fixed_value)
+                })
+                .collect();
+            cbor::Value::Map(fixed_entries)
+        },
+        // other types are atomic and do not cause problems, so we just return them directly
+        _ => value.to_owned(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tari_common_types::types::PublicKey;
+    use tari_crypto::commitment::HomomorphicCommitment;
+    use tari_engine_types::{
+        confidential::ConfidentialOutput,
+        resource_container::ResourceContainer,
+        substate::{Substate, SubstateValue},
+        vault::Vault,
+    };
+    use tari_template_lib::{
+        models::{Amount, ResourceAddress, VaultId},
+        Hash,
+    };
+
+    use super::*;
+
+    #[test]
+    fn it_decodes_confidential_vaults() {
+        let address = ResourceAddress::new(Hash::default());
+
+        let public_key = PublicKey::default();
+        let confidential_output = ConfidentialOutput {
+            commitment: HomomorphicCommitment::from_public_key(&public_key),
+            stealth_public_nonce: public_key.clone(),
+            encrypted_data: Default::default(),
+            minimum_value_promise: 0,
+        };
+        let commitment = Some((public_key, confidential_output));
+
+        let revealed_amount = Amount::zero();
+        let container = ResourceContainer::confidential(address, commitment, revealed_amount);
+
+        let vault_id = VaultId::new(Hash::default());
+        let vault = Vault::new(vault_id, container);
+
+        let substate_value = SubstateValue::Vault(vault);
+        let substate = Substate::new(0, substate_value);
+        let substate_cbor = tari_bor::encode(&substate).unwrap();
+
+        assert!(cbor_to_json(&substate_cbor).is_ok());
+    }
+}

--- a/dan_layer/engine/src/lib.rs
+++ b/dan_layer/engine/src/lib.rs
@@ -5,6 +5,7 @@ mod bootstrap;
 pub mod fees;
 pub mod flow;
 pub mod function_definitions;
+pub mod json_encoder;
 pub mod packager;
 pub mod runtime;
 pub mod state_store;

--- a/dan_layer/engine/src/runtime/working_state.rs
+++ b/dan_layer/engine/src/runtime/working_state.rs
@@ -290,7 +290,8 @@ impl WorkingState {
 
         let VirtualSubstate::UnclaimedValidatorFee(fee_claim) = substate else {
             return Err(RuntimeError::FeeClaimNotPermitted {
-                epoch, address: validator_public_key
+                epoch,
+                address: validator_public_key,
             });
         };
         Ok(fee_claim)
@@ -305,7 +306,7 @@ impl WorkingState {
                     address: address.clone(),
                 })?;
         let VirtualSubstate::CurrentEpoch(epoch) = current_epoch else {
-            return Err(RuntimeError::VirtualSubstateNotFound { address});
+            return Err(RuntimeError::VirtualSubstateNotFound { address });
         };
         Ok(Epoch(*epoch))
     }

--- a/dan_layer/engine/src/transaction/error.rs
+++ b/dan_layer/engine/src/transaction/error.rs
@@ -46,4 +46,6 @@ pub enum TransactionError {
     BorError(#[from] tari_bor::BorError),
     #[error("Value visitor error: {0}")]
     ValueVisitorError(#[from] IndexedValueVisitorError),
+    #[error("JSON decoding error: {0}")]
+    JsonError(#[from] serde_json::Error),
 }

--- a/dan_layer/engine/src/transaction/processor.rs
+++ b/dan_layer/engine/src/transaction/processor.rs
@@ -281,6 +281,7 @@ impl<TTemplateProvider: TemplateProvider<Template = LoadedTemplate> + 'static> T
                 let encoded = encode(&bucket_id)?;
                 Ok(InstructionResult {
                     value: IndexedValue::from_raw(&encoded)?,
+                    json: serde_json::to_value(bucket_id)?,
                     raw: encoded,
                     return_type: Type::Other {
                         name: "BucketId".to_string(),

--- a/dan_layer/engine/src/wasm/error.rs
+++ b/dan_layer/engine/src/wasm/error.rs
@@ -6,7 +6,7 @@ use tari_engine_types::indexed_value::IndexedValueVisitorError;
 use thiserror::Error;
 use wasmer::{ExportError, HostEnvInitError, InstantiationError};
 
-use crate::runtime::RuntimeError;
+use crate::{json_encoder::JsonEncodingError, runtime::RuntimeError};
 
 #[derive(Debug, Error)]
 pub enum WasmError {
@@ -61,6 +61,8 @@ pub enum WasmExecutionError {
     },
     #[error("Value visitor error: {0}")]
     ValueVisitorError(#[from] IndexedValueVisitorError),
+    #[error("JSON encoding error: {0}")]
+    JsonEncodingError(#[from] JsonEncodingError),
 }
 impl From<wasmer::InstantiationError> for WasmExecutionError {
     fn from(value: InstantiationError) -> Self {

--- a/dan_layer/engine/src/wasm/process.rs
+++ b/dan_layer/engine/src/wasm/process.rs
@@ -46,6 +46,7 @@ use tari_template_lib::{
 use wasmer::{Function, Instance, Module, Val, WasmerEnv};
 
 use crate::{
+    json_encoder,
     runtime::Runtime,
     traits::Invokable,
     wasm::{
@@ -250,9 +251,11 @@ impl Invokable for WasmProcess {
         }
 
         let value = IndexedValue::from_raw(&raw)?;
+        let json = json_encoder::cbor_to_json(&raw)?;
 
         Ok(InstructionResult {
             raw,
+            json,
             value,
             return_type: func_def.output.clone(),
         })

--- a/dan_layer/engine_types/src/instruction_result.rs
+++ b/dan_layer/engine_types/src/instruction_result.rs
@@ -21,6 +21,7 @@
 //   USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde_json::Value;
 use tari_bor::BorError;
 use tari_template_abi::Type;
 
@@ -30,6 +31,7 @@ use crate::{indexed_value::IndexedValue, serde_with};
 pub struct InstructionResult {
     #[serde(with = "serde_with::hex")]
     pub raw: Vec<u8>,
+    pub json: Value,
     pub value: IndexedValue,
     pub return_type: Type,
 }
@@ -38,6 +40,7 @@ impl InstructionResult {
     pub fn empty() -> Self {
         InstructionResult {
             raw: Vec::new(),
+            json: Value::Null,
             value: IndexedValue::default(),
             return_type: Type::Unit,
         }


### PR DESCRIPTION
Description
---
* Added a new `json` field in the `InstructionResult` struct, alongside the existing raw CBOR value. 
* Some of the sanity checks of the CBOR to JSON conversion is common with the indexer operations, so it was carried over to the engine instead.
* The wasm instruction processor fills the new `json` field in the result after a successful execution.
* A few unrelated code was reformatted by `rust fmt` 

Motivation and Context
---
Up until now, the instruction results of a transaction included only the raw CBOR value and the decoded substates. From user web applications this is insufficient as many template methods/functions can return any type of data, and CBOR decoding in the web may not be the best approach.

This PR aims to solve this problem by adding a new field (`json`) in the `InstructionResult` struct in the engine, alongside the existing raw CBOR value. 

How Has This Been Tested?
---
* Manually by inspecting the execution results of a template method that returns values
* The logic for JSON decoding was already present in the indexer with a unit test that was carried over

What process can a PR reviewer use to test or verify this change?
---
Call a template method/function and inspecting the new field value in the result

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify