### PR TITLE
fix: default committee size

### DIFF
--- a/applications/tari_dan_app_utilities/src/consensus_constants.rs
+++ b/applications/tari_dan_app_utilities/src/consensus_constants.rs
@@ -33,7 +33,7 @@ impl ConsensusConstants {
     pub const fn devnet() -> Self {
         Self {
             base_layer_confirmations: 3,
-            committee_size: 1,
+            committee_size: 7,
             hotstuff_rounds: 4,
         }
     }


### PR DESCRIPTION
Description
---
The default committee size of 1 is breaking some tests.

Motivation and Context
---

How Has This Been Tested?
---
Running the failed cucumber tests `New validator node registers and syncs` and `Template registration and invocation in a 2-VN committee`

What process can a PR reviewer use to test or verify this change?
---
The CI should pass, or run the same test.


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify