### PR TITLE
feat(template): allow resource actions to be restricted by component

### DIFF
--- a/dan_layer/engine/src/runtime/error.rs
+++ b/dan_layer/engine/src/runtime/error.rs
@@ -220,6 +220,11 @@ pub enum RuntimeError {
     DuplicateBucket { bucket_id: BucketId },
     #[error("Duplicate proof {proof_id}")]
     DuplicateProof { proof_id: ProofId },
+
+    #[error("Address allocation not found with id {id}")]
+    AddressAllocationNotFound { id: u32 },
+    #[error("Address allocation type mismatch: {address}")]
+    AddressAllocationTypeMismatch { address: SubstateAddress },
 }
 
 impl RuntimeError {
@@ -251,6 +256,8 @@ pub enum TransactionCommitError {
     DanglingProofs { count: usize },
     #[error("Locked value (amount: {locked_amount}) remaining in vault {vault_id}")]
     DanglingLockedValueInVault { vault_id: VaultId, locked_amount: Amount },
+    #[error("{count} dangling address allocations remain after transaction execution")]
+    DanglingAddressAllocations { count: usize },
     #[error("{} orphaned substate(s) detected: {}", .substates.len(), .substates.join(", "))]
     OrphanedSubstates { substates: Vec<String> },
     #[error("{count} dangling items in workspace after transaction execution")]

--- a/dan_layer/engine/src/runtime/impl.rs
+++ b/dan_layer/engine/src/runtime/impl.rs
@@ -282,6 +282,12 @@ impl<TTemplateProvider: TemplateProvider<Template = LoadedTemplate>> RuntimeInte
                     .map(|l| l.address().as_component_address().unwrap());
                 Ok(InvokeResult::encode(&maybe_address)?)
             }),
+            CallerContextAction::AllocateNewComponentAddress => self.tracker.write_with(|state| {
+                let (template, _) = state.current_template()?;
+                let address = self.tracker.id_provider().new_component_address(*template, None)?;
+                let allocation = state.new_address_allocation(address)?;
+                Ok(InvokeResult::encode(&allocation)?)
+            }),
         }
     }
 
@@ -322,6 +328,7 @@ impl<TTemplateProvider: TemplateProvider<Template = LoadedTemplate>> RuntimeInte
                     arg.owner_rule,
                     arg.access_rules,
                     arg.component_id,
+                    arg.address_allocation,
                 )?;
                 Ok(InvokeResult::encode(&component_address)?)
             },

--- a/dan_layer/engine/tests/address_allocation.rs
+++ b/dan_layer/engine/tests/address_allocation.rs
@@ -1,0 +1,52 @@
+//   Copyright 2023 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+use tari_dan_engine::runtime::TransactionCommitError;
+use tari_template_lib::{args, models::ComponentAddress};
+use tari_template_test_tooling::{support::assert_error::assert_reject_reason, TemplateTest};
+use tari_transaction::Transaction;
+
+#[test]
+fn it_uses_allocation_address() {
+    let mut test = TemplateTest::new(["tests/templates/address_allocation"]);
+
+    let result = test.execute_expect_success(
+        Transaction::builder()
+            .call_function(test.get_template_address("AddressAllocationTest"), "create", args![])
+            .sign(test.get_test_secret_key())
+            .build(),
+        vec![],
+    );
+
+    let actual = result
+        .finalize
+        .result
+        .accept()
+        .unwrap()
+        .up_iter()
+        .find_map(|(k, _)| k.as_component_address())
+        .unwrap();
+
+    let allocated = result.finalize.execution_results[0]
+        .indexed
+        .get_value::<ComponentAddress>("$.1")
+        .unwrap()
+        .unwrap();
+    assert_eq!(actual, allocated);
+}
+
+#[test]
+fn it_fails_if_allocation_is_not_used() {
+    let mut test = TemplateTest::new(["tests/templates/address_allocation"]);
+    let template_addr = test.get_template_address("AddressAllocationTest");
+
+    let reason = test.execute_expect_failure(
+        Transaction::builder()
+            .call_function(template_addr, "drop_allocation", args![])
+            .sign(test.get_test_secret_key())
+            .build(),
+        vec![],
+    );
+
+    assert_reject_reason(reason, TransactionCommitError::DanglingAddressAllocations { count: 1 });
+}

--- a/dan_layer/engine/tests/templates/address_allocation/Cargo.toml
+++ b/dan_layer/engine/tests/templates/address_allocation/Cargo.toml
@@ -1,0 +1,13 @@
+[workspace]
+[package]
+name = "address_allocation"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+tari_template_lib = { path = "../../../../template_lib" }
+
+[lib]
+crate-type = ["cdylib", "lib"]

--- a/dan_layer/engine/tests/templates/address_allocation/src/lib.rs
+++ b/dan_layer/engine/tests/templates/address_allocation/src/lib.rs
@@ -1,0 +1,26 @@
+//   Copyright 2023 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+use tari_template_lib::prelude::*;
+
+#[template]
+mod template {
+    use super::*;
+
+    pub struct AddressAllocationTest {}
+
+    impl AddressAllocationTest {
+        pub fn create() -> (Component<Self>, ComponentAddress) {
+            let allocation = CallerContext::allocate_component_address();
+            let address = allocation.address().clone();
+            (
+                Component::new(Self {}).with_address_allocation(allocation).create(),
+                address,
+            )
+        }
+
+        pub fn drop_allocation() {
+            let _allocation = CallerContext::allocate_component_address();
+        }
+    }
+}

--- a/dan_layer/engine_types/src/lib.rs
+++ b/dan_layer/engine_types/src/lib.rs
@@ -30,4 +30,5 @@ mod template;
 pub use template::{calculate_template_binary_hash, parse_template_address, TemplateAddress};
 
 mod argument_parser;
+
 pub use argument_parser::parse_arg;

--- a/dan_layer/engine_types/src/substate.rs
+++ b/dan_layer/engine_types/src/substate.rs
@@ -263,6 +263,17 @@ impl From<TransactionReceiptAddress> for SubstateAddress {
     }
 }
 
+impl TryFrom<SubstateAddress> for ComponentAddress {
+    type Error = SubstateAddress;
+
+    fn try_from(value: SubstateAddress) -> Result<Self, Self::Error> {
+        match value {
+            SubstateAddress::Component(addr) => Ok(addr),
+            _ => Err(value),
+        }
+    }
+}
+
 impl Display for SubstateAddress {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/dan_layer/template_lib/src/args/types.rs
+++ b/dan_layer/template_lib/src/args/types.rs
@@ -33,6 +33,7 @@ use crate::{
     auth::{OwnerRule, ResourceAccessRules},
     crypto::PedersonCommitmentBytes,
     models::{
+        AddressAllocation,
         Amount,
         BucketId,
         ComponentAddress,
@@ -157,6 +158,7 @@ pub struct CreateComponentArg {
     pub owner_rule: OwnerRule,
     pub access_rules: ComponentAccessRules,
     pub component_id: Option<Hash>,
+    pub address_allocation: Option<AddressAllocation<ComponentAddress>>,
 }
 
 // -------------------------------- Events -------------------------------- //
@@ -478,6 +480,7 @@ pub struct CallerContextInvokeArg {
 pub enum CallerContextAction {
     GetCallerPublicKey,
     GetComponentAddress,
+    AllocateNewComponentAddress,
 }
 
 // -------------------------------- CallInvoke -------------------------------- //

--- a/dan_layer/template_lib/src/auth/access_rules.rs
+++ b/dan_layer/template_lib/src/auth/access_rules.rs
@@ -4,7 +4,7 @@
 use serde::{Deserialize, Serialize};
 use tari_template_abi::rust::collections::BTreeMap;
 
-use crate::models::{NonFungibleAddress, ResourceAddress};
+use crate::models::{ComponentAddress, NonFungibleAddress, ResourceAddress, TemplateAddress};
 
 /// Represents the types of possible access control rules over a component method or resource
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -54,31 +54,49 @@ impl RestrictedAccessRule {
     }
 }
 
-/// An enum that allows passing either a resource or a non-fungible argument
+/// Specifies a requirement for a [RequireRule].
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum ResourceOrNonFungibleAddress {
+pub enum RuleRequirement {
+    /// Requires ownership of a specific resource
     Resource(ResourceAddress),
+    /// Requires ownership of a specific non-fungible token
     NonFungibleAddress(NonFungibleAddress),
+    /// Requires execution within a specific component
+    ScopedToComponent(ComponentAddress),
+    /// Requires execution within a specific template
+    ScopedToTemplate(TemplateAddress),
 }
 
-impl From<ResourceAddress> for ResourceOrNonFungibleAddress {
+impl From<ResourceAddress> for RuleRequirement {
     fn from(address: ResourceAddress) -> Self {
         Self::Resource(address)
     }
 }
 
-impl From<NonFungibleAddress> for ResourceOrNonFungibleAddress {
+impl From<NonFungibleAddress> for RuleRequirement {
     fn from(address: NonFungibleAddress) -> Self {
         Self::NonFungibleAddress(address)
+    }
+}
+
+impl From<ComponentAddress> for RuleRequirement {
+    fn from(address: ComponentAddress) -> Self {
+        Self::ScopedToComponent(address)
+    }
+}
+
+impl From<TemplateAddress> for RuleRequirement {
+    fn from(address: TemplateAddress) -> Self {
+        Self::ScopedToTemplate(address)
     }
 }
 
 /// An enum that represents the possible ways to require access to components or resources
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum RequireRule {
-    Require(ResourceOrNonFungibleAddress),
-    AnyOf(Vec<ResourceOrNonFungibleAddress>),
-    AllOf(Vec<ResourceOrNonFungibleAddress>),
+    Require(RuleRequirement),
+    AnyOf(Vec<RuleRequirement>),
+    AllOf(Vec<RuleRequirement>),
 }
 
 /// Information needed to specify access rules to methods of a component

--- a/dan_layer/template_lib/src/caller_context.rs
+++ b/dan_layer/template_lib/src/caller_context.rs
@@ -8,7 +8,7 @@ use tari_template_abi::{call_engine, EngineOp};
 use crate::{
     args::{CallerContextAction, CallerContextInvokeArg, InvokeResult},
     crypto::RistrettoPublicKeyBytes,
-    models::ComponentAddress,
+    models::{AddressAllocation, ComponentAddress},
 };
 
 /// Allows a template to access information about the current instruction's caller
@@ -34,5 +34,14 @@ impl CallerContext {
         resp.decode::<Option<ComponentAddress>>()
             .expect("Failed to decode Option<ComponentAddress>")
             .expect("Not in a component instance context")
+    }
+
+    pub fn allocate_component_address() -> AddressAllocation<ComponentAddress> {
+        let resp: InvokeResult = call_engine(EngineOp::CallerContextInvoke, &CallerContextInvokeArg {
+            action: CallerContextAction::AllocateNewComponentAddress,
+        });
+
+        resp.decode()
+            .expect("Failed to decode AddressAllocation<ComponentAddress>")
     }
 }

--- a/dan_layer/template_lib/src/component/instance.rs
+++ b/dan_layer/template_lib/src/component/instance.rs
@@ -6,7 +6,7 @@ use std::marker::PhantomData;
 use crate::{
     auth::{ComponentAccessRules, OwnerRule},
     engine,
-    models::ComponentAddress,
+    models::{AddressAllocation, ComponentAddress},
     Hash,
 };
 
@@ -16,6 +16,7 @@ pub struct ComponentBuilder<T> {
     owner_rule: OwnerRule,
     access_rules: ComponentAccessRules,
     component_id: Option<Hash>,
+    address_allocation: Option<AddressAllocation<ComponentAddress>>,
 }
 
 impl<T: serde::Serialize> ComponentBuilder<T> {
@@ -26,7 +27,14 @@ impl<T: serde::Serialize> ComponentBuilder<T> {
             owner_rule: OwnerRule::default(),
             access_rules: ComponentAccessRules::new(),
             component_id: None,
+            address_allocation: None,
         }
+    }
+
+    /// Use an allocated address for the component.
+    pub fn with_address_allocation(mut self, allocation: AddressAllocation<ComponentAddress>) -> Self {
+        self.address_allocation = Some(allocation);
+        self
     }
 
     /// Sets up who will be the owner of the component.
@@ -50,7 +58,13 @@ impl<T: serde::Serialize> ComponentBuilder<T> {
 
     /// Creates the new component and returns it
     pub fn create(self) -> Component<T> {
-        let address = engine().create_component(self.component, self.owner_rule, self.access_rules, self.component_id);
+        let address = engine().create_component(
+            self.component,
+            self.owner_rule,
+            self.access_rules,
+            self.component_id,
+            self.address_allocation,
+        );
         Component::from_address(address)
     }
 }

--- a/dan_layer/template_lib/src/component/manager.rs
+++ b/dan_layer/template_lib/src/component/manager.rs
@@ -127,4 +127,8 @@ impl ComponentManager {
             .decode()
             .expect("failed to decode component template address from engine")
     }
+
+    pub fn component_address(&self) -> ComponentAddress {
+        self.address
+    }
 }

--- a/dan_layer/template_lib/src/engine.rs
+++ b/dan_layer/template_lib/src/engine.rs
@@ -30,7 +30,7 @@ use crate::{
     component::ComponentManager,
     context::Context,
     get_context,
-    models::ComponentAddress,
+    models::{AddressAllocation, ComponentAddress},
     prelude::ComponentAccessRules,
     Hash,
 };
@@ -57,6 +57,7 @@ impl TariEngine {
         owner_rule: OwnerRule,
         access_rules: ComponentAccessRules,
         component_id: Option<Hash>,
+        address_allocation: Option<AddressAllocation<ComponentAddress>>,
     ) -> ComponentAddress {
         let encoded_state = to_value(&initial_state).unwrap();
 
@@ -68,6 +69,7 @@ impl TariEngine {
                 owner_rule,
                 access_rules,
                 component_id,
+                address_allocation
             }],
         });
 

--- a/dan_layer/template_lib/src/models/address_allocation.rs
+++ b/dan_layer/template_lib/src/models/address_allocation.rs
@@ -1,0 +1,22 @@
+//   Copyright 2024 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct AddressAllocation<T> {
+    id: u32,
+    address: T,
+}
+
+impl<T> AddressAllocation<T> {
+    pub fn new(id: u32, address: T) -> Self {
+        Self { id, address }
+    }
+
+    pub fn id(&self) -> u32 {
+        self.id
+    }
+
+    pub fn address(&self) -> &T {
+        &self.address
+    }
+}

--- a/dan_layer/template_lib/src/models/mod.rs
+++ b/dan_layer/template_lib/src/models/mod.rs
@@ -23,6 +23,9 @@
 //! The collection of all struct definitions that represent data in the Tari network (e.g., resources, components,
 //! proofs, etc.)
 
+mod address_allocation;
+pub use address_allocation::AddressAllocation;
+
 mod non_fungible_index;
 pub use non_fungible_index::NonFungibleIndexAddress;
 

--- a/dan_layer/template_lib/src/prelude.rs
+++ b/dan_layer/template_lib/src/prelude.rs
@@ -40,6 +40,7 @@ pub use crate::{
     events::emit_event,
     invoke_args,
     models::{
+        AddressAllocation,
         Amount,
         Bucket,
         BucketId,

--- a/dan_layer/template_lib/src/resource/builder/non_fungible.rs
+++ b/dan_layer/template_lib/src/resource/builder/non_fungible.rs
@@ -5,7 +5,6 @@ use std::collections::BTreeMap;
 
 use serde::Serialize;
 use tari_bor::encode;
-use tari_template_abi::rust::{fmt, ops::RangeInclusive};
 
 use super::TOKEN_SYMBOL;
 use crate::{
@@ -130,13 +129,12 @@ impl NonFungibleResourceBuilder {
 
     /// Sets up multiple initial non-fungible tokens to be minted on resource creation by applying the provided function
     /// N times
-    pub fn mint_many_with<F, T>(mut self, bounds: RangeInclusive<usize>, mut f: F) -> Self
+    pub fn mint_many_with<F, I, V>(mut self, iter: I, f: F) -> Self
     where
-        F: FnMut(T) -> (NonFungibleId, (Vec<u8>, Vec<u8>)),
-        T: TryFrom<usize>,
-        T::Error: fmt::Debug,
+        F: FnMut(V) -> (NonFungibleId, (Vec<u8>, Vec<u8>)),
+        I: IntoIterator<Item = V>,
     {
-        self.tokens_ids.extend(bounds.map(|n| f(n.try_into().unwrap())));
+        self.tokens_ids.extend(iter.into_iter().map(f));
         self
     }
 

--- a/dan_layer/template_lib/src/resource/manager.rs
+++ b/dan_layer/template_lib/src/resource/manager.rs
@@ -96,7 +96,7 @@ impl ResourceManager {
     /// * `metadata` - Collection of information used to describe the resource
     /// * `mint_arg` - Specification of the initial tokens that will be minted on resource creation
     pub fn create(
-        &mut self,
+        &self,
         resource_type: ResourceType,
         owner_rule: OwnerRule,
         access_rules: ResourceAccessRules,
@@ -130,7 +130,7 @@ impl ResourceManager {
     ///
     /// * `proof` - A zero-knowledge proof that specifies the amount of tokens to be minted and returned back to the
     ///   caller
-    pub fn mint_confidential(&mut self, proof: ConfidentialOutputProof) -> Bucket {
+    pub fn mint_confidential(&self, proof: ConfidentialOutputProof) -> Bucket {
         self.mint_internal(MintResourceArg {
             mint_arg: MintArg::Confidential { proof: Box::new(proof) },
         })
@@ -150,7 +150,7 @@ impl ResourceManager {
     /// * `mutable_data` - Initial data that the token will hold and that can potentially be updated in future
     ///   instructions
     pub fn mint_non_fungible<T: Serialize, U: Serialize>(
-        &mut self,
+        &self,
         id: NonFungibleId,
         metadata: &T,
         mutable_data: &U,
@@ -178,7 +178,7 @@ impl ResourceManager {
     ///   instructions
     /// * `supply` - The amount of new tokens to be minted
     pub fn mint_many_non_fungible<T: Serialize, U: Serialize>(
-        &mut self,
+        &self,
         metadata: &T,
         mutable_data: &U,
         supply: usize,
@@ -204,7 +204,7 @@ impl ResourceManager {
     /// # Arguments
     ///
     /// * `amount` - The amount of new tokens to be minted
-    pub fn mint_fungible(&mut self, amount: Amount) -> Bucket {
+    pub fn mint_fungible(&self, amount: Amount) -> Bucket {
         self.mint_internal(MintResourceArg {
             mint_arg: MintArg::Fungible { amount },
         })
@@ -368,7 +368,7 @@ impl ResourceManager {
         Bucket::from_id(bucket_id)
     }
 
-    fn mint_internal(&mut self, arg: MintResourceArg) -> Bucket {
+    fn mint_internal(&self, arg: MintResourceArg) -> Bucket {
         let resp: InvokeResult = call_engine(EngineOp::ResourceInvoke, &ResourceInvokeArg {
             resource_ref: self.expect_resource_address(),
             action: ResourceAction::Mint,

--- a/dan_layer/template_macros/src/template/dispatcher.rs
+++ b/dan_layer/template_macros/src/template/dispatcher.rs
@@ -201,7 +201,13 @@ fn replace_self_in_single_value(type_path: &TypePath) -> Option<Stmt> {
     if type_ident == "Self" {
         // When we return self we use default rules - which only permit the owner of the component to call methods
         return Some(parse_quote! {
-            let rtn = engine().create_component(rtn, ::tari_template_lib::auth::OwnerRule::default(), ::tari_template_lib::auth::ComponentAccessRules::new(), None);
+            let rtn = engine().create_component(
+                rtn,
+                ::tari_template_lib::auth::OwnerRule::default(),
+                ::tari_template_lib::auth::ComponentAccessRules::new(),
+                None,
+                None,
+            );
         });
     }
 
@@ -219,9 +225,16 @@ fn replace_self_in_tuple(type_tuple: &TypeTuple) -> Stmt {
                 let ident = path.path.segments[0].ident.clone();
                 let field_expr = build_tuple_field_expr("rtn".to_string(), i as u32);
                 if ident == "Self" {
-                    // When we return self we use default rules - which only permit the owner of the component to call methods
+                    // When we return self we use default rules - which only permit the owner of the component to call
+                    // methods
                     parse_quote! {
-                        engine().create_component(#field_expr, ::tari_template_lib::auth::OwnerRule::default(), ::tari_template_lib::auth::ComponentAccessRules::new(), None)
+                        engine().create_component(
+                            #field_expr,
+                            ::tari_template_lib::auth::OwnerRule::default(),
+                            :tari_template_lib::auth::ComponentAccessRules::new(),
+                            None,
+                            None,
+                        )
                     }
                 } else {
                     field_expr


### PR DESCRIPTION
Description
---
Allows resource access rules  to restrict actions to one or more specific components/templates
Adds the ability to get pre-allocate component addresses in code before component creation

Motivation and Context
---
Thanks to @mrnaveira for this idea!

Some use cases may want a user to mint their own badge by executing a method on a specific template without explicit permission from the component owner (permissionless). This PR allows a template author to be permissable in who can perform resource actions, but force all users to interact with their component/template to control how those resource actions are used. 

To set component-restricted rules in code, the component address is required. Often access rules are set in the constructor of the component, where the address is not known. This PR adds the ability ask the runtime for a "pre-allocated" component address and later apply that to the component that is to be created.

How Has This Been Tested?
---
New unit tests

What process can a PR reviewer use to test or verify this change?
---

Template using the new access rules, e.g
```rust
  let allocation = CallerContext::allocate_component_address();
            let tokens = ResourceBuilder::fungible()
                .initial_supply(1000)
                .mintable(AccessRule::Restricted(RestrictedAccessRule::Require(
                    RequireRule::Require(allocation.address().clone().into()),
                )))
                .build_bucket();

  Component::new(Self {
                tokens: Vault::from_bucket(tokens),
            })
            .with_address_allocation(allocation)
            .create()
```

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify