### PR TITLE
chore: bump up the tari-crypto and tari-utilities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,31 +140,32 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+checksum = "5a824f2aa7e75a0c98c5a504fceb80649e9c35265d44525b5f94de4771a395cd"
 dependencies = [
  "getrandom 0.2.10",
  "once_cell",
- "version_check 0.9.4",
+ "version_check",
 ]
 
 [[package]]
 name = "ahash"
-version = "0.8.3"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
 dependencies = [
  "cfg-if",
  "once_cell",
- "version_check 0.9.4",
+ "version_check",
+ "zerocopy",
 ]
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea5d730647d4fadd988536d06fecce94b7b4f2a7efdae548f1cf4b63205518ab"
+checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
 dependencies = [
  "memchr",
 ]
@@ -175,7 +176,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc0fac0fc16baf1f63f78b47c3d24718f3619b0714076f6a02957d808d52cbef"
 dependencies = [
- "arrayvec 0.7.4",
+ "arrayvec",
  "bytes 1.5.0",
  "smol_str",
 ]
@@ -197,9 +198,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.1"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6cd65a4b849ace0b7f6daeebcc1a1d111282227ca745458c61dbf670e52a597"
+checksum = "2ab91ebe16eb252986481c5b62f6098f3b698a45e34b5b98200cf20dd2484a44"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -235,9 +236,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0238ca56c96dfa37bdf7c373c8886dd591322500aceeeccdb2216fe06dc2f796"
+checksum = "f0699d10d2f4d628a98ee7b57b289abbc98ff3bad977cb3152709d4bf2330628"
 dependencies = [
  "anstyle",
  "windows-sys 0.48.0",
@@ -383,7 +384,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand",
 ]
 
 [[package]]
@@ -393,7 +394,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand",
 ]
 
 [[package]]
@@ -401,12 +402,6 @@ name = "arrayref"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
-
-[[package]]
-name = "arrayvec"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "arrayvec"
@@ -438,7 +433,7 @@ dependencies = [
  "asn1-rs-derive 0.1.0",
  "asn1-rs-impl",
  "displaydoc",
- "nom 7.1.3",
+ "nom",
  "num-traits",
  "rusticata-macros",
  "thiserror",
@@ -454,7 +449,7 @@ dependencies = [
  "asn1-rs-derive 0.4.0",
  "asn1-rs-impl",
  "displaydoc",
- "nom 7.1.3",
+ "nom",
  "num-traits",
  "rusticata-macros",
  "thiserror",
@@ -519,15 +514,15 @@ dependencies = [
 
 [[package]]
 name = "async-executor"
-version = "1.5.4"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c1da3ae8dabd9c00f453a329dfe1fb28da3c0a72e2478cdcd93171740c20499"
+checksum = "4b0c4a4f319e45986f347ee47fef8bf5e81c9abc3f6f58dc2391439f30df65f0"
 dependencies = [
- "async-lock",
+ "async-lock 2.8.0",
  "async-task",
  "concurrent-queue",
  "fastrand 2.0.1",
- "futures-lite",
+ "futures-lite 1.13.0",
  "slab",
 ]
 
@@ -539,10 +534,10 @@ checksum = "f1b6f5d7df27bd294849f8eec66ecfc63d11814df7a4f5d74168a2394467b776"
 dependencies = [
  "async-channel",
  "async-executor",
- "async-io",
- "async-lock",
+ "async-io 1.13.0",
+ "async-lock 2.8.0",
  "blocking",
- "futures-lite",
+ "futures-lite 1.13.0",
  "once_cell",
 ]
 
@@ -592,7 +587,7 @@ dependencies = [
  "futures-util",
  "http-body",
  "serde_json",
- "tokio-util 0.7.9",
+ "tokio-util 0.7.10",
  "tower-service",
 ]
 
@@ -642,18 +637,38 @@ version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fc5b45d93ef0529756f812ca52e44c221b35341892d3dcc34132ac02f3dd2af"
 dependencies = [
- "async-lock",
+ "async-lock 2.8.0",
  "autocfg",
  "cfg-if",
  "concurrent-queue",
- "futures-lite",
+ "futures-lite 1.13.0",
  "log",
  "parking",
- "polling",
- "rustix 0.37.23",
+ "polling 2.8.0",
+ "rustix 0.37.27",
  "slab",
- "socket2 0.4.9",
+ "socket2 0.4.10",
  "waker-fn",
+]
+
+[[package]]
+name = "async-io"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41ed9d5715c2d329bf1b4da8d60455b99b187f27ba726df2883799af9af60997"
+dependencies = [
+ "async-lock 3.0.0",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite 2.0.1",
+ "parking",
+ "polling 3.3.0",
+ "rustix 0.38.21",
+ "slab",
+ "tracing",
+ "waker-fn",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -663,6 +678,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "287272293e9d8c41773cec55e365490fe034813a2f172f502d6ddcf75b2f582b"
 dependencies = [
  "event-listener 2.5.3",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45e900cdcd39bb94a14487d3f7ef92ca222162e6c7c3fe7cb3550ea75fb486ed"
+dependencies = [
+ "event-listener 3.0.1",
+ "event-listener-strategy",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -676,35 +702,34 @@ dependencies = [
 
 [[package]]
 name = "async-process"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf012553ce51eb7aa6dc2143804cc8252bd1cb681a1c5cb7fa94ca88682dee1d"
+checksum = "ea6438ba0a08d81529c69b36700fa2f95837bfe3e776ab39cde9c14d9149da88"
 dependencies = [
- "async-io",
- "async-lock",
+ "async-io 1.13.0",
+ "async-lock 2.8.0",
  "async-signal",
  "blocking",
  "cfg-if",
- "event-listener 3.0.0",
- "futures-lite",
- "rustix 0.38.14",
+ "event-listener 3.0.1",
+ "futures-lite 1.13.0",
+ "rustix 0.38.21",
  "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "async-signal"
-version = "0.2.2"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c99f3cb3f9ff89f7d718fbb942c9eb91bedff12e396adf09a622dfe7ffec2bc2"
+checksum = "9e47d90f65a225c4527103a8d747001fc56e375203592b25ad103e1ca13124c5"
 dependencies = [
- "async-io",
- "async-lock",
+ "async-io 2.2.0",
+ "async-lock 2.8.0",
  "atomic-waker",
  "cfg-if",
- "concurrent-queue",
  "futures-core",
  "futures-io",
- "libc",
+ "rustix 0.38.21",
  "signal-hook-registry",
  "slab",
  "windows-sys 0.48.0",
@@ -718,14 +743,14 @@ checksum = "62565bb4402e926b29953c785397c6dc0391b7b446e45008b0049eb43cec6f5d"
 dependencies = [
  "async-channel",
  "async-global-executor",
- "async-io",
- "async-lock",
+ "async-io 1.13.0",
+ "async-lock 2.8.0",
  "async-process",
  "crossbeam-utils",
  "futures-channel",
  "futures-core",
  "futures-io",
- "futures-lite",
+ "futures-lite 1.13.0",
  "gloo-timers",
  "kv-log-macro",
  "log",
@@ -756,24 +781,24 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.39",
 ]
 
 [[package]]
 name = "async-task"
-version = "4.4.1"
+version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9441c6b2fe128a7c2bf680a44c34d0df31ce09e5b7e401fcca3faa483dbc921"
+checksum = "b4eb2cdb97421e01129ccb49169d8279ed21e829929144f4a22a6e54ac549ca1"
 
 [[package]]
 name = "async-trait"
-version = "0.1.73"
+version = "0.1.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
+checksum = "a66537f1bb974b254c98ed142ff995236e81b9d0fe4db0575f46612cb15eb0f9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -828,7 +853,7 @@ checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
 dependencies = [
  "async-trait",
  "axum-core",
- "base64 0.21.4",
+ "base64 0.21.5",
  "bitflags 1.3.2",
  "bytes 1.5.0",
  "futures-util",
@@ -909,6 +934,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base58-monero"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -940,9 +971,9 @@ checksum = "0ea22880d78093b0cbe17c89f64a7d457941e65759157ec6cb31a31d652b05e5"
 
 [[package]]
 name = "base64"
-version = "0.21.4"
+version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2"
+checksum = "35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9"
 
 [[package]]
 name = "base64ct"
@@ -963,9 +994,9 @@ dependencies = [
 
 [[package]]
 name = "bigdecimal"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "454bca3db10617b88b566f205ed190aedb0e0e6dd4cad61d3988a72e8c5594cb"
+checksum = "c06619be423ea5bb86c95f087d5707942791a08a85530df0db2209a3ecfb8bc9"
 dependencies = [
  "autocfg",
  "libm",
@@ -1019,9 +1050,9 @@ checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitfield"
-version = "0.13.2"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46afbd2983a5d5a7bd740ccb198caf5b82f45c40c09c0eed36052d91cb92e719"
+checksum = "2d7e60934ceec538daadb9d8432424ed043a904d8e0243f3c6446bce549a46ac"
 
 [[package]]
 name = "bitflags"
@@ -1037,9 +1068,12 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
+checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitstring"
@@ -1074,7 +1108,6 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "block-padding",
  "generic-array",
 ]
 
@@ -1093,18 +1126,8 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57a0e8073e8baa88212fb5823574c02ebccb395136ba9a164ab89379ec6072f0"
 dependencies = [
- "block-padding",
+ "block-padding 0.2.1",
  "cipher 0.2.5",
-]
-
-[[package]]
-name = "block-modes"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cb03d1bed155d89dce0f845b7899b18a9a163e148fd004e1c28421a783e2d8e"
-dependencies = [
- "block-padding",
- "cipher 0.3.0",
 ]
 
 [[package]]
@@ -1114,30 +1137,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
-name = "blocking"
-version = "1.4.0"
+name = "block-padding"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94c4ef1f913d78636d78d538eec1f18de81e481f44b1be0a81060090530846e1"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "blocking"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c36a4d0d48574b3dd360b4b7d95cc651d2b6557b6402848a27d4b228a473e2a"
 dependencies = [
  "async-channel",
- "async-lock",
+ "async-lock 2.8.0",
  "async-task",
  "fastrand 2.0.1",
  "futures-io",
- "futures-lite",
+ "futures-lite 1.13.0",
  "piper",
  "tracing",
 ]
 
 [[package]]
 name = "blowfish"
-version = "0.8.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe3ff3fc1de48c1ac2e3341c4df38b0d1bfb8fdf04632a187c8b75aaa319a7ab"
+checksum = "e412e2cd0f2b2d93e02543ceae7917b3c70331573df19ee046bcbc35e45e87d7"
 dependencies = [
  "byteorder",
- "cipher 0.3.0",
- "opaque-debug",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -1193,19 +1224,19 @@ checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
 
 [[package]]
 name = "bstr"
-version = "1.6.2"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c2f7349907b712260e64b0afe2f84692af14a454be26187d9df565c7f69266a"
+checksum = "c79ad7fb2dd38f3dabd76b09c6a5a20c038fc0213ef1e9afd30eb777f120f019"
 dependencies = [
  "memchr",
  "serde",
 ]
 
 [[package]]
-name = "buf_redux"
-version = "0.8.4"
+name = "buffer-redux"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b953a6887648bb07a535631f2bc00fbdb2a2216f135552cb3f534ed136b9c07f"
+checksum = "d2886ea01509598caac116942abd33ab5a88fa32acdf7e4abfa0fc489ca520c9"
 dependencies = [
  "memchr",
  "safemem",
@@ -1247,9 +1278,9 @@ dependencies = [
 
 [[package]]
 name = "bytecount"
-version = "0.6.3"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c676a478f63e9fa2dd5368a42f28bba0d6c560b775f38583c8bbaa7fcd67c9c"
+checksum = "e1e5f035d16fc623ae5f74981db80a439803888314e3a555fd6f04acd51a3205"
 
 [[package]]
 name = "bytemuck"
@@ -1259,9 +1290,9 @@ checksum = "374d28ec25809ee0e23827c2ab573d729e293f281dfe393500e7ad618baa61c6"
 
 [[package]]
 name = "byteorder"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -1289,6 +1320,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "camellia"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3264e2574e9ef2b53ce6f536dea83a69ac0bc600b762d1523ff83fe07230ce30"
+dependencies = [
+ "byteorder",
+ "cipher 0.4.4",
+]
+
+[[package]]
 name = "camino"
 version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1299,9 +1340,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-platform"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cfa25e60aea747ec7e1124f238816749faa93759c6ff5b31f1ccdda137f4479"
+checksum = "12024c4645c97566567129c204f65d5815a8c9aecf30fcbe682b2fe034996d36"
 dependencies = [
  "serde",
 ]
@@ -1314,7 +1355,7 @@ checksum = "4acbb09d9ee8e23699b9634375c72795d095bf268439da88562cf9b501f181fa"
 dependencies = [
  "camino",
  "cargo-platform",
- "semver 1.0.19",
+ "semver 1.0.20",
  "serde",
  "serde_json",
 ]
@@ -1327,7 +1368,7 @@ checksum = "eee4243f1f26fc7a42710e7439c149e2b10b05472f88090acce52632f231a73a"
 dependencies = [
  "camino",
  "cargo-platform",
- "semver 1.0.19",
+ "semver 1.0.20",
  "serde",
  "serde_json",
  "thiserror",
@@ -1352,13 +1393,11 @@ checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
 
 [[package]]
 name = "cast5"
-version = "0.10.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f69790da27038b52ffcf09e7874e1aae353c674d65242549a733ad9372e7281f"
+checksum = "26b07d673db1ccf000e90f54b819db9e75a8348d6eb056e9b8ab53231b7a9911"
 dependencies = [
- "byteorder",
- "cipher 0.3.0",
- "opaque-debug",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -1390,11 +1429,11 @@ dependencies = [
 
 [[package]]
 name = "cfb-mode"
-version = "0.7.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "750dfbb1b1f84475c1a92fed10fa5e76cb11adc0cda5225f137c5cac84e80860"
+checksum = "738b8d467867f80a71351933f70461f5b56f24d5c93e0cf216e59229c968d330"
 dependencies = [
- "cipher 0.3.0",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -1548,12 +1587,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "circular"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fc239e0f6cb375d2402d48afb92f76f5404fd1df208a41930ec81eda078bea"
-
-[[package]]
 name = "clap"
 version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1576,31 +1609,31 @@ dependencies = [
  "clap_lex 0.2.4",
  "indexmap 1.9.3",
  "once_cell",
- "strsim 0.10.0",
+ "strsim",
  "termcolor",
  "textwrap 0.16.0",
 ]
 
 [[package]]
 name = "clap"
-version = "4.4.6"
+version = "4.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d04704f56c2cde07f43e8e2c154b43f216dc5c92fc98ada720177362f953b956"
+checksum = "ac495e00dcec98c83465d5ad66c5c4fabd652fd6686e7c6269b117e729a6f17b"
 dependencies = [
  "clap_builder",
- "clap_derive 4.4.2",
+ "clap_derive 4.4.7",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.4.6"
+version = "4.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e231faeaca65ebd1ea3c737966bf858971cd38c3849107aa3ea7de90a804e45"
+checksum = "c77ed9a32a62e6ca27175d00d29d05ca32e396ea1eb5fb01d8256b669cec7663"
 dependencies = [
  "anstream",
  "anstyle",
- "clap_lex 0.5.1",
- "strsim 0.10.0",
+ "clap_lex 0.6.0",
+ "strsim",
  "terminal_size",
 ]
 
@@ -1619,14 +1652,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.4.2"
+version = "4.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0862016ff20d69b84ef8247369fabf5c008a7417002411897d40ee1f4532b873"
+checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
 dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -1640,18 +1673,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
-
-[[package]]
-name = "clear_on_drop"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38508a63f4979f0048febc9966fadbd48e5dab31fd0ec6a3f151bbf4a74f7423"
-dependencies = [
- "cc",
-]
+checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 
 [[package]]
 name = "clipboard-win"
@@ -1694,7 +1718,7 @@ dependencies = [
  "async-trait",
  "json5 0.4.1",
  "lazy_static",
- "nom 7.1.3",
+ "nom",
  "pathdiff",
  "ron",
  "rust-ini",
@@ -1711,11 +1735,11 @@ dependencies = [
  "anyhow",
  "async-trait",
  "fern",
- "futures 0.3.28",
+ "futures 0.3.29",
  "humantime",
  "itertools 0.11.0",
  "log",
- "rand 0.8.5",
+ "rand",
  "serde",
  "tari_common_types",
  "tari_consensus",
@@ -1766,7 +1790,7 @@ dependencies = [
  "console-api",
  "crossbeam-channel",
  "crossbeam-utils",
- "futures 0.3.28",
+ "futures 0.3.29",
  "hdrhistogram",
  "humantime",
  "prost-types 0.11.9",
@@ -1780,12 +1804,6 @@ dependencies = [
  "tracing-core",
  "tracing-subscriber",
 ]
-
-[[package]]
-name = "const-oid"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4c78c047431fee22c1a7bb92e00ad095a02a983affe4d8a72e2a2c62c1b94f3"
 
 [[package]]
 name = "const-oid"
@@ -1848,9 +1866,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.9"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
+checksum = "ce420fe07aecd3e67c5f910618fe65e94158f6dcc0adf44e00d69ce2bdfe0fd0"
 dependencies = [
  "libc",
 ]
@@ -1925,9 +1943,9 @@ dependencies = [
 
 [[package]]
 name = "crc-catalog"
-version = "2.2.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cace84e55f07e7301bae1c519df89cdad8cc3cd868413d3fdbdeca9ff3db484"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
 name = "crc24"
@@ -2038,7 +2056,7 @@ dependencies = [
  "crossterm_winapi 0.9.1",
  "futures-core",
  "libc",
- "mio 0.8.8",
+ "mio 0.8.9",
  "parking_lot 0.12.1",
  "signal-hook",
  "signal-hook-mio",
@@ -2054,7 +2072,7 @@ dependencies = [
  "bitflags 1.3.2",
  "crossterm_winapi 0.9.1",
  "libc",
- "mio 0.8.8",
+ "mio 0.8.9",
  "parking_lot 0.12.1",
  "signal-hook",
  "signal-hook-mio",
@@ -2087,19 +2105,21 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.3.2"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c6a1d5fa1de37e071642dfa44ec552ca5b299adb128fab16138e24b548fd21"
+checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "subtle",
+ "zeroize",
 ]
 
 [[package]]
 name = "crypto-bigint"
-version = "0.4.9"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
+checksum = "740fe28e594155f10cfc383984cbefd529d7396050557148f79cb0f621204124"
 dependencies = [
  "generic-array",
  "rand_core 0.6.4",
@@ -2155,14 +2175,14 @@ dependencies = [
  "anyhow",
  "async-trait",
  "atty",
- "clap 4.4.6",
+ "clap 4.4.7",
  "console",
  "cucumber-codegen",
  "cucumber-expressions",
  "derive_more",
  "drain_filter_polyfill",
  "either",
- "futures 0.3.28",
+ "futures 0.3.29",
  "gherkin",
  "globwalk",
  "humantime",
@@ -2201,7 +2221,7 @@ checksum = "d40d2fdf5e1bb4ae7e6b25c97bf9b9d249a02243fc0fbd91075592b5f00a3bc1"
 dependencies = [
  "derive_more",
  "either",
- "nom 7.1.3",
+ "nom",
  "nom_locate",
  "regex",
  "regex-syntax 0.6.29",
@@ -2218,15 +2238,15 @@ dependencies = [
  "openssl-probe",
  "openssl-sys",
  "schannel",
- "socket2 0.4.9",
+ "socket2 0.4.10",
  "winapi",
 ]
 
 [[package]]
 name = "curl-sys"
-version = "0.4.66+curl-8.3.0"
+version = "0.4.68+curl-8.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70c44a72e830f0e40ad90dda8a6ab6ed6314d39776599a58a2e5e37fbc6db5b9"
+checksum = "b4a0d18d88360e374b16b2273c832b5e57258ffc1d4aa4f96b108e0738d5752f"
 dependencies = [
  "cc",
  "libc",
@@ -2260,7 +2280,8 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "curve25519-dalek-derive",
- "fiat-crypto 0.2.1",
+ "digest 0.10.7",
+ "fiat-crypto 0.2.2",
  "platforms",
  "rustc_version 0.4.0",
  "subtle",
@@ -2269,13 +2290,13 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek-derive"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fdaf97f4804dcebfa5862639bc9ce4121e82140bec2a987ac5140294865b5b"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -2287,16 +2308,6 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
-]
-
-[[package]]
-name = "darling"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d706e75d87e35569db781a9b5e2416cff1236a47ed380831f959382ccd5f858"
-dependencies = [
- "darling_core 0.10.2",
- "darling_macro 0.10.2",
 ]
 
 [[package]]
@@ -2321,20 +2332,6 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c960ae2da4de88a91b2d920c2a7233b400bc33cb28453a2987822d8392519b"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim 0.9.3",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "darling_core"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
@@ -2343,7 +2340,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.10.0",
+ "strsim",
  "syn 1.0.109",
 ]
 
@@ -2357,19 +2354,8 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.10.0",
- "syn 2.0.37",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
-dependencies = [
- "darling_core 0.10.2",
- "quote",
- "syn 1.0.109",
+ "strsim",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -2391,7 +2377,7 @@ checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
 dependencies = [
  "darling_core 0.20.3",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -2401,10 +2387,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
 dependencies = [
  "cfg-if",
- "hashbrown 0.14.1",
+ "hashbrown 0.14.2",
  "lock_api",
  "once_cell",
- "parking_lot_core 0.9.8",
+ "parking_lot_core 0.9.9",
 ]
 
 [[package]]
@@ -2424,23 +2410,23 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6919815d73839e7ad218de758883aae3a257ba6759ce7a9992501efbb53d705c"
-dependencies = [
- "const-oid 0.7.1",
- "crypto-bigint 0.3.2",
- "pem-rfc7468 0.3.1",
-]
-
-[[package]]
-name = "der"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
 dependencies = [
- "const-oid 0.9.5",
+ "const-oid",
  "pem-rfc7468 0.6.0",
+ "zeroize",
+]
+
+[[package]]
+name = "der"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fffa369a668c8af7dbf8b5e56c9f744fbd399949ed171606040001947de40b1c"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468 0.7.0",
  "zeroize",
 ]
 
@@ -2452,7 +2438,7 @@ checksum = "fe398ac75057914d7d07307bf67dc7f3f574a26783b4fc7805a20ffa9f506e82"
 dependencies = [
  "asn1-rs 0.3.1",
  "displaydoc",
- "nom 7.1.3",
+ "nom",
  "num-bigint",
  "num-traits",
  "rusticata-macros",
@@ -2466,7 +2452,7 @@ checksum = "dbd676fbbab537128ef0278adb5576cf363cff6aa22a7b24effe97347cfab61e"
 dependencies = [
  "asn1-rs 0.5.2",
  "displaydoc",
- "nom 7.1.3",
+ "nom",
  "num-bigint",
  "num-traits",
  "rusticata-macros",
@@ -2474,10 +2460,11 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2696e8a945f658fd14dc3b87242e6b80cd0f36ff04ea560fa39082368847946"
+checksum = "0f32d04922c60427da6f9fef14d042d9edddef64cb9d4ce0d64d0685fbeb1fd3"
 dependencies = [
+ "powerfmt",
  "serde",
 ]
 
@@ -2494,23 +2481,10 @@ dependencies = [
 
 [[package]]
 name = "derive-getters"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0122f262bf9c9a367829da84f808d9fb128c10ef283bbe7b0922a77cf07b2747"
+checksum = "7a2c35ab6e03642397cdda1dd58abbc05d418aef8e36297f336d5aba060fe8df"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "derive_builder"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2658621297f2cf68762a6f7dc0bb7e1ff2cfd6583daef8ee0fed6f7ec468ec0"
-dependencies = [
- "darling 0.10.2",
- "derive_builder_core 0.9.0",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -2532,18 +2506,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d67778784b508018359cbc8696edb3db78160bab2c2a28ba7f56ef6932997f8"
 dependencies = [
  "derive_builder_macro 0.12.0",
-]
-
-[[package]]
-name = "derive_builder_core"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2791ea3e372c8495c0bc2033991d76b512cd799d07491fbd6890124db9458bef"
-dependencies = [
- "darling 0.10.2",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -2605,13 +2567,11 @@ dependencies = [
 
 [[package]]
 name = "des"
-version = "0.7.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac41dd49fb554432020d52c875fc290e110113f864c6b1b525cd62c7e7747a5d"
+checksum = "ffdd80ce8ce993de27e9f063a444a4d53ce8e8db4c1f00cc03af5ad5a9867a1e"
 dependencies = [
- "byteorder",
- "cipher 0.3.0",
- "opaque-debug",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -2622,9 +2582,9 @@ checksum = "3c877555693c14d2f84191cfd3ad8582790fc52b5e2274b40b59cf5f5cea25c7"
 
 [[package]]
 name = "diesel"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53c8a2cb22327206568569e5a45bb5a2c946455efdd76e24d15b7e82171af95e"
+checksum = "2268a214a6f118fce1838edba3d1561cf0e78d8de785475957a580a7f8c69d33"
 dependencies = [
  "bigdecimal",
  "chrono",
@@ -2647,7 +2607,7 @@ dependencies = [
  "diesel_table_macro_syntax",
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -2667,7 +2627,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc5557efc453706fed5e4fa85006fe9817c224c3f480a34c7e5959fd700921c5"
 dependencies = [
- "syn 2.0.37",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -2692,6 +2652,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
+ "const-oid",
  "crypto-common",
  "subtle",
 ]
@@ -2755,7 +2716,7 @@ checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -2783,31 +2744,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
 dependencies = [
  "der 0.6.1",
- "elliptic-curve",
- "rfc6979",
- "signature",
+ "elliptic-curve 0.12.3",
+ "rfc6979 0.3.1",
+ "signature 1.6.4",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.16.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4b1e0c257a9e9f25f90ff76d7a68360ed497ee519c8e428d1825ef0000799d4"
+dependencies = [
+ "der 0.7.8",
+ "digest 0.10.7",
+ "elliptic-curve 0.13.6",
+ "rfc6979 0.4.0",
+ "signature 2.1.0",
+ "spki 0.7.2",
 ]
 
 [[package]]
 name = "ed25519"
-version = "1.5.3"
+version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91cff35c70bba8a626e3185d8cd48cc11b5437e1a5bcd15b9b5fa3c64b6dfee7"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
- "signature",
+ "pkcs8 0.10.2",
+ "signature 2.1.0",
 ]
 
 [[package]]
 name = "ed25519-dalek"
-version = "1.0.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
+checksum = "7277392b266383ef8396db7fdeb1e77b6c52fed775f5df15bb24f35b72156980"
 dependencies = [
- "curve25519-dalek 3.2.0",
+ "curve25519-dalek 4.1.1",
  "ed25519",
- "rand 0.7.3",
  "serde",
- "sha2 0.9.9",
+ "sha2",
  "zeroize",
 ]
 
@@ -2823,18 +2798,39 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
 dependencies = [
- "base16ct",
+ "base16ct 0.1.1",
  "crypto-bigint 0.4.9",
  "der 0.6.1",
  "digest 0.10.7",
- "ff",
+ "ff 0.12.1",
  "generic-array",
- "group",
+ "group 0.12.1",
  "hkdf",
  "pem-rfc7468 0.6.0",
  "pkcs8 0.9.0",
  "rand_core 0.6.4",
- "sec1",
+ "sec1 0.3.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d97ca172ae9dc9f9b779a6e3a65d308f2af74e5b8c921299075bdb4a0370e914"
+dependencies = [
+ "base16ct 0.2.0",
+ "crypto-bigint 0.5.3",
+ "digest 0.10.7",
+ "ff 0.13.0",
+ "generic-array",
+ "group 0.13.0",
+ "hkdf",
+ "pem-rfc7468 0.7.0",
+ "pkcs8 0.10.2",
+ "rand_core 0.6.4",
+ "sec1 0.7.3",
  "subtle",
  "zeroize",
 ]
@@ -2903,9 +2899,9 @@ dependencies = [
 
 [[package]]
 name = "enumset"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e875f1719c16de097dee81ed675e2d9bb63096823ed3f0ca827b7dea3028bbbb"
+checksum = "226c0da7462c13fb57e5cc9e0dc8f0635e7d27f276a3a7fd30054647f669007d"
 dependencies = [
  "enumset_derive",
 ]
@@ -2919,7 +2915,7 @@ dependencies = [
  "darling 0.20.3",
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -2930,23 +2926,12 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.3"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "136526188508e25c6fef639d7927dfb3e0e3084488bf202267829cf7fc23dbdd"
+checksum = "ac3e13f66a2f95e32a39eaa81f6b95d42878ca0e1db0c7543723dfe12557e860"
 dependencies = [
- "errno-dragonfly",
  "libc",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
-dependencies = [
- "cc",
- "libc",
 ]
 
 [[package]]
@@ -2955,7 +2940,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
 dependencies = [
- "version_check 0.9.4",
+ "version_check",
 ]
 
 [[package]]
@@ -2976,12 +2961,22 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "event-listener"
-version = "3.0.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29e56284f00d94c1bc7fd3c77027b4623c88c1f53d8d2394c6199f2921dea325"
+checksum = "01cec0252c2afff729ee6f00e903d479fba81784c8e2bd77447673471fdfaea1"
 dependencies = [
  "concurrent-queue",
  "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d96b852f1345da36d551b9473fa1e2b1eb5c5195585c6c018118bc92a8d91160"
+dependencies = [
+ "event-listener 3.0.1",
  "pin-project-lite",
 ]
 
@@ -3031,7 +3026,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "139834ddba373bbdd213dffe02c8d110508dcf1726c2be27e8d1f7d7e1856418"
 dependencies = [
- "arrayvec 0.7.4",
+ "arrayvec",
  "auto_impl",
  "bytes 1.5.0",
 ]
@@ -3043,7 +3038,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef033ed5e9bad94e55838ca0ca906db0e043f517adda0c8b79c7a8c66c93c1b5"
 dependencies = [
  "cfg-if",
- "rustix 0.38.14",
+ "rustix 0.38.21",
  "windows-sys 0.48.0",
 ]
 
@@ -3067,6 +3062,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ff"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "fiat-crypto"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3074,9 +3079,9 @@ checksum = "e825f6987101665dea6ec934c09ec6d721de7bc1bf92248e1d5810c8cd636b77"
 
 [[package]]
 name = "fiat-crypto"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0870c84016d4b481be5c9f323c24f65e31e901ae618f0e80f4308fb00de1d2d"
+checksum = "a481586acf778f1b1455424c343f71124b048ffa5f4fc3f8f6ae9dc432dcb3c7"
 
 [[package]]
 name = "fixed-hash"
@@ -3085,7 +3090,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
 dependencies = [
  "byteorder",
- "rand 0.8.5",
+ "rand",
  "rustc-hex",
  "static_assertions",
 ]
@@ -3098,9 +3103,9 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6c98ee8095e9d1dcbf2fcc6d95acccb90d1c81db1e44725c6a984b1dbdfb010"
+checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -3160,9 +3165,9 @@ checksum = "3a471a38ef8ed83cd6e40aa59c1ffe17db6855c18e3604d9c4ed8c08ebc28678"
 
 [[package]]
 name = "futures"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
+checksum = "da0290714b38af9b4a7b094b8a37086d1b4e61f2df9122c3cad2577669145335"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -3175,9 +3180,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
+checksum = "ff4dd66668b557604244583e3e1e1eada8c5c2e96a6d0d6653ede395b78bbacb"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -3185,15 +3190,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
+checksum = "eb1d22c66e66d9d72e1758f0bd7d4fd0bee04cad842ee34587d68c07e45d088c"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
+checksum = "0f4fb8693db0cf099eadcca0efe2a5a22e4550f98ed16aba6c48700da29597bc"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -3202,9 +3207,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
+checksum = "8bf34a163b5c4c52d0478a4d757da8fb65cabef42ba90515efee0f6f9fa45aaa"
 
 [[package]]
 name = "futures-lite"
@@ -3222,33 +3227,43 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-macro"
-version = "0.3.28"
+name = "futures-lite"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
+checksum = "d3831c2651acb5177cbd83943f3d9c8912c5ad03c76afcc0e9511ba568ec5ebb"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "futures-macro"
+version = "0.3.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53b153fd91e4b0147f4aced87be237c98248656bb01050b96bf3ee89220a8ddb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.39",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
+checksum = "e36d3378ee38c2a36ad710c5d30c2911d752cb941c00c72dbabfb786a7970817"
 
 [[package]]
 name = "futures-task"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
+checksum = "efd193069b0ddadc69c46389b740bbccdd97203899b48d09c5f7969591d6bae2"
 
 [[package]]
 name = "futures-util"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
+checksum = "a19526d624e703a3179b3d322efec918b6246ea0fa51d41124525f00f1cc8104"
 dependencies = [
  "futures 0.1.31",
  "futures-channel",
@@ -3270,7 +3285,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
- "version_check 0.9.4",
+ "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -3410,7 +3426,18 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
 dependencies = [
- "ff",
+ "ff 0.12.1",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff 0.13.0",
  "rand_core 0.6.4",
  "subtle",
 ]
@@ -3430,7 +3457,7 @@ dependencies = [
  "indexmap 1.9.3",
  "slab",
  "tokio",
- "tokio-util 0.7.9",
+ "tokio-util 0.7.10",
  "tracing",
 ]
 
@@ -3460,7 +3487,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 dependencies = [
- "ahash 0.7.6",
+ "ahash 0.7.7",
 ]
 
 [[package]]
@@ -3469,7 +3496,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash 0.7.6",
+ "ahash 0.7.7",
 ]
 
 [[package]]
@@ -3478,14 +3505,14 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
- "ahash 0.8.3",
+ "ahash 0.8.6",
 ]
 
 [[package]]
 name = "hashbrown"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dfda62a12f55daeae5015f81b0baea145391cb4520f86c248fc615d72640d12"
+checksum = "f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156"
 
 [[package]]
 name = "hdrhistogram"
@@ -3496,7 +3523,7 @@ dependencies = [
  "base64 0.13.1",
  "byteorder",
  "flate2",
- "nom 7.1.3",
+ "nom",
  "num-traits",
 ]
 
@@ -3506,7 +3533,7 @@ version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06683b93020a07e3dbcf5f8c0f6d40080d725bea7936fc01ad345c01b97dc270"
 dependencies = [
- "base64 0.21.4",
+ "base64 0.21.5",
  "bytes 1.5.0",
  "headers-core",
  "http",
@@ -3655,7 +3682,7 @@ dependencies = [
  "assert-json-diff",
  "async-object-pool",
  "async-trait",
- "base64 0.21.4",
+ "base64 0.21.5",
  "basic-cookies",
  "crossbeam-utils",
  "form_urlencoded",
@@ -3707,7 +3734,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.9",
+ "socket2 0.4.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -3741,16 +3768,16 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.57"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fad5b825842d2b38bd206f3e81d6957625fd7f0a361e345c30e01a0ae2dd613"
+checksum = "8326b86b6cff230b97d0d312a6c40a60726df3332e721f72a1b035f451663b20"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows",
+ "windows-core",
 ]
 
 [[package]]
@@ -3760,6 +3787,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "idea"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "075557004419d7f2031b8bb7f44bb43e55a83ca7b63076a8fb8fe75753836477"
+dependencies = [
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -3872,12 +3908,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad227c3af19d4914570ad36d30409928b75967c298feb9ea1969db3a610bb14e"
+checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.1",
+ "hashbrown 0.14.2",
 ]
 
 [[package]]
@@ -3921,7 +3957,7 @@ name = "integration_tests"
 version = "0.50.0-pre.0"
 dependencies = [
  "anyhow",
- "base64 0.21.4",
+ "base64 0.21.5",
  "config",
  "cucumber",
  "httpmock",
@@ -3934,7 +3970,7 @@ dependencies = [
  "minotari_node",
  "minotari_node_grpc_client",
  "minotari_wallet",
- "rand 0.8.5",
+ "rand",
  "reqwest",
  "serde",
  "serde_json",
@@ -3976,7 +4012,7 @@ dependencies = [
  "async-trait",
  "bytes 1.5.0",
  "log",
- "rand 0.8.5",
+ "rand",
  "rtcp",
  "rtp 0.6.8",
  "thiserror",
@@ -3988,9 +4024,9 @@ dependencies = [
 
 [[package]]
 name = "inventory"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1be380c410bf0595e94992a648ea89db4dd3f3354ba54af206fd2a68cf5ac8e"
+checksum = "0508c56cfe9bfd5dfeb0c22ab9a6abfda2f27bdca422132e494266351ed8d83c"
 
 [[package]]
 name = "io-lifetimes"
@@ -4014,9 +4050,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28b29a3cd74f0f4598934efe3aeba42bae0eb4680554128851ebbecb02af14e6"
+checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
 name = "is-terminal"
@@ -4025,7 +4061,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
  "hermit-abi 0.3.3",
- "rustix 0.38.14",
+ "rustix 0.38.21",
  "windows-sys 0.48.0",
 ]
 
@@ -4042,12 +4078,12 @@ dependencies = [
  "curl-sys",
  "encoding_rs",
  "event-listener 2.5.3",
- "futures-lite",
+ "futures-lite 1.13.0",
  "http",
  "log",
  "mime",
  "once_cell",
- "polling",
+ "polling 2.8.0",
  "slab",
  "sluice",
  "tracing",
@@ -4104,18 +4140,18 @@ dependencies = [
 
 [[package]]
 name = "jobserver"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2"
+checksum = "8c37f63953c4c63420ed5fd3d6d398c719489b9f872b9fa683262f8edd363c7d"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.64"
+version = "0.3.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
+checksum = "54c0c35952f67de54bb584e9fd912b3023117cbafc0a77d8f3dee1fb5f572fe8"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -4148,9 +4184,9 @@ version = "8.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6971da4d9c3aa03c3d8f3ff0f4155b534aad021292003895a469716b2a230378"
 dependencies = [
- "base64 0.21.4",
+ "base64 0.21.5",
  "pem",
- "ring",
+ "ring 0.16.20",
  "serde",
  "serde_json",
  "simple_asn1",
@@ -4158,9 +4194,9 @@ dependencies = [
 
 [[package]]
 name = "junit-report"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99a97b4b11e561bd6fb6fea12937abef06db0b5e4303be9cd413adc5a7f9e010"
+checksum = "06c3a3342e6720a82d7d179f380e9841b73a1dd49344e33959fdfe571ce56b55"
 dependencies = [
  "derive-getters",
  "quick-xml",
@@ -4250,9 +4286,9 @@ checksum = "db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760"
 
 [[package]]
 name = "libc"
-version = "0.2.148"
+version = "0.2.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
+checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
 
 [[package]]
 name = "libgit2-sys"
@@ -4287,9 +4323,9 @@ dependencies = [
 
 [[package]]
 name = "libm"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
+checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
 name = "libnghttp2-sys"
@@ -4299,6 +4335,17 @@ checksum = "4fae956c192dadcdb5dace96db71fa0b827333cce7c7b38dc71446f024d8a340"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "libredox"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
+dependencies = [
+ "bitflags 2.4.1",
+ "libc",
+ "redox_syscall 0.4.1",
 ]
 
 [[package]]
@@ -4338,9 +4385,9 @@ checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.7"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a9bad9f94746442c783ca431b22403b519cd7fbeed0533fdd6328b2f2212128"
+checksum = "da2479e8c062e40bf0066ffa0bc823de0a9368974af99c9f6df941d2c231e03f"
 
 [[package]]
 name = "liquid"
@@ -4381,7 +4428,7 @@ checksum = "fc2fb41a9bb4257a3803154bdf7e2df7d45197d1941c9b1a90ad815231630721"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -4413,9 +4460,9 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
+checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -4540,17 +4587,6 @@ checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "md-5"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5a279bb9607f9f53c22d496eade00d138d1bdcccd07d74650387cf94942a15"
-dependencies = [
- "block-buffer 0.9.0",
- "digest 0.9.0",
- "opaque-debug",
-]
-
-[[package]]
-name = "md-5"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
@@ -4561,9 +4597,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.6.3"
+version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c"
+checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
 name = "memmap2"
@@ -4673,8 +4709,8 @@ dependencies = [
 
 [[package]]
 name = "minotari_app_grpc"
-version = "0.52.0-dan.1"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#edfcb5c204a2e6a371aeb594207ebdd3977811cc"
+version = "0.52.0-dan.6"
+source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#ae10c6398768632cc032fb58a073551ddcba6d65"
 dependencies = [
  "argon2",
  "base64 0.13.1",
@@ -4683,13 +4719,13 @@ dependencies = [
  "log",
  "prost 0.9.0",
  "prost-types 0.9.0",
- "rand 0.8.5",
+ "rand",
  "tari_common_types",
  "tari_comms",
  "tari_core",
  "tari_crypto",
  "tari_script",
- "tari_utilities 0.5.1",
+ "tari_utilities",
  "thiserror",
  "tonic 0.6.2",
  "tonic-build",
@@ -4698,30 +4734,30 @@ dependencies = [
 
 [[package]]
 name = "minotari_app_utilities"
-version = "0.52.0-dan.1"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#edfcb5c204a2e6a371aeb594207ebdd3977811cc"
+version = "0.52.0-dan.6"
+source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#ae10c6398768632cc032fb58a073551ddcba6d65"
 dependencies = [
  "clap 3.2.25",
- "futures 0.3.28",
+ "futures 0.3.29",
  "json5 0.4.1",
  "log",
- "rand 0.8.5",
+ "rand",
  "serde",
  "tari_common",
  "tari_common_types",
  "tari_comms",
  "tari_features",
- "tari_utilities 0.5.1",
+ "tari_utilities",
  "thiserror",
  "tokio",
 ]
 
 [[package]]
 name = "minotari_console_wallet"
-version = "0.52.0-dan.1"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#edfcb5c204a2e6a371aeb594207ebdd3977811cc"
+version = "0.52.0-dan.6"
+source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#ae10c6398768632cc032fb58a073551ddcba6d65"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.1",
  "blake2",
  "chrono",
  "clap 3.2.25",
@@ -4729,21 +4765,21 @@ dependencies = [
  "console-subscriber",
  "crossterm 0.25.0",
  "digest 0.10.7",
- "futures 0.3.28",
+ "futures 0.3.29",
  "log",
  "log4rs 1.2.0 (git+https://github.com/tari-project/log4rs.git)",
  "minotari_app_grpc",
  "minotari_app_utilities",
  "minotari_wallet",
  "qrcode",
- "rand 0.8.5",
+ "rand",
  "regex",
  "reqwest",
  "rpassword",
  "rustyline",
  "serde",
  "serde_json",
- "sha2 0.10.8",
+ "sha2",
  "strum",
  "strum_macros",
  "tari_common",
@@ -4758,7 +4794,7 @@ dependencies = [
  "tari_p2p",
  "tari_script",
  "tari_shutdown",
- "tari_utilities 0.5.1",
+ "tari_utilities",
  "thiserror",
  "tokio",
  "tonic 0.6.2",
@@ -4772,8 +4808,8 @@ dependencies = [
 
 [[package]]
 name = "minotari_node"
-version = "0.52.0-dan.1"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#edfcb5c204a2e6a371aeb594207ebdd3977811cc"
+version = "0.52.0-dan.6"
+source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#ae10c6398768632cc032fb58a073551ddcba6d65"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4786,13 +4822,13 @@ dependencies = [
  "crossterm 0.23.2",
  "derive_more",
  "either",
- "futures 0.3.28",
+ "futures 0.3.29",
  "log",
  "log-mdc",
  "log4rs 1.2.0 (git+https://github.com/tari-project/log4rs.git)",
  "minotari_app_grpc",
  "minotari_app_utilities",
- "nom 7.1.3",
+ "nom",
  "qrcode",
  "rustyline",
  "rustyline-derive",
@@ -4810,7 +4846,7 @@ dependencies = [
  "tari_service_framework",
  "tari_shutdown",
  "tari_storage",
- "tari_utilities 0.5.1",
+ "tari_utilities",
  "thiserror",
  "tokio",
  "tonic 0.6.2",
@@ -4819,15 +4855,15 @@ dependencies = [
 [[package]]
 name = "minotari_node_grpc_client"
 version = "0.1.0"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#edfcb5c204a2e6a371aeb594207ebdd3977811cc"
+source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#ae10c6398768632cc032fb58a073551ddcba6d65"
 dependencies = [
  "minotari_app_grpc",
 ]
 
 [[package]]
 name = "minotari_wallet"
-version = "0.52.0-dan.1"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#edfcb5c204a2e6a371aeb594207ebdd3977811cc"
+version = "0.52.0-dan.6"
+source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#ae10c6398768632cc032fb58a073551ddcba6d65"
 dependencies = [
  "argon2",
  "async-trait",
@@ -4841,15 +4877,15 @@ dependencies = [
  "diesel_migrations",
  "digest 0.10.7",
  "fs2",
- "futures 0.3.28",
+ "futures 0.3.29",
  "itertools 0.10.5",
  "libsqlite3-sys",
  "log",
  "prost 0.9.0",
- "rand 0.8.5",
+ "rand",
  "serde",
  "serde_json",
- "sha2 0.10.8",
+ "sha2",
  "strum",
  "strum_macros",
  "tari_common",
@@ -4865,7 +4901,7 @@ dependencies = [
  "tari_script",
  "tari_service_framework",
  "tari_shutdown",
- "tari_utilities 0.5.1",
+ "tari_utilities",
  "tempfile",
  "thiserror",
  "tokio",
@@ -4876,7 +4912,7 @@ dependencies = [
 [[package]]
 name = "minotari_wallet_grpc_client"
 version = "0.1.0"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#edfcb5c204a2e6a371aeb594207ebdd3977811cc"
+source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#ae10c6398768632cc032fb58a073551ddcba6d65"
 dependencies = [
  "minotari_app_grpc",
  "tari_common_types",
@@ -4899,9 +4935,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
+checksum = "3dce281c5e46beae905d4de1870d8b1509a9142b62eedf18b443b011ca8343d0"
 dependencies = [
  "libc",
  "log",
@@ -4956,7 +4992,7 @@ dependencies = [
  "memchr",
  "mime",
  "spin 0.9.8",
- "version_check 0.9.4",
+ "version_check",
 ]
 
 [[package]]
@@ -5080,16 +5116,6 @@ checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "nom"
-version = "4.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
-dependencies = [
- "memchr",
- "version_check 0.1.5",
-]
-
-[[package]]
-name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
@@ -5106,7 +5132,7 @@ checksum = "1e3c83c053b0713da60c5b8de47fe8e494fe3ece5267b2f23090a07a053ba8f3"
 dependencies = [
  "bytecount",
  "memchr",
- "nom 7.1.3",
+ "nom",
 ]
 
 [[package]]
@@ -5141,7 +5167,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.5",
+ "rand",
  "serde",
  "smallvec",
  "zeroize",
@@ -5159,12 +5185,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-derive"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfb77679af88f8b125209d354a202862602672222e7f2313fdd6dc349bad4712"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+]
+
+[[package]]
 name = "num-format"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
 dependencies = [
- "arrayvec 0.7.4",
+ "arrayvec",
  "itoa",
 ]
 
@@ -5202,9 +5239,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
+checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
 dependencies = [
  "autocfg",
  "libm",
@@ -5277,11 +5314,11 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.57"
+version = "0.10.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bac25ee399abb46215765b1cb35bc0212377e58a061560d8b29b024fd0430e7c"
+checksum = "7a257ad03cd8fb16ad4172fedf8094451e1af1c4b70097636ef2eac9a5f0cc33"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags 2.4.1",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -5298,7 +5335,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -5309,9 +5346,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.93"
+version = "0.9.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db4d56a4c0478783083cfafcc42493dd4a981d41669da64b4572a2a089b51b1d"
+checksum = "40a4130519a360279579c2053038317e40eff64d13fd3f004f9e1b72b8a6aaf9"
 dependencies = [
  "cc",
  "libc",
@@ -5321,9 +5358,9 @@ dependencies = [
 
 [[package]]
 name = "ordered-float"
-version = "2.10.0"
+version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7940cf2ca942593318d07fcf2596cdca60a85c9e7fab408a5e21a4f9dcd40d87"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
 dependencies = [
  "num-traits",
 ]
@@ -5340,9 +5377,9 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "6.5.1"
+version = "6.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d5d9eb14b174ee9aa2ef96dc2b94637a2d4b6e7cb873c7e171f0c20c6cf3eac"
+checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
 
 [[package]]
 name = "p256"
@@ -5350,9 +5387,21 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51f44edd08f51e2ade572f141051021c5af22677e42b7dd28a88155151c33594"
 dependencies = [
- "ecdsa",
- "elliptic-curve",
- "sha2 0.10.8",
+ "ecdsa 0.14.8",
+ "elliptic-curve 0.12.3",
+ "sha2",
+]
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa 0.16.8",
+ "elliptic-curve 0.13.6",
+ "primeorder",
+ "sha2",
 ]
 
 [[package]]
@@ -5361,9 +5410,21 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfc8c5bf642dde52bb9e87c0ecd8ca5a76faac2eeed98dedb7c717997e1080aa"
 dependencies = [
- "ecdsa",
- "elliptic-curve",
- "sha2 0.10.8",
+ "ecdsa 0.14.8",
+ "elliptic-curve 0.12.3",
+ "sha2",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70786f51bcc69f6a4c0360e063a4cac5419ef7c5cd5b3c99ad70f3be5ba79209"
+dependencies = [
+ "ecdsa 0.16.8",
+ "elliptic-curve 0.13.6",
+ "primeorder",
+ "sha2",
 ]
 
 [[package]]
@@ -5372,7 +5433,7 @@ version = "3.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dec8a8073036902368c2cdc0387e85ff9a37054d7e7c98e592145e0c92cd4fb"
 dependencies = [
- "arrayvec 0.7.4",
+ "arrayvec",
  "bitvec",
  "byte-slice-cast",
  "impl-trait-for-tuples",
@@ -5394,9 +5455,9 @@ dependencies = [
 
 [[package]]
 name = "parking"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e52c774a4c39359c1d1c52e43f73dd91a75a614652c825408eec30c95a9b2067"
+checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
 
 [[package]]
 name = "parking_lot"
@@ -5416,7 +5477,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.8",
+ "parking_lot_core 0.9.9",
 ]
 
 [[package]]
@@ -5435,13 +5496,13 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
+checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.3.5",
+ "redox_syscall 0.4.1",
  "smallvec",
  "windows-targets 0.48.5",
 ]
@@ -5513,18 +5574,18 @@ dependencies = [
 
 [[package]]
 name = "pem-rfc7468"
-version = "0.3.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01de5d978f34aa4b2296576379fcc416034702fd94117c56ffd8a1a767cefb30"
+checksum = "24d159833a9105500e0398934e205e0773f0b27529557134ecfc51c27646adac"
 dependencies = [
  "base64ct",
 ]
 
 [[package]]
 name = "pem-rfc7468"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d159833a9105500e0398934e205e0773f0b27529557134ecfc51c27646adac"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
 dependencies = [
  "base64ct",
 ]
@@ -5537,9 +5598,9 @@ checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pest"
-version = "2.7.4"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c022f1e7b65d6a24c0dbbd5fb344c66881bc01f3e5ae74a1c8100f2f985d98a4"
+checksum = "ae9cee2a55a544be8b89dc6848072af97a20f2422603c10865be2a42b580fff5"
 dependencies = [
  "memchr",
  "thiserror",
@@ -5548,9 +5609,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.7.4"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35513f630d46400a977c4cb58f78e1bfbe01434316e60c37d27b9ad6139c66d8"
+checksum = "81d78524685f5ef2a3b3bd1cafbc9fcabb036253d9b1463e726a91cd16e2dfc2"
 dependencies = [
  "pest",
  "pest_generator",
@@ -5558,26 +5619,26 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.4"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc9fc1b9e7057baba189b5c626e2d6f40681ae5b6eb064dc7c7834101ec8123a"
+checksum = "68bd1206e71118b5356dae5ddc61c8b11e28b09ef6a31acbd15ea48a28e0c227"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.39",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.7.4"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1df74e9e7ec4053ceb980e7c0c8bd3594e977fde1af91daba9c928e8e8c6708d"
+checksum = "7c747191d4ad9e4a4ab9c8798f1e82a39affe7ef9648390b7e5548d18e099de6"
 dependencies = [
  "once_cell",
  "pest",
- "sha2 0.10.8",
+ "sha2",
 ]
 
 [[package]]
@@ -5587,55 +5648,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
- "indexmap 2.0.1",
+ "indexmap 2.1.0",
 ]
 
 [[package]]
 name = "pgp"
-version = "0.8.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0c63db779c3f090b540dfa0484f8adc2d380e3aa60cdb0f3a7a97454e22edc5"
+checksum = "27e1f8e085bfa9b85763fe3ddaacbe90a09cd847b3833129153a6cb063bbe132"
 dependencies = [
- "aes 0.7.5",
- "base64 0.13.1",
+ "aes 0.8.3",
+ "base64 0.21.5",
  "bitfield",
- "block-modes 0.8.1",
- "block-padding",
+ "block-padding 0.3.3",
  "blowfish",
- "buf_redux",
+ "bstr",
+ "buffer-redux",
  "byteorder",
+ "camellia",
  "cast5",
  "cfb-mode",
  "chrono",
- "cipher 0.3.0",
- "circular",
- "clear_on_drop",
+ "cipher 0.4.4",
  "crc24",
- "derive_builder 0.9.0",
+ "curve25519-dalek 4.1.1",
+ "derive_builder 0.12.0",
  "des",
- "digest 0.9.0",
+ "digest 0.10.7",
  "ed25519-dalek",
+ "elliptic-curve 0.13.6",
  "flate2",
  "generic-array",
  "hex",
- "lazy_static",
+ "idea",
  "log",
- "md-5 0.9.1",
- "nom 4.2.3",
+ "md-5",
+ "nom",
  "num-bigint-dig",
- "num-derive",
+ "num-derive 0.4.1",
  "num-traits",
- "rand 0.8.5",
- "ripemd160",
+ "p256 0.13.2",
+ "p384 0.13.0",
+ "rand",
+ "ripemd",
  "rsa",
- "sha-1",
- "sha2 0.9.9",
- "sha3 0.9.1",
- "signature",
+ "sha1",
+ "sha2",
+ "sha3",
+ "signature 2.1.0",
  "smallvec",
  "thiserror",
  "twofish",
- "x25519-dalek 1.1.1",
+ "x25519-dalek",
  "zeroize",
 ]
 
@@ -5685,7 +5749,7 @@ checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -5713,24 +5777,13 @@ dependencies = [
 
 [[package]]
 name = "pkcs1"
-version = "0.3.3"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a78f66c04ccc83dd4486fd46c33896f4e17b24a7a3a6400dedc48ed0ddd72320"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
 dependencies = [
- "der 0.5.1",
- "pkcs8 0.8.0",
- "zeroize",
-]
-
-[[package]]
-name = "pkcs8"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cabda3fb821068a9a4fab19a683eac3af12edf0f34b94a8be53c4972b8149d0"
-dependencies = [
- "der 0.5.1",
- "spki 0.5.4",
- "zeroize",
+ "der 0.7.8",
+ "pkcs8 0.10.2",
+ "spki 0.7.2",
 ]
 
 [[package]]
@@ -5744,6 +5797,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der 0.7.8",
+ "spki 0.7.2",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5751,9 +5814,9 @@ checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
 name = "platforms"
-version = "3.1.2"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4503fa043bf02cee09a9582e9554b4c6403b2ef55e4612e96561d294419429f8"
+checksum = "14e6ab3f592e6fb464fc9712d8d6e6912de6473954635fd76a589d832cffcbb0"
 
 [[package]]
 name = "polling"
@@ -5768,6 +5831,20 @@ dependencies = [
  "libc",
  "log",
  "pin-project-lite",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "polling"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e53b6af1f60f36f8c2ac2aad5459d75a5a9b4be1e8cdd40264f315d78193e531"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "pin-project-lite",
+ "rustix 0.38.21",
+ "tracing",
  "windows-sys 0.48.0",
 ]
 
@@ -5818,6 +5895,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5830,10 +5913,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
-name = "primitive-types"
-version = "0.12.1"
+name = "primeorder"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f3486ccba82358b11a77516035647c34ba167dfa53312630de83b12bd4f3d66"
+checksum = "c7dbe9ed3b56368bd99483eb32fe9c17fdd3730aebadc906918ce78d54c7eeb4"
+dependencies = [
+ "elliptic-curve 0.13.6",
+]
+
+[[package]]
+name = "primitive-types"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
 dependencies = [
  "fixed-hash",
  "impl-codec",
@@ -5869,7 +5961,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
- "version_check 0.9.4",
+ "version_check",
 ]
 
 [[package]]
@@ -5880,14 +5972,14 @@ checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
  "proc-macro2",
  "quote",
- "version_check 0.9.4",
+ "version_check",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.67"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
+checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
 dependencies = [
  "unicode-ident",
 ]
@@ -5909,18 +6001,17 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "1.2.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e35c06b98bf36aba164cc17cb25f7e232f5c4aeea73baa14b8a9f0d92dbfa65"
+checksum = "7c003ac8c77cb07bb74f5f198bce836a689bcd5a42574612bf14d17bfd08c20e"
 dependencies = [
- "bitflags 1.3.2",
- "byteorder",
+ "bitflags 2.4.1",
  "lazy_static",
  "num-traits",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
+ "rand",
+ "rand_chacha",
  "rand_xorshift",
- "regex-syntax 0.6.29",
+ "regex-syntax 0.7.5",
  "unarray",
 ]
 
@@ -6064,9 +6155,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
-version = "0.26.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f50b1c63b38611e7d4d7f68b82d3ad0cc71a2ad2e7f61fc10f1328d917c93cd"
+checksum = "1004a344b30a54e2ee58d66a71b32d2db2feb0a31f9a2d302bf0536f15de2a33"
 dependencies = [
  "memchr",
 ]
@@ -6109,36 +6200,13 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom 0.1.16",
- "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
+ "rand_chacha",
  "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -6170,15 +6238,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
-]
-
-[[package]]
 name = "rand_xorshift"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6189,9 +6248,9 @@ dependencies = [
 
 [[package]]
 name = "randomx-rs"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebdae2c085f3467f5681c26d3e835ca89a022b18c84c777d69e12c9100176f98"
+checksum = "14fb999f322669968fd0e80aeca5cb91e7a817a94ebf2b0fcd345a4a7c695203"
 dependencies = [
  "bitflags 1.3.2",
  "libc",
@@ -6225,7 +6284,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffbe84efe2f38dea12e9bfc1f65377fdf03e53a18cb3b995faedf7934c7e785b"
 dependencies = [
  "pem",
- "ring",
+ "ring 0.16.20",
  "time",
  "x509-parser 0.14.0",
  "yasna",
@@ -6242,21 +6301,21 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.3.5"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
  "bitflags 1.3.2",
 ]
 
 [[package]]
 name = "redox_users"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+checksum = "a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4"
 dependencies = [
  "getrandom 0.2.10",
- "redox_syscall 0.2.16",
+ "libredox",
  "thiserror",
 ]
 
@@ -6273,14 +6332,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.9.5"
+version = "1.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "697061221ea1b4a94a624f67d0ae2bfe4e22b8a17b6a192afb11046542cc8c47"
+checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.3.8",
- "regex-syntax 0.7.5",
+ "regex-automata 0.4.3",
+ "regex-syntax 0.8.2",
 ]
 
 [[package]]
@@ -6294,13 +6353,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.8"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2f401f4955220693b56f8ec66ee9c78abffd8d1c4f23dc41a23839eb88f0795"
+checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.7.5",
+ "regex-syntax 0.8.2",
 ]
 
 [[package]]
@@ -6314,6 +6373,12 @@ name = "regex-syntax"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "region"
@@ -6338,11 +6403,11 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.20"
+version = "0.11.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e9ad3fe7488d7e34558a2033d45a0c90b72d97b4f80705666fea71472e2e6a1"
+checksum = "046cd98826c46c2ac8ddecae268eb5c2e58628688a5fc7a2643704a73faba95b"
 dependencies = [
- "base64 0.21.4",
+ "base64 0.21.5",
  "bytes 1.5.0",
  "encoding_rs",
  "futures-core",
@@ -6363,6 +6428,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
+ "system-configuration",
  "tokio",
  "tokio-native-tls",
  "tower-service",
@@ -6385,6 +6451,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac 0.12.1",
+ "subtle",
+]
+
+[[package]]
 name = "ring"
 version = "0.16.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6394,20 +6470,32 @@ dependencies = [
  "libc",
  "once_cell",
  "spin 0.5.2",
- "untrusted",
+ "untrusted 0.7.1",
  "web-sys",
  "winapi",
 ]
 
 [[package]]
-name = "ripemd160"
-version = "0.9.1"
+name = "ring"
+version = "0.17.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eca4ecc81b7f313189bf73ce724400a07da2a6dac19588b03c8bd76a2dcc251"
+checksum = "fb0205304757e5d899b9c2e448b867ffd03ae7f988002e47cd24954391394d0b"
 dependencies = [
- "block-buffer 0.9.0",
- "digest 0.9.0",
- "opaque-debug",
+ "cc",
+ "getrandom 0.2.10",
+ "libc",
+ "spin 0.9.8",
+ "untrusted 0.9.0",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "ripemd"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
+dependencies = [
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -6424,7 +6512,7 @@ dependencies = [
  "rkyv_derive",
  "seahash",
  "tinyvec",
- "uuid 1.4.1",
+ "uuid 1.5.0",
 ]
 
 [[package]]
@@ -6471,20 +6559,20 @@ dependencies = [
 
 [[package]]
 name = "rsa"
-version = "0.6.1"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cf22754c49613d2b3b119f0e5d46e34a2c628a937e3024b8762de4e7d8c710b"
+checksum = "86ef35bf3e7fe15a53c4ab08a998e42271eab13eb0db224126bc7bc4c4bad96d"
 dependencies = [
- "byteorder",
+ "const-oid",
  "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
- "num-iter",
  "num-traits",
  "pkcs1",
- "pkcs8 0.8.0",
+ "pkcs8 0.10.2",
  "rand_core 0.6.4",
- "smallvec",
+ "signature 2.1.0",
+ "spki 0.7.2",
  "subtle",
  "zeroize",
 ]
@@ -6508,7 +6596,7 @@ checksum = "a2a095411ff00eed7b12e4c6a118ba984d113e1079582570d56a5ee723f11f80"
 dependencies = [
  "async-trait",
  "bytes 1.5.0",
- "rand 0.8.5",
+ "rand",
  "serde",
  "thiserror",
  "webrtc-util",
@@ -6521,7 +6609,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b728adb99b88d932f2f0622b540bf7ccb196f81e9823b5b0eeb166526c88138c"
 dependencies = [
  "bytes 1.5.0",
- "rand 0.8.5",
+ "rand",
  "serde",
  "thiserror",
  "webrtc-util",
@@ -6529,9 +6617,9 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95294d6e3a6192f3aabf91c38f56505a625aa495533442744185a36d75a790c4"
+checksum = "724fd11728a3804e9944b14cab63825024c40bf42f8af87c8b5d97c4bbacf426"
 dependencies = [
  "alloy-rlp",
  "ark-ff 0.3.0",
@@ -6539,10 +6627,11 @@ dependencies = [
  "bytes 1.5.0",
  "fastrlp",
  "num-bigint",
+ "num-traits",
  "parity-scale-codec",
  "primitive-types",
  "proptest",
- "rand 0.8.5",
+ "rand",
  "rlp",
  "ruint-macro",
  "serde",
@@ -6599,7 +6688,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.19",
+ "semver 1.0.20",
 ]
 
 [[package]]
@@ -6608,14 +6697,14 @@ version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
 dependencies = [
- "nom 7.1.3",
+ "nom",
 ]
 
 [[package]]
 name = "rustix"
-version = "0.37.23"
+version = "0.37.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d69718bf81c6127a49dc64e44a742e8bb9213c0ff8869a22c308f84c1d4ab06"
+checksum = "fea8ca367a3a01fe35e6943c400addf443c0f57670e6ec51196f71a4b8762dd2"
 dependencies = [
  "bitflags 1.3.2",
  "errno",
@@ -6627,14 +6716,14 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.14"
+version = "0.38.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "747c788e9ce8e92b12cd485c49ddf90723550b654b32508f979b71a7b1ecda4f"
+checksum = "2b426b0506e5d50a7d8dafcf2e81471400deb602392c7dd110815afb4eaf02a3"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags 2.4.1",
  "errno",
  "libc",
- "linux-raw-sys 0.4.7",
+ "linux-raw-sys 0.4.10",
  "windows-sys 0.48.0",
 ]
 
@@ -6646,7 +6735,7 @@ checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
 dependencies = [
  "base64 0.13.1",
  "log",
- "ring",
+ "ring 0.16.20",
  "sct 0.6.1",
  "webpki 0.21.4",
 ]
@@ -6658,9 +6747,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b80e3dec595989ea8510028f30c408a4630db12c9cbb8de34203b89d6577e99"
 dependencies = [
  "log",
- "ring",
- "sct 0.7.0",
- "webpki 0.22.1",
+ "ring 0.16.20",
+ "sct 0.7.1",
+ "webpki 0.22.4",
 ]
 
 [[package]]
@@ -6678,7 +6767,7 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d3987094b1d07b653b7dfdc3f70ce9a1da9c51ac18c1b06b662e4f9a0e9f4b2"
 dependencies = [
- "base64 0.21.4",
+ "base64 0.21.5",
 ]
 
 [[package]]
@@ -6778,18 +6867,18 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
 dependencies = [
- "ring",
- "untrusted",
+ "ring 0.16.20",
+ "untrusted 0.7.1",
 ]
 
 [[package]]
 name = "sct"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
- "ring",
- "untrusted",
+ "ring 0.17.5",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -6798,7 +6887,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d22a5ef407871893fd72b4562ee15e4742269b173959db4b8df6f538c414e13"
 dependencies = [
- "rand 0.8.5",
+ "rand",
  "substring",
  "thiserror",
  "url",
@@ -6840,10 +6929,24 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
 dependencies = [
- "base16ct",
+ "base16ct 0.1.1",
  "der 0.6.1",
  "generic-array",
  "pkcs8 0.9.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct 0.2.0",
+ "der 0.7.8",
+ "generic-array",
+ "pkcs8 0.10.2",
  "subtle",
  "zeroize",
 ]
@@ -6882,9 +6985,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad977052201c6de01a8ef2aa3378c4bd23217a056337d1d6da40468d267a4fb0"
+checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
 dependencies = [
  "serde",
 ]
@@ -6900,9 +7003,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.188"
+version = "1.0.192"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
+checksum = "bca2a08484b285dcb282d0f67b26cadc0df8b19f8c12502c13d966bf9482f001"
 dependencies = [
  "serde_derive",
 ]
@@ -6937,20 +7040,20 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.188"
+version = "1.0.192"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
+checksum = "d6c7207fbec9faa48073f3e3074cbe553af6ea512d7c21ba46e434e70ea9fbc1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.39",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.107"
+version = "1.0.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
+checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
 dependencies = [
  "itoa",
  "ryu",
@@ -6979,20 +7082,20 @@ dependencies = [
 
 [[package]]
 name = "serde_repr"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8725e1dfadb3a50f7e5ce0b1a540466f6ed3fe7a0fca2ac2b8b831d31316bd00"
+checksum = "3081f5ffbb02284dda55132aa26daecedd7372a42417bbbab6f14ab7d6bb9145"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.39",
 ]
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96426c9936fd7a0124915f9185ea1d20aa9445cc9821142f0a73bc9207a2e186"
+checksum = "12022b835073e5b11e90a14f86838ceb1c8fb0325b72416845c487ac0fa95e80"
 dependencies = [
  "serde",
 ]
@@ -7034,7 +7137,7 @@ dependencies = [
  "darling 0.20.3",
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -7051,11 +7154,11 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.25"
+version = "0.9.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a49e178e4452f45cb61d0cd8cebc1b0fafd3e41929e996cef79aa3aca91f574"
+checksum = "3cc7a1570e38322cfe4154732e5110f887ea57e22b76f4bfd32b5bdd3368666c"
 dependencies = [
- "indexmap 2.0.1",
+ "indexmap 2.1.0",
  "itoa",
  "ryu",
  "serde",
@@ -7088,19 +7191,6 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
-dependencies = [
- "block-buffer 0.9.0",
- "cfg-if",
- "cpufeatures",
- "digest 0.9.0",
- "opaque-debug",
-]
-
-[[package]]
-name = "sha2"
 version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
@@ -7108,18 +7198,6 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest 0.10.7",
-]
-
-[[package]]
-name = "sha3"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f81199417d4e5de3f04b1e871023acea7389672c4135918f05aa9cbf2f2fa809"
-dependencies = [
- "block-buffer 0.9.0",
- "digest 0.9.0",
- "keccak",
- "opaque-debug",
 ]
 
 [[package]]
@@ -7134,9 +7212,9 @@ dependencies = [
 
 [[package]]
 name = "sharded-slab"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1b21f559e07218024e7e9f90f96f601825397de0e25420135f7f952453fed0b"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
@@ -7159,7 +7237,7 @@ checksum = "29ad2e15f37ec9a6cc544097b78a1ec90001e9f71b81338ca39f430adaca99af"
 dependencies = [
  "libc",
  "mio 0.7.14",
- "mio 0.8.8",
+ "mio 0.8.9",
  "signal-hook",
 ]
 
@@ -7183,6 +7261,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e1788eed21689f9cf370582dfc467ef36ed9c707f073528ddafa8d83e3b8500"
+dependencies = [
+ "digest 0.10.7",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "simdutf8"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7190,9 +7278,9 @@ checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
 
 [[package]]
 name = "similar"
-version = "2.2.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "420acb44afdae038210c99e69aae24109f32f15500aa708e81d46c9f29d55fcf"
+checksum = "2aeaf503862c419d66959f5d7ca015337d864e9c49485d771b732e2a20453597"
 
 [[package]]
 name = "simple_asn1"
@@ -7302,15 +7390,15 @@ dependencies = [
  "curve25519-dalek 4.1.1",
  "rand_core 0.6.4",
  "rustc_version 0.4.0",
- "sha2 0.10.8",
+ "sha2",
  "subtle",
 ]
 
 [[package]]
 name = "socket2"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
+checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
 dependencies = [
  "libc",
  "winapi",
@@ -7318,9 +7406,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4031e820eb552adee9295814c0ced9e5cf38ddf1e8b7d566d6de8e2538ea989e"
+checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
 dependencies = [
  "libc",
  "windows-sys 0.48.0",
@@ -7340,22 +7428,22 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "spki"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d01ac02a6ccf3e07db148d2be087da624fea0221a16152ed01f0496a6b0a27"
-dependencies = [
- "base64ct",
- "der 0.5.1",
-]
-
-[[package]]
-name = "spki"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
 dependencies = [
  "base64ct",
  "der 0.6.1",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1e996ef02c474957d681f1b05213dfb0abab947b446a62d37770b23500184a"
+dependencies = [
+ "base64ct",
+ "der 0.7.8",
 ]
 
 [[package]]
@@ -7403,18 +7491,12 @@ dependencies = [
 
 [[package]]
 name = "strip-ansi-escapes"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "011cbb39cf7c1f62871aea3cc46e5817b0937b49e9447370c93cacbe93a766d8"
+checksum = "55ff8ef943b384c414f54aefa961dd2bd853add74ec75e7ac74cf91dba62bcfa"
 dependencies = [
  "vte",
 ]
-
-[[package]]
-name = "strsim"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
 
 [[package]]
 name = "strsim"
@@ -7476,9 +7558,9 @@ dependencies = [
  "base64 0.13.1",
  "crc",
  "lazy_static",
- "md-5 0.10.6",
- "rand 0.8.5",
- "ring",
+ "md-5",
+ "rand",
+ "ring 0.16.20",
  "subtle",
  "thiserror",
  "tokio",
@@ -7520,9 +7602,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.37"
+version = "2.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7303ef2c05cd654186cb250d29049a24840ca25d2747c25c0381c8d9e2f582e8"
+checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7581,6 +7663,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "tagptr"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7594,9 +7697,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.11"
+version = "0.12.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d0e916b1148c8e263850e1ebcbd046f333e0683c724876bb0da63ea4373dc8a"
+checksum = "14c39fd04924ca3a864207c66fc2cd7d22d7c016007f9ce846cbb9326331930a"
 
 [[package]]
 name = "tari-curve25519-dalek"
@@ -7629,7 +7732,7 @@ dependencies = [
  "tari_core",
  "tari_dan_common_types",
  "tari_engine_types",
- "tari_utilities 0.5.1",
+ "tari_utilities",
  "thiserror",
  "tonic 0.6.2",
 ]
@@ -7658,10 +7761,10 @@ dependencies = [
  "itertools 0.6.5",
  "lazy_static",
  "merlin",
- "rand 0.8.5",
+ "rand",
  "rand_core 0.6.4",
  "serde",
- "sha3 0.10.8",
+ "sha3",
  "tari-curve25519-dalek",
  "thiserror",
  "zeroize",
@@ -7669,8 +7772,8 @@ dependencies = [
 
 [[package]]
 name = "tari_common"
-version = "0.52.0-dan.1"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#edfcb5c204a2e6a371aeb594207ebdd3977811cc"
+version = "0.52.0-dan.6"
+source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#ae10c6398768632cc032fb58a073551ddcba6d65"
 dependencies = [
  "anyhow",
  "blake2",
@@ -7684,8 +7787,8 @@ dependencies = [
  "prost-build",
  "serde",
  "serde_json",
- "serde_yaml 0.9.25",
- "sha2 0.10.8",
+ "serde_yaml 0.9.27",
+ "sha2",
  "structopt",
  "tari_crypto",
  "tari_features",
@@ -7696,47 +7799,47 @@ dependencies = [
 
 [[package]]
 name = "tari_common_sqlite"
-version = "0.52.0-dan.1"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#edfcb5c204a2e6a371aeb594207ebdd3977811cc"
+version = "0.52.0-dan.6"
+source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#ae10c6398768632cc032fb58a073551ddcba6d65"
 dependencies = [
  "diesel",
  "diesel_migrations",
  "log",
  "serde",
- "tari_utilities 0.5.1",
+ "tari_utilities",
  "thiserror",
  "tokio",
 ]
 
 [[package]]
 name = "tari_common_types"
-version = "0.52.0-dan.1"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#edfcb5c204a2e6a371aeb594207ebdd3977811cc"
+version = "0.52.0-dan.6"
+source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#ae10c6398768632cc032fb58a073551ddcba6d65"
 dependencies = [
- "base64 0.21.4",
+ "base64 0.21.5",
  "blake2",
  "borsh",
  "chacha20poly1305 0.10.1",
  "digest 0.10.7",
  "lazy_static",
  "newtype-ops",
- "rand 0.8.5",
+ "rand",
  "serde",
  "tari_common",
  "tari_crypto",
- "tari_utilities 0.5.1",
+ "tari_utilities",
  "thiserror",
  "tokio",
 ]
 
 [[package]]
 name = "tari_comms"
-version = "0.52.0-dan.1"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#edfcb5c204a2e6a371aeb594207ebdd3977811cc"
+version = "0.52.0-dan.6"
+source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#ae10c6398768632cc032fb58a073551ddcba6d65"
 dependencies = [
  "anyhow",
  "async-trait",
- "bitflags 1.3.2",
+ "bitflags 2.4.1",
  "blake2",
  "bytes 1.5.0",
  "chrono",
@@ -7744,27 +7847,27 @@ dependencies = [
  "data-encoding",
  "derivative",
  "digest 0.10.7",
- "futures 0.3.28",
+ "futures 0.3.29",
  "lazy_static",
  "lmdb-zero",
  "log",
  "log-mdc",
  "multiaddr",
- "nom 7.1.3",
+ "nom",
  "once_cell",
  "pin-project 1.1.3",
  "prost 0.9.0",
- "rand 0.8.5",
+ "rand",
  "serde",
  "serde_derive",
- "sha3 0.10.8",
+ "sha3",
  "snow",
  "tari_common",
  "tari_crypto",
  "tari_metrics",
  "tari_shutdown",
  "tari_storage",
- "tari_utilities 0.5.1",
+ "tari_utilities",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -7777,24 +7880,24 @@ dependencies = [
 
 [[package]]
 name = "tari_comms_dht"
-version = "0.52.0-dan.1"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#edfcb5c204a2e6a371aeb594207ebdd3977811cc"
+version = "0.52.0-dan.6"
+source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#ae10c6398768632cc032fb58a073551ddcba6d65"
 dependencies = [
  "anyhow",
- "bitflags 1.3.2",
+ "bitflags 2.4.1",
+ "blake2",
  "chacha20 0.7.3",
  "chacha20poly1305 0.10.1",
  "chrono",
  "diesel",
  "diesel_migrations",
  "digest 0.10.7",
- "futures 0.3.28",
+ "futures 0.3.29",
  "log",
  "log-mdc",
  "pin-project 0.4.30",
  "prost 0.9.0",
- "prost-types 0.9.0",
- "rand 0.8.5",
+ "rand",
  "serde",
  "tari_common",
  "tari_common_sqlite",
@@ -7803,7 +7906,7 @@ dependencies = [
  "tari_crypto",
  "tari_shutdown",
  "tari_storage",
- "tari_utilities 0.5.1",
+ "tari_utilities",
  "thiserror",
  "tokio",
  "tower",
@@ -7824,8 +7927,8 @@ dependencies = [
 
 [[package]]
 name = "tari_comms_rpc_macros"
-version = "0.52.0-dan.1"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#edfcb5c204a2e6a371aeb594207ebdd3977811cc"
+version = "0.52.0-dan.6"
+source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#ae10c6398768632cc032fb58a073551ddcba6d65"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7838,7 +7941,7 @@ version = "0.50.0-pre.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "futures 0.3.28",
+ "futures 0.3.29",
  "log",
  "tari_comms",
  "tari_consensus",
@@ -7871,18 +7974,20 @@ dependencies = [
 
 [[package]]
 name = "tari_contacts"
-version = "0.52.0-dan.1"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#edfcb5c204a2e6a371aeb594207ebdd3977811cc"
+version = "0.52.0-dan.6"
+source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#ae10c6398768632cc032fb58a073551ddcba6d65"
 dependencies = [
  "chrono",
  "diesel",
  "diesel_migrations",
- "futures 0.3.28",
+ "futures 0.3.29",
  "log",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "prost 0.9.0",
- "rand 0.8.5",
+ "rand",
+ "serde",
+ "serde_json",
  "tari_common",
  "tari_common_sqlite",
  "tari_common_types",
@@ -7892,32 +7997,31 @@ dependencies = [
  "tari_p2p",
  "tari_service_framework",
  "tari_shutdown",
- "tari_utilities 0.5.1",
+ "tari_utilities",
  "thiserror",
  "tokio",
  "tower",
- "uuid 1.4.1",
+ "uuid 1.5.0",
 ]
 
 [[package]]
 name = "tari_core"
-version = "0.52.0-dan.1"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#edfcb5c204a2e6a371aeb594207ebdd3977811cc"
+version = "0.52.0-dan.6"
+source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#ae10c6398768632cc032fb58a073551ddcba6d65"
 dependencies = [
  "async-trait",
  "bincode 1.3.3",
- "bitflags 1.3.2",
+ "bitflags 2.4.1",
  "blake2",
  "borsh",
  "bytes 0.5.6",
  "chacha20poly1305 0.10.1",
  "chrono",
- "croaring",
  "decimal-rs",
  "derivative",
  "digest 0.10.7",
  "fs2",
- "futures 0.3.28",
+ "futures 0.3.29",
  "hex",
  "integer-encoding",
  "lmdb-zero",
@@ -7925,17 +8029,17 @@ dependencies = [
  "log-mdc",
  "monero",
  "newtype-ops",
- "num-derive",
+ "num-derive 0.3.3",
  "num-format",
  "num-traits",
  "once_cell",
  "prost 0.9.0",
- "rand 0.8.5",
+ "rand",
  "randomx-rs",
  "serde",
  "serde_json",
  "serde_repr",
- "sha3 0.10.8",
+ "sha3",
  "strum",
  "strum_macros",
  "tari_common",
@@ -7954,7 +8058,7 @@ dependencies = [
  "tari_shutdown",
  "tari_storage",
  "tari_test_utils",
- "tari_utilities 0.5.1",
+ "tari_utilities",
  "thiserror",
  "tokio",
  "tracing",
@@ -7964,23 +8068,23 @@ dependencies = [
 
 [[package]]
 name = "tari_crypto"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc09581fc1a9709e54be25e0a50437dc405370b3f5795ee65dc913f4f7e726e5"
+checksum = "c74907b0c0237bc545e1da9b3ad6654fff934bdbd291bbe2a0e57e61933d6fc4"
 dependencies = [
  "blake2",
  "borsh",
  "digest 0.10.7",
  "log",
  "once_cell",
- "rand_chacha 0.3.1",
+ "rand_chacha",
  "rand_core 0.6.4",
  "serde",
- "sha3 0.10.8",
+ "sha3",
  "snafu",
  "tari-curve25519-dalek",
  "tari_bulletproofs_plus",
- "tari_utilities 0.5.1",
+ "tari_utilities",
  "zeroize",
 ]
 
@@ -7992,7 +8096,7 @@ dependencies = [
  "bytes 1.5.0",
  "chrono",
  "dashmap",
- "futures 0.3.28",
+ "futures 0.3.29",
  "lazy_static",
  "log",
  "mini-moka",
@@ -8030,7 +8134,7 @@ dependencies = [
  "newtype-ops",
  "prost 0.9.0",
  "prost-types 0.9.0",
- "rand 0.8.5",
+ "rand",
  "ruint",
  "serde",
  "tari_bor",
@@ -8050,7 +8154,7 @@ dependencies = [
  "cargo_toml",
  "d3ne",
  "log",
- "rand 0.8.5",
+ "rand",
  "serde",
  "serde_json",
  "tari_bor",
@@ -8064,7 +8168,7 @@ dependencies = [
  "tari_template_test_tooling",
  "tari_transaction",
  "tari_transaction_manifest",
- "tari_utilities 0.4.10",
+ "tari_utilities",
  "tempfile",
  "thiserror",
  "wasmer",
@@ -8090,7 +8194,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "log",
- "rand 0.8.5",
+ "rand",
  "serde",
  "tari_common_types",
  "tari_core",
@@ -8099,7 +8203,7 @@ dependencies = [
  "tari_engine_types",
  "tari_mmr",
  "tari_transaction",
- "tari_utilities 0.4.10",
+ "tari_utilities",
  "thiserror",
  "time",
 ]
@@ -8126,14 +8230,14 @@ dependencies = [
  "diesel",
  "diesel_migrations",
  "log",
- "rand 0.8.5",
+ "rand",
  "serde",
  "serde_json",
  "tari_common_types",
  "tari_crypto",
  "tari_dan_common_types",
  "tari_dan_storage",
- "tari_utilities 0.5.1",
+ "tari_utilities",
  "thiserror",
 ]
 
@@ -8156,7 +8260,7 @@ dependencies = [
  "tari_template_lib",
  "tari_transaction",
  "tari_transaction_manifest",
- "tari_utilities 0.5.1",
+ "tari_utilities",
  "tari_wallet_daemon_client",
  "thiserror",
  "time",
@@ -8174,7 +8278,7 @@ dependencies = [
  "base64 0.20.0",
  "clap 3.2.25",
  "config",
- "futures 0.3.28",
+ "futures 0.3.29",
  "humantime-serde",
  "include_dir",
  "libsqlite3-sys",
@@ -8182,7 +8286,7 @@ dependencies = [
  "log4rs 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime_guess",
  "minotari_app_utilities",
- "rand 0.8.5",
+ "rand",
  "reqwest",
  "serde",
  "serde_json",
@@ -8198,7 +8302,7 @@ dependencies = [
  "tari_template_builtin",
  "tari_template_lib",
  "tari_transaction",
- "tari_utilities 0.4.10",
+ "tari_utilities",
  "tari_wallet_daemon_client",
  "thiserror",
  "tokio",
@@ -8219,7 +8323,7 @@ dependencies = [
  "jsonwebtoken",
  "lazy_static",
  "log",
- "rand 0.8.5",
+ "rand",
  "serde",
  "serde_json",
  "tari_common_types",
@@ -8231,7 +8335,7 @@ dependencies = [
  "tari_key_manager",
  "tari_template_lib",
  "tari_transaction",
- "tari_utilities 0.4.10",
+ "tari_utilities",
  "tempfile",
  "thiserror",
  "zeroize",
@@ -8256,20 +8360,20 @@ dependencies = [
  "tari_engine_types",
  "tari_template_lib",
  "tari_transaction",
- "tari_utilities 0.5.1",
+ "tari_utilities",
 ]
 
 [[package]]
 name = "tari_engine_types"
 version = "0.0.3"
 dependencies = [
- "base64 0.21.4",
+ "base64 0.21.5",
  "blake2",
  "borsh",
  "digest 0.10.7",
  "hex",
  "lazy_static",
- "rand 0.8.5",
+ "rand",
  "serde",
  "serde_json",
  "tari_bor",
@@ -8277,7 +8381,7 @@ dependencies = [
  "tari_crypto",
  "tari_template_abi",
  "tari_template_lib",
- "tari_utilities 0.5.1",
+ "tari_utilities",
  "thiserror",
 ]
 
@@ -8304,8 +8408,8 @@ dependencies = [
 
 [[package]]
 name = "tari_features"
-version = "0.52.0-dan.1"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#edfcb5c204a2e6a371aeb594207ebdd3977811cc"
+version = "0.52.0-dan.6"
+source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#ae10c6398768632cc032fb58a073551ddcba6d65"
 
 [[package]]
 name = "tari_indexer"
@@ -8321,7 +8425,7 @@ dependencies = [
  "config",
  "diesel",
  "diesel_migrations",
- "futures 0.3.28",
+ "futures 0.3.29",
  "include_dir",
  "lmdb-zero",
  "log",
@@ -8329,7 +8433,7 @@ dependencies = [
  "mime_guess",
  "minotari_app_utilities",
  "prost 0.9.0",
- "rand 0.8.5",
+ "rand",
  "reqwest",
  "serde",
  "serde_json",
@@ -8389,7 +8493,7 @@ name = "tari_indexer_lib"
 version = "0.50.0-pre.0"
 dependencies = [
  "log",
- "rand 0.8.5",
+ "rand",
  "serde",
  "tari_dan_common_types",
  "tari_engine_types",
@@ -8402,8 +8506,8 @@ dependencies = [
 
 [[package]]
 name = "tari_key_manager"
-version = "0.52.0-dan.1"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#edfcb5c204a2e6a371aeb594207ebdd3977811cc"
+version = "0.52.0-dan.6"
+source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#ae10c6398768632cc032fb58a073551ddcba6d65"
 dependencies = [
  "argon2",
  "async-trait",
@@ -8416,9 +8520,9 @@ dependencies = [
  "diesel",
  "diesel_migrations",
  "digest 0.10.7",
- "futures 0.3.28",
+ "futures 0.3.29",
  "log",
- "rand 0.8.5",
+ "rand",
  "serde",
  "strum",
  "strum_macros",
@@ -8427,7 +8531,7 @@ dependencies = [
  "tari_common_types",
  "tari_crypto",
  "tari_service_framework",
- "tari_utilities 0.5.1",
+ "tari_utilities",
  "thiserror",
  "tokio",
  "zeroize",
@@ -8436,10 +8540,10 @@ dependencies = [
 [[package]]
 name = "tari_metrics"
 version = "0.1.0"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#edfcb5c204a2e6a371aeb594207ebdd3977811cc"
+source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#ae10c6398768632cc032fb58a073551ddcba6d65"
 dependencies = [
  "anyhow",
- "futures 0.3.28",
+ "futures 0.3.29",
  "log",
  "once_cell",
  "prometheus",
@@ -8451,8 +8555,8 @@ dependencies = [
 
 [[package]]
 name = "tari_mmr"
-version = "0.52.0-dan.1"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#edfcb5c204a2e6a371aeb594207ebdd3977811cc"
+version = "0.52.0-dan.6"
+source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#ae10c6398768632cc032fb58a073551ddcba6d65"
 dependencies = [
  "borsh",
  "croaring",
@@ -8461,26 +8565,26 @@ dependencies = [
  "serde",
  "tari_common",
  "tari_crypto",
- "tari_utilities 0.5.1",
+ "tari_utilities",
  "thiserror",
 ]
 
 [[package]]
 name = "tari_p2p"
-version = "0.52.0-dan.1"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#edfcb5c204a2e6a371aeb594207ebdd3977811cc"
+version = "0.52.0-dan.6"
+source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#ae10c6398768632cc032fb58a073551ddcba6d65"
 dependencies = [
  "anyhow",
  "fs2",
- "futures 0.3.28",
+ "futures 0.3.29",
  "lmdb-zero",
  "log",
  "pgp",
  "prost 0.9.0",
- "rand 0.8.5",
+ "rand",
  "reqwest",
  "rustls 0.20.9",
- "semver 1.0.19",
+ "semver 1.0.20",
  "serde",
  "tari_common",
  "tari_comms",
@@ -8489,13 +8593,13 @@ dependencies = [
  "tari_service_framework",
  "tari_shutdown",
  "tari_storage",
- "tari_utilities 0.5.1",
+ "tari_utilities",
  "thiserror",
  "tokio",
  "tokio-stream",
  "tower",
  "trust-dns-client",
- "webpki 0.21.4",
+ "webpki 0.22.4",
 ]
 
 [[package]]
@@ -8511,28 +8615,28 @@ dependencies = [
 [[package]]
 name = "tari_script"
 version = "0.12.0"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#edfcb5c204a2e6a371aeb594207ebdd3977811cc"
+source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#ae10c6398768632cc032fb58a073551ddcba6d65"
 dependencies = [
  "blake2",
  "borsh",
  "digest 0.10.7",
  "integer-encoding",
  "serde",
- "sha2 0.10.8",
- "sha3 0.10.8",
+ "sha2",
+ "sha3",
  "tari_crypto",
- "tari_utilities 0.5.1",
+ "tari_utilities",
  "thiserror",
 ]
 
 [[package]]
 name = "tari_service_framework"
-version = "0.52.0-dan.1"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#edfcb5c204a2e6a371aeb594207ebdd3977811cc"
+version = "0.52.0-dan.6"
+source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#ae10c6398768632cc032fb58a073551ddcba6d65"
 dependencies = [
  "anyhow",
  "async-trait",
- "futures 0.3.28",
+ "futures 0.3.29",
  "log",
  "tari_shutdown",
  "thiserror",
@@ -8542,10 +8646,10 @@ dependencies = [
 
 [[package]]
 name = "tari_shutdown"
-version = "0.52.0-dan.1"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#edfcb5c204a2e6a371aeb594207ebdd3977811cc"
+version = "0.52.0-dan.6"
+source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#ae10c6398768632cc032fb58a073551ddcba6d65"
 dependencies = [
- "futures 0.3.28",
+ "futures 0.3.29",
 ]
 
 [[package]]
@@ -8556,7 +8660,7 @@ dependencies = [
  "axum",
  "axum-jrpc",
  "chrono",
- "clap 4.4.6",
+ "clap 4.4.7",
  "dirs",
  "jsonwebtoken",
  "log",
@@ -8581,7 +8685,7 @@ dependencies = [
  "diesel_migrations",
  "hex",
  "log",
- "rand 0.8.5",
+ "rand",
  "serde",
  "serde_json",
  "tari_common_types",
@@ -8594,8 +8698,8 @@ dependencies = [
 
 [[package]]
 name = "tari_storage"
-version = "0.52.0-dan.1"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#edfcb5c204a2e6a371aeb594207ebdd3977811cc"
+version = "0.52.0-dan.6"
+source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#ae10c6398768632cc032fb58a073551ddcba6d65"
 dependencies = [
  "bincode 1.3.3",
  "lmdb-zero",
@@ -8665,11 +8769,11 @@ dependencies = [
 
 [[package]]
 name = "tari_test_utils"
-version = "0.52.0-dan.1"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#edfcb5c204a2e6a371aeb594207ebdd3977811cc"
+version = "0.52.0-dan.6"
+source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#ae10c6398768632cc032fb58a073551ddcba6d65"
 dependencies = [
- "futures 0.3.28",
- "rand 0.8.5",
+ "futures 0.3.29",
+ "rand",
  "tari_comms",
  "tari_shutdown",
  "tempfile",
@@ -8680,7 +8784,7 @@ dependencies = [
 name = "tari_transaction"
 version = "0.0.3"
 dependencies = [
- "rand 0.8.5",
+ "rand",
  "serde",
  "tari_common_types",
  "tari_crypto",
@@ -8704,27 +8808,9 @@ dependencies = [
 
 [[package]]
 name = "tari_utilities"
-version = "0.4.10"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96ee4eb0990ee7c898b955a24b8479134851c301b31d2426a7606f57d2d6f181"
-dependencies = [
- "base58-monero 0.3.2",
- "base64 0.13.1",
- "bincode 1.3.3",
- "generic-array",
- "newtype-ops",
- "serde",
- "serde_json",
- "subtle",
- "thiserror",
- "zeroize",
-]
-
-[[package]]
-name = "tari_utilities"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "367d17d09cf48e4cf45222fd48536e206f8ef3aaa5eed449c7df38d2ab4586c6"
+checksum = "0c396f014de7fa290ea8decd7238df9f1c175f243480a4ebef9ec61f144b1c95"
 dependencies = [
  "base58-monero 0.3.2",
  "base64 0.13.1",
@@ -8747,11 +8833,12 @@ dependencies = [
  "async-trait",
  "axum",
  "axum-jrpc",
+ "blake2",
  "clap 3.2.25",
  "config",
- "futures 0.3.28",
+ "futures 0.3.29",
  "include_dir",
- "indexmap 2.0.1",
+ "indexmap 2.1.0",
  "json5 0.2.8",
  "libsqlite3-sys",
  "lmdb-zero",
@@ -8762,7 +8849,7 @@ dependencies = [
  "minotari_app_utilities",
  "minotari_wallet_grpc_client",
  "prost 0.9.0",
- "rand 0.8.5",
+ "rand",
  "reqwest",
  "serde",
  "serde_json",
@@ -8893,14 +8980,14 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.8.0"
+version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
+checksum = "7ef1adac450ad7f4b3c28589471ade84f25f731a7a0fe30d71dfa9f60fd808e5"
 dependencies = [
  "cfg-if",
  "fastrand 2.0.1",
- "redox_syscall 0.3.5",
- "rustix 0.38.14",
+ "redox_syscall 0.4.1",
+ "rustix 0.38.21",
  "windows-sys 0.48.0",
 ]
 
@@ -8930,7 +9017,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
 dependencies = [
- "rustix 0.38.14",
+ "rustix 0.38.21",
  "windows-sys 0.48.0",
 ]
 
@@ -8956,32 +9043,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.49"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1177e8c6d7ede7afde3585fd2513e611227efd6481bd78d2e82ba1ce16557ed4"
+checksum = "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.49"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10712f02019e9288794769fba95cd6847df9874d49d871d062172f9dd41bc4cc"
+checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.39",
 ]
 
 [[package]]
 name = "thread-id"
-version = "4.2.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79474f573561cdc4871a0de34a51c92f7f5a56039113fbb5b9c9f96bdb756669"
+checksum = "f0ec81c46e9eb50deaa257be2f148adf052d1fb7701cfd55ccfab2525280b70b"
 dependencies = [
  "libc",
- "redox_syscall 0.2.16",
  "winapi",
 ]
 
@@ -8997,12 +9083,13 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "426f806f4089c493dcac0d24c29c01e2c38baf8e30f1b716ee37e83d200b18fe"
+checksum = "c4a34ab300f2dee6e562c10a046fc05e358b29f9bf92277f30c3c8d82275f6f5"
 dependencies = [
  "deranged",
  "itoa",
+ "powerfmt",
  "serde",
  "time-core",
  "time-macros",
@@ -9049,19 +9136,19 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.32.0"
+version = "1.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17ed6077ed6cd6c74735e21f37eb16dc3935f96878b1fe961074089cc80893f9"
+checksum = "4f38200e3ef7995e5ef13baec2f432a6da0aa9ac495b2c0e8f3b7eec2c92d653"
 dependencies = [
  "backtrace",
  "bytes 1.5.0",
  "libc",
- "mio 0.8.8",
+ "mio 0.8.9",
  "num_cpus",
  "parking_lot 0.12.1",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.5.4",
+ "socket2 0.5.5",
  "tokio-macros",
  "tracing",
  "windows-sys 0.48.0",
@@ -9085,7 +9172,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -9106,7 +9193,7 @@ checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
 dependencies = [
  "rustls 0.20.9",
  "tokio",
- "webpki 0.22.1",
+ "webpki 0.22.4",
 ]
 
 [[package]]
@@ -9118,7 +9205,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
- "tokio-util 0.7.9",
+ "tokio-util 0.7.10",
 ]
 
 [[package]]
@@ -9150,9 +9237,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d68074620f57a0b21594d9735eb2e98ab38b17f80d3fcb189fca266771ca60d"
+checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
 dependencies = [
  "bytes 1.5.0",
  "futures-core",
@@ -9186,9 +9273,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
 dependencies = [
  "serde",
 ]
@@ -9199,7 +9286,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.0.1",
+ "indexmap 2.1.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -9245,7 +9332,7 @@ checksum = "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a"
 dependencies = [
  "async-trait",
  "axum",
- "base64 0.21.4",
+ "base64 0.21.5",
  "bytes 1.5.0",
  "futures-core",
  "futures-util",
@@ -9289,10 +9376,10 @@ dependencies = [
  "indexmap 1.9.3",
  "pin-project 1.1.3",
  "pin-project-lite",
- "rand 0.8.5",
+ "rand",
  "slab",
  "tokio",
- "tokio-util 0.7.9",
+ "tokio-util 0.7.10",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -9331,11 +9418,10 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.37"
+version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
- "cfg-if",
  "log",
  "pin-project-lite",
  "tracing-attributes",
@@ -9344,20 +9430,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
+checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.39",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.31"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
+checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
  "valuable",
@@ -9395,9 +9481,9 @@ dependencies = [
  "anyhow",
  "bincode 2.0.0-rc.3",
  "bytes 0.4.12",
- "clap 4.4.6",
+ "clap 4.4.7",
  "once_cell",
- "rand 0.8.5",
+ "rand",
  "rayon",
  "tari_crypto",
  "tari_engine_types",
@@ -9411,8 +9497,8 @@ name = "transaction_submitter"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 4.4.6",
- "futures 0.3.28",
+ "clap 4.4.7",
+ "futures 0.3.29",
  "tari_validator_node_client",
  "tokio",
  "transaction_generator",
@@ -9437,14 +9523,14 @@ dependencies = [
  "lazy_static",
  "log",
  "radix_trie",
- "rand 0.8.5",
- "ring",
+ "rand",
+ "ring 0.16.20",
  "rustls 0.20.9",
  "thiserror",
  "time",
  "tokio",
  "trust-dns-proto",
- "webpki 0.22.1",
+ "webpki 0.22.4",
 ]
 
 [[package]]
@@ -9464,8 +9550,8 @@ dependencies = [
  "ipnet",
  "lazy_static",
  "log",
- "rand 0.8.5",
- "ring",
+ "rand",
+ "ring 0.16.20",
  "rustls 0.20.9",
  "rustls-pemfile 0.3.0",
  "smallvec",
@@ -9474,7 +9560,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "url",
- "webpki 0.22.1",
+ "webpki 0.22.4",
 ]
 
 [[package]]
@@ -9508,7 +9594,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.8.5",
+ "rand",
  "sha1",
  "thiserror",
  "url",
@@ -9523,11 +9609,11 @@ checksum = "4712ee30d123ec7ae26d1e1b218395a16c87cdbaf4b3925d170d684af62ea5e8"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
- "futures 0.3.28",
+ "futures 0.3.29",
  "log",
- "md-5 0.10.6",
- "rand 0.8.5",
- "ring",
+ "md-5",
+ "rand",
+ "ring 0.16.20",
  "stun",
  "thiserror",
  "tokio",
@@ -9536,13 +9622,11 @@ dependencies = [
 
 [[package]]
 name = "twofish"
-version = "0.6.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "728f6b7e784825d272fe9d2a77e44063f4197a570cbedc6fdcc90a6ddac91296"
+checksum = "a78e83a30223c757c3947cd144a31014ff04298d8719ae10d03c31c0448c8013"
 dependencies = [
- "byteorder",
- "cipher 0.3.0",
- "opaque-debug",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -9601,7 +9685,7 @@ version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
 dependencies = [
- "version_check 0.9.4",
+ "version_check",
 ]
 
 [[package]]
@@ -9697,6 +9781,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9730,9 +9820,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d"
+checksum = "88ad59a7560b41a70d191093a945f0b87bc1deeda46fb237479708a1d6b6cdfc"
 dependencies = [
  "getrandom 0.2.10",
 ]
@@ -9745,21 +9835,15 @@ checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "value-bag"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d92ccd67fb88503048c01b59152a04effd0782d035a83a6d256ce6085f08f4a3"
+checksum = "4a72e1902dde2bd6441347de2b70b7f5d59bf157c6c62f0c44572607a1d55bbe"
 
 [[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "version_check"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 
 [[package]]
 name = "version_check"
@@ -9775,11 +9859,10 @@ checksum = "9dcc60c0624df774c82a0ef104151231d37da4962957d691c011c852b2473314"
 
 [[package]]
 name = "vte"
-version = "0.10.1"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cbce692ab4ca2f1f3047fcf732430249c0e971bfdd2b234cf2c47ad93af5983"
+checksum = "f5022b5fbf9407086c180e9557be968742d839e68346af7792b8592489732197"
 dependencies = [
- "arrayvec 0.5.2",
  "utf8parse",
  "vte_generate_state_changes",
 ]
@@ -9852,7 +9935,7 @@ dependencies = [
  "serde_urlencoded",
  "tokio",
  "tokio-stream",
- "tokio-util 0.7.9",
+ "tokio-util 0.7.10",
  "tower-service",
  "tracing",
 ]
@@ -9871,9 +9954,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.87"
+version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
+checksum = "7daec296f25a1bae309c0cd5c29c4b260e510e6d813c286b19eaadf409d40fce"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -9881,24 +9964,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.87"
+version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
+checksum = "e397f4664c0e4e428e8313a469aaa58310d302159845980fd23b0f22a847f217"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.39",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.37"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c02dbc21516f9f1f04f187958890d7e6026df8d16540b7ad9492bc34a67cea03"
+checksum = "9afec9963e3d0994cac82455b2b3502b81a7f40f9a0d32181f7528d9f4b43e02"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -9908,9 +9991,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.87"
+version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
+checksum = "5961017b3b08ad5f3fe39f1e79877f8ee7c23c5e5fd5eb80de95abc41f1f16b2"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -9918,28 +10001,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.87"
+version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
+checksum = "c5353b8dab669f5e10f5bd76df26a9360c748f054f862ff5f3f8aae0c7fb3907"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.39",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.87"
+version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
+checksum = "0d046c5d029ba91a1ed14da14dca44b68bf2f124cfbaf741c54151fdb3e0750b"
 
 [[package]]
 name = "wasm-encoder"
-version = "0.33.2"
+version = "0.36.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34180c89672b3e4825c3a8db4b61a674f1447afd5fe2445b2d22c3d8b6ea086c"
+checksum = "822b645bf4f2446b949776ffca47e2af60b167209ffb70814ef8779d299cd421"
 dependencies = [
  "leb128",
 ]
@@ -10195,9 +10278,9 @@ checksum = "718ed7c55c2add6548cca3ddd6383d738cd73b892df400e96b9aa876f0141d7a"
 
 [[package]]
 name = "wast"
-version = "65.0.2"
+version = "67.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55a88724cf8c2c0ebbf32c8e8f4ac0d6aa7ba6d73a1cfd94b254aa8f894317e"
+checksum = "a974d82fac092b5227c1663e16514e7a85f32014e22e6fdcb08b71aec9d3fb1e"
 dependencies = [
  "leb128",
  "memchr",
@@ -10207,18 +10290,18 @@ dependencies = [
 
 [[package]]
 name = "wat"
-version = "1.0.74"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d83e1a8d86d008adc7bafa5cf4332d448699a08fcf2a715a71fbb75e2c5ca188"
+checksum = "adb220934f92f8551144c0003d1bc57a060674c99139f45ed623fbbf6d9262e7"
 dependencies = [
  "wast",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.64"
+version = "0.3.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
+checksum = "5db499c5f66323272151db0e666cd34f78617522fb0c1604d31a27c50c206a85"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -10230,18 +10313,18 @@ version = "0.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
 dependencies = [
- "ring",
- "untrusted",
+ "ring 0.16.20",
+ "untrusted 0.7.1",
 ]
 
 [[package]]
 name = "webpki"
-version = "0.22.1"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0e74f82d49d545ad128049b7e88f6576df2da6b02e9ce565c6f533be576957e"
+checksum = "ed63aea5ce73d0ff405984102c42de94fc55a6b75765d621c65262469b3c9b53"
 dependencies = [
- "ring",
- "untrusted",
+ "ring 0.17.5",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -10257,17 +10340,17 @@ dependencies = [
  "interceptor",
  "lazy_static",
  "log",
- "rand 0.8.5",
+ "rand",
  "rcgen",
  "regex",
- "ring",
+ "ring 0.16.20",
  "rtcp",
  "rtp 0.6.8",
  "rustls 0.19.1",
  "sdp",
  "serde",
  "serde_json",
- "sha2 0.10.8",
+ "sha2",
  "stun",
  "thiserror",
  "time",
@@ -10310,33 +10393,33 @@ dependencies = [
  "aes-gcm 0.10.3",
  "async-trait",
  "bincode 1.3.3",
- "block-modes 0.7.0",
+ "block-modes",
  "byteorder",
  "ccm",
  "curve25519-dalek 3.2.0",
  "der-parser 8.2.0",
- "elliptic-curve",
+ "elliptic-curve 0.12.3",
  "hkdf",
  "hmac 0.12.1",
  "log",
- "p256",
- "p384",
- "rand 0.8.5",
+ "p256 0.11.1",
+ "p384 0.11.2",
+ "rand",
  "rand_core 0.6.4",
  "rcgen",
- "ring",
+ "ring 0.16.20",
  "rustls 0.19.1",
- "sec1",
+ "sec1 0.3.0",
  "serde",
  "sha1",
- "sha2 0.10.8",
- "signature",
+ "sha2",
+ "signature 1.6.4",
  "subtle",
  "thiserror",
  "tokio",
  "webpki 0.21.4",
  "webrtc-util",
- "x25519-dalek 2.0.0",
+ "x25519-dalek",
  "x509-parser 0.13.2",
 ]
 
@@ -10350,7 +10433,7 @@ dependencies = [
  "async-trait",
  "crc",
  "log",
- "rand 0.8.5",
+ "rand",
  "serde",
  "serde_json",
  "stun",
@@ -10358,7 +10441,7 @@ dependencies = [
  "tokio",
  "turn",
  "url",
- "uuid 1.4.1",
+ "uuid 1.5.0",
  "waitgroup",
  "webrtc-mdns",
  "webrtc-util",
@@ -10371,7 +10454,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f08dfd7a6e3987e255c4dbe710dde5d94d0f0574f8a21afa95d171376c143106"
 dependencies = [
  "log",
- "socket2 0.4.9",
+ "socket2 0.4.10",
  "thiserror",
  "tokio",
  "webrtc-util",
@@ -10385,7 +10468,7 @@ checksum = "cd8e3711a321f6a375973144f48065cf705316ab6709672954aace020c668eb6"
 dependencies = [
  "byteorder",
  "bytes 1.5.0",
- "rand 0.8.5",
+ "rand",
  "rtp 0.8.0",
  "thiserror",
 ]
@@ -10401,7 +10484,7 @@ dependencies = [
  "bytes 1.5.0",
  "crc",
  "log",
- "rand 0.8.5",
+ "rand",
  "thiserror",
  "tokio",
  "webrtc-util",
@@ -10446,7 +10529,7 @@ dependencies = [
  "libc",
  "log",
  "nix 0.24.3",
- "rand 0.8.5",
+ "rand",
  "thiserror",
  "tokio",
  "winapi",
@@ -10461,7 +10544,7 @@ dependencies = [
  "either",
  "home",
  "once_cell",
- "rustix 0.38.14",
+ "rustix 0.38.21",
 ]
 
 [[package]]
@@ -10496,10 +10579,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows"
-version = "0.48.0"
+name = "windows-core"
+version = "0.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+checksum = "f1f8cf84f35d2db49a46868f947758c7a1138116f7fac3bc844f43ade1292e64"
 dependencies = [
  "windows-targets 0.48.5",
 ]
@@ -10681,9 +10764,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "winnow"
-version = "0.5.15"
+version = "0.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c2e3184b9c4e92ad5167ca73039d0c42476302ab603e2fec4487511f38ccefc"
+checksum = "829846f3e3db426d4cee4510841b71a8e58aa2a76b1132579487ae430ccd9c7b"
 dependencies = [
  "memchr",
 ]
@@ -10709,17 +10792,6 @@ dependencies = [
 
 [[package]]
 name = "x25519-dalek"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a0c105152107e3b96f6a00a65e86ce82d9b125230e1c4302940eca58ff71f4f"
-dependencies = [
- "curve25519-dalek 3.2.0",
- "rand_core 0.5.1",
- "zeroize",
-]
-
-[[package]]
-name = "x25519-dalek"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb66477291e7e8d2b0ff1bcb900bf29489a9692816d79874bea351e7a8b6de96"
@@ -10741,7 +10813,7 @@ dependencies = [
  "data-encoding",
  "der-parser 7.0.0",
  "lazy_static",
- "nom 7.1.3",
+ "nom",
  "oid-registry 0.4.0",
  "rusticata-macros",
  "thiserror",
@@ -10759,9 +10831,9 @@ dependencies = [
  "data-encoding",
  "der-parser 8.2.0",
  "lazy_static",
- "nom 7.1.3",
+ "nom",
  "oid-registry 0.6.1",
- "ring",
+ "ring 0.16.20",
  "rusticata-macros",
  "thiserror",
  "time",
@@ -10782,11 +10854,11 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5d9ba232399af1783a58d8eb26f6b5006fbefe2dc9ef36bd283324792d03ea5"
 dependencies = [
- "futures 0.3.28",
+ "futures 0.3.29",
  "log",
  "nohash-hasher",
  "parking_lot 0.12.1",
- "rand 0.8.5",
+ "rand",
  "static_assertions",
 ]
 
@@ -10797,6 +10869,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
 dependencies = [
  "time",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.7.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cd369a67c0edfef15010f980c3cbe45d7f651deac2cd67ce097cd801de16557"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2f140bda219a26ccc0cdb03dba58af72590c53b22642577d88a927bc5c87d6b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -10816,7 +10908,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.39",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8755,6 +8755,7 @@ name = "tari_template_test_tooling"
 version = "0.0.3"
 dependencies = [
  "anyhow",
+ "rand",
  "serde",
  "tari_bor",
  "tari_crypto",

--- a/applications/tari_dan_app_utilities/Cargo.toml
+++ b/applications/tari_dan_app_utilities/Cargo.toml
@@ -7,8 +7,10 @@ license = "BSD-3-Clause"
 
 [dependencies]
 tari_common_types = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan2" }
-tari_core = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan2", default-features = false, features = ["transactions"] }
-tari_crypto = "0.18"
+tari_core = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan2", default-features = false, features = [
+  "transactions",
+] }
+tari_crypto = "0.19"
 tari_shutdown = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan2" }
 
 tari_dan_common_types = { path = "../../dan_layer/common_types" }
@@ -17,7 +19,9 @@ tari_dan_engine = { path = "../../dan_layer/engine" }
 tari_dan_storage = { path = "../../dan_layer/storage" }
 tari_dan_storage_sqlite = { path = "../../dan_layer/storage_sqlite" }
 tari_engine_types = { path = "../../dan_layer/engine_types" }
-tari_epoch_manager = { path = "../../dan_layer/epoch_manager", features = ["base_layer"] }
+tari_epoch_manager = { path = "../../dan_layer/epoch_manager", features = [
+  "base_layer",
+] }
 tari_base_node_client = { path = "../../clients/base_node_client" }
 tari_template_builtin = { path = "../../dan_layer/template_builtin" }
 tari_template_lib = { path = "../../dan_layer/template_lib" }
@@ -38,5 +42,10 @@ reqwest = "0.11.11"
 serde = { version = "1.0.126", features = ["derive"] }
 serde_json = "1.0.64"
 thiserror = "^1.0.20"
-tokio = { version = "1.10", features = ["macros", "time", "sync", "rt-multi-thread"] }
+tokio = { version = "1.10", features = [
+  "macros",
+  "time",
+  "sync",
+  "rt-multi-thread",
+] }
 tokio-stream = { version = "0.1.7", features = ["sync"] }

--- a/applications/tari_dan_wallet_cli/Cargo.toml
+++ b/applications/tari_dan_wallet_cli/Cargo.toml
@@ -12,7 +12,7 @@ tari_common_types = { git = "https://github.com/tari-project/tari.git", branch =
 tari_dan_common_types = { path = "../../dan_layer/common_types" }
 tari_dan_engine = { path = "../../dan_layer/engine" }
 tari_engine_types = { path = "../../dan_layer/engine_types" }
-tari_utilities = "0.5.1"
+tari_utilities = "0.6"
 tari_wallet_daemon_client = { path = "../../clients/wallet_daemon_client" }
 tari_template_lib = { path = "../../dan_layer/template_lib" }
 tari_transaction = { path = "../../dan_layer/transaction" }

--- a/applications/tari_dan_wallet_cli/src/command/account.rs
+++ b/applications/tari_dan_wallet_cli/src/command/account.rs
@@ -31,8 +31,8 @@ use std::{
 use anyhow::anyhow;
 use clap::{Args, Subcommand};
 use serde_json as json;
+use tari_dan_common_types::NodeAddressable;
 use tari_template_lib::models::Amount;
-use tari_utilities::ByteArray;
 use tari_wallet_daemon_client::{
     types::{
         AccountInfo,

--- a/applications/tari_dan_wallet_cli/src/command/transaction.rs
+++ b/applications/tari_dan_wallet_cli/src/command/transaction.rs
@@ -321,7 +321,7 @@ pub async fn handle_send(args: SendArgs, client: &mut WalletDaemonClient) -> Res
     } = args;
 
     let destination_public_key =
-        PublicKey::from_bytes(&destination_public_key.into_inner()).map_err(anyhow::Error::msg)?;
+        PublicKey::from_canonical_bytes(&destination_public_key.into_inner()).map_err(anyhow::Error::msg)?;
 
     let fee = common.max_fee.map(|f| f.try_into()).transpose()?;
     let resp = client
@@ -356,7 +356,7 @@ pub async fn handle_confidential_transfer(
 
     // let AccountByNameResponse { account, .. } = client.accounts_get_by_name(&source_account_name).await?;
     let destination_public_key =
-        PublicKey::from_bytes(&destination_public_key.into_inner()).map_err(anyhow::Error::msg)?;
+        PublicKey::from_canonical_bytes(&destination_public_key.into_inner()).map_err(anyhow::Error::msg)?;
     let resp = client
         .accounts_confidential_transfer(ConfidentialTransferRequest {
             account: source_account,

--- a/applications/tari_dan_wallet_cli/src/command/validator.rs
+++ b/applications/tari_dan_wallet_cli/src/command/validator.rs
@@ -58,7 +58,7 @@ pub async fn handle_get_fees(args: GetFeesArgs, client: &mut WalletDaemonClient)
     // TODO: complete this handler once this request is implemented
     let resp = client
         .get_validator_fee_summary(GetValidatorFeesRequest {
-            validator_public_key: PublicKey::from_bytes(args.validator_public_key.into_inner().as_bytes())
+            validator_public_key: PublicKey::from_canonical_bytes(args.validator_public_key.into_inner().as_bytes())
                 .map_err(anyhow::Error::msg)?,
             epoch: Epoch(0),
         })
@@ -87,7 +87,7 @@ pub async fn handle_claim_validator_fees(
                 .map(|name| ComponentAddressOrName::from_str(&name))
                 .transpose()?,
             max_fee: max_fee.map(Amount::from),
-            validator_public_key: PublicKey::from_bytes(validator_public_key.into_inner().as_bytes())
+            validator_public_key: PublicKey::from_canonical_bytes(validator_public_key.into_inner().as_bytes())
                 .map_err(anyhow::Error::msg)?,
             epoch: Epoch(epoch),
         })

--- a/applications/tari_dan_wallet_daemon/Cargo.toml
+++ b/applications/tari_dan_wallet_daemon/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 [dependencies]
 minotari_app_utilities = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan2" }
 tari_common = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan2" }
-tari_crypto = "0.18"
+tari_crypto = "0.19"
 tari_common_types = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan2" }
 tari_shutdown = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan2" }
 tari_dan_wallet_sdk = { path = "../../dan_layer/wallet/sdk" }
@@ -40,16 +40,25 @@ serde = "1.0.152"
 serde_json = "1.0.92"
 thiserror = "1.0.38"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
-tower-http = { version = "0.3.5", default-features = false, features = ["cors", "trace"] }
+tower-http = { version = "0.3.5", default-features = false, features = [
+    "cors",
+    "trace",
+] }
 webrtc = "0.7.1"
 
 libsqlite3-sys = { version = "0.25", features = ["bundled"] }
-log4rs = { version = "1.1.1", features = ["rolling_file_appender", "compound_policy", "size_trigger", "fixed_window_roller", "console_appender"] }
+log4rs = { version = "1.1.1", features = [
+    "rolling_file_appender",
+    "compound_policy",
+    "size_trigger",
+    "fixed_window_roller",
+    "console_appender",
+] }
 mime_guess = "2.0.4"
 url = "2.4.1"
 
 [dev-dependencies]
-tari_utilities = "0.4.10"
+tari_utilities = "0.6"
 
 [package.metadata.cargo-machete]
 ignored = [

--- a/applications/tari_dan_wallet_daemon/src/handlers/accounts.rs
+++ b/applications/tari_dan_wallet_daemon/src/handlers/accounts.rs
@@ -488,7 +488,7 @@ pub async fn handle_claim_burn(
         return Err(invalid_params("fee", Some("cannot be negative")));
     }
 
-    let reciprocal_claim_public_key = PublicKey::from_bytes(
+    let reciprocal_claim_public_key = PublicKey::from_canonical_bytes(
         &base64::decode(
             claim_proof["reciprocal_claim_public_key"]
                 .as_str()
@@ -511,7 +511,7 @@ pub async fn handle_claim_burn(
     )
     .map_err(|e| invalid_params("range_proof", Some(e)))?;
 
-    let public_nonce = PublicKey::from_bytes(
+    let public_nonce = PublicKey::from_canonical_bytes(
         &base64::decode(
             claim_proof["ownership_proof"]["public_nonce"]
                 .as_str()
@@ -520,7 +520,7 @@ pub async fn handle_claim_burn(
         .map_err(|e| invalid_params("ownership_proof.public_nonce", Some(e)))?,
     )
     .map_err(|e| invalid_params("ownership_proof.public_nonce", Some(e)))?;
-    let u = PrivateKey::from_bytes(
+    let u = PrivateKey::from_canonical_bytes(
         &base64::decode(
             claim_proof["ownership_proof"]["u"]
                 .as_str()
@@ -529,7 +529,7 @@ pub async fn handle_claim_burn(
         .map_err(|e| invalid_params("ownership_proof.u", Some(e)))?,
     )
     .map_err(|e| invalid_params("ownership_proof.u", Some(e)))?;
-    let v = PrivateKey::from_bytes(
+    let v = PrivateKey::from_canonical_bytes(
         &base64::decode(
             claim_proof["ownership_proof"]["v"]
                 .as_str()

--- a/applications/tari_indexer/Cargo.toml
+++ b/applications/tari_indexer/Cargo.toml
@@ -13,7 +13,7 @@ tari_common = { git = "https://github.com/tari-project/tari.git", branch = "feat
 tari_common_types = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan2" }
 tari_comms = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan2" }
 tari_comms_logging = { path = "../../comms/tari_comms_logging" }
-tari_crypto = "0.18"
+tari_crypto = "0.19"
 tari_p2p = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan2" }
 tari_shutdown = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan2" }
 tari_storage = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan2" }
@@ -44,20 +44,33 @@ async-graphql-axum = "5.0.7"
 axum-jrpc = { version = "0.3.2", features = ["anyhow_error"] }
 clap = { version = "3.2.22", features = ["derive", "env"] }
 config = "0.13.0"
-diesel = { version = "2", default-features = false, features = ["sqlite", "chrono"] }
+diesel = { version = "2", default-features = false, features = [
+    "sqlite",
+    "chrono",
+] }
 diesel_migrations = "2"
 futures = { version = "^0.3.1" }
 include_dir = "0.7.2"
 lmdb-zero = "0.4.4"
 log = { version = "0.4.8", features = ["std"] }
-log4rs = { version = "1.1.1", features = ["rolling_file_appender", "compound_policy", "size_trigger", "fixed_window_roller"] }
+log4rs = { version = "1.1.1", features = [
+    "rolling_file_appender",
+    "compound_policy",
+    "size_trigger",
+    "fixed_window_roller",
+] }
 prost = "0.9"
 rand = "0.8"
 reqwest = "0.11.11"
 serde = { version = "1.0.126", features = ["derive"] }
 serde_json = "1.0.64"
 thiserror = "^1.0.20"
-tokio = { version = "1.10", features = ["macros", "time", "sync", "rt-multi-thread"] }
+tokio = { version = "1.10", features = [
+    "macros",
+    "time",
+    "sync",
+    "rt-multi-thread",
+] }
 tonic = "0.6.2"
 tower = "0.4"
 tower-layer = "0.3"

--- a/applications/tari_validator_node/Cargo.toml
+++ b/applications/tari_validator_node/Cargo.toml
@@ -14,8 +14,10 @@ tari_common = { git = "https://github.com/tari-project/tari.git", branch = "feat
 tari_common_types = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan2" }
 tari_comms = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan2" }
 tari_comms_logging = { path = "../../comms/tari_comms_logging" }
-tari_core = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan2", default-features = false, features = ["transactions"] }
-tari_crypto = "0.18"
+tari_core = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan2", default-features = false, features = [
+    "transactions",
+] }
+tari_crypto = "0.19"
 tari_validator_node_rpc = { path = "../../dan_layer/validator_node_rpc" }
 tari_dan_app_utilities = { path = "../tari_dan_app_utilities" }
 tari_dan_common_types = { path = "../../dan_layer/common_types" }
@@ -32,7 +34,9 @@ tari_transaction = { path = "../../dan_layer/transaction" }
 tari_validator_node_client = { path = "../../clients/validator_node_client" }
 minotari_wallet_grpc_client = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan2" }
 tari_base_node_client = { path = "../../clients/base_node_client" }
-tari_epoch_manager = { path = "../../dan_layer/epoch_manager", features = ["base_layer"] }
+tari_epoch_manager = { path = "../../dan_layer/epoch_manager", features = [
+    "base_layer",
+] }
 tari_indexer_lib = { path = "../../dan_layer/indexer_lib" }
 tari_comms_rpc_state_sync = { path = "../../dan_layer/comms_rpc_state_sync" }
 
@@ -43,6 +47,7 @@ anyhow = "1.0.53"
 async-trait = "0.1.50"
 axum = "0.6.0"
 axum-jrpc = { version = "0.3.2", features = ["anyhow_error"] }
+blake2 = "0.10"
 clap = { version = "3.2.5", features = ["env"] }
 config = "0.13.0"
 futures = { version = "^0.3.1" }
@@ -52,7 +57,12 @@ json5 = "0.2.2"
 libsqlite3-sys = { version = "0.25", features = ["bundled"] }
 lmdb-zero = "0.4.4"
 log = { version = "0.4.8", features = ["std"] }
-log4rs = { version = "1.1.1", features = ["rolling_file_appender", "compound_policy", "size_trigger", "fixed_window_roller"] }
+log4rs = { version = "1.1.1", features = [
+    "rolling_file_appender",
+    "compound_policy",
+    "size_trigger",
+    "fixed_window_roller",
+] }
 prost = "0.9"
 rand = "0.8"
 reqwest = "0.11.11"
@@ -60,7 +70,12 @@ serde = { version = "1.0.126", features = ["derive"] }
 serde_json = "1.0.64"
 thiserror = "^1.0.20"
 time = "0.3.15"
-tokio = { version = "1.10", features = ["macros", "time", "sync", "rt-multi-thread"] }
+tokio = { version = "1.10", features = [
+    "macros",
+    "time",
+    "sync",
+    "rt-multi-thread",
+] }
 tonic = "0.6.2"
 tower = "0.4"
 tower-http = { version = "0.3.0", features = ["cors"] }
@@ -68,7 +83,9 @@ tower-layer = "0.3"
 mime_guess = "2.0.4"
 
 [build-dependencies]
-tari_common = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan2", package = "tari_common", features = ["build"] }
+tari_common = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan2", package = "tari_common", features = [
+    "build",
+] }
 
 [package.metadata.cargo-machete]
 ignored = [

--- a/applications/tari_validator_node/src/consensus/signature_service.rs
+++ b/applications/tari_validator_node/src/consensus/signature_service.rs
@@ -22,7 +22,7 @@ impl TariSignatureService {
 
 impl ValidatorSignatureService<PublicKey> for TariSignatureService {
     fn sign<M: AsRef<[u8]>>(&self, message: M) -> ValidatorSchnorrSignature {
-        ValidatorSchnorrSignature::sign_message(self.node_identity.secret_key(), message, &mut OsRng).unwrap()
+        ValidatorSchnorrSignature::sign(self.node_identity.secret_key(), message, &mut OsRng).unwrap()
     }
 
     fn public_key(&self) -> &PublicKey {

--- a/applications/tari_validator_node/src/template_registration_signing.rs
+++ b/applications/tari_validator_node/src/template_registration_signing.rs
@@ -20,6 +20,7 @@
 //   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //   USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+use blake2::{digest::typenum::U32, Blake2b};
 use rand::rngs::OsRng;
 use tari_common_types::types::{FixedHash, PrivateKey, PublicKey, Signature};
 use tari_core::{consensus::DomainSeparatedConsensusHasher, transactions::TransactionHashDomain};
@@ -34,12 +35,12 @@ pub fn sign_template_registration(private_key: &PrivateKey, binary_hash: Vec<u8>
     // TODO: epoch should be committed to, but this is currently not the case on the base node, so we leave it out for
     //       now so that the transaction passes validation.
     let challenge = construct_challenge(&public_key, &public_nonce, &binary_hash, b"");
-    Signature::sign_raw(private_key, secret_nonce, &*challenge)
+    Signature::sign_raw_uniform(private_key, secret_nonce, &*challenge)
         .expect("Sign cannot fail with 32-byte challenge and a RistrettoPublicKey")
 }
 
 fn construct_challenge(public_key: &PublicKey, public_nonce: &PublicKey, binary_hash: &[u8], msg: &[u8]) -> FixedHash {
-    DomainSeparatedConsensusHasher::<TransactionHashDomain>::new("template_registration")
+    DomainSeparatedConsensusHasher::<TransactionHashDomain, Blake2b<U32>>::new("template_registration")
         .chain(public_key)
         .chain(public_nonce)
         .chain(&binary_hash)

--- a/applications/tari_validator_node/src/template_registration_signing.rs
+++ b/applications/tari_validator_node/src/template_registration_signing.rs
@@ -20,9 +20,9 @@
 //   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //   USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use blake2::{digest::typenum::U32, Blake2b};
+use blake2::{digest::typenum::U64, Blake2b};
 use rand::rngs::OsRng;
-use tari_common_types::types::{FixedHash, PrivateKey, PublicKey, Signature};
+use tari_common_types::types::{PrivateKey, PublicKey, Signature};
 use tari_core::{consensus::DomainSeparatedConsensusHasher, transactions::TransactionHashDomain};
 use tari_crypto::keys::PublicKey as PublicKeyT;
 
@@ -35,16 +35,15 @@ pub fn sign_template_registration(private_key: &PrivateKey, binary_hash: Vec<u8>
     // TODO: epoch should be committed to, but this is currently not the case on the base node, so we leave it out for
     //       now so that the transaction passes validation.
     let challenge = construct_challenge(&public_key, &public_nonce, &binary_hash, b"");
-    Signature::sign_raw_uniform(private_key, secret_nonce, &*challenge)
+    Signature::sign_raw_uniform(private_key, secret_nonce, &challenge)
         .expect("Sign cannot fail with 32-byte challenge and a RistrettoPublicKey")
 }
 
-fn construct_challenge(public_key: &PublicKey, public_nonce: &PublicKey, binary_hash: &[u8], msg: &[u8]) -> FixedHash {
-    DomainSeparatedConsensusHasher::<TransactionHashDomain, Blake2b<U32>>::new("template_registration")
+fn construct_challenge(public_key: &PublicKey, public_nonce: &PublicKey, binary_hash: &[u8], msg: &[u8]) -> [u8; 64] {
+    DomainSeparatedConsensusHasher::<TransactionHashDomain, Blake2b<U64>>::new("template_registration")
         .chain(public_key)
         .chain(public_nonce)
         .chain(&binary_hash)
         .chain(&msg)
         .finalize()
-        .into()
 }

--- a/applications/tari_validator_node_cli/Cargo.toml
+++ b/applications/tari_validator_node_cli/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 
 [dependencies]
 tari_common_types = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan2" }
-tari_crypto = "0.18"
+tari_crypto = "0.19"
 tari_dan_common_types = { path = "../../dan_layer/common_types" }
 tari_dan_engine = { path = "../../dan_layer/engine" }
 tari_engine_types = { path = "../../dan_layer/engine_types" }

--- a/applications/tari_validator_node_cli/src/command/vn.rs
+++ b/applications/tari_validator_node_cli/src/command/vn.rs
@@ -41,7 +41,7 @@ impl VnSubcommand {
     pub async fn handle(self, mut client: ValidatorNodeClient) -> Result<(), anyhow::Error> {
         match self {
             VnSubcommand::Register(args) => {
-                let claim_public_key = PublicKey::from_bytes(args.claim_public_key.into_inner().as_bytes())
+                let claim_public_key = PublicKey::from_canonical_bytes(args.claim_public_key.into_inner().as_bytes())
                     .map_err(|e| anyhow!("{}", e))?;
                 let tx_id = client.register_validator_node(claim_public_key).await?;
                 println!("✅ Validator node registration submitted (tx_id: {})", tx_id);
@@ -86,7 +86,7 @@ async fn handle_get_fee_info(args: GetFeesArgs, client: &mut ValidatorNodeClient
             epoch_range,
             validator_public_key: args
                 .validator_public_key
-                .map(|pk| PublicKey::from_bytes(pk.into_inner().as_bytes()))
+                .map(|pk| PublicKey::from_canonical_bytes(pk.into_inner().as_bytes()))
                 .transpose()
                 .map_err(anyhow::Error::msg)?,
         })

--- a/clients/base_node_client/Cargo.toml
+++ b/clients/base_node_client/Cargo.toml
@@ -9,8 +9,10 @@ license = "BSD-3-Clause"
 minotari_app_grpc = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan2" }
 minotari_node_grpc_client = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan2" }
 tari_common_types = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan2" }
-tari_core = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan2", default-features = false, features = ["transactions"] }
-tari_utilities = "0.5.1"
+tari_core = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan2", default-features = false, features = [
+  "transactions",
+] }
+tari_utilities = "0.6"
 
 tari_dan_common_types = { path = "../../dan_layer/common_types" }
 tari_engine_types = { path = "../../dan_layer/engine_types" }

--- a/clients/base_node_client/src/grpc.rs
+++ b/clients/base_node_client/src/grpc.rs
@@ -31,7 +31,7 @@ use minotari_node_grpc_client::BaseNodeGrpcClient;
 use tari_common_types::types::{FixedHash, PublicKey};
 use tari_core::{blocks::BlockHeader, transactions::transaction_components::CodeTemplateRegistration};
 use tari_dan_common_types::ShardId;
-use tari_utilities::byte_array::ByteArray;
+use tari_utilities::ByteArray;
 
 use crate::{
     types::{BaseLayerConsensusConstants, BaseLayerMetadata, BlockInfo, SideChainUtxos, ValidatorNode},
@@ -125,7 +125,7 @@ impl BaseNodeClient for GrpcBaseNodeClient {
             match stream.message().await {
                 Ok(Some(val)) => {
                     vns.push(ValidatorNode {
-                        public_key: PublicKey::from_bytes(&val.public_key).map_err(|_| {
+                        public_key: PublicKey::from_canonical_bytes(&val.public_key).map_err(|_| {
                             BaseNodeClientError::InvalidPeerMessage("public_key was not a valid public key".to_string())
                         })?,
                         shard_key: ShardId::from_bytes(&val.shard_key).map_err(|_| {
@@ -160,7 +160,7 @@ impl BaseNodeClient for GrpcBaseNodeClient {
         let inner = self.connection().await?;
         let request = GetShardKeyRequest {
             height,
-            public_key: public_key.to_vec(),
+            public_key: public_key.as_bytes().to_vec(),
         };
         let result = inner.get_shard_key(request).await?.into_inner();
         if result.shard_key.is_empty() {

--- a/dan_layer/common_types/Cargo.toml
+++ b/dan_layer/common_types/Cargo.toml
@@ -8,7 +8,7 @@ license = "BSD-3-Clause"
 
 [dependencies]
 tari_common_types = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan2" }
-tari_crypto = { version = "0.18", features = ["borsh"] }
+tari_crypto = { version = "0.19", features = ["borsh"] }
 tari_engine_types = { path = "../engine_types" }
 tari_bor = { path = "../tari_bor" }
 tari_mmr = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan2" }
@@ -22,7 +22,9 @@ serde = "1.0.126"
 ruint = "1.8.0"
 
 [build-dependencies]
-tari_common = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan2", package = "tari_common", features = ["build"] }
+tari_common = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan2", package = "tari_common", features = [
+  "build",
+] }
 
 [package.metadata.cargo-machete]
 ignored = ["prost", "prost-types"] # false positive, used in OUT_DIR structs

--- a/dan_layer/common_types/src/node_addressable.rs
+++ b/dan_layer/common_types/src/node_addressable.rs
@@ -43,6 +43,6 @@ impl NodeAddressable for PublicKey {
     }
 
     fn from_bytes(bytes: &[u8]) -> Option<Self> {
-        ByteArray::from_bytes(bytes).ok()
+        ByteArray::from_canonical_bytes(bytes).ok()
     }
 }

--- a/dan_layer/common_types/src/shard_id.rs
+++ b/dan_layer/common_types/src/shard_id.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 use tari_common_types::types::{FixedHash, FixedHashSizeError};
 use tari_crypto::tari_utilities::hex::{from_hex, Hex};
 use tari_engine_types::{
-    hashing::{hasher, EngineHashDomainLabel},
+    hashing::{hasher32, EngineHashDomainLabel},
     serde_with,
     substate::SubstateAddress,
 };
@@ -30,7 +30,7 @@ impl ShardId {
     }
 
     pub fn from_hash(hash: &[u8], version: u32) -> Self {
-        let new_addr = hasher(EngineHashDomainLabel::ShardId)
+        let new_addr = hasher32(EngineHashDomainLabel::ShardId)
             .chain(&hash)
             .chain(&version)
             .result();

--- a/dan_layer/consensus_tests/Cargo.toml
+++ b/dan_layer/consensus_tests/Cargo.toml
@@ -21,14 +21,17 @@ tari_epoch_manager = { path = "../epoch_manager" }
 tari_common_types = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan2" }
 tari_mmr = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan2" }
 tari_shutdown = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan2" }
-tari_crypto = "0.18"
+tari_crypto = "0.19"
 
 anyhow = "1.0"
 async-trait = "0.1.68"
 log = "0.4"
 serde = "1.0"
 thiserror = "1.0"
-tokio = { version = "1", default-features = false, features = ["sync", "rt-multi-thread"] }
+tokio = { version = "1", default-features = false, features = [
+  "sync",
+  "rt-multi-thread",
+] }
 rand = "0.8"
 futures = "0.3"
 fern = "0.6.2"

--- a/dan_layer/consensus_tests/src/support/signing_service.rs
+++ b/dan_layer/consensus_tests/src/support/signing_service.rs
@@ -28,7 +28,7 @@ impl<TAddr> TestVoteSignatureService<TAddr> {
 
 impl<TAddr> ValidatorSignatureService<TAddr> for TestVoteSignatureService<TAddr> {
     fn sign<M: AsRef<[u8]>>(&self, message: M) -> ValidatorSchnorrSignature {
-        ValidatorSchnorrSignature::sign_message(&self.secret_key, message, &mut OsRng).unwrap()
+        ValidatorSchnorrSignature::sign(&self.secret_key, message, &mut OsRng).unwrap()
     }
 
     fn public_key(&self) -> &TAddr {

--- a/dan_layer/engine/Cargo.toml
+++ b/dan_layer/engine/Cargo.toml
@@ -10,13 +10,13 @@ license = "BSD-3-Clause"
 [dependencies]
 tari_bor = { path = "../tari_bor" }
 tari_common_types = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan2", package = "tari_common_types" }
-tari_crypto = { version = "0.18", features = ["borsh"] }
+tari_crypto = { version = "0.19", features = ["borsh"] }
 tari_dan_common_types = { path = "../common_types" }
 tari_engine_types = { path = "../engine_types" }
 tari_mmr = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan2", package = "tari_mmr" }
 tari_template_abi = { path = "../template_abi", features = ["std"] }
 tari_template_lib = { path = "../template_lib" }
-tari_utilities = "0.4.10"
+tari_utilities = "0.6"
 tari_transaction = { path = "../transaction" }
 
 anyhow = "1.0.53"

--- a/dan_layer/engine/src/runtime/impl.rs
+++ b/dan_layer/engine/src/runtime/impl.rs
@@ -27,7 +27,7 @@ use tari_common_types::types::PublicKey;
 use tari_crypto::{range_proof::RangeProofService, ristretto::RistrettoPublicKey, tari_utilities::ByteArray};
 use tari_dan_common_types::{optional::Optional, services::template_provider::TemplateProvider, Epoch};
 use tari_engine_types::{
-    base_layer_hashing::ownership_proof_hasher,
+    base_layer_hashing::ownership_proof_hasher64,
     commit_result::FinalizeResult,
     component::ComponentHeader,
     confidential::{get_commitment_factory, get_range_proof_service, ConfidentialClaim, ConfidentialOutput},
@@ -1153,7 +1153,7 @@ impl<TTemplateProvider: TemplateProvider<Template = LoadedTemplate>> RuntimeInte
         // 1. Must exist
         let unclaimed_output = self.tracker.take_unclaimed_confidential_output(output_address)?;
         // 2. owner_sig must be valid
-        let challenge = ownership_proof_hasher()
+        let challenge = ownership_proof_hasher64()
             .chain_update(proof_of_knowledge.public_nonce())
             .chain_update(&unclaimed_output.commitment)
             .chain_update(&self.sender_public_key)

--- a/dan_layer/engine/src/transaction/error.rs
+++ b/dan_layer/engine/src/transaction/error.rs
@@ -22,7 +22,6 @@
 
 use tari_engine_types::indexed_value::IndexedValueError;
 use tari_template_lib::models::TemplateAddress;
-use tari_utilities::ByteArrayError;
 
 use crate::{runtime::RuntimeError, wasm::WasmExecutionError};
 
@@ -34,8 +33,6 @@ pub enum TransactionError {
     TemplateNotFound { address: TemplateAddress },
     #[error(transparent)]
     RuntimeError(#[from] RuntimeError),
-    #[error(transparent)]
-    ByteArrayError(#[from] ByteArrayError),
     #[error(transparent)]
     FlowEngineError(#[from] crate::flow::FlowEngineError),
     #[error("Recursion limit exceeded")]

--- a/dan_layer/engine/tests/confidential.rs
+++ b/dan_layer/engine/tests/confidential.rs
@@ -421,7 +421,7 @@ pub mod utilities {
         let secret_excess = input_mask - output_mask - change_mask.unwrap_or(&PrivateKey::default());
         let excess = PublicKey::from_secret_key(&secret_excess);
         let (nonce, public_nonce) = PublicKey::random_keypair(&mut OsRng);
-        let challenge = challenges::confidential_withdraw(&excess, &public_nonce, revealed_amount);
+        let challenge = challenges::confidential_withdraw64(&excess, &public_nonce, revealed_amount);
 
         let sig = Signature::sign_raw_uniform(&secret_excess, nonce, &challenge).unwrap();
         BalanceProofSignature::try_from_parts(sig.get_public_nonce().as_bytes(), sig.get_signature().as_bytes())

--- a/dan_layer/engine/tests/confidential.rs
+++ b/dan_layer/engine/tests/confidential.rs
@@ -423,7 +423,7 @@ pub mod utilities {
         let (nonce, public_nonce) = PublicKey::random_keypair(&mut OsRng);
         let challenge = challenges::confidential_withdraw(&excess, &public_nonce, revealed_amount);
 
-        let sig = Signature::sign_raw(&secret_excess, nonce, &challenge).unwrap();
+        let sig = Signature::sign_raw_uniform(&secret_excess, nonce, &challenge).unwrap();
         BalanceProofSignature::try_from_parts(sig.get_public_nonce().as_bytes(), sig.get_signature().as_bytes())
             .unwrap()
     }

--- a/dan_layer/engine/tests/test.rs
+++ b/dan_layer/engine/tests/test.rs
@@ -246,7 +246,7 @@ fn test_caller_context() {
     let value: RistrettoPublicKeyBytes = template_test.call_method(component, "caller_pub_key", args![], vec![]);
     assert_eq!(
         to_hex(value.as_bytes()),
-        "66cad05f12652276f0656288f60963753f50a7947c54a640aa1e1c62097a406d"
+        "d884dd886cc7464402a04920485aebe6dd657b98072de655c46ec6179a52cd0d"
     );
 }
 

--- a/dan_layer/engine_types/Cargo.toml
+++ b/dan_layer/engine_types/Cargo.toml
@@ -10,10 +10,10 @@ license = "BSD-3-Clause"
 [dependencies]
 tari_bor = { path = "../tari_bor" }
 tari_common_types = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan2" }
-tari_crypto = { version = "0.18", features = ["borsh"] }
+tari_crypto = { version = "0.19", features = ["borsh"] }
 tari_template_abi = { path = "../template_abi", features = ["std"] }
 tari_template_lib = { path = "../template_lib" }
-tari_utilities = "0.5.1"
+tari_utilities = "0.6"
 
 borsh = "0.10"
 base64 = "0.21.0"

--- a/dan_layer/engine_types/src/base_layer_hashing.rs
+++ b/dan_layer/engine_types/src/base_layer_hashing.rs
@@ -24,7 +24,7 @@ use std::{io, io::Write};
 
 use blake2::Blake2b;
 use borsh::BorshSerialize;
-use digest::{consts::U32, Digest};
+use digest::{consts::U32, typenum::U64, Digest};
 use tari_crypto::{
     hash_domain,
     hashing::{DomainSeparatedHasher, DomainSeparation},
@@ -43,7 +43,7 @@ fn confidential_hasher(label: &'static str) -> TariBaseLayerHasher {
     TariBaseLayerHasher::new_with_label::<ConfidentialOutputHashDomain>(label)
 }
 
-type WalletOutputEncryptionKeysDomainHasher = DomainSeparatedHasher<Blake2b<U32>, WalletOutputEncryptionKeysDomain>;
+type WalletOutputEncryptionKeysDomainHasher = DomainSeparatedHasher<Blake2b<U64>, WalletOutputEncryptionKeysDomain>;
 pub fn encrypted_data_hasher() -> WalletOutputEncryptionKeysDomainHasher {
     WalletOutputEncryptionKeysDomainHasher::new_with_label("")
 }

--- a/dan_layer/engine_types/src/component.rs
+++ b/dan_layer/engine_types/src/component.rs
@@ -30,12 +30,12 @@ use tari_template_lib::{
 };
 
 use crate::{
-    hashing::{hasher, EngineHashDomainLabel},
+    hashing::{hasher32, EngineHashDomainLabel},
     serde_with,
 };
 
 pub fn new_component_address_from_parts(template_address: &TemplateAddress, component_id: &Hash) -> ComponentAddress {
-    let address = hasher(EngineHashDomainLabel::ComponentAddress)
+    let address = hasher32(EngineHashDomainLabel::ComponentAddress)
         .chain(template_address)
         .chain(component_id)
         .result();

--- a/dan_layer/engine_types/src/confidential/proof.rs
+++ b/dan_layer/engine_types/src/confidential/proof.rs
@@ -34,22 +34,42 @@ pub mod challenges {
     use tari_common_types::types::{Commitment, PublicKey};
     use tari_template_lib::{models::Amount, Hash};
 
-    use crate::hashing::{hasher, EngineHashDomainLabel};
+    use crate::hashing::{hasher32, hasher64, EngineHashDomainLabel};
 
-    pub fn confidential_commitment_proof(
+    pub fn confidential_commitment_proof64(
         public_key: &PublicKey,
         public_nonce: &PublicKey,
         commitment: &Commitment,
-    ) -> Hash {
-        hasher(EngineHashDomainLabel::ConfidentialProof)
+    ) -> [u8; 64] {
+        hasher64(EngineHashDomainLabel::ConfidentialProof)
             .chain(&public_key)
             .chain(&public_nonce)
             .chain(commitment.as_public_key())
             .result()
     }
 
-    pub fn confidential_withdraw(excess: &PublicKey, public_nonce: &PublicKey, revealed_amount: Amount) -> Hash {
-        hasher(EngineHashDomainLabel::ConfidentialTransfer)
+    pub fn confidential_withdraw64(excess: &PublicKey, public_nonce: &PublicKey, revealed_amount: Amount) -> [u8; 64] {
+        hasher64(EngineHashDomainLabel::ConfidentialTransfer)
+            .chain(excess)
+            .chain(public_nonce)
+            .chain(&revealed_amount)
+            .result()
+    }
+
+    pub fn confidential_commitment_proof32(
+        public_key: &PublicKey,
+        public_nonce: &PublicKey,
+        commitment: &Commitment,
+    ) -> Hash {
+        hasher32(EngineHashDomainLabel::ConfidentialProof)
+            .chain(&public_key)
+            .chain(&public_nonce)
+            .chain(commitment.as_public_key())
+            .result()
+    }
+
+    pub fn confidential_withdraw32(excess: &PublicKey, public_nonce: &PublicKey, revealed_amount: Amount) -> Hash {
+        hasher32(EngineHashDomainLabel::ConfidentialTransfer)
             .chain(excess)
             .chain(public_nonce)
             .chain(&revealed_amount)

--- a/dan_layer/engine_types/src/confidential/validation.rs
+++ b/dan_layer/engine_types/src/confidential/validation.rs
@@ -35,42 +35,41 @@ pub fn validate_confidential_proof(
         });
     }
 
-    let output_commitment = Commitment::from_bytes(&proof.output_statement.commitment).map_err(|_| {
+    let output_commitment = Commitment::from_canonical_bytes(&proof.output_statement.commitment).map_err(|_| {
         ResourceError::InvalidConfidentialProof {
             details: "Invalid commitment".to_string(),
         }
     })?;
 
-    let output_public_nonce =
-        PublicKey::from_bytes(proof.output_statement.sender_public_nonce.as_bytes()).map_err(|_| {
-            ResourceError::InvalidConfidentialProof {
-                details: "Invalid sender public nonce".to_string(),
-            }
+    let output_public_nonce = PublicKey::from_canonical_bytes(proof.output_statement.sender_public_nonce.as_bytes())
+        .map_err(|_| ResourceError::InvalidConfidentialProof {
+            details: "Invalid sender public nonce".to_string(),
         })?;
 
-    let change = proof
-        .change_statement
-        .as_ref()
-        .map(|stmt| {
-            let commitment =
-                Commitment::from_bytes(&stmt.commitment).map_err(|_| ResourceError::InvalidConfidentialProof {
-                    details: "Invalid commitment".to_string(),
+    let change =
+        proof
+            .change_statement
+            .as_ref()
+            .map(|stmt| {
+                let commitment = Commitment::from_canonical_bytes(&stmt.commitment).map_err(|_| {
+                    ResourceError::InvalidConfidentialProof {
+                        details: "Invalid commitment".to_string(),
+                    }
                 })?;
 
-            let stealth_public_nonce = PublicKey::from_bytes(stmt.sender_public_nonce.as_bytes()).map_err(|_| {
-                ResourceError::InvalidConfidentialProof {
-                    details: "Invalid sender public nonce".to_string(),
-                }
-            })?;
+                let stealth_public_nonce = PublicKey::from_canonical_bytes(stmt.sender_public_nonce.as_bytes())
+                    .map_err(|_| ResourceError::InvalidConfidentialProof {
+                        details: "Invalid sender public nonce".to_string(),
+                    })?;
 
-            Ok(ConfidentialOutput {
-                commitment,
-                stealth_public_nonce,
-                encrypted_data: stmt.encrypted_data.clone(),
-                minimum_value_promise: stmt.minimum_value_promise,
+                Ok(ConfidentialOutput {
+                    commitment,
+                    stealth_public_nonce,
+                    encrypted_data: stmt.encrypted_data.clone(),
+                    minimum_value_promise: stmt.minimum_value_promise,
+                })
             })
-        })
-        .transpose()?;
+            .transpose()?;
 
     validate_bullet_proof(proof)?;
 
@@ -90,10 +89,11 @@ fn validate_bullet_proof(proof: &ConfidentialOutputProof) -> Result<(), Resource
         .chain(proof.change_statement.as_ref())
         .cloned()
         .map(|stmt| {
-            let commitment =
-                Commitment::from_bytes(&stmt.commitment).map_err(|_| ResourceError::InvalidConfidentialProof {
+            let commitment = Commitment::from_canonical_bytes(&stmt.commitment).map_err(|_| {
+                ResourceError::InvalidConfidentialProof {
                     details: "Invalid commitment".to_string(),
-                })?;
+                }
+            })?;
             Ok(Statement {
                 commitment,
                 minimum_value_promise: stmt.minimum_value_promise,

--- a/dan_layer/engine_types/src/confidential/withdraw.rs
+++ b/dan_layer/engine_types/src/confidential/withdraw.rs
@@ -62,7 +62,7 @@ pub fn validate_confidential_withdraw<'a, I: IntoIterator<Item = &'a PublicKey>>
             .unwrap_or(&PublicKey::default());
 
     let challenge =
-        challenges::confidential_withdraw(&public_excess, balance_proof.get_public_nonce(), revealed_amount);
+        challenges::confidential_withdraw64(&public_excess, balance_proof.get_public_nonce(), revealed_amount);
 
     if !balance_proof.verify_raw_uniform(&public_excess, &challenge) {
         return Err(ResourceError::InvalidBalanceProof {

--- a/dan_layer/engine_types/src/confidential/withdraw.rs
+++ b/dan_layer/engine_types/src/confidential/withdraw.rs
@@ -64,7 +64,7 @@ pub fn validate_confidential_withdraw<'a, I: IntoIterator<Item = &'a PublicKey>>
     let challenge =
         challenges::confidential_withdraw(&public_excess, balance_proof.get_public_nonce(), revealed_amount);
 
-    if !balance_proof.verify_challenge(&public_excess, &challenge) {
+    if !balance_proof.verify_raw_uniform(&public_excess, &challenge) {
         return Err(ResourceError::InvalidBalanceProof {
             details: "Balance proof was invalid".to_string(),
         });
@@ -84,7 +84,7 @@ pub fn validate_confidential_withdraw<'a, I: IntoIterator<Item = &'a PublicKey>>
 }
 
 fn try_decode_to_signature(balance_proof: &BalanceProofSignature) -> Option<Signature> {
-    let public_nonce = PublicKey::from_bytes(balance_proof.as_public_nonce()).ok()?;
-    let signature = PrivateKey::from_bytes(balance_proof.as_signature()).ok()?;
+    let public_nonce = PublicKey::from_canonical_bytes(balance_proof.as_public_nonce()).ok()?;
+    let signature = PrivateKey::from_canonical_bytes(balance_proof.as_signature()).ok()?;
     Some(Signature::new(public_nonce, signature))
 }

--- a/dan_layer/engine_types/src/fee_claim.rs
+++ b/dan_layer/engine_types/src/fee_claim.rs
@@ -8,7 +8,7 @@ use tari_bor::BorTag;
 use tari_common_types::types::PublicKey;
 use tari_template_lib::{models::BinaryTag, prelude::Amount, Hash};
 
-use crate::hashing::{hasher, EngineHashDomainLabel};
+use crate::hashing::{hasher32, EngineHashDomainLabel};
 
 const TAG: u64 = BinaryTag::FeeClaim.as_u64();
 
@@ -21,7 +21,7 @@ impl FeeClaimAddress {
     }
 
     pub fn from_addr<TAddr: AsRef<[u8]>>(epoch: u64, addr: TAddr) -> Self {
-        let hash = hasher(EngineHashDomainLabel::FeeClaimAddress)
+        let hash = hasher32(EngineHashDomainLabel::FeeClaimAddress)
             .chain(&epoch)
             .chain(addr.as_ref())
             .result();

--- a/dan_layer/engine_types/src/hashing.rs
+++ b/dan_layer/engine_types/src/hashing.rs
@@ -22,7 +22,10 @@
 
 use std::{io, io::Write};
 
-use blake2::{digest::consts::U32, Blake2b};
+use blake2::{
+    digest::consts::{U32, U64},
+    Blake2b,
+};
 use digest::Digest;
 use serde::Serialize;
 use tari_bor::encode_into;
@@ -31,22 +34,29 @@ use tari_template_lib::Hash;
 
 hash_domain!(TariEngineHashDomain, "com.tari.dan.engine", 0);
 
-pub fn hasher(label: EngineHashDomainLabel) -> TariHasher {
-    TariHasher::new_with_label::<TariEngineHashDomain>(label.as_label())
+pub fn hasher64(label: EngineHashDomainLabel) -> TariHasher64 {
+    TariHasher64::new_with_label::<TariEngineHashDomain>(label.as_label())
 }
 
-pub fn template_hasher() -> TariHasher {
-    hasher(EngineHashDomainLabel::Template)
+pub fn template_hasher64() -> TariHasher64 {
+    hasher64(EngineHashDomainLabel::Template)
+}
+
+pub fn hasher32(label: EngineHashDomainLabel) -> TariHasher32 {
+    TariHasher32::new_with_label::<TariEngineHashDomain>(label.as_label())
+}
+
+pub fn template_hasher32() -> TariHasher32 {
+    hasher32(EngineHashDomainLabel::Template)
 }
 
 hash_domain!(ConfidentialOutputHashDomain, "com.tari.dan.confidential_output", 1);
 
 #[derive(Debug, Clone)]
-pub struct TariHasher {
+pub struct TariHasher32 {
     hasher: Blake2b<U32>,
 }
-
-impl TariHasher {
+impl TariHasher32 {
     pub fn new_with_label<TDomain: DomainSeparation>(label: &'static str) -> Self {
         let mut hasher = Blake2b::<U32>::new();
         TDomain::add_domain_separation_tag(&mut hasher, label);
@@ -81,6 +91,59 @@ impl TariHasher {
 
     fn hash_writer(&mut self) -> impl Write + '_ {
         struct HashWriter<'a>(&'a mut Blake2b<U32>);
+        impl Write for HashWriter<'_> {
+            fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+                self.0.update(buf);
+                Ok(buf.len())
+            }
+
+            fn flush(&mut self) -> io::Result<()> {
+                Ok(())
+            }
+        }
+        HashWriter(&mut self.hasher)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct TariHasher64 {
+    hasher: Blake2b<U64>,
+}
+
+impl TariHasher64 {
+    pub fn new_with_label<TDomain: DomainSeparation>(label: &'static str) -> Self {
+        let mut hasher = Blake2b::<U64>::new();
+        TDomain::add_domain_separation_tag(&mut hasher, label);
+        Self { hasher }
+    }
+
+    pub fn update<T: Serialize + ?Sized>(&mut self, data: &T) {
+        // CBOR encoding does not make any contract to say that if the writer is infallible (as it is here) then
+        // encoding in infallible. However this should be the case. Since it is very unergonomic to return an
+        // error in hash chain functions, and therefore all usages of the hasher, we assume all types implement
+        // infallible encoding.
+        encode_into(data, &mut self.hash_writer()).expect("encoding failed")
+    }
+
+    pub fn chain<T: Serialize + ?Sized>(mut self, data: &T) -> Self {
+        self.update(data);
+        self
+    }
+
+    pub fn digest<T: Serialize + ?Sized>(self, data: &T) -> [u8; 64] {
+        self.chain(data).result()
+    }
+
+    pub fn result(self) -> [u8; 64] {
+        self.hasher.finalize().into()
+    }
+
+    pub fn finalize_into(self, output: &mut digest::Output<Blake2b<U64>>) {
+        digest::FixedOutput::finalize_into(self.hasher, output)
+    }
+
+    fn hash_writer(&mut self) -> impl Write + '_ {
+        struct HashWriter<'a>(&'a mut Blake2b<U64>);
         impl Write for HashWriter<'_> {
             fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
                 self.0.update(buf);

--- a/dan_layer/engine_types/src/indexed_value.rs
+++ b/dan_layer/engine_types/src/indexed_value.rs
@@ -277,10 +277,10 @@ mod tests {
     use tari_template_lib::models::NonFungibleId;
 
     use super::*;
-    use crate::hashing::{hasher, EngineHashDomainLabel};
+    use crate::hashing::{hasher32, EngineHashDomainLabel};
 
     fn new_hash() -> Hash {
-        hasher(EngineHashDomainLabel::ComponentAddress)
+        hasher32(EngineHashDomainLabel::ComponentAddress)
             .chain(&OsRng.next_u32())
             .result()
     }

--- a/dan_layer/engine_types/src/instruction.rs
+++ b/dan_layer/engine_types/src/instruction.rs
@@ -5,11 +5,11 @@ use std::fmt::{Display, Formatter};
 
 use serde::{Deserialize, Serialize};
 use tari_common_types::types::PublicKey;
+use tari_crypto::tari_utilities::hex::Hex;
 use tari_template_lib::{
     args::{Arg, LogLevel},
     models::{Amount, ComponentAddress, TemplateAddress},
 };
-use tari_utilities::hex::Hex;
 
 use crate::{
     confidential::{ConfidentialClaim, ConfidentialOutput},

--- a/dan_layer/engine_types/src/resource_container.rs
+++ b/dan_layer/engine_types/src/resource_container.rs
@@ -9,12 +9,12 @@ use std::{collections::BTreeMap, iter, mem};
 
 use serde::{Deserialize, Serialize};
 use tari_common_types::types::PublicKey;
+use tari_crypto::tari_utilities::ByteArray;
 use tari_template_abi::rust::collections::BTreeSet;
 use tari_template_lib::{
     models::{Amount, ConfidentialOutputProof, ConfidentialWithdrawProof, NonFungibleId, ResourceAddress},
     prelude::ResourceType,
 };
-use tari_utilities::ByteArray;
 
 use crate::{
     confidential::{validate_confidential_proof, validate_confidential_withdraw, ConfidentialOutput},
@@ -315,10 +315,11 @@ impl ResourceContainer {
                     .inputs
                     .iter()
                     .map(|input| {
-                        let commitment =
-                            PublicKey::from_bytes(input).map_err(|_| ResourceError::InvalidConfidentialProof {
+                        let commitment = PublicKey::from_canonical_bytes(input).map_err(|_| {
+                            ResourceError::InvalidConfidentialProof {
                                 details: "Invalid input commitment".to_string(),
-                            })?;
+                            }
+                        })?;
                         match commitments.remove(&commitment) {
                             Some(_) => Ok(commitment),
                             None => Err(ResourceError::InvalidConfidentialProof {

--- a/dan_layer/engine_types/src/substate.rs
+++ b/dan_layer/engine_types/src/substate.rs
@@ -44,7 +44,7 @@ use crate::{
     component::ComponentHeader,
     confidential::UnclaimedConfidentialOutput,
     fee_claim::{FeeClaim, FeeClaimAddress},
-    hashing::{hasher, EngineHashDomainLabel},
+    hashing::{hasher32, EngineHashDomainLabel},
     non_fungible::NonFungibleContainer,
     non_fungible_index::NonFungibleIndex,
     resource::Resource,
@@ -136,11 +136,11 @@ impl SubstateAddress {
             SubstateAddress::Resource(address) => *address.hash(),
             SubstateAddress::Vault(id) => *id.hash(),
             SubstateAddress::UnclaimedConfidentialOutput(address) => *address.hash(),
-            SubstateAddress::NonFungible(address) => hasher(EngineHashDomainLabel::NonFungibleId)
+            SubstateAddress::NonFungible(address) => hasher32(EngineHashDomainLabel::NonFungibleId)
                 .chain(address.resource_address().hash())
                 .chain(address.id())
                 .result(),
-            SubstateAddress::NonFungibleIndex(address) => hasher(EngineHashDomainLabel::NonFungibleIndex)
+            SubstateAddress::NonFungibleIndex(address) => hasher32(EngineHashDomainLabel::NonFungibleIndex)
                 .chain(address.resource_address().hash())
                 .chain(&address.index())
                 .result(),

--- a/dan_layer/engine_types/src/template.rs
+++ b/dan_layer/engine_types/src/template.rs
@@ -24,7 +24,7 @@ use std::str::FromStr;
 
 use tari_common_types::types::FixedHash;
 
-use crate::hashing::{hasher, EngineHashDomainLabel};
+use crate::hashing::{hasher32, EngineHashDomainLabel};
 
 /// Package (template) identifier
 pub type TemplateAddress = tari_template_lib::Hash;
@@ -41,6 +41,6 @@ pub fn parse_template_address(s: String) -> Option<TemplateAddress> {
 }
 
 pub fn calculate_template_binary_hash(wasm_code: &[u8]) -> FixedHash {
-    let hash = hasher(EngineHashDomainLabel::Template).chain(wasm_code).result();
+    let hash = hasher32(EngineHashDomainLabel::Template).chain(wasm_code).result();
     FixedHash::from(hash.into_array())
 }

--- a/dan_layer/epoch_manager/Cargo.toml
+++ b/dan_layer/epoch_manager/Cargo.toml
@@ -16,7 +16,7 @@ tari_comms = { git = "https://github.com/tari-project/tari.git", branch = "featu
 tari_dan_storage = { path = "../storage" }
 tari_dan_storage_sqlite = { path = "../storage_sqlite", optional = true }
 tari_base_node_client = { path = "../../clients/base_node_client", optional = true }
-tari_crypto = "0.18"
+tari_crypto = "0.19"
 tari_mmr = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan2", optional = true }
 tokio = { version = "1", default-features = false, features = ["sync"] }
 
@@ -26,4 +26,10 @@ thiserror = "1.0"
 log = { version = "0.4", optional = true }
 
 [features]
-base_layer = ["log", "tari_base_node_client", "tari_comms", "tari_dan_storage_sqlite", "tari_mmr"]
+base_layer = [
+  "log",
+  "tari_base_node_client",
+  "tari_comms",
+  "tari_dan_storage_sqlite",
+  "tari_mmr",
+]

--- a/dan_layer/storage/Cargo.toml
+++ b/dan_layer/storage/Cargo.toml
@@ -15,8 +15,8 @@ tari_engine_types = { path = "../engine_types" }
 tari_transaction = { path = "../transaction" }
 tari_core = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan2" }
 tari_mmr = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan2" }
-tari_crypto = "0.18"
-tari_utilities = "0.4.10"
+tari_crypto = "0.19"
+tari_utilities = "0.6"
 
 anyhow = "1.0"
 chrono = "0.4.23"

--- a/dan_layer/storage/src/consensus_models/vote_signature.rs
+++ b/dan_layer/storage/src/consensus_models/vote_signature.rs
@@ -28,13 +28,13 @@ impl<TAddr: NodeAddressable> ValidatorSignature<TAddr> {
 
 impl ValidatorSignature<PublicKey> {
     pub fn sign<M: AsRef<[u8]>>(secret_key: &PrivateKey, message: M) -> Self {
-        let signature = ValidatorSchnorrSignature::sign_message(secret_key, message, &mut OsRng)
-            .expect("sign_message is infallible");
+        let signature =
+            ValidatorSchnorrSignature::sign(secret_key, message, &mut OsRng).expect("sign_message is infallible");
         let public_key = PublicKey::from_secret_key(secret_key);
         Self::new(public_key, signature)
     }
 
     pub fn verify<M: AsRef<[u8]>>(&self, message: M) -> bool {
-        self.signature.verify_message(&self.public_key, message)
+        self.signature.verify(&self.public_key, message)
     }
 }

--- a/dan_layer/storage_sqlite/Cargo.toml
+++ b/dan_layer/storage_sqlite/Cargo.toml
@@ -7,10 +7,13 @@ license = "BSD-3-Clause"
 [dependencies]
 tari_common_types = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan2", package = "tari_common_types" }
 tari_dan_common_types = { path = "../common_types" }
-tari_utilities = "0.5.1"
+tari_utilities = "0.6"
 tari_dan_storage = { path = "../storage" }
 
-diesel = { version = "2", default-features = false, features = ["sqlite", "chrono"] }
+diesel = { version = "2", default-features = false, features = [
+  "sqlite",
+  "chrono",
+] }
 diesel_migrations = "2"
 thiserror = "1.0.30"
 chrono = "0.4.19"
@@ -20,4 +23,4 @@ serde = "1.0"
 
 [dev-dependencies]
 rand = "0.8"
-tari_crypto = "0.18"
+tari_crypto = "0.19"

--- a/dan_layer/storage_sqlite/src/global/models/validator_node.rs
+++ b/dan_layer/storage_sqlite/src/global/models/validator_node.rs
@@ -45,13 +45,13 @@ impl TryFrom<DbValidatorNode> for ValidatorNode<PublicKey> {
             shard_key: ShardId::try_from(vn.shard_key).map_err(|_| {
                 SqliteStorageError::MalformedDbData(format!("Invalid shard id in validator node record id={}", vn.id))
             })?,
-            address: PublicKey::from_bytes(&vn.public_key).map_err(|_| {
+            address: PublicKey::from_canonical_bytes(&vn.public_key).map_err(|_| {
                 SqliteStorageError::MalformedDbData(format!("Invalid public key in validator node record id={}", vn.id))
             })?,
             epoch: Epoch(vn.epoch as u64),
             committee_bucket: vn.committee_bucket.map(|v| v as u32).map(ShardBucket::from),
 
-            fee_claim_public_key: PublicKey::from_bytes(&vn.fee_claim_public_key).map_err(|_| {
+            fee_claim_public_key: PublicKey::from_canonical_bytes(&vn.fee_claim_public_key).map_err(|_| {
                 SqliteStorageError::MalformedDbData(format!(
                     "Invalid fee claim public key in validator node record id={}",
                     vn.id

--- a/dan_layer/template_test_tooling/Cargo.toml
+++ b/dan_layer/template_test_tooling/Cargo.toml
@@ -21,3 +21,4 @@ tari_bor = { path = "../tari_bor" }
 
 anyhow = "1.0.68"
 serde = { version = "1.0.144", features = ["derive"] }
+rand = "0.8"

--- a/dan_layer/template_test_tooling/Cargo.toml
+++ b/dan_layer/template_test_tooling/Cargo.toml
@@ -10,7 +10,7 @@ license = "BSD-3-Clause"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
 tari_dan_engine = { path = "../engine" }
-tari_crypto = "0.18"
+tari_crypto = "0.19"
 tari_template_lib = { path = "../template_lib" }
 tari_engine_types = { path = "../engine_types" }
 tari_transaction_manifest = { path = "../transaction_manifest" }

--- a/dan_layer/template_test_tooling/src/template_test.rs
+++ b/dan_layer/template_test_tooling/src/template_test.rs
@@ -12,9 +12,9 @@ use anyhow::anyhow;
 use serde::de::DeserializeOwned;
 use tari_bor::encode;
 use tari_crypto::{
-    keys::PublicKey,
+    keys::{PublicKey, SecretKey},
     ristretto::{RistrettoPublicKey, RistrettoSecretKey},
-    tari_utilities::{hex::Hex, ByteArray},
+    tari_utilities::ByteArray,
 };
 use tari_dan_common_types::crypto::create_key_pair;
 use tari_dan_engine::{
@@ -60,6 +60,7 @@ use crate::track_calls::TrackCallsModule;
 pub fn test_faucet_component() -> ComponentAddress {
     ComponentAddress::new(Hash::from_array([0xfau8; 32]))
 }
+use rand::rngs::OsRng;
 
 pub struct TemplateTest {
     package: Arc<Package>,
@@ -76,8 +77,7 @@ pub struct TemplateTest {
 
 impl TemplateTest {
     pub fn new<I: IntoIterator<Item = P>, P: AsRef<Path>>(template_paths: I) -> Self {
-        let secret_key =
-            RistrettoSecretKey::from_hex("7e100429f979d37999f051e65b94734e206925e9346759fd73caafb2f3232578").unwrap();
+        let secret_key = RistrettoSecretKey::random(&mut OsRng);
         let public_key = RistrettoPublicKey::from_secret_key(&secret_key);
 
         let mut name_to_template = HashMap::new();

--- a/dan_layer/transaction/Cargo.toml
+++ b/dan_layer/transaction/Cargo.toml
@@ -11,7 +11,7 @@ license = "BSD-3-Clause"
 tari_common_types = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan2" }
 tari_engine_types = { path = "../engine_types" }
 tari_dan_common_types = { path = "../common_types" }
-tari_crypto = { version = "0.18", features = ["borsh"] }
+tari_crypto = { version = "0.19", features = ["borsh"] }
 tari_template_lib = { path = "../template_lib" }
 
 rand = "0.8"

--- a/dan_layer/transaction/src/id_provider.rs
+++ b/dan_layer/transaction/src/id_provider.rs
@@ -5,7 +5,7 @@ use std::sync::{atomic::AtomicU32, Arc, Mutex};
 
 use tari_engine_types::{
     component::new_component_address_from_parts,
-    hashing::{hasher, EngineHashDomainLabel},
+    hashing::{hasher32, EngineHashDomainLabel},
 };
 use tari_template_lib::{
     models::{BucketId, ComponentAddress, ProofId, ResourceAddress, TemplateAddress, VaultId},
@@ -100,7 +100,7 @@ impl IdProvider {
 
     pub fn new_uuid(&self) -> Result<[u8; 32], IdProviderError> {
         let n = self.uuid.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        let id = hasher(EngineHashDomainLabel::UuidOutput)
+        let id = hasher32(EngineHashDomainLabel::UuidOutput)
             .chain(&self.transaction_hash)
             .chain(&n)
             .result();
@@ -113,7 +113,9 @@ impl IdProvider {
         })?;
         let mut result = Vec::with_capacity(len as usize);
         while result.len() < len as usize {
-            let new_random = hasher(EngineHashDomainLabel::RandomBytes).chain(&*last_random).result();
+            let new_random = hasher32(EngineHashDomainLabel::RandomBytes)
+                .chain(&*last_random)
+                .result();
             result.extend_from_slice(&new_random);
             *last_random = new_random;
         }
@@ -126,7 +128,7 @@ impl IdProvider {
 }
 
 fn generate_output_id(hash: &Hash, n: u32) -> Hash {
-    hasher(EngineHashDomainLabel::Output).chain(hash).chain(&n).result()
+    hasher32(EngineHashDomainLabel::Output).chain(hash).chain(&n).result()
 }
 
 #[cfg(test)]

--- a/dan_layer/transaction/src/signature.rs
+++ b/dan_layer/transaction/src/signature.rs
@@ -9,7 +9,7 @@ use tari_crypto::{
     ristretto::{RistrettoPublicKey, RistrettoSecretKey},
 };
 use tari_engine_types::{
-    hashing::{hasher, EngineHashDomainLabel},
+    hashing::{hasher64, EngineHashDomainLabel},
     instruction::Instruction,
 };
 
@@ -26,7 +26,7 @@ impl TransactionSignature {
 
     pub fn sign(secret_key: &RistrettoSecretKey, instructions: &[Instruction]) -> Self {
         let public_key = RistrettoPublicKey::from_secret_key(secret_key);
-        let challenge = hasher(EngineHashDomainLabel::InstructionSignature)
+        let challenge = hasher64(EngineHashDomainLabel::InstructionSignature)
             .chain(instructions)
             .result();
 

--- a/dan_layer/transaction/src/signature.rs
+++ b/dan_layer/transaction/src/signature.rs
@@ -31,7 +31,7 @@ impl TransactionSignature {
             .result();
 
         Self {
-            signature: Signature::sign_message(secret_key, challenge, &mut OsRng).unwrap(),
+            signature: Signature::sign(secret_key, challenge, &mut OsRng).unwrap(),
             public_key,
         }
     }

--- a/dan_layer/transaction/src/transaction.rs
+++ b/dan_layer/transaction/src/transaction.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use tari_common_types::types::PublicKey;
 use tari_dan_common_types::{Epoch, ShardId};
 use tari_engine_types::{
-    hashing::{hasher, EngineHashDomainLabel},
+    hashing::{hasher32, EngineHashDomainLabel},
     instruction::Instruction,
     serde_with,
     substate::SubstateAddress,
@@ -65,7 +65,7 @@ impl Transaction {
     }
 
     fn calculate_hash(&self) -> TransactionId {
-        hasher(EngineHashDomainLabel::Transaction)
+        hasher32(EngineHashDomainLabel::Transaction)
             .chain(&self.signature)
             .chain(&self.fee_instructions)
             .chain(&self.instructions)

--- a/dan_layer/validator_node_rpc/Cargo.toml
+++ b/dan_layer/validator_node_rpc/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 tari_common_types = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan2" }
 tari_comms = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan2" }
 tari_comms_rpc_macros = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan2" }
-tari_crypto = "0.18"
+tari_crypto = "0.19"
 
 tari_consensus = { path = "../consensus" }
 tari_dan_common_types = { path = "../common_types" }
@@ -32,7 +32,9 @@ thiserror = "1.0"
 tokio-stream = "0.1"
 
 [build-dependencies]
-tari_common = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan2", package = "tari_common", features = ["build"] }
+tari_common = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan2", package = "tari_common", features = [
+    "build",
+] }
 
 [package.metadata.cargo-machete]
 ignored = [

--- a/dan_layer/validator_node_rpc/src/client.rs
+++ b/dan_layer/validator_node_rpc/src/client.rs
@@ -154,7 +154,7 @@ impl ValidatorNodeRpcClient for TariCommsValidatorNodeRpcClient {
                     .map(|a| PeerIdentityClaim::try_from(a).map_err(ValidatorNodeRpcClientError::InvalidResponse))
                     .collect::<Result<Vec<_>, _>>()?;
                 Result::<_, ValidatorNodeRpcClientError>::Ok(DanPeer {
-                    identity: ByteArray::from_bytes(&p.identity)
+                    identity: ByteArray::from_canonical_bytes(&p.identity)
                         .map_err(|_| ValidatorNodeRpcClientError::InvalidResponse(anyhow!("Invalid identity")))?,
                     claims,
                 })

--- a/dan_layer/validator_node_rpc/src/conversions/common.rs
+++ b/dan_layer/validator_node_rpc/src/conversions/common.rs
@@ -36,8 +36,8 @@ impl<H: DomainSeparation> TryFrom<proto::common::Signature> for SchnorrSignature
     type Error = anyhow::Error;
 
     fn try_from(sig: proto::common::Signature) -> Result<Self, Self::Error> {
-        let public_nonce = ByteArray::from_bytes(&sig.public_nonce).map_err(anyhow::Error::msg)?;
-        let signature = PrivateKey::from_bytes(&sig.signature).map_err(anyhow::Error::msg)?;
+        let public_nonce = ByteArray::from_canonical_bytes(&sig.public_nonce).map_err(anyhow::Error::msg)?;
+        let signature = PrivateKey::from_canonical_bytes(&sig.signature).map_err(anyhow::Error::msg)?;
 
         Ok(Self::new(public_nonce, signature))
     }
@@ -57,8 +57,8 @@ impl<TAddr: NodeAddressable> TryFrom<proto::common::SignatureAndPublicKey> for V
 
     fn try_from(sig: proto::common::SignatureAndPublicKey) -> Result<Self, Self::Error> {
         let public_key = TAddr::from_bytes(&sig.public_key).ok_or_else(|| anyhow!("Public key was not valid bytes"))?;
-        let public_nonce = ByteArray::from_bytes(&sig.public_nonce).map_err(anyhow::Error::msg)?;
-        let signature = PrivateKey::from_bytes(&sig.signature).map_err(anyhow::Error::msg)?;
+        let public_nonce = ByteArray::from_canonical_bytes(&sig.public_nonce).map_err(anyhow::Error::msg)?;
+        let signature = PrivateKey::from_canonical_bytes(&sig.signature).map_err(anyhow::Error::msg)?;
 
         Ok(Self::new(
             public_key,
@@ -83,9 +83,9 @@ impl TryFrom<proto::common::SignatureAndPublicKey> for TransactionSignature {
     type Error = anyhow::Error;
 
     fn try_from(sig: proto::common::SignatureAndPublicKey) -> Result<Self, Self::Error> {
-        let public_key = ByteArray::from_bytes(&sig.public_key).map_err(anyhow::Error::msg)?;
-        let public_nonce = ByteArray::from_bytes(&sig.public_nonce).map_err(anyhow::Error::msg)?;
-        let signature = PrivateKey::from_bytes(&sig.signature).map_err(anyhow::Error::msg)?;
+        let public_key = ByteArray::from_canonical_bytes(&sig.public_key).map_err(anyhow::Error::msg)?;
+        let public_nonce = ByteArray::from_canonical_bytes(&sig.public_nonce).map_err(anyhow::Error::msg)?;
+        let signature = PrivateKey::from_canonical_bytes(&sig.signature).map_err(anyhow::Error::msg)?;
 
         Ok(Self::new(public_key, Signature::new(public_nonce, signature)))
     }

--- a/dan_layer/validator_node_rpc/src/conversions/consensus.rs
+++ b/dan_layer/validator_node_rpc/src/conversions/consensus.rs
@@ -448,7 +448,7 @@ impl TryFrom<proto::consensus::ValidatorMetadata> for ValidatorMetadata {
 
     fn try_from(value: proto::consensus::ValidatorMetadata) -> Result<Self, Self::Error> {
         Ok(ValidatorMetadata {
-            public_key: ByteArray::from_bytes(&value.public_key).map_err(anyhow::Error::msg)?,
+            public_key: ByteArray::from_canonical_bytes(&value.public_key).map_err(anyhow::Error::msg)?,
             vn_shard_key: value.vn_shard_key.try_into()?,
             signature: value
                 .signature

--- a/dan_layer/validator_node_rpc/src/conversions/network.rs
+++ b/dan_layer/validator_node_rpc/src/conversions/network.rs
@@ -88,7 +88,7 @@ impl<T: ByteArray> TryFrom<proto::network::NetworkAnnounce> for NetworkAnnounce<
 
     fn try_from(value: proto::network::NetworkAnnounce) -> Result<Self, Self::Error> {
         Ok(NetworkAnnounce {
-            identity: T::from_bytes(&value.identity).map_err(anyhow::Error::msg)?,
+            identity: T::from_canonical_bytes(&value.identity).map_err(anyhow::Error::msg)?,
             claim: value
                 .claim
                 .ok_or_else(|| anyhow!("claim not provided in NetworkAnnounce"))?

--- a/dan_layer/validator_node_rpc/src/conversions/transaction.rs
+++ b/dan_layer/validator_node_rpc/src/conversions/transaction.rs
@@ -200,7 +200,7 @@ impl TryFrom<proto::transaction::Instruction> for Instruction {
             },
             InstructionType::ClaimBurn => Instruction::ClaimBurn {
                 claim: Box::new(ConfidentialClaim {
-                    public_key: PublicKey::from_bytes(&request.claim_burn_public_key)
+                    public_key: PublicKey::from_canonical_bytes(&request.claim_burn_public_key)
                         .map_err(|e| anyhow!("claim_burn_public_key: {}", e))?,
                     output_address: request
                         .claim_burn_commitment_address
@@ -218,8 +218,10 @@ impl TryFrom<proto::transaction::Instruction> for Instruction {
             },
             InstructionType::ClaimValidatorFees => Instruction::ClaimValidatorFees {
                 epoch: request.claim_validator_fees_epoch,
-                validator_public_key: PublicKey::from_bytes(&request.claim_validator_fees_validator_public_key)
-                    .map_err(|e| anyhow!("claim_validator_fees_validator_public_key: {}", e))?,
+                validator_public_key: PublicKey::from_canonical_bytes(
+                    &request.claim_validator_fees_validator_public_key,
+                )
+                .map_err(|e| anyhow!("claim_validator_fees_validator_public_key: {}", e))?,
             },
             InstructionType::DropAllProofsInWorkspace => Instruction::DropAllProofsInWorkspace,
             InstructionType::CreateFreeTestCoins => Instruction::CreateFreeTestCoins {
@@ -375,9 +377,9 @@ impl TryFrom<proto::transaction::CommitmentSignature> for RistrettoComSig {
     type Error = anyhow::Error;
 
     fn try_from(val: proto::transaction::CommitmentSignature) -> Result<Self, Self::Error> {
-        let u = PrivateKey::from_bytes(&val.signature_u).map_err(anyhow::Error::msg)?;
-        let v = PrivateKey::from_bytes(&val.signature_v).map_err(anyhow::Error::msg)?;
-        let public_nonce = PublicKey::from_bytes(&val.public_nonce_commitment).map_err(anyhow::Error::msg)?;
+        let u = PrivateKey::from_canonical_bytes(&val.signature_u).map_err(anyhow::Error::msg)?;
+        let v = PrivateKey::from_canonical_bytes(&val.signature_v).map_err(anyhow::Error::msg)?;
+        let public_nonce = PublicKey::from_canonical_bytes(&val.public_nonce_commitment).map_err(anyhow::Error::msg)?;
 
         Ok(RistrettoComSig::new(Commitment::from_public_key(&public_nonce), u, v))
     }

--- a/dan_layer/validator_node_rpc/src/peer_sync.rs
+++ b/dan_layer/validator_node_rpc/src/peer_sync.rs
@@ -58,7 +58,7 @@ impl<TPeerProvider: PeerProvider<Addr = CommsPublicKey>> PeerSyncProtocol<TPeerP
         let mut count = 0usize;
         while let Some(resp) = stream.next().await {
             let resp = resp?;
-            let identity = CommsPublicKey::from_bytes(&resp.identity).map_err(anyhow::Error::msg)?;
+            let identity = CommsPublicKey::from_canonical_bytes(&resp.identity).map_err(anyhow::Error::msg)?;
             if self.our_identity == identity {
                 continue;
             }

--- a/dan_layer/wallet/sdk/Cargo.toml
+++ b/dan_layer/wallet/sdk/Cargo.toml
@@ -9,7 +9,7 @@ license = "BSD-3-Clause"
 
 [dependencies]
 tari_common_types = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan2" }
-tari_crypto = { version = "0.18", features = ["borsh"] }
+tari_crypto = { version = "0.19", features = ["borsh"] }
 tari_engine_types = { path = "../../engine_types" }
 tari_dan_common_types = { path = "../../common_types" }
 # Just used for QuorumCertificate
@@ -17,7 +17,7 @@ tari_dan_storage = { path = "../../storage" }
 tari_key_manager = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan2" }
 tari_transaction = { path = "../../transaction" }
 tari_template_lib = { path = "../../template_lib" }
-tari_utilities = "0.4.10"
+tari_utilities = "0.6"
 
 anyhow = "1.0"
 async-trait = "0.1"

--- a/dan_layer/wallet/sdk/src/apis/confidential_crypto.rs
+++ b/dan_layer/wallet/sdk/src/apis/confidential_crypto.rs
@@ -181,7 +181,7 @@ fn generate_balance_proof(
     let secret_excess = input_mask - output_mask - change_mask.unwrap_or(&PrivateKey::default());
     let excess = PublicKey::from_secret_key(&secret_excess);
     let (nonce, public_nonce) = PublicKey::random_keypair(&mut OsRng);
-    let challenge = challenges::confidential_withdraw(&excess, &public_nonce, reveal_amount);
+    let challenge = challenges::confidential_withdraw64(&excess, &public_nonce, reveal_amount);
 
     let sig = Signature::sign_raw_uniform(&secret_excess, nonce, &challenge).unwrap();
     BalanceProofSignature::try_from_parts(sig.get_public_nonce().as_bytes(), sig.get_signature().as_bytes()).unwrap()

--- a/dan_layer/wallet/sdk/src/apis/confidential_crypto.rs
+++ b/dan_layer/wallet/sdk/src/apis/confidential_crypto.rs
@@ -183,7 +183,7 @@ fn generate_balance_proof(
     let (nonce, public_nonce) = PublicKey::random_keypair(&mut OsRng);
     let challenge = challenges::confidential_withdraw(&excess, &public_nonce, reveal_amount);
 
-    let sig = Signature::sign_raw(&secret_excess, nonce, &challenge).unwrap();
+    let sig = Signature::sign_raw_uniform(&secret_excess, nonce, &challenge).unwrap();
     BalanceProofSignature::try_from_parts(sig.get_public_nonce().as_bytes(), sig.get_signature().as_bytes()).unwrap()
 }
 

--- a/dan_layer/wallet/sdk/src/apis/key_manager.rs
+++ b/dan_layer/wallet/sdk/src/apis/key_manager.rs
@@ -2,7 +2,7 @@
 //   SPDX-License-Identifier: BSD-3-Clause
 
 use blake2::Blake2b;
-use digest::consts::U32;
+use digest::consts::U64;
 use tari_common_types::types::PublicKey;
 use tari_crypto::keys::PublicKey as PublicKeyTrait;
 //
@@ -15,7 +15,7 @@ use tari_key_manager::{
 
 use crate::storage::{WalletStorageError, WalletStore, WalletStoreReader, WalletStoreWriter};
 
-pub type WalletKeyManager = KeyManager<RistrettoPublicKey, Blake2b<U32>>;
+pub type WalletKeyManager = KeyManager<RistrettoPublicKey, Blake2b<U64>>;
 
 pub const TRANSACTION_BRANCH: &str = "transactions";
 

--- a/dan_layer/wallet/sdk/src/confidential/kdfs.rs
+++ b/dan_layer/wallet/sdk/src/confidential/kdfs.rs
@@ -1,25 +1,25 @@
 //   Copyright 2023 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use chacha20poly1305::{aead::generic_array::GenericArray, Key};
+use chacha20poly1305::aead::generic_array::GenericArray;
 use digest::FixedOutput;
 use tari_common_types::types::{PrivateKey, PublicKey};
-use tari_crypto::{dhke::DiffieHellmanSharedSecret, tari_utilities::ByteArray};
+use tari_crypto::{dhke::DiffieHellmanSharedSecret, keys::SecretKey};
 use tari_engine_types::base_layer_hashing::encrypted_data_hasher;
 use tari_utilities::{hidden_type, safe_array::SafeArray, Hidden};
 use zeroize::Zeroize;
 
-pub(crate) const AEAD_KEY_LEN: usize = std::mem::size_of::<Key>();
-hidden_type!(EncryptedDataKey, SafeArray<u8, AEAD_KEY_LEN>);
+hidden_type!(EncryptedDataKey32, SafeArray<u8, 32>);
+hidden_type!(EncryptedDataKey64, SafeArray<u8, 64>);
 
 /// Generate a ChaCha20-Poly1305 key from a private key and commitment using Blake2b
 pub fn encrypted_data_dh_kdf_aead(private_key: &PrivateKey, public_nonce: &PublicKey) -> PrivateKey {
     let shared_secret = DiffieHellmanSharedSecret::<PublicKey>::new(private_key, public_nonce);
-    let mut aead_key = EncryptedDataKey::from(SafeArray::default());
+    let mut aead_key = EncryptedDataKey64::from(SafeArray::default());
     // Must match base layer burn
     encrypted_data_hasher()
         .chain(shared_secret.as_bytes())
         .finalize_into(GenericArray::from_mut_slice(aead_key.reveal_mut()));
 
-    PrivateKey::from_bytes(aead_key.reveal()).unwrap()
+    PrivateKey::from_uniform_bytes(aead_key.reveal()).unwrap()
 }

--- a/dan_layer/wallet/sdk/src/confidential/proof.rs
+++ b/dan_layer/wallet/sdk/src/confidential/proof.rs
@@ -37,7 +37,7 @@ use zeroize::Zeroizing;
 
 use crate::{
     byte_utils::copy_fixed,
-    confidential::{error::ConfidentialProofError, kdfs::EncryptedDataKey},
+    confidential::{error::ConfidentialProofError, kdfs::EncryptedDataKey32},
 };
 
 lazy_static! {
@@ -117,8 +117,8 @@ pub fn generate_confidential_proof(
     })
 }
 
-fn inner_encrypted_data_kdf_aead(encryption_key: &PrivateKey, commitment: &Commitment) -> EncryptedDataKey {
-    let mut aead_key = EncryptedDataKey::from(SafeArray::default());
+fn inner_encrypted_data_kdf_aead(encryption_key: &PrivateKey, commitment: &Commitment) -> EncryptedDataKey32 {
+    let mut aead_key = EncryptedDataKey32::from(SafeArray::default());
     // This has to be the same as the base layer so that burn claims are spendable
     hash_domain!(
         TransactionSecureNonceKdfDomain,
@@ -193,7 +193,7 @@ pub fn decrypt_data_and_mask(
     value_bytes.clone_from_slice(&bytes[0..SIZE_VALUE]);
     Ok((
         u64::from_le_bytes(value_bytes),
-        PrivateKey::from_bytes(&bytes[SIZE_VALUE..]).expect("The length of bytes is exactly SIZE_MASK"),
+        PrivateKey::from_canonical_bytes(&bytes[SIZE_VALUE..]).expect("The length of bytes is exactly SIZE_MASK"),
     ))
 }
 

--- a/dan_layer/wallet/storage_sqlite/Cargo.toml
+++ b/dan_layer/wallet/storage_sqlite/Cargo.toml
@@ -14,7 +14,7 @@ tari_dan_wallet_sdk = { path = "../sdk" }
 tari_engine_types = { path = "../../engine_types" }
 tari_template_lib = { path = "../../template_lib" }
 tari_transaction = { path = "../../transaction" }
-tari_utilities = "0.5.1"
+tari_utilities = "0.6"
 # Just used for QuorumCertificate
 tari_dan_storage = { path = "../../storage" }
 

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -21,7 +21,7 @@ minotari_wallet = { git = "https://github.com/tari-project/tari.git", branch = "
 tari_p2p = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan2" }
 tari_shutdown = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan2" }
 
-tari_crypto = "0.18"
+tari_crypto = "0.19"
 tari_indexer = { path = "../applications/tari_indexer" }
 tari_validator_node_cli = { path = "../applications/tari_validator_node_cli" }
 tari_dan_common_types = { path = "../dan_layer/common_types" }
@@ -44,22 +44,36 @@ tari_dan_wallet_sdk = { path = "../dan_layer/wallet/sdk" }
 anyhow = "1.0.53"
 base64 = "0.21.0"
 config = "0.13.0"
-cucumber = { version = "0.18.0", features = ["default", "libtest", "output-junit"] }
+cucumber = { version = "0.18.0", features = [
+    "default",
+    "libtest",
+    "output-junit",
+] }
 httpmock = "0.6.8"
 indexmap = "1.9.1"
 log = { version = "0.4.8", features = ["std"] }
-log4rs = { version = "1.1.1", features = ["rolling_file_appender", "compound_policy", "size_trigger", "fixed_window_roller"] }
+log4rs = { version = "1.1.1", features = [
+    "rolling_file_appender",
+    "compound_policy",
+    "size_trigger",
+    "fixed_window_roller",
+] }
 rand = "0.8"
 reqwest = "0.11.11"
 serde = { version = "1.0.126", features = ["derive"] }
 serde_json = "1.0.64"
 time = "0.3.15"
-tokio = { version = "1.10", features = ["macros", "time", "sync", "rt-multi-thread"] }
+tokio = { version = "1.10", features = [
+    "macros",
+    "time",
+    "sync",
+    "rt-multi-thread",
+] }
 tonic = "0.6.2"
 
 [[test]]
 name = "cucumber" # this should be the same as the filename of your test target
-harness = false # allows Cucumber to print output instead of libtest
+harness = false   # allows Cucumber to print output instead of libtest
 
 [package.metadata.cargo-machete]
 ignored = [

--- a/integration_tests/src/base_node.rs
+++ b/integration_tests/src/base_node.rs
@@ -107,6 +107,7 @@ pub async fn spawn_base_node(world: &mut TariWorld, bn_name: String) {
                 database_url: DbConnectionUrl::File(temp_dir.join("dht.sqlite")),
                 ..DhtConfig::default_local_test()
             };
+            base_node_config.base_node.grpc_server_deny_methods = vec![];
 
             let result = run_base_node(shutdown, Arc::new(base_node_identity), Arc::new(base_node_config)).await;
             if let Err(e) = result {

--- a/integration_tests/src/template.rs
+++ b/integration_tests/src/template.rs
@@ -4,7 +4,7 @@
 use std::path::PathBuf;
 
 use tari_dan_engine::wasm::compile::compile_template;
-use tari_engine_types::{hashing::template_hasher, TemplateAddress};
+use tari_engine_types::{hashing::template_hasher32, TemplateAddress};
 use tari_template_lib::Hash;
 use tari_validator_node_client::types::{TemplateRegistrationRequest, TemplateRegistrationResponse};
 
@@ -57,7 +57,7 @@ pub fn compile_wasm_template(template_name: String) -> Result<Hash, anyhow::Erro
     template_path.push(template_name);
     let wasm_module = compile_template(template_path.as_path(), &[])?;
     let wasm_code = wasm_module.code();
-    Ok(template_hasher().chain(&wasm_code).result())
+    Ok(template_hasher32().chain(&wasm_code).result())
 }
 
 pub fn get_template_wasm_path(template_name: String) -> PathBuf {

--- a/integration_tests/src/templates/fees/Cargo.toml
+++ b/integration_tests/src/templates/fees/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tari_template_lib = {path="../../../../dan_layer/template_lib"}
+tari_template_lib = { path = "../../../../dan_layer/template_lib" }
 
 [profile.release]
 opt-level = 's'     # Optimize for size.
@@ -23,5 +23,5 @@ crate-type = ["cdylib", "lib"]
 tari_dan_engine = { path = "../../../../dan_layer/engine" }
 tari_dan_common_types = { path = "../../../../dan_layer/common_types" }
 
-tari_crypto = "0.18"
+tari_crypto = "0.19"
 tari_common_types = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan2", package = "tari_common_types" }

--- a/integration_tests/tests/steps/wallet.rs
+++ b/integration_tests/tests/steps/wallet.rs
@@ -59,15 +59,15 @@ async fn when_i_burn_on_wallet(
     world.commitment_ownership_proofs.insert(
         proof,
         RistrettoComSig::new(
-            Commitment::from_public_key(&PublicKey::from_bytes(&ownership_proof.public_nonce).unwrap()),
-            PrivateKey::from_bytes(&ownership_proof.u).unwrap(),
-            PrivateKey::from_bytes(&ownership_proof.v).unwrap(),
+            Commitment::from_public_key(&PublicKey::from_canonical_bytes(&ownership_proof.public_nonce).unwrap()),
+            PrivateKey::from_canonical_bytes(&ownership_proof.u).unwrap(),
+            PrivateKey::from_canonical_bytes(&ownership_proof.v).unwrap(),
         ),
     );
     world.rangeproofs.insert(range_proof, resp.range_proof);
     world.claim_public_keys.insert(
         claim_public_key_name,
-        PublicKey::from_bytes(&resp.reciprocal_claim_public_key).unwrap(),
+        PublicKey::from_canonical_bytes(&resp.reciprocal_claim_public_key).unwrap(),
     );
 }
 

--- a/integration_tests/tests/steps/wallet_daemon.rs
+++ b/integration_tests/tests/steps/wallet_daemon.rs
@@ -262,15 +262,15 @@ async fn when_i_burn_funds_with_wallet_daemon(
     world.commitment_ownership_proofs.insert(
         ownership_proof_name,
         RistrettoComSig::new(
-            Commitment::from_public_key(&PublicKey::from_bytes(&ownership_proof.public_nonce).unwrap()),
-            PrivateKey::from_bytes(&ownership_proof.u).unwrap(),
-            PrivateKey::from_bytes(&ownership_proof.v).unwrap(),
+            Commitment::from_public_key(&PublicKey::from_canonical_bytes(&ownership_proof.public_nonce).unwrap()),
+            PrivateKey::from_canonical_bytes(&ownership_proof.u).unwrap(),
+            PrivateKey::from_canonical_bytes(&ownership_proof.v).unwrap(),
         ),
     );
     world.rangeproofs.insert(rangeproof_name, resp.range_proof);
     world.claim_public_keys.insert(
         claim_pubkey_name,
-        PublicKey::from_bytes(&resp.reciprocal_claim_public_key).unwrap(),
+        PublicKey::from_canonical_bytes(&resp.reciprocal_claim_public_key).unwrap(),
     );
 }
 

--- a/utilities/transaction_generator/Cargo.toml
+++ b/utilities/transaction_generator/Cargo.toml
@@ -8,7 +8,7 @@ tari_template_lib = { path = "../../dan_layer/template_lib" }
 tari_transaction = { path = "../../dan_layer/transaction" }
 tari_engine_types = { path = "../../dan_layer/engine_types" }
 tari_template_builtin = { path = "../../dan_layer/template_builtin" }
-tari_crypto = "0.18"
+tari_crypto = "0.19"
 
 anyhow = "1.0.72"
 bincode = { version = "2.0.0-rc.3", features = ["serde"] }


### PR DESCRIPTION
Description
---
Bump up the versions of `tari-crypto` and `tari-utilities`

Motivation and Context
---

How Has This Been Tested?
---
I run the dan-testing with stress test enabled.

What process can a PR reviewer use to test or verify this change?
---
The same as above.


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify