### PR TITLE
feat: create get_non_fungible_ids action for buckets

### DIFF
--- a/dan_layer/engine/src/runtime/impl.rs
+++ b/dan_layer/engine/src/runtime/impl.rs
@@ -1229,6 +1229,22 @@ impl<TTemplateProvider: TemplateProvider<Template = LoadedTemplate>> RuntimeInte
                     Ok(InvokeResult::encode(&proof_id)?)
                 })
             },
+            BucketAction::GetNonFungibleIds => {
+                let bucket_id = bucket_ref.bucket_id().ok_or_else(|| RuntimeError::InvalidArgument {
+                    argument: "bucket_ref",
+                    reason: "GetNonFungibleIds bucket action requires a bucket id".to_string(),
+                })?;
+                args.assert_no_args("Bucket::GetNonFungibleIds")?;
+
+                self.tracker.write_with(|state| {
+                    let bucket = state.get_bucket(bucket_id)?;
+                    let non_fungible_ids = bucket
+                        .non_fungible_ids()
+                        .iter()
+                        .collect::<Vec<_>>();
+                    Ok(InvokeResult::encode(&non_fungible_ids)?)
+                })
+            },
         }
     }
 

--- a/dan_layer/engine/src/runtime/impl.rs
+++ b/dan_layer/engine/src/runtime/impl.rs
@@ -1238,10 +1238,7 @@ impl<TTemplateProvider: TemplateProvider<Template = LoadedTemplate>> RuntimeInte
 
                 self.tracker.write_with(|state| {
                     let bucket = state.get_bucket(bucket_id)?;
-                    let non_fungible_ids = bucket
-                        .non_fungible_ids()
-                        .iter()
-                        .collect::<Vec<_>>();
+                    let non_fungible_ids = bucket.non_fungible_ids().iter().collect::<Vec<_>>();
                     Ok(InvokeResult::encode(&non_fungible_ids)?)
                 })
             },

--- a/dan_layer/template_lib/src/args/types.rs
+++ b/dan_layer/template_lib/src/args/types.rs
@@ -393,6 +393,7 @@ pub enum BucketAction {
     RevealConfidential,
     Burn,
     CreateProof,
+    GetNonFungibleIds,
 }
 
 /// A bucket burn operation argument

--- a/dan_layer/template_lib/src/models/bucket.rs
+++ b/dan_layer/template_lib/src/models/bucket.rs
@@ -24,13 +24,12 @@ use serde::{Deserialize, Serialize};
 use tari_bor::BorTag;
 use tari_template_abi::{call_engine, rust::fmt, EngineOp};
 
+use super::NonFungibleId;
 use crate::{
     args::{BucketAction, BucketInvokeArg, BucketRef, InvokeResult},
     models::{Amount, BinaryTag, ConfidentialWithdrawProof, Proof, ResourceAddress},
     prelude::ResourceType,
 };
-
-use super::NonFungibleId;
 
 const TAG: u64 = BinaryTag::BucketId.as_u64();
 

--- a/dan_layer/template_lib/src/models/bucket.rs
+++ b/dan_layer/template_lib/src/models/bucket.rs
@@ -30,6 +30,8 @@ use crate::{
     prelude::ResourceType,
 };
 
+use super::NonFungibleId;
+
 const TAG: u64 = BinaryTag::BucketId.as_u64();
 
 /// A bucket's unique identification during the transaction execution
@@ -174,5 +176,17 @@ impl Bucket {
         });
 
         resp.decode().expect("Bucket CreateProof returned invalid proof")
+    }
+
+    /// Returns the IDs of all the non-fungibles in this bucket
+    pub fn get_non_fungible_ids(&self) -> Vec<NonFungibleId> {
+        let resp: InvokeResult = call_engine(EngineOp::BucketInvoke, &BucketInvokeArg {
+            bucket_ref: BucketRef::Ref(self.id),
+            action: BucketAction::GetNonFungibleIds,
+            args: invoke_args![],
+        });
+
+        resp.decode()
+            .expect("get_non_fungible_ids returned invalid non fungible ids")
     }
 }


### PR DESCRIPTION
Description
---
* Created a new `GetNonFungibleIds` action for buckets in the engine
* Created a `get_non_fungible_ids` method in `template_lib` for Buckets, that calls the new engine action

Motivation and Context
---
Currently in `template_lib` we have a convenient `get_non_fungible_ids` method in vaults that returns all the NFT ids contained in the vault. Buckets should also have the same method, so this PR adds it.

How Has This Been Tested?
---
Manually with a template that uses the new method

What process can a PR reviewer use to test or verify this change?
---
Create a template that uses the new method

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify