### PR TITLE
fix(messaging): check and clear closed substreams before use

### DIFF
--- a/networking/libp2p-messaging/src/stream.rs
+++ b/networking/libp2p-messaging/src/stream.rs
@@ -71,6 +71,10 @@ impl<TMsg> MessageSink<TMsg> {
         self.sender.unbounded_send(msg).map_err(|_| crate::Error::ChannelClosed)
     }
 
+    pub fn is_closed(&self) -> bool {
+        self.sender.is_closed()
+    }
+
     pub async fn send_all<TStream>(&mut self, stream: &mut TStream) -> Result<(), crate::Error>
     where TStream: Stream<Item = Result<TMsg, mpsc::SendError>> + Unpin + ?Sized {
         self.sender


### PR DESCRIPTION
Description
---
fix(messaging): check and clear closed substreams before use

Motivation and Context
---
Observed error in logs, when outbound message is being sent that messaging channel, was closed. This PR ensures that we check this before returning the channel back to users.

How Has This Been Tested?
---
Messaging behaviour needs more testing, Manually

What process can a PR reviewer use to test or verify this change?
---
VN can send messages

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify