### PR TITLE
chore(integration_test): show GraphQL port in cucumber world

### DIFF
--- a/integration_tests/tests/cucumber.rs
+++ b/integration_tests/tests/cucumber.rs
@@ -565,8 +565,8 @@ async fn print_world(world: &mut TariWorld) {
     // indexes
     for (name, node) in &world.indexers {
         eprintln!(
-            "Indexer \"{}\": json rpc port \"{}\", http ui port  \"{}\", temp dir path \"{}\"",
-            name, node.json_rpc_port, node.http_ui_port, node.temp_dir_path
+            "Indexer \"{}\": json rpc port \"{}\", graphql port \"{}\", http ui port  \"{}\", temp dir path \"{}\"",
+            name, node.json_rpc_port, node.graphql_port, node.http_ui_port, node.temp_dir_path
         );
     }
 


### PR DESCRIPTION
Description
---
Added indexer's GraphQL port info in cucumber

Motivation and Context
---
In cucumber, when using the `When I print the cucumber world` step, it does not show the indexer's GraphQL port. This makes it difficult for manual testing if we want to stop the execution and query the indexer's GraphQL API for events.

This PRs adds the GraphQL port info to the cucumber world display.

How Has This Been Tested?
---
Inspecting the result of the `When I print the cucumber world` cucumber step

What process can a PR reviewer use to test or verify this change?
---
See previous section

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify