### PR TITLE
feat: request foreign blocks

### DIFF
--- a/dan_layer/consensus/src/hotstuff/error.rs
+++ b/dan_layer/consensus/src/hotstuff/error.rs
@@ -146,4 +146,6 @@ pub enum ProposalValidationError {
     },
     #[error("Proposed block {block_id} {height} already has been processed")]
     BlockAlreadyProcessed { block_id: BlockId, height: NodeHeight },
+    #[error("Internal channel send error when {context}")]
+    InternalChannelClosed { context: &'static str },
 }

--- a/dan_layer/consensus/src/hotstuff/mod.rs
+++ b/dan_layer/consensus/src/hotstuff/mod.rs
@@ -14,6 +14,7 @@ mod on_ready_to_vote_on_local_block;
 mod on_receive_foreign_proposal;
 mod on_receive_local_proposal;
 mod on_receive_new_view;
+mod on_receive_request_missing_foreign_blocks;
 mod on_receive_request_missing_transactions;
 mod on_receive_requested_transactions;
 mod on_receive_vote;

--- a/dan_layer/consensus/src/hotstuff/on_receive_request_missing_foreign_blocks.rs
+++ b/dan_layer/consensus/src/hotstuff/on_receive_request_missing_foreign_blocks.rs
@@ -1,0 +1,66 @@
+//   Copyright 2023 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+use log::*;
+use tari_dan_storage::{StateStore, StateStoreReadTransaction};
+use tari_epoch_manager::EpochManagerReader;
+use tokio::sync::mpsc;
+
+use crate::{
+    hotstuff::error::HotStuffError,
+    messages::{HotstuffMessage, ProposalMessage, RequestMissingForeignBlocksMessage},
+    traits::ConsensusSpec,
+};
+
+const LOG_TARGET: &str = "tari::dan::consensus::hotstuff::on_receive_request_missing_transactions";
+
+pub struct OnReceiveRequestMissingForeignBlocksHandler<TConsensusSpec: ConsensusSpec> {
+    store: TConsensusSpec::StateStore,
+    epoch_manager: TConsensusSpec::EpochManager,
+    tx_request_missing_foreign_blocks: mpsc::Sender<(TConsensusSpec::Addr, HotstuffMessage<TConsensusSpec::Addr>)>,
+}
+
+impl<TConsensusSpec> OnReceiveRequestMissingForeignBlocksHandler<TConsensusSpec>
+where TConsensusSpec: ConsensusSpec
+{
+    pub fn new(
+        store: TConsensusSpec::StateStore,
+        epoch_manager: TConsensusSpec::EpochManager,
+        tx_request_missing_foreign_blocks: mpsc::Sender<(TConsensusSpec::Addr, HotstuffMessage<TConsensusSpec::Addr>)>,
+    ) -> Self {
+        Self {
+            store,
+            epoch_manager,
+            tx_request_missing_foreign_blocks,
+        }
+    }
+
+    pub async fn handle(
+        &mut self,
+        from: TConsensusSpec::Addr,
+        msg: RequestMissingForeignBlocksMessage,
+    ) -> Result<(), HotStuffError> {
+        debug!(target: LOG_TARGET, "{} is requesting {}..{} missing blocks from epoch {}", from, msg.from, msg.to, msg.epoch);
+        let foreign_shard = self
+            .epoch_manager
+            .get_committee_shard_by_validator_address(msg.epoch, &from)
+            .await?;
+        let missing_blocks = self
+            .store
+            .with_read_tx(|tx| tx.blocks_get_foreign_ids(foreign_shard.bucket(), msg.from, msg.to))?;
+        for block in missing_blocks {
+            // We send the proposal back to the requester via hotstuff, so they follow the normal path including
+            // validation.
+            self.tx_request_missing_foreign_blocks
+                .send((
+                    from.clone(),
+                    HotstuffMessage::ForeignProposal(ProposalMessage { block: block.clone() }),
+                ))
+                .await
+                .map_err(|_| HotStuffError::InternalChannelClosed {
+                    context: "tx_leader in OnReceiveRequestMissingForeignBlocksHandler::handle",
+                })?;
+        }
+        Ok(())
+    }
+}

--- a/dan_layer/consensus/src/messages/message.rs
+++ b/dan_layer/consensus/src/messages/message.rs
@@ -6,7 +6,13 @@ use std::fmt::Display;
 use serde::Serialize;
 use tari_dan_common_types::Epoch;
 
-use super::{NewViewMessage, ProposalMessage, RequestedTransactionMessage, VoteMessage};
+use super::{
+    NewViewMessage,
+    ProposalMessage,
+    RequestMissingForeignBlocksMessage,
+    RequestedTransactionMessage,
+    VoteMessage,
+};
 use crate::messages::{RequestMissingTransactionsMessage, SyncRequestMessage, SyncResponseMessage};
 
 // Serialize is implemented for the message logger
@@ -20,6 +26,7 @@ pub enum HotstuffMessage<TAddr> {
     RequestedTransaction(RequestedTransactionMessage),
     SyncRequest(SyncRequestMessage),
     SyncResponse(SyncResponseMessage<TAddr>),
+    RequestMissingForeignBlocks(RequestMissingForeignBlocksMessage),
 }
 
 impl<TAddr> HotstuffMessage<TAddr> {
@@ -33,6 +40,7 @@ impl<TAddr> HotstuffMessage<TAddr> {
             HotstuffMessage::RequestedTransaction(_) => "RequestedTransaction",
             HotstuffMessage::SyncRequest(_) => "SyncRequest",
             HotstuffMessage::SyncResponse(_) => "SyncResponse",
+            HotstuffMessage::RequestMissingForeignBlocks(_) => "RequestMissingForeignBlocks",
         }
     }
 
@@ -46,6 +54,7 @@ impl<TAddr> HotstuffMessage<TAddr> {
             Self::RequestedTransaction(msg) => msg.epoch,
             Self::SyncRequest(msg) => msg.epoch,
             Self::SyncResponse(msg) => msg.epoch,
+            Self::RequestMissingForeignBlocks(msg) => msg.epoch,
         }
     }
 
@@ -70,6 +79,9 @@ impl<TAddr> Display for HotstuffMessage<TAddr> {
             HotstuffMessage::RequestedTransaction(msg) => write!(f, "RequestedTransaction({})", msg.transactions.len()),
             HotstuffMessage::SyncRequest(msg) => write!(f, "SyncRequest({})", msg.high_qc),
             HotstuffMessage::SyncResponse(msg) => write!(f, "SyncResponse({} block(s))", msg.blocks.len()),
+            HotstuffMessage::RequestMissingForeignBlocks(msg) => {
+                write!(f, "RequestMissingForeignBlocks({}..{})", msg.from, msg.to)
+            },
         }
     }
 }

--- a/dan_layer/consensus/src/messages/mod.rs
+++ b/dan_layer/consensus/src/messages/mod.rs
@@ -12,6 +12,9 @@ pub use proposal::*;
 mod vote;
 pub use vote::*;
 
+mod request_missing_foreign_blocks;
+pub use request_missing_foreign_blocks::*;
+
 mod request_missing_transaction;
 pub use request_missing_transaction::*;
 

--- a/dan_layer/consensus/src/messages/request_missing_foreign_blocks.rs
+++ b/dan_layer/consensus/src/messages/request_missing_foreign_blocks.rs
@@ -1,0 +1,12 @@
+//   Copyright 2023 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+use serde::Serialize;
+use tari_dan_common_types::Epoch;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RequestMissingForeignBlocksMessage {
+    pub epoch: Epoch,
+    pub from: u64,
+    pub to: u64,
+}

--- a/dan_layer/state_store_sqlite/migrations/2023-06-08-091819_create_state_store/up.sql
+++ b/dan_layer/state_store_sqlite/migrations/2023-06-08-091819_create_state_store/up.sql
@@ -271,6 +271,16 @@ CREATE TABLE foreign_receive_counters
     created_at timestamp not NULL DEFAULT CURRENT_TIMESTAMP
 );
 
+CREATE TABLE blocks_foreign_id_mapping
+(
+    id             integer   not NULL primary key AUTOINCREMENT,
+    foreign_bucket integer   not NULL,
+    foreign_index  integer   not NULL,
+    block_id       text      not NULL,
+    created_at     timestamp not NULL DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (block_id) REFERENCES blocks (block_id)
+);
+
 -- Debug Triggers
 CREATE TABLE transaction_pool_history
 (

--- a/dan_layer/state_store_sqlite/src/schema.rs
+++ b/dan_layer/state_store_sqlite/src/schema.rs
@@ -59,6 +59,16 @@ diesel::table! {
 }
 
 diesel::table! {
+    blocks_foreign_id_mapping (id) {
+        id -> Integer,
+        foreign_bucket -> BigInt,
+        foreign_index -> BigInt,
+        block_id -> Text,
+        created_at -> Timestamp,
+    }
+}
+
+diesel::table! {
     last_executed (id) {
         id -> Integer,
         block_id -> Text,
@@ -278,6 +288,7 @@ diesel::table! {
 
 diesel::allow_tables_to_appear_in_same_query!(
     blocks,
+    blocks_foreign_id_mapping,
     high_qcs,
     last_executed,
     last_proposed,

--- a/dan_layer/storage/src/state_store/mod.rs
+++ b/dan_layer/storage/src/state_store/mod.rs
@@ -9,7 +9,7 @@ use std::{
 
 use serde::{Deserialize, Serialize};
 use tari_common_types::types::FixedHash;
-use tari_dan_common_types::{Epoch, NodeAddressable, NodeHeight, ShardId};
+use tari_dan_common_types::{shard_bucket::ShardBucket, Epoch, NodeAddressable, NodeHeight, ShardId};
 use tari_transaction::{Transaction, TransactionId};
 
 use crate::{
@@ -116,6 +116,12 @@ pub trait StateStoreReadTransaction {
         asc_desc_created_at: Option<Ordering>,
     ) -> Result<Vec<TransactionRecord>, StorageError>;
     fn blocks_get(&mut self, block_id: &BlockId) -> Result<Block<Self::Addr>, StorageError>;
+    fn blocks_get_foreign_ids(
+        &mut self,
+        bucket: ShardBucket,
+        from: u64,
+        to: u64,
+    ) -> Result<Vec<Block<Self::Addr>>, StorageError>;
     fn blocks_get_tip(&mut self) -> Result<Block<Self::Addr>, StorageError>;
     fn blocks_get_all_between(
         &mut self,

--- a/dan_layer/validator_node_rpc/proto/consensus.proto
+++ b/dan_layer/validator_node_rpc/proto/consensus.proto
@@ -18,6 +18,7 @@ message HotStuffMessage {
     RequestedTransactionMessage requested_transaction = 6;
     SyncRequest sync_request = 7;
     SyncResponse sync_response = 8;
+    RequestMissingForeignBlocksMessage request_missing_foreign_blocks = 9;
   }
 }
 
@@ -163,6 +164,12 @@ message UpState {
 message DownState {
   bytes deleted_by = 1;
   uint64 fees_accrued = 2;
+}
+
+message RequestMissingForeignBlocksMessage {
+  uint64 epoch = 1;
+  uint64 from = 2;
+  uint64 to = 3;
 }
 
 message RequestMissingTransactionsMessage {

--- a/dan_layer/validator_node_rpc/src/conversions/consensus.rs
+++ b/dan_layer/validator_node_rpc/src/conversions/consensus.rs
@@ -30,6 +30,7 @@ use tari_consensus::messages::{
     HotstuffMessage,
     NewViewMessage,
     ProposalMessage,
+    RequestMissingForeignBlocksMessage,
     RequestMissingTransactionsMessage,
     RequestedTransactionMessage,
     SyncRequestMessage,
@@ -68,6 +69,9 @@ impl<TAddr: NodeAddressable> From<&HotstuffMessage<TAddr>> for proto::consensus:
                 proto::consensus::hot_stuff_message::Message::ForeignProposal(msg.into())
             },
             HotstuffMessage::Vote(msg) => proto::consensus::hot_stuff_message::Message::Vote(msg.into()),
+            HotstuffMessage::RequestMissingForeignBlocks(msg) => {
+                proto::consensus::hot_stuff_message::Message::RequestMissingForeignBlocks(msg.into())
+            },
             HotstuffMessage::RequestMissingTransactions(msg) => {
                 proto::consensus::hot_stuff_message::Message::RequestMissingTransactions(msg.into())
             },
@@ -97,6 +101,9 @@ impl<TAddr: NodeAddressable + Serialize> TryFrom<proto::consensus::HotStuffMessa
             proto::consensus::hot_stuff_message::Message::Vote(msg) => HotstuffMessage::Vote(msg.try_into()?),
             proto::consensus::hot_stuff_message::Message::RequestMissingTransactions(msg) => {
                 HotstuffMessage::RequestMissingTransactions(msg.try_into()?)
+            },
+            proto::consensus::hot_stuff_message::Message::RequestMissingForeignBlocks(msg) => {
+                HotstuffMessage::RequestMissingForeignBlocks(msg.try_into()?)
             },
             proto::consensus::hot_stuff_message::Message::RequestedTransaction(msg) => {
                 HotstuffMessage::RequestedTransaction(msg.try_into()?)
@@ -188,6 +195,29 @@ impl<TAddr: NodeAddressable> TryFrom<proto::consensus::VoteMessage> for VoteMess
                 .signature
                 .ok_or_else(|| anyhow!("Signature is missing"))?
                 .try_into()?,
+        })
+    }
+}
+
+//---------------------------------- RequestMissingForeignBlocksMessage --------------------------------------------//
+impl From<&RequestMissingForeignBlocksMessage> for proto::consensus::RequestMissingForeignBlocksMessage {
+    fn from(msg: &RequestMissingForeignBlocksMessage) -> Self {
+        Self {
+            epoch: msg.epoch.as_u64(),
+            from: msg.from,
+            to: msg.to,
+        }
+    }
+}
+
+impl TryFrom<proto::consensus::RequestMissingForeignBlocksMessage> for RequestMissingForeignBlocksMessage {
+    type Error = anyhow::Error;
+
+    fn try_from(value: proto::consensus::RequestMissingForeignBlocksMessage) -> Result<Self, Self::Error> {
+        Ok(RequestMissingForeignBlocksMessage {
+            epoch: Epoch(value.epoch),
+            from: value.from,
+            to: value.to,
         })
     }
 }


### PR DESCRIPTION
Description
---
When VN receives foreign proposal that was not expected, it requests all the missing proposals. They are send in order. So the node can process them as they come.

Motivation and Context
---

How Has This Been Tested?
---
Not tested.

What process can a PR reviewer use to test or verify this change?
---
You can change the code to VN to not receive foreign proposal and then request it again later when another foreign proposal comes in.


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify