### PR TITLE
fix(indexer): cors settings for web clients

### DIFF
--- a/applications/tari_indexer/src/graphql/server.rs
+++ b/applications/tari_indexer/src/graphql/server.rs
@@ -39,6 +39,7 @@ use axum::{
 };
 use log::*;
 use serde::Serialize;
+use tower_http::cors::CorsLayer;
 
 use crate::{
     graphql::model::events::{EventQuery, EventSchema},
@@ -60,6 +61,7 @@ pub async fn run_graphql(
     let router = Router::new()
         .route("/", get(graphql_playground).post(graphql_handler))
         .route("/health", get(health))
+        .layer(CorsLayer::permissive())
         .layer(Extension(schema));
 
     axum::Server::try_bind(&preferred_address)


### PR DESCRIPTION
Description
---
Setting permissive CORS in the indexer's GraphQL server setting

Motivation and Context
---
We now have web clients that need to query the indexer's GraphQL API to fetch event data (e.g. the stable coin web). Web applications need the proper CORS setting for the GraphQL API, similar to what we have in the JSON RPC API.

How Has This Been Tested?
---
By querying the GraphQL API via a web client

What process can a PR reviewer use to test or verify this change?
---
See previous section

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify