### PR TITLE
fix!: always account for version when querying substates

### DIFF
--- a/dan_layer/engine_types/src/hashing.rs
+++ b/dan_layer/engine_types/src/hashing.rs
@@ -166,6 +166,7 @@ impl TariHasher64 {
 #[derive(Debug)]
 pub enum EngineHashDomainLabel {
     Template,
+    SubstateAddress,
     ConfidentialProof,
     ConfidentialTransfer,
     ShardPledgeCollection,
@@ -189,6 +190,7 @@ impl EngineHashDomainLabel {
     pub fn as_label(&self) -> &'static str {
         match self {
             Self::Template => "Template",
+            Self::SubstateAddress => "SubstateAddress",
             Self::ConfidentialProof => "ConfidentialProof",
             Self::ConfidentialTransfer => "ConfidentialTransfer",
             Self::ShardPledgeCollection => "ShardPledgeCollection",

--- a/integration_tests/tests/features/claim_burn.feature
+++ b/integration_tests/tests/features/claim_burn.feature
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 Feature: Claim Burn
+
   @serial
   Scenario: Claim base layer burn funds with wallet daemon
     # Initialize a base node, wallet, miner and VN


### PR DESCRIPTION
Description
---
Hash in the version parameter when generating non-versionable substates
Fix race condition when waiting for transaction and account results

Motivation and Context
---
Although the unspent commitment, fee claim, and tx receipt are non-versionable. We cannot ignore the version parameter because clients may query these substates with a version > 0, in this case the VNs should respond with `DoesNotExist`. Previously, due to ignoring the version, we would respond either with UP or DOWN if the substate exists `@v0` regardless of the version. For a DOWN result, the scanner would increment the version and query again, leading to an infinite loop.

How Has This Been Tested?
---
`Double Claim base layer burn funds with wallet daemon. should fail` cucumber passes

What process can a PR reviewer use to test or verify this change?
---
CI, query a spent commitment, fee claim or tx receipt  with v > 0 and check that DoesNotExist is returned


Breaking Changes
---

- [ ] None
- [x] Requires data directory to be deleted
- [x] Other - Please specify

BREAKING CHANGE: substate address for unspent commitment, fee claim, and tx receipt are derived differently