### PR TITLE
fix(consensus): commit the block that forms a 3-chain

### DIFF
--- a/applications/tari_validator_node_cli/src/command/transaction.rs
+++ b/applications/tari_validator_node_cli/src/command/transaction.rs
@@ -309,9 +309,10 @@ async fn wait_for_transaction_result(
 
         if let Some(resp) = resp {
             if resp.is_finalized {
-                if let Some(result) = resp.result {
-                    return Ok(result);
-                }
+                let result = resp
+                    .result
+                    .ok_or_else(|| anyhow!("Transaction finalized but no result returned"))?;
+                return Ok(result);
             }
         }
         if let Some(t) = timeout {

--- a/dan_layer/consensus/src/hotstuff/on_receive_proposal.rs
+++ b/dan_layer/consensus/src/hotstuff/on_receive_proposal.rs
@@ -668,9 +668,11 @@ where TConsensusSpec: ConsensusSpec
                 prepare_node,
             );
 
+            // Commit prepare_node (b)
+            let prepare_node = Block::get(tx.deref_mut(), prepare_node)?;
             let last_executed = LastExecuted::get(tx.deref_mut())?;
-            self.on_commit(tx, &last_executed, block, local_committee_shard)?;
-            block.as_last_executed().set(tx)?;
+            self.on_commit(tx, &last_executed, &prepare_node, local_committee_shard)?;
+            prepare_node.as_last_executed().set(tx)?;
         } else {
             debug!(
                 target: LOG_TARGET,


### PR DESCRIPTION
Description
---
Only commit node once it forms a 3-chain

Motivation and Context
---
The proposed block is committed instead of the `prepare_node` block. This is incorrect as per https://arxiv.org/pdf/1804.00399.pdf

```
b* is the proposed block
b'' ← b∗.justify.node; 
b' ← b''.justify.node
b ← b'.justify.node

if b forms a 3-chain {
   // Bug was here - b* was committed previously 
    commit(b); 
    execute(b.cmd)
 }
```

How Has This Been Tested?
---
Existing consensus tests pass - fast block production stops after a 3 chain

What process can a PR reviewer use to test or verify this change?
---
Submit a transaction and check that 3 empty blocks are created after the transaction has been accepted

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify