### PR TITLE
fix(engine)!: determinism bug with log entries

### DIFF
--- a/applications/tari_dan_wallet_web_ui/src/routes/Transactions/Logs.tsx
+++ b/applications/tari_dan_wallet_web_ui/src/routes/Transactions/Logs.tsx
@@ -26,7 +26,6 @@ import { DataTableCell } from "../../Components/StyledComponents";
 interface Log {
   level: string;
   message: string;
-  timestamp: string;
 }
 
 export default function Logs({ data }: { data: Log[] }) {
@@ -37,16 +36,14 @@ export default function Logs({ data }: { data: Log[] }) {
           <TableRow>
             <TableCell>Level</TableCell>
             <TableCell>Message</TableCell>
-            <TableCell>Timestamp</TableCell>
           </TableRow>
         </TableHead>
         <TableBody>
-          {data.map(({ level, message, timestamp }: any, index: number) => {
+          {data.map(({ level, message }, index: number) => {
             return (
               <TableRow key={index}>
                 <DataTableCell>{level}</DataTableCell>
                 <DataTableCell>{message}</DataTableCell>
-                <DataTableCell>{timestamp}</DataTableCell>
               </TableRow>
             );
           })}

--- a/applications/tari_validator_node_web_ui/src/routes/Transactions/Logs.tsx
+++ b/applications/tari_validator_node_web_ui/src/routes/Transactions/Logs.tsx
@@ -26,7 +26,6 @@ import { DataTableCell } from "../../Components/StyledComponents";
 interface Log {
   level: string;
   message: string;
-  timestamp: string;
 }
 
 export default function Logs({ data }: { data: Log[] }) {
@@ -37,16 +36,14 @@ export default function Logs({ data }: { data: Log[] }) {
           <TableRow>
             <TableCell>Level</TableCell>
             <TableCell>Message</TableCell>
-            <TableCell>Timestamp</TableCell>
           </TableRow>
         </TableHead>
         <TableBody>
-          {data.map(({ level, message, timestamp }: any, index: number) => {
+          {data.map(({ level, message }, index: number) => {
             return (
               <TableRow key={index}>
                 <DataTableCell>{level}</DataTableCell>
                 <DataTableCell>{message}</DataTableCell>
-                <DataTableCell>{timestamp}</DataTableCell>
               </TableRow>
             );
           })}

--- a/dan_layer/engine_types/src/logs.rs
+++ b/dan_layer/engine_types/src/logs.rs
@@ -20,10 +20,7 @@
 //   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //   USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::{
-    fmt::Display,
-    time::{Duration, SystemTime, UNIX_EPOCH},
-};
+use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
 pub use tari_template_lib::args::LogLevel;
@@ -33,29 +30,18 @@ use ts_rs::TS;
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[cfg_attr(feature = "ts", derive(TS), ts(export, export_to = "../../bindings/src/types/"))]
 pub struct LogEntry {
-    #[cfg_attr(feature = "ts", ts(type = "number"))]
-    pub timestamp: u64,
     pub message: String,
     pub level: LogLevel,
 }
 
 impl LogEntry {
     pub fn new(level: LogLevel, message: String) -> Self {
-        let now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            // If the errors, the clock has been set before the UNIX_EPOCH
-            .unwrap_or_else(|_| Duration::from_secs(0))
-            .as_secs();
-        Self {
-            timestamp: now,
-            message,
-            level,
-        }
+        Self { message, level }
     }
 }
 
 impl Display for LogEntry {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{} {} {}", self.timestamp, self.level, self.message)
+        write!(f, "{} {}", self.level, self.message)
     }
 }


### PR DESCRIPTION
Description
---
Remove timestamp from LogEntry to fix determinism bug in txreceipt
Removed timestamp from UI

Motivation and Context
---
Initially logs were not part of any substate, but these are added in TxReceipt. Logs contained a timestamp based on the local clock of the VN.

This PR removes the timestamp, ordering is maintained by the Vec.

How Has This Been Tested?
---
Not explicitly tested. This caused Merkle root mismatches in #924 

What process can a PR reviewer use to test or verify this change?
---
Check that tx receipt does not have local time in it

Breaking Changes
---

- [ ] None
- [x] Requires data directory to be deleted
- [ ] Other - Please specify