### PR TITLE
fix(integration_test): broken indexer event test

### DIFF
--- a/integration_tests/tests/features/indexer.feature
+++ b/integration_tests/tests/features/indexer.feature
@@ -97,7 +97,7 @@ Feature: Indexer node
     Then the indexer IDX returns 6 non fungibles for resource NFT/resources/0
 
     # Scan the network for the event emitted on ACC_1 creation
-    When indexer IDX scans the network 7 events for account ACC1 with topics component-created,deposit,deposit,deposit,deposit,deposit,deposit
+    When indexer IDX scans the network 13 events for account ACC1 with topics component-created,deposit,std.vault.deposit,deposit,std.vault.deposit,deposit,std.vault.deposit,deposit,std.vault.deposit,deposit,std.vault.deposit,deposit,std.vault.deposit
 
   # When I print the cucumber world
   # When I wait 5000 seconds


### PR DESCRIPTION
Description
---
Fixed the expected events on the indexer integration test

Motivation and Context
---
Recently in https://github.com/tari-project/tari-dan/pull/975 we introduced builtin events for vault deposits and withdrawals. The change broke an existing integration test for the indexer related to events, as we are now generating more events than expected. This PR fixes the test to match up the current behaviour.

How Has This Been Tested?
---
The previously broken test now pass

What process can a PR reviewer use to test or verify this change?
---
Check that all the test pass

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify