### PR TITLE
fix: gossip

### DIFF
--- a/applications/tari_validator_node/src/p2p/services/mempool/gossip.rs
+++ b/applications/tari_validator_node/src/p2p/services/mempool/gossip.rs
@@ -86,10 +86,12 @@ impl Gossip<PeerAddress> {
         exclude_bucket: Option<ShardBucket>,
     ) -> Result<(), MempoolError> {
         let n = self.epoch_manager.get_num_committees(epoch).await?;
+        let local_shard = self.epoch_manager.get_local_committee_shard(epoch).await?;
+        let local_bucket = local_shard.bucket();
         let buckets = shards
             .into_iter()
             .map(|s| s.to_committee_bucket(n))
-            .filter(|b| exclude_bucket.as_ref() != Some(b))
+            .filter(|b| exclude_bucket.as_ref() != Some(b) && b != &local_bucket)
             .collect::<HashSet<_>>();
 
         for bucket in buckets {

--- a/networking/swarm/src/behaviour.rs
+++ b/networking/swarm/src/behaviour.rs
@@ -170,6 +170,7 @@ where
 fn get_message_id(message: &gossipsub::Message) -> gossipsub::MessageId {
     let mut hasher = DefaultHasher::new();
     hasher.write(&message.data);
+    hasher.write(message.topic.as_str().as_bytes());
     gossipsub::MessageId::from(hasher.finish().to_be_bytes())
 }
 


### PR DESCRIPTION
Description
---
Fix the gossiping duplicate problem.

Motivation and Context
---
The gossiping discard duplicates, it doesn't take into account that the same message is being send to different topic. So when a message was send to local committee and then to foreign committee (this was counted as a duplicated), the foreign committee never received it. The topic is now added to the message id.

How Has This Been Tested?
---
Running dan-testing with multiple committees and now I see `tx_<id>` in the `message_log.sqlite`.

What process can a PR reviewer use to test or verify this change?
---
Do the same as above.


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify