### PR TITLE
fix(consensus)!: allow multiple read-only shard references in proposals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4012,6 +4012,7 @@ checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
+ "serde",
 ]
 
 [[package]]
@@ -9192,6 +9193,7 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "chrono",
+ "indexmap 2.1.0",
  "log",
  "rand",
  "serde",
@@ -9740,6 +9742,7 @@ dependencies = [
  "tari_common_types",
  "tari_dan_common_types",
  "tari_dan_storage",
+ "tari_engine_types",
  "tari_transaction",
  "tari_utilities",
  "thiserror",

--- a/dan_layer/engine_types/src/lock.rs
+++ b/dan_layer/engine_types/src/lock.rs
@@ -3,8 +3,10 @@
 
 use std::fmt::Display;
 
+use tari_bor::{Deserialize, Serialize};
+
 pub type LockId = u32;
-#[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum LockFlag {
     Read,
     Write,

--- a/dan_layer/state_store_sqlite/Cargo.toml
+++ b/dan_layer/state_store_sqlite/Cargo.toml
@@ -11,6 +11,7 @@ license.workspace = true
 tari_dan_storage = { workspace = true }
 tari_dan_common_types = { workspace = true }
 tari_transaction = { workspace = true }
+tari_engine_types = { workspace = true }
 # TODO: needed for FixedHash
 tari_common_types = { workspace = true }
 tari_utilities = { workspace = true }

--- a/dan_layer/storage/Cargo.toml
+++ b/dan_layer/storage/Cargo.toml
@@ -21,6 +21,7 @@ tari_crypto = { workspace = true }
 
 anyhow = { workspace = true }
 chrono = { workspace = true }
+indexmap = { workspace = true, features = ["serde"] }
 log = { workspace = true }
 rand = { workspace = true }
 thiserror = { workspace = true }

--- a/dan_layer/storage/src/consensus_models/command.rs
+++ b/dan_layer/storage/src/consensus_models/command.rs
@@ -3,12 +3,13 @@
 
 use std::{
     cmp::Ordering,
-    collections::BTreeMap,
     fmt::{Display, Formatter},
 };
 
+use indexmap::{IndexMap, IndexSet};
 use serde::{Deserialize, Serialize};
 use tari_dan_common_types::ShardId;
+use tari_engine_types::lock::LockFlag;
 use tari_transaction::TransactionId;
 
 use super::ForeignProposal;
@@ -18,15 +19,15 @@ use crate::{
     StorageError,
 };
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct Evidence {
-    evidence: BTreeMap<ShardId, Vec<QcId>>,
+    evidence: IndexMap<ShardId, ShardEvidence>,
 }
 
 impl Evidence {
-    pub const fn empty() -> Self {
+    pub fn empty() -> Self {
         Self {
-            evidence: BTreeMap::new(),
+            evidence: IndexMap::new(),
         }
     }
 
@@ -43,15 +44,22 @@ impl Evidence {
         self.evidence.len()
     }
 
-    pub fn num_complete_shards(&self) -> usize {
-        self.evidence.values().filter(|qc_ids| !qc_ids.is_empty()).count()
+    pub fn get(&self, shard_id: &ShardId) -> Option<&ShardEvidence> {
+        self.evidence.get(shard_id)
     }
 
-    pub fn iter(&self) -> impl Iterator<Item = (&ShardId, &Vec<QcId>)> {
+    pub fn num_complete_shards(&self) -> usize {
+        self.evidence
+            .values()
+            .filter(|evidence| !evidence.qc_ids.is_empty())
+            .count()
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (&ShardId, &ShardEvidence)> {
         self.evidence.iter()
     }
 
-    pub fn iter_mut(&mut self) -> impl Iterator<Item = (&ShardId, &mut Vec<QcId>)> {
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = (&ShardId, &mut ShardEvidence)> {
         self.evidence.iter_mut()
     }
 
@@ -60,31 +68,60 @@ impl Evidence {
     }
 
     pub fn qc_ids_iter(&self) -> impl Iterator<Item = &QcId> + '_ {
-        self.evidence.values().flatten()
+        self.evidence.values().flat_map(|e| e.qc_ids.iter())
     }
 
     pub fn merge(&mut self, other: Evidence) -> &mut Self {
-        for (shard_id, qc_ids) in other.evidence {
-            let entry = self.evidence.entry(shard_id).or_default();
-            for qc_id in qc_ids {
-                if !entry.contains(&qc_id) {
-                    entry.push(qc_id);
-                }
-            }
+        for (shard_id, shard_evidence) in other.evidence {
+            let entry = self.evidence.entry(shard_id).or_insert_with(|| ShardEvidence {
+                qc_ids: IndexSet::new(),
+                lock: shard_evidence.lock,
+            });
+            entry.qc_ids.extend(shard_evidence.qc_ids);
         }
         self
     }
 }
 
-impl FromIterator<(ShardId, Vec<QcId>)> for Evidence {
-    fn from_iter<T: IntoIterator<Item = (ShardId, Vec<QcId>)>>(iter: T) -> Self {
+impl FromIterator<(ShardId, ShardEvidence)> for Evidence {
+    fn from_iter<T: IntoIterator<Item = (ShardId, ShardEvidence)>>(iter: T) -> Self {
         Evidence {
             evidence: iter.into_iter().collect(),
         }
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+impl Extend<(ShardId, ShardEvidence)> for Evidence {
+    fn extend<T: IntoIterator<Item = (ShardId, ShardEvidence)>>(&mut self, iter: T) {
+        self.evidence.extend(iter.into_iter())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ShardEvidence {
+    pub qc_ids: IndexSet<QcId>,
+    pub lock: LockFlag,
+}
+
+impl ShardEvidence {
+    pub fn new(qc_ids: IndexSet<QcId>, lock: LockFlag) -> Self {
+        Self { qc_ids, lock }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.qc_ids.is_empty()
+    }
+
+    pub fn contains(&self, qc_id: &QcId) -> bool {
+        self.qc_ids.contains(qc_id)
+    }
+
+    pub fn insert(&mut self, qc_id: QcId) {
+        self.qc_ids.insert(qc_id);
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TransactionAtom {
     pub id: TransactionId,
     pub decision: Decision,
@@ -116,7 +153,7 @@ impl Display for TransactionAtom {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Command {
     /// Command to prepare a transaction.
     Prepare(TransactionAtom),

--- a/dan_layer/storage/src/consensus_models/transaction_decision.rs
+++ b/dan_layer/storage/src/consensus_models/transaction_decision.rs
@@ -32,14 +32,18 @@ impl Decision {
             Decision::Abort => Decision::Abort,
         }
     }
+
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Decision::Commit => "Commit",
+            Decision::Abort => "Abort",
+        }
+    }
 }
 
 impl Display for Decision {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        match self {
-            Decision::Commit => write!(f, "Commit"),
-            Decision::Abort => write!(f, "Abort"),
-        }
+        f.write_str(self.as_str())
     }
 }
 

--- a/dan_layer/storage/src/consensus_models/transaction_pool.rs
+++ b/dan_layer/storage/src/consensus_models/transaction_pool.rs
@@ -350,9 +350,9 @@ impl TransactionPoolRecord {
 
     pub fn add_evidence(&mut self, committee_shard: &CommitteeShard, qc_id: QcId) -> &mut Self {
         let evidence = &mut self.transaction.evidence;
-        for (shard, qcs_mut) in evidence.iter_mut() {
+        for (shard, evidence_mut) in evidence.iter_mut() {
             if committee_shard.includes_shard(shard) {
-                qcs_mut.push(qc_id);
+                evidence_mut.qc_ids.insert(qc_id);
             }
         }
 


### PR DESCRIPTION
Description
---
Includes locks in evidence
Checks locks when proposing to allow multiple input refs

Motivation and Context
---
Evidence for each shard within a TransactionAtom now includes the lock type. 
Updated the proposal db query to check each lock type and ensure that conflicts either don't occur or if they do they are all read locks.

How Has This Been Tested?
---
Ran a stress test from #880, previously after #885 was merged, funding the tariswap components would take a very long time (I've never actually run it to completion, but ran for 30 mins without completing). With this PR funding took roughly a minute on my test. Swap batches are also reaching finalization within an acceptable timeframe.

What process can a PR reviewer use to test or verify this change?
---
Submit multiple transactions which use a single substate as an input ref and check that they can be added to the same block.

Breaking Changes
---

- [ ] None
- [x] Requires data directory to be deleted (Evidence struct changed)
- [ ] Other - Please specify