### PR TITLE
fix(engine): prevent creation of mismatched resource type bucket

### DIFF
--- a/dan_layer/engine/src/runtime/working_state.rs
+++ b/dan_layer/engine/src/runtime/working_state.rs
@@ -25,7 +25,7 @@ use tari_engine_types::{
     non_fungible_index::NonFungibleIndex,
     proof::{ContainerRef, LockedResource, Proof},
     resource::Resource,
-    resource_container::ResourceContainer,
+    resource_container::{ResourceContainer, ResourceError},
     substate::{Substate, SubstateDiff, SubstateId, SubstateValue},
     transaction_receipt::TransactionReceipt,
     vault::Vault,
@@ -533,6 +533,14 @@ impl WorkingState {
         // Increase the total supply, this also validates that the resource already exists.
         {
             let resource_mut = self.get_resource_mut(locked_resource)?;
+            if resource_mut.resource_type() != resource_container.resource_type() {
+                return Err(ResourceError::ResourceTypeMismatch {
+                    operate: "mint",
+                    expected: resource_mut.resource_type(),
+                    given: resource_container.resource_type(),
+                }
+                .into());
+            }
             resource_mut.increase_total_supply(resource_container.amount());
         }
 

--- a/dan_layer/engine/tests/templates/resource_shenanigans/Cargo.toml
+++ b/dan_layer/engine/tests/templates/resource_shenanigans/Cargo.toml
@@ -1,0 +1,13 @@
+[workspace]
+[package]
+name = "resource_shenanigans"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+tari_template_lib = { path = "../../../../template_lib" }
+
+[lib]
+crate-type = ["cdylib", "lib"]

--- a/dan_layer/engine/tests/templates/resource_shenanigans/src/lib.rs
+++ b/dan_layer/engine/tests/templates/resource_shenanigans/src/lib.rs
@@ -1,0 +1,29 @@
+//   Copyright 2023 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+use tari_template_lib::prelude::*;
+
+#[template]
+mod template {
+    use super::*;
+
+    pub struct Shenanigans {
+        vault: Vault,
+    }
+
+    impl Shenanigans {
+        pub fn new() -> Component<Shenanigans> {
+            let resource = ResourceBuilder::non_fungible().mintable(AccessRule::AllowAll).build();
+
+            Component::new(Self {
+                vault: Vault::new_empty(resource),
+            })
+            .with_access_rules(AccessRules::allow_all())
+            .create()
+        }
+
+        pub fn mint_different_resource_type(&mut self) -> Bucket {
+            ResourceManager::get(self.vault.resource_address()).mint_fungible(Amount(1000))
+        }
+    }
+}


### PR DESCRIPTION
Description
---
fix(engine): add resource type check when processing mint args
fix(engine): improve error for resource type mismatch
fix(engine): erroneous dangling resource error when creating an empty vault from a resource
test(engine): add previously failing test for minting a different resource type

Motivation and Context
---
By specifying mismatching MintArgs you were previously able to create a bucket for a resource type that did not match the resource being operated on.

This test exposed another bug which is also tested in the new test. This occurs when you create an empty vault from a new resource, the engine fails with a dangling resource error because it does not recognise that the new empty resource is contained within the new empty vault.

How Has This Been Tested?
---
A new failing test, that passes after changes

What process can a PR reviewer use to test or verify this change?
---
Run engine tests

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify