### PR TITLE
feat: remove serde-byte-array

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7991,15 +7991,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde-byte-array"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63213ee4ed648dbd87db6fa993d4275b46bfb4ddfd95b3756045007c2b28f742"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "serde-value"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8011,9 +8002,9 @@ dependencies = [
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.12"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab33ec92f677585af6d88c65593ae2375adde54efdbf16d597f2cbc7a6d368ff"
+checksum = "8b8497c313fd43ab992087548117643f6fcd935cbf36f176ffda0aacf9591734"
 dependencies = [
  "serde",
 ]
@@ -9797,8 +9788,8 @@ version = "0.3.0"
 dependencies = [
  "newtype-ops",
  "serde",
- "serde-byte-array",
  "serde_json",
+ "serde_with",
  "tari_bor",
  "tari_template_abi",
  "tari_template_macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,8 +58,8 @@ resolver = "2"
 # specifying them in a single place and having them applied to all crates
 
 # internal dependencies among workspace crates
-libp2p-messaging = { path = "networking/libp2p-messaging"}
-libp2p-peersync = { path = "networking/libp2p-peersync"}
+libp2p-messaging = { path = "networking/libp2p-messaging" }
+libp2p-peersync = { path = "networking/libp2p-peersync" }
 libp2p-substream = { path = "networking/libp2p-substream" }
 proto_builder = { path = "networking/proto_builder" }
 sqlite_message_logger = { path = "networking/sqlite_message_logger" }
@@ -87,10 +87,10 @@ tari_rpc_framework = { path = "networking/rpc_framework" }
 tari_rpc_macros = { path = "networking/rpc_macros" }
 tari_state_store_sqlite = { path = "dan_layer/state_store_sqlite" }
 tari_swarm = { path = "networking/swarm" }
-tari_template_abi = { version="0.3.0", path = "dan_layer/template_abi" }
+tari_template_abi = { version = "0.3.0", path = "dan_layer/template_abi" }
 tari_template_builtin = { path = "dan_layer/template_builtin" }
 tari_template_lib = { path = "dan_layer/template_lib" }
-tari_template_macros = { version="0.3.0", path = "dan_layer/template_macros" }
+tari_template_macros = { version = "0.3.0", path = "dan_layer/template_macros" }
 tari_template_test_tooling = { path = "dan_layer/template_test_tooling" }
 tari_transaction = { path = "dan_layer/transaction" }
 tari_transaction_manifest = { path = "dan_layer/transaction_manifest" }
@@ -198,7 +198,6 @@ semver = "1.0"
 serde = { version = "1.0", default-features = false }
 serde_json = "1.0"
 serde_with = "2.3"
-serde-byte-array = "0.1.2"
 sha2 = "0.10.8"
 smallvec = "2.0.0-alpha.1"
 std-semaphore = "0.1.0"
@@ -211,7 +210,7 @@ tokio-stream = "0.1.7"
 tokio-util = "0.7.10"
 tonic = "0.6.2"
 tower = "0.4"
-tower-http = { version = "0.3.5", default-features = false}
+tower-http = { version = "0.3.5", default-features = false }
 tower-layer = "0.3"
 tracing = "0.1.40"
 url = "2.4.1"

--- a/dan_layer/template_lib/Cargo.toml
+++ b/dan_layer/template_lib/Cargo.toml
@@ -13,8 +13,11 @@ tari_template_macros = { workspace = true, optional = true }
 tari_bor = { workspace = true, default-features = false }
 
 newtype-ops = { workspace = true }
-serde = { workspace = true, default-features = false, features = ["derive", "alloc"] }
-serde-byte-array = { workspace = true }
+serde = { workspace = true, default-features = false, features = [
+    "derive",
+    "alloc",
+] }
+serde_with = { workspace = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }
@@ -23,9 +26,3 @@ serde_json = { workspace = true }
 default = ["macro", "std"]
 macro = ["tari_template_macros"]
 std = ["serde/std", "tari_bor/std"]
-
-[package.metadata.cargo-machete]
-ignored = [
-    # Used but not detectable by machete
-    "serde-byte-array",
-]

--- a/dan_layer/template_lib/src/crypto/balance_proof.rs
+++ b/dan_layer/template_lib/src/crypto/balance_proof.rs
@@ -1,13 +1,15 @@
 //   Copyright 2023 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 use serde::{Deserialize, Serialize};
+use serde_with::{serde_as, Bytes};
 
 use crate::crypto::InvalidByteLengthError;
 
 /// The signature of a balance proof, used to validate the authorship of confidential transfers
+#[serde_as]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(transparent)]
-pub struct BalanceProofSignature(#[serde(with = "serde_byte_array")] [u8; BalanceProofSignature::length()]);
+pub struct BalanceProofSignature(#[serde_as(as = "Bytes")] [u8; BalanceProofSignature::length()]);
 
 impl BalanceProofSignature {
     pub const fn length() -> usize {

--- a/dan_layer/template_lib/src/crypto/commitment.rs
+++ b/dan_layer/template_lib/src/crypto/commitment.rs
@@ -2,14 +2,16 @@
 //   SPDX-License-Identifier: BSD-3-Clause
 
 use serde::{Deserialize, Serialize};
+use serde_with::{serde_as, Bytes};
 use tari_template_abi::rust::fmt::{Display, Formatter};
 
 use crate::{crypto::InvalidByteLengthError, Hash};
 
 /// A Pederson Commitment byte contents
+#[serde_as]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Ord, PartialOrd, Hash, Default, Serialize, Deserialize)]
 #[serde(transparent)]
-pub struct PedersonCommitmentBytes(#[serde(with = "serde_byte_array")] [u8; PedersonCommitmentBytes::length()]);
+pub struct PedersonCommitmentBytes(#[serde_as(as = "Bytes")] [u8; PedersonCommitmentBytes::length()]);
 
 impl PedersonCommitmentBytes {
     pub const fn length() -> usize {

--- a/dan_layer/template_lib/src/crypto/ristretto.rs
+++ b/dan_layer/template_lib/src/crypto/ristretto.rs
@@ -2,14 +2,16 @@
 //   SPDX-License-Identifier: BSD-3-Clause
 
 use serde::{Deserialize, Serialize};
+use serde_with::{serde_as, Bytes};
 use tari_template_abi::rust::fmt::{Display, Formatter};
 
 use crate::{crypto::InvalidByteLengthError, models::NonFungibleAddress, Hash};
 
 /// A Ristretto public key byte contents
+#[serde_as]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default, Serialize, Deserialize)]
 #[serde(transparent)]
-pub struct RistrettoPublicKeyBytes(#[serde(with = "serde_byte_array")] [u8; RistrettoPublicKeyBytes::length()]);
+pub struct RistrettoPublicKeyBytes(#[serde_as(as = "Bytes")] [u8; RistrettoPublicKeyBytes::length()]);
 
 impl RistrettoPublicKeyBytes {
     pub const fn length() -> usize {

--- a/dan_layer/template_lib/src/hash.rs
+++ b/dan_layer/template_lib/src/hash.rs
@@ -29,11 +29,13 @@ use std::{
 };
 
 use serde::{Deserialize, Serialize};
+use serde_with::{serde_as, Bytes};
 
 /// Representation of a 32-byte hash value
+#[serde_as]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Ord, PartialOrd, Hash, Default, Serialize, Deserialize)]
 #[serde(transparent)]
-pub struct Hash([u8; 32]);
+pub struct Hash(#[serde_as(as = "Bytes")] [u8; 32]);
 
 impl Hash {
     pub const fn from_array(bytes: [u8; 32]) -> Self {

--- a/dan_layer/template_lib/src/models/confidential_proof.rs
+++ b/dan_layer/template_lib/src/models/confidential_proof.rs
@@ -2,6 +2,7 @@
 //   SPDX-License-Identifier: BSD-3-Clause
 
 use serde::{Deserialize, Serialize};
+use serde_with::{serde_as, Bytes};
 
 use crate::{
     crypto::{BalanceProofSignature, PedersonCommitmentBytes, RistrettoPublicKeyBytes},
@@ -21,9 +22,10 @@ pub struct ConfidentialOutputProof {
 }
 
 /// A zero-knowledge proof that a confidential resource amount is valid
+#[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ConfidentialStatement {
-    #[serde(with = "serde_byte_array")]
+    #[serde_as(as = "Bytes")]
     pub commitment: [u8; 32],
     /// Public nonce (R) that was used to generate the commitment mask
     // #[cfg_attr(feature = "serde", serde(with = "hex::serde"))]
@@ -47,9 +49,10 @@ pub struct ConfidentialWithdrawProof {
 
 /// Used by the receiver to determine the value component of the commitment, in both confidential transfers and Minotari
 /// burns
+#[serde_as]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(transparent)]
-pub struct EncryptedData(#[serde(with = "serde_byte_array")] pub [u8; EncryptedData::size()]);
+pub struct EncryptedData(#[serde_as(as = "Bytes")] pub [u8; EncryptedData::size()]);
 
 impl EncryptedData {
     pub const fn size() -> usize {

--- a/dan_layer/template_lib/src/models/non_fungible.rs
+++ b/dan_layer/template_lib/src/models/non_fungible.rs
@@ -2,6 +2,7 @@
 //   SPDX-License-Identifier: BSD-3-Clause
 
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde_with::{serde_as, Bytes};
 use tari_bor::BorTag;
 use tari_template_abi::{
     call_engine,
@@ -22,9 +23,10 @@ use crate::{
 const DELIM: char = ':';
 
 /// The unique identification of a non-fungible token inside it's parent resource
+#[serde_as]
 #[derive(Debug, Clone, Ord, PartialOrd, PartialEq, Eq, Serialize, Deserialize, Hash)]
 pub enum NonFungibleId {
-    U256(#[serde(with = "serde_byte_array")] [u8; 32]),
+    U256(#[serde_as(as = "Bytes")] [u8; 32]),
     String(String),
     Uint32(u32),
     Uint64(u64),


### PR DESCRIPTION
Description
---
Remove `serde-byte-array` crate, use `serde_as(as = "Bytes")` ([available ](https://docs.rs/serde_with/2.3.3/serde_with/struct.Bytes.html)in `serde_with` crate, that we are already using) instead where necessary. Also add this serialization to `Hash`. This fixes the variable fees for transaction which was caused by the default CBOR serialization of arrays.
Before this change the fees for transactions were:
account create 371-375
transaction(non confidential) 736-742

After this change.
account create 355
transaction(non confidential) 701

Motivation and Context
---

How Has This Been Tested?
---
Running dan-testing with 2 committees and 10 accounts and transactions in between.

What process can a PR reviewer use to test or verify this change?
---
Probably something similar as above. 


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify