### PR TITLE
fix(cucumber): correct component ID length for graphQL test

### DIFF
--- a/integration_tests/src/indexer.rs
+++ b/integration_tests/src/indexer.rs
@@ -108,7 +108,7 @@ impl IndexerProcess {
 
     pub async fn insert_event_mock_data(&mut self) {
         let mut graphql_client = self.get_graphql_indexer_client().await;
-        let component_address = [0u8; 32].to_hex();
+        let component_address = ObjectKey::default().to_string();
         let template_address = [0u8; 32].to_hex();
         let tx_hash = [0u8; 32].to_hex();
         let topic = "my_event".to_string();


### PR DESCRIPTION
Description
---
fix(cucumber): correct component ID length for graphQL test

Motivation and Context
---
Hardcoded component id length was invalid for `Scenario: Indexer GraphQL requests work`

How Has This Been Tested?
---
`Scenario: Indexer GraphQL requests work` passes

What process can a PR reviewer use to test or verify this change?
---
CI

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify