### PR TITLE
fix: the genesis block_id values should be 0

### DIFF
--- a/applications/tari_validator_node/src/bootstrap.rs
+++ b/applications/tari_validator_node/src/bootstrap.rs
@@ -46,7 +46,7 @@ use tari_dan_app_utilities::{
 use tari_dan_common_types::{Epoch, NodeAddressable, NodeHeight, ShardId};
 use tari_dan_engine::fees::FeeTable;
 use tari_dan_storage::{
-    consensus_models::{Block, ExecutedTransaction, SubstateRecord},
+    consensus_models::{Block, BlockId, ExecutedTransaction, SubstateRecord},
     global::GlobalDb,
     StateStore,
     StateStoreReadTransaction,
@@ -441,7 +441,7 @@ where
             state_hash: Default::default(),
             created_by_transaction: Default::default(),
             created_justify: *genesis_block.justify().id(),
-            created_block: *genesis_block.id(),
+            created_block: BlockId::genesis(),
             created_height: NodeHeight(0),
             created_at_epoch: Epoch(0),
             destroyed: None,
@@ -468,7 +468,7 @@ where
             state_hash: Default::default(),
             created_by_transaction: Default::default(),
             created_justify: *genesis_block.justify().id(),
-            created_block: *genesis_block.id(),
+            created_block: BlockId::genesis(),
             created_height: NodeHeight(0),
             created_at_epoch: Epoch(0),
             destroyed: None,

--- a/dan_layer/comms_rpc_state_sync/src/manager.rs
+++ b/dan_layer/comms_rpc_state_sync/src/manager.rs
@@ -410,7 +410,7 @@ where
             let locked_block = self
                 .state_store
                 .with_read_tx(|tx| LockedBlock::get(tx).optional())?
-                .unwrap_or_else(|| Block::<CommsPublicKey>::genesis().as_locked_block());
+                .unwrap_or_else(|| Block::<CommsPublicKey>::zero_block().as_locked_block());
 
             match self.sync_with_peer(&member, &locked_block).await {
                 Ok(()) => {


### PR DESCRIPTION
Description
---
Sometimes the real hash of genesis block was used. Which resulted in a queries for a block that never existed because the real block_id of genesis is not zero.

Motivation and Context
---

How Has This Been Tested?
---
Letting the github actions do it.

What process can a PR reviewer use to test or verify this change?
---


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify