### PR TITLE
ci(fix): docker - add openssl and ca-certificates to runtime

### DIFF
--- a/docker_rig/tari-dan.Dockerfile
+++ b/docker_rig/tari-dan.Dockerfile
@@ -112,7 +112,9 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
     apt-get --no-install-recommends install -y \
-      dumb-init
+      dumb-init \
+      ca-certificates \
+      openssl
 
 RUN groupadd --gid 1000 tari && \
     useradd --create-home --no-log-init --shell /bin/bash \


### PR DESCRIPTION
Description
Add openssl and ca-certificates packages to docker runtime image

Motivation and Context
Fix missing openssl requirements

How Has This Been Tested?
Tested in local fork.

What process can a PR reviewer use to test or verify this change?
---


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify