### PR TITLE
fix: indexer webui mime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8243,6 +8243,7 @@ dependencies = [
  "lmdb-zero",
  "log",
  "log4rs 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mime_guess",
  "minotari_app_utilities",
  "prost 0.9.0",
  "rand 0.8.5",

--- a/applications/tari_indexer/Cargo.toml
+++ b/applications/tari_indexer/Cargo.toml
@@ -62,6 +62,7 @@ tonic = "0.6.2"
 tower = "0.4"
 tower-layer = "0.3"
 tower-http = { version = "0.3.0", features = ["cors"] }
+mime_guess = "2.0.4"
 
 [package.metadata.cargo-machete]
 ignored = [


### PR DESCRIPTION
Description
---
The content type in header was not set for webui.

Motivation and Context
---
The ui will not render properly when the content type is not set.

How Has This Been Tested?
---
Manually checking the content type in header in indexer webui.

What process can a PR reviewer use to test or verify this change?
---
Same as above.


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify