### PR TITLE
fix: account parser in claim fee request

### DIFF
--- a/clients/wallet_daemon_client/src/types.rs
+++ b/clients/wallet_daemon_client/src/types.rs
@@ -557,6 +557,7 @@ pub struct GetValidatorFeesResponse {
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ClaimValidatorFeesRequest {
+    #[serde(default, deserialize_with = "opt_string_or_struct")]
     pub account: Option<ComponentAddressOrName>,
     pub max_fee: Option<Amount>,
     pub validator_public_key: PublicKey,


### PR DESCRIPTION
Description
---
Allow the account to be parsed from string

Motivation and Context
---
Upon some testing I came to this issue.

How Has This Been Tested?
---
In my testing environment I'm doing claiming fees, and I was able to claim them successfuly.

What process can a PR reviewer use to test or verify this change?
---
You can try to call the jrpc with string and you will see an error without this change.


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify