### PR TITLE
feat: change bindings package usage to git instead of local

### DIFF
--- a/clients/javascript/wallet_daemon_client/package-lock.json
+++ b/clients/javascript/wallet_daemon_client/package-lock.json
@@ -1,7 +1,7 @@
 {
   "name": "@tariproject/wallet_jrpc_client",
   "version": "1.0.0",
-  "lockfileVersion": 2,
+  "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
@@ -9,24 +9,17 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@tariproject/typescript-bindings": "file:../../../bindings"
+        "@tariproject/typescript-bindings": "https://gitpkg.now.sh/tari-project/tari-dan/bindings?development"
       },
       "devDependencies": {
         "typescript": "^5.3.3"
       }
     },
-    "../../../bindings": {
-      "name": "@tariproject/typescript-bindings",
-      "version": "1.0.0",
-      "license": "ISC",
-      "devDependencies": {
-        "shx": "^0.3.4",
-        "typescript": "^5.3.3"
-      }
-    },
     "node_modules/@tariproject/typescript-bindings": {
-      "resolved": "../../../bindings",
-      "link": true
+      "version": "1.0.0",
+      "resolved": "https://gitpkg.now.sh/tari-project/tari-dan/bindings?development",
+      "integrity": "sha512-CheNrnFWF3lSQtBi/BUtgMs/ZjLJsyLGve4EeBGLNs270sym3BEn3VOszAi4cj3RmRW4vFwhScOuTROgY2E6Uw==",
+      "license": "ISC"
     },
     "node_modules/typescript": {
       "version": "5.3.3",
@@ -40,21 +33,6 @@
       "engines": {
         "node": ">=14.17"
       }
-    }
-  },
-  "dependencies": {
-    "@tariproject/typescript-bindings": {
-      "version": "file:../../../bindings",
-      "requires": {
-        "shx": "^0.3.4",
-        "typescript": "^5.3.3"
-      }
-    },
-    "typescript": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
-      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
-      "dev": true
     }
   }
 }

--- a/clients/javascript/wallet_daemon_client/package.json
+++ b/clients/javascript/wallet_daemon_client/package.json
@@ -14,7 +14,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@tariproject/typescript-bindings": "file:../../../bindings"
+    "@tariproject/typescript-bindings": "https://gitpkg.now.sh/tari-project/tari-dan/bindings?development"
   },
   "devDependencies": {
     "typescript": "^5.3.3"


### PR DESCRIPTION
Description
---
Change the package from local reference to git reference, this is useful for further referencing of the `wallet_daemon_client` package.

Motivation and Context
---
I have prepared couple changes so in the end we can add the template-web to the dan-testing without relying on package on local paths.

How Has This Been Tested?
---
I have running template web with no package being locally referenced in the package.json.

What process can a PR reviewer use to test or verify this change?
---
For now you can only try to compile the `wallet_daemon_client` to see that it's working.


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify