### PR TITLE
feat(template_lib): adds log macros

### DIFF
--- a/dan_layer/template_lib/src/macros.rs
+++ b/dan_layer/template_lib/src/macros.rs
@@ -15,3 +15,47 @@ macro_rules! debug {
         $crate::macros::call_debug(format!($fmt, $($args)*))
     };
 }
+
+/// Macro for emitting log messages from inside templates
+#[macro_export]
+macro_rules! log {
+    ($lvl:expr, $fmt:expr) => {
+        $crate::engine::engine().emit_log($lvl, $fmt)
+    };
+    ($lvl:expr, $fmt:expr, $($args:tt)*) => {
+        $crate::engine::engine().emit_log($lvl, format!($fmt, $($args)*))
+    };
+}
+
+/// Macro for emitting log messages from inside templates
+#[macro_export]
+macro_rules! info {
+    ($fmt:expr) => {
+        $crate::macros::log!($crate::args::LogLevel::Info, $fmt)
+    };
+    ($fmt:expr, $($args:tt)*) => {
+        $crate::macros::log!($crate::args::LogLevel::Info, $fmt, $($args)*)
+    };
+}
+
+/// Macro for emitting warn log messages from inside templates
+#[macro_export]
+macro_rules! warn {
+    ($fmt:expr) => {
+        $crate::macros::log!($crate::args::LogLevel::Warn, $fmt)
+    };
+    ($fmt:expr, $($args:tt)*) => {
+        $crate::macros::log!($crate::args::LogLevel::Warn, $fmt, $($args)*)
+    };
+}
+
+/// Macro for emitting error log messages from inside templates
+#[macro_export]
+macro_rules! error {
+    ($fmt:expr) => {
+        $crate::macros::log!($crate::args::LogLevel::Error, $fmt)
+    };
+    ($fmt:expr, $($args:tt)*) => {
+        $crate::macros::log!($crate::args::LogLevel::Error, $fmt, $($args)*)
+    };
+}

--- a/dan_layer/template_lib/src/prelude.rs
+++ b/dan_layer/template_lib/src/prelude.rs
@@ -37,8 +37,11 @@ pub use crate::{
     constants::{CONFIDENTIAL_TARI_RESOURCE_ADDRESS, PUBLIC_IDENTITY_RESOURCE_ADDRESS, XTR2},
     crypto::{PedersonCommitmentBytes, RistrettoPublicKeyBytes},
     debug,
+    error,
     events::emit_event,
+    info,
     invoke_args,
+    log,
     models::{
         AddressAllocation,
         Amount,
@@ -61,4 +64,5 @@ pub use crate::{
     rand,
     resource::{ResourceBuilder, ResourceManager, ResourceType},
     template::{BuiltinTemplate, TemplateManager},
+    warn,
 };


### PR DESCRIPTION
Description
---
feat(template_lib): adds log macros

Motivation and Context
---

Adds log macros to template lib. `info!`, `warn!`, `error!` will call `engine().emit_log(LogLevel::XXXX, format!(...))` 

How Has This Been Tested?
---
emit_log is already tested

What process can a PR reviewer use to test or verify this change?
---


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify