### PR TITLE
feat(consensus): block sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8147,6 +8147,7 @@ dependencies = [
  "diesel_migrations",
  "hex",
  "log",
+ "rand 0.8.5",
  "serde",
  "serde_json",
  "tari_common_types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -618,9 +618,9 @@ checksum = "ecc7ab41815b3c653ccd2978ec3255c81349336702dfdf62ee6f7069b12a3aae"
 
 [[package]]
 name = "async-trait"
-version = "0.1.68"
+version = "0.1.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
+checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1531,7 +1531,7 @@ dependencies = [
 
 [[package]]
 name = "consensus_tests"
-version = "0.1.0"
+version = "0.50.0-pre.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4134,9 +4134,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.19"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 dependencies = [
  "serde",
  "value-bag",
@@ -5729,9 +5729,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.28"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
@@ -7412,6 +7412,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "tari_comms_rpc_state_sync"
+version = "0.50.0-pre.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "futures 0.3.28",
+ "log",
+ "tari_comms",
+ "tari_consensus",
+ "tari_dan_common_types",
+ "tari_dan_storage",
+ "tari_epoch_manager",
+ "tari_transaction",
+ "tari_validator_node_rpc",
+ "thiserror",
+]
+
+[[package]]
 name = "tari_consensus"
 version = "0.50.0-pre.0"
 dependencies = [
@@ -8316,6 +8334,7 @@ dependencies = [
  "tari_common_types",
  "tari_comms",
  "tari_comms_logging",
+ "tari_comms_rpc_state_sync",
  "tari_consensus",
  "tari_core",
  "tari_crypto",
@@ -8518,18 +8537,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.40"
+version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
+checksum = "9d6d7a740b8a666a7e828dd00da9c0dc290dff53154ea77ac109281de90589b7"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.40"
+version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
+checksum = "49922ecae66cc8a249b77e68d1d0623c1b2c514f0060c27cdc68bd62a1219d35"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "clients/base_node_client",
     "clients/validator_node_client",
     "clients/wallet_daemon_client",
+    "dan_layer/comms_rpc_state_sync",
     "dan_layer/consensus",
     "dan_layer/consensus_tests",
     "dan_layer/epoch_manager",

--- a/applications/tari_dan_app_utilities/src/base_layer_scanner.rs
+++ b/applications/tari_dan_app_utilities/src/base_layer_scanner.rs
@@ -386,11 +386,8 @@ impl BaseLayerScanner {
                     created_justify: *genesis.justify().id(),
                     created_block: *genesis.id(),
                     created_height: NodeHeight::zero(),
-                    destroyed_by_transaction: None,
-                    destroyed_justify: None,
-                    destroyed_by_block: None,
                     created_at_epoch: Epoch(0),
-                    destroyed_at_epoch: None,
+                    destroyed: None,
                 }
                 .create(tx)
             })

--- a/applications/tari_validator_node/Cargo.toml
+++ b/applications/tari_validator_node/Cargo.toml
@@ -34,6 +34,7 @@ minotari_wallet_grpc_client = { git = "https://github.com/tari-project/tari.git"
 tari_base_node_client = { path = "../../clients/base_node_client" }
 tari_epoch_manager = { path = "../../dan_layer/epoch_manager", features = ["base_layer"] }
 tari_indexer_lib = { path = "../../dan_layer/indexer_lib" }
+tari_comms_rpc_state_sync = { path = "../../dan_layer/comms_rpc_state_sync" }
 
 tari_consensus = { path = "../../dan_layer/consensus" }
 tari_state_store_sqlite = { path = "../../dan_layer/state_store_sqlite" }

--- a/applications/tari_validator_node/log4rs_sample.yml
+++ b/applications/tari_validator_node/log4rs_sample.yml
@@ -29,7 +29,7 @@ appenders:
       kind: compound
       trigger:
         kind: size
-        limit: 10mb
+        limit: 100mb
       roller:
         kind: fixed_window
         base: 1
@@ -46,7 +46,7 @@ appenders:
       kind: compound
       trigger:
         kind: size
-        limit: 10mb
+        limit: 100mb
       roller:
         kind: fixed_window
         base: 1
@@ -63,7 +63,7 @@ appenders:
       kind: compound
       trigger:
         kind: size
-        limit: 10mb
+        limit: 100mb
       roller:
         kind: fixed_window
         base: 1
@@ -80,7 +80,7 @@ appenders:
       kind: compound
       trigger:
         kind: size
-        limit: 10mb
+        limit: 100mb
       roller:
         kind: fixed_window
         base: 1
@@ -98,7 +98,7 @@ appenders:
       kind: compound
       trigger:
         kind: size
-        limit: 10mb
+        limit: 100mb
       roller:
         kind: fixed_window
         base: 1

--- a/applications/tari_validator_node/src/bootstrap.rs
+++ b/applications/tari_validator_node/src/bootstrap.rs
@@ -133,7 +133,7 @@ pub async fn spawn_services(
     let (comms, message_channels) = comms::initialize(node_identity.clone(), config, shutdown.clone()).await?;
 
     // Spawn messaging
-    let (message_senders, message_receivers) = messaging::new_messaging_channel(10);
+    let (message_senders, message_receivers) = messaging::new_messaging_channel(30);
     let (outbound_messaging, join_handle) = messaging::spawn(
         node_identity.public_key().clone(),
         message_channels,
@@ -245,6 +245,7 @@ pub async fn spawn_services(
         rx_consensus_message,
         outbound_messaging,
         mempool.clone(),
+        validator_node_client_factory.clone(),
         shutdown.clone(),
     )
     .await;
@@ -383,11 +384,8 @@ where
             created_justify: *genesis_block.justify().id(),
             created_block: *genesis_block.id(),
             created_height: NodeHeight(0),
-            destroyed_by_transaction: None,
-            destroyed_justify: None,
-            destroyed_by_block: None,
             created_at_epoch: Epoch(0),
-            destroyed_at_epoch: None,
+            destroyed: None,
         }
         .create(tx)?;
     }
@@ -404,11 +402,8 @@ where
             created_justify: *genesis_block.justify().id(),
             created_block: *genesis_block.id(),
             created_height: NodeHeight(0),
-            destroyed_by_transaction: None,
-            destroyed_justify: None,
-            destroyed_by_block: None,
             created_at_epoch: Epoch(0),
-            destroyed_at_epoch: None,
+            destroyed: None,
         }
         .create(tx)?;
     }

--- a/applications/tari_validator_node/src/consensus/spec.rs
+++ b/applications/tari_validator_node/src/consensus/spec.rs
@@ -2,6 +2,7 @@
 //    SPDX-License-Identifier: BSD-3-Clause
 
 use tari_comms::types::CommsPublicKey;
+use tari_comms_rpc_state_sync::CommsRpcStateSyncManager;
 use tari_consensus::traits::ConsensusSpec;
 use tari_epoch_manager::base_layer::EpochManagerHandle;
 use tari_state_store_sqlite::SqliteStateStore;
@@ -20,5 +21,6 @@ impl ConsensusSpec for TariConsensusSpec {
     type LeaderStrategy = RoundRobinLeaderStrategy;
     type StateManager = TariStateManager;
     type StateStore = SqliteStateStore<Self::Addr>;
+    type SyncManager = CommsRpcStateSyncManager<Self::EpochManager, Self::StateStore>;
     type VoteSignatureService = TariSignatureService;
 }

--- a/applications/tari_validator_node/src/consensus/state_manager.rs
+++ b/applications/tari_validator_node/src/consensus/state_manager.rs
@@ -6,7 +6,6 @@ use tari_dan_common_types::ShardId;
 use tari_dan_storage::{
     consensus_models::{Block, ExecutedTransaction, SubstateRecord},
     StateStore,
-    StateStoreWriteTransaction,
     StorageError,
 };
 
@@ -35,7 +34,15 @@ impl<TStateStore: StateStore> StateManager<TStateStore> for TariStateManager {
         let down_shards = diff
             .down_iter()
             .map(|(addr, version)| ShardId::from_address(addr, *version));
-        tx.substate_down_many(down_shards, block.epoch(), block.id(), transaction.id())?;
+        SubstateRecord::destroy_many(
+            tx,
+            down_shards,
+            block.epoch(),
+            block.id(),
+            block.justify().id(),
+            transaction.id(),
+            true,
+        )?;
 
         let to_up = diff.up_iter().map(|(addr, substate)| {
             SubstateRecord::new(

--- a/applications/tari_validator_node/src/json_rpc/jrpc_errors.rs
+++ b/applications/tari_validator_node/src/json_rpc/jrpc_errors.rs
@@ -57,3 +57,14 @@ pub fn internal_error<T: Display>(answer_id: i64) -> impl Fn(T) -> JsonRpcRespon
         )
     }
 }
+
+pub fn not_found<T: Into<String>>(answer_id: i64, details: T) -> JsonRpcResponse {
+    JsonRpcResponse::error(
+        answer_id,
+        JsonRpcError::new(
+            JsonRpcErrorReason::ApplicationError(404),
+            details.into(),
+            serde_json::Value::Null,
+        ),
+    )
+}

--- a/applications/tari_validator_node/src/json_rpc/server.rs
+++ b/applications/tari_validator_node/src/json_rpc/server.rs
@@ -67,6 +67,7 @@ async fn handler(Extension(handlers): Extension<Arc<JsonRpcHandlers>>, value: Js
         "get_substate" => handlers.get_substate(value).await,
         "get_substates_created_by_transaction" => handlers.get_substates_created_by_transaction(value).await,
         "get_substates_destroyed_by_transaction" => handlers.get_substates_destroyed_by_transaction(value).await,
+        "list_blocks" => handlers.list_blocks(value).await,
         // Template
         "get_template" => handlers.get_template(value).await,
         "get_templates" => handlers.get_templates(value).await,

--- a/applications/tari_validator_node/src/p2p/rpc/mod.rs
+++ b/applications/tari_validator_node/src/p2p/rpc/mod.rs
@@ -21,6 +21,7 @@
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 mod service_impl;
+mod sync_task;
 
 pub use service_impl::ValidatorNodeRpcServiceImpl;
 use tari_common_types::types::PublicKey;

--- a/applications/tari_validator_node/src/p2p/rpc/sync_task.rs
+++ b/applications/tari_validator_node/src/p2p/rpc/sync_task.rs
@@ -1,0 +1,163 @@
+//   Copyright 2023 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+use std::collections::HashSet;
+
+use log::*;
+use tari_comms::protocol::rpc::RpcStatus;
+use tari_dan_storage::{
+    consensus_models::{Block, BlockId, QuorumCertificate, SubstateUpdate},
+    StateStore,
+    StateStoreReadTransaction,
+    StorageError,
+};
+use tari_validator_node_rpc::proto::rpc::SyncBlocksResponse;
+use tokio::sync::mpsc;
+
+const LOG_TARGET: &str = "tari::dan::rpc::sync_task";
+
+const BLOCK_BUFFER_SIZE: usize = 10;
+
+type BlockBuffer<TAddr> = Vec<(Block<TAddr>, Vec<QuorumCertificate<TAddr>>, Vec<SubstateUpdate<TAddr>>)>;
+
+pub struct BlockSyncTask<TStateStore: StateStore> {
+    store: TStateStore,
+    current_block: Block<TStateStore::Addr>,
+    sender: mpsc::Sender<Result<SyncBlocksResponse, RpcStatus>>,
+}
+
+impl<TStateStore: StateStore> BlockSyncTask<TStateStore> {
+    pub fn new(
+        store: TStateStore,
+        current_block: Block<TStateStore::Addr>,
+        sender: mpsc::Sender<Result<SyncBlocksResponse, RpcStatus>>,
+    ) -> Self {
+        Self {
+            store,
+            current_block,
+            sender,
+        }
+    }
+
+    pub async fn run(mut self) -> Result<(), ()> {
+        let mut buffer = Vec::with_capacity(BLOCK_BUFFER_SIZE);
+        let mut current_block_id = *self.current_block.id();
+        loop {
+            match self.fetch_next_batch(&mut buffer, &current_block_id) {
+                Ok(last_block) => {
+                    current_block_id = last_block;
+                },
+                Err(err) => {
+                    self.send(Err(RpcStatus::log_internal_error(LOG_TARGET)(err))).await?;
+                    return Err(());
+                },
+            }
+
+            let num_items = buffer.len();
+
+            for (block, quorum_certificates, updates) in buffer.drain(..) {
+                self.send(Ok(SyncBlocksResponse {
+                    block: Some(block.into()),
+                    quorum_certificates: quorum_certificates.iter().map(Into::into).collect(),
+                    substate_updates: updates.into_iter().map(Into::into).collect(),
+                }))
+                .await?;
+            }
+
+            // If we didnt fill up the buffer, send the final blocks
+            // TODO: It may be better to ask each leader to resend each proposal
+            if num_items < buffer.capacity() {
+                match self.fetch_last_blocks(&mut buffer, &current_block_id) {
+                    Ok(_) => (),
+                    Err(err) => {
+                        self.send(Err(RpcStatus::log_internal_error(LOG_TARGET)(err))).await?;
+                        return Err(());
+                    },
+                }
+
+                for (block, quorum_certificates, updates) in buffer.drain(..) {
+                    self.send(Ok(SyncBlocksResponse {
+                        block: Some(block.into()),
+                        quorum_certificates: quorum_certificates.iter().map(Into::into).collect(),
+                        substate_updates: updates.into_iter().map(Into::into).collect(),
+                    }))
+                    .await?;
+                }
+
+                break;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn fetch_last_blocks(
+        &self,
+        buffer: &mut BlockBuffer<TStateStore::Addr>,
+        current_block_id: &BlockId,
+    ) -> Result<(), StorageError> {
+        self.store.with_read_tx(|tx| {
+            let mut current = Block::get_tip(tx)?;
+            loop {
+                let all_qcs = current
+                    .commands()
+                    .iter()
+                    .flat_map(|cmd| cmd.evidence().qc_ids_iter())
+                    .collect::<HashSet<_>>();
+                let certificates = QuorumCertificate::get_all(tx, all_qcs)?;
+                let updates = current.get_substate_updates(tx)?;
+
+                let parent = current.get_parent(tx)?;
+                buffer.push((current, certificates, updates));
+                if parent.id() == current_block_id {
+                    break;
+                }
+                current = parent;
+            }
+
+            buffer.reverse();
+            Ok::<_, StorageError>(())
+        })
+    }
+
+    fn fetch_next_batch(
+        &self,
+        buffer: &mut BlockBuffer<TStateStore::Addr>,
+        current_block_id: &BlockId,
+    ) -> Result<BlockId, StorageError> {
+        self.store.with_read_tx(|tx| {
+            let mut current_block_id = *current_block_id;
+            loop {
+                let children = tx.blocks_get_all_by_parent(&current_block_id)?;
+                let Some(child) = children.into_iter().find(|b| b.is_committed()) else {
+                    break;
+                };
+
+                current_block_id = *child.id();
+                let all_qcs = child
+                    .commands()
+                    .iter()
+                    .flat_map(|cmd| cmd.evidence().qc_ids_iter())
+                    .collect::<HashSet<_>>();
+                let certificates = QuorumCertificate::get_all(tx, all_qcs)?;
+                let updates = child.get_substate_updates(tx)?;
+                buffer.push((child, certificates, updates));
+                if buffer.len() == buffer.capacity() {
+                    break;
+                }
+            }
+            Ok::<_, StorageError>(current_block_id)
+        })
+    }
+
+    async fn send(&mut self, result: Result<SyncBlocksResponse, RpcStatus>) -> Result<(), ()> {
+        if self.sender.send(result).await.is_err() {
+            debug!(
+                target: LOG_TARGET,
+                "Peer stream closed by client before completing. Aborting"
+            );
+            return Err(());
+        }
+        Ok(())
+    }
+}

--- a/applications/tari_validator_node/src/p2p/services/messaging/inbound.rs
+++ b/applications/tari_validator_node/src/p2p/services/messaging/inbound.rs
@@ -50,9 +50,11 @@ impl<TAddr: Clone> InboundMessaging<TAddr> {
 
     pub async fn next_message(&mut self) -> Option<(TAddr, Message<TAddr>)> {
         tokio::select! {
+           // BIASED: messaging priority is loopback, consensus, then other
+           biased;
            maybe_msg = self.loopback_receiver.recv() => maybe_msg.map(|msg| (self.our_node_addr.clone(), msg)),
-           maybe_msg = self.inbound_messages.recv() => maybe_msg.map(|(from, msg)| (from, Message::Dan(msg))),
            maybe_msg = self.inbound_consensus_messages.recv() => maybe_msg.map(|(from, msg)| (from, Message::Consensus(msg))),
+           maybe_msg = self.inbound_messages.recv() => maybe_msg.map(|(from, msg)| (from, Message::Dan(msg))),
         }
     }
 }

--- a/applications/tari_validator_node/src/p2p/services/mod.rs
+++ b/applications/tari_validator_node/src/p2p/services/mod.rs
@@ -20,7 +20,7 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-pub mod committee_state_sync;
+// pub mod committee_state_sync;
 pub mod comms_peer_provider;
 pub mod mempool;
 pub mod messaging;

--- a/clients/validator_node_client/src/lib.rs
+++ b/clients/validator_node_client/src/lib.rs
@@ -51,6 +51,8 @@ use crate::types::{
     GetTransactionResultResponse,
     GetValidatorFeesRequest,
     GetValidatorFeesResponse,
+    ListBlocksRequest,
+    ListBlocksResponse,
     RegisterValidatorNodeRequest,
     RegisterValidatorNodeResponse,
     SubmitTransactionRequest,
@@ -161,6 +163,13 @@ impl ValidatorNodeClient {
         request: GetRecentTransactionsRequest,
     ) -> Result<GetRecentTransactionsResponse, ValidatorNodeClientError> {
         self.send_request("get_recent_transactions", request).await
+    }
+
+    pub async fn list_blocks(
+        &mut self,
+        request: ListBlocksRequest,
+    ) -> Result<ListBlocksResponse, ValidatorNodeClientError> {
+        self.send_request("list_blocks", request).await
     }
 
     pub async fn submit_transaction(

--- a/clients/validator_node_client/src/types.rs
+++ b/clients/validator_node_client/src/types.rs
@@ -181,6 +181,19 @@ pub struct GetRecentTransactionsResponse {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ListBlocksRequest {
+    /// If provided, `limit` blocks from the specified block back will be returned. Otherwise `limit` blocks from the
+    /// leaf block will be provided.
+    pub from_id: Option<BlockId>,
+    pub limit: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ListBlocksResponse {
+    pub blocks: Vec<Block<PublicKey>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LogEntry {
     pub timestamp: u64,
     pub message: String,

--- a/dan_layer/common_types/src/committee.rs
+++ b/dan_layer/common_types/src/committee.rs
@@ -31,16 +31,6 @@ impl<TAddr: NodeAddressable> Committee<TAddr> {
         &self.members
     }
 
-    /// Returns n - f where n is the number of committee members and f is the tolerated failure nodes.
-    pub fn consensus_threshold(&self) -> usize {
-        let len = self.members.len();
-        if len == 0 {
-            return 0;
-        }
-        let max_failures = (len - 1) / 3;
-        len - max_failures
-    }
-
     pub fn max_failures(&self) -> usize {
         let len = self.members.len();
         if len == 0 {

--- a/dan_layer/comms_rpc_state_sync/Cargo.toml
+++ b/dan_layer/comms_rpc_state_sync/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "tari_comms_rpc_state_sync"
+version = "0.50.0-pre.0"
+edition = "2021"
+authors = ["The Tari Development Community"]
+description = "Tari template runtime engine"
+repository = "https://github.com/tari-project/tari-dan"
+license = "BSD-3-Clause"
+
+[dependencies]
+tari_epoch_manager = { path = "../epoch_manager" }
+tari_dan_storage = { path = "../storage" }
+tari_validator_node_rpc = { path = "../validator_node_rpc" }
+tari_consensus = { path = "../consensus" }
+tari_dan_common_types = { path = "../common_types" }
+tari_transaction = { path = "../transaction" }
+
+tari_comms = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan2" }
+
+anyhow = "1.0.75"
+async-trait = "0.1.73"
+futures = "0.3.28"
+log = "0.4.20"
+thiserror = "1.0.48"

--- a/dan_layer/comms_rpc_state_sync/src/error.rs
+++ b/dan_layer/comms_rpc_state_sync/src/error.rs
@@ -1,0 +1,35 @@
+//   Copyright 2023 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+use tari_comms::protocol::rpc::RpcError;
+use tari_consensus::hotstuff::HotStuffError;
+use tari_dan_storage::{
+    consensus_models::{BlockId, TransactionPoolError},
+    StorageError,
+};
+use tari_epoch_manager::EpochManagerError;
+use tari_validator_node_rpc::ValidatorNodeRpcClientError;
+
+#[derive(Debug, thiserror::Error)]
+pub enum CommsRpcConsensusSyncError {
+    #[error("Epoch manager error: {0}")]
+    EpochManagerError(#[from] EpochManagerError),
+    #[error("RPC error: {0}")]
+    RpcError(#[from] RpcError),
+    #[error("Storage error: {0}")]
+    StorageError(#[from] StorageError),
+    #[error("Validator node client error: {0}")]
+    ValidatorNodeClientError(#[from] ValidatorNodeRpcClientError),
+    #[error("Transaction pool error: {0}")]
+    TransactionPoolError(#[from] TransactionPoolError),
+    #[error("Invalid response: {0}")]
+    InvalidResponse(anyhow::Error),
+    #[error("Block {block_id} failed SafeNode predicate")]
+    BlockNotSafe { block_id: BlockId },
+}
+
+impl From<CommsRpcConsensusSyncError> for HotStuffError {
+    fn from(value: CommsRpcConsensusSyncError) -> Self {
+        HotStuffError::SyncError(value.into())
+    }
+}

--- a/dan_layer/comms_rpc_state_sync/src/lib.rs
+++ b/dan_layer/comms_rpc_state_sync/src/lib.rs
@@ -1,0 +1,18 @@
+//   Copyright 2023 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+//! # Comms RPC State Sync Protocol
+//!
+//! ```mermaid
+//! sequenceDiagram
+//!     participant A as Client
+//!     participant B as Server
+//!  A->>B: CheckSync
+//!  B->>A: SyncStatus
+//! ```
+
+mod error;
+mod manager;
+
+pub use error::*;
+pub use manager::*;

--- a/dan_layer/comms_rpc_state_sync/src/manager.rs
+++ b/dan_layer/comms_rpc_state_sync/src/manager.rs
@@ -1,0 +1,335 @@
+//   Copyright 2023 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+use std::ops::DerefMut;
+
+use async_trait::async_trait;
+use futures::StreamExt;
+use log::*;
+use tari_comms::{protocol::rpc::RpcError, types::CommsPublicKey};
+use tari_consensus::traits::{SyncManager, SyncStatus};
+use tari_dan_common_types::{committee::Committee, optional::Optional, Epoch, NodeHeight};
+use tari_dan_storage::{
+    consensus_models::{Block, HighQc, LastExecuted, QuorumCertificate, SubstateUpdate, TransactionPoolRecord},
+    StateStore,
+    StateStoreWriteTransaction,
+};
+use tari_epoch_manager::EpochManagerReader;
+use tari_validator_node_rpc::{
+    client::{TariCommsValidatorNodeClientFactory, ValidatorNodeClientFactory},
+    proto::rpc::{GetHighQcRequest, SyncBlocksRequest},
+    rpc_service::ValidatorNodeRpcClient,
+};
+
+use crate::error::CommsRpcConsensusSyncError;
+
+const LOG_TARGET: &str = "tari::dan::comms_rpc_state_sync";
+
+pub struct CommsRpcStateSyncManager<TEpochManager, TStateStore> {
+    epoch_manager: TEpochManager,
+    state_store: TStateStore,
+    client_factory: TariCommsValidatorNodeClientFactory,
+}
+
+impl<TEpochManager, TStateStore> CommsRpcStateSyncManager<TEpochManager, TStateStore>
+where
+    TEpochManager: EpochManagerReader<Addr = CommsPublicKey>,
+    TStateStore: StateStore<Addr = CommsPublicKey>,
+{
+    pub fn new(
+        epoch_manager: TEpochManager,
+        state_store: TStateStore,
+        client_factory: TariCommsValidatorNodeClientFactory,
+    ) -> Self {
+        Self {
+            epoch_manager,
+            state_store,
+            client_factory,
+        }
+    }
+
+    async fn get_sync_peers(
+        &self,
+        current_epoch: Epoch,
+    ) -> Result<Committee<CommsPublicKey>, CommsRpcConsensusSyncError> {
+        let this_vn = self.epoch_manager.get_our_validator_node(current_epoch).await?;
+        let mut committee = self.epoch_manager.get_local_committee(current_epoch).await?;
+        committee.members.retain(|m| *m != this_vn.address);
+        committee.shuffle();
+        Ok(committee)
+    }
+
+    async fn sync_with_peer(&self, addr: &CommsPublicKey, high_qc: &HighQc) -> Result<(), CommsRpcConsensusSyncError> {
+        self.create_zero_block_if_required()?;
+        let mut rpc_client = self.client_factory.create_client(addr);
+        let mut client = rpc_client.client_connection().await?;
+
+        info!(target: LOG_TARGET, "🌐 Syncing blocks from {} from high QC {}", addr, high_qc);
+        self.sync_blocks(&mut client, high_qc).await?;
+
+        Ok(())
+    }
+
+    fn create_zero_block_if_required(&self) -> Result<(), CommsRpcConsensusSyncError> {
+        let mut tx = self.state_store.create_write_tx()?;
+
+        let zero_block = Block::zero_block();
+        if !zero_block.exists(tx.deref_mut())? {
+            debug!(target: LOG_TARGET, "Creating zero block");
+            zero_block.justify().insert(&mut tx)?;
+            zero_block.insert(&mut tx)?;
+            zero_block.as_locked().set(&mut tx)?;
+            zero_block.as_leaf_block().set(&mut tx)?;
+            zero_block.as_last_executed().set(&mut tx)?;
+            zero_block.justify().as_high_qc().set(&mut tx)?;
+            zero_block.commit(&mut tx)?;
+        }
+
+        tx.commit()?;
+
+        Ok(())
+    }
+
+    async fn sync_blocks(
+        &self,
+        client: &mut ValidatorNodeRpcClient,
+        high_qc: &HighQc,
+    ) -> Result<(), CommsRpcConsensusSyncError> {
+        let mut stream = client
+            .sync_blocks(SyncBlocksRequest {
+                start_block_id: high_qc.block_id.as_bytes().to_vec(),
+            })
+            .await?;
+
+        let mut counter = 0usize;
+
+        let mut expected_height = high_qc.block_height() + NodeHeight(1);
+
+        while let Some(resp) = stream.next().await {
+            let msg = resp.map_err(RpcError::from)?;
+            let block = msg
+                .block
+                .map(Block::<CommsPublicKey>::try_from)
+                .transpose()
+                .map_err(CommsRpcConsensusSyncError::InvalidResponse)?
+                .ok_or_else(|| {
+                    CommsRpcConsensusSyncError::InvalidResponse(anyhow::anyhow!(
+                        "Peer returned an empty block response"
+                    ))
+                })?;
+            if block.height() != expected_height {
+                return Err(CommsRpcConsensusSyncError::InvalidResponse(anyhow::anyhow!(
+                    "Peer returned block at height {} but expected {}",
+                    block.height(),
+                    expected_height,
+                )));
+            }
+            let qcs = msg
+                .quorum_certificates
+                .into_iter()
+                .map(QuorumCertificate::<CommsPublicKey>::try_from)
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(CommsRpcConsensusSyncError::InvalidResponse)?;
+            let updates = msg
+                .substate_updates
+                .into_iter()
+                .map(SubstateUpdate::try_from)
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(CommsRpcConsensusSyncError::InvalidResponse)?;
+
+            // TODO: Validate
+            debug!(
+                target: LOG_TARGET,
+                "🌐 Received block {}, {} qcs and {} substate updates",
+                block,
+                qcs.len(),
+                updates.len(),
+            );
+            counter += 1;
+            if counter % 100 == 0 {
+                info!(target: LOG_TARGET, "🌐 Syncing block {block}");
+            }
+            expected_height += NodeHeight(1);
+            self.commit_block(block, qcs, updates)?;
+        }
+
+        info!(target: LOG_TARGET, "🌐 {} blocks synced", counter);
+
+        Ok(())
+    }
+
+    fn commit_block(
+        &self,
+        block: Block<CommsPublicKey>,
+        qcs: Vec<QuorumCertificate<CommsPublicKey>>,
+        updates: Vec<SubstateUpdate<CommsPublicKey>>,
+    ) -> Result<(), CommsRpcConsensusSyncError> {
+        self.state_store.with_write_tx(|tx| {
+            if !block.is_safe(tx.deref_mut())? {
+                return Err(CommsRpcConsensusSyncError::BlockNotSafe { block_id: *block.id() });
+            }
+
+            block.justify().save(tx)?;
+            block.save(tx)?;
+            for qc in qcs {
+                qc.save(tx)?;
+            }
+            block.update_nodes(
+                tx,
+                |_, _| Ok(()),
+                |tx, last_executed, block| {
+                    Self::mark_block_executed(tx, last_executed, block)?;
+                    TransactionPoolRecord::remove_any(
+                        tx,
+                        block.commands().iter().filter_map(|cmd| cmd.accept()).map(|t| t.id),
+                    )?;
+                    Ok::<_, CommsRpcConsensusSyncError>(())
+                },
+            )?;
+            let (ups, downs) = updates.into_iter().partition::<Vec<_>, _>(|u| u.is_create());
+            // First do UPs then do DOWNs
+            for update in ups {
+                update.apply(tx, &block)?;
+            }
+            for update in downs {
+                update.apply(tx, &block)?;
+            }
+            Ok(())
+        })
+    }
+
+    fn mark_block_executed(
+        tx: &mut <TStateStore as StateStore>::WriteTransaction<'_>,
+        last_executed: &LastExecuted,
+        block: &Block<TStateStore::Addr>,
+    ) -> Result<(), CommsRpcConsensusSyncError> {
+        if last_executed.height < block.height() {
+            let parent = block.get_parent(tx.deref_mut())?;
+            // Recurse to "catch up" any parent parent blocks we may not have executed
+            block.commit(tx)?;
+            Self::mark_block_executed(tx, last_executed, &parent)?;
+            debug!(
+                target: LOG_TARGET,
+                "✅ COMMIT block {}, last executed height = {}",
+                block,
+                last_executed.height
+            );
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl<TEpochManager, TStateStore> SyncManager for CommsRpcStateSyncManager<TEpochManager, TStateStore>
+where
+    TEpochManager: EpochManagerReader<Addr = CommsPublicKey> + Send + Sync + 'static,
+    TStateStore: StateStore<Addr = CommsPublicKey> + Send + Sync + 'static,
+{
+    type Error = CommsRpcConsensusSyncError;
+
+    async fn check_sync(&self) -> Result<SyncStatus, Self::Error> {
+        let current_epoch = self.epoch_manager.current_epoch().await?;
+        let committee = self.get_sync_peers(current_epoch).await?;
+        let mut highest_qc: Option<QuorumCertificate<CommsPublicKey>> = None;
+        let mut num_succeeded = 0;
+        let max_failures = committee.max_failures();
+        for addr in committee {
+            let mut rpc_client = self.client_factory.create_client(&addr);
+            let mut client = match rpc_client.client_connection().await {
+                Ok(client) => client,
+                Err(err) => {
+                    warn!(target: LOG_TARGET, "Failed to connect to peer {}: {}", addr, err);
+                    continue;
+                },
+            };
+            let result = client
+                .get_high_qc(GetHighQcRequest {})
+                .await
+                .map_err(CommsRpcConsensusSyncError::RpcError)
+                .and_then(|resp| {
+                    resp.high_qc
+                        .map(QuorumCertificate::<CommsPublicKey>::try_from)
+                        .transpose()
+                        .map_err(CommsRpcConsensusSyncError::InvalidResponse)?
+                        .ok_or_else(|| {
+                            CommsRpcConsensusSyncError::InvalidResponse(anyhow::anyhow!(
+                                "Peer returned an empty high qc"
+                            ))
+                        })
+                });
+            let remote_high_qc = match result {
+                Ok(resp) => resp,
+                Err(err) => {
+                    warn!("Failed to get high qc from peer {}: {}", addr, err);
+                    continue;
+                },
+            };
+
+            num_succeeded += 1;
+            if highest_qc
+                .as_ref()
+                .map(|qc| qc.block_height() < remote_high_qc.block_height())
+                .unwrap_or(true)
+            {
+                // TODO: validate
+
+                highest_qc = Some(remote_high_qc);
+            }
+
+            if num_succeeded == max_failures {
+                break;
+            }
+        }
+
+        if let Some(highest_qc) = highest_qc {
+            let local_high_qc = self.state_store.with_read_tx(|tx| HighQc::get(tx).optional())?;
+            let local_height = local_high_qc
+                .as_ref()
+                .map(|qc| qc.block_height())
+                .unwrap_or(NodeHeight(0));
+            if highest_qc.block_height() > local_height {
+                info!(
+                    target: LOG_TARGET,
+                    "Highest QC from peers is at height {} and local high QC is at height {}",
+                    highest_qc.block_height(),
+                    local_height,
+                );
+                return Ok(SyncStatus::Behind);
+            }
+        }
+
+        Ok(SyncStatus::UpToDate)
+    }
+
+    async fn sync(&self) -> Result<(), Self::Error> {
+        let current_epoch = self.epoch_manager.current_epoch().await?;
+        let committee = self.get_sync_peers(current_epoch).await?;
+
+        let mut sync_error = None;
+        for member in committee {
+            // Refresh the HighQC each time because a partial sync could have been achieved from a peer
+            let high_qc = self
+                .state_store
+                .with_read_tx(|tx| HighQc::get(tx).optional())?
+                .unwrap_or_else(|| QuorumCertificate::<CommsPublicKey>::genesis().as_high_qc());
+
+            match self.sync_with_peer(&member, &high_qc).await {
+                Ok(()) => {
+                    sync_error = None;
+                    break;
+                },
+                Err(err) => {
+                    warn!(target: LOG_TARGET, "Failed to sync with peer {}: {}", member, err);
+                    sync_error = Some(err);
+                    continue;
+                },
+            }
+        }
+
+        if let Some(err) = sync_error {
+            return Err(err);
+        }
+
+        Ok(())
+    }
+}

--- a/dan_layer/consensus/Cargo.toml
+++ b/dan_layer/consensus/Cargo.toml
@@ -2,6 +2,9 @@
 name = "tari_consensus"
 version = "0.50.0-pre.0"
 edition = "2021"
+authors = ["The Tari Development Community"]
+description = "Tari template runtime engine"
+repository = "https://github.com/tari-project/tari-dan"
 license = "BSD-3-Clause"
 
 [dependencies]

--- a/dan_layer/consensus/src/hotstuff/common.rs
+++ b/dan_layer/consensus/src/hotstuff/common.rs
@@ -1,16 +1,9 @@
 //   Copyright 2023 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use std::ops::DerefMut;
-
 use log::*;
 use tari_dan_common_types::{committee::Committee, Epoch, NodeAddressable, NodeHeight};
-use tari_dan_storage::{
-    consensus_models::{Block, HighQc, QuorumCertificate, QuorumDecision},
-    StateStoreReadTransaction,
-    StateStoreWriteTransaction,
-    StorageError,
-};
+use tari_dan_storage::consensus_models::{Block, QuorumCertificate, QuorumDecision};
 
 use crate::{messages::HotstuffMessage, traits::LeaderStrategy};
 
@@ -24,36 +17,6 @@ pub const EXHAUST_DIVISOR: u64 = 0;
 // To avoid clippy::type_complexity
 pub(super) type CommitteeAndMessage<TAddr> = (Committee<TAddr>, HotstuffMessage<TAddr>);
 
-pub fn update_high_qc<TTx, TAddr: NodeAddressable>(
-    tx: &mut TTx,
-    qc: &QuorumCertificate<TAddr>,
-) -> Result<(), StorageError>
-where
-    TTx: StateStoreWriteTransaction<Addr = TAddr> + DerefMut,
-    TTx::Target: StateStoreReadTransaction,
-{
-    let high_qc = HighQc::get(tx.deref_mut())?;
-    let high_qc = high_qc.get_quorum_certificate(tx.deref_mut())?;
-
-    if high_qc.block_height() < qc.block_height() {
-        debug!(
-            target: LOG_TARGET,
-            "🔥 UPDATE_HIGH_QC (node: {} {}, previous high QC: {} {})",
-            qc.id(),
-            qc.block_height(),
-            high_qc.block_id(),
-            high_qc.block_height(),
-        );
-
-        qc.save(tx)?;
-        // This will fail if the block doesnt exist
-        qc.as_leaf_block().set(tx)?;
-        qc.as_high_qc().set(tx)?;
-    }
-
-    Ok(())
-}
-
 pub fn calculate_dummy_blocks<TAddr: NodeAddressable, TLeaderStrategy: LeaderStrategy<TAddr>>(
     epoch: Epoch,
     high_qc: &QuorumCertificate<TAddr>,
@@ -63,6 +26,15 @@ pub fn calculate_dummy_blocks<TAddr: NodeAddressable, TLeaderStrategy: LeaderStr
 ) -> Vec<Block<TAddr>> {
     let mut parent_block = high_qc.as_leaf_block();
     let mut current_height = high_qc.block_height() + NodeHeight(1);
+    if current_height > new_height {
+        warn!(
+            target: LOG_TARGET,
+            "BUG: 🍼 no dummy blocks to calculate. current height {} is greater than new height {}",
+            current_height,
+            new_height,
+        );
+        return Vec::new();
+    }
     debug!(
         target: LOG_TARGET,
         "🍼 calculating dummy blocks from {} to {}",

--- a/dan_layer/consensus/src/hotstuff/common.rs
+++ b/dan_layer/consensus/src/hotstuff/common.rs
@@ -35,6 +35,9 @@ pub fn calculate_dummy_blocks<TAddr: NodeAddressable, TLeaderStrategy: LeaderStr
         );
         return Vec::new();
     }
+    if current_height == new_height {
+        return Vec::new();
+    }
     debug!(
         target: LOG_TARGET,
         "🍼 calculating dummy blocks from {} to {}",
@@ -51,6 +54,11 @@ pub fn calculate_dummy_blocks<TAddr: NodeAddressable, TLeaderStrategy: LeaderStr
             current_height,
             high_qc.clone(),
             epoch,
+        );
+        debug!(
+            target: LOG_TARGET,
+            "🍼 new dummy block: {}",
+            dummy_block,
         );
         parent_block = dummy_block.as_leaf_block();
         blocks.push(dummy_block);

--- a/dan_layer/consensus/src/hotstuff/error.rs
+++ b/dan_layer/consensus/src/hotstuff/error.rs
@@ -129,4 +129,6 @@ pub enum ProposalValidationError {
         locked_block: LockedBlock,
         candidate_block: LeafBlock,
     },
+    #[error("Proposed block {block_id} {height} already has been processed")]
+    BlockAlreadyProcessed { block_id: BlockId, height: NodeHeight },
 }

--- a/dan_layer/consensus/src/hotstuff/error.rs
+++ b/dan_layer/consensus/src/hotstuff/error.rs
@@ -54,6 +54,8 @@ pub enum HotStuffError {
     },
     #[error("BUG Invariant error occurred: {0}")]
     InvariantError(String),
+    #[error("Sync error: {0}")]
+    SyncError(anyhow::Error),
 }
 
 impl From<EpochManagerError> for HotStuffError {
@@ -76,10 +78,10 @@ pub enum ProposalValidationError {
     NotSafeBlock { proposed_by: String, hash: BlockId },
     #[error("Node proposed by {proposed_by} with hash {hash} is the genesis block")]
     ProposingGenesisBlock { proposed_by: String, hash: BlockId },
-    #[error("Justification block {justify_block} for proposed block {hash} by {proposed_by} not found")]
+    #[error("Justification block {justify_block} for proposed block {block_id} by {proposed_by} not found")]
     JustifyBlockNotFound {
         proposed_by: String,
-        hash: BlockId,
+        block_id: BlockId,
         justify_block: BlockId,
     },
     #[error("QC in block {block_id} that was proposed by {proposed_by} is invalid: {details}")]

--- a/dan_layer/consensus/src/hotstuff/on_next_sync_view.rs
+++ b/dan_layer/consensus/src/hotstuff/on_next_sync_view.rs
@@ -1,8 +1,6 @@
 //  Copyright 2022 The Tari Project
 //  SPDX-License-Identifier: BSD-3-Clause
 
-use std::ops::DerefMut;
-
 use log::*;
 use tari_dan_common_types::{Epoch, NodeHeight};
 use tari_dan_storage::{consensus_models::HighQc, StateStore};
@@ -10,7 +8,7 @@ use tari_epoch_manager::EpochManagerReader;
 use tokio::sync::mpsc;
 
 use crate::{
-    hotstuff::{common::calculate_dummy_blocks, HotStuffError},
+    hotstuff::HotStuffError,
     messages::{HotstuffMessage, NewViewMessage},
     traits::{ConsensusSpec, LeaderStrategy},
 };
@@ -44,22 +42,9 @@ impl<TConsensusSpec: ConsensusSpec> OnNextSyncViewHandler<TConsensusSpec> {
         let local_committee = self.epoch_manager.get_local_committee(epoch).await?;
         let current_epoch = self.epoch_manager.current_epoch().await?;
 
-        let high_qc = self.store.with_write_tx(|tx| {
-            let high_qc = HighQc::get(tx.deref_mut())?.get_quorum_certificate(tx.deref_mut())?;
-            let dummy_blocks = calculate_dummy_blocks(
-                current_epoch,
-                &high_qc,
-                new_height,
-                &self.leader_strategy,
-                &local_committee,
-            );
-            // Set the last voted block so that we do not vote on other conflicting blocks
-            if let Some(new_last_voted) = dummy_blocks.last().map(|b| b.as_last_voted()) {
-                new_last_voted.set(tx)?;
-            }
-
-            Ok::<_, HotStuffError>(high_qc)
-        })?;
+        let high_qc = self
+            .store
+            .with_read_tx(|tx| HighQc::get(tx)?.get_quorum_certificate(tx))?;
 
         let next_leader = self
             .leader_strategy

--- a/dan_layer/consensus/src/hotstuff/on_next_sync_view.rs
+++ b/dan_layer/consensus/src/hotstuff/on_next_sync_view.rs
@@ -54,11 +54,9 @@ impl<TConsensusSpec: ConsensusSpec> OnNextSyncViewHandler<TConsensusSpec> {
                 &local_committee,
             );
             // Set the last voted block so that we do not vote on other conflicting blocks
-            let new_last_voted = dummy_blocks
-                .last()
-                .map(|b| b.as_last_voted())
-                .unwrap_or_else(|| high_qc.as_last_voted());
-            new_last_voted.set(tx)?;
+            if let Some(new_last_voted) = dummy_blocks.last().map(|b| b.as_last_voted()) {
+                new_last_voted.set(tx)?;
+            }
 
             Ok::<_, HotStuffError>(high_qc)
         })?;

--- a/dan_layer/consensus/src/hotstuff/on_propose.rs
+++ b/dan_layer/consensus/src/hotstuff/on_propose.rs
@@ -75,44 +75,47 @@ where TConsensusSpec: ConsensusSpec
         epoch: Epoch,
         local_committee: Committee<TConsensusSpec::Addr>,
         leaf_block: LeafBlock,
+        is_newview_propose: bool,
     ) -> Result<(), HotStuffError> {
-        let last_proposed = self.store.with_read_tx(|tx| LastProposed::get(tx).optional())?;
-        let last_proposed_height = last_proposed.as_ref().map(|lp| lp.height).unwrap_or(NodeHeight(0));
-        if last_proposed_height > leaf_block.height {
-            debug!(
-                target: LOG_TARGET,
-                "⤵️ Skipping on_propose for next block because we have already proposed a block at height {}",
-                last_proposed_height
-            );
+        if let Some(last_proposed) = self.store.with_read_tx(|tx| LastProposed::get(tx).optional())? {
+            if last_proposed.height > leaf_block.height {
+                // must_propose means that a NEWVIEW has reached quorum and nodes are expecting us to propose.
+                if !is_newview_propose {
+                    debug!(
+                        target: LOG_TARGET,
+                        "⤵️ Skipping on_propose for next block because we have already proposed a block at height {}",
+                        last_proposed.height
+                    );
 
-            // if must_proposed {
-            //     if let Some(last_proposed) = last_proposed {
-            //         let validator = self.epoch_manager.get_our_validator_node(epoch).await?;
-            //         let num_committees = self.epoch_manager.get_num_committees(epoch).await?;
-            //         let local_bucket = validator.shard_key.to_committee_bucket(num_committees);
-            //
-            //         let (next_block, non_local_buckets) = self.store.with_read_tx(|tx| {
-            //             let block = Block::get(tx, &last_proposed.block_id)?;
-            //             let non_local_buckets = get_non_local_buckets(tx, &block, num_committees, local_bucket)?;
-            //             Ok::<_, HotStuffError>((block, non_local_buckets))
-            //         })?;
-            //         info!(
-            //             target: LOG_TARGET,
-            //             "🌿 RE-BROADCASTING block {}({}) to {} validators. {} command(s), {} foreign shards, justify:
-            // {} ({}), parent: {}",             next_block.id(),
-            //             next_block.height(),
-            //             local_committee.len(),
-            //             next_block.commands().len(),
-            //             non_local_buckets.len(),
-            //             next_block.justify().block_id(),
-            //             next_block.justify().block_height(),
-            //             next_block.parent());
-            //         self.broadcast_proposal(epoch, next_block, non_local_buckets, local_committee)
-            //             .await?;
-            //     }
-            // }
+                    return Ok(());
+                }
 
-            return Ok(());
+                // let validator = self.epoch_manager.get_our_validator_node(epoch).await?;
+                // let num_committees = self.epoch_manager.get_num_committees(epoch).await?;
+                // let local_bucket = validator.shard_key.to_committee_bucket(num_committees);
+                //
+                // if let Some(next_block) = self.store.with_read_tx(|tx| last_proposed.get_block(tx)).optional()? {
+                //     let non_local_buckets = self
+                //         .store
+                //         .with_read_tx(|tx| get_non_local_buckets(tx, &next_block, num_committees, local_bucket))?;
+                //     info!(
+                //         target: LOG_TARGET,
+                //         "🌿 RE-BROADCASTING block {}({}) to {} validators. {} command(s), {} foreign shards, justify:
+                // {} ({}), parent: {}",         next_block.id(),
+                //         next_block.height(),
+                //         local_committee.len(),
+                //         next_block.commands().len(),
+                //         non_local_buckets.len(),
+                //         next_block.justify().block_id(),
+                //         next_block.justify().block_height(),
+                //         next_block.parent()
+                //     );
+                //     self.broadcast_proposal(epoch, next_block, non_local_buckets, local_committee)
+                //         .await?;
+                //
+                //     return Ok(());
+                // }
+            }
         }
 
         let validator = self.epoch_manager.get_our_validator_node(epoch).await?;
@@ -135,7 +138,11 @@ where TConsensusSpec: ConsensusSpec
                 high_qc,
                 validator.address,
                 &local_committee_shard,
+                // TODO: This just avoids issues with proposed transactions causing leader failures. Not sure if this
+                //       is a good idea.
+                is_newview_propose,
             )?;
+            next_block.save(&mut tx)?;
             next_block.as_last_proposed().set(&mut tx)?;
 
             // Get involved shards for all LocalPrepared commands in the block.
@@ -218,10 +225,15 @@ where TConsensusSpec: ConsensusSpec
         high_qc: QuorumCertificate<TConsensusSpec::Addr>,
         proposed_by: <TConsensusSpec::EpochManager as EpochManagerReader>::Addr,
         local_committee_shard: &CommitteeShard,
+        empty_block: bool,
     ) -> Result<Block<TConsensusSpec::Addr>, HotStuffError> {
         // TODO: Configure
         const TARGET_BLOCK_SIZE: usize = 1000;
-        let batch = self.transaction_pool.get_batch(tx, TARGET_BLOCK_SIZE)?;
+        let batch = if empty_block {
+            vec![]
+        } else {
+            self.transaction_pool.get_batch(tx, TARGET_BLOCK_SIZE)?
+        };
 
         let mut total_leader_fee = 0;
         let commands = batch

--- a/dan_layer/consensus/src/hotstuff/on_receive_proposal.rs
+++ b/dan_layer/consensus/src/hotstuff/on_receive_proposal.rs
@@ -279,7 +279,7 @@ where TConsensusSpec: ConsensusSpec
             if maybe_decision.is_some() {
                 block.update_nodes(
                     &mut tx,
-                    |tx, block| self.on_lock_block(tx, block),
+                    |tx, _, block| self.on_lock_block(tx, block),
                     |tx, last_exec, commit_block| self.on_commit(tx, last_exec, commit_block, local_committee_shard),
                 )?;
 

--- a/dan_layer/consensus/src/hotstuff/on_receive_proposal.rs
+++ b/dan_layer/consensus/src/hotstuff/on_receive_proposal.rs
@@ -138,8 +138,30 @@ where TConsensusSpec: ConsensusSpec
         let local_committee_shard = self.epoch_manager.get_local_committee_shard(block.epoch()).await?;
 
         // First save the block in one db transaction
-        let (missing_tx_ids, awaiting_execution) = self.store.with_write_tx(|tx| {
-            self.validate_local_proposed_block_and_fill_dummy_blocks(&mut *tx, &from, &block, &local_committee)?;
+        let (missing_tx_ids, awaiting_execution) = {
+            let mut tx = self.store.create_write_tx()?;
+            if let Err(err) =
+                self.validate_local_proposed_block_and_fill_dummy_blocks(&mut tx, &from, &block, &local_committee)
+            {
+                match err {
+                    err @ HotStuffError::ProposalValidationError(ProposalValidationError::JustifyBlockNotFound {
+                        ..
+                    }) => {
+                        tx.rollback()?;
+                        return Err(err);
+                    },
+                    HotStuffError::ProposalValidationError(err) => {
+                        warn!(target: LOG_TARGET, "❌ Block failed validation: {}", err);
+                        // A bad block should not disrupt consensus
+                        tx.rollback()?;
+                        return Ok(());
+                    },
+                    e => {
+                        tx.rollback()?;
+                        return Err(e);
+                    },
+                }
+            }
             // Now that we have all dummy blocks (if any) in place, we can check if the candidate block is safe.
             // Specifically, it should extend the locked block via the dummy blocks.
             if !block.is_safe(tx.deref_mut())? {
@@ -151,17 +173,18 @@ where TConsensusSpec: ConsensusSpec
             }
 
             // Insert the block if it doesnt already exist
-            block.justify().save(tx)?;
-            block.save(tx)?;
+            block.justify().save(&mut tx)?;
+            if block.save(&mut tx)? {
+                debug!(
+                    target: LOG_TARGET,
+                    "🔥 Block {} saved.", block
+                );
+            }
 
-            block.update_nodes(
-                tx,
-                |tx, block| self.on_lock_block(tx, block),
-                |tx, last_exec, commit_block| self.on_commit(tx, last_exec, commit_block, &local_committee_shard),
-            )?;
-
-            self.block_get_missing_transaction(tx, &block)
-        })?;
+            let missing_tuple = self.block_get_missing_transaction(&mut tx, &block)?;
+            tx.commit()?;
+            missing_tuple
+        };
 
         if !missing_tx_ids.is_empty() {
             self.send_to_leader(
@@ -254,6 +277,12 @@ where TConsensusSpec: ConsensusSpec
             }
 
             if maybe_decision.is_some() {
+                block.update_nodes(
+                    &mut tx,
+                    |tx, block| self.on_lock_block(tx, block),
+                    |tx, last_exec, commit_block| self.on_commit(tx, last_exec, commit_block, local_committee_shard),
+                )?;
+
                 tx.commit()?;
             } else {
                 tx.rollback()?;
@@ -448,7 +477,7 @@ where TConsensusSpec: ConsensusSpec
             );
             match cmd {
                 Command::Prepare(t) => {
-                    if !tx_rec.current_stage().is_new() {
+                    if !tx_rec.current_stage().is_new() && !tx_rec.current_stage().is_prepared() {
                         warn!(
                             target: LOG_TARGET,
                             "❌ Stage disagreement for tx {} in block {}. Leader proposed Prepare, local stage is {}",
@@ -473,51 +502,55 @@ where TConsensusSpec: ConsensusSpec
                     }
 
                     if tx_rec.current_decision() == t.decision {
-                        if tx_rec.current_decision().is_commit() {
-                            let transaction = ExecutedTransaction::get(tx.deref_mut(), cmd.transaction_id())?;
-                            // Lock all inputs for the transaction as part of LocalPrepare
-                            if !self.lock_inputs(tx, transaction.transaction(), local_committee_shard)? {
-                                // Unable to lock all inputs - do not vote
-                                warn!(
-                                    target: LOG_TARGET,
-                                    "❌ Unable to lock all inputs for transaction {} in block {}. Leader proposed {}, we decided {}",
-                                    block.id(),
-                                    transaction.id(),
-                                    t.decision,
-                                    Decision::Abort
-                                );
-                                // We change our decision to ABORT so that the next time we propose/receive a proposal
-                                // we will check for ABORT. It may happen that the transaction causing the lock failure
-                                // is ABORTED too and the locks released allowing this transaction to succeed.
-                                // Currently, the client would have to resubmit the transaction to resolve this.
-                                // tx_rec.update_local_decision(tx, Decision::Abort)?;
-                                abort_transactions.push(tx_rec);
-                                // This brings up an interesting problem. If we decide to abstain from voting, then
-                                // object conflicts essentially induce leader failures. This is problematic since it
-                                // puts leader failure under the control of users and potentially malicious parties.
-                                decision.dont_vote();
-                                continue;
+                        // We allow blocks to ask us to prepare more than once - only lock objects if the stage is New
+                        if tx_rec.current_stage().is_new() {
+                            if tx_rec.current_decision().is_commit() {
+                                let transaction = ExecutedTransaction::get(tx.deref_mut(), cmd.transaction_id())?;
+                                // Lock all inputs for the transaction as part of LocalPrepare
+                                if !self.lock_inputs(tx, transaction.transaction(), local_committee_shard)? {
+                                    // Unable to lock all inputs - do not vote
+                                    warn!(
+                                        target: LOG_TARGET,
+                                        "❌ Unable to lock all inputs for transaction {} in block {}. Leader proposed {}, we decided {}",
+                                        block.id(),
+                                        transaction.id(),
+                                        t.decision,
+                                        Decision::Abort
+                                    );
+                                    // We change our decision to ABORT so that the next time we propose/receive a
+                                    // proposal we will check for ABORT. It may
+                                    // happen that the transaction causing the lock failure
+                                    // is ABORTED too and the locks released allowing this transaction to succeed.
+                                    // Currently, the client would have to resubmit the transaction to resolve this.
+                                    // tx_rec.update_local_decision(tx, Decision::Abort)?;
+                                    abort_transactions.push(tx_rec);
+                                    // This brings up an interesting problem. If we decide to abstain from voting, then
+                                    // object conflicts essentially induce leader failures. This is problematic since it
+                                    // puts leader failure under the control of users and potentially malicious parties.
+                                    decision.dont_vote();
+                                    continue;
+                                }
+                                if !self.lock_outputs(tx, block.id(), &transaction)? {
+                                    // Unable to lock all outputs - do not vote
+                                    warn!(
+                                        target: LOG_TARGET,
+                                        "❌ Unable to lock all outputs for transaction {} in block {}. Leader proposed {}, we decided {}",
+                                        block.id(),
+                                        transaction.id(),
+                                        t.decision,
+                                        Decision::Abort
+                                    );
+                                    // We change our decision to ABORT so that the next time we propose/receive a
+                                    // proposal we will check for ABORT
+                                    abort_transactions.push(tx_rec);
+                                    // tx_rec.update_local_decision(tx, Decision::Abort)?;
+                                    decision.dont_vote();
+                                    continue;
+                                }
                             }
-                            if !self.lock_outputs(tx, block.id(), &transaction)? {
-                                // Unable to lock all outputs - do not vote
-                                warn!(
-                                    target: LOG_TARGET,
-                                    "❌ Unable to lock all outputs for transaction {} in block {}. Leader proposed {}, we decided {}",
-                                    block.id(),
-                                    transaction.id(),
-                                    t.decision,
-                                    Decision::Abort
-                                );
-                                // We change our decision to ABORT so that the next time we propose/receive a proposal
-                                // we will check for ABORT
-                                abort_transactions.push(tx_rec);
-                                // tx_rec.update_local_decision(tx, Decision::Abort)?;
-                                decision.dont_vote();
-                                continue;
-                            }
-                        }
 
-                        tx_rec.pending_transition(tx, TransactionPoolStage::Prepared, true)?;
+                            tx_rec.pending_transition(tx, TransactionPoolStage::Prepared, true)?;
+                        }
                     } else {
                         // If we disagree with any local decision we abstain from voting
                         warn!(
@@ -539,9 +572,10 @@ where TConsensusSpec: ConsensusSpec
                     if !tx_rec.current_stage().is_prepared() {
                         warn!(
                             target: LOG_TARGET,
-                            "❌ Stage disagreement in block {} for transaction {}. Leader proposed LocalPrepared, but we have not prepared",
+                            "❌ Stage disagreement in block {} for transaction {}. Leader proposed LocalPrepared, but local stage is {}",
                             block.id(),
-                            tx_rec.transaction_id()
+                            tx_rec.transaction_id(),
+                            tx_rec.current_stage()
                         );
                         decision.dont_vote();
                         continue;
@@ -758,6 +792,14 @@ where TConsensusSpec: ConsensusSpec
         block_id: &BlockId,
         transaction: &ExecutedTransaction,
     ) -> Result<bool, HotStuffError> {
+        debug!(
+            target: LOG_TARGET,
+            "Acquiring {} output locks for block `{}` and transaction `{}`",
+            transaction.resulting_outputs().len(),
+            block_id,
+            transaction.id(),
+        );
+
         let state = LockedOutput::try_acquire_all(tx, block_id, transaction.id(), transaction.resulting_outputs())?;
 
         if !state.is_acquired() {
@@ -992,7 +1034,6 @@ where TConsensusSpec: ConsensusSpec
         // Check that details included in the justify match previously added blocks
         let Some(justify_block) = candidate_block.justify().get_block(tx.deref_mut()).optional()? else {
             // This will trigger a sync
-            // TODO: I think we should maintain our current block height (view number) and check if high_qc > tip_block.
             return Err(ProposalValidationError::JustifyBlockNotFound {
                 proposed_by: from.to_string(),
                 block_id: *candidate_block.id(),

--- a/dan_layer/consensus/src/hotstuff/on_receive_vote.rs
+++ b/dan_layer/consensus/src/hotstuff/on_receive_vote.rs
@@ -12,10 +12,9 @@ use tari_dan_storage::{
     StateStoreWriteTransaction,
 };
 use tari_epoch_manager::EpochManagerReader;
-use thiserror::__private::DisplayAsDisplay;
 
 use crate::{
-    hotstuff::{common::update_high_qc, error::HotStuffError, pacemaker_handle::PaceMakerHandle},
+    hotstuff::{error::HotStuffError, pacemaker_handle::PaceMakerHandle},
     messages::VoteMessage,
     traits::{ConsensusSpec, LeaderStrategy, VoteSignatureService},
 };
@@ -194,7 +193,7 @@ where TConsensusSpec: ConsensusSpec
 
             info!(target: LOG_TARGET, "🔥 New QC {}", qc);
 
-            update_high_qc(&mut tx, &qc)?;
+            qc.update_high_qc(&mut tx)?;
             tx.commit()?;
         }
         self.on_beat.beat();
@@ -236,7 +235,7 @@ where TConsensusSpec: ConsensusSpec
                 .create_challenge(sender_leaf_hash, &message.block_id, &message.decision);
         if !self.vote_signature_service.verify(&message.signature, &challenge) {
             return Err(HotStuffError::InvalidVoteSignature {
-                signer_public_key: message.signature.public_key().as_display().to_string(),
+                signer_public_key: message.signature.public_key().to_string(),
             });
         }
         Ok(())

--- a/dan_layer/consensus/src/hotstuff/on_receive_vote.rs
+++ b/dan_layer/consensus/src/hotstuff/on_receive_vote.rs
@@ -105,6 +105,7 @@ where TConsensusSpec: ConsensusSpec
 
         // We only generate the next high qc once when we have a quorum of votes. Any subsequent votes are not included
         // in the QC.
+
         info!(
             target: LOG_TARGET,
             "🔥 Received vote for block {} from {} ({} of {})",
@@ -121,11 +122,12 @@ where TConsensusSpec: ConsensusSpec
             let Some(block) = Block::get(tx.deref_mut(), &message.block_id).optional()? else {
                 warn!(
                     target: LOG_TARGET,
-                    "❌ Received vote for unknown block {} from {}",message.block_id,from
+                    "❌ Received vote for unknown block {} from {}", message.block_id, from
                 );
                 tx.rollback()?;
                 return Ok(());
             };
+
             if !self
                 .leader_strategy
                 .is_leader_for_next_block(&vn.address, &committee, block.height())
@@ -138,6 +140,7 @@ where TConsensusSpec: ConsensusSpec
                     ),
                 });
             }
+
             let high_qc = HighQc::get(tx.deref_mut())?;
             if high_qc.block_id == *block.id() {
                 debug!(

--- a/dan_layer/consensus/src/hotstuff/state_machine/syncing.rs
+++ b/dan_layer/consensus/src/hotstuff/state_machine/syncing.rs
@@ -9,19 +9,22 @@ use crate::{
         ConsensusWorkerContext,
         HotStuffError,
     },
-    traits::ConsensusSpec,
+    traits::{ConsensusSpec, SyncManager},
 };
 
 #[derive(Debug)]
 pub struct Syncing<TSpec>(PhantomData<TSpec>);
 
-impl<TSpec: ConsensusSpec> Syncing<TSpec> {
+impl<TSpec> Syncing<TSpec>
+where
+    TSpec: ConsensusSpec,
+    HotStuffError: From<<TSpec::SyncManager as SyncManager>::Error>,
+{
     pub(super) async fn on_enter(
         &self,
-        _context: &mut ConsensusWorkerContext<TSpec>,
+        context: &mut ConsensusWorkerContext<TSpec>,
     ) -> Result<ConsensusStateEvent, HotStuffError> {
-        // let mut sync = SyncWorker::new(context);
-        // sync.start().await?;
+        context.state_sync.sync().await?;
         Ok(ConsensusStateEvent::SyncComplete)
     }
 }

--- a/dan_layer/consensus/src/hotstuff/worker.rs
+++ b/dan_layer/consensus/src/hotstuff/worker.rs
@@ -90,7 +90,7 @@ where
         tx_mempool: mpsc::UnboundedSender<Transaction>,
         shutdown: ShutdownSignal,
     ) -> Self {
-        let pacemaker = PaceMaker::new(shutdown.clone());
+        let pacemaker = PaceMaker::new();
         Self {
             validator_addr: validator_addr.clone(),
             rx_new_transactions,
@@ -226,7 +226,10 @@ where TConsensusSpec: ConsensusSpec
         }
 
         self.on_receive_new_view.clear_new_views();
-        self.pacemaker_handle.stop().await?;
+        // This only happens if we're shutting down.
+        if let Err(err) = self.pacemaker_handle.stop().await {
+            debug!(target: LOG_TARGET, "Pacemaker channel dropped: {}", err);
+        }
 
         Ok(())
     }

--- a/dan_layer/consensus/src/traits/mod.rs
+++ b/dan_layer/consensus/src/traits/mod.rs
@@ -4,10 +4,12 @@
 mod leader_strategy;
 mod signing_service;
 mod state_manager;
+mod sync;
 
 pub use leader_strategy::*;
 use serde::Serialize;
 pub use state_manager::*;
+pub use sync::*;
 use tari_dan_common_types::NodeAddressable;
 use tari_dan_storage::StateStore;
 use tari_epoch_manager::EpochManagerReader;
@@ -22,4 +24,5 @@ pub trait ConsensusSpec: Send + Sync + 'static {
     type LeaderStrategy: LeaderStrategy<Self::Addr> + Send + Sync + 'static;
     type VoteSignatureService: VoteSignatureService<Self::Addr> + Send + Sync + 'static;
     type StateManager: StateManager<Self::StateStore> + Send + Sync + 'static;
+    type SyncManager: SyncManager + Send + Sync + 'static;
 }

--- a/dan_layer/consensus/src/traits/sync.rs
+++ b/dan_layer/consensus/src/traits/sync.rs
@@ -1,0 +1,19 @@
+//   Copyright 2023 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+use async_trait::async_trait;
+
+#[async_trait]
+pub trait SyncManager {
+    type Error: std::error::Error + Send + Sync + 'static;
+
+    async fn check_sync(&self) -> Result<SyncStatus, Self::Error>;
+
+    async fn sync(&self) -> Result<(), Self::Error>;
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum SyncStatus {
+    UpToDate,
+    Behind,
+}

--- a/dan_layer/consensus_tests/Cargo.toml
+++ b/dan_layer/consensus_tests/Cargo.toml
@@ -1,9 +1,11 @@
 [package]
 name = "consensus_tests"
-version = "0.1.0"
+version = "0.50.0-pre.0"
 edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+authors = ["The Tari Development Community"]
+description = "Tari template runtime engine"
+repository = "https://github.com/tari-project/tari-dan"
+license = "BSD-3-Clause"
 
 [dependencies]
 

--- a/dan_layer/consensus_tests/src/support/mod.rs
+++ b/dan_layer/consensus_tests/src/support/mod.rs
@@ -14,6 +14,7 @@ mod network;
 mod signing_service;
 mod spec;
 mod state_manager;
+mod sync;
 mod transaction;
 mod validator;
 

--- a/dan_layer/consensus_tests/src/support/spec.rs
+++ b/dan_layer/consensus_tests/src/support/spec.rs
@@ -8,6 +8,7 @@ use crate::support::{
     address::TestAddress,
     epoch_manager::TestEpochManager,
     signing_service::TestVoteSignatureService,
+    sync::AlwaysSyncedSyncManager,
     NoopStateManager,
     RoundRobinLeaderStrategy,
 };
@@ -20,5 +21,6 @@ impl ConsensusSpec for TestConsensusSpec {
     type LeaderStrategy = RoundRobinLeaderStrategy;
     type StateManager = NoopStateManager;
     type StateStore = SqliteStateStore<Self::Addr>;
+    type SyncManager = AlwaysSyncedSyncManager;
     type VoteSignatureService = TestVoteSignatureService<Self::Addr>;
 }

--- a/dan_layer/consensus_tests/src/support/sync.rs
+++ b/dan_layer/consensus_tests/src/support/sync.rs
@@ -1,0 +1,23 @@
+//   Copyright 2023 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+use async_trait::async_trait;
+use tari_consensus::{
+    hotstuff::HotStuffError,
+    traits::{SyncManager, SyncStatus},
+};
+
+pub struct AlwaysSyncedSyncManager;
+
+#[async_trait]
+impl SyncManager for AlwaysSyncedSyncManager {
+    type Error = HotStuffError;
+
+    async fn check_sync(&self) -> Result<SyncStatus, Self::Error> {
+        Ok(SyncStatus::UpToDate)
+    }
+
+    async fn sync(&self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+}

--- a/dan_layer/consensus_tests/src/support/validator/builder.rs
+++ b/dan_layer/consensus_tests/src/support/validator/builder.rs
@@ -12,6 +12,7 @@ use crate::support::{
     address::TestAddress,
     epoch_manager::TestEpochManager,
     signing_service::TestVoteSignatureService,
+    sync::AlwaysSyncedSyncManager,
     NoopStateManager,
     RoundRobinLeaderStrategy,
     TestConsensusSpec,
@@ -106,6 +107,7 @@ impl ValidatorBuilder {
             epoch_manager,
             epoch_events: rx_epoch_events,
             hotstuff: worker,
+            state_sync: AlwaysSyncedSyncManager,
         };
 
         let mut worker = ConsensusWorker::new(shutdown_signal);

--- a/dan_layer/epoch_manager/src/base_layer/base_layer_epoch_manager.rs
+++ b/dan_layer/epoch_manager/src/base_layer/base_layer_epoch_manager.rs
@@ -279,6 +279,10 @@ impl BaseLayerEpochManager<SqliteGlobalDbAdapter, GrpcBaseNodeClient> {
         public_key: &CommsPublicKey,
     ) -> Result<Option<ValidatorNode<CommsPublicKey>>, EpochManagerError> {
         let (start_epoch, end_epoch) = self.get_epoch_range(epoch)?;
+        debug!(
+            target: LOG_TARGET,
+            "get_validator_node: epoch {}-{} with public key {}", start_epoch, end_epoch, public_key,
+        );
         let mut tx = self.global_db.create_transaction()?;
         let vn = self
             .global_db

--- a/dan_layer/state_store_sqlite/Cargo.toml
+++ b/dan_layer/state_store_sqlite/Cargo.toml
@@ -24,3 +24,6 @@ serde = "1.0"
 serde_json = "1.0"
 thiserror = "1.0"
 time = "0.3"
+
+[dev-dependencies]
+rand = "0.8"

--- a/dan_layer/state_store_sqlite/migrations/2023-06-08-091819_create_state_store/up.sql
+++ b/dan_layer/state_store_sqlite/migrations/2023-06-08-091819_create_state_store/up.sql
@@ -16,7 +16,7 @@ create table blocks
 (
     id               integer   not null primary key AUTOINCREMENT,
     block_id         text      not NULL,
-    parent_block_id  text      not NULL,
+    parent_block_id  text      NULL,
     height           bigint    not NULL,
     epoch            bigint    not NULL,
     proposed_by      text      not NULL,

--- a/dan_layer/state_store_sqlite/src/error.rs
+++ b/dan_layer/state_store_sqlite/src/error.rs
@@ -29,6 +29,12 @@ pub enum SqliteStorageError {
     NotAllTransactionsFound { operation: &'static str, details: String },
     #[error("[{operation}] Not all queried substates were found: {details}")]
     NotAllSubstatesFound { operation: &'static str, details: String },
+    #[error("[{operation}] Not all {items} were found: {details}")]
+    NotAllItemsFound {
+        items: &'static str,
+        operation: &'static str,
+        details: String,
+    },
     #[error("[{operation}] One or more substates were are write locked")]
     SubstatesWriteLocked { operation: &'static str },
     #[error("[{operation}] lock error: {details}")]
@@ -59,12 +65,6 @@ impl From<SqliteStorageError> for StorageError {
         }
     }
 }
-
-// impl From<FixedHashSizeError> for SqliteStorageError {
-//     fn from(_: FixedHashSizeError) -> Self {
-//         SqliteStorageError::MalformedHashData
-//     }
-// }
 
 impl IsNotFoundError for SqliteStorageError {
     fn is_not_found_error(&self) -> bool {

--- a/dan_layer/state_store_sqlite/src/sql_models/block.rs
+++ b/dan_layer/state_store_sqlite/src/sql_models/block.rs
@@ -1,18 +1,19 @@
 //   Copyright 2023 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use diesel::Queryable;
+use diesel::{Queryable, QueryableByName};
 use serde::Serialize;
 use tari_dan_common_types::{Epoch, NodeAddressable, NodeHeight};
 use tari_dan_storage::{consensus_models, StorageError};
 use time::PrimitiveDateTime;
 
 use crate::{
+    schema::blocks,
     serialization::{deserialize_hex, deserialize_hex_try_from, deserialize_json},
     sql_models,
 };
 
-#[derive(Debug, Clone, Queryable)]
+#[derive(Debug, Clone, Queryable, QueryableByName)]
 pub struct Block {
     pub id: i32,
     pub block_id: String,
@@ -23,7 +24,7 @@ pub struct Block {
     pub qc_id: String,
     pub command_count: i64,
     pub commands: String,
-    pub total_leader_fees: i64,
+    pub total_leader_fee: i64,
     pub is_committed: bool,
     pub is_processed: bool,
     pub is_dummy: bool,
@@ -47,9 +48,10 @@ impl Block {
                 details: format!("Block #{} proposed_by is malformed", self.id),
             })?,
             deserialize_json(&self.commands)?,
-            self.total_leader_fees as u64,
+            self.total_leader_fee as u64,
             self.is_dummy,
             self.is_processed,
+            self.is_committed,
         ))
     }
 }

--- a/dan_layer/state_store_sqlite/src/sql_models/quorum_certificate.rs
+++ b/dan_layer/state_store_sqlite/src/sql_models/quorum_certificate.rs
@@ -1,14 +1,14 @@
 //   Copyright 2023 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use diesel::Queryable;
+use diesel::{Queryable, QueryableByName};
 use tari_dan_common_types::NodeAddressable;
 use tari_dan_storage::{consensus_models, StorageError};
 use time::PrimitiveDateTime;
 
-use crate::serialization::deserialize_json;
+use crate::{schema::quorum_certificates, serialization::deserialize_json};
 
-#[derive(Debug, Clone, Queryable)]
+#[derive(Debug, Clone, Queryable, QueryableByName)]
 pub struct QuorumCertificate {
     pub id: i32,
     pub qc_id: String,

--- a/dan_layer/state_store_sqlite/src/writer.rs
+++ b/dan_layer/state_store_sqlite/src/writer.rs
@@ -1048,7 +1048,7 @@ impl<TAddr: NodeAddressable> StateStoreWriteTransaction for SqliteStateStoreWrit
                     Ok(SubstateLockState::SomeAlreadyWriteLocked)
                 } else {
                     Err(SqliteStorageError::DieselError {
-                        operation: "locked_outputs_acquire",
+                        operation: "locked_outputs_acquire_all",
                         source: e,
                     })
                 }

--- a/dan_layer/storage/src/consensus_models/block.rs
+++ b/dan_layer/storage/src/consensus_models/block.rs
@@ -7,18 +7,31 @@ use std::{
     ops::{DerefMut, RangeInclusive},
 };
 
+use log::*;
 use serde::{Deserialize, Serialize};
 use tari_common_types::types::{FixedHash, FixedHashSizeError};
-use tari_dan_common_types::{hashing, serde_with, Epoch, NodeAddressable, NodeHeight, ShardId};
+use tari_dan_common_types::{hashing, optional::Optional, serde_with, Epoch, NodeAddressable, NodeHeight, ShardId};
 use tari_transaction::TransactionId;
 
 use super::QuorumCertificate;
 use crate::{
-    consensus_models::{Command, LastExecuted, LastProposed, LastVoted, LeafBlock, LockedBlock, Vote},
+    consensus_models::{
+        Command,
+        LastExecuted,
+        LastProposed,
+        LastVoted,
+        LeafBlock,
+        LockedBlock,
+        SubstateCreatedProof,
+        SubstateUpdate,
+        Vote,
+    },
     StateStoreReadTransaction,
     StateStoreWriteTransaction,
     StorageError,
 };
+
+const LOG_TARGET: &str = "tari::dan::storage::consensus_models::block";
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Block<TAddr> {
@@ -40,6 +53,8 @@ pub struct Block<TAddr> {
     is_dummy: bool,
     /// Flag that indicates that the block locked objects and made transaction stage transitions.
     is_processed: bool,
+    /// Flag that indicates that the block has been committed.
+    is_committed: bool,
 }
 
 impl<TAddr: NodeAddressable + Serialize> Block<TAddr> {
@@ -65,6 +80,7 @@ impl<TAddr: NodeAddressable + Serialize> Block<TAddr> {
             total_leader_fee,
             is_dummy: false,
             is_processed: false,
+            is_committed: false,
         };
         block.id = block.calculate_hash().into();
         block
@@ -81,6 +97,7 @@ impl<TAddr: NodeAddressable + Serialize> Block<TAddr> {
         total_leader_fee: u64,
         is_dummy: bool,
         is_processed: bool,
+        is_committed: bool,
     ) -> Self {
         Self {
             id,
@@ -95,6 +112,7 @@ impl<TAddr: NodeAddressable + Serialize> Block<TAddr> {
             total_leader_fee,
             is_dummy,
             is_processed,
+            is_committed,
         }
     }
 
@@ -124,6 +142,7 @@ impl<TAddr: NodeAddressable + Serialize> Block<TAddr> {
             total_leader_fee: 0,
             is_dummy: false,
             is_processed: false,
+            is_committed: true,
         }
     }
 
@@ -155,7 +174,7 @@ impl<TAddr: NodeAddressable + Serialize> Block<TAddr> {
 
 impl<TAddr> Block<TAddr> {
     pub fn is_genesis(&self) -> bool {
-        self.id == BlockId::genesis()
+        self.id.is_genesis()
     }
 
     pub fn all_transaction_ids(&self) -> impl Iterator<Item = &TransactionId> + '_ {
@@ -248,6 +267,10 @@ impl<TAddr> Block<TAddr> {
     pub fn is_processed(&self) -> bool {
         self.is_processed
     }
+
+    pub fn is_committed(&self) -> bool {
+        self.is_committed
+    }
 }
 
 impl<TAddr: NodeAddressable> Block<TAddr> {
@@ -331,6 +354,10 @@ impl<TAddr: NodeAddressable> Block<TAddr> {
         if self.parent == *ancestor {
             return Ok(true);
         }
+        // First check the parent here, if it does not exist, then this block cannot extend anything.
+        if !Block::record_exists(tx, self.parent())? {
+            return Ok(false);
+        }
 
         tx.blocks_is_ancestor(self.parent(), ancestor)
     }
@@ -340,6 +367,14 @@ impl<TAddr: NodeAddressable> Block<TAddr> {
         tx: &mut TTx,
     ) -> Result<Block<TAddr>, StorageError> {
         Block::get(tx, &self.parent)
+    }
+
+    pub fn get_parent_chain<TTx: StateStoreReadTransaction<Addr = TAddr>>(
+        &self,
+        tx: &mut TTx,
+        limit: usize,
+    ) -> Result<Vec<Block<TAddr>>, StorageError> {
+        tx.blocks_get_parent_chain(self.id(), limit)
     }
 
     pub fn get_votes<TTx: StateStoreReadTransaction<Addr = TAddr>>(
@@ -370,6 +405,146 @@ impl<TAddr: NodeAddressable> Block<TAddr> {
         validator_public_key: Option<&TAddr>,
     ) -> Result<Vec<Self>, StorageError> {
         tx.blocks_get_any_with_epoch_range(range, validator_public_key)
+    }
+
+    pub fn get_substate_updates<TTx: StateStoreReadTransaction<Addr = TAddr>>(
+        &self,
+        tx: &mut TTx,
+    ) -> Result<Vec<SubstateUpdate<TAddr>>, StorageError> {
+        let committed = self
+            .commands()
+            .iter()
+            .filter_map(|c| c.accept())
+            .filter(|t| t.decision.is_commit())
+            .collect::<Vec<_>>();
+
+        let mut updates = Vec::with_capacity(committed.len());
+        for transaction in committed {
+            let substates = tx.substates_get_all_for_transaction(&transaction.id)?;
+            for substate in substates {
+                if let Some(destroyed) = substate.destroyed() {
+                    // This substate is destroyed. One of the following are possible:
+                    // 1. The substate was destroyed by this transaction and created in an earlier transaction
+                    // 2. The substate was created by this transaction and destroyed in a later transaction
+                    // It isn't possible for a substate to be created and destroyed by the same transaction
+                    // because the engine can never emit such a substate diff.
+                    if substate.created_by_transaction == transaction.id {
+                        updates.push(SubstateUpdate::Create(SubstateCreatedProof {
+                            created_qc: substate.get_created_quorum_certificate(tx)?,
+                            substate: substate.into(),
+                        }));
+                    } else {
+                        updates.push(SubstateUpdate::Destroy {
+                            shard_id: substate.to_shard_id(),
+                            proof: QuorumCertificate::get(tx, &destroyed.justify)?,
+                            destroyed_by_transaction: destroyed.by_transaction,
+                        });
+                    }
+                } else {
+                    updates.push(SubstateUpdate::Create(SubstateCreatedProof {
+                        created_qc: substate.get_created_quorum_certificate(tx)?,
+                        substate: substate.into(),
+                    }));
+                };
+            }
+        }
+
+        Ok(updates)
+    }
+
+    pub fn update_nodes<TTx, TFnOnLock, TFnOnCommit, E>(
+        &self,
+        tx: &mut TTx,
+        on_lock_block: TFnOnLock,
+        on_commit: TFnOnCommit,
+    ) -> Result<(), E>
+    where
+        TTx: StateStoreWriteTransaction<Addr = TAddr> + DerefMut + ?Sized,
+        TTx::Target: StateStoreReadTransaction<Addr = TAddr>,
+        TFnOnLock: FnOnce(&mut TTx, &Block<TAddr>) -> Result<(), E>,
+        TFnOnCommit: FnOnce(&mut TTx, &LastExecuted, &Block<TAddr>) -> Result<(), E>,
+        E: From<StorageError>,
+    {
+        self.justify().update_high_qc(tx)?;
+
+        // b'' <- b*.justify.node
+        let Some(commit_node) = self.justify().get_block(tx.deref_mut()).optional()? else {
+            return Ok(());
+        };
+
+        // b' <- b''.justify.node
+        let Some(precommit_node) = commit_node.justify().get_block(tx.deref_mut()).optional()? else {
+            return Ok(());
+        };
+
+        let locked_block = LockedBlock::get(tx.deref_mut())?;
+        if precommit_node.height() > locked_block.height {
+            precommit_node.as_locked().set(tx)?;
+            on_lock_block(tx, &precommit_node)?;
+        }
+
+        // b <- b'.justify.node
+        let prepare_node = precommit_node.justify().block_id();
+        if commit_node.parent() == precommit_node.id() && precommit_node.parent() == prepare_node {
+            debug!(
+                target: LOG_TARGET,
+                "✅ Node {} {} forms a 3-chain b'' = {}, b' = {}, b = {}",
+                self.height(),
+                self.id(),
+                commit_node.id(),
+                precommit_node.id(),
+                prepare_node,
+            );
+
+            // Commit prepare_node (b)
+            let prepare_node = Block::get(tx.deref_mut(), prepare_node)?;
+            let last_executed = LastExecuted::get(tx.deref_mut())?;
+            on_commit(tx, &last_executed, &prepare_node)?;
+            prepare_node.as_last_executed().set(tx)?;
+        } else {
+            debug!(
+                target: LOG_TARGET,
+                "Node {} {} DOES NOT form a 3-chain b'' = {}, b' = {}, b = {}, b* = {}",
+                self.height(),
+                self.id(),
+                commit_node.id(),
+                precommit_node.id(),
+                prepare_node,
+                self.id()
+            );
+        }
+
+        Ok(())
+    }
+
+    /// safeNode predicate (https://arxiv.org/pdf/1803.05069v6.pdf)
+    ///
+    /// The safeNode predicate is a core ingredient of the protocol. It examines a proposal message
+    /// m carrying a QC justification m.justify, and determines whether m.node is safe to accept. The safety rule to
+    /// accept a proposal is the branch of m.node extends from the currently locked node lockedQC.node. On the other
+    /// hand, the liveness rule is the replica will accept m if m.justify has a higher view than the current
+    /// lockedQC. The predicate is true as long as either one of two rules holds.
+    pub fn is_safe<TTx: StateStoreReadTransaction<Addr = TAddr>>(&self, tx: &mut TTx) -> Result<bool, StorageError> {
+        let locked = LockedBlock::get(tx)?;
+        let locked_block = locked.get_block(tx)?;
+
+        // Liveness rules
+        if self.justify().block_height() > locked_block.height() {
+            return Ok(true);
+        }
+
+        // Safety rule
+        if self.extends(tx, locked_block.id())? {
+            return Ok(true);
+        }
+
+        info!(
+            target: LOG_TARGET,
+            "❌ Block {} does satisfy the liveness or safety rules of the safeNode predicate. Locked block {}",
+            self,
+            locked_block,
+        );
+        Ok(false)
     }
 }
 

--- a/dan_layer/storage/src/consensus_models/command.rs
+++ b/dan_layer/storage/src/consensus_models/command.rs
@@ -56,6 +56,10 @@ impl Evidence {
     pub fn shards_iter(&self) -> impl Iterator<Item = &ShardId> + '_ {
         self.evidence.keys()
     }
+
+    pub fn qc_ids_iter(&self) -> impl Iterator<Item = &QcId> + '_ {
+        self.evidence.values().flatten()
+    }
 }
 
 impl FromIterator<(ShardId, Vec<QcId>)> for Evidence {
@@ -139,6 +143,14 @@ impl Command {
             Command::Prepare(tx) => tx.evidence.shards_iter(),
             Command::LocalPrepared(tx) => tx.evidence.shards_iter(),
             Command::Accept(tx) => tx.evidence.shards_iter(),
+        }
+    }
+
+    pub fn evidence(&self) -> &Evidence {
+        match self {
+            Command::Prepare(tx) => &tx.evidence,
+            Command::LocalPrepared(tx) => &tx.evidence,
+            Command::Accept(tx) => &tx.evidence,
         }
     }
 }

--- a/dan_layer/storage/src/consensus_models/high_qc.rs
+++ b/dan_layer/storage/src/consensus_models/high_qc.rs
@@ -64,7 +64,7 @@ impl HighQc {
         QuorumCertificate::get(tx, &self.qc_id)
     }
 
-    pub fn set<TTx: StateStoreWriteTransaction>(&self, tx: &mut TTx) -> Result<(), StorageError> {
+    pub fn set<TTx: StateStoreWriteTransaction + ?Sized>(&self, tx: &mut TTx) -> Result<(), StorageError> {
         tx.high_qc_set(self)
     }
 }

--- a/dan_layer/storage/src/consensus_models/last_executed.rs
+++ b/dan_layer/storage/src/consensus_models/last_executed.rs
@@ -11,11 +11,11 @@ pub struct LastExecuted {
 }
 
 impl LastExecuted {
-    pub fn get<TTx: StateStoreReadTransaction>(tx: &mut TTx) -> Result<Self, StorageError> {
+    pub fn get<TTx: StateStoreReadTransaction + ?Sized>(tx: &mut TTx) -> Result<Self, StorageError> {
         tx.last_executed_get()
     }
 
-    pub fn set<TTx: StateStoreWriteTransaction>(&self, tx: &mut TTx) -> Result<(), StorageError> {
+    pub fn set<TTx: StateStoreWriteTransaction + ?Sized>(&self, tx: &mut TTx) -> Result<(), StorageError> {
         tx.last_executed_set(self)
     }
 }

--- a/dan_layer/storage/src/consensus_models/last_proposed.rs
+++ b/dan_layer/storage/src/consensus_models/last_proposed.rs
@@ -3,7 +3,12 @@
 
 use tari_dan_common_types::NodeHeight;
 
-use crate::{consensus_models::BlockId, StateStoreReadTransaction, StateStoreWriteTransaction, StorageError};
+use crate::{
+    consensus_models::{Block, BlockId},
+    StateStoreReadTransaction,
+    StateStoreWriteTransaction,
+    StorageError,
+};
 
 pub struct LastProposed {
     pub height: NodeHeight,
@@ -21,5 +26,12 @@ impl LastProposed {
 
     pub fn unset<TTx: StateStoreWriteTransaction>(&self, tx: &mut TTx) -> Result<(), StorageError> {
         tx.last_proposed_unset(self)
+    }
+
+    pub fn get_block<TTx: StateStoreReadTransaction + ?Sized>(
+        &self,
+        tx: &mut TTx,
+    ) -> Result<Block<TTx::Addr>, StorageError> {
+        Block::get(tx, &self.block_id)
     }
 }

--- a/dan_layer/storage/src/consensus_models/last_voted.rs
+++ b/dan_layer/storage/src/consensus_models/last_voted.rs
@@ -11,6 +11,16 @@ pub struct LastVoted {
 }
 
 impl LastVoted {
+    pub fn block_id(&self) -> &BlockId {
+        &self.block_id
+    }
+
+    pub fn height(&self) -> NodeHeight {
+        self.height
+    }
+}
+
+impl LastVoted {
     pub fn get<TTx: StateStoreReadTransaction>(tx: &mut TTx) -> Result<Self, StorageError> {
         tx.last_voted_get()
     }
@@ -21,5 +31,11 @@ impl LastVoted {
 
     pub fn unset<TTx: StateStoreWriteTransaction>(&self, tx: &mut TTx) -> Result<(), StorageError> {
         tx.last_votes_unset(self)
+    }
+}
+
+impl std::fmt::Display for LastVoted {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "(block_id: {}, height: {})", self.block_id, self.height)
     }
 }

--- a/dan_layer/storage/src/consensus_models/leaf_block.rs
+++ b/dan_layer/storage/src/consensus_models/leaf_block.rs
@@ -63,7 +63,7 @@ impl LeafBlock {
         tx.leaf_block_get()
     }
 
-    pub fn set<TTx: StateStoreWriteTransaction>(&self, tx: &mut TTx) -> Result<(), StorageError> {
+    pub fn set<TTx: StateStoreWriteTransaction + ?Sized>(&self, tx: &mut TTx) -> Result<(), StorageError> {
         tx.leaf_block_set(self)
     }
 

--- a/dan_layer/storage/src/consensus_models/locked_block.rs
+++ b/dan_layer/storage/src/consensus_models/locked_block.rs
@@ -29,7 +29,7 @@ impl LockedBlock {
 }
 
 impl LockedBlock {
-    pub fn get<TTx: StateStoreReadTransaction>(tx: &mut TTx) -> Result<Self, StorageError> {
+    pub fn get<TTx: StateStoreReadTransaction + ?Sized>(tx: &mut TTx) -> Result<Self, StorageError> {
         tx.locked_block_get()
     }
 
@@ -37,7 +37,7 @@ impl LockedBlock {
         tx.blocks_get(&self.block_id)
     }
 
-    pub fn set<TTx: StateStoreWriteTransaction>(&self, tx: &mut TTx) -> Result<(), StorageError> {
+    pub fn set<TTx: StateStoreWriteTransaction + ?Sized>(&self, tx: &mut TTx) -> Result<(), StorageError> {
         tx.locked_block_set(self)
     }
 }

--- a/dan_layer/storage/src/consensus_models/substate.rs
+++ b/dan_layer/storage/src/consensus_models/substate.rs
@@ -1,8 +1,14 @@
 //   Copyright 2023 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use std::{borrow::Borrow, collections::HashSet, ops::RangeInclusive};
+use std::{
+    borrow::Borrow,
+    collections::HashSet,
+    iter,
+    ops::{DerefMut, RangeInclusive},
+};
 
+use log::*;
 use serde::{Deserialize, Serialize};
 use tari_common_types::types::FixedHash;
 use tari_dan_common_types::{optional::Optional, Epoch, NodeHeight, ShardId};
@@ -10,11 +16,13 @@ use tari_engine_types::substate::{Substate, SubstateAddress, SubstateValue};
 use tari_transaction::TransactionId;
 
 use crate::{
-    consensus_models::{BlockId, QcId, QuorumCertificate},
+    consensus_models::{Block, BlockId, QcId, QuorumCertificate},
     StateStoreReadTransaction,
     StateStoreWriteTransaction,
     StorageError,
 };
+
+const LOG_TARGET: &str = "tari::dan::storage::consensus_models::substate";
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SubstateRecord {
@@ -26,11 +34,16 @@ pub struct SubstateRecord {
     pub created_justify: QcId,
     pub created_block: BlockId,
     pub created_height: NodeHeight,
-    pub destroyed_by_transaction: Option<TransactionId>,
-    pub destroyed_justify: Option<QcId>,
-    pub destroyed_by_block: Option<BlockId>,
     pub created_at_epoch: Epoch,
-    pub destroyed_at_epoch: Option<Epoch>,
+    pub destroyed: Option<SubstateDestroyed>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SubstateDestroyed {
+    pub by_transaction: TransactionId,
+    pub justify: QcId,
+    pub by_block: BlockId,
+    pub at_epoch: Epoch,
 }
 
 impl SubstateRecord {
@@ -51,13 +64,10 @@ impl SubstateRecord {
             state_hash: Default::default(),
             created_height,
             created_justify,
-            destroyed_justify: None,
-            destroyed_by_block: None,
             created_at_epoch,
-            destroyed_at_epoch: None,
             created_by_transaction,
             created_block,
-            destroyed_by_transaction: None,
+            destroyed: None,
         }
     }
 
@@ -93,10 +103,6 @@ impl SubstateRecord {
         self.created_height
     }
 
-    pub fn destroyed_by_block(&self) -> Option<BlockId> {
-        self.destroyed_by_block
-    }
-
     pub fn created_block(&self) -> BlockId {
         self.created_block
     }
@@ -105,20 +111,16 @@ impl SubstateRecord {
         self.created_by_transaction
     }
 
-    pub fn destroyed_by_transaction(&self) -> Option<TransactionId> {
-        self.destroyed_by_transaction
-    }
-
     pub fn created_justify(&self) -> &QcId {
         &self.created_justify
     }
 
-    pub fn destroyed_justify(&self) -> Option<&QcId> {
-        self.destroyed_justify.as_ref()
+    pub fn destroyed(&self) -> Option<&SubstateDestroyed> {
+        self.destroyed.as_ref()
     }
 
     pub fn is_destroyed(&self) -> bool {
-        self.destroyed_by_transaction.is_some()
+        self.destroyed.is_some()
     }
 }
 
@@ -215,9 +217,135 @@ impl SubstateRecord {
         &self,
         tx: &mut TTx,
     ) -> Result<Option<QuorumCertificate<TTx::Addr>>, StorageError> {
-        self.destroyed_justify()
-            .map(|justify| tx.quorum_certificates_get(justify))
+        self.destroyed()
+            .map(|destroyed| tx.quorum_certificates_get(&destroyed.justify))
             .transpose()
+    }
+
+    pub fn destroy_many<TTx: StateStoreWriteTransaction, I: IntoIterator<Item = ShardId>>(
+        tx: &mut TTx,
+        shard_ids: I,
+        epoch: Epoch,
+        destroyed_by_block: &BlockId,
+        destroyed_justify: &QcId,
+        destroyed_by_transaction: &TransactionId,
+        require_locks: bool,
+    ) -> Result<(), StorageError> {
+        tx.substate_down_many(
+            shard_ids,
+            epoch,
+            destroyed_by_block,
+            destroyed_by_transaction,
+            destroyed_justify,
+            require_locks,
+        )
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SubstateCreatedProof<TAddr> {
+    pub substate: SubstateData,
+    pub created_qc: QuorumCertificate<TAddr>,
+}
+
+#[derive(Debug, Clone)]
+pub struct SubstateData {
+    pub address: SubstateAddress,
+    pub version: u32,
+    pub substate_value: SubstateValue,
+    pub created_by_transaction: TransactionId,
+}
+
+impl From<SubstateRecord> for SubstateData {
+    fn from(value: SubstateRecord) -> Self {
+        Self {
+            address: value.address,
+            version: value.version,
+            substate_value: value.substate_value,
+            created_by_transaction: value.created_by_transaction,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum SubstateUpdate<TAddr> {
+    Create(SubstateCreatedProof<TAddr>),
+    Destroy {
+        shard_id: ShardId,
+        proof: QuorumCertificate<TAddr>,
+        destroyed_by_transaction: TransactionId,
+    },
+}
+
+impl<TAddr> SubstateUpdate<TAddr> {
+    pub fn is_create(&self) -> bool {
+        matches!(self, Self::Create(_))
+    }
+
+    pub fn is_destroy(&self) -> bool {
+        matches!(self, Self::Destroy { .. })
+    }
+}
+
+impl<TAddr> SubstateUpdate<TAddr> {
+    pub fn apply<TTx>(self, tx: &mut TTx, block: &Block<TAddr>) -> Result<(), StorageError>
+    where
+        TTx: StateStoreWriteTransaction<Addr = TAddr> + DerefMut,
+        TTx::Target: StateStoreReadTransaction,
+    {
+        match self {
+            Self::Create(proof) => {
+                debug!(
+                    target: LOG_TARGET,
+                    "🔥 Applying substate CREATE for {} v{}",
+                    proof.substate.address, proof.substate.version
+                );
+                proof.created_qc.save(tx)?;
+                SubstateRecord {
+                    address: proof.substate.address,
+                    version: proof.substate.version,
+                    substate_value: proof.substate.substate_value,
+                    state_hash: Default::default(),
+                    created_by_transaction: proof.substate.created_by_transaction,
+                    created_justify: *proof.created_qc.id(),
+                    created_block: *block.id(),
+                    created_height: block.height(),
+                    created_at_epoch: block.epoch(),
+                    destroyed: None,
+                }
+                .create(tx)?;
+            },
+            Self::Destroy {
+                shard_id,
+                proof,
+                destroyed_by_transaction,
+            } => {
+                debug!(
+                    target: LOG_TARGET,
+                    "🔥 Applying substate DESTROY for shard {} (transaction {})",
+                    shard_id,
+                    destroyed_by_transaction
+                );
+                proof.save(tx)?;
+                SubstateRecord::destroy_many(
+                    tx,
+                    iter::once(shard_id),
+                    block.epoch(),
+                    block.id(),
+                    proof.id(),
+                    &destroyed_by_transaction,
+                    false,
+                )?;
+            },
+        }
+
+        Ok(())
+    }
+}
+
+impl<TAddr> From<SubstateCreatedProof<TAddr>> for SubstateUpdate<TAddr> {
+    fn from(value: SubstateCreatedProof<TAddr>) -> Self {
+        Self::Create(value)
     }
 }
 

--- a/dan_layer/storage/src/consensus_models/transaction_pool.rs
+++ b/dan_layer/storage/src/consensus_models/transaction_pool.rs
@@ -443,6 +443,18 @@ impl TransactionPoolRecord {
         tx.transaction_pool_remove(&self.transaction.id)?;
         Ok(())
     }
+
+    pub fn remove_any<TTx, I>(tx: &mut TTx, transaction_ids: I) -> Result<(), TransactionPoolError>
+    where
+        TTx: StateStoreWriteTransaction,
+        I: IntoIterator<Item = TransactionId>,
+    {
+        // TODO(perf): n queries
+        for id in transaction_ids {
+            let _ = tx.transaction_pool_remove(&id).optional()?;
+        }
+        Ok(())
+    }
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/dan_layer/storage/src/consensus_models/transaction_pool.rs
+++ b/dan_layer/storage/src/consensus_models/transaction_pool.rs
@@ -62,6 +62,10 @@ impl TransactionPoolStage {
         matches!(self, Self::AllPrepared)
     }
 
+    pub fn is_accepted(&self) -> bool {
+        self.is_all_prepared() || self.is_some_prepared()
+    }
+
     pub fn next_stage(&self) -> Option<Self> {
         match self {
             TransactionPoolStage::New => Some(TransactionPoolStage::Prepared),

--- a/dan_layer/storage/src/error.rs
+++ b/dan_layer/storage/src/error.rs
@@ -20,24 +20,17 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::io;
-
 use tari_common_types::types::FixedHashSizeError;
 use tari_dan_common_types::optional::IsNotFoundError;
-use tari_utilities::ByteArrayError;
 
 #[derive(Debug, thiserror::Error)]
 pub enum StorageError {
     #[error("Could not connect to storage:{reason}")]
     ConnectionError { reason: String },
-    #[error("IO Error: {0}")]
-    Io(#[from] io::Error),
     #[error("Query error:{reason}")]
     QueryError { reason: String },
     #[error("Migration error: {reason}")]
     MigrationError { reason: String },
-    #[error("Invalid unit of work tracker type")]
-    InvalidUnitOfWorkTrackerType,
     #[error("Not found: item: {item}, key: {key}")]
     NotFound { item: String, key: String },
     #[error("Not found in operation {operation}: {source}")]
@@ -63,15 +56,10 @@ pub enum StorageError {
     FixedHashSizeError(#[from] FixedHashSizeError),
     #[error("Invalid integer cast")]
     InvalidIntegerCast,
-    #[error("Invalid ByteArray conversion: `{0}`")]
-    InvalidByteArrayConversion(#[from] ByteArrayError),
-    #[error("Invalid type cast: {reason}")]
-    InvalidTypeCasting { reason: String },
-
+    #[error("Data inconsistency: {details}")]
+    DataInconsistency { details: String },
     #[error("General storage error: {details}")]
     General { details: String },
-    #[error("Error converting substate type: {substate_type}")]
-    InvalidSubStateType { substate_type: String },
 }
 
 impl IsNotFoundError for StorageError {

--- a/dan_layer/storage/src/state_store/mod.rs
+++ b/dan_layer/storage/src/state_store/mod.rs
@@ -100,6 +100,7 @@ pub trait StateStoreReadTransaction {
     ) -> Result<Vec<TransactionRecord>, StorageError>;
     fn blocks_get(&mut self, block_id: &BlockId) -> Result<Block<Self::Addr>, StorageError>;
     fn blocks_get_tip(&mut self) -> Result<Block<Self::Addr>, StorageError>;
+    fn blocks_all_after(&mut self, block_id: &BlockId) -> Result<Vec<Block<Self::Addr>>, StorageError>;
     fn blocks_exists(&mut self, block_id: &BlockId) -> Result<bool, StorageError>;
     fn blocks_is_ancestor(&mut self, descendant: &BlockId, ancestor: &BlockId) -> Result<bool, StorageError>;
     fn blocks_get_all_by_parent(&mut self, parent: &BlockId) -> Result<Vec<Block<Self::Addr>>, StorageError>;

--- a/dan_layer/storage/src/state_store/mod.rs
+++ b/dan_layer/storage/src/state_store/mod.rs
@@ -103,6 +103,11 @@ pub trait StateStoreReadTransaction {
     fn blocks_exists(&mut self, block_id: &BlockId) -> Result<bool, StorageError>;
     fn blocks_is_ancestor(&mut self, descendant: &BlockId, ancestor: &BlockId) -> Result<bool, StorageError>;
     fn blocks_get_all_by_parent(&mut self, parent: &BlockId) -> Result<Vec<Block<Self::Addr>>, StorageError>;
+    fn blocks_get_parent_chain(
+        &mut self,
+        block_id: &BlockId,
+        limit: usize,
+    ) -> Result<Vec<Block<Self::Addr>>, StorageError>;
     fn blocks_get_pending_transactions(&mut self, block_id: &BlockId) -> Result<Vec<TransactionId>, StorageError>;
     fn blocks_get_total_leader_fee_for_epoch(
         &mut self,
@@ -116,6 +121,10 @@ pub trait StateStoreReadTransaction {
     ) -> Result<Vec<Block<Self::Addr>>, StorageError>;
 
     fn quorum_certificates_get(&mut self, qc_id: &QcId) -> Result<QuorumCertificate<Self::Addr>, StorageError>;
+    fn quorum_certificates_get_all<'a, I: IntoIterator<Item = &'a QcId>>(
+        &mut self,
+        qc_ids: I,
+    ) -> Result<Vec<QuorumCertificate<Self::Addr>>, StorageError>;
     fn quorum_certificates_get_by_block_id(
         &mut self,
         block_id: &BlockId,
@@ -165,6 +174,11 @@ pub trait StateStoreReadTransaction {
     fn substates_get_many_by_destroyed_transaction(
         &mut self,
         tx_id: &TransactionId,
+    ) -> Result<Vec<SubstateRecord>, StorageError>;
+    fn substates_get_all_for_block(&mut self, block_id: &BlockId) -> Result<Vec<SubstateRecord>, StorageError>;
+    fn substates_get_all_for_transaction(
+        &mut self,
+        transaction_id: &TransactionId,
     ) -> Result<Vec<SubstateRecord>, StorageError>;
 }
 
@@ -259,6 +273,8 @@ pub trait StateStoreWriteTransaction {
         epoch: Epoch,
         destroyed_block_id: &BlockId,
         destroyed_transaction_id: &TransactionId,
+        destroyed_qc_id: &QcId,
+        require_locks: bool,
     ) -> Result<(), StorageError>;
     fn substates_create(&mut self, substate: SubstateRecord) -> Result<(), StorageError>;
     // -------------------------------- Locked Outputs -------------------------------- //

--- a/dan_layer/validator_node_rpc/proto/consensus.proto
+++ b/dan_layer/validator_node_rpc/proto/consensus.proto
@@ -147,13 +147,34 @@ message DownState {
 }
 
 message RequestMissingTransactionsMessage {
-    uint64 epoch = 1;
-    bytes block_id = 2;
-    repeated bytes transaction_ids = 3;
+  uint64 epoch = 1;
+  bytes block_id = 2;
+  repeated bytes transaction_ids = 3;
 }
 
 message RequestedTransactionMessage {
-    uint64 epoch = 1;
-    bytes block_id = 2;
-    repeated tari.dan.transaction.Transaction transactions = 3;
+  uint64 epoch = 1;
+  bytes block_id = 2;
+  repeated tari.dan.transaction.Transaction transactions = 3;
+}
+
+message Substate {
+  bytes address = 1;
+  uint32 version = 2;
+  bytes substate = 3;
+
+  uint64 created_epoch = 4;
+  uint64 created_height = 5;
+  bytes created_block = 6;
+  bytes created_transaction = 7;
+  bytes created_justify = 8;
+
+  SubstateDestroyed destroyed = 10;
+}
+
+message SubstateDestroyed {
+  tari.dan.common.Epoch epoch = 9;
+  bytes block = 10;
+  bytes transaction = 11;
+  bytes justify = 12;
 }

--- a/dan_layer/validator_node_rpc/proto/rpc.proto
+++ b/dan_layer/validator_node_rpc/proto/rpc.proto
@@ -152,3 +152,55 @@ message GetVirtualSubstateResponse {
   bytes substate = 1;
   repeated tari.dan.consensus.QuorumCertificate quorum_certificates = 2;
 }
+
+message SyncStateRequest {
+  bytes start_block_id = 1;
+  uint64 end_epoch = 2;
+}
+
+message SyncStateResponse {
+  SubstateUpdate update = 1;
+}
+
+message SubstateCreatedProof {
+  SubstateData substate = 1;
+  tari.dan.consensus.QuorumCertificate created_justify = 2;
+}
+
+// Minimal substate data
+message SubstateData {
+  bytes address = 1;
+  uint32 version = 2;
+  bytes substate_value = 3;
+  bytes created_transaction = 7;
+}
+
+message SubstateDestroyedProof {
+  bytes shard_id = 1;
+  tari.dan.consensus.QuorumCertificate destroyed_justify = 2;
+  bytes destroyed_by_transaction = 3;
+}
+
+message SubstateUpdate {
+  oneof update {
+    SubstateCreatedProof create = 1;
+    SubstateDestroyedProof destroy = 2;
+  }
+}
+
+message SyncBlocksRequest {
+  bytes start_block_id = 1;
+}
+
+message SyncBlocksResponse {
+  tari.dan.consensus.Block block = 1;
+  repeated tari.dan.consensus.QuorumCertificate quorum_certificates = 2;
+  repeated SubstateUpdate substate_updates = 3;
+}
+
+message GetHighQcRequest { }
+
+message GetHighQcResponse {
+  tari.dan.consensus.QuorumCertificate high_qc = 1;
+}
+

--- a/dan_layer/validator_node_rpc/src/conversions/rpc.rs
+++ b/dan_layer/validator_node_rpc/src/conversions/rpc.rs
@@ -3,71 +3,100 @@
 
 use std::convert::{TryFrom, TryInto};
 
-use tari_dan_common_types::{Epoch, NodeHeight};
-use tari_dan_storage::consensus_models::SubstateRecord;
+use anyhow::anyhow;
+use tari_dan_common_types::NodeAddressable;
+use tari_dan_storage::consensus_models::{SubstateCreatedProof, SubstateData, SubstateUpdate};
 use tari_engine_types::substate::{SubstateAddress, SubstateValue};
 
 use crate::proto;
 
-impl TryFrom<proto::rpc::VnStateSyncResponse> for SubstateRecord {
+impl<TAddr: NodeAddressable> TryFrom<proto::rpc::SubstateCreatedProof> for SubstateCreatedProof<TAddr> {
     type Error = anyhow::Error;
 
-    fn try_from(value: proto::rpc::VnStateSyncResponse) -> Result<Self, Self::Error> {
+    fn try_from(value: proto::rpc::SubstateCreatedProof) -> Result<Self, Self::Error> {
         Ok(Self {
-            address: SubstateAddress::from_bytes(&value.address)?,
-            version: value.version,
-            substate_value: SubstateValue::from_bytes(&value.substate)?,
-            state_hash: Default::default(),
-
-            created_at_epoch: Epoch(value.created_epoch),
-            created_by_transaction: value.created_transaction.try_into()?,
-            created_justify: value.created_justify.try_into()?,
-            created_block: value.created_block.try_into()?,
-            created_height: NodeHeight(value.created_height),
-
-            destroyed_by_transaction: Some(value.destroyed_transaction)
-                .filter(|v| !v.is_empty())
+            substate: value
+                .substate
                 .map(TryInto::try_into)
-                .transpose()?,
-            destroyed_justify: Some(value.destroyed_justify)
-                .filter(|v| !v.is_empty())
+                .transpose()?
+                .ok_or_else(|| anyhow!("substate not provided"))?,
+            created_qc: value
+                .created_justify
                 .map(TryInto::try_into)
-                .transpose()?,
-            destroyed_by_block: Some(value.destroyed_block)
-                .filter(|v| !v.is_empty())
-                .map(TryInto::try_into)
-                .transpose()?,
-            destroyed_at_epoch: value.destroyed_epoch.map(Into::into),
+                .transpose()?
+                .ok_or_else(|| anyhow!("created_justify not provided"))?,
         })
     }
 }
 
-impl From<SubstateRecord> for proto::rpc::VnStateSyncResponse {
-    fn from(value: SubstateRecord) -> Self {
+impl<TAddr: NodeAddressable> From<SubstateCreatedProof<TAddr>> for proto::rpc::SubstateCreatedProof {
+    fn from(value: SubstateCreatedProof<TAddr>) -> Self {
+        Self {
+            substate: Some(value.substate.into()),
+            created_justify: Some((&value.created_qc).into()),
+        }
+    }
+}
+
+impl<TAddr: NodeAddressable> TryFrom<proto::rpc::SubstateUpdate> for SubstateUpdate<TAddr> {
+    type Error = anyhow::Error;
+
+    fn try_from(value: proto::rpc::SubstateUpdate) -> Result<Self, Self::Error> {
+        let update = value.update.ok_or_else(|| anyhow!("update not provided"))?;
+        match update {
+            proto::rpc::substate_update::Update::Create(substate_proof) => Ok(Self::Create(substate_proof.try_into()?)),
+            proto::rpc::substate_update::Update::Destroy(proof) => Ok(Self::Destroy {
+                shard_id: proof.shard_id.try_into()?,
+                proof: proof
+                    .destroyed_justify
+                    .map(TryInto::try_into)
+                    .transpose()?
+                    .ok_or_else(|| anyhow!("destroyed_justify not provided"))?,
+                destroyed_by_transaction: proof.destroyed_by_transaction.try_into()?,
+            }),
+        }
+    }
+}
+
+impl<TAddr: NodeAddressable> From<SubstateUpdate<TAddr>> for proto::rpc::SubstateUpdate {
+    fn from(value: SubstateUpdate<TAddr>) -> Self {
+        let update = match value {
+            SubstateUpdate::Create(proof) => proto::rpc::substate_update::Update::Create(proof.into()),
+            SubstateUpdate::Destroy {
+                proof,
+                shard_id,
+                destroyed_by_transaction,
+            } => proto::rpc::substate_update::Update::Destroy(proto::rpc::SubstateDestroyedProof {
+                shard_id: shard_id.as_bytes().to_vec(),
+                destroyed_justify: Some((&proof).into()),
+                destroyed_by_transaction: destroyed_by_transaction.as_bytes().to_vec(),
+            }),
+        };
+
+        Self { update: Some(update) }
+    }
+}
+
+impl TryFrom<proto::rpc::SubstateData> for SubstateData {
+    type Error = anyhow::Error;
+
+    fn try_from(value: proto::rpc::SubstateData) -> Result<Self, Self::Error> {
+        Ok(Self {
+            address: SubstateAddress::from_bytes(&value.address)?,
+            version: value.version,
+            substate_value: SubstateValue::from_bytes(&value.substate_value)?,
+            created_by_transaction: value.created_transaction.try_into()?,
+        })
+    }
+}
+
+impl From<SubstateData> for proto::rpc::SubstateData {
+    fn from(value: SubstateData) -> Self {
         Self {
             address: value.address.to_bytes(),
             version: value.version,
-            substate: value.substate_value.to_bytes(),
-
+            substate_value: value.substate_value.to_bytes(),
             created_transaction: value.created_by_transaction.as_bytes().to_vec(),
-            created_justify: value.created_justify.as_bytes().to_vec(),
-            created_block: value.created_block.as_bytes().to_vec(),
-            created_height: value.created_height.as_u64(),
-            created_epoch: value.created_at_epoch.as_u64(),
-
-            destroyed_transaction: value
-                .destroyed_by_transaction
-                .map(|s| s.as_bytes().to_vec())
-                .unwrap_or_default(),
-            destroyed_justify: value
-                .destroyed_justify
-                .map(|id| id.as_bytes().to_vec())
-                .unwrap_or_default(),
-            destroyed_block: value
-                .destroyed_by_block
-                .map(|s| s.as_bytes().to_vec())
-                .unwrap_or_default(),
-            destroyed_epoch: value.destroyed_at_epoch.map(Into::into),
         }
     }
 }

--- a/dan_layer/validator_node_rpc/src/rpc_service.rs
+++ b/dan_layer/validator_node_rpc/src/rpc_service.rs
@@ -20,11 +20,11 @@ pub trait ValidatorNodeRpcService: Send + Sync + 'static {
         request: Request<proto::GetPeersRequest>,
     ) -> Result<Streaming<proto::GetPeersResponse>, RpcStatus>;
 
-    #[rpc(method = 3)]
-    async fn vn_state_sync(
-        &self,
-        request: Request<proto::VnStateSyncRequest>,
-    ) -> Result<Streaming<proto::VnStateSyncResponse>, RpcStatus>;
+    // #[rpc(method = 3)]
+    // async fn vn_state_sync(
+    //     &self,
+    //     request: Request<proto::VnStateSyncRequest>,
+    // ) -> Result<Streaming<proto::VnStateSyncResponse>, RpcStatus>;
 
     #[rpc(method = 4)]
     async fn get_substate(
@@ -43,4 +43,15 @@ pub trait ValidatorNodeRpcService: Send + Sync + 'static {
         &self,
         req: Request<proto::GetVirtualSubstateRequest>,
     ) -> Result<Response<proto::GetVirtualSubstateResponse>, RpcStatus>;
+
+    #[rpc(method = 7)]
+    async fn sync_blocks(
+        &self,
+        request: Request<proto::SyncBlocksRequest>,
+    ) -> Result<Streaming<proto::SyncBlocksResponse>, RpcStatus>;
+    #[rpc(method = 8)]
+    async fn get_high_qc(
+        &self,
+        request: Request<proto::GetHighQcRequest>,
+    ) -> Result<Response<proto::GetHighQcResponse>, RpcStatus>;
 }

--- a/integration_tests/tests/features/block_sync.feature
+++ b/integration_tests/tests/features/block_sync.feature
@@ -1,0 +1,57 @@
+# Copyright 2022 The Tari Project
+# SPDX-License-Identifier: BSD-3-Clause
+
+Feature: Block Sync
+
+  @serial
+  Scenario: New validator node registers and syncs
+    Given fees are enabled
+
+    # Initialize a base node, wallet, miner and VN
+    Given a base node BASE
+    Given a wallet WALLET connected to base node BASE
+    Given a miner MINER connected to base node BASE and wallet WALLET
+
+    # Initialize an indexer
+    Given an indexer IDX connected to base node BASE
+
+    # Initialize the wallet daemon
+    Given a wallet daemon WALLET_D connected to indexer IDX
+    When I create a key named K1 for WALLET_D
+
+    # Initialize a VN
+    Given a seed validator node VN connected to base node BASE and wallet WALLET
+    When miner MINER mines 4 new blocks
+    When validator node VN sends a registration transaction allowing fee claims from wallet WALLET_D using key K1
+    When miner MINER mines 16 new blocks
+    Then VN has scanned to height 17 within 10 seconds
+    And indexer IDX has scanned to height 17 within 10 seconds
+    Then the validator node VN is listed as registered
+
+    When indexer IDX connects to all other validators
+
+    # Submit a few transactions
+    When I create an account ACC1 via the wallet daemon WALLET_D with 10000 free coins
+    When I create an account UNUSED1 via the wallet daemon WALLET_D
+    When I create an account UNUSED2 via the wallet daemon WALLET_D
+    When I create an account UNUSED3 via the wallet daemon WALLET_D
+
+    When I wait for validator VN has leaf block height of at least 20
+
+    # Start a new VN that needs to sync
+    Given a validator node VN2 connected to base node BASE and wallet WALLET
+    Given validator VN2 nodes connect to all other validators
+    When indexer IDX connects to all other validators
+    When validator node VN2 sends a registration transaction allowing fee claims from wallet WALLET_D using key K1
+    When miner MINER mines 20 new blocks
+    Then VN2 has scanned to height 37 within 10 seconds
+    Then the validator node VN2 is listed as registered
+
+    When I wait for validator VN2 has leaf block height of at least 20
+
+    When I create an account UNUSED4 via the wallet daemon WALLET_D
+    When I create an account UNUSED5 via the wallet daemon WALLET_D
+
+    When I wait for validator VN has leaf block height of at least 40
+    When I wait for validator VN2 has leaf block height of at least 40
+

--- a/integration_tests/tests/steps/validator_node.rs
+++ b/integration_tests/tests/steps/validator_node.rs
@@ -368,7 +368,11 @@ async fn when_i_wait_for_validator_leaf_block_at_least(world: &mut TariWorld, na
         })
         .await
         .unwrap();
-    if resp.blocks.last().unwrap().height().as_u64() < height {
-        panic!("Validator {} leaf block height is less than {}", name, height);
+    let actual_height = resp.blocks.last().unwrap().height().as_u64();
+    if actual_height < height {
+        panic!(
+            "Validator {} leaf block height {} is less than {}",
+            name, actual_height, height
+        );
     }
 }

--- a/integration_tests/tests/steps/validator_node.rs
+++ b/integration_tests/tests/steps/validator_node.rs
@@ -17,10 +17,10 @@ use integration_tests::{
 use tari_base_node_client::{grpc::GrpcBaseNodeClient, BaseNodeClient};
 use tari_common_types::types::PublicKey;
 use tari_comms::multiaddr::Multiaddr;
-use tari_dan_common_types::{Epoch, ShardId};
+use tari_dan_common_types::{optional::Optional, Epoch, ShardId};
 use tari_engine_types::substate::SubstateAddress;
 use tari_template_lib::Hash;
-use tari_validator_node_client::types::{AddPeerRequest, GetStateRequest, GetTemplateRequest};
+use tari_validator_node_client::types::{AddPeerRequest, GetStateRequest, GetTemplateRequest, ListBlocksRequest};
 
 #[given(expr = "a seed validator node {word} connected to base node {word} and wallet {word}")]
 async fn start_seed_validator_node(world: &mut TariWorld, seed_vn_name: String, bn_name: String, wallet_name: String) {
@@ -338,4 +338,37 @@ async fn vn_has_scanned_to_height(world: &mut TariWorld, vn_name: String, block_
 #[when(expr = "I create a new key pair {word}")]
 async fn when_i_create_new_key_pair(world: &mut TariWorld, key_name: String) {
     create_key(world, key_name);
+}
+
+#[when(expr = "I wait for validator {word} has leaf block height of at least {int}")]
+async fn when_i_wait_for_validator_leaf_block_at_least(world: &mut TariWorld, name: String, height: u64) {
+    let vn = world.get_validator_node(&name);
+    let mut client = vn.create_client();
+    for _ in 0..20 {
+        let resp = client
+            .list_blocks(ListBlocksRequest {
+                from_id: None,
+                limit: 1,
+            })
+            .await
+            .optional()
+            .unwrap();
+        if let Some(resp) = resp {
+            if resp.blocks.last().unwrap().height().as_u64() >= height {
+                return;
+            }
+        }
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+
+    let resp = client
+        .list_blocks(ListBlocksRequest {
+            from_id: None,
+            limit: 1,
+        })
+        .await
+        .unwrap();
+    if resp.blocks.last().unwrap().height().as_u64() < height {
+        panic!("Validator {} leaf block height is less than {}", name, height);
+    }
 }

--- a/utilities/transaction_submitter/src/main.rs
+++ b/utilities/transaction_submitter/src/main.rs
@@ -75,6 +75,10 @@ async fn stress_test(args: StressTestArgs) -> anyhow::Result<()> {
 
     println!("⚠️ Submitting {} transactions", num_transactions);
 
+    if num_transactions == 0 {
+        return Ok(());
+    }
+
     let transactions = read_transactions(File::open(args.transaction_file)?, args.skip_transactions.unwrap_or(0))?;
 
     let mut count = 0usize;
@@ -105,7 +109,7 @@ async fn stress_test(args: StressTestArgs) -> anyhow::Result<()> {
             .await;
 
         count += 1;
-        if args.num_transactions.map(|n| n == count as u64).unwrap_or(false) {
+        if num_transactions <= count as u64 {
             break;
         }
     }


### PR DESCRIPTION
Description
---
Adds block sync when joining a committee and when a justify is received for an unknown block.
Moves update_nodes and safeblock predicate into Block model for easy reuse by block sync.

Motivation and Context
---
The block sync procedure first requests the high qcs of remote nodes and compares that to the current high qc. 
If the remote high qc is valid and higher we begin block sync. Block sync streams `<Block, [Qc], [SubstateUpdates]>` which are added to the local chain. We currently process blocks by verifying 3-chains, once we have a state hash in blocks we can verify the substate updates too. 

Non-committed blocks are also sent, though this needs to either be changed to re-requesting proposals from the locked block to the last known proposal (maybe without voting) or check that blocks after the remote locked block do not contain any substate updates.

For now, this PR allows a node to join a committee that has processed blocks and also adds some robustness if a vn falls behind (due to restart, crash or temporary DoS)

How Has This Been Tested?
---
Manually. New cucumber to test initial sync.

What process can a PR reviewer use to test or verify this change?
---
Run some VNs, process some transactions, run another vn and observe that the new VN successfully processes new transactions.

Breaking Changes
---

- [ ] None
- [x] Requires data directory to be deleted
- [ ] Other - Please specify