### PR TITLE
feat(p2p): validate gossipsub messages and update peer score

### DIFF
--- a/networking/libp2p-peersync/src/error.rs
+++ b/networking/libp2p-peersync/src/error.rs
@@ -30,8 +30,6 @@ pub enum Error {
     InvalidMessage { peer_id: PeerId, details: String },
     #[error("Failed to decode multiaddr: {0}")]
     DecodeMultiaddr(#[from] multiaddr::Error),
-    #[error("ProtoBuf peer record has no signature")]
-    ProtoBufMissingSignature,
 
     #[error("Invalid signed peer receord from peer `{peer_id}`: {details}")]
     InvalidSignedPeer { peer_id: PeerId, details: String },

--- a/networking/swarm/src/behaviour.rs
+++ b/networking/swarm/src/behaviour.rs
@@ -87,6 +87,7 @@ where
             // Gossipsub
             let gossipsub_config = gossipsub::ConfigBuilder::default()
                 .validation_mode(gossipsub::ValidationMode::Strict) // This sets the kind of message validation. The default is Strict (enforce message signing)
+                .validate_messages()
                 .message_id_fn(get_message_id) // content-address messages. No two messages of the same content will be propagated.
                 .build()
                 .unwrap();


### PR DESCRIPTION
Description
---
Enable and implement gossipsub message validation.

Motivation and Context
---
https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.1.md#the-score-function

This PR enables message validation by checking the message validity and reporting back to gossipsub, which then updates the peer score accordingly. 

Validation fails if the message cannot be decoded by the provided codec. In addition, peer announce messages require a valid `SignedPeerRecord`.

How Has This Been Tested?
---
Manually: Failure case not explicitly tested but gossipsub works as before

What process can a PR reviewer use to test or verify this change?
---
Changing the code in the VN to send a malformed gossipsub message to other peers

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify