### PR TITLE
feat: add metadata string parser

### DIFF
--- a/dan_layer/engine_types/src/argument_parser.rs
+++ b/dan_layer/engine_types/src/argument_parser.rs
@@ -5,7 +5,11 @@ use std::str::FromStr;
 
 use serde::{Deserialize, Deserializer};
 use serde_json as json;
-use tari_template_lib::{arg, args::Arg, models::Amount};
+use tari_template_lib::{
+    arg,
+    args::Arg,
+    models::{Amount, Metadata},
+};
 
 use crate::{substate::SubstateAddress, template::parse_template_address, TemplateAddress};
 
@@ -76,6 +80,10 @@ fn try_parse_special_string_arg(s: &str) -> Result<StringArg<'_>, ArgParseError>
         return Ok(StringArg::TemplateAddress(address));
     }
 
+    if let Ok(metadata) = Metadata::from_str(s) {
+        return Ok(StringArg::Metadata(metadata));
+    }
+
     match s {
         "true" => return Ok(StringArg::Bool(true)),
         "false" => return Ok(StringArg::Bool(false)),
@@ -102,6 +110,7 @@ pub enum StringArg<'a> {
     UnsignedInteger(u64),
     SignedInteger(i64),
     Bool(bool),
+    Metadata(Metadata),
 }
 
 impl From<StringArg<'_>> for Arg {
@@ -124,6 +133,7 @@ impl From<StringArg<'_>> for Arg {
             StringArg::SignedInteger(v) => arg!(v),
             StringArg::Bool(v) => arg!(v),
             StringArg::Workspace(s) => arg!(Workspace(s)),
+            StringArg::Metadata(m) => arg!(m),
         }
     }
 }

--- a/dan_layer/template_lib/src/models/metadata.rs
+++ b/dan_layer/template_lib/src/models/metadata.rs
@@ -20,6 +20,8 @@
 //   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //   USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+use std::str::FromStr;
+
 use serde::{Deserialize, Serialize};
 use tari_bor::BorTag;
 use tari_template_abi::rust::{collections::BTreeMap, fmt::Display};
@@ -49,6 +51,25 @@ impl Metadata {
     pub fn merge(&mut self, other: Metadata) -> &mut Self {
         self.0.extend(other.0.into_inner());
         self
+    }
+}
+
+impl FromStr for Metadata {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let pairs = s.split(',').map(|pair| {
+            let mut split = pair.split('=');
+            let key = split.next().ok_or_else(|| "Missing key".to_string())?;
+            let value = split.next().ok_or_else(|| "Missing value".to_string())?;
+            Ok::<(String, String), String>((key.to_string(), value.to_string()))
+        });
+        let mut map = BTreeMap::new();
+        for pair in pairs {
+            let (key, value) = pair?;
+            map.insert(key, value);
+        }
+        Ok(Self(BorTag::new(map)))
     }
 }
 


### PR DESCRIPTION
Description
---
Adds the ability to pass in a string that will converted to a Metadata table in the dan_wallet_client

Motivation and Context
---
It was previously not possible to create a Metadata object from args passed to a scaffolded CLI program. I believe this would have been a problem for JS clients as well. 

This makes it possible to pass a CLI arg in the form `key=value, key2=value` and it will be converted to a Metadata table.

How Has This Been Tested?
---
Tested using the scaffold of the stablecoin contract, passing in `provider_name=mike`

What process can a PR reviewer use to test or verify this change?
---
Scaffold a contract that takes in a parameter of type Metadata, then call that method using the above syntax


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify