### PR TITLE
fix(template-macro)!: template ABI uses global export byte literal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8641,6 +8641,8 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+ "tari_bor",
+ "tari_template_abi",
 ]
 
 [[package]]

--- a/applications/tari_dan_app_utilities/src/template_manager/implementation/service.rs
+++ b/applications/tari_dan_app_utilities/src/template_manager/implementation/service.rs
@@ -136,10 +136,10 @@ impl TemplateManagerService {
             .get_template_module(&address)?
             .ok_or(TemplateManagerError::TemplateNotFound { address })?;
         Ok(TemplateAbi {
-            template_name: loaded.template_def().template_name.clone(),
+            template_name: loaded.template_def().template_name().to_string(),
             functions: loaded
                 .template_def()
-                .functions
+                .functions()
                 .iter()
                 .map(|f| FunctionDef {
                     name: f.name.clone(),

--- a/applications/tari_scaffolder/src/main.rs
+++ b/applications/tari_scaffolder/src/main.rs
@@ -93,7 +93,7 @@ fn replace_tokens(in_file: &str, loaded_template: &LoadedTemplate, cli: &Cli) ->
 
     match loaded_template {
         Wasm(loaded_wasm_template) => {
-            for f in &loaded_wasm_template.template_def().functions {
+            for f in loaded_wasm_template.template_def().functions() {
                 let arr = globals.get_mut("commands").unwrap().as_array_mut().unwrap();
                 let mut args = vec![];
                 let mut is_method = false;

--- a/dan_layer/engine/src/flow/flow_factory.rs
+++ b/dan_layer/engine/src/flow/flow_factory.rs
@@ -7,7 +7,7 @@ use d3ne::WorkersBuilder;
 use serde_json::Value as JsValue;
 use tari_dan_common_types::services::template_provider::TemplateProvider;
 use tari_engine_types::instruction_result::InstructionResult;
-use tari_template_abi::{ArgDef, FunctionDef, TemplateDef, Type};
+use tari_template_abi::{ArgDef, FunctionDef, TemplateDef, TemplateDefV1, Type};
 use tari_template_lib::args::Arg;
 
 use crate::{
@@ -28,7 +28,7 @@ impl FlowFactory {
     pub fn try_create<TTemplateProvider: TemplateProvider<Template = LoadedTemplate>>(
         flow_definition: FlowFunctionDefinition,
     ) -> Result<Self, FlowEngineError> {
-        let template_def = TemplateDef {
+        let template_def = TemplateDef::V1(TemplateDefV1 {
             template_name: flow_definition.name.clone(),
             functions: vec![FunctionDef {
                 name: "main".to_string(),
@@ -43,7 +43,7 @@ impl FlowFactory {
                 output: Type::Unit,
                 is_mut: false,
             }],
-        };
+        });
 
         let _test_build = FlowInstance::try_build(
             flow_definition.flow.clone(),

--- a/dan_layer/engine/src/flow/workers/call_method_worker.rs
+++ b/dan_layer/engine/src/flow/workers/call_method_worker.rs
@@ -58,7 +58,7 @@ impl<TTemplateProvider: TemplateProvider<Template = LoadedTemplate>> Worker<Flow
             .get_template_module(&template_address)?
             .ok_or_else(|| anyhow::anyhow!("could not find template {}", template_address))?
             .template_def()
-            .functions
+            .functions()
             .iter()
             .find(|f| f.name == *method_name)
             .ok_or_else(|| anyhow::anyhow!("could not find method"))?

--- a/dan_layer/engine/src/packager/error.rs
+++ b/dan_layer/engine/src/packager/error.rs
@@ -28,8 +28,6 @@ use crate::wasm::WasmExecutionError;
 pub enum PackageError {
     #[error(transparent)]
     WasmModuleError(#[from] WasmExecutionError),
-    #[error("Template called engine during initialization")]
-    TemplateCalledEngineDuringInitialization,
     #[error(transparent)]
     CompileError(#[from] wasmer::CompileError),
     #[error(transparent)]

--- a/dan_layer/engine/src/runtime/impl.rs
+++ b/dan_layer/engine/src/runtime/impl.rs
@@ -1284,9 +1284,9 @@ fn validate_component_access_rule_methods(
     template_def: &TemplateDef,
 ) -> Result<(), RuntimeError> {
     for (name, _) in access_rules.method_access_rules_iter() {
-        if template_def.functions.iter().all(|f| f.name != *name) {
+        if template_def.functions().iter().all(|f| f.name != *name) {
             return Err(RuntimeError::InvalidMethodAccessRule {
-                template_name: template_def.template_name.clone(),
+                template_name: template_def.template_name().to_string(),
                 details: format!("No method '{}' found in template", name),
             });
         }

--- a/dan_layer/engine/src/wasm/environment.rs
+++ b/dan_layer/engine/src/wasm/environment.rs
@@ -129,8 +129,9 @@ impl<T: Clone + Sync + Send + 'static> WasmEnv<T> {
 
     pub(super) fn read_from_memory(&self, ptr: u32, len: u32) -> Result<Vec<u8>, WasmExecutionError> {
         let memory = self.get_memory()?;
-        let size = memory.data_size();
-        if u64::from(ptr) >= size || u64::from(ptr + len) >= memory.data_size() {
+        let mem_size = memory.data_size();
+        let ptr_plus_len = ptr.checked_add(len).ok_or(WasmExecutionError::MaxMemorySizeExceeded)?;
+        if u64::from(ptr) >= mem_size || u64::from(ptr_plus_len) >= mem_size {
             return Err(WasmExecutionError::MemoryPointerOutOfRange {
                 size: memory.data_size(),
                 pointer: u64::from(ptr),

--- a/dan_layer/engine/src/wasm/error.rs
+++ b/dan_layer/engine/src/wasm/error.rs
@@ -48,10 +48,6 @@ pub enum WasmExecutionError {
     MaxMemorySizeExceeded,
     #[error("Failed to decode ABI: {0:?}")]
     AbiDecodeError(BorError),
-    #[error("package ABI function returned an invalid type")]
-    InvalidReturnTypeFromAbiFunc,
-    #[error("package did not contain an ABI definition")]
-    NoAbiDefinition,
     #[error("Unexpected ABI function {name}")]
     UnexpectedAbiFunction { name: String },
     #[error("Panic! {message}")]

--- a/dan_layer/engine/tests/templates/buggy/Cargo.toml
+++ b/dan_layer/engine/tests/templates/buggy/Cargo.toml
@@ -16,6 +16,6 @@ lol_alloc = "0.4.0"
 crate-type = ["cdylib", "lib"]
 
 [features]
-call_engine_in_abi = []
 return_null_abi = []
+return_empty_abi = []
 unexpected_export_function = []

--- a/dan_layer/engine/tests/templates/buggy/src/lib.rs
+++ b/dan_layer/engine/tests/templates/buggy/src/lib.rs
@@ -29,27 +29,13 @@ pub use tari_template_abi::{tari_alloc, tari_free};
 static ALLOC: lol_alloc::AssumeSingleThreaded<lol_alloc::FreeListAllocator> =
     unsafe { lol_alloc::AssumeSingleThreaded::new(lol_alloc::FreeListAllocator::new()) };
 
-#[cfg(any(feature = "call_engine_in_abi", feature = "unexpected_export_function"))]
-#[no_mangle]
-pub extern "C" fn Buggy_abi() -> *mut u8 {
-    use tari_bor::encode_with_len;
-    use tari_template_abi::*;
-    // Call the engine in the ABI code, you aren't allowed to do that *shakes head*
-    #[cfg(feature = "call_engine_in_abi")]
-    unsafe {
-        tari_engine(123, ptr::null_mut(), 0)
-    };
-    wrap_ptr(encode_with_len(&TemplateDef {
-        template_name: "".to_string(),
-        functions: vec![],
-    }))
-}
-
 #[cfg(feature = "return_null_abi")]
 #[no_mangle]
-pub extern "C" fn Buggy_abi() -> *mut u8 {
-    ptr::null_mut()
-}
+pub static _ABI_TEMPLATE_DEF: [u8; 0] = [];
+
+#[cfg(feature = "return_empty_abi")]
+#[no_mangle]
+pub static _ABI_TEMPLATE_DEF: [u8; 4] = [0, 0, 0, 0];
 
 #[no_mangle]
 pub extern "C" fn Buggy_main(_call_info: *mut u8, _call_info_len: usize) -> *mut u8 {

--- a/dan_layer/template_abi/src/lib.rs
+++ b/dan_layer/template_abi/src/lib.rs
@@ -40,3 +40,6 @@ pub mod rust;
 
 mod types;
 pub use types::*;
+
+/// The name of the global export that defines the template definition
+pub const ABI_TEMPLATE_DEF_GLOBAL_NAME: &str = "_ABI_TEMPLATE_DEF";

--- a/dan_layer/template_abi/src/types.rs
+++ b/dan_layer/template_abi/src/types.rs
@@ -25,12 +25,37 @@ use serde::{Deserialize, Serialize};
 use crate::rust::{boxed::Box, string::String, vec::Vec};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct TemplateDef {
+pub enum TemplateDef {
+    V1(TemplateDefV1),
+}
+
+impl TemplateDef {
+    pub fn template_name(&self) -> &str {
+        match self {
+            TemplateDef::V1(def) => def.template_name.as_str(),
+        }
+    }
+
+    pub fn get_function(&self, name: &str) -> Option<&FunctionDef> {
+        match self {
+            TemplateDef::V1(def) => def.get_function(name),
+        }
+    }
+
+    pub fn functions(&self) -> &[FunctionDef] {
+        match self {
+            TemplateDef::V1(def) => &def.functions,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TemplateDefV1 {
     pub template_name: String,
     pub functions: Vec<FunctionDef>,
 }
 
-impl TemplateDef {
+impl TemplateDefV1 {
     pub fn get_function(&self, name: &str) -> Option<&FunctionDef> {
         self.functions.iter().find(|f| f.name.as_str() == name)
     }

--- a/dan_layer/template_lib/src/template_dependencies.rs
+++ b/dan_layer/template_lib/src/template_dependencies.rs
@@ -22,6 +22,6 @@
 
 //! Public types that are available to all template authors.
 pub use tari_bor::{decode, decode_exact, encode_with_len, from_value, serde};
-pub use tari_template_abi::{call_debug as debug, wrap_ptr, ArgDef, CallInfo, FunctionDef, TemplateDef, Type};
+pub use tari_template_abi::{call_debug as debug, wrap_ptr, CallInfo};
 
 pub use crate::{args::LogLevel, engine, get_context as context};

--- a/dan_layer/template_macros/Cargo.toml
+++ b/dan_layer/template_macros/Cargo.toml
@@ -11,6 +11,9 @@ license = "BSD-3-Clause"
 proc-macro = true
 
 [dependencies]
+tari_template_abi = { path = "../template_abi" }
+tari_bor = { path = "../tari_bor" }
+
 proc-macro2 = "1.0.42"
 quote = "1.0.20"
 syn = { version = "1.0.98", features = ["full", "extra-traits"] }

--- a/dan_layer/template_macros/src/template/abi.rs
+++ b/dan_layer/template_macros/src/template/abi.rs
@@ -22,258 +22,167 @@
 
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
-use syn::{parse_quote, AngleBracketedGenericArguments, Expr, GenericArgument, PathArguments, Result, Type};
+use syn::{AngleBracketedGenericArguments, GenericArgument, PathArguments, PathSegment, Result, Type, TypeTuple};
+use tari_template_abi::{
+    ArgDef,
+    FunctionDef,
+    TemplateDef,
+    TemplateDefV1,
+    Type as ArgType,
+    ABI_TEMPLATE_DEF_GLOBAL_NAME,
+};
 
-use crate::template::ast::{FunctionAst, TemplateAst, TypeAst};
+use crate::template::ast::{TemplateAst, TypeAst};
 
 pub fn generate_abi(ast: &TemplateAst) -> Result<TokenStream> {
-    let abi_function_name = format_ident!("{}_abi", ast.template_name);
     let template_name_as_str = ast.template_name.to_string();
-    let function_defs = ast
-        .get_functions()
-        .map(|func| generate_function_def(&template_name_as_str, &func));
+
+    let template_def = TemplateDef::V1(TemplateDefV1 {
+        template_name: template_name_as_str.clone(),
+        functions: ast
+            .get_functions()
+            .map(|func| {
+                Ok::<_, syn::Error>(FunctionDef {
+                    name: func.name,
+                    arguments: func
+                        .input_types
+                        .iter()
+                        .map(|ty| convert_to_arg_def(&template_name_as_str, ty))
+                        .collect::<Result<_>>()?,
+                    output: func
+                        .output_type
+                        .as_ref()
+                        .map(|ty| convert_to_arg_type(&template_name_as_str, ty))
+                        .unwrap_or(ArgType::Unit),
+                    is_mut: false,
+                })
+            })
+            .collect::<Result<_>>()?,
+    });
+
+    let template_def_data_as_slice = tari_bor::encode_with_len(&template_def);
+    let len = template_def_data_as_slice.len();
+    let template_def_name = format_ident!("{ABI_TEMPLATE_DEF_GLOBAL_NAME}");
 
     let output = quote! {
         #[no_mangle]
-        pub unsafe extern "C" fn #abi_function_name() -> *mut u8 {
-            use ::tari_template_lib::template_dependencies::{encode_with_len, ArgDef, FunctionDef, TemplateDef, Type, wrap_ptr};
-
-            let template = TemplateDef {
-                template_name: #template_name_as_str.to_string(),
-                functions: vec![ #(#function_defs),* ],
-            };
-
-            let buf = encode_with_len(&template);
-            wrap_ptr(buf)
-        }
+        pub static #template_def_name: [u8;#len] = [#(#template_def_data_as_slice),*];
     };
 
     Ok(output)
 }
 
-fn generate_function_def(template_name: &str, f: &FunctionAst) -> Expr {
-    let name = f.name.clone();
-    let is_mut = f.input_types.first().map(|a| a.is_mut()).unwrap_or(false);
-    let arguments = f.input_types.iter().map(|t| generate_abi_type(template_name, t));
-
-    let output = match &f.output_type {
-        Some(type_ast) => generate_abi_type(template_name, type_ast),
-        None => parse_quote!(Type::Unit),
-    };
-
-    parse_quote!(
-        FunctionDef {
-            name: #name.to_string(),
-            arguments: vec![ #(#arguments),* ],
-            output: #output,
-            is_mut: #is_mut,
-        }
-    )
+fn convert_to_arg_type(template_name: &str, ty: &TypeAst) -> ArgType {
+    match ty {
+        TypeAst::Receiver { mutability: true } => ArgType::Other {
+            name: "&mut self".to_string(),
+        },
+        TypeAst::Receiver { mutability: false } => ArgType::Other {
+            name: "&self".to_string(),
+        },
+        TypeAst::Typed { type_path, .. } => path_segment_to_arg_type(template_name, &type_path.path.segments[0]),
+        TypeAst::Tuple(tuple) => {
+            // TODO: improve
+            let tuple_str = tuple
+                .elems
+                .iter()
+                .map(|t| format!("{:?}", t))
+                .collect::<Vec<_>>()
+                .join(",");
+            ArgType::Other {
+                name: tuple_str.to_string(),
+            }
+        },
+    }
 }
 
-fn generate_abi_type(template_name: &str, rust_type: &TypeAst) -> Expr {
+fn convert_to_arg_def(template_name: &str, rust_type: &TypeAst) -> Result<ArgDef> {
     match rust_type {
         // on "&self" we want to pass the component id
-        TypeAst::Receiver { mutability: false } => {
-            let ty = get_component_address_type("&self");
-            parse_quote!(ArgDef {
-                name: "self".to_string(),
-                arg_type: #ty
-            })
-        },
-        TypeAst::Receiver { mutability: true } => {
-            let ty = get_component_address_type("&mut self");
-            parse_quote!(ArgDef {
-                name: "self".to_string(),
-                arg_type: #ty
-            })
-        },
+        TypeAst::Receiver { mutability: false } => Ok(ArgDef {
+            name: "self".to_string(),
+            arg_type: ArgType::Other {
+                name: "&self".to_string(),
+            },
+        }),
+        TypeAst::Receiver { mutability: true } => Ok(ArgDef {
+            name: "self".to_string(),
+            arg_type: ArgType::Other {
+                name: "&mut self".to_string(),
+            },
+        }),
         // basic type
-        // TODO: there may be a better way of handling this
         TypeAst::Typed {
             name: arg_name,
             type_path: path,
         } => {
-            let type_str = match path.path.segments[0].ident.to_string().as_str() {
-                "" => parse_quote!(Type::Unit),
-                "bool" => parse_quote!(Type::Bool),
-                "i8" => parse_quote!(Type::I8),
-                "i16" => parse_quote!(Type::I16),
-                "i32" => parse_quote!(Type::I32),
-                "i64" => parse_quote!(Type::I64),
-                "i128" => parse_quote!(Type::I128),
-                "u8" => parse_quote!(Type::U8),
-                "u16" => parse_quote!(Type::U16),
-                "u32" => parse_quote!(Type::U32),
-                "u64" => parse_quote!(Type::U64),
-                "u128" => parse_quote!(Type::U128),
-                "String" => parse_quote!(Type::String),
-                "Vec" => {
-                    let ty = match &path.path.segments[0].arguments {
-                        PathArguments::AngleBracketed(AngleBracketedGenericArguments { args, .. }) => {
-                            match &args[0] {
-                                GenericArgument::Type(Type::Path(path)) => {
-                                    match path.path.segments[0].ident.to_string().as_str() {
-                                        "" => parse_quote!(Type::Unit),
-                                        "bool" => parse_quote!(Type::Bool),
-                                        "i8" => parse_quote!(Type::I8),
-                                        "i16" => parse_quote!(Type::I16),
-                                        "i32" => parse_quote!(Type::I32),
-                                        "i64" => parse_quote!(Type::I64),
-                                        "i128" => parse_quote!(Type::I128),
-                                        "u8" => parse_quote!(Type::U8),
-                                        "u16" => parse_quote!(Type::U16),
-                                        "u32" => parse_quote!(Type::U32),
-                                        "u64" => parse_quote!(Type::U64),
-                                        "u128" => parse_quote!(Type::U128),
-                                        "String" => parse_quote!(Type::String),
-                                        "Vec" => {
-                                            panic!("Nested Vecs are not supported")
-                                        },
-                                        "Self" => get_component_address_type(&format!("{}Component", template_name)),
-                                        name => parse_quote!(Type::Other { name: #name.to_string() }),
-                                    }
-                                },
-                                GenericArgument::Type(Type::Tuple(tuple)) => {
-                                    // FIXME: improve
-                                    let tuple_str = tuple
-                                        .elems
-                                        .iter()
-                                        .map(|t| format!("{:?}", t))
-                                        .collect::<Vec<_>>()
-                                        .join(",");
-                                    parse_quote!(Type::Other { name: #tuple_str.to_string() })
-                                },
-                                // TODO: These should be errors
-                                a => panic!("Invalid vec generic argument {:?}", a),
-                            }
-                        },
-                        PathArguments::Parenthesized(_) | PathArguments::None => {
-                            panic!("Vec must specify a type {:?}", path.path)
-                        },
-                    };
-
-                    parse_quote!(Type::Vec(Box::new(#ty)))
-                },
-                "Self" => get_component_address_type(&format!("{}Component", template_name)),
-                type_name => parse_quote!(Type::Other { name: #type_name.to_string() }),
+            let Some(arg_name) = arg_name else {
+                return Err(syn::Error::new_spanned(
+                    path,
+                    "convert_to_arg_def: Unnamed type is not valid in this context",
+                ));
             };
-            // For arguments, put the name and type. For return types, just return the type
-            match arg_name {
-                Some(name) => parse_quote!(ArgDef {
-                    name: #name.to_string(),
-                    arg_type: #type_str,
-                }),
-                None => type_str,
-            }
-        },
 
-        TypeAst::Tuple(_) => {
-            // TODO: Handle tuples properly
-            parse_quote!(Type::Other {
-                name: "tuple".to_string()
+            let arg_type = path_segment_to_arg_type(template_name, &path.path.segments[0]);
+
+            Ok(ArgDef {
+                name: arg_name.to_string(),
+                arg_type,
             })
         },
+
+        TypeAst::Tuple(TypeTuple { elems, .. }) => Err(syn::Error::new_spanned(elems, "Tuples are not supported")),
     }
 }
 
-fn get_component_address_type(name: &str) -> Expr {
-    parse_quote!(Type::Other { name: #name.to_string() })
-}
-
-#[cfg(test)]
-mod tests {
-    use std::str::FromStr;
-
-    use indoc::indoc;
-    use proc_macro2::TokenStream;
-    use quote::quote;
-    use syn::parse2;
-
-    use super::generate_abi;
-    use crate::template::ast::TemplateAst;
-
-    #[test]
-    fn test_codegen() {
-        let input = TokenStream::from_str(indoc! {"
-            mod foo {
-                struct Foo {}
-                impl Foo {
-                    pub fn no_args_function() -> String {
-                        \"Hello World!\".to_string()
+fn path_segment_to_arg_type(template_name: &str, segment: &PathSegment) -> ArgType {
+    match segment.ident.to_string().as_str() {
+        "" => ArgType::Unit,
+        "bool" => ArgType::Bool,
+        "i8" => ArgType::I8,
+        "i16" => ArgType::I16,
+        "i32" => ArgType::I32,
+        "i64" => ArgType::I64,
+        "i128" => ArgType::I128,
+        "u8" => ArgType::U8,
+        "u16" => ArgType::U16,
+        "u32" => ArgType::U32,
+        "u64" => ArgType::U64,
+        "u128" => ArgType::U128,
+        "String" => ArgType::String,
+        "Vec" => {
+            let ty = match &segment.arguments {
+                PathArguments::AngleBracketed(AngleBracketedGenericArguments { args, .. }) => {
+                    match &args[0] {
+                        GenericArgument::Type(Type::Path(path)) => {
+                            path_segment_to_arg_type(template_name, &path.path.segments[0])
+                        },
+                        GenericArgument::Type(Type::Tuple(tuple)) => {
+                            // FIXME: improve
+                            let tuple_str = tuple
+                                .elems
+                                .iter()
+                                .map(|t| format!("{:?}", t))
+                                .collect::<Vec<_>>()
+                                .join(",");
+                            ArgType::Other { name: tuple_str }
+                        },
+                        // TODO: These should be errors
+                        a => panic!("Invalid vec generic argument {:?}", a),
                     }
-                    pub fn some_args_function(a: i8, b: String) -> u32 {
-                        1_u32
-                    }
-                    pub fn no_return_function() {}
-                    pub fn constructor() -> Self {}
-                    pub fn method(&self){}
-                    pub fn method_mut(&mut self){}
-                    fn private_function() {}
-                }
-            }
-        "})
-        .unwrap();
+                },
+                PathArguments::Parenthesized(_) | PathArguments::None => {
+                    panic!("Vec must specify a type {:?}", segment)
+                },
+            };
 
-        let ast = parse2::<TemplateAst>(input).unwrap();
-
-        let output = generate_abi(&ast).unwrap();
-
-        assert_code_eq(output, quote! {
-            #[no_mangle]
-            pub unsafe extern "C" fn Foo_abi() -> *mut u8 {
-                use ::tari_template_lib::template_dependencies::{encode_with_len, ArgDef, FunctionDef, TemplateDef, Type, wrap_ptr};
-
-                let template = TemplateDef {
-                    template_name: "Foo".to_string(),
-                    functions: vec![
-                        FunctionDef {
-                            name: "no_args_function".to_string(),
-                            arguments: vec![],
-                            output: Type::String,
-                            is_mut: false,
-                        },
-                        FunctionDef {
-                            name: "some_args_function".to_string(),
-                            arguments: vec![ArgDef{ name: "a".to_string(), arg_type: Type::I8, },
-                                ArgDef{ name: "b".to_string(), arg_type: Type::String, }],
-                            output: Type::U32,
-                            is_mut: false,
-                        },
-                        FunctionDef {
-                            name: "no_return_function".to_string(),
-                            arguments: vec![],
-                            output: Type::Unit,
-                            is_mut: false,
-                        },
-                        FunctionDef {
-                            name: "constructor".to_string(),
-                            arguments: vec![],
-                            output: Type::Other { name: "FooComponent".to_string() },
-                            is_mut: false,
-                        },
-                        FunctionDef {
-                            name: "method".to_string(),
-                            arguments: vec![ArgDef{ name: "self".to_string(), arg_type: Type::Other { name: "&self".to_string() }}],
-                            output: Type::Unit,
-                            is_mut: false,
-                        },
-                         FunctionDef {
-                            name: "method_mut".to_string(),
-                            arguments: vec![ArgDef{ name: "self".to_string(), arg_type: Type::Other { name: "&mut self".to_string() }}],
-                            output: Type::Unit,
-                            is_mut: true,
-                        }
-                    ],
-                };
-
-                let buf = encode_with_len(&template);
-                wrap_ptr(buf)
-            }
-        });
-    }
-
-    fn assert_code_eq(a: TokenStream, b: TokenStream) {
-        assert_eq!(a.to_string(), b.to_string());
+            ArgType::Vec(Box::new(ty))
+        },
+        "Self" => ArgType::Other {
+            name: format!("Component<{}>", template_name),
+        },
+        type_name => ArgType::Other {
+            name: type_name.to_string(),
+        },
     }
 }

--- a/dan_layer/template_macros/src/template/ast.rs
+++ b/dan_layer/template_macros/src/template/ast.rs
@@ -20,6 +20,8 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+use std::fmt::{Debug, Formatter};
+
 use syn::{
     parse::{Parse, ParseStream},
     punctuated::Punctuated,
@@ -216,11 +218,12 @@ pub enum TypeAst {
     Tuple(TypeTuple),
 }
 
-impl TypeAst {
-    pub fn is_mut(&self) -> bool {
+impl Debug for TypeAst {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            TypeAst::Receiver { mutability } => *mutability,
-            _ => false,
+            TypeAst::Receiver { mutability } => write!(f, "Receiver {{ mutability: {} }}", mutability),
+            TypeAst::Typed { name, type_path } => write!(f, "Typed {{ name: {:?}, type_path: {:?} }}", name, type_path),
+            TypeAst::Tuple(tuple) => write!(f, "Tuple {{ tuple: {:?} }}", tuple),
         }
     }
 }

--- a/dan_layer/template_macros/src/template/definition.rs
+++ b/dan_layer/template_macros/src/template/definition.rs
@@ -79,32 +79,32 @@ mod tests {
         let output = generate_definition(&ast);
 
         assert_code_eq(output, quote! {
-        #[allow(non_snake_case)]
-        pub mod Foo_template {
-            use ::tari_template_lib::template_dependencies::*;
-            #[derive(Debug, serde :: Serialize, serde :: Deserialize)]
-            #[serde(crate = "self::serde")]
-            struct Foo {}
-            impl Foo {
-                pub fn no_args_function() -> String {
-                    "Hello World!".to_string()
+            #[allow(non_snake_case)]
+            pub mod Foo_template {
+                use ::tari_template_lib::template_dependencies::*;
+                #[derive(Debug, serde :: Serialize, serde :: Deserialize)]
+                #[serde(crate = "self::serde")]
+                struct Foo {}
+                impl Foo {
+                    pub fn no_args_function() -> String {
+                        "Hello World!".to_string()
+                    }
+
+                    pub fn some_args_function(a: i8, b: String) -> u32 {
+                        1_u32
+                    }
+
+                    pub fn no_return_function() {}
+
+                    pub fn constructor() -> Self {
+                        Self {}
+                    }
+
+                    pub fn method(&self) {}
+
+                    fn private_function() {}
                 }
-
-                pub fn some_args_function(a: i8, b: String) -> u32 {
-                    1_u32
-                }
-
-                pub fn no_return_function() {}
-
-                pub fn constructor() -> Self {
-                    Self {}
-                }
-
-                pub fn method(&self) {}
-
-                fn private_function() {}
             }
-        }
         });
     }
 

--- a/dan_layer/template_test_tooling/templates/faucet/Cargo.lock
+++ b/dan_layer/template_test_tooling/templates/faucet/Cargo.lock
@@ -105,7 +105,7 @@ dependencies = [
 
 [[package]]
 name = "tari_bor"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "ciborium",
  "ciborium-io",
@@ -114,7 +114,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_abi"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "serde",
  "tari_bor",
@@ -122,7 +122,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_lib"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "newtype-ops",
  "serde",
@@ -134,11 +134,13 @@ dependencies = [
 
 [[package]]
 name = "tari_template_macros"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+ "tari_bor",
+ "tari_template_abi",
 ]
 
 [[package]]


### PR DESCRIPTION
Description
---
Load template ABI from `Global` exported byte literal
Versioning Template ABI definition

Motivation and Context
---
Previously, the template definition would be loaded by invoking the `{component}_abi` function which would return a pointer containing the serialized template definition which is read by the template loader. An implementer could add an infinite loop preventing the function from returning and causing the template loader to halt. 

I initially wanted to try detect this, but then started investigating other ways to export data. 

In this PR, we define a global that is read from the wasm without executing code which removes the possibility of malicious code executing. This avoids the template having to build and encode the template definition when loaded, which should decrease loading time. 

Also added versioning for the ABI definition.

How Has This Been Tested?
---
Existing tests, updated "buggy" test

What process can a PR reviewer use to test or verify this change?
---
Recompile templates and check that they work

Breaking Changes
---

- [ ] None
- [ ] Requires data directory to be deleted
- [x] Other - all templates need to be recompiled