### PR TITLE
feat: foreign proposal transaction timeout

### DIFF
--- a/dan_layer/consensus/src/hotstuff/on_receive_foreign_proposal.rs
+++ b/dan_layer/consensus/src/hotstuff/on_receive_foreign_proposal.rs
@@ -16,6 +16,7 @@ use tari_dan_storage::{
     StateStore,
 };
 use tari_epoch_manager::EpochManagerReader;
+use tari_transaction::TransactionId;
 
 use crate::{
     hotstuff::{error::HotStuffError, pacemaker_handle::PaceMakerHandle, ProposalValidationError},
@@ -70,7 +71,36 @@ where TConsensusSpec: ConsensusSpec
             .epoch_manager
             .get_committee_shard(block.epoch(), vn.shard_key)
             .await?;
-        let foreign_proposal = ForeignProposal::new(committee_shard.shard(), *block.id());
+
+        let local_shard = self.epoch_manager.get_local_committee_shard(block.epoch()).await?;
+        self.validate_proposed_block(
+            &from,
+            &block,
+            committee_shard.shard(),
+            local_shard.shard(),
+            &foreign_receive_counter,
+        )?;
+        // Is this ok? Can foreign node send invalid block that should still increment the counter?
+        foreign_receive_counter.increment(&committee_shard.shard());
+
+        let tx_ids = block
+            .commands()
+            .iter()
+            .filter_map(|command| {
+                if let Some(tx) = command.local_prepared() {
+                    if !committee_shard.includes_any_shard(command.evidence().shards_iter()) {
+                        return None;
+                    }
+                    // We are interested in the commands that are for us, they will be in local prepared and one of the
+                    // evidence shards will be ours
+                    Some(tx.id)
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<TransactionId>>();
+
+        let foreign_proposal = ForeignProposal::new(committee_shard.shard(), *block.id(), tx_ids);
         if self
             .store
             .with_read_tx(|tx| ForeignProposal::exists(tx, &foreign_proposal))?
@@ -83,15 +113,6 @@ where TConsensusSpec: ConsensusSpec
             return Ok(());
         }
 
-        let local_shard = self.epoch_manager.get_local_committee_shard(block.epoch()).await?;
-        self.validate_proposed_block(
-            &from,
-            &block,
-            committee_shard.shard(),
-            local_shard.shard(),
-            &foreign_receive_counter,
-        )?;
-        foreign_receive_counter.increment(&committee_shard.shard());
         self.store.with_write_tx(|tx| {
             foreign_receive_counter.save(tx)?;
             foreign_proposal.upsert(tx)?;

--- a/dan_layer/consensus/src/hotstuff/on_receive_local_proposal.rs
+++ b/dan_layer/consensus/src/hotstuff/on_receive_local_proposal.rs
@@ -372,11 +372,11 @@ impl<TConsensusSpec: ConsensusSpec> OnReceiveLocalProposalHandler<TConsensusSpec
 
         // TODO: Move this to consensus constants
         const TIMEOUT: u64 = 1000;
-        let all_mined_proposals = ForeignProposal::get_all_mined(
+        let all_proposed = ForeignProposal::get_all_proposed(
             tx.deref_mut(),
             candidate_block.height().saturating_sub(NodeHeight(TIMEOUT)),
         )?;
-        for proposal in all_mined_proposals {
+        for proposal in all_proposed {
             let mut has_unresolved_transactions = false;
             for tx_id in proposal.transactions.clone() {
                 let transaction = tx.transactions_get(&tx_id).optional()?;

--- a/dan_layer/p2p/proto/consensus.proto
+++ b/dan_layer/p2p/proto/consensus.proto
@@ -75,6 +75,7 @@ message ForeignProposal {
   bytes block_id = 2;
   ForeignProposalState state = 3;
   uint64 mined_at = 4;
+  repeated bytes transactions = 5;
 }
 
 message TransactionAtom {

--- a/dan_layer/p2p/src/conversions/consensus.rs
+++ b/dan_layer/p2p/src/conversions/consensus.rs
@@ -397,6 +397,7 @@ impl From<&ForeignProposal> for proto::consensus::ForeignProposal {
             block_id: value.block_id.as_bytes().to_vec(),
             state: proto::consensus::ForeignProposalState::from(value.state).into(),
             mined_at: value.proposed_height.map(|a| a.0).unwrap_or(0),
+            transactions: value.transactions.iter().map(|tx| tx.as_bytes().to_vec()).collect(),
         }
     }
 }
@@ -416,6 +417,11 @@ impl TryFrom<proto::consensus::ForeignProposal> for ForeignProposal {
             } else {
                 Some(NodeHeight(value.mined_at))
             },
+            transactions: value
+                .transactions
+                .into_iter()
+                .map(|tx| tx.try_into())
+                .collect::<Result<_, _>>()?,
         })
     }
 }

--- a/dan_layer/state_store_sqlite/migrations/2023-06-08-091819_create_state_store/up.sql
+++ b/dan_layer/state_store_sqlite/migrations/2023-06-08-091819_create_state_store/up.sql
@@ -257,6 +257,7 @@ CREATE TABLE foreign_proposals
     block_id        text      not NULL,
     state           text      not NULL,
     proposed_height bigint    NULL,
+    transactions    text      not NULL,
     created_at      timestamp not NULL DEFAULT CURRENT_TIMESTAMP,
     UNIQUE (bucket, block_id)
 );

--- a/dan_layer/state_store_sqlite/src/reader.rs
+++ b/dan_layer/state_store_sqlite/src/reader.rs
@@ -439,7 +439,10 @@ impl<TAddr: NodeAddressable + Serialize + DeserializeOwned> StateStoreReadTransa
             .collect::<Vec<ForeignProposal>>())
     }
 
-    fn foreign_proposal_get_all_mined(&mut self, to_height: NodeHeight) -> Result<Vec<ForeignProposal>, StorageError> {
+    fn foreign_proposal_get_all_proposed(
+        &mut self,
+        to_height: NodeHeight,
+    ) -> Result<Vec<ForeignProposal>, StorageError> {
         use crate::schema::foreign_proposals;
 
         let foreign_proposals = foreign_proposals::table

--- a/dan_layer/state_store_sqlite/src/reader.rs
+++ b/dan_layer/state_store_sqlite/src/reader.rs
@@ -444,7 +444,7 @@ impl<TAddr: NodeAddressable + Serialize + DeserializeOwned> StateStoreReadTransa
 
         let foreign_proposals = foreign_proposals::table
             .filter(foreign_proposals::state.eq("Mined"))
-            .filter(foreign_proposals::mined_at.le(to_height.0 as i64))
+            .filter(foreign_proposals::proposed_height.le(to_height.0 as i64))
             .load::<sql_models::ForeignProposal>(self.connection())
             .map_err(|e| SqliteStorageError::DieselError {
                 operation: "foreign_proposal_get_all",

--- a/dan_layer/state_store_sqlite/src/reader.rs
+++ b/dan_layer/state_store_sqlite/src/reader.rs
@@ -443,7 +443,7 @@ impl<TAddr: NodeAddressable + Serialize + DeserializeOwned> StateStoreReadTransa
         use crate::schema::foreign_proposals;
 
         let foreign_proposals = foreign_proposals::table
-            .filter(foreign_proposals::state.eq("Mined"))
+            .filter(foreign_proposals::state.eq(ForeignProposalState::Proposed.to_string()))
             .filter(foreign_proposals::proposed_height.le(to_height.0 as i64))
             .load::<sql_models::ForeignProposal>(self.connection())
             .map_err(|e| SqliteStorageError::DieselError {

--- a/dan_layer/state_store_sqlite/src/schema.rs
+++ b/dan_layer/state_store_sqlite/src/schema.rs
@@ -29,6 +29,7 @@ diesel::table! {
         block_id -> Text,
         state -> Text,
         proposed_height -> Nullable<BigInt>,
+        transactions -> Text,
         created_at -> Timestamp,
     }
 }

--- a/dan_layer/state_store_sqlite/src/sql_models/bookkeeping.rs
+++ b/dan_layer/state_store_sqlite/src/sql_models/bookkeeping.rs
@@ -42,6 +42,7 @@ pub struct ForeignProposal {
     pub block_id: String,
     pub state: String,
     pub mined_at: Option<i64>,
+    pub transactions: String,
     pub created_at: PrimitiveDateTime,
 }
 
@@ -54,6 +55,7 @@ impl TryFrom<ForeignProposal> for consensus_models::ForeignProposal {
             block_id: deserialize_hex_try_from(&value.block_id)?,
             state: parse_from_string(&value.state)?,
             proposed_height: value.mined_at.map(|mined_at| NodeHeight(mined_at as u64)),
+            transactions: deserialize_json(&value.transactions)?,
         })
     }
 }

--- a/dan_layer/state_store_sqlite/src/writer.rs
+++ b/dan_layer/state_store_sqlite/src/writer.rs
@@ -580,6 +580,7 @@ impl<TAddr: NodeAddressable> StateStoreWriteTransaction for SqliteStateStoreWrit
             foreign_proposals::block_id.eq(serialize_hex(foreign_proposal.block_id)),
             foreign_proposals::state.eq(foreign_proposal.state.to_string()),
             foreign_proposals::proposed_height.eq(foreign_proposal.proposed_height.map(|h| h.as_u64() as i64)),
+            foreign_proposals::transactions.eq(serialize_json(&foreign_proposal.transactions)?),
         );
 
         diesel::insert_into(foreign_proposals::table)

--- a/dan_layer/storage/src/consensus_models/foreign_proposal.rs
+++ b/dan_layer/storage/src/consensus_models/foreign_proposal.rs
@@ -106,10 +106,10 @@ impl ForeignProposal {
         tx.foreign_proposal_get_all_pending(from_block_id, to_block_id)
     }
 
-    pub fn get_all_mined<TTx: StateStoreReadTransaction + ?Sized>(
+    pub fn get_all_proposed<TTx: StateStoreReadTransaction + ?Sized>(
         tx: &mut TTx,
         to_height: NodeHeight,
     ) -> Result<Vec<Self>, StorageError> {
-        tx.foreign_proposal_get_all_mined(to_height)
+        tx.foreign_proposal_get_all_proposed(to_height)
     }
 }

--- a/dan_layer/storage/src/consensus_models/foreign_proposal.rs
+++ b/dan_layer/storage/src/consensus_models/foreign_proposal.rs
@@ -9,6 +9,7 @@ use std::{
 
 use serde::{Deserialize, Serialize};
 use tari_dan_common_types::{shard::Shard, NodeHeight};
+use tari_transaction::TransactionId;
 #[cfg(feature = "ts")]
 use ts_rs::TS;
 
@@ -53,15 +54,18 @@ pub struct ForeignProposal {
     pub block_id: BlockId,
     pub state: ForeignProposalState,
     pub proposed_height: Option<NodeHeight>,
+    #[cfg_attr(feature = "ts", ts(type = "Array<string>"))]
+    pub transactions: Vec<TransactionId>,
 }
 
 impl ForeignProposal {
-    pub fn new(bucket: Shard, block_id: BlockId) -> Self {
+    pub fn new(bucket: Shard, block_id: BlockId, transactions: Vec<TransactionId>) -> Self {
         Self {
             bucket,
             block_id,
             state: ForeignProposalState::New,
             proposed_height: None,
+            transactions,
         }
     }
 
@@ -100,5 +104,12 @@ impl ForeignProposal {
         to_block_id: &BlockId,
     ) -> Result<Vec<Self>, StorageError> {
         tx.foreign_proposal_get_all_pending(from_block_id, to_block_id)
+    }
+
+    pub fn get_all_mined<TTx: StateStoreReadTransaction + ?Sized>(
+        tx: &mut TTx,
+        to_height: NodeHeight,
+    ) -> Result<Vec<Self>, StorageError> {
+        tx.foreign_proposal_get_all_mined(to_height)
     }
 }

--- a/dan_layer/storage/src/state_store/mod.rs
+++ b/dan_layer/storage/src/state_store/mod.rs
@@ -102,6 +102,7 @@ pub trait StateStoreReadTransaction {
         from_block_id: &BlockId,
         to_block_id: &BlockId,
     ) -> Result<Vec<ForeignProposal>, StorageError>;
+    fn foreign_proposal_get_all_mined(&mut self, to_height: NodeHeight) -> Result<Vec<ForeignProposal>, StorageError>;
     fn foreign_send_counters_get(&mut self, block_id: &BlockId) -> Result<ForeignSendCounters, StorageError>;
     fn foreign_receive_counters_get(&mut self) -> Result<ForeignReceiveCounters, StorageError>;
     fn transactions_get(&mut self, tx_id: &TransactionId) -> Result<TransactionRecord, StorageError>;

--- a/dan_layer/storage/src/state_store/mod.rs
+++ b/dan_layer/storage/src/state_store/mod.rs
@@ -102,7 +102,10 @@ pub trait StateStoreReadTransaction {
         from_block_id: &BlockId,
         to_block_id: &BlockId,
     ) -> Result<Vec<ForeignProposal>, StorageError>;
-    fn foreign_proposal_get_all_mined(&mut self, to_height: NodeHeight) -> Result<Vec<ForeignProposal>, StorageError>;
+    fn foreign_proposal_get_all_proposed(
+        &mut self,
+        to_height: NodeHeight,
+    ) -> Result<Vec<ForeignProposal>, StorageError>;
     fn foreign_send_counters_get(&mut self, block_id: &BlockId) -> Result<ForeignSendCounters, StorageError>;
     fn foreign_receive_counters_get(&mut self) -> Result<ForeignReceiveCounters, StorageError>;
     fn transactions_get(&mut self, tx_id: &TransactionId) -> Result<TransactionRecord, StorageError>;


### PR DESCRIPTION
Description
---
Transaction (from foreign proposals) timeout.
For every Foreign proposal we store new column with all the transactions id. Once we receive local block where the transaction should be resolved and it's not (it's not finalized, or the current state is not at least LocalPrepared) we update the local decision to abort.

Motivation and Context
---

How Has This Been Tested?
---
N/A

What process can a PR reviewer use to test or verify this change?
---


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify