### PR TITLE
fix(swarm): mine enough funds to allow many vns

### DIFF
--- a/applications/tari_swarm_daemon/src/main.rs
+++ b/applications/tari_swarm_daemon/src/main.rs
@@ -180,7 +180,7 @@ fn get_base_config(cli: &Cli) -> anyhow::Result<Config> {
             .with_context(|| anyhow!("Base path '{}' does not exist", base_dir.display()))?,
         webserver: WebserverConfig::default(),
         processes: ProcessesConfig {
-            force_compile: false,
+            force_compile: true,
             instances,
             executables,
         },

--- a/applications/tari_swarm_daemon/src/process_manager/instances/manager.rs
+++ b/applications/tari_swarm_daemon/src/process_manager/instances/manager.rs
@@ -236,6 +236,10 @@ impl InstanceManager {
         self.validator_nodes.values()
     }
 
+    pub fn num_validator_nodes(&self) -> u64 {
+        self.validator_nodes.len() as u64
+    }
+
     pub fn validator_nodes_mut(&mut self) -> impl Iterator<Item = &mut ValidatorNodeProcess> + Sized {
         self.validator_nodes.values_mut()
     }

--- a/applications/tari_swarm_daemon/src/process_manager/manager.rs
+++ b/applications/tari_swarm_daemon/src/process_manager/manager.rs
@@ -134,12 +134,9 @@ impl ProcessManager {
                         .find(|i| i.id() == instance_id)
                         .ok_or_else(|| anyhow!("Instance with ID '{}' not found", instance_id))?;
                     let instance_type = instance.instance_type();
-                    self.executable_manager.get_executable(instance_type).ok_or_else(|| {
-                        anyhow!(
-                            "No configuration for instance type '{instance_type}'. Please add this to the \
-                             configuration",
-                        )
-                    })?
+                    self.executable_manager
+                        .compile_executable_if_required(instance_type)
+                        .await?
                 };
 
                 let result = self.instance_manager.start_instance(instance_id, executable).await;

--- a/applications/tari_swarm_daemon/src/process_manager/processes/minotari_wallet.rs
+++ b/applications/tari_swarm_daemon/src/process_manager/processes/minotari_wallet.rs
@@ -35,7 +35,7 @@ impl MinoTariWalletProcess {
         Ok(client)
     }
 
-    pub async fn register_validator_node(&self, info: ValidatorRegistrationInfo) -> anyhow::Result<()> {
+    pub async fn register_validator_node(&self, info: ValidatorRegistrationInfo) -> anyhow::Result<u64> {
         let mut client = self.connect_client().await?;
         let resp = client
             .register_validator_node(grpc::RegisterValidatorNodeRequest {
@@ -55,8 +55,7 @@ impl MinoTariWalletProcess {
             return Err(anyhow!("Failed to register validator node: {}", resp.failure_message));
         }
 
-        log::info!("🟢 Registered validator node with tx_id: {}", resp.transaction_id);
-        Ok(())
+        Ok(resp.transaction_id)
     }
 
     pub async fn get_balance(&self) -> anyhow::Result<grpc::GetBalanceResponse> {

--- a/applications/tari_swarm_daemon/src/webserver/rpc/indexers.rs
+++ b/applications/tari_swarm_daemon/src/webserver/rpc/indexers.rs
@@ -42,9 +42,7 @@ pub async fn list(context: &HandlerContext, _req: ListIndexersRequest) -> Result
                 name: instance.name,
                 web,
                 jrpc,
-                // TODO
-                // is_running: status == InstanceStatus::Running
-                is_running: true,
+                is_running: instance.is_running,
             })
         })
         .collect::<anyhow::Result<_>>()?;

--- a/applications/tari_swarm_daemon/src/webserver/server.rs
+++ b/applications/tari_swarm_daemon/src/webserver/server.rs
@@ -40,7 +40,7 @@ pub async fn run(context: HandlerContext) -> anyhow::Result<()> {
         ServeDir::new(context.config().base_dir.join("templates")).not_found_service(not_found.into_service());
 
     let router = Router::new()
-        .route("/json_rpc/upload_template", post(templates::upload))
+        .route("/upload_template", post(templates::upload))
         .route("/json_rpc", post(json_rpc_handler))
         .nest_service("/templates", serve_templates)
         .fallback(handler)

--- a/applications/tari_swarm_daemon/webui/.gitignore
+++ b/applications/tari_swarm_daemon/webui/.gitignore
@@ -8,7 +8,8 @@ pnpm-debug.log*
 lerna-debug.log*
 
 node_modules
-dist
+dist/*
+!dist/.gitkeep
 dist-ssr
 *.local
 

--- a/applications/tari_swarm_daemon/webui/src/routes/Main.tsx
+++ b/applications/tari_swarm_daemon/webui/src/routes/Main.tsx
@@ -451,10 +451,10 @@ export default function Main() {
     if (!selectedFile) {
       return;
     }
-    const address = import.meta.env.VITE_DAEMON_JRPC_ADDRESS || "localhost:9000";
+    const address = import.meta.env.VITE_DAEMON_JRPC_ADDRESS || ""; //Current host
     const formData = new FormData();
     formData.append("file", selectedFile);
-    fetch(`http://${address}/upload_template`, { method: "POST", body: formData }).then((resp) => {
+    fetch(`${address}/upload_template`, { method: "POST", body: formData }).then((resp) => {
       console.log("resp", resp);
     });
   };

--- a/applications/tari_swarm_daemon/webui/src/routes/Main.tsx
+++ b/applications/tari_swarm_daemon/webui/src/routes/Main.tsx
@@ -330,7 +330,7 @@ function ShowInfo(params: any) {
 }
 
 interface NodeControlsProps {
-  isRunning: bool,
+  isRunning: boolean,
   onStart: () => void;
   onStop: () => void;
   onDeleteData: () => void;

--- a/applications/tari_swarm_daemon/webui/src/utils/json_rpc.tsx
+++ b/applications/tari_swarm_daemon/webui/src/utils/json_rpc.tsx
@@ -30,7 +30,7 @@ export async function jsonRpc(method: string, args: any = {}) {
 
   const address = import.meta.env.VITE_DAEMON_JRPC_ADDRESS || "/json_rpc";
   const headers: { [key: string]: string } = { "Content-Type": "application/json" };
-  const response = await fetch(`http://${address}`, {
+  const response = await fetch(address, {
     method: "POST",
     body: JSON.stringify({
       method: method,

--- a/applications/tari_swarm_daemon/webui/src/utils/json_rpc.tsx
+++ b/applications/tari_swarm_daemon/webui/src/utils/json_rpc.tsx
@@ -28,9 +28,9 @@ export async function jsonRpc(method: string, args: any = {}) {
 
   json_id += 1;
 
-  const address = import.meta.env.VITE_DAEMON_JRPC_ADDRESS || "/json_rpc";
+  const address = import.meta.env.VITE_DAEMON_JRPC_ADDRESS || "";
   const headers: { [key: string]: string } = { "Content-Type": "application/json" };
-  const response = await fetch(address, {
+  const response = await fetch(`${address}/json_rpc`, {
     method: "POST",
     body: JSON.stringify({
       method: method,

--- a/applications/tari_validator_node_web_ui/src/utils/json_rpc.tsx
+++ b/applications/tari_validator_node_web_ui/src/utils/json_rpc.tsx
@@ -64,24 +64,34 @@ import type {
   VNGetValidatorFeesResponse,
 } from "@tariproject/typescript-bindings/validator-node-client";
 
+
+const DEFAULT_ADDRESS = new URL("http://127.0.0.1:18200");
+
+export async function getClientAddress(): Promise<URL> {
+  try {
+    let resp = await fetch("/json_rpc_address");
+    if (resp.status === 200) {
+      let url = await resp.text();
+      console.log("Got URL from server:", url);
+      return new URL(`http://${url}`);
+    }
+  } catch (e) {
+    console.warn(e);
+  }
+
+  return DEFAULT_ADDRESS;
+}
+
 async function jsonRpc(method: string, params: any = null) {
   let id = 0;
   id += 1;
-  let address = "http://localhost:18300";
-  try {
-    address = await (await fetch("/json_rpc_address")).text();
-    if (!address.startsWith("http")) {
-      address = "http://" + address;
-    }
-  } catch (e) {
-    console.warn("Failed to fetch address", e);
-  }
+  let address = await getClientAddress();
   let response = await fetch(address, {
     method: "POST",
     body: JSON.stringify({
       method: method,
       jsonrpc: "2.0",
-      id: id,
+      id,
       params: params,
     }),
     headers: {


### PR DESCRIPTION
Description
---
fix(swarm): mine enough funds to allow many vns
fix(swarm/webui): correct jrpc url when  not provided by vite env
fix(swarm/webui): prevent compile error by committing(gitkeep) empty dist directory
fix(swarm): default force_compile to true

Motivation and Context
---
When registering many VNs we ensure that we have mined enough funds

To prevent confusion, force_compile defaults to true as this is a common use case in development i.e. you want to compile the local changes you've made. This is already explicitly turned off in the docker case using the `--no-compile` flag.

How Has This Been Tested?
---
Manually 10 vns

What process can a PR reviewer use to test or verify this change?
---
Set num_instances on validator nodes to a high number

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify