### PR TITLE
fix(mempool): correct shard id for transaction receipt

### DIFF
--- a/applications/tari_validator_node/src/p2p/services/mempool/service.rs
+++ b/applications/tari_validator_node/src/p2p/services/mempool/service.rs
@@ -320,7 +320,7 @@ where
             warn!(target: LOG_TARGET, "⚠ No involved shards for payload");
         }
 
-        let tx_shard_id = ShardId::from(transaction.id().into_array());
+        let tx_shard_id = ShardId::for_transaction_receipt(transaction.id().into_array().into());
 
         let local_committee_shard = self.epoch_manager.get_local_committee_shard(current_epoch).await?;
 

--- a/dan_layer/common_types/src/shard_id.rs
+++ b/dan_layer/common_types/src/shard_id.rs
@@ -16,6 +16,7 @@ use tari_engine_types::{
     hashing::{hasher32, EngineHashDomainLabel},
     serde_with,
     substate::SubstateAddress,
+    transaction_receipt::TransactionReceiptAddress,
 };
 
 use crate::{shard_bucket::ShardBucket, uint::U256};
@@ -27,6 +28,10 @@ impl ShardId {
     /// Defines the mapping of SubstateAddress to ShardId
     pub fn from_address(addr: &SubstateAddress, version: u32) -> Self {
         Self::from_hash(&addr.to_canonical_hash(), version)
+    }
+
+    pub fn for_transaction_receipt(tx_receipt: TransactionReceiptAddress) -> Self {
+        Self::from_address(&tx_receipt.into(), 0)
     }
 
     pub fn from_hash(hash: &[u8], version: u32) -> Self {

--- a/dan_layer/engine_types/src/substate.rs
+++ b/dan_layer/engine_types/src/substate.rs
@@ -258,6 +258,12 @@ impl From<FeeClaimAddress> for SubstateAddress {
     }
 }
 
+impl From<TransactionReceiptAddress> for SubstateAddress {
+    fn from(address: TransactionReceiptAddress) -> Self {
+        Self::TransactionReceipt(address)
+    }
+}
+
 impl Display for SubstateAddress {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {


### PR DESCRIPTION
Description
---
Calculate the correct shard id for the transaction receipt in the mempool and indexer
fix(indexer): indexer submits the auto-filled transaction instead of the original transaction
feat(indexer): indexer attempts to submit the transaction to any member of all input shards

Motivation and Context
---
The transaction receipt shard id was calculated incorrectly causing the incorrect output shard to be selected for propagation in some cases. Thanks to @Cifko for discovering the issue.

How Has This Been Tested?
---
This case is not explicitly tested :/

What process can a PR reviewer use to test or verify this change?
---
Check that the transaction is propagated to the correct output shards in a multi-shard network

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify