### PR TITLE
feat: propagation of foreign proposal by non leader

### DIFF
--- a/dan_layer/consensus/src/hotstuff/on_ready_to_vote_on_local_block.rs
+++ b/dan_layer/consensus/src/hotstuff/on_ready_to_vote_on_local_block.rs
@@ -937,15 +937,8 @@ where TConsensusSpec: ConsensusSpec
 
     async fn propose_newly_locked_blocks(&self, blocks: Vec<Block<TConsensusSpec::Addr>>) -> Result<(), HotStuffError> {
         for block in blocks {
-            let local_committee = self.epoch_manager.get_local_committee(block.epoch()).await?;
-            let is_leader = self
-                .leader_strategy
-                .is_leader(&self.validator_addr, &local_committee, block.height());
-            // TODO: This will be changed to different strategy where not only leader is responsible for foreign block
-            // proposal.
-            if is_leader {
-                self.proposer.broadcast_proposal_foreignly(&block).await?;
-            }
+            // It's not guranteed that we will broadcast anything, see Proposer::broadcast_proposal_foreignly
+            self.proposer.broadcast_proposal_foreignly(&block).await?;
         }
         Ok(())
     }

--- a/dan_layer/consensus/src/hotstuff/proposer.rs
+++ b/dan_layer/consensus/src/hotstuff/proposer.rs
@@ -4,7 +4,7 @@
 use std::collections::{BTreeSet, HashSet};
 
 use log::{debug, info};
-use tari_dan_common_types::shard_bucket::ShardBucket;
+use tari_dan_common_types::{committee::Committee, shard_bucket::ShardBucket};
 use tari_dan_storage::{
     consensus_models::{Block, Command, ExecutedTransaction},
     StateStore,
@@ -75,15 +75,45 @@ where TConsensusSpec: ConsensusSpec
             block,
             non_local_committees.len(),
         );
-        self.tx_broadcast
-            .send((
-                non_local_committees.into_values().collect(),
-                HotstuffMessage::ForeignProposal(ProposalMessage { block: block.clone() }),
-            ))
-            .await
-            .map_err(|_| HotStuffError::InternalChannelClosed {
-                context: "proposing locked block to foreing committees",
-            })?;
+        let local_committee = self.epoch_manager.get_local_committee(block.epoch()).await?;
+        let my_index = local_committee
+            .members
+            .iter()
+            .position(|member| *member == validator.address)
+            .expect("I should be part of my local committee");
+
+        let mut foreign_nodes = Vec::new();
+        for non_local_committee in non_local_committees.values() {
+            // Get the indices in foreign committee whom I should send the block. We shift the index for some
+            // deterministic randomness. Otherwise the same nodes will be senders all the time.
+            let send_to = whom_should_i_resend_the_block(
+                (my_index + block.height().as_u64() as usize) % local_committee.len(),
+                local_committee.len(),
+                non_local_committee.len(),
+            );
+            debug!(target:LOG_TARGET, "I should send the block to {:?}", send_to);
+            // Adding the block.height is to make it little bit random, otherwise we will always send it to the same
+            // nodes. It has to be deterministic, so all the nodes in the committee agree on the same nodes.
+            foreign_nodes.extend(send_to.into_iter().map(|index| {
+                non_local_committee.members[(index + block.height().as_u64() as usize) % non_local_committee.len()]
+                    .clone()
+            }))
+        }
+        // If the foreign_nodes is empty, that means we are not reponsible for distributing the block to the foreign
+        // committees
+        if !foreign_nodes.is_empty() {
+            // foreign_nodes holds all the nodes in the foreign committees that we should send the block to, there can
+            // be nodes from more than one committee, or it can be nodes only from single committee
+            self.tx_broadcast
+                .send((
+                    Committee::new(foreign_nodes),
+                    HotstuffMessage::ForeignProposal(ProposalMessage { block: block.clone() }),
+                ))
+                .await
+                .map_err(|_| HotStuffError::InternalChannelClosed {
+                    context: "proposing locked block to foreing committees",
+                })?;
+        }
 
         Ok(())
     }
@@ -113,4 +143,86 @@ pub fn get_non_local_buckets_from_commands<TTx: StateStoreReadTransaction>(
         .filter(|bucket| *bucket != local_bucket)
         .collect();
     Ok(non_local_buckets)
+}
+
+// Returns the indices in foreign committee whom I should send the block, so we guarantee that at least one
+// honest node receives it in the foreign committee. So we need to send it to at least f+1 node in the foreign
+// committee. But also take into consideration that our committee can have f dishonest nodes.
+fn whom_should_i_resend_the_block(
+    my_index: usize,
+    my_committee_size: usize,
+    foreign_committee_size: usize,
+) -> Vec<usize> {
+    if foreign_committee_size / 3 + my_committee_size / 3 < my_committee_size {
+        // We can do n to 1 mapping, but am I one that should be sending it?
+        if foreign_committee_size / 3 + my_committee_size / 3 + 1 > my_index {
+            vec![my_index % foreign_committee_size]
+        } else {
+            vec![]
+        }
+    } else {
+        // We can't do n to 1 mapping, the foreign committee is too big (more than 2 times), so now we have need
+        // 1 to N mapping.
+        // Lets the size of the committee be the 3f+1 and the foreign committee 3g+1.
+        // We know that f+g+1 > 3f+1 (that's above)
+        // So now we need to send more than 1 message per node. If we send n messages per node from x nodes, then we
+        // need (x-f)*n > g, because f nodes can be faulty, and we need to hit at least one honest node. So the
+        // smallest n is n=g/(x-f)+1. If we send it from the whole committee then n=g/(2f+1)+1. Ok but now, due to
+        // rounding, we don't have to send it from all the nodes. We just need to satify the (x-f)*n>g. So now we
+        // compute the x, x=g/n+f+1.
+        let my_f = (my_committee_size - 1) / 3;
+        let foreign_f = (foreign_committee_size - 1) / 3;
+        let n = foreign_f / (my_committee_size - my_f) + 1;
+        let nodes = foreign_f / n + 1 + my_f;
+        // So now we have 1 to N mapping, nodes will each send n messages
+        if my_index < nodes {
+            ((my_index * n)..((my_index + 1) * n))
+                .map(|i| i % foreign_committee_size)
+                .collect()
+        } else {
+            vec![]
+        }
+    }
+}
+#[cfg(test)]
+mod test {
+    use super::whom_should_i_resend_the_block;
+
+    #[test]
+    fn test_whom_should_i_resend_the_block() {
+        let to = whom_should_i_resend_the_block(0, 1, 1);
+        // If we are the only one and there is only one person in the other committee, we have to send it.
+        assert_eq!(to, vec![0]);
+        let to = whom_should_i_resend_the_block(0, 1, 7);
+        // If we are the only one and there are 7 people in the other committee, we have to send it, but not to all,
+        // just f+1 (so at least one honest node receives it)
+        assert_eq!(to, vec![0, 1, 2]);
+        for index in 0..3 {
+            // We need to make sure that at least one honest node sends it, so we select f+1 nodes to send it.
+            let to = whom_should_i_resend_the_block(index, 7, 1);
+            assert_eq!(to, vec![0]);
+        }
+        for index in 3..7 {
+            // We already selected f+1 nodes.
+            let to = whom_should_i_resend_the_block(index, 7, 1);
+            assert!(to.is_empty());
+        }
+        for index in 0..5 {
+            // If we have committees of equal sizes we need to guarantee that at least one honest node receives it. So
+            // we select 2f+1 nodes to send to 2f+1 nodes. If we have f dishonest nodes, then only f+1 messages go
+            // through. And if we have f dishonest nodes in the other committee, then at least one honest node receives
+            // it.
+            let to = whom_should_i_resend_the_block(index, 7, 7);
+            assert_eq!(to, vec![index]);
+        }
+        for index in 5..7 {
+            let to = whom_should_i_resend_the_block(index, 7, 7);
+            assert!(to.is_empty());
+        }
+        for index in 0..4 {
+            // If we are much smaller committee, we need to send more messages per node.
+            let to = whom_should_i_resend_the_block(index, 4, 19);
+            assert_eq!(to, vec![index * 3, index * 3 + 1, index * 3 + 2]);
+        }
+    }
 }

--- a/dan_layer/consensus/src/hotstuff/worker.rs
+++ b/dan_layer/consensus/src/hotstuff/worker.rs
@@ -144,6 +144,8 @@ impl<TConsensusSpec: ConsensusSpec> HotstuffWorker<TConsensusSpec> {
                 transaction_pool.clone(),
                 pacemaker.clone_handle(),
                 foreign_receive_counter,
+                leader_strategy.clone(),
+                tx_broadcast.clone(),
                 tx_leader.clone(),
             ),
             on_receive_vote: OnReceiveVoteHandler::new(vote_receiver.clone()),

--- a/dan_layer/consensus_tests/src/consensus.rs
+++ b/dan_layer/consensus_tests/src/consensus.rs
@@ -404,3 +404,57 @@ async fn leader_failure_node_goes_down() {
     log::info!("total messages sent: {}", test.network().total_messages_sent());
     test.assert_clean_shutdown().await;
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn foreign_block_distribution() {
+    setup_logger();
+    let mut test = Test::builder()
+        .with_test_timeout(Duration::from_secs(60))
+        .with_hotstuff_filter(Box::new(|from: &TestAddress, to: &TestAddress, _| {
+            match from.0.as_str() {
+                // We filter our message from each leader to the foreign committees. So we will rely on other members of
+                // the local committees to send the message to the foreign committee members. And then on
+                // the distribution within the foreign committee.
+                "1" => *to == TestAddress::new("1") || *to == TestAddress::new("2") || *to == TestAddress::new("3"),
+                "4" => *to == TestAddress::new("4") || *to == TestAddress::new("5") || *to == TestAddress::new("6"),
+                "7" => *to == TestAddress::new("7") || *to == TestAddress::new("8") || *to == TestAddress::new("9"),
+                _ => true,
+            }
+        }))
+        .add_committee(0, vec!["1", "2", "3"])
+        .add_committee(1, vec!["4", "5", "6"])
+        .add_committee(2, vec!["7", "8", "9"])
+        .start()
+        .await;
+    for _ in 0..20 {
+        test.send_transaction_to_all(Decision::Commit, 1, 5).await;
+    }
+
+    test.wait_all_have_at_least_n_new_transactions_in_pool(20).await;
+    test.network().start();
+    test.start_epoch(Epoch(0)).await;
+
+    loop {
+        test.on_block_committed().await;
+
+        if test.is_transaction_pool_empty() {
+            break;
+        }
+
+        let leaf1 = test.get_validator(&TestAddress::new("1")).get_leaf_block();
+        let leaf2 = test.get_validator(&TestAddress::new("4")).get_leaf_block();
+        let leaf3 = test.get_validator(&TestAddress::new("7")).get_leaf_block();
+        if leaf1.height > NodeHeight(20) || leaf2.height > NodeHeight(20) || leaf3.height > NodeHeight(20) {
+            panic!(
+                "Not all transaction committed after {}/{}/{} blocks",
+                leaf1.height, leaf2.height, leaf3.height
+            );
+        }
+    }
+
+    test.assert_all_validators_at_same_height().await;
+
+    log::info!("total messages sent: {}", test.network().total_messages_sent());
+    log::info!("total messages filtered: {}", test.network().total_messages_filtered());
+    test.assert_clean_shutdown().await;
+}

--- a/dan_layer/consensus_tests/src/support/harness.rs
+++ b/dan_layer/consensus_tests/src/support/harness.rs
@@ -19,6 +19,7 @@ use tari_shutdown::{Shutdown, ShutdownSignal};
 use tari_transaction::TransactionId;
 use tokio::{sync::broadcast, task};
 
+use super::HotstuffFilter;
 use crate::support::{
     address::TestAddress,
     epoch_manager::TestEpochManager,
@@ -280,6 +281,7 @@ pub struct TestBuilder {
     sql_address: String,
     timeout: Option<Duration>,
     debug_sql_file: Option<String>,
+    hotstuff_filter: Option<HotstuffFilter>,
 }
 
 impl TestBuilder {
@@ -289,35 +291,41 @@ impl TestBuilder {
             sql_address: ":memory:".to_string(),
             timeout: Some(Duration::from_secs(10)),
             debug_sql_file: None,
+            hotstuff_filter: None,
         }
     }
 
     #[allow(dead_code)]
-    pub fn disable_timeout(&mut self) -> &mut Self {
+    pub fn disable_timeout(mut self) -> Self {
         self.timeout = None;
         self
     }
 
     #[allow(dead_code)]
-    pub fn debug_sql<P: Into<String>>(&mut self, path: P) -> &mut Self {
+    pub fn debug_sql<P: Into<String>>(mut self, path: P) -> Self {
         self.debug_sql_file = Some(path.into());
         self
     }
 
     #[allow(dead_code)]
-    pub fn with_sql_url<T: Into<String>>(&mut self, sql_address: T) -> &mut Self {
+    pub fn with_sql_url<T: Into<String>>(mut self, sql_address: T) -> Self {
         self.sql_address = sql_address.into();
         self
     }
 
-    pub fn with_test_timeout(&mut self, timeout: Duration) -> &mut Self {
+    pub fn with_test_timeout(mut self, timeout: Duration) -> Self {
         self.timeout = Some(timeout);
         self
     }
 
-    pub fn add_committee<T: Into<ShardBucket>>(&mut self, bucket: T, addresses: Vec<&'static str>) -> &mut Self {
+    pub fn add_committee<T: Into<ShardBucket>>(mut self, bucket: T, addresses: Vec<&'static str>) -> Self {
         self.committees
             .insert(bucket.into(), addresses.into_iter().map(TestAddress::new).collect());
+        self
+    }
+
+    pub fn with_hotstuff_filter(mut self, hotstuff_filter: HotstuffFilter) -> Self {
+        self.hotstuff_filter = Some(hotstuff_filter);
         self
     }
 
@@ -346,7 +354,7 @@ impl TestBuilder {
             .unzip()
     }
 
-    pub async fn start(&mut self) -> Test {
+    pub async fn start(mut self) -> Test {
         if let Some(ref sql_file) = self.debug_sql_file {
             // Delete any previous database files
             for path in self
@@ -368,7 +376,7 @@ impl TestBuilder {
         let (channels, validators) = self
             .build_validators(&leader_strategy, &epoch_manager, shutdown.to_signal())
             .await;
-        let network = spawn_network(channels, shutdown.to_signal());
+        let network = spawn_network(channels, shutdown.to_signal(), self.hotstuff_filter);
 
         Test {
             validators,

--- a/dan_layer/consensus_tests/src/support/network.rs
+++ b/dan_layer/consensus_tests/src/support/network.rs
@@ -25,7 +25,14 @@ use tokio::sync::{
 
 use crate::support::{address::TestAddress, ValidatorChannels};
 
-pub fn spawn_network(channels: Vec<ValidatorChannels>, shutdown_signal: ShutdownSignal) -> TestNetwork {
+pub type HotstuffFilter =
+    Box<dyn Fn(&TestAddress, &TestAddress, &HotstuffMessage<TestAddress>) -> bool + Sync + Send + 'static>;
+
+pub fn spawn_network(
+    channels: Vec<ValidatorChannels>,
+    shutdown_signal: ShutdownSignal,
+    hotstuff_filter: Option<HotstuffFilter>,
+) -> TestNetwork {
     let tx_new_transactions = channels
         .iter()
         .map(|c| {
@@ -53,6 +60,7 @@ pub fn spawn_network(channels: Vec<ValidatorChannels>, shutdown_signal: Shutdown
     let (tx_network_status, network_status) = watch::channel(NetworkStatus::Paused);
     let (tx_on_message, rx_on_message) = watch::channel(None);
     let num_sent_messages = Arc::new(AtomicUsize::new(0));
+    let num_filtered_messages = Arc::new(AtomicUsize::new(0));
 
     let offline_destinations = Arc::new(RwLock::new(Vec::new()));
 
@@ -66,9 +74,11 @@ pub fn spawn_network(channels: Vec<ValidatorChannels>, shutdown_signal: Shutdown
         rx_mempool: Some(rx_mempool),
         on_message: tx_on_message,
         num_sent_messages: num_sent_messages.clone(),
+        num_filtered_messages: num_filtered_messages.clone(),
         transaction_store: Arc::new(Default::default()),
         offline_destinations: offline_destinations.clone(),
         shutdown_signal,
+        hotstuff_filter,
     }
     .spawn();
 
@@ -77,6 +87,7 @@ pub fn spawn_network(channels: Vec<ValidatorChannels>, shutdown_signal: Shutdown
         network_status: tx_network_status,
         offline_destinations,
         num_sent_messages,
+        num_filtered_messages,
         _on_message: rx_on_message,
     }
 }
@@ -98,6 +109,7 @@ pub struct TestNetwork {
     network_status: watch::Sender<NetworkStatus>,
     offline_destinations: Arc<RwLock<Vec<TestNetworkDestination>>>,
     num_sent_messages: Arc<AtomicUsize>,
+    num_filtered_messages: Arc<AtomicUsize>,
     _on_message: watch::Receiver<Option<HotstuffMessage<TestAddress>>>,
 }
 
@@ -131,6 +143,10 @@ impl TestNetwork {
 
     pub fn total_messages_sent(&self) -> usize {
         self.num_sent_messages.load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    pub fn total_messages_filtered(&self) -> usize {
+        self.num_filtered_messages.load(std::sync::atomic::Ordering::Relaxed)
     }
 }
 
@@ -168,10 +184,12 @@ pub struct TestNetworkWorker {
     network_status: watch::Receiver<NetworkStatus>,
     on_message: watch::Sender<Option<HotstuffMessage<TestAddress>>>,
     num_sent_messages: Arc<AtomicUsize>,
+    num_filtered_messages: Arc<AtomicUsize>,
     transaction_store: Arc<RwLock<HashMap<TransactionId, ExecutedTransaction>>>,
 
     offline_destinations: Arc<RwLock<Vec<TestNetworkDestination>>>,
     shutdown_signal: ShutdownSignal,
+    hotstuff_filter: Option<HotstuffFilter>,
 }
 
 impl TestNetworkWorker {
@@ -272,9 +290,14 @@ impl TestNetworkWorker {
         msg: HotstuffMessage<TestAddress>,
     ) {
         log::debug!("🌎️ Broadcast {} from {} to {}", msg, from, to.iter().join(", "));
-        self.num_sent_messages
-            .fetch_add(to.len(), std::sync::atomic::Ordering::Relaxed);
         for vn in to {
+            if let Some(hotstuff_filter) = &self.hotstuff_filter {
+                if !hotstuff_filter(&from, &vn, &msg) {
+                    self.num_filtered_messages
+                        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    continue;
+                }
+            }
             // TODO: support for taking a whole committee bucket offline
             if vn != from && self.is_offline_destination(&vn, u32::MAX.into()).await {
                 continue;
@@ -286,11 +309,20 @@ impl TestNetworkWorker {
                 .send((from.clone(), msg.clone()))
                 .await
                 .unwrap();
+            self.num_sent_messages
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         }
         self.on_message.send(Some(msg.clone())).unwrap();
     }
 
     async fn handle_leader(&mut self, from: TestAddress, to: TestAddress, msg: HotstuffMessage<TestAddress>) {
+        if let Some(hotstuff_filter) = &self.hotstuff_filter {
+            if !hotstuff_filter(&from, &to, &msg) {
+                self.num_filtered_messages
+                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                return;
+            }
+        }
         log::debug!("✉️ Message {} from {} to {}", msg, from, to);
         if from != to && self.is_offline_destination(&from, u32::MAX.into()).await {
             return;


### PR DESCRIPTION
Description
---
If a node locks a new local block, it checks if it needs to resend it to foreign committees. If a node receives a foreign block and it's not the leader, it sends it to the leader. The local leader is responsible for distributing the foreign block within its committee members.

Motivation and Context
---
We need to make sure that at least one honest node sends the block to at least one honest node in the foreign committee.

How Has This Been Tested?
---
There is a new test `foreign_block_distribution` where non of the leaders can send messages to the foreign committee. So other nodes are responsible to get the message across and to the leaders. Also there are new tests for the computation of the indexes for sending (who to whom).

What process can a PR reviewer use to test or verify this change?
---
Read and run the `foreign_block_distribution`.

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify