### PR TITLE
feat(consensus): consensus state machine

### DIFF
--- a/clients/tari_indexer_client/src/graphql_client.rs
+++ b/clients/tari_indexer_client/src/graphql_client.rs
@@ -70,12 +70,12 @@ impl IndexerGraphQLClient {
         }
         let resp = req.body(serde_json::to_string(&body)?).send().await?;
         let val = resp.json::<Value>().await?;
-        let data: Value = graphql_data(val)?;
-        serde_json::from_value::<R>(data).map_err(|e| anyhow!("Failed to deserialize response: {}", e))
+        let data: Value = graphql_data(&val)?;
+        serde_json::from_value::<R>(data).map_err(|e| anyhow!("Failed to deserialize response {}: {}", val, e))
     }
 }
 
-fn graphql_data(val: Value) -> Result<Value, anyhow::Error> {
+fn graphql_data(val: &Value) -> Result<Value, anyhow::Error> {
     if let Some(err) = val.get("error") {
         let code = err.get("code").and_then(|c| c.as_i64()).unwrap_or(-1);
         let message = err.get("message").and_then(|m| m.as_str()).unwrap_or("Unknown error");

--- a/clients/tari_indexer_client/src/graphql_client.rs
+++ b/clients/tari_indexer_client/src/graphql_client.rs
@@ -68,18 +68,25 @@ impl IndexerGraphQLClient {
         if let Some(headers) = headers {
             req = req.headers(headers);
         }
-        let resp = req.body(serde_json::to_string(&body)?).send().await?;
+        let resp = req.json(&body).send().await?;
         let val = resp.json::<Value>().await?;
-        let data: Value = graphql_data(&val)?;
+        let data: Value = graphql_data(&body, &val)?;
         serde_json::from_value::<R>(data).map_err(|e| anyhow!("Failed to deserialize response {}: {}", val, e))
     }
 }
 
-fn graphql_data(val: &Value) -> Result<Value, anyhow::Error> {
-    if let Some(err) = val.get("error") {
-        let code = err.get("code").and_then(|c| c.as_i64()).unwrap_or(-1);
-        let message = err.get("message").and_then(|m| m.as_str()).unwrap_or("Unknown error");
-        return Err(anyhow!("GraphQL error {}: {}", code, message));
+fn graphql_data(req: &Value, val: &Value) -> Result<Value, anyhow::Error> {
+    if let Some(err) = val.get("errors") {
+        if let Some(errors) = err.as_array() {
+            let mut msgs = Vec::new();
+            for err in errors {
+                let message = err.get("message").and_then(|m| m.as_str()).unwrap_or("Unknown error");
+                msgs.push(message);
+            }
+            return Err(anyhow!("Request failed:\n{}\n\nGraphQL error {}", req, msgs.join("\n")));
+        }
+
+        return Err(anyhow!("Request failed:\n{}\n\nGraphQL error {}", req, err));
     }
 
     let result = val.get("data").ok_or_else(|| anyhow!("Missing result field"))?;

--- a/dan_layer/consensus/src/hotstuff/mod.rs
+++ b/dan_layer/consensus/src/hotstuff/mod.rs
@@ -15,8 +15,10 @@ mod on_receive_requested_transactions;
 mod on_receive_vote;
 mod pacemaker;
 mod pacemaker_handle;
+mod state_machine;
 mod worker;
 
 pub use error::*;
 pub use event::*;
+pub use state_machine::*;
 pub use worker::*;

--- a/dan_layer/consensus/src/hotstuff/on_receive_new_view.rs
+++ b/dan_layer/consensus/src/hotstuff/on_receive_new_view.rs
@@ -152,7 +152,7 @@ where TConsensusSpec: ConsensusSpec
 
             debug!(target: LOG_TARGET, "🍼 dummy leaf block {}", parent_block);
             // Force beat so that a block is proposed even if there are no transactions
-            self.pacemaker.force_beat(parent_block).await?;
+            self.pacemaker.force_beat(parent_block);
         }
 
         Ok(())

--- a/dan_layer/consensus/src/hotstuff/on_receive_proposal.rs
+++ b/dan_layer/consensus/src/hotstuff/on_receive_proposal.rs
@@ -320,7 +320,7 @@ where TConsensusSpec: ConsensusSpec
             .with_write_tx(|tx| self.on_receive_foreign_block(tx, &block, &committee_shard))?;
 
         // We could have ready transactions at this point, so if we're the leader for the next block we can propose
-        self.pacemaker.beat().await?;
+        self.pacemaker.beat();
 
         Ok(())
     }
@@ -1047,7 +1047,8 @@ where TConsensusSpec: ConsensusSpec
 
         // Check that details included in the justify match previously added blocks
         let Some(justify_block) = candidate_block.justify().get_block(tx.deref_mut()).optional()? else {
-            // TODO: This may mean that we have to catch up
+            // This will trigger a sync
+            // TODO: I think we should maintain our current block height (view number) and check if high_qc > tip_block.
             return Err(ProposalValidationError::JustifyBlockNotFound {
                 proposed_by: from.to_string(),
                 hash: *candidate_block.id(),

--- a/dan_layer/consensus/src/hotstuff/on_receive_vote.rs
+++ b/dan_layer/consensus/src/hotstuff/on_receive_vote.rs
@@ -197,7 +197,7 @@ where TConsensusSpec: ConsensusSpec
             update_high_qc(&mut tx, &qc)?;
             tx.commit()?;
         }
-        self.on_beat.beat().await?;
+        self.on_beat.beat();
 
         Ok(())
     }

--- a/dan_layer/consensus/src/hotstuff/state_machine/check_sync.rs
+++ b/dan_layer/consensus/src/hotstuff/state_machine/check_sync.rs
@@ -1,0 +1,46 @@
+//   Copyright 2023 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+use std::marker::PhantomData;
+
+use log::*;
+
+use crate::{
+    hotstuff::{
+        state_machine::{
+            event::ConsensusStateEvent,
+            idle::IdleState,
+            running::Running,
+            worker::ConsensusWorkerContext,
+        },
+        HotStuffError,
+    },
+    traits::ConsensusSpec,
+};
+
+const LOG_TARGET: &str = "tari::dan::consensus::sm::check_sync";
+
+#[derive(Debug, Clone)]
+pub struct CheckSync<TSpec>(PhantomData<TSpec>);
+
+impl<TSpec: ConsensusSpec> CheckSync<TSpec> {
+    pub(super) async fn on_enter(
+        &self,
+        _context: &mut ConsensusWorkerContext<TSpec>,
+    ) -> Result<ConsensusStateEvent, HotStuffError> {
+        warn!(target: LOG_TARGET, "CheckSync not implemented");
+        Ok(ConsensusStateEvent::Ready)
+    }
+}
+
+impl<TSpec> From<IdleState<TSpec>> for CheckSync<TSpec> {
+    fn from(_: IdleState<TSpec>) -> Self {
+        Self(PhantomData)
+    }
+}
+
+impl<TSpec> From<Running<TSpec>> for CheckSync<TSpec> {
+    fn from(_: Running<TSpec>) -> Self {
+        Self(PhantomData)
+    }
+}

--- a/dan_layer/consensus/src/hotstuff/state_machine/event.rs
+++ b/dan_layer/consensus/src/hotstuff/state_machine/event.rs
@@ -1,0 +1,35 @@
+//   Copyright 2023 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+use std::{fmt, fmt::Display};
+
+use tari_dan_common_types::Epoch;
+
+use crate::hotstuff::HotStuffError;
+
+#[derive(Debug)]
+pub enum ConsensusStateEvent {
+    RegisteredForEpoch { epoch: Epoch },
+    NeedSync,
+    SyncComplete,
+    Ready,
+    Failure { error: HotStuffError },
+    Resume,
+    Shutdown,
+}
+
+impl Display for ConsensusStateEvent {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        #[allow(clippy::enum_glob_use)]
+        use ConsensusStateEvent::*;
+        match self {
+            RegisteredForEpoch { epoch } => write!(f, "Registered for epoch {}", epoch),
+            NeedSync => write!(f, "Behind peers"),
+            SyncComplete => write!(f, "Sync complete"),
+            Ready => write!(f, "Ready"),
+            Failure { error } => write!(f, "Failure({error})"),
+            Resume => write!(f, "Resume"),
+            Shutdown => write!(f, "Shutdown"),
+        }
+    }
+}

--- a/dan_layer/consensus/src/hotstuff/state_machine/idle.rs
+++ b/dan_layer/consensus/src/hotstuff/state_machine/idle.rs
@@ -1,0 +1,75 @@
+//   Copyright 2023 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+use std::marker::PhantomData;
+
+use log::*;
+use tari_dan_common_types::Epoch;
+use tari_epoch_manager::{EpochManagerEvent, EpochManagerReader};
+
+use crate::{
+    hotstuff::{
+        state_machine::{event::ConsensusStateEvent, worker::ConsensusWorkerContext},
+        HotStuffError,
+    },
+    traits::ConsensusSpec,
+};
+
+const LOG_TARGET: &str = "tari::dan::consensus::sm::idle";
+
+#[derive(Debug, Clone)]
+pub struct IdleState<TSpec>(PhantomData<TSpec>);
+
+impl<TSpec: ConsensusSpec> IdleState<TSpec> {
+    pub fn new() -> Self {
+        Self(PhantomData)
+    }
+
+    pub(super) async fn on_enter(
+        &self,
+        context: &mut ConsensusWorkerContext<TSpec>,
+    ) -> Result<ConsensusStateEvent, HotStuffError> {
+        let current_epoch = context.epoch_manager.current_epoch().await?;
+        if self.is_registered_for_epoch(context, current_epoch).await? {
+            return Ok(ConsensusStateEvent::RegisteredForEpoch { epoch: current_epoch });
+        }
+
+        while let Ok(event) = context.epoch_events.recv().await {
+            if let Some(event) = self.on_epoch_event(context, event).await? {
+                return Ok(event);
+            }
+        }
+
+        debug!(target: LOG_TARGET, "Idle event triggering shutdown because epoch manager event stream closed");
+        Ok(ConsensusStateEvent::Shutdown)
+    }
+
+    async fn is_registered_for_epoch(
+        &self,
+        context: &mut ConsensusWorkerContext<TSpec>,
+        epoch: Epoch,
+    ) -> Result<bool, HotStuffError> {
+        let is_registered = context
+            .epoch_manager
+            .is_local_validator_registered_for_epoch(epoch)
+            .await?;
+        Ok(is_registered)
+    }
+
+    async fn on_epoch_event(
+        &self,
+        context: &mut ConsensusWorkerContext<TSpec>,
+        event: EpochManagerEvent,
+    ) -> Result<Option<ConsensusStateEvent>, HotStuffError> {
+        match event {
+            EpochManagerEvent::EpochChanged(epoch) => {
+                if self.is_registered_for_epoch(context, epoch).await? {
+                    Ok(Some(ConsensusStateEvent::RegisteredForEpoch { epoch }))
+                } else {
+                    Ok(None)
+                }
+            },
+            EpochManagerEvent::ThisValidatorIsRegistered { .. } => Ok(None),
+        }
+    }
+}

--- a/dan_layer/consensus/src/hotstuff/state_machine/mod.rs
+++ b/dan_layer/consensus/src/hotstuff/state_machine/mod.rs
@@ -1,0 +1,12 @@
+//   Copyright 2023 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+mod check_sync;
+mod event;
+mod idle;
+mod running;
+mod state;
+mod syncing;
+mod worker;
+
+pub use worker::{ConsensusWorker, ConsensusWorkerContext};

--- a/dan_layer/consensus/src/hotstuff/state_machine/running.rs
+++ b/dan_layer/consensus/src/hotstuff/state_machine/running.rs
@@ -1,0 +1,65 @@
+//   Copyright 2023 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+use log::*;
+
+use crate::{
+    hotstuff::{
+        state_machine::{
+            check_sync::CheckSync,
+            event::ConsensusStateEvent,
+            syncing::Syncing,
+            worker::ConsensusWorkerContext,
+        },
+        HotStuffError,
+        ProposalValidationError,
+    },
+    traits::ConsensusSpec,
+};
+
+const LOG_TARGET: &str = "tari::dan::consensus::sm::running";
+
+#[derive(Debug)]
+pub(super) struct Running<TSpec> {
+    _phantom: std::marker::PhantomData<TSpec>,
+}
+
+impl<TSpec> Running<TSpec>
+where TSpec: ConsensusSpec
+{
+    pub(super) async fn on_enter(
+        &self,
+        context: &mut ConsensusWorkerContext<TSpec>,
+    ) -> Result<ConsensusStateEvent, HotStuffError> {
+        match context.hotstuff.start().await {
+            Ok(_) => {
+                info!(target: LOG_TARGET, "HotStuff shut down");
+                Ok(ConsensusStateEvent::Shutdown)
+            },
+            Err(HotStuffError::ProposalValidationError(ProposalValidationError::JustifyBlockNotFound { .. })) => {
+                info!(target: LOG_TARGET, "Behind peers, starting sync");
+                Ok(ConsensusStateEvent::NeedSync)
+            },
+            Err(err) => {
+                error!(target: LOG_TARGET, "HotStuff failed to start: {}", err);
+                Err(err)
+            },
+        }
+    }
+}
+
+impl<TSpec> From<CheckSync<TSpec>> for Running<TSpec> {
+    fn from(_: CheckSync<TSpec>) -> Self {
+        Self {
+            _phantom: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<TSpec> From<Syncing<TSpec>> for Running<TSpec> {
+    fn from(_: Syncing<TSpec>) -> Self {
+        Self {
+            _phantom: std::marker::PhantomData,
+        }
+    }
+}

--- a/dan_layer/consensus/src/hotstuff/state_machine/state.rs
+++ b/dan_layer/consensus/src/hotstuff/state_machine/state.rs
@@ -1,0 +1,37 @@
+//   Copyright 2023 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+use std::fmt::Display;
+
+use crate::hotstuff::state_machine::{check_sync::CheckSync, idle::IdleState, running::Running, syncing::Syncing};
+
+#[derive(Debug)]
+pub(super) enum ConsensusState<TSpec> {
+    Idle(IdleState<TSpec>),
+    CheckSync(CheckSync<TSpec>),
+    Syncing(Syncing<TSpec>),
+    Running(Running<TSpec>),
+    Sleeping,
+    Shutdown,
+}
+
+impl<TSpec> ConsensusState<TSpec> {
+    pub fn is_shutdown(&self) -> bool {
+        matches!(self, ConsensusState::Shutdown)
+    }
+}
+
+impl<TSpec> Display for ConsensusState<TSpec> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        #[allow(clippy::enum_glob_use)]
+        use ConsensusState::*;
+        match self {
+            Idle(_) => write!(f, "Idle"),
+            CheckSync(_) => write!(f, "CheckSync"),
+            Syncing(_) => write!(f, "Syncing"),
+            Running(_) => write!(f, "Running"),
+            Sleeping => write!(f, "Sleeping"),
+            Shutdown => write!(f, "Shutdown"),
+        }
+    }
+}

--- a/dan_layer/consensus/src/hotstuff/state_machine/syncing.rs
+++ b/dan_layer/consensus/src/hotstuff/state_machine/syncing.rs
@@ -1,0 +1,33 @@
+//   Copyright 2023 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+use std::marker::PhantomData;
+
+use crate::{
+    hotstuff::{
+        state_machine::{check_sync::CheckSync, event::ConsensusStateEvent},
+        ConsensusWorkerContext,
+        HotStuffError,
+    },
+    traits::ConsensusSpec,
+};
+
+#[derive(Debug)]
+pub struct Syncing<TSpec>(PhantomData<TSpec>);
+
+impl<TSpec: ConsensusSpec> Syncing<TSpec> {
+    pub(super) async fn on_enter(
+        &self,
+        _context: &mut ConsensusWorkerContext<TSpec>,
+    ) -> Result<ConsensusStateEvent, HotStuffError> {
+        // let mut sync = SyncWorker::new(context);
+        // sync.start().await?;
+        Ok(ConsensusStateEvent::SyncComplete)
+    }
+}
+
+impl<TSpec> From<CheckSync<TSpec>> for Syncing<TSpec> {
+    fn from(_: CheckSync<TSpec>) -> Self {
+        Self(PhantomData)
+    }
+}

--- a/dan_layer/consensus/src/hotstuff/state_machine/worker.rs
+++ b/dan_layer/consensus/src/hotstuff/state_machine/worker.rs
@@ -1,0 +1,122 @@
+//   Copyright 2023 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+use std::{future::Future, marker::PhantomData, time::Duration};
+
+use log::*;
+use tari_epoch_manager::EpochManagerEvent;
+use tari_shutdown::ShutdownSignal;
+use tokio::{sync::broadcast, time};
+
+use crate::{
+    hotstuff::{
+        state_machine::{event::ConsensusStateEvent, idle::IdleState, state::ConsensusState},
+        HotStuffError,
+        HotstuffWorker,
+    },
+    traits::ConsensusSpec,
+};
+
+const LOG_TARGET: &str = "tari::dan::consensus::sm::worker";
+
+#[derive(Debug)]
+pub struct ConsensusWorker<TSpec> {
+    pub(super) shutdown_signal: ShutdownSignal,
+    _spec: PhantomData<TSpec>,
+}
+
+#[derive(Debug)]
+pub struct ConsensusWorkerContext<TSpec: ConsensusSpec> {
+    pub epoch_manager: TSpec::EpochManager,
+    pub epoch_events: broadcast::Receiver<EpochManagerEvent>,
+    pub hotstuff: HotstuffWorker<TSpec>,
+}
+
+impl<TSpec: ConsensusSpec> ConsensusWorker<TSpec> {
+    pub fn new(shutdown_signal: ShutdownSignal) -> Self {
+        Self {
+            shutdown_signal,
+            _spec: PhantomData,
+        }
+    }
+
+    async fn next_event(
+        &self,
+        context: &mut ConsensusWorkerContext<TSpec>,
+        state: &ConsensusState<TSpec>,
+    ) -> ConsensusStateEvent {
+        match state {
+            ConsensusState::Idle(state) => self.result_or_shutdown(state.on_enter(context)).await,
+            ConsensusState::CheckSync(state) => self.result_or_shutdown(state.on_enter(context)).await,
+            ConsensusState::Syncing(state) => self.result_or_shutdown(state.on_enter(context)).await,
+            ConsensusState::Sleeping => {
+                time::sleep(Duration::from_secs(1)).await;
+                ConsensusStateEvent::Resume
+            },
+            ConsensusState::Running(state) => state
+                .on_enter(context)
+                .await
+                .unwrap_or_else(|err| ConsensusStateEvent::Failure { error: err }),
+            ConsensusState::Shutdown => ConsensusStateEvent::Shutdown,
+        }
+    }
+
+    fn transition(&mut self, state: ConsensusState<TSpec>, event: ConsensusStateEvent) -> ConsensusState<TSpec> {
+        let state_str = state.to_string();
+        let event_str = event.to_string();
+
+        let next_state = match (state, event) {
+            (ConsensusState::Idle(state), ConsensusStateEvent::RegisteredForEpoch { .. }) => {
+                ConsensusState::CheckSync(state.into())
+            },
+            (ConsensusState::CheckSync(state), ConsensusStateEvent::NeedSync) => ConsensusState::Syncing(state.into()),
+            (ConsensusState::CheckSync(state), ConsensusStateEvent::Ready) => ConsensusState::Running(state.into()),
+            (ConsensusState::Syncing(state), ConsensusStateEvent::SyncComplete) => {
+                ConsensusState::Running(state.into())
+            },
+            (ConsensusState::Sleeping, ConsensusStateEvent::Resume) => ConsensusState::Idle(IdleState::new()),
+            (ConsensusState::Running(state), ConsensusStateEvent::NeedSync) => ConsensusState::CheckSync(state.into()),
+            (_, ConsensusStateEvent::Failure { error }) => {
+                error!(target: LOG_TARGET, "🚨 Failure: {}", error);
+                ConsensusState::Sleeping
+            },
+            (_, ConsensusStateEvent::Shutdown) => ConsensusState::Shutdown,
+            (state, event) => unreachable!("Invalid state transition from {} via {}", state, event),
+        };
+
+        info!(target: LOG_TARGET, "⚙️ TRANSITION: {state_str} --- {event_str} ---> {next_state}");
+        next_state
+    }
+
+    pub fn spawn(
+        mut self,
+        context: ConsensusWorkerContext<TSpec>,
+    ) -> tokio::task::JoinHandle<Result<(), anyhow::Error>> {
+        tokio::spawn(async move {
+            self.run(context).await;
+            Ok(())
+        })
+    }
+
+    pub async fn run(&mut self, mut context: ConsensusWorkerContext<TSpec>) {
+        let mut state = ConsensusState::Idle(IdleState::new());
+        loop {
+            let next_event = self.next_event(&mut context, &state).await;
+            state = self.transition(state, next_event);
+            if state.is_shutdown() {
+                break;
+            }
+        }
+    }
+
+    async fn result_or_shutdown<Fut>(&self, fut: Fut) -> ConsensusStateEvent
+    where Fut: Future<Output = Result<ConsensusStateEvent, HotStuffError>> {
+        let mut shutdown_signal = self.shutdown_signal.clone();
+        let result = tokio::select! {
+            _ = shutdown_signal.wait() => Ok(ConsensusStateEvent::Shutdown),
+            ret = fut => ret,
+        };
+
+        result.unwrap_or_else(|err| ConsensusStateEvent::Failure { error: err })
+    }
+}

--- a/dan_layer/consensus/src/hotstuff/worker.rs
+++ b/dan_layer/consensus/src/hotstuff/worker.rs
@@ -1,7 +1,10 @@
 //   Copyright 2023 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use std::ops::DerefMut;
+use std::{
+    fmt::{Debug, Formatter},
+    ops::DerefMut,
+};
 
 use log::*;
 use tari_dan_common_types::{Epoch, NodeHeight};
@@ -10,13 +13,10 @@ use tari_dan_storage::{
     StateStore,
     StateStoreWriteTransaction,
 };
-use tari_epoch_manager::{EpochManagerEvent, EpochManagerReader};
+use tari_epoch_manager::EpochManagerReader;
 use tari_shutdown::ShutdownSignal;
 use tari_transaction::{Transaction, TransactionId};
-use tokio::{
-    sync::{broadcast, mpsc},
-    task::JoinHandle,
-};
+use tokio::sync::{broadcast, mpsc};
 
 use super::on_receive_requested_transactions::OnReceiveRequestedTransactions;
 use crate::{
@@ -60,9 +60,6 @@ pub struct HotstuffWorker<TConsensusSpec: ConsensusSpec> {
     transaction_pool: TransactionPool<TConsensusSpec::StateStore>,
 
     epoch_manager: TConsensusSpec::EpochManager,
-    epoch_events: broadcast::Receiver<EpochManagerEvent>,
-    latest_epoch: Option<Epoch>,
-    is_epoch_synced: bool,
 
     pacemaker: Option<PaceMaker>,
     pacemaker_handle: PaceMakerHandle,
@@ -82,7 +79,6 @@ where
         rx_new_transactions: mpsc::Receiver<TransactionId>,
         rx_hs_message: mpsc::Receiver<(TConsensusSpec::Addr, HotstuffMessage<TConsensusSpec::Addr>)>,
         state_store: TConsensusSpec::StateStore,
-        epoch_events: broadcast::Receiver<EpochManagerEvent>,
         epoch_manager: TConsensusSpec::EpochManager,
         leader_strategy: TConsensusSpec::LeaderStrategy,
         signing_service: TConsensusSpec::VoteSignatureService,
@@ -139,30 +135,49 @@ where
                 transaction_pool.clone(),
                 tx_broadcast,
             ),
-            // on_leader_timeout: OnLeaderTimeout::qnew(shutdown.clone()),
+
             state_store,
             leader_strategy,
             epoch_manager,
-            epoch_events,
-            latest_epoch: None,
-            is_epoch_synced: false,
             transaction_pool,
             pacemaker_handle: pacemaker.clone_handle(),
             pacemaker: Some(pacemaker),
             shutdown,
         }
     }
+}
+impl<TConsensusSpec> HotstuffWorker<TConsensusSpec>
+where TConsensusSpec: ConsensusSpec
+{
+    pub async fn start(&mut self) -> Result<(), HotStuffError> {
+        self.create_genesis_block_if_required(Epoch(0))?;
+        let (leaf_block, high_qc) = self
+            .state_store
+            .with_read_tx(|tx| Ok::<_, HotStuffError>((LeafBlock::get(tx)?, HighQc::get(tx)?)))?;
+        info!(
+            target: LOG_TARGET,
+            "⏰ Pacemaker starting leaf_block: {}, high_qc: {}",
+            leaf_block,
+            high_qc
+        );
 
-    pub fn spawn(self) -> JoinHandle<Result<(), anyhow::Error>> {
-        tokio::spawn(async move {
-            self.run().await?;
-            Ok(())
-        })
+        self.pacemaker_handle
+            .start(leaf_block.height(), high_qc.block_height())
+            .await?;
+
+        self.run().await?;
+        Ok(())
     }
 
-    pub async fn run(mut self) -> Result<(), HotStuffError> {
-        self.create_genesis_block_if_required(Epoch(0))?;
-        let (mut on_beat, mut on_force_beat, mut on_leader_timeout) = self.pacemaker.take().map(|p| p.spawn()).unwrap();
+    async fn run(&mut self) -> Result<(), HotStuffError> {
+        // Spawn pacemaker if not spawned already
+        if let Some(pm) = self.pacemaker.take() {
+            pm.spawn();
+        }
+
+        let mut on_beat = self.pacemaker_handle.get_on_beat();
+        let mut on_force_beat = self.pacemaker_handle.get_on_force_beat();
+        let mut on_leader_timeout = self.pacemaker_handle.get_on_leader_timeout();
 
         loop {
             tokio::select! {
@@ -172,14 +187,14 @@ where
                         self.publish_event(HotstuffEvent::Failure { message: e.to_string() });
                         debug!(target: LOG_TARGET, "on_new_hs_message error: {} {:?}", e, msg);
                         error!(target: LOG_TARGET, "Error while processing new hotstuff message (on_new_hs_message): {}", e);
+                        if let Err(e) = self.pacemaker_handle.stop().await {
+                            error!(target: LOG_TARGET, "Error while stopping pacemaker: {}", e);
+                        }
+                        // Failures here will be handled in the state machine
+                        return Err(e);
                     }
                 },
 
-                Ok(event) = self.epoch_events.recv() => {
-                    if let Err(e) = self.on_epoch_event(event).await {
-                        error!(target: LOG_TARGET, "Error while processing epoch change (on_epoch_event): {}", e);
-                    }
-                },
                 Some(msg) = self.rx_new_transactions.recv() => {
                     if let Err(e) = self.on_new_executed_transaction(msg).await {
                        error!(target: LOG_TARGET, "Error while processing new payload (on_new_executed_transaction): {}", e);
@@ -201,11 +216,7 @@ where
                         error!(target: LOG_TARGET, "Error (on_leader_timeout): {}", e);
                     }
                 },
-                // _ = self.on_leader_timeout.o() => {
-                //     if let Err(e) = self.on_leader_timeout().await {
-                //         error!(target: LOG_TARGET, "Error (on_leader_timeout): {}", e);
-                //     }
-                // }
+
                 _ = self.shutdown.wait() => {
                     info!(target: LOG_TARGET, "💤 Shutting down");
                     break;
@@ -213,39 +224,7 @@ where
             }
         }
 
-        Ok(())
-    }
-
-    async fn on_epoch_event(&mut self, event: EpochManagerEvent) -> Result<(), HotStuffError> {
-        match event {
-            EpochManagerEvent::EpochChanged(epoch) => {
-                self.is_epoch_synced = true;
-                // TODO: merge chain(s) from previous epoch?
-
-                if self
-                    .epoch_manager
-                    .is_local_validator_registered_for_epoch(epoch)
-                    .await?
-                {
-                    let (leaf_block, high_qc) = self
-                        .state_store
-                        .with_read_tx(|tx| Ok::<_, HotStuffError>((LeafBlock::get(tx)?, HighQc::get(tx)?)))?;
-                    info!(
-                        target: LOG_TARGET,
-                        "⏰ Pacemaker starting for epoch {}, leaf_block: {}, high_qc: {}",
-                        epoch,
-                        leaf_block,
-                        high_qc
-                    );
-                    self.pacemaker_handle
-                        .start(leaf_block.height(), high_qc.block_height())
-                        .await?;
-                } else {
-                    self.pacemaker_handle.stop().await?;
-                }
-            },
-            EpochManagerEvent::ThisValidatorIsRegistered { .. } => {},
-        }
+        self.pacemaker_handle.stop().await?;
 
         Ok(())
     }
@@ -262,17 +241,11 @@ where
         if let Some(block_id) = maybe_block_id {
             self.on_receive_proposal.reprocess_block(&block_id).await?;
         }
-        self.pacemaker_handle.beat().await?;
+        self.pacemaker_handle.beat();
         Ok(())
     }
 
     async fn on_leader_timeout(&mut self, new_height: NodeHeight) -> Result<(), HotStuffError> {
-        // TODO: perhaps the leader should not be increasing the timeout
-        if !self.is_epoch_synced {
-            warn!(target: LOG_TARGET, "Waiting for epoch change before worrying about leader timeout");
-            return Ok(());
-        }
-
         let epoch = self.epoch_manager.current_epoch().await?;
         // Is the VN registered?
         if !self.epoch_manager.is_epoch_active(epoch).await? {
@@ -291,13 +264,6 @@ where
     }
 
     async fn on_beat(&mut self) -> Result<(), HotStuffError> {
-        // TODO: This is a temporary hack to ensure that the VN has synced the blockchain before proposing
-        if !self.is_epoch_synced {
-            warn!(target: LOG_TARGET, "Waiting for epoch change before proposing");
-            return Ok(());
-        }
-
-        // Are there any transactions in the pools?
         if !self
             .state_store
             .with_read_tx(|tx| self.transaction_pool.has_uncommitted_transactions(tx))?
@@ -312,12 +278,6 @@ where
     }
 
     async fn propose_if_leader(&mut self, leaf_block: Option<LeafBlock>) -> Result<(), HotStuffError> {
-        // TODO: This is a temporary hack to ensure that the VN has synced the blockchain before proposing
-        if !self.is_epoch_synced {
-            warn!(target: LOG_TARGET, "Waiting for epoch change before proposing");
-            return Ok(());
-        }
-
         let must_propose = leaf_block.is_some();
         let leaf_block = match leaf_block {
             Some(leaf_block) => leaf_block,
@@ -385,11 +345,6 @@ where
     }
 
     fn create_genesis_block_if_required(&mut self, epoch: Epoch) -> Result<(), HotStuffError> {
-        // If we've already created the genesis block for this epoch then we can return early
-        if self.latest_epoch.map(|e| e >= epoch).unwrap_or(false) {
-            return Ok(());
-        }
-
         let mut tx = self.state_store.create_write_tx()?;
 
         // The parent for all genesis blocks refer to this zero block
@@ -424,13 +379,23 @@ where
             epoch
         );
 
-        self.latest_epoch = Some(epoch);
-
         Ok(())
     }
 
     fn publish_event(&self, event: HotstuffEvent) {
         let _ignore = self.tx_events.send(event);
+    }
+}
+
+impl<TConsensusSpec: ConsensusSpec> Debug for HotstuffWorker<TConsensusSpec> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("HotstuffWorker")
+            .field("validator_addr", &self.validator_addr)
+            .field("epoch_manager", &"EpochManager")
+            .field("pacemaker_handle", &self.pacemaker_handle)
+            .field("pacemaker", &"Pacemaker")
+            .field("shutdown", &self.shutdown)
+            .finish()
     }
 }
 

--- a/dan_layer/consensus_tests/src/consensus.rs
+++ b/dan_layer/consensus_tests/src/consensus.rs
@@ -286,7 +286,6 @@ async fn foreign_shard_decides_to_abort() {
     test.assert_clean_shutdown().await;
 }
 
-#[ignore = "flaky should be fixed in https://github.com/tari-project/tari-dan/pull/677"]
 #[tokio::test(flavor = "multi_thread")]
 async fn leader_failure_output_conflict() {
     setup_logger();

--- a/integration_tests/tests/cucumber.rs
+++ b/integration_tests/tests/cucumber.rs
@@ -561,18 +561,14 @@ async fn indexer_scans_network_events(
     let component_address = accounts_component_addresses
         .into_iter()
         .find(|(k, _)| k.contains("components/Account"))
-        .map(|(_, v)| {
-            v.address
-                .as_component_address()
-                .expect("Failed to parse `ComponentAddress`")
-        })
+        .map(|(_, v)| v)
         .expect("Did not find component address");
 
     let mut graphql_client = indexer.get_graphql_indexer_client().await;
     let query = format!(
-        "{{ getEventsForComponent(componentAddress: {:?}, version: 0) {{ componentAddress, templateAddress, txHash, \
+        "{{ getEventsForComponent(componentAddress: {}, version: {}) {{ componentAddress, templateAddress, txHash, \
          topic, payload }} }}",
-        component_address.to_string()
+        component_address.address, component_address.version
     );
     let res = graphql_client
         .send_request::<HashMap<String, Vec<tari_indexer::graphql::model::events::Event>>>(&query, None, None)

--- a/integration_tests/tests/cucumber.rs
+++ b/integration_tests/tests/cucumber.rs
@@ -566,8 +566,7 @@ async fn indexer_scans_network_events(
 
     let mut graphql_client = indexer.get_graphql_indexer_client().await;
     let query = format!(
-        "{{ getEventsForComponent(componentAddress: {}, version: {}) {{ componentAddress, templateAddress, txHash, \
-         topic, payload }} }}",
+        r#"{{ getEventsForComponent(componentAddress: "{}", version: {}) {{ componentAddress, templateAddress, txHash, topic, payload }} }}"#,
         component_address.address, component_address.version
     );
     let res = graphql_client

--- a/integration_tests/tests/features/indexer.feature
+++ b/integration_tests/tests/features/indexer.feature
@@ -1,6 +1,7 @@
 # Copyright 2022 The Tari Project
 # SPDX-License-Identifier: BSD-3-Clause
 
+
 Feature: Indexer node
 
   @serial

--- a/integration_tests/tests/steps/validator_node.rs
+++ b/integration_tests/tests/steps/validator_node.rs
@@ -205,6 +205,20 @@ async fn assert_vn_is_registered(world: &mut TariWorld, vn_name: String) {
 
     // check that the vn's public key is in the list of registered vns
     assert!(vns.iter().any(|vn| vn.public_key == identity.public_key));
+
+    let mut count = 0;
+    loop {
+        // wait for the validator to pick up the registration
+        let stats = client.get_epoch_manager_stats().await.unwrap();
+        if stats.current_block_height >= height || stats.is_valid {
+            break;
+        }
+        if count > 10 {
+            panic!("Timed out waiting for validator node to pick up registration");
+        }
+        count += 1;
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
 }
 
 #[then(expr = "the template \"{word}\" is listed as registered by the validator node {word}")]


### PR DESCRIPTION
Description
---
Adds a state machine for consensus worker to allow consensus to switch to/from sync and running modes.

Motivation and Context
---
This PR adds the state machine, the sync implementation will be in a follow-up PR. 
Consensus should not be processing messages during sync. This pattern also fits well with consensus switching to idle when not registered for an epoch.

Diagram [here](https://github.com/tari-project/tari-dan/blob/development/docs/consensus_state_machine.md). This diagram needs to be updated once the transitions and events are closer to final.

The current sync state immediately returns a SyncComplete event, so behaviour is almost identical to the current consensus behaviour.

How Has This Been Tested?
---
Existing test harness updated to use state machine.

What process can a PR reviewer use to test or verify this change?
---
VN works as before

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify