### PR TITLE
fix!: peer sync

### DIFF
--- a/applications/tari_indexer/src/p2p/services/comms_peer_provider.rs
+++ b/applications/tari_indexer/src/p2p/services/comms_peer_provider.rs
@@ -53,14 +53,11 @@ impl PeerProvider for CommsPeerProvider {
         match self.peer_manager.find_by_public_key(addr).await? {
             Some(peer) => Ok(DanPeer {
                 identity: peer.public_key,
-                addresses: peer
+                claims: peer
                     .addresses
                     .addresses()
                     .iter()
-                    .filter_map(|a| {
-                        let claim = a.source.peer_identity_claim().cloned();
-                        claim.map(|claim| (a.address().clone(), claim))
-                    })
+                    .filter_map(|a| a.source.peer_identity_claim().cloned())
                     .collect(),
             }),
             None => Err(CommsPeerProviderError::PeerNotFound),
@@ -74,14 +71,11 @@ impl PeerProvider for CommsPeerProvider {
         Box::new(self.peer_manager.all().await.unwrap().into_iter().map(|p| {
             Ok(DanPeer {
                 identity: p.public_key,
-                addresses: p
+                claims: p
                     .addresses
                     .addresses()
                     .iter()
-                    .filter_map(|a| {
-                        let claim = a.source.peer_identity_claim().cloned();
-                        claim.map(|claim| (a.address().clone(), claim))
-                    })
+                    .filter_map(|a| a.source.peer_identity_claim().cloned())
                     .collect(),
             })
         }))
@@ -89,21 +83,24 @@ impl PeerProvider for CommsPeerProvider {
 
     async fn add_peer(&self, peer: DanPeer<Self::Addr>) -> Result<(), Self::Error> {
         let node_id = NodeId::from_public_key(&peer.identity);
+        let addresses = MultiaddressesWithStats::new(
+            peer.claims
+                .iter()
+                .flat_map(|claim| {
+                    claim.addresses.iter().map(|addr| {
+                        MultiaddrWithStats::new(addr.clone(), PeerAddressSource::FromAnotherPeer {
+                            peer_identity_claim: claim.clone(),
+                            source_peer: peer.identity.clone(),
+                        })
+                    })
+                })
+                .collect(),
+        );
         self.peer_manager
             .add_peer(Peer::new(
-                peer.identity.clone(),
+                peer.identity,
                 node_id,
-                MultiaddressesWithStats::new(
-                    peer.addresses
-                        .iter()
-                        .map(|(addr, claim)| {
-                            MultiaddrWithStats::new(addr.clone(), PeerAddressSource::FromAnotherPeer {
-                                peer_identity_claim: claim.clone(),
-                                source_peer: peer.identity.clone(),
-                            })
-                        })
-                        .collect(),
-                ),
+                addresses,
                 PeerFlags::NONE,
                 PeerFeatures::NONE,
                 vec![],
@@ -122,16 +119,15 @@ impl PeerProvider for CommsPeerProvider {
             peer.identity.clone(),
             node_id,
             MultiaddressesWithStats::new(
-                peer.addresses
+                peer.claims
                     .iter()
-                    .map(|(addr, claim)| {
-                        MultiaddrWithStats::new(
-                            addr.clone(),
-                            tari_comms::net_address::PeerAddressSource::FromAnotherPeer {
+                    .flat_map(|claim| {
+                        claim.addresses.iter().map(|addr| {
+                            MultiaddrWithStats::new(addr.clone(), PeerAddressSource::FromAnotherPeer {
                                 peer_identity_claim: claim.clone(),
                                 source_peer: peer.identity.clone(),
-                            },
-                        )
+                            })
+                        })
                     })
                     .collect(),
             ),
@@ -156,14 +152,11 @@ impl PeerProvider for CommsPeerProvider {
         match self.peer_manager.find_by_node_id(node_id).await? {
             Some(peer) => Ok(DanPeer {
                 identity: peer.public_key,
-                addresses: peer
+                claims: peer
                     .addresses
                     .addresses()
                     .iter()
-                    .filter_map(|a| {
-                        let claim = a.source.peer_identity_claim().cloned();
-                        claim.map(|claim| (a.address().clone(), claim))
-                    })
+                    .filter_map(|a| a.source.peer_identity_claim().cloned())
                     .collect(),
             }),
             None => Err(CommsPeerProviderError::PeerNotFound),

--- a/applications/tari_validator_node/src/p2p/rpc/service_impl.rs
+++ b/applications/tari_validator_node/src/p2p/rpc/service_impl.rs
@@ -121,8 +121,7 @@ where TPeerProvider: PeerProvider + Clone + Send + Sync + 'static
                 if tx
                     .send(Ok(proto::rpc::GetPeersResponse {
                         identity: peer.identity.as_bytes().to_vec(),
-                        addresses: peer.addresses.iter().map(|(a, _)| a.to_vec()).collect(),
-                        claims: peer.addresses.into_iter().map(|(_, c)| c.into()).collect(),
+                        claims: peer.claims.into_iter().map(Into::into).collect(),
                     }))
                     .await
                     .is_err()

--- a/applications/tari_validator_node/src/p2p/services/comms_peer_provider.rs
+++ b/applications/tari_validator_node/src/p2p/services/comms_peer_provider.rs
@@ -53,14 +53,11 @@ impl PeerProvider for CommsPeerProvider {
         match self.peer_manager.find_by_public_key(addr).await? {
             Some(peer) => Ok(DanPeer {
                 identity: peer.public_key,
-                addresses: peer
+                claims: peer
                     .addresses
                     .addresses()
                     .iter()
-                    .filter_map(|a| {
-                        let claim = a.source.peer_identity_claim().cloned();
-                        claim.map(|claim| (a.address().clone(), claim))
-                    })
+                    .filter_map(|a| a.source.peer_identity_claim().cloned())
                     .collect(),
             }),
             None => Err(CommsPeerProviderError::PeerNotFound),
@@ -74,14 +71,11 @@ impl PeerProvider for CommsPeerProvider {
         Box::new(self.peer_manager.all().await.unwrap().into_iter().map(|p| {
             Ok(DanPeer {
                 identity: p.public_key,
-                addresses: p
+                claims: p
                     .addresses
                     .addresses()
                     .iter()
-                    .filter_map(|a| {
-                        let claim = a.source.peer_identity_claim().cloned();
-                        claim.map(|claim| (a.address().clone(), claim))
-                    })
+                    .filter_map(|a| a.source.peer_identity_claim().cloned())
                     .collect(),
             })
         }))
@@ -89,21 +83,23 @@ impl PeerProvider for CommsPeerProvider {
 
     async fn add_peer(&self, peer: DanPeer<Self::Addr>) -> Result<(), Self::Error> {
         let node_id = NodeId::from_public_key(&peer.identity);
+        let addresses = peer
+            .claims
+            .iter()
+            .flat_map(|claim| {
+                claim.addresses.iter().map(|addr| {
+                    MultiaddrWithStats::new(addr.clone(), PeerAddressSource::FromAnotherPeer {
+                        peer_identity_claim: claim.clone(),
+                        source_peer: peer.identity.clone(),
+                    })
+                })
+            })
+            .collect();
         self.peer_manager
             .add_peer(Peer::new(
                 peer.identity.clone(),
                 node_id,
-                MultiaddressesWithStats::new(
-                    peer.addresses
-                        .iter()
-                        .map(|(addr, claim)| {
-                            MultiaddrWithStats::new(addr.clone(), PeerAddressSource::FromAnotherPeer {
-                                peer_identity_claim: claim.clone(),
-                                source_peer: peer.identity.clone(),
-                            })
-                        })
-                        .collect(),
-                ),
+                MultiaddressesWithStats::new(addresses),
                 PeerFlags::NONE,
                 PeerFeatures::NONE,
                 vec![],
@@ -122,16 +118,15 @@ impl PeerProvider for CommsPeerProvider {
             peer.identity.clone(),
             node_id,
             MultiaddressesWithStats::new(
-                peer.addresses
+                peer.claims
                     .iter()
-                    .map(|(addr, claim)| {
-                        MultiaddrWithStats::new(
-                            addr.clone(),
-                            tari_comms::net_address::PeerAddressSource::FromAnotherPeer {
+                    .flat_map(|claim| {
+                        claim.addresses.iter().map(|addr| {
+                            MultiaddrWithStats::new(addr.clone(), PeerAddressSource::FromAnotherPeer {
                                 peer_identity_claim: claim.clone(),
                                 source_peer: peer.identity.clone(),
-                            },
-                        )
+                            })
+                        })
                     })
                     .collect(),
             ),
@@ -156,14 +151,11 @@ impl PeerProvider for CommsPeerProvider {
         match self.peer_manager.find_by_node_id(node_id).await? {
             Some(peer) => Ok(DanPeer {
                 identity: peer.public_key,
-                addresses: peer
+                claims: peer
                     .addresses
                     .addresses()
                     .iter()
-                    .filter_map(|a| {
-                        let claim = a.source.peer_identity_claim().cloned();
-                        claim.map(|claim| (a.address().clone(), claim))
-                    })
+                    .filter_map(|a| a.source.peer_identity_claim().cloned())
                     .collect(),
             }),
             None => Err(CommsPeerProviderError::PeerNotFound),

--- a/dan_layer/p2p/src/message.rs
+++ b/dan_layer/p2p/src/message.rs
@@ -2,7 +2,7 @@
 //    SPDX-License-Identifier: BSD-3-Clause
 
 use serde::Serialize;
-use tari_comms::{multiaddr::Multiaddr, peer_manager::IdentitySignature};
+use tari_comms::peer_manager::PeerIdentityClaim;
 use tari_consensus::messages::HotstuffMessage;
 use tari_dan_common_types::NodeAddressable;
 use tari_transaction::Transaction;
@@ -38,6 +38,5 @@ impl<TAddr: NodeAddressable> DanMessage<TAddr> {
 #[derive(Debug, Clone, Serialize)]
 pub struct NetworkAnnounce<TAddr> {
     pub identity: TAddr,
-    pub addresses: Vec<Multiaddr>,
-    pub identity_signature: IdentitySignature,
+    pub claim: PeerIdentityClaim,
 }

--- a/dan_layer/p2p/src/peer_service.rs
+++ b/dan_layer/p2p/src/peer_service.rs
@@ -24,8 +24,7 @@ use std::fmt::{Display, Formatter};
 
 use async_trait::async_trait;
 use tari_comms::{
-    multiaddr::Multiaddr,
-    peer_manager::{Peer, PeerFeatures, PeerIdentityClaim},
+    peer_manager::{Peer, PeerIdentityClaim},
     types::CommsPublicKey,
 };
 use tari_dan_common_types::NodeAddressable;
@@ -50,14 +49,15 @@ pub trait PeerProvider {
 
 pub struct DanPeer<TAddr> {
     pub identity: TAddr,
-    pub addresses: Vec<(Multiaddr, PeerIdentityClaim)>,
+    pub claims: Vec<PeerIdentityClaim>,
 }
 
 impl DanPeer<CommsPublicKey> {
     pub fn is_valid(&self) -> bool {
-        self.addresses.iter().all(|(addr, claim)| {
-            let identity_signature = &claim.signature;
-            identity_signature.is_valid(&self.identity, PeerFeatures::COMMUNICATION_NODE, &[addr.clone()])
+        self.claims.iter().all(|claim| {
+            claim
+                .signature
+                .is_valid(&self.identity, claim.features, &claim.addresses)
         })
     }
 }
@@ -66,14 +66,11 @@ impl From<Peer> for DanPeer<CommsPublicKey> {
     fn from(peer: Peer) -> Self {
         Self {
             identity: peer.public_key,
-            addresses: peer
+            claims: peer
                 .addresses
                 .addresses()
                 .iter()
-                .filter_map(|a| {
-                    let claim = a.source.peer_identity_claim().cloned();
-                    claim.map(|claim| (a.address().clone(), claim))
-                })
+                .filter_map(|a| a.source.peer_identity_claim().cloned())
                 .collect(),
         }
     }
@@ -85,9 +82,10 @@ impl<TAddr: Display> Display for DanPeer<TAddr> {
             f,
             "DanPeer({}, {})",
             self.identity,
-            self.addresses
+            self.claims
                 .iter()
-                .map(|a| ToString::to_string(&a.0))
+                .flat_map(|a| &a.addresses)
+                .map(|a| a.to_string())
                 .collect::<Vec<_>>()
                 .join(", ")
         )

--- a/dan_layer/validator_node_rpc/proto/network.proto
+++ b/dan_layer/validator_node_rpc/proto/network.proto
@@ -48,34 +48,13 @@ message DanMessage {
 
 message NetworkAnnounce {
   bytes identity = 1;
-  repeated bytes addresses = 2;
-  IdentitySignature identity_signature = 3;
+  PeerIdentityClaim claim = 2;
 }
 
 message IdentitySignature {
   uint32 version = 1;
   tari.dan.common.Signature signature = 2;
   int64 updated_at = 3;
-}
-
-message RecoveryMessage {
-  oneof message {
-    MissingProposal missing_proposal = 1;
-    ElectionInProgress election_in_progress = 2;
-  }
-}
-
-message MissingProposal {
-  uint64 epoch = 1;
-  bytes shard_id = 2;
-  bytes payload_id = 3;
-  uint64 last_known_height = 4;
-}
-
-message ElectionInProgress {
-  uint64 epoch = 1;
-  bytes shard_id = 2;
-  bytes payload_id = 3;
 }
 
 message PeerIdentityClaim {

--- a/dan_layer/validator_node_rpc/proto/rpc.proto
+++ b/dan_layer/validator_node_rpc/proto/rpc.proto
@@ -80,8 +80,7 @@ message GetPeersRequest {
 
 message GetPeersResponse {
   bytes identity = 1;
-  repeated bytes addresses = 2;
-  repeated tari.dan.network.PeerIdentityClaim claims = 3;
+  repeated tari.dan.network.PeerIdentityClaim claims = 2;
 }
 
 message VnStateSyncRequest {

--- a/dan_layer/validator_node_rpc/src/client.rs
+++ b/dan_layer/validator_node_rpc/src/client.rs
@@ -10,7 +10,6 @@ use tari_bor::{decode, decode_exact, encode};
 use tari_common_types::types::PublicKey;
 use tari_comms::{
     connectivity::ConnectivityRequester,
-    multiaddr::Multiaddr,
     peer_manager::{NodeId, PeerIdentityClaim},
     protocol::rpc::RpcPoolClient,
     types::CommsPublicKey,
@@ -149,26 +148,15 @@ impl ValidatorNodeRpcClient for TariCommsValidatorNodeRpcClient {
             .await?
             .map(|result| {
                 let p = result?;
-                let addresses: Vec<Multiaddr> = p
-                    .addresses
-                    .into_iter()
-                    .map(|a| {
-                        Multiaddr::try_from(a)
-                            .map_err(|_| ValidatorNodeRpcClientError::InvalidResponse(anyhow!("Invalid address")))
-                    })
-                    .collect::<Result<_, _>>()?;
-                let claims: Vec<PeerIdentityClaim> = p
+                let claims = p
                     .claims
                     .into_iter()
-                    .map(|c| {
-                        PeerIdentityClaim::try_from(c)
-                            .map_err(|_| ValidatorNodeRpcClientError::InvalidResponse(anyhow!("Invalid claim")))
-                    })
-                    .collect::<Result<_, _>>()?;
+                    .map(|a| PeerIdentityClaim::try_from(a).map_err(ValidatorNodeRpcClientError::InvalidResponse))
+                    .collect::<Result<Vec<_>, _>>()?;
                 Result::<_, ValidatorNodeRpcClientError>::Ok(DanPeer {
                     identity: ByteArray::from_bytes(&p.identity)
                         .map_err(|_| ValidatorNodeRpcClientError::InvalidResponse(anyhow!("Invalid identity")))?,
-                    addresses: addresses.into_iter().zip(claims).collect(),
+                    claims,
                 })
             })
             .collect::<Result<Vec<_>, _>>()

--- a/dan_layer/validator_node_rpc/src/peer_sync.rs
+++ b/dan_layer/validator_node_rpc/src/peer_sync.rs
@@ -20,10 +20,8 @@
 //   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //   USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::convert::TryInto;
-
 use log::*;
-use tari_comms::{multiaddr::Multiaddr, peer_manager::PeerIdentityClaim, types::CommsPublicKey, PeerConnection};
+use tari_comms::{peer_manager::PeerIdentityClaim, types::CommsPublicKey, PeerConnection};
 use tari_crypto::tari_utilities::ByteArray;
 use tari_dan_p2p::{DanPeer, PeerProvider};
 use tokio_stream::StreamExt;
@@ -65,23 +63,13 @@ impl<TPeerProvider: PeerProvider<Addr = CommsPublicKey>> PeerSyncProtocol<TPeerP
                 continue;
             }
 
-            let addresses: Vec<Multiaddr> = resp
-                .addresses
-                .clone()
-                .into_iter()
-                .map(TryInto::try_into)
-                .collect::<Result<_, _>>()?;
-            let claims: Vec<PeerIdentityClaim> = resp
+            let claims = resp
                 .claims
-                .clone()
                 .into_iter()
-                .map(TryInto::try_into)
-                .collect::<Result<_, _>>()?;
+                .map(PeerIdentityClaim::try_from)
+                .collect::<Result<Vec<_>, _>>()?;
 
-            let peer = DanPeer {
-                identity,
-                addresses: addresses.into_iter().zip(claims).collect(),
-            };
+            let peer = DanPeer { identity, claims };
             debug!(target: LOG_TARGET, "Received peer: {}", peer);
             if !peer.is_valid() {
                 return Err(anyhow::anyhow!(


### PR DESCRIPTION
Description
---
Fix peer sync and announce by correctly handling peer signature claims

Motivation and Context
---
Peer sync and announce worked only when a single address is used, when multiple addresses are added (this happens whenever an address is changed), the identity signature validation fails. 

How Has This Been Tested?
---
100 validator nodes which local address changes on each startup, able to peer sync and receiving valid announces

What process can a PR reviewer use to test or verify this change?
---
Change the validator node address and check that the network can receive the updated address

Breaking Changes
---

- [ ] None
- [ ] Requires data directory to be deleted
- [x] Other - peer sync and announce messages have breaking changes