### PR TITLE
fix: propagation

### DIFF
--- a/applications/tari_validator_node/src/p2p/rpc/sync_task.rs
+++ b/applications/tari_validator_node/src/p2p/rpc/sync_task.rs
@@ -157,6 +157,7 @@ impl<TStateStore: StateStore> BlockSyncTask<TStateStore> {
                 let all_qcs = block
                     .commands()
                     .iter()
+                    .filter(|cmd| cmd.transaction().is_some())
                     .flat_map(|cmd| cmd.evidence().qc_ids_iter())
                     .collect::<HashSet<_>>();
                 let certificates = QuorumCertificate::get_all(tx, all_qcs)?;

--- a/applications/tari_validator_node/src/p2p/services/mempool/service.rs
+++ b/applications/tari_validator_node/src/p2p/services/mempool/service.rs
@@ -331,7 +331,8 @@ where
                         current_epoch,
                         NewTransactionMessage {
                             transaction: transaction.clone(),
-                            output_shards: vec![],
+                            output_shards: unverified_output_shards, /* Or send to local only when we are input shard
+                                                                      * and if we are output send after execution */
                         }
                         .into(),
                     )

--- a/applications/tari_validator_node/src/p2p/services/mempool/service.rs
+++ b/applications/tari_validator_node/src/p2p/services/mempool/service.rs
@@ -344,7 +344,7 @@ where
                     );
                 }
 
-                // Only tx receipt shards propagate to foreign shards
+                // Only input shards propagate to foreign shards
                 if is_input_shard {
                     // Forward to foreign replicas.
                     // We assume that at least f other local replicas receive this transaction and also forward to their


### PR DESCRIPTION
Description
---
Fix propagation from indexer. Now it propagates to `tx_receipt` only when there are no inputs. Because the rest of the propagation is done only by input shards.

Motivation and Context
---

How Has This Been Tested?
---
Same as bellow.

What process can a PR reviewer use to test or verify this change?
---
Run multi committee transaction to see if it's fine.


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify