### PR TITLE
feat: random JWT secrets on wallet daemon and signaling server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8152,6 +8152,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tari_common",
+ "tari_dan_common_types",
  "tari_dan_wallet_sdk",
  "tari_shutdown",
  "tokio",

--- a/applications/tari_dan_wallet_daemon/src/config.rs
+++ b/applications/tari_dan_wallet_daemon/src/config.rs
@@ -25,6 +25,7 @@ use std::{net::SocketAddr, time::Duration};
 use config::Config;
 use serde::{Deserialize, Serialize};
 use tari_common::{configuration::CommonConfig, ConfigurationError, DefaultConfigLoader, SubConfigPath};
+use tari_dan_common_types::crypto::create_secret;
 
 #[derive(Debug, Clone)]
 pub struct ApplicationConfig {
@@ -75,9 +76,7 @@ impl Default for WalletDaemonConfig {
             indexer_node_json_rpc_url: "http://127.0.0.1:18300/json_rpc".to_string(),
             // TODO: Come up with a reasonable default value
             jwt_expiry: Some(Duration::from_secs(500 * 60)),
-            // TODO: Generate a random secret key at start if not set by hand. Otherwise anyone can generate a JWT token
-            // when they know the secret_key.
-            jwt_secret_key: Some("secret_key".to_string()),
+            jwt_secret_key: Some(create_secret()),
             http_ui_address: Some("127.0.0.1:5100".parse().unwrap()),
         }
     }

--- a/applications/tari_signaling_server/Cargo.toml
+++ b/applications/tari_signaling_server/Cargo.toml
@@ -11,6 +11,7 @@ license = "BSD-3-Clause"
 tari_common = { git = "https://github.com/tari-project/tari.git", tag = "v0.51.0-pre.4" }
 tari_shutdown = { git = "https://github.com/tari-project/tari.git", tag = "v0.51.0-pre.4" }
 tari_dan_wallet_sdk = { path = "../../dan_layer/wallet/sdk" }
+tari_dan_common_types = { path = "../../dan_layer/common_types" }
 
 anyhow = "1.0.69"
 axum = { version = "0.6", features = ["headers"] }

--- a/applications/tari_signaling_server/src/data.rs
+++ b/applications/tari_signaling_server/src/data.rs
@@ -9,6 +9,7 @@ use jsonwebtoken::{decode, encode, DecodingKey, EncodingKey, Header, TokenData, 
 use serde::{Deserialize, Serialize};
 use tari_dan_wallet_sdk::apis::jwt::JrpcPermissions;
 use webrtc::ice_transport::ice_candidate::RTCIceCandidateInit;
+use tari_dan_common_types::crypto::create_secret;
 
 pub struct Data {
     pub offers: HashMap<u64, String>,
@@ -38,7 +39,7 @@ impl Data {
             offer_ice_candidates: HashMap::new(),
             answer_ice_candidates: HashMap::new(),
             expiration: Duration::minutes(5),
-            secret_key: "jwt-secret_key".into(),
+            secret_key: create_secret(),
             low_id: 0,
             id: 0,
         }

--- a/applications/tari_signaling_server/src/data.rs
+++ b/applications/tari_signaling_server/src/data.rs
@@ -7,9 +7,9 @@ use anyhow::Result;
 use chrono::{Duration, Utc};
 use jsonwebtoken::{decode, encode, DecodingKey, EncodingKey, Header, TokenData, Validation};
 use serde::{Deserialize, Serialize};
+use tari_dan_common_types::crypto::create_secret;
 use tari_dan_wallet_sdk::apis::jwt::JrpcPermissions;
 use webrtc::ice_transport::ice_candidate::RTCIceCandidateInit;
-use tari_dan_common_types::crypto::create_secret;
 
 pub struct Data {
     pub offers: HashMap<u64, String>,

--- a/dan_layer/common_types/src/crypto.rs
+++ b/dan_layer/common_types/src/crypto.rs
@@ -4,7 +4,13 @@
 use rand::rngs::OsRng;
 use tari_common_types::types::{PrivateKey, PublicKey};
 use tari_crypto::keys::PublicKey as PublicKeyT;
+use tari_utilities::hex::Hex;
 
 pub fn create_key_pair() -> (PrivateKey, PublicKey) {
     PublicKey::random_keypair(&mut OsRng)
+}
+
+pub fn create_secret() -> String {
+    let (secret, _) = create_key_pair();
+    secret.to_hex()
 }


### PR DESCRIPTION
Description
---
* Add a new common utility function on `tari_common_types` for secret generation
* Update wallet daemon and signaling server JWT secrets to be randomized at startup

Motivation and Context
---
Right now JWT secrets are hardcoded both in the wallet daemon as well as in the signaling server. This is not acceptable from a security standpoint if we want to create a public test network. So the purpose of this PR is to change both the wallet daemon and the signaling server to haver random JWT secrets each time they start.

Please do not merge this PR until https://github.com/tari-project/tari-connector/pull/9 is merged 

How Has This Been Tested?
---
Manually launching both applications and inspecting the JWTs

What process can a PR reviewer use to test or verify this change?
---
Add log instructions to see the JWTs and launch both wallet daemon and signaling server

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify