### PR TITLE
feat(engine)!: allow revealed-only mint and transfers

### DIFF
--- a/applications/tari_dan_wallet_daemon/src/handlers/accounts.rs
+++ b/applications/tari_dan_wallet_daemon/src/handlers/accounts.rs
@@ -397,9 +397,9 @@ pub async fn handle_reveal_funds(
             .confidential_outputs_api()
             .resolve_output_masks(inputs, key_manager::TRANSACTION_BRANCH)?;
 
-        let reveal_proof = sdk
-            .confidential_crypto_api()
-            .generate_withdraw_proof(&inputs, &output_statement, None)?;
+        let reveal_proof =
+            sdk.confidential_crypto_api()
+                .generate_withdraw_proof(&inputs, Amount::zero(), &output_statement, None)?;
 
         info!(
             target: LOG_TARGET,
@@ -629,9 +629,12 @@ pub async fn handle_claim_burn(
         reveal_amount: max_fee,
     };
 
-    let reveal_proof =
-        sdk.confidential_crypto_api()
-            .generate_withdraw_proof(&[unmasked_output], &output_statement, None)?;
+    let reveal_proof = sdk.confidential_crypto_api().generate_withdraw_proof(
+        &[unmasked_output],
+        Amount::zero(),
+        &output_statement,
+        None,
+    )?;
 
     let instructions = vec![Instruction::ClaimBurn {
         claim: Box::new(ConfidentialClaim {
@@ -1174,6 +1177,8 @@ pub async fn handle_confidential_transfer(
 
         let proof = crypto_api.generate_withdraw_proof(
             &confidential_inputs,
+            // TODO: Support withdraw from revealed funds
+            Amount::zero(),
             &output_statement,
             maybe_change_statement.as_ref(),
         )?;

--- a/applications/tari_dan_wallet_daemon/src/handlers/confidential.rs
+++ b/applications/tari_dan_wallet_daemon/src/handlers/confidential.rs
@@ -140,6 +140,8 @@ pub async fn handle_create_transfer_proof(
 
     let proof = sdk.confidential_crypto_api().generate_withdraw_proof(
         &inputs,
+        // TODO: support for using revealed funds as input for proof generation
+        Amount::zero(),
         &output_statement,
         maybe_change_statement.as_ref(),
     )?;

--- a/dan_layer/engine/src/runtime/impl.rs
+++ b/dan_layer/engine/src/runtime/impl.rs
@@ -104,6 +104,7 @@ use crate::{
     template::LoadedTemplate,
     transaction::TransactionProcessor,
 };
+
 const LOG_TARGET: &str = "tari::dan::engine::runtime::impl";
 
 #[derive(Clone)]
@@ -1285,6 +1286,18 @@ impl<TTemplateProvider: TemplateProvider<Template = LoadedTemplate>> RuntimeInte
                         .collect();
 
                     Ok(InvokeResult::encode(&nfts)?)
+                })
+            },
+            BucketAction::CountConfidentialCommitments => {
+                let bucket_id = bucket_ref.bucket_id().ok_or_else(|| RuntimeError::InvalidArgument {
+                    argument: "bucket_ref",
+                    reason: "CountConfidentialCommitments bucket action requires a bucket id".to_string(),
+                })?;
+                args.assert_no_args("Bucket::CountConfidentialCommitments")?;
+
+                self.tracker.write_with(|state| {
+                    let bucket = state.get_bucket(bucket_id)?;
+                    Ok(InvokeResult::encode(&bucket.number_of_confidential_commitments())?)
                 })
             },
         }

--- a/dan_layer/engine/src/runtime/impl.rs
+++ b/dan_layer/engine/src/runtime/impl.rs
@@ -1354,6 +1354,20 @@ impl<TTemplateProvider: TemplateProvider<Template = LoadedTemplate>> RuntimeInte
                     Ok(InvokeResult::encode(&proof.resource_type())?)
                 })
             },
+            ProofAction::GetNonFungibles => {
+                let proof_id = proof_ref.proof_id().ok_or_else(|| RuntimeError::InvalidArgument {
+                    argument: "proof_ref",
+                    reason: "GetNonFungibles proof action requires a proof id".to_string(),
+                })?;
+
+                args.assert_no_args("Proof.GetNonFungibles")?;
+
+                self.tracker.write_with(|state| {
+                    let proof = state.get_proof(proof_id)?;
+                    let nfts = proof.non_fungible_token_ids();
+                    Ok(InvokeResult::encode(&nfts)?)
+                })
+            },
             ProofAction::Authorize => {
                 let proof_id = proof_ref.proof_id().ok_or_else(|| RuntimeError::InvalidArgument {
                     argument: "proof_ref",

--- a/dan_layer/engine/src/runtime/working_state.rs
+++ b/dan_layer/engine/src/runtime/working_state.rs
@@ -525,7 +525,7 @@ impl WorkingState {
                     target: LOG_TARGET,
                     "Minting confidential tokens on resource: {}", resource_address
                 );
-                ResourceContainer::validate_confidential_mint(resource_address, *proof)?
+                ResourceContainer::mint_confidential(resource_address, *proof)?
             },
         };
 

--- a/dan_layer/engine/tests/confidential.rs
+++ b/dan_layer/engine/tests/confidential.rs
@@ -1,17 +1,16 @@
 //   Copyright 2023 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use tari_engine_types::substate::SubstateId;
+use tari_engine_types::{resource_container::ResourceError, substate::SubstateId};
 use tari_template_lib::{
     args,
     models::{Amount, ComponentAddress},
     prelude::ConfidentialOutputProof,
 };
 use tari_template_test_tooling::{
-    support::confidential::{
-        generate_confidential_proof,
-        generate_withdraw_proof,
-        generate_withdraw_proof_with_inputs,
+    support::{
+        assert_error::assert_reject_reason,
+        confidential::{generate_confidential_proof, generate_withdraw_proof, generate_withdraw_proof_with_inputs},
     },
     SubstateType,
     TemplateTest,
@@ -385,4 +384,32 @@ fn multi_commitment_join() {
     assert_eq!(result.finalize.execution_results[3].decode::<u32>().unwrap(), 1);
     assert_eq!(result.finalize.execution_results[7].decode::<u32>().unwrap(), 2);
     assert_eq!(result.finalize.execution_results[9].decode::<u32>().unwrap(), 1);
+}
+
+#[test]
+fn mint_revealed() {
+    let (confidential_proof, _mask, _change) = generate_confidential_proof(Amount(100), None);
+    let (mut template_test, faucet, _faucet_resx) = setup(confidential_proof);
+
+    template_test.call_method::<()>(faucet, "mint_revealed", args![Amount(123)], vec![]);
+    let balance: Amount = template_test.call_method(faucet, "vault_balance", args![], vec![]);
+    assert_eq!(balance, Amount(123));
+}
+
+#[test]
+fn mint_revealed_with_invalid_proof() {
+    let (confidential_proof, _mask, _change) = generate_confidential_proof(Amount(100), None);
+    let (mut template_test, faucet, _faucet_resx) = setup(confidential_proof);
+
+    let reason = template_test.execute_expect_failure(
+        Transaction::builder()
+            .call_method(faucet, "mint_revealed_with_range_proof", args![Amount(123)])
+            .sign(template_test.get_test_secret_key())
+            .build(),
+        vec![],
+    );
+
+    assert_reject_reason(reason, ResourceError::InvalidConfidentialProof {
+        details: String::new(),
+    });
 }

--- a/dan_layer/engine/tests/recall.rs
+++ b/dan_layer/engine/tests/recall.rs
@@ -20,7 +20,7 @@ fn it_recalls_all_resource_types() {
     let (account, _, _) = test.create_empty_account();
 
     let (mut initial_supply, mask, _) = generate_confidential_proof(Amount(1000), None);
-    initial_supply.output_statement.revealed_amount = Amount(1000);
+    initial_supply.output_revealed_amount = Amount(1000);
 
     let result = test.execute_expect_success(
         Transaction::builder()

--- a/dan_layer/engine/tests/templates/access_rules/Cargo.toml
+++ b/dan_layer/engine/tests/templates/access_rules/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 
 [dependencies]
 tari_template_lib = { path = "../../../../template_lib" }
+tari_bor = { path = "../../../../tari_bor" }
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/dan_layer/engine/tests/templates/confidential/faucet/src/lib.rs
+++ b/dan_layer/engine/tests/templates/confidential/faucet/src/lib.rs
@@ -44,6 +44,19 @@ mod faucet_template {
             .create()
         }
 
+        pub fn mint_revealed(&mut self, amount: Amount) {
+            let proof = ConfidentialOutputProof::mint_revealed(amount);
+            let bucket = ResourceManager::get(self.vault.resource_address()).mint_confidential(proof);
+            self.vault.deposit(bucket);
+        }
+
+        pub fn mint_revealed_with_range_proof(&mut self, amount: Amount) {
+            let mut proof = ConfidentialOutputProof::mint_revealed(amount);
+            proof.range_proof = vec![1, 2, 3];
+            let bucket = ResourceManager::get(self.vault.resource_address()).mint_confidential(proof);
+            self.vault.deposit(bucket);
+        }
+
         pub fn mint_more(&mut self, proof: ConfidentialOutputProof) {
             let bucket = ResourceManager::get(self.vault.resource_address()).mint_confidential(proof);
             self.vault.deposit(bucket);
@@ -61,6 +74,10 @@ mod faucet_template {
         /// Utility function for tests
         pub fn split_coins(bucket: Bucket, proof: ConfidentialWithdrawProof) -> (Bucket, Bucket) {
             bucket.split_confidential(proof)
+        }
+
+        pub fn vault_balance(&self) -> Amount {
+            self.vault.balance()
         }
     }
 }

--- a/dan_layer/engine/tests/templates/confidential/faucet/src/lib.rs
+++ b/dan_layer/engine/tests/templates/confidential/faucet/src/lib.rs
@@ -63,7 +63,11 @@ mod faucet_template {
         }
 
         pub fn take_free_coins(&mut self, proof: ConfidentialWithdrawProof) -> Bucket {
-            debug!("Withdrawing <unknown> coins from faucet");
+            debug!(
+                "Withdrawing {} revealed coins from faucet and {} commitments",
+                proof.revealed_input_amount(),
+                proof.inputs.len()
+            );
             self.vault.withdraw_confidential(proof)
         }
 

--- a/dan_layer/engine_types/src/bucket.rs
+++ b/dan_layer/engine_types/src/bucket.rs
@@ -51,6 +51,10 @@ impl Bucket {
         self.resource_container.amount()
     }
 
+    pub fn number_of_confidential_commitments(&self) -> usize {
+        self.resource_container.number_of_confidential_commitments()
+    }
+
     pub fn locked_amount(&self) -> Amount {
         self.resource_container.locked_amount()
     }

--- a/dan_layer/engine_types/src/confidential/proof.rs
+++ b/dan_layer/engine_types/src/confidential/proof.rs
@@ -48,11 +48,17 @@ pub mod challenges {
             .result()
     }
 
-    pub fn confidential_withdraw64(excess: &PublicKey, public_nonce: &PublicKey, revealed_amount: Amount) -> [u8; 64] {
+    pub fn confidential_withdraw64(
+        excess: &PublicKey,
+        public_nonce: &PublicKey,
+        input_revealed_amount: Amount,
+        output_revealed_amount: Amount,
+    ) -> [u8; 64] {
         hasher64(EngineHashDomainLabel::ConfidentialTransfer)
             .chain(excess)
             .chain(public_nonce)
-            .chain(&revealed_amount)
+            .chain(&input_revealed_amount)
+            .chain(&output_revealed_amount)
             .result()
     }
 

--- a/dan_layer/engine_types/src/confidential/validation.rs
+++ b/dan_layer/engine_types/src/confidential/validation.rs
@@ -1,50 +1,57 @@
 //   Copyright 2023 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use std::iter;
-
 use tari_common_types::types::{Commitment, PublicKey};
 use tari_crypto::{
     extended_range_proof::{ExtendedRangeProofService, Statement},
     ristretto::bulletproofs_plus::RistrettoAggregatedPublicStatement,
     tari_utilities::ByteArray,
 };
-use tari_template_lib::models::ConfidentialOutputProof;
+use tari_template_lib::models::{Amount, ConfidentialOutputProof};
 
 use super::get_range_proof_service;
 use crate::{confidential::ConfidentialOutput, resource_container::ResourceError};
 
 #[derive(Debug)]
 pub struct ValidatedConfidentialProof {
-    pub output: ConfidentialOutput,
+    pub output: Option<ConfidentialOutput>,
     pub change_output: Option<ConfidentialOutput>,
+    pub output_revealed_amount: Amount,
+    pub change_revealed_amount: Amount,
 }
 
 pub fn validate_confidential_proof(
     proof: &ConfidentialOutputProof,
 ) -> Result<ValidatedConfidentialProof, ResourceError> {
-    if proof.output_statement.revealed_amount.is_negative() ||
-        proof
-            .change_statement
-            .as_ref()
-            .map(|s| s.revealed_amount.is_negative())
-            .unwrap_or(false)
-    {
+    if proof.output_revealed_amount.is_negative() || proof.change_revealed_amount.is_negative() {
         return Err(ResourceError::InvalidConfidentialProof {
-            details: "Revealed amount must be positive".to_string(),
+            details: "Revealed amounts must be positive".to_string(),
         });
     }
 
-    let output_commitment = Commitment::from_canonical_bytes(&proof.output_statement.commitment).map_err(|_| {
-        ResourceError::InvalidConfidentialProof {
-            details: "Invalid commitment".to_string(),
-        }
-    })?;
+    let maybe_output = proof
+        .output_statement
+        .as_ref()
+        .map(|statement| {
+            let output_commitment = Commitment::from_canonical_bytes(&statement.commitment).map_err(|_| {
+                ResourceError::InvalidConfidentialProof {
+                    details: "Invalid commitment".to_string(),
+                }
+            })?;
 
-    let output_public_nonce = PublicKey::from_canonical_bytes(proof.output_statement.sender_public_nonce.as_bytes())
-        .map_err(|_| ResourceError::InvalidConfidentialProof {
-            details: "Invalid sender public nonce".to_string(),
-        })?;
+            let output_public_nonce = PublicKey::from_canonical_bytes(statement.sender_public_nonce.as_bytes())
+                .map_err(|_| ResourceError::InvalidConfidentialProof {
+                    details: "Invalid sender public nonce".to_string(),
+                })?;
+
+            Ok(ConfidentialOutput {
+                commitment: output_commitment,
+                stealth_public_nonce: output_public_nonce,
+                encrypted_data: statement.encrypted_data.clone(),
+                minimum_value_promise: statement.minimum_value_promise,
+            })
+        })
+        .transpose()?;
 
     let change =
         proof
@@ -74,20 +81,18 @@ pub fn validate_confidential_proof(
     validate_bullet_proof(proof)?;
 
     Ok(ValidatedConfidentialProof {
-        output: ConfidentialOutput {
-            commitment: output_commitment,
-            stealth_public_nonce: output_public_nonce,
-            encrypted_data: proof.output_statement.encrypted_data.clone(),
-            minimum_value_promise: proof.output_statement.minimum_value_promise,
-        },
+        output: maybe_output,
         change_output: change,
+        output_revealed_amount: proof.output_revealed_amount,
+        change_revealed_amount: proof.change_revealed_amount,
     })
 }
 
 fn validate_bullet_proof(proof: &ConfidentialOutputProof) -> Result<(), ResourceError> {
-    let statements = iter::once(&proof.output_statement)
-        .chain(proof.change_statement.as_ref())
-        .cloned()
+    let statements = proof
+        .output_statement
+        .iter()
+        .chain(proof.change_statement.iter())
         .map(|stmt| {
             let commitment = Commitment::from_canonical_bytes(&stmt.commitment).map_err(|_| {
                 ResourceError::InvalidConfidentialProof {
@@ -101,7 +106,18 @@ fn validate_bullet_proof(proof: &ConfidentialOutputProof) -> Result<(), Resource
         })
         .collect::<Result<Vec<_>, _>>()?;
 
+    // Either 0, 1 or 2
     let agg_factor = statements.len();
+    if agg_factor == 0 {
+        // No outputs, so no rangeproof needed (revealed mint)
+        if proof.range_proof.is_empty() {
+            return Ok(());
+        }
+        return Err(ResourceError::InvalidConfidentialProof {
+            details: "Range proof is invalid because it was provided but the proof contained no outputs".to_string(),
+        });
+    }
+
     let public_statement = RistrettoAggregatedPublicStatement::init(statements).unwrap();
 
     let proofs = vec![&proof.range_proof];

--- a/dan_layer/engine_types/src/confidential/withdraw.rs
+++ b/dan_layer/engine_types/src/confidential/withdraw.rs
@@ -16,10 +16,17 @@ use crate::resource_container::ResourceError;
 
 #[derive(Debug, Clone)]
 pub struct ValidatedConfidentialWithdrawProof {
+    /// Optional confidential output of the withdraw. This will be created as a new output commitment.
     pub output: Option<ConfidentialOutput>,
+    /// Optional confidential change output of the withdraw. This will replace any inputs used.
     pub change_output: Option<ConfidentialOutput>,
+    /// Range proof
     pub range_proof: BulletRangeProof,
+    /// Amount of revealed value to use as an input.
+    pub input_revealed_amount: Amount,
+    /// Amount of revealed value to include in the revealed value of the output
     pub output_revealed_amount: Amount,
+    /// Amount of revealed value to include in the revealed value of the change output
     pub change_revealed_amount: Amount,
 }
 
@@ -42,8 +49,9 @@ pub fn validate_confidential_withdraw<'a, I: IntoIterator<Item = &'a Commitment>
 ) -> Result<ValidatedConfidentialWithdrawProof, ResourceError> {
     let validated_proof = validate_confidential_proof(&withdraw_proof.output_proof)?;
 
+    let input_revealed_amount = withdraw_proof.input_revealed_amount;
     // We expect the revealed amount to be excluded from the output commitment.
-    let revealed_amount =
+    let output_revealed_amount =
         withdraw_proof.output_proof.output_revealed_amount + withdraw_proof.output_proof.change_revealed_amount;
 
     // k.G + v.H or 0.G if None
@@ -55,7 +63,7 @@ pub fn validate_confidential_withdraw<'a, I: IntoIterator<Item = &'a Commitment>
 
     // 0.G + v.H
     let revealed_output_commitment =
-        get_commitment_factory().commit_value(&PrivateKey::default(), revealed_amount.value() as u64);
+        get_commitment_factory().commit_value(&PrivateKey::default(), output_revealed_amount.value() as u64);
     let output_commitment_with_revealed = output_commitment + revealed_output_commitment.as_public_key();
 
     let balance_proof =
@@ -63,9 +71,16 @@ pub fn validate_confidential_withdraw<'a, I: IntoIterator<Item = &'a Commitment>
             details: "Malformed balance proof".to_string(),
         })?;
 
+    // 0.G + v.H - users may convert revealed funds to confidential outputs so this must be part of the balance proof
+    let revealed_input_commitment = get_commitment_factory().commit_value(
+        &PrivateKey::default(),
+        withdraw_proof.input_revealed_amount.value() as u64,
+    );
     let total_inputs = inputs
         .into_iter()
-        .fold(PublicKey::default(), |sum, commit| sum + commit.as_public_key());
+        .fold(PublicKey::default(), |sum, commit| sum + commit.as_public_key()) +
+        revealed_input_commitment.as_public_key();
+
     let public_excess = total_inputs -
         &output_commitment_with_revealed -
         validated_proof
@@ -74,8 +89,12 @@ pub fn validate_confidential_withdraw<'a, I: IntoIterator<Item = &'a Commitment>
             .map(|output| output.commitment.as_public_key())
             .unwrap_or(&PublicKey::default());
 
-    let challenge =
-        challenges::confidential_withdraw64(&public_excess, balance_proof.get_public_nonce(), revealed_amount);
+    let challenge = challenges::confidential_withdraw64(
+        &public_excess,
+        balance_proof.get_public_nonce(),
+        input_revealed_amount,
+        output_revealed_amount,
+    );
 
     if !balance_proof.verify_raw_uniform(&public_excess, &challenge) {
         return Err(ResourceError::InvalidBalanceProof {
@@ -87,6 +106,7 @@ pub fn validate_confidential_withdraw<'a, I: IntoIterator<Item = &'a Commitment>
         output: validated_proof.output,
         change_output: validated_proof.change_output,
         range_proof: BulletRangeProof(withdraw_proof.output_proof.range_proof),
+        input_revealed_amount: withdraw_proof.input_revealed_amount,
         output_revealed_amount: withdraw_proof.output_proof.output_revealed_amount,
         change_revealed_amount: withdraw_proof.output_proof.change_revealed_amount,
     })

--- a/dan_layer/engine_types/src/resource_container.rs
+++ b/dan_layer/engine_types/src/resource_container.rs
@@ -127,6 +127,17 @@ impl ResourceContainer {
         }
     }
 
+    pub fn number_of_confidential_commitments(&self) -> usize {
+        match self {
+            ResourceContainer::Confidential {
+                commitments,
+                locked_commitments,
+                ..
+            } => commitments.len() + locked_commitments.len(),
+            _ => 0,
+        }
+    }
+
     pub fn locked_amount(&self) -> Amount {
         match self {
             ResourceContainer::Fungible { locked_amount, .. } => *locked_amount,

--- a/dan_layer/p2p/proto/transaction.proto
+++ b/dan_layer/p2p/proto/transaction.proto
@@ -93,8 +93,9 @@ message OptionalVersion {
 
 message ConfidentialWithdrawProof {
   repeated bytes inputs = 1;
-  ConfidentialOutputProof output_proof = 2;
-  bytes balance_proof = 3;
+  uint64 input_revealed_amount = 2;
+  ConfidentialOutputProof output_proof = 3;
+  bytes balance_proof = 4;
 }
 
 message ConfidentialOutputProof {

--- a/dan_layer/p2p/proto/transaction.proto
+++ b/dan_layer/p2p/proto/transaction.proto
@@ -101,6 +101,8 @@ message ConfidentialOutputProof {
   ConfidentialStatement output_statement = 1;
   ConfidentialStatement change_statement = 2;
   bytes range_proof = 3;
+  uint64 output_revealed_amount = 4;
+  uint64 change_revealed_amount = 5;
 }
 
 message ConfidentialStatement {
@@ -108,5 +110,4 @@ message ConfidentialStatement {
   bytes sender_public_nonce = 2;
   bytes encrypted_value = 3;
   uint64 minimum_value_promise = 4;
-  uint64 revealed_amount = 5;
 }

--- a/dan_layer/p2p/src/conversions/transaction.rs
+++ b/dan_layer/p2p/src/conversions/transaction.rs
@@ -178,7 +178,7 @@ impl TryFrom<proto::transaction::Instruction> for Instruction {
                     function,
                     args,
                 }
-            }
+            },
             InstructionType::Method => {
                 let method = request.method;
                 let component_address = Hash::try_from(request.component_address)?.into();
@@ -187,10 +187,10 @@ impl TryFrom<proto::transaction::Instruction> for Instruction {
                     method,
                     args,
                 }
-            }
+            },
             InstructionType::PutOutputInWorkspace => {
                 Instruction::PutLastInstructionOutputOnWorkspace { key: request.key }
-            }
+            },
             InstructionType::EmitLog => Instruction::EmitLog {
                 level: request.log_level.parse()?,
                 message: request.log_message,
@@ -218,7 +218,7 @@ impl TryFrom<proto::transaction::Instruction> for Instruction {
                 validator_public_key: PublicKey::from_canonical_bytes(
                     &request.claim_validator_fees_validator_public_key,
                 )
-                    .map_err(|e| anyhow!("claim_validator_fees_validator_public_key: {}", e))?,
+                .map_err(|e| anyhow!("claim_validator_fees_validator_public_key: {}", e))?,
             },
             InstructionType::DropAllProofsInWorkspace => Instruction::DropAllProofsInWorkspace,
             InstructionType::CreateFreeTestCoins => Instruction::CreateFreeTestCoins {
@@ -245,7 +245,7 @@ impl From<Instruction> for proto::transaction::Instruction {
                 result.template_address = template_address.to_vec();
                 result.function = function;
                 result.args = args.into_iter().map(|a| a.into()).collect();
-            }
+            },
             Instruction::CallMethod {
                 component_address,
                 method,
@@ -255,16 +255,16 @@ impl From<Instruction> for proto::transaction::Instruction {
                 result.component_address = component_address.as_bytes().to_vec();
                 result.method = method;
                 result.args = args.into_iter().map(|a| a.into()).collect();
-            }
+            },
             Instruction::PutLastInstructionOutputOnWorkspace { key } => {
                 result.instruction_type = InstructionType::PutOutputInWorkspace as i32;
                 result.key = key;
-            }
+            },
             Instruction::EmitLog { level, message } => {
                 result.instruction_type = InstructionType::EmitLog as i32;
                 result.log_level = level.to_string();
                 result.log_message = message;
-            }
+            },
             Instruction::ClaimBurn { claim } => {
                 result.instruction_type = InstructionType::ClaimBurn as i32;
                 result.claim_burn_commitment_address = claim.output_address.to_vec();
@@ -272,7 +272,7 @@ impl From<Instruction> for proto::transaction::Instruction {
                 result.claim_burn_proof_of_knowledge = Some(claim.proof_of_knowledge.into());
                 result.claim_burn_public_key = claim.public_key.to_vec();
                 result.claim_burn_withdraw_proof = claim.withdraw_proof.map(Into::into);
-            }
+            },
             Instruction::ClaimValidatorFees {
                 epoch,
                 validator_public_key,
@@ -280,10 +280,10 @@ impl From<Instruction> for proto::transaction::Instruction {
                 result.instruction_type = InstructionType::ClaimValidatorFees as i32;
                 result.claim_validator_fees_epoch = epoch;
                 result.claim_validator_fees_validator_public_key = validator_public_key.to_vec();
-            }
+            },
             Instruction::DropAllProofsInWorkspace => {
                 result.instruction_type = InstructionType::DropAllProofsInWorkspace as i32;
-            }
+            },
             // TODO: debugging feature should not be the default. Perhaps a better way to create faucet coins is to mint
             //       a faucet vault in the genesis state for dev networks and use faucet builtin template to withdraw
             //       funds.
@@ -296,7 +296,7 @@ impl From<Instruction> for proto::transaction::Instruction {
                 result.create_free_test_coins_output_blob = output
                     .map(|o| tari_bor::encode(&o).unwrap())
                     .unwrap_or_else(|| tari_bor::encode(&None::<ConfidentialOutput>).unwrap());
-            }
+            },
         }
         result
     }
@@ -327,11 +327,11 @@ impl From<Arg> for proto::transaction::Arg {
             Arg::Literal(data) => {
                 result.arg_type = 0;
                 result.data = tari_bor::encode(&data).unwrap();
-            }
+            },
             Arg::Workspace(data) => {
                 result.arg_type = 1;
                 result.data = data;
-            }
+            },
         }
 
         result

--- a/dan_layer/p2p/src/conversions/transaction.rs
+++ b/dan_layer/p2p/src/conversions/transaction.rs
@@ -405,6 +405,7 @@ impl TryFrom<proto::transaction::ConfidentialWithdrawProof> for ConfidentialWith
                     PedersonCommitmentBytes::from_bytes(&v).map_err(|e| anyhow!("Invalid input commitment bytes: {e}"))
                 })
                 .collect::<Result<_, _>>()?,
+            input_revealed_amount: val.input_revealed_amount.try_into()?,
             output_proof: val
                 .output_proof
                 .ok_or_else(|| anyhow!("output_proof is missing"))?
@@ -419,6 +420,10 @@ impl From<ConfidentialWithdrawProof> for proto::transaction::ConfidentialWithdra
     fn from(val: ConfidentialWithdrawProof) -> Self {
         Self {
             inputs: val.inputs.iter().map(|v| v.as_bytes().to_vec()).collect(),
+            input_revealed_amount: val
+                .input_revealed_amount
+                .as_u64_checked()
+                .expect("input_revealed_amount is negative or too large"),
             output_proof: Some(val.output_proof.into()),
             balance_proof: val.balance_proof.as_bytes().to_vec(),
         }

--- a/dan_layer/p2p/src/conversions/transaction.rs
+++ b/dan_layer/p2p/src/conversions/transaction.rs
@@ -178,7 +178,7 @@ impl TryFrom<proto::transaction::Instruction> for Instruction {
                     function,
                     args,
                 }
-            },
+            }
             InstructionType::Method => {
                 let method = request.method;
                 let component_address = Hash::try_from(request.component_address)?.into();
@@ -187,10 +187,10 @@ impl TryFrom<proto::transaction::Instruction> for Instruction {
                     method,
                     args,
                 }
-            },
+            }
             InstructionType::PutOutputInWorkspace => {
                 Instruction::PutLastInstructionOutputOnWorkspace { key: request.key }
-            },
+            }
             InstructionType::EmitLog => Instruction::EmitLog {
                 level: request.log_level.parse()?,
                 message: request.log_message,
@@ -218,7 +218,7 @@ impl TryFrom<proto::transaction::Instruction> for Instruction {
                 validator_public_key: PublicKey::from_canonical_bytes(
                     &request.claim_validator_fees_validator_public_key,
                 )
-                .map_err(|e| anyhow!("claim_validator_fees_validator_public_key: {}", e))?,
+                    .map_err(|e| anyhow!("claim_validator_fees_validator_public_key: {}", e))?,
             },
             InstructionType::DropAllProofsInWorkspace => Instruction::DropAllProofsInWorkspace,
             InstructionType::CreateFreeTestCoins => Instruction::CreateFreeTestCoins {
@@ -245,7 +245,7 @@ impl From<Instruction> for proto::transaction::Instruction {
                 result.template_address = template_address.to_vec();
                 result.function = function;
                 result.args = args.into_iter().map(|a| a.into()).collect();
-            },
+            }
             Instruction::CallMethod {
                 component_address,
                 method,
@@ -255,16 +255,16 @@ impl From<Instruction> for proto::transaction::Instruction {
                 result.component_address = component_address.as_bytes().to_vec();
                 result.method = method;
                 result.args = args.into_iter().map(|a| a.into()).collect();
-            },
+            }
             Instruction::PutLastInstructionOutputOnWorkspace { key } => {
                 result.instruction_type = InstructionType::PutOutputInWorkspace as i32;
                 result.key = key;
-            },
+            }
             Instruction::EmitLog { level, message } => {
                 result.instruction_type = InstructionType::EmitLog as i32;
                 result.log_level = level.to_string();
                 result.log_message = message;
-            },
+            }
             Instruction::ClaimBurn { claim } => {
                 result.instruction_type = InstructionType::ClaimBurn as i32;
                 result.claim_burn_commitment_address = claim.output_address.to_vec();
@@ -272,7 +272,7 @@ impl From<Instruction> for proto::transaction::Instruction {
                 result.claim_burn_proof_of_knowledge = Some(claim.proof_of_knowledge.into());
                 result.claim_burn_public_key = claim.public_key.to_vec();
                 result.claim_burn_withdraw_proof = claim.withdraw_proof.map(Into::into);
-            },
+            }
             Instruction::ClaimValidatorFees {
                 epoch,
                 validator_public_key,
@@ -280,10 +280,10 @@ impl From<Instruction> for proto::transaction::Instruction {
                 result.instruction_type = InstructionType::ClaimValidatorFees as i32;
                 result.claim_validator_fees_epoch = epoch;
                 result.claim_validator_fees_validator_public_key = validator_public_key.to_vec();
-            },
+            }
             Instruction::DropAllProofsInWorkspace => {
                 result.instruction_type = InstructionType::DropAllProofsInWorkspace as i32;
-            },
+            }
             // TODO: debugging feature should not be the default. Perhaps a better way to create faucet coins is to mint
             //       a faucet vault in the genesis state for dev networks and use faucet builtin template to withdraw
             //       funds.
@@ -296,7 +296,7 @@ impl From<Instruction> for proto::transaction::Instruction {
                 result.create_free_test_coins_output_blob = output
                     .map(|o| tari_bor::encode(&o).unwrap())
                     .unwrap_or_else(|| tari_bor::encode(&None::<ConfidentialOutput>).unwrap());
-            },
+            }
         }
         result
     }
@@ -327,11 +327,11 @@ impl From<Arg> for proto::transaction::Arg {
             Arg::Literal(data) => {
                 result.arg_type = 0;
                 result.data = tari_bor::encode(&data).unwrap();
-            },
+            }
             Arg::Workspace(data) => {
                 result.arg_type = 1;
                 result.data = data;
-            },
+            }
         }
 
         result
@@ -432,12 +432,11 @@ impl TryFrom<proto::transaction::ConfidentialOutputProof> for ConfidentialOutput
 
     fn try_from(val: proto::transaction::ConfidentialOutputProof) -> Result<Self, Self::Error> {
         Ok(ConfidentialOutputProof {
-            output_statement: val
-                .output_statement
-                .ok_or_else(|| anyhow!("output is missing"))?
-                .try_into()?,
+            output_statement: val.output_statement.map(TryInto::try_into).transpose()?,
             change_statement: val.change_statement.map(TryInto::try_into).transpose()?,
             range_proof: val.range_proof,
+            output_revealed_amount: val.output_revealed_amount.try_into()?,
+            change_revealed_amount: val.change_revealed_amount.try_into()?,
         })
     }
 }
@@ -445,9 +444,17 @@ impl TryFrom<proto::transaction::ConfidentialOutputProof> for ConfidentialOutput
 impl From<ConfidentialOutputProof> for proto::transaction::ConfidentialOutputProof {
     fn from(val: ConfidentialOutputProof) -> Self {
         Self {
-            output_statement: Some(val.output_statement.into()),
+            output_statement: val.output_statement.map(Into::into),
             change_statement: val.change_statement.map(Into::into),
             range_proof: val.range_proof,
+            output_revealed_amount: val
+                .output_revealed_amount
+                .as_u64_checked()
+                .expect("output_revealed_amount is negative or too large"),
+            change_revealed_amount: val
+                .change_revealed_amount
+                .as_u64_checked()
+                .expect("change_revealed_amount is negative or too large"),
         }
     }
 }
@@ -476,7 +483,6 @@ impl TryFrom<proto::transaction::ConfidentialStatement> for ConfidentialStatemen
                     .ok_or_else(|| anyhow!("Invalid length of encrypted_value bytes"))?,
             ),
             minimum_value_promise: val.minimum_value_promise,
-            revealed_amount: val.revealed_amount.try_into()?,
         })
     }
 }
@@ -488,10 +494,6 @@ impl From<ConfidentialStatement> for proto::transaction::ConfidentialStatement {
             sender_public_nonce: val.sender_public_nonce.as_bytes().to_vec(),
             encrypted_value: val.encrypted_data.as_ref().to_vec(),
             minimum_value_promise: val.minimum_value_promise,
-            revealed_amount: val
-                .revealed_amount
-                .as_u64_checked()
-                .expect("revealed_amount is negative or too large"),
         }
     }
 }

--- a/dan_layer/template_lib/src/args/types.rs
+++ b/dan_layer/template_lib/src/args/types.rs
@@ -402,6 +402,7 @@ pub enum BucketAction {
     CreateProof,
     GetNonFungibleIds,
     GetNonFungibles,
+    CountConfidentialCommitments,
 }
 
 /// A bucket burn operation argument

--- a/dan_layer/template_lib/src/args/types.rs
+++ b/dan_layer/template_lib/src/args/types.rs
@@ -572,6 +572,7 @@ pub enum ProofAction {
     GetAmount,
     GetResourceAddress,
     GetResourceType,
+    GetNonFungibles,
     Authorize,
     DropAuthorize,
     Drop,

--- a/dan_layer/template_lib/src/models/bucket.rs
+++ b/dan_layer/template_lib/src/models/bucket.rs
@@ -202,4 +202,15 @@ impl Bucket {
 
         resp.decode().expect("get_non_fungibles returned invalid non fungibles")
     }
+
+    pub fn count_confidential_commitments(&self) -> u32 {
+        let resp: InvokeResult = call_engine(EngineOp::BucketInvoke, &BucketInvokeArg {
+            bucket_ref: BucketRef::Ref(self.id),
+            action: BucketAction::CountConfidentialCommitments,
+            args: invoke_args![],
+        });
+
+        resp.decode()
+            .expect("count_confidential_commitments returned invalid u32")
+    }
 }

--- a/dan_layer/template_lib/src/models/confidential_proof.rs
+++ b/dan_layer/template_lib/src/models/confidential_proof.rs
@@ -16,12 +16,27 @@ use crate::{
 #[cfg_attr(feature = "ts", derive(TS), ts(export, export_to = "../../bindings/src/types/"))]
 pub struct ConfidentialOutputProof {
     /// Proof of the confidential resources that are going to be transferred to the receiver
-    pub output_statement: ConfidentialStatement,
+    pub output_statement: Option<ConfidentialStatement>,
     /// Proof of the transaction change, which goes back to the sender's vault
     pub change_statement: Option<ConfidentialStatement>,
     // #[cfg_attr(feature = "hex", serde(with = "hex::serde"))]
     /// Needed to prove that no coins were created
     pub range_proof: Vec<u8>,
+    pub output_revealed_amount: Amount,
+    pub change_revealed_amount: Amount,
+}
+
+impl ConfidentialOutputProof {
+    /// Creates an output proof for minting which only mints a revealed amount.
+    pub fn mint_revealed(amount: Amount) -> Self {
+        Self {
+            output_statement: None,
+            change_statement: None,
+            range_proof: vec![],
+            output_revealed_amount: amount,
+            change_revealed_amount: Amount::zero(),
+        }
+    }
 }
 
 /// A zero-knowledge proof that a confidential resource amount is valid
@@ -32,16 +47,13 @@ pub struct ConfidentialStatement {
     #[serde_as(as = "Bytes")]
     pub commitment: [u8; 32],
     /// Public nonce (R) that was used to generate the commitment mask
-    // #[cfg_attr(feature = "serde", serde(with = "hex::serde"))]
     #[cfg_attr(feature = "ts", ts(type = "Array<number>"))]
     pub sender_public_nonce: RistrettoPublicKeyBytes,
-    /// Commitment value encrypted for the receiver. Without this it would be difficult (not impossible) for the
-    /// receiver to determine the value component of the commitment.
+    /// Encrypted mask and value for the recipient.
     #[cfg_attr(feature = "ts", ts(type = "Array<number>"))]
     pub encrypted_data: EncryptedData,
     #[cfg_attr(feature = "ts", ts(type = "number"))]
     pub minimum_value_promise: u64,
-    pub revealed_amount: Amount,
 }
 
 /// A zero-knowledge proof that a withdrawal of confidential resources from a vault is valid

--- a/dan_layer/template_lib/src/models/confidential_proof.rs
+++ b/dan_layer/template_lib/src/models/confidential_proof.rs
@@ -63,10 +63,41 @@ pub struct ConfidentialWithdrawProof {
     // #[cfg_attr(feature = "hex", serde(with = "hex::serde"))]
     #[cfg_attr(feature = "ts", ts(type = "Array<number>"))]
     pub inputs: Vec<PedersonCommitmentBytes>,
+    /// The amount to withdraw from revealed funds i.e. the revealed funds as inputs
+    #[cfg_attr(feature = "ts", ts(type = "number"))]
+    pub input_revealed_amount: Amount,
     pub output_proof: ConfidentialOutputProof,
     /// Balance proof
     #[cfg_attr(feature = "ts", ts(type = "Array<number>"))]
     pub balance_proof: BalanceProofSignature,
+}
+
+impl ConfidentialWithdrawProof {
+    /// Creates a withdrawal proof for revealed funds of a specific amount
+    pub fn revealed_withdraw(amount: Amount) -> Self {
+        // There are no confidential inputs or outputs (this amounts to the same thing as a Fungible resource transfer)
+        // So signature s = 0 + e.x where x is a 0 excess, is valid.
+        let balance_proof = BalanceProofSignature::try_from_parts(&[0u8; 32], &[0u8; 32]).unwrap();
+
+        Self {
+            inputs: vec![],
+            input_revealed_amount: amount,
+            output_proof: ConfidentialOutputProof::mint_revealed(amount),
+            balance_proof,
+        }
+    }
+
+    pub fn revealed_input_amount(&self) -> Amount {
+        self.input_revealed_amount
+    }
+
+    pub fn revealed_output_amount(&self) -> Amount {
+        self.output_proof.output_revealed_amount
+    }
+
+    pub fn revealed_change_amount(&self) -> Amount {
+        self.output_proof.change_revealed_amount
+    }
 }
 
 /// Used by the receiver to determine the value component of the commitment, in both confidential transfers and Minotari

--- a/dan_layer/template_lib/src/models/metadata.rs
+++ b/dan_layer/template_lib/src/models/metadata.rs
@@ -29,6 +29,7 @@ use tari_template_abi::rust::{collections::BTreeMap, fmt::Display};
 use ts_rs::TS;
 
 use super::BinaryTag;
+
 const TAG: u64 = BinaryTag::Metadata as u64;
 
 /// A collection of user-defined data used to describe other types, for example, non-fungible tokens or events
@@ -50,6 +51,10 @@ impl Metadata {
 
     pub fn get(&self, key: &str) -> Option<&String> {
         self.0.get(key)
+    }
+
+    pub fn contains_key(&self, key: &str) -> bool {
+        self.0.contains_key(key)
     }
 
     pub fn merge(&mut self, other: Metadata) -> &mut Self {

--- a/dan_layer/template_lib/src/models/proof.rs
+++ b/dan_layer/template_lib/src/models/proof.rs
@@ -20,6 +20,8 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+use std::collections::BTreeSet;
+
 use serde::{Deserialize, Serialize};
 use tari_bor::BorTag;
 use tari_template_abi::{call_engine, rust::fmt, EngineOp};
@@ -28,7 +30,7 @@ use ts_rs::TS;
 
 use crate::{
     args::{InvokeResult, ProofAction, ProofInvokeArg, ProofRef},
-    models::{Amount, BinaryTag, ResourceAddress},
+    models::{Amount, BinaryTag, NonFungibleId, ResourceAddress},
     prelude::ResourceType,
 };
 
@@ -88,6 +90,17 @@ impl Proof {
 
         resp.decode()
             .expect("Proof GetResourceType returned invalid resource type")
+    }
+
+    pub fn get_non_fungibles(&self) -> BTreeSet<NonFungibleId> {
+        let resp: InvokeResult = call_engine(EngineOp::ProofInvoke, &ProofInvokeArg {
+            proof_ref: ProofRef::Ref(self.id),
+            action: ProofAction::GetNonFungibles,
+            args: invoke_args![],
+        });
+
+        resp.decode()
+            .expect("Proof GetNonFungibles returned invalid non-fungibles")
     }
 
     pub fn amount(&self) -> Amount {

--- a/dan_layer/template_lib/src/resource/builder/non_fungible.rs
+++ b/dan_layer/template_lib/src/resource/builder/non_fungible.rs
@@ -116,8 +116,8 @@ impl NonFungibleResourceBuilder {
     pub fn with_non_fungibles<'a, I, T, U>(mut self, tokens: I) -> Self
     where
         I: IntoIterator<Item = (NonFungibleId, (&'a T, &'a U))>,
-        T: Serialize + 'a,
-        U: Serialize + 'a,
+        T: Serialize + ?Sized + 'a,
+        U: Serialize + ?Sized + 'a,
     {
         self.tokens_ids.extend(
             tokens

--- a/dan_layer/wallet/sdk/src/apis/confidential_crypto.rs
+++ b/dan_layer/wallet/sdk/src/apis/confidential_crypto.rs
@@ -47,6 +47,7 @@ impl ConfidentialCryptoApi {
     pub fn generate_withdraw_proof(
         &self,
         inputs: &[ConfidentialOutputWithMask],
+        input_revealed_amount: Amount,
         output_statement: &ConfidentialProofStatement,
         change_statement: Option<&ConfidentialProofStatement>,
     ) -> Result<ConfidentialWithdrawProof, ConfidentialCryptoApiError> {
@@ -60,12 +61,13 @@ impl ConfidentialCryptoApi {
             .iter()
             .fold(PrivateKey::default(), |acc, output| acc + &output.mask);
 
-        let revealed_amount = output_proof.output_revealed_amount + output_proof.change_revealed_amount;
+        let output_revealed_amount = output_proof.output_revealed_amount + output_proof.change_revealed_amount;
         let balance_proof = generate_balance_proof(
             &agg_input_mask,
+            input_revealed_amount,
             &output_statement.mask,
             change_statement.as_ref().map(|ch| &ch.mask),
-            revealed_amount,
+            output_revealed_amount,
         );
 
         let output_statement = output_proof.output_statement;
@@ -73,6 +75,7 @@ impl ConfidentialCryptoApi {
 
         Ok(ConfidentialWithdrawProof {
             inputs: input_commitments,
+            input_revealed_amount: Amount::zero(),
             output_proof: ConfidentialOutputProof {
                 output_statement,
                 change_statement,
@@ -171,14 +174,16 @@ impl ConfidentialCryptoApi {
 
 fn generate_balance_proof(
     input_mask: &PrivateKey,
+    input_revealed_amount: Amount,
     output_mask: &PrivateKey,
     change_mask: Option<&PrivateKey>,
-    reveal_amount: Amount,
+    output_reveal_amount: Amount,
 ) -> BalanceProofSignature {
     let secret_excess = input_mask - output_mask - change_mask.unwrap_or(&PrivateKey::default());
     let excess = PublicKey::from_secret_key(&secret_excess);
     let (nonce, public_nonce) = PublicKey::random_keypair(&mut OsRng);
-    let challenge = challenges::confidential_withdraw64(&excess, &public_nonce, reveal_amount);
+    let challenge =
+        challenges::confidential_withdraw64(&excess, &public_nonce, input_revealed_amount, output_reveal_amount);
 
     let sig = Signature::sign_raw_uniform(&secret_excess, nonce, &challenge).unwrap();
     BalanceProofSignature::try_from_parts(sig.get_public_nonce().as_bytes(), sig.get_signature().as_bytes()).unwrap()

--- a/dan_layer/wallet/sdk/src/apis/confidential_crypto.rs
+++ b/dan_layer/wallet/sdk/src/apis/confidential_crypto.rs
@@ -60,12 +60,7 @@ impl ConfidentialCryptoApi {
             .iter()
             .fold(PrivateKey::default(), |acc, output| acc + &output.mask);
 
-        let revealed_amount = output_proof.output_statement.revealed_amount +
-            output_proof
-                .change_statement
-                .as_ref()
-                .map(|st| st.revealed_amount)
-                .unwrap_or_default();
+        let revealed_amount = output_proof.output_revealed_amount + output_proof.change_revealed_amount;
         let balance_proof = generate_balance_proof(
             &agg_input_mask,
             &output_statement.mask,
@@ -82,6 +77,8 @@ impl ConfidentialCryptoApi {
                 output_statement,
                 change_statement,
                 range_proof: output_proof.range_proof,
+                output_revealed_amount: output_proof.output_revealed_amount,
+                change_revealed_amount: output_proof.change_revealed_amount,
             },
             balance_proof,
         })


### PR DESCRIPTION
Description
---
feat(engine)!: allow revealed-only mint and transfers
feat(engine): add the ability to count confidential commitments in a bucket
feat(engine): allow fetching of badge data from proofs

Motivation and Context
---
There are use cases where you want to mint or transfer confidential assets using only revealed funds. This was previously possible if the wallet generated a new (0) output commitment and set the revealed funds. This PR allows the user to explicitly omit the confidential output and only specify the revealed output. A user may still create the (0) output ($k.G + 0.H$) as before if required. For mints, this change will mint only revealed funds, and for transfers this will consume the inputs and only produce revealed funds for the transfer output/change output or both.

This allows the template to create a confidential output proof that only creates revealed funds (like a fungible resource) without the wallet having to generate commitments/rangeproofs.

```rust
       pub fn mint_revealed(&mut self, amount: Amount) {
            let proof = ConfidentialOutputProof::mint_revealed(amount);
            let bucket = ResourceManager::get(self.vault.resource_address()).mint_confidential(proof);
            self.vault.deposit(bucket);
        }
```

By allowing a template to fetch the number of confidential commitments in a bucket, a template author can either prevent confidential commitments from being used, or assert that they are being used.

Allowing the template to fetch NFT data from proofs enables templates to implement more complex rules for badges.

Breaking changes are due to the ConfidentialOutputProof struct change

How Has This Been Tested?
---
New unit tests that check minting

What process can a PR reviewer use to test or verify this change?
---
Create a template with the code above.

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify