### PR TITLE
fix: dan wallet ui for failed transaction

### DIFF
--- a/applications/tari_dan_wallet_web_ui/src/routes/Transactions/TransactionDetails.tsx
+++ b/applications/tari_dan_wallet_web_ui/src/routes/Transactions/TransactionDetails.tsx
@@ -125,9 +125,9 @@ export default function TransactionDetails() {
                 <TableRow>
                   <TableCell>Reason</TableCell>
                   <DataTableCell>
-                    {`${Object.keys(data.transaction_failure)[0]}: ${
+                    {data?.transaction_failure?`${Object.keys(data.transaction_failure)[0]}: ${
                       Object.values(data.transaction_failure)[0]
-                    }`}
+                    }`:"No reason"}
                   </DataTableCell>
                 </TableRow>
               </TableBody>

--- a/applications/tari_dan_wallet_web_ui/src/routes/Transactions/Transactions.tsx
+++ b/applications/tari_dan_wallet_web_ui/src/routes/Transactions/Transactions.tsx
@@ -74,7 +74,7 @@ export default function Transactions() {
               {data?.transactions
                 ?.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
                 .map((t: any) => {
-                  if (t[0].id !== undefined) {
+                  if (t?.[0]?.id !== undefined) {
                     const hash = t[0].id;
                     return (
                       <TableRow key={hash}>
@@ -93,9 +93,7 @@ export default function Transactions() {
                           <StatusChip status={t[2]} showTitle />
                         </DataTableCell>
                         <DataTableCell>
-                          {t[1] !== null
-                            ? t[1].cost_breakdown?.total_fees_charged
-                            : 0}
+                          {t?.[1]?.cost_breakdown?.total_fees_charged || 0}
                         </DataTableCell>
                         <DataTableCell>
                           <IconButton


### PR DESCRIPTION
Description
---
When the transaction gives no reason why it fails, the UI will crash.

Motivation and Context
---

How Has This Been Tested?
---
Manually.

What process can a PR reviewer use to test or verify this change?
---
Just create a transaction that will fail (e.g. send more funds than you have) and go to the UI.


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify