### PR TITLE
fix(consensus)!: undo pending transaction stage transitions on leader fail

### DIFF
--- a/applications/tari_validator_node/src/dan_node.rs
+++ b/applications/tari_validator_node/src/dan_node.rs
@@ -115,7 +115,7 @@ impl DanNode {
     }
 
     async fn handle_hotstuff_event(&self, event: HotstuffEvent) -> Result<(), anyhow::Error> {
-        let HotstuffEvent::BlockCommitted { block_id } = event else {
+        let HotstuffEvent::BlockCommitted { block_id, .. } = event else {
             return Ok(());
         };
 

--- a/dan_layer/consensus/src/hotstuff/common.rs
+++ b/dan_layer/consensus/src/hotstuff/common.rs
@@ -4,15 +4,15 @@
 use std::ops::DerefMut;
 
 use log::*;
-use tari_dan_common_types::{committee::Committee, NodeAddressable};
+use tari_dan_common_types::{committee::Committee, Epoch, NodeAddressable, NodeHeight};
 use tari_dan_storage::{
-    consensus_models::{HighQc, QuorumCertificate},
+    consensus_models::{Block, HighQc, QuorumCertificate, QuorumDecision},
     StateStoreReadTransaction,
     StateStoreWriteTransaction,
     StorageError,
 };
 
-use crate::messages::HotstuffMessage;
+use crate::{messages::HotstuffMessage, traits::LeaderStrategy};
 
 const LOG_TARGET: &str = "tari::dan::consensus::hotstuff";
 
@@ -52,4 +52,67 @@ where
     }
 
     Ok(())
+}
+
+pub fn calculate_dummy_blocks<TAddr: NodeAddressable, TLeaderStrategy: LeaderStrategy<TAddr>>(
+    epoch: Epoch,
+    high_qc: &QuorumCertificate<TAddr>,
+    new_height: NodeHeight,
+    leader_strategy: &TLeaderStrategy,
+    local_committee: &Committee<TAddr>,
+) -> Vec<Block<TAddr>> {
+    let mut parent_block = high_qc.as_leaf_block();
+    let mut current_height = high_qc.block_height() + NodeHeight(1);
+    debug!(
+        target: LOG_TARGET,
+        "🍼 calculating dummy blocks from {} to {}",
+        current_height,
+        new_height,
+    );
+    let num_blocks = new_height.saturating_sub(current_height).as_u64() as usize;
+    let mut blocks = Vec::with_capacity(num_blocks);
+    loop {
+        let leader = leader_strategy.get_leader(local_committee, current_height);
+        let dummy_block = Block::dummy_block(
+            *parent_block.block_id(),
+            leader.clone(),
+            current_height,
+            high_qc.clone(),
+            epoch,
+        );
+        parent_block = dummy_block.as_leaf_block();
+        blocks.push(dummy_block);
+
+        if current_height == new_height {
+            break;
+        }
+        current_height += NodeHeight(1);
+    }
+
+    blocks
+}
+
+#[derive(Debug)]
+pub struct BlockDecision(bool);
+
+impl BlockDecision {
+    pub fn vote_accept() -> Self {
+        Self(true)
+    }
+
+    pub fn is_accept(&self) -> bool {
+        self.0
+    }
+
+    pub fn as_quorum_decision(&self) -> Option<QuorumDecision> {
+        if self.0 {
+            Some(QuorumDecision::Accept)
+        } else {
+            None
+        }
+    }
+
+    pub fn dont_vote(&mut self) {
+        self.0 = false;
+    }
 }

--- a/dan_layer/consensus/src/hotstuff/error.rs
+++ b/dan_layer/consensus/src/hotstuff/error.rs
@@ -3,7 +3,7 @@
 
 use tari_dan_common_types::{Epoch, NodeHeight};
 use tari_dan_storage::{
-    consensus_models::{BlockId, LeafBlock, TransactionPoolError},
+    consensus_models::{BlockId, LeafBlock, LockedBlock, TransactionPoolError},
     StorageError,
 };
 use tari_epoch_manager::EpochManagerError;
@@ -42,8 +42,6 @@ pub enum HotStuffError {
     TransactionPoolError(#[from] TransactionPoolError),
     #[error("Transaction {transaction_id} does not exist")]
     TransactionDoesNotExist { transaction_id: TransactionId },
-    #[error("Received vote for unknown block {block_id} from {sent_by}")]
-    ReceivedVoteForUnknownBlock { block_id: BlockId, sent_by: String },
     #[error("Pacemaker channel dropped: {details}")]
     PacemakerChannelDropped { details: String },
     #[error(
@@ -118,6 +116,15 @@ pub enum ProposalValidationError {
     CandidateBlockNotHigherThanLeafBlock {
         proposed_by: String,
         leaf_block: LeafBlock,
+        candidate_block: LeafBlock,
+    },
+    #[error(
+        "Block {candidate_block} justify proposed by {proposed_by} is less than or equal to the current locked \
+         {locked_block}"
+    )]
+    CandidateBlockNotHigherThanLockedBlock {
+        proposed_by: String,
+        locked_block: LockedBlock,
         candidate_block: LeafBlock,
     },
 }

--- a/dan_layer/consensus/src/hotstuff/event.rs
+++ b/dan_layer/consensus/src/hotstuff/event.rs
@@ -7,7 +7,7 @@ use tari_dan_storage::consensus_models::BlockId;
 #[derive(Debug, Clone)]
 pub enum HotstuffEvent {
     /// A block has been committed
-    BlockCommitted { block_id: BlockId },
+    BlockCommitted { block_id: BlockId, height: NodeHeight },
     /// A critical failure occurred in consensus
     Failure { message: String },
     /// A leader has timed out

--- a/dan_layer/consensus/src/hotstuff/on_next_sync_view.rs
+++ b/dan_layer/consensus/src/hotstuff/on_next_sync_view.rs
@@ -10,7 +10,7 @@ use tari_epoch_manager::EpochManagerReader;
 use tokio::sync::mpsc;
 
 use crate::{
-    hotstuff::HotStuffError,
+    hotstuff::{common::calculate_dummy_blocks, HotStuffError},
     messages::{HotstuffMessage, NewViewMessage},
     traits::{ConsensusSpec, LeaderStrategy},
 };
@@ -44,9 +44,24 @@ impl<TConsensusSpec: ConsensusSpec> OnNextSyncViewHandler<TConsensusSpec> {
         let local_committee = self.epoch_manager.get_local_committee(epoch).await?;
         let current_epoch = self.epoch_manager.current_epoch().await?;
 
-        let high_qc = self
-            .store
-            .with_write_tx(|tx| HighQc::get(tx.deref_mut())?.get_quorum_certificate(tx.deref_mut()))?;
+        let high_qc = self.store.with_write_tx(|tx| {
+            let high_qc = HighQc::get(tx.deref_mut())?.get_quorum_certificate(tx.deref_mut())?;
+            let dummy_blocks = calculate_dummy_blocks(
+                current_epoch,
+                &high_qc,
+                new_height,
+                &self.leader_strategy,
+                &local_committee,
+            );
+            // Set the last voted block so that we do not vote on other conflicting blocks
+            let new_last_voted = dummy_blocks
+                .last()
+                .map(|b| b.as_last_voted())
+                .unwrap_or_else(|| high_qc.as_last_voted());
+            new_last_voted.set(tx)?;
+
+            Ok::<_, HotStuffError>(high_qc)
+        })?;
 
         let next_leader = self
             .leader_strategy
@@ -58,7 +73,7 @@ impl<TConsensusSpec: ConsensusSpec> OnNextSyncViewHandler<TConsensusSpec> {
             epoch: current_epoch,
         };
 
-        info!(target: LOG_TARGET, "🔥 Send NEWVIEW ({new_height}) to {next_leader}");
+        info!(target: LOG_TARGET, "🔥 Send NEWVIEW {new_height} to {next_leader}");
 
         self.tx_leader
             .send((next_leader.clone(), HotstuffMessage::NewView(message)))

--- a/dan_layer/consensus/src/hotstuff/worker.rs
+++ b/dan_layer/consensus/src/hotstuff/worker.rs
@@ -330,7 +330,8 @@ where
                 .is_leader_for_next_block(&self.validator_addr, &local_committee, leaf_block.height);
         info!(
             target: LOG_TARGET,
-            "🔥 [on_beat] Is leader: {:?}, leaf_block: {}, local_committee: {}, must_propose: {}",
+            "🔥 [on_beat] {} Is leader: {:?}, leaf_block: {}, local_committee: {}, must_propose: {}",
+            self.validator_addr,
             is_leader,
             leaf_block,
             local_committee

--- a/dan_layer/consensus/src/traits/leader_strategy.rs
+++ b/dan_layer/consensus/src/traits/leader_strategy.rs
@@ -25,13 +25,7 @@ use tari_dan_common_types::{committee::Committee, NodeAddressable, NodeHeight};
 pub trait LeaderStrategy<TAddr: NodeAddressable> {
     fn calculate_leader(&self, committee: &Committee<TAddr>, height: NodeHeight) -> u32;
 
-    fn is_leader(
-        &self,
-        validator_addr: &TAddr,
-        committee: &Committee<TAddr>,
-        // block: &BlockId,
-        height: NodeHeight,
-    ) -> bool {
+    fn is_leader(&self, validator_addr: &TAddr, committee: &Committee<TAddr>, height: NodeHeight) -> bool {
         let position = self.calculate_leader(committee, height);
         if let Some(vn) = committee.members.get(position as usize) {
             vn == validator_addr

--- a/dan_layer/consensus_tests/src/consensus.rs
+++ b/dan_layer/consensus_tests/src/consensus.rs
@@ -11,7 +11,7 @@
 use std::time::Duration;
 
 use tari_consensus::hotstuff::HotStuffError;
-use tari_dan_common_types::NodeHeight;
+use tari_dan_common_types::{Epoch, NodeHeight};
 use tari_dan_storage::{
     consensus_models::{BlockId, Decision},
     StateStore,
@@ -31,14 +31,14 @@ use crate::support::{
 
 // Although these tests will pass with a single thread, we enable multi threaded mode so that any unhandled race
 // conditions can be picked up, plus tests run a little quicker.
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn single_transaction() {
     setup_logger();
     let mut test = Test::builder().add_committee(0, vec!["1"]).start().await;
     // First get transaction in the mempool
     test.send_transaction_to_all(Decision::Commit, 1, 1).await;
     test.wait_until_new_pool_count(1).await;
-    test.network().start();
+    test.start_epoch(Epoch(0));
 
     loop {
         test.on_block_committed().await;
@@ -47,7 +47,7 @@ async fn single_transaction() {
             break;
         }
         let leaf = test.get_validator(&TestAddress::new("1")).get_leaf_block();
-        if leaf.height > NodeHeight(4) {
+        if leaf.height >= NodeHeight(10) {
             panic!("Not all transaction committed after {} blocks", leaf.height);
         }
     }
@@ -57,7 +57,7 @@ async fn single_transaction() {
     test.assert_clean_shutdown().await;
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn propose_blocks_with_queued_up_transactions_until_all_committed() {
     setup_logger();
     let mut test = Test::builder().add_committee(0, vec!["1"]).start().await;
@@ -66,7 +66,7 @@ async fn propose_blocks_with_queued_up_transactions_until_all_committed() {
         test.send_transaction_to_all(Decision::Commit, 1, 5).await;
     }
     test.wait_until_new_pool_count(10).await;
-    test.network().start();
+    test.start_epoch(Epoch(0));
 
     loop {
         test.on_block_committed().await;
@@ -84,30 +84,27 @@ async fn propose_blocks_with_queued_up_transactions_until_all_committed() {
     test.assert_clean_shutdown().await;
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn node_requests_missing_transaction_from_local_leader() {
     setup_logger();
-    let mut test = Test::builder()
-        .with_test_timeout(Duration::MAX)
-        .add_committee(0, vec!["1", "2"])
-        .start()
-        .await;
-    // First get all transactions in the mempool of node "1"
+    let mut test = Test::builder().add_committee(0, vec!["1", "2"]).start().await;
+    // First get all transactions in the mempool of node "2". We send to "2" because it is the leader for the next
+    // block. We could send to "1" but the test would have to wait for the block time to be hit and block 1 to be
+    // proposed before node "1" can propose block 2 with all the transactions.
     for _ in 0..10 {
-        test.send_transaction_to(&TestAddress::new("1"), Decision::Commit, 1, 5)
+        test.send_transaction_to(&TestAddress::new("2"), Decision::Commit, 1, 5)
             .await;
     }
-    test.wait_until_new_pool_count_for_vn(10, TestAddress::new("1")).await;
-    test.network().start();
+    test.wait_until_new_pool_count_for_vn(10, TestAddress::new("2")).await;
+    test.start_epoch(Epoch(0));
     loop {
-        test.on_block_committed().await;
+        let (_, committed_height) = test.on_block_committed().await;
 
         if test.is_transaction_pool_empty() {
             break;
         }
-        let leaf = test.get_validator(&TestAddress::new("1")).get_leaf_block();
-        if leaf.height > NodeHeight(10) {
-            panic!("Not all transaction committed after {} blocks", leaf.height);
+        if committed_height >= NodeHeight(10) {
+            panic!("Not all transaction committed after {} blocks", committed_height);
         }
     }
 
@@ -116,10 +113,22 @@ async fn node_requests_missing_transaction_from_local_leader() {
         .state_store
         .with_read_tx(|tx| {
             let mut block_id = BlockId::genesis();
-            while let Ok(block) = tx.blocks_get_by_parent(&block_id) {
-                let missing = tx.blocks_get_pending_transactions(block.id()).unwrap();
-                assert!(missing.is_empty());
-                block_id = *block.id();
+            loop {
+                let children = tx.blocks_get_all_by_parent(&block_id).unwrap();
+                if children.is_empty() {
+                    break;
+                }
+                if !block_id.is_genesis() {
+                    assert_eq!(children.len(), 1);
+                }
+                for block in children {
+                    if block.id().is_genesis() {
+                        continue;
+                    }
+                    let missing = tx.blocks_get_pending_transactions(block.id()).unwrap();
+                    assert!(missing.is_empty());
+                    block_id = *block.id();
+                }
             }
             Ok::<_, HotStuffError>(())
         })
@@ -130,12 +139,12 @@ async fn node_requests_missing_transaction_from_local_leader() {
     test.assert_clean_shutdown().await;
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn propose_blocks_with_new_transactions_until_all_committed() {
     setup_logger();
     let mut test = Test::builder().add_committee(0, vec!["1"]).start().await;
     let mut remaining_txs = 10;
-    test.network().start();
+    test.start_epoch(Epoch(0));
     loop {
         if remaining_txs > 0 {
             test.send_transaction_to_all(Decision::Commit, 1, 5).await;
@@ -156,7 +165,7 @@ async fn propose_blocks_with_new_transactions_until_all_committed() {
     test.assert_clean_shutdown().await;
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn multi_validator_propose_blocks_with_new_transactions_until_all_committed() {
     setup_logger();
     let mut test = Test::builder()
@@ -164,7 +173,7 @@ async fn multi_validator_propose_blocks_with_new_transactions_until_all_committe
         .start()
         .await;
     let mut remaining_txs = 10u32;
-    test.network().start();
+    test.start_epoch(Epoch(0));
     loop {
         if remaining_txs > 0 {
             test.send_transaction_to_all(Decision::Commit, 1, 5).await;
@@ -188,7 +197,7 @@ async fn multi_validator_propose_blocks_with_new_transactions_until_all_committe
     test.assert_clean_shutdown().await;
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn multi_shard_propose_blocks_with_new_transactions_until_all_committed() {
     setup_logger();
     let mut test = Test::builder()
@@ -202,7 +211,7 @@ async fn multi_shard_propose_blocks_with_new_transactions_until_all_committed() 
     }
 
     test.wait_all_have_at_least_n_new_transactions_in_pool(20).await;
-    test.network().start();
+    test.start_epoch(Epoch(0));
 
     loop {
         test.on_block_committed().await;
@@ -214,7 +223,7 @@ async fn multi_shard_propose_blocks_with_new_transactions_until_all_committed() 
         let leaf1 = test.get_validator(&TestAddress::new("1")).get_leaf_block();
         let leaf2 = test.get_validator(&TestAddress::new("4")).get_leaf_block();
         let leaf3 = test.get_validator(&TestAddress::new("7")).get_leaf_block();
-        if leaf1.height > NodeHeight(20) || leaf2.height > NodeHeight(20) || leaf3.height > NodeHeight(20) {
+        if leaf1.height > NodeHeight(30) || leaf2.height > NodeHeight(30) || leaf3.height > NodeHeight(30) {
             panic!(
                 "Not all transaction committed after {}/{}/{} blocks",
                 leaf1.height, leaf2.height, leaf3.height
@@ -229,11 +238,10 @@ async fn multi_shard_propose_blocks_with_new_transactions_until_all_committed() 
     test.assert_clean_shutdown().await;
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn foreign_shard_decides_to_abort() {
     setup_logger();
     let mut test = Test::builder()
-        .with_test_timeout(Duration::from_secs(20))
         .add_committee(0, vec!["1", "3", "4"])
         .add_committee(1, vec!["2", "5", "6"])
         .start()
@@ -250,7 +258,7 @@ async fn foreign_shard_decides_to_abort() {
     assert_eq!(tx1.id(), tx2.id());
 
     test.wait_all_have_at_least_n_new_transactions_in_pool(1).await;
-    test.network().start();
+    test.start_epoch(Epoch(0));
 
     loop {
         test.on_block_committed().await;
@@ -261,7 +269,7 @@ async fn foreign_shard_decides_to_abort() {
 
         let leaf1 = test.get_validator(&TestAddress::new("1")).get_leaf_block();
         let leaf2 = test.get_validator(&TestAddress::new("2")).get_leaf_block();
-        if leaf1.height > NodeHeight(10) || leaf2.height > NodeHeight(10) {
+        if leaf1.height > NodeHeight(40) || leaf2.height > NodeHeight(40) {
             panic!(
                 "Not all transaction committed after {}/{} blocks",
                 leaf1.height, leaf2.height,
@@ -278,7 +286,7 @@ async fn foreign_shard_decides_to_abort() {
     test.assert_clean_shutdown().await;
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn leader_failure_output_conflict() {
     setup_logger();
     let mut test = Test::builder()
@@ -307,7 +315,7 @@ async fn leader_failure_output_conflict() {
         .await;
 
     test.wait_all_have_at_least_n_new_transactions_in_pool(2).await;
-    test.network().start();
+    test.start_epoch(Epoch(0));
 
     loop {
         test.on_block_committed().await;
@@ -318,7 +326,7 @@ async fn leader_failure_output_conflict() {
 
         let leaf1 = test.get_validator(&TestAddress::new("1")).get_leaf_block();
         let leaf2 = test.get_validator(&TestAddress::new("2")).get_leaf_block();
-        if leaf1.height > NodeHeight(10) || leaf2.height > NodeHeight(10) {
+        if leaf1.height > NodeHeight(30) || leaf2.height > NodeHeight(30) {
             panic!(
                 "Not all transaction committed after {}/{} blocks",
                 leaf1.height, leaf2.height,
@@ -332,6 +340,58 @@ async fn leader_failure_output_conflict() {
     test.assert_all_validators_have_decision(sorted_tx_ids[1], Decision::Abort)
         .await;
     test.assert_all_validators_committed();
+
+    log::info!("total messages sent: {}", test.network().total_messages_sent());
+    test.assert_clean_shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn leader_failure_node_goes_down() {
+    setup_logger();
+    let mut test = Test::builder()
+        .with_test_timeout(Duration::from_secs(60))
+        .add_committee(0, vec!["1", "2", "3", "4", "5"])
+        .start()
+        .await;
+
+    let failure_node = TestAddress::new("2");
+
+    for _ in 0..10 {
+        test.send_transaction_to_all(Decision::Commit, 1, 2).await;
+    }
+    test.wait_all_have_at_least_n_new_transactions_in_pool(10).await;
+    test.start_epoch(Epoch(0));
+
+    loop {
+        let (_, committed_height) = test.on_block_committed().await;
+
+        if committed_height == NodeHeight(1) {
+            log::info!("😴 Node 2 goes offline");
+            test.network()
+                .go_offline(TestNetworkDestination::Address(failure_node.clone()))
+                .await;
+        }
+
+        if test.validators().filter(|vn| vn.address != failure_node).all(|v| {
+            let c = v.get_transaction_pool_count();
+            log::info!("{} has {} transactions in pool", v.address, c);
+            c == 0
+        }) {
+            break;
+        }
+
+        if committed_height > NodeHeight(20) {
+            panic!("Not all transaction committed after {} blocks", committed_height);
+        }
+    }
+
+    test.assert_all_validators_at_same_height_except(&[failure_node.clone()])
+        .await;
+
+    assert!(test
+        .validators()
+        .filter(|vn| vn.address != failure_node)
+        .all(|v| v.state_manager().is_committed()));
 
     log::info!("total messages sent: {}", test.network().total_messages_sent());
     test.assert_clean_shutdown().await;

--- a/dan_layer/consensus_tests/src/support/harness.rs
+++ b/dan_layer/consensus_tests/src/support/harness.rs
@@ -328,7 +328,6 @@ impl TestBuilder {
             .await
             .into_iter()
             .map(|(address, bucket, shard)| {
-                let leader_strategy = leader_strategy.clone();
                 let sql_address = self.sql_address.replace("{}", &address.0);
                 let (channels, validator) = Validator::builder()
                     .with_sql_url(sql_address)
@@ -336,7 +335,7 @@ impl TestBuilder {
                     .with_shard(shard)
                     .with_bucket(bucket)
                     .with_epoch_manager(epoch_manager.clone_for(address.clone(), shard))
-                    .with_leader_strategy(leader_strategy)
+                    .with_leader_strategy(*leader_strategy)
                     .spawn(shutdown_signal.clone());
                 (channels, (address, validator))
             })

--- a/dan_layer/consensus_tests/src/support/leader_strategy.rs
+++ b/dan_layer/consensus_tests/src/support/leader_strategy.rs
@@ -1,47 +1,19 @@
 //   Copyright 2023 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use std::sync::{
-    atomic::{AtomicU32, Ordering},
-    Arc,
-};
-
 use tari_consensus::traits::LeaderStrategy;
 use tari_dan_common_types::{committee::Committee, NodeAddressable, NodeHeight};
 
-use crate::support::address::TestAddress;
-
-pub struct AlwaysFirstLeader;
-
-impl<TAddr: NodeAddressable> LeaderStrategy<TAddr> for AlwaysFirstLeader {
-    fn calculate_leader(&self, _committee: &Committee<TAddr>, _height: NodeHeight) -> u32 {
-        0
+#[derive(Debug, Clone, Copy, Default)]
+pub struct RoundRobinLeaderStrategy;
+impl RoundRobinLeaderStrategy {
+    pub fn new() -> Self {
+        Self
     }
 }
 
-#[derive(Debug, Clone)]
-pub struct SelectedIndexLeaderStrategy(Arc<AtomicU32>);
-
-impl SelectedIndexLeaderStrategy {
-    pub fn new(index: u32) -> Self {
-        Self(Arc::new(AtomicU32::new(index)))
-    }
-
-    #[allow(dead_code)]
-    pub fn set_index(&self, index: u32) {
-        self.0.store(index, Ordering::SeqCst);
-    }
-}
-
-impl LeaderStrategy<TestAddress> for SelectedIndexLeaderStrategy {
-    fn calculate_leader(&self, committee: &Committee<TestAddress>, _height: NodeHeight) -> u32 {
-        let index = self.0.load(Ordering::SeqCst);
-        assert!(
-            (index as usize) < committee.len(),
-            "SelectedIndexLeaderStrategy index out of bounds index={} len={}",
-            index,
-            committee.len()
-        );
-        index
+impl<TAddr: NodeAddressable> LeaderStrategy<TAddr> for RoundRobinLeaderStrategy {
+    fn calculate_leader(&self, committee: &Committee<TAddr>, height: NodeHeight) -> u32 {
+        (height.0 % committee.members.len() as u64) as u32
     }
 }

--- a/dan_layer/consensus_tests/src/support/logging.rs
+++ b/dan_layer/consensus_tests/src/support/logging.rs
@@ -2,13 +2,17 @@
 //   SPDX-License-Identifier: BSD-3-Clause
 
 pub fn setup_logger() {
+    if option_env!("CI").is_some() {
+        return;
+    }
+
     let _ignore = fern::Dispatch::new()
         // Perform allocation-free log formatting
         .format(|out, message, record| {
             out.finish(format_args!(
                 "{} [{}] {} {}",
                 humantime::format_rfc3339(std::time::SystemTime::now()),
-                record.target().strip_prefix("tari::dan::consensus::hotstuff").unwrap_or(record.target()),
+                record.target().strip_prefix("tari::dan::consensus::hotstuff::").unwrap_or(record.target()),
                 record.level(),
                 message
             ))

--- a/dan_layer/consensus_tests/src/support/spec.rs
+++ b/dan_layer/consensus_tests/src/support/spec.rs
@@ -9,7 +9,7 @@ use crate::support::{
     epoch_manager::TestEpochManager,
     signing_service::TestVoteSignatureService,
     NoopStateManager,
-    SelectedIndexLeaderStrategy,
+    RoundRobinLeaderStrategy,
 };
 
 pub struct TestConsensusSpec;
@@ -17,7 +17,7 @@ pub struct TestConsensusSpec;
 impl ConsensusSpec for TestConsensusSpec {
     type Addr = TestAddress;
     type EpochManager = TestEpochManager;
-    type LeaderStrategy = SelectedIndexLeaderStrategy;
+    type LeaderStrategy = RoundRobinLeaderStrategy;
     type StateManager = NoopStateManager;
     type StateStore = SqliteStateStore<Self::Addr>;
     type VoteSignatureService = TestVoteSignatureService<Self::Addr>;

--- a/dan_layer/consensus_tests/src/support/validator/builder.rs
+++ b/dan_layer/consensus_tests/src/support/validator/builder.rs
@@ -91,7 +91,7 @@ impl ValidatorBuilder {
             store.clone(),
             rx_epoch_events,
             self.epoch_manager.clone_for(self.address.clone(), self.shard),
-            self.leader_strategy.clone(),
+            self.leader_strategy,
             signing_service,
             noop_state_manager.clone(),
             transaction_pool,
@@ -123,7 +123,7 @@ impl ValidatorBuilder {
             epoch_manager: self.epoch_manager.clone_for(self.address.clone(), self.shard),
             tx_epoch_events,
             state_manager: noop_state_manager,
-            leader_strategy: self.leader_strategy.clone(),
+            leader_strategy: self.leader_strategy,
             events: tx_events.subscribe(),
             handle,
         };

--- a/dan_layer/consensus_tests/src/support/validator/builder.rs
+++ b/dan_layer/consensus_tests/src/support/validator/builder.rs
@@ -2,9 +2,8 @@
 //   SPDX-License-Identifier: BSD-3-Clause
 
 use tari_consensus::hotstuff::HotstuffWorker;
-use tari_dan_common_types::{shard_bucket::ShardBucket, Epoch, ShardId};
+use tari_dan_common_types::{shard_bucket::ShardBucket, ShardId};
 use tari_dan_storage::consensus_models::TransactionPool;
-use tari_epoch_manager::EpochManagerEvent;
 use tari_shutdown::ShutdownSignal;
 use tari_state_store_sqlite::SqliteStateStore;
 use tokio::sync::{broadcast, mpsc};
@@ -14,7 +13,7 @@ use crate::support::{
     epoch_manager::TestEpochManager,
     signing_service::TestVoteSignatureService,
     NoopStateManager,
-    SelectedIndexLeaderStrategy,
+    RoundRobinLeaderStrategy,
     TestConsensusSpec,
     Validator,
     ValidatorChannels,
@@ -25,7 +24,7 @@ pub struct ValidatorBuilder {
     pub shard: ShardId,
     pub bucket: ShardBucket,
     pub sql_url: String,
-    pub leader_strategy: SelectedIndexLeaderStrategy,
+    pub leader_strategy: RoundRobinLeaderStrategy,
     pub epoch_manager: TestEpochManager,
 }
 
@@ -36,7 +35,7 @@ impl ValidatorBuilder {
             shard: ShardId::zero(),
             bucket: ShardBucket::from(0),
             sql_url: ":memory".to_string(),
-            leader_strategy: SelectedIndexLeaderStrategy::new(0),
+            leader_strategy: RoundRobinLeaderStrategy::new(),
             epoch_manager: TestEpochManager::new(),
         }
     }
@@ -66,7 +65,7 @@ impl ValidatorBuilder {
         self
     }
 
-    pub fn with_leader_strategy(&mut self, leader_strategy: SelectedIndexLeaderStrategy) -> &mut Self {
+    pub fn with_leader_strategy(&mut self, leader_strategy: RoundRobinLeaderStrategy) -> &mut Self {
         self.leader_strategy = leader_strategy;
         self
     }
@@ -116,9 +115,6 @@ impl ValidatorBuilder {
             rx_leader,
             rx_mempool,
         };
-
-        // Fire off initial epoch change event so that the pacemaker starts
-        tx_epoch_events.send(EpochManagerEvent::EpochChanged(Epoch(0))).unwrap();
 
         let validator = Validator {
             address: self.address.clone(),

--- a/dan_layer/consensus_tests/src/support/validator/instance.rs
+++ b/dan_layer/consensus_tests/src/support/validator/instance.rs
@@ -16,7 +16,7 @@ use crate::support::{
     address::TestAddress,
     epoch_manager::TestEpochManager,
     NoopStateManager,
-    SelectedIndexLeaderStrategy,
+    RoundRobinLeaderStrategy,
     ValidatorBuilder,
 };
 
@@ -38,7 +38,7 @@ pub struct Validator {
 
     pub state_store: SqliteStateStore<TestAddress>,
     pub epoch_manager: TestEpochManager,
-    pub leader_strategy: SelectedIndexLeaderStrategy,
+    pub leader_strategy: RoundRobinLeaderStrategy,
     pub events: broadcast::Receiver<HotstuffEvent>,
     pub tx_epoch_events: broadcast::Sender<EpochManagerEvent>,
     pub state_manager: NoopStateManager,
@@ -52,7 +52,7 @@ impl Validator {
     }
 
     #[allow(dead_code)]
-    pub fn leader_strategy(&self) -> &SelectedIndexLeaderStrategy {
+    pub fn leader_strategy(&self) -> &RoundRobinLeaderStrategy {
         &self.leader_strategy
     }
 

--- a/dan_layer/state_store_sqlite/migrations/2023-06-08-091819_create_state_store/up.sql
+++ b/dan_layer/state_store_sqlite/migrations/2023-06-08-091819_create_state_store/up.sql
@@ -24,7 +24,8 @@ create table blocks
     command_count    bigint    not NULL,
     commands         text      not NULL,
     total_leader_fee bigint    not NULL,
-    is_committed     boolean   not NULL,
+    is_committed     boolean   not NULL default '0',
+    is_processed     boolean   not NULL,
     is_dummy         boolean   not NULL,
     created_at       timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (qc_id) REFERENCES quorum_certificates (qc_id)
@@ -87,8 +88,7 @@ create table last_voted
     id         integer   not null primary key autoincrement,
     block_id   text      not null,
     height     bigint    not null,
-    created_at timestamp NOT NULL default current_timestamp,
-    FOREIGN KEY (block_id) REFERENCES blocks (block_id)
+    created_at timestamp NOT NULL default current_timestamp
 );
 
 create table last_executed
@@ -158,6 +158,20 @@ create table transaction_pool
 );
 create unique index transaction_pool_uniq_idx_transaction_id on transaction_pool (transaction_id);
 create index transaction_pool_idx_is_ready on transaction_pool (is_ready);
+
+create table transaction_pool_status
+(
+    id             integer   not null primary key AUTOINCREMENT,
+    block_id       text      not null,
+    block_height   bigint    not null,
+    transaction_id text      not null,
+    stage          text      not null,
+    is_ready       boolean   not null,
+    created_at     timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (block_id) REFERENCES blocks (block_id),
+    FOREIGN KEY (transaction_id) REFERENCES transactions (transaction_id)
+);
+create index transaction_pool_idx_block_id_transaction_id on transaction_pool_status (block_id, transaction_id);
 
 create table locked_outputs
 (

--- a/dan_layer/state_store_sqlite/src/reader.rs
+++ b/dan_layer/state_store_sqlite/src/reader.rs
@@ -7,6 +7,7 @@ use bigdecimal::{BigDecimal, ToPrimitive};
 use diesel::{
     sql_query,
     sql_types::Text,
+    BoolExpressionMethods,
     ExpressionMethods,
     JoinOnDsl,
     NullableExpressionMethods,
@@ -299,29 +300,34 @@ impl<TAddr: NodeAddressable + Serialize + DeserializeOwned> StateStoreReadTransa
         block.try_convert(qc)
     }
 
-    fn blocks_get_by_parent(&mut self, parent_id: &BlockId) -> Result<Block<TAddr>, StorageError> {
+    fn blocks_get_all_by_parent(&mut self, parent_id: &BlockId) -> Result<Vec<Block<TAddr>>, StorageError> {
         use crate::schema::{blocks, quorum_certificates};
 
-        let (block, qc) = blocks::table
+        let results = blocks::table
             .left_join(quorum_certificates::table.on(blocks::qc_id.eq(quorum_certificates::qc_id)))
             .select((blocks::all_columns, quorum_certificates::all_columns.nullable()))
             .filter(blocks::parent_block_id.eq(serialize_hex(parent_id)))
             .filter(blocks::block_id.ne(blocks::parent_block_id)) // Exclude the genesis block
-            .first::<(sql_models::Block, Option<sql_models::QuorumCertificate>)>(self.connection())
+            .get_results::<(sql_models::Block, Option<sql_models::QuorumCertificate>)>(self.connection())
             .map_err(|e| SqliteStorageError::DieselError {
                 operation: "blocks_get_by_parent",
                 source: e,
             })?;
 
-        let qc = qc.ok_or_else(|| SqliteStorageError::DbInconsistency {
-            operation: "blocks_get_by_parent",
-            details: format!(
-                "block {} references non-existent quorum certificate {}",
-                parent_id, block.qc_id
-            ),
-        })?;
+        results
+            .into_iter()
+            .map(|(block, qc)| {
+                let qc = qc.ok_or_else(|| SqliteStorageError::DbInconsistency {
+                    operation: "blocks_get_by_parent",
+                    details: format!(
+                        "block {} references non-existent quorum certificate {}",
+                        parent_id, block.qc_id
+                    ),
+                })?;
 
-        block.try_convert(qc)
+                block.try_convert(qc)
+            })
+            .collect()
     }
 
     fn blocks_exists(&mut self, block_id: &BlockId) -> Result<bool, StorageError> {
@@ -612,7 +618,13 @@ impl<TAddr: NodeAddressable + Serialize + DeserializeOwned> StateStoreReadTransa
 
         let mut query = transaction_pool::table.into_boxed();
         if let Some(stage) = stage {
-            query = query.filter(transaction_pool::stage.eq(stage.to_string()));
+            query = query.filter(
+                transaction_pool::pending_stage
+                    .eq(stage.to_string())
+                    .or(transaction_pool::pending_stage
+                        .is_null()
+                        .and(transaction_pool::stage.eq(stage.to_string()))),
+            );
         }
         if let Some(is_ready) = is_ready {
             query = query.filter(transaction_pool::is_ready.eq(is_ready));

--- a/dan_layer/state_store_sqlite/src/schema.rs
+++ b/dan_layer/state_store_sqlite/src/schema.rs
@@ -22,6 +22,7 @@ diesel::table! {
         commands -> Text,
         total_leader_fee -> BigInt,
         is_committed -> Bool,
+        is_processed -> Bool,
         is_dummy -> Bool,
         created_at -> Timestamp,
     }
@@ -157,6 +158,18 @@ diesel::table! {
 }
 
 diesel::table! {
+    transaction_pool_status (id) {
+        id -> Integer,
+        block_id -> Text,
+        block_height -> BigInt,
+        transaction_id -> Text,
+        stage -> Text,
+        is_ready -> Bool,
+        created_at -> Timestamp,
+    }
+}
+
+diesel::table! {
     transactions (id) {
         id -> Integer,
         transaction_id -> Text,
@@ -204,6 +217,7 @@ diesel::allow_tables_to_appear_in_same_query!(
     quorum_certificates,
     substates,
     transaction_pool,
+    transaction_pool_status,
     transactions,
     votes,
 );

--- a/dan_layer/state_store_sqlite/src/sql_models/block.rs
+++ b/dan_layer/state_store_sqlite/src/sql_models/block.rs
@@ -25,6 +25,7 @@ pub struct Block {
     pub commands: String,
     pub total_leader_fees: i64,
     pub is_committed: bool,
+    pub is_processed: bool,
     pub is_dummy: bool,
     pub created_at: PrimitiveDateTime,
 }
@@ -48,6 +49,7 @@ impl Block {
             deserialize_json(&self.commands)?,
             self.total_leader_fees as u64,
             self.is_dummy,
+            self.is_processed,
         ))
     }
 }

--- a/dan_layer/state_store_sqlite/src/sql_models/transaction_pool.rs
+++ b/dan_layer/state_store_sqlite/src/sql_models/transaction_pool.rs
@@ -45,3 +45,14 @@ impl TryFrom<TransactionPoolRecord> for consensus_models::TransactionPoolRecord 
         ))
     }
 }
+
+#[derive(Debug, Clone, Queryable)]
+pub struct TransactionPoolState {
+    pub id: i32,
+    pub block_id: String,
+    pub block_height: i64,
+    pub transaction_id: String,
+    pub stage: String,
+    pub is_ready: bool,
+    pub created_at: PrimitiveDateTime,
+}

--- a/dan_layer/storage/src/consensus_models/command.rs
+++ b/dan_layer/storage/src/consensus_models/command.rs
@@ -76,6 +76,10 @@ pub struct TransactionAtom {
 }
 
 impl TransactionAtom {
+    pub fn id(&self) -> &TransactionId {
+        &self.id
+    }
+
     pub fn get_transaction<TTx: StateStoreReadTransaction>(
         &self,
         tx: &mut TTx,

--- a/dan_layer/storage/src/consensus_models/last_proposed.rs
+++ b/dan_layer/storage/src/consensus_models/last_proposed.rs
@@ -18,4 +18,8 @@ impl LastProposed {
     pub fn set<TTx: StateStoreWriteTransaction>(&self, tx: &mut TTx) -> Result<(), StorageError> {
         tx.last_proposed_set(self)
     }
+
+    pub fn unset<TTx: StateStoreWriteTransaction>(&self, tx: &mut TTx) -> Result<(), StorageError> {
+        tx.last_proposed_unset(self)
+    }
 }

--- a/dan_layer/storage/src/consensus_models/last_voted.rs
+++ b/dan_layer/storage/src/consensus_models/last_voted.rs
@@ -18,4 +18,8 @@ impl LastVoted {
     pub fn set<TTx: StateStoreWriteTransaction>(&self, tx: &mut TTx) -> Result<(), StorageError> {
         tx.last_voted_set(self)
     }
+
+    pub fn unset<TTx: StateStoreWriteTransaction>(&self, tx: &mut TTx) -> Result<(), StorageError> {
+        tx.last_votes_unset(self)
+    }
 }

--- a/dan_layer/storage/src/consensus_models/leaf_block.rs
+++ b/dan_layer/storage/src/consensus_models/leaf_block.rs
@@ -67,6 +67,10 @@ impl LeafBlock {
         tx.leaf_block_set(self)
     }
 
+    pub fn unset<TTx: StateStoreWriteTransaction>(&self, tx: &mut TTx) -> Result<(), StorageError> {
+        tx.leaf_block_unset(self)
+    }
+
     pub fn get_block<TTx: StateStoreReadTransaction>(&self, tx: &mut TTx) -> Result<Block<TTx::Addr>, StorageError> {
         tx.blocks_get(&self.block_id)
     }

--- a/dan_layer/storage/src/consensus_models/locked_block.rs
+++ b/dan_layer/storage/src/consensus_models/locked_block.rs
@@ -1,6 +1,8 @@
 //   Copyright 2023 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
+use std::fmt::Display;
+
 use tari_dan_common_types::NodeHeight;
 
 use crate::{
@@ -37,5 +39,11 @@ impl LockedBlock {
 
     pub fn set<TTx: StateStoreWriteTransaction>(&self, tx: &mut TTx) -> Result<(), StorageError> {
         tx.locked_block_set(self)
+    }
+}
+
+impl Display for LockedBlock {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "LockedBlock({}, {})", self.height, self.block_id)
     }
 }

--- a/dan_layer/storage/src/consensus_models/quorum_certificate.rs
+++ b/dan_layer/storage/src/consensus_models/quorum_certificate.rs
@@ -21,7 +21,7 @@ use tari_dan_common_types::{
 use tari_mmr::MergedBalancedBinaryMerkleProof;
 
 use crate::{
-    consensus_models::{Block, BlockId, HighQc, LeafBlock, QuorumDecision, ValidatorSignature},
+    consensus_models::{Block, BlockId, HighQc, LastVoted, LeafBlock, QuorumDecision, ValidatorSignature},
     StateStoreReadTransaction,
     StateStoreWriteTransaction,
     StorageError,
@@ -142,6 +142,13 @@ impl<TAddr> QuorumCertificate<TAddr> {
 
     pub fn as_leaf_block(&self) -> LeafBlock {
         LeafBlock {
+            block_id: self.block_id,
+            height: self.block_height,
+        }
+    }
+
+    pub fn as_last_voted(&self) -> LastVoted {
+        LastVoted {
             block_id: self.block_id,
             height: self.block_height,
         }

--- a/dan_layer/storage/src/consensus_models/transaction_pool.rs
+++ b/dan_layer/storage/src/consensus_models/transaction_pool.rs
@@ -372,18 +372,15 @@ impl TransactionPoolRecord {
     ) -> Result<(), TransactionPoolError> {
         // Check that only permitted stage transactions are performed
         match ((self.current_stage(), pending_stage), is_ready) {
-            ((TransactionPoolStage::New, TransactionPoolStage::Prepared), false) |
-            ((TransactionPoolStage::Prepared, TransactionPoolStage::Prepared), true) |
+            ((TransactionPoolStage::New, TransactionPoolStage::Prepared), true) |
             ((TransactionPoolStage::Prepared, TransactionPoolStage::LocalPrepared), _) |
-            ((TransactionPoolStage::LocalPrepared, TransactionPoolStage::LocalPrepared), _) |
+            ((TransactionPoolStage::LocalPrepared, TransactionPoolStage::LocalPrepared), true) |
             ((TransactionPoolStage::LocalPrepared, TransactionPoolStage::AllPrepared), false) |
             ((TransactionPoolStage::LocalPrepared, TransactionPoolStage::SomePrepared), false) |
-            ((TransactionPoolStage::AllPrepared, TransactionPoolStage::SomePrepared), false) |
-            ((TransactionPoolStage::SomePrepared, TransactionPoolStage::SomePrepared), false) |
-            ((TransactionPoolStage::AllPrepared, TransactionPoolStage::AllPrepared), false) => {},
+            ((TransactionPoolStage::AllPrepared, TransactionPoolStage::SomePrepared), false) => {},
             _ => {
                 return Err(TransactionPoolError::InvalidTransactionTransition {
-                    from: self.current_stage(),
+                    from: self.stage,
                     to: pending_stage,
                     is_ready,
                 })

--- a/dan_layer/storage/src/consensus_models/transaction_pool.rs
+++ b/dan_layer/storage/src/consensus_models/transaction_pool.rs
@@ -5,9 +5,11 @@ use std::{
     fmt::{Display, Formatter},
     marker::PhantomData,
     num::NonZeroU64,
+    ops::DerefMut,
     str::FromStr,
 };
 
+use log::*;
 use tari_dan_common_types::{
     committee::CommitteeShard,
     optional::{IsNotFoundError, Optional},
@@ -15,12 +17,14 @@ use tari_dan_common_types::{
 use tari_transaction::TransactionId;
 
 use crate::{
-    consensus_models::{Decision, QcId, TransactionAtom},
+    consensus_models::{Block, Command, Decision, QcId, TransactionAtom},
     StateStore,
     StateStoreReadTransaction,
     StateStoreWriteTransaction,
     StorageError,
 };
+
+const LOG_TARGET: &str = "tari::dan::storage::transaction_pool";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TransactionPoolStage {
@@ -153,18 +157,26 @@ impl<TStateStore: StateStore> TransactionPool<TStateStore> {
         &self,
         tx: &mut TStateStore::ReadTransaction<'_>,
     ) -> Result<bool, TransactionPoolError> {
-        let count = tx.transaction_pool_count(None, Some(true))?;
+        let count = tx.transaction_pool_count(None, None)?;
         if count > 0 {
             return Ok(true);
         }
-        let count = tx.transaction_pool_count(Some(TransactionPoolStage::AllPrepared), None)?;
-        if count > 0 {
-            return Ok(true);
-        }
-        let count = tx.transaction_pool_count(Some(TransactionPoolStage::SomePrepared), None)?;
-        if count > 0 {
-            return Ok(true);
-        }
+        // let count = tx.transaction_pool_count(Some(TransactionPoolStage::Prepared), None)?;
+        // if count > 0 {
+        //     return Ok(true);
+        // }
+        // let count = tx.transaction_pool_count(Some(TransactionPoolStage::LocalPrepared), None)?;
+        // if count > 0 {
+        //     return Ok(true);
+        // }
+        // let count = tx.transaction_pool_count(Some(TransactionPoolStage::AllPrepared), None)?;
+        // if count > 0 {
+        //     return Ok(true);
+        // }
+        // let count = tx.transaction_pool_count(Some(TransactionPoolStage::SomePrepared), None)?;
+        // if count > 0 {
+        //     return Ok(true);
+        // }
         Ok(count > 0)
     }
 
@@ -173,22 +185,55 @@ impl<TStateStore: StateStore> TransactionPool<TStateStore> {
         Ok(count)
     }
 
-    pub fn confirm_all_transitions<'a, TTx: StateStoreWriteTransaction, I: IntoIterator<Item = &'a TransactionId>>(
+    pub fn confirm_all_transitions<'a, I: IntoIterator<Item = &'a TransactionId>>(
         &self,
-        tx: &mut TTx,
+        tx: &mut TStateStore::WriteTransaction<'_>,
         tx_ids: I,
     ) -> Result<(), TransactionPoolError> {
         tx.transaction_pool_set_all_transitions(tx_ids)?;
         Ok(())
     }
 
-    pub fn clear_pending_stages<'a, TTx: StateStoreWriteTransaction, I: IntoIterator<Item = &'a TransactionId>>(
+    pub fn rollback_pending_stages(
         &self,
-        tx: &mut TTx,
-        tx_ids: I,
+        tx: &mut TStateStore::WriteTransaction<'_>,
+        block: &Block<TStateStore::Addr>,
     ) -> Result<(), TransactionPoolError> {
-        for tx_id in tx_ids {
-            tx.transaction_pool_update(tx_id, None, Some(None), None, None, None)?;
+        for cmd in block.commands() {
+            let transaction = self.get(tx.deref_mut(), cmd.transaction_id())?;
+
+            debug!(
+                target: LOG_TARGET,
+                "↩️ Rolling back pending stage for transaction {} from {:?} ",
+                cmd.transaction_id(),
+                transaction.pending_stage,
+            );
+            match cmd {
+                Command::Prepare(t) => {
+                    tx.transaction_pool_update(t.id(), None, Some(None), None, None, Some(true))?;
+                },
+                Command::LocalPrepared(t) => {
+                    // TODO: We can never go back from <LocalPrepared, true> to Prepared
+                    tx.transaction_pool_update(
+                        t.id(),
+                        None,
+                        Some(Some(TransactionPoolStage::Prepared)),
+                        None,
+                        None,
+                        Some(true),
+                    )?;
+                },
+                Command::Accept(t) => {
+                    tx.transaction_pool_update(
+                        t.id(),
+                        None,
+                        Some(Some(TransactionPoolStage::LocalPrepared)),
+                        None,
+                        None,
+                        Some(true),
+                    )?;
+                },
+            }
         }
         Ok(())
     }
@@ -224,8 +269,8 @@ impl TransactionPoolRecord {
     }
 
     pub fn current_decision(&self) -> Decision {
-        self.local_decision()
-            .or_else(|| self.remote_decision())
+        self.remote_decision()
+            .or_else(|| self.local_decision())
             .unwrap_or(self.original_decision())
     }
 
@@ -327,15 +372,18 @@ impl TransactionPoolRecord {
     ) -> Result<(), TransactionPoolError> {
         // Check that only permitted stage transactions are performed
         match ((self.current_stage(), pending_stage), is_ready) {
-            ((TransactionPoolStage::New, TransactionPoolStage::Prepared), true) |
+            ((TransactionPoolStage::New, TransactionPoolStage::Prepared), false) |
+            ((TransactionPoolStage::Prepared, TransactionPoolStage::Prepared), true) |
             ((TransactionPoolStage::Prepared, TransactionPoolStage::LocalPrepared), _) |
-            ((TransactionPoolStage::LocalPrepared, TransactionPoolStage::LocalPrepared), true) |
+            ((TransactionPoolStage::LocalPrepared, TransactionPoolStage::LocalPrepared), _) |
             ((TransactionPoolStage::LocalPrepared, TransactionPoolStage::AllPrepared), false) |
             ((TransactionPoolStage::LocalPrepared, TransactionPoolStage::SomePrepared), false) |
-            ((TransactionPoolStage::AllPrepared, TransactionPoolStage::SomePrepared), false) => {},
+            ((TransactionPoolStage::AllPrepared, TransactionPoolStage::SomePrepared), false) |
+            ((TransactionPoolStage::SomePrepared, TransactionPoolStage::SomePrepared), false) |
+            ((TransactionPoolStage::AllPrepared, TransactionPoolStage::AllPrepared), false) => {},
             _ => {
                 return Err(TransactionPoolError::InvalidTransactionTransition {
-                    from: self.stage,
+                    from: self.current_stage(),
                     to: pending_stage,
                     is_ready,
                 })
@@ -355,23 +403,13 @@ impl TransactionPoolRecord {
         Ok(())
     }
 
-    pub fn set_pending_stage<TTx: StateStoreWriteTransaction>(
-        &mut self,
-        tx: &mut TTx,
-        pending_stage: TransactionPoolStage,
-    ) -> Result<(), TransactionPoolError> {
-        self.pending_stage = Some(pending_stage);
-        tx.transaction_pool_update(&self.transaction.id, None, Some(Some(pending_stage)), None, None, None)?;
-        Ok(())
-    }
-
     pub fn update_remote_decision<TTx: StateStoreWriteTransaction>(
         &mut self,
         tx: &mut TTx,
         decision: Decision,
     ) -> Result<(), TransactionPoolError> {
-        self.set_remote_decision(decision);
         tx.transaction_pool_update(&self.transaction.id, None, None, None, Some(decision), None)?;
+        self.set_remote_decision(decision);
         Ok(())
     }
 
@@ -380,8 +418,10 @@ impl TransactionPoolRecord {
         tx: &mut TTx,
         decision: Decision,
     ) -> Result<(), TransactionPoolError> {
-        self.set_local_decision(decision);
-        tx.transaction_pool_update(&self.transaction.id, None, None, Some(decision), None, None)?;
+        if self.local_decision.map(|d| d != decision).unwrap_or(true) {
+            self.set_local_decision(decision);
+            tx.transaction_pool_update(&self.transaction.id, None, None, Some(decision), None, None)?;
+        }
         Ok(())
     }
 

--- a/dan_layer/storage/src/error.rs
+++ b/dan_layer/storage/src/error.rs
@@ -20,7 +20,7 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::{io, sync::PoisonError};
+use std::io;
 
 use tari_common_types::types::FixedHashSizeError;
 use tari_dan_common_types::optional::IsNotFoundError;
@@ -70,16 +70,8 @@ pub enum StorageError {
 
     #[error("General storage error: {details}")]
     General { details: String },
-    #[error("Lock error")]
-    LockError,
     #[error("Error converting substate type: {substate_type}")]
     InvalidSubStateType { substate_type: String },
-}
-
-impl<T> From<PoisonError<T>> for StorageError {
-    fn from(_err: PoisonError<T>) -> Self {
-        Self::LockError
-    }
 }
 
 impl IsNotFoundError for StorageError {

--- a/dan_layer/storage/src/state_store/mod.rs
+++ b/dan_layer/storage/src/state_store/mod.rs
@@ -102,7 +102,7 @@ pub trait StateStoreReadTransaction {
     fn blocks_get_tip(&mut self) -> Result<Block<Self::Addr>, StorageError>;
     fn blocks_exists(&mut self, block_id: &BlockId) -> Result<bool, StorageError>;
     fn blocks_is_ancestor(&mut self, descendant: &BlockId, ancestor: &BlockId) -> Result<bool, StorageError>;
-    fn blocks_get_by_parent(&mut self, parent: &BlockId) -> Result<Block<Self::Addr>, StorageError>;
+    fn blocks_get_all_by_parent(&mut self, parent: &BlockId) -> Result<Vec<Block<Self::Addr>>, StorageError>;
     fn blocks_get_pending_transactions(&mut self, block_id: &BlockId) -> Result<Vec<TransactionId>, StorageError>;
     fn blocks_get_total_leader_fee_for_epoch(
         &mut self,
@@ -176,16 +176,24 @@ pub trait StateStoreWriteTransaction {
 
     // -------------------------------- Block -------------------------------- //
     fn blocks_insert(&mut self, block: &Block<Self::Addr>) -> Result<(), StorageError>;
-    fn blocks_commit(&mut self, block_id: &BlockId) -> Result<(), StorageError>;
+    fn blocks_set_flags(
+        &mut self,
+        block_id: &BlockId,
+        is_committed: Option<bool>,
+        is_processed: Option<bool>,
+    ) -> Result<(), StorageError>;
 
     // -------------------------------- QuorumCertificate -------------------------------- //
     fn quorum_certificates_insert(&mut self, qc: &QuorumCertificate<Self::Addr>) -> Result<(), StorageError>;
 
     // -------------------------------- Bookkeeping -------------------------------- //
     fn last_voted_set(&mut self, last_voted: &LastVoted) -> Result<(), StorageError>;
+    fn last_votes_unset(&mut self, last_voted: &LastVoted) -> Result<(), StorageError>;
     fn last_executed_set(&mut self, last_exec: &LastExecuted) -> Result<(), StorageError>;
     fn last_proposed_set(&mut self, last_proposed: &LastProposed) -> Result<(), StorageError>;
+    fn last_proposed_unset(&mut self, last_proposed: &LastProposed) -> Result<(), StorageError>;
     fn leaf_block_set(&mut self, leaf_node: &LeafBlock) -> Result<(), StorageError>;
+    fn leaf_block_unset(&mut self, leaf_node: &LeafBlock) -> Result<(), StorageError>;
     fn locked_block_set(&mut self, locked_block: &LockedBlock) -> Result<(), StorageError>;
     fn high_qc_set(&mut self, high_qc: &HighQc) -> Result<(), StorageError>;
 


### PR DESCRIPTION
Description
---
undo pending transaction stage transitions on leader fail
Add leader failure test where one node in 5 goes offline
Use RoundRobin leader strategy in consensus_tests

Motivation and Context
---
Each head block affects stage changes and object locks which need to be undone when the block(s) fail.

This PR doesn't have this quite right. An alternative is to not do any state changes when processing the block and 
rather do stage transition processing when proposing by processing blocks from the locked block up to and excluding the next proposed block (typically a single block). This would avoid the need for any "reorg" logic.

How Has This Been Tested?
---
Manually by inducing leader failure by spamming nodes with transactions.

What process can a PR reviewer use to test or verify this change?
---
As above

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify