### PR TITLE
feat: foreign proposal command

### DIFF
--- a/applications/tari_validator_node/src/p2p/rpc/sync_task.rs
+++ b/applications/tari_validator_node/src/p2p/rpc/sync_task.rs
@@ -123,7 +123,8 @@ impl<TStateStore: StateStore> BlockSyncTask<TStateStore> {
                 let all_qcs = child
                     .commands()
                     .iter()
-                    .flat_map(|cmd| cmd.evidence().qc_ids_iter())
+                    .filter_map(|cmd| cmd.transaction())
+                    .flat_map(|transaction| transaction.evidence.qc_ids_iter())
                     .collect::<HashSet<_>>();
                 let certificates = QuorumCertificate::get_all(tx, all_qcs)?;
                 let updates = child.get_substate_updates(tx)?;

--- a/dan_layer/consensus/src/hotstuff/on_propose.rs
+++ b/dan_layer/consensus/src/hotstuff/on_propose.rs
@@ -204,7 +204,10 @@ where TConsensusSpec: ConsensusSpec
         let commands = ForeignProposal::get_all_new(tx)?
             .into_iter()
             .filter_map(|foreign_proposal| {
-                if pending_proposals.contains(&foreign_proposal) {
+                if pending_proposals.iter().any(|pending_proposal| {
+                    pending_proposal.bucket == foreign_proposal.bucket &&
+                        pending_proposal.block_id == foreign_proposal.block_id
+                }) {
                     None
                 } else {
                     Some(Ok(Command::ForeignProposal(

--- a/dan_layer/consensus/src/hotstuff/on_propose.rs
+++ b/dan_layer/consensus/src/hotstuff/on_propose.rs
@@ -14,10 +14,12 @@ use tari_dan_storage::{
     consensus_models::{
         Block,
         Command,
+        ForeignProposal,
         ForeignSendCounters,
         HighQc,
         LastProposed,
         LeafBlock,
+        LockedBlock,
         QuorumCertificate,
         TransactionPool,
         TransactionPoolStage,
@@ -197,17 +199,28 @@ where TConsensusSpec: ConsensusSpec
         };
 
         let mut total_leader_fee = 0;
-        let commands = batch
+        let locked_block = LockedBlock::get(tx)?;
+        let pending_proposals = ForeignProposal::get_all_pending(tx, locked_block.block_id(), parent_block.block_id())?;
+        let commands = ForeignProposal::get_all_new(tx)?
             .into_iter()
-            .map(|t| match t.current_stage() {
+            .filter_map(|foreign_proposal| {
+                if pending_proposals.contains(&foreign_proposal) {
+                    None
+                } else {
+                    Some(Ok(Command::ForeignProposal(
+                        foreign_proposal.set_mined_at(parent_block.height().saturating_add(NodeHeight(1))),
+                    )))
+                }
+            })
+            .chain(batch.into_iter().map(|t| match t.current_stage() {
                 // If the transaction is New, propose to Prepare it
                 TransactionPoolStage::New => Ok(Command::Prepare(t.get_local_transaction_atom())),
                 // The transaction is Prepared, this stage is only _ready_ once we know that all local nodes
                 // accepted Prepared so we propose LocalPrepared
                 TransactionPoolStage::Prepared => Ok(Command::LocalPrepared(t.get_local_transaction_atom())),
                 // The transaction is LocalPrepared, meaning that we know that all foreign and local nodes have
-                // prepared. We can now propose to Accept it. We also propose the decision change which everyone should
-                // agree with if they received the same foreign LocalPrepare.
+                // prepared. We can now propose to Accept it. We also propose the decision change which everyone
+                // should agree with if they received the same foreign LocalPrepare.
                 TransactionPoolStage::LocalPrepared => {
                     let involved = local_committee_shard.count_distinct_buckets(t.transaction().evidence.shards_iter());
                     let involved = NonZeroU64::new(involved as u64).ok_or_else(|| {
@@ -220,16 +233,16 @@ where TConsensusSpec: ConsensusSpec
                     total_leader_fee += leader_fee;
                     Ok(Command::Accept(t.get_final_transaction_atom(leader_fee)))
                 },
-                // Not reachable as there is nothing to propose for these stages. To confirm that all local nodes agreed
-                // with the Accept, more (possibly empty) blocks with QCs will be proposed and accepted,
-                // otherwise the Accept block will not be committed.
+                // Not reachable as there is nothing to propose for these stages. To confirm that all local nodes
+                // agreed with the Accept, more (possibly empty) blocks with QCs will be
+                // proposed and accepted, otherwise the Accept block will not be committed.
                 TransactionPoolStage::AllPrepared | TransactionPoolStage::SomePrepared => {
                     unreachable!(
                         "It is invalid for TransactionPoolStage::{} to be ready to propose",
                         t.current_stage()
                     )
                 },
-            })
+            }))
             .collect::<Result<BTreeSet<_>, HotStuffError>>()?;
 
         debug!(

--- a/dan_layer/consensus/src/hotstuff/on_receive_foreign_proposal.rs
+++ b/dan_layer/consensus/src/hotstuff/on_receive_foreign_proposal.rs
@@ -5,7 +5,14 @@ use std::ops::DerefMut;
 use log::*;
 use tari_dan_common_types::{committee::CommitteeShard, optional::Optional, shard_bucket::ShardBucket, NodeHeight};
 use tari_dan_storage::{
-    consensus_models::{Block, ForeignReceiveCounters, LeafBlock, TransactionPool, TransactionPoolStage},
+    consensus_models::{
+        Block,
+        ForeignProposal,
+        ForeignReceiveCounters,
+        LeafBlock,
+        TransactionPool,
+        TransactionPoolStage,
+    },
     StateStore,
 };
 use tari_epoch_manager::EpochManagerReader;
@@ -72,6 +79,7 @@ where TConsensusSpec: ConsensusSpec
         self.foreign_receive_counter.increment(&committee_shard.bucket());
         self.store.with_write_tx(|tx| {
             self.foreign_receive_counter.save(tx)?;
+            ForeignProposal::new(committee_shard.bucket(), *block.id()).upsert(tx)?;
             self.on_receive_foreign_block(tx, &block, &committee_shard)
         })?;
 

--- a/dan_layer/state_store_sqlite/migrations/2023-06-08-091819_create_state_store/up.sql
+++ b/dan_layer/state_store_sqlite/migrations/2023-06-08-091819_create_state_store/up.sql
@@ -245,6 +245,17 @@ CREATE TABLE missing_transactions
     FOREIGN KEY (block_id) REFERENCES parked_blocks (block_id)
 );
 
+CREATE TABLE foreign_proposals
+(
+    id         integer   not NULL primary key AUTOINCREMENT,
+    bucket     bigint    not NULL,
+    block_id   text      not NULL,
+    state      text      not NULL,
+    mined_at   bigint    NULL,
+    created_at timestamp not NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (bucket, block_id)
+);
+
 CREATE TABLE foreign_send_counters
 (
     id         integer   not NULL primary key AUTOINCREMENT,

--- a/dan_layer/state_store_sqlite/src/schema.rs
+++ b/dan_layer/state_store_sqlite/src/schema.rs
@@ -21,6 +21,17 @@ diesel::table! {
 }
 
 diesel::table! {
+    foreign_proposals (id) {
+        id -> Integer,
+        bucket -> Integer,
+        block_id -> Text,
+        state -> Text,
+        mined_at -> Nullable<BigInt>,
+        created_at -> Timestamp,
+    }
+}
+
+diesel::table! {
     foreign_receive_counters (id) {
         id -> Integer,
         counters -> Text,

--- a/dan_layer/storage/src/consensus_models/foreign_proposal.rs
+++ b/dan_layer/storage/src/consensus_models/foreign_proposal.rs
@@ -3,6 +3,7 @@
 
 use std::{
     fmt::{self, Display, Formatter},
+    hash::Hash,
     str::FromStr,
 };
 
@@ -42,18 +43,12 @@ impl FromStr for ForeignProposalState {
     }
 }
 
-#[derive(Debug, Clone, Eq, Hash, Serialize, Deserialize, PartialOrd, Ord)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize, PartialOrd, Ord)]
 pub struct ForeignProposal {
     pub bucket: ShardBucket,
     pub block_id: BlockId,
     pub state: ForeignProposalState,
     pub mined_at: Option<NodeHeight>,
-}
-
-impl PartialEq for ForeignProposal {
-    fn eq(&self, other: &Self) -> bool {
-        self.bucket == other.bucket && self.block_id == other.block_id
-    }
 }
 
 impl ForeignProposal {

--- a/dan_layer/storage/src/consensus_models/foreign_proposal.rs
+++ b/dan_layer/storage/src/consensus_models/foreign_proposal.rs
@@ -1,0 +1,105 @@
+//    Copyright 2023 The Tari Project
+//    SPDX-License-Identifier: BSD-3-Clause
+
+use std::{
+    fmt::{self, Display, Formatter},
+    str::FromStr,
+};
+
+use serde::{Deserialize, Serialize};
+use tari_dan_common_types::{shard_bucket::ShardBucket, NodeHeight};
+
+use super::BlockId;
+use crate::{StateStoreReadTransaction, StateStoreWriteTransaction, StorageError};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, PartialOrd, Ord)]
+pub enum ForeignProposalState {
+    New,
+    Mined,
+    Deleted,
+}
+
+impl Display for ForeignProposalState {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            ForeignProposalState::New => write!(f, "New"),
+            ForeignProposalState::Mined => write!(f, "Mined"),
+            ForeignProposalState::Deleted => write!(f, "Deleted"),
+        }
+    }
+}
+
+impl FromStr for ForeignProposalState {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "New" => Ok(ForeignProposalState::New),
+            "Mined" => Ok(ForeignProposalState::Mined),
+            "Deleted" => Ok(ForeignProposalState::Deleted),
+            _ => Err(anyhow::anyhow!("Invalid foreign proposal state {}", s)),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Eq, Hash, Serialize, Deserialize, PartialOrd, Ord)]
+pub struct ForeignProposal {
+    pub bucket: ShardBucket,
+    pub block_id: BlockId,
+    pub state: ForeignProposalState,
+    pub mined_at: Option<NodeHeight>,
+}
+
+impl PartialEq for ForeignProposal {
+    fn eq(&self, other: &Self) -> bool {
+        self.bucket == other.bucket && self.block_id == other.block_id
+    }
+}
+
+impl ForeignProposal {
+    pub fn new(bucket: ShardBucket, block_id: BlockId) -> Self {
+        Self {
+            bucket,
+            block_id,
+            state: ForeignProposalState::New,
+            mined_at: None,
+        }
+    }
+
+    pub fn set_mined_at(mut self, mined_at: NodeHeight) -> Self {
+        self.mined_at = Some(mined_at);
+        self.state = ForeignProposalState::Mined;
+        self
+    }
+}
+
+impl ForeignProposal {
+    pub fn upsert<TTx: StateStoreWriteTransaction + ?Sized>(&self, tx: &mut TTx) -> Result<(), StorageError> {
+        tx.foreign_proposal_upsert(self)?;
+        Ok(())
+    }
+
+    pub fn delete<TTx: StateStoreWriteTransaction + ?Sized>(&self, tx: &mut TTx) -> Result<(), StorageError> {
+        tx.foreign_proposal_delete(self)?;
+        Ok(())
+    }
+
+    pub fn exists<TTx: StateStoreReadTransaction + ?Sized>(
+        tx: &mut TTx,
+        foreign_proposal: &Self,
+    ) -> Result<bool, StorageError> {
+        tx.foreign_proposal_exists(foreign_proposal)
+    }
+
+    pub fn get_all_new<TTx: StateStoreReadTransaction + ?Sized>(tx: &mut TTx) -> Result<Vec<Self>, StorageError> {
+        tx.foreign_proposal_get_all_new()
+    }
+
+    pub fn get_all_pending<TTx: StateStoreReadTransaction + ?Sized>(
+        tx: &mut TTx,
+        from_block_id: &BlockId,
+        to_block_id: &BlockId,
+    ) -> Result<Vec<Self>, StorageError> {
+        tx.foreign_proposal_get_all_pending(from_block_id, to_block_id)
+    }
+}

--- a/dan_layer/storage/src/consensus_models/mod.rs
+++ b/dan_layer/storage/src/consensus_models/mod.rs
@@ -4,6 +4,7 @@
 mod block;
 mod command;
 mod executed_transaction;
+mod foreign_proposal;
 mod foreign_receive_counters;
 mod foreign_send_counters;
 mod high_qc;
@@ -28,6 +29,7 @@ mod vote_signature;
 pub use block::*;
 pub use command::*;
 pub use executed_transaction::*;
+pub use foreign_proposal::*;
 pub use foreign_receive_counters::*;
 pub use foreign_send_counters::*;
 pub use high_qc::*;

--- a/dan_layer/storage/src/state_store/mod.rs
+++ b/dan_layer/storage/src/state_store/mod.rs
@@ -18,6 +18,7 @@ use crate::{
         BlockId,
         Decision,
         Evidence,
+        ForeignProposal,
         ForeignReceiveCounters,
         ForeignSendCounters,
         HighQc,
@@ -92,6 +93,13 @@ pub trait StateStoreReadTransaction {
     fn locked_block_get(&mut self) -> Result<LockedBlock, StorageError>;
     fn leaf_block_get(&mut self) -> Result<LeafBlock, StorageError>;
     fn high_qc_get(&mut self) -> Result<HighQc, StorageError>;
+    fn foreign_proposal_exists(&mut self, foreign_proposal: &ForeignProposal) -> Result<bool, StorageError>;
+    fn foreign_proposal_get_all_new(&mut self) -> Result<Vec<ForeignProposal>, StorageError>;
+    fn foreign_proposal_get_all_pending(
+        &mut self,
+        from_block_id: &BlockId,
+        to_block_id: &BlockId,
+    ) -> Result<Vec<ForeignProposal>, StorageError>;
     fn foreign_send_counters_get(&mut self, block_id: &BlockId) -> Result<ForeignSendCounters, StorageError>;
     fn foreign_receive_counters_get(&mut self) -> Result<ForeignReceiveCounters, StorageError>;
     fn transactions_get(&mut self, tx_id: &TransactionId) -> Result<TransactionRecord, StorageError>;
@@ -255,6 +263,8 @@ pub trait StateStoreWriteTransaction {
     fn leaf_block_set(&mut self, leaf_node: &LeafBlock) -> Result<(), StorageError>;
     fn locked_block_set(&mut self, locked_block: &LockedBlock) -> Result<(), StorageError>;
     fn high_qc_set(&mut self, high_qc: &HighQc) -> Result<(), StorageError>;
+    fn foreign_proposal_upsert(&mut self, foreign_proposal: &ForeignProposal) -> Result<(), StorageError>;
+    fn foreign_proposal_delete(&mut self, foreign_proposal: &ForeignProposal) -> Result<(), StorageError>;
     fn foreign_send_counters_set(
         &mut self,
         foreign_send_counter: &ForeignSendCounters,

--- a/dan_layer/validator_node_rpc/proto/consensus.proto
+++ b/dan_layer/validator_node_rpc/proto/consensus.proto
@@ -57,7 +57,22 @@ message Command {
     TransactionAtom prepare = 1;
     TransactionAtom local_prepared = 2;
     TransactionAtom accept = 3;
+    ForeignProposal foreign_proposal = 4;
   }
+}
+
+enum ForeignProposalState {
+  UNKNOWN_STATE = 0;
+  NEW = 1;
+  MINED = 2;
+  DELETED = 3;
+}
+
+message ForeignProposal {
+  uint32 bucket = 1;
+  bytes block_id = 2;
+  ForeignProposalState state = 3;
+  uint64 mined_at = 4;
 }
 
 message TransactionAtom {


### PR DESCRIPTION
Description
---
It's build on top of #757 
In current state everyone propose the foreign proposal command all the time.
If I build on top of block where the foreign proposal is, then I can not propose it and mark it as proposed.
But everyone else needs to check if there is a block on top of the block where the command is to mark it as well. But the command is not in the locked block. So it can be rollbacked, right?
For the transactions we have something similar where we keep track of the changes until they are locked, in the `transaction_pool_state_updates` table.

Motivation and Context
---

How Has This Been Tested?
---

What process can a PR reviewer use to test or verify this change?
---


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify