### PR TITLE
feat(indexer): new jrpc method to get all transactions related to a substate

### DIFF
--- a/applications/tari_indexer/src/json_rpc/handlers.rs
+++ b/applications/tari_indexer/src/json_rpc/handlers.rs
@@ -24,9 +24,7 @@ use std::{collections::HashMap, fmt::Display, sync::Arc};
 
 use axum_jrpc::{
     error::{JsonRpcError, JsonRpcErrorReason},
-    JrpcResult,
-    JsonRpcExtractor,
-    JsonRpcResponse,
+    JrpcResult, JsonRpcExtractor, JsonRpcResponse,
 };
 use log::{error, warn};
 use serde::Serialize;
@@ -36,8 +34,7 @@ use tari_comms::{
     multiaddr::Multiaddr,
     peer_manager::{NodeId, PeerFeatures},
     types::CommsPublicKey,
-    CommsNode,
-    NodeIdentity,
+    CommsNode, NodeIdentity,
 };
 use tari_crypto::tari_utilities::hex::Hex;
 use tari_dan_common_types::{optional::Optional, Epoch};
@@ -68,10 +65,8 @@ use tari_validator_node_rpc::client::{SubstateResult, TariCommsValidatorNodeClie
 
 use super::json_encoding::{encode_execute_result_into_json, encode_finalized_result_into_json};
 use crate::{
-    bootstrap::Services,
-    dry_run::processor::DryRunTransactionProcessor,
-    json_rpc::json_encoding::encode_substate_into_json,
-    substate_manager::SubstateManager,
+    bootstrap::Services, dry_run::processor::DryRunTransactionProcessor,
+    json_rpc::json_encoding::encode_substate_into_json, substate_manager::SubstateManager,
     transaction_manager::TransactionManager,
 };
 
@@ -272,12 +267,15 @@ impl JsonRpcHandlers {
                 warn!(target: LOG_TARGET, "Error getting substate: {}", e);
                 Self::internal_error(answer_id, format!("Error getting substate: {}", e))
             })? {
-            Some(substate_resp) => Ok(JsonRpcResponse::success(answer_id, GetSubstateResponse {
-                address: substate_resp.address,
-                version: substate_resp.version,
-                substate: substate_resp.substate,
-                created_by_transaction: substate_resp.created_by_transaction,
-            })),
+            Some(substate_resp) => Ok(JsonRpcResponse::success(
+                answer_id,
+                GetSubstateResponse {
+                    address: substate_resp.address,
+                    version: substate_resp.version,
+                    substate: substate_resp.substate,
+                    created_by_transaction: substate_resp.created_by_transaction,
+                },
+            )),
             None => {
                 if request.local_search_only {
                     Err(JsonRpcResponse::error(
@@ -326,12 +324,15 @@ impl JsonRpcHandlers {
                             address,
                             substate,
                             created_by_tx,
-                        } => Ok(JsonRpcResponse::success(answer_id, GetSubstateResponse {
-                            address,
-                            version: substate.version(),
-                            substate,
-                            created_by_transaction: created_by_tx,
-                        })),
+                        } => Ok(JsonRpcResponse::success(
+                            answer_id,
+                            GetSubstateResponse {
+                                address,
+                                version: substate.version(),
+                                substate,
+                                created_by_transaction: created_by_tx,
+                            },
+                        )),
                         SubstateResult::Down { version, .. } => Err(JsonRpcResponse::error(
                             answer_id,
                             JsonRpcError::new(
@@ -379,13 +380,16 @@ impl JsonRpcHandlers {
                 )
             })?;
 
-        Ok(JsonRpcResponse::success(answer_id, InspectSubstateResponse {
-            address: resp.address,
-            version: resp.version,
-            substate_contents: encode_substate_into_json(&resp.substate)
-                .map_err(|e| Self::internal_error(answer_id, e))?,
-            created_by_transaction: resp.created_by_transaction,
-        }))
+        Ok(JsonRpcResponse::success(
+            answer_id,
+            InspectSubstateResponse {
+                address: resp.address,
+                version: resp.version,
+                substate_contents: encode_substate_into_json(&resp.substate)
+                    .map_err(|e| Self::internal_error(answer_id, e))?,
+                created_by_transaction: resp.created_by_transaction,
+            },
+        ))
     }
 
     pub async fn get_addresses(&self, value: JsonRpcExtractor) -> JrpcResult {
@@ -495,16 +499,19 @@ impl JsonRpcHandlers {
             .await
             .map_err(|e| Self::internal_error(answer_id, e))?;
 
-        Ok(JsonRpcResponse::success(answer_id, GetNonFungiblesResponse {
-            non_fungibles: res
-                .into_iter()
-                .map(|v| NonFungibleSubstate {
-                    index: v.index,
-                    address: v.address,
-                    substate: v.substate,
-                })
-                .collect(),
-        }))
+        Ok(JsonRpcResponse::success(
+            answer_id,
+            GetNonFungiblesResponse {
+                non_fungibles: res
+                    .into_iter()
+                    .map(|v| NonFungibleSubstate {
+                        index: v.index,
+                        address: v.address,
+                        substate: v.substate,
+                    })
+                    .collect(),
+            },
+        ))
     }
 
     pub async fn submit_transaction(&self, value: JsonRpcExtractor) -> JrpcResult {
@@ -522,15 +529,18 @@ impl JsonRpcHandlers {
             let json_results =
                 encode_execute_result_into_json(&exec_result).map_err(|e| Self::internal_error(answer_id, e))?;
 
-            Ok(JsonRpcResponse::success(answer_id, SubmitTransactionResponse {
-                result: IndexerTransactionFinalizedResult::Finalized {
-                    execution_result: Some(exec_result),
-                    final_decision: Decision::Commit,
-                    abort_details: None,
-                    json_results,
+            Ok(JsonRpcResponse::success(
+                answer_id,
+                SubmitTransactionResponse {
+                    result: IndexerTransactionFinalizedResult::Finalized {
+                        execution_result: Some(exec_result),
+                        final_decision: Decision::Commit,
+                        abort_details: None,
+                        json_results,
+                    },
+                    transaction_id,
                 },
-                transaction_id,
-            }))
+            ))
         } else {
             let transaction_id = self
                 .transaction_manager
@@ -538,10 +548,13 @@ impl JsonRpcHandlers {
                 .await
                 .map_err(|e| Self::internal_error(answer_id, e))?;
 
-            Ok(JsonRpcResponse::success(answer_id, SubmitTransactionResponse {
-                result: IndexerTransactionFinalizedResult::Pending,
-                transaction_id,
-            }))
+            Ok(JsonRpcResponse::success(
+                answer_id,
+                SubmitTransactionResponse {
+                    result: IndexerTransactionFinalizedResult::Pending,
+                    transaction_id,
+                },
+            ))
         }
     }
 
@@ -605,6 +618,64 @@ impl JsonRpcHandlers {
                 }
             },
         };
+
+        Ok(JsonRpcResponse::success(answer_id, resp))
+    }
+
+    pub async fn get_substate_transactions(&self, value: JsonRpcExtractor) -> JrpcResult {
+        let answer_id = value.get_answer_id();
+        let request: GetRelatedTransactionsRequest = value.parse_params()?;
+
+        let mut version = request.version.unwrap_or(0);
+        let mut transaction_ids = vec![];
+
+        loop {
+            let res = self
+                .substate_manager
+                .get_specific_substate(&request.address, version)
+                .await;
+
+            if let Ok(substate_result) = res {
+                let transaction_id = match substate_result {
+                    SubstateResult::DoesNotExist => break,
+                    SubstateResult::Up { created_by_tx, .. } => created_by_tx,
+                    SubstateResult::Down { deleted_by_tx, .. } => deleted_by_tx,
+                };
+                transaction_ids.push(transaction_id);
+                version += 1;
+            } else {
+                break;
+            }
+        }
+
+        // the last transaction may both down and up a substate
+        transaction_ids.dedup();
+
+        let mut transaction_results = vec![];
+        for transaction_id in transaction_ids {
+            let transaction_result = self.transaction_manager
+                .get_transaction_result(transaction_id)
+                .await
+                .map_err(|e| Self::internal_error(answer_id, e))?;
+
+            let indexer_transaction_result = match transaction_result {
+                TransactionResultStatus::Pending => IndexerTransactionFinalizedResult::Pending,
+                TransactionResultStatus::Finalized(finalized) => {
+                    let json_results = encode_finalized_result_into_json(&finalized)
+                        .map_err(|e| Self::internal_error(answer_id, e))?;
+                    IndexerTransactionFinalizedResult::Finalized {
+                        final_decision: finalized.final_decision,
+                        execution_result: finalized.execute_result,
+                        abort_details: finalized.abort_details,
+                        json_results,
+                    }
+                },
+            };
+
+            transaction_results.push(indexer_transaction_result);
+        }
+
+        let resp = GetRelatedTransactionsResponse { transaction_results };
 
         Ok(JsonRpcResponse::success(answer_id, resp))
     }

--- a/applications/tari_indexer/src/json_rpc/handlers.rs
+++ b/applications/tari_indexer/src/json_rpc/handlers.rs
@@ -24,7 +24,9 @@ use std::{collections::HashMap, fmt::Display, sync::Arc};
 
 use axum_jrpc::{
     error::{JsonRpcError, JsonRpcErrorReason},
-    JrpcResult, JsonRpcExtractor, JsonRpcResponse,
+    JrpcResult,
+    JsonRpcExtractor,
+    JsonRpcResponse,
 };
 use log::{error, warn};
 use serde::Serialize;
@@ -34,7 +36,8 @@ use tari_comms::{
     multiaddr::Multiaddr,
     peer_manager::{NodeId, PeerFeatures},
     types::CommsPublicKey,
-    CommsNode, NodeIdentity,
+    CommsNode,
+    NodeIdentity,
 };
 use tari_crypto::tari_utilities::hex::Hex;
 use tari_dan_common_types::{optional::Optional, Epoch};
@@ -65,8 +68,10 @@ use tari_validator_node_rpc::client::{SubstateResult, TariCommsValidatorNodeClie
 
 use super::json_encoding::{encode_execute_result_into_json, encode_finalized_result_into_json};
 use crate::{
-    bootstrap::Services, dry_run::processor::DryRunTransactionProcessor,
-    json_rpc::json_encoding::encode_substate_into_json, substate_manager::SubstateManager,
+    bootstrap::Services,
+    dry_run::processor::DryRunTransactionProcessor,
+    json_rpc::json_encoding::encode_substate_into_json,
+    substate_manager::SubstateManager,
     transaction_manager::TransactionManager,
 };
 
@@ -267,15 +272,12 @@ impl JsonRpcHandlers {
                 warn!(target: LOG_TARGET, "Error getting substate: {}", e);
                 Self::internal_error(answer_id, format!("Error getting substate: {}", e))
             })? {
-            Some(substate_resp) => Ok(JsonRpcResponse::success(
-                answer_id,
-                GetSubstateResponse {
-                    address: substate_resp.address,
-                    version: substate_resp.version,
-                    substate: substate_resp.substate,
-                    created_by_transaction: substate_resp.created_by_transaction,
-                },
-            )),
+            Some(substate_resp) => Ok(JsonRpcResponse::success(answer_id, GetSubstateResponse {
+                address: substate_resp.address,
+                version: substate_resp.version,
+                substate: substate_resp.substate,
+                created_by_transaction: substate_resp.created_by_transaction,
+            })),
             None => {
                 if request.local_search_only {
                     Err(JsonRpcResponse::error(
@@ -324,15 +326,12 @@ impl JsonRpcHandlers {
                             address,
                             substate,
                             created_by_tx,
-                        } => Ok(JsonRpcResponse::success(
-                            answer_id,
-                            GetSubstateResponse {
-                                address,
-                                version: substate.version(),
-                                substate,
-                                created_by_transaction: created_by_tx,
-                            },
-                        )),
+                        } => Ok(JsonRpcResponse::success(answer_id, GetSubstateResponse {
+                            address,
+                            version: substate.version(),
+                            substate,
+                            created_by_transaction: created_by_tx,
+                        })),
                         SubstateResult::Down { version, .. } => Err(JsonRpcResponse::error(
                             answer_id,
                             JsonRpcError::new(
@@ -380,16 +379,13 @@ impl JsonRpcHandlers {
                 )
             })?;
 
-        Ok(JsonRpcResponse::success(
-            answer_id,
-            InspectSubstateResponse {
-                address: resp.address,
-                version: resp.version,
-                substate_contents: encode_substate_into_json(&resp.substate)
-                    .map_err(|e| Self::internal_error(answer_id, e))?,
-                created_by_transaction: resp.created_by_transaction,
-            },
-        ))
+        Ok(JsonRpcResponse::success(answer_id, InspectSubstateResponse {
+            address: resp.address,
+            version: resp.version,
+            substate_contents: encode_substate_into_json(&resp.substate)
+                .map_err(|e| Self::internal_error(answer_id, e))?,
+            created_by_transaction: resp.created_by_transaction,
+        }))
     }
 
     pub async fn get_addresses(&self, value: JsonRpcExtractor) -> JrpcResult {
@@ -499,19 +495,16 @@ impl JsonRpcHandlers {
             .await
             .map_err(|e| Self::internal_error(answer_id, e))?;
 
-        Ok(JsonRpcResponse::success(
-            answer_id,
-            GetNonFungiblesResponse {
-                non_fungibles: res
-                    .into_iter()
-                    .map(|v| NonFungibleSubstate {
-                        index: v.index,
-                        address: v.address,
-                        substate: v.substate,
-                    })
-                    .collect(),
-            },
-        ))
+        Ok(JsonRpcResponse::success(answer_id, GetNonFungiblesResponse {
+            non_fungibles: res
+                .into_iter()
+                .map(|v| NonFungibleSubstate {
+                    index: v.index,
+                    address: v.address,
+                    substate: v.substate,
+                })
+                .collect(),
+        }))
     }
 
     pub async fn submit_transaction(&self, value: JsonRpcExtractor) -> JrpcResult {
@@ -529,18 +522,15 @@ impl JsonRpcHandlers {
             let json_results =
                 encode_execute_result_into_json(&exec_result).map_err(|e| Self::internal_error(answer_id, e))?;
 
-            Ok(JsonRpcResponse::success(
-                answer_id,
-                SubmitTransactionResponse {
-                    result: IndexerTransactionFinalizedResult::Finalized {
-                        execution_result: Some(exec_result),
-                        final_decision: Decision::Commit,
-                        abort_details: None,
-                        json_results,
-                    },
-                    transaction_id,
+            Ok(JsonRpcResponse::success(answer_id, SubmitTransactionResponse {
+                result: IndexerTransactionFinalizedResult::Finalized {
+                    execution_result: Some(exec_result),
+                    final_decision: Decision::Commit,
+                    abort_details: None,
+                    json_results,
                 },
-            ))
+                transaction_id,
+            }))
         } else {
             let transaction_id = self
                 .transaction_manager
@@ -548,13 +538,10 @@ impl JsonRpcHandlers {
                 .await
                 .map_err(|e| Self::internal_error(answer_id, e))?;
 
-            Ok(JsonRpcResponse::success(
-                answer_id,
-                SubmitTransactionResponse {
-                    result: IndexerTransactionFinalizedResult::Pending,
-                    transaction_id,
-                },
-            ))
+            Ok(JsonRpcResponse::success(answer_id, SubmitTransactionResponse {
+                result: IndexerTransactionFinalizedResult::Pending,
+                transaction_id,
+            }))
         }
     }
 
@@ -653,7 +640,8 @@ impl JsonRpcHandlers {
 
         let mut transaction_results = vec![];
         for transaction_id in transaction_ids {
-            let transaction_result = self.transaction_manager
+            let transaction_result = self
+                .transaction_manager
                 .get_transaction_result(transaction_id)
                 .await
                 .map_err(|e| Self::internal_error(answer_id, e))?;

--- a/applications/tari_indexer/src/json_rpc/handlers.rs
+++ b/applications/tari_indexer/src/json_rpc/handlers.rs
@@ -53,6 +53,8 @@ use tari_indexer_client::types::{
     GetNonFungibleCountRequest,
     GetNonFungiblesRequest,
     GetNonFungiblesResponse,
+    GetRelatedTransactionsRequest,
+    GetRelatedTransactionsResponse,
     GetSubstateRequest,
     GetSubstateResponse,
     GetTransactionResultRequest,

--- a/applications/tari_indexer/src/json_rpc/server.rs
+++ b/applications/tari_indexer/src/json_rpc/server.rs
@@ -74,6 +74,7 @@ async fn handler(Extension(handlers): Extension<Arc<JsonRpcHandlers>>, value: Js
         "get_non_fungibles" => handlers.get_non_fungibles(value).await,
         "submit_transaction" => handlers.submit_transaction(value).await,
         "get_transaction_result" => handlers.get_transaction_result(value).await,
+        "get_substate_transactions" => handlers.get_substate_transactions(value).await,
         "get_epoch_manager_stats" => handlers.get_epoch_manager_stats(value).await,
         method => Ok(value.method_not_found(method)),
     }

--- a/applications/tari_indexer/src/substate_manager.rs
+++ b/applications/tari_indexer/src/substate_manager.rs
@@ -262,7 +262,10 @@ impl SubstateManager {
         substate_address: &SubstateAddress,
         version: u32,
     ) -> Result<SubstateResult, anyhow::Error> {
-        let substate_result = self.substate_scanner.get_specific_substate_from_committee(substate_address, version).await?;
+        let substate_result = self
+            .substate_scanner
+            .get_specific_substate_from_committee(substate_address, version)
+            .await?;
         return Ok(substate_result);
     }
 

--- a/applications/tari_indexer/src/substate_manager.rs
+++ b/applications/tari_indexer/src/substate_manager.rs
@@ -266,7 +266,7 @@ impl SubstateManager {
             .substate_scanner
             .get_specific_substate_from_committee(substate_address, version)
             .await?;
-        return Ok(substate_result);
+        Ok(substate_result)
     }
 
     pub async fn get_non_fungible_collections(&self) -> Result<Vec<(String, i64)>, anyhow::Error> {

--- a/applications/tari_indexer/src/substate_manager.rs
+++ b/applications/tari_indexer/src/substate_manager.rs
@@ -257,6 +257,15 @@ impl SubstateManager {
         Ok(None)
     }
 
+    pub async fn get_specific_substate(
+        &self,
+        substate_address: &SubstateAddress,
+        version: u32,
+    ) -> Result<SubstateResult, anyhow::Error> {
+        let substate_result = self.substate_scanner.get_specific_substate_from_committee(substate_address, version).await?;
+        return Ok(substate_result);
+    }
+
     pub async fn get_non_fungible_collections(&self) -> Result<Vec<(String, i64)>, anyhow::Error> {
         let mut tx = self.substate_store.create_read_tx()?;
         tx.get_non_fungible_collections().map_err(|e| e.into())

--- a/clients/tari_indexer_client/src/types.rs
+++ b/clients/tari_indexer_client/src/types.rs
@@ -136,6 +136,19 @@ pub struct NonFungibleSubstate {
     pub substate: Substate,
 }
 
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GetRelatedTransactionsRequest {
+    #[serde_as(as = "DisplayFromStr")]
+    pub address: SubstateAddress,
+    pub version: Option<u32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GetRelatedTransactionsResponse {
+    pub transaction_results: Vec<IndexerTransactionFinalizedResult>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AddPeerRequest {
     pub public_key: PublicKey,


### PR DESCRIPTION
Description
---
Added new jrpc method `get_substate_transactions` that returns a (ordered) list of transactions that updated the requested substate address.

Motivation and Context
---
For the standalone Metamask Snap wallet we want to show the list of transactions. As the snap is standalone (no wallet daemon connection), we need an easy way to fetch all the transactions of a particular account (component substate) from the indexer. This PR adds a new method to accomplish this, in a general way that can be used for any kind of substate address (component, vaults, nfts, etc.).

How Has This Been Tested?
---
Manually querying the new method using Postman

What process can a PR reviewer use to test or verify this change?
---
Query the new method using Postman

Breaking Changes
---
- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify