### PR TITLE
fix(tx-generator): fix compile err by forcing critical-section feature for once_cell

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9393,6 +9393,7 @@ dependencies = [
  "bincode 2.0.0-rc.3",
  "bytes 0.4.12",
  "clap 4.4.6",
+ "once_cell",
  "rand 0.8.5",
  "rayon",
  "tari_crypto",

--- a/dan_layer/storage_sqlite/src/global/backend_adapter.rs
+++ b/dan_layer/storage_sqlite/src/global/backend_adapter.rs
@@ -578,7 +578,6 @@ impl GlobalDbAdapter for SqliteGlobalDbAdapter {
     ) -> Result<(), Self::Error> {
         use crate::global::schema::bmt_cache;
 
-        println!("Inserting");
         diesel::insert_into(bmt_cache::table)
             .values((
                 bmt_cache::epoch.eq(epoch as i64),
@@ -589,7 +588,7 @@ impl GlobalDbAdapter for SqliteGlobalDbAdapter {
                 source,
                 operation: "insert::bmt".to_string(),
             })?;
-        println!("Insert done");
+
         Ok(())
     }
 

--- a/utilities/transaction_generator/Cargo.toml
+++ b/utilities/transaction_generator/Cargo.toml
@@ -16,3 +16,10 @@ bytes = "0.4"
 clap = { version = "4.3.21", features = ["derive"] }
 rayon = "1.7.0"
 rand = "0.8"
+once_cell = { version = "1.18.0", features = ["critical-section"] }
+
+[package.metadata.cargo-machete]
+ignored = [
+    # Need to force critical_section feature
+    "once_cell",
+]


### PR DESCRIPTION
Description
---
fix(tx-generator): fix compile err by forcing critical-section feature for once_cell

Motivation and Context
---
transaction generator fails to compile for [this reason](https://docs.rs/critical-section/1.1.1/critical_section/#undefined-reference-errors). This forces once_cell to include the critical section implementation. I believe this is required because of once_cell usage in tari_crypto, which correctly includes the critical section feature but for some reason this doesn't carry over, not sure really.

How Has This Been Tested?
---
Running the transaction generator

What process can a PR reviewer use to test or verify this change?
---
Run the transaction generator

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify