### PR TITLE
fix(engine): return engine error from instruction invocation 

### DIFF
--- a/applications/tari_dan_wallet_cli/src/command/transaction.rs
+++ b/applications/tari_dan_wallet_cli/src/command/transaction.rs
@@ -137,7 +137,7 @@ pub struct SubmitManifestArgs {
 
 #[derive(Debug, Args, Clone)]
 pub struct SendArgs {
-    amount: u32,
+    amount: u64,
     resource_address: ResourceAddress,
     destination_public_key: FromHex<Vec<u8>>,
     #[clap(flatten)]
@@ -147,7 +147,7 @@ pub struct SendArgs {
 
 #[derive(Debug, Args, Clone)]
 pub struct ConfidentialTransferArgs {
-    amount: u32,
+    amount: u64,
     destination_public_key: FromHex<Vec<u8>>,
     #[clap(flatten)]
     common: CommonSubmitArgs,
@@ -370,7 +370,7 @@ pub async fn handle_send(args: SendArgs, client: &mut WalletDaemonClient) -> Res
     let resp = client
         .accounts_transfer(TransferRequest {
             account: source_account_name,
-            amount: Amount::from(amount),
+            amount: Amount::try_from(amount)?,
             resource_address,
             destination_public_key,
             fee,
@@ -402,7 +402,7 @@ pub async fn handle_confidential_transfer(
     let resp = client
         .accounts_confidential_transfer(ConfidentialTransferRequest {
             account: source_account,
-            amount: Amount::from(amount),
+            amount: Amount::try_from(amount)?,
             resource_address: resource_address.unwrap_or(*CONFIDENTIAL_TARI_RESOURCE_ADDRESS),
             validator_public_key: destination_public_key,
             fee: common.fee.map(|f| f.try_into()).transpose()?,

--- a/dan_layer/consensus/src/hotstuff/on_receive_proposal.rs
+++ b/dan_layer/consensus/src/hotstuff/on_receive_proposal.rs
@@ -753,7 +753,10 @@ where TConsensusSpec: ConsensusSpec
                         },
                         // Unlock the aborted inputs.
                         Decision::Abort => {
-                            self.unlock_inputs(tx, executed.transaction(), local_committee_shard)?;
+                            // We only locked the inputs if we originally decided to commit
+                            if tx_rec.original_decision().is_commit() {
+                                self.unlock_inputs(tx, executed.transaction(), local_committee_shard)?;
+                            }
                         },
                     }
 

--- a/dan_layer/engine/src/wasm/process.rs
+++ b/dan_layer/engine/src/wasm/process.rs
@@ -167,6 +167,9 @@ impl WasmProcess {
             }
             eprintln!("{}", err);
             log::error!(target: LOG_TARGET, "{}", err);
+            if let WasmExecutionError::RuntimeError(e) = err {
+                env.set_last_engine_error(e);
+            }
             0
         })
     }
@@ -222,6 +225,9 @@ impl Invokable for WasmProcess {
         let val = match res {
             Ok(res) => res,
             Err(err) => {
+                if let Some(err) = self.env.take_last_engine_error() {
+                    return Err(WasmExecutionError::RuntimeError(err));
+                }
                 if let Some(message) = self.env.take_last_panic_message() {
                     return Err(WasmExecutionError::Panic {
                         message,

--- a/dan_layer/engine/tests/templates/errors/src/lib.rs
+++ b/dan_layer/engine/tests/templates/errors/src/lib.rs
@@ -35,5 +35,11 @@ mod template {
         pub fn please_pass_invalid_args(amount: Amount) {
             panic!("You didn't pass an invalid arg! {}", amount);
         }
+
+        pub fn invalid_engine_call() {
+            let resource_addr = ResourceAddress::new([123u8; 32].into());
+            // Cannot create a vault for a resource that doesnt exist
+            let vault = Vault::new_empty(resource_addr);
+        }
     }
 }

--- a/dan_layer/wallet/sdk/src/apis/transaction.rs
+++ b/dan_layer/wallet/sdk/src/apis/transaction.rs
@@ -5,6 +5,7 @@ use log::*;
 use tari_common_types::types::PublicKey;
 use tari_dan_common_types::optional::{IsNotFoundError, Optional};
 use tari_engine_types::{
+    commit_result::RejectReason,
     indexed_value::{IndexedValue, IndexedValueVisitorError},
     substate::SubstateDiff,
 };
@@ -167,8 +168,7 @@ where
             TransactionFinalizedResult::Finalized {
                 final_decision,
                 execution_result,
-                // TODO: incorporate abort_details
-                abort_details: _abort_details,
+                abort_details,
             } => {
                 let new_status = if final_decision.is_commit() {
                     TransactionStatus::Accepted
@@ -196,10 +196,14 @@ where
                         self.commit_result(tx, transaction_id, diff)?;
                     }
 
+                    let transaction_failure = execution_result
+                        .as_ref()
+                        .and_then(|e| e.transaction_failure.clone())
+                        .or_else(|| abort_details.map(RejectReason::ExecutionFailure));
                     tx.transactions_set_result_and_status(
                         transaction_id,
                         execution_result.as_ref().map(|e| &e.finalize),
-                        execution_result.as_ref().and_then(|e| e.transaction_failure.as_ref()),
+                        transaction_failure.as_ref(),
                         execution_result
                             .as_ref()
                             .and_then(|e| e.fee_receipt.as_ref())


### PR DESCRIPTION
Description
---
fix(engine): return engine error from instruction invocation 
fix: only unlock on abort if inputs were originally locked
fix(wallet): propagate result error from vn to wallet cli
fix(wallet/cli): enable amounts bigger than u32::MAX to be input as an arg

Motivation and Context
---
Hook up errors returned by the runtime to the final transaction result. This takes precedence over a panic (which MUST always occur after an engine error). 

Hook up the result properly so that it is returned even when the transaction is aborted. This allows the client to get the actual error that occurred during execution.

How Has This Been Tested?
---
New engine unit test that performs an invalid engine call, the WASM panics and we check that the result includes the underlying engine error rather than the null ptr panic error.
Manually, send more funds than available.

What process can a PR reviewer use to test or verify this change?
---
Create a wallet and send more funds than available, the error is now output rather than a unknown error or WASM panic text


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify