### PR TITLE
chore(integration_test): show more info about wallet daemons

### DIFF
--- a/integration_tests/tests/cucumber.rs
+++ b/integration_tests/tests/cucumber.rs
@@ -585,8 +585,10 @@ async fn print_world(world: &mut TariWorld) {
 
     // wallet daemons
     for (name, daemon) in &world.wallet_daemons {
-        eprintln!("Wallet daemons \"{}\"", name);
-        eprintln!("  - {}: {}", name, daemon.name);
+        eprintln!(
+            "Wallet daemon \"{}\": json rpc port \"{}\", indexer jrpc port \"{}\", temp dir path \"{:?}\"",
+            name, daemon.json_rpc_port, daemon.indexer_jrpc_port, daemon.temp_path_dir
+        );
     }
 
     eprintln!();


### PR DESCRIPTION
Description
---
Added port and path info about wallet daemons in cucumber

Motivation and Context
---
In cucumber, when using the `When I print the cucumber world` step, it only shows the wallet daemon name. This makes it difficult for manual testing if we want to stop the execution and inspect the wallet daemon.

This PRs adds port and path info similar to VNs and indexers.

How Has This Been Tested?
---
Inspecting the result of the `When I print the cucumber world` cucumber step

What process can a PR reviewer use to test or verify this change?
---
See previous section

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify