### PR TITLE
test(engine): fix infinite loop test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1148,7 +1148,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4114279215a005bc675e386011e594e1d9b800918cea18fcadadcce864a2046b"
 dependencies = [
  "borsh-derive",
- "hashbrown 0.11.2",
+ "hashbrown 0.13.2",
 ]
 
 [[package]]


### PR DESCRIPTION
Description
---
Fix infinite loop test

Motivation and Context
---
Exact string matching cannot be used for this error

```
---- test_break_infinity_loop stdout ----
note: panic did not contain expected string
      panic message: `"called `Result::unwrap()` on an `Err` value: Transaction failed: Execution failure: RuntimeError: unreachable\n    at tari_free (<module>[328]:0x23b3c)"`,
 expected substring: `"called `Result::unwrap()` on an `Err` value: Transaction failed: Execution failure: RuntimeError: unreachable\n    at tari_free (<module>[327]:0x2390c)"`
```
https://github.com/tari-project/tari-dan/actions/runs/7406320369/job/20150567753?pr=872

How Has This Been Tested?
---
Test passes

What process can a PR reviewer use to test or verify this change?
---
CI

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify