### PR TITLE
feat!: foreign broadcast reliability counter

### DIFF
--- a/applications/tari_validator_node/src/bootstrap.rs
+++ b/applications/tari_validator_node/src/bootstrap.rs
@@ -46,7 +46,7 @@ use tari_dan_app_utilities::{
 use tari_dan_common_types::{Epoch, NodeAddressable, NodeHeight, ShardId};
 use tari_dan_engine::fees::FeeTable;
 use tari_dan_storage::{
-    consensus_models::{Block, BlockId, ExecutedTransaction, SubstateRecord},
+    consensus_models::{Block, BlockId, ExecutedTransaction, ForeignReceiveCounters, SubstateRecord},
     global::GlobalDb,
     StateStore,
     StateStoreReadTransaction,
@@ -206,6 +206,7 @@ pub async fn spawn_services(
 
     // Consensus
     let (tx_executed_transaction, rx_executed_transaction) = mpsc::channel(10);
+    let foreign_receive_counter = state_store.with_read_tx(|tx| ForeignReceiveCounters::get(tx))?;
     let (consensus_join_handle, consensus_handle, rx_consensus_to_mempool) = consensus::spawn(
         state_store.clone(),
         node_identity.clone(),
@@ -214,6 +215,7 @@ pub async fn spawn_services(
         rx_consensus_message,
         outbound_messaging.clone(),
         validator_node_client_factory.clone(),
+        foreign_receive_counter,
         shutdown.clone(),
     )
     .await;

--- a/applications/tari_validator_node/src/consensus/mod.rs
+++ b/applications/tari_validator_node/src/consensus/mod.rs
@@ -12,7 +12,7 @@ use tari_consensus::{
 };
 use tari_dan_common_types::committee::Committee;
 use tari_dan_p2p::{Message, OutboundService};
-use tari_dan_storage::consensus_models::TransactionPool;
+use tari_dan_storage::consensus_models::{ForeignReceiveCounters, TransactionPool};
 use tari_epoch_manager::base_layer::EpochManagerHandle;
 use tari_shutdown::ShutdownSignal;
 use tari_state_store_sqlite::SqliteStateStore;
@@ -50,6 +50,7 @@ pub async fn spawn(
     rx_hs_message: mpsc::Receiver<(CommsPublicKey, HotstuffMessage<PublicKey>)>,
     outbound_messaging: OutboundMessaging,
     client_factory: TariCommsValidatorNodeClientFactory,
+    foreign_receive_counter: ForeignReceiveCounters,
     shutdown_signal: ShutdownSignal,
 ) -> (
     JoinHandle<Result<(), anyhow::Error>>,
@@ -81,6 +82,7 @@ pub async fn spawn(
         tx_leader,
         tx_hotstuff_events.clone(),
         tx_mempool,
+        foreign_receive_counter,
         shutdown_signal.clone(),
     );
 

--- a/dan_layer/consensus/src/hotstuff/error.rs
+++ b/dan_layer/consensus/src/hotstuff/error.rs
@@ -92,6 +92,10 @@ pub enum ProposalValidationError {
     },
     #[error("Node proposed by {proposed_by} with hash {hash} did not satisfy the safeNode predicate")]
     NotSafeBlock { proposed_by: String, hash: BlockId },
+    #[error("Node proposed by {proposed_by} with hash {hash} is missing foreign index")]
+    MissingForeignCounters { proposed_by: String, hash: BlockId },
+    #[error("Node proposed by {proposed_by} with hash {hash} has invalid foreign counters")]
+    InvalidForeignCounters { proposed_by: String, hash: BlockId },
     #[error("Node proposed by {proposed_by} with hash {hash} is the genesis block")]
     ProposingGenesisBlock { proposed_by: String, hash: BlockId },
     #[error("Justification block {justify_block} for proposed block {block_description} by {proposed_by} not found")]

--- a/dan_layer/consensus/src/hotstuff/on_receive_local_proposal.rs
+++ b/dan_layer/consensus/src/hotstuff/on_receive_local_proposal.rs
@@ -5,16 +5,23 @@
 // ----[foreign:LocalPrepared]--->(LocalPrepared, true) ----cmd:AllPrepare ---> (AllPrepared, true) ---cmd:Accept --->
 // Complete
 
+use std::{collections::HashMap, ops::DerefMut};
+
 use log::*;
-use tari_dan_common_types::{committee::Committee, optional::Optional, NodeHeight};
+use tari_dan_common_types::{
+    committee::{Committee, CommitteeShard},
+    optional::Optional,
+    shard_bucket::ShardBucket,
+    NodeHeight,
+};
 use tari_dan_storage::{
-    consensus_models::{Block, HighQc, TransactionPool, ValidBlock},
+    consensus_models::{Block, ForeignSendCounters, HighQc, TransactionPool, ValidBlock},
     StateStore,
 };
 use tari_epoch_manager::EpochManagerReader;
 use tokio::sync::{broadcast, mpsc};
 
-use super::proposer::Proposer;
+use super::proposer::{self, Proposer};
 use crate::{
     hotstuff::{
         error::HotStuffError,
@@ -128,9 +135,10 @@ impl<TConsensusSpec: ConsensusSpec> OnReceiveProposalHandler<TConsensusSpec> {
             .epoch_manager
             .get_committee_by_validator_address(block.epoch(), block.proposed_by())
             .await?;
+        let local_committee_shard = self.epoch_manager.get_local_committee_shard(block.epoch()).await?;
         // First save the block in one db transaction
-        self.store.with_read_tx(|tx| {
-            match self.validate_local_proposed_block(tx, block, &local_committee) {
+        self.store.with_write_tx(|tx| {
+            match self.validate_local_proposed_block(tx, block, &local_committee, &local_committee_shard) {
                 Ok(validated) => Ok(Some(validated)),
                 // Validation errors should not cause a FAILURE state transition
                 Err(HotStuffError::ProposalValidationError(err)) => {
@@ -143,15 +151,35 @@ impl<TConsensusSpec: ConsensusSpec> OnReceiveProposalHandler<TConsensusSpec> {
         })
     }
 
+    fn check_foreign_indexes(
+        &self,
+        tx: &mut <TConsensusSpec::StateStore as StateStore>::WriteTransaction<'_>,
+        num_committees: u32,
+        local_bucket: ShardBucket,
+        block: &Block<TConsensusSpec::Addr>,
+    ) -> Result<bool, HotStuffError> {
+        let mut foreign_counters = ForeignSendCounters::get(tx.deref_mut(), block.parent())?;
+        let non_local_buckets = proposer::get_non_local_buckets(tx.deref_mut(), block, num_committees, local_bucket)?;
+        let mut foreign_indexes = HashMap::new();
+        for non_local_bucket in non_local_buckets {
+            foreign_indexes
+                .entry(non_local_bucket)
+                .or_insert(foreign_counters.increment_counter(non_local_bucket));
+        }
+        foreign_counters.set(tx, block.id())?;
+        Ok(foreign_indexes == *block.get_foreign_indexes())
+    }
+
     /// Perform final block validations (TODO: implement all validations)
     /// We assume at this point that initial stateless validations have been done (in inbound messages)
     fn validate_local_proposed_block(
         &self,
-        tx: &mut <TConsensusSpec::StateStore as StateStore>::ReadTransaction<'_>,
+        tx: &mut <TConsensusSpec::StateStore as StateStore>::WriteTransaction<'_>,
         candidate_block: Block<TConsensusSpec::Addr>,
         local_committee: &Committee<TConsensusSpec::Addr>,
+        local_committee_shard: &CommitteeShard,
     ) -> Result<ValidBlock<TConsensusSpec::Addr>, HotStuffError> {
-        if Block::has_been_processed(tx, candidate_block.id())? {
+        if Block::has_been_processed(tx.deref_mut(), candidate_block.id())? {
             return Err(ProposalValidationError::BlockAlreadyProcessed {
                 block_id: *candidate_block.id(),
                 height: candidate_block.height(),
@@ -160,7 +188,7 @@ impl<TConsensusSpec: ConsensusSpec> OnReceiveProposalHandler<TConsensusSpec> {
         }
 
         // Check that details included in the justify match previously added blocks
-        let Some(justify_block) = candidate_block.justify().get_block(tx).optional()? else {
+        let Some(justify_block) = candidate_block.justify().get_block(tx.deref_mut()).optional()? else {
             // This will trigger a sync
             return Err(ProposalValidationError::JustifyBlockNotFound {
                 proposed_by: candidate_block.proposed_by().to_string(),
@@ -241,8 +269,20 @@ impl<TConsensusSpec: ConsensusSpec> OnReceiveProposalHandler<TConsensusSpec> {
 
         // Now that we have all dummy blocks (if any) in place, we can check if the candidate block is safe.
         // Specifically, it should extend the locked block via the dummy blocks.
-        if !candidate_block.is_safe(tx)? {
+        if !candidate_block.is_safe(tx.deref_mut())? {
             return Err(ProposalValidationError::NotSafeBlock {
+                proposed_by: candidate_block.proposed_by().to_string(),
+                hash: *candidate_block.id(),
+            }
+            .into());
+        }
+        if !self.check_foreign_indexes(
+            tx,
+            local_committee_shard.num_committees(),
+            local_committee_shard.bucket(),
+            &candidate_block,
+        )? {
+            return Err(ProposalValidationError::InvalidForeignCounters {
                 proposed_by: candidate_block.proposed_by().to_string(),
                 hash: *candidate_block.id(),
             }

--- a/dan_layer/consensus/src/hotstuff/worker.rs
+++ b/dan_layer/consensus/src/hotstuff/worker.rs
@@ -10,7 +10,7 @@ use std::{
 use log::*;
 use tari_dan_common_types::{optional::Optional, NodeHeight};
 use tari_dan_storage::{
-    consensus_models::{Block, HighQc, LastSentVote, LastVoted, LeafBlock, TransactionPool},
+    consensus_models::{Block, ForeignReceiveCounters, HighQc, LastSentVote, LastVoted, LeafBlock, TransactionPool},
     StateStore,
     StateStoreWriteTransaction,
 };
@@ -86,6 +86,7 @@ impl<TConsensusSpec: ConsensusSpec> HotstuffWorker<TConsensusSpec> {
         tx_leader: mpsc::Sender<(TConsensusSpec::Addr, HotstuffMessage<TConsensusSpec::Addr>)>,
         tx_events: broadcast::Sender<HotstuffEvent>,
         tx_mempool: mpsc::UnboundedSender<Transaction>,
+        foreign_receive_counter: ForeignReceiveCounters,
         shutdown: ShutdownSignal,
     ) -> Self {
         let pacemaker = PaceMaker::new();
@@ -137,6 +138,7 @@ impl<TConsensusSpec: ConsensusSpec> HotstuffWorker<TConsensusSpec> {
                 epoch_manager.clone(),
                 transaction_pool.clone(),
                 pacemaker.clone_handle(),
+                foreign_receive_counter,
             ),
             on_receive_vote: OnReceiveVoteHandler::new(vote_receiver.clone()),
             on_receive_new_view: OnReceiveNewViewHandler::new(

--- a/dan_layer/consensus_tests/src/support/validator/builder.rs
+++ b/dan_layer/consensus_tests/src/support/validator/builder.rs
@@ -3,7 +3,7 @@
 
 use tari_consensus::hotstuff::{ConsensusWorker, ConsensusWorkerContext, HotstuffWorker};
 use tari_dan_common_types::{shard_bucket::ShardBucket, ShardId};
-use tari_dan_storage::consensus_models::TransactionPool;
+use tari_dan_storage::consensus_models::{ForeignReceiveCounters, TransactionPool};
 use tari_shutdown::ShutdownSignal;
 use tari_state_store_sqlite::SqliteStateStore;
 use tokio::sync::{broadcast, mpsc, watch};
@@ -103,6 +103,7 @@ impl ValidatorBuilder {
             tx_leader,
             tx_events.clone(),
             tx_mempool,
+            ForeignReceiveCounters::default(),
             shutdown_signal.clone(),
         );
 

--- a/dan_layer/state_store_sqlite/migrations/2023-06-08-091819_create_state_store/up.sql
+++ b/dan_layer/state_store_sqlite/migrations/2023-06-08-091819_create_state_store/up.sql
@@ -25,6 +25,7 @@ create table blocks
     is_committed     boolean   not NULL default '0',
     is_processed     boolean   not NULL,
     is_dummy         boolean   not NULL,
+    foreign_indexes  text      not NULL,
     created_at       timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (qc_id) REFERENCES quorum_certificates (qc_id)
 );
@@ -44,6 +45,7 @@ create table parked_blocks
     command_count    bigint    not NULL,
     commands         text      not NULL,
     total_leader_fee bigint    not NULL,
+    foreign_indexes  text      not NULL,
     created_at       timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
@@ -241,6 +243,21 @@ CREATE TABLE missing_transactions
     is_awaiting_execution boolean   not NULL,
     created_at            timestamp not NULL DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (block_id) REFERENCES parked_blocks (block_id)
+);
+
+CREATE TABLE foreign_send_counters
+(
+    id         integer   not NULL primary key AUTOINCREMENT,
+    block_id   text      not NULL,
+    counters   text      not NULL,
+    created_at timestamp not NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE foreign_receive_counters
+(
+    id         integer   not NULL primary key AUTOINCREMENT,
+    counters   text      not NULL,
+    created_at timestamp not NULL DEFAULT CURRENT_TIMESTAMP
 );
 
 -- Debug Triggers

--- a/dan_layer/state_store_sqlite/src/schema.rs
+++ b/dan_layer/state_store_sqlite/src/schema.rs
@@ -15,6 +15,24 @@ diesel::table! {
         is_committed -> Bool,
         is_processed -> Bool,
         is_dummy -> Bool,
+        foreign_indexes -> Text,
+        created_at -> Timestamp,
+    }
+}
+
+diesel::table! {
+    foreign_receive_counters (id) {
+        id -> Integer,
+        counters -> Text,
+        created_at -> Timestamp,
+    }
+}
+
+diesel::table! {
+    foreign_send_counters (id) {
+        id -> Integer,
+        block_id -> Text,
+        counters -> Text,
         created_at -> Timestamp,
     }
 }
@@ -119,6 +137,7 @@ diesel::table! {
         command_count -> BigInt,
         commands -> Text,
         total_leader_fee -> BigInt,
+        foreign_indexes -> Text,
         created_at -> Timestamp,
     }
 }

--- a/dan_layer/state_store_sqlite/src/sql_models/block.rs
+++ b/dan_layer/state_store_sqlite/src/sql_models/block.rs
@@ -28,6 +28,7 @@ pub struct Block {
     pub is_committed: bool,
     pub is_processed: bool,
     pub is_dummy: bool,
+    pub foreign_indexes: String,
     pub created_at: PrimitiveDateTime,
 }
 
@@ -52,6 +53,7 @@ impl Block {
             self.is_dummy,
             self.is_processed,
             self.is_committed,
+            deserialize_json(&self.foreign_indexes)?,
             self.created_at,
         ))
     }
@@ -69,6 +71,7 @@ pub struct ParkedBlock {
     pub command_count: i64,
     pub commands: String,
     pub total_leader_fee: i64,
+    pub foreign_indexes: String,
     pub created_at: PrimitiveDateTime,
 }
 
@@ -92,6 +95,7 @@ impl<TAddr: NodeAddressable> TryFrom<ParkedBlock> for consensus_models::Block<TA
             false,
             false,
             false,
+            deserialize_json(&value.foreign_indexes)?,
             value.created_at,
         ))
     }

--- a/dan_layer/state_store_sqlite/src/sql_models/bookkeeping.rs
+++ b/dan_layer/state_store_sqlite/src/sql_models/bookkeeping.rs
@@ -36,6 +36,41 @@ impl TryFrom<HighQc> for consensus_models::HighQc {
 }
 
 #[derive(Debug, Clone, Queryable)]
+pub struct ForeignSendCounters {
+    pub id: i32,
+    pub block_id: String,
+    pub counters: String,
+    pub created_at: PrimitiveDateTime,
+}
+
+impl TryFrom<ForeignSendCounters> for consensus_models::ForeignSendCounters {
+    type Error = StorageError;
+
+    fn try_from(value: ForeignSendCounters) -> Result<Self, Self::Error> {
+        Ok(Self {
+            counters: deserialize_json(&value.counters)?,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Queryable)]
+pub struct ForeignReceiveCounters {
+    pub id: i32,
+    pub counters: String,
+    pub created_at: PrimitiveDateTime,
+}
+
+impl TryFrom<ForeignReceiveCounters> for consensus_models::ForeignReceiveCounters {
+    type Error = StorageError;
+
+    fn try_from(value: ForeignReceiveCounters) -> Result<Self, Self::Error> {
+        Ok(Self {
+            counters: deserialize_json(&value.counters)?,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Queryable)]
 pub struct LockedBlock {
     pub id: i32,
     pub block_id: String,

--- a/dan_layer/state_store_sqlite/tests/tests.rs
+++ b/dan_layer/state_store_sqlite/tests/tests.rs
@@ -30,6 +30,8 @@ fn create_tx_atom() -> TransactionAtom {
 
 mod confirm_all_transitions {
 
+    use std::collections::HashMap;
+
     use super::*;
 
     #[test]
@@ -55,6 +57,7 @@ mod confirm_all_transitions {
             // cannot cause a state change without any commands
             [Command::Prepare(atom1.clone())].into_iter().collect(),
             Default::default(),
+            HashMap::new(),
         );
         block1.insert(&mut tx).unwrap();
 

--- a/dan_layer/storage/src/consensus_models/foreign_receive_counters.rs
+++ b/dan_layer/storage/src/consensus_models/foreign_receive_counters.rs
@@ -1,0 +1,47 @@
+//    Copyright 2023 The Tari Project
+//    SPDX-License-Identifier: BSD-3-Clause
+
+use std::collections::HashMap;
+
+use tari_dan_common_types::shard_bucket::ShardBucket;
+
+use crate::{StateStoreReadTransaction, StateStoreWriteTransaction, StorageError};
+
+#[derive(Debug, Clone)]
+pub struct ForeignReceiveCounters {
+    pub counters: HashMap<ShardBucket, u64>,
+}
+
+impl Default for ForeignReceiveCounters {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ForeignReceiveCounters {
+    pub fn new() -> Self {
+        Self {
+            counters: HashMap::new(),
+        }
+    }
+
+    pub fn increment(&mut self, bucket: &ShardBucket) {
+        *self.counters.entry(*bucket).or_default() += 1;
+    }
+
+    // If we haven't received any messages from this shard yet, return 0
+    pub fn get_index(&self, bucket: &ShardBucket) -> u64 {
+        self.counters.get(bucket).copied().unwrap_or_default()
+    }
+}
+
+impl ForeignReceiveCounters {
+    pub fn save<TTx: StateStoreWriteTransaction + ?Sized>(&self, tx: &mut TTx) -> Result<(), StorageError> {
+        tx.foreign_receive_counters_set(self)?;
+        Ok(())
+    }
+
+    pub fn get<TTx: StateStoreReadTransaction + ?Sized>(tx: &mut TTx) -> Result<Self, StorageError> {
+        tx.foreign_receive_counters_get()
+    }
+}

--- a/dan_layer/storage/src/consensus_models/foreign_send_counters.rs
+++ b/dan_layer/storage/src/consensus_models/foreign_send_counters.rs
@@ -1,0 +1,50 @@
+//    Copyright 2023 The Tari Project
+//    SPDX-License-Identifier: BSD-3-Clause
+
+use std::collections::HashMap;
+
+use tari_dan_common_types::shard_bucket::ShardBucket;
+
+use super::BlockId;
+use crate::{StateStoreReadTransaction, StateStoreWriteTransaction, StorageError};
+
+#[derive(Debug, Clone)]
+pub struct ForeignSendCounters {
+    pub counters: HashMap<ShardBucket, u64>,
+}
+
+impl Default for ForeignSendCounters {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ForeignSendCounters {
+    pub fn new() -> Self {
+        Self {
+            counters: HashMap::new(),
+        }
+    }
+
+    pub fn increment_counter(&mut self, bucket: ShardBucket) -> u64 {
+        *self.counters.entry(bucket).and_modify(|v| *v += 1).or_insert(1)
+    }
+}
+
+impl ForeignSendCounters {
+    pub fn set<TTx: StateStoreWriteTransaction + ?Sized>(
+        &self,
+        tx: &mut TTx,
+        block_id: &BlockId,
+    ) -> Result<(), StorageError> {
+        tx.foreign_send_counters_set(self, block_id)?;
+        Ok(())
+    }
+
+    pub fn get<TTx: StateStoreReadTransaction + ?Sized>(
+        tx: &mut TTx,
+        block_id: &BlockId,
+    ) -> Result<Self, StorageError> {
+        tx.foreign_send_counters_get(block_id)
+    }
+}

--- a/dan_layer/storage/src/consensus_models/mod.rs
+++ b/dan_layer/storage/src/consensus_models/mod.rs
@@ -4,6 +4,8 @@
 mod block;
 mod command;
 mod executed_transaction;
+mod foreign_receive_counters;
+mod foreign_send_counters;
 mod high_qc;
 mod last_executed;
 mod last_proposed;
@@ -26,6 +28,8 @@ mod vote_signature;
 pub use block::*;
 pub use command::*;
 pub use executed_transaction::*;
+pub use foreign_receive_counters::*;
+pub use foreign_send_counters::*;
 pub use high_qc::*;
 pub use last_executed::*;
 pub use last_proposed::*;

--- a/dan_layer/storage/src/state_store/mod.rs
+++ b/dan_layer/storage/src/state_store/mod.rs
@@ -18,6 +18,8 @@ use crate::{
         BlockId,
         Decision,
         Evidence,
+        ForeignReceiveCounters,
+        ForeignSendCounters,
         HighQc,
         LastExecuted,
         LastProposed,
@@ -90,6 +92,8 @@ pub trait StateStoreReadTransaction {
     fn locked_block_get(&mut self) -> Result<LockedBlock, StorageError>;
     fn leaf_block_get(&mut self) -> Result<LeafBlock, StorageError>;
     fn high_qc_get(&mut self) -> Result<HighQc, StorageError>;
+    fn foreign_send_counters_get(&mut self, block_id: &BlockId) -> Result<ForeignSendCounters, StorageError>;
+    fn foreign_receive_counters_get(&mut self) -> Result<ForeignReceiveCounters, StorageError>;
     fn transactions_get(&mut self, tx_id: &TransactionId) -> Result<TransactionRecord, StorageError>;
     fn transactions_exists(&mut self, tx_id: &TransactionId) -> Result<bool, StorageError>;
 
@@ -251,6 +255,15 @@ pub trait StateStoreWriteTransaction {
     fn leaf_block_set(&mut self, leaf_node: &LeafBlock) -> Result<(), StorageError>;
     fn locked_block_set(&mut self, locked_block: &LockedBlock) -> Result<(), StorageError>;
     fn high_qc_set(&mut self, high_qc: &HighQc) -> Result<(), StorageError>;
+    fn foreign_send_counters_set(
+        &mut self,
+        foreign_send_counter: &ForeignSendCounters,
+        block_id: &BlockId,
+    ) -> Result<(), StorageError>;
+    fn foreign_receive_counters_set(
+        &mut self,
+        foreign_send_counter: &ForeignReceiveCounters,
+    ) -> Result<(), StorageError>;
 
     // -------------------------------- Transaction -------------------------------- //
     fn transactions_insert(&mut self, transaction: &Transaction) -> Result<(), StorageError>;

--- a/dan_layer/validator_node_rpc/proto/consensus.proto
+++ b/dan_layer/validator_node_rpc/proto/consensus.proto
@@ -49,6 +49,7 @@ message Block {
   bytes merkle_root = 7;
   repeated Command commands = 8;
   uint64 total_leader_fee = 9;
+  bytes foreign_indexes = 10;
 }
 
 message Command {
@@ -116,7 +117,6 @@ message ValidatorMetadata {
 message TariDanPayload {
   tari.dan.transaction.Transaction transaction = 1;
 }
-
 
 enum QuorumDecision {
   QUORUM_DECISION_UNKNOWN = 0;
@@ -204,4 +204,3 @@ message FullBlock {
   repeated QuorumCertificate qcs = 2;
   repeated tari.dan.transaction.Transaction transactions = 3;
 }
-

--- a/dan_layer/validator_node_rpc/src/conversions/consensus.rs
+++ b/dan_layer/validator_node_rpc/src/conversions/consensus.rs
@@ -256,6 +256,7 @@ impl<TAddr: NodeAddressable> From<&tari_dan_storage::consensus_models::Block<TAd
             justify: Some(value.justify().into()),
             total_leader_fee: value.total_leader_fee(),
             commands: value.commands().iter().map(Into::into).collect(),
+            foreign_indexes: encode(value.get_foreign_indexes()).unwrap(),
         }
     }
 }
@@ -281,6 +282,7 @@ impl<TAddr: NodeAddressable + Serialize> TryFrom<proto::consensus::Block>
                 .map(TryInto::try_into)
                 .collect::<Result<_, _>>()?,
             value.total_leader_fee,
+            decode_exact(&value.foreign_indexes)?,
         ))
     }
 }


### PR DESCRIPTION
Description
---
Add indexes/counters to blocks. So nodes in foreign committees know if they missed some foreign proposals. The VN ignores blocks with invalid foreign counter :
- receive foreign proposal with invalid index
- foreign proposal is missing index for our bucket
- local proposal has wrong foreign indexes

Motivation and Context
---

How Has This Been Tested?
---

What process can a PR reviewer use to test or verify this change?
---


Breaking Changes
---

- [ ] None
- [ ] Requires data directory to be deleted
- [x] Other - Please specify

BREAKING CHANGE: New consensus message structure