### PR TITLE
fix(walletd): emit AccountChanged event on changes for account refresh

### DIFF
--- a/dan_layer/consensus_tests/src/consensus.rs
+++ b/dan_layer/consensus_tests/src/consensus.rs
@@ -445,7 +445,7 @@ async fn foreign_block_distribution() {
         let leaf1 = test.get_validator(&TestAddress::new("1")).get_leaf_block();
         let leaf2 = test.get_validator(&TestAddress::new("4")).get_leaf_block();
         let leaf3 = test.get_validator(&TestAddress::new("7")).get_leaf_block();
-        if leaf1.height > NodeHeight(20) || leaf2.height > NodeHeight(20) || leaf3.height > NodeHeight(20) {
+        if leaf1.height > NodeHeight(40) || leaf2.height > NodeHeight(40) || leaf3.height > NodeHeight(40) {
             panic!(
                 "Not all transaction committed after {}/{}/{} blocks",
                 leaf1.height, leaf2.height, leaf3.height

--- a/integration_tests/tests/log4rs/cucumber.yml
+++ b/integration_tests/tests/log4rs/cucumber.yml
@@ -80,10 +80,26 @@ appenders:
     encoder:
       pattern: "{d(%Y-%m-%d %H:%M:%S.%f)} [{t}] [{X(node-public-key)},{X(node-id)}] {l:5} {m} // {f}:{L}{n}"
 
+  wallet_daemon:
+    kind: rolling_file
+    path: "{{log_dir}}/wallet_daemon.log"
+    policy:
+      kind: compound
+      trigger:
+        kind: size
+        limit: 10mb
+      roller:
+        kind: fixed_window
+        base: 1
+        count: 5
+        pattern: "log/validator-node/wallet_daemon.{}.log"
+    encoder:
+      pattern: "{d(%Y-%m-%d %H:%M:%S.%f)} [{t}] [{X(node-public-key)},{X(node-id)}] {l:5} {m} // {f}:{L}{n}"
+
   # An appender named "other" that writes to a file with a custom pattern encoder
   other:
     kind: rolling_file
-    path: "log/validator-node/other.log"
+    path: "{{log_dir}}/other.log"
     policy:
       kind: compound
       trigger:
@@ -119,6 +135,17 @@ loggers:
     level: debug
     appenders:
       - dan_layer
+    additive: false
+
+  tari::dan::wallet_daemon:
+    level: debug
+    appenders:
+      - wallet_daemon
+    additive: false
+  tari::dan::wallet_sdk:
+    level: debug
+    appenders:
+      - wallet_daemon
     additive: false
 
   tari::dan:


### PR DESCRIPTION
Description
---
Emit missing event if the account is updated via refresh.

Motivation and Context
---
The account monitor only emitted the AccountChanged event after a successful transaction involving the account is detected. However, if a client (e.g. cucumber) is polling the account refresh, the refresh can detect changes to the account before the transaction is detected as complete. This is the typical case as the cucumber polls faster than the wallet polls the indexer for a transaction result.

This bug led to `Claim and transfer confidential assets via wallet daemon` never finishing because once the finalised transaction comes through, there are no changes detected because the refresh already updated the account.

How Has This Been Tested?
---
`Claim and transfer confidential assets via wallet daemon` cucumber completes.

What process can a PR reviewer use to test or verify this change?
---
CI

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify