### PR TITLE
fix(template-lib): minor cross-template call api improvement

### DIFF
--- a/dan_layer/template_lib/src/component/manager.rs
+++ b/dan_layer/template_lib/src/component/manager.rs
@@ -62,8 +62,9 @@ impl ComponentManager {
         Self::new(CallerContext::current_component_address())
     }
 
-    /// Executes a method of the component. Used for template composability.
-    /// Component methods can be called from another component method or from template functions
+    /// Calls a method of another component and returns the result.
+    /// This is used to call external component methods and can be used in a component method or template function
+    /// context.
     pub fn call<T: Into<String>, R: DeserializeOwned>(&self, method: T, args: Vec<Arg>) -> R {
         self.call_internal(CallMethodArg {
             component_address: self.address,
@@ -81,6 +82,12 @@ impl ComponentManager {
         result
             .decode()
             .expect("failed to decode component call result from engine")
+    }
+
+    /// Calls a method of another component. The called method must return a unit type.
+    /// Equivalent to [`call::<_, ()>(method, args)`](ComponentManager::call).
+    pub fn invoke<T: Into<String>>(&self, method: T, args: Vec<Arg>) {
+        self.call(method, args)
     }
 
     /// Get the component state

--- a/dan_layer/template_lib/src/template/manager.rs
+++ b/dan_layer/template_lib/src/template/manager.rs
@@ -40,7 +40,7 @@ impl TemplateManager {
         Self { template_address }
     }
 
-    /// Executes a function of the template. Used for template composability.
+    /// Executes a function in the template.
     /// Template functions can be called from another template function or from component methods.
     pub fn call<F: Into<String>, T: DeserializeOwned>(&self, function: F, args: Vec<Arg>) -> T {
         self.call_internal(CallFunctionArg {
@@ -59,5 +59,11 @@ impl TemplateManager {
         result
             .decode()
             .expect("failed to decode template function call result from engine")
+    }
+
+    /// Calls a function in the template. The invoked function must return a unit type or a panic will occur.
+    /// Equivalent to `call::<_, ()>(function, args)`.
+    pub fn invoke<F: Into<String>>(&self, function: F, args: Vec<Arg>) {
+        self.call(function, args)
     }
 }


### PR DESCRIPTION
Description
---
Add "shortcut" for cross-template calls that return the unit type i.e `call::<_, ()>(...)`

Motivation and Context
---
It is a little unwieldy to use `manager.call::<_, ()>(...)`. This PR adds `manager.invoke(...)`

How Has This Been Tested?
---
`call` has been tested in "composability" tests

What process can a PR reviewer use to test or verify this change?
---
Use `manager.invoke`

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify