### PR TITLE
feat(integration_tests): new test for downed substates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3766,6 +3766,7 @@ dependencies = [
  "base64 0.21.5",
  "config",
  "cucumber",
+ "futures 0.3.29",
  "httpmock",
  "indexmap 1.9.3",
  "log",

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -49,6 +49,7 @@ cucumber = { version = "0.18.0", features = [
     "libtest",
     "output-junit",
 ] }
+futures = "0.3.29"
 httpmock = "0.6.8"
 indexmap = "1.9.1"
 log = { version = "0.4.8", features = ["std"] }

--- a/integration_tests/tests/cucumber.rs
+++ b/integration_tests/tests/cucumber.rs
@@ -207,11 +207,32 @@ async fn call_component_method(
     method_call: String,
     output_name: String,
 ) {
-    let resp = validator_node_cli::call_method(world, vn_name, component_name, output_name, method_call).await;
+    let resp = validator_node_cli::call_method(world, vn_name, component_name, output_name, method_call)
+        .await
+        .unwrap();
     assert_eq!(resp.dry_run_result.unwrap().decision, QuorumDecision::Accept);
 
     // give it some time between transactions
     // tokio::time::sleep(Duration::from_secs(4)).await;
+}
+
+#[when(
+    expr = r#"I invoke on {word} on component {word} the method call "{word}" named "{word}" the result is error {string}"#
+)]
+async fn call_component_method_must_error(
+    world: &mut TariWorld,
+    vn_name: String,
+    component_name: String,
+    method_call: String,
+    output_name: String,
+    error_msg: String,
+) {
+    let res = validator_node_cli::call_method(world, vn_name, component_name, output_name, method_call).await;
+    if let Err(reject) = res {
+        assert!(reject.to_string().contains(&error_msg));
+    } else {
+        panic!("Expected an error but the call was successful");
+    }
 }
 
 #[when(expr = r#"I invoke on all validator nodes on component {word} the method call "{word}" named "{word}""#)]
@@ -230,7 +251,8 @@ async fn call_component_method_on_all_vns(
             output_name.clone(),
             method_call.clone(),
         )
-        .await;
+        .await
+        .unwrap();
         assert_eq!(resp.dry_run_result.unwrap().decision, QuorumDecision::Accept);
     }
     // give it some time between transactions
@@ -246,7 +268,9 @@ async fn call_component_method_and_check_result(
     expected_result: String,
 ) {
     let resp =
-        validator_node_cli::call_method(world, vn_name, component_name, "dummy_outputs".to_string(), method_call).await;
+        validator_node_cli::call_method(world, vn_name, component_name, "dummy_outputs".to_string(), method_call)
+            .await
+            .unwrap();
     let finalize_result = resp.dry_run_result.unwrap();
     assert_eq!(finalize_result.decision, QuorumDecision::Accept);
 
@@ -283,7 +307,8 @@ async fn call_component_method_on_all_vns_and_check_result(
             "dummy_outputs".to_string(),
             method_call.clone(),
         )
-        .await;
+        .await
+        .unwrap();
         let finalize_result = resp.dry_run_result.unwrap();
         assert_eq!(finalize_result.decision, QuorumDecision::Accept);
 

--- a/integration_tests/tests/features/substates.feature
+++ b/integration_tests/tests/features/substates.feature
@@ -1,0 +1,48 @@
+# Copyright 2022 The Tari Project
+# SPDX-License-Identifier: BSD-3-Clause
+
+Feature: Substates
+
+  @serial
+  Scenario: Transactions with DOWN local substates are rejected
+    Given fees are disabled
+    # Initialize a base node, wallet, miner and VN
+    Given a base node BASE
+    Given a wallet WALLET connected to base node BASE
+    Given a miner MINER connected to base node BASE and wallet WALLET
+
+    # Initialize a VN
+    Given a validator node VAL_1 connected to base node BASE and wallet WALLET
+
+    # The wallet must have some funds before the VN sends transactions
+    When miner MINER mines 6 new blocks
+    When wallet WALLET has at least 20 T
+
+    # VN registration
+    When validator node VAL_1 sends a registration transaction
+
+    # Register the "counter" template
+    When validator node VAL_1 registers the template "counter"
+    When miner MINER mines 13 new blocks
+    Then VAL_1 has scanned to height 16
+    Then the validator node VAL_1 is listed as registered
+    Then the template "counter" is listed as registered by the validator node VAL_1
+
+    # A file-base CLI account must be created to sign future calls
+    When I use an account key named K1
+
+    # Create a new Counter component
+    When I create a component COUNTER_1 of template "counter" on VAL_1 using "new"
+
+    # Increase the counter an check the value
+    When I invoke on VAL_1 on component COUNTER_1/components/Counter the method call "increase" named "TX1"
+    When I invoke on VAL_1 on component TX1/components/Counter the method call "value" the result is "1"
+
+    # We should get an error if we se as inputs the same component version thas has already been downed from previous transactions
+    # We can achieve this by reusing inputs from COUNTER_1 instead of the most recent TX1
+    When I invoke on VAL_1 on component COUNTER_1/components/Counter the method call "increase" named "TX2" the result is error "Shard was rejected"
+
+    # Check that the counter has NOT been increased by the previous erroneous transaction
+    When I invoke on VAL_1 on component TX1/components/Counter the method call "value" the result is "1"
+
+


### PR DESCRIPTION
Description
---
* Refactored the VN util of the integration test so method calls return a result, making it easier to assert expected errors.
* New cucumber test for downed local substates.

Motivation and Context
---
We want to assert that a substate that has been downed cannot be used again as an input. There are two situations:
* The substate is local to the VN
* The substate is a remote committee

This PR adds a new test for the first situation, downed local substates. The second situation requires a more advance integration test setup where we can manipulate multiple committees deterministically, so it's left out of scope of this PR.

Ref https://github.com/tari-project/tari-dan/issues/387

How Has This Been Tested?
---
New test passes

What process can a PR reviewer use to test or verify this change?
---
Execute the test

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify