### PR TITLE
feat: set refresh balance interval to 5 sec

### DIFF
--- a/applications/tari_dan_wallet_web_ui/src/api/hooks/useAccounts.tsx
+++ b/applications/tari_dan_wallet_web_ui/src/api/hooks/useAccounts.tsx
@@ -157,6 +157,7 @@ export const useAccountsGetBalances = (accountName: string | null) => {
     onError: (error: apiError) => {
       error;
     },
+    refetchInterval: 5000,
   });
 };
 


### PR DESCRIPTION
Description
---
Set refresh balance interval to 5 sec (was manual only when the balance redraw was triggered). 5sec is the same as for the transaction.

Motivation and Context
---

How Has This Been Tested?
---
Same as below.

What process can a PR reviewer use to test or verify this change?
---
Setup a dan wallet. Send some money. Wait for UI change.

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify