### PR TITLE
fix(engine): claiming burns/fees call frame error

### DIFF
--- a/applications/tari_dan_wallet_cli/src/command/nfts.rs
+++ b/applications/tari_dan_wallet_cli/src/command/nfts.rs
@@ -140,6 +140,7 @@ pub async fn handle_mint_account_nft(
         metadata,
         mint_fee: mint_fee.map(|f| Amount::new(i64::from(f))),
         create_account_nft_fee: create_account_nft_fee.map(|f| Amount::new(i64::from(f))),
+        existing_nft_component: None,
     };
 
     let resp = client

--- a/applications/tari_dan_wallet_daemon/src/handlers/accounts.rs
+++ b/applications/tari_dan_wallet_daemon/src/handlers/accounts.rs
@@ -23,7 +23,7 @@ use tari_dan_wallet_sdk::{
 };
 use tari_dan_wallet_storage_sqlite::SqliteWalletStore;
 use tari_engine_types::{
-    component::new_component_address_from_parts,
+    component::new_account_address_from_parts,
     confidential::ConfidentialClaim,
     instruction::Instruction,
     substate::{Substate, SubstateId},
@@ -32,7 +32,6 @@ use tari_key_manager::key_manager::DerivedKey;
 use tari_template_builtin::ACCOUNT_TEMPLATE_ADDRESS;
 use tari_template_lib::{
     args,
-    crypto::RistrettoPublicKeyBytes,
     models::{Amount, UnclaimedConfidentialOutputAddress},
     prelude::{ComponentAddress, ResourceType, CONFIDENTIAL_TARI_RESOURCE_ADDRESS},
 };
@@ -856,8 +855,7 @@ fn get_or_create_account<T: WalletStore>(
                 .unwrap_or_else(|| sdk.key_manager_api().next_key(key_manager::TRANSACTION_BRANCH))?;
             let account_pk = PublicKey::from_secret_key(&account_secret_key.key);
 
-            let account_pk_bytes = RistrettoPublicKeyBytes::from_bytes(account_pk.as_bytes())?;
-            let account_address = new_component_address_from_parts(&ACCOUNT_TEMPLATE_ADDRESS, &account_pk_bytes);
+            let account_address = new_account_address_from_parts(&ACCOUNT_TEMPLATE_ADDRESS, &account_pk);
 
             // We have no involved substate addresses, so we need to add an output
             (account_address.into(), account_secret_key, Some(name.to_string()))
@@ -1015,8 +1013,7 @@ async fn get_or_create_account_address(
     instructions: &mut Vec<Instruction>,
 ) -> Result<ComponentAddress, anyhow::Error> {
     // calculate the account component address from the public key
-    let public_key_bytes = RistrettoPublicKeyBytes::try_from(public_key.as_bytes())?;
-    let account_address = new_component_address_from_parts(&ACCOUNT_TEMPLATE_ADDRESS, &public_key_bytes);
+    let account_address = new_account_address_from_parts(&ACCOUNT_TEMPLATE_ADDRESS, public_key);
 
     let account_scan = sdk
         .substate_api()

--- a/clients/wallet_daemon_client/src/types.rs
+++ b/clients/wallet_daemon_client/src/types.rs
@@ -868,6 +868,7 @@ pub struct MintAccountNftRequest {
     pub metadata: serde_json::Value,
     pub mint_fee: Option<Amount>,
     pub create_account_nft_fee: Option<Amount>,
+    pub existing_nft_component: Option<ComponentAddress>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/dan_layer/engine/src/runtime/impl.rs
+++ b/dan_layer/engine/src/runtime/impl.rs
@@ -1688,7 +1688,7 @@ impl<TTemplateProvider: TemplateProvider<Template = LoadedTemplate>> RuntimeInte
         }
 
         self.tracker.write_with(|state| {
-            let bucket_id = state.id_provider()?.new_bucket_id();
+            let bucket_id = state.new_bucket_id();
             state.new_bucket(bucket_id, resource)?;
             state.set_last_instruction_output(IndexedValue::from_type(&bucket_id)?);
             Ok::<_, RuntimeError>(())
@@ -1700,7 +1700,7 @@ impl<TTemplateProvider: TemplateProvider<Template = LoadedTemplate>> RuntimeInte
     fn claim_validator_fees(&self, epoch: Epoch, validator_public_key: PublicKey) -> Result<(), RuntimeError> {
         self.tracker.write_with(|state| {
             let resource = state.claim_fee(epoch, validator_public_key)?;
-            let bucket_id = state.id_provider()?.new_bucket_id();
+            let bucket_id = state.new_bucket_id();
             state.new_bucket(bucket_id, resource)?;
             state.set_last_instruction_output(IndexedValue::from_type(&bucket_id)?);
             Ok::<_, RuntimeError>(())

--- a/dan_layer/engine/tests/test.rs
+++ b/dan_layer/engine/tests/test.rs
@@ -1331,7 +1331,7 @@ mod nft_indexes {
 
 // TODO: these tests can be removed when create free test coins is removed
 mod free_test_coins {
-    use tari_engine_types::component::new_component_address_from_parts;
+    use tari_engine_types::component::new_account_address_from_parts;
 
     use super::*;
     #[test]
@@ -1342,10 +1342,8 @@ mod free_test_coins {
         let (other, _, _) = test.create_owner_proof();
 
         let owner_token = test.get_test_proof();
-        let future_account_component = new_component_address_from_parts(
-            &ACCOUNT_TEMPLATE_ADDRESS,
-            &test.get_test_public_key_bytes().into_array().into(),
-        );
+        let future_account_component =
+            new_account_address_from_parts(&ACCOUNT_TEMPLATE_ADDRESS, test.get_test_public_key());
 
         test.execute_expect_success(
             Transaction::builder()

--- a/dan_layer/engine_types/src/component.rs
+++ b/dan_layer/engine_types/src/component.rs
@@ -21,12 +21,15 @@
 //   USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use serde::{Deserialize, Serialize};
+use tari_common_types::types::PublicKey;
 use tari_template_lib::{
     auth::{ComponentAccessRules, OwnerRule, Ownership},
     crypto::RistrettoPublicKeyBytes,
     models::{ComponentKey, EntityId, ObjectKey, TemplateAddress},
     prelude::ComponentAddress,
+    Hash,
 };
+use tari_utilities::ByteArray;
 #[cfg(feature = "ts")]
 use ts_rs::TS;
 
@@ -41,16 +44,13 @@ use crate::{
 ///
 /// This can be used to derive the component address from a public key if the component sets OwnerRule::OwnedBySigner or
 /// OwnerRule::ByPublicKey
-pub fn new_component_address_from_parts(
-    template_address: &TemplateAddress,
-    public_key: &RistrettoPublicKeyBytes,
-) -> ComponentAddress {
+pub fn new_account_address_from_parts(template_address: &TemplateAddress, public_key: &PublicKey) -> ComponentAddress {
     let address = hasher32(EngineHashDomainLabel::ComponentAddress)
         .chain(template_address)
         .chain(public_key)
         .result();
     let key = ObjectKey::new(
-        EntityId::from_array(public_key.as_hash().leading_bytes()),
+        EntityId::from_array(Hash::try_from(public_key.as_bytes()).unwrap().leading_bytes()),
         ComponentKey::new(address.trailing_bytes()),
     );
     ComponentAddress::new(key)

--- a/integration_tests/src/wallet_daemon_cli.rs
+++ b/integration_tests/src/wallet_daemon_cli.rs
@@ -35,7 +35,7 @@ use tari_template_lib::{
     args,
     constants::CONFIDENTIAL_TARI_RESOURCE_ADDRESS,
     models::Amount,
-    prelude::ResourceAddress,
+    prelude::{ComponentAddress, ResourceAddress},
     resource::TOKEN_SYMBOL,
 };
 use tari_transaction::SubstateRequirement;
@@ -329,6 +329,7 @@ pub async fn mint_new_nft_on_account(
     _nft_name: String,
     account_name: String,
     wallet_daemon_name: String,
+    existing_nft_component: Option<ComponentAddress>,
     metadata: Option<serde_json::Value>,
 ) {
     let mut client = get_auth_wallet_daemon_client(world, &wallet_daemon_name).await;
@@ -347,6 +348,7 @@ pub async fn mint_new_nft_on_account(
         metadata,
         mint_fee: Some(Amount::new(1_000)),
         create_account_nft_fee: None,
+        existing_nft_component,
     };
     let resp = client
         .mint_account_nft(request)

--- a/integration_tests/tests/cucumber.rs
+++ b/integration_tests/tests/cucumber.rs
@@ -424,7 +424,7 @@ async fn mint_new_nft_on_account(
     account_name: String,
     wallet_daemon_name: String,
 ) {
-    wallet_daemon_cli::mint_new_nft_on_account(world, nft_name, account_name, wallet_daemon_name, None).await;
+    wallet_daemon_cli::mint_new_nft_on_account(world, nft_name, account_name, wallet_daemon_name, None, None).await;
 }
 
 #[when(expr = "I mint a new non fungible token {word} on {word} using wallet daemon with metadata {word}")]
@@ -436,7 +436,8 @@ async fn mint_new_nft_on_account_with_metadata(
     metadata: String,
 ) {
     let metadata = serde_json::from_str::<serde_json::Value>(&metadata).expect("Failed to parse metadata");
-    wallet_daemon_cli::mint_new_nft_on_account(world, nft_name, account_name, wallet_daemon_name, Some(metadata)).await;
+    wallet_daemon_cli::mint_new_nft_on_account(world, nft_name, account_name, wallet_daemon_name, None, Some(metadata))
+        .await;
 }
 
 fn wrap_manifest_in_main(world: &TariWorld, contents: &str) -> String {

--- a/utilities/tariswap_test_bench/src/accounts.rs
+++ b/utilities/tariswap_test_bench/src/accounts.rs
@@ -3,11 +3,11 @@
 
 use std::ops::RangeInclusive;
 
-use tari_crypto::{keys::PublicKey as _, ristretto::RistrettoPublicKey, tari_utilities::ByteArray};
+use tari_crypto::{keys::PublicKey as _, ristretto::RistrettoPublicKey};
 use tari_dan_wallet_sdk::{apis::key_manager::TRANSACTION_BRANCH, models::Account};
-use tari_engine_types::component::new_component_address_from_parts;
+use tari_engine_types::component::new_account_address_from_parts;
 use tari_template_builtin::ACCOUNT_TEMPLATE_ADDRESS;
-use tari_template_lib::{args, crypto::RistrettoPublicKeyBytes, models::Amount};
+use tari_template_lib::{args, models::Amount};
 use tari_transaction::{Instruction, Transaction};
 
 use crate::{faucet::Faucet, runner::Runner};
@@ -16,10 +16,8 @@ impl Runner {
     pub async fn create_account_with_free_coins(&mut self) -> anyhow::Result<Account> {
         let key = self.sdk.key_manager_api().derive_key(TRANSACTION_BRANCH, 0)?;
         let owner_public_key = RistrettoPublicKey::from_secret_key(&key.key);
-        let owner_pk = RistrettoPublicKeyBytes::from_bytes(owner_public_key.as_bytes()).unwrap();
 
-        let account_address =
-            new_component_address_from_parts(&ACCOUNT_TEMPLATE_ADDRESS, &owner_pk.into_array().into());
+        let account_address = new_account_address_from_parts(&ACCOUNT_TEMPLATE_ADDRESS, &owner_public_key);
 
         let transaction = Transaction::builder()
             .with_fee_instructions_builder(|builder| {

--- a/utilities/transaction_generator/src/transaction_builders/free_coins.rs
+++ b/utilities/transaction_generator/src/transaction_builders/free_coins.rs
@@ -2,16 +2,17 @@
 //   SPDX-License-Identifier: BSD-3-Clause
 
 use rand::rngs::OsRng;
-use tari_crypto::{keys::PublicKey, ristretto::RistrettoPublicKey, tari_utilities::ByteArray};
-use tari_engine_types::{component::new_component_address_from_parts, instruction::Instruction};
+use tari_crypto::{keys::PublicKey, ristretto::RistrettoPublicKey};
+use tari_engine_types::{component::new_account_address_from_parts, instruction::Instruction};
 use tari_template_builtin::ACCOUNT_TEMPLATE_ADDRESS;
-use tari_template_lib::{args, crypto::RistrettoPublicKeyBytes, models::Amount};
+use tari_template_lib::{args, models::Amount};
 use tari_transaction::Transaction;
 
 pub fn builder(_: u64) -> Transaction {
     let (signer_secret_key, signer_public_key) = RistrettoPublicKey::random_keypair(&mut OsRng);
 
-    let owner_pk = RistrettoPublicKeyBytes::from_bytes(signer_public_key.as_bytes()).unwrap();
+    let account_address = new_account_address_from_parts(&ACCOUNT_TEMPLATE_ADDRESS, &signer_public_key);
+
     Transaction::builder()
         .with_fee_instructions_builder(|builder| {
             builder
@@ -21,11 +22,7 @@ pub fn builder(_: u64) -> Transaction {
                 })
                 .put_last_instruction_output_on_workspace(b"free_coins")
                 .create_account_with_bucket(signer_public_key, "free_coins")
-                .call_method(
-                    new_component_address_from_parts(&ACCOUNT_TEMPLATE_ADDRESS, &owner_pk.into_array().into()),
-                    "pay_fee",
-                    args![Amount(1000)],
-                )
+                .call_method(account_address, "pay_fee", args![Amount(1000)])
         })
         .sign(&signer_secret_key)
         .build()


### PR DESCRIPTION
Description
---
fix(engine): claiming burns/fees call frame error

Motivation and Context
---
Id provider needs a call stack to get the correct entity ID, however creating bucket ids do not require an entity id. Claiming burns and fees do not have a call frame since they are native instructions, and so would error when getting the id provider.
This PR allocates a bucket id without requiring an active call frame.

How Has This Been Tested?
---
Claim burn cucumber passes

What process can a PR reviewer use to test or verify this change?
---
Claim burn/fee

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify