### PR TITLE
fix(consensus): dont transition to error state with invalid foreign proposal

### DIFF
--- a/dan_layer/consensus_tests/src/consensus.rs
+++ b/dan_layer/consensus_tests/src/consensus.rs
@@ -405,12 +405,12 @@ async fn leader_failure_node_goes_down() {
     test.assert_clean_shutdown().await;
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn foreign_block_distribution() {
     setup_logger();
     let mut test = Test::builder()
         .with_test_timeout(Duration::from_secs(60))
-        .with_hotstuff_filter(Box::new(|from: &TestAddress, to: &TestAddress, _| {
+        .with_message_filter(Box::new(move |from: &TestAddress, to: &TestAddress, _| {
             match from.0.as_str() {
                 // We filter our message from each leader to the foreign committees. So we will rely on other members of
                 // the local committees to send the message to the foreign committee members. And then on

--- a/dan_layer/consensus_tests/src/support/harness.rs
+++ b/dan_layer/consensus_tests/src/support/harness.rs
@@ -21,7 +21,7 @@ use tari_shutdown::{Shutdown, ShutdownSignal};
 use tari_transaction::TransactionId;
 use tokio::{sync::broadcast, task};
 
-use super::HotstuffFilter;
+use super::MessageFilter;
 use crate::support::{
     address::TestAddress,
     epoch_manager::TestEpochManager,
@@ -283,7 +283,7 @@ pub struct TestBuilder {
     sql_address: String,
     timeout: Option<Duration>,
     debug_sql_file: Option<String>,
-    hotstuff_filter: Option<HotstuffFilter>,
+    message_filter: Option<MessageFilter>,
 }
 
 impl TestBuilder {
@@ -293,7 +293,7 @@ impl TestBuilder {
             sql_address: ":memory:".to_string(),
             timeout: Some(Duration::from_secs(10)),
             debug_sql_file: None,
-            hotstuff_filter: None,
+            message_filter: None,
         }
     }
 
@@ -337,8 +337,8 @@ impl TestBuilder {
         self
     }
 
-    pub fn with_hotstuff_filter(mut self, hotstuff_filter: HotstuffFilter) -> Self {
-        self.hotstuff_filter = Some(hotstuff_filter);
+    pub fn with_message_filter(mut self, message_filter: MessageFilter) -> Self {
+        self.message_filter = Some(message_filter.into());
         self
     }
 
@@ -389,7 +389,7 @@ impl TestBuilder {
         let (channels, validators) = self
             .build_validators(&leader_strategy, &epoch_manager, shutdown.to_signal())
             .await;
-        let network = spawn_network(channels, shutdown.to_signal(), self.hotstuff_filter);
+        let network = spawn_network(channels, shutdown.to_signal(), self.message_filter);
 
         Test {
             validators,


### PR DESCRIPTION
Description
---
fix(consensus): dont transition to error state with invalid foreign proposal
test(consensus): fix flaky `foreign_block_distribution` test

Motivation and Context
---
Invalid messages should not cause the state machine to transition to error.
foreign_block_distribution is often flaky in CI. Hopefully this will fix it :crossed_fingers: 

How Has This Been Tested?
---
Ran `foreign_block_distribution`

What process can a PR reviewer use to test or verify this change?
---
CI

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify