### PR TITLE
feat: add jrpc address for webui to connect to

### DIFF
--- a/applications/tari_indexer/src/config.rs
+++ b/applications/tari_indexer/src/config.rs
@@ -83,6 +83,8 @@ pub struct IndexerConfig {
     pub graphql_address: Option<SocketAddr>,
     /// The address of the HTTP UI
     pub http_ui_address: Option<SocketAddr>,
+    /// The jrpc address where the UI should connect
+    pub jrpc_for_ui_address: Option<String>,
     /// Substate addresses to keep watching
     pub address_watchlist: Vec<SubstateAddress>,
     /// How often do we want to scan the second layer for new versions
@@ -129,6 +131,7 @@ impl Default for IndexerConfig {
             json_rpc_address: Some("127.0.0.1:18300".parse().unwrap()),
             graphql_address: Some("127.0.0.1:18301".parse().unwrap()),
             http_ui_address: Some("127.0.0.1:15000".parse().unwrap()),
+            jrpc_for_ui_address: None,
             address_watchlist: vec![],
             dan_layer_scanning_internal: Duration::from_secs(10),
             templates: TemplateConfig::default(),

--- a/applications/tari_indexer/src/http_ui/server.rs
+++ b/applications/tari_indexer/src/http_ui/server.rs
@@ -34,10 +34,7 @@ use reqwest::{header::CONTENT_TYPE, StatusCode};
 
 const LOG_TARGET: &str = "tari::indexer::http_ui::server";
 
-pub async fn run_http_ui_server(
-    address: SocketAddr,
-    json_rpc_address: Option<SocketAddr>,
-) -> Result<(), anyhow::Error> {
+pub async fn run_http_ui_server(address: SocketAddr, json_rpc_address: Option<String>) -> Result<(), anyhow::Error> {
     let json_rpc_address = Arc::new(json_rpc_address);
     let router = Router::new()
         .route(

--- a/applications/tari_indexer/src/lib.rs
+++ b/applications/tari_indexer/src/lib.rs
@@ -150,6 +150,10 @@ pub async fn run_indexer(config: ApplicationConfig, mut shutdown_signal: Shutdow
     }
     // Run the http ui
     if let Some(address) = config.indexer.http_ui_address {
+        let jrpc_address = match config.indexer.jrpc_for_ui_address {
+            Some(jrpc_address) => Some(jrpc_address),
+            None => jrpc_address.map(|address| address.to_string()),
+        };
         task::spawn(run_http_ui_server(address, jrpc_address));
     }
 


### PR DESCRIPTION
Description
---

Motivation and Context
---

How Has This Been Tested?
---
I created a new [PR](https://github.com/tari-project/dan-testing/pull/43) in dan-testing that set the listening address to `0.0.0.0:<port>` and the webui jrpc address to `127.0.0.1:<port>`. 

What process can a PR reviewer use to test or verify this change?
---
Either do the same as me or test my other 


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify