### PR TITLE
fix: claim burn to create account

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9293,6 +9293,7 @@ dependencies = [
  "tari_dan_wallet_storage_sqlite",
  "tari_engine_types",
  "tari_indexer_client",
+ "tari_key_manager",
  "tari_shutdown",
  "tari_template_builtin",
  "tari_template_lib",

--- a/applications/tari_dan_wallet_cli/src/command/account.rs
+++ b/applications/tari_dan_wallet_cli/src/command/account.rs
@@ -286,6 +286,7 @@ pub async fn handle_claim_burn(args: ClaimBurnArgs, client: &mut WalletDaemonCli
         account,
         claim_proof,
         max_fee: fee.map(Into::into),
+        key_id: None,
     };
 
     let resp = client

--- a/applications/tari_dan_wallet_cli/src/command/account.rs
+++ b/applications/tari_dan_wallet_cli/src/command/account.rs
@@ -116,6 +116,8 @@ pub struct ClaimBurnArgs {
     proof_json: Option<serde_json::Value>,
     #[clap(long, short = 'f')]
     fee: Option<u32>,
+    #[clap(long)]
+    key_id: Option<u64>,
 }
 
 #[derive(Debug, Args, Clone)]
@@ -262,6 +264,7 @@ pub async fn handle_claim_burn(args: ClaimBurnArgs, client: &mut WalletDaemonCli
         proof_json,
         fee,
         proof_file,
+        key_id,
     } = args;
 
     let claim_proof = if let Some(proof_json) = proof_json {
@@ -286,7 +289,7 @@ pub async fn handle_claim_burn(args: ClaimBurnArgs, client: &mut WalletDaemonCli
         account,
         claim_proof,
         max_fee: fee.map(Into::into),
-        key_id: None,
+        key_id,
     };
 
     let resp = client

--- a/applications/tari_dan_wallet_daemon/Cargo.toml
+++ b/applications/tari_dan_wallet_daemon/Cargo.toml
@@ -23,6 +23,7 @@ tari_template_builtin = { workspace = true }
 # TODO: Ideally we should not have to include the WASM template lib, we should perhaps extract the address types into a separate crate (e.g. template_types)
 tari_template_lib = { workspace = true }
 tari_indexer_client = { workspace = true }
+tari_key_manager = { workspace = true }
 
 anyhow = { workspace = true }
 axum = { workspace = true, features = ["headers"] }
@@ -42,18 +43,20 @@ log4rs = { workspace = true, features = [
     "fixed_window_roller",
     "console_appender",
 ] }
-mime_guess =  { workspace = true }
+mime_guess = { workspace = true }
 rand = { workspace = true }
-reqwest =  { workspace = true }
+reqwest = { workspace = true }
 serde = { workspace = true, default-features = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
-tokio = { workspace = true, features = ["default", "rt-multi-thread", "macros", "time"] }
-tower-http = { workspace = true, features = [
-    "cors",
-    "trace",
+tokio = { workspace = true, features = [
+    "default",
+    "rt-multi-thread",
+    "macros",
+    "time",
 ] }
-url =  { workspace = true }
+tower-http = { workspace = true, features = ["cors", "trace"] }
+url = { workspace = true }
 webrtc = { workspace = true }
 
 [dev-dependencies]

--- a/clients/wallet_daemon_client/src/types.rs
+++ b/clients/wallet_daemon_client/src/types.rs
@@ -392,6 +392,7 @@ pub struct ClaimBurnRequest {
     pub account: Option<ComponentAddressOrName>,
     pub claim_proof: serde_json::Value,
     pub max_fee: Option<Amount>,
+    pub key_id: Option<u64>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/integration_tests/src/wallet_daemon_cli.rs
+++ b/integration_tests/src/wallet_daemon_cli.rs
@@ -93,6 +93,7 @@ pub async fn claim_burn(
             "range_proof": BASE64.encode(range_proof.as_bytes()),
         }),
         max_fee: Some(Amount(max_fee)),
+        key_id: None,
     };
 
     client.claim_burn(claim_burn_request).await


### PR DESCRIPTION
Description
---
The claim burn was working only for account that were already created. I refactored the code for create-free-test-coins as well, because it has a lot in common with claiming burns.

Motivation and Context
---
Before this PR there was no way to create an account without having fees and claiming burn needed an account to work.

How Has This Been Tested?
---
Burned and claimed funds for a new account.

What process can a PR reviewer use to test or verify this change?
---
The claim public key for burning needs to be filled with key from the dan wallet. After that you can call the claim burn with new account name and key index for the respective key.

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify