### PR TITLE
fix(walletd): fix query for NonFungible

### DIFF
--- a/bindings/src/helpers/helpers.ts
+++ b/bindings/src/helpers/helpers.ts
@@ -1,134 +1,145 @@
 //   Copyright 2023 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-import { JrpcPermission } from "../types/JrpcPermission";
-import { RejectReason } from "../types/RejectReason";
-import { SubstateDiff } from "../types/SubstateDiff";
-import { SubstateId } from "../types/SubstateId";
-import { TransactionResult } from "../types/TransactionResult";
+import {JrpcPermission} from "../types/JrpcPermission";
+import {RejectReason} from "../types/RejectReason";
+import {SubstateDiff} from "../types/SubstateDiff";
+import {SubstateId} from "../types/SubstateId";
+import {TransactionResult} from "../types/TransactionResult";
 
 export function substateIdToString(substateId: SubstateId | null): string {
-  if (substateId === null) {
-    return "";
-  }
-  if ("Component" in substateId) {
-    return substateId.Component;
-  }
-  if ("Resource" in substateId) {
-    return substateId.Resource;
-  }
-  if ("Vault" in substateId) {
-    return substateId.Vault;
-  }
-  if ("UnclaimedConfidentialOutput" in substateId) {
-    return substateId.UnclaimedConfidentialOutput;
-  }
-  if ("NonFungible" in substateId) {
-    return substateId.NonFungible;
-  }
-  if ("NonFungibleIndex" in substateId) {
-    return `${substateId.NonFungibleIndex.resource_address}:${substateId.NonFungibleIndex.index}`;
-  }
-  if ("TransactionReceipt" in substateId) {
-    return substateId.TransactionReceipt;
-  }
-  if ("FeeClaim" in substateId) {
-    return substateId.FeeClaim;
-  }
-  console.error("Unknown substate id", substateId);
-  return "Unknown";
+    if (substateId === null) {
+        return "";
+    }
+    if ("Component" in substateId) {
+        return substateId.Component;
+    }
+    if ("Resource" in substateId) {
+        return substateId.Resource;
+    }
+    if ("Vault" in substateId) {
+        return substateId.Vault;
+    }
+    if ("UnclaimedConfidentialOutput" in substateId) {
+        return substateId.UnclaimedConfidentialOutput;
+    }
+    if ("NonFungible" in substateId) {
+        return substateId.NonFungible;
+    }
+    if ("NonFungibleIndex" in substateId) {
+        return `${substateId.NonFungibleIndex.resource_address}:${substateId.NonFungibleIndex.index}`;
+    }
+    if ("TransactionReceipt" in substateId) {
+        return substateId.TransactionReceipt;
+    }
+    if ("FeeClaim" in substateId) {
+        return substateId.FeeClaim;
+    }
+    console.error("Unknown substate id", substateId);
+    return "Unknown";
 }
 
 export function stringToSubstateId(substateId: string): SubstateId {
-  const parts = substateId.split("_", 2);
-  if (parts.length !== 2) {
-    throw new Error(`Invalid substate id: ${substateId}`);
-  }
+    const parts = splitOnce(substateId, "_");
+    if (!parts) {
+        throw new Error(`Invalid substate id: ${substateId}`);
+    }
 
-  switch (parts[0]) {
-    case "component":
-      return { Component: parts[1] };
-    case "resource":
-      return { Resource: parts[1] };
-    case "vault":
-      return { Vault: parts[1] };
-    case "commitment":
-      return { UnclaimedConfidentialOutput: parts[1] };
-    case "nft":
-      return { NonFungible: parts[1] };
-    case "txreceipt":
-      return { TransactionReceipt: parts[1] };
-    case "feeclaim":
-      return { FeeClaim: parts[1] };
-    default:
-      throw new Error(`Unknown substate id: ${substateId}`);
-  }
+    switch (parts[0]) {
+        case "component":
+            return {Component: parts[1]};
+        case "resource":
+            if (parts[1].includes(' nft_')) {
+                return {NonFungible: parts[1]};
+            }
+
+            return {Resource: parts[1]};
+        case "vault":
+            return {Vault: parts[1]};
+        case "commitment":
+            return {UnclaimedConfidentialOutput: parts[1]};
+        case "txreceipt":
+            return {TransactionReceipt: parts[1]};
+        case "feeclaim":
+            return {FeeClaim: parts[1]};
+        default:
+            throw new Error(`Unknown substate id: ${substateId}`);
+    }
 }
 
 export function rejectReasonToString(reason: RejectReason | null): string {
-  if (reason === null) {
-    return "";
-  }
-  if (typeof reason === "string") {
-    return reason;
-  }
-  if ("ShardsNotPledged" in reason) {
-    return `ShardsNotPledged(${reason.ShardsNotPledged})`;
-  }
-  if ("ExecutionFailure" in reason) {
-    return `ExecutionFailure(${reason.ExecutionFailure})`;
-  }
-  if ("ShardPledgedToAnotherPayload" in reason) {
-    return `ShardPledgedToAnotherPayload(${reason.ShardPledgedToAnotherPayload})`;
-  }
-  if ("ShardRejected" in reason) {
-    return `ShardRejected(${reason.ShardRejected})`;
-  }
-  if ("FeesNotPaid" in reason) {
-    return `FeesNotPaid(${reason.FeesNotPaid})`;
-  }
-  console.error("Unknown reason", reason);
-  return "Unknown";
+    if (reason === null) {
+        return "";
+    }
+    if (typeof reason === "string") {
+        return reason;
+    }
+    if ("ShardsNotPledged" in reason) {
+        return `ShardsNotPledged(${reason.ShardsNotPledged})`;
+    }
+    if ("ExecutionFailure" in reason) {
+        return `ExecutionFailure(${reason.ExecutionFailure})`;
+    }
+    if ("ShardPledgedToAnotherPayload" in reason) {
+        return `ShardPledgedToAnotherPayload(${reason.ShardPledgedToAnotherPayload})`;
+    }
+    if ("ShardRejected" in reason) {
+        return `ShardRejected(${reason.ShardRejected})`;
+    }
+    if ("FeesNotPaid" in reason) {
+        return `FeesNotPaid(${reason.FeesNotPaid})`;
+    }
+    console.error("Unknown reason", reason);
+    return "Unknown";
 }
 
 export function getSubstateDiffFromTransactionResult(result: TransactionResult): SubstateDiff | null {
-  if ("Accept" in result) {
-    return result.Accept;
-  }
-  if ("AcceptFeeRejectRest" in result) {
-    return result.AcceptFeeRejectRest[0];
-  }
-  return null;
+    if ("Accept" in result) {
+        return result.Accept;
+    }
+    if ("AcceptFeeRejectRest" in result) {
+        return result.AcceptFeeRejectRest[0];
+    }
+    return null;
 }
 
 export function getRejectReasonFromTransactionResult(result: TransactionResult): RejectReason | null {
-  if ("Reject" in result) {
-    return result.Reject;
-  }
-  if ("AcceptFeeRejectRest" in result) {
-    return result.AcceptFeeRejectRest[1];
-  }
-  return null;
+    if ("Reject" in result) {
+        return result.Reject;
+    }
+    if ("AcceptFeeRejectRest" in result) {
+        return result.AcceptFeeRejectRest[1];
+    }
+    return null;
 }
 
 export function jrpcPermissionToString(jrpcPermission: JrpcPermission): string {
-  if (typeof jrpcPermission === "string") {
-    return jrpcPermission;
-  }
-  if ("NftGetOwnershipProof" in jrpcPermission) {
-    return `NftGetOwnershipProof(${jrpcPermission.NftGetOwnershipProof})`;
-  }
-  if ("AccountBalance" in jrpcPermission) {
-    return `AccountBalance(${substateIdToString(jrpcPermission.AccountBalance)})`;
-  }
-  if ("AccountList" in jrpcPermission) {
-    return `AccountList(${jrpcPermission.AccountList})`;
-  }
-  if ("TransactionSend" in jrpcPermission) {
-    return `TransactionSend(${jrpcPermission.TransactionSend})`;
-  }
-  if ("GetNft" in jrpcPermission) {
-    return `GetNft(${substateIdToString(jrpcPermission.GetNft[0])}, ${jrpcPermission.GetNft[1]})`;
-  }
-  return "Unknown";
+    if (typeof jrpcPermission === "string") {
+        return jrpcPermission;
+    }
+    if ("NftGetOwnershipProof" in jrpcPermission) {
+        return `NftGetOwnershipProof(${jrpcPermission.NftGetOwnershipProof})`;
+    }
+    if ("AccountBalance" in jrpcPermission) {
+        return `AccountBalance(${substateIdToString(jrpcPermission.AccountBalance)})`;
+    }
+    if ("AccountList" in jrpcPermission) {
+        return `AccountList(${jrpcPermission.AccountList})`;
+    }
+    if ("TransactionSend" in jrpcPermission) {
+        return `TransactionSend(${jrpcPermission.TransactionSend})`;
+    }
+    if ("GetNft" in jrpcPermission) {
+        return `GetNft(${substateIdToString(jrpcPermission.GetNft[0])}, ${jrpcPermission.GetNft[1]})`;
+    }
+    return "Unknown";
+}
+
+
+function splitOnce(str: string, separator: string): [string, string] | null {
+    const index = str.indexOf(separator);
+    if (index === -1) {
+        return null;
+    }
+    return [str.slice(0, index), str.slice(index + 1)];
 }

--- a/dan_layer/engine_types/src/substate.rs
+++ b/dan_layer/engine_types/src/substate.rs
@@ -99,7 +99,7 @@ pub enum SubstateId {
     Resource(#[serde(with = "serde_with::string")] ResourceAddress),
     Vault(#[serde(with = "serde_with::string")] VaultId),
     UnclaimedConfidentialOutput(#[cfg_attr(feature = "ts", ts(type = "string"))] UnclaimedConfidentialOutputAddress),
-    NonFungible(NonFungibleAddress),
+    NonFungible(#[serde(with = "serde_with::string")] NonFungibleAddress),
     NonFungibleIndex(NonFungibleIndexAddress),
     TransactionReceipt(TransactionReceiptAddress),
     FeeClaim(FeeClaimAddress),

--- a/dan_layer/template_lib/src/models/non_fungible.rs
+++ b/dan_layer/template_lib/src/models/non_fungible.rs
@@ -2,7 +2,7 @@
 //   SPDX-License-Identifier: BSD-3-Clause
 
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use serde_with::{serde_as, Bytes};
+use serde_with::serde_as;
 use tari_bor::BorTag;
 use tari_template_abi::{
     call_engine,
@@ -29,7 +29,7 @@ const DELIM: char = ':';
 #[derive(Debug, Clone, Ord, PartialOrd, PartialEq, Eq, Serialize, Deserialize, Hash)]
 #[cfg_attr(feature = "ts", derive(TS), ts(export, export_to = "../../bindings/src/types/"))]
 pub enum NonFungibleId {
-    U256(#[serde_as(as = "Bytes")] [u8; 32]),
+    U256(#[serde_as(as = "serde_with::Bytes")] [u8; 32]),
     String(String),
     Uint32(u32),
     Uint64(#[cfg_attr(feature = "ts", ts(type = "number"))] u64),

--- a/dan_layer/wallet/storage_sqlite/src/reader.rs
+++ b/dan_layer/wallet/storage_sqlite/src/reader.rs
@@ -257,7 +257,15 @@ impl WalletStoreReader for ReadTransaction<'_> {
             query = query.filter(substates::template_address.eq(template_address.to_string()));
         }
         if let Some(substate_type) = by_type {
-            query = query.filter(substates::address.like(format!("{}_%", substate_type.as_prefix_str())));
+            match substate_type {
+                SubstateType::NonFungible => {
+                    query = query
+                        .filter(substates::address.like(format!("resource_% {}_%", substate_type.as_prefix_str())));
+                },
+                _ => {
+                    query = query.filter(substates::address.like(format!("{}_%", substate_type.as_prefix_str())));
+                },
+            }
         }
         if let Some(limit) = limit {
             query = query.limit(limit as i64);


### PR DESCRIPTION
Description
---
fix(walletd): fix query for NonFungible
fix(walletd): serialize NFT id as string
chore: update bindings 
fix(bindings): fix NonFungible parsing in stringToSubstateId helper

Motivation and Context
---
Fetching by substate type `NonFungible` never returned any results. This PR fixes this.

How Has This Been Tested?
---
Calling `substates.list` with `filter_by_type: "NonFungible"`

What process can a PR reviewer use to test or verify this change?
---
Calling `substates.list` with `filter_by_type: "NonFungible"`

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify