### PR TITLE
feat: show substate version in dan wallet ui

### DIFF
--- a/applications/tari_dan_wallet_web_ui/src/routes/Transactions/Substates.tsx
+++ b/applications/tari_dan_wallet_web_ui/src/routes/Transactions/Substates.tsx
@@ -75,6 +75,7 @@ function RowData({ info, state }: any, index: number) {
               />
             )}
             {state}
+            ({info?.[1]?.version !== undefined ? info[1].version : info?.[1]})
           </div>
         </DataTableCell>
         <DataTableCell>{itemKey}</DataTableCell>


### PR DESCRIPTION
Description
---
Show substate version in dan wallet ui in transactions details. I put the version after the state. e.g. `Up(1)` or `Down(0)`.

Motivation and Context
---

How Has This Been Tested?
---
Run the wallet with some transaction.

What process can a PR reviewer use to test or verify this change?
---
Same as above.

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify