### PR TITLE
fix(p2p): configurable relay limits, set noise prologue for relay client

### DIFF
--- a/applications/tari_indexer/src/bootstrap.rs
+++ b/applications/tari_indexer/src/bootstrap.rs
@@ -42,7 +42,7 @@ use tari_dan_p2p::TariMessagingSpec;
 use tari_dan_storage::global::GlobalDb;
 use tari_dan_storage_sqlite::global::SqliteGlobalDbAdapter;
 use tari_epoch_manager::base_layer::{EpochManagerConfig, EpochManagerHandle};
-use tari_networking::{MessagingMode, NetworkingHandle, SwarmConfig};
+use tari_networking::{MessagingMode, NetworkingHandle, RelayCircuitLimits, RelayReservationLimits, SwarmConfig};
 use tari_shutdown::ShutdownSignal;
 use tari_state_store_sqlite::SqliteStateStore;
 use tari_validator_node_rpc::client::TariValidatorNodeRpcClientFactory;
@@ -96,6 +96,9 @@ pub async fn spawn_services(
                 protocol_version: format!("/tari/{}/0.0.1", config.network).parse().unwrap(),
                 user_agent: "/tari/indexer/0.0.1".to_string(),
                 enable_mdns: config.indexer.p2p.enable_mdns,
+                enable_relay: true,
+                relay_circuit_limits: RelayCircuitLimits::high(),
+                relay_reservation_limits: RelayReservationLimits::high(),
                 ..Default::default()
             },
             reachability_mode: config.indexer.p2p.reachability_mode.into(),

--- a/applications/tari_validator_node/src/bootstrap.rs
+++ b/applications/tari_validator_node/src/bootstrap.rs
@@ -63,7 +63,7 @@ use tari_dan_storage_sqlite::global::SqliteGlobalDbAdapter;
 use tari_engine_types::{resource::Resource, substate::SubstateId};
 use tari_epoch_manager::base_layer::{EpochManagerConfig, EpochManagerHandle};
 use tari_indexer_lib::substate_scanner::SubstateScanner;
-use tari_networking::{MessagingMode, NetworkingHandle, SwarmConfig};
+use tari_networking::{MessagingMode, NetworkingHandle, RelayCircuitLimits, RelayReservationLimits, SwarmConfig};
 use tari_rpc_framework::RpcServer;
 use tari_shutdown::ShutdownSignal;
 use tari_state_store_sqlite::SqliteStateStore;
@@ -161,6 +161,10 @@ pub async fn spawn_services(
                 protocol_version: format!("/tari/{}/0.0.1", config.network).parse().unwrap(),
                 user_agent: "/tari/validator/0.0.1".to_string(),
                 enable_mdns: config.validator_node.p2p.enable_mdns,
+                enable_relay: true,
+                // TODO: allow node operator to configure
+                relay_circuit_limits: RelayCircuitLimits::high(),
+                relay_reservation_limits: RelayReservationLimits::high(),
                 ..Default::default()
             },
             reachability_mode: config.validator_node.p2p.reachability_mode.into(),

--- a/networking/core/src/lib.rs
+++ b/networking/core/src/lib.rs
@@ -32,7 +32,10 @@ pub use connection::*;
 pub use handle::*;
 pub use message::*;
 pub use spawn::*;
-pub use tari_swarm::{is_supported_multiaddr, Config as SwarmConfig};
+pub use tari_swarm::{
+    config::{Config as SwarmConfig, LimitPerInterval, RelayCircuitLimits, RelayReservationLimits},
+    is_supported_multiaddr,
+};
 
 #[async_trait]
 pub trait NetworkingService<TMsg: MessageSpec> {

--- a/networking/core/src/worker.rs
+++ b/networking/core/src/worker.rs
@@ -861,6 +861,7 @@ where
         let Some(dialled_address) = relay.dialled_address.as_ref() else {
             return false;
         };
+
         let circuit_addr = dialled_address.clone().with(Protocol::P2pCircuit);
 
         match self.swarm.listen_on(circuit_addr.clone()) {

--- a/networking/swarm/src/behaviour.rs
+++ b/networking/swarm/src/behaviour.rs
@@ -30,7 +30,10 @@ use libp2p_peersync as peer_sync;
 use libp2p_peersync::store::MemoryPeerStore;
 use libp2p_substream as substream;
 
-use crate::{config::Config, error::TariSwarmError};
+use crate::{
+    config::{Config, RelayCircuitLimits, RelayReservationLimits},
+    error::TariSwarmError,
+};
 
 #[derive(NetworkBehaviour)]
 pub struct TariNodeBehaviour<TCodec>
@@ -80,7 +83,7 @@ where
             yamux::Config::default,
         )?
         .with_quic()
-        .with_relay_client(noise::Config::new, yamux::Config::default)?
+        .with_relay_client(noise_config, yamux::Config::default)?
         .with_behaviour(|keypair, relay_client| {
             let local_peer_id = keypair.public().to_peer_id();
 
@@ -104,18 +107,21 @@ where
             // Dcutr
             let dcutr = dcutr::Behaviour::new(local_peer_id);
 
+            // Relay
+            let maybe_relay = if config.enable_relay {
+                Some(relay::Behaviour::new(
+                    local_peer_id,
+                    create_relay_config(&config.relay_circuit_limits, &config.relay_reservation_limits),
+                ))
+            } else {
+                None
+            };
+
             // Identify
             let identify = identify::Behaviour::new(
                 identify::Config::new(config.protocol_version.to_string(), keypair.public())
                     .with_agent_version(config.user_agent),
             );
-
-            // Relay
-            let maybe_relay = if config.enable_relay {
-                Some(relay::Behaviour::new(local_peer_id, relay::Config::default()))
-            } else {
-                None
-            };
 
             // Messaging
             let messaging = if config.enable_messaging {
@@ -169,6 +175,39 @@ where
         .build();
 
     Ok(swarm)
+}
+
+fn create_relay_config(circuit: &RelayCircuitLimits, reservations: &RelayReservationLimits) -> relay::Config {
+    let mut config = relay::Config {
+        reservation_rate_limiters: vec![],
+        circuit_src_rate_limiters: vec![],
+        ..Default::default()
+    };
+
+    config.max_circuits = circuit.max_limit;
+    config.max_circuits_per_peer = circuit.max_per_peer;
+    config.max_circuit_duration = circuit.max_duration;
+    config.max_circuit_bytes = circuit.max_byte_limit;
+    if let Some(ref limits) = circuit.per_peer {
+        config = config.circuit_src_per_peer(limits.limit, limits.interval);
+    }
+
+    if let Some(ref limits) = circuit.per_ip {
+        config = config.circuit_src_per_ip(limits.limit, limits.interval);
+    }
+
+    config.max_reservations = reservations.max_limit;
+    config.max_reservations_per_peer = reservations.max_per_peer;
+    config.reservation_duration = reservations.max_duration;
+    if let Some(ref limits) = reservations.per_peer {
+        config = config.reservation_rate_per_peer(limits.limit, limits.interval);
+    }
+
+    if let Some(ref limits) = reservations.per_ip {
+        config = config.reservation_rate_per_ip(limits.limit, limits.interval);
+    }
+
+    config
 }
 
 /// Generates a hash of contents of the message

--- a/networking/swarm/src/lib.rs
+++ b/networking/swarm/src/lib.rs
@@ -2,12 +2,12 @@
 //   SPDX-License-Identifier: BSD-4-Clause
 
 mod behaviour;
-mod config;
+pub mod config;
 mod error;
 mod protocol_version;
 
 pub use behaviour::*;
-pub use config::*;
+pub use config::Config;
 pub use error::*;
 pub use protocol_version::*;
 


### PR DESCRIPTION
Description
---
configurable relay limits
set noise prologue for relay client

Motivation and Context
---
Some nodes will act primarily as relays, this increases the relay resource limits to accommodate this.

@stringhandler found a potential issue where the relay client was not using the same noise prologue as the base swarm instance. This was an oversight and corrected in this PR.

How Has This Been Tested?
---
In progress

What process can a PR reviewer use to test or verify this change?
---


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify