### PR TITLE
feat(template_lib): improve API for extracting data from NFTs

### DIFF
--- a/dan_layer/engine/tests/templates/nft/basic_nft/src/lib.rs
+++ b/dan_layer/engine/tests/templates/nft/basic_nft/src/lib.rs
@@ -129,5 +129,14 @@ mod sparkle_nft_template {
             // native instruction can be used instead
             bucket.burn();
         }
+
+        pub fn get_non_fungibles_from_bucket(&mut self) -> Vec<NonFungible> {
+            let bucket = self.vault.withdraw_all();
+            let nfts = bucket.get_non_fungibles();
+            // deposit the nfts back into the vault
+            self.vault.deposit(bucket);
+
+            nfts
+        }
     }
 }

--- a/dan_layer/engine/tests/templates/nft/basic_nft/src/lib.rs
+++ b/dan_layer/engine/tests/templates/nft/basic_nft/src/lib.rs
@@ -138,5 +138,9 @@ mod sparkle_nft_template {
 
             nfts
         }
+
+        pub fn get_non_fungibles_from_vault(&self) -> Vec<NonFungible> {
+            self.vault.get_non_fungibles()
+        }
     }
 }

--- a/dan_layer/engine/tests/test.rs
+++ b/dan_layer/engine/tests/test.rs
@@ -870,13 +870,13 @@ mod basic_nft {
         result.finalize.result.expect("execution failed");
 
         // sparkle_nft.get_non_fungibles_from_bucket()
-        let nfts_from_bucket = result.finalize.execution_results[1]
+        let nfts_from_bucket = result.finalize.execution_results[0]
             .decode::<Vec<NonFungible>>()
             .unwrap();
         assert_eq!(nfts_from_bucket.len(), 4);
 
         // sparkle_nft.get_non_fungibles_from_vault()
-        let nfts_from_bucket = result.finalize.execution_results[2]
+        let nfts_from_bucket = result.finalize.execution_results[1]
             .decode::<Vec<NonFungible>>()
             .unwrap();
         assert_eq!(nfts_from_bucket.len(), 4);

--- a/dan_layer/engine/tests/test.rs
+++ b/dan_layer/engine/tests/test.rs
@@ -478,6 +478,7 @@ mod fungible {
 
 mod basic_nft {
     use serde::{Deserialize, Serialize};
+    use tari_template_lib::models::NonFungible;
 
     use super::*;
 
@@ -839,6 +840,39 @@ mod basic_nft {
                 vec![],
             )
             .unwrap_err();
+    }
+
+    #[test]
+    fn get_non_fungibles_from_containers() {
+        let (mut template_test, (account_address, account_owner), nft_component, nft_resx) = setup();
+
+        let vars = vec![
+            ("account", account_address.into()),
+            ("nft", nft_component.into()),
+            ("nft_resx", nft_resx.into()),
+        ];
+
+        let total_supply: Amount = template_test.call_method(nft_component, "total_supply", args![], vec![]);
+        assert_eq!(total_supply, Amount(4));
+
+        let result = template_test
+            .execute_and_commit_manifest(
+                r#"
+            let sparkle_nft = var!["nft"];
+            sparkle_nft.get_non_fungibles_from_bucket();
+        "#,
+                vars.clone(),
+                vec![account_owner],
+            )
+            .unwrap();
+
+        result.finalize.result.expect("execution failed");
+
+        // sparkle_nft.get_non_fungibles_from_bucket()
+        let nfts_from_bucket = result.finalize.execution_results[1]
+            .decode::<Vec<NonFungible>>()
+            .unwrap();
+        assert_eq!(nfts_from_bucket.len(), 4);
     }
 }
 

--- a/dan_layer/engine/tests/test.rs
+++ b/dan_layer/engine/tests/test.rs
@@ -860,6 +860,7 @@ mod basic_nft {
                 r#"
             let sparkle_nft = var!["nft"];
             sparkle_nft.get_non_fungibles_from_bucket();
+            sparkle_nft.get_non_fungibles_from_vault();
         "#,
                 vars.clone(),
                 vec![account_owner],
@@ -870,6 +871,12 @@ mod basic_nft {
 
         // sparkle_nft.get_non_fungibles_from_bucket()
         let nfts_from_bucket = result.finalize.execution_results[1]
+            .decode::<Vec<NonFungible>>()
+            .unwrap();
+        assert_eq!(nfts_from_bucket.len(), 4);
+
+        // sparkle_nft.get_non_fungibles_from_vault()
+        let nfts_from_bucket = result.finalize.execution_results[2]
             .decode::<Vec<NonFungible>>()
             .unwrap();
         assert_eq!(nfts_from_bucket.len(), 4);

--- a/dan_layer/template_lib/src/args/types.rs
+++ b/dan_layer/template_lib/src/args/types.rs
@@ -316,6 +316,7 @@ pub enum VaultAction {
     CreateProofByFungibleAmount,
     CreateProofByNonFungibles,
     CreateProofByConfidentialResource,
+    GetNonFungibles,
 }
 
 /// A vault withdraw operation argument

--- a/dan_layer/template_lib/src/args/types.rs
+++ b/dan_layer/template_lib/src/args/types.rs
@@ -397,6 +397,7 @@ pub enum BucketAction {
     Burn,
     CreateProof,
     GetNonFungibleIds,
+    GetNonFungibles,
 }
 
 /// A bucket burn operation argument

--- a/dan_layer/template_lib/src/models/bucket.rs
+++ b/dan_layer/template_lib/src/models/bucket.rs
@@ -189,7 +189,7 @@ impl Bucket {
             .expect("get_non_fungible_ids returned invalid non fungible ids")
     }
 
-    /// Returns the all the non-fungibles in this bucket
+    /// Returns all the non-fungibles in this bucket
     pub fn get_non_fungibles(&self) -> Vec<NonFungible> {
         let resp: InvokeResult = call_engine(EngineOp::BucketInvoke, &BucketInvokeArg {
             bucket_ref: BucketRef::Ref(self.id),

--- a/dan_layer/template_lib/src/models/bucket.rs
+++ b/dan_layer/template_lib/src/models/bucket.rs
@@ -24,7 +24,7 @@ use serde::{Deserialize, Serialize};
 use tari_bor::BorTag;
 use tari_template_abi::{call_engine, rust::fmt, EngineOp};
 
-use super::NonFungibleId;
+use super::{NonFungible, NonFungibleId};
 use crate::{
     args::{BucketAction, BucketInvokeArg, BucketRef, InvokeResult},
     models::{Amount, BinaryTag, ConfidentialWithdrawProof, Proof, ResourceAddress},
@@ -182,6 +182,18 @@ impl Bucket {
         let resp: InvokeResult = call_engine(EngineOp::BucketInvoke, &BucketInvokeArg {
             bucket_ref: BucketRef::Ref(self.id),
             action: BucketAction::GetNonFungibleIds,
+            args: invoke_args![],
+        });
+
+        resp.decode()
+            .expect("get_non_fungible_ids returned invalid non fungible ids")
+    }
+
+    /// Returns the all the non-fungibles in this bucket
+    pub fn get_non_fungibles(&self) -> Vec<NonFungible> {
+        let resp: InvokeResult = call_engine(EngineOp::BucketInvoke, &BucketInvokeArg {
+            bucket_ref: BucketRef::Ref(self.id),
+            action: BucketAction::GetNonFungibles,
             args: invoke_args![],
         });
 

--- a/dan_layer/template_lib/src/models/bucket.rs
+++ b/dan_layer/template_lib/src/models/bucket.rs
@@ -197,7 +197,6 @@ impl Bucket {
             args: invoke_args![],
         });
 
-        resp.decode()
-            .expect("get_non_fungible_ids returned invalid non fungible ids")
+        resp.decode().expect("get_non_fungibles returned invalid non fungibles")
     }
 }

--- a/dan_layer/template_lib/src/models/vault.rs
+++ b/dan_layer/template_lib/src/models/vault.rs
@@ -33,7 +33,7 @@ use tari_template_abi::{
     EngineOp,
 };
 
-use super::{BinaryTag, Proof, ProofAuth};
+use super::{BinaryTag, NonFungible, Proof, ProofAuth};
 use crate::{
     args::{
         ConfidentialRevealArg,
@@ -271,6 +271,17 @@ impl Vault {
 
         resp.decode()
             .expect("get_non_fungible_ids returned invalid non fungible ids")
+    }
+
+    /// Returns the all the non-fungibles in this vault
+    pub fn get_non_fungibles(&self) -> Vec<NonFungible> {
+        let resp: InvokeResult = call_engine(EngineOp::VaultInvoke, &VaultInvokeArg {
+            vault_ref: self.vault_ref(),
+            action: VaultAction::GetNonFungibles,
+            args: invoke_args![],
+        });
+
+        resp.decode().expect("get_non_fungibles returned invalid non fungibles")
     }
 
     /// Returns the resource address of the tokens that this vault holds

--- a/dan_layer/template_lib/src/models/vault.rs
+++ b/dan_layer/template_lib/src/models/vault.rs
@@ -273,7 +273,7 @@ impl Vault {
             .expect("get_non_fungible_ids returned invalid non fungible ids")
     }
 
-    /// Returns the all the non-fungibles in this vault
+    /// Returns all the non-fungibles in this vault
     pub fn get_non_fungibles(&self) -> Vec<NonFungible> {
         let resp: InvokeResult = call_engine(EngineOp::VaultInvoke, &VaultInvokeArg {
             vault_ref: self.vault_ref(),


### PR DESCRIPTION
Description
---
* Added new `get_non_fungibles` method to vaults and buckets in `template_lib`, that returns all the `NonFungible` objects contained within.
* Added new engine operations to support the new method in both vaults and buckets

Motivation and Context
---
We expect templates to often read NFT data from buckets or vaults. Currently the only way to do it is doing something like:
```
 let seller_badge_id = &seller_badge_bucket.get_non_fungible_ids()[0];
 let seller_badge = ResourceManager::get(self.seller_badge_resource).get_non_fungible(&seller_badge_id);
 let nft_metadata = seller_badge.get_data::<Metadata>();
```

This PR adds a new method `get_non_fungibles` to vaults and buckets to we can write the previous example as:
```
 let seller_badge = seller_badge_bucket.get_non_fungibles()[0];
 let nft_metadata = seller_badge.get_mutable_data::<Metadata>();
```

How Has This Been Tested?
---
New unit test in the `engine` crate for the new methods

What process can a PR reviewer use to test or verify this change?
---
Call the new methods inside a template

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify