### PR TITLE
fix: use fallback jrpc address in webui for indexer and wallet

### DIFF
--- a/applications/tari_dan_wallet_daemon/src/lib.rs
+++ b/applications/tari_dan_wallet_daemon/src/lib.rs
@@ -84,7 +84,8 @@ pub async fn run_tari_dan_wallet_daemon(
         services.account_monitor_handle.clone(),
         config.dan_wallet_daemon.clone(),
     );
-    let listen_fut = jrpc_server::listen(jrpc_address, signaling_server_address, handlers, shutdown_signal);
+    let (jrpc_address, listen_fut) =
+        jrpc_server::spawn_listener(jrpc_address, signaling_server_address, handlers, shutdown_signal)?;
 
     // Run the http ui
     if let Some(http_address) = config.dan_wallet_daemon.http_ui_address {
@@ -111,7 +112,7 @@ pub async fn run_tari_dan_wallet_daemon(
     // Wait for shutdown, or for any service to error
     tokio::select! {
         res = listen_fut => {
-            res?;
+            res??;
         },
         res = services.services_fut => {
             res?;

--- a/applications/tari_indexer/src/json_rpc/mod.rs
+++ b/applications/tari_indexer/src/json_rpc/mod.rs
@@ -27,4 +27,4 @@ mod error;
 // mod json_encoding;
 mod server;
 
-pub use server::run_json_rpc;
+pub use server::spawn_json_rpc;

--- a/applications/tari_indexer/src/json_rpc/server.rs
+++ b/applications/tari_indexer/src/json_rpc/server.rs
@@ -31,7 +31,7 @@ use super::handlers::JsonRpcHandlers;
 
 const LOG_TARGET: &str = "tari::indexer::json_rpc";
 
-pub async fn run_json_rpc(preferred_address: SocketAddr, handlers: JsonRpcHandlers) -> Result<(), anyhow::Error> {
+pub fn spawn_json_rpc(preferred_address: SocketAddr, handlers: JsonRpcHandlers) -> anyhow::Result<SocketAddr> {
     let router = Router::new()
         .route("/", post(handler))
         .route("/json_rpc", post(handler))
@@ -47,11 +47,11 @@ pub async fn run_json_rpc(preferred_address: SocketAddr, handlers: JsonRpcHandle
         axum::Server::try_bind(&"127.0.0.1:0".parse().unwrap())
     })?;
     let server = server.serve(router.into_make_service());
-    info!(target: LOG_TARGET, "🌐 JSON-RPC listening on {}", server.local_addr());
-    server.await?;
+    let listen_addr = server.local_addr();
+    info!(target: LOG_TARGET, "🌐 JSON-RPC listening on {listen_addr}");
+    tokio::spawn(server);
 
-    info!(target: LOG_TARGET, "💤 Stopping JSON-RPC");
-    Ok(())
+    Ok(listen_addr)
 }
 
 async fn handler(Extension(handlers): Extension<Arc<JsonRpcHandlers>>, value: JsonRpcExtractor) -> JrpcResult {

--- a/applications/tari_indexer/src/lib.rs
+++ b/applications/tari_indexer/src/lib.rs
@@ -67,7 +67,7 @@ use crate::{
     dry_run::processor::DryRunTransactionProcessor,
     event_manager::EventManager,
     graphql::server::run_graphql,
-    json_rpc::{run_json_rpc, JsonRpcHandlers},
+    json_rpc::{spawn_json_rpc, JsonRpcHandlers},
     transaction_manager::TransactionManager,
 };
 
@@ -149,7 +149,7 @@ pub async fn run_indexer(config: ApplicationConfig, mut shutdown_signal: Shutdow
             services.template_manager.clone(),
             dry_run_transaction_processor,
         );
-        task::spawn(run_json_rpc(jrpc_address, handlers));
+        let jrpc_address = spawn_json_rpc(jrpc_address, handlers)?;
         // Run the http ui
         if let Some(address) = config.indexer.http_ui_address {
             task::spawn(run_http_ui_server(

--- a/applications/tari_validator_node/src/json_rpc/server.rs
+++ b/applications/tari_validator_node/src/json_rpc/server.rs
@@ -58,7 +58,6 @@ pub fn spawn_json_rpc(
     info!(target: LOG_TARGET, "🌐 JSON-RPC listening on {}", addr);
     tokio::spawn(server);
 
-    info!(target: LOG_TARGET, "💤 Stopping JSON-RPC");
     Ok(addr)
 }
 


### PR DESCRIPTION
Description
---
fix: use fallback jrpc address in webui for indexer and wallet

Motivation and Context
---
When we're unable to bind on the preferred JRPC port, an OS-selected port is used. This PR ensures that the webui uses the correct port in this case.

This was already implemented on the validator node, but not on the indexer and wallet 

How Has This Been Tested?
---
Manually

What process can a PR reviewer use to test or verify this change?
---
Open multiple indexers/wallets and check that their webuis use the correct JRPC address.

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify