### PR TITLE
fix: claim burn in the ui

### DIFF
--- a/applications/tari_dan_wallet_web_ui/src/routes/AssetVault/Components/ClaimBurn.tsx
+++ b/applications/tari_dan_wallet_web_ui/src/routes/AssetVault/Components/ClaimBurn.tsx
@@ -95,7 +95,7 @@ export default function ClaimBurn() {
       await accountsClaimBurn(claimBurnFormState.account, JSON.parse(claimBurnFormState.claimProof), +claimBurnFormState.fee);
       setOpen(false);
       setPopup({ title: "Claimed", error: false });
-      setClaimBurnFormState({ account: "", claimProof: "", fee: "", filled: false, disabled: false });
+      setClaimBurnFormState({ account: "", claimProof: "", fee: "", is_valid_json: false, filled: false, disabled: false });
     } catch (e: any) {
       setClaimBurnFormState({ ...claimBurnFormState, disabled: false });
       setPopup({ title: "Claim burn failed: " + e.message, error: true });

--- a/applications/tari_dan_wallet_web_ui/src/routes/AssetVault/Components/ClaimBurn.tsx
+++ b/applications/tari_dan_wallet_web_ui/src/routes/AssetVault/Components/ClaimBurn.tsx
@@ -20,65 +20,90 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import { useState } from 'react';
-import { Form } from 'react-router-dom';
-import Button from '@mui/material/Button';
-import TextField from '@mui/material/TextField';
-import Dialog from '@mui/material/Dialog';
-import DialogContent from '@mui/material/DialogContent';
-import DialogTitle from '@mui/material/DialogTitle';
-import FormControl from '@mui/material/FormControl';
-import InputLabel from '@mui/material/InputLabel';
-import Select, { SelectChangeEvent } from '@mui/material/Select/Select';
-import MenuItem from '@mui/material/MenuItem';
-import Box from '@mui/material/Box';
-import {
-  useAccountsList,
-  useAccountsClaimBurn,
-} from '../../../api/hooks/useAccounts';
-import { toHexString } from '../../../utils/helpers';
-import { useTheme } from '@mui/material/styles';
+import { useState } from "react";
+import { Form } from "react-router-dom";
+import Button from "@mui/material/Button";
+import TextField from "@mui/material/TextField";
+import Dialog from "@mui/material/Dialog";
+import DialogContent from "@mui/material/DialogContent";
+import DialogTitle from "@mui/material/DialogTitle";
+import FormControl from "@mui/material/FormControl";
+import InputLabel from "@mui/material/InputLabel";
+import Select, { SelectChangeEvent } from "@mui/material/Select/Select";
+import MenuItem from "@mui/material/MenuItem";
+import Box from "@mui/material/Box";
+import { useAccountsList, useAccountsClaimBurn } from "../../../api/hooks/useAccounts";
+import { useTheme } from "@mui/material/styles";
+import { accountsClaimBurn } from "../../../utils/json_rpc";
+import useAccountStore from "../../../store/accountStore";
 
 export default function ClaimBurn() {
   const [open, setOpen] = useState(false);
   const [claimBurnFormState, setClaimBurnFormState] = useState({
-    account: '',
-    claimProof: '',
-    fee: '',
+    account: "",
+    claimProof: "",
+    fee: "",
+    is_valid_json: false,
+    filled: false,
+    disabled: false,
   });
-  const { mutateAsync: mutateClaimBurn } = useAccountsClaimBurn(
-    claimBurnFormState.account,
-    claimBurnFormState.claimProof
-      ? JSON.parse(claimBurnFormState.claimProof)
-      : null,
-    +claimBurnFormState.fee
-  );
 
   const { data: dataAccountsList } = useAccountsList(0, 10);
+  const { setPopup } = useAccountStore();
 
   const onClaimBurnAccountChange = (e: SelectChangeEvent<string>) => {
     setClaimBurnFormState({
       ...claimBurnFormState,
       [e.target.name]: e.target.value,
+      filled: claimBurnFormState.is_valid_json && claimBurnFormState.fee !== "" && e.target.value !== "",
     });
   };
 
   const theme = useTheme();
 
-  const onClaimBurnChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const onClaimBurnClaimProofChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    // We have to check if the claim proof is valid JSON
+    try {
+      JSON.parse(e.target.value);
+      setClaimBurnFormState({
+        ...claimBurnFormState,
+        [e.target.name]: e.target.value,
+        is_valid_json: true,
+        filled: claimBurnFormState.account !== "" && claimBurnFormState.fee !== "" && e.target.value !== "",
+      });
+    } catch {
+      setClaimBurnFormState({
+        ...claimBurnFormState,
+        [e.target.name]: e.target.value,
+        is_valid_json: false,
+        filled: false,
+      });
+    }
+  };
+
+  const onClaimBurnFeeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setClaimBurnFormState({
       ...claimBurnFormState,
       [e.target.name]: e.target.value,
+      filled: claimBurnFormState.account !== "" && claimBurnFormState.is_valid_json && e.target.value !== "",
     });
-  };
+  }
 
   const onClaimBurn = async () => {
-    await mutateClaimBurn();
-    setClaimBurnFormState({ account: '', claimProof: '', fee: '' });
-    setOpen(false);
+    try {
+      setClaimBurnFormState({ ...claimBurnFormState, disabled: true });
+      await accountsClaimBurn(claimBurnFormState.account, JSON.parse(claimBurnFormState.claimProof), +claimBurnFormState.fee);
+      setOpen(false);
+      setPopup({ title: "Claimed", error: false });
+      setClaimBurnFormState({ account: "", claimProof: "", fee: "", filled: false, disabled: false });
+    } catch (e: any) {
+      setClaimBurnFormState({ ...claimBurnFormState, disabled: false });
+      setPopup({ title: "Claim burn failed: " + e.message, error: true });
+    }
   };
 
   const handleClickOpen = () => {
+    setClaimBurnFormState({ ...claimBurnFormState, disabled: false });
     setOpen(true);
   };
 
@@ -94,11 +119,7 @@ export default function ClaimBurn() {
       <Dialog open={open} onClose={handleClose}>
         <DialogTitle>Claim Burn</DialogTitle>
         <DialogContent className="dialog-content">
-          <Form
-            onSubmit={onClaimBurn}
-            className="flex-container-vertical"
-            style={{ paddingTop: theme.spacing(1) }}
-          >
+          <Form onSubmit={onClaimBurn} className="flex-container-vertical" style={{ paddingTop: theme.spacing(1) }}>
             <FormControl>
               <InputLabel id="account">Account</InputLabel>
               <Select
@@ -107,17 +128,12 @@ export default function ClaimBurn() {
                 label="Account"
                 value={claimBurnFormState.account}
                 onChange={onClaimBurnAccountChange}
-                style={{ flexGrow: 1, minWidth: '200px' }}
+                style={{ flexGrow: 1, minWidth: "200px" }}
+                disabled={claimBurnFormState.disabled}
               >
                 {dataAccountsList?.accounts.map((account: any) => (
-                  <MenuItem
-                    key={toHexString(account.account.address.Component)}
-                    value={
-                      'component_' +
-                      toHexString(account.account.address.Component)
-                    }
-                  >
-                    {account.account.name}{' '}
+                  <MenuItem key={account.account.address.Component} value={account.account.address.Component}>
+                    {account.account.name}
                   </MenuItem>
                 ))}
               </Select>
@@ -126,26 +142,28 @@ export default function ClaimBurn() {
               name="claimProof"
               label="Claim Proof"
               value={claimBurnFormState.claimProof}
-              onChange={onClaimBurnChange}
+              onChange={onClaimBurnClaimProofChange}
               style={{ flexGrow: 1 }}
+              disabled={claimBurnFormState.disabled}
             />
             <TextField
               name="fee"
               label="Fee"
               value={claimBurnFormState.fee}
-              onChange={onClaimBurnChange}
+              onChange={onClaimBurnFeeChange}
               style={{ flexGrow: 1 }}
+              disabled={claimBurnFormState.disabled}
             />
             <Box
               className="flex-container"
               style={{
-                justifyContent: 'flex-end',
+                justifyContent: "flex-end",
               }}
             >
-              <Button variant="outlined" onClick={handleClose}>
+              <Button variant="outlined" onClick={handleClose} disabled={claimBurnFormState.disabled}>
                 Cancel
               </Button>
-              <Button variant="contained" type="submit">
+              <Button variant="contained" type="submit" disabled={!claimBurnFormState.filled || claimBurnFormState.disabled}>
                 Claim Burn
               </Button>
             </Box>


### PR DESCRIPTION
Description
---
- fix the claim burn ui in dan wallet. 
- disable `Claim Burn` button when the form is not filled properly
- dialog feedback when claiming

Motivation and Context
---

How Has This Been Tested?
---
Manually.

What process can a PR reviewer use to test or verify this change?
---
Try to claim a burn in the dan wallet ui.


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify