### PR TITLE
fix(p2p/peer-sync): request peer if connection fails due to no addresses

### DIFF
--- a/networking/libp2p-peersync/src/handler.rs
+++ b/networking/libp2p-peersync/src/handler.rs
@@ -225,8 +225,10 @@ where TStore: PeerStore
             self.pending_events.shrink_to_fit();
         }
 
-        // If we've synced from the peer already, there's nothing further to do except release the semaphore lock
+        // If we've synced from the peer already or if the sync failed, there's nothing further to do
         if self.is_complete {
+            // Ensure that the semaphore is released
+            self.aquired = None;
             return Poll::Pending;
         }
 
@@ -273,6 +275,8 @@ where TStore: PeerStore
     }
 
     fn on_behaviour_event(&mut self, want_list: Self::FromBehaviour) {
+        // Sync from existing connections if there are more want-peers
+        self.is_complete = !want_list.is_empty();
         self.current_want_list = want_list;
     }
 


### PR DESCRIPTION
Description
---
fix(p2p/peer-sync): request peer if connection fails due to no addresses

Motivation and Context
---
The peer sync protocol only requests peers after connecting to a peer. A peer may not have sent their signed peer record to a seed node or may not have requested a relay yet. When a dial fails because have no addresses for a peer, we add the peer to the peer sync protocol want list so that it can request the missing peer record from connected nodes.

How Has This Been Tested?
---
Partially tested on small network

What process can a PR reviewer use to test or verify this change?
---
Connect to a small network (1-5 nodes) and observe if vns/indexers are able to learn VN peer addresses.

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify