### PR TITLE
fix: add base node proto to fix compile error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,9 +111,7 @@ minotari_wallet = { git = "https://github.com/tari-project/tari.git", branch = "
 minotari_wallet_grpc_client = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan2" }
 tari_common = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan2" }
 tari_common_types = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan2" }
-tari_comms = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan2" }
-tari_comms_dht = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan2" }
-tari_comms_rpc_macros = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan2" }
+
 # avoid including default features so each crate can choose which ones to import
 tari_core = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan2", default-features = false }
 tari_crypto = "0.19"

--- a/dan_layer/common_types/Cargo.toml
+++ b/dan_layer/common_types/Cargo.toml
@@ -14,6 +14,7 @@ tari_bor = { workspace = true, default-features = true }
 tari_mmr = { workspace = true }
 tari_core = { workspace = true, default-features = false, features = [
   "transactions",
+  "base_node_proto"
 ] }
 
 libp2p-identity = { workspace = true, features = [

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -15,8 +15,6 @@ minotari_node = { workspace = true }
 minotari_node_grpc_client = { workspace = true }
 tari_common = { workspace = true }
 tari_common_types = { workspace = true }
-tari_comms = { workspace = true }
-tari_comms_dht = { workspace = true }
 minotari_console_wallet = { workspace = true }
 minotari_wallet = { workspace = true }
 tari_p2p = { workspace = true }
@@ -41,6 +39,9 @@ tari_wallet_daemon_client = { workspace = true }
 tari_base_node_client = { workspace = true }
 tari_transaction_manifest = { workspace = true }
 #tari_dan_wallet_sdk = { workspace = true }
+
+tari_comms = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan2" }
+tari_comms_dht = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan2" }
 
 anyhow = { workspace = true }
 # if we set this version in the workspace it would break other crates


### PR DESCRIPTION
Description
---
adds base node proto to common_types to fix compile error
removes tari_comms from common deps and adds them to integration_tests crate

Motivation and Context
---
tari_core fails to compile without base_node_proto. This happens in transaction_generator. This issue might be fixed in the [features-dan2](https://github.com/tari-project/tari/pull/6078) PR

How Has This Been Tested?
---
transaction_generator compiles

What process can a PR reviewer use to test or verify this change?
---
transaction_generator compiles

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify