### PR TITLE
fix: multi committee transaction

### DIFF
--- a/dan_layer/consensus/src/hotstuff/on_ready_to_vote_on_local_block.rs
+++ b/dan_layer/consensus/src/hotstuff/on_ready_to_vote_on_local_block.rs
@@ -977,7 +977,7 @@ where TConsensusSpec: ConsensusSpec
                         }
 
                         self.state_manager
-                            .commit_transaction(tx, block, &executed)
+                            .commit_transaction(tx, block, &executed, local_committee_shard)
                             .map_err(|e| HotStuffError::StateManagerError(e.into()))?;
                     }
 

--- a/dan_layer/consensus/src/traits/state_manager.rs
+++ b/dan_layer/consensus/src/traits/state_manager.rs
@@ -1,6 +1,7 @@
 //    Copyright 2023 The Tari Project
 //    SPDX-License-Identifier: BSD-3-Clause
 
+use tari_dan_common_types::committee::CommitteeShard;
 use tari_dan_storage::{
     consensus_models::{Block, ExecutedTransaction},
     StateStore,
@@ -14,5 +15,6 @@ pub trait StateManager<TStateStore: StateStore> {
         tx: &mut TStateStore::WriteTransaction<'_>,
         block: &Block<TStateStore::Addr>,
         transaction: &ExecutedTransaction,
+        local_committee_shard: &CommitteeShard,
     ) -> Result<(), Self::Error>;
 }

--- a/dan_layer/consensus_tests/src/support/state_manager.rs
+++ b/dan_layer/consensus_tests/src/support/state_manager.rs
@@ -4,6 +4,7 @@
 use std::sync::{atomic::AtomicBool, Arc};
 
 use tari_consensus::traits::StateManager;
+use tari_dan_common_types::committee::CommitteeShard;
 use tari_dan_storage::{
     consensus_models::{Block, ExecutedTransaction},
     StateStore,
@@ -35,6 +36,7 @@ impl<TStateStore: StateStore> StateManager<TStateStore> for NoopStateManager {
         _tx: &mut TStateStore::WriteTransaction<'_>,
         _block: &Block<TStateStore::Addr>,
         _transaction: &ExecutedTransaction,
+        _local_committee_shard: &CommitteeShard,
     ) -> Result<(), Self::Error> {
         self.0.store(true, std::sync::atomic::Ordering::Relaxed);
         Ok(())

--- a/dan_layer/state_store_sqlite/src/reader.rs
+++ b/dan_layer/state_store_sqlite/src/reader.rs
@@ -1079,7 +1079,7 @@ impl<TAddr: NodeAddressable + Serialize + DeserializeOwned> StateStoreReadTransa
                 let maybe_update = updates.remove(&rec.transaction_id);
                 match rec.try_convert(maybe_update) {
                     Ok(rec) => {
-                        if rec.is_ready() || rec.stage().is_new() {
+                        if rec.is_ready() {
                             Some(Ok(rec))
                         } else {
                             None


### PR DESCRIPTION
Description
---
This fixes two bugs:
- every VN now distributes the transaction after execution (we can maybe limit this to the VNs that have the TxReceipt, because that's the shard where is it always distributed).
- VNs is no longer trying to delete substates that are in foreign committees.

Motivation and Context
---

How Has This Been Tested?
---
Running dan-testing with 2 committees and several transactions.

What process can a PR reviewer use to test or verify this change?
---
Same as above.


Breaking Changes
---

- [ ] None
- [ ] Requires data directory to be deleted
- [x] Other - Older VNs are currently not working 100% properly and they need to be recompiled.