### PR TITLE
chore: rename fee to max_fee

### DIFF
--- a/applications/tari_dan_wallet_cli/src/command/transaction.rs
+++ b/applications/tari_dan_wallet_cli/src/command/transaction.rs
@@ -111,7 +111,7 @@ pub struct CommonSubmitArgs {
     #[clap(long)]
     pub dry_run: bool,
     #[clap(long)]
-    pub fee: Option<u64>,
+    pub max_fee: Option<u64>,
     #[clap(long, short = 'f', alias = "fee-account")]
     pub fee_account: Option<ComponentAddressOrName>,
     #[clap(long)]
@@ -258,7 +258,7 @@ pub async fn handle_submit(args: SubmitArgs, client: &mut WalletDaemonClient) ->
     let fee_instructions = vec![Instruction::CallMethod {
         component_address: fee_account.address.as_component_address().unwrap(),
         method: "pay_fee".to_string(),
-        args: args![Amount::try_from(common.fee.unwrap_or(1000))?],
+        args: args![Amount::try_from(common.max_fee.unwrap_or(1000))?],
     }];
 
     let request = TransactionSubmitRequest {
@@ -296,7 +296,7 @@ async fn handle_submit_manifest(
         fee_instructions: vec![Instruction::CallMethod {
             component_address: fee_account.address.as_component_address().unwrap(),
             method: "pay_fee".to_string(),
-            args: args![Amount::try_from(common.fee.unwrap_or(1000))?],
+            args: args![Amount::try_from(common.max_fee.unwrap_or(1000))?],
         }],
         instructions,
         inputs: common.inputs,
@@ -323,14 +323,14 @@ pub async fn handle_send(args: SendArgs, client: &mut WalletDaemonClient) -> Res
     let destination_public_key =
         PublicKey::from_bytes(&destination_public_key.into_inner()).map_err(anyhow::Error::msg)?;
 
-    let fee = common.fee.map(|f| f.try_into()).transpose()?;
+    let fee = common.max_fee.map(|f| f.try_into()).transpose()?;
     let resp = client
         .accounts_transfer(TransferRequest {
             account: source_account_name,
             amount: Amount::try_from(amount)?,
             resource_address,
             destination_public_key,
-            fee,
+            max_fee: fee,
         })
         .await?;
 
@@ -363,7 +363,7 @@ pub async fn handle_confidential_transfer(
             amount: Amount::try_from(amount)?,
             resource_address: resource_address.unwrap_or(CONFIDENTIAL_TARI_RESOURCE_ADDRESS),
             destination_public_key,
-            fee: common.fee.map(|f| f.try_into()).transpose()?,
+            max_fee: common.max_fee.map(|f| f.try_into()).transpose()?,
         })
         .await?;
 

--- a/applications/tari_dan_wallet_cli/src/command/validator.rs
+++ b/applications/tari_dan_wallet_cli/src/command/validator.rs
@@ -31,7 +31,7 @@ pub struct ClaimFeesArgs {
     #[clap(long, short = 'e')]
     pub epoch: u64,
     #[clap(long)]
-    pub fee: Option<u32>,
+    pub max_fee: Option<u32>,
 }
 
 #[derive(Debug, Args, Clone)]
@@ -76,7 +76,7 @@ pub async fn handle_claim_validator_fees(
         dest_account_name,
         validator_public_key,
         epoch,
-        fee,
+        max_fee,
     } = args;
 
     println!("Submitting claim validator fees transaction...");
@@ -86,7 +86,7 @@ pub async fn handle_claim_validator_fees(
             account: dest_account_name
                 .map(|name| ComponentAddressOrName::from_str(&name))
                 .transpose()?,
-            fee: fee.map(Amount::from),
+            max_fee: max_fee.map(Amount::from),
             validator_public_key: PublicKey::from_bytes(validator_public_key.into_inner().as_bytes())
                 .map_err(anyhow::Error::msg)?,
             epoch: Epoch(epoch),

--- a/applications/tari_dan_wallet_daemon/src/handlers/transaction.rs
+++ b/applications/tari_dan_wallet_daemon/src/handlers/transaction.rs
@@ -71,7 +71,7 @@ pub async fn handle_submit_instruction(
         fee_instructions: vec![Instruction::CallMethod {
             component_address: fee_account.address.as_component_address().unwrap(),
             method: "pay_fee".to_string(),
-            args: args![Amount::try_from(req.fee)?],
+            args: args![Amount::try_from(req.max_fee)?],
         }],
         instructions,
         inputs: req.inputs,

--- a/applications/tari_dan_wallet_daemon/src/handlers/validator.rs
+++ b/applications/tari_dan_wallet_daemon/src/handlers/validator.rs
@@ -48,7 +48,7 @@ pub async fn handle_claim_validator_fees(
     let account_address = account.address.as_component_address().unwrap();
 
     // build the transaction
-    let fee = req.fee.unwrap_or(DEFAULT_FEE);
+    let max_fee = req.max_fee.unwrap_or(DEFAULT_FEE);
     fee_instructions.extend([
         Instruction::ClaimValidatorFees {
             validator_public_key: req.validator_public_key.clone(),
@@ -65,7 +65,7 @@ pub async fn handle_claim_validator_fees(
         Instruction::CallMethod {
             component_address: account_address,
             method: "pay_fee".to_string(),
-            args: args![fee],
+            args: args![max_fee],
         },
     ]);
 

--- a/clients/wallet_daemon_client/src/types.rs
+++ b/clients/wallet_daemon_client/src/types.rs
@@ -57,7 +57,7 @@ pub struct CallInstructionRequest {
     pub fee_account: ComponentAddressOrName,
     #[serde(default, deserialize_with = "opt_string_or_struct")]
     pub dump_outputs_into: Option<ComponentAddressOrName>,
-    pub fee: u64,
+    pub max_fee: u64,
     #[serde(default)]
     pub inputs: Vec<SubstateRequirement>,
     #[serde(default)]
@@ -194,7 +194,7 @@ pub struct KeysCreateResponse {
 pub struct AccountsCreateRequest {
     pub account_name: Option<String>,
     pub custom_access_rules: Option<ComponentAccessRules>,
-    pub fee: Option<Amount>,
+    pub max_fee: Option<Amount>,
     pub is_default: bool,
     pub key_id: Option<u64>,
 }
@@ -212,7 +212,7 @@ pub struct AccountsInvokeRequest {
     pub account: Option<ComponentAddressOrName>,
     pub method: String,
     pub args: Vec<Arg>,
-    pub fee: Option<Amount>,
+    pub max_fee: Option<Amount>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -319,7 +319,7 @@ pub struct TransferRequest {
     pub amount: Amount,
     pub resource_address: ResourceAddress,
     pub destination_public_key: PublicKey,
-    pub fee: Option<Amount>,
+    pub max_fee: Option<Amount>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -378,7 +378,7 @@ pub struct ConfidentialTransferRequest {
     pub amount: Amount,
     pub resource_address: ResourceAddress,
     pub destination_public_key: PublicKey,
-    pub fee: Option<Amount>,
+    pub max_fee: Option<Amount>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -393,7 +393,7 @@ pub struct ClaimBurnRequest {
     #[serde(deserialize_with = "opt_string_or_struct")]
     pub account: Option<ComponentAddressOrName>,
     pub claim_proof: serde_json::Value,
-    pub fee: Option<Amount>,
+    pub max_fee: Option<Amount>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -416,7 +416,7 @@ pub struct RevealFundsRequest {
     /// Pay fee from revealed funds. If false, previously revealed funds in the account are used.
     pub pay_fee_from_reveal: bool,
     /// The amount of fees to add to the transaction. Any fees not charged are refunded.
-    pub fee: Option<Amount>,
+    pub max_fee: Option<Amount>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -430,7 +430,7 @@ pub struct RevealFundsResponse {
 pub struct AccountsCreateFreeTestCoinsRequest {
     pub account: Option<ComponentAddressOrName>,
     pub amount: Amount,
-    pub fee: Option<Amount>,
+    pub max_fee: Option<Amount>,
     pub key_id: Option<u64>,
 }
 
@@ -559,7 +559,7 @@ pub struct GetValidatorFeesResponse {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ClaimValidatorFeesRequest {
     pub account: Option<ComponentAddressOrName>,
-    pub fee: Option<Amount>,
+    pub max_fee: Option<Amount>,
     pub validator_public_key: PublicKey,
     pub epoch: Epoch,
 }

--- a/dan_layer/transaction/src/builder.rs
+++ b/dan_layer/transaction/src/builder.rs
@@ -48,11 +48,12 @@ impl TransactionBuilder {
     /// Adds a fee instruction that calls the "take_fee" method on a component.
     /// This method must exist and return a Bucket with containing revealed confidential XTR resource.
     /// This allows the fee to originate from sources other than the transaction sender's account.
-    pub fn fee_transaction_pay_from_component(mut self, component_address: ComponentAddress, fee: Amount) -> Self {
+    /// The fee instruction will lock up the "max_fee" amount for the duration of the transaction.
+    pub fn fee_transaction_pay_from_component(mut self, component_address: ComponentAddress, max_fee: Amount) -> Self {
         self.fee_instructions.push(Instruction::CallMethod {
             component_address,
             method: "pay_fee".to_string(),
-            args: args![fee],
+            args: args![max_fee],
         });
         self
     }

--- a/integration_tests/src/wallet_daemon_cli.rs
+++ b/integration_tests/src/wallet_daemon_cli.rs
@@ -76,7 +76,7 @@ pub async fn claim_burn(
     ownership_proof: CommitmentSignature<RistrettoPublicKey, RistrettoSecretKey>,
     reciprocal_claim_public_key: RistrettoPublicKey,
     wallet_daemon_name: String,
-    fee: i64,
+    max_fee: i64,
 ) -> Result<ClaimBurnResponse, WalletDaemonClientError> {
     let mut client = get_auth_wallet_daemon_client(world, &wallet_daemon_name).await;
 
@@ -92,7 +92,7 @@ pub async fn claim_burn(
             "reciprocal_claim_public_key": BASE64.encode(reciprocal_claim_public_key.as_bytes()),
             "range_proof": BASE64.encode(range_proof.as_bytes()),
         }),
-        fee: Some(Amount(fee)),
+        max_fee: Some(Amount(max_fee)),
     };
 
     client.claim_burn(claim_burn_request).await
@@ -111,7 +111,7 @@ pub async fn claim_fees(
 
     let request = ClaimValidatorFeesRequest {
         account: Some(ComponentAddressOrName::Name(account_name)),
-        fee: None,
+        max_fee: None,
         validator_public_key: vn.public_key.clone(),
         epoch: Epoch(epoch),
     };
@@ -125,7 +125,7 @@ pub async fn reveal_burned_funds(world: &mut TariWorld, account_name: String, am
     let request = RevealFundsRequest {
         account: Some(ComponentAddressOrName::Name(account_name)),
         amount_to_reveal: Amount(amount as i64),
-        fee: Some(Amount(1)),
+        max_fee: Some(Amount(1)),
         pay_fee_from_reveal: true,
     };
 
@@ -260,7 +260,7 @@ pub async fn create_account(world: &mut TariWorld, account_name: String, wallet_
         account_name: Some(account_name.clone()),
         custom_access_rules: None,
         is_default: false,
-        fee: None,
+        max_fee: None,
         key_id: None,
     };
 
@@ -300,7 +300,7 @@ pub async fn create_account_with_free_coins(
     let request = AccountsCreateFreeTestCoinsRequest {
         account: Some(ComponentAddressOrName::Name(account_name.clone())),
         amount,
-        fee: None,
+        max_fee: None,
         key_id: key_index,
     };
 
@@ -663,14 +663,14 @@ pub async fn transfer(
     let mut client = get_auth_wallet_daemon_client(world, &wallet_daemon_name).await;
 
     let account = Some(ComponentAddressOrName::Name(account_name));
-    let fee = Some(Amount(1));
+    let max_fee = Some(Amount(1));
 
     let request = TransferRequest {
         account,
         amount,
         resource_address,
         destination_public_key,
-        fee,
+        max_fee,
     };
 
     let resp = client.accounts_transfer(request).await.unwrap();
@@ -688,13 +688,13 @@ pub async fn confidential_transfer(
     let mut client = get_auth_wallet_daemon_client(world, &wallet_daemon_name).await;
 
     let account = Some(ComponentAddressOrName::Name(account_name));
-    let fee = Some(Amount(2000));
+    let max_fee = Some(Amount(2000));
 
     let request = ConfidentialTransferRequest {
         account,
         amount,
         destination_public_key,
-        fee,
+        max_fee,
         resource_address: CONFIDENTIAL_TARI_RESOURCE_ADDRESS,
     };
 


### PR DESCRIPTION
Description
---
Rename fee to max fee which is more accurate naming.

Motivation and Context
---
When user specify the fee for a transaction, it's not the actual fee. But it's the max fee that can be paid. If the fees are less, the change is refunded.

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify