### PR TITLE
feat!: check the incoming base layer block hash in proposals

### DIFF
--- a/applications/tari_dan_app_utilities/src/consensus_constants.rs
+++ b/applications/tari_dan_app_utilities/src/consensus_constants.rs
@@ -24,6 +24,8 @@
 pub struct ConsensusConstants {
     pub base_layer_confirmations: u64,
     pub committee_size: u32,
+    pub max_base_layer_blocks_ahead: u64,
+    pub max_base_layer_blocks_behind: u64,
 }
 
 impl ConsensusConstants {
@@ -31,6 +33,8 @@ impl ConsensusConstants {
         Self {
             base_layer_confirmations: 3,
             committee_size: 7,
+            max_base_layer_blocks_ahead: 5,
+            max_base_layer_blocks_behind: 5,
         }
     }
 }

--- a/applications/tari_validator_node/src/bootstrap.rs
+++ b/applications/tari_validator_node/src/bootstrap.rs
@@ -264,6 +264,7 @@ pub async fn spawn_services(
         metrics,
         shutdown.clone(),
         transaction_executor_builder,
+        consensus_constants.clone(),
     )
     .await;
     handles.push(consensus_join_handle);

--- a/applications/tari_validator_node/src/consensus/mod.rs
+++ b/applications/tari_validator_node/src/consensus/mod.rs
@@ -2,7 +2,7 @@
 //    SPDX-License-Identifier: BSD-3-Clause
 
 use tari_common::configuration::Network;
-use tari_consensus::hotstuff::{ConsensusWorker, ConsensusWorkerContext, HotstuffWorker};
+use tari_consensus::hotstuff::{ConsensusWorker, ConsensusWorkerContext, HotstuffConfig, HotstuffWorker};
 use tari_dan_storage::consensus_models::TransactionPool;
 use tari_epoch_manager::base_layer::EpochManagerHandle;
 use tari_shutdown::ShutdownSignal;
@@ -38,6 +38,7 @@ pub use handle::*;
 use sqlite_message_logger::SqliteMessageLogger;
 use tari_consensus::traits::ConsensusSpec;
 use tari_dan_app_utilities::{
+    consensus_constants::ConsensusConstants,
     keypair::RistrettoKeypair,
     template_manager::implementation::TemplateManager,
     transaction_executor::TariDanTransactionProcessor,
@@ -62,6 +63,7 @@ pub async fn spawn(
         EpochManagerHandle<PeerAddress>,
         TariDanTransactionProcessor<TemplateManager<PeerAddress>>,
     >,
+    consensus_constants: ConsensusConstants,
 ) -> (
     JoinHandle<Result<(), anyhow::Error>>,
     ConsensusHandle,
@@ -93,6 +95,10 @@ pub async fn spawn(
         tx_mempool,
         hooks,
         shutdown_signal.clone(),
+        HotstuffConfig {
+            max_base_layer_blocks_behind: consensus_constants.max_base_layer_blocks_behind,
+            max_base_layer_blocks_ahead: consensus_constants.max_base_layer_blocks_ahead,
+        },
     );
 
     let (tx_current_state, rx_current_state) = watch::channel(Default::default());

--- a/dan_layer/consensus/src/block_validations.rs
+++ b/dan_layer/consensus/src/block_validations.rs
@@ -46,12 +46,13 @@ pub async fn check_base_layer_block_hash<TConsensusSpec: ConsensusSpec>(
     }
     // Check if the base layer block height is within the acceptable range
     let current_height = epoch_manager.current_base_layer_block_info().await?.0;
-    if base_layer_block_height + config.max_base_layer_blocks_behind < current_height {
-        Err(ProposalValidationError::BlockHeightTooSmall {
-            proposed: base_layer_block_height,
-            current: current_height,
-        })?;
-    }
+    // TODO: uncomment this when the sync information is available here, otherwise during sync this will fail
+    // if base_layer_block_height + config.max_base_layer_blocks_behind < current_height {
+    //     Err(ProposalValidationError::BlockHeightTooSmall {
+    //         proposed: base_layer_block_height,
+    //         current: current_height,
+    //     })?;
+    // }
     if base_layer_block_height > current_height + config.max_base_layer_blocks_ahead {
         Err(ProposalValidationError::BlockHeightTooHigh {
             proposed: base_layer_block_height,

--- a/dan_layer/consensus/src/block_validations.rs
+++ b/dan_layer/consensus/src/block_validations.rs
@@ -31,30 +31,30 @@ pub async fn check_base_layer_block_hash<TConsensusSpec: ConsensusSpec>(
         return Ok(());
     }
     // Check if know the base layer block hash
-    let base_layer_height = epoch_manager
+    let base_layer_block_height = epoch_manager
         .get_base_layer_block_height(*block.base_layer_block_hash())
         .await?
         .ok_or_else(|| ProposalValidationError::BlockHashNotFound {
             hash: *block.base_layer_block_hash(),
         })?;
     // Check if the base layer block height is matching the base layer block hash
-    if base_layer_height != block.base_layer_block_height() {
+    if base_layer_block_height != block.base_layer_block_height() {
         Err(ProposalValidationError::BlockHeightMismatch {
             height: block.base_layer_block_height(),
-            real_height: base_layer_height,
+            real_height: base_layer_block_height,
         })?;
     }
     // Check if the base layer block height is within the acceptable range
     let current_height = epoch_manager.current_base_layer_block_info().await?.0;
-    if base_layer_height + config.max_base_layer_blocks_behind < current_height {
+    if base_layer_block_height + config.max_base_layer_blocks_behind < current_height {
         Err(ProposalValidationError::BlockHeightTooSmall {
-            proposed: base_layer_height,
+            proposed: base_layer_block_height,
             current: current_height,
         })?;
     }
-    if base_layer_height > current_height + config.max_base_layer_blocks_ahead {
+    if base_layer_block_height > current_height + config.max_base_layer_blocks_ahead {
         Err(ProposalValidationError::BlockHeightTooHigh {
-            proposed: base_layer_height,
+            proposed: base_layer_block_height,
             current: current_height,
         })?;
     }

--- a/dan_layer/consensus/src/hotstuff/common.rs
+++ b/dan_layer/consensus/src/hotstuff/common.rs
@@ -39,6 +39,7 @@ pub fn calculate_last_dummy_block<TAddr: NodeAddressable, TLeaderStrategy: Leade
     leader_strategy: &TLeaderStrategy,
     local_committee: &Committee<TAddr>,
     parent_timestamp: u64,
+    parent_base_layer_block_height: u64,
     parent_base_layer_block_hash: FixedHash,
 ) -> Option<LeafBlock> {
     let mut parent_block = high_qc.as_leaf_block();
@@ -70,6 +71,7 @@ pub fn calculate_last_dummy_block<TAddr: NodeAddressable, TLeaderStrategy: Leade
             epoch,
             parent_merkle_root,
             parent_timestamp,
+            parent_base_layer_block_height,
             parent_base_layer_block_hash,
         );
         debug!(

--- a/dan_layer/consensus/src/hotstuff/config.rs
+++ b/dan_layer/consensus/src/hotstuff/config.rs
@@ -1,0 +1,8 @@
+//   Copyright 2023 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+#[derive(Debug, Clone)]
+pub struct HotstuffConfig {
+    pub max_base_layer_blocks_ahead: u64,
+    pub max_base_layer_blocks_behind: u64,
+}

--- a/dan_layer/consensus/src/hotstuff/error.rs
+++ b/dan_layer/consensus/src/hotstuff/error.rs
@@ -190,4 +190,12 @@ pub enum ProposalValidationError {
         calculated: FixedHash,
         from_block: FixedHash,
     },
+    #[error("Base layer block hash for block with height {proposed} too high, current height {current}")]
+    BlockHeightTooHigh { proposed: u64, current: u64 },
+    #[error("Base layer block hash for block with height {proposed} too small, current height {current}")]
+    BlockHeightTooSmall { proposed: u64, current: u64 },
+    #[error("Base layer block hash ({hash}) is not known to the node")]
+    BlockHashNotFound { hash: FixedHash },
+    #[error("Base layer block height {height} does not match the real height {real_height}")]
+    BlockHeightMismatch { height: u64, real_height: u64 },
 }

--- a/dan_layer/consensus/src/hotstuff/mod.rs
+++ b/dan_layer/consensus/src/hotstuff/mod.rs
@@ -1,6 +1,7 @@
 //   Copyright 2023 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 mod common;
+mod config;
 mod current_height;
 mod error;
 mod event;
@@ -27,6 +28,7 @@ mod vote_receiver;
 mod worker;
 
 pub use common::*;
+pub use config::HotstuffConfig;
 pub use error::*;
 pub use event::*;
 pub use state_machine::*;

--- a/dan_layer/consensus/src/hotstuff/on_propose.rs
+++ b/dan_layer/consensus/src/hotstuff/on_propose.rs
@@ -338,8 +338,8 @@ where TConsensusSpec: ConsensusSpec
             foreign_indexes,
             None,
             EpochTime::now().as_u64(),
-            base_layer_block_hash,
             base_layer_block_height,
+            base_layer_block_hash,
         );
 
         let signature = self.signing_service.sign(next_block.id());

--- a/dan_layer/consensus/src/hotstuff/on_receive_foreign_proposal.rs
+++ b/dan_layer/consensus/src/hotstuff/on_receive_foreign_proposal.rs
@@ -109,7 +109,16 @@ where TConsensusSpec: ConsensusSpec
             })
             .collect::<Vec<TransactionId>>();
 
-        let foreign_proposal = ForeignProposal::new(committee_shard.shard(), *block.id(), tx_ids);
+        let base_layer_block_height = self
+            .epoch_manager
+            .get_base_layer_block_height(*block.base_layer_block_hash())
+            .await?
+            .ok_or_else(|| ProposalValidationError::BlockHashNotFound {
+                hash: *block.base_layer_block_hash(),
+            })?;
+
+        let foreign_proposal =
+            ForeignProposal::new(committee_shard.shard(), *block.id(), tx_ids, base_layer_block_height);
         if self
             .store
             .with_read_tx(|tx| ForeignProposal::exists(tx, &foreign_proposal))?

--- a/dan_layer/consensus/src/hotstuff/on_receive_foreign_proposal.rs
+++ b/dan_layer/consensus/src/hotstuff/on_receive_foreign_proposal.rs
@@ -109,16 +109,13 @@ where TConsensusSpec: ConsensusSpec
             })
             .collect::<Vec<TransactionId>>();
 
-        let base_layer_block_height = self
-            .epoch_manager
-            .get_base_layer_block_height(*block.base_layer_block_hash())
-            .await?
-            .ok_or_else(|| ProposalValidationError::BlockHashNotFound {
-                hash: *block.base_layer_block_hash(),
-            })?;
-
-        let foreign_proposal =
-            ForeignProposal::new(committee_shard.shard(), *block.id(), tx_ids, base_layer_block_height);
+        // The block height was validated earlier, so we can use the height only and not store the hash anymore
+        let foreign_proposal = ForeignProposal::new(
+            committee_shard.shard(),
+            *block.id(),
+            tx_ids,
+            block.base_layer_block_height(),
+        );
         if self
             .store
             .with_read_tx(|tx| ForeignProposal::exists(tx, &foreign_proposal))?

--- a/dan_layer/consensus/src/hotstuff/on_receive_local_proposal.rs
+++ b/dan_layer/consensus/src/hotstuff/on_receive_local_proposal.rs
@@ -410,6 +410,7 @@ impl<TConsensusSpec: ConsensusSpec> OnReceiveLocalProposalHandler<TConsensusSpec
                     candidate_block.epoch(),
                     *candidate_block.merkle_root(),
                     last_dummy_block.timestamp(),
+                    last_dummy_block.base_layer_block_height(),
                     *last_dummy_block.base_layer_block_hash(),
                 ));
                 last_dummy_block = dummy_blocks.last().unwrap();

--- a/dan_layer/consensus/src/hotstuff/on_receive_new_view.rs
+++ b/dan_layer/consensus/src/hotstuff/on_receive_new_view.rs
@@ -202,6 +202,7 @@ where TConsensusSpec: ConsensusSpec
                 &self.leader_strategy,
                 &local_committee,
                 high_qc_block.timestamp(),
+                high_qc_block.base_layer_block_height(),
                 *high_qc_block.base_layer_block_hash(),
             );
             // Set the last voted block so that we do not vote on other conflicting blocks

--- a/dan_layer/consensus/src/hotstuff/worker.rs
+++ b/dan_layer/consensus/src/hotstuff/worker.rs
@@ -19,7 +19,11 @@ use tari_shutdown::ShutdownSignal;
 use tari_transaction::{Transaction, TransactionId};
 use tokio::sync::{broadcast, mpsc};
 
-use super::{on_receive_requested_transactions::OnReceiveRequestedTransactions, proposer::Proposer};
+use super::{
+    config::HotstuffConfig,
+    on_receive_requested_transactions::OnReceiveRequestedTransactions,
+    proposer::Proposer,
+};
 use crate::{
     hotstuff::{
         error::HotStuffError,
@@ -92,6 +96,7 @@ impl<TConsensusSpec: ConsensusSpec> HotstuffWorker<TConsensusSpec> {
         tx_mempool: mpsc::UnboundedSender<Transaction>,
         hooks: TConsensusSpec::Hooks,
         shutdown: ShutdownSignal,
+        config: HotstuffConfig,
     ) -> Self {
         let pacemaker = PaceMaker::new();
         let vote_receiver = VoteReceiver::new(
@@ -114,6 +119,7 @@ impl<TConsensusSpec: ConsensusSpec> HotstuffWorker<TConsensusSpec> {
 
             on_inbound_message: OnInboundMessage::new(
                 network,
+                config,
                 state_store.clone(),
                 epoch_manager.clone(),
                 leader_strategy.clone(),

--- a/dan_layer/consensus_tests/src/support/epoch_manager.rs
+++ b/dan_layer/consensus_tests/src/support/epoch_manager.rs
@@ -262,6 +262,10 @@ impl EpochManagerReader for TestEpochManager {
             fee_claim_public_key: PublicKey::default(),
         })
     }
+
+    async fn get_base_layer_block_height(&self, _hash: FixedHash) -> Result<Option<u64>, EpochManagerError> {
+        Ok(Some(self.inner.lock().await.current_block_info.0))
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/dan_layer/consensus_tests/src/support/validator/builder.rs
+++ b/dan_layer/consensus_tests/src/support/validator/builder.rs
@@ -3,7 +3,7 @@
 
 use tari_common_types::types::PublicKey;
 use tari_consensus::{
-    hotstuff::{ConsensusWorker, ConsensusWorkerContext, HotstuffWorker},
+    hotstuff::{ConsensusWorker, ConsensusWorkerContext, HotstuffConfig, HotstuffWorker},
     traits::hooks::NoopHooks,
 };
 use tari_dan_common_types::{shard::Shard, SubstateAddress};
@@ -121,6 +121,10 @@ impl ValidatorBuilder {
             tx_mempool,
             NoopHooks,
             shutdown_signal.clone(),
+            HotstuffConfig {
+                max_base_layer_blocks_ahead: 5,
+                max_base_layer_blocks_behind: 5,
+            },
         );
 
         let (tx_current_state, _) = watch::channel(Default::default());

--- a/dan_layer/epoch_manager/src/base_layer/base_layer_epoch_manager.rs
+++ b/dan_layer/epoch_manager/src/base_layer/base_layer_epoch_manager.rs
@@ -709,6 +709,15 @@ impl<TAddr: NodeAddressable + DerivableFromPublicKey>
     fn publish_event(&mut self, event: EpochManagerEvent) {
         let _ignore = self.tx_events.send(event);
     }
+
+    pub async fn get_base_layer_block_height(&self, hash: FixedHash) -> Result<Option<u64>, EpochManagerError> {
+        let mut tx = self.global_db.create_transaction()?;
+        let mut base_layer_hashes = self.global_db.base_layer_hashes(&mut tx);
+        let info = base_layer_hashes
+            .get_base_layer_block_height(hash)?
+            .map(|info| info.height);
+        Ok(info)
+    }
 }
 
 fn calculate_num_committees(num_vns: u64, committee_size: u32) -> u32 {

--- a/dan_layer/epoch_manager/src/base_layer/epoch_manager_service.rs
+++ b/dan_layer/epoch_manager/src/base_layer/epoch_manager_service.rs
@@ -225,6 +225,9 @@ impl<TAddr: NodeAddressable + DerivableFromPublicKey + 'static>
             EpochManagerRequest::SetFeeClaimPublicKey { public_key, reply } => {
                 handle(reply, self.inner.set_fee_claim_public_key(public_key))
             },
+            EpochManagerRequest::GetBaseLayerBlockHeight { hash, reply } => {
+                handle(reply, self.inner.get_base_layer_block_height(hash).await)
+            },
         }
     }
 }

--- a/dan_layer/epoch_manager/src/base_layer/handle.rs
+++ b/dan_layer/epoch_manager/src/base_layer/handle.rs
@@ -408,4 +408,13 @@ impl<TAddr: NodeAddressable> EpochManagerReader for EpochManagerHandle<TAddr> {
 
         rx.await.map_err(|_| EpochManagerError::ReceiveError)?
     }
+
+    async fn get_base_layer_block_height(&self, hash: FixedHash) -> Result<Option<u64>, EpochManagerError> {
+        let (tx, rx) = oneshot::channel();
+        self.tx_request
+            .send(EpochManagerRequest::GetBaseLayerBlockHeight { hash, reply: tx })
+            .await
+            .map_err(|_| EpochManagerError::SendError)?;
+        rx.await.map_err(|_| EpochManagerError::ReceiveError)?
+    }
 }

--- a/dan_layer/epoch_manager/src/base_layer/types.rs
+++ b/dan_layer/epoch_manager/src/base_layer/types.rs
@@ -143,6 +143,10 @@ pub enum EpochManagerRequest<TAddr> {
         buckets: HashSet<Shard>,
         reply: Reply<HashMap<Shard, Committee<TAddr>>>,
     },
+    GetBaseLayerBlockHeight {
+        hash: FixedHash,
+        reply: Reply<Option<u64>>,
+    },
     GetFeeClaimPublicKey {
         reply: Reply<Option<PublicKey>>,
     },

--- a/dan_layer/epoch_manager/src/traits.rs
+++ b/dan_layer/epoch_manager/src/traits.rs
@@ -177,4 +177,6 @@ pub trait EpochManagerReader: Send + Sync {
                 }
             })
     }
+
+    async fn get_base_layer_block_height(&self, hash: FixedHash) -> Result<Option<u64>, EpochManagerError>;
 }

--- a/dan_layer/p2p/proto/consensus.proto
+++ b/dan_layer/p2p/proto/consensus.proto
@@ -53,7 +53,8 @@ message Block {
   bytes foreign_indexes = 11;
   tari.dan.common.Signature signature = 12;
   uint64 timestamp = 13;
-  bytes base_layer_block_hash = 14;
+  uint64 base_layer_block_height = 14;
+  bytes base_layer_block_hash = 15;
 }
 
 message LeaderFee {
@@ -83,6 +84,7 @@ message ForeignProposal {
   ForeignProposalState state = 3;
   uint64 mined_at = 4;
   repeated bytes transactions = 5;
+  uint64 base_layer_block_height = 6;
 }
 
 message TransactionAtom {

--- a/dan_layer/p2p/src/conversions/consensus.rs
+++ b/dan_layer/p2p/src/conversions/consensus.rs
@@ -263,6 +263,7 @@ impl From<&tari_dan_storage::consensus_models::Block> for proto::consensus::Bloc
             foreign_indexes: encode(value.foreign_indexes()).unwrap(),
             signature: value.get_signature().map(Into::into),
             timestamp: value.timestamp(),
+            base_layer_block_height: value.base_layer_block_height(),
             base_layer_block_hash: value.base_layer_block_hash().as_bytes().to_vec(),
         }
     }
@@ -297,6 +298,7 @@ impl TryFrom<proto::consensus::Block> for tari_dan_storage::consensus_models::Bl
             decode_exact(&value.foreign_indexes)?,
             value.signature.map(TryInto::try_into).transpose()?,
             value.timestamp,
+            value.base_layer_block_height,
             value.base_layer_block_hash.try_into()?,
         ))
     }
@@ -335,7 +337,7 @@ impl TryFrom<proto::consensus::Command> for Command {
     }
 }
 
-//---------------------------------- TranactionAtom --------------------------------------------//
+//---------------------------------- TransactionAtom --------------------------------------------//
 
 impl From<&TransactionAtom> for proto::consensus::TransactionAtom {
     fn from(value: &TransactionAtom) -> Self {
@@ -425,6 +427,7 @@ impl From<&ForeignProposal> for proto::consensus::ForeignProposal {
             state: proto::consensus::ForeignProposalState::from(value.state).into(),
             mined_at: value.proposed_height.map(|a| a.0).unwrap_or(0),
             transactions: value.transactions.iter().map(|tx| tx.as_bytes().to_vec()).collect(),
+            base_layer_block_height: value.base_layer_block_height,
         }
     }
 }
@@ -449,6 +452,7 @@ impl TryFrom<proto::consensus::ForeignProposal> for ForeignProposal {
                 .into_iter()
                 .map(|tx| tx.try_into())
                 .collect::<Result<_, _>>()?,
+            base_layer_block_height: value.base_layer_block_height,
         })
     }
 }

--- a/dan_layer/rpc_state_sync/src/manager.rs
+++ b/dan_layer/rpc_state_sync/src/manager.rs
@@ -302,6 +302,7 @@ where TConsensusSpec: ConsensusSpec<Addr = PeerAddress>
                         block.epoch(),
                         *block.merkle_root(),
                         block.timestamp(),
+                        block.base_layer_block_height(),
                         *block.base_layer_block_hash(),
                     );
                     dummy_block.save(tx)?;

--- a/dan_layer/state_store_sqlite/migrations/2023-06-08-091819_create_state_store/up.sql
+++ b/dan_layer/state_store_sqlite/migrations/2023-06-08-091819_create_state_store/up.sql
@@ -12,27 +12,28 @@ create unique index quorum_certificates_uniq_idx_id on quorum_certificates (qc_i
 
 create table blocks
 (
-    id                    integer   not null primary key AUTOINCREMENT,
-    block_id              text      not NULL,
-    parent_block_id       text      not NULL,
-    merkle_root           text      not NULL,
-    network               text      not NULL,
-    height                bigint    not NULL,
-    epoch                 bigint    not NULL,
-    proposed_by           text      not NULL,
-    qc_id                 text      not NULL,
-    command_count         bigint    not NULL,
-    commands              text      not NULL,
-    total_leader_fee      bigint    not NULL,
-    is_committed          boolean   not NULL default '0',
-    is_processed          boolean   not NULL,
-    is_dummy              boolean   not NULL,
-    foreign_indexes       text      not NULL,
-    signature             text      NULL,
-    created_at            timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    block_time            bigint    NULL,
-    timestamp             bigint    not NULL,
-    base_layer_block_hash text not NULL,
+    id                      integer   not null primary key AUTOINCREMENT,
+    block_id                text      not NULL,
+    parent_block_id         text      not NULL,
+    merkle_root             text      not NULL,
+    network                 text      not NULL,
+    height                  bigint    not NULL,
+    epoch                   bigint    not NULL,
+    proposed_by             text      not NULL,
+    qc_id                   text      not NULL,
+    command_count           bigint    not NULL,
+    commands                text      not NULL,
+    total_leader_fee        bigint    not NULL,
+    is_committed            boolean   not NULL default '0',
+    is_processed            boolean   not NULL,
+    is_dummy                boolean   not NULL,
+    foreign_indexes         text      not NULL,
+    signature               text          NULL,
+    block_time              bigint        NULL,
+    timestamp               bigint    not NULL,
+    base_layer_block_height bigint    not NULL,
+    base_layer_block_hash   text      not NULL,
+    created_at              timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (qc_id) REFERENCES quorum_certificates (qc_id)
 );
 
@@ -41,24 +42,25 @@ create unique index blocks_uniq_idx_id on blocks (block_id);
 
 create table parked_blocks
 (   
-    id                    integer not null primary key AUTOINCREMENT,
-    block_id              text    not NULL,
-    parent_block_id       text    not NULL,
-    merkle_root           text    not NULL,
-    network               text    not NULL,
-    height                bigint  not NULL,
-    epoch                 bigint  not NULL,
-    proposed_by           text    not NULL,
-    justify               text    not NULL,
-    command_count         bigint  not NULL,
-    commands              text    not NULL,
-    total_leader_fee      bigint  not NULL,
-    foreign_indexes       text    not NULL,
-    signature             text        NULL,
-    block_time            bigint      NULL,
-    timestamp             bigint  not NULL,
-    base_layer_block_hash text    not NULL,
-    created_at            timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP
+    id                      integer   not null primary key AUTOINCREMENT,
+    block_id                text      not NULL,
+    parent_block_id         text      not NULL,
+    merkle_root             text      not NULL,
+    network                 text      not NULL,
+    height                  bigint    not NULL,
+    epoch                   bigint    not NULL,
+    proposed_by             text      not NULL,
+    justify                 text      not NULL,
+    command_count           bigint    not NULL,
+    commands                text      not NULL,
+    total_leader_fee        bigint    not NULL,
+    foreign_indexes         text      not NULL,
+    signature               text          NULL,
+    block_time              bigint        NULL,
+    timestamp               bigint    not NULL,
+    base_layer_block_height bigint    not NULL,
+    base_layer_block_hash   text      not NULL,
+    created_at              timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
 -- block_id must be unique. Optimise fetching by block_id
@@ -261,13 +263,14 @@ CREATE TABLE missing_transactions
 
 CREATE TABLE foreign_proposals
 (
-    id              integer   not NULL primary key AUTOINCREMENT,
-    bucket          int       not NULL,
-    block_id        text      not NULL,
-    state           text      not NULL,
-    proposed_height bigint    NULL,
-    transactions    text      not NULL,
-    created_at      timestamp not NULL DEFAULT CURRENT_TIMESTAMP,
+    id                      integer   not NULL primary key AUTOINCREMENT,
+    bucket                  int       not NULL,
+    block_id                text      not NULL,
+    state                   text      not NULL,
+    proposed_height         bigint        NULL,
+    transactions            text      not NULL,
+    base_layer_block_height bigint    not NULL,
+    created_at              timestamp not NULL DEFAULT CURRENT_TIMESTAMP,
     UNIQUE (bucket, block_id)
 );
 

--- a/dan_layer/state_store_sqlite/src/reader.rs
+++ b/dan_layer/state_store_sqlite/src/reader.rs
@@ -388,6 +388,7 @@ impl<'tx, TAddr: NodeAddressable + Serialize + DeserializeOwned + 'tx> StateStor
             .filter(foreign_proposals::bucket.eq(foreign_proposal.bucket.as_u32() as i32))
             .filter(foreign_proposals::block_id.eq(serialize_hex(foreign_proposal.block_id)))
             .filter(foreign_proposals::transactions.eq(serialize_json(&foreign_proposal.transactions)?))
+            .filter(foreign_proposals::base_layer_block_height.eq(foreign_proposal.base_layer_block_height as i64))
             .count()
             .limit(1)
             .get_result::<i64>(self.connection())

--- a/dan_layer/state_store_sqlite/src/schema.rs
+++ b/dan_layer/state_store_sqlite/src/schema.rs
@@ -22,6 +22,7 @@ diesel::table! {
         created_at -> Timestamp,
         block_time -> Nullable<BigInt>,
         timestamp -> BigInt,
+        base_layer_block_height -> BigInt,
         base_layer_block_hash -> Text,
     }
 }
@@ -34,6 +35,7 @@ diesel::table! {
         state -> Text,
         proposed_height -> Nullable<BigInt>,
         transactions -> Text,
+        base_layer_block_height -> BigInt,
         created_at -> Timestamp,
     }
 }
@@ -162,6 +164,7 @@ diesel::table! {
         created_at -> Timestamp,
         block_time -> Nullable<BigInt>,
         timestamp -> BigInt,
+        base_layer_block_height -> BigInt,
         base_layer_block_hash -> Text,
     }
 }

--- a/dan_layer/state_store_sqlite/src/sql_models/block.rs
+++ b/dan_layer/state_store_sqlite/src/sql_models/block.rs
@@ -36,6 +36,7 @@ pub struct Block {
     pub created_at: PrimitiveDateTime,
     pub block_time: Option<i64>,
     pub timestamp: i64,
+    pub base_layer_block_height: i64,
     pub base_layer_block_hash: String,
 }
 
@@ -69,8 +70,9 @@ impl Block {
             deserialize_json(&self.foreign_indexes)?,
             self.signature.map(|val| deserialize_json(&val)).transpose()?,
             self.created_at,
-            self.block_time.map(|v| v as u64),
             self.timestamp as u64,
+            self.block_time.map(|v| v as u64),
+            self.base_layer_block_height as u64,
             deserialize_hex_try_from(&self.base_layer_block_hash)?,
         ))
     }
@@ -95,6 +97,7 @@ pub struct ParkedBlock {
     pub created_at: PrimitiveDateTime,
     pub block_time: Option<i64>,
     pub timestamp: i64,
+    pub base_layer_block_height: i64,
     pub base_layer_block_hash: String,
 }
 
@@ -132,6 +135,7 @@ impl TryFrom<ParkedBlock> for consensus_models::Block {
             value.created_at,
             value.block_time.map(|v| v as u64),
             value.timestamp as u64,
+            value.base_layer_block_height as u64,
             deserialize_hex_try_from(&value.base_layer_block_hash)?,
         ))
     }

--- a/dan_layer/state_store_sqlite/src/sql_models/block.rs
+++ b/dan_layer/state_store_sqlite/src/sql_models/block.rs
@@ -70,8 +70,8 @@ impl Block {
             deserialize_json(&self.foreign_indexes)?,
             self.signature.map(|val| deserialize_json(&val)).transpose()?,
             self.created_at,
-            self.timestamp as u64,
             self.block_time.map(|v| v as u64),
+            self.timestamp as u64,
             self.base_layer_block_height as u64,
             deserialize_hex_try_from(&self.base_layer_block_hash)?,
         ))

--- a/dan_layer/state_store_sqlite/src/sql_models/bookkeeping.rs
+++ b/dan_layer/state_store_sqlite/src/sql_models/bookkeeping.rs
@@ -43,6 +43,7 @@ pub struct ForeignProposal {
     pub state: String,
     pub mined_at: Option<i64>,
     pub transactions: String,
+    pub base_layer_block_height: i64,
     pub created_at: PrimitiveDateTime,
 }
 
@@ -56,6 +57,7 @@ impl TryFrom<ForeignProposal> for consensus_models::ForeignProposal {
             state: parse_from_string(&value.state)?,
             proposed_height: value.mined_at.map(|mined_at| NodeHeight(mined_at as u64)),
             transactions: deserialize_json(&value.transactions)?,
+            base_layer_block_height: value.base_layer_block_height as u64,
         })
     }
 }

--- a/dan_layer/state_store_sqlite/src/writer.rs
+++ b/dan_layer/state_store_sqlite/src/writer.rs
@@ -210,6 +210,7 @@ impl<'tx, TAddr: NodeAddressable + 'tx> StateStoreWriteTransaction for SqliteSta
             blocks::signature.eq(block.get_signature().map(serialize_json).transpose()?),
             blocks::foreign_indexes.eq(serialize_json(block.foreign_indexes())?),
             blocks::timestamp.eq(block.timestamp() as i64),
+            blocks::base_layer_block_height.eq(block.base_layer_block_height() as i64),
             blocks::base_layer_block_hash.eq(serialize_hex(block.base_layer_block_hash())),
         );
 
@@ -479,6 +480,7 @@ impl<'tx, TAddr: NodeAddressable + 'tx> StateStoreWriteTransaction for SqliteSta
             foreign_proposals::state.eq(foreign_proposal.state.to_string()),
             foreign_proposals::proposed_height.eq(foreign_proposal.proposed_height.map(|h| h.as_u64() as i64)),
             foreign_proposals::transactions.eq(serialize_json(&foreign_proposal.transactions)?),
+            foreign_proposals::base_layer_block_height.eq(foreign_proposal.base_layer_block_height as i64),
         );
 
         diesel::insert_into(foreign_proposals::table)

--- a/dan_layer/state_store_sqlite/src/writer.rs
+++ b/dan_layer/state_store_sqlite/src/writer.rs
@@ -160,6 +160,7 @@ impl<'a, TAddr: NodeAddressable> SqliteStateStoreWriteTransaction<'a, TAddr> {
             parked_blocks::foreign_indexes.eq(serialize_json(block.foreign_indexes())?),
             parked_blocks::block_time.eq(block.block_time().map(|v| v as i64)),
             parked_blocks::timestamp.eq(block.timestamp() as i64),
+            parked_blocks::base_layer_block_height.eq(block.base_layer_block_height() as i64),
             parked_blocks::base_layer_block_hash.eq(serialize_hex(block.base_layer_block_hash())),
         );
 

--- a/dan_layer/state_store_sqlite/tests/tests.rs
+++ b/dan_layer/state_store_sqlite/tests/tests.rs
@@ -63,6 +63,7 @@ mod confirm_all_transitions {
             Default::default(),
             None,
             EpochTime::now().as_u64(),
+            0,
             FixedHash::zero(),
         );
         block1.insert(&mut tx).unwrap();

--- a/dan_layer/storage/src/consensus_models/block.rs
+++ b/dan_layer/storage/src/consensus_models/block.rs
@@ -100,6 +100,8 @@ pub struct Block {
     block_time: Option<u64>,
     #[cfg_attr(feature = "ts", ts(type = "number"))]
     timestamp: u64,
+    #[cfg_attr(feature = "ts", ts(type = "number"))]
+    base_layer_block_height: u64,
     #[cfg_attr(feature = "ts", ts(type = "string"))]
     base_layer_block_hash: FixedHash,
 }
@@ -118,6 +120,7 @@ impl Block {
         sorted_foreign_indexes: IndexMap<Shard, u64>,
         signature: Option<ValidatorSchnorrSignature>,
         timestamp: u64,
+        base_layer_block_height: u64,
         base_layer_block_hash: FixedHash,
     ) -> Self {
         let mut block = Self {
@@ -139,6 +142,7 @@ impl Block {
             signature,
             block_time: None,
             timestamp,
+            base_layer_block_height,
             base_layer_block_hash,
         };
         block.id = block.calculate_hash().into();
@@ -164,6 +168,7 @@ impl Block {
         created_at: PrimitiveDateTime,
         block_time: Option<u64>,
         timestamp: u64,
+        base_layer_block_height: u64,
         base_layer_block_hash: FixedHash,
     ) -> Self {
         Self {
@@ -185,6 +190,7 @@ impl Block {
             signature,
             block_time,
             timestamp,
+            base_layer_block_height,
             base_layer_block_hash,
         }
     }
@@ -203,6 +209,7 @@ impl Block {
             IndexMap::new(),
             None,
             EpochTime::now().as_u64(),
+            0,
             FixedHash::zero(),
         )
     }
@@ -228,6 +235,7 @@ impl Block {
             signature: None,
             block_time: None,
             timestamp: EpochTime::now().as_u64(),
+            base_layer_block_height: 0,
             base_layer_block_hash: FixedHash::zero(),
         }
     }
@@ -241,6 +249,7 @@ impl Block {
         epoch: Epoch,
         parent_merkle_root: FixedHash,
         parent_timestamp: u64,
+        parent_base_layer_block_height: u64,
         parent_base_layer_block_hash: FixedHash,
     ) -> Self {
         let mut block = Self::new(
@@ -256,6 +265,7 @@ impl Block {
             IndexMap::new(),
             None,
             parent_timestamp,
+            parent_base_layer_block_height,
             parent_base_layer_block_hash,
         );
         block.is_dummy = true;
@@ -276,6 +286,7 @@ impl Block {
             .chain(&self.commands)
             .chain(&self.foreign_indexes)
             .chain(&self.timestamp)
+            .chain(&self.base_layer_block_height)
             .chain(&self.base_layer_block_hash)
             .result()
     }
@@ -419,6 +430,10 @@ impl Block {
 
     pub fn is_proposed_by_addr<A: NodeAddressable + PartialEq<A>>(&self, address: &A) -> Option<bool> {
         Some(A::try_from_public_key(&self.proposed_by)? == *address)
+    }
+
+    pub fn base_layer_block_height(&self) -> u64 {
+        self.base_layer_block_height
     }
 
     pub fn base_layer_block_hash(&self) -> &FixedHash {

--- a/dan_layer/storage/src/consensus_models/foreign_proposal.rs
+++ b/dan_layer/storage/src/consensus_models/foreign_proposal.rs
@@ -58,16 +58,23 @@ pub struct ForeignProposal {
     pub proposed_height: Option<NodeHeight>,
     #[cfg_attr(feature = "ts", ts(type = "Array<string>"))]
     pub transactions: Vec<TransactionId>,
+    pub base_layer_block_height: u64,
 }
 
 impl ForeignProposal {
-    pub fn new(bucket: Shard, block_id: BlockId, transactions: Vec<TransactionId>) -> Self {
+    pub fn new(
+        bucket: Shard,
+        block_id: BlockId,
+        transactions: Vec<TransactionId>,
+        base_layer_block_height: u64,
+    ) -> Self {
         Self {
             bucket,
             block_id,
             state: ForeignProposalState::New,
             proposed_height: None,
             transactions,
+            base_layer_block_height,
         }
     }
 


### PR DESCRIPTION
Description
---
We are adding the check for the base layer hash in the proposal to be within some +- from the current synced height. And it has to be known.
The check if the proposed block is too much behind is disabled. It's causing issues during sync (added TODO).

Motivation and Context
---

How Has This Been Tested?
---
I just did some logging to see if the height is being compared. But not the failing path.

What process can a PR reviewer use to test or verify this change?
---
Maybe run a couple vns, with running miner and see what's going on, will it fail? Make sure you run multiple committees to also test that foreignproposals will be validated.

Breaking Changes
---

- [ ] None
- [ ] Requires data directory to be deleted
- [x] Other - The 2nd layer should be restarted, otherwise the blocks validation will fail. But wait for the next PR that also have new breaking changes.