### PR TITLE
fix(scanner): reduce calls to epoch manager NotifyScanningComplete

### DIFF
--- a/applications/tari_dan_app_utilities/src/base_layer_scanner.rs
+++ b/applications/tari_dan_app_utilities/src/base_layer_scanner.rs
@@ -241,7 +241,7 @@ impl<TAddr: NodeAddressable + 'static> BaseLayerScanner<TAddr> {
             },
         }
 
-        self.has_attempted_scan = false;
+        self.has_attempted_scan = true;
 
         Ok(())
     }


### PR DESCRIPTION
Description
---
fix(scanner): reduce calls to epoch manager NotifyScanningComplete

Motivation and Context
---
Observed many calls to EpochManager::NotifyScanningComplete due to a bug in the code.

How Has This Been Tested?
---
Tari swarm, logs previously showed many NotifyScanningComplete calls now they do not.

What process can a PR reviewer use to test or verify this change?
---
As above

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify