### PR TITLE
fix: correctly strip prefix from VaultId

### DIFF
--- a/dan_layer/template_lib/src/models/component.rs
+++ b/dan_layer/template_lib/src/models/component.rs
@@ -70,11 +70,7 @@ impl FromStr for ComponentAddress {
     type Err = HashParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let s = if let Some(stripped) = s.strip_prefix("component_") {
-            stripped
-        } else {
-            s
-        };
+        let s = s.strip_prefix("component_").unwrap_or(s);
         let hash = Hash::from_hex(s)?;
         Ok(Self::new(hash))
     }

--- a/dan_layer/template_lib/src/models/resource.rs
+++ b/dan_layer/template_lib/src/models/resource.rs
@@ -58,11 +58,7 @@ impl FromStr for ResourceAddress {
     type Err = HashParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let s = if let Some(stripped) = s.strip_prefix("resource_") {
-            stripped
-        } else {
-            s
-        };
+        let s = s.strip_prefix("resource_").unwrap_or(s);
         let hash = Hash::from_hex(s)?;
         Ok(Self::new(hash))
     }

--- a/dan_layer/template_lib/src/models/vault.rs
+++ b/dan_layer/template_lib/src/models/vault.rs
@@ -99,7 +99,7 @@ impl FromStr for VaultId {
     type Err = HashParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let s = s.strip_prefix("vault_").ok_or(HashParseError)?;
+        let s = s.strip_prefix("vault_").unwrap_or(s);
         let hash = Hash::from_hex(s)?;
         Ok(Self::new(hash))
     }


### PR DESCRIPTION
Description
---
Fix VaultId FromStr implementation to optionally strip the prefix rather than error

Motivation and Context
---
All other substates will accept `{type}_{hash}` and `{hash}`. VaultId only accepted `{type}_{hash}`

How Has This Been Tested?
---
Submitting a `{Vault: "xxxxxx"}` to get substates via javascript. This previously would error.


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify