### PR TITLE
feat: store base layer block hashes

### DIFF
--- a/applications/tari_dan_app_utilities/src/base_layer_scanner.rs
+++ b/applications/tari_dan_app_utilities/src/base_layer_scanner.rs
@@ -277,7 +277,7 @@ impl<TAddr: NodeAddressable + 'static> BaseLayerScanner<TAddr> {
                 // This will be processed down below.
                 break;
             }
-            self.epoch_manager.update_epoch(header.height, scan, false).await?;
+            self.epoch_manager.add_block_hash(header.height, scan).await?;
             scan = header.prev_hash;
         }
         for current_height in start_scan_height..=end_height {
@@ -352,7 +352,7 @@ impl<TAddr: NodeAddressable + 'static> BaseLayerScanner<TAddr> {
 
             // Once we have all the UTXO data, we "activate" the new epoch if applicable.
             self.epoch_manager
-                .update_epoch(block_info.height, block_info.hash, true)
+                .update_epoch(block_info.height, block_info.hash)
                 .await?;
 
             self.set_last_scanned_block(tip.tip_hash, &block_info)?;

--- a/dan_layer/epoch_manager/src/base_layer/base_layer_epoch_manager.rs
+++ b/dan_layer/epoch_manager/src/base_layer/base_layer_epoch_manager.rs
@@ -107,19 +107,10 @@ impl<TAddr: NodeAddressable + DerivableFromPublicKey>
         Ok(())
     }
 
-    pub async fn update_epoch(
-        &mut self,
-        block_height: u64,
-        block_hash: FixedHash,
-        confirmed: bool,
-    ) -> Result<(), EpochManagerError> {
+    pub async fn update_epoch(&mut self, block_height: u64, block_hash: FixedHash) -> Result<(), EpochManagerError> {
         let base_layer_constants = self.base_node_client.get_consensus_constants(block_height).await?;
         let epoch = base_layer_constants.height_to_epoch(block_height);
         self.add_base_layer_block_info(block_height, block_hash)?;
-        if !confirmed {
-            // This is not a confirmed block, so we don't need to update the epoch
-            return Ok(());
-        }
         self.update_current_block_info(block_height, block_hash)?;
         if self.current_epoch >= epoch {
             // no need to update the epoch
@@ -273,7 +264,11 @@ impl<TAddr: NodeAddressable + DerivableFromPublicKey>
         Ok(())
     }
 
-    fn add_base_layer_block_info(&mut self, block_height: u64, block_hash: FixedHash) -> Result<(), EpochManagerError> {
+    pub fn add_base_layer_block_info(
+        &mut self,
+        block_height: u64,
+        block_hash: FixedHash,
+    ) -> Result<(), EpochManagerError> {
         let mut tx = self.global_db.create_transaction()?;
         self.global_db
             .base_layer_hashes(&mut tx)

--- a/dan_layer/epoch_manager/src/base_layer/base_layer_epoch_manager.rs
+++ b/dan_layer/epoch_manager/src/base_layer/base_layer_epoch_manager.rs
@@ -41,7 +41,7 @@ use tari_dan_common_types::{
     NodeAddressable,
     SubstateAddress,
 };
-use tari_dan_storage::global::{models::ValidatorNode, DbEpoch, GlobalDb, MetadataKey};
+use tari_dan_storage::global::{models::ValidatorNode, DbBaseLayerBlockInfo, DbEpoch, GlobalDb, MetadataKey};
 use tari_dan_storage_sqlite::global::SqliteGlobalDbAdapter;
 use tari_mmr::MergedBalancedBinaryMerkleProof;
 use tokio::sync::broadcast;
@@ -107,9 +107,19 @@ impl<TAddr: NodeAddressable + DerivableFromPublicKey>
         Ok(())
     }
 
-    pub async fn update_epoch(&mut self, block_height: u64, block_hash: FixedHash) -> Result<(), EpochManagerError> {
+    pub async fn update_epoch(
+        &mut self,
+        block_height: u64,
+        block_hash: FixedHash,
+        confirmed: bool,
+    ) -> Result<(), EpochManagerError> {
         let base_layer_constants = self.base_node_client.get_consensus_constants(block_height).await?;
         let epoch = base_layer_constants.height_to_epoch(block_height);
+        self.add_base_layer_block_info(block_height, block_hash)?;
+        if !confirmed {
+            // This is not a confirmed block, so we don't need to update the epoch
+            return Ok(());
+        }
         self.update_current_block_info(block_height, block_hash)?;
         if self.current_epoch >= epoch {
             // no need to update the epoch
@@ -260,6 +270,18 @@ impl<TAddr: NodeAddressable + DerivableFromPublicKey>
             .set_metadata(MetadataKey::BaseLayerConsensusConstants, &base_layer_constants)?;
         tx.commit()?;
         self.base_layer_consensus_constants = Some(base_layer_constants);
+        Ok(())
+    }
+
+    fn add_base_layer_block_info(&mut self, block_height: u64, block_hash: FixedHash) -> Result<(), EpochManagerError> {
+        let mut tx = self.global_db.create_transaction()?;
+        self.global_db
+            .base_layer_hashes(&mut tx)
+            .insert_base_layer_block_info(DbBaseLayerBlockInfo {
+                hash: block_hash,
+                height: block_height,
+            })?;
+        tx.commit()?;
         Ok(())
     }
 

--- a/dan_layer/epoch_manager/src/base_layer/epoch_manager_service.rs
+++ b/dan_layer/epoch_manager/src/base_layer/epoch_manager_service.rs
@@ -134,9 +134,13 @@ impl<TAddr: NodeAddressable + DerivableFromPublicKey + 'static>
             EpochManagerRequest::UpdateEpoch {
                 block_height,
                 block_hash,
+                confirmed,
                 reply,
             } => {
-                handle(reply, self.inner.update_epoch(block_height, block_hash).await);
+                handle(
+                    reply,
+                    self.inner.update_epoch(block_height, block_hash, confirmed).await,
+                );
             },
             EpochManagerRequest::LastRegistrationEpoch { reply } => handle(reply, self.inner.last_registration_epoch()),
 

--- a/dan_layer/epoch_manager/src/base_layer/epoch_manager_service.rs
+++ b/dan_layer/epoch_manager/src/base_layer/epoch_manager_service.rs
@@ -131,16 +131,19 @@ impl<TAddr: NodeAddressable + DerivableFromPublicKey + 'static>
             EpochManagerRequest::GetManyValidatorNodes { query, reply } => {
                 handle(reply, self.inner.get_many_validator_nodes(query));
             },
+            EpochManagerRequest::AddBlockHash {
+                block_height,
+                block_hash,
+                reply,
+            } => {
+                handle(reply, self.inner.add_base_layer_block_info(block_height, block_hash));
+            },
             EpochManagerRequest::UpdateEpoch {
                 block_height,
                 block_hash,
-                confirmed,
                 reply,
             } => {
-                handle(
-                    reply,
-                    self.inner.update_epoch(block_height, block_hash, confirmed).await,
-                );
+                handle(reply, self.inner.update_epoch(block_height, block_hash).await);
             },
             EpochManagerRequest::LastRegistrationEpoch { reply } => handle(reply, self.inner.last_registration_epoch()),
 

--- a/dan_layer/epoch_manager/src/base_layer/handle.rs
+++ b/dan_layer/epoch_manager/src/base_layer/handle.rs
@@ -38,12 +38,18 @@ impl<TAddr: NodeAddressable> EpochManagerHandle<TAddr> {
         Self { tx_request }
     }
 
-    pub async fn update_epoch(&self, block_height: u64, block_hash: FixedHash) -> Result<(), EpochManagerError> {
+    pub async fn update_epoch(
+        &self,
+        block_height: u64,
+        block_hash: FixedHash,
+        confirmed: bool,
+    ) -> Result<(), EpochManagerError> {
         let (tx, rx) = oneshot::channel();
         self.tx_request
             .send(EpochManagerRequest::UpdateEpoch {
                 block_height,
                 block_hash,
+                confirmed,
                 reply: tx,
             })
             .await

--- a/dan_layer/epoch_manager/src/base_layer/types.rs
+++ b/dan_layer/epoch_manager/src/base_layer/types.rs
@@ -50,10 +50,14 @@ pub enum EpochManagerRequest<TAddr> {
         registration: ValidatorNodeRegistration,
         reply: Reply<()>,
     },
+    AddBlockHash {
+        block_height: u64,
+        block_hash: FixedHash,
+        reply: Reply<()>,
+    },
     UpdateEpoch {
         block_height: u64,
         block_hash: FixedHash,
-        confirmed: bool,
         reply: Reply<()>,
     },
     LastRegistrationEpoch {

--- a/dan_layer/epoch_manager/src/base_layer/types.rs
+++ b/dan_layer/epoch_manager/src/base_layer/types.rs
@@ -53,6 +53,7 @@ pub enum EpochManagerRequest<TAddr> {
     UpdateEpoch {
         block_height: u64,
         block_hash: FixedHash,
+        confirmed: bool,
         reply: Reply<()>,
     },
     LastRegistrationEpoch {

--- a/dan_layer/storage/src/global/backend_adapter.rs
+++ b/dan_layer/storage/src/global/backend_adapter.rs
@@ -26,7 +26,7 @@ use std::{
 };
 
 use serde::{de::DeserializeOwned, Serialize};
-use tari_common_types::types::PublicKey;
+use tari_common_types::types::{FixedHash, PublicKey};
 use tari_dan_common_types::{
     committee::Committee,
     hashing::ValidatorNodeBalancedMerkleTree,
@@ -36,7 +36,7 @@ use tari_dan_common_types::{
     SubstateAddress,
 };
 
-use super::DbEpoch;
+use super::{base_layer_hashes_db::DbBaseLayerBlockInfo, DbEpoch};
 use crate::{
     atomic::AtomicDb,
     global::{
@@ -147,6 +147,17 @@ pub trait GlobalDbAdapter: AtomicDb + Send + Sync + Clone {
 
     fn insert_epoch(&self, tx: &mut Self::DbTransaction<'_>, epoch: DbEpoch) -> Result<(), Self::Error>;
     fn get_epoch(&self, tx: &mut Self::DbTransaction<'_>, epoch: u64) -> Result<Option<DbEpoch>, Self::Error>;
+
+    fn insert_base_layer_block_info(
+        &self,
+        tx: &mut Self::DbTransaction<'_>,
+        info: DbBaseLayerBlockInfo,
+    ) -> Result<(), Self::Error>;
+    fn get_base_layer_block_info(
+        &self,
+        tx: &mut Self::DbTransaction<'_>,
+        hash: FixedHash,
+    ) -> Result<Option<DbBaseLayerBlockInfo>, Self::Error>;
 
     fn insert_bmt(
         &self,

--- a/dan_layer/storage/src/global/base_layer_hashes_db.rs
+++ b/dan_layer/storage/src/global/base_layer_hashes_db.rs
@@ -1,0 +1,57 @@
+//   Copyright 2022. The Tari Project
+//
+//   Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//   following conditions are met:
+//
+//   1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//   disclaimer.
+//
+//   2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//   following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//   3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//   products derived from this software without specific prior written permission.
+//
+//   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//   SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//   USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use tari_common_types::types::FixedHash;
+
+use crate::global::GlobalDbAdapter;
+
+pub struct BaseLayerHashesDb<'a, 'tx, TGlobalDbAdapter: GlobalDbAdapter> {
+    backend: &'a TGlobalDbAdapter,
+    tx: &'tx mut TGlobalDbAdapter::DbTransaction<'a>,
+}
+
+impl<'a, 'tx, TGlobalDbAdapter: GlobalDbAdapter> BaseLayerHashesDb<'a, 'tx, TGlobalDbAdapter> {
+    pub fn new(backend: &'a TGlobalDbAdapter, tx: &'tx mut TGlobalDbAdapter::DbTransaction<'a>) -> Self {
+        Self { backend, tx }
+    }
+
+    pub fn insert_base_layer_block_info(&mut self, info: DbBaseLayerBlockInfo) -> Result<(), TGlobalDbAdapter::Error> {
+        self.backend
+            .insert_base_layer_block_info(self.tx, info)
+            .map_err(TGlobalDbAdapter::Error::into)
+    }
+
+    pub fn get_base_layer_block_height(
+        &mut self,
+        hash: FixedHash,
+    ) -> Result<Option<DbBaseLayerBlockInfo>, TGlobalDbAdapter::Error> {
+        self.backend
+            .get_base_layer_block_info(self.tx, hash)
+            .map_err(TGlobalDbAdapter::Error::into)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct DbBaseLayerBlockInfo {
+    pub hash: FixedHash,
+    pub height: u64,
+}

--- a/dan_layer/storage/src/global/global_db.rs
+++ b/dan_layer/storage/src/global/global_db.rs
@@ -22,7 +22,7 @@
 
 use std::sync::Arc;
 
-use super::{validator_node_db::ValidatorNodeDb, BmtDb, EpochDb};
+use super::{validator_node_db::ValidatorNodeDb, BaseLayerHashesDb, BmtDb, EpochDb};
 use crate::{
     global::{backend_adapter::GlobalDbAdapter, metadata_db::MetadataDb, template_db::TemplateDb},
     StorageError,
@@ -85,6 +85,13 @@ impl<TGlobalDbAdapter: GlobalDbAdapter> GlobalDb<TGlobalDbAdapter> {
         tx: &'tx mut TGlobalDbAdapter::DbTransaction<'a>,
     ) -> EpochDb<'a, 'tx, TGlobalDbAdapter> {
         EpochDb::new(&self.adapter, tx)
+    }
+
+    pub fn base_layer_hashes<'a, 'tx>(
+        &'a self,
+        tx: &'tx mut TGlobalDbAdapter::DbTransaction<'a>,
+    ) -> BaseLayerHashesDb<'a, 'tx, TGlobalDbAdapter> {
+        BaseLayerHashesDb::new(&self.adapter, tx)
     }
 
     pub fn bmt<'a, 'tx>(

--- a/dan_layer/storage_sqlite/global_db_migrations/2024-03-11-135158_base_layer_block_info/down.sql
+++ b/dan_layer/storage_sqlite/global_db_migrations/2024-03-11-135158_base_layer_block_info/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE base_layer_block_info;

--- a/dan_layer/storage_sqlite/global_db_migrations/2024-03-11-135158_base_layer_block_info/up.sql
+++ b/dan_layer/storage_sqlite/global_db_migrations/2024-03-11-135158_base_layer_block_info/up.sql
@@ -1,0 +1,5 @@
+create table base_layer_block_info
+(
+    hash blob primary key not null,
+    height bigint not null
+);

--- a/dan_layer/storage_sqlite/src/global/models/mod.rs
+++ b/dan_layer/storage_sqlite/src/global/models/mod.rs
@@ -30,6 +30,9 @@ pub use template::*;
 mod epoch;
 pub use epoch::*;
 
+mod base_layer_block_info;
+pub use base_layer_block_info::*;
+
 mod validator_node;
 pub use validator_node::*;
 

--- a/dan_layer/storage_sqlite/src/global/schema.rs
+++ b/dan_layer/storage_sqlite/src/global/schema.rs
@@ -15,6 +15,13 @@ diesel::table! {
 }
 
 diesel::table! {
+    base_layer_block_info (hash) {
+        hash -> Binary,
+        height -> BigInt,
+    }
+}
+
+diesel::table! {
     metadata (key_name) {
         key_name -> Binary,
         value -> Binary,


### PR DESCRIPTION
Description
---
Store the base layer block hashes (not just the ones we sync, but to the very tip of the chain).

Motivation and Context
---
We will need this for accepting/rejecting the proposed blocks. Currently we have base layer block hash in the blocks, but we do nothing with it. We need to validate if the hash is indeed correct. For that we need all the hashes from the base layer.

What process can a PR reviewer use to test or verify this change?
---
Look into the `global_storage.sqlite` table to see that the correct data is stored.


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify