### PR TITLE
fix(consensus)!: remove merkle_proof from votes

### DIFF
--- a/dan_layer/common_types/src/node_addressable.rs
+++ b/dan_layer/common_types/src/node_addressable.rs
@@ -10,7 +10,9 @@ use serde::{de::DeserializeOwned, Serialize};
 use tari_common_types::types::PublicKey;
 use tari_crypto::tari_utilities::ByteArray;
 
-pub trait NodeAddressable: Eq + Hash + Clone + Debug + Send + Sync + Display + Serialize + DeserializeOwned {
+pub trait NodeAddressable:
+    Eq + Hash + Clone + Debug + Ord + Send + Sync + Display + Serialize + DeserializeOwned
+{
     fn zero() -> Self;
     fn as_bytes(&self) -> &[u8];
 

--- a/dan_layer/consensus/src/hotstuff/on_ready_to_vote_on_local_block.rs
+++ b/dan_layer/consensus/src/hotstuff/on_ready_to_vote_on_local_block.rs
@@ -333,7 +333,6 @@ where TConsensusSpec: ConsensusSpec
                 block_height: vote.block_height,
                 decision: vote.decision,
                 signature: vote.signature,
-                merkle_proof: vote.merkle_proof,
             };
             last_sent_vote.set(tx)
         })?;
@@ -830,10 +829,6 @@ where TConsensusSpec: ConsensusSpec
         block: &Block<TConsensusSpec::Addr>,
         decision: QuorumDecision,
     ) -> Result<VoteMessage<TConsensusSpec::Addr>, HotStuffError> {
-        let merkle_proof = self
-            .epoch_manager
-            .get_validator_node_merkle_proof(block.epoch())
-            .await?;
         let vn = self
             .epoch_manager
             .get_validator_node(block.epoch(), &self.validator_addr)
@@ -848,7 +843,6 @@ where TConsensusSpec: ConsensusSpec
             block_height: block.height(),
             decision,
             signature,
-            merkle_proof,
         })
     }
 

--- a/dan_layer/consensus/src/messages/vote.rs
+++ b/dan_layer/consensus/src/messages/vote.rs
@@ -2,7 +2,7 @@
 //   SPDX-License-Identifier: BSD-3-Clause
 
 use serde::Serialize;
-use tari_dan_common_types::{hashing::ValidatorNodeMerkleProof, Epoch, NodeHeight};
+use tari_dan_common_types::{Epoch, NodeHeight};
 use tari_dan_storage::consensus_models::{BlockId, LastSentVote, QuorumDecision, ValidatorSignature};
 
 #[derive(Debug, Clone, Serialize)]
@@ -12,9 +12,6 @@ pub struct VoteMessage<TAddr> {
     pub block_height: NodeHeight,
     pub decision: QuorumDecision,
     pub signature: ValidatorSignature<TAddr>,
-    // TODO: Surely the current leader can generate the aggregate proof for the new QC. I dont think we need to include
-    //       it in each vote message.
-    pub merkle_proof: ValidatorNodeMerkleProof,
 }
 
 impl<TAddr> From<LastSentVote<TAddr>> for VoteMessage<TAddr> {
@@ -25,7 +22,6 @@ impl<TAddr> From<LastSentVote<TAddr>> for VoteMessage<TAddr> {
             block_height: value.block_height,
             decision: value.decision,
             signature: value.signature,
-            merkle_proof: value.merkle_proof,
         }
     }
 }

--- a/dan_layer/consensus_tests/src/support/epoch_manager.rs
+++ b/dan_layer/consensus_tests/src/support/epoch_manager.rs
@@ -10,7 +10,7 @@ use std::{
 use async_trait::async_trait;
 use tari_dan_common_types::{
     committee::{Committee, CommitteeShard},
-    hashing::{ValidatorNodeBalancedMerkleTree, ValidatorNodeMerkleProof},
+    hashing::{MergedValidatorNodeMerkleProof, ValidatorNodeBalancedMerkleTree, ValidatorNodeMerkleProof},
     shard_bucket::ShardBucket,
     Epoch,
     ShardId,
@@ -152,13 +152,15 @@ impl EpochManagerReader for TestEpochManager {
         Ok(self.inner.lock().await.committees.len() as u32)
     }
 
-    async fn get_validator_node_merkle_proof(
+    async fn get_validator_set_merged_merkle_proof(
         &self,
         _epoch: Epoch,
-    ) -> Result<ValidatorNodeMerkleProof, EpochManagerError> {
+        _validators: Vec<Self::Addr>,
+    ) -> Result<MergedValidatorNodeMerkleProof, EpochManagerError> {
         let leaves = vec![];
         let tree = ValidatorNodeBalancedMerkleTree::create(leaves);
-        Ok(ValidatorNodeMerkleProof::generate_proof(&tree, 0).unwrap())
+        let proof = ValidatorNodeMerkleProof::generate_proof(&tree, 0).unwrap();
+        Ok(MergedValidatorNodeMerkleProof::create_from_proofs(&[proof]).unwrap())
     }
 
     async fn get_committees_by_buckets(

--- a/dan_layer/epoch_manager/src/base_layer/base_layer_epoch_manager.rs
+++ b/dan_layer/epoch_manager/src/base_layer/base_layer_epoch_manager.rs
@@ -34,7 +34,7 @@ use tari_core::{blocks::BlockHeader, transactions::transaction_components::Valid
 use tari_crypto::tari_utilities::ByteArray;
 use tari_dan_common_types::{
     committee::{Committee, CommitteeShard},
-    hashing::{ValidatorNodeBalancedMerkleTree, ValidatorNodeMerkleProof},
+    hashing::{MergedValidatorNodeMerkleProof, ValidatorNodeBalancedMerkleTree, ValidatorNodeMerkleProof},
     optional::Optional,
     shard_bucket::ShardBucket,
     Epoch,
@@ -42,6 +42,7 @@ use tari_dan_common_types::{
 };
 use tari_dan_storage::global::{models::ValidatorNode, DbEpoch, GlobalDb, MetadataKey};
 use tari_dan_storage_sqlite::global::SqliteGlobalDbAdapter;
+use tari_mmr::MergedBalancedBinaryMerkleProof;
 use tokio::sync::broadcast;
 
 use crate::{base_layer::config::EpochManagerConfig, error::EpochManagerError, EpochManagerEvent};
@@ -474,19 +475,28 @@ impl BaseLayerEpochManager<SqliteGlobalDbAdapter, GrpcBaseNodeClient> {
         Ok(vn_bmt)
     }
 
-    pub fn get_validator_node_merkle_proof(&self, epoch: Epoch) -> Result<ValidatorNodeMerkleProof, EpochManagerError> {
+    pub fn get_validator_set_merged_merkle_proof(
+        &self,
+        epoch: Epoch,
+        validators: Vec<CommsPublicKey>,
+    ) -> Result<MergedValidatorNodeMerkleProof, EpochManagerError> {
+        let mut proofs = Vec::with_capacity(validators.len());
         let bmt = self.get_validator_node_balanced_merkle_tree(epoch)?;
 
-        let vn = self.get_validator_node(epoch, &self.node_public_key)?.ok_or_else(|| {
-            EpochManagerError::ValidatorNodeNotRegistered {
-                address: self.node_public_key.to_string(),
-                epoch,
-            }
-        })?;
-        let leaf_index = bmt.find_leaf_index_for_hash(&vn.node_hash().to_vec())?;
+        for validator in &validators {
+            let vn = self.get_validator_node(epoch, validator)?.ok_or_else(|| {
+                EpochManagerError::ValidatorNodeNotRegistered {
+                    address: self.node_public_key.to_string(),
+                    epoch,
+                }
+            })?;
+            let leaf_index = bmt.find_leaf_index_for_hash(&vn.node_hash().to_vec())?;
 
-        let proof = ValidatorNodeMerkleProof::generate_proof(&bmt, leaf_index as usize)?;
-        Ok(proof)
+            let proof = ValidatorNodeMerkleProof::generate_proof(&bmt, leaf_index as usize)?;
+            proofs.push(proof);
+        }
+
+        Ok(MergedBalancedBinaryMerkleProof::create_from_proofs(&proofs).unwrap())
     }
 
     pub async fn on_scanning_complete(&mut self) -> Result<(), EpochManagerError> {

--- a/dan_layer/epoch_manager/src/base_layer/epoch_manager_service.rs
+++ b/dan_layer/epoch_manager/src/base_layer/epoch_manager_service.rs
@@ -136,8 +136,15 @@ impl EpochManagerService<SqliteGlobalDbAdapter, GrpcBaseNodeClient> {
             EpochManagerRequest::GetValidatorNodeBalancedMerkleTree { epoch, reply } => {
                 handle(reply, self.inner.get_validator_node_balanced_merkle_tree(epoch))
             },
-            EpochManagerRequest::GetValidatorNodeMerkleProof { epoch, reply } => {
-                handle(reply, self.inner.get_validator_node_merkle_proof(epoch));
+            EpochManagerRequest::GetValidatorSetMergedMerkleProof {
+                epoch,
+                validator_set,
+                reply,
+            } => {
+                handle(
+                    reply,
+                    self.inner.get_validator_set_merged_merkle_proof(epoch, validator_set),
+                );
             },
             EpochManagerRequest::GetValidatorNodeMerkleRoot { epoch, reply } => {
                 handle(reply, self.inner.get_validator_node_merkle_root(epoch))

--- a/dan_layer/epoch_manager/src/base_layer/epoch_manager_service.rs
+++ b/dan_layer/epoch_manager/src/base_layer/epoch_manager_service.rs
@@ -133,9 +133,6 @@ impl EpochManagerService<SqliteGlobalDbAdapter, GrpcBaseNodeClient> {
                 handle(reply, self.inner.is_validator_in_committee(epoch, shard, &identity));
             },
             EpochManagerRequest::Subscribe { reply } => handle(reply, Ok(self.events.subscribe())),
-            EpochManagerRequest::GetValidatorNodeBalancedMerkleTree { epoch, reply } => {
-                handle(reply, self.inner.get_validator_node_balanced_merkle_tree(epoch))
-            },
             EpochManagerRequest::GetValidatorSetMergedMerkleProof {
                 epoch,
                 validator_set,

--- a/dan_layer/epoch_manager/src/base_layer/handle.rs
+++ b/dan_layer/epoch_manager/src/base_layer/handle.rs
@@ -13,7 +13,7 @@ use tari_comms::types::CommsPublicKey;
 use tari_core::transactions::transaction_components::ValidatorNodeRegistration;
 use tari_dan_common_types::{
     committee::{Committee, CommitteeShard},
-    hashing::ValidatorNodeMerkleProof,
+    hashing::MergedValidatorNodeMerkleProof,
     shard_bucket::ShardBucket,
     Epoch,
     ShardId,
@@ -254,13 +254,18 @@ impl EpochManagerReader for EpochManagerHandle {
         rx.await.map_err(|_| EpochManagerError::ReceiveError)?
     }
 
-    async fn get_validator_node_merkle_proof(
+    async fn get_validator_set_merged_merkle_proof(
         &self,
         epoch: Epoch,
-    ) -> Result<ValidatorNodeMerkleProof, EpochManagerError> {
+        validator_set: Vec<Self::Addr>,
+    ) -> Result<MergedValidatorNodeMerkleProof, EpochManagerError> {
         let (tx, rx) = oneshot::channel();
         self.tx_request
-            .send(EpochManagerRequest::GetValidatorNodeMerkleProof { epoch, reply: tx })
+            .send(EpochManagerRequest::GetValidatorSetMergedMerkleProof {
+                epoch,
+                reply: tx,
+                validator_set,
+            })
             .await
             .map_err(|_| EpochManagerError::SendError)?;
 

--- a/dan_layer/epoch_manager/src/base_layer/types.rs
+++ b/dan_layer/epoch_manager/src/base_layer/types.rs
@@ -12,7 +12,7 @@ use tari_comms::types::CommsPublicKey;
 use tari_core::transactions::transaction_components::ValidatorNodeRegistration;
 use tari_dan_common_types::{
     committee::{Committee, CommitteeShard},
-    hashing::{MergedValidatorNodeMerkleProof, ValidatorNodeBalancedMerkleTree},
+    hashing::MergedValidatorNodeMerkleProof,
     shard_bucket::ShardBucket,
     Epoch,
     ShardId,
@@ -80,10 +80,6 @@ pub enum EpochManagerRequest {
     GetValidatorNodesPerEpoch {
         epoch: Epoch,
         reply: Reply<Vec<ValidatorNode<PublicKey>>>,
-    },
-    GetValidatorNodeBalancedMerkleTree {
-        epoch: Epoch,
-        reply: Reply<ValidatorNodeBalancedMerkleTree>,
     },
     GetValidatorSetMergedMerkleProof {
         epoch: Epoch,

--- a/dan_layer/epoch_manager/src/base_layer/types.rs
+++ b/dan_layer/epoch_manager/src/base_layer/types.rs
@@ -12,7 +12,7 @@ use tari_comms::types::CommsPublicKey;
 use tari_core::transactions::transaction_components::ValidatorNodeRegistration;
 use tari_dan_common_types::{
     committee::{Committee, CommitteeShard},
-    hashing::{ValidatorNodeBalancedMerkleTree, ValidatorNodeMerkleProof},
+    hashing::{MergedValidatorNodeMerkleProof, ValidatorNodeBalancedMerkleTree},
     shard_bucket::ShardBucket,
     Epoch,
     ShardId,
@@ -85,9 +85,10 @@ pub enum EpochManagerRequest {
         epoch: Epoch,
         reply: Reply<ValidatorNodeBalancedMerkleTree>,
     },
-    GetValidatorNodeMerkleProof {
+    GetValidatorSetMergedMerkleProof {
         epoch: Epoch,
-        reply: Reply<ValidatorNodeMerkleProof>,
+        validator_set: Vec<CommsPublicKey>,
+        reply: Reply<MergedValidatorNodeMerkleProof>,
     },
     GetValidatorNodeMerkleRoot {
         epoch: Epoch,

--- a/dan_layer/epoch_manager/src/traits.rs
+++ b/dan_layer/epoch_manager/src/traits.rs
@@ -28,7 +28,7 @@ use std::{
 use async_trait::async_trait;
 use tari_dan_common_types::{
     committee::{Committee, CommitteeShard},
-    hashing::ValidatorNodeMerkleProof,
+    hashing::MergedValidatorNodeMerkleProof,
     shard_bucket::ShardBucket,
     Epoch,
     NodeAddressable,
@@ -38,54 +38,6 @@ use tari_dan_storage::global::models::ValidatorNode;
 use tokio::sync::broadcast;
 
 use crate::{EpochManagerError, EpochManagerEvent};
-
-// // TODO: Rename to reflect that it's a read only interface (e.g. EpochReader, EpochQuery)
-// #[async_trait]
-// pub trait EpochManager<TAddr: NodeAddressable>: Clone {
-//     type Error;
-//
-//     async fn current_epoch(&self) -> Result<Epoch, Self::Error>;
-//     async fn current_block_height(&self) -> Result<u64, Self::Error>;
-//     async fn get_validator_node(&self, epoch: Epoch, addr: TAddr) -> Result<ValidatorNode<TAddr>, Self::Error>;
-//     async fn is_epoch_valid(&self, epoch: Epoch) -> Result<bool, Self::Error>;
-//     async fn get_committees(
-//         &self,
-//         epoch: Epoch,
-//         shards: &[ShardId],
-//     ) -> Result<Vec<ShardCommitteeAllocation<TAddr>>, Self::Error>;
-//
-//     async fn get_committee(&self, epoch: Epoch, shard: ShardId) -> Result<Committee<TAddr>, Self::Error>;
-//     async fn get_committee_for_shard_range(
-//         &self,
-//         epoch: Epoch,
-//         shard_range: RangeInclusive<ShardId>,
-//     ) -> Result<Committee<TAddr>, Self::Error>;
-//     async fn is_validator_in_committee_for_current_epoch(
-//         &self,
-//         shard: ShardId,
-//         identity: TAddr,
-//     ) -> Result<bool, Self::Error>;
-//     /// Filters out from the available_shards, returning the ShardIds for committees for each available_shard that
-//     /// `for_addr` is part of.
-//     async fn filter_to_local_shards(
-//         &self,
-//         epoch: Epoch,
-//         for_addr: &TAddr,
-//         available_shards: &[ShardId],
-//     ) -> Result<Vec<ShardId>, Self::Error>;
-//
-//     async fn get_validator_nodes_per_epoch(&self, epoch: Epoch) -> Result<Vec<ValidatorNode<TAddr>>, Self::Error>;
-//     async fn get_validator_node_balanced_merkle_tree(
-//         &self,
-//         epoch: Epoch,
-//     ) -> Result<ValidatorNodeBalancedMerkleTree, Self::Error>;
-//     async fn get_validator_node_merkle_root(&self, epoch: Epoch) -> Result<Vec<u8>, Self::Error>;
-//
-//     async fn get_local_shard_range(&self, epoch: Epoch, addr: TAddr) -> Result<RangeInclusive<ShardId>, Self::Error>;
-//
-//     // TODO: Should be part of VN state machine
-//     async fn notify_scanning_complete(&self) -> Result<(), Self::Error>;
-// }
 
 #[async_trait]
 pub trait EpochManagerReader: Send + Sync {
@@ -119,10 +71,11 @@ pub trait EpochManagerReader: Send + Sync {
         Ok(results)
     }
 
-    async fn get_validator_node_merkle_proof(
+    async fn get_validator_set_merged_merkle_proof(
         &self,
         epoch: Epoch,
-    ) -> Result<ValidatorNodeMerkleProof, EpochManagerError>;
+        validators: Vec<Self::Addr>,
+    ) -> Result<MergedValidatorNodeMerkleProof, EpochManagerError>;
 
     async fn get_our_validator_node(&self, epoch: Epoch) -> Result<ValidatorNode<Self::Addr>, EpochManagerError>;
     async fn get_local_committee_shard(&self, epoch: Epoch) -> Result<CommitteeShard, EpochManagerError>;

--- a/dan_layer/state_store_sqlite/migrations/2023-06-08-091819_create_state_store/up.sql
+++ b/dan_layer/state_store_sqlite/migrations/2023-06-08-091819_create_state_store/up.sql
@@ -115,12 +115,11 @@ create table last_voted
 create table last_sent_vote
 (
     id           integer   NOT NULL PRIMARY KEY AUTOINCREMENT,
-    epoch        integer,
-    block_id     text,
-    block_height integer,
-    decision     integer,
-    signature    text,
-    merkle_proof text,
+    epoch        bigint    NOT NULL,
+    block_id     text      NOT NULL,
+    block_height bigint    NOT NULL,
+    decision     integer   NOT NULL,
+    signature    text      NOT NULL,
     created_at   timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (block_id) REFERENCES blocks (block_id)
 );
@@ -230,7 +229,6 @@ create table votes
     decision         integer   not null,
     sender_leaf_hash text      not NULL,
     signature        text      not NULL,
-    merkle_proof     text      not NULL,
     created_at       timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 

--- a/dan_layer/state_store_sqlite/src/schema.rs
+++ b/dan_layer/state_store_sqlite/src/schema.rs
@@ -48,15 +48,6 @@ diesel::table! {
 }
 
 diesel::table! {
-    last_voted (id) {
-        id -> Integer,
-        block_id -> Text,
-        height -> BigInt,
-        created_at -> Timestamp,
-    }
-}
-
-diesel::table! {
     last_sent_vote (id) {
         id -> Integer,
         epoch -> BigInt,
@@ -64,7 +55,15 @@ diesel::table! {
         block_height -> BigInt,
         decision -> Integer,
         signature -> Text,
-        merkle_proof -> Text,
+        created_at -> Timestamp,
+    }
+}
+
+diesel::table! {
+    last_voted (id) {
+        id -> Integer,
+        block_id -> Text,
+        height -> BigInt,
         created_at -> Timestamp,
     }
 }
@@ -242,7 +241,6 @@ diesel::table! {
         decision -> Integer,
         sender_leaf_hash -> Text,
         signature -> Text,
-        merkle_proof -> Text,
         created_at -> Timestamp,
     }
 }
@@ -252,6 +250,7 @@ diesel::allow_tables_to_appear_in_same_query!(
     high_qcs,
     last_executed,
     last_proposed,
+    last_sent_vote,
     last_voted,
     leaf_blocks,
     locked_block,

--- a/dan_layer/state_store_sqlite/src/sql_models/bookkeeping.rs
+++ b/dan_layer/state_store_sqlite/src/sql_models/bookkeeping.rs
@@ -100,7 +100,6 @@ pub struct LastSentVote {
     pub block_height: i64,
     pub decision: i32,
     pub signature: String,
-    pub merkle_proof: String,
     pub created_at: PrimitiveDateTime,
 }
 
@@ -123,7 +122,6 @@ impl<TAddr: NodeAddressable> TryFrom<LastSentVote> for consensus_models::LastSen
                 details: format!("Could not convert {} to QuorumDecision", value.decision),
             })?,
             signature: deserialize_json(&value.signature)?,
-            merkle_proof: deserialize_json(&value.merkle_proof)?,
         })
     }
 }

--- a/dan_layer/state_store_sqlite/src/sql_models/vote.rs
+++ b/dan_layer/state_store_sqlite/src/sql_models/vote.rs
@@ -20,7 +20,6 @@ pub struct Vote {
     pub decision: i32,
     pub sender: String,
     pub signature: String,
-    pub merkle_proof: String,
     pub created_at: PrimitiveDateTime,
 }
 
@@ -43,7 +42,6 @@ impl<TAddr: NodeAddressable> TryFrom<Vote> for consensus_models::Vote<TAddr> {
             })?,
             sender_leaf_hash: deserialize_hex_try_from(&value.sender)?,
             signature: deserialize_json(&value.signature)?,
-            merkle_proof: deserialize_json(&value.merkle_proof)?,
         })
     }
 }

--- a/dan_layer/state_store_sqlite/src/writer.rs
+++ b/dan_layer/state_store_sqlite/src/writer.rs
@@ -394,7 +394,6 @@ impl<TAddr: NodeAddressable> StateStoreWriteTransaction for SqliteStateStoreWrit
             last_sent_vote::block_height.eq(last_sent_vote.block_height.as_u64() as i64),
             last_sent_vote::decision.eq(i32::from(last_sent_vote.decision.as_u8())),
             last_sent_vote::signature.eq(serialize_json(&last_sent_vote.signature)?),
-            last_sent_vote::merkle_proof.eq(serialize_json(&last_sent_vote.merkle_proof)?),
         );
 
         diesel::insert_into(last_sent_vote::table)
@@ -919,7 +918,6 @@ impl<TAddr: NodeAddressable> StateStoreWriteTransaction for SqliteStateStoreWrit
             votes::sender_leaf_hash.eq(serialize_hex(vote.sender_leaf_hash)),
             votes::decision.eq(i32::from(vote.decision.as_u8())),
             votes::signature.eq(serialize_json(&vote.signature)?),
-            votes::merkle_proof.eq(serialize_json(&vote.merkle_proof)?),
         );
 
         diesel::insert_into(votes::table)

--- a/dan_layer/storage/src/consensus_models/last_sent_vote.rs
+++ b/dan_layer/storage/src/consensus_models/last_sent_vote.rs
@@ -1,7 +1,7 @@
 //   Copyright 2023 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use tari_dan_common_types::{hashing::ValidatorNodeMerkleProof, Epoch, NodeHeight};
+use tari_dan_common_types::{Epoch, NodeHeight};
 
 use super::{QuorumDecision, ValidatorSignature};
 use crate::{consensus_models::BlockId, StateStoreReadTransaction, StateStoreWriteTransaction, StorageError};
@@ -12,7 +12,6 @@ pub struct LastSentVote<TAddr> {
     pub block_height: NodeHeight,
     pub decision: QuorumDecision,
     pub signature: ValidatorSignature<TAddr>,
-    pub merkle_proof: ValidatorNodeMerkleProof,
 }
 
 impl<TAddr> LastSentVote<TAddr> {

--- a/dan_layer/storage/src/consensus_models/quorum_certificate.rs
+++ b/dan_layer/storage/src/consensus_models/quorum_certificate.rs
@@ -184,6 +184,13 @@ impl<TAddr> QuorumCertificate<TAddr> {
         Block::get(tx, &self.block_id)
     }
 
+    pub fn get_by_block_id<TTx: StateStoreReadTransaction<Addr = TAddr> + ?Sized>(
+        tx: &mut TTx,
+        block_id: &BlockId,
+    ) -> Result<Self, StorageError> {
+        tx.quorum_certificates_get_by_block_id(block_id)
+    }
+
     pub fn insert<TTx: StateStoreWriteTransaction<Addr = TAddr> + ?Sized>(
         &self,
         tx: &mut TTx,

--- a/dan_layer/storage/src/consensus_models/vote.rs
+++ b/dan_layer/storage/src/consensus_models/vote.rs
@@ -5,11 +5,7 @@ use std::ops::DerefMut;
 
 use serde::{Deserialize, Serialize};
 use tari_common_types::types::FixedHash;
-use tari_dan_common_types::{
-    hashing::{vote_hasher, ValidatorNodeMerkleProof},
-    optional::Optional,
-    Epoch,
-};
+use tari_dan_common_types::{hashing::vote_hasher, optional::Optional, Epoch};
 
 use crate::{
     consensus_models::{BlockId, QuorumDecision, ValidatorSignature},
@@ -25,7 +21,6 @@ pub struct Vote<TAddr> {
     pub decision: QuorumDecision,
     pub sender_leaf_hash: FixedHash,
     pub signature: ValidatorSignature<TAddr>,
-    pub merkle_proof: ValidatorNodeMerkleProof,
 }
 
 impl<TAddr: Serialize> Vote<TAddr> {

--- a/dan_layer/storage/src/global/backend_adapter.rs
+++ b/dan_layer/storage/src/global/backend_adapter.rs
@@ -146,6 +146,6 @@ pub trait GlobalDbAdapter: AtomicDb + Send + Sync + Clone {
     fn get_bmt(
         &self,
         tx: &mut Self::DbTransaction<'_>,
-        epoch: u64,
+        epoch: Epoch,
     ) -> Result<Option<ValidatorNodeBalancedMerkleTree>, Self::Error>;
 }

--- a/dan_layer/storage/src/global/bmt_db.rs
+++ b/dan_layer/storage/src/global/bmt_db.rs
@@ -20,7 +20,7 @@
 //   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //   USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use tari_dan_common_types::hashing::ValidatorNodeBalancedMerkleTree;
+use tari_dan_common_types::{hashing::ValidatorNodeBalancedMerkleTree, Epoch};
 
 use crate::global::GlobalDbAdapter;
 
@@ -44,7 +44,10 @@ impl<'a, 'tx, TGlobalDbAdapter: GlobalDbAdapter> BmtDb<'a, 'tx, TGlobalDbAdapter
             .map_err(TGlobalDbAdapter::Error::into)
     }
 
-    pub fn get_bmt(&mut self, epoch: u64) -> Result<Option<ValidatorNodeBalancedMerkleTree>, TGlobalDbAdapter::Error> {
+    pub fn get_bmt(
+        &mut self,
+        epoch: Epoch,
+    ) -> Result<Option<ValidatorNodeBalancedMerkleTree>, TGlobalDbAdapter::Error> {
         self.backend
             .get_bmt(self.tx, epoch)
             .map_err(TGlobalDbAdapter::Error::into)

--- a/dan_layer/storage_sqlite/src/global/backend_adapter.rs
+++ b/dan_layer/storage_sqlite/src/global/backend_adapter.rs
@@ -596,12 +596,12 @@ impl GlobalDbAdapter for SqliteGlobalDbAdapter {
     fn get_bmt(
         &self,
         tx: &mut Self::DbTransaction<'_>,
-        epoch: u64,
+        epoch: Epoch,
     ) -> Result<Option<ValidatorNodeBalancedMerkleTree>, Self::Error> {
         use crate::global::schema::bmt_cache::dsl;
 
         let query_res: Option<models::Bmt> = dsl::bmt_cache
-            .find(epoch as i64)
+            .find(epoch.as_u64() as i64)
             .first(tx.connection())
             .optional()
             .map_err(|source| SqliteStorageError::DieselError {

--- a/dan_layer/validator_node_rpc/proto/consensus.proto
+++ b/dan_layer/validator_node_rpc/proto/consensus.proto
@@ -38,7 +38,6 @@ message VoteMessage {
   uint64 block_height = 3;
   QuorumDecision decision = 4;
   tari.dan.common.SignatureAndPublicKey signature = 5;
-  bytes merkle_proof = 6;
 }
 
 message Block {

--- a/dan_layer/validator_node_rpc/src/conversions/consensus.rs
+++ b/dan_layer/validator_node_rpc/src/conversions/consensus.rs
@@ -168,7 +168,6 @@ impl<TAddr: NodeAddressable> From<&VoteMessage<TAddr>> for proto::consensus::Vot
             block_height: msg.block_height.as_u64(),
             decision: i32::from(msg.decision.as_u8()),
             signature: Some((&msg.signature).into()),
-            merkle_proof: encode(&msg.merkle_proof).unwrap(),
         }
     }
 }
@@ -187,7 +186,6 @@ impl<TAddr: NodeAddressable> TryFrom<proto::consensus::VoteMessage> for VoteMess
                 .signature
                 .ok_or_else(|| anyhow!("Signature is missing"))?
                 .try_into()?,
-            merkle_proof: decode_exact(&value.merkle_proof)?,
         })
     }
 }


### PR DESCRIPTION
Description
---
Removed Merkle proof from vote messages. 

Motivation and Context
---
A valid merged Merkle proof of all signers can be generated by any node without each validator sending their Merkle proof each time and having each validator store these each time.

Message size reduction from variable ~370 bytes to a fixed 145 bytes.

How Has This Been Tested?
---
Existing tests and manually

What process can a PR reviewer use to test or verify this change?
---


Breaking Changes
---

- [ ] None
- [x] Requires data directory to be deleted
- [ ] Other - Please specify