### PR TITLE
feat: reduce messages sent when broadcasting to foreign committee

### DIFF
--- a/dan_layer/consensus_tests/src/support/harness.rs
+++ b/dan_layer/consensus_tests/src/support/harness.rs
@@ -21,6 +21,7 @@ use tari_shutdown::{Shutdown, ShutdownSignal};
 use tari_transaction::TransactionId;
 use tokio::{sync::broadcast, task};
 
+use super::HotstuffFilter;
 use crate::support::{
     address::TestAddress,
     epoch_manager::TestEpochManager,
@@ -282,6 +283,7 @@ pub struct TestBuilder {
     sql_address: String,
     timeout: Option<Duration>,
     debug_sql_file: Option<String>,
+    hotstuff_filter: Option<HotstuffFilter>,
 }
 
 impl TestBuilder {
@@ -291,33 +293,34 @@ impl TestBuilder {
             sql_address: ":memory:".to_string(),
             timeout: Some(Duration::from_secs(10)),
             debug_sql_file: None,
+            hotstuff_filter: None,
         }
     }
 
     #[allow(dead_code)]
-    pub fn disable_timeout(&mut self) -> &mut Self {
+    pub fn disable_timeout(mut self) -> Self {
         self.timeout = None;
         self
     }
 
     #[allow(dead_code)]
-    pub fn debug_sql<P: Into<String>>(&mut self, path: P) -> &mut Self {
+    pub fn debug_sql<P: Into<String>>(mut self, path: P) -> Self {
         self.debug_sql_file = Some(path.into());
         self
     }
 
     #[allow(dead_code)]
-    pub fn with_sql_url<T: Into<String>>(&mut self, sql_address: T) -> &mut Self {
+    pub fn with_sql_url<T: Into<String>>(mut self, sql_address: T) -> Self {
         self.sql_address = sql_address.into();
         self
     }
 
-    pub fn with_test_timeout(&mut self, timeout: Duration) -> &mut Self {
+    pub fn with_test_timeout(mut self, timeout: Duration) -> Self {
         self.timeout = Some(timeout);
         self
     }
 
-    pub fn add_committee<T: Into<ShardBucket>>(&mut self, bucket: T, addresses: Vec<&'static str>) -> &mut Self {
+    pub fn add_committee<T: Into<ShardBucket>>(mut self, bucket: T, addresses: Vec<&'static str>) -> Self {
         let entry = self
             .committees
             .entry(bucket.into())
@@ -331,6 +334,11 @@ impl TestBuilder {
                 .members
                 .push((TestAddress::new(addr), PublicKey::from_secret_key(&secret_key)));
         }
+        self
+    }
+
+    pub fn with_hotstuff_filter(mut self, hotstuff_filter: HotstuffFilter) -> Self {
+        self.hotstuff_filter = Some(hotstuff_filter);
         self
     }
 
@@ -359,7 +367,7 @@ impl TestBuilder {
             .unzip()
     }
 
-    pub async fn start(&mut self) -> Test {
+    pub async fn start(mut self) -> Test {
         if let Some(ref sql_file) = self.debug_sql_file {
             // Delete any previous database files
             for path in self
@@ -381,7 +389,7 @@ impl TestBuilder {
         let (channels, validators) = self
             .build_validators(&leader_strategy, &epoch_manager, shutdown.to_signal())
             .await;
-        let network = spawn_network(channels, shutdown.to_signal());
+        let network = spawn_network(channels, shutdown.to_signal(), self.hotstuff_filter);
 
         Test {
             validators,

--- a/dan_layer/consensus_tests/src/support/network.rs
+++ b/dan_layer/consensus_tests/src/support/network.rs
@@ -25,7 +25,13 @@ use tokio::sync::{
 
 use crate::support::{address::TestAddress, ValidatorChannels};
 
-pub fn spawn_network(channels: Vec<ValidatorChannels>, shutdown_signal: ShutdownSignal) -> TestNetwork {
+pub type HotstuffFilter = Box<dyn Fn(&TestAddress, &TestAddress, &HotstuffMessage) -> bool + Sync + Send + 'static>;
+
+pub fn spawn_network(
+    channels: Vec<ValidatorChannels>,
+    shutdown_signal: ShutdownSignal,
+    hotstuff_filter: Option<HotstuffFilter>,
+) -> TestNetwork {
     let tx_new_transactions = channels
         .iter()
         .map(|c| {
@@ -53,6 +59,7 @@ pub fn spawn_network(channels: Vec<ValidatorChannels>, shutdown_signal: Shutdown
     let (tx_network_status, network_status) = watch::channel(NetworkStatus::Paused);
     let (tx_on_message, rx_on_message) = watch::channel(None);
     let num_sent_messages = Arc::new(AtomicUsize::new(0));
+    let num_filtered_messages = Arc::new(AtomicUsize::new(0));
 
     let offline_destinations = Arc::new(RwLock::new(Vec::new()));
 
@@ -66,9 +73,11 @@ pub fn spawn_network(channels: Vec<ValidatorChannels>, shutdown_signal: Shutdown
         rx_mempool: Some(rx_mempool),
         on_message: tx_on_message,
         num_sent_messages: num_sent_messages.clone(),
+        num_filtered_messages: num_filtered_messages.clone(),
         transaction_store: Arc::new(Default::default()),
         offline_destinations: offline_destinations.clone(),
         shutdown_signal,
+        hotstuff_filter,
     }
     .spawn();
 
@@ -77,6 +86,7 @@ pub fn spawn_network(channels: Vec<ValidatorChannels>, shutdown_signal: Shutdown
         network_status: tx_network_status,
         offline_destinations,
         num_sent_messages,
+        num_filtered_messages,
         _on_message: rx_on_message,
     }
 }
@@ -98,6 +108,7 @@ pub struct TestNetwork {
     network_status: watch::Sender<NetworkStatus>,
     offline_destinations: Arc<RwLock<Vec<TestNetworkDestination>>>,
     num_sent_messages: Arc<AtomicUsize>,
+    num_filtered_messages: Arc<AtomicUsize>,
     _on_message: watch::Receiver<Option<HotstuffMessage>>,
 }
 
@@ -131,6 +142,10 @@ impl TestNetwork {
 
     pub fn total_messages_sent(&self) -> usize {
         self.num_sent_messages.load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    pub fn total_messages_filtered(&self) -> usize {
+        self.num_filtered_messages.load(std::sync::atomic::Ordering::Relaxed)
     }
 }
 
@@ -168,10 +183,12 @@ pub struct TestNetworkWorker {
     network_status: watch::Receiver<NetworkStatus>,
     on_message: watch::Sender<Option<HotstuffMessage>>,
     num_sent_messages: Arc<AtomicUsize>,
+    num_filtered_messages: Arc<AtomicUsize>,
     transaction_store: Arc<RwLock<HashMap<TransactionId, ExecutedTransaction>>>,
 
     offline_destinations: Arc<RwLock<Vec<TestNetworkDestination>>>,
     shutdown_signal: ShutdownSignal,
+    hotstuff_filter: Option<HotstuffFilter>,
 }
 
 impl TestNetworkWorker {
@@ -267,9 +284,14 @@ impl TestNetworkWorker {
 
     pub async fn handle_broadcast(&mut self, from: TestAddress, to: Committee<TestAddress>, msg: HotstuffMessage) {
         log::debug!("🌎️ Broadcast {} from {} to {}", msg, from, to.addresses().join(", "));
-        self.num_sent_messages
-            .fetch_add(to.len(), std::sync::atomic::Ordering::Relaxed);
         for vn in to.addresses() {
+            if let Some(hotstuff_filter) = &self.hotstuff_filter {
+                if !hotstuff_filter(&from, &vn, &msg) {
+                    self.num_filtered_messages
+                        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    continue;
+                }
+            }
             // TODO: support for taking a whole committee bucket offline
             if *vn != from && self.is_offline_destination(vn, u32::MAX.into()).await {
                 continue;
@@ -281,11 +303,20 @@ impl TestNetworkWorker {
                 .send((from.clone(), msg.clone()))
                 .await
                 .unwrap();
+            self.num_sent_messages
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         }
         self.on_message.send(Some(msg.clone())).unwrap();
     }
 
     async fn handle_leader(&mut self, from: TestAddress, to: TestAddress, msg: HotstuffMessage) {
+        if let Some(hotstuff_filter) = &self.hotstuff_filter {
+            if !hotstuff_filter(&from, &to, &msg) {
+                self.num_filtered_messages
+                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                return;
+            }
+        }
         log::debug!("✉️ Message {} from {} to {}", msg, from, to);
         if from != to && self.is_offline_destination(&from, u32::MAX.into()).await {
             return;

--- a/dan_layer/consensus_tests/src/support/network.rs
+++ b/dan_layer/consensus_tests/src/support/network.rs
@@ -286,7 +286,7 @@ impl TestNetworkWorker {
         log::debug!("🌎️ Broadcast {} from {} to {}", msg, from, to.addresses().join(", "));
         for vn in to.addresses() {
             if let Some(hotstuff_filter) = &self.hotstuff_filter {
-                if !hotstuff_filter(&from, &vn, &msg) {
+                if !hotstuff_filter(&from, vn, &msg) {
                     self.num_filtered_messages
                         .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                     continue;


### PR DESCRIPTION
Description
---
This is simple propagation of foreign proposal. We pick `f+1` nodes that will send it to the whole foreign committee. This way at least one node is honest.

Motivation and Context
---

How Has This Been Tested?
---
There is a new test `foreign_block_distribution`.

What process can a PR reviewer use to test or verify this change?
---
Run the test, it's very hard to manually check this.


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify