### PR TITLE
fix: qc was validated based on current epoch, not the qc's epoch

### DIFF
--- a/dan_layer/consensus/src/block_validations.rs
+++ b/dan_layer/consensus/src/block_validations.rs
@@ -109,7 +109,13 @@ pub async fn check_quorum_certificate<TConsensusSpec: ConsensusSpec>(
         }
     }
     let committee_shard = epoch_manager
-        .get_committee_shard_by_validator_public_key(candidate_block.epoch(), candidate_block.proposed_by())
+        .get_committee_shard_by_validator_public_key(
+            qc.epoch(),
+            qc.signatures()
+                .first()
+                .ok_or::<HotStuffError>(ProposalValidationError::QuorumWasNotReached { qc: qc.clone() }.into())?
+                .public_key(),
+        )
         .await?;
 
     if committee_shard.quorum_threshold() >


### PR DESCRIPTION
Description
---
The qc validation was based on the epoch of the candidate block. So if the QC was from previous epoch the committee shard could be different. E.g. when you add a new VN into the committee, the qc was expected to have 2 signatures. But in the previous epoch there was only one VN so the QC never passed the validation.

Motivation and Context
---

How Has This Been Tested?
---
Start dan-testing with 1 VN, add a new VN and mine it into the committee. Without this change you would never see a new block coming in. You still have to wait for some leader failure on the epoch change but eventually new blocks starts coming in.

What process can a PR reviewer use to test or verify this change?
---
As above.


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify