### PR TITLE
fix(validator_node_web_ui): infinite loop on transaction details

### DIFF
--- a/applications/tari_validator_node_web_ui/src/routes/Transactions/TransactionDetails.tsx
+++ b/applications/tari_validator_node_web_ui/src/routes/Transactions/TransactionDetails.tsx
@@ -113,7 +113,7 @@ export default function TransactionDetails() {
 
   useEffect(() => {
     getTransactionByHash();
-  });
+  }, []);
 
   const handleChange = (panel: string) => (event: React.SyntheticEvent, isExpanded: boolean) => {
     setExpandedPanels((prevExpandedPanels) => {


### PR DESCRIPTION
Description
---
Fixed a `useEffect` call on the VN's transaction page to avoid an infinite refreshing issue

Motivation and Context
---
The VN UI transaction details page is currently broken due to an infinite loop.

How Has This Been Tested?
---
Manually: Blocks -> More Info -> Expand "Accept" -> Click on one of the transactions

What process can a PR reviewer use to test or verify this change?
---
See previous section

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify