### PR TITLE
fix(engine): correctly revert to fee checkpoint if insufficient fees paid

### DIFF
--- a/dan_layer/engine/src/runtime/mod.rs
+++ b/dan_layer/engine/src/runtime/mod.rs
@@ -164,7 +164,7 @@ pub trait RuntimeInterface: Send + Sync {
         revealed_amount: Amount,
         confidential_output: Option<ConfidentialOutput>,
     ) -> Result<BucketId, RuntimeError>;
-    fn fee_checkpoint(&self) -> Result<(), RuntimeError>;
+    fn set_fee_checkpoint(&self) -> Result<(), RuntimeError>;
     fn reset_to_fee_checkpoint(&self) -> Result<(), RuntimeError>;
     fn finalize(&self) -> Result<FinalizeResult, RuntimeError>;
 

--- a/dan_layer/engine/src/runtime/module.rs
+++ b/dan_layer/engine/src/runtime/module.rs
@@ -1,9 +1,6 @@
 //   Copyright 2023 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use indexmap::IndexMap;
-use tari_engine_types::substate::{SubstateId, SubstateValue};
-
 use crate::runtime::StateTracker;
 
 pub trait RuntimeModule: Send + Sync {
@@ -15,11 +12,7 @@ pub trait RuntimeModule: Send + Sync {
         Ok(())
     }
 
-    fn on_before_finalize(
-        &self,
-        _track: &StateTracker,
-        _changes: &IndexMap<SubstateId, SubstateValue>,
-    ) -> Result<(), RuntimeModuleError> {
+    fn on_before_finalize(&self, _track: &StateTracker) -> Result<(), RuntimeModuleError> {
         Ok(())
     }
 }

--- a/dan_layer/engine/src/runtime/state_store.rs
+++ b/dan_layer/engine/src/runtime/state_store.rs
@@ -135,6 +135,10 @@ impl WorkingStateStore {
         mem::take(&mut self.new_substates)
     }
 
+    pub fn mutated_substates(&self) -> &IndexMap<SubstateId, SubstateValue> {
+        &self.new_substates
+    }
+
     pub fn new_vaults(&self) -> impl Iterator<Item = (VaultId, &Vault)> + '_ {
         self.new_substates
             .iter()

--- a/dan_layer/engine/src/runtime/tracker.rs
+++ b/dan_layer/engine/src/runtime/tracker.rs
@@ -344,19 +344,23 @@ impl StateTracker {
         self.write_with(|state| state.take_mutated_substates())
     }
 
+    pub fn with_substates_to_persist<F: FnMut(&IndexMap<SubstateId, SubstateValue>) -> R, R>(&self, mut f: F) -> R {
+        self.write_with(|state| f(state.mutated_substates()))
+    }
+
     pub fn are_fees_paid_in_full(&self) -> bool {
         self.read_with(|state| {
             let total_payments = state.fee_state().total_payments();
-            let total_charges = Amount::try_from(state.fee_state().total_charges()).expect("fee overflowed i64::MAX");
+            let total_charges = state.fee_state().total_charges();
             total_payments >= total_charges
         })
     }
 
-    pub fn total_payments(&self) -> Amount {
+    pub fn total_fee_payments(&self) -> Amount {
         self.read_with(|state| state.fee_state().total_payments())
     }
 
-    pub fn total_charges(&self) -> Amount {
+    pub fn total_fee_charges(&self) -> Amount {
         self.read_with(|state| Amount::try_from(state.fee_state().total_charges()).expect("fee overflowed i64::MAX"))
     }
 

--- a/dan_layer/engine_types/src/commit_result.rs
+++ b/dan_layer/engine_types/src/commit_result.rs
@@ -70,6 +70,16 @@ impl ExecuteResult {
         }
     }
 
+    pub fn expect_fee_accept_transaction_reject(&self) -> (&SubstateDiff, &RejectReason) {
+        match self.finalize.result {
+            TransactionResult::AcceptFeeRejectRest(ref diff, ref reason) => (diff, reason),
+            _ => panic!(
+                "Expected fee accept, transaction reject but got {:?}",
+                self.finalize.result
+            ),
+        }
+    }
+
     pub fn expect_transaction_failure(&self) -> &RejectReason {
         if let Some(reason) = self.finalize.full_reject() {
             reason
@@ -155,6 +165,10 @@ impl FinalizeResult {
         self.result.full_reject()
     }
 
+    pub fn fee_accept_transaction_reject(&self) -> Option<(&SubstateDiff, &RejectReason)> {
+        self.result.fee_accept_transaction_reject()
+    }
+
     pub fn is_full_accept(&self) -> bool {
         matches!(self.result, TransactionResult::Accept(_))
     }
@@ -202,6 +216,13 @@ impl TransactionResult {
             Self::Accept(_) => None,
             Self::AcceptFeeRejectRest(_, _) => None,
             Self::Reject(reject_result) => Some(reject_result),
+        }
+    }
+
+    pub fn fee_accept_transaction_reject(&self) -> Option<(&SubstateDiff, &RejectReason)> {
+        match self {
+            Self::AcceptFeeRejectRest(substate_diff, reject_result) => Some((substate_diff, reject_result)),
+            _ => None,
         }
     }
 

--- a/dan_layer/template_test_tooling/src/support/assert_error.rs
+++ b/dan_layer/template_test_tooling/src/support/assert_error.rs
@@ -7,11 +7,11 @@ use tari_dan_engine::runtime::{ActionIdent, RuntimeError};
 use tari_engine_types::{commit_result::RejectReason, resource_container::ResourceError};
 
 pub fn assert_reject_reason<B: Borrow<RejectReason>, E: Display>(reason: B, error: E) {
-    match reason.borrow() {
-        // TODO: Would be great if we could enumerate specific reasons from within the engine rather than simply
-        //       turning RuntimeError into a string
-        RejectReason::ExecutionFailure(s) if s.contains(&error.to_string()) => {},
-        r => panic!("Expected reject reason \"{}\" but got \"{}\"", error, r),
+    let s = reason.borrow().to_string();
+    // TODO: Would be great if we could enumerate specific reasons from within the engine rather than simply
+    //       turning RuntimeError into a string
+    if !s.contains(&error.to_string()) {
+        panic!("Expected reject reason \"{}\" but got \"{}\"", error, s)
     }
 }
 

--- a/dan_layer/template_test_tooling/templates/faucet/Cargo.lock
+++ b/dan_layer/template_test_tooling/templates/faucet/Cargo.lock
@@ -376,7 +376,7 @@ dependencies = [
 
 [[package]]
 name = "tari_bor"
-version = "0.4.1"
+version = "0.5.1"
 dependencies = [
  "ciborium",
  "ciborium-io",
@@ -385,7 +385,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_abi"
-version = "0.4.1"
+version = "0.5.1"
 dependencies = [
  "serde",
  "tari_bor",
@@ -393,7 +393,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_lib"
-version = "0.4.1"
+version = "0.5.1"
 dependencies = [
  "newtype-ops",
  "serde",
@@ -405,7 +405,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_macros"
-version = "0.4.1"
+version = "0.5.1"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
Description
---
revert to fee checkpoint if insufficient fees paid after successful main transaction execution.

Motivation and Context
---
If the user paid sufficient fees for the fee transaction and insufficient fees for the main transaction, the transaction processor would still return a substate diff for the changes in the main transaction. This PR fixes this.

How Has This Been Tested?
---
Updated existing test for this case to explicitly check that this does not occur (failing test). This test passes after these changes.

What process can a PR reviewer use to test or verify this change?
---
Pay sufficient fees for the fee transaction, but insufficient for the main transaction.

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify