### PR TITLE
fix(swarm): exit with error if unsupported seed multiaddr

### DIFF
--- a/dan_layer/common_types/src/lib.rs
+++ b/dan_layer/common_types/src/lib.rs
@@ -27,7 +27,7 @@ mod shard_id;
 pub use shard_id::ShardId;
 
 mod peer_address;
-pub use peer_address::PeerAddress;
+pub use peer_address::*;
 pub mod uint;
 
 pub use tari_engine_types::serde_with;

--- a/dan_layer/common_types/src/peer_address.rs
+++ b/dan_layer/common_types/src/peer_address.rs
@@ -47,9 +47,7 @@ impl Display for PeerAddress {
 
 impl From<RistrettoPublicKey> for PeerAddress {
     fn from(pk: RistrettoPublicKey) -> Self {
-        let pk = identity::PublicKey::from(identity::sr25519::PublicKey::from(pk));
-        let peer_id = pk.to_peer_id();
-        Self(peer_id)
+        Self(public_key_to_peer_id(pk))
     }
 }
 
@@ -72,6 +70,10 @@ impl PartialEq<PeerId> for PeerAddress {
 }
 
 impl DerivableFromPublicKey for PeerAddress {}
+
+pub fn public_key_to_peer_id(public_key: RistrettoPublicKey) -> PeerId {
+    identity::PublicKey::from(identity::sr25519::PublicKey::from(public_key)).to_peer_id()
+}
 
 #[cfg(test)]
 mod tests {

--- a/networking/core/src/lib.rs
+++ b/networking/core/src/lib.rs
@@ -30,7 +30,7 @@ pub use config::*;
 pub use connection::*;
 pub use handle::*;
 pub use spawn::*;
-pub use tari_swarm::{Config as SwarmConfig, TariNetwork};
+pub use tari_swarm::{is_supported_multiaddr, Config as SwarmConfig, TariNetwork};
 
 #[async_trait]
 pub trait NetworkingService<TMsg> {

--- a/networking/core/src/spawn.rs
+++ b/networking/core/src/spawn.rs
@@ -3,15 +3,16 @@
 
 use std::collections::HashSet;
 
+use anyhow::anyhow;
 use libp2p::{identity::Keypair, Multiaddr, PeerId};
 use tari_shutdown::ShutdownSignal;
-use tari_swarm::{messaging, messaging::prost::ProstCodec};
+use tari_swarm::{is_supported_multiaddr, messaging, messaging::prost::ProstCodec};
 use tokio::{
     sync::{broadcast, mpsc},
     task::JoinHandle,
 };
 
-use crate::{worker::NetworkingWorker, NetworkingError, NetworkingHandle};
+use crate::{worker::NetworkingWorker, NetworkingHandle};
 
 pub fn spawn<TMsg>(
     identity: Keypair,
@@ -19,10 +20,16 @@ pub fn spawn<TMsg>(
     mut config: crate::Config,
     seed_peers: Vec<(PeerId, Multiaddr)>,
     shutdown_signal: ShutdownSignal,
-) -> Result<(NetworkingHandle<TMsg>, JoinHandle<anyhow::Result<()>>), NetworkingError>
+) -> anyhow::Result<(NetworkingHandle<TMsg>, JoinHandle<anyhow::Result<()>>)>
 where
     TMsg: messaging::prost::Message + Default + Clone + 'static,
 {
+    for (_, addr) in &seed_peers {
+        if !is_supported_multiaddr(addr) {
+            return Err(anyhow!("Unsupported seed peer multi-address: {}", addr));
+        }
+    }
+
     config.swarm.enable_relay = config.swarm.enable_relay || !config.reachability_mode.is_private();
     let swarm = tari_swarm::create_swarm::<ProstCodec<TMsg>>(identity, HashSet::new(), config.swarm.clone())?;
     let local_peer_id = *swarm.local_peer_id();

--- a/networking/core/src/worker.rs
+++ b/networking/core/src/worker.rs
@@ -15,7 +15,6 @@ use libp2p::{
     futures::StreamExt,
     gossipsub,
     identify,
-    identity,
     kad,
     kad::{QueryResult, RoutingUpdate},
     mdns,
@@ -189,21 +188,6 @@ where
                         let _ignore = reply_tx.send(Err(err.into()));
                     },
                 }
-            },
-            NetworkingRequest::AddPeer {
-                public_key,
-                addresses,
-                reply_tx,
-            } => {
-                let kad_mut = &mut self.swarm.behaviour_mut().kad;
-                let peer_id = PeerId::from_public_key(&identity::PublicKey::from(identity::sr25519::PublicKey::from(
-                    public_key,
-                )));
-                for address in addresses {
-                    kad_mut.add_address(&peer_id, address);
-                }
-
-                let _ignore = reply_tx.send(Ok(peer_id));
             },
             NetworkingRequest::GetConnectedPeers { reply_tx } => {
                 let peers = self.swarm.connected_peers().copied().collect();

--- a/networking/swarm/src/behaviour.rs
+++ b/networking/swarm/src/behaviour.rs
@@ -51,6 +51,17 @@ where TCodec: messaging::Codec + Send + Clone + 'static
     pub gossipsub: gossipsub::Behaviour,
 }
 
+/// Returns true if the given Multiaddr is supported by the Tari swarm, otherwise false.
+/// NOTE: this function only currently returns false for onion addresses.
+pub fn is_supported_multiaddr(addr: &libp2p::Multiaddr) -> bool {
+    !addr.iter().any(|p| {
+        matches!(
+            p,
+            libp2p::core::multiaddr::Protocol::Onion(_, _) | libp2p::core::multiaddr::Protocol::Onion3(_)
+        )
+    })
+}
+
 pub fn create_swarm<TCodec>(
     identity: Keypair,
     supported_protocols: HashSet<StreamProtocol>,


### PR DESCRIPTION
Description
---
Exit with a helpful error message if an invalid seed peer address is used
Prevents kademlia bootstrap OOM if using unsupported addresses 
Remove add peer NetworkHandle call as new _valid_ addresses are automatically added on successful dials

Motivation and Context
---
bootstrapping with unsupported multiaddr causes kad to misbehave and dial thousands of times, This PR checks the addresses and exits if they are unsupported.

How Has This Been Tested?
---
Manually, current default configs contain onioin addresses that are not supported

What process can a PR reviewer use to test or verify this change?
---


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify