### PR TITLE
fix: use hash domains from tari_hash_domains

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9336,6 +9336,7 @@ dependencies = [
  "tari_dan_storage",
  "tari_dan_wallet_storage_sqlite",
  "tari_engine_types",
+ "tari_hash_domains",
  "tari_key_manager",
  "tari_template_lib",
  "tari_transaction",

--- a/dan_layer/engine_types/src/hashing.rs
+++ b/dan_layer/engine_types/src/hashing.rs
@@ -29,10 +29,9 @@ use blake2::{
 use digest::Digest;
 use serde::Serialize;
 use tari_bor::encode_into;
-use tari_crypto::{hash_domain, hashing::DomainSeparation};
+use tari_crypto::hashing::DomainSeparation;
+use tari_hash_domains::TariEngineHashDomain;
 use tari_template_lib::Hash;
-
-hash_domain!(TariEngineHashDomain, "com.tari.dan.engine", 0);
 
 pub fn hasher64(label: EngineHashDomainLabel) -> TariHasher64 {
     TariHasher64::new_with_label::<TariEngineHashDomain>(label.as_label())

--- a/dan_layer/wallet/sdk/Cargo.toml
+++ b/dan_layer/wallet/sdk/Cargo.toml
@@ -14,6 +14,7 @@ tari_engine_types = { workspace = true }
 tari_dan_common_types = { workspace = true }
 # Just used for QuorumCertificate
 tari_dan_storage = { workspace = true }
+tari_hash_domains = { workspace = true }
 tari_key_manager = { workspace = true }
 tari_transaction = { workspace = true }
 tari_template_lib = { workspace = true }

--- a/dan_layer/wallet/sdk/src/confidential/proof.rs
+++ b/dan_layer/wallet/sdk/src/confidential/proof.rs
@@ -22,7 +22,6 @@ use tari_crypto::{
     commitment::{ExtensionDegree, HomomorphicCommitmentFactory},
     errors::RangeProofError,
     extended_range_proof::ExtendedRangeProofService,
-    hash_domain,
     hashing::DomainSeparatedHasher,
     keys::SecretKey,
     ristretto::bulletproofs_plus::{BulletproofsPlusService, RistrettoExtendedMask, RistrettoExtendedWitness},

--- a/dan_layer/wallet/sdk/src/confidential/proof.rs
+++ b/dan_layer/wallet/sdk/src/confidential/proof.rs
@@ -28,6 +28,7 @@ use tari_crypto::{
     ristretto::bulletproofs_plus::{BulletproofsPlusService, RistrettoExtendedMask, RistrettoExtendedWitness},
     tari_utilities::ByteArray,
 };
+use tari_hash_domains::TransactionSecureNonceKdfDomain;
 use tari_template_lib::{
     crypto::RistrettoPublicKeyBytes,
     models::{Amount, ConfidentialOutputProof, ConfidentialStatement, EncryptedData},
@@ -119,12 +120,6 @@ pub fn generate_confidential_proof(
 
 fn inner_encrypted_data_kdf_aead(encryption_key: &PrivateKey, commitment: &Commitment) -> EncryptedDataKey32 {
     let mut aead_key = EncryptedDataKey32::from(SafeArray::default());
-    // This has to be the same as the base layer so that burn claims are spendable
-    hash_domain!(
-        TransactionSecureNonceKdfDomain,
-        "com.tari.base_layer.core.transactions.secure_nonce_kdf",
-        0
-    );
     DomainSeparatedHasher::<Blake2b<U32>, TransactionSecureNonceKdfDomain>::new_with_label("encrypted_value_and_mask")
         .chain(encryption_key.as_bytes())
         .chain(commitment.as_bytes())


### PR DESCRIPTION
Description
---
Use hash domains from the `tari` repo.

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify