### PR TITLE
fix(walletd): correctly set indexer url via JRPC

### DIFF
--- a/applications/tari_dan_wallet_daemon/src/indexer_jrpc_impl.rs
+++ b/applications/tari_dan_wallet_daemon/src/indexer_jrpc_impl.rs
@@ -46,6 +46,15 @@ impl IndexerJsonRpcNetworkInterface {
         let client = IndexerJsonRpcClient::connect((*self.indexer_jrpc_address.lock().unwrap()).clone())?;
         Ok(client)
     }
+
+    pub fn set_endpoint(&mut self, endpoint: &str) -> Result<(), IndexerJrpcError> {
+        *self.indexer_jrpc_address.lock().unwrap() = Url::parse(endpoint)?;
+        Ok(())
+    }
+
+    pub fn get_endpoint(&self) -> Url {
+        (*self.indexer_jrpc_address.lock().unwrap()).clone()
+    }
 }
 
 #[async_trait]
@@ -123,11 +132,6 @@ impl WalletNetworkInterface for IndexerJsonRpcNetworkInterface {
             transaction_id,
             result: convert_indexer_result_to_wallet_result(resp.result),
         })
-    }
-
-    fn set_endpoint(&mut self, endpoint: &str) -> Result<(), Self::Error> {
-        *self.indexer_jrpc_address.lock().unwrap() = Url::parse(endpoint)?;
-        Ok(())
     }
 }
 

--- a/applications/tari_dan_wallet_daemon/src/lib.rs
+++ b/applications/tari_dan_wallet_daemon/src/lib.rs
@@ -73,7 +73,6 @@ pub async fn run_tari_dan_wallet_daemon(
     let sdk_config = WalletSdkConfig {
         // TODO: Configure
         password: None,
-        indexer_jrpc_endpoint: config.dan_wallet_daemon.indexer_node_json_rpc_url,
         jwt_expiry: config.dan_wallet_daemon.jwt_expiry.unwrap(),
         jwt_secret_key: config.dan_wallet_daemon.jwt_secret_key.unwrap(),
     };
@@ -81,7 +80,7 @@ pub async fn run_tari_dan_wallet_daemon(
     let indexer_jrpc_endpoint = if let Some(indexer_url) = config_api.get(ConfigKey::IndexerUrl).optional()? {
         indexer_url
     } else {
-        sdk_config.indexer_jrpc_endpoint.clone()
+        config.dan_wallet_daemon.indexer_node_json_rpc_url.clone()
     };
     let indexer = IndexerJsonRpcNetworkInterface::new(indexer_jrpc_endpoint);
     let wallet_sdk = DanWalletSdk::initialize(store, indexer, sdk_config)?;

--- a/dan_layer/wallet/sdk/src/network.rs
+++ b/dan_layer/wallet/sdk/src/network.rs
@@ -38,8 +38,6 @@ pub trait WalletNetworkInterface {
         &self,
         transaction_id: TransactionId,
     ) -> Result<TransactionQueryResult, Self::Error>;
-
-    fn set_endpoint(&mut self, endpoint: &str) -> Result<(), Self::Error>;
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/dan_layer/wallet/sdk/src/sdk.rs
+++ b/dan_layer/wallet/sdk/src/sdk.rs
@@ -27,7 +27,10 @@ use crate::{
 pub struct WalletSdkConfig {
     /// Encryption password for the wallet database. NOTE: Not yet implemented, this field is ignored
     pub password: Option<SafePassword>,
-    pub indexer_jrpc_endpoint: String,
+    // TODO: remove JWT stuff from wallet SDK. The SDK should not have anything to do with JWTs, this is a web/jrpc
+    //       handler concern. It appears that the main reason it is done this way is to use the wallet database to
+    //       store JWT state. However this can be achieved by calling the _SQLite_ (non-abstract) store directly
+    // outside       of the SDK in the JWT handler.
     pub jwt_expiry: Duration,
     pub jwt_secret_key: String,
 }
@@ -69,7 +72,11 @@ where
         &self.config
     }
 
-    pub fn get_network_interface(&mut self) -> &mut TNetworkInterface {
+    pub fn get_network_interface(&self) -> &TNetworkInterface {
+        &self.network_interface
+    }
+
+    pub fn get_network_interface_mut(&mut self) -> &mut TNetworkInterface {
         &mut self.network_interface
     }
 

--- a/dan_layer/wallet/sdk/tests/confidential_output_api.rs
+++ b/dan_layer/wallet/sdk/tests/confidential_output_api.rs
@@ -142,7 +142,6 @@ impl Test {
 
         let sdk = DanWalletSdk::initialize(store.clone(), PanicIndexer, WalletSdkConfig {
             password: None,
-            indexer_jrpc_endpoint: "".to_string(),
             jwt_expiry: Duration::from_secs(60),
             jwt_secret_key: "secret_key".to_string(),
         })
@@ -264,11 +263,6 @@ impl WalletNetworkInterface for PanicIndexer {
         &self,
         _transaction_id: TransactionId,
     ) -> Result<TransactionQueryResult, Self::Error> {
-        panic!("PanicIndexer called")
-    }
-
-    #[allow(clippy::diverging_sub_expression)]
-    fn set_endpoint(&mut self, _endpoint: &str) -> Result<(), Self::Error> {
         panic!("PanicIndexer called")
     }
 }


### PR DESCRIPTION
Description
---
Fixes bug where the indexer URL is set temporarily but is not persisted on restart

Motivation and Context
---
The indexer URL setting did not persist when set via JRPC.
Removes the indexer config from the wallet SDK. The wallet SDK should be decoupled from the indexer. Similarly, the interface to the network used to resolve substates does not necessarily have a JRPC endpoint to set and so cannot be part of the interface.


How Has This Been Tested?
---

Manually

What process can a PR reviewer use to test or verify this change?
---
Setting indexer URL and checking that the setting is persisted across webUI page refreshes

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify