### PR TITLE
feat(template_lib): add from_str for NFT addresses

### DIFF
--- a/dan_layer/engine_types/src/substate.rs
+++ b/dan_layer/engine_types/src/substate.rs
@@ -31,7 +31,6 @@ use tari_template_lib::{
     models::{
         ComponentAddress,
         NonFungibleAddress,
-        NonFungibleId,
         NonFungibleIndexAddress,
         ResourceAddress,
         UnclaimedConfidentialOutputAddress,
@@ -296,12 +295,10 @@ impl FromStr for SubstateAddress {
                 match addr.split_once(' ') {
                     Some((resource_str, addr)) => match addr.split_once('_') {
                         // resource_xxxx nft_xxxxx
-                        Some(("nft", addr)) => {
-                            let resource_addr = ResourceAddress::from_hex(resource_str)
-                                .map_err(|_| InvalidSubstateAddressFormat(s.to_string()))?;
-                            let id = NonFungibleId::try_from_canonical_string(addr)
-                                .map_err(|_| InvalidSubstateAddressFormat(s.to_string()))?;
-                            Ok(SubstateAddress::NonFungible(NonFungibleAddress::new(resource_addr, id)))
+                        Some(("nft", _)) => {
+                            let nft_address = NonFungibleAddress::from_str(s)
+                                .map_err(|e| InvalidSubstateAddressFormat(e.to_string()))?;
+                            Ok(SubstateAddress::NonFungible(nft_address))
                         },
                         // resource_xxxx index_
                         Some(("index", index_str)) => {

--- a/dan_layer/template_lib/src/models/non_fungible.rs
+++ b/dan_layer/template_lib/src/models/non_fungible.rs
@@ -253,7 +253,7 @@ impl FromStr for NonFungibleAddress {
                     let resource_addr = ResourceAddress::from_str(resource_str)
                         .map_err(|e| ParseNonFungibleAddressError::InvalidResource(e.to_string()))?;
                     let id = NonFungibleId::try_from_canonical_string(id_str)
-                        .map_err(|e| ParseNonFungibleAddressError::InvalidId(e))?;
+                        .map_err(ParseNonFungibleAddressError::InvalidId)?;
                     Ok(NonFungibleAddress::new(resource_addr, id))
                 },
                 _ => Err(ParseNonFungibleAddressError::InvalidFormat),

--- a/dan_layer/template_lib/src/models/non_fungible.rs
+++ b/dan_layer/template_lib/src/models/non_fungible.rs
@@ -340,6 +340,7 @@ impl Display for ParseNonFungibleIdError {
 }
 
 /// All the types of errors that can occur when parsing a non-fungible addresses
+#[allow(clippy::enum_variant_names)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ParseNonFungibleAddressError {
     InvalidFormat,


### PR DESCRIPTION
Description
---
* Add from_str string for NFT addresses
* Refactor the `SubstateAddress` parsing for NFTs so it reuses the new parsing

Motivation and Context
---
In template code we need a convenience method to parse a `NonFungibleAddress`, because right now the only way is to separately do it for the resource address, then for the NFT id and at the end build the address.

How Has This Been Tested?
---
* New unit tests for `NonFungibleAddress` parsing
* Existing unit tests for `SubstateAddress` pass

What process can a PR reviewer use to test or verify this change?
---
Try to parse a NFT address from inside template code.

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify