### PR TITLE
feat: create registration file on startup

### DIFF
--- a/applications/tari_validator_node/src/config.rs
+++ b/applications/tari_validator_node/src/config.rs
@@ -35,6 +35,7 @@ use tari_common::{
     SubConfigPath,
 };
 use tari_comms::multiaddr::Multiaddr;
+use tari_crypto::ristretto::RistrettoPublicKey;
 use tari_dan_app_utilities::template_manager::implementation::TemplateConfig;
 use tari_p2p::{P2pConfig, PeerSeedsConfig};
 
@@ -99,6 +100,8 @@ pub struct ValidatorNodeConfig {
     pub templates: TemplateConfig,
     /// Dont charge fees
     pub no_fees: bool,
+    /// Fee claim public key
+    pub fee_claim_public_key: RistrettoPublicKey,
 }
 
 impl ValidatorNodeConfig {
@@ -149,6 +152,8 @@ impl Default for ValidatorNodeConfig {
             auto_register: true,
             templates: TemplateConfig::default(),
             no_fees: false,
+            // Burn your fees
+            fee_claim_public_key: RistrettoPublicKey::default(),
         }
     }
 }


### PR DESCRIPTION
Description
---
Creates a registration file on startup. 
Adds a fee claim public key to the config file 

Motivation and Context
---
Currently, the only way to register a validator node is by calling the json-rpc, via CLI or the web UI. This allows a user to register the validator node via an unconnected minotari wallet.

I've left the jsonrpc registration as is for now, but I think it should be removed as it is unsafe to leave a hot wallet running on the validator node

How Has This Been Tested?
---
Tested start up.

What process can a PR reviewer use to test or verify this change?
---
Run the VN, look for the registration.json file in the base path

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify