### PR TITLE
feat(template_test_tooling): include account_nft builtin template

### DIFF
--- a/dan_layer/engine/tests/account_nfts.rs
+++ b/dan_layer/engine/tests/account_nfts.rs
@@ -7,7 +7,7 @@ use tari_template_test_tooling::TemplateTest;
 
 #[test]
 fn basic_nft_mint() {
-    let mut account_nft_template_test = TemplateTest::new(vec!["../template_builtin/templates/account_nfts/"]);
+    let mut account_nft_template_test = TemplateTest::new::<_, &str>([]);
 
     let account_nft_template = account_nft_template_test.get_template_address("AccountNonFungible");
 

--- a/dan_layer/template_test_tooling/src/package_builder.rs
+++ b/dan_layer/template_test_tooling/src/package_builder.rs
@@ -7,9 +7,10 @@ use tari_dan_common_types::services::template_provider::TemplateProvider;
 use tari_dan_engine::{
     abi::TemplateDef,
     template::{LoadedTemplate, TemplateModuleLoader},
-    wasm::compile::compile_template,
+    wasm::{compile::compile_template, WasmModule},
 };
 use tari_engine_types::hashing::template_hasher32;
+use tari_template_builtin::get_template_builtin;
 use tari_template_lib::models::TemplateAddress;
 
 #[derive(Debug, Clone)]
@@ -68,6 +69,14 @@ impl PackageBuilder {
 
     pub fn add_loaded_template(&mut self, address: TemplateAddress, template: LoadedTemplate) -> &mut Self {
         self.templates.insert(address, template);
+        self
+    }
+
+    pub fn add_builtin_template(&mut self, address: &TemplateAddress) -> &mut Self {
+        let wasm = get_template_builtin(address);
+        let template = WasmModule::from_code(wasm.to_vec()).load_template().unwrap();
+        self.add_loaded_template(*address, template);
+
         self
     }
 

--- a/dan_layer/template_test_tooling/src/template_test.rs
+++ b/dan_layer/template_test_tooling/src/template_test.rs
@@ -26,9 +26,9 @@ use tari_dan_engine::{
         AtomicDb,
         StateWriter,
     },
-    template::{LoadedTemplate, TemplateModuleLoader},
+    template::LoadedTemplate,
     transaction::{TransactionError, TransactionProcessor},
-    wasm::{LoadedWasmTemplate, WasmModule},
+    wasm::LoadedWasmTemplate,
 };
 use tari_engine_types::{
     commit_result::{ExecuteResult, RejectReason},
@@ -39,7 +39,7 @@ use tari_engine_types::{
     vault::Vault,
     virtual_substate::{VirtualSubstate, VirtualSubstateAddress},
 };
-use tari_template_builtin::{get_template_builtin, ACCOUNT_TEMPLATE_ADDRESS};
+use tari_template_builtin::{ACCOUNT_NFT_TEMPLATE_ADDRESS, ACCOUNT_TEMPLATE_ADDRESS};
 use tari_template_lib::{
     args,
     args::Arg,
@@ -74,12 +74,15 @@ pub struct TemplateTest {
 impl TemplateTest {
     pub fn new<I: IntoIterator<Item = P>, P: AsRef<Path>>(template_paths: I) -> Self {
         let mut builder = Package::builder();
-        // Add Account template builtin
-        let wasm = get_template_builtin(&ACCOUNT_TEMPLATE_ADDRESS);
-        let template = WasmModule::from_code(wasm.to_vec()).load_template().unwrap();
-        builder.add_loaded_template(*ACCOUNT_TEMPLATE_ADDRESS, template);
 
+        // Add builtin templates
+        builder.add_builtin_template(&ACCOUNT_TEMPLATE_ADDRESS);
+        builder.add_builtin_template(&ACCOUNT_NFT_TEMPLATE_ADDRESS);
+
+        // Add the faucet template for fungible tokens
         builder.add_template(concat!(env!("CARGO_MANIFEST_DIR"), "/templates/faucet"));
+
+        // Add all of the templates specified in the argument
         for path in template_paths {
             builder.add_template(path);
         }


### PR DESCRIPTION
Description
---
* Updated the `TemplateTest` to include the account NFT builtin template
* Added a convenience method in the `PackageBuilder` to load a builtin template

Motivation and Context
---
On the `TemplateTest` util we automatically include some common templates, like the builtin account template and a fungible faucet.

We have another builtin template in Tari for account NFTs, which would be convenient to include for all NFT-related projects.

How Has This Been Tested?
---
On external template projects that use the `template_test_tooling` crate, by minting account NFTs

What process can a PR reviewer use to test or verify this change?
---
Use the `template_test_tooling` crate to mint account NFTs

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify