### PR TITLE
fix: clippy on new rust stable

### DIFF
--- a/applications/tari_indexer/src/json_rpc/handlers.rs
+++ b/applications/tari_indexer/src/json_rpc/handlers.rs
@@ -253,14 +253,16 @@ impl JsonRpcHandlers {
         let answer_id = value.get_answer_id();
         let request: GetSubstateRequest = value.parse_params()?;
 
-        match self
+        let maybe_substate = self
             .substate_manager
             .get_substate(&request.address, request.version)
             .await
             .map_err(|e| {
                 warn!(target: LOG_TARGET, "Error getting substate: {}", e);
                 Self::internal_error(answer_id, format!("Error getting substate: {}", e))
-            })? {
+            })?;
+
+        match maybe_substate {
             Some(substate_resp) => Ok(JsonRpcResponse::success(answer_id, GetSubstateResponse {
                 address: substate_resp.address,
                 version: substate_resp.version,

--- a/dan_layer/consensus_tests/src/support/harness.rs
+++ b/dan_layer/consensus_tests/src/support/harness.rs
@@ -338,7 +338,7 @@ impl TestBuilder {
     }
 
     pub fn with_message_filter(mut self, message_filter: MessageFilter) -> Self {
-        self.message_filter = Some(message_filter.into());
+        self.message_filter = Some(message_filter);
         self
     }
 


### PR DESCRIPTION
Description
---
Fixes clippy error on new rust stable 1.76

Motivation and Context
---
Clippy breaks on CI

How Has This Been Tested?
---
Clippy passes



Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify