### PR TITLE
fix(vn/jrpc): error when calling get_epoch_manager_stats before validator is registered

### DIFF
--- a/dan_layer/epoch_manager/src/base_layer/epoch_manager_service.rs
+++ b/dan_layer/epoch_manager/src/base_layer/epoch_manager_service.rs
@@ -131,17 +131,6 @@ impl EpochManagerService<SqliteGlobalDbAdapter, GrpcBaseNodeClient> {
                 let epoch = self.inner.current_epoch();
                 handle(reply, self.inner.is_validator_in_committee(epoch, shard, &identity));
             },
-            EpochManagerRequest::FilterToLocalShards {
-                epoch,
-                for_addr,
-                available_shards,
-                reply,
-            } => {
-                handle(
-                    reply,
-                    self.inner.filter_to_local_shards(epoch, &for_addr, available_shards),
-                );
-            },
             EpochManagerRequest::Subscribe { reply } => handle(reply, Ok(self.events.subscribe())),
             EpochManagerRequest::GetValidatorNodeBalancedMerkleTree { epoch, reply } => {
                 handle(reply, self.inner.get_validator_node_balanced_merkle_tree(epoch))

--- a/dan_layer/epoch_manager/src/base_layer/types.rs
+++ b/dan_layer/epoch_manager/src/base_layer/types.rs
@@ -98,12 +98,6 @@ pub enum EpochManagerRequest {
         identity: PublicKey,
         reply: Reply<bool>,
     },
-    FilterToLocalShards {
-        epoch: Epoch,
-        for_addr: PublicKey,
-        available_shards: Vec<ShardId>,
-        reply: Reply<Vec<ShardId>>,
-    },
     Subscribe {
         reply: Reply<broadcast::Receiver<EpochManagerEvent>>,
     },

--- a/dan_layer/epoch_manager/src/error.rs
+++ b/dan_layer/epoch_manager/src/error.rs
@@ -41,3 +41,9 @@ pub enum EpochManagerError {
     #[error("Invalid epoch: {epoch}")]
     InvalidEpoch { epoch: Epoch },
 }
+
+impl EpochManagerError {
+    pub fn is_not_registered_error(&self) -> bool {
+        matches!(self, Self::ValidatorNodeNotRegistered { .. })
+    }
+}


### PR DESCRIPTION
Description
---
fix(vn/jrpc): error when calling get_epoch_manager_stats before validator is registered
chore(epochmanager): remove unused FilterToLocalShard epoch manager request variant

Motivation and Context
---
Fixes a bug: error is returned from get_epoch_manager_stats if the validator is not registered.

How Has This Been Tested?
---
Manually, calling the method before the validator is registered. None is returned for committee_shard instead of an error.

What process can a PR reviewer use to test or verify this change?
---
Load the VN ui on an unregistered VN

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify