### PR TITLE
fix: add http prefix if it is missing

### DIFF
--- a/applications/tari_dan_wallet_web_ui/src/utils/json_rpc.tsx
+++ b/applications/tari_dan_wallet_web_ui/src/utils/json_rpc.tsx
@@ -41,6 +41,9 @@ async function internalJsonRpc(
   let address = import.meta.env.VITE_DAEMON_JRPC_ADDRESS || 'http://localhost:9000';
   try {
     address = await (await fetch('/json_rpc_address')).text();
+    if (!address.startsWith("http")) {
+        address = "http://" + address;
+    }
   } catch {}
   let headers: { [key: string]: string } = {
     'Content-Type': 'application/json',

--- a/applications/tari_indexer_web_ui/src/utils/json_rpc.tsx
+++ b/applications/tari_indexer_web_ui/src/utils/json_rpc.tsx
@@ -26,6 +26,9 @@ async function jsonRpc(method: string, params: any = null) {
   let address = 'http://localhost:3333';
   try {
     address = await (await fetch('/json_rpc_address')).text();
+    if (!address.startsWith("http")) {
+      address = "http://" + address;
+    }
   } catch {}
   let response = await fetch(address, {
     method: 'POST',

--- a/applications/tari_validator_node_web_ui/src/utils/json_rpc.tsx
+++ b/applications/tari_validator_node_web_ui/src/utils/json_rpc.tsx
@@ -28,6 +28,9 @@ async function jsonRpc(method: string, params: any = null) {
   let address = "http://127.0.0.1:18010";
   try {
     address = await (await fetch("/json_rpc_address")).text();
+    if (!address.startsWith("http")) {
+      address = "http://" + address;
+    }
   } catch {}
   let response = await fetch(address, {
     method: "POST",


### PR DESCRIPTION
New settings mean that the `http://` prefix was not included, making the javascript think it is a relative path:

![image](https://github.com/tari-project/tari-dan/assets/4200336/b587633b-eee2-43ec-be41-f2f470a14b40)
