### PR TITLE
fix(cucumber): fix test in wallet_daemon.feature + improve scan step

### DIFF
--- a/integration_tests/tests/features/block_sync.feature
+++ b/integration_tests/tests/features/block_sync.feature
@@ -23,8 +23,8 @@ Feature: Block Sync
     When wallet WALLET has at least 5000 T
     When validator node VN sends a registration transaction allowing fee claims from wallet WALLET_D using key K1
     When miner MINER mines 16 new blocks
-    Then VN has scanned to height 17 within 10 seconds
-    And indexer IDX has scanned to height 17 within 10 seconds
+    Then VN has scanned to height 17
+    And indexer IDX has scanned to height 17
     Then the validator node VN is listed as registered
 
     When indexer IDX connects to all other validators
@@ -44,8 +44,8 @@ Feature: Block Sync
 
     When validator node VN2 sends a registration transaction allowing fee claims from wallet WALLET_D using key K1
     When miner MINER mines 20 new blocks
-    Then VN has scanned to height 37 within 20 seconds
-    Then VN2 has scanned to height 37 within 10 seconds
+    Then VN has scanned to height 37
+    Then VN2 has scanned to height 37
     Then the validator node VN2 is listed as registered
 
     When I wait for validator VN2 has leaf block height of at least 20

--- a/integration_tests/tests/features/claim_burn.feature
+++ b/integration_tests/tests/features/claim_burn.feature
@@ -15,7 +15,7 @@ Feature: Claim Burn
     When wallet WALLET has at least 5000 T
     When validator node VN sends a registration transaction
     When miner MINER mines 16 new blocks
-    Then VN has scanned to height 17 within 10 seconds
+    Then VN has scanned to height 17
     Then the validator node VN is listed as registered
 
     # Initialize an indexer
@@ -32,7 +32,7 @@ Feature: Claim Burn
     # unfortunately have to wait for this to get into the mempool....
     Then there is 1 transaction in the mempool of BASE within 10 seconds
     When miner MINER mines 13 new blocks
-    Then VN has scanned to height 30 within 10 seconds
+    Then VN has scanned to height 30
 
     When I convert commitment COMMITMENT into COMM_ADDRESS address
     Then validator node VN has state at COMM_ADDRESS
@@ -53,7 +53,7 @@ Feature: Claim Burn
     When wallet WALLET has at least 10000 T
     When validator node VN sends a registration transaction
     When miner MINER mines 16 new blocks
-    Then VN has scanned to height 17 within 10 seconds
+    Then VN has scanned to height 17
     Then the validator node VN is listed as registered
 
     # Initialize an indexer
@@ -70,7 +70,7 @@ Feature: Claim Burn
     # unfortunately have to wait for this to get into the mempool....
     Then there is 1 transaction in the mempool of BASE within 10 seconds
     When miner MINER mines 13 new blocks
-    Then VN has scanned to height 30 within 10 seconds
+    Then VN has scanned to height 30
 
     When I convert commitment COMMITMENT into COMM_ADDRESS address
     Then validator node VN has state at COMM_ADDRESS

--- a/integration_tests/tests/features/claim_fees.feature
+++ b/integration_tests/tests/features/claim_fees.feature
@@ -22,8 +22,8 @@ Feature: Claim Fees
     When wallet WALLET has at least 5000 T
     When validator node VN sends a registration transaction allowing fee claims from wallet WALLET_D using key K1
     When miner MINER mines 16 new blocks
-    Then VN has scanned to height 17 within 10 seconds
-    And indexer IDX has scanned to height 17 within 10 seconds
+    Then VN has scanned to height 17
+    And indexer IDX has scanned to height 17
     Then the validator node VN is listed as registered
 
     When indexer IDX connects to all other validators
@@ -35,7 +35,7 @@ Feature: Claim Fees
 
     # Progress to the next epoch
     When miner MINER mines 10 new blocks
-    Then VN has scanned to height 27 within 10 seconds
+    Then VN has scanned to height 27
 
     # Claim fees into ACC2
     When I claim fees for validator VN and epoch 1 into account ACC2 using the wallet daemon WALLET_D
@@ -62,8 +62,8 @@ Feature: Claim Fees
     When wallet WALLET has at least 10000 T
     When validator node VN sends a registration transaction allowing fee claims from wallet WALLET_D using key K1
     When miner MINER mines 16 new blocks
-    Then VN has scanned to height 17 within 10 seconds
-    And indexer IDX has scanned to height 17 within 10 seconds
+    Then VN has scanned to height 17
+    And indexer IDX has scanned to height 17
     Then the validator node VN is listed as registered
 
     When indexer IDX connects to all other validators
@@ -76,7 +76,7 @@ Feature: Claim Fees
 
     # Progress to the next epoch
     When miner MINER mines 10 new blocks
-    Then VN has scanned to height 27 within 20 seconds
+    Then VN has scanned to height 27
 
     # Claim fees into ACC2
     When I claim fees for validator VN and epoch 1 into account ACC2 using the wallet daemon WALLET_D
@@ -107,8 +107,8 @@ Feature: Claim Fees
     When wallet WALLET has at least 10000 T
     When validator node VN sends a registration transaction allowing fee claims from wallet WALLET1 using key K1
     When miner MINER mines 16 new blocks
-    Then VN has scanned to height 17 within 10 seconds
-    And indexer IDX has scanned to height 17 within 10 seconds
+    Then VN has scanned to height 17
+    And indexer IDX has scanned to height 17
     Then the validator node VN is listed as registered
 
     When indexer IDX connects to all other validators
@@ -124,7 +124,7 @@ Feature: Claim Fees
 
     # Progress to the next epoch
     When miner MINER mines 10 new blocks
-    Then VN has scanned to height 27 within 10 seconds
+    Then VN has scanned to height 27
 
     # Claim fees using unauthorized wallet
     When I claim fees for validator VN and epoch 1 into account ACC2 using the wallet daemon WALLET2, it fails

--- a/integration_tests/tests/features/committee.feature
+++ b/integration_tests/tests/features/committee.feature
@@ -28,8 +28,8 @@ Feature: Committee scenarios
     # Register the "counter" template
     When validator node VAL_1 registers the template "counter"
     When miner MINER mines 15 new blocks
-    Then VAL_1 has scanned to height 18 within 10 seconds
-    Then VAL_2 has scanned to height 18 within 10 seconds
+    Then VAL_1 has scanned to height 18
+    Then VAL_2 has scanned to height 18
     Then the validator node VAL_1 is listed as registered
     Then the validator node VAL_2 is listed as registered
     Then the template "counter" is listed as registered by the validator node VAL_1
@@ -84,7 +84,7 @@ Feature: Committee scenarios
 #    # Register the "counter" template
 #    When validator node VAL_1 registers the template "counter"
 #    When miner MINER mines 23 new blocks
-#    Then all validators have scanned to height 29 within 10 seconds
+#    Then all validators have scanned to height 29
 #    Then all validator nodes are listed as registered
 #    Then the template "counter" is listed as registered by all validator nodes
 #

--- a/integration_tests/tests/features/counter.feature
+++ b/integration_tests/tests/features/counter.feature
@@ -24,7 +24,7 @@ Feature: Counter template
     # Register the "counter" template
     When validator node VAL_1 registers the template "counter"
     When miner MINER mines 13 new blocks
-    Then VAL_1 has scanned to height 16 within 10 seconds
+    Then VAL_1 has scanned to height 16
     Then the validator node VAL_1 is listed as registered
     Then the template "counter" is listed as registered by the validator node VAL_1
 

--- a/integration_tests/tests/features/fungible.feature
+++ b/integration_tests/tests/features/fungible.feature
@@ -13,18 +13,15 @@ Feature: Fungible tokens
 
     # Initialize a VN
     Given a validator node VN connected to base node BASE and wallet WALLET
-    When miner MINER mines 4 new blocks
-    When wallet WALLET has at least 5000 T
+    When miner MINER mines 6 new blocks
+    When wallet WALLET has at least 10000 T
     When validator node VN sends a registration transaction
-    When miner MINER mines 16 new blocks
-    Then the validator node VN is listed as registered
-
     # Register the "faucet" template
     When validator node VN registers the template "faucet"
-
     # Mine some blocks until the UTXOs are scanned
-    When miner MINER mines 4 new blocks
-    Then VN has scanned to height 21 within 10 seconds
+    When miner MINER mines 14 new blocks
+    Then VN has scanned to height 17
+    Then the validator node VN is listed as registered
     Then the template "faucet" is listed as registered by the validator node VN
 
     # A file-base CLI account must be created to sign future calls

--- a/integration_tests/tests/features/indexer.feature
+++ b/integration_tests/tests/features/indexer.feature
@@ -26,7 +26,7 @@ Feature: Indexer node
     When validator node VN registers the template "counter"
     When validator node VN registers the template "basic_nft"
     When miner MINER mines 10 new blocks
-    Then VN has scanned to height 13 within 10 seconds
+    Then VN has scanned to height 13
     Then the validator node VN is listed as registered
     Then the template "counter" is listed as registered by the validator node VN
     Then the template "basic_nft" is listed as registered by the validator node VN
@@ -72,7 +72,7 @@ Feature: Indexer node
 
     # Initialize an indexer
     Given an indexer IDX connected to base node BASE
-    Then indexer IDX has scanned to height 13 within 10 seconds
+    Then indexer IDX has scanned to height 13
 
     # Track a component
     When the indexer IDX tracks the address ACC1/components/Account
@@ -136,8 +136,8 @@ Feature: Indexer node
     When validator node VN sends a registration transaction
 
     When miner MINER mines 16 new blocks
-    Then VN has scanned to height 19 within 10 seconds
-    Then indexer IDX has scanned to height 19 within 10 seconds
+    Then VN has scanned to height 19
+    Then indexer IDX has scanned to height 19
     Then the validator node VN is listed as registered
 
     # A file-base CLI account must be created to sign future calls

--- a/integration_tests/tests/features/nft.feature
+++ b/integration_tests/tests/features/nft.feature
@@ -24,7 +24,7 @@ Feature: NFTs
     # Register the "basic_nft" template
     When validator node VN registers the template "basic_nft"
     When miner MINER mines 13 new blocks
-    Then VN has scanned to height 17 within 10 seconds
+    Then VN has scanned to height 17
     Then the validator node VN is listed as registered
     Then the template "basic_nft" is listed as registered by the validator node VN
 
@@ -90,7 +90,7 @@ Feature: NFTs
     # Register the "basic_nft" template
     When validator node VN registers the template "basic_nft"
     When miner MINER mines 13 new blocks
-    Then VN has scanned to height 17 within 10 seconds
+    Then VN has scanned to height 17
     Then the validator node VN is listed as registered
     Then the template "basic_nft" is listed as registered by the validator node VN
 

--- a/integration_tests/tests/features/transfer.feature
+++ b/integration_tests/tests/features/transfer.feature
@@ -31,8 +31,8 @@ Feature: Account transfers
     When miner MINER mines 15 new blocks
     Then the validator node VN is listed as registered
     Then the template "faucet" is listed as registered by the validator node VN
-    Then VN has scanned to height 32 within 10 seconds
-    Then indexer IDX has scanned to height 32 within 10 seconds
+    Then VN has scanned to height 32
+    Then indexer IDX has scanned to height 32
 
     # Create the sender account
     When I create an account ACCOUNT via the wallet daemon WALLET_D with 10000 free coins
@@ -43,8 +43,8 @@ Feature: Account transfers
     # Burn some tari in the base layer to have funds for fees in the sender account
     When I burn 10T on wallet WALLET with wallet daemon WALLET_D into commitment COMMITMENT with proof PROOF for ACCOUNT, range proof RANGEPROOF and claim public key CLAIM_PUBKEY
     When miner MINER mines 13 new blocks
-    Then VN has scanned to height 45 within 10 seconds
-    Then indexer IDX has scanned to height 45 within 10 seconds
+    Then VN has scanned to height 45
+    Then indexer IDX has scanned to height 45
 
     When I convert commitment COMMITMENT into COMM_ADDRESS address
     Then validator node VN has state at COMM_ADDRESS
@@ -111,8 +111,8 @@ Feature: Account transfers
     Then the validator node VN is listed as registered
     Then the template "faucet" is listed as registered by the validator node VN
 
-    Then VN has scanned to height 32 within 10 seconds
-    Then indexer IDX has scanned to height 32 within 10 seconds
+    Then VN has scanned to height 32
+    Then indexer IDX has scanned to height 32
 
     # Create the sender account with some tokens
     When I create an account ACCOUNT_1 via the wallet daemon WALLET_D with 10000 free coins
@@ -124,8 +124,8 @@ Feature: Account transfers
     # Burn some tari in the base layer to have funds for fees in the sender account
     When I burn 10T on wallet WALLET with wallet daemon WALLET_D into commitment COMMITMENT with proof PROOF for ACCOUNT_1, range proof RANGEPROOF and claim public key CLAIM_PUBKEY
     When miner MINER mines 13 new blocks
-    Then VN has scanned to height 45 within 10 seconds
-    Then indexer IDX has scanned to height 45 within 10 seconds
+    Then VN has scanned to height 45
+    Then indexer IDX has scanned to height 45
 
     When I convert commitment COMMITMENT into COMM_ADDRESS address
     Then validator node VN has state at COMM_ADDRESS
@@ -180,8 +180,8 @@ Feature: Account transfers
     # Initialize the wallet daemon
     Given a wallet daemon WALLET_D connected to indexer IDX
 
-    Then VN has scanned to height 17 within 10 seconds
-    Then indexer IDX has scanned to height 17 within 10 seconds
+    Then VN has scanned to height 17
+    Then indexer IDX has scanned to height 17
 
     # Create the sender account
     When I create an account ACC_1 via the wallet daemon WALLET_D with 10000 free coins

--- a/integration_tests/tests/features/wallet_daemon.feature
+++ b/integration_tests/tests/features/wallet_daemon.feature
@@ -21,7 +21,7 @@ Feature: Wallet Daemon
         # VN registration
         When validator node VAL_1 sends a registration transaction
         When miner MINER mines 16 new blocks
-        Then VAL_1 has scanned to height 17 within 10 seconds
+        Then VAL_1 has scanned to height 17
         Then the validator node VAL_1 is listed as registered
 
         # Initialize an indexer
@@ -35,8 +35,8 @@ Feature: Wallet Daemon
 
         # Mine some blocks until the UTXOs are scanned
         When miner MINER mines 5 new blocks
-        Then VAL_1 has scanned to height 22 within 10 seconds
-        Then indexer IDX has scanned to height 22 within 10 seconds
+        Then VAL_1 has scanned to height 22
+        Then indexer IDX has scanned to height 22
         Then the template "faucet" is listed as registered by the validator node VAL_1
 
         # Create two accounts to test sending the tokens
@@ -116,7 +116,7 @@ Feature: Wallet Daemon
         # unfortunately have to wait for this to get into the mempool....
         Then there is 1 transaction in the mempool of BASE within 10 seconds
         When miner MINER mines 13 new blocks
-        Then VN has scanned to height 30 within 10 seconds
+        Then VN has scanned to height 30
 
         When I convert commitment COMMITMENT into COMM_ADDRESS address
         Then validator node VN has state at COMM_ADDRESS


### PR DESCRIPTION
Description
---
Improve the reliability of `Claim and transfer confidential assets via wallet daemon`
Remove time param from `VN has scanned to height {int}`, timer is reset if the height progresses

Motivation and Context
---
CI failures due to VN not quite reaching the height within 10 seconds. These failures show that the VN had scanned, but was timed out just before it could reach the correct height. This allows more time as long as the scanning has progressed to alleviate timeouts due to slow CI and to automatically increase time which should be proportional to the number of blocks that need to be scanned while still timing out if progress is too slow.

How Has This Been Tested?
---
Cucumbers pass locally

What process can a PR reviewer use to test or verify this change?
---
CI


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify