### PR TITLE
refactor(mempool): move epoch range check to validators

### DIFF
--- a/applications/tari_validator_node/src/bootstrap.rs
+++ b/applications/tari_validator_node/src/bootstrap.rs
@@ -82,6 +82,7 @@ use crate::{
             mempool,
             mempool::{
                 ClaimFeeTransactionValidator,
+                EpochRangeValidator,
                 FeeTransactionValidator,
                 HasInputs,
                 HasInvolvedShards,
@@ -474,6 +475,7 @@ fn create_mempool_before_execute_validator(
     epoch_manager: EpochManagerHandle,
 ) -> impl Validator<Transaction, Error = MempoolError> {
     let mut validator = TemplateExistsValidator::new(template_manager)
+        .and_then(EpochRangeValidator::new(epoch_manager.clone()))
         .and_then(ClaimFeeTransactionValidator::new(epoch_manager))
         .boxed();
     if !config.no_fees {

--- a/applications/tari_validator_node/src/p2p/services/mempool/service.rs
+++ b/applications/tari_validator_node/src/p2p/services/mempool/service.rs
@@ -286,25 +286,6 @@ where
 
         let transaction = transaction.into_transaction();
 
-        let current_epoch = self.epoch_manager.current_epoch().await?;
-        if let Some(min_epoch) = transaction.min_epoch() {
-            if current_epoch < min_epoch {
-                return Err(MempoolError::CurrentEpochLessThanMinimum {
-                    current_epoch,
-                    min_epoch,
-                });
-            }
-        }
-
-        if let Some(max_epoch) = transaction.max_epoch() {
-            if current_epoch > max_epoch {
-                return Err(MempoolError::CurrentEpochGreaterThanMaximum {
-                    current_epoch,
-                    max_epoch,
-                });
-            }
-        }
-
         // Get the shards involved in claim fees.
         let fee_claims = transaction.fee_claims().collect::<Vec<_>>();
 
@@ -320,6 +301,7 @@ where
             warn!(target: LOG_TARGET, "⚠ No involved shards for payload");
         }
 
+        let current_epoch = self.epoch_manager.current_epoch().await?;
         let tx_shard_id = ShardId::for_transaction_receipt(transaction.id().into_array().into());
 
         let local_committee_shard = self.epoch_manager.get_local_committee_shard(current_epoch).await?;

--- a/applications/tari_validator_node/src/p2p/services/mempool/validators/before/epoch_range.rs
+++ b/applications/tari_validator_node/src/p2p/services/mempool/validators/before/epoch_range.rs
@@ -1,0 +1,47 @@
+//    Copyright 2023 The Tari Project
+//    SPDX-License-Identifier: BSD-3-Clause
+
+use async_trait::async_trait;
+use tari_epoch_manager::{base_layer::EpochManagerHandle, EpochManagerReader};
+use tari_transaction::Transaction;
+
+use crate::p2p::services::mempool::{MempoolError, Validator};
+
+#[derive(Debug)]
+pub struct EpochRangeValidator {
+    epoch_manager: EpochManagerHandle,
+}
+
+impl EpochRangeValidator {
+    pub fn new(epoch_manager: EpochManagerHandle) -> Self {
+        Self { epoch_manager }
+    }
+}
+
+#[async_trait]
+impl Validator<Transaction> for EpochRangeValidator {
+    type Error = MempoolError;
+
+    async fn validate(&self, transaction: &Transaction) -> Result<(), MempoolError> {
+        let current_epoch = self.epoch_manager.current_epoch().await?;
+        if let Some(min_epoch) = transaction.min_epoch() {
+            if current_epoch < min_epoch {
+                return Err(MempoolError::CurrentEpochLessThanMinimum {
+                    current_epoch,
+                    min_epoch,
+                });
+            }
+        }
+
+        if let Some(max_epoch) = transaction.max_epoch() {
+            if current_epoch > max_epoch {
+                return Err(MempoolError::CurrentEpochGreaterThanMaximum {
+                    current_epoch,
+                    max_epoch,
+                });
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/applications/tari_validator_node/src/p2p/services/mempool/validators/before/mod.rs
+++ b/applications/tari_validator_node/src/p2p/services/mempool/validators/before/mod.rs
@@ -1,11 +1,13 @@
 //   Copyright 2023 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 mod claim_fee_instructions;
+mod epoch_range;
 mod fee;
 mod has_inputs;
 mod template_exists;
 
 pub use claim_fee_instructions::*;
+pub use epoch_range::*;
 pub use fee::*;
 pub use has_inputs::*;
 pub use template_exists::*;


### PR DESCRIPTION
Description
---
refactor(mempool): move epoch range check to validators

Motivation and Context
---
The epoch range check is a validation so should be implemented as a validator.

How Has This Been Tested?
---
Ran a single cucumber test

What process can a PR reviewer use to test or verify this change?
---
Works as before

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify