### PR TITLE
feat: better tuple support in templates

### DIFF
--- a/applications/tari_dan_wallet_cli/src/command/transaction.rs
+++ b/applications/tari_dan_wallet_cli/src/command/transaction.rs
@@ -668,7 +668,7 @@ pub fn print_execution_results(results: &[InstructionResult]) {
                     },
                 }
             },
-            Type::Tuple(subtypes)=> {
+            Type::Tuple(subtypes) => {
                 let str = format_tuple(subtypes, result);
                 println!("{}", str);
             },

--- a/applications/tari_dan_wallet_cli/src/command/transaction.rs
+++ b/applications/tari_dan_wallet_cli/src/command/transaction.rs
@@ -610,7 +610,7 @@ fn display_vec<W: fmt::Write>(writer: &mut W, ty: &Type, result: &InstructionRes
     Ok(())
 }
 
-fn format_tuple(subtypes: &Vec<Type>, result: &InstructionResult) -> String {
+fn format_tuple(subtypes: &[Type], result: &InstructionResult) -> String {
     let tuple_type = Type::Tuple(subtypes.to_vec());
     let result_json = serde_json::to_string(&result.indexed).unwrap();
     format!("{}: {}", tuple_type, result_json)

--- a/applications/tari_dan_wallet_cli/src/command/transaction.rs
+++ b/applications/tari_dan_wallet_cli/src/command/transaction.rs
@@ -589,6 +589,10 @@ fn display_vec<W: fmt::Write>(writer: &mut W, ty: &Type, result: &InstructionRes
                 },
             }
         },
+        Type::Tuple(_) => {
+            // TODO: proper Vec<Tuple<A,B,...>> display
+            write!(writer, "{}", serde_json::to_string(&result.indexed).unwrap())?;
+        },
         Type::Other { name } if name == "Amount" => {
             write!(writer, "{}", stringify_slice(&result.decode::<Vec<Amount>>().unwrap()))?;
         },
@@ -657,6 +661,11 @@ pub fn print_execution_results(results: &[InstructionResult]) {
                         println!("Vec<{:?}>: {}", ty, vec_ty);
                     },
                 }
+            },
+            Type::Tuple(subtypes)=> {
+                let tuple_type = Type::Tuple(subtypes.to_vec());
+                // TODO: proper display of tuples
+                println!("{}: TODO", tuple_type);
             },
             Type::Other { ref name } if name == "Amount" => {
                 println!("{}: {}", name, result.decode::<Amount>().unwrap());

--- a/applications/tari_dan_wallet_cli/src/command/transaction.rs
+++ b/applications/tari_dan_wallet_cli/src/command/transaction.rs
@@ -589,9 +589,9 @@ fn display_vec<W: fmt::Write>(writer: &mut W, ty: &Type, result: &InstructionRes
                 },
             }
         },
-        Type::Tuple(_) => {
-            // TODO: proper Vec<Tuple<A,B,...>> display
-            write!(writer, "{}", serde_json::to_string(&result.indexed).unwrap())?;
+        Type::Tuple(subtypes) => {
+            let str = format_tuple(subtypes, result);
+            write!(writer, "{}", str)?;
         },
         Type::Other { name } if name == "Amount" => {
             write!(writer, "{}", stringify_slice(&result.decode::<Vec<Amount>>().unwrap()))?;
@@ -608,6 +608,12 @@ fn display_vec<W: fmt::Write>(writer: &mut W, ty: &Type, result: &InstructionRes
         },
     }
     Ok(())
+}
+
+fn format_tuple(subtypes: &Vec<Type>, result: &InstructionResult) -> String {
+    let tuple_type = Type::Tuple(subtypes.to_vec());
+    let result_json = serde_json::to_string(&result.indexed).unwrap();
+    format!("{}: {}", tuple_type, result_json)
 }
 
 pub fn print_execution_results(results: &[InstructionResult]) {
@@ -663,9 +669,8 @@ pub fn print_execution_results(results: &[InstructionResult]) {
                 }
             },
             Type::Tuple(subtypes)=> {
-                let tuple_type = Type::Tuple(subtypes.to_vec());
-                // TODO: proper display of tuples
-                println!("{}: TODO", tuple_type);
+                let str = format_tuple(subtypes, result);
+                println!("{}", str);
             },
             Type::Other { ref name } if name == "Amount" => {
                 println!("{}: {}", name, result.decode::<Amount>().unwrap());

--- a/applications/tari_validator_node_cli/src/command/transaction.rs
+++ b/applications/tari_validator_node_cli/src/command/transaction.rs
@@ -472,7 +472,7 @@ fn summarize_finalize_result(finalize: &FinalizeResult) {
                     },
                 }
             },
-            Type::Tuple(subtypes)=> {
+            Type::Tuple(subtypes) => {
                 let str = format_tuple(subtypes, result);
                 println!("{}", str);
             },

--- a/applications/tari_validator_node_cli/src/command/transaction.rs
+++ b/applications/tari_validator_node_cli/src/command/transaction.rs
@@ -473,9 +473,8 @@ fn summarize_finalize_result(finalize: &FinalizeResult) {
                 }
             },
             Type::Tuple(subtypes)=> {
-                let tuple_type = Type::Tuple(subtypes.to_vec());
-                // TODO: proper display of tuples
-                println!("{}: TODO", tuple_type);
+                let str = format_tuple(subtypes, result);
+                println!("{}", str);
             },
             Type::Other { ref name } if name == "Amount" => {
                 println!("{}: {}", name, result.decode::<Amount>().unwrap());
@@ -551,9 +550,9 @@ fn display_vec<W: fmt::Write>(writer: &mut W, ty: &Type, result: &InstructionRes
                 },
             }
         },
-        Type::Tuple(_) => {
-            // TODO: proper Vec<Tuple<A,B,...>> display
-            write!(writer, "{}", serde_json::to_string(&result.indexed).unwrap())?;
+        Type::Tuple(subtypes) => {
+            let str = format_tuple(subtypes, result);
+            write!(writer, "{}", str)?;
         },
         Type::Other { name } if name == "Amount" => {
             write!(writer, "{}", stringify_slice(&result.decode::<Vec<Amount>>().unwrap()))?;
@@ -570,6 +569,12 @@ fn display_vec<W: fmt::Write>(writer: &mut W, ty: &Type, result: &InstructionRes
         },
     }
     Ok(())
+}
+
+fn format_tuple(subtypes: &Vec<Type>, result: &InstructionResult) -> String {
+    let tuple_type = Type::Tuple(subtypes.to_vec());
+    let result_json = serde_json::to_string(&result.indexed).unwrap();
+    format!("{}: {}", tuple_type, result_json)
 }
 
 fn load_inputs(

--- a/applications/tari_validator_node_cli/src/command/transaction.rs
+++ b/applications/tari_validator_node_cli/src/command/transaction.rs
@@ -472,6 +472,11 @@ fn summarize_finalize_result(finalize: &FinalizeResult) {
                     },
                 }
             },
+            Type::Tuple(subtypes)=> {
+                let tuple_type = Type::Tuple(subtypes.to_vec());
+                // TODO: proper display of tuples
+                println!("{}: TODO", tuple_type);
+            },
             Type::Other { ref name } if name == "Amount" => {
                 println!("{}: {}", name, result.decode::<Amount>().unwrap());
             },
@@ -545,6 +550,10 @@ fn display_vec<W: fmt::Write>(writer: &mut W, ty: &Type, result: &InstructionRes
                     write!(writer, "Vec<{:?}>: {}", ty, vec_ty)?;
                 },
             }
+        },
+        Type::Tuple(_) => {
+            // TODO: proper Vec<Tuple<A,B,...>> display
+            write!(writer, "{}", serde_json::to_string(&result.indexed).unwrap())?;
         },
         Type::Other { name } if name == "Amount" => {
             write!(writer, "{}", stringify_slice(&result.decode::<Vec<Amount>>().unwrap()))?;

--- a/applications/tari_validator_node_cli/src/command/transaction.rs
+++ b/applications/tari_validator_node_cli/src/command/transaction.rs
@@ -571,7 +571,7 @@ fn display_vec<W: fmt::Write>(writer: &mut W, ty: &Type, result: &InstructionRes
     Ok(())
 }
 
-fn format_tuple(subtypes: &Vec<Type>, result: &InstructionResult) -> String {
+fn format_tuple(subtypes: &[Type], result: &InstructionResult) -> String {
     let tuple_type = Type::Tuple(subtypes.to_vec());
     let result_json = serde_json::to_string(&result.indexed).unwrap();
     format!("{}: {}", tuple_type, result_json)

--- a/dan_layer/engine/tests/templates/tuples/src/lib.rs
+++ b/dan_layer/engine/tests/templates/tuples/src/lib.rs
@@ -27,29 +27,27 @@ mod tuple_template {
     use super::*;
 
     pub struct Tuple {
-        pub value: u32,
+        pub value_a: String,
+        pub value_b: u32,
     }
 
     impl Tuple {
         pub fn new() -> (Component<Self>, String) {
             (
-                Component::new(Self { value: 0 })
+                Component::new(Self { value_a: "Hello World!".to_string(), value_b: 0 })
                     .with_access_rules(AccessRules::allow_all())
                     .create(),
                 "Hello World!".to_string(),
             )
         }
 
-        pub fn tuple_output() -> (String, u32) {
-            ("Hello World!".to_string(), 100)
+        pub fn get(&self) -> (String, u32) {
+            (self.value_a.clone(), self.value_b)
         }
 
-        pub fn set(&mut self, value: u32) {
-            self.value = value;
-        }
-
-        pub fn get(&self) -> u32 {
-            self.value
+        pub fn set(&mut self, value: (String, u32)) {
+            self.value_a = value.0;
+            self.value_b = value.1;
         }
     }
 }

--- a/dan_layer/engine/tests/test.rs
+++ b/dan_layer/engine/tests/test.rs
@@ -238,10 +238,10 @@ fn test_tuples() {
     assert_eq!(message, "Hello World!");
 
     // tuples returned in a method
-    let (message, number): (String, u32) =  template_test.call_method(component_id, "get", args![], vec![]);
+    let (message, number): (String, u32) = template_test.call_method(component_id, "get", args![], vec![]);
     assert_eq!(message, "Hello World!");
     assert_eq!(number, 0);
-    
+
     // tuples passed as arguments to methods
     let new_value = ("New String".to_string(), 1);
     template_test.call_method::<()>(component_id, "set", args![new_value], vec![]);

--- a/dan_layer/engine/tests/test.rs
+++ b/dan_layer/engine/tests/test.rs
@@ -220,20 +220,33 @@ fn test_engine_errors() {
 fn test_tuples() {
     let mut template_test = TemplateTest::new(vec!["tests/templates/tuples"]);
 
-    // tuples returned in a regular function
-    let (message, number): (String, u32) = template_test.call_function("Tuple", "tuple_output", args![], vec![]);
-    assert_eq!(message, "Hello World!");
-    assert_eq!(number, 100);
+    // check that the ABI is valid
+    let module = template_test.get_module("Tuple");
+    // the "new" constructor returns a tuple (Component, String)
+    let fn_new = module.find_func_by_name("new").unwrap();
+    assert_eq!(fn_new.output.to_string(), "Tuple<Other { name: \"Component\" },String>");
+    // the "get" method returns a tuple (String, u32)
+    let fn_get = module.find_func_by_name("get").unwrap();
+    assert_eq!(fn_get.output.to_string(), "Tuple<String,U32>");
+    // the "set" method accepts a tuple (String, u32) as argument
+    let fn_set = module.find_func_by_name("set").unwrap();
+    assert_eq!(fn_set.arguments[1].arg_type.to_string(), "Tuple<String,U32>");
 
     // tuples returned in a constructor
     let (component_id, message): (ComponentAddress, String) =
         template_test.call_function("Tuple", "new", args![], vec![]);
     assert_eq!(message, "Hello World!");
 
-    // the component id returned in the tuple must be valid and usable
-    let new_value = 20_u32;
+    // tuples returned in a method
+    let (message, number): (String, u32) =  template_test.call_method(component_id, "get", args![], vec![]);
+    assert_eq!(message, "Hello World!");
+    assert_eq!(number, 0);
+    
+    // tuples passed as arguments to methods
+    let new_value = ("New String".to_string(), 1);
     template_test.call_method::<()>(component_id, "set", args![new_value], vec![]);
-    let value: u32 = template_test.call_method(component_id, "get", args![], vec![]);
+    // check that the component state was actually updated
+    let value: (String, u32) = template_test.call_method(component_id, "get", args![], vec![]);
     assert_eq!(value, new_value);
 }
 

--- a/dan_layer/template_abi/src/types.rs
+++ b/dan_layer/template_abi/src/types.rs
@@ -92,6 +92,7 @@ pub enum Type {
     U128,
     String,
     Vec(Box<Type>),
+    Tuple(Vec<Type>),
     Other {
         name: String,
     },
@@ -115,6 +116,13 @@ impl std::fmt::Display for Type {
             Type::U128 => write!(f, "U128"),
             Type::String => write!(f, "String"),
             Type::Vec(t) => write!(f, "Vec<{}>", t),
+            Type::Tuple(types) => {
+                let type_list = types.iter()
+                    .map(|t| format!("{:?}", t))
+                    .collect::<Vec<_>>()
+                    .join(",");
+                write!(f, "Tuple<{}>", type_list)
+            },
             Type::Other { name } => write!(f, "{}", name),
         }
     }

--- a/dan_layer/template_abi/src/types.rs
+++ b/dan_layer/template_abi/src/types.rs
@@ -117,10 +117,7 @@ impl std::fmt::Display for Type {
             Type::String => write!(f, "String"),
             Type::Vec(t) => write!(f, "Vec<{}>", t),
             Type::Tuple(types) => {
-                let type_list = types.iter()
-                    .map(|t| format!("{:?}", t))
-                    .collect::<Vec<_>>()
-                    .join(",");
+                let type_list = types.iter().map(|t| format!("{:?}", t)).collect::<Vec<_>>().join(",");
                 write!(f, "Tuple<{}>", type_list)
             },
             Type::Other { name } => write!(f, "{}", name),

--- a/dan_layer/template_macros/src/template/abi.rs
+++ b/dan_layer/template_macros/src/template/abi.rs
@@ -82,9 +82,7 @@ fn convert_to_arg_type(template_name: &str, ty: &TypeAst) -> ArgType {
             name: "&self".to_string(),
         },
         TypeAst::Typed { type_path, .. } => path_segment_to_arg_type(template_name, &type_path.path.segments[0]),
-        TypeAst::Tuple { type_tuple, ..} => {
-            tuple_to_arg_type(template_name, type_tuple)
-        },
+        TypeAst::Tuple { type_tuple, .. } => tuple_to_arg_type(template_name, type_tuple),
     }
 }
 
@@ -124,7 +122,7 @@ fn convert_to_arg_def(template_name: &str, rust_type: &TypeAst) -> Result<ArgDef
         },
         TypeAst::Tuple {
             name: arg_name,
-            type_tuple
+            type_tuple,
         } => {
             let Some(arg_name) = arg_name else {
                 return Err(syn::Error::new_spanned(
@@ -164,9 +162,7 @@ fn path_segment_to_arg_type(template_name: &str, segment: &PathSegment) -> ArgTy
                             let ty = path_segment_to_arg_type(template_name, &path.path.segments[0]);
                             ArgType::Vec(Box::new(ty))
                         },
-                        GenericArgument::Type(Type::Tuple(tuple)) => {
-                            tuple_to_arg_type(template_name, tuple)
-                        },
+                        GenericArgument::Type(Type::Tuple(tuple)) => tuple_to_arg_type(template_name, tuple),
                         // TODO: These should be errors
                         a => panic!("Invalid vec generic argument {:?}", a),
                     }
@@ -186,14 +182,18 @@ fn path_segment_to_arg_type(template_name: &str, segment: &PathSegment) -> ArgTy
 }
 
 fn tuple_to_arg_type(template_name: &str, tuple: &TypeTuple) -> ArgType {
-    let subtypes = tuple.elems.iter().map(|t| {
-        match t {
-            Type::Path(path) => path_segment_to_arg_type(template_name,&path.path.segments[0]),
-            Type::Tuple(subtuple) => tuple_to_arg_type(template_name, subtuple),
-            // TODO: These should be errors
-            a => panic!("Invalid Tuple subtype argument {:?}", a),
-        }
-    }).collect::<Vec<_>>();
+    let subtypes = tuple
+        .elems
+        .iter()
+        .map(|t| {
+            match t {
+                Type::Path(path) => path_segment_to_arg_type(template_name, &path.path.segments[0]),
+                Type::Tuple(subtuple) => tuple_to_arg_type(template_name, subtuple),
+                // TODO: These should be errors
+                a => panic!("Invalid Tuple subtype argument {:?}", a),
+            }
+        })
+        .collect::<Vec<_>>();
 
     ArgType::Tuple(subtypes)
 }

--- a/dan_layer/template_macros/src/template/ast.rs
+++ b/dan_layer/template_macros/src/template/ast.rs
@@ -180,22 +180,30 @@ impl TemplateAst {
                 // TODO: handle "Self"
                 // TODO: detect more complex types
                 TypeAst::Typed {
-                    name: pat.map(|p| match p {
-                        syn::Pat::Ident(ident) => ident.ident.to_string(),
-                        // There may be other patterns we are interested in, the following code
-                        // will print out the details, and the resulting code will not compile
-                        // but it will allow us to see the patterns we need.
-                        _ => format!("{:?}", p),
-                    }),
-
+                    name: pat.map(Self::get_pat_name),
                     type_path: type_path.clone(),
                 }
             },
-            syn::Type::Tuple(tuple) => TypeAst::Tuple(tuple.clone()),
+            syn::Type::Tuple(type_tuple) => {
+                TypeAst::Tuple {
+                    name: pat.map(Self::get_pat_name),
+                    type_tuple: type_tuple.clone(),
+                }
+            },
             _ => todo!(
                 "get_type_ast only supports paths and tuples. Encountered:{:?}",
                 syn_type
             ),
+        }
+    }
+
+    fn get_pat_name(pat: &syn::Pat) -> String {
+        match pat {
+            syn::Pat::Ident(ident) => ident.ident.to_string(),
+            // There may be other patterns we are interested in, the following code
+            // will print out the details, and the resulting code will not compile
+            // but it will allow us to see the patterns we need.
+            _ => format!("{:?}", pat)
         }
     }
 
@@ -239,7 +247,7 @@ impl FunctionAst {
 pub enum TypeAst {
     Receiver { mutability: bool },
     Typed { name: Option<String>, type_path: TypePath },
-    Tuple(TypeTuple),
+    Tuple { name: Option<String>, type_tuple: TypeTuple },
 }
 
 impl Debug for TypeAst {
@@ -247,7 +255,7 @@ impl Debug for TypeAst {
         match self {
             TypeAst::Receiver { mutability } => write!(f, "Receiver {{ mutability: {} }}", mutability),
             TypeAst::Typed { name, type_path } => write!(f, "Typed {{ name: {:?}, type_path: {:?} }}", name, type_path),
-            TypeAst::Tuple(tuple) => write!(f, "Tuple {{ tuple: {:?} }}", tuple),
+            TypeAst::Tuple { name, type_tuple} => write!(f, "Tuple {{ name: {:?}, type_tuple: {:?} }}", name, type_tuple),
         }
     }
 }

--- a/dan_layer/template_macros/src/template/ast.rs
+++ b/dan_layer/template_macros/src/template/ast.rs
@@ -184,11 +184,9 @@ impl TemplateAst {
                     type_path: type_path.clone(),
                 }
             },
-            syn::Type::Tuple(type_tuple) => {
-                TypeAst::Tuple {
-                    name: pat.map(Self::get_pat_name),
-                    type_tuple: type_tuple.clone(),
-                }
+            syn::Type::Tuple(type_tuple) => TypeAst::Tuple {
+                name: pat.map(Self::get_pat_name),
+                type_tuple: type_tuple.clone(),
             },
             _ => todo!(
                 "get_type_ast only supports paths and tuples. Encountered:{:?}",
@@ -203,7 +201,7 @@ impl TemplateAst {
             // There may be other patterns we are interested in, the following code
             // will print out the details, and the resulting code will not compile
             // but it will allow us to see the patterns we need.
-            _ => format!("{:?}", pat)
+            _ => format!("{:?}", pat),
         }
     }
 
@@ -245,9 +243,17 @@ impl FunctionAst {
 }
 
 pub enum TypeAst {
-    Receiver { mutability: bool },
-    Typed { name: Option<String>, type_path: TypePath },
-    Tuple { name: Option<String>, type_tuple: TypeTuple },
+    Receiver {
+        mutability: bool,
+    },
+    Typed {
+        name: Option<String>,
+        type_path: TypePath,
+    },
+    Tuple {
+        name: Option<String>,
+        type_tuple: TypeTuple,
+    },
 }
 
 impl Debug for TypeAst {
@@ -255,7 +261,9 @@ impl Debug for TypeAst {
         match self {
             TypeAst::Receiver { mutability } => write!(f, "Receiver {{ mutability: {} }}", mutability),
             TypeAst::Typed { name, type_path } => write!(f, "Typed {{ name: {:?}, type_path: {:?} }}", name, type_path),
-            TypeAst::Tuple { name, type_tuple} => write!(f, "Tuple {{ name: {:?}, type_tuple: {:?} }}", name, type_tuple),
+            TypeAst::Tuple { name, type_tuple } => {
+                write!(f, "Tuple {{ name: {:?}, type_tuple: {:?} }}", name, type_tuple)
+            },
         }
     }
 }

--- a/dan_layer/template_macros/src/template/dispatcher.rs
+++ b/dan_layer/template_macros/src/template/dispatcher.rs
@@ -184,7 +184,7 @@ fn replace_self_in_output(ast: &FunctionAst) -> Vec<Stmt> {
                     stmts.push(stmt);
                 }
             },
-            TypeAst::Tuple { type_tuple, ..} => {
+            TypeAst::Tuple { type_tuple, .. } => {
                 stmts.push(replace_self_in_tuple(type_tuple));
             },
             _ => todo!("replace_self_in_output only supports typed and tuple"),

--- a/dan_layer/template_macros/src/template/dispatcher.rs
+++ b/dan_layer/template_macros/src/template/dispatcher.rs
@@ -131,11 +131,11 @@ fn get_function_block(template_ident: &Ident, ast: FunctionAst) -> Expr {
                         .unwrap_or_else(|e| panic!("failed to decode argument at position {} for function '{}': {}", #i, #func_name, e));
                 })
             },
-            TypeAst::Tuple(tuple) => {
+            TypeAst::Tuple { type_tuple, .. } => {
                 args.push(parse_quote! { #arg_ident });
                 stmts.push(parse_quote! {
-                    let #arg_ident = from_value::<#tuple>(&call_info.args[#i])
-                        .unwrap_or_else(|e| panic!("failed to decode tuple argument at position {} for function '{}'.", #i, #func_name, e));
+                    let #arg_ident = from_value::<#type_tuple>(&call_info.args[#i])
+                        .unwrap_or_else(|e| panic!("failed to decode tuple argument at position {} for function '{}': {}", #i, #func_name, e));
                 });
             },
         }
@@ -184,7 +184,7 @@ fn replace_self_in_output(ast: &FunctionAst) -> Vec<Stmt> {
                     stmts.push(stmt);
                 }
             },
-            TypeAst::Tuple(type_tuple) => {
+            TypeAst::Tuple { type_tuple, ..} => {
                 stmts.push(replace_self_in_tuple(type_tuple));
             },
             _ => todo!("replace_self_in_output only supports typed and tuple"),

--- a/dan_layer/template_test_tooling/templates/faucet/Cargo.lock
+++ b/dan_layer/template_test_tooling/templates/faucet/Cargo.lock
@@ -105,7 +105,7 @@ dependencies = [
 
 [[package]]
 name = "tari_bor"
-version = "0.0.7"
+version = "0.1.0"
 dependencies = [
  "ciborium",
  "ciborium-io",
@@ -114,7 +114,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_abi"
-version = "0.0.7"
+version = "0.1.0"
 dependencies = [
  "serde",
  "tari_bor",
@@ -122,7 +122,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_lib"
-version = "0.0.7"
+version = "0.1.0"
 dependencies = [
  "newtype-ops",
  "serde",
@@ -134,7 +134,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_macros"
-version = "0.0.7"
+version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
Description
---
* Added a new variant (`Type::Tuple`) for tuples in the template ABI definition
* Updated the template macros to generate correct ABI for tuples and support tuple arguments
* Updated the existing engine test (and associated template) regarding tuples
* Updated CLI display for tuples in `validator_node_cli` and `tari_dan_wallet_cli` 

Motivation and Context
---
Up until now we had support for tuples in templates, but only for return types (https://github.com/tari-project/tari-dan/pull/10)

Recently we have stumbled upon some limitations with tuples:
* The ABI definition is not descriptive, as we lack a specific variant to handle tuples. We want the display to look like `Tuple<String,U32>`
* Tuples are not supported as arguments to functions or methods

This PR aims to fix those limitations.

How Has This Been Tested?
---
Improved existing tuple template test in the engine:
* It checks more scenarios (tuples as arguments as well as return types)
* It checks ABI for both tuple arguments and return types

What process can a PR reviewer use to test or verify this change?
---
Deploy a template that deals with tuples and inspect ABI or do calls

Breaking Changes
---

- [ ] None
- [ ] Requires data directory to be deleted
- [x] Requires network reset. Template ABI has changed, so new templates may be incompatible with previous versions of the network.