### PR TITLE
fix(mempool): allow local transactions with unversioned inputs

### DIFF
--- a/applications/tari_validator_node/src/p2p/services/mempool/error.rs
+++ b/applications/tari_validator_node/src/p2p/services/mempool/error.rs
@@ -1,15 +1,19 @@
 //    Copyright 2023 The Tari Project
 //    SPDX-License-Identifier: BSD-3-Clause
 
+use std::collections::HashSet;
+
+use indexmap::IndexMap;
 use tari_dan_app_utilities::{
     template_manager::interface::TemplateManagerError,
     transaction_executor::TransactionProcessorError,
 };
 use tari_dan_common_types::Epoch;
 use tari_dan_storage::{consensus_models::TransactionPoolError, StorageError};
+use tari_engine_types::substate::{Substate, SubstateId};
 use tari_epoch_manager::EpochManagerError;
 use tari_networking::NetworkingError;
-use tari_transaction::TransactionId;
+use tari_transaction::{SubstateRequirement, TransactionId};
 use tokio::sync::{mpsc, oneshot};
 
 use crate::{
@@ -30,7 +34,12 @@ pub enum MempoolError {
     #[error("DryRunTransactionProcessor Error: {0}")]
     DryRunTransactionProcessorError(#[from] DryRunTransactionProcessorError),
     #[error("Execution thread failure: {0}")]
-    ExecutionThreadFailure(String),
+    ExecutionThreadPanicked(String),
+    #[error("Requires consensus for local substates: {local_substates:?}")]
+    MustDeferExecution {
+        local_substates: IndexMap<SubstateId, Substate>,
+        foreign_substates: HashSet<SubstateRequirement>,
+    },
     #[error("SubstateResolver Error: {0}")]
     SubstateResolverError(#[from] SubstateResolverError),
     #[error("Transaction Execution Error: {0}")]

--- a/applications/tari_validator_node/src/p2p/services/mempool/initializer.rs
+++ b/applications/tari_validator_node/src/p2p/services/mempool/initializer.rs
@@ -20,6 +20,7 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+use log::*;
 use tari_dan_app_utilities::transaction_executor::{TransactionExecutor, TransactionProcessorError};
 use tari_dan_common_types::PeerAddress;
 use tari_dan_storage::consensus_models::ExecutedTransaction;
@@ -38,6 +39,8 @@ use crate::{
     },
     substate_resolver::SubstateResolverError,
 };
+
+const LOG_TARGET: &str = "tari::dan::validator_node::mempool";
 
 pub fn spawn<TExecutor, TValidator, TExecutedValidator, TSubstateResolver>(
     gossip: Gossip,
@@ -82,6 +85,7 @@ where
     let handle = MempoolHandle::new(tx_mempool_request);
 
     let join_handle = task::spawn(mempool.run());
+    debug!(target: LOG_TARGET, "Spawning mempool service (task: {:?})", join_handle);
 
     (handle, join_handle)
 }

--- a/applications/tari_validator_node/src/p2p/services/mempool/metrics.rs
+++ b/applications/tari_validator_node/src/p2p/services/mempool/metrics.rs
@@ -4,8 +4,8 @@
 //   Copyright 2024 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 use prometheus::{Histogram, HistogramOpts, IntCounter, Registry};
-use tari_dan_storage::consensus_models::{ExecutedTransaction, TransactionRecord};
-use tari_transaction::TransactionId;
+use tari_dan_storage::consensus_models::ExecutedTransaction;
+use tari_transaction::{Transaction, TransactionId};
 
 use crate::{metrics::CollectorRegister, p2p::services::mempool::MempoolError};
 
@@ -49,7 +49,7 @@ impl PrometheusMempoolMetrics {
         }
     }
 
-    pub fn on_transaction_received(&mut self, _transaction: &TransactionRecord) {
+    pub fn on_transaction_received(&mut self, _transaction: &Transaction) {
         self.transactions_received.inc();
     }
 

--- a/applications/tari_validator_node/src/p2p/services/mempool/traits.rs
+++ b/applications/tari_validator_node/src/p2p/services/mempool/traits.rs
@@ -1,6 +1,8 @@
 //    Copyright 2023 The Tari Project
 //    SPDX-License-Identifier: BSD-3-Clause
 
+use std::collections::HashSet;
+
 use async_trait::async_trait;
 use indexmap::IndexMap;
 use tari_dan_common_types::Epoch;
@@ -8,13 +10,23 @@ use tari_engine_types::{
     substate::{Substate, SubstateId},
     virtual_substate::VirtualSubstates,
 };
-use tari_transaction::Transaction;
+use tari_transaction::{SubstateRequirement, Transaction};
+
+pub struct ResolvedSubstates {
+    pub local: IndexMap<SubstateId, Substate>,
+    pub unresolved_foreign: HashSet<SubstateRequirement>,
+}
 
 #[async_trait]
 pub trait SubstateResolver {
     type Error: Send + Sync + 'static;
 
-    async fn resolve(&self, transaction: &Transaction) -> Result<IndexMap<SubstateId, Substate>, Self::Error>;
+    fn try_resolve_local(&self, transaction: &Transaction) -> Result<ResolvedSubstates, Self::Error>;
+
+    async fn try_resolve_foreign(
+        &self,
+        requested_substates: &HashSet<SubstateRequirement>,
+    ) -> Result<IndexMap<SubstateId, Substate>, Self::Error>;
 
     async fn resolve_virtual_substates(
         &self,

--- a/applications/tari_validator_node/src/substate_resolver.rs
+++ b/applications/tari_validator_node/src/substate_resolver.rs
@@ -17,11 +17,11 @@ use tari_engine_types::{
 };
 use tari_epoch_manager::{EpochManagerError, EpochManagerReader};
 use tari_indexer_lib::{error::IndexerError, substate_cache::SubstateCache, substate_scanner::SubstateScanner};
-use tari_transaction::Transaction;
+use tari_transaction::{SubstateRequirement, Transaction};
 use tari_validator_node_rpc::client::{SubstateResult, ValidatorNodeClientFactory};
 
 use crate::{
-    p2p::services::mempool::SubstateResolver,
+    p2p::services::mempool::{ResolvedSubstates, SubstateResolver},
     virtual_substate::{VirtualSubstateError, VirtualSubstateManager},
 };
 
@@ -57,40 +57,107 @@ where
         }
     }
 
-    fn resolve_local_substates(
-        &self,
-        transaction: &Transaction,
-        out: &mut IndexMap<SubstateId, Substate>,
-    ) -> Result<HashSet<SubstateAddress>, SubstateResolverError> {
-        let inputs = transaction.all_input_addresses_iter();
-        let (local_substates, missing_shards) = self.store.with_read_tx(|tx| SubstateRecord::get_any(tx, inputs))?;
+    fn resolve_local_substates(&self, transaction: &Transaction) -> Result<ResolvedSubstates, SubstateResolverError> {
+        let mut substates = IndexMap::new();
+        let inputs = transaction.all_inputs_substate_ids_iter();
+        let (mut found_local_substates, missing_substate_ids) = self
+            .store
+            .with_read_tx(|tx| SubstateRecord::get_any_max_version(tx, inputs))?;
+
+        // Reconcile requested inputs with found local substates
+        let mut missing_substates = HashSet::with_capacity(missing_substate_ids.len());
+        for requested_input in transaction.all_inputs_iter() {
+            if missing_substate_ids.contains(requested_input.substate_id()) {
+                missing_substates.insert(requested_input);
+                // Not a local substate, so we will need to fetch it remotely
+                continue;
+            }
+
+            match requested_input.version() {
+                // Specific version requested
+                Some(requested_version) => {
+                    let maybe_match = found_local_substates
+                        .iter()
+                        .find(|s| s.version() == requested_version && s.substate_id() == requested_input.substate_id());
+
+                    match maybe_match {
+                        Some(substate) => {
+                            if substate.is_destroyed() {
+                                return Err(SubstateResolverError::InputSubstateDowned {
+                                    id: requested_input.into_substate_id(),
+                                    version: requested_version,
+                                });
+                            }
+                            // OK
+                        },
+                        // Requested substate or version not found. We know that the requested substate is not foreign
+                        // because we checked missing_substate_ids
+                        None => {
+                            return Err(SubstateResolverError::InputSubstateDoesNotExist {
+                                substate_requirement: requested_input,
+                            });
+                        },
+                    }
+                },
+                // No version specified, so we will use the latest version
+                None => {
+                    let (pos, substate) = found_local_substates
+                        .iter()
+                        .enumerate()
+                        .find(|(_, s)| s.substate_id() == requested_input.substate_id())
+                        // This is not possible
+                        .ok_or_else(|| {
+                            error!(
+                                target: LOG_TARGET,
+                                "🐞 BUG: Requested substate {} was not missing but was also not found",
+                                requested_input.substate_id()
+                            );
+                            SubstateResolverError::InputSubstateDoesNotExist { substate_requirement: requested_input.clone()}
+                        })?;
+
+                    if substate.is_destroyed() {
+                        // The requested substate is downed locally, it may be available in a foreign shard so we add it
+                        // to missing
+                        let _substate = found_local_substates.remove(pos);
+                        missing_substates.insert(requested_input);
+                        continue;
+                    }
+
+                    // User did not specify the version, so we will use the latest version
+                    // Ok
+                },
+            }
+        }
 
         info!(
             target: LOG_TARGET,
-            "Found {} local substates and {} missing shards",
-            local_substates.len(),
-            missing_shards.len());
+            "Found {} local substates and {} missing substates",
+            found_local_substates.len(),
+            missing_substate_ids.len(),
+        );
 
-        out.extend(
-            local_substates
+        substates.extend(
+            found_local_substates
                 .into_iter()
                 .map(|s| (s.substate_id.clone(), s.into_substate())),
         );
 
-        Ok(missing_shards)
+        Ok(ResolvedSubstates {
+            local: substates,
+            unresolved_foreign: missing_substates,
+        })
     }
 
     async fn resolve_remote_substates(
         &self,
-        substate_addresses: HashSet<SubstateAddress>,
-        out: &mut IndexMap<SubstateId, Substate>,
-    ) -> Result<(), SubstateResolverError> {
-        out.reserve(substate_addresses.len());
-        for substate_address in substate_addresses {
+        requested_substates: &HashSet<SubstateRequirement>,
+    ) -> Result<IndexMap<SubstateId, Substate>, SubstateResolverError> {
+        let mut substates = IndexMap::with_capacity(requested_substates.len());
+        for substate_req in requested_substates {
             let timer = Instant::now();
             let substate_result = self
                 .scanner
-                .get_specific_substate_from_committee_by_shard(substate_address)
+                .get_substate(substate_req.substate_id(), substate_req.version())
                 .await?;
 
             match substate_result {
@@ -101,20 +168,20 @@ where
                         id,
                         timer.elapsed().as_millis()
                     );
-                    out.insert(id, substate);
+                    substates.insert(id, substate);
                 },
                 SubstateResult::Down { id, version, .. } => {
                     return Err(SubstateResolverError::InputSubstateDowned { id, version });
                 },
                 SubstateResult::DoesNotExist => {
                     return Err(SubstateResolverError::InputSubstateDoesNotExist {
-                        address: substate_address,
+                        substate_requirement: substate_req.clone(),
                     });
                 },
             }
         }
 
-        Ok(())
+        Ok(substates)
     }
 
     async fn resolve_remote_virtual_substates(
@@ -158,17 +225,15 @@ where
 {
     type Error = SubstateResolverError;
 
-    async fn resolve(&self, transaction: &Transaction) -> Result<IndexMap<SubstateId, Substate>, Self::Error> {
-        let mut substates = IndexMap::new();
+    fn try_resolve_local(&self, transaction: &Transaction) -> Result<ResolvedSubstates, Self::Error> {
+        self.resolve_local_substates(transaction)
+    }
 
-        let missing_shards = self.resolve_local_substates(transaction, &mut substates)?;
-
-        // TODO: If any of the missing shards are local we should error early here rather than asking the local
-        //       committee
-
-        self.resolve_remote_substates(missing_shards, &mut substates).await?;
-
-        Ok(substates)
+    async fn try_resolve_foreign(
+        &self,
+        requested_substates: &HashSet<SubstateRequirement>,
+    ) -> Result<IndexMap<SubstateId, Substate>, Self::Error> {
+        self.resolve_remote_substates(requested_substates).await
     }
 
     async fn resolve_virtual_substates(
@@ -247,8 +312,8 @@ pub enum SubstateResolverError {
     StorageError(#[from] StorageError),
     #[error("Indexer error: {0}")]
     IndexerError(#[from] IndexerError),
-    #[error("Input substate does not exist: {address}")]
-    InputSubstateDoesNotExist { address: SubstateAddress },
+    #[error("Input substate does not exist: {substate_requirement}")]
+    InputSubstateDoesNotExist { substate_requirement: SubstateRequirement },
     #[error("Input substate is downed: {id} (version: {version})")]
     InputSubstateDowned { id: SubstateId, version: u32 },
     #[error("Virtual substate error: {0}")]

--- a/dan_layer/state_store_sqlite/migrations/2023-06-08-091819_create_state_store/up.sql
+++ b/dan_layer/state_store_sqlite/migrations/2023-06-08-091819_create_state_store/up.sql
@@ -101,8 +101,10 @@ create table substates
     destroyed_at             timestamp NULL
 );
 
--- All shard ids are unique
-create unique index substates_uniq_shard_id on substates (address);
+-- All addresses are unique
+create unique index substates_uniq_address on substates (address);
+-- All substate_id, version pairs are unique. This is a common query
+create unique index substates_uniq_substate_id_and_version on substates (substate_id, version);
 -- querying for transaction ids that either Upd or Downd a substate
 create index substates_idx_created_by_transaction on substates (created_by_transaction);
 create index substates_idx_destroyed_by_transaction on substates (destroyed_by_transaction) where destroyed_by_transaction is not null;

--- a/dan_layer/state_store_sqlite/src/lib.rs
+++ b/dan_layer/state_store_sqlite/src/lib.rs
@@ -1,5 +1,6 @@
 //   Copyright 2023 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
+
 mod error;
 mod reader;
 mod schema;

--- a/dan_layer/storage/src/state_store/mod.rs
+++ b/dan_layer/storage/src/state_store/mod.rs
@@ -10,8 +10,9 @@ use std::{
 use serde::{Deserialize, Serialize};
 use tari_common_types::types::{FixedHash, PublicKey};
 use tari_dan_common_types::{Epoch, NodeAddressable, NodeHeight, SubstateAddress};
+use tari_engine_types::substate::SubstateId;
 use tari_state_tree::{TreeStore, TreeStoreReader, Version};
-use tari_transaction::{TransactionId, VersionedSubstateId};
+use tari_transaction::{SubstateRequirement, TransactionId, VersionedSubstateId};
 #[cfg(feature = "ts")]
 use ts_rs::TS;
 
@@ -207,7 +208,11 @@ pub trait StateStoreReadTransaction {
     fn substates_get(&mut self, substate_id: &SubstateAddress) -> Result<SubstateRecord, StorageError>;
     fn substates_get_any(
         &mut self,
-        substate_ids: &HashSet<SubstateAddress>,
+        substate_ids: &HashSet<SubstateRequirement>,
+    ) -> Result<Vec<SubstateRecord>, StorageError>;
+    fn substates_get_any_max_version<'a, I: IntoIterator<Item = &'a SubstateId>>(
+        &mut self,
+        substate_ids: I,
     ) -> Result<Vec<SubstateRecord>, StorageError>;
     fn substates_any_exist<I, S>(&mut self, substates: I) -> Result<bool, StorageError>
     where

--- a/integration_tests/tests/features/concurrency.feature
+++ b/integration_tests/tests/features/concurrency.feature
@@ -3,44 +3,43 @@
 
 Feature: Concurrency
 
-# TODO: This feature is currently disabled
-#  @serial
-#  Scenario: Concurrent calls to the Counter template
-#    Given fees are disabled
-#    # Initialize a base node, wallet, miner and VN
-#    Given a base node BASE
-#    Given a wallet WALLET connected to base node BASE
-#    Given a miner MINER connected to base node BASE and wallet WALLET
-#
-#    # Initialize a VN
-#    Given a validator node VAL_1 connected to base node BASE and wallet daemon WALLET_D
-#
-#    # The wallet must have some funds before the VN sends transactions
-#    When miner MINER mines 6 new blocks
-#    When wallet WALLET has at least 20 T
-#
-#    # VN registration
-#    When validator node VAL_1 sends a registration transaction to base wallet WALLET
-#
-#    # Register the "counter" template
-#    When base wallet WALLET registers the template "counter"
-#    When miner MINER mines 13 new blocks
-#    Then VAL_1 has scanned to height 16
-#    Then the validator node VAL_1 is listed as registered
-#    Then the template "counter" is listed as registered by the validator node VAL_1
-#
-#    # A file-base CLI account must be created to sign future calls
-#    When I use an account key named K1
-#
-#    # Create a new Counter component
-#    When I create a component COUNTER_1 of template "counter" on VAL_1 using "new"
-#    When I print the cucumber world
-#
-#    # Send multiple concurrent transactions to increase the counter
-#    # TODO: when concurrency is fully working, call it with "2 times" or higher
-#    When I invoke on VAL_1 on component COUNTER_1/components/Counter the method call "increase" concurrently 1 times
-#    When I print the cucumber world
-#
-#    # Check that the counter has been increased
-#    # TODO: uncomment when concurrency is fully working
-#    # When I invoke on VAL_1 on component TX1/components/Counter the method call "value" the result is "2"
+  @serial
+  Scenario: Concurrent calls to the Counter template
+    Given fees are disabled
+    # Initialize a base node, wallet, miner and VN
+    Given a base node BASE
+    Given a wallet WALLET connected to base node BASE
+    Given a miner MINER connected to base node BASE and wallet WALLET
+
+    # Initialize a VN
+    Given a validator node VAL_1 connected to base node BASE and wallet daemon WALLET_D
+
+    # The wallet must have some funds before the VN sends transactions
+    When miner MINER mines 6 new blocks
+    When wallet WALLET has at least 20 T
+
+    # VN registration
+    When validator node VAL_1 sends a registration transaction to base wallet WALLET
+
+    # Register the "counter" template
+    When base wallet WALLET registers the template "counter"
+    When miner MINER mines 13 new blocks
+    Then VAL_1 has scanned to height 16
+    Then the validator node VAL_1 is listed as registered
+    Then the template "counter" is listed as registered by the validator node VAL_1
+
+    # A file-base CLI account must be created to sign future calls
+    When I use an account key named K1
+
+    # Create a new Counter component
+    When I create a component COUNTER_1 of template "counter" on VAL_1 using "new"
+    When I print the cucumber world
+
+    # Send multiple concurrent transactions to increase the counter
+    # TODO: when concurrency is fully working, call it with "2 times" or higher
+    When I invoke on VAL_1 on component COUNTER_1/components/Counter the method call "increase" concurrently 1 times
+    When I print the cucumber world
+
+    # Check that the counter has been increased
+    # TODO: uncomment when concurrency is fully working
+    # When I invoke on VAL_1 on component TX1/components/Counter the method call "value" the result is "2"  


### PR DESCRIPTION
Description
---
fix(mempool): resolve local unversioned inputs before execution

Motivation and Context
---
Allow local only transactions with unversioned  inputs to be resolved in the mempool 

High-level Notes:
- Versioned local and foreign inputs may be safely executed and passed to consensus. If an input conflicts or has been downed since execution this transaction will (and must) ABORT.
- Unversioned inputs are more complicated. 
- **Local-only unversioned in mempool**: the mempool resolves all inputs as local and assigns the current UP version. Since inputs are not locked yet, another transaction may consume these inputs rendering one of the transactions to ABORT when it shouldn't. This can be resolved by executing the local-only transactions within the context of the object state of the current block.
- **Local-only consensus execution**: The version applicable to the current leaf proposal which accounts for the uncommitted chain (to commit block/3-chain) is selected and proposed as LocalOnly. This implicitly pledges and locks the inputs. 
- **Local-only with foreign conflicts in consensus**: ...



How Has This Been Tested?
---
Cucumber test re-added that tests unversioned inputs.

What process can a PR reviewer use to test or verify this change?
---
Submit a transaction with at least one unversioned input local to the shard

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify

NOTE: Added an index to the database, that requires the database to be deleted to be applied. This is non-breaking but does ensure data integrity and improves the SQLite implementation query performance