### PR TITLE
wip chore: move domain hash names to separate crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9140,6 +9140,7 @@ dependencies = [
  "tari_core",
  "tari_crypto",
  "tari_engine_types",
+ "tari_hash_domains",
  "tari_mmr",
 ]
 
@@ -9333,6 +9334,7 @@ dependencies = [
  "tari_dan_storage",
  "tari_dan_wallet_storage_sqlite",
  "tari_engine_types",
+ "tari_hash_domains",
  "tari_key_manager",
  "tari_template_lib",
  "tari_transaction",
@@ -9380,6 +9382,7 @@ dependencies = [
  "tari_bor",
  "tari_common_types",
  "tari_crypto",
+ "tari_hash_domains",
  "tari_template_abi",
  "tari_template_lib",
  "tari_utilities",
@@ -9409,6 +9412,14 @@ dependencies = [
 name = "tari_features"
 version = "0.53.0-dan.0"
 source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#9a871656e4ce1464d54107a4e3fc52181ed13e02"
+
+[[package]]
+name = "tari_hash_domains"
+version = "0.1.0"
+source = "git+https://github.com/tari-project/tari_hash_domains.git#2ccb81e2ce5dbfb213192b67af15aed3f3d0bc03"
+dependencies = [
+ "tari_crypto",
+]
 
 [[package]]
 name = "tari_indexer"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,8 +58,8 @@ resolver = "2"
 # specifying them in a single place and having them applied to all crates
 
 # internal dependencies among workspace crates
-libp2p-messaging = { path = "networking/libp2p-messaging"}
-libp2p-peersync = { path = "networking/libp2p-peersync"}
+libp2p-messaging = { path = "networking/libp2p-messaging" }
+libp2p-peersync = { path = "networking/libp2p-peersync" }
 libp2p-substream = { path = "networking/libp2p-substream" }
 proto_builder = { path = "networking/proto_builder" }
 sqlite_message_logger = { path = "networking/sqlite_message_logger" }
@@ -87,10 +87,10 @@ tari_rpc_framework = { path = "networking/rpc_framework" }
 tari_rpc_macros = { path = "networking/rpc_macros" }
 tari_state_store_sqlite = { path = "dan_layer/state_store_sqlite" }
 tari_swarm = { path = "networking/swarm" }
-tari_template_abi = { version="0.3.0", path = "dan_layer/template_abi" }
+tari_template_abi = { version = "0.3.0", path = "dan_layer/template_abi" }
 tari_template_builtin = { path = "dan_layer/template_builtin" }
 tari_template_lib = { path = "dan_layer/template_lib" }
-tari_template_macros = { version="0.3.0", path = "dan_layer/template_macros" }
+tari_template_macros = { version = "0.3.0", path = "dan_layer/template_macros" }
 tari_template_test_tooling = { path = "dan_layer/template_test_tooling" }
 tari_transaction = { path = "dan_layer/transaction" }
 tari_transaction_manifest = { path = "dan_layer/transaction_manifest" }
@@ -117,6 +117,7 @@ tari_comms_rpc_macros = { git = "https://github.com/tari-project/tari.git", bran
 # avoid including default features so each crate can choose which ones to import
 tari_core = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan2", default-features = false }
 tari_crypto = "0.19"
+tari_hash_domains = { git = "https://github.com/tari-project/tari_hash_domains.git" }
 tari_key_manager = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan2" }
 tari_metrics = { git = "https://github.com/tari-project/tari.git" }
 tari_mmr = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan2" }
@@ -212,7 +213,7 @@ tokio-stream = "0.1.7"
 tokio-util = "0.7.10"
 tonic = "0.6.2"
 tower = "0.4"
-tower-http = { version = "0.3.5", default-features = false}
+tower-http = { version = "0.3.5", default-features = false }
 tower-layer = "0.3"
 tracing = "0.1.40"
 url = "2.4.1"

--- a/dan_layer/common_types/Cargo.toml
+++ b/dan_layer/common_types/Cargo.toml
@@ -15,6 +15,7 @@ tari_mmr = { workspace = true }
 tari_core = { workspace = true, default-features = false, features = [
   "transactions",
 ] }
+tari_hash_domains = { git = "https://github.com/tari-project/tari_hash_domains.git" }
 
 libp2p-identity = { workspace = true, features = [
   "sr25519",

--- a/dan_layer/common_types/Cargo.toml
+++ b/dan_layer/common_types/Cargo.toml
@@ -15,7 +15,7 @@ tari_mmr = { workspace = true }
 tari_core = { workspace = true, default-features = false, features = [
   "transactions",
 ] }
-tari_hash_domains = { git = "https://github.com/tari-project/tari_hash_domains.git" }
+tari_hash_domains = { workspace = true }
 
 libp2p-identity = { workspace = true, features = [
   "sr25519",

--- a/dan_layer/common_types/src/hashing.rs
+++ b/dan_layer/common_types/src/hashing.rs
@@ -25,6 +25,7 @@
 
 use blake2::{digest::consts::U32, Blake2b};
 use tari_crypto::{hash_domain, hashing::DomainSeparatedHasher};
+use tari_hash_domains::ValidatorNodeBmtHashDomain;
 use tari_mmr::{BalancedBinaryMerkleProof, BalancedBinaryMerkleTree, MergedBalancedBinaryMerkleProof};
 
 use crate::hasher::{tari_hasher, TariHasher};
@@ -55,12 +56,6 @@ fn dan_hasher(label: &'static str) -> TariHasher {
     tari_hasher::<TariDanConsensusHashDomain>(label)
 }
 
-// From tari_core
-hash_domain!(
-    ValidatorNodeBmtHashDomain,
-    "com.tari.base_layer.core.validator_node_mmr",
-    1
-);
 pub type ValidatorNodeBmtHasherBlake2b = DomainSeparatedHasher<Blake2b<U32>, ValidatorNodeBmtHashDomain>;
 pub type ValidatorNodeBalancedMerkleTree = BalancedBinaryMerkleTree<ValidatorNodeBmtHasherBlake2b>;
 pub type ValidatorNodeMerkleProof = BalancedBinaryMerkleProof<ValidatorNodeBmtHasherBlake2b>;

--- a/dan_layer/engine_types/Cargo.toml
+++ b/dan_layer/engine_types/Cargo.toml
@@ -14,6 +14,7 @@ tari_crypto = { workspace = true, features = ["borsh"] }
 tari_template_abi = { workspace = true, features = ["std"] }
 tari_template_lib = { workspace = true }
 tari_utilities = { workspace = true }
+tari_hash_domains = { git = "https://github.com/tari-project/tari_hash_domains.git" }
 
 borsh = { workspace = true }
 # if we set this version in the workspace it would break other crates

--- a/dan_layer/engine_types/Cargo.toml
+++ b/dan_layer/engine_types/Cargo.toml
@@ -14,7 +14,7 @@ tari_crypto = { workspace = true, features = ["borsh"] }
 tari_template_abi = { workspace = true, features = ["std"] }
 tari_template_lib = { workspace = true }
 tari_utilities = { workspace = true }
-tari_hash_domains = { git = "https://github.com/tari-project/tari_hash_domains.git" }
+tari_hash_domains = { workspace = true }
 
 borsh = { workspace = true }
 # if we set this version in the workspace it would break other crates

--- a/dan_layer/engine_types/src/base_layer_hashing.rs
+++ b/dan_layer/engine_types/src/base_layer_hashing.rs
@@ -28,19 +28,9 @@ use digest::{
     consts::{U32, U64},
     Digest,
 };
-use tari_crypto::{
-    hash_domain,
-    hashing::{DomainSeparatedHasher, DomainSeparation},
-};
+use tari_crypto::hashing::{DomainSeparatedHasher, DomainSeparation};
+use tari_hash_domains::{ConfidentialOutputHashDomain, WalletOutputEncryptionKeysDomain};
 use tari_template_lib::Hash;
-
-hash_domain!(ConfidentialOutputHashDomain, "com.tari.dan.confidential_output", 1);
-
-hash_domain!(
-    WalletOutputEncryptionKeysDomain,
-    "com.tari.base_layer.wallet.output_encryption_keys",
-    1
-);
 
 fn confidential_hasher32(label: &'static str) -> TariBaseLayerHasher32 {
     TariBaseLayerHasher32::new_with_label::<ConfidentialOutputHashDomain>(label)

--- a/dan_layer/engine_types/src/hashing.rs
+++ b/dan_layer/engine_types/src/hashing.rs
@@ -29,10 +29,9 @@ use blake2::{
 use digest::Digest;
 use serde::Serialize;
 use tari_bor::encode_into;
-use tari_crypto::{hash_domain, hashing::DomainSeparation};
+use tari_crypto::hashing::DomainSeparation;
+use tari_hash_domains::TariEngineHashDomain;
 use tari_template_lib::Hash;
-
-hash_domain!(TariEngineHashDomain, "com.tari.dan.engine", 0);
 
 pub fn hasher64(label: EngineHashDomainLabel) -> TariHasher64 {
     TariHasher64::new_with_label::<TariEngineHashDomain>(label.as_label())
@@ -49,8 +48,6 @@ pub fn hasher32(label: EngineHashDomainLabel) -> TariHasher32 {
 pub fn template_hasher32() -> TariHasher32 {
     hasher32(EngineHashDomainLabel::Template)
 }
-
-hash_domain!(ConfidentialOutputHashDomain, "com.tari.dan.confidential_output", 1);
 
 #[derive(Debug, Clone)]
 pub struct TariHasher32 {

--- a/dan_layer/wallet/sdk/Cargo.toml
+++ b/dan_layer/wallet/sdk/Cargo.toml
@@ -18,7 +18,7 @@ tari_key_manager = { workspace = true }
 tari_transaction = { workspace = true }
 tari_template_lib = { workspace = true }
 tari_utilities = { workspace = true }
-tari_hash_domains = { git = "https://github.com/tari-project/tari_hash_domains.git" }
+tari_hash_domains = { workspace = true }
 
 anyhow = { workspace = true }
 async-trait = { workspace = true }

--- a/dan_layer/wallet/sdk/Cargo.toml
+++ b/dan_layer/wallet/sdk/Cargo.toml
@@ -18,6 +18,7 @@ tari_key_manager = { workspace = true }
 tari_transaction = { workspace = true }
 tari_template_lib = { workspace = true }
 tari_utilities = { workspace = true }
+tari_hash_domains = { git = "https://github.com/tari-project/tari_hash_domains.git" }
 
 anyhow = { workspace = true }
 async-trait = { workspace = true }

--- a/dan_layer/wallet/sdk/src/confidential/proof.rs
+++ b/dan_layer/wallet/sdk/src/confidential/proof.rs
@@ -22,12 +22,12 @@ use tari_crypto::{
     commitment::{ExtensionDegree, HomomorphicCommitmentFactory},
     errors::RangeProofError,
     extended_range_proof::ExtendedRangeProofService,
-    hash_domain,
     hashing::DomainSeparatedHasher,
     keys::SecretKey,
     ristretto::bulletproofs_plus::{BulletproofsPlusService, RistrettoExtendedMask, RistrettoExtendedWitness},
     tari_utilities::ByteArray,
 };
+use tari_hash_domains::TransactionSecureNonceKdfDomain;
 use tari_template_lib::{
     crypto::RistrettoPublicKeyBytes,
     models::{Amount, ConfidentialOutputProof, ConfidentialStatement, EncryptedData},
@@ -119,12 +119,6 @@ pub fn generate_confidential_proof(
 
 fn inner_encrypted_data_kdf_aead(encryption_key: &PrivateKey, commitment: &Commitment) -> EncryptedDataKey32 {
     let mut aead_key = EncryptedDataKey32::from(SafeArray::default());
-    // This has to be the same as the base layer so that burn claims are spendable
-    hash_domain!(
-        TransactionSecureNonceKdfDomain,
-        "com.tari.base_layer.core.transactions.secure_nonce_kdf",
-        0
-    );
     DomainSeparatedHasher::<Blake2b<U32>, TransactionSecureNonceKdfDomain>::new_with_label("encrypted_value_and_mask")
         .chain(encryption_key.as_bytes())
         .chain(commitment.as_bytes())


### PR DESCRIPTION
Description
---
Refactor out the common hash domain names between tari and tari-dan repos.

Motivation and Context
---
Constants should always be defined at one place.

Requires PR https://github.com/tari-project/tari/pull/6076

How Has This Been Tested?
---

What process can a PR reviewer use to test or verify this change?
---


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify