### PR TITLE
fix: shard range computation

### DIFF
--- a/dan_layer/common_types/src/shard_bucket.rs
+++ b/dan_layer/common_types/src/shard_bucket.rs
@@ -23,11 +23,14 @@ impl ShardBucket {
         if num_committees == 0 {
             return RangeInclusive::new(ShardId::zero(), ShardId::from_u256(U256::MAX));
         }
-        let bucket_size = U256::MAX / U256::from(num_committees);
-        let start = bucket_size * U256::from(self.0);
+        let bucket = U256::from(self.0);
+        let num_committees = U256::from(num_committees);
+        let bucket_size = U256::MAX / num_committees;
+        let bucket_remainder = U256::MAX % num_committees;
+        let next_bucket = bucket + U256_ONE;
+        let start = bucket_size * bucket + bucket_remainder.min(bucket);
         let mut end = start + bucket_size;
-        // Edge case: The start of the next bucket is excluded except for the last bucket
-        if end < U256::MAX {
+        if next_bucket != num_committees && bucket_remainder <= bucket {
             end -= U256_ONE;
         }
         RangeInclusive::new(ShardId::from_u256(start), ShardId::from_u256(end))
@@ -54,5 +57,38 @@ impl PartialEq<ShardBucket> for u32 {
 impl Display for ShardBucket {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.as_u32())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::uint::{U256, U256_ONE};
+
+    #[test]
+    fn committee_is_properly_computed() {
+        for num_of_committees in 1..100 {
+            let mut previous_end = U256::ZERO;
+            let mut min_committee_size = U256::MAX;
+            let mut max_committee_size = U256::ZERO;
+            for bucket_index in 0..num_of_committees {
+                let bucket = super::ShardBucket::from(bucket_index);
+                let range = bucket.to_shard_range(num_of_committees);
+                if bucket_index > 0 {
+                    assert_eq!(
+                        range.start().to_u256(),
+                        previous_end + U256_ONE,
+                        "Bucket should start where the previous one ended+1"
+                    );
+                }
+                min_committee_size = min_committee_size.min(range.end().to_u256() - range.start().to_u256());
+                max_committee_size = max_committee_size.max(range.end().to_u256() - range.start().to_u256());
+                previous_end = range.end().to_u256();
+            }
+            assert!(
+                num_of_committees <= 1 || max_committee_size <= min_committee_size + U256_ONE,
+                "Committee sizes should be balanced {min_committee_size} {max_committee_size}"
+            );
+            assert_eq!(previous_end, U256::MAX, "Last bucket should end at U256::MAX");
+        }
     }
 }


### PR DESCRIPTION
Description
---
Proper shard range computation with tests.

Motivation and Context
---
There can't be any gap in the shard space.

How Has This Been Tested?
---
There is a new cargo test.

What process can a PR reviewer use to test or verify this change?
---
You can run the test: `cargo test --package tari_dan_common_types --lib -- shard_bucket::test::committee_is_properly_computed --exact`

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify