### PR TITLE
fix(wallet_daemon_web_ui): send correct max_fee param on transfers

### DIFF
--- a/applications/tari_dan_wallet_web_ui/src/api/hooks/useAccounts.tsx
+++ b/applications/tari_dan_wallet_web_ui/src/api/hooks/useAccounts.tsx
@@ -77,7 +77,7 @@ export const useAccountsTransfer = (
   amount: number,
   resource_address: string,
   destination_public_key: string,
-  fee: number | null,
+  max_fee: number | null,
   confidential: boolean
 ) => {
   return useMutation(
@@ -87,7 +87,7 @@ export const useAccountsTransfer = (
         amount,
         resource_address,
         destination_public_key,
-        fee,
+        max_fee,
       }),
     {
       onError: (error: apiError) => {


### PR DESCRIPTION
Description
---
Use the expected `max_fee` param on the transfer request from the wallet daemon UI to the wallet daemon JRPC.

Motivation and Context
---
Up until now, when sending account transfers through the wallet daemon UI, the fee field was send to the wallet daemon as `fee` instead of the expected `max_fee`. This means that he default fee (1500 Tari) was always used regardless of what the user specified on the input.

This PR fixes this problem. With this fix transactions will be rejected if the user inputs a fee too low for the transfer

How Has This Been Tested?
---
Manually doing transfers on a local testnet

What process can a PR reviewer use to test or verify this change?
---
Doing transfers with the wallet daemon UI and different values of fees

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify