### PR TITLE
fix: foreign vaults/accounts

### DIFF
--- a/applications/tari_dan_wallet_daemon/src/services/account_monitor.rs
+++ b/applications/tari_dan_wallet_daemon/src/services/account_monitor.rs
@@ -150,6 +150,11 @@ where
         let substate_api = self.wallet_sdk.substate_api();
         let accounts_api = self.wallet_sdk.accounts_api();
 
+        if !accounts_api.exists_by_address(account_address)? {
+            // This is not our account
+            return Ok(false);
+        }
+
         let mut is_updated = false;
         let account_substate = substate_api.get_substate(account_address)?;
         let ValidatorScanResult {
@@ -227,6 +232,10 @@ where
 
         let balance = vault.balance();
         let vault_addr = SubstateAddress::Vault(*vault.vault_id());
+        if !accounts_api.exists_by_address(account_addr)? {
+            // This is not our account
+            return Ok(());
+        }
         if !accounts_api.has_vault(&vault_addr)? {
             info!(
                 target: LOG_TARGET,
@@ -434,6 +443,10 @@ where
     ) -> Result<(), AccountMonitorError> {
         let vault_addr = SubstateAddress::Vault(*vault.vault_id());
         let accounts_api = self.wallet_sdk.accounts_api();
+        if !accounts_api.exists_by_address(account_addr)? {
+            // This is not our account
+            return Ok(());
+        }
         if accounts_api.has_vault(&vault_addr)? {
             return Ok(());
         }

--- a/dan_layer/wallet/sdk/src/apis/accounts.rs
+++ b/dan_layer/wallet/sdk/src/apis/accounts.rs
@@ -86,6 +86,10 @@ impl<'a, TStore: WalletStore> AccountsApi<'a, TStore> {
         Ok(())
     }
 
+    pub fn exists_by_address(&self, address: &SubstateAddress) -> Result<bool, AccountsApiError> {
+        Ok(self.get_account_by_address(address).optional()?.is_some())
+    }
+
     pub fn get_account_by_address(&self, address: &SubstateAddress) -> Result<Account, AccountsApiError> {
         let mut tx = self.store.create_read_tx()?;
         let account = tx.accounts_get(address)?;


### PR DESCRIPTION
Description
---
Don't add foreign vaults/accounts to your DB.


Motivation and Context
---

How Has This Been Tested?
---
Run dan-testing with some transaction and look into the DB to see there are no foreign vaults.

What process can a PR reviewer use to test or verify this change?
---
Same as above.


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify