### PR TITLE
chore: update to latest feature-dan2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3994,7 +3994,7 @@ dependencies = [
  "indexmap 2.1.0",
  "libp2p",
  "log",
- "log4rs 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log4rs",
  "minotari_app_grpc",
  "minotari_app_utilities",
  "minotari_console_wallet",
@@ -5044,9 +5044,9 @@ checksum = "a94d21414c1f4a51209ad204c1776a3d0765002c76c6abcb602a6f09f1e881c7"
 
 [[package]]
 name = "log4rs"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d36ca1786d9e79b8193a68d480a0907b612f109537115c6ff655a3a1967533fd"
+checksum = "0816135ae15bd0391cf284eab37e6e3ee0a6ee63d2ceeb659862bd8d0a984ca6"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -5057,35 +5057,13 @@ dependencies = [
  "libc",
  "log",
  "log-mdc",
+ "once_cell",
  "parking_lot 0.12.1",
+ "rand",
  "serde",
  "serde-value",
  "serde_json",
- "serde_yaml 0.8.26",
- "thiserror",
- "thread-id",
- "typemap-ors",
- "winapi",
-]
-
-[[package]]
-name = "log4rs"
-version = "1.2.0"
-source = "git+https://github.com/tari-project/log4rs.git#e1051fd3a1bec9c55d055f60176a96cf11e58505"
-dependencies = [
- "anyhow",
- "arc-swap",
- "chrono",
- "derivative",
- "fnv",
- "humantime 2.1.0",
- "libc",
- "log",
- "log-mdc",
- "parking_lot 0.12.1",
- "serde",
- "serde-value",
- "serde_yaml 0.8.26",
+ "serde_yaml",
  "thiserror",
  "thread-id",
  "typemap-ors",
@@ -5324,7 +5302,7 @@ dependencies = [
 [[package]]
 name = "minotari_app_grpc"
 version = "1.0.0-dan.5"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#e422a12d86b8f6f4df3dedb961883f8ee58c55d3"
+source = "git+https://github.com/sdbondi/tari.git?branch=update-feature-dan2#f8a3ec2da4bd3ca970b5e982f91b5da9f6e1e358"
 dependencies = [
  "argon2",
  "base64 0.13.1",
@@ -5352,7 +5330,7 @@ dependencies = [
 [[package]]
 name = "minotari_app_utilities"
 version = "1.0.0-dan.5"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#e422a12d86b8f6f4df3dedb961883f8ee58c55d3"
+source = "git+https://github.com/sdbondi/tari.git?branch=update-feature-dan2#f8a3ec2da4bd3ca970b5e982f91b5da9f6e1e358"
 dependencies = [
  "clap 3.2.25",
  "dialoguer",
@@ -5374,7 +5352,7 @@ dependencies = [
 [[package]]
 name = "minotari_console_wallet"
 version = "1.0.0-dan.5"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#e422a12d86b8f6f4df3dedb961883f8ee58c55d3"
+source = "git+https://github.com/sdbondi/tari.git?branch=update-feature-dan2#f8a3ec2da4bd3ca970b5e982f91b5da9f6e1e358"
 dependencies = [
  "blake2",
  "chrono",
@@ -5385,7 +5363,7 @@ dependencies = [
  "digest 0.10.7",
  "futures 0.3.30",
  "log",
- "log4rs 1.2.0 (git+https://github.com/tari-project/log4rs.git)",
+ "log4rs",
  "minotari_app_grpc",
  "minotari_app_utilities",
  "minotari_wallet",
@@ -5408,7 +5386,7 @@ dependencies = [
  "tari_core",
  "tari_crypto",
  "tari_features",
- "tari_hash_domains",
+ "tari_hash_domains 1.0.0-dan.5",
  "tari_key_manager",
  "tari_libtor",
  "tari_p2p",
@@ -5429,7 +5407,7 @@ dependencies = [
 [[package]]
 name = "minotari_node"
 version = "1.0.0-dan.5"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#e422a12d86b8f6f4df3dedb961883f8ee58c55d3"
+source = "git+https://github.com/sdbondi/tari.git?branch=update-feature-dan2#f8a3ec2da4bd3ca970b5e982f91b5da9f6e1e358"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5445,7 +5423,7 @@ dependencies = [
  "futures 0.3.30",
  "log",
  "log-mdc",
- "log4rs 1.2.0 (git+https://github.com/tari-project/log4rs.git)",
+ "log4rs",
  "minotari_app_grpc",
  "minotari_app_utilities",
  "nom",
@@ -5462,7 +5440,6 @@ dependencies = [
  "tari_crypto",
  "tari_features",
  "tari_libtor",
- "tari_metrics",
  "tari_p2p",
  "tari_service_framework",
  "tari_shutdown",
@@ -5476,7 +5453,7 @@ dependencies = [
 [[package]]
 name = "minotari_node_grpc_client"
 version = "0.1.0"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#e422a12d86b8f6f4df3dedb961883f8ee58c55d3"
+source = "git+https://github.com/sdbondi/tari.git?branch=update-feature-dan2#f8a3ec2da4bd3ca970b5e982f91b5da9f6e1e358"
 dependencies = [
  "minotari_app_grpc",
 ]
@@ -5484,7 +5461,7 @@ dependencies = [
 [[package]]
 name = "minotari_wallet"
 version = "1.0.0-dan.5"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#e422a12d86b8f6f4df3dedb961883f8ee58c55d3"
+source = "git+https://github.com/sdbondi/tari.git?branch=update-feature-dan2#f8a3ec2da4bd3ca970b5e982f91b5da9f6e1e358"
 dependencies = [
  "argon2",
  "async-trait",
@@ -5533,7 +5510,7 @@ dependencies = [
 [[package]]
 name = "minotari_wallet_grpc_client"
 version = "0.1.0"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#e422a12d86b8f6f4df3dedb961883f8ee58c55d3"
+source = "git+https://github.com/sdbondi/tari.git?branch=update-feature-dan2#f8a3ec2da4bd3ca970b5e982f91b5da9f6e1e358"
 dependencies = [
  "minotari_app_grpc",
  "tari_common_types",
@@ -7798,12 +7775,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scoped-tls"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8065,18 +8036,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.48",
-]
-
-[[package]]
-name = "serde_yaml"
-version = "0.8.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578a7433b776b56a35785ed5ce9a7e777ac0598aac5a6dd1b4b18a307c7fc71b"
-dependencies = [
- "indexmap 1.9.3",
- "ryu",
- "serde",
- "yaml-rust",
 ]
 
 [[package]]
@@ -8744,7 +8703,7 @@ dependencies = [
 [[package]]
 name = "tari_common"
 version = "1.0.0-dan.5"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#e422a12d86b8f6f4df3dedb961883f8ee58c55d3"
+source = "git+https://github.com/sdbondi/tari.git?branch=update-feature-dan2#f8a3ec2da4bd3ca970b5e982f91b5da9f6e1e358"
 dependencies = [
  "anyhow",
  "blake2",
@@ -8752,13 +8711,13 @@ dependencies = [
  "dirs-next 1.0.2",
  "git2",
  "log",
- "log4rs 1.2.0 (git+https://github.com/tari-project/log4rs.git)",
+ "log4rs",
  "multiaddr 0.14.0",
  "path-clean",
  "prost-build 0.11.9",
  "serde",
  "serde_json",
- "serde_yaml 0.9.27",
+ "serde_yaml",
  "sha2",
  "structopt",
  "tari_crypto",
@@ -8771,7 +8730,7 @@ dependencies = [
 [[package]]
 name = "tari_common_sqlite"
 version = "1.0.0-dan.5"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#e422a12d86b8f6f4df3dedb961883f8ee58c55d3"
+source = "git+https://github.com/sdbondi/tari.git?branch=update-feature-dan2#f8a3ec2da4bd3ca970b5e982f91b5da9f6e1e358"
 dependencies = [
  "diesel",
  "diesel_migrations",
@@ -8785,7 +8744,7 @@ dependencies = [
 [[package]]
 name = "tari_common_types"
 version = "1.0.0-dan.5"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#e422a12d86b8f6f4df3dedb961883f8ee58c55d3"
+source = "git+https://github.com/sdbondi/tari.git?branch=update-feature-dan2#f8a3ec2da4bd3ca970b5e982f91b5da9f6e1e358"
 dependencies = [
  "base64 0.21.7",
  "blake2",
@@ -8807,7 +8766,7 @@ dependencies = [
 [[package]]
 name = "tari_comms"
 version = "1.0.0-dan.5"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#e422a12d86b8f6f4df3dedb961883f8ee58c55d3"
+source = "git+https://github.com/sdbondi/tari.git?branch=update-feature-dan2#f8a3ec2da4bd3ca970b5e982f91b5da9f6e1e358"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8835,7 +8794,6 @@ dependencies = [
  "snow",
  "tari_common",
  "tari_crypto",
- "tari_metrics",
  "tari_shutdown",
  "tari_storage",
  "tari_utilities",
@@ -8852,7 +8810,7 @@ dependencies = [
 [[package]]
 name = "tari_comms_dht"
 version = "1.0.0-dan.5"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#e422a12d86b8f6f4df3dedb961883f8ee58c55d3"
+source = "git+https://github.com/sdbondi/tari.git?branch=update-feature-dan2#f8a3ec2da4bd3ca970b5e982f91b5da9f6e1e358"
 dependencies = [
  "anyhow",
  "bitflags 2.4.1",
@@ -8887,7 +8845,7 @@ dependencies = [
 [[package]]
 name = "tari_comms_rpc_macros"
 version = "1.0.0-dan.5"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#e422a12d86b8f6f4df3dedb961883f8ee58c55d3"
+source = "git+https://github.com/sdbondi/tari.git?branch=update-feature-dan2#f8a3ec2da4bd3ca970b5e982f91b5da9f6e1e358"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8920,7 +8878,7 @@ dependencies = [
 [[package]]
 name = "tari_contacts"
 version = "1.0.0-dan.5"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#e422a12d86b8f6f4df3dedb961883f8ee58c55d3"
+source = "git+https://github.com/sdbondi/tari.git?branch=update-feature-dan2#f8a3ec2da4bd3ca970b5e982f91b5da9f6e1e358"
 dependencies = [
  "chrono",
  "diesel",
@@ -8952,7 +8910,7 @@ dependencies = [
 [[package]]
 name = "tari_core"
 version = "1.0.0-dan.5"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#e422a12d86b8f6f4df3dedb961883f8ee58c55d3"
+source = "git+https://github.com/sdbondi/tari.git?branch=update-feature-dan2#f8a3ec2da4bd3ca970b5e982f91b5da9f6e1e358"
 dependencies = [
  "async-trait",
  "bincode 1.3.3",
@@ -8996,7 +8954,7 @@ dependencies = [
  "tari_comms_dht",
  "tari_comms_rpc_macros",
  "tari_crypto",
- "tari_hash_domains",
+ "tari_hash_domains 1.0.0-dan.5",
  "tari_key_manager",
  "tari_mmr",
  "tari_p2p",
@@ -9101,7 +9059,7 @@ dependencies = [
  "tari_core",
  "tari_crypto",
  "tari_engine_types",
- "tari_hash_domains",
+ "tari_hash_domains 0.1.0",
  "tari_mmr",
  "ts-rs",
 ]
@@ -9259,7 +9217,7 @@ dependencies = [
  "include_dir",
  "libsqlite3-sys",
  "log",
- "log4rs 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log4rs",
  "mime_guess",
  "minotari_app_utilities",
  "rand",
@@ -9312,7 +9270,7 @@ dependencies = [
  "tari_dan_storage",
  "tari_dan_wallet_storage_sqlite",
  "tari_engine_types",
- "tari_hash_domains",
+ "tari_hash_domains 0.1.0",
  "tari_key_manager",
  "tari_template_abi",
  "tari_template_lib",
@@ -9363,7 +9321,7 @@ dependencies = [
  "tari_common",
  "tari_common_types",
  "tari_crypto",
- "tari_hash_domains",
+ "tari_hash_domains 0.1.0",
  "tari_template_abi",
  "tari_template_lib",
  "tari_utilities",
@@ -9394,12 +9352,20 @@ dependencies = [
 [[package]]
 name = "tari_features"
 version = "1.0.0-dan.5"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#e422a12d86b8f6f4df3dedb961883f8ee58c55d3"
+source = "git+https://github.com/sdbondi/tari.git?branch=update-feature-dan2#f8a3ec2da4bd3ca970b5e982f91b5da9f6e1e358"
 
 [[package]]
 name = "tari_hash_domains"
 version = "0.1.0"
 source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#e422a12d86b8f6f4df3dedb961883f8ee58c55d3"
+dependencies = [
+ "tari_crypto",
+]
+
+[[package]]
+name = "tari_hash_domains"
+version = "1.0.0-dan.5"
+source = "git+https://github.com/sdbondi/tari.git?branch=update-feature-dan2#f8a3ec2da4bd3ca970b5e982f91b5da9f6e1e358"
 dependencies = [
  "tari_crypto",
 ]
@@ -9420,7 +9386,7 @@ dependencies = [
  "include_dir",
  "libp2p",
  "log",
- "log4rs 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log4rs",
  "mime_guess",
  "minotari_app_utilities",
  "reqwest",
@@ -9495,7 +9461,7 @@ dependencies = [
 [[package]]
 name = "tari_key_manager"
 version = "1.0.0-dan.5"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#e422a12d86b8f6f4df3dedb961883f8ee58c55d3"
+source = "git+https://github.com/sdbondi/tari.git?branch=update-feature-dan2#f8a3ec2da4bd3ca970b5e982f91b5da9f6e1e358"
 dependencies = [
  "argon2",
  "async-trait",
@@ -9527,8 +9493,8 @@ dependencies = [
 
 [[package]]
 name = "tari_libtor"
-version = "0.24.0"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#e422a12d86b8f6f4df3dedb961883f8ee58c55d3"
+version = "1.0.0-pre.8"
+source = "git+https://github.com/sdbondi/tari.git?branch=update-feature-dan2#f8a3ec2da4bd3ca970b5e982f91b5da9f6e1e358"
 dependencies = [
  "derivative",
  "libtor",
@@ -9537,7 +9503,6 @@ dependencies = [
  "rand",
  "tari_common",
  "tari_p2p",
- "tari_shutdown",
  "tempfile",
  "tor-hash-passwd",
 ]
@@ -9547,21 +9512,15 @@ name = "tari_metrics"
 version = "0.1.0"
 source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#e422a12d86b8f6f4df3dedb961883f8ee58c55d3"
 dependencies = [
- "anyhow",
- "futures 0.3.30",
- "log",
  "once_cell",
  "prometheus",
- "reqwest",
  "thiserror",
- "tokio",
- "warp",
 ]
 
 [[package]]
 name = "tari_mmr"
 version = "1.0.0-dan.5"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#e422a12d86b8f6f4df3dedb961883f8ee58c55d3"
+source = "git+https://github.com/sdbondi/tari.git?branch=update-feature-dan2#f8a3ec2da4bd3ca970b5e982f91b5da9f6e1e358"
 dependencies = [
  "borsh",
  "digest 0.10.7",
@@ -9592,7 +9551,7 @@ dependencies = [
 [[package]]
 name = "tari_p2p"
 version = "1.0.0-dan.5"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#e422a12d86b8f6f4df3dedb961883f8ee58c55d3"
+source = "git+https://github.com/sdbondi/tari.git?branch=update-feature-dan2#f8a3ec2da4bd3ca970b5e982f91b5da9f6e1e358"
 dependencies = [
  "anyhow",
  "fs2",
@@ -9693,8 +9652,8 @@ dependencies = [
 
 [[package]]
 name = "tari_script"
-version = "0.12.0"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#e422a12d86b8f6f4df3dedb961883f8ee58c55d3"
+version = "1.0.0-pre.8"
+source = "git+https://github.com/sdbondi/tari.git?branch=update-feature-dan2#f8a3ec2da4bd3ca970b5e982f91b5da9f6e1e358"
 dependencies = [
  "blake2",
  "borsh",
@@ -9711,7 +9670,7 @@ dependencies = [
 [[package]]
 name = "tari_service_framework"
 version = "1.0.0-dan.5"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#e422a12d86b8f6f4df3dedb961883f8ee58c55d3"
+source = "git+https://github.com/sdbondi/tari.git?branch=update-feature-dan2#f8a3ec2da4bd3ca970b5e982f91b5da9f6e1e358"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9726,7 +9685,7 @@ dependencies = [
 [[package]]
 name = "tari_shutdown"
 version = "1.0.0-dan.5"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#e422a12d86b8f6f4df3dedb961883f8ee58c55d3"
+source = "git+https://github.com/sdbondi/tari.git?branch=update-feature-dan2#f8a3ec2da4bd3ca970b5e982f91b5da9f6e1e358"
 dependencies = [
  "futures 0.3.30",
 ]
@@ -9798,7 +9757,7 @@ dependencies = [
 [[package]]
 name = "tari_storage"
 version = "1.0.0-dan.5"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#e422a12d86b8f6f4df3dedb961883f8ee58c55d3"
+source = "git+https://github.com/sdbondi/tari.git?branch=update-feature-dan2#f8a3ec2da4bd3ca970b5e982f91b5da9f6e1e358"
 dependencies = [
  "bincode 1.3.3",
  "lmdb-zero",
@@ -9885,7 +9844,7 @@ dependencies = [
 [[package]]
 name = "tari_test_utils"
 version = "1.0.0-dan.5"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#e422a12d86b8f6f4df3dedb961883f8ee58c55d3"
+source = "git+https://github.com/sdbondi/tari.git?branch=update-feature-dan2#f8a3ec2da4bd3ca970b5e982f91b5da9f6e1e358"
 dependencies = [
  "futures 0.3.30",
  "rand",
@@ -9960,7 +9919,7 @@ dependencies = [
  "libp2p",
  "libsqlite3-sys",
  "log",
- "log4rs 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log4rs",
  "mime_guess",
  "minotari_app_grpc",
  "minotari_app_utilities",
@@ -11131,35 +11090,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "warp"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e92e22e03ff1230c03a1a8ee37d2f89cd489e2e541b7550d6afad96faed169"
-dependencies = [
- "bytes 1.5.0",
- "futures-channel",
- "futures-util",
- "headers",
- "http",
- "hyper",
- "log",
- "mime",
- "mime_guess",
- "percent-encoding",
- "pin-project 1.1.3",
- "rustls-pemfile 1.0.4",
- "scoped-tls",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "tokio",
- "tokio-stream",
- "tokio-util 0.7.10",
- "tower-service",
- "tracing",
-]
-
-[[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12259,3 +12189,8 @@ dependencies = [
  "regex",
  "time",
 ]
+
+[[patch.unused]]
+name = "tari_metrics"
+version = "1.0.0-pre.8"
+source = "git+https://github.com/sdbondi/tari.git?branch=update-feature-dan2#f8a3ec2da4bd3ca970b5e982f91b5da9f6e1e358"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,9 +39,9 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac1f845298e95f983ff1944b728ae08b8cebab80d684f0a832ed0fc74dfa27e2"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher 0.4.4",
@@ -64,9 +64,9 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a824f2aa7e75a0c98c5a504fceb80649e9c35265d44525b5f94de4771a395cd"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
 dependencies = [
  "getrandom",
  "once_cell",
@@ -75,9 +75,9 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.6"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
+checksum = "42cd52102d3df161c77a887b608d7a4897d7cc112886a9537b738a887a03aaff"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -102,13 +102,12 @@ checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 
 [[package]]
 name = "alloy-rlp"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc0fac0fc16baf1f63f78b47c3d24718f3619b0714076f6a02957d808d52cbef"
+checksum = "8d58d9f5da7b40e9bfff0b7e7816700be4019db97d4b6359fe7f94a9e22e42ac"
 dependencies = [
  "arrayvec",
  "bytes 1.5.0",
- "smol_str",
 ]
 
 [[package]]
@@ -137,9 +136,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.5"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d664a92ecae85fd0a7392615844904654d1d5f5514837f471ddef4a057aba1b6"
+checksum = "6e2e1ebcb11de5c03c67de28a7df593d32191b44939c482e97702baaaa6ab6a5"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -151,9 +150,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.4"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
+checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
 
 [[package]]
 name = "anstyle-parse"
@@ -185,9 +184,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.75"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
+checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
 
 [[package]]
 name = "anymap2"
@@ -425,13 +424,13 @@ dependencies = [
 
 [[package]]
 name = "async-channel"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ca33f4bc4ed1babef42cad36cc1f51fa88be00420404e5b1e80ab1b18f7678c"
+checksum = "f28243a43d821d11341ab73c80bed182dc015c514b951616cf79bd4af39af0c3"
 dependencies = [
  "concurrent-queue",
- "event-listener 4.0.0",
- "event-listener-strategy",
+ "event-listener 5.0.0",
+ "event-listener-strategy 0.5.0",
  "futures-core",
  "pin-project-lite",
 ]
@@ -442,26 +441,26 @@ version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17ae5ebefcc48e7452b4987947920dac9450be1110cadf34d1b8c116bdbaf97c"
 dependencies = [
- "async-lock 3.2.0",
+ "async-lock 3.3.0",
  "async-task",
  "concurrent-queue",
  "fastrand 2.0.1",
- "futures-lite 2.1.0",
+ "futures-lite 2.2.0",
  "slab",
 ]
 
 [[package]]
 name = "async-global-executor"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b4353121d5644cdf2beb5726ab752e79a8db1ebb52031770ec47db31d245526"
+checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
 dependencies = [
- "async-channel 2.1.1",
+ "async-channel 2.2.0",
  "async-executor",
- "async-io 2.2.1",
- "async-lock 3.2.0",
+ "async-io 2.3.1",
+ "async-lock 3.3.0",
  "blocking",
- "futures-lite 2.1.0",
+ "futures-lite 2.2.0",
  "once_cell",
 ]
 
@@ -577,18 +576,18 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "2.2.1"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6d3b15875ba253d1110c740755e246537483f152fa334f91abd7fe84c88b3ff"
+checksum = "8f97ab0c5b00a7cdbe5a371b9a782ee7be1316095885c8a4ea1daf490eb0ef65"
 dependencies = [
- "async-lock 3.2.0",
+ "async-lock 3.3.0",
  "cfg-if",
  "concurrent-queue",
  "futures-io",
- "futures-lite 2.1.0",
+ "futures-lite 2.2.0",
  "parking",
- "polling 3.3.1",
- "rustix 0.38.28",
+ "polling 3.4.0",
+ "rustix 0.38.31",
  "slab",
  "tracing",
  "windows-sys 0.52.0",
@@ -605,12 +604,12 @@ dependencies = [
 
 [[package]]
 name = "async-lock"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7125e42787d53db9dd54261812ef17e937c95a51e4d291373b670342fa44310c"
+checksum = "d034b430882f8381900d3fe6f0aaa3ad94f2cb4ac519b429692a1bc2dda4ae7b"
 dependencies = [
- "event-listener 4.0.0",
- "event-listener-strategy",
+ "event-listener 4.0.3",
+ "event-listener-strategy 0.4.0",
  "pin-project-lite",
 ]
 
@@ -636,7 +635,7 @@ dependencies = [
  "cfg-if",
  "event-listener 3.1.0",
  "futures-lite 1.13.0",
- "rustix 0.38.28",
+ "rustix 0.38.31",
  "windows-sys 0.48.0",
 ]
 
@@ -655,13 +654,13 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e47d90f65a225c4527103a8d747001fc56e375203592b25ad103e1ca13124c5"
 dependencies = [
- "async-io 2.2.1",
+ "async-io 2.3.1",
  "async-lock 2.8.0",
  "atomic-waker",
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix 0.38.28",
+ "rustix 0.38.31",
  "signal-hook-registry",
  "slab",
  "windows-sys 0.48.0",
@@ -713,14 +712,14 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
 name = "async-task"
-version = "4.5.0"
+version = "4.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4eb2cdb97421e01129ccb49169d8279ed21e829929144f4a22a6e54ac549ca1"
+checksum = "fbb36e985947064623dbd357f727af08ffd077f93d696782f3c56365fa2e2799"
 
 [[package]]
 name = "async-trait"
@@ -730,7 +729,7 @@ checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -776,14 +775,13 @@ dependencies = [
 
 [[package]]
 name = "auto_impl"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fee3da8ef1276b0bee5dd1c7258010d8fffd31801447323115a25560e1327b89"
+checksum = "823b8bb275161044e2ac7a25879cb3e2480cb403e3943022c7c769c599b756aa"
 dependencies = [
- "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -879,7 +877,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "miniz_oxide",
- "object 0.32.1",
+ "object 0.32.2",
  "rustc-demangle",
 ]
 
@@ -939,9 +937,9 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "basic-cookies"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb53b6b315f924c7f113b162e53b3901c05fc9966baf84d201dfcc7432a4bb38"
+checksum = "67bd8fd42c16bdb08688243dc5f0cc117a3ca9efeeaba3a345a18a6159ad96f7"
 dependencies = [
  "lalrpop",
  "lalrpop-util",
@@ -1024,9 +1022,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
+checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
 dependencies = [
  "serde",
 ]
@@ -1082,12 +1080,12 @@ version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a37913e8dc4ddcc604f0c6d3bf2887c995153af3611de9e23c352b44c1b9118"
 dependencies = [
- "async-channel 2.1.1",
- "async-lock 3.2.0",
+ "async-channel 2.2.0",
+ "async-lock 3.3.0",
  "async-task",
  "fastrand 2.0.1",
  "futures-io",
- "futures-lite 2.1.0",
+ "futures-lite 2.2.0",
  "piper",
  "tracing",
 ]
@@ -1122,7 +1120,7 @@ dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
  "syn_derive",
 ]
 
@@ -1143,9 +1141,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "542f33a8835a0884b006a0c3df3dadd99c0c3f296ed26c2fdc8028e01ad6230c"
+checksum = "c48f0051a4b4c5e0b6d365cd04af53aeaa209e3cc15ec2cdb69e73cc87fbd0dc"
 dependencies = [
  "memchr",
  "serde",
@@ -1163,9 +1161,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.14.0"
+version = "3.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
+checksum = "d32a994c2b3ca201d9b263612a374263f05e7adde37c4707f693dcd375076d1f"
 
 [[package]]
 name = "byte-slice-cast"
@@ -1175,9 +1173,9 @@ checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
 
 [[package]]
 name = "bytecheck"
-version = "0.6.11"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6372023ac861f6e6dc89c8344a8f398fb42aaba2b5dbc649ca0c0e9dbcb627"
+checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
 dependencies = [
  "bytecheck_derive",
  "ptr_meta",
@@ -1186,9 +1184,9 @@ dependencies = [
 
 [[package]]
 name = "bytecheck_derive"
-version = "0.6.11"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7ec4c6f261935ad534c0c22dbef2201b45918860eb1c574b972bd213a76af61"
+checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1203,9 +1201,9 @@ checksum = "e1e5f035d16fc623ae5f74981db80a439803888314e3a555fd6f04acd51a3205"
 
 [[package]]
 name = "bytemuck"
-version = "1.14.0"
+version = "1.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "374d28ec25809ee0e23827c2ab573d729e293f281dfe393500e7ad618baa61c6"
+checksum = "a2ef034f05691a48569bd920a96c81b9d91bbad1ab5ac7c4616c1f6ef36cb79f"
 
 [[package]]
 name = "byteorder"
@@ -1275,9 +1273,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-platform"
-version = "0.1.5"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e34637b3140142bdf929fb439e8aa4ebad7651ebf7b1080b3930aa16ac1459ff"
+checksum = "694c8807f2ae16faecc43dc17d74b3eb042482789fd0eb64b39a2e04e087053f"
 dependencies = [
  "serde",
 ]
@@ -1436,9 +1434,9 @@ checksum = "17cc5e6b5ab06331c33589842070416baa137e8b0eb912b008cfd4a78ada7919"
 
 [[package]]
 name = "chrono"
-version = "0.4.31"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
+checksum = "5bc015644b92d5890fab7489e49d21f879d5c990186827d42ec511919404f38b"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -1446,7 +1444,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.0",
 ]
 
 [[package]]
@@ -1537,24 +1535,24 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.13"
+version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52bdc885e4cacc7f7c9eedc1ef6da641603180c783c41a15c264944deeaab642"
+checksum = "80c21025abd42669a92efc996ef13cfb2c5c627858421ea58d5c3b331a6c134f"
 dependencies = [
  "clap_builder",
- "clap_derive 4.4.7",
+ "clap_derive 4.5.0",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.4.12"
+version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb7fb5e4e979aec3be7791562fcba452f94ad85e954da024396433e0e25a79e9"
+checksum = "458bf1f341769dfcf849846f65dffdf9146daa56bcd2a47cb4e1de9915567c99"
 dependencies = [
  "anstream",
  "anstyle",
- "clap_lex 0.6.0",
- "strsim 0.10.0",
+ "clap_lex 0.7.0",
+ "strsim 0.11.0",
  "terminal_size",
 ]
 
@@ -1573,14 +1571,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.4.7"
+version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
+checksum = "307bc0538d5f0f83b8248db3087aa92fe504e4691294d0c96c0eabc33f47ba47"
 dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -1594,9 +1592,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
+checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
 name = "clipboard-win"
@@ -1691,15 +1689,15 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.7"
+version = "0.15.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c926e00cc70edefdc64d3a5ff31cc65bb97a3460097762bd23afb4d8145fccf8"
+checksum = "0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb"
 dependencies = [
  "encode_unicode",
  "lazy_static",
  "libc",
  "unicode-width",
- "windows-sys 0.45.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1740,9 +1738,9 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28c122c3980598d243d63d9a704629a2d748d101f278052ff068be5a4423ab6f"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "convert_case"
@@ -1799,9 +1797,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce420fe07aecd3e67c5f910618fe65e94158f6dcc0adf44e00d69ce2bdfe0fd0"
+checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
 dependencies = [
  "libc",
 ]
@@ -1888,9 +1886,9 @@ checksum = "fd121741cf3eb82c08dd3023eb55bf2665e5f60ec20f89760cf836ae4562e6a0"
 
 [[package]]
 name = "crc32fast"
-version = "1.3.2"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+checksum = "b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa"
 dependencies = [
  "cfg-if",
 ]
@@ -1903,46 +1901,37 @@ checksum = "7059fff8937831a9ae6f0fe4d658ffabf58f2ca96aa9dec1c889f936f705f216"
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.8"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
+checksum = "176dc175b78f56c0f321911d9c8eb2b77a78a4860b9c19db83835fea1a46649b"
 dependencies = [
- "cfg-if",
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
 dependencies = [
- "cfg-if",
  "crossbeam-epoch",
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.15"
+version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
 dependencies = [
- "autocfg",
- "cfg-if",
  "crossbeam-utils",
- "memoffset 0.9.0",
- "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.16"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
-dependencies = [
- "cfg-if",
-]
+checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 
 [[package]]
 name = "crossterm"
@@ -2058,7 +2047,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "atty",
- "clap 4.4.13",
+ "clap 4.5.0",
  "console",
  "cucumber-codegen",
  "cucumber-expressions",
@@ -2112,24 +2101,24 @@ dependencies = [
 
 [[package]]
 name = "curl"
-version = "0.4.44"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "509bd11746c7ac09ebd19f0b17782eae80aadee26237658a6b4808afb5c11a22"
+checksum = "1e2161dd6eba090ff1594084e95fd67aeccf04382ffea77999ea94ed42ec67b6"
 dependencies = [
  "curl-sys",
  "libc",
  "openssl-probe",
  "openssl-sys",
  "schannel",
- "socket2 0.4.10",
- "winapi",
+ "socket2 0.5.5",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "curl-sys"
-version = "0.4.70+curl-8.5.0"
+version = "0.4.72+curl-8.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c0333d8849afe78a4c8102a429a446bfdd055832af071945520e835ae2d841e"
+checksum = "29cbdc8314c447d11e8fd156dcdd031d9e02a7a976163e396b548c03153bc9ea"
 dependencies = [
  "cc",
  "libc",
@@ -2138,20 +2127,20 @@ dependencies = [
  "openssl-sys",
  "pkg-config",
  "vcpkg",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.1.1"
+version = "4.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89b8c6a2e4b1f45971ad09761aafb85514a84744b67a95e32c3cc1352d1f65c"
+checksum = "0a677b8922c94e01bdbb12126b0bc852f00447528dee1782229af9c720c3f348"
 dependencies = [
  "cfg-if",
  "cpufeatures",
  "curve25519-dalek-derive",
  "digest 0.10.7",
- "fiat-crypto 0.2.5",
+ "fiat-crypto 0.2.6",
  "platforms",
  "rustc_version 0.4.0",
  "subtle",
@@ -2166,7 +2155,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -2192,12 +2181,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.3"
+version = "0.20.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0209d94da627ab5605dcccf08bb18afa5009cfbef48d8a8b7d7bdbc79be25c5e"
+checksum = "c376d08ea6aa96aafe61237c7200d1241cb177b7d3a542d791f2d118e9cbb955"
 dependencies = [
- "darling_core 0.20.3",
- "darling_macro 0.20.3",
+ "darling_core 0.20.6",
+ "darling_macro 0.20.6",
 ]
 
 [[package]]
@@ -2216,16 +2205,16 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.3"
+version = "0.20.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "177e3443818124b357d8e76f53be906d60937f0d3a90773a664fa63fa253e621"
+checksum = "33043dcd19068b8192064c704b3f83eb464f91f1ff527b44a4e2b08d9cdb8855"
 dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
  "strsim 0.10.0",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -2241,13 +2230,13 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.3"
+version = "0.20.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
+checksum = "c5a91391accf613803c2a9bf9abccdbaa07c54b4244a5b64883f9c3c137c86be"
 dependencies = [
- "darling_core 0.20.3",
+ "darling_core 0.20.6",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -2325,9 +2314,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eb30d70a07a3b04884d2677f06bec33509dc67ca60d92949e5535352d3191dc"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
  "serde",
@@ -2453,7 +2442,7 @@ dependencies = [
  "diesel_table_macro_syntax",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -2473,7 +2462,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc5557efc453706fed5e4fa85006fe9817c224c3f480a34c7e5959fd700921c5"
 dependencies = [
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -2562,7 +2551,7 @@ checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -2615,9 +2604,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f628eaec48bfd21b865dc2950cfa014450c01d2fa2b69a86c2fd5844ec523c0"
+checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
@@ -2630,9 +2619,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
 
 [[package]]
 name = "elliptic-curve"
@@ -2706,7 +2695,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -2744,10 +2733,10 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e08b6c6ab82d70f08844964ba10c7babb716de2ecaeab9be5717918a5177d3af"
 dependencies = [
- "darling 0.20.3",
+ "darling 0.20.6",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -2765,9 +2754,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95b3f3e67048839cb0d0781f445682a35113da7121f7c949db0e2be96a4fbece"
+checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
 dependencies = [
  "humantime 2.1.0",
  "is-terminal",
@@ -2830,9 +2819,20 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "4.0.0"
+version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "770d968249b5d99410d61f5bf89057f3199a077a04d087092f58e7d10692baae"
+checksum = "67b215c49b2b248c855fb73579eb1f4f26c38ffdc12973e20e07b91d78d5646e"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b72557800024fabbaa2449dd4bf24e37b93702d457a4d4f2b0dd1f0f039f20c1"
 dependencies = [
  "concurrent-queue",
  "parking",
@@ -2845,7 +2845,17 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "958e4d70b6d5e81971bebec42271ec641e7ff4e170a6fa605f2b8a8b65cb97d3"
 dependencies = [
- "event-listener 4.0.0",
+ "event-listener 4.0.3",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "feedafcaa9b749175d5ac357452a9d41ea2911da598fde46ce1fe02c37751291"
+dependencies = [
+ "event-listener 5.0.0",
  "pin-project-lite",
 ]
 
@@ -2907,7 +2917,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef033ed5e9bad94e55838ca0ca906db0e043f517adda0c8b79c7a8c66c93c1b5"
 dependencies = [
  "cfg-if",
- "rustix 0.38.28",
+ "rustix 0.38.31",
  "windows-sys 0.48.0",
 ]
 
@@ -2939,9 +2949,9 @@ checksum = "e825f6987101665dea6ec934c09ec6d721de7bc1bf92248e1d5810c8cd636b77"
 
 [[package]]
 name = "fiat-crypto"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27573eac26f4dd11e2b1916c3fe1baa56407c83c71a773a8ba17ec0bca03b6b7"
+checksum = "1676f435fc1dadde4d03e43f5d62b259e1ce5f40bd4ffb21db2b42ebe59c1382"
 
 [[package]]
 name = "fixed-hash"
@@ -3114,9 +3124,9 @@ dependencies = [
 
 [[package]]
 name = "futures-lite"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aeee267a1883f7ebef3700f262d2d54de95dfaf38189015a74fdc4e0c7ad8143"
+checksum = "445ba825b27408685aaecefd65178908c36c6e96aaf6d8599419d46e624192ba"
 dependencies = [
  "fastrand 2.0.1",
  "futures-core",
@@ -3133,7 +3143,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -3268,11 +3278,11 @@ checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "git2"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbf97ba92db08df386e10c8ede66a2a0369bd277090afd8710e19e38de9ec0cd"
+checksum = "1b3ba52851e73b46a4c3df1d89343741112003f0f6f13beb0dfac9e457c3fdcd"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "libc",
  "libgit2-sys",
  "log",
@@ -3344,7 +3354,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap 2.1.0",
+ "indexmap 2.2.3",
  "slab",
  "tokio",
  "tokio-util 0.7.10",
@@ -3377,7 +3387,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 dependencies = [
- "ahash 0.7.7",
+ "ahash 0.7.8",
 ]
 
 [[package]]
@@ -3386,7 +3396,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash 0.7.7",
+ "ahash 0.7.8",
 ]
 
 [[package]]
@@ -3395,7 +3405,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
- "ahash 0.8.6",
+ "ahash 0.8.8",
 ]
 
 [[package]]
@@ -3404,7 +3414,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 dependencies = [
- "ahash 0.8.6",
+ "ahash 0.8.8",
  "allocator-api2",
 ]
 
@@ -3471,9 +3481,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.3"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
+checksum = "bd5256b483761cd23699d0da46cc6fd2ee3be420bbe6d020ae4a091e70b7e9fd"
 
 [[package]]
 name = "hex"
@@ -3550,9 +3560,9 @@ dependencies = [
 
 [[package]]
 name = "hkdf"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "791a029f6b9fc27657f6f188ec6e5e43f6911f6f878e0dc5501396e09809d437"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
  "hmac",
 ]
@@ -3568,11 +3578,11 @@ dependencies = [
 
 [[package]]
 name = "home"
-version = "0.5.5"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3681,9 +3691,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.14.27"
+version = "0.14.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb1cfd654a8219eaef89881fdb3bb3b1cdc5fa75ded05d6933b2b382e395468"
+checksum = "bf96e135eb83a2a8ddf766e426a841d8ddd7449d5f00d34ea02b41d2f19eef80"
 dependencies = [
  "bytes 1.5.0",
  "futures-channel",
@@ -3696,7 +3706,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2 0.5.5",
  "tokio",
  "tower-service",
  "tracing",
@@ -3730,16 +3740,16 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.58"
+version = "0.1.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8326b86b6cff230b97d0d312a6c40a60726df3332e721f72a1b035f451663b20"
+checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows-core 0.51.1",
+ "windows-core 0.52.0",
 ]
 
 [[package]]
@@ -3813,7 +3823,7 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6b0422c86d7ce0e97169cc42e04ae643caf278874a7a3c87b8150a220dc7e1e"
 dependencies = [
- "async-io 2.2.1",
+ "async-io 2.3.1",
  "core-foundation",
  "fnv",
  "futures 0.3.30",
@@ -3847,9 +3857,9 @@ dependencies = [
 
 [[package]]
 name = "ignore"
-version = "0.4.21"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "747ad1b4ae841a78e8aba0d63adbfbeaea26b517b63705d47856b73015d27060"
+checksum = "b46810df39e66e925525d6e38ce1e7f6e1d208f72dc39757880fcb66e2c58af1"
 dependencies = [
  "crossbeam-deque",
  "globset",
@@ -3936,9 +3946,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.1.0"
+version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
+checksum = "233cf39063f058ea2caae4091bf4a3ef70a653afbc026f5c4a4135d114e3c177"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
@@ -3991,7 +4001,7 @@ dependencies = [
  "config",
  "cucumber",
  "httpmock",
- "indexmap 2.1.0",
+ "indexmap 2.2.3",
  "libp2p",
  "log",
  "log4rs",
@@ -4057,9 +4067,9 @@ dependencies = [
 
 [[package]]
 name = "inventory"
-version = "0.3.13"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0508c56cfe9bfd5dfeb0c22ab9a6abfda2f27bdca422132e494266351ed8d83c"
+checksum = "f958d3d68f4167080a18141e10381e7634563984a537f2a49a30fd8e53ac5767"
 
 [[package]]
 name = "io-lifetimes"
@@ -4067,7 +4077,7 @@ version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
- "hermit-abi 0.3.3",
+ "hermit-abi 0.3.6",
  "libc",
  "windows-sys 0.48.0",
 ]
@@ -4092,13 +4102,13 @@ checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.9"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
+checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
 dependencies = [
- "hermit-abi 0.3.3",
- "rustix 0.38.28",
- "windows-sys 0.48.0",
+ "hermit-abi 0.3.6",
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4176,18 +4186,18 @@ dependencies = [
 
 [[package]]
 name = "jobserver"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c37f63953c4c63420ed5fd3d6d398c719489b9f872b9fa683262f8edd363c7d"
+checksum = "ab46a6e9526ddef3ae7f787c06f0f2600639ba80ea3eade3d8e670a2230f51d6"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.66"
+version = "0.3.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cee9c64da59eae3b50095c18d3e74f8b73c0b86d2792824ff01bbce68ba229ca"
+checksum = "406cda4b368d531c842222cf9d2600a9a4acce8d29423695379c6868a143a9ee"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -4231,9 +4241,9 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f6d5ed8676d904364de097082f4e7d240b571b67989ced0240f08b7f966f940"
+checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
 dependencies = [
  "cpufeatures",
 ]
@@ -4259,9 +4269,9 @@ dependencies = [
 
 [[package]]
 name = "lalrpop"
-version = "0.19.12"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a1cbf952127589f2851ab2046af368fd20645491bb4b376f04b7f94d7a9837b"
+checksum = "da4081d44f4611b66c6dd725e6de3169f9f63905421e8626fcb86b6a898998b8"
 dependencies = [
  "ascii-canvas",
  "bit-set",
@@ -4271,8 +4281,9 @@ dependencies = [
  "itertools 0.10.5",
  "lalrpop-util",
  "petgraph",
+ "pico-args",
  "regex",
- "regex-syntax 0.6.29",
+ "regex-syntax 0.7.5",
  "string_cache",
  "term",
  "tiny-keccak 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4281,9 +4292,9 @@ dependencies = [
 
 [[package]]
 name = "lalrpop-util"
-version = "0.19.12"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3c48237b9604c5a4702de6b824e02006c3214327564636aef27c1028a8fa0ed"
+checksum = "3f35c735096c0293d313e8f2a641627472b83d01b937177fe76e5e2708d31e0d"
 dependencies = [
  "regex",
 ]
@@ -4355,9 +4366,9 @@ checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
 name = "libnghttp2-sys"
-version = "0.1.8+1.55.1"
+version = "0.1.9+1.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fae956c192dadcdb5dace96db71fa0b827333cce7c7b38dc71446f024d8a340"
+checksum = "b57e858af2798e167e709b9d969325b6d8e9d50232fcbc494d7d54f976854a64"
 dependencies = [
  "cc",
  "libc",
@@ -4394,7 +4405,7 @@ dependencies = [
  "libp2p-upnp",
  "libp2p-yamux",
  "multiaddr 0.18.1",
- "pin-project 1.1.3",
+ "pin-project 1.1.4",
  "rw-stream-sink",
  "thiserror",
 ]
@@ -4457,7 +4468,7 @@ dependencies = [
  "multistream-select",
  "once_cell",
  "parking_lot 0.12.1",
- "pin-project 1.1.3",
+ "pin-project 1.1.4",
  "quick-protobuf",
  "rand",
  "rw-stream-sink",
@@ -4604,7 +4615,7 @@ dependencies = [
  "futures-bounded 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "libp2p",
  "prost 0.12.3",
- "smallvec 2.0.0-alpha.1",
+ "smallvec 2.0.0-alpha.3",
  "tracing",
 ]
 
@@ -4623,7 +4634,7 @@ dependencies = [
  "libp2p-ping",
  "libp2p-relay",
  "libp2p-swarm",
- "pin-project 1.1.3",
+ "pin-project 1.1.4",
  "prometheus-client",
 ]
 
@@ -4792,7 +4803,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -4864,7 +4875,7 @@ version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "libc",
  "redox_syscall 0.4.1",
 ]
@@ -4919,9 +4930,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.12"
+version = "1.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d97137b25e321a73eef1418d1d5d2eda4d77e12813f8e6dead84bc52c5870a7b"
+checksum = "037731f5d3aaa87a5675e895b63ddff1a87624bc29f77004ea829809654e48f6"
 dependencies = [
  "cc",
  "libc",
@@ -4943,9 +4954,9 @@ checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4cd1a83af159aa67994778be9070f0ae1bd732942279cabb14f86f986a21456"
+checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
 name = "liquid"
@@ -4986,7 +4997,7 @@ checksum = "fc2fb41a9bb4257a3803154bdf7e2df7d45197d1941c9b1a90ad815231630721"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -5093,9 +5104,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2994eeba8ed550fd9b47a0b38f0242bc3344e496483c6180b69139cc2fa5d1d7"
+checksum = "db2c024b41519440580066ba82aab04092b333e09066a5eb86c7c4890df31f22"
 dependencies = [
  "hashbrown 0.14.3",
 ]
@@ -5157,9 +5168,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.6.4"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
+checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
 name = "memmap2"
@@ -5184,15 +5195,6 @@ name = "memoffset"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
-name = "memoffset"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
 dependencies = [
  "autocfg",
 ]
@@ -5229,7 +5231,7 @@ checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -5271,9 +5273,9 @@ dependencies = [
 
 [[package]]
 name = "mini-moka"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23e0b72e7c9042467008b10279fc732326bd605459ae03bda88825909dd19b56"
+checksum = "c325dfab65f261f386debee8b0969da215b3fa0037e74c8a1234db7ba986d803"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-utils",
@@ -5292,9 +5294,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
 dependencies = [
  "adler",
 ]
@@ -5302,7 +5304,7 @@ dependencies = [
 [[package]]
 name = "minotari_app_grpc"
 version = "1.0.0-dan.5"
-source = "git+https://github.com/sdbondi/tari.git?branch=update-feature-dan2#f8a3ec2da4bd3ca970b5e982f91b5da9f6e1e358"
+source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#6ac80796eb882b4086e24be2110d79f025571d3f"
 dependencies = [
  "argon2",
  "base64 0.13.1",
@@ -5330,7 +5332,7 @@ dependencies = [
 [[package]]
 name = "minotari_app_utilities"
 version = "1.0.0-dan.5"
-source = "git+https://github.com/sdbondi/tari.git?branch=update-feature-dan2#f8a3ec2da4bd3ca970b5e982f91b5da9f6e1e358"
+source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#6ac80796eb882b4086e24be2110d79f025571d3f"
 dependencies = [
  "clap 3.2.25",
  "dialoguer",
@@ -5352,7 +5354,7 @@ dependencies = [
 [[package]]
 name = "minotari_console_wallet"
 version = "1.0.0-dan.5"
-source = "git+https://github.com/sdbondi/tari.git?branch=update-feature-dan2#f8a3ec2da4bd3ca970b5e982f91b5da9f6e1e358"
+source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#6ac80796eb882b4086e24be2110d79f025571d3f"
 dependencies = [
  "blake2",
  "chrono",
@@ -5386,7 +5388,7 @@ dependencies = [
  "tari_core",
  "tari_crypto",
  "tari_features",
- "tari_hash_domains 1.0.0-dan.5",
+ "tari_hash_domains",
  "tari_key_manager",
  "tari_libtor",
  "tari_p2p",
@@ -5407,7 +5409,7 @@ dependencies = [
 [[package]]
 name = "minotari_node"
 version = "1.0.0-dan.5"
-source = "git+https://github.com/sdbondi/tari.git?branch=update-feature-dan2#f8a3ec2da4bd3ca970b5e982f91b5da9f6e1e358"
+source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#6ac80796eb882b4086e24be2110d79f025571d3f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5453,7 +5455,7 @@ dependencies = [
 [[package]]
 name = "minotari_node_grpc_client"
 version = "0.1.0"
-source = "git+https://github.com/sdbondi/tari.git?branch=update-feature-dan2#f8a3ec2da4bd3ca970b5e982f91b5da9f6e1e358"
+source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#6ac80796eb882b4086e24be2110d79f025571d3f"
 dependencies = [
  "minotari_app_grpc",
 ]
@@ -5461,7 +5463,7 @@ dependencies = [
 [[package]]
 name = "minotari_wallet"
 version = "1.0.0-dan.5"
-source = "git+https://github.com/sdbondi/tari.git?branch=update-feature-dan2#f8a3ec2da4bd3ca970b5e982f91b5da9f6e1e358"
+source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#6ac80796eb882b4086e24be2110d79f025571d3f"
 dependencies = [
  "argon2",
  "async-trait",
@@ -5510,7 +5512,7 @@ dependencies = [
 [[package]]
 name = "minotari_wallet_grpc_client"
 version = "0.1.0"
-source = "git+https://github.com/sdbondi/tari.git?branch=update-feature-dan2#f8a3ec2da4bd3ca970b5e982f91b5da9f6e1e358"
+source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#6ac80796eb882b4086e24be2110d79f025571d3f"
 dependencies = [
  "minotari_app_grpc",
  "tari_common_types",
@@ -5688,7 +5690,7 @@ source = "git+https://github.com/tari-project/rust-libp2p.git?rev=49ca2a88961f71
 dependencies = [
  "bytes 1.5.0",
  "futures 0.3.30",
- "pin-project 1.1.3",
+ "pin-project 1.1.4",
  "smallvec 1.13.1",
  "tracing",
  "unsigned-varint 0.8.0",
@@ -5902,6 +5904,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "num-derive"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5914,13 +5922,13 @@ dependencies = [
 
 [[package]]
 name = "num-derive"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfb77679af88f8b125209d354a202862602672222e7f2313fdd6dc349bad4712"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -5935,19 +5943,18 @@ dependencies = [
 
 [[package]]
 name = "num-integer"
-version = "0.1.45"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
- "autocfg",
  "num-traits",
 ]
 
 [[package]]
 name = "num-iter"
-version = "0.1.43"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
+checksum = "d869c01cc0c455284163fd0092f1f93835385ccab5a98a0dcc497b2f8bf055a9"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -5967,9 +5974,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
+checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
 dependencies = [
  "autocfg",
  "libm",
@@ -5981,7 +5988,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.3",
+ "hermit-abi 0.3.6",
  "libc",
 ]
 
@@ -5999,9 +6006,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.32.1"
+version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf5f9dd3933bd50a9e1f149ec995f39ae2c496d31fd772c1fd45ebc27e902b0"
+checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
 dependencies = [
  "memchr",
 ]
@@ -6033,11 +6040,11 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.61"
+version = "0.10.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b8419dc8cc6d866deb801274bba2e6f8f6108c1bb7fcc10ee5ab864931dbb45"
+checksum = "15c9d69dd87a29568d4d017cfe8ec518706046a05184e5aea92d0af890b803c8"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -6054,7 +6061,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -6065,18 +6072,18 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "300.2.1+3.2.0"
+version = "300.2.3+3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fe476c29791a5ca0d1273c697e96085bbabbbea2ef7afd5617e78a4b40332d3"
+checksum = "5cff92b6f71555b61bb9315f7c64da3ca43d87531622120fea0195fc761b4843"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.97"
+version = "0.9.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3eaad34cdd97d81de97964fc7f29e2d104f483840d906ef56daa1912338460b"
+checksum = "22e1bf214306098e4832460f797824c05d25aacdf896f64a985fb0fd992454ae"
 dependencies = [
  "cc",
  "libc",
@@ -6293,9 +6300,9 @@ dependencies = [
 
 [[package]]
 name = "pem"
-version = "3.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3163d2912b7c3b52d651a055f2c7eec9ba5cd22d26ef75b8dd3a59980b185923"
+checksum = "1b8fcc794035347fb64beda2d3b462595dd2753e3f268d89c5aae77e8cf2c310"
 dependencies = [
  "base64 0.21.7",
  "serde",
@@ -6318,9 +6325,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.7.5"
+version = "2.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae9cee2a55a544be8b89dc6848072af97a20f2422603c10865be2a42b580fff5"
+checksum = "219c0dcc30b6a27553f9cc242972b67f75b60eb0db71f0b5462f38b058c41546"
 dependencies = [
  "memchr",
  "thiserror",
@@ -6329,9 +6336,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.7.5"
+version = "2.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81d78524685f5ef2a3b3bd1cafbc9fcabb036253d9b1463e726a91cd16e2dfc2"
+checksum = "22e1288dbd7786462961e69bfd4df7848c1e37e8b74303dbdab82c3a9cdd2809"
 dependencies = [
  "pest",
  "pest_generator",
@@ -6339,22 +6346,22 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.5"
+version = "2.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68bd1206e71118b5356dae5ddc61c8b11e28b09ef6a31acbd15ea48a28e0c227"
+checksum = "1381c29a877c6d34b8c176e734f35d7f7f5b3adaefe940cb4d1bb7af94678e2e"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.7.5"
+version = "2.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c747191d4ad9e4a4ab9c8798f1e82a39affe7ef9648390b7e5548d18e099de6"
+checksum = "d0934d6907f148c22a3acbda520c7eed243ad7487a30f51f6ce52b58b7077a8a"
 dependencies = [
  "once_cell",
  "pest",
@@ -6368,7 +6375,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
- "indexmap 2.1.0",
+ "indexmap 2.2.3",
 ]
 
 [[package]]
@@ -6405,7 +6412,7 @@ dependencies = [
  "md-5",
  "nom",
  "num-bigint-dig",
- "num-derive 0.4.1",
+ "num-derive 0.4.2",
  "num-traits",
  "p256",
  "p384",
@@ -6433,6 +6440,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pico-args"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
+
+[[package]]
 name = "pin-project"
 version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6443,11 +6456,11 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fda4ed1c6c173e3fc7a83629421152e01d7b1f9b7f65fb301e490e8cfc656422"
+checksum = "0302c4a0442c456bd56f841aee5c3bfd17967563f6fadc9ceb9f9c23cf3807e0"
 dependencies = [
- "pin-project-internal 1.1.3",
+ "pin-project-internal 1.1.4",
 ]
 
 [[package]]
@@ -6463,13 +6476,13 @@ dependencies = [
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
+checksum = "266c042b60c9c76b8d53061e52b2e0d1116abc57cefc8c5cd671619a56ac3690"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -6518,15 +6531,15 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.27"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
+checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "platforms"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14e6ab3f592e6fb464fc9712d8d6e6912de6473954635fd76a589d832cffcbb0"
+checksum = "626dec3cac7cc0e1577a2ec3fc496277ec2baa084bebad95bb6fdbfae235f84c"
 
 [[package]]
 name = "polling"
@@ -6546,14 +6559,14 @@ dependencies = [
 
 [[package]]
 name = "polling"
-version = "3.3.1"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf63fa624ab313c11656b4cda960bfc46c410187ad493c41f6ba2d8c1e991c9e"
+checksum = "30054e72317ab98eddd8561db0f6524df3367636884b7b21b703e4b280a84a14"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
  "pin-project-lite",
- "rustix 0.38.28",
+ "rustix 0.38.31",
  "tracing",
  "windows-sys 0.52.0",
 ]
@@ -6617,12 +6630,12 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae005bd773ab59b4725093fd7df83fd7892f7d8eafb48dbd7de6e024e4215f9d"
+checksum = "a41cf62165e97c7f814d2221421dbb9afcbcdb0a88068e5ea206e19951c2cbb5"
 dependencies = [
  "proc-macro2",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -6671,7 +6684,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
 dependencies = [
- "toml_edit 0.21.0",
+ "toml_edit 0.21.1",
 ]
 
 [[package]]
@@ -6700,9 +6713,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.76"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95fc56cda0b5c3325f5fbbd7ff9fda9e02bb00bb3dac51252d2f1bfa1cb8cc8c"
+checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
 dependencies = [
  "unicode-ident",
 ]
@@ -6724,9 +6737,9 @@ dependencies = [
 
 [[package]]
 name = "prometheus-client"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "510c4f1c9d81d556458f94c98f857748130ea9737bbd6053da497503b26ea63c"
+checksum = "6f87c10af16e0af74010d2a123d202e8363c04db5acfa91d8747f64a8524da3a"
 dependencies = [
  "dtoa",
  "itoa",
@@ -6742,7 +6755,7 @@ checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -6751,7 +6764,7 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b476131c3c86cb68032fdc5cb6d5a1045e3e42d96b69fa599fd77701e1f5bf"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "lazy_static",
  "num-traits",
  "rand",
@@ -6826,11 +6839,11 @@ dependencies = [
  "multimap",
  "once_cell",
  "petgraph",
- "prettyplease 0.2.15",
+ "prettyplease 0.2.16",
  "prost 0.12.3",
  "prost-types 0.12.3",
  "regex",
- "syn 2.0.48",
+ "syn 2.0.49",
  "tempfile",
  "which",
 ]
@@ -6871,7 +6884,7 @@ dependencies = [
  "itertools 0.11.0",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -6938,11 +6951,11 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.9.3"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a1a2f1f0a7ecff9c31abbe177637be0e97a0aef46cf8738ece09327985d998"
+checksum = "57206b407293d2bcd3af849ce869d52068623f19e1b5ff8e8778e3309439682b"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.2",
  "memchr",
  "unicase",
 ]
@@ -7148,9 +7161,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c27db03db7734835b3f53954b534c91069375ce6ccaa2e065441e07d9b6cdb1"
+checksum = "fa7237101a77a10773db45d62004a272517633fbcc3df19d96455ede1122e051"
 dependencies = [
  "either",
  "rayon-core",
@@ -7158,9 +7171,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ce3fb6ad83f861aac485e76e1985cd109d9a3713802152be56c3b1f0e0658ed"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
@@ -7172,7 +7185,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52c4f3084aa3bc7dfbba4eff4fab2a54db4324965d8872ab933565e6fbd83bc6"
 dependencies = [
- "pem 3.0.2",
+ "pem 3.0.3",
  "ring 0.16.20",
  "time",
  "x509-parser",
@@ -7210,12 +7223,12 @@ dependencies = [
 
 [[package]]
 name = "reflink-copy"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c509b49b989bce68439387eb469cbe301c6cfb08e28612ddc3a179bd7b0a012"
+checksum = "767be24c0da52e7448d495b8d162506a9aa125426651d547d545d6c2b4b65b62"
 dependencies = [
  "cfg-if",
- "rustix 0.38.28",
+ "rustix 0.38.31",
  "windows 0.52.0",
 ]
 
@@ -7270,6 +7283,12 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
+
+[[package]]
+name = "regex-syntax"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
@@ -7288,18 +7307,18 @@ dependencies = [
 
 [[package]]
 name = "rend"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2571463863a6bd50c32f94402933f03457a3fbaf697a707c5be741e459f08fd"
+checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
 dependencies = [
  "bytecheck",
 ]
 
 [[package]]
 name = "reqwest"
-version = "0.11.22"
+version = "0.11.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046cd98826c46c2ac8ddecae268eb5c2e58628688a5fc7a2643704a73faba95b"
+checksum = "c6920094eb85afde5e4a138be3f2de8bbdf28000f0029e72c45025a56b042251"
 dependencies = [
  "base64 0.21.7",
  "bytes 1.5.0",
@@ -7319,9 +7338,11 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
  "serde_urlencoded",
+ "sync_wrapper",
  "system-configuration",
  "tokio",
  "tokio-native-tls",
@@ -7393,26 +7414,27 @@ dependencies = [
 
 [[package]]
 name = "rkyv"
-version = "0.7.42"
+version = "0.7.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0200c8230b013893c0b2d6213d6ec64ed2b9be2e0e016682b7224ff82cff5c58"
+checksum = "5cba464629b3394fc4dbc6f940ff8f5b4ff5c7aef40f29166fd4ad12acbc99c0"
 dependencies = [
  "bitvec",
  "bytecheck",
+ "bytes 1.5.0",
  "hashbrown 0.12.3",
  "ptr_meta",
  "rend",
  "rkyv_derive",
  "seahash",
  "tinyvec",
- "uuid 1.6.1",
+ "uuid 1.7.0",
 ]
 
 [[package]]
 name = "rkyv_derive"
-version = "0.7.42"
+version = "0.7.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2e06b915b5c230a17d7a736d1e2e63ee753c256a8614ef3f5147b13a4f5541d"
+checksum = "a7dddfff8de25e6f62b9d64e6e432bf1c6736c57d20323e15ee10435fbda7c65"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7610,14 +7632,14 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.28"
+version = "0.38.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72e572a5e8ca657d7366229cdde4bd14c4eb5499a9573d4d366fe1b599daa316"
+checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "errno",
  "libc",
- "linux-raw-sys 0.4.12",
+ "linux-raw-sys 0.4.13",
  "windows-sys 0.52.0",
 ]
 
@@ -7731,7 +7753,7 @@ version = "0.4.0"
 source = "git+https://github.com/tari-project/rust-libp2p.git?rev=49ca2a88961f7131d3e496b579b522a823ae0418#49ca2a88961f7131d3e496b579b522a823ae0418"
 dependencies = [
  "futures 0.3.30",
- "pin-project 1.1.3",
+ "pin-project 1.1.4",
  "static_assertions",
 ]
 
@@ -7758,11 +7780,11 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c3733bf4cf7ea0880754e19cb5a462007c4a8c1914bff372ccc95b464f1df88"
+checksum = "fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7841,7 +7863,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -7910,9 +7932,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.195"
+version = "1.0.196"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63261df402c67811e9ac6def069e4786148c4563f4b50fd4bf30aa370d626b02"
+checksum = "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32"
 dependencies = [
  "serde_derive",
 ]
@@ -7938,20 +7960,20 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.195"
+version = "1.0.196"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46fe8f8603d81ba86327b23a2e9cdf49e1255fb94a4c5f297f6ee0547178ea2c"
+checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.108"
+version = "1.0.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
+checksum = "69801b70b1c3dac963ecb03a364ba0ceda9cf60c71cfe475e99864759c8b8a79"
 dependencies = [
  "itoa",
  "ryu",
@@ -7960,9 +7982,9 @@ dependencies = [
 
 [[package]]
 name = "serde_path_to_error"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4beec8bce849d58d06238cb50db2e1c417cfeafa4c63f692b15c82b7c80f8335"
+checksum = "ebd154a240de39fdebcf5775d2675c204d7c13cf39a4c697be6493c8e734337c"
 dependencies = [
  "itoa",
  "serde",
@@ -7980,20 +8002,20 @@ dependencies = [
 
 [[package]]
 name = "serde_repr"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3081f5ffbb02284dda55132aa26daecedd7372a42417bbbab6f14ab7d6bb9145"
+checksum = "0b2e6b945e9d3df726b65d6ee24060aff8e3533d431f677a9695db04eff9dfdb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12022b835073e5b11e90a14f86838ceb1c8fb0325b72416845c487ac0fa95e80"
+checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
 dependencies = [
  "serde",
 ]
@@ -8032,19 +8054,19 @@ version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "881b6f881b17d13214e5d494c939ebab463d01264ce1811e9d4ac3a882e7695f"
 dependencies = [
- "darling 0.20.3",
+ "darling 0.20.6",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.27"
+version = "0.9.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cc7a1570e38322cfe4154732e5110f887ea57e22b76f4bfd32b5bdd3368666c"
+checksum = "adf8a49373e98a4c5f0ceb5d05aa7c648d75f63774981ed95b7c7443bbd50c6e"
 dependencies = [
- "indexmap 2.1.0",
+ "indexmap 2.2.3",
  "itoa",
  "ryu",
  "serde",
@@ -8164,9 +8186,9 @@ checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
 
 [[package]]
 name = "similar"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aeaf503862c419d66959f5d7ca015337d864e9c49485d771b732e2a20453597"
+checksum = "32fea41aca09ee824cc9724996433064c89f7777e60762749a4170a14abbfa21"
 
 [[package]]
 name = "simple_asn1"
@@ -8229,9 +8251,9 @@ checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
 
 [[package]]
 name = "smallvec"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af12b8880f45a593fc99ac6d0a066f762861ea6822a6a6790fa1363d70a8089"
+checksum = "030388a4fad918f857b2510fe5f217293eefdfcd895f2ec92b61b5c0df3f8bc2"
 
 [[package]]
 name = "smawk"
@@ -8241,9 +8263,9 @@ checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
 
 [[package]]
 name = "smol_str"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74212e6bbe9a4352329b2f68ba3130c15a3f26fe88ff22dbdc6cdd58fa85e99c"
+checksum = "e6845563ada680337a52d43bb0b29f396f2d911616f6573012645b9e3d048a49"
 dependencies = [
  "serde",
 ]
@@ -8423,6 +8445,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
+name = "strsim"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
+
+[[package]]
 name = "structopt"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8520,9 +8548,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.48"
+version = "2.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
+checksum = "915aea9e586f80826ee59f8453c1101f9d1c4b3964cd2460185ee8e299ada496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8538,7 +8566,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -8627,9 +8655,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.12"
+version = "0.12.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c39fd04924ca3a864207c66fc2cd7d22d7c016007f9ce846cbb9326331930a"
+checksum = "69758bda2e78f098e4ccb393021a0963bb3442eac05f135c30f61b7370bbafae"
 
 [[package]]
 name = "tari-curve25519-dalek"
@@ -8703,7 +8731,7 @@ dependencies = [
 [[package]]
 name = "tari_common"
 version = "1.0.0-dan.5"
-source = "git+https://github.com/sdbondi/tari.git?branch=update-feature-dan2#f8a3ec2da4bd3ca970b5e982f91b5da9f6e1e358"
+source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#6ac80796eb882b4086e24be2110d79f025571d3f"
 dependencies = [
  "anyhow",
  "blake2",
@@ -8730,7 +8758,7 @@ dependencies = [
 [[package]]
 name = "tari_common_sqlite"
 version = "1.0.0-dan.5"
-source = "git+https://github.com/sdbondi/tari.git?branch=update-feature-dan2#f8a3ec2da4bd3ca970b5e982f91b5da9f6e1e358"
+source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#6ac80796eb882b4086e24be2110d79f025571d3f"
 dependencies = [
  "diesel",
  "diesel_migrations",
@@ -8744,7 +8772,7 @@ dependencies = [
 [[package]]
 name = "tari_common_types"
 version = "1.0.0-dan.5"
-source = "git+https://github.com/sdbondi/tari.git?branch=update-feature-dan2#f8a3ec2da4bd3ca970b5e982f91b5da9f6e1e358"
+source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#6ac80796eb882b4086e24be2110d79f025571d3f"
 dependencies = [
  "base64 0.21.7",
  "blake2",
@@ -8760,17 +8788,16 @@ dependencies = [
  "tari_crypto",
  "tari_utilities",
  "thiserror",
- "tokio",
 ]
 
 [[package]]
 name = "tari_comms"
 version = "1.0.0-dan.5"
-source = "git+https://github.com/sdbondi/tari.git?branch=update-feature-dan2#f8a3ec2da4bd3ca970b5e982f91b5da9f6e1e358"
+source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#6ac80796eb882b4086e24be2110d79f025571d3f"
 dependencies = [
  "anyhow",
  "async-trait",
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "blake2",
  "bytes 1.5.0",
  "chrono",
@@ -8785,7 +8812,7 @@ dependencies = [
  "multiaddr 0.14.0",
  "nom",
  "once_cell",
- "pin-project 1.1.3",
+ "pin-project 1.1.4",
  "prost 0.11.9",
  "rand",
  "serde",
@@ -8810,10 +8837,10 @@ dependencies = [
 [[package]]
 name = "tari_comms_dht"
 version = "1.0.0-dan.5"
-source = "git+https://github.com/sdbondi/tari.git?branch=update-feature-dan2#f8a3ec2da4bd3ca970b5e982f91b5da9f6e1e358"
+source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#6ac80796eb882b4086e24be2110d79f025571d3f"
 dependencies = [
  "anyhow",
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "blake2",
  "chacha20 0.7.3",
  "chacha20poly1305",
@@ -8845,7 +8872,7 @@ dependencies = [
 [[package]]
 name = "tari_comms_rpc_macros"
 version = "1.0.0-dan.5"
-source = "git+https://github.com/sdbondi/tari.git?branch=update-feature-dan2#f8a3ec2da4bd3ca970b5e982f91b5da9f6e1e358"
+source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#6ac80796eb882b4086e24be2110d79f025571d3f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8858,7 +8885,7 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "indexmap 2.1.0",
+ "indexmap 2.2.3",
  "log",
  "serde",
  "tari_common",
@@ -8878,7 +8905,7 @@ dependencies = [
 [[package]]
 name = "tari_contacts"
 version = "1.0.0-dan.5"
-source = "git+https://github.com/sdbondi/tari.git?branch=update-feature-dan2#f8a3ec2da4bd3ca970b5e982f91b5da9f6e1e358"
+source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#6ac80796eb882b4086e24be2110d79f025571d3f"
 dependencies = [
  "chrono",
  "diesel",
@@ -8904,17 +8931,17 @@ dependencies = [
  "thiserror",
  "tokio",
  "tower",
- "uuid 1.6.1",
+ "uuid 1.7.0",
 ]
 
 [[package]]
 name = "tari_core"
 version = "1.0.0-dan.5"
-source = "git+https://github.com/sdbondi/tari.git?branch=update-feature-dan2#f8a3ec2da4bd3ca970b5e982f91b5da9f6e1e358"
+source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#6ac80796eb882b4086e24be2110d79f025571d3f"
 dependencies = [
  "async-trait",
  "bincode 1.3.3",
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "blake2",
  "borsh",
  "bytes 0.5.6",
@@ -8954,7 +8981,7 @@ dependencies = [
  "tari_comms_dht",
  "tari_comms_rpc_macros",
  "tari_crypto",
- "tari_hash_domains 1.0.0-dan.5",
+ "tari_hash_domains",
  "tari_key_manager",
  "tari_mmr",
  "tari_p2p",
@@ -9056,10 +9083,9 @@ dependencies = [
  "tari_bor",
  "tari_common",
  "tari_common_types",
- "tari_core",
  "tari_crypto",
  "tari_engine_types",
- "tari_hash_domains 0.1.0",
+ "tari_hash_domains",
  "tari_mmr",
  "ts-rs",
 ]
@@ -9072,8 +9098,8 @@ dependencies = [
  "blake2",
  "cargo_toml",
  "d3ne",
- "env_logger 0.10.1",
- "indexmap 2.1.0",
+ "env_logger 0.10.2",
+ "indexmap 2.2.3",
  "log",
  "rand",
  "semver 1.0.21",
@@ -9124,7 +9150,7 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "chrono",
- "indexmap 2.1.0",
+ "indexmap 2.2.3",
  "log",
  "rand",
  "serde",
@@ -9270,7 +9296,7 @@ dependencies = [
  "tari_dan_storage",
  "tari_dan_wallet_storage_sqlite",
  "tari_engine_types",
- "tari_hash_domains 0.1.0",
+ "tari_hash_domains",
  "tari_key_manager",
  "tari_template_abi",
  "tari_template_lib",
@@ -9321,7 +9347,7 @@ dependencies = [
  "tari_common",
  "tari_common_types",
  "tari_crypto",
- "tari_hash_domains 0.1.0",
+ "tari_hash_domains",
  "tari_template_abi",
  "tari_template_lib",
  "tari_utilities",
@@ -9352,20 +9378,12 @@ dependencies = [
 [[package]]
 name = "tari_features"
 version = "1.0.0-dan.5"
-source = "git+https://github.com/sdbondi/tari.git?branch=update-feature-dan2#f8a3ec2da4bd3ca970b5e982f91b5da9f6e1e358"
-
-[[package]]
-name = "tari_hash_domains"
-version = "0.1.0"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#e422a12d86b8f6f4df3dedb961883f8ee58c55d3"
-dependencies = [
- "tari_crypto",
-]
+source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#6ac80796eb882b4086e24be2110d79f025571d3f"
 
 [[package]]
 name = "tari_hash_domains"
 version = "1.0.0-dan.5"
-source = "git+https://github.com/sdbondi/tari.git?branch=update-feature-dan2#f8a3ec2da4bd3ca970b5e982f91b5da9f6e1e358"
+source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#6ac80796eb882b4086e24be2110d79f025571d3f"
 dependencies = [
  "tari_crypto",
 ]
@@ -9461,7 +9479,7 @@ dependencies = [
 [[package]]
 name = "tari_key_manager"
 version = "1.0.0-dan.5"
-source = "git+https://github.com/sdbondi/tari.git?branch=update-feature-dan2#f8a3ec2da4bd3ca970b5e982f91b5da9f6e1e358"
+source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#6ac80796eb882b4086e24be2110d79f025571d3f"
 dependencies = [
  "argon2",
  "async-trait",
@@ -9494,7 +9512,7 @@ dependencies = [
 [[package]]
 name = "tari_libtor"
 version = "1.0.0-pre.8"
-source = "git+https://github.com/sdbondi/tari.git?branch=update-feature-dan2#f8a3ec2da4bd3ca970b5e982f91b5da9f6e1e358"
+source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#6ac80796eb882b4086e24be2110d79f025571d3f"
 dependencies = [
  "derivative",
  "libtor",
@@ -9509,8 +9527,8 @@ dependencies = [
 
 [[package]]
 name = "tari_metrics"
-version = "0.1.0"
-source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#e422a12d86b8f6f4df3dedb961883f8ee58c55d3"
+version = "1.0.0-pre.8"
+source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#6ac80796eb882b4086e24be2110d79f025571d3f"
 dependencies = [
  "once_cell",
  "prometheus",
@@ -9520,7 +9538,7 @@ dependencies = [
 [[package]]
 name = "tari_mmr"
 version = "1.0.0-dan.5"
-source = "git+https://github.com/sdbondi/tari.git?branch=update-feature-dan2#f8a3ec2da4bd3ca970b5e982f91b5da9f6e1e358"
+source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#6ac80796eb882b4086e24be2110d79f025571d3f"
 dependencies = [
  "borsh",
  "digest 0.10.7",
@@ -9551,7 +9569,7 @@ dependencies = [
 [[package]]
 name = "tari_p2p"
 version = "1.0.0-dan.5"
-source = "git+https://github.com/sdbondi/tari.git?branch=update-feature-dan2#f8a3ec2da4bd3ca970b5e982f91b5da9f6e1e358"
+source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#6ac80796eb882b4086e24be2110d79f025571d3f"
 dependencies = [
  "anyhow",
  "fs2",
@@ -9586,14 +9604,14 @@ name = "tari_rpc_framework"
 version = "0.3.0"
 dependencies = [
  "async-trait",
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "bytes 1.5.0",
  "futures 0.3.30",
  "libp2p",
  "libp2p-substream",
  "log",
  "once_cell",
- "pin-project 1.1.3",
+ "pin-project 1.1.4",
  "prost 0.12.3",
  "prost-build 0.12.3",
  "proto_builder",
@@ -9653,7 +9671,7 @@ dependencies = [
 [[package]]
 name = "tari_script"
 version = "1.0.0-pre.8"
-source = "git+https://github.com/sdbondi/tari.git?branch=update-feature-dan2#f8a3ec2da4bd3ca970b5e982f91b5da9f6e1e358"
+source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#6ac80796eb882b4086e24be2110d79f025571d3f"
 dependencies = [
  "blake2",
  "borsh",
@@ -9670,7 +9688,7 @@ dependencies = [
 [[package]]
 name = "tari_service_framework"
 version = "1.0.0-dan.5"
-source = "git+https://github.com/sdbondi/tari.git?branch=update-feature-dan2#f8a3ec2da4bd3ca970b5e982f91b5da9f6e1e358"
+source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#6ac80796eb882b4086e24be2110d79f025571d3f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9685,7 +9703,7 @@ dependencies = [
 [[package]]
 name = "tari_shutdown"
 version = "1.0.0-dan.5"
-source = "git+https://github.com/sdbondi/tari.git?branch=update-feature-dan2#f8a3ec2da4bd3ca970b5e982f91b5da9f6e1e358"
+source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#6ac80796eb882b4086e24be2110d79f025571d3f"
 dependencies = [
  "futures 0.3.30",
 ]
@@ -9698,7 +9716,7 @@ dependencies = [
  "axum",
  "axum-jrpc",
  "chrono",
- "clap 4.4.13",
+ "clap 4.5.0",
  "dirs",
  "jsonwebtoken",
  "log",
@@ -9742,7 +9760,7 @@ name = "tari_state_tree"
 version = "0.3.0"
 dependencies = [
  "hex",
- "indexmap 2.1.0",
+ "indexmap 2.2.3",
  "itertools 0.11.0",
  "log",
  "serde",
@@ -9757,7 +9775,7 @@ dependencies = [
 [[package]]
 name = "tari_storage"
 version = "1.0.0-dan.5"
-source = "git+https://github.com/sdbondi/tari.git?branch=update-feature-dan2#f8a3ec2da4bd3ca970b5e982f91b5da9f6e1e358"
+source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#6ac80796eb882b4086e24be2110d79f025571d3f"
 dependencies = [
  "bincode 1.3.3",
  "lmdb-zero",
@@ -9844,7 +9862,7 @@ dependencies = [
 [[package]]
 name = "tari_test_utils"
 version = "1.0.0-dan.5"
-source = "git+https://github.com/sdbondi/tari.git?branch=update-feature-dan2#f8a3ec2da4bd3ca970b5e982f91b5da9f6e1e358"
+source = "git+https://github.com/tari-project/tari.git?branch=feature-dan2#6ac80796eb882b4086e24be2110d79f025571d3f"
 dependencies = [
  "futures 0.3.30",
  "rand",
@@ -9914,7 +9932,7 @@ dependencies = [
  "config",
  "futures 0.3.30",
  "include_dir",
- "indexmap 2.1.0",
+ "indexmap 2.2.3",
  "json5",
  "libp2p",
  "libsqlite3-sys",
@@ -10056,7 +10074,7 @@ name = "tariswap_bench"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "clap 4.4.13",
+ "clap 4.5.0",
  "fern",
  "log",
  "tari_crypto",
@@ -10075,15 +10093,14 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.8.1"
+version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef1adac450ad7f4b3c28589471ade84f25f731a7a0fe30d71dfa9f60fd808e5"
+checksum = "a365e8cd18e44762ef95d87f284f4b5cd04107fec2ff3052bd6a3e6069669e67"
 dependencies = [
  "cfg-if",
  "fastrand 2.0.1",
- "redox_syscall 0.4.1",
- "rustix 0.38.28",
- "windows-sys 0.48.0",
+ "rustix 0.38.31",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10112,7 +10129,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
 dependencies = [
- "rustix 0.38.28",
+ "rustix 0.38.31",
  "windows-sys 0.48.0",
 ]
 
@@ -10138,22 +10155,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.56"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
+checksum = "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.56"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
+checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -10178,12 +10195,13 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.30"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4a34ab300f2dee6e562c10a046fc05e358b29f9bf92277f30c3c8d82275f6f5"
+checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
 dependencies = [
  "deranged",
  "itoa",
+ "num-conv",
  "powerfmt",
  "serde",
  "time-core",
@@ -10198,10 +10216,11 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.15"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ad70d68dba9e1f8aceda7aa6711965dfec1cac869f311a51bd08b3a2ccbce20"
+checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
 dependencies = [
+ "num-conv",
  "time-core",
 ]
 
@@ -10276,7 +10295,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -10390,7 +10409,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.1.0",
+ "indexmap 2.2.3",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -10403,18 +10422,18 @@ version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
 dependencies = [
- "indexmap 2.1.0",
+ "indexmap 2.2.3",
  "toml_datetime",
  "winnow",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.21.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34d383cd00a163b4a5b85053df514d45bc330f6de7737edfe0a93311d1eaa03"
+checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
 dependencies = [
- "indexmap 2.1.0",
+ "indexmap 2.2.3",
  "toml_datetime",
  "winnow",
 ]
@@ -10438,7 +10457,7 @@ dependencies = [
  "hyper",
  "hyper-timeout",
  "percent-encoding",
- "pin-project 1.1.3",
+ "pin-project 1.1.4",
  "prost 0.11.9",
  "prost-derive 0.11.9",
  "rustls-native-certs",
@@ -10472,7 +10491,7 @@ dependencies = [
  "hyper",
  "hyper-timeout",
  "percent-encoding",
- "pin-project 1.1.3",
+ "pin-project 1.1.4",
  "prost 0.11.9",
  "tokio",
  "tokio-stream",
@@ -10518,7 +10537,7 @@ dependencies = [
  "futures-util",
  "hdrhistogram",
  "indexmap 1.9.3",
- "pin-project 1.1.3",
+ "pin-project 1.1.4",
  "pin-project-lite",
  "rand",
  "slab",
@@ -10580,7 +10599,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -10599,7 +10618,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
 dependencies = [
- "pin-project 1.1.3",
+ "pin-project 1.1.4",
  "tracing",
 ]
 
@@ -10625,7 +10644,7 @@ dependencies = [
  "anyhow",
  "bincode 2.0.0-rc.3",
  "bytes 1.5.0",
- "clap 4.4.13",
+ "clap 4.5.0",
  "once_cell",
  "rand",
  "rayon",
@@ -10642,7 +10661,7 @@ name = "transaction_submitter"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "clap 4.4.13",
+ "clap 4.5.0",
  "tari_transaction",
  "tari_validator_node_client",
  "tokio",
@@ -10721,7 +10740,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2cae1fc5d05d47aa24b64f9a4f7cba24cdc9187a2084dd97ac57bef5eccae6"
 dependencies = [
  "chrono",
- "indexmap 2.1.0",
+ "indexmap 2.2.3",
  "thiserror",
  "ts-rs-macros",
 ]
@@ -10735,7 +10754,7 @@ dependencies = [
  "Inflector",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
  "termcolor",
 ]
 
@@ -10860,9 +10879,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f2528f27a9eb2b21e69c95319b30bd0efd85d09c379741b0f78ea1d86be2416"
+checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
 
 [[package]]
 name = "unicode-ident"
@@ -10887,9 +10906,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
+checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
 
 [[package]]
 name = "unicode-width"
@@ -10986,9 +11005,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e395fcf16a7a3d8127ec99782007af141946b4795001f876d54fb0d55978560"
+checksum = "f00cc9702ca12d3c81455259621e676d0f7251cec66a21e98fe2e9a37db93b2a"
 dependencies = [
  "getrandom",
 ]
@@ -11001,9 +11020,9 @@ checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "value-bag"
-version = "1.4.2"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a72e1902dde2bd6441347de2b70b7f5d59bf157c6c62f0c44572607a1d55bbe"
+checksum = "126e423afe2dd9ac52142e7e9d5ce4135d7e13776c529d27fd6bc49f19e3280b"
 
 [[package]]
 name = "vcpkg"
@@ -11097,9 +11116,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.89"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ed0d4f68a3015cc185aff4db9506a015f4b96f95303897bfa23f846db54064e"
+checksum = "c1e124130aee3fb58c5bdd6b639a0509486b0338acaaae0c84a5124b0f588b7f"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -11107,24 +11126,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.89"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b56f625e64f3a1084ded111c4d5f477df9f8c92df113852fa5a374dbda78826"
+checksum = "c9e7e1900c352b609c8488ad12639a311045f40a35491fb69ba8c12f758af70b"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.39"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac36a15a220124ac510204aec1c3e5db8a22ab06fd6706d881dc6149f8ed9a12"
+checksum = "877b9c3f61ceea0e56331985743b13f3d25c406a7098d45180fb5f09bc19ed97"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -11134,9 +11153,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.89"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0162dbf37223cd2afce98f3d0785506dcb8d266223983e4b5b525859e6e182b2"
+checksum = "b30af9e2d358182b5c7449424f017eba305ed32a7010509ede96cdc4696c46ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -11144,28 +11163,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.89"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
+checksum = "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.89"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
+checksum = "4f186bd2dcf04330886ce82d6f33dd75a7bfcf69ecf5763b89fcde53b6ac9838"
 
 [[package]]
 name = "wasm-encoder"
-version = "0.38.1"
+version = "0.200.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad2b51884de9c7f4fe2fd1043fccb8dcad4b1e29558146ee57a144d15779f3f"
+checksum = "b9e3fb0c8fbddd78aa6095b850dfeedbc7506cf5f81e633f69cf8f2333ab84b9"
 dependencies = [
  "leb128",
 ]
@@ -11421,10 +11440,11 @@ checksum = "718ed7c55c2add6548cca3ddd6383d738cd73b892df400e96b9aa876f0141d7a"
 
 [[package]]
 name = "wast"
-version = "69.0.1"
+version = "200.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1ee37317321afde358e4d7593745942c48d6d17e0e6e943704de9bbee121e7a"
+checksum = "d1810d14e6b03ebb8fb05eef4009ad5749c989b65197d83bce7de7172ed91366"
 dependencies = [
+ "bumpalo",
  "leb128",
  "memchr",
  "unicode-width",
@@ -11433,18 +11453,18 @@ dependencies = [
 
 [[package]]
 name = "wat"
-version = "1.0.82"
+version = "1.200.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aeb338ee8dee4d4cd05e6426683f21c5087dc7cfc8903e839ccf48d43332da3c"
+checksum = "776cbd10e217f83869beaa3f40e312bb9e91d5eee29bbf6f560db1261b6a4c3d"
 dependencies = [
  "wast",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.66"
+version = "0.3.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50c24a44ec86bb68fbecd1b3efed7e85ea5621b39b35ef2766b66cd984f8010f"
+checksum = "96565907687f7aceb35bc5fc03770a8a0471d82e479f25832f54a0e3f4b28446"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -11571,7 +11591,7 @@ dependencies = [
  "tokio",
  "turn",
  "url",
- "uuid 1.6.1",
+ "uuid 1.7.0",
  "waitgroup",
  "webrtc-mdns",
  "webrtc-util",
@@ -11673,7 +11693,7 @@ dependencies = [
  "either",
  "home",
  "once_cell",
- "rustix 0.38.28",
+ "rustix 0.38.31",
 ]
 
 [[package]]
@@ -11766,15 +11786,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -11789,21 +11800,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
  "windows-targets 0.52.0",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -11838,12 +11834,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -11859,12 +11849,6 @@ name = "windows_aarch64_msvc"
 version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd761fd3eb9ab8cc1ed81e56e567f02dd82c4c837e48ac3b2181b9ffc5060807"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -11886,12 +11870,6 @@ checksum = "cab0cf703a96bab2dc0c02c0fa748491294bf9b7feb27e1f4f96340f208ada0e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
-
-[[package]]
-name = "windows_i686_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
@@ -11907,12 +11885,6 @@ name = "windows_i686_msvc"
 version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cfdbe89cc9ad7ce618ba34abc34bbb6c36d99e96cae2245b7943cd75ee773d0"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -11934,12 +11906,6 @@ checksum = "b4dd9b0c0e9ece7bb22e84d70d01b71c6d6248b81a3c60d11869451b4cb24784"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
-
-[[package]]
-name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
@@ -11949,12 +11915,6 @@ name = "windows_x86_64_gnu"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -11976,12 +11936,6 @@ checksum = "ff1e4aa646495048ec7f3ffddc411e1d829c026a2ec62b39da15c1055e406eaa"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
-
-[[package]]
-name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
@@ -11994,9 +11948,9 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winnow"
-version = "0.5.26"
+version = "0.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67b5f0a4e7a27a64c651977932b9dc5667ca7fc31ac44b03ed37a0cf42fdfff"
+checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
 dependencies = [
  "memchr",
 ]
@@ -12022,9 +11976,9 @@ dependencies = [
 
 [[package]]
 name = "x25519-dalek"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb66477291e7e8d2b0ff1bcb900bf29489a9692816d79874bea351e7a8b6de96"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
 dependencies = [
  "curve25519-dalek",
  "rand_core",
@@ -12067,9 +12021,9 @@ dependencies = [
 
 [[package]]
 name = "xxhash-rust"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9828b178da53440fa9c766a3d2f73f7cf5d0ac1fe3980c1e5018d899fd19e07b"
+checksum = "53be06678ed9e83edb1745eb72efc0bbcd7b5c3c35711a860906aed827a13d61"
 
 [[package]]
 name = "yaml-rust"
@@ -12104,7 +12058,7 @@ dependencies = [
  "log",
  "nohash-hasher",
  "parking_lot 0.12.1",
- "pin-project 1.1.3",
+ "pin-project 1.1.4",
  "rand",
  "static_assertions",
 ]
@@ -12120,7 +12074,7 @@ dependencies = [
  "log",
  "nohash-hasher",
  "parking_lot 0.12.1",
- "pin-project 1.1.3",
+ "pin-project 1.1.4",
  "rand",
  "static_assertions",
 ]
@@ -12136,22 +12090,22 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.31"
+version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c4061bedbb353041c12f413700357bec76df2c7e2ca8e4df8bac24c6bf68e3d"
+checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.31"
+version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3c129550b3e6de3fd0ba67ba5c81818f9805e58b8d7fee80a3a59d2c9fc601a"
+checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -12171,7 +12125,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -12189,8 +12143,3 @@ dependencies = [
  "regex",
  "time",
 ]
-
-[[patch.unused]]
-name = "tari_metrics"
-version = "1.0.0-pre.8"
-source = "git+https://github.com/sdbondi/tari.git?branch=update-feature-dan2#f8a3ec2da4bd3ca970b5e982f91b5da9f6e1e358"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -267,26 +267,3 @@ overflow-checks = true
 #minotari_node = { git = "https://github.com/account/tari.git", branch = "my-branch" }
 #tari_metrics = { git = "https://github.com/account/tari.git", branch = "my-branch" }
 
-# Make a copy of this code, uncomment and replace account and my-branch with the name of your fork and the branch you want to temporarily use
-[patch."https://github.com/tari-project/tari.git"]
-minotari_app_grpc = { git = "https://github.com/sdbondi/tari.git", branch = "update-feature-dan2" }
-minotari_wallet_grpc_client= { git = "https://github.com/sdbondi/tari.git", branch = "update-feature-dan2" }
-minotari_node_grpc_client = { git = "https://github.com/sdbondi/tari.git", branch = "update-feature-dan2" }
-tari_common = { git = "https://github.com/sdbondi/tari.git", branch = "update-feature-dan2" }
-tari_common_types = { git = "https://github.com/sdbondi/tari.git", branch = "update-feature-dan2" }
-tari_comms = { git = "https://github.com/sdbondi/tari.git", branch = "update-feature-dan2" }
-tari_comms_rpc_macros = { git = "https://github.com/sdbondi/tari.git", branch = "update-feature-dan2" }
-tari_core = { git = "https://github.com/sdbondi/tari.git", branch = "update-feature-dan2" }
-tari_key_manager = { git = "https://github.com/sdbondi/tari.git", branch = "update-feature-dan2" }
-tari_mmr = { git = "https://github.com/sdbondi/tari.git", branch = "update-feature-dan2" }
-tari_p2p = { git = "https://github.com/sdbondi/tari.git", branch = "update-feature-dan2" }
-tari_shutdown = { git = "https://github.com/sdbondi/tari.git", branch = "update-feature-dan2" }
-tari_storage = { git = "https://github.com/sdbondi/tari.git", branch = "update-feature-dan2" }
-tari_script = { git = "https://github.com/sdbondi/tari.git", branch = "update-feature-dan2" }
-minotari_wallet = { git = "https://github.com/sdbondi/tari.git", branch = "update-feature-dan2" }
-minotari_console_wallet = { git = "https://github.com/sdbondi/tari.git", branch = "update-feature-dan2" }
-tari_service_framework = { git = "https://github.com/sdbondi/tari.git", branch = "update-feature-dan2" }
-tari_comms_dht = { git = "https://github.com/sdbondi/tari.git", branch = "update-feature-dan2" }
-minotari_app_utilities = { git = "https://github.com/sdbondi/tari.git", branch = "update-feature-dan2" }
-minotari_node = { git = "https://github.com/sdbondi/tari.git", branch = "update-feature-dan2" }
-tari_metrics = { git = "https://github.com/sdbondi/tari.git", branch = "update-feature-dan2" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,7 +186,7 @@ libsqlite3-sys = "0.25"
 liquid = "0.26.4"
 lmdb-zero = "0.4.4"
 log = "0.4.20"
-log4rs = "1.1.1"
+log4rs = "1.3"
 mime_guess = "2.0.4"
 mini-moka = "0.10.0"
 multiaddr = { git = "https://github.com/tari-project/rust-libp2p.git", rev = "49ca2a88961f7131d3e496b579b522a823ae0418" }
@@ -267,3 +267,26 @@ overflow-checks = true
 #minotari_node = { git = "https://github.com/account/tari.git", branch = "my-branch" }
 #tari_metrics = { git = "https://github.com/account/tari.git", branch = "my-branch" }
 
+# Make a copy of this code, uncomment and replace account and my-branch with the name of your fork and the branch you want to temporarily use
+[patch."https://github.com/tari-project/tari.git"]
+minotari_app_grpc = { git = "https://github.com/sdbondi/tari.git", branch = "update-feature-dan2" }
+minotari_wallet_grpc_client= { git = "https://github.com/sdbondi/tari.git", branch = "update-feature-dan2" }
+minotari_node_grpc_client = { git = "https://github.com/sdbondi/tari.git", branch = "update-feature-dan2" }
+tari_common = { git = "https://github.com/sdbondi/tari.git", branch = "update-feature-dan2" }
+tari_common_types = { git = "https://github.com/sdbondi/tari.git", branch = "update-feature-dan2" }
+tari_comms = { git = "https://github.com/sdbondi/tari.git", branch = "update-feature-dan2" }
+tari_comms_rpc_macros = { git = "https://github.com/sdbondi/tari.git", branch = "update-feature-dan2" }
+tari_core = { git = "https://github.com/sdbondi/tari.git", branch = "update-feature-dan2" }
+tari_key_manager = { git = "https://github.com/sdbondi/tari.git", branch = "update-feature-dan2" }
+tari_mmr = { git = "https://github.com/sdbondi/tari.git", branch = "update-feature-dan2" }
+tari_p2p = { git = "https://github.com/sdbondi/tari.git", branch = "update-feature-dan2" }
+tari_shutdown = { git = "https://github.com/sdbondi/tari.git", branch = "update-feature-dan2" }
+tari_storage = { git = "https://github.com/sdbondi/tari.git", branch = "update-feature-dan2" }
+tari_script = { git = "https://github.com/sdbondi/tari.git", branch = "update-feature-dan2" }
+minotari_wallet = { git = "https://github.com/sdbondi/tari.git", branch = "update-feature-dan2" }
+minotari_console_wallet = { git = "https://github.com/sdbondi/tari.git", branch = "update-feature-dan2" }
+tari_service_framework = { git = "https://github.com/sdbondi/tari.git", branch = "update-feature-dan2" }
+tari_comms_dht = { git = "https://github.com/sdbondi/tari.git", branch = "update-feature-dan2" }
+minotari_app_utilities = { git = "https://github.com/sdbondi/tari.git", branch = "update-feature-dan2" }
+minotari_node = { git = "https://github.com/sdbondi/tari.git", branch = "update-feature-dan2" }
+tari_metrics = { git = "https://github.com/sdbondi/tari.git", branch = "update-feature-dan2" }

--- a/clients/base_node_client/src/grpc.rs
+++ b/clients/base_node_client/src/grpc.rs
@@ -107,8 +107,8 @@ impl BaseNodeClient for GrpcBaseNodeClient {
             .metadata
             .ok_or_else(|| BaseNodeClientError::InvalidPeerMessage("Base node returned no metadata".to_string()))?;
         Ok(BaseLayerMetadata {
-            height_of_longest_chain: metadata.height_of_longest_chain,
-            tip_hash: metadata.best_block.try_into().map_err(|_| {
+            height_of_longest_chain: metadata.best_block_height,
+            tip_hash: metadata.best_block_hash.try_into().map_err(|_| {
                 BaseNodeClientError::InvalidPeerMessage("best_block was not a valid fixed hash".to_string())
             })?,
         })

--- a/dan_layer/common_types/Cargo.toml
+++ b/dan_layer/common_types/Cargo.toml
@@ -14,10 +14,6 @@ tari_engine_types = { workspace = true }
 tari_hash_domains = { workspace = true }
 tari_bor = { workspace = true, default-features = true }
 tari_mmr = { workspace = true }
-tari_core = { workspace = true, default-features = false, features = [
-  "transactions",
-  "base_node_proto",
-] }
 
 libp2p-identity = { workspace = true, features = [
   "sr25519",

--- a/dan_layer/common_types/Cargo.toml
+++ b/dan_layer/common_types/Cargo.toml
@@ -30,9 +30,6 @@ serde = { workspace = true, default-features = true }
 ruint = { workspace = true }
 ts-rs = { workspace = true, optional = true }
 
-[build-dependencies]
-tari_common = { workspace = true, features = ["build"] }
-
 [package.metadata.cargo-machete]
 ignored = ["prost", "prost-types"] # false positive, used in OUT_DIR structs
 

--- a/dan_layer/common_types/src/validator_metadata.rs
+++ b/dan_layer/common_types/src/validator_metadata.rs
@@ -1,13 +1,11 @@
 //   Copyright 2022 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use blake2::{digest::consts::U32, Blake2b};
 use serde::{Deserialize, Serialize};
 use tari_common::configuration::Network;
 use tari_common_types::types::{FixedHash, PublicKey, Signature};
-use tari_crypto::{hash_domain, hashing::DomainSeparation};
-use tari_engine_types::hashing::TariHasher32;
-use tari_hash_domains::TariEngineHashDomain;
+use tari_crypto::hash_domain;
+use tari_engine_types::base_layer_hashing::TariBaseLayerHasher32;
 
 // TODO: add to tari_hash_domains
 hash_domain!(TransactionHashDomain, "com.tari.base_layer.core.transactions", 0);
@@ -32,16 +30,13 @@ impl ValidatorMetadata {
 }
 
 pub fn vn_node_hash(network: Network, public_key: &PublicKey, substate_address: &SubstateAddress) -> FixedHash {
-    let mut digest = Blake2b::<U32>::default();
-    TariEngineHashDomain::add_domain_separation_tag(&mut digest, &format!("validator_node.n{}", network.as_byte()));
-    // TODO: TariHasher32 is the same as the consensus hasher in tari_core. The consensus hasher should be part of the
-    // common hashing crate, currently called tari_hash_domains. Should rename it to tari_hasher/tari_hashing and
-    // include the consensus hasher. This is done to remove the dependency on tari_core which has a bunch of
+    // TODO: TariBaseLayerHasher32 is the same as the consensus hasher in tari_core. The consensus hasher should be part
+    // of the common hashing crate, currently called tari_hash_domains. Should rename it to tari_hasher/tari_hashing
+    // and include the consensus hasher. This is done to remove the dependency on tari_core which has a bunch of
     // dependencies e.g. tari_comms, dht etc. "Type" crates should always have minimal dependencies.
-    TariHasher32::from_digest(digest)
+    TariBaseLayerHasher32::new_with_label::<TransactionHashDomain>(network, "validator_node")
         .chain(public_key)
         .chain(&substate_address.0)
         .result()
-        .into_array()
         .into()
 }

--- a/dan_layer/engine_types/src/base_layer_hashing.rs
+++ b/dan_layer/engine_types/src/base_layer_hashing.rs
@@ -24,7 +24,10 @@ use std::{io, io::Write};
 
 use blake2::Blake2b;
 use borsh::BorshSerialize;
-use digest::{consts::U64, Digest};
+use digest::{
+    consts::{U32, U64},
+    Digest,
+};
 use tari_common::configuration::Network;
 use tari_crypto::hashing::{DomainSeparatedHasher, DomainSeparation};
 use tari_hash_domains::{ConfidentialOutputHashDomain, WalletOutputEncryptionKeysDomain};
@@ -55,6 +58,10 @@ impl TariBaseLayerHasher64 {
         Self { hasher }
     }
 
+    pub fn from_digest(digest: Blake2b<U64>) -> Self {
+        Self { hasher: digest }
+    }
+
     pub fn update<T: BorshSerialize>(&mut self, data: &T) {
         BorshSerialize::serialize(data, &mut self.hash_writer())
             .expect("Incorrect implementation of BorshSerialize encountered. Implementations MUST be infallible.");
@@ -83,6 +90,63 @@ impl TariBaseLayerHasher64 {
 
     fn hash_writer(&mut self) -> impl Write + '_ {
         struct HashWriter<'a>(&'a mut Blake2b<U64>);
+        impl Write for HashWriter<'_> {
+            fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+                self.0.update(buf);
+                Ok(buf.len())
+            }
+
+            fn flush(&mut self) -> io::Result<()> {
+                Ok(())
+            }
+        }
+        HashWriter(&mut self.hasher)
+    }
+}
+#[derive(Debug, Clone)]
+pub struct TariBaseLayerHasher32 {
+    hasher: Blake2b<U32>,
+}
+
+impl TariBaseLayerHasher32 {
+    pub fn new_with_label<TDomain: DomainSeparation>(network: Network, label: &'static str) -> Self {
+        let mut hasher = Blake2b::<U32>::new();
+        TDomain::add_domain_separation_tag(&mut hasher, &format!("{}.n{}", label, network.as_byte()));
+        Self { hasher }
+    }
+
+    pub fn from_digest(digest: Blake2b<U32>) -> Self {
+        Self { hasher: digest }
+    }
+
+    pub fn update<T: BorshSerialize>(&mut self, data: &T) {
+        BorshSerialize::serialize(data, &mut self.hash_writer())
+            .expect("Incorrect implementation of BorshSerialize encountered. Implementations MUST be infallible.");
+    }
+
+    pub fn chain<T: BorshSerialize>(mut self, data: &T) -> Self {
+        self.update(data);
+        self
+    }
+
+    pub fn chain_update<T: BorshSerialize>(self, data: &T) -> Self {
+        self.chain(data)
+    }
+
+    pub fn digest<T: BorshSerialize>(self, data: &T) -> [u8; 32] {
+        self.chain(data).result()
+    }
+
+    pub fn result(self) -> [u8; 32] {
+        self.hasher.finalize().into()
+    }
+
+    pub fn finalize_into(self, output: &mut digest::Output<Blake2b<U32>>) {
+        digest::FixedOutput::finalize_into(self.hasher, output)
+    }
+
+    fn hash_writer(&mut self) -> impl Write + '_ {
+        struct HashWriter<'a>(&'a mut Blake2b<U32>);
         impl Write for HashWriter<'_> {
             fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
                 self.0.update(buf);

--- a/dan_layer/engine_types/src/hashing.rs
+++ b/dan_layer/engine_types/src/hashing.rs
@@ -64,6 +64,10 @@ impl TariHasher32 {
         Self { hasher }
     }
 
+    pub fn from_digest(digest: Blake2b<U32>) -> Self {
+        Self { hasher: digest }
+    }
+
     pub fn update<T: Serialize + ?Sized>(&mut self, data: &T) {
         // CBOR encoding does not make any contract to say that if the writer is infallible (as it is here) then
         // encoding in infallible. However this should be the case. Since it is very unergonomic to return an

--- a/integration_tests/src/base_node.rs
+++ b/integration_tests/src/base_node.rs
@@ -22,7 +22,7 @@
 
 use std::{path::PathBuf, str::FromStr, sync::Arc};
 
-use minotari_node::{run_base_node, BaseNodeConfig, MetricsConfig};
+use minotari_node::{run_base_node, BaseNodeConfig};
 use rand::rngs::OsRng;
 use tari_base_node_client::grpc::GrpcBaseNodeClient;
 use tari_common::{configuration::CommonConfig, exit_codes::ExitError};
@@ -88,7 +88,6 @@ pub async fn spawn_base_node(world: &mut TariWorld, bn_name: String) {
                     peer_seeds: peer_seeds.into(),
                     ..Default::default()
                 },
-                metrics: MetricsConfig::default(),
             };
 
             println!("Using base_node temp_dir: {}", temp_dir.display());


### PR DESCRIPTION
Description
---
Update to use latest feature-dan2

Removes unused tari common dependency from tari dan common types
Removes tari_core dependency from dan_common_types

Motivation and Context
---
~~Blocked by https://github.com/tari-project/tari/pull/6149~~ merged


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify