### PR TITLE
fix(transactions)!: remove transaction output

### DIFF
--- a/applications/tari_validator_node/src/p2p/services/mempool/service.rs
+++ b/applications/tari_validator_node/src/p2p/services/mempool/service.rs
@@ -332,7 +332,6 @@ where
             // Known output shards
             // This is to allow for the txreceipt output
             iter::once(&tx_shard_id)
-                .chain(transaction.outputs())
                 .chain(unverified_output_shards.iter())
                 .chain(claim_shards.iter()),
         );

--- a/dan_layer/state_store_sqlite/migrations/2023-06-08-091819_create_state_store/up.sql
+++ b/dan_layer/state_store_sqlite/migrations/2023-06-08-091819_create_state_store/up.sql
@@ -159,7 +159,6 @@ create table transactions
     signature         text      not NULL,
     inputs            text      not NULL,
     input_refs        text      not NULL,
-    outputs           text      not NULL,
     filled_inputs     text      not NULL,
     resulting_outputs text      NULL,
     result            text      NULL,

--- a/dan_layer/state_store_sqlite/src/schema.rs
+++ b/dan_layer/state_store_sqlite/src/schema.rs
@@ -221,7 +221,6 @@ diesel::table! {
         signature -> Text,
         inputs -> Text,
         input_refs -> Text,
-        outputs -> Text,
         filled_inputs -> Text,
         resulting_outputs -> Nullable<Text>,
         result -> Nullable<Text>,

--- a/dan_layer/state_store_sqlite/src/sql_models/transaction.rs
+++ b/dan_layer/state_store_sqlite/src/sql_models/transaction.rs
@@ -19,7 +19,6 @@ pub struct Transaction {
     pub signature: String,
     pub inputs: String,
     pub input_refs: String,
-    pub outputs: String,
     pub filled_inputs: String,
     pub resulting_outputs: Option<String>,
     pub result: Option<String>,
@@ -41,7 +40,6 @@ impl TryFrom<Transaction> for tari_transaction::Transaction {
 
         let inputs = deserialize_json(&value.inputs)?;
         let input_refs = deserialize_json(&value.input_refs)?;
-        let outputs = deserialize_json(&value.outputs)?;
         let filled_inputs = deserialize_json(&value.filled_inputs)?;
         let min_epoch = value.min_epoch.map(|epoch| Epoch(epoch as u64));
         let max_epoch = value.max_epoch.map(|epoch| Epoch(epoch as u64));
@@ -52,7 +50,6 @@ impl TryFrom<Transaction> for tari_transaction::Transaction {
             signature,
             inputs,
             input_refs,
-            outputs,
             filled_inputs,
             min_epoch,
             max_epoch,

--- a/dan_layer/state_store_sqlite/src/writer.rs
+++ b/dan_layer/state_store_sqlite/src/writer.rs
@@ -653,7 +653,6 @@ impl<TAddr: NodeAddressable> StateStoreWriteTransaction for SqliteStateStoreWrit
                     transactions::signature.eq(serialize_json(transaction.signature())?),
                     transactions::inputs.eq(serialize_json(transaction.inputs())?),
                     transactions::input_refs.eq(serialize_json(transaction.input_refs())?),
-                    transactions::outputs.eq(serialize_json(transaction.outputs())?),
                     transactions::filled_inputs.eq(serialize_json(transaction.filled_inputs())?),
                     transactions::resulting_outputs.eq(serialize_json(rec.resulting_outputs())?),
                     transactions::result.eq(rec.result().map(serialize_json).transpose()?),

--- a/dan_layer/state_store_sqlite/src/writer.rs
+++ b/dan_layer/state_store_sqlite/src/writer.rs
@@ -573,7 +573,6 @@ impl<TAddr: NodeAddressable> StateStoreWriteTransaction for SqliteStateStoreWrit
             transactions::signature.eq(serialize_json(transaction.signature())?),
             transactions::inputs.eq(serialize_json(transaction.inputs())?),
             transactions::input_refs.eq(serialize_json(transaction.input_refs())?),
-            transactions::outputs.eq(serialize_json(transaction.outputs())?),
             transactions::filled_inputs.eq(serialize_json(transaction.filled_inputs())?),
             transactions::resulting_outputs.eq(serialize_json(&serde_json::Value::Array(vec![]))?),
         );

--- a/dan_layer/transaction/src/builder.rs
+++ b/dan_layer/transaction/src/builder.rs
@@ -201,7 +201,6 @@ impl TransactionBuilder {
             self.signature.take().expect("not signed"),
             self.inputs,
             self.input_refs,
-            self.outputs,
             vec![],
             self.min_epoch,
             self.max_epoch,

--- a/dan_layer/transaction/src/transaction.rs
+++ b/dan_layer/transaction/src/transaction.rs
@@ -28,8 +28,6 @@ pub struct Transaction {
     inputs: Vec<ShardId>,
     /// Input objects that must exist but cannot be downed by this transaction
     input_refs: Vec<ShardId>,
-    /// Output objects that will be created by this transaction
-    outputs: Vec<ShardId>,
     /// Inputs filled by some authority. These are not part of the transaction hash. (TODO: Secure this somehow)
     filled_inputs: Vec<ShardId>,
     min_epoch: Option<Epoch>,
@@ -47,7 +45,6 @@ impl Transaction {
         signature: TransactionSignature,
         inputs: Vec<ShardId>,
         input_refs: Vec<ShardId>,
-        outputs: Vec<ShardId>,
         filled_inputs: Vec<ShardId>,
         min_epoch: Option<Epoch>,
         max_epoch: Option<Epoch>,
@@ -59,7 +56,6 @@ impl Transaction {
             signature,
             inputs,
             input_refs,
-            outputs,
             filled_inputs,
             min_epoch,
             max_epoch,
@@ -75,7 +71,6 @@ impl Transaction {
             .chain(&self.instructions)
             .chain(&self.inputs)
             .chain(&self.input_refs)
-            .chain(&self.outputs)
             .chain(&self.min_epoch)
             .chain(&self.max_epoch)
             .result()
@@ -111,12 +106,11 @@ impl Transaction {
         self.inputs()
             .iter()
             .chain(self.input_refs())
-            .chain(self.outputs())
             .chain(self.filled_inputs())
     }
 
     pub fn num_involved_shards(&self) -> usize {
-        self.inputs().len() + self.input_refs().len() + self.outputs().len() + self.filled_inputs().len()
+        self.inputs().len() + self.input_refs().len() + self.filled_inputs().len()
     }
 
     pub fn input_refs(&self) -> &[ShardId] {
@@ -145,10 +139,6 @@ impl Transaction {
 
     pub fn filled_inputs_mut(&mut self) -> &mut Vec<ShardId> {
         &mut self.filled_inputs
-    }
-
-    pub fn outputs(&self) -> &[ShardId] {
-        &self.outputs
     }
 
     pub fn fee_claims(&self) -> impl Iterator<Item = (Epoch, PublicKey)> + '_ {

--- a/dan_layer/validator_node_rpc/proto/transaction.proto
+++ b/dan_layer/validator_node_rpc/proto/transaction.proto
@@ -24,7 +24,6 @@ message Transaction {
   tari.dan.common.SignatureAndPublicKey signature = 3;
   repeated bytes inputs = 4;
   repeated bytes input_refs = 5;
-  repeated bytes outputs = 6;
   repeated bytes filled_inputs = 7;
   tari.dan.common.Epoch min_epoch = 8;
   tari.dan.common.Epoch max_epoch = 9;

--- a/dan_layer/validator_node_rpc/src/conversions/transaction.rs
+++ b/dan_layer/validator_node_rpc/src/conversions/transaction.rs
@@ -106,11 +106,6 @@ impl TryFrom<proto::transaction::Transaction> for Transaction {
             .into_iter()
             .map(TryInto::try_into)
             .collect::<Result<_, _>>()?;
-        let outputs = request
-            .outputs
-            .into_iter()
-            .map(TryInto::try_into)
-            .collect::<Result<_, _>>()?;
         let filled_inputs = request
             .filled_inputs
             .into_iter()
@@ -124,7 +119,6 @@ impl TryFrom<proto::transaction::Transaction> for Transaction {
             signature,
             inputs,
             input_refs,
-            outputs,
             filled_inputs,
             min_epoch,
             max_epoch,
@@ -139,7 +133,6 @@ impl From<&Transaction> for proto::transaction::Transaction {
         let signature = transaction.signature().clone().into();
         let inputs = transaction.inputs().iter().map(|s| s.as_bytes().to_vec()).collect();
         let input_refs = transaction.input_refs().iter().map(|s| s.as_bytes().to_vec()).collect();
-        let outputs = transaction.outputs().iter().map(|s| s.as_bytes().to_vec()).collect();
         let filled_inputs = transaction
             .filled_inputs()
             .iter()
@@ -161,7 +154,6 @@ impl From<&Transaction> for proto::transaction::Transaction {
             signature: Some(signature),
             inputs,
             input_refs,
-            outputs,
             filled_inputs,
             min_epoch,
             max_epoch,

--- a/dan_layer/wallet/storage_sqlite/src/models/mod.rs
+++ b/dan_layer/wallet/storage_sqlite/src/models/mod.rs
@@ -14,7 +14,7 @@ mod substate;
 pub use substate::Substate;
 
 mod transaction;
-pub use transaction::{InputsAndOutputs, Transaction};
+pub use transaction::{Transaction, TransactionInputs};
 
 mod vault;
 pub use vault::Vault;

--- a/dan_layer/wallet/storage_sqlite/src/models/transaction.rs
+++ b/dan_layer/wallet/storage_sqlite/src/models/transaction.rs
@@ -44,7 +44,6 @@ pub struct Transaction {
 pub struct InputsAndOutputs {
     pub inputs: Vec<ShardId>,
     pub input_refs: Vec<ShardId>,
-    pub outputs: Vec<ShardId>,
 }
 
 impl Transaction {
@@ -57,11 +56,7 @@ impl Transaction {
                 details: e.to_string(),
             })?;
         let signature = TransactionSignature::new(sender_public_key, signature);
-        let InputsAndOutputs {
-            inputs,
-            input_refs,
-            outputs,
-        } = deserialize_json(&self.meta)?;
+        let InputsAndOutputs { inputs, input_refs } = deserialize_json(&self.meta)?;
 
         Ok(WalletTransaction {
             transaction: tari_transaction::Transaction::new(
@@ -70,7 +65,6 @@ impl Transaction {
                 signature,
                 inputs,
                 input_refs,
-                outputs,
                 vec![],
                 self.min_epoch.map(|epoch| Epoch(epoch as u64)),
                 self.max_epoch.map(|epoch| Epoch(epoch as u64)),

--- a/dan_layer/wallet/storage_sqlite/src/models/transaction.rs
+++ b/dan_layer/wallet/storage_sqlite/src/models/transaction.rs
@@ -41,7 +41,7 @@ pub struct Transaction {
 
 /// Struct used to keep inputs and outputs in a single field as json
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct InputsAndOutputs {
+pub struct TransactionInputs {
     pub inputs: Vec<ShardId>,
     pub input_refs: Vec<ShardId>,
 }
@@ -56,7 +56,7 @@ impl Transaction {
                 details: e.to_string(),
             })?;
         let signature = TransactionSignature::new(sender_public_key, signature);
-        let InputsAndOutputs { inputs, input_refs } = deserialize_json(&self.meta)?;
+        let TransactionInputs { inputs, input_refs } = deserialize_json(&self.meta)?;
 
         Ok(WalletTransaction {
             transaction: tari_transaction::Transaction::new(

--- a/dan_layer/wallet/storage_sqlite/src/writer.rs
+++ b/dan_layer/wallet/storage_sqlite/src/writer.rs
@@ -263,7 +263,6 @@ impl WalletStoreWriter for WriteTransaction<'_> {
                 transactions::meta.eq(serialize_json(&InputsAndOutputs {
                     inputs: transaction.inputs().to_vec(),
                     input_refs: transaction.input_refs().to_vec(),
-                    outputs: transaction.outputs().to_vec(),
                 })?),
                 transactions::status.eq(TransactionStatus::default().as_key_str()),
                 transactions::dry_run.eq(is_dry_run),

--- a/dan_layer/wallet/storage_sqlite/src/writer.rs
+++ b/dan_layer/wallet/storage_sqlite/src/writer.rs
@@ -43,7 +43,7 @@ use tari_utilities::hex::Hex;
 
 use crate::{
     diesel::ExpressionMethods,
-    models::{self, InputsAndOutputs},
+    models::{self, TransactionInputs},
     reader::ReadTransaction,
     schema::auth_status,
     serialization::serialize_json,
@@ -260,7 +260,7 @@ impl WalletStoreWriter for WriteTransaction<'_> {
                 transactions::instructions.eq(serialize_json(transaction.instructions())?),
                 transactions::sender_public_key.eq(transaction.signer_public_key().to_hex()),
                 transactions::signature.eq(serialize_json(transaction.signature().signature())?),
-                transactions::meta.eq(serialize_json(&InputsAndOutputs {
+                transactions::meta.eq(serialize_json(&TransactionInputs {
                     inputs: transaction.inputs().to_vec(),
                     input_refs: transaction.input_refs().to_vec(),
                 })?),


### PR DESCRIPTION
Description
---
Remove explicit outputs from transaction.

Motivation and Context
---
Outputs are always determined for the transaction by the validator. A client application will never need to specify these This also enables a vulnerability allowing any user to involve any number of validators in their transaction.

How Has This Been Tested?
---
Dan testing still works.

What process can a PR reviewer use to test or verify this change?
---


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify