### PR TITLE
fix(template-manager): prevent unncessary wasm loading in high concurrency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2307,12 +2307,12 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "5.4.0"
+version = "5.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc"
+checksum = "edd72493923899c6f10c641bdbdeddc7183d6396641d99c1a0d1597f37f92e28"
 dependencies = [
  "cfg-if 1.0.0",
- "hashbrown 0.12.3",
+ "hashbrown 0.14.0",
  "lock_api",
  "once_cell",
  "parking_lot_core 0.9.8",
@@ -6833,6 +6833,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "std-semaphore"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ae9eec00137a8eed469fb4148acd9fc6ac8c3f9b110f52cd34698c8b5bfa0e"
+
+[[package]]
 name = "str-buf"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7603,6 +7609,7 @@ dependencies = [
  "anyhow",
  "bytes 1.4.0",
  "chrono",
+ "dashmap",
  "futures 0.3.28",
  "lazy_static",
  "log",
@@ -7611,6 +7618,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "std-semaphore",
  "tari_base_node_client",
  "tari_common_types",
  "tari_core",

--- a/applications/tari_dan_app_utilities/Cargo.toml
+++ b/applications/tari_dan_app_utilities/Cargo.toml
@@ -31,6 +31,8 @@ futures = { version = "^0.3.1" }
 lazy_static = "1.4.0"
 log = { version = "0.4.8", features = ["std"] }
 mini-moka = "0.10.0"
+dashmap = "5.5.0"
+std-semaphore = "0.1.0"
 prost = "0.9"
 reqwest = "0.11.11"
 serde = { version = "1.0.126", features = ["derive"] }

--- a/applications/tari_dan_app_utilities/src/template_manager/implementation/cmap_semaphore.rs
+++ b/applications/tari_dan_app_utilities/src/template_manager/implementation/cmap_semaphore.rs
@@ -1,0 +1,67 @@
+//   Copyright 2023 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+use std::{
+    fmt::{Debug, Formatter},
+    hash::Hash,
+    sync::{Arc, Mutex, MutexGuard},
+};
+
+#[derive(Clone)]
+pub struct CMapSemaphore<K: Hash + Eq> {
+    map: Arc<dashmap::DashMap<K, Arc<Mutex<()>>>>,
+    global: Arc<std_semaphore::Semaphore>,
+}
+
+impl<K: Hash + Eq + Clone> CMapSemaphore<K> {
+    pub fn new(max_global_access: isize) -> Self {
+        Self {
+            map: Arc::new(dashmap::DashMap::new()),
+            global: Arc::new(std_semaphore::Semaphore::new(max_global_access)),
+        }
+    }
+
+    pub fn acquire(&self, key: K) -> CMapSemaphoreGuard<'_, K> {
+        let global_access = self.global.access();
+        let map_mutex = self
+            .map
+            .entry(key.clone())
+            .or_insert_with(|| Arc::new(Mutex::new(())))
+            .clone();
+        CMapSemaphoreGuard {
+            _global_access: global_access,
+            map: self.map.clone(),
+            map_mutex,
+            key,
+        }
+    }
+}
+
+impl<K: Hash + Eq> Debug for CMapSemaphore<K> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CMapSemaphore")
+            .field("map", &self.map.len())
+            .field("global", &"...")
+            .finish()
+    }
+}
+
+pub struct CMapSemaphoreGuard<'a, K: Hash + Eq> {
+    _global_access: std_semaphore::SemaphoreGuard<'a>,
+    map: Arc<dashmap::DashMap<K, Arc<Mutex<()>>>>,
+    map_mutex: Arc<Mutex<()>>,
+    key: K,
+}
+
+impl<'a, K: Hash + Eq> CMapSemaphoreGuard<'a, K> {
+    pub fn access(&self) -> MutexGuard<'_, ()> {
+        // Unwrap: only errors if the mutex is poisoned, which is a bug
+        self.map_mutex.lock().unwrap()
+    }
+}
+
+impl<K: Hash + Eq> Drop for CMapSemaphoreGuard<'_, K> {
+    fn drop(&mut self) {
+        self.map.remove(&self.key);
+    }
+}

--- a/applications/tari_dan_app_utilities/src/template_manager/implementation/manager.rs
+++ b/applications/tari_dan_app_utilities/src/template_manager/implementation/manager.rs
@@ -59,7 +59,7 @@ pub struct TemplateManager {
     config: TemplateConfig,
     builtin_templates: Arc<HashMap<TemplateAddress, Template>>,
     cache: mini_moka::sync::Cache<TemplateAddress, LoadedTemplate>,
-    cmap_semaphore: cmap_semaphore::CMapSemaphore<TemplateAddress>,
+    cmap_semaphore: cmap_semaphore::ConcurrentMapSemaphore<TemplateAddress>,
 }
 
 impl TemplateManager {
@@ -84,7 +84,7 @@ impl TemplateManager {
             builtin_templates: Arc::new(builtin_templates),
             cache,
             config,
-            cmap_semaphore: cmap_semaphore::CMapSemaphore::new(CONCURRENT_ACCESS_LIMIT),
+            cmap_semaphore: cmap_semaphore::ConcurrentMapSemaphore::new(CONCURRENT_ACCESS_LIMIT),
         })
     }
 

--- a/applications/tari_dan_app_utilities/src/template_manager/implementation/manager.rs
+++ b/applications/tari_dan_app_utilities/src/template_manager/implementation/manager.rs
@@ -24,6 +24,7 @@ use std::{
     collections::HashMap,
     convert::{TryFrom, TryInto},
     fs,
+    sync::Arc,
 };
 
 use chrono::Utc;
@@ -43,38 +44,48 @@ use tari_template_builtin::{get_template_builtin, ACCOUNT_NFT_TEMPLATE_ADDRESS, 
 use tari_template_lib::models::TemplateAddress;
 
 use super::TemplateConfig;
-use crate::template_manager::interface::{
-    Template,
-    TemplateExecutable,
-    TemplateManagerError,
-    TemplateMetadata,
-    TemplateRegistration,
+use crate::template_manager::{
+    implementation::cmap_semaphore,
+    interface::{Template, TemplateExecutable, TemplateManagerError, TemplateMetadata, TemplateRegistration},
 };
 
 const LOG_TARGET: &str = "tari::validator_node::template_manager";
+
+const CONCURRENT_ACCESS_LIMIT: isize = 100;
 
 #[derive(Debug, Clone)]
 pub struct TemplateManager {
     global_db: GlobalDb<SqliteGlobalDbAdapter>,
     config: TemplateConfig,
-    builtin_templates: HashMap<TemplateAddress, Template>,
+    builtin_templates: Arc<HashMap<TemplateAddress, Template>>,
     cache: mini_moka::sync::Cache<TemplateAddress, LoadedTemplate>,
+    cmap_semaphore: cmap_semaphore::CMapSemaphore<TemplateAddress>,
 }
 
 impl TemplateManager {
-    pub fn new(global_db: GlobalDb<SqliteGlobalDbAdapter>, config: TemplateConfig) -> Self {
+    pub fn initialize(
+        global_db: GlobalDb<SqliteGlobalDbAdapter>,
+        config: TemplateConfig,
+    ) -> Result<Self, TemplateManagerError> {
         // load the builtin account templates
         let builtin_templates = Self::load_builtin_templates();
+        let cache = mini_moka::sync::Cache::builder()
+            .weigher(|_, t: &LoadedTemplate| u32::try_from(t.code_size()).unwrap_or(u32::MAX))
+            .max_capacity(config.max_cache_size_bytes())
+            .build();
 
-        Self {
-            global_db,
-            builtin_templates,
-            cache: mini_moka::sync::Cache::builder()
-                .weigher(|_, t: &LoadedTemplate| u32::try_from(t.code_size()).unwrap_or(u32::MAX))
-                .max_capacity(config.max_cache_size_bytes())
-                .build(),
-            config,
+        // Precache builtins
+        for addr in builtin_templates.keys() {
+            cache.insert(*addr, WasmModule::load_template_from_code(get_template_builtin(addr))?);
         }
+
+        Ok(Self {
+            global_db,
+            builtin_templates: Arc::new(builtin_templates),
+            cache,
+            config,
+            cmap_semaphore: cmap_semaphore::CMapSemaphore::new(CONCURRENT_ACCESS_LIMIT),
+        })
     }
 
     fn load_builtin_templates() -> HashMap<TemplateAddress, Template> {
@@ -82,12 +93,12 @@ impl TemplateManager {
         let mut builtin_templates = HashMap::new();
 
         // get the builtin WASM code of the account template
-        let compiled_code = get_template_builtin(*ACCOUNT_TEMPLATE_ADDRESS);
+        let compiled_code = get_template_builtin(&ACCOUNT_TEMPLATE_ADDRESS);
         let template = Self::load_builtin_template("account", *ACCOUNT_TEMPLATE_ADDRESS, compiled_code.to_vec());
         builtin_templates.insert(*ACCOUNT_TEMPLATE_ADDRESS, template);
 
         // get the builtin WASM code of the account nft template
-        let compiled_code = get_template_builtin(*ACCOUNT_NFT_TEMPLATE_ADDRESS);
+        let compiled_code = get_template_builtin(&ACCOUNT_NFT_TEMPLATE_ADDRESS);
         let template =
             Self::load_builtin_template("account_nft", *ACCOUNT_NFT_TEMPLATE_ADDRESS, compiled_code.to_vec());
         builtin_templates.insert(*ACCOUNT_NFT_TEMPLATE_ADDRESS, template);
@@ -231,6 +242,20 @@ impl TemplateProvider for TemplateManager {
     type Template = LoadedTemplate;
 
     fn get_template_module(&self, address: &TemplateAddress) -> Result<Option<Self::Template>, Self::Error> {
+        if let Some(template) = self.cache.get(address) {
+            debug!(target: LOG_TARGET, "CACHE HIT: Template {}", address);
+            return Ok(Some(template));
+        }
+
+        // This protects the following critical area by:
+        // 1. preventing more than CONCURRENT_ACCESS_LIMIT concurrent accesses
+        // 2. preventing more than one load of the same template
+        // The reasons are:
+        // 1. for efficiency, to only ever load the template once (until it is purged from the cache), and
+        // 2. to prevent stack overflow. This happens in stress testing, if around 200 templates are loaded concurrently
+        let guard = self.cmap_semaphore.acquire(*address);
+        let _access = guard.access();
+
         if let Some(template) = self.cache.get(address) {
             debug!(target: LOG_TARGET, "CACHE HIT: Template {}", address);
             return Ok(Some(template));

--- a/applications/tari_dan_app_utilities/src/template_manager/implementation/mod.rs
+++ b/applications/tari_dan_app_utilities/src/template_manager/implementation/mod.rs
@@ -29,5 +29,7 @@ mod manager;
 pub use manager::TemplateManager;
 mod service;
 
+mod cmap_semaphore;
 mod template_config;
+
 pub use template_config::TemplateConfig;

--- a/applications/tari_dan_app_utilities/src/transaction_executor.rs
+++ b/applications/tari_dan_app_utilities/src/transaction_executor.rs
@@ -3,6 +3,7 @@
 
 use std::{sync::Arc, time::Instant};
 
+use log::*;
 use tari_common_types::types::PublicKey;
 use tari_crypto::tari_utilities::ByteArray;
 use tari_dan_common_types::{services::template_provider::TemplateProvider, ShardId};
@@ -17,6 +18,8 @@ use tari_dan_storage::consensus_models::ExecutedTransaction;
 use tari_engine_types::commit_result::{ExecuteResult, FinalizeResult, RejectReason};
 use tari_template_lib::{crypto::RistrettoPublicKeyBytes, prelude::NonFungibleAddress};
 use tari_transaction::Transaction;
+
+const _LOG_TARGET: &str = "tari::dan::transaction_executor";
 
 pub trait TransactionExecutor {
     type Error: Send + Sync + 'static;
@@ -90,7 +93,7 @@ where TTemplateProvider: TemplateProvider<Template = LoadedTemplate>
             .map(|diff| {
                 diff.up_iter()
                     .map(|(addr, substate)| ShardId::from_address(addr, substate.version()))
-                    .collect()
+                    .collect::<Vec<_>>()
             })
             .unwrap_or_default();
 

--- a/applications/tari_indexer/src/bootstrap.rs
+++ b/applications/tari_indexer/src/bootstrap.rs
@@ -98,7 +98,7 @@ pub async fn spawn_services(
     );
 
     // Template manager
-    let template_manager = TemplateManager::new(global_db.clone(), config.indexer.templates.clone());
+    let template_manager = TemplateManager::initialize(global_db.clone(), config.indexer.templates.clone())?;
     let (template_manager_service, _) =
         template_manager::implementation::spawn(template_manager.clone(), shutdown.clone());
 

--- a/applications/tari_validator_node/src/bootstrap.rs
+++ b/applications/tari_validator_node/src/bootstrap.rs
@@ -179,7 +179,7 @@ pub async fn spawn_services(
     handles.push(join_handle);
 
     // Template manager
-    let template_manager = TemplateManager::new(global_db.clone(), config.validator_node.templates.clone());
+    let template_manager = TemplateManager::initialize(global_db.clone(), config.validator_node.templates.clone())?;
     let (template_manager_service, join_handle) =
         template_manager::implementation::spawn(template_manager.clone(), shutdown.clone());
     handles.push(join_handle);

--- a/dan_layer/template_builtin/src/lib.rs
+++ b/dan_layer/template_builtin/src/lib.rs
@@ -29,10 +29,10 @@ lazy_static! {
     ]);
 }
 
-pub fn get_template_builtin(address: TemplateAddress) -> &'static [u8] {
-    if address == *ACCOUNT_TEMPLATE_ADDRESS {
+pub fn get_template_builtin(address: &TemplateAddress) -> &'static [u8] {
+    if *address == *ACCOUNT_TEMPLATE_ADDRESS {
         include_bytes!("../templates/account/account.wasm")
-    } else if address == *ACCOUNT_NFT_TEMPLATE_ADDRESS {
+    } else if *address == *ACCOUNT_NFT_TEMPLATE_ADDRESS {
         include_bytes!("../templates/account_nfts/account_nfts.wasm")
     } else {
         panic!("Unknown builtin template address")

--- a/dan_layer/template_test_tooling/src/template_test.rs
+++ b/dan_layer/template_test_tooling/src/template_test.rs
@@ -79,7 +79,7 @@ impl TemplateTest {
         let mut builder = Package::builder();
 
         // Add Account template builtin
-        let wasm = get_template_builtin(*ACCOUNT_TEMPLATE_ADDRESS);
+        let wasm = get_template_builtin(&ACCOUNT_TEMPLATE_ADDRESS);
         let template = WasmModule::from_code(wasm.to_vec()).load_template().unwrap();
         builder.add_template(*ACCOUNT_TEMPLATE_ADDRESS, template);
         name_to_template.insert("Account".to_string(), *ACCOUNT_TEMPLATE_ADDRESS);


### PR DESCRIPTION
Description
---
- Protect a critical area for template loading by
1. preventing more than 100 concurrent accesses
2. preventing more than one load of the same template
      
- Preload the builtin templates

Motivation and Context
---
In stress testing, when submitting around 200+ transactions, the validator's stack overflows. This is because the template manager would load the (same) template 200+ times concurrently. This PR prevents concurrent loading of the same template, instead loading from the cache once loaded and more than CONCURRENT_ACCESS_LIMIT (100) concurrent template loads.

We validate that all templates used in transactions exist. So a user can not use up the CONCURRENT_ACCESS_LIMIT with non-existent templates.

In this PR, we preload builtin templates into the cache, as we assume that these are used more commonly. 

How Has This Been Tested?
---
Manually, stress testing without first preloading the builtin templates

What process can a PR reviewer use to test or verify this change?
---
Submit 1000+ transactions before any templates have been loaded does not stack overflow. 
Note since the stress tester currently only submits ACCOUNT template instructions and since ACCOUNT is now preloaded, the stack overflow would not occur even without the locks.

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify