### PR TITLE
fix: force txs refetch on account change in UI

### DIFF
--- a/applications/tari_dan_wallet_web_ui/src/routes/Transactions/Transactions.tsx
+++ b/applications/tari_dan_wallet_web_ui/src/routes/Transactions/Transactions.tsx
@@ -33,7 +33,7 @@ import {
   TableRow,
 } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import FetchStatusCheck from '../../Components/FetchStatusCheck';
 import StatusChip from '../../Components/StatusChip';
@@ -50,10 +50,13 @@ export default function Transactions({ accountName }: { accountName: string }) {
   const { data: accountsData } = useAccountsGet(accountName);
   const [page, setPage] = useState(0);
   const [rowsPerPage, setRowsPerPage] = useState(10);
-  const { data, isLoading, error, isError } = useGetAllTransactions(
+  const { data, isLoading, error, isError, refetch } = useGetAllTransactions(
     null,
     accountsData?.account.address.Component || null
   );
+  useEffect(() => {
+    refetch();
+  }, [accountsData?.account.address.Component]);
   const theme = useTheme();
 
   return (


### PR DESCRIPTION
Description
---
Force refetch of transaction when account changes.

Motivation and Context
---
The refetch was triggered every 5 seconds. So when you changed account just after the fetch, you have to wait 5 seconds to refetch the transaction list.

How Has This Been Tested?
---
Same as below.

What process can a PR reviewer use to test or verify this change?
---
Run a wallet with 2+ accounts and change between them, you should see immediate change in the transaction list.


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify