### PR TITLE
fix: broken webui builds and abort compilation when this happens

### DIFF
--- a/applications/tari_dan_wallet_daemon/build.rs
+++ b/applications/tari_dan_wallet_daemon/build.rs
@@ -20,13 +20,19 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::{env, process::Command};
+use std::process::Command;
+
+fn exit_on_ci() {
+    if option_env!("CI").is_some() {
+        std::process::exit(1);
+    }
+}
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("cargo:rerun-if-changed=../tari_dan_wallet_web_ui/src");
     println!("cargo:rerun-if-changed=../tari_dan_wallet_web_ui/public");
 
-    if env::var_os("CARGO_FEATURE_TS").is_some() {
+    if option_env!("CARGO_FEATURE_TS").is_some() {
         println!("cargo:warning=The web ui is not being compiled when we are generating typescript types/interfaces.");
         return Ok(());
     }
@@ -39,7 +45,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .status()
     {
         println!("cargo:warning='npm ci' error : {:?}", error);
-        std::process::exit(1);
+        exit_on_ci();
     }
     match Command::new(npm)
         .args(["run", "build"])
@@ -50,12 +56,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             println!("cargo:warning='npm run build' exited with non-zero status code");
             println!("cargo:warning=Output: {}", String::from_utf8_lossy(&output.stdout));
             println!("cargo:warning=Error: {}", String::from_utf8_lossy(&output.stderr));
-            std::process::exit(1);
+            exit_on_ci();
         },
         Err(error) => {
             println!("cargo:warning='npm run build' error : {:?}", error);
             println!("cargo:warning=The web ui will not be included!");
-            std::process::exit(1);
+            exit_on_ci();
         },
         _ => {},
     }

--- a/applications/tari_dan_wallet_daemon/build.rs
+++ b/applications/tari_dan_wallet_daemon/build.rs
@@ -20,7 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::process::Command;
+use std::{env, process::Command};
 
 fn exit_on_ci() {
     if option_env!("CI").is_some() {
@@ -32,7 +32,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("cargo:rerun-if-changed=../tari_dan_wallet_web_ui/src");
     println!("cargo:rerun-if-changed=../tari_dan_wallet_web_ui/public");
 
-    if option_env!("CARGO_FEATURE_TS").is_some() {
+    if env::var("CARGO_FEATURE_TS").is_ok() {
         println!("cargo:warning=The web ui is not being compiled when we are generating typescript types/interfaces.");
         return Ok(());
     }

--- a/applications/tari_dan_wallet_daemon/build.rs
+++ b/applications/tari_dan_wallet_daemon/build.rs
@@ -39,23 +39,25 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .status()
     {
         println!("cargo:warning='npm ci' error : {:?}", error);
+        std::process::exit(1);
     }
     match Command::new(npm)
         .args(["run", "build"])
         .current_dir("../tari_dan_wallet_web_ui")
-        .status()
+        .output()
     {
-        Ok(s) => {
-            if !s.success() || s.code().unwrap_or(0) != 0 {
-                println!("cargo:warning='npm run build' failed!");
-                println!("cargo:warning=The web ui will not be included!");
-                panic!("npm run build failed");
-            }
+        Ok(output) if !output.status.success() => {
+            println!("cargo:warning='npm run build' exited with non-zero status code");
+            println!("cargo:warning=Output: {}", String::from_utf8_lossy(&output.stdout));
+            println!("cargo:warning=Error: {}", String::from_utf8_lossy(&output.stderr));
+            std::process::exit(1);
         },
         Err(error) => {
             println!("cargo:warning='npm run build' error : {:?}", error);
             println!("cargo:warning=The web ui will not be included!");
+            std::process::exit(1);
         },
+        _ => {},
     }
     Ok(())
 }

--- a/applications/tari_indexer/build.rs
+++ b/applications/tari_indexer/build.rs
@@ -20,7 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::process::Command;
+use std::{env, process::Command};
 
 fn exit_on_ci() {
     if option_env!("CI").is_some() {
@@ -32,7 +32,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("cargo:rerun-if-changed=../tari_indexer_web_ui/src");
     println!("cargo:rerun-if-changed=../tari_indexer_web_ui/public");
 
-    if option_env!("CARGO_FEATURE_TS").is_some() {
+    if env::var("CARGO_FEATURE_TS").is_ok() {
         println!("cargo:warning=The web ui is not being compiled when we are generating typescript types/interfaces.");
         return Ok(());
     }

--- a/applications/tari_indexer/build.rs
+++ b/applications/tari_indexer/build.rs
@@ -20,13 +20,19 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::{env, process::Command};
+use std::process::Command;
+
+fn exit_on_ci() {
+    if option_env!("CI").is_some() {
+        std::process::exit(1);
+    }
+}
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("cargo:rerun-if-changed=../tari_indexer_web_ui/src");
     println!("cargo:rerun-if-changed=../tari_indexer_web_ui/public");
 
-    if env::var_os("CARGO_FEATURE_TS").is_some() {
+    if option_env!("CARGO_FEATURE_TS").is_some() {
         println!("cargo:warning=The web ui is not being compiled when we are generating typescript types/interfaces.");
         return Ok(());
     }
@@ -39,7 +45,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .status()
     {
         println!("cargo:warning='npm ci' error : {:?}", error);
-        std::process::exit(1);
+        exit_on_ci();
     }
     match Command::new(npm)
         .args(["run", "build"])
@@ -50,12 +56,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             println!("cargo:warning='npm run build' exited with non-zero status code");
             println!("cargo:warning=Output: {}", String::from_utf8_lossy(&output.stdout));
             println!("cargo:warning=Error: {}", String::from_utf8_lossy(&output.stderr));
-            std::process::exit(1);
+            exit_on_ci();
         },
         Err(error) => {
             println!("cargo:warning='npm run build' error : {:?}", error);
             println!("cargo:warning=The web ui will not be included!");
-            std::process::exit(1);
+            exit_on_ci();
         },
         _ => {},
     }

--- a/applications/tari_indexer_web_ui/package-lock.json
+++ b/applications/tari_indexer_web_ui/package-lock.json
@@ -40,7 +40,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "shx": "^0.3.4"
+        "shx": "^0.3.4",
+        "typescript": "^5.3.3"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/applications/tari_validator_node/Cargo.toml
+++ b/applications/tari_validator_node/Cargo.toml
@@ -10,6 +10,7 @@ license.workspace = true
 [features]
 default = ["metrics"]
 metrics = ["prometheus"]
+ts = []                  # this is just for the build script to skip the build
 
 [dependencies]
 minotari_app_grpc = { workspace = true }
@@ -93,4 +94,3 @@ ignored = [
     # Want to enable some log4rs features
     "log4rs",
 ]
-

--- a/applications/tari_validator_node/build.rs
+++ b/applications/tari_validator_node/build.rs
@@ -20,7 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::process::Command;
+use std::{env, process::Command};
 
 fn exit_on_ci() {
     if option_env!("CI").is_some() {
@@ -32,7 +32,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("cargo:rerun-if-changed=../tari_validator_node_web_ui/src");
     println!("cargo:rerun-if-changed=../tari_validator_node_web_ui/public");
 
-    if option_env!("CARGO_FEATURE_TS").is_some() {
+    if env::var("CARGO_FEATURE_TS").is_ok() {
         println!("cargo:warning=The web ui is not being compiled when we are generating typescript types/interfaces.");
         return Ok(());
     }

--- a/applications/tari_validator_node/build.rs
+++ b/applications/tari_validator_node/build.rs
@@ -39,14 +39,25 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .status()
     {
         println!("cargo:warning='npm ci' error : {:?}", error);
+        std::process::exit(1);
     }
-    if let Err(error) = Command::new(npm)
+    match Command::new(npm)
         .args(["run", "build"])
         .current_dir("../tari_validator_node_web_ui")
-        .status()
+        .output()
     {
-        println!("cargo:warning='npm run build' error : {:?}", error);
-        println!("cargo:warning=The web ui will not be included!");
+        Ok(output) if !output.status.success() => {
+            println!("cargo:warning='npm run build' exited with non-zero status code");
+            println!("cargo:warning=Output: {}", String::from_utf8_lossy(&output.stdout));
+            println!("cargo:warning=Error: {}", String::from_utf8_lossy(&output.stderr));
+            std::process::exit(1);
+        },
+        Err(error) => {
+            println!("cargo:warning='npm run build' error : {:?}", error);
+            println!("cargo:warning=The web ui will not be included!");
+            std::process::exit(1);
+        },
+        _ => {},
     }
     Ok(())
 }

--- a/applications/tari_validator_node_web_ui/src/routes/Blocks/BlockDetails.tsx
+++ b/applications/tari_validator_node_web_ui/src/routes/Blocks/BlockDetails.tsx
@@ -148,7 +148,7 @@ export default function BlockDetails() {
                             <TableCell>Total Fees</TableCell>
                             <DataTableCell>
                               <div className={block!.proposed_by === identity!.public_key ? "my_money" : ""}>
-                                {block!.block_fee.leader_fee}
+                                {block!.total_leader_fee}
                               </div>
                             </DataTableCell>
                           </TableRow>

--- a/applications/tari_validator_node_web_ui/src/routes/Blocks/Transactions.tsx
+++ b/applications/tari_validator_node_web_ui/src/routes/Blocks/Transactions.tsx
@@ -34,7 +34,7 @@ function Transaction({ transaction }: { transaction: TransactionAtom }) {
       <TableCell>
         <StatusChip status={transaction.decision} />
       </TableCell>
-      <TableCell>{transaction.leader_fee}</TableCell>
+      <TableCell>{transaction.leader_fee?.fee}</TableCell>
       <TableCell>{transaction.transaction_fee}</TableCell>
     </TableRow>
   );

--- a/applications/tari_validator_node_web_ui/src/routes/VN/Components/Blocks.tsx
+++ b/applications/tari_validator_node_web_ui/src/routes/VN/Components/Blocks.tsx
@@ -94,7 +94,7 @@ function Blocks() {
               epoch: block.epoch,
               height: block.height,
               decision: block.justify.decision,
-              total_leader_fee: block.block_fee.leader_fee,
+              total_leader_fee: block.total_leader_fee,
               proposed_by_me: block.proposed_by === identity.public_key,
               transactions_cnt: block.commands.length,
               block_time: times[block.id] - times[block.justify.block_id],

--- a/bindings/src/types/Block.ts
+++ b/bindings/src/types/Block.ts
@@ -13,7 +13,7 @@ export interface Block {
   height: NodeHeight;
   epoch: Epoch;
   proposed_by: string;
-  total_leader_fee: bigint;
+  total_leader_fee: number;
   merkle_root: string;
   commands: Array<Command>;
   is_dummy: boolean;

--- a/dan_layer/storage/src/consensus_models/block.rs
+++ b/dan_layer/storage/src/consensus_models/block.rs
@@ -73,6 +73,7 @@ pub struct Block {
     epoch: Epoch,
     #[cfg_attr(feature = "ts", ts(type = "string"))]
     proposed_by: PublicKey,
+    #[cfg_attr(feature = "ts", ts(type = "number"))]
     total_leader_fee: u64,
 
     // Body


### PR DESCRIPTION
Description
---
Fix the broken web ui builds (some of the types in the webui did not exists).
The build scripts were update to catch these errors.you
Also apply `.prettierrc` to all files in the repo.

Motivation and Context
---

How Has This Been Tested?
---

What process can a PR reviewer use to test or verify this change?
---


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify