### PR TITLE
chore: use different hash crate

### DIFF
--- a/dan_layer/common_types/Cargo.toml
+++ b/dan_layer/common_types/Cargo.toml
@@ -13,7 +13,7 @@ tari_common = { workspace = true }
 tari_common_types = { workspace = true }
 tari_crypto = { workspace = true, features = ["borsh"] }
 tari_engine_types = { workspace = true }
-tari_hashing = {workspace = true }
+tari_hashing = { workspace = true }
 tari_mmr = { workspace = true }
 
 libp2p-identity = { workspace = true, features = [

--- a/dan_layer/common_types/src/validator_metadata.rs
+++ b/dan_layer/common_types/src/validator_metadata.rs
@@ -4,11 +4,8 @@
 use serde::{Deserialize, Serialize};
 use tari_common::configuration::Network;
 use tari_common_types::types::{FixedHash, PublicKey, Signature};
-use tari_crypto::hash_domain;
 use tari_engine_types::base_layer_hashing::TariBaseLayerHasher32;
-
-// TODO: add to tari_hash_domains
-hash_domain!(TransactionHashDomain, "com.tari.base_layer.core.transactions", 0);
+use tari_hashing::TransactionHashDomain;
 
 use crate::SubstateAddress;
 

--- a/dan_layer/wallet/crypto/Cargo.toml
+++ b/dan_layer/wallet/crypto/Cargo.toml
@@ -10,7 +10,7 @@ license.workspace = true
 tari_engine_types = { workspace = true }
 tari_template_lib = { workspace = true }
 tari_crypto = { workspace = true }
-tari_hashing = {workspace = true }
+tari_hashing = { workspace = true }
 tari_utilities = { workspace = true }
 
 blake2 = { workspace = true }


### PR DESCRIPTION
Description
---
There are 2 hash crates on `feature-dan2` in the `tari` repo. I'm going to remove the old one.

Motivation and Context
---

How Has This Been Tested?
---

What process can a PR reviewer use to test or verify this change?
---


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify