### PR TITLE
feat(wallet/indexer): add decoded json field on transaction results

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7827,6 +7827,7 @@ dependencies = [
  "log",
  "rand 0.7.3",
  "serde",
+ "serde_json",
  "tari_common_types",
  "tari_crypto",
  "tari_dan_common_types",

--- a/applications/tari_dan_wallet_daemon/src/handlers/transaction.rs
+++ b/applications/tari_dan_wallet_daemon/src/handlers/transaction.rs
@@ -6,7 +6,7 @@ use anyhow::anyhow;
 use futures::{future, future::Either};
 use log::*;
 use tari_dan_common_types::optional::Optional;
-use tari_dan_wallet_sdk::apis::{jwt::JrpcPermission, key_manager};
+use tari_dan_wallet_sdk::{apis::{jwt::JrpcPermission, key_manager}, network::{TransactionQueryResult, TransactionFinalizedResult}};
 use tari_engine_types::{instruction::Instruction, substate::SubstateAddress};
 use tari_template_lib::{args, models::Amount};
 use tari_transaction::Transaction;
@@ -133,14 +133,20 @@ pub async fn handle_submit(
         transaction.hash()
     );
     if req.is_dry_run {
-        let response = sdk
+        let response: TransactionQueryResult = sdk
             .transaction_api()
             .submit_dry_run_transaction(transaction, inputs.clone())
             .await?;
 
+        let json_result  = match &response.result {
+            TransactionFinalizedResult::Pending => None,
+            TransactionFinalizedResult::Finalized { json_results, .. } => Some(json_results.clone()),
+        };
+
         Ok(TransactionSubmitResponse {
             transaction_id: response.transaction_id,
             result: response.result.into_execute_result(),
+            json_result,
             inputs,
         })
     } else {
@@ -158,6 +164,7 @@ pub async fn handle_submit(
             transaction_id,
             inputs,
             result: None,
+            json_result: None,
         })
     }
 }
@@ -227,6 +234,7 @@ pub async fn handle_get_result(
         transaction_id: req.transaction_id,
         result: transaction.finalize,
         status: transaction.status,
+        json_result: transaction.json_result,
     })
 }
 
@@ -255,6 +263,7 @@ pub async fn handle_wait_result(
             final_fee: transaction.final_fee.unwrap_or_default(),
             timed_out: false,
             transaction_failure: transaction.transaction_failure,
+            json_result: transaction.json_result,
         });
     }
 
@@ -284,6 +293,7 @@ pub async fn handle_wait_result(
                     transaction_failure: event.transaction_failure,
                     final_fee: event.final_fee,
                     timed_out: false,
+                    json_result: event.json_result,
                 });
             },
             Some(WalletEvent::TransactionInvalid(event)) if event.transaction_id == req.transaction_id => {
@@ -294,6 +304,7 @@ pub async fn handle_wait_result(
                     transaction_failure: event.transaction_failure,
                     final_fee: event.final_fee.unwrap_or_default(),
                     timed_out: false,
+                    json_result: None,
                 });
             },
             Some(_) => continue,
@@ -305,6 +316,7 @@ pub async fn handle_wait_result(
                     transaction_failure: transaction.transaction_failure,
                     final_fee: Amount::zero(),
                     timed_out: true,
+                    json_result: None,
                 });
             },
         };

--- a/applications/tari_dan_wallet_daemon/src/handlers/transaction.rs
+++ b/applications/tari_dan_wallet_daemon/src/handlers/transaction.rs
@@ -6,7 +6,10 @@ use anyhow::anyhow;
 use futures::{future, future::Either};
 use log::*;
 use tari_dan_common_types::optional::Optional;
-use tari_dan_wallet_sdk::{apis::{jwt::JrpcPermission, key_manager}, network::{TransactionQueryResult, TransactionFinalizedResult}};
+use tari_dan_wallet_sdk::{
+    apis::{jwt::JrpcPermission, key_manager},
+    network::{TransactionFinalizedResult, TransactionQueryResult},
+};
 use tari_engine_types::{instruction::Instruction, substate::SubstateAddress};
 use tari_template_lib::{args, models::Amount};
 use tari_transaction::Transaction;
@@ -138,7 +141,7 @@ pub async fn handle_submit(
             .submit_dry_run_transaction(transaction, inputs.clone())
             .await?;
 
-        let json_result  = match &response.result {
+        let json_result = match &response.result {
             TransactionFinalizedResult::Pending => None,
             TransactionFinalizedResult::Finalized { json_results, .. } => Some(json_results.clone()),
         };

--- a/applications/tari_dan_wallet_daemon/src/indexer_jrpc_impl.rs
+++ b/applications/tari_dan_wallet_daemon/src/indexer_jrpc_impl.rs
@@ -146,10 +146,12 @@ fn convert_indexer_result_to_wallet_result(result: IndexerTransactionFinalizedRe
             final_decision,
             execution_result,
             abort_details,
+            json_results,
         } => TransactionFinalizedResult::Finalized {
             final_decision,
             execution_result,
             abort_details,
+            json_results,
         },
     }
 }

--- a/applications/tari_dan_wallet_daemon/src/services/events.rs
+++ b/applications/tari_dan_wallet_daemon/src/services/events.rs
@@ -3,6 +3,7 @@
 
 use std::time::SystemTime;
 
+use serde_json::Value;
 use tari_dan_wallet_sdk::models::TransactionStatus;
 use tari_engine_types::{
     commit_result::{FinalizeResult, RejectReason},
@@ -71,6 +72,7 @@ pub struct TransactionFinalizedEvent {
     pub transaction_failure: Option<RejectReason>,
     pub final_fee: Amount,
     pub status: TransactionStatus,
+    pub json_result: Option<Vec<Value>>,
 }
 
 #[derive(Debug, Clone)]

--- a/applications/tari_dan_wallet_daemon/src/services/transaction_service.rs
+++ b/applications/tari_dan_wallet_daemon/src/services/transaction_service.rs
@@ -151,6 +151,7 @@ where
                                 transaction_failure: transaction.transaction_failure,
                                 final_fee: transaction.final_fee.unwrap_or_default(),
                                 status: transaction.status,
+                                json_result: transaction.json_result,
                             });
                         },
                         None => notify.notify(TransactionInvalidEvent {

--- a/applications/tari_indexer/src/json_rpc/handlers.rs
+++ b/applications/tari_indexer/src/json_rpc/handlers.rs
@@ -71,10 +71,12 @@ use tari_validator_node_rpc::client::{SubstateResult, TariCommsValidatorNodeClie
 use crate::{
     bootstrap::Services,
     dry_run::processor::DryRunTransactionProcessor,
-    json_rpc::special_substate_encoding::encode_substate_into_json,
+    json_rpc::json_encoding::encode_substate_into_json,
     substate_manager::SubstateManager,
     transaction_manager::TransactionManager,
 };
+
+use super::json_encoding::{encode_execute_result_into_json, encode_finalized_result_into_json};
 
 const LOG_TARGET: &str = "tari::indexer::json_rpc::handlers";
 
@@ -531,11 +533,14 @@ impl JsonRpcHandlers {
                 .await
                 .map_err(|e| Self::internal_error(answer_id, e))?;
 
+            let json_results = encode_execute_result_into_json(&exec_result).map_err(|e| Self::internal_error(answer_id, e))?;
+
             Ok(JsonRpcResponse::success(answer_id, SubmitTransactionResponse {
                 result: IndexerTransactionFinalizedResult::Finalized {
                     execution_result: Some(exec_result),
                     final_decision: Decision::Commit,
                     abort_details: None,
+                    json_results,
                 },
                 transaction_id,
             }))
@@ -613,13 +618,17 @@ impl JsonRpcHandlers {
             TransactionResultStatus::Pending => GetTransactionResultResponse {
                 result: IndexerTransactionFinalizedResult::Pending,
             },
-            TransactionResultStatus::Finalized(finalized) => GetTransactionResultResponse {
-                result: IndexerTransactionFinalizedResult::Finalized {
-                    final_decision: finalized.final_decision,
-                    execution_result: finalized.execute_result,
-                    abort_details: finalized.abort_details,
-                },
-            },
+            TransactionResultStatus::Finalized(finalized) => {
+                let json_results = encode_finalized_result_into_json(&finalized).map_err(|e| Self::internal_error(answer_id, e))?;
+                GetTransactionResultResponse {
+                    result: IndexerTransactionFinalizedResult::Finalized {
+                        final_decision: finalized.final_decision,
+                        execution_result: finalized.execute_result,
+                        abort_details: finalized.abort_details,
+                        json_results,
+                    }
+                }
+            }
         };
 
         Ok(JsonRpcResponse::success(answer_id, resp))

--- a/applications/tari_indexer/src/json_rpc/handlers.rs
+++ b/applications/tari_indexer/src/json_rpc/handlers.rs
@@ -68,6 +68,7 @@ use tari_validator_node_client::types::{
 };
 use tari_validator_node_rpc::client::{SubstateResult, TariCommsValidatorNodeClientFactory, TransactionResultStatus};
 
+use super::json_encoding::{encode_execute_result_into_json, encode_finalized_result_into_json};
 use crate::{
     bootstrap::Services,
     dry_run::processor::DryRunTransactionProcessor,
@@ -75,8 +76,6 @@ use crate::{
     substate_manager::SubstateManager,
     transaction_manager::TransactionManager,
 };
-
-use super::json_encoding::{encode_execute_result_into_json, encode_finalized_result_into_json};
 
 const LOG_TARGET: &str = "tari::indexer::json_rpc::handlers";
 
@@ -533,7 +532,8 @@ impl JsonRpcHandlers {
                 .await
                 .map_err(|e| Self::internal_error(answer_id, e))?;
 
-            let json_results = encode_execute_result_into_json(&exec_result).map_err(|e| Self::internal_error(answer_id, e))?;
+            let json_results =
+                encode_execute_result_into_json(&exec_result).map_err(|e| Self::internal_error(answer_id, e))?;
 
             Ok(JsonRpcResponse::success(answer_id, SubmitTransactionResponse {
                 result: IndexerTransactionFinalizedResult::Finalized {
@@ -619,16 +619,17 @@ impl JsonRpcHandlers {
                 result: IndexerTransactionFinalizedResult::Pending,
             },
             TransactionResultStatus::Finalized(finalized) => {
-                let json_results = encode_finalized_result_into_json(&finalized).map_err(|e| Self::internal_error(answer_id, e))?;
+                let json_results =
+                    encode_finalized_result_into_json(&finalized).map_err(|e| Self::internal_error(answer_id, e))?;
                 GetTransactionResultResponse {
                     result: IndexerTransactionFinalizedResult::Finalized {
                         final_decision: finalized.final_decision,
                         execution_result: finalized.execute_result,
                         abort_details: finalized.abort_details,
                         json_results,
-                    }
+                    },
                 }
-            }
+            },
         };
 
         Ok(JsonRpcResponse::success(answer_id, resp))

--- a/applications/tari_indexer/src/json_rpc/json_encoding.rs
+++ b/applications/tari_indexer/src/json_rpc/json_encoding.rs
@@ -24,6 +24,9 @@ pub enum JsonEncodingError {
 }
 
 pub fn cbor_to_json(raw: &[u8]) -> Result<json::Value, JsonEncodingError> {
+    if raw.is_empty() {
+        return Ok(json::Value::Null);
+    }
     let decoded_cbor: CborValue = tari_bor::decode(raw)?;
     let decoded_cbor = fix_invalid_object_keys(&decoded_cbor);
     let result = serde_json::to_value(decoded_cbor)?;

--- a/applications/tari_indexer/src/json_rpc/json_encoding.rs
+++ b/applications/tari_indexer/src/json_rpc/json_encoding.rs
@@ -3,9 +3,10 @@
 
 use serde_json as json;
 use tari_engine_types::{
+    commit_result::ExecuteResult,
     component::ComponentHeader,
     non_fungible::NonFungibleContainer,
-    substate::{Substate, SubstateValue}, commit_result::ExecuteResult,
+    substate::{Substate, SubstateValue},
 };
 use tari_validator_node_rpc::client::FinalizedResult;
 
@@ -38,7 +39,12 @@ pub fn encode_finalized_result_into_json(result: &FinalizedResult) -> Result<Vec
 }
 
 pub fn encode_execute_result_into_json(result: &ExecuteResult) -> Result<Vec<json::Value>, JsonEncodingError> {
-    let encoded_results = result.finalize.execution_results.iter().map(|r| cbor_to_json(&r.raw)).collect::<Result<_, JsonEncodingError>>()?;
+    let encoded_results = result
+        .finalize
+        .execution_results
+        .iter()
+        .map(|r| cbor_to_json(&r.raw))
+        .collect::<Result<_, JsonEncodingError>>()?;
     Ok(encoded_results)
 }
 

--- a/applications/tari_indexer/src/json_rpc/mod.rs
+++ b/applications/tari_indexer/src/json_rpc/mod.rs
@@ -23,7 +23,7 @@
 mod handlers;
 pub use handlers::JsonRpcHandlers;
 
-mod server;
 mod json_encoding;
+mod server;
 
 pub use server::run_json_rpc;

--- a/applications/tari_indexer/src/json_rpc/mod.rs
+++ b/applications/tari_indexer/src/json_rpc/mod.rs
@@ -24,6 +24,6 @@ mod handlers;
 pub use handlers::JsonRpcHandlers;
 
 mod server;
-mod special_substate_encoding;
+mod json_encoding;
 
 pub use server::run_json_rpc;

--- a/applications/tari_validator_node/src/p2p/services/mempool/validators/input_refs.rs
+++ b/applications/tari_validator_node/src/p2p/services/mempool/validators/input_refs.rs
@@ -22,8 +22,8 @@ impl Validator<ExecutedTransaction> for InputRefsValidator {
 
     async fn validate(&self, executed: &ExecutedTransaction) -> Result<(), Self::Error> {
         let Some(diff) = executed.result().finalize.result.accept() else {
-                return Ok(());
-            };
+            return Ok(());
+        };
 
         let is_input_refs_downed = diff
             .down_iter()

--- a/applications/tari_validator_node_cli/src/cli_range.rs
+++ b/applications/tari_validator_node_cli/src/cli_range.rs
@@ -39,14 +39,13 @@ impl FromStr for CliRange<u64> {
 }
 
 fn parse_range(s: &str) -> Result<ParsedRange<'_>, anyhow::Error> {
-    let Some((start, end)) = s
-        .split_once("..") else {
+    let Some((start, end)) = s.split_once("..") else {
         // If the user enters just a value, we treat it as a V..=V range
-        return Ok(ParsedRange{
+        return Ok(ParsedRange {
             start: Some(s),
             end: Some(s),
             inclusive: true,
-        })
+        });
     };
 
     let inclusive = end.starts_with('=');

--- a/clients/tari_indexer_client/src/types.rs
+++ b/clients/tari_indexer_client/src/types.rs
@@ -2,6 +2,7 @@
 //   SPDX-License-Identifier: BSD-3-Clause
 
 use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
 use serde_with::{serde_as, DisplayFromStr};
 use tari_dan_storage::consensus_models::Decision;
 use tari_engine_types::{
@@ -10,7 +11,6 @@ use tari_engine_types::{
     substate::{Substate, SubstateAddress},
 };
 use tari_transaction::{SubstateRequirement, Transaction, TransactionId};
-use serde_json::Value as JsonValue;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GetSubstateRequest {

--- a/clients/tari_indexer_client/src/types.rs
+++ b/clients/tari_indexer_client/src/types.rs
@@ -10,6 +10,7 @@ use tari_engine_types::{
     substate::{Substate, SubstateAddress},
 };
 use tari_transaction::{SubstateRequirement, Transaction, TransactionId};
+use serde_json::Value as JsonValue;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GetSubstateRequest {
@@ -77,6 +78,7 @@ pub enum IndexerTransactionFinalizedResult {
         final_decision: Decision,
         execution_result: Option<ExecuteResult>,
         abort_details: Option<String>,
+        json_results: Vec<JsonValue>,
     },
 }
 

--- a/clients/wallet_daemon_client/src/types.rs
+++ b/clients/wallet_daemon_client/src/types.rs
@@ -23,6 +23,7 @@
 use std::{collections::HashMap, time::Duration};
 
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use tari_common_types::types::PublicKey;
 use tari_dan_common_types::{Epoch, ShardId};
 use tari_dan_wallet_sdk::{
@@ -102,6 +103,7 @@ pub struct TransactionSubmitResponse {
     pub transaction_id: TransactionId,
     pub inputs: Vec<SubstateRequirement>,
     pub result: Option<ExecuteResult>,
+    pub json_result: Option<Vec<Value>>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -140,8 +142,9 @@ pub struct TransactionGetResultRequest {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct TransactionGetResultResponse {
     pub transaction_id: TransactionId,
-    pub result: Option<FinalizeResult>,
     pub status: TransactionStatus,
+    pub result: Option<FinalizeResult>,
+    pub json_result: Option<Vec<Value>>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -154,6 +157,7 @@ pub struct TransactionWaitResultRequest {
 pub struct TransactionWaitResultResponse {
     pub transaction_id: TransactionId,
     pub result: Option<FinalizeResult>,
+    pub json_result: Option<Vec<Value>>,
     pub status: TransactionStatus,
     pub transaction_failure: Option<RejectReason>,
     pub final_fee: Amount,

--- a/dan_layer/engine/src/runtime/working_state.rs
+++ b/dan_layer/engine/src/runtime/working_state.rs
@@ -290,7 +290,8 @@ impl WorkingState {
 
         let VirtualSubstate::UnclaimedValidatorFee(fee_claim) = substate else {
             return Err(RuntimeError::FeeClaimNotPermitted {
-                epoch, address: validator_public_key
+                epoch,
+                address: validator_public_key,
             });
         };
         Ok(fee_claim)
@@ -305,7 +306,7 @@ impl WorkingState {
                     address: address.clone(),
                 })?;
         let VirtualSubstate::CurrentEpoch(epoch) = current_epoch else {
-            return Err(RuntimeError::VirtualSubstateNotFound { address});
+            return Err(RuntimeError::VirtualSubstateNotFound { address });
         };
         Ok(Epoch(*epoch))
     }

--- a/dan_layer/wallet/sdk/Cargo.toml
+++ b/dan_layer/wallet/sdk/Cargo.toml
@@ -28,6 +28,7 @@ lazy_static = "1.4.0"
 log = "0.4.14"
 rand = "0.7.3"
 serde = "1.0.126"
+serde_json = "1.0"
 thiserror = "1.0.38"
 zeroize = "1"
 

--- a/dan_layer/wallet/sdk/src/apis/transaction.rs
+++ b/dan_layer/wallet/sdk/src/apis/transaction.rs
@@ -149,7 +149,7 @@ where
                 final_decision,
                 execution_result,
                 abort_details,
-                json_results: _,
+                json_results,
             } => {
                 let new_status = if final_decision.is_commit() {
                     TransactionStatus::Accepted
@@ -223,6 +223,7 @@ where
                     // qcs: qc_resp.qcs,
                     qcs: vec![],
                     is_dry_run: transaction.is_dry_run,
+                    json_result: Some(json_results),
                 }))
             },
         }

--- a/dan_layer/wallet/sdk/src/apis/transaction.rs
+++ b/dan_layer/wallet/sdk/src/apis/transaction.rs
@@ -149,6 +149,7 @@ where
                 final_decision,
                 execution_result,
                 abort_details,
+                json_results: _,
             } => {
                 let new_status = if final_decision.is_commit() {
                     TransactionStatus::Accepted

--- a/dan_layer/wallet/sdk/src/models/wallet_transaction.rs
+++ b/dan_layer/wallet/sdk/src/models/wallet_transaction.rs
@@ -5,6 +5,7 @@ use std::{fmt::Display, str::FromStr};
 
 use anyhow::anyhow;
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use tari_dan_storage::consensus_models::QuorumCertificate;
 use tari_engine_types::commit_result::{FinalizeResult, RejectReason};
 use tari_template_lib::models::Amount;
@@ -18,6 +19,7 @@ pub struct WalletTransaction<TAddr> {
     pub transaction_failure: Option<RejectReason>,
     pub final_fee: Option<Amount>,
     pub qcs: Vec<QuorumCertificate<TAddr>>,
+    pub json_result: Option<Vec<Value>>,
     pub is_dry_run: bool,
 }
 

--- a/dan_layer/wallet/sdk/src/network.rs
+++ b/dan_layer/wallet/sdk/src/network.rs
@@ -3,6 +3,7 @@
 
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use tari_dan_storage::consensus_models::Decision;
 use tari_engine_types::{
     commit_result::ExecuteResult,
@@ -60,6 +61,7 @@ pub enum TransactionFinalizedResult {
         final_decision: Decision,
         execution_result: Option<ExecuteResult>,
         abort_details: Option<String>,
+        json_results: Vec<Value>,
     },
 }
 

--- a/dan_layer/wallet/storage_sqlite/migrations/2023-09-04-200422_add_json_result_to_transactions/up.sql
+++ b/dan_layer/wallet/storage_sqlite/migrations/2023-09-04-200422_add_json_result_to_transactions/up.sql
@@ -1,0 +1,5 @@
+--  // Copyright 2022 The Tari Project
+--  // SPDX-License-Identifier: BSD-3-Clause
+
+ALTER TABLE transactions
+    ADD COLUMN json_result TEXT NULL;

--- a/dan_layer/wallet/storage_sqlite/src/models/transaction.rs
+++ b/dan_layer/wallet/storage_sqlite/src/models/transaction.rs
@@ -27,6 +27,7 @@ pub struct Transaction {
     pub fee_instructions: String,
     pub meta: String,
     pub result: Option<String>,
+    pub json_result: Option<String>,
     pub transaction_failure: Option<String>,
     pub qcs: Option<String>,
     pub final_fee: Option<i64>,
@@ -80,6 +81,7 @@ impl Transaction {
             final_fee: self.final_fee.map(|f| f.into()),
             qcs: self.qcs.map(|q| deserialize_json(&q)).transpose()?.unwrap_or_default(),
             is_dry_run: self.is_dry_run,
+            json_result: self.json_result.map(|r| deserialize_json(&r)).transpose()?.unwrap_or_default(),
         })
     }
 }

--- a/dan_layer/wallet/storage_sqlite/src/models/transaction.rs
+++ b/dan_layer/wallet/storage_sqlite/src/models/transaction.rs
@@ -81,7 +81,11 @@ impl Transaction {
             final_fee: self.final_fee.map(|f| f.into()),
             qcs: self.qcs.map(|q| deserialize_json(&q)).transpose()?.unwrap_or_default(),
             is_dry_run: self.is_dry_run,
-            json_result: self.json_result.map(|r| deserialize_json(&r)).transpose()?.unwrap_or_default(),
+            json_result: self
+                .json_result
+                .map(|r| deserialize_json(&r))
+                .transpose()?
+                .unwrap_or_default(),
         })
     }
 }

--- a/dan_layer/wallet/storage_sqlite/src/schema.rs
+++ b/dan_layer/wallet/storage_sqlite/src/schema.rs
@@ -107,6 +107,7 @@ table! {
         fee_instructions -> Text,
         meta -> Text,
         result -> Nullable<Text>,
+        json_result -> Nullable<Text>,
         transaction_failure -> Nullable<Text>,
         qcs -> Nullable<Text>,
         final_fee -> Nullable<BigInt>,


### PR DESCRIPTION
Description
---
* Added a new `json_result` field in multiple JSON RPC result types (both in the indexer as well as the wallet daemon) 
* The execution results of a transaction are decoded as JSON in the indexer, reusing some of the substate decoding logic already existing in the indexer
* Added a new column for the `json_result` field of a transaction in In the wallet sqlite storage
* A few unrelated code was reformatted by rust fmt

Motivation and Context
---
Up until now, the instruction results of a transaction included only the raw CBOR value and the decoded substates. From user web applications this is insufficient as many template methods/functions can return any type of data, and CBOR decoding in the web may not be the best approach.

This PR aims to solve this problem by adding a new field (`json_result`) in the indexer and wallet JSON RPC responses

How Has This Been Tested?
---
Manually by inspecting the execution results of a template method that returns values

What process can a PR reviewer use to test or verify this change?
---
Call a template method/function and inspecting the new field value in the result

Breaking Changes
---
- [ ] None
- [x] Requires data directory to be deleted (wallet daemon sqlite)
- [ ] Other - Please specify