### PR TITLE
feat: add sidechain config

### DIFF
--- a/applications/tari_dan_app_utilities/src/base_layer_scanner.rs
+++ b/applications/tari_dan_app_utilities/src/base_layer_scanner.rs
@@ -37,9 +37,10 @@ use tari_core::transactions::transaction_components::{
     TransactionOutput,
     ValidatorNodeRegistration,
 };
-use tari_crypto::ristretto::RistrettoPublicKey;
-use tari_crypto::tari_utilities::ByteArray;
-use tari_crypto::tari_utilities::hex::Hex;
+use tari_crypto::{
+    ristretto::RistrettoPublicKey,
+    tari_utilities::{hex::Hex, ByteArray},
+};
 use tari_dan_common_types::{optional::Optional, Epoch, NodeAddressable, NodeHeight};
 use tari_dan_storage::{
     consensus_models::{Block, SubstateRecord},
@@ -94,7 +95,7 @@ pub fn spawn<TAddr: NodeAddressable + 'static>(
             base_layer_scanning_interval,
             validator_node_sidechain_id,
             template_sidechain_id,
-            burnt_utxo_sidechain_id
+            burnt_utxo_sidechain_id,
         );
 
         base_layer_scanner.start().await?;
@@ -120,7 +121,7 @@ pub struct BaseLayerScanner<TAddr> {
     has_attempted_scan: bool,
     validator_node_sidechain_id: Option<PublicKey>,
     template_sidechain_id: Option<PublicKey>,
-    burnt_utxo_sidechain_id: Option<PublicKey>
+    burnt_utxo_sidechain_id: Option<PublicKey>,
 }
 
 impl<TAddr: NodeAddressable + 'static> BaseLayerScanner<TAddr> {
@@ -137,7 +138,7 @@ impl<TAddr: NodeAddressable + 'static> BaseLayerScanner<TAddr> {
         base_layer_scanning_interval: Duration,
         validator_node_sidechain_id: Option<PublicKey>,
         template_sidechain_id: Option<PublicKey>,
-        burnt_utxo_sidechain_id: Option<PublicKey>
+        burnt_utxo_sidechain_id: Option<PublicKey>,
     ) -> Self {
         Self {
             network,
@@ -157,7 +158,7 @@ impl<TAddr: NodeAddressable + 'static> BaseLayerScanner<TAddr> {
             has_attempted_scan: false,
             validator_node_sidechain_id,
             template_sidechain_id,
-            burnt_utxo_sidechain_id
+            burnt_utxo_sidechain_id,
         }
     }
 

--- a/applications/tari_dan_app_utilities/src/base_layer_scanner.rs
+++ b/applications/tari_dan_app_utilities/src/base_layer_scanner.rs
@@ -346,7 +346,7 @@ impl<TAddr: NodeAddressable + 'static> BaseLayerScanner<TAddr> {
                         }
                     },
                     SideChainFeature::CodeTemplateRegistration(reg) => {
-                        if &reg.sidechain_id != &self.template_sidechain_id {
+                        if reg.sidechain_id != self.template_sidechain_id {
                             warn!(
                                 target: LOG_TARGET,
                                 "Ignoring code template registration for sidechain ID {:?}. Expected sidechain ID: {:?}",

--- a/applications/tari_dan_app_utilities/src/base_layer_scanner.rs
+++ b/applications/tari_dan_app_utilities/src/base_layer_scanner.rs
@@ -30,14 +30,16 @@ use tari_base_node_client::{
     BaseNodeClientError,
 };
 use tari_common::configuration::Network;
-use tari_common_types::types::{Commitment, FixedHash, FixedHashSizeError};
+use tari_common_types::types::{Commitment, FixedHash, FixedHashSizeError, PublicKey};
 use tari_core::transactions::transaction_components::{
     CodeTemplateRegistration,
     SideChainFeature,
     TransactionOutput,
     ValidatorNodeRegistration,
 };
+use tari_crypto::ristretto::RistrettoPublicKey;
 use tari_crypto::tari_utilities::ByteArray;
+use tari_crypto::tari_utilities::hex::Hex;
 use tari_dan_common_types::{optional::Optional, Epoch, NodeAddressable, NodeHeight};
 use tari_dan_storage::{
     consensus_models::{Block, SubstateRecord},
@@ -74,6 +76,9 @@ pub fn spawn<TAddr: NodeAddressable + 'static>(
     shard_store: SqliteStateStore<TAddr>,
     scan_base_layer: bool,
     base_layer_scanning_interval: Duration,
+    validator_node_sidechain_id: Option<RistrettoPublicKey>,
+    template_sidechain_id: Option<RistrettoPublicKey>,
+    burnt_utxo_sidechain_id: Option<RistrettoPublicKey>,
 ) -> JoinHandle<anyhow::Result<()>> {
     task::spawn(async move {
         let base_layer_scanner = BaseLayerScanner::new(
@@ -87,6 +92,9 @@ pub fn spawn<TAddr: NodeAddressable + 'static>(
             shard_store,
             scan_base_layer,
             base_layer_scanning_interval,
+            validator_node_sidechain_id,
+            template_sidechain_id,
+            burnt_utxo_sidechain_id
         );
 
         base_layer_scanner.start().await?;
@@ -110,6 +118,9 @@ pub struct BaseLayerScanner<TAddr> {
     scan_base_layer: bool,
     base_layer_scanning_interval: Duration,
     has_attempted_scan: bool,
+    validator_node_sidechain_id: Option<PublicKey>,
+    template_sidechain_id: Option<PublicKey>,
+    burnt_utxo_sidechain_id: Option<PublicKey>
 }
 
 impl<TAddr: NodeAddressable + 'static> BaseLayerScanner<TAddr> {
@@ -124,6 +135,9 @@ impl<TAddr: NodeAddressable + 'static> BaseLayerScanner<TAddr> {
         state_store: SqliteStateStore<TAddr>,
         scan_base_layer: bool,
         base_layer_scanning_interval: Duration,
+        validator_node_sidechain_id: Option<PublicKey>,
+        template_sidechain_id: Option<PublicKey>,
+        burnt_utxo_sidechain_id: Option<PublicKey>
     ) -> Self {
         Self {
             network,
@@ -141,6 +155,9 @@ impl<TAddr: NodeAddressable + 'static> BaseLayerScanner<TAddr> {
             scan_base_layer,
             base_layer_scanning_interval,
             has_attempted_scan: false,
+            validator_node_sidechain_id,
+            template_sidechain_id,
+            burnt_utxo_sidechain_id
         }
     }
 
@@ -316,10 +333,26 @@ impl<TAddr: NodeAddressable + 'static> BaseLayerScanner<TAddr> {
                 };
                 match sidechain_feature {
                     SideChainFeature::ValidatorNodeRegistration(reg) => {
-                        self.register_validator_node_registration(current_height, reg.clone())
-                            .await?;
+                        if reg.sidechain_id() == self.validator_node_sidechain_id.as_ref() {
+                            self.register_validator_node_registration(current_height, reg.clone())
+                                .await?;
+                        } else {
+                            warn!(
+                                target: LOG_TARGET,
+                                "Ignoring validator node registration for sidechain ID {:?}. Expected sidechain ID: {:?}",
+                                reg.sidechain_id().map(|v| v.to_hex()),
+                                self.validator_node_sidechain_id.as_ref().map(|v| v.to_hex()));
+                        }
                     },
                     SideChainFeature::CodeTemplateRegistration(reg) => {
+                        if &reg.sidechain_id != &self.template_sidechain_id {
+                            warn!(
+                                target: LOG_TARGET,
+                                "Ignoring code template registration for sidechain ID {:?}. Expected sidechain ID: {:?}",
+                                reg.sidechain_id.as_ref().map(|v| v.to_hex()),
+                                self.template_sidechain_id.as_ref().map(|v| v.to_hex()));
+                            continue;
+                        }
                         self.register_code_template_registration(
                             reg.template_name.to_string(),
                             (*output_hash).into(),
@@ -328,7 +361,7 @@ impl<TAddr: NodeAddressable + 'static> BaseLayerScanner<TAddr> {
                         )
                         .await?;
                     },
-                    SideChainFeature::ConfidentialOutput(_data) => {
+                    SideChainFeature::ConfidentialOutput(data) => {
                         // Should be checked by the base layer
                         if !output.is_burned() {
                             warn!(
@@ -337,6 +370,14 @@ impl<TAddr: NodeAddressable + 'static> BaseLayerScanner<TAddr> {
                                 output_hash,
                                 output.commitment.as_public_key()
                             );
+                            continue;
+                        }
+                        if data.sidechain_id.as_ref() != self.burnt_utxo_sidechain_id.as_ref() {
+                            warn!(
+                                target: LOG_TARGET,
+                                "Ignoring burnt UTXO for sidechain ID {:?}. Expected sidechain ID: {:?}",
+                                data.sidechain_id.as_ref().map(|v| v.to_hex()),
+                                self.burnt_utxo_sidechain_id.as_ref().map(|v| v.to_hex()));
                             continue;
                         }
                         info!(

--- a/applications/tari_indexer/src/bootstrap.rs
+++ b/applications/tari_indexer/src/bootstrap.rs
@@ -115,6 +115,7 @@ pub async fn spawn_services(
         EpochManagerConfig {
             base_layer_confirmations: consensus_constants.base_layer_confirmations,
             committee_size: consensus_constants.committee_size,
+            validator_node_sidechain_id: config.indexer.sidechain_id.clone()
         },
         global_db.clone(),
         base_node_client.clone(),
@@ -143,6 +144,9 @@ pub async fn spawn_services(
         ))?,
         true,
         config.indexer.base_layer_scanning_interval,
+        config.indexer.sidechain_id.clone(),
+        config.indexer.templates_sidechain_id.clone(),
+        config.indexer.burnt_utxo_sidechain_id.clone(),
     );
 
     // Save final node identity after comms has initialized. This is required because the public_address can be

--- a/applications/tari_indexer/src/bootstrap.rs
+++ b/applications/tari_indexer/src/bootstrap.rs
@@ -115,7 +115,7 @@ pub async fn spawn_services(
         EpochManagerConfig {
             base_layer_confirmations: consensus_constants.base_layer_confirmations,
             committee_size: consensus_constants.committee_size,
-            validator_node_sidechain_id: config.indexer.sidechain_id.clone()
+            validator_node_sidechain_id: config.indexer.sidechain_id.clone(),
         },
         global_db.clone(),
         base_node_client.clone(),

--- a/applications/tari_indexer/src/config.rs
+++ b/applications/tari_indexer/src/config.rs
@@ -34,6 +34,7 @@ use tari_common::{
     DefaultConfigLoader,
     SubConfigPath,
 };
+use tari_crypto::ristretto::RistrettoPublicKey;
 use tari_dan_app_utilities::{
     p2p_config::{P2pConfig, PeerSeedsConfig},
     template_manager::implementation::TemplateConfig,
@@ -95,6 +96,12 @@ pub struct IndexerConfig {
     pub dan_layer_scanning_internal: Duration,
     /// Template config
     pub templates: TemplateConfig,
+    /// The sidechain to listen on.
+    pub sidechain_id: Option<RistrettoPublicKey>,
+    /// The templates sidechain id
+    pub templates_sidechain_id: Option<RistrettoPublicKey>,
+    /// the burnt utxos sidechain id
+    pub burnt_utxo_sidechain_id: Option<RistrettoPublicKey>,
 }
 
 impl IndexerConfig {
@@ -132,6 +139,9 @@ impl Default for IndexerConfig {
             address_watchlist: vec![],
             dan_layer_scanning_internal: Duration::from_secs(10),
             templates: TemplateConfig::default(),
+            sidechain_id: None,
+            templates_sidechain_id: None,
+            burnt_utxo_sidechain_id: None,
         }
     }
 }

--- a/applications/tari_validator_node/src/bootstrap.rs
+++ b/applications/tari_validator_node/src/bootstrap.rs
@@ -190,6 +190,7 @@ pub async fn spawn_services(
         EpochManagerConfig {
             base_layer_confirmations: consensus_constants.base_layer_confirmations,
             committee_size: consensus_constants.committee_size,
+            validator_node_sidechain_id: config.validator_node.validator_node_sidechain_id.clone()
         },
         global_db.clone(),
         base_node_client.clone(),
@@ -316,6 +317,9 @@ pub async fn spawn_services(
         state_store.clone(),
         config.validator_node.scan_base_layer,
         config.validator_node.base_layer_scanning_interval,
+        config.validator_node.validator_node_sidechain_id.clone(),
+        config.validator_node.template_sidechain_id.clone(),
+        config.validator_node.burnt_utxo_sidechain_id.clone()
     );
     handles.push(join_handle);
 

--- a/applications/tari_validator_node/src/bootstrap.rs
+++ b/applications/tari_validator_node/src/bootstrap.rs
@@ -190,7 +190,7 @@ pub async fn spawn_services(
         EpochManagerConfig {
             base_layer_confirmations: consensus_constants.base_layer_confirmations,
             committee_size: consensus_constants.committee_size,
-            validator_node_sidechain_id: config.validator_node.validator_node_sidechain_id.clone()
+            validator_node_sidechain_id: config.validator_node.validator_node_sidechain_id.clone(),
         },
         global_db.clone(),
         base_node_client.clone(),
@@ -319,7 +319,7 @@ pub async fn spawn_services(
         config.validator_node.base_layer_scanning_interval,
         config.validator_node.validator_node_sidechain_id.clone(),
         config.validator_node.template_sidechain_id.clone(),
-        config.validator_node.burnt_utxo_sidechain_id.clone()
+        config.validator_node.burnt_utxo_sidechain_id.clone(),
     );
     handles.push(join_handle);
 

--- a/applications/tari_validator_node/src/config.rs
+++ b/applications/tari_validator_node/src/config.rs
@@ -102,6 +102,12 @@ pub struct ValidatorNodeConfig {
     pub fee_claim_public_key: RistrettoPublicKey,
     /// Create identity file if not exists
     pub dont_create_id: bool,
+    /// The (optional) sidechain to run this on
+    pub validator_node_sidechain_id: Option<RistrettoPublicKey>,
+    /// The templates sidechain id
+    pub template_sidechain_id: Option<RistrettoPublicKey>,
+    /// The burnt utxo sidechain id
+    pub burnt_utxo_sidechain_id: Option<RistrettoPublicKey>
 }
 
 impl ValidatorNodeConfig {
@@ -143,6 +149,9 @@ impl Default for ValidatorNodeConfig {
             // Burn your fees
             fee_claim_public_key: RistrettoPublicKey::default(),
             dont_create_id: false,
+            validator_node_sidechain_id: None,
+            template_sidechain_id: None,
+            burnt_utxo_sidechain_id: None
         }
     }
 }

--- a/applications/tari_validator_node/src/config.rs
+++ b/applications/tari_validator_node/src/config.rs
@@ -107,7 +107,7 @@ pub struct ValidatorNodeConfig {
     /// The templates sidechain id
     pub template_sidechain_id: Option<RistrettoPublicKey>,
     /// The burnt utxo sidechain id
-    pub burnt_utxo_sidechain_id: Option<RistrettoPublicKey>
+    pub burnt_utxo_sidechain_id: Option<RistrettoPublicKey>,
 }
 
 impl ValidatorNodeConfig {
@@ -151,7 +151,7 @@ impl Default for ValidatorNodeConfig {
             dont_create_id: false,
             validator_node_sidechain_id: None,
             template_sidechain_id: None,
-            burnt_utxo_sidechain_id: None
+            burnt_utxo_sidechain_id: None,
         }
     }
 }

--- a/dan_layer/epoch_manager/src/base_layer/base_layer_epoch_manager.rs
+++ b/dan_layer/epoch_manager/src/base_layer/base_layer_epoch_manager.rs
@@ -46,6 +46,8 @@ use tari_utilities::byte_array::ByteArray;
 use tokio::sync::broadcast;
 
 use crate::{base_layer::config::EpochManagerConfig, error::EpochManagerError, EpochManagerEvent};
+use tari_utilities::hex::Hex;
+
 
 const LOG_TARGET: &str = "tari::dan::epoch_manager::base_layer";
 
@@ -187,6 +189,12 @@ impl<TAddr: NodeAddressable + DerivableFromPublicKey>
         block_height: u64,
         registration: ValidatorNodeRegistration,
     ) -> Result<(), EpochManagerError> {
+        if registration.sidechain_id() != self.config.validator_node_sidechain_id.as_ref() {
+            return Err(EpochManagerError::ValidatorNodeRegistrationSidechainIdMismatch {
+                expected: self.config.validator_node_sidechain_id.as_ref().map(|v| v.to_hex()),
+                actual: registration.sidechain_id().map(|v| v.to_hex())
+            });
+        }
         let constants = self.get_base_layer_consensus_constants().await?;
         let next_epoch = constants.height_to_epoch(block_height) + Epoch(1);
         let next_epoch_height = constants.epoch_to_height(next_epoch);

--- a/dan_layer/epoch_manager/src/base_layer/base_layer_epoch_manager.rs
+++ b/dan_layer/epoch_manager/src/base_layer/base_layer_epoch_manager.rs
@@ -42,12 +42,10 @@ use tari_dan_common_types::{
 };
 use tari_dan_storage::global::{models::ValidatorNode, DbBaseLayerBlockInfo, DbEpoch, GlobalDb, MetadataKey};
 use tari_dan_storage_sqlite::global::SqliteGlobalDbAdapter;
-use tari_utilities::byte_array::ByteArray;
+use tari_utilities::{byte_array::ByteArray, hex::Hex};
 use tokio::sync::broadcast;
 
 use crate::{base_layer::config::EpochManagerConfig, error::EpochManagerError, EpochManagerEvent};
-use tari_utilities::hex::Hex;
-
 
 const LOG_TARGET: &str = "tari::dan::epoch_manager::base_layer";
 
@@ -192,7 +190,7 @@ impl<TAddr: NodeAddressable + DerivableFromPublicKey>
         if registration.sidechain_id() != self.config.validator_node_sidechain_id.as_ref() {
             return Err(EpochManagerError::ValidatorNodeRegistrationSidechainIdMismatch {
                 expected: self.config.validator_node_sidechain_id.as_ref().map(|v| v.to_hex()),
-                actual: registration.sidechain_id().map(|v| v.to_hex())
+                actual: registration.sidechain_id().map(|v| v.to_hex()),
             });
         }
         let constants = self.get_base_layer_consensus_constants().await?;

--- a/dan_layer/epoch_manager/src/base_layer/config.rs
+++ b/dan_layer/epoch_manager/src/base_layer/config.rs
@@ -1,8 +1,11 @@
 //   Copyright 2023 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
+use tari_common_types::types::PublicKey;
+
 #[derive(Debug, Clone)]
 pub struct EpochManagerConfig {
     pub base_layer_confirmations: u64,
     pub committee_size: u32,
+    pub validator_node_sidechain_id : Option<PublicKey>
 }

--- a/dan_layer/epoch_manager/src/base_layer/config.rs
+++ b/dan_layer/epoch_manager/src/base_layer/config.rs
@@ -7,5 +7,5 @@ use tari_common_types::types::PublicKey;
 pub struct EpochManagerConfig {
     pub base_layer_confirmations: u64,
     pub committee_size: u32,
-    pub validator_node_sidechain_id : Option<PublicKey>
+    pub validator_node_sidechain_id: Option<PublicKey>,
 }

--- a/dan_layer/epoch_manager/src/error.rs
+++ b/dan_layer/epoch_manager/src/error.rs
@@ -39,6 +39,8 @@ pub enum EpochManagerError {
     IntegerOverflow { func: &'static str },
     #[error("Invalid epoch: {epoch}")]
     InvalidEpoch { epoch: Epoch },
+    #[error("Validator node registration sidechain id mismatch. Actual: {actual:?}, Expected: {expected:?}")]
+    ValidatorNodeRegistrationSidechainIdMismatch {  actual: Option<String>, expected: Option<String>}
 }
 
 impl EpochManagerError {

--- a/dan_layer/epoch_manager/src/error.rs
+++ b/dan_layer/epoch_manager/src/error.rs
@@ -40,7 +40,10 @@ pub enum EpochManagerError {
     #[error("Invalid epoch: {epoch}")]
     InvalidEpoch { epoch: Epoch },
     #[error("Validator node registration sidechain id mismatch. Actual: {actual:?}, Expected: {expected:?}")]
-    ValidatorNodeRegistrationSidechainIdMismatch {  actual: Option<String>, expected: Option<String>}
+    ValidatorNodeRegistrationSidechainIdMismatch {
+        actual: Option<String>,
+        expected: Option<String>,
+    },
 }
 
 impl EpochManagerError {


### PR DESCRIPTION
Description
---
Adds config for using a specific sidechain.

Motivation and Context
---
This may not make it all the way to mainnet, but it allows us to use a single base layer (igor) to host multiple second layer sidechains

How Has This Been Tested?
---
Tested locally

What process can a PR reviewer use to test or verify this change?
---
Register a VN on the console wallet using a sidechain_deployment_key, then change the config for the VN and start it.


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify