### PR TITLE
feat(ci): add cucumber logs as artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,12 +270,18 @@ jobs:
         with:
           command: test
           args: --all-features --release --package integration_tests
-      - name: upload artifact
+      - name: upload test result artifact
         uses: actions/upload-artifact@v3  # upload test results as artifact
         if: success() || failure()
         with:
             name: cucumber-test-results
             path: ${{ github.workspace }}/integration_tests/cucumber-output-junit.xml
+      - name: Upload cucumber log artifacts
+        uses: actions/upload-artifact@v3
+        if: success() || failure()
+        with:
+          name: cucumber-log-artifacts
+          path: ${{ github.workspace }}/integration_tests/tests/temp/cucumber_*/*.log
 
   # needed for test results
   event_file:

--- a/dan_layer/consensus/src/hotstuff/error.rs
+++ b/dan_layer/consensus/src/hotstuff/error.rs
@@ -113,16 +113,7 @@ pub enum ProposalValidationError {
     #[error("Block {block_id} proposed by {proposed_by} is not the leader")]
     NotLeader { proposed_by: String, block_id: BlockId },
     #[error(
-        "Block {candidate_block} proposed by {proposed_by} is less than or equal to the current leaf {leaf_block}"
-    )]
-    CandidateBlockNotHigherThanLeafBlock {
-        proposed_by: String,
-        leaf_block: LeafBlock,
-        candidate_block: LeafBlock,
-    },
-    #[error(
-        "Block {candidate_block} justify proposed by {proposed_by} is less than or equal to the current locked \
-         {locked_block}"
+        "Block {candidate_block} justify proposed by {proposed_by} is less than the current locked {locked_block}"
     )]
     CandidateBlockNotHigherThanLockedBlock {
         proposed_by: String,

--- a/dan_layer/consensus/src/hotstuff/on_receive_new_view.rs
+++ b/dan_layer/consensus/src/hotstuff/on_receive_new_view.rs
@@ -92,8 +92,8 @@ where TConsensusSpec: ConsensusSpec
 
         // We can never accept NEWVIEWS for heights that are lower than the locked block height
         let locked = self.store.with_read_tx(|tx| LockedBlock::get(tx))?;
-        if new_height <= locked.height() {
-            warn!(target: LOG_TARGET, "❌ Ignoring NEWVIEW for height less than equal to locked block, locked block: {} new height: {}", locked, new_height);
+        if new_height < locked.height() {
+            warn!(target: LOG_TARGET, "❌ Ignoring NEWVIEW for height less than the locked block, locked block: {} new height: {}", locked, new_height);
             return Ok(());
         }
 

--- a/dan_layer/consensus/src/hotstuff/on_receive_proposal.rs
+++ b/dan_layer/consensus/src/hotstuff/on_receive_proposal.rs
@@ -1055,16 +1055,6 @@ where TConsensusSpec: ConsensusSpec
             .into());
         }
 
-        // let leaf_block = LeafBlock::get(tx.deref_mut())?;
-        // if candidate_block.height() <= leaf_block.height() {
-        //     return Err(ProposalValidationError::CandidateBlockNotHigherThanLeafBlock {
-        //         proposed_by: from.to_string(),
-        //         leaf_block,
-        //         candidate_block: candidate_block.as_leaf_block(),
-        //     }
-        //     .into());
-        // }
-
         // Special case for genesis block
         if candidate_block.parent().is_genesis() && candidate_block.justify().is_genesis() {
             return Ok(());
@@ -1072,7 +1062,7 @@ where TConsensusSpec: ConsensusSpec
 
         // Part of the safenode predicate. Exclude this block early if this is the case
         let locked_block = LockedBlock::get(tx.deref_mut())?;
-        if !locked_block.block_id.is_genesis() && candidate_block.justify().block_height() <= locked_block.height() {
+        if !locked_block.block_id.is_genesis() && candidate_block.justify().block_height() < locked_block.height() {
             return Err(ProposalValidationError::CandidateBlockNotHigherThanLockedBlock {
                 proposed_by: from.to_string(),
                 locked_block,

--- a/integration_tests/tests/cucumber.rs
+++ b/integration_tests/tests/cucumber.rs
@@ -53,6 +53,8 @@ use tari_dan_storage::consensus_models::QuorumDecision;
 use tari_shutdown::Shutdown;
 use tari_validator_node_client::types::{AddPeerRequest, GetRecentTransactionsRequest, GetTransactionResultRequest};
 
+const LOG_TARGET: &str = "cucumber";
+
 #[tokio::main]
 async fn main() {
     let log_path = create_log_config_file();
@@ -74,6 +76,10 @@ async fn main() {
                 .summarized(),
         ))
         .before(move |_feature, _rule, scenario, world| {
+            log::info!(target: LOG_TARGET, "-------------------------------------------------------");
+            log::info!(target: LOG_TARGET, "------------- {} -------------", scenario.name);
+            log::info!(target: LOG_TARGET, "-------------------------------------------------------");
+            log::info!(target: LOG_TARGET, "\n\n\n");
             world.current_scenario_name = Some(scenario.name.clone());
             Box::pin(async move {
                 // Each scenario gets a mock connection. As each connection is dropped after the scenario, all the mock

--- a/integration_tests/tests/cucumber.rs
+++ b/integration_tests/tests/cucumber.rs
@@ -76,8 +76,9 @@ async fn main() {
                 .summarized(),
         ))
         .before(move |_feature, _rule, scenario, world| {
+            log::info!(target: LOG_TARGET, "\n\n\n");
             log::info!(target: LOG_TARGET, "-------------------------------------------------------");
-            log::info!(target: LOG_TARGET, "------------- {} -------------", scenario.name);
+            log::info!(target: LOG_TARGET, "------------- SCENARIO: {} -------------", scenario.name);
             log::info!(target: LOG_TARGET, "-------------------------------------------------------");
             log::info!(target: LOG_TARGET, "\n\n\n");
             world.current_scenario_name = Some(scenario.name.clone());

--- a/integration_tests/tests/features/block_sync.feature
+++ b/integration_tests/tests/features/block_sync.feature
@@ -22,6 +22,7 @@ Feature: Block Sync
     # Initialize a VN
     Given a seed validator node VN connected to base node BASE and wallet WALLET
     When miner MINER mines 4 new blocks
+    When wallet WALLET has at least 5000 T
     When validator node VN sends a registration transaction allowing fee claims from wallet WALLET_D using key K1
     When miner MINER mines 16 new blocks
     Then VN has scanned to height 17 within 10 seconds

--- a/integration_tests/tests/features/block_sync.feature
+++ b/integration_tests/tests/features/block_sync.feature
@@ -53,6 +53,6 @@ Feature: Block Sync
     When I create an account UNUSED4 via the wallet daemon WALLET_D
     When I create an account UNUSED5 via the wallet daemon WALLET_D
 
-    When I wait for validator VN has leaf block height of at least 40
-    When I wait for validator VN2 has leaf block height of at least 40
+    When I wait for validator VN has leaf block height of at least 26
+    When I wait for validator VN2 has leaf block height of at least 26
 

--- a/integration_tests/tests/features/claim_burn.feature
+++ b/integration_tests/tests/features/claim_burn.feature
@@ -12,6 +12,7 @@ Feature: Claim Burn
     # Initialize a VN
     Given a validator node VN connected to base node BASE and wallet WALLET
     When miner MINER mines 4 new blocks
+    When wallet WALLET has at least 5000 T
     When validator node VN sends a registration transaction
     When miner MINER mines 16 new blocks
     Then VN has scanned to height 17 within 10 seconds

--- a/integration_tests/tests/features/claim_fees.feature
+++ b/integration_tests/tests/features/claim_fees.feature
@@ -22,6 +22,7 @@ Feature: Claim Fees
     # Initialize a VN
     Given a seed validator node VN connected to base node BASE and wallet WALLET
     When miner MINER mines 4 new blocks
+    When wallet WALLET has at least 5000 T
     When validator node VN sends a registration transaction allowing fee claims from wallet WALLET_D using key K1
     When miner MINER mines 16 new blocks
     Then VN has scanned to height 17 within 10 seconds

--- a/integration_tests/tests/features/claim_fees.feature
+++ b/integration_tests/tests/features/claim_fees.feature
@@ -79,7 +79,7 @@ Feature: Claim Fees
 
     # Progress to the next epoch
     When miner MINER mines 10 new blocks
-    Then VN has scanned to height 27 within 10 seconds
+    Then VN has scanned to height 27 within 20 seconds
 
     # Claim fees into ACC2
     When I claim fees for validator VN and epoch 1 into account ACC2 using the wallet daemon WALLET_D

--- a/integration_tests/tests/features/fungible.feature
+++ b/integration_tests/tests/features/fungible.feature
@@ -13,6 +13,7 @@ Feature: Fungible tokens
     # Initialize a VN
     Given a validator node VN connected to base node BASE and wallet WALLET
     When miner MINER mines 4 new blocks
+    When wallet WALLET has at least 5000 T
     When validator node VN sends a registration transaction
     When miner MINER mines 16 new blocks
     Then the validator node VN is listed as registered

--- a/integration_tests/tests/features/transfer.feature
+++ b/integration_tests/tests/features/transfer.feature
@@ -13,6 +13,7 @@ Feature: Account transfers
     # Initialize a VN
     Given a validator node VN connected to base node BASE and wallet WALLET
     When miner MINER mines 4 new blocks
+    When wallet WALLET has at least 5000 T
     When validator node VN sends a registration transaction
     When miner MINER mines 16 new blocks
     Then the validator node VN is listed as registered
@@ -87,6 +88,7 @@ Feature: Account transfers
     # Initialize a VN
     Given a validator node VN connected to base node BASE and wallet WALLET
     When miner MINER mines 4 new blocks
+    When wallet WALLET has at least 5000 T
     When validator node VN sends a registration transaction
     When miner MINER mines 16 new blocks
     Then the validator node VN is listed as registered
@@ -158,6 +160,7 @@ Feature: Account transfers
     # Initialize a VN
     Given a validator node VN connected to base node BASE and wallet WALLET
     When miner MINER mines 4 new blocks
+    When wallet WALLET has at least 5000 T
     When validator node VN sends a registration transaction
     When miner MINER mines 16 new blocks
     Then the validator node VN is listed as registered

--- a/integration_tests/tests/features/wallet_daemon.feature
+++ b/integration_tests/tests/features/wallet_daemon.feature
@@ -91,6 +91,7 @@ Feature: Wallet Daemon
         # Initialize a VN
         Given a validator node VN connected to base node BASE and wallet WALLET
         When miner MINER mines 4 new blocks
+        When wallet WALLET has at least 5000 T
         When validator node VN sends a registration transaction
         When miner MINER mines 16 new blocks
         Then the validator node VN is listed as registered

--- a/integration_tests/tests/log4rs/cucumber.yml
+++ b/integration_tests/tests/log4rs/cucumber.yml
@@ -103,6 +103,12 @@ root:
     - other
 
 loggers:
+  cucumber:
+    level: debug
+    appenders:
+      - dan_layer
+    additive: false
+
   tari::application:
     level: debug
     appenders:


### PR DESCRIPTION
Description
---
Adds cucumber logs as an artifact so that they can be inspected

Motivation and Context
---
Tests fail on CI but never locally, e.g.
https://github.com/tari-project/tari-dan/pull/706/checks?check_run_id=17382036316&pr=706

Need to be able to inspect logs on CI to debug.

How Has This Been Tested?
---
Works in #706  https://github.com/tari-project/tari-dan/actions/runs/6402895290

What process can a PR reviewer use to test or verify this change?
---
See artifacts in this PR

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify