### PR TITLE
fix(walletd): handle null NFT metadata case

### DIFF
--- a/dan_layer/engine_types/src/non_fungible.rs
+++ b/dan_layer/engine_types/src/non_fungible.rs
@@ -68,7 +68,11 @@ impl NonFungible {
     }
 
     pub fn decode_data(&self) -> Result<Metadata, BorError> {
-        decode_exact(&self.data)
+        let value = decode_exact::<tari_bor::Value>(&self.data)?;
+        if value.is_null() {
+            return Ok(Metadata::default());
+        }
+        tari_bor::from_value(&value)
     }
 
     pub fn set_mutable_data(&mut self, mutable_data: Vec<u8>) {


### PR DESCRIPTION
Description
---
fix(walletd): handle null NFT metadata case

Motivation and Context
---
Wallet will now correctly store NFTs with null metadata

How Has This Been Tested?
---
Manually

What process can a PR reviewer use to test or verify this change?
---


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify