### PR TITLE
fix: shorten string on small strings

### DIFF
--- a/applications/tari_dan_wallet_web_ui/src/utils/helpers.tsx
+++ b/applications/tari_dan_wallet_web_ui/src/utils/helpers.tsx
@@ -94,6 +94,10 @@ function fromHexString(hexString: string) {
 }
 
 function shortenString(string: string, start: number = 8, end: number = 8) {
+  // The number 3 is from the characters for ellipsis
+  if (string.length < start + end + 3) {
+    return string;
+  }
   return string.substring(0, start) + '...' + string.slice(-end);
 }
 


### PR DESCRIPTION
Description
---
Fix `shortenString` function for small strings.

Motivation and Context
---
When `shortenString` was called on token_symbol instead of a resource address. e.g. `tXTR2` instead of doing nothing it generated a weird looking string `tXTR2...tXTR2`. Now if the string is smaller than (or equal size) the generated string it will just return the same string.

How Has This Been Tested?
---
As below.

What process can a PR reviewer use to test or verify this change?
---
Try to run a wallet daemon, you should see this weird string as described above, with this PR you will see only `tXTR2`.


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify