### PR TITLE
fix: lock rust stable version to 1.77

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ name: CI
 
 env:
   nightly_toolchain: nightly-2023-06-12
-  stable_toolchain: stable
+  stable_toolchain: 1.77
   CARGO_HTTP_MULTIPLEXING: false
   CARGO_TERM_COLOR: always
   TARI_TARGET_NETWORK: localnet
@@ -28,7 +28,7 @@ env:
 jobs:
   fmt:
     name: fmt
-    runs-on: [self-hosted, ubuntu-high-cpu]
+    runs-on: [ self-hosted, ubuntu-high-cpu ]
 
     steps:
       - name: checkout
@@ -52,7 +52,7 @@ jobs:
         run: cargo +${{ env.nightly_toolchain }} fmt --all -- --check
   prettier:
     name: prettier
-    runs-on: [self-hosted, ubuntu-high-cpu]
+    runs-on: [ self-hosted, ubuntu-high-cpu ]
 
     steps:
       - name: checkout
@@ -68,7 +68,7 @@ jobs:
 
   clippy:
     name: clippy
-    runs-on: [self-hosted, ubuntu-high-cpu]
+    runs-on: [ self-hosted, ubuntu-high-cpu ]
 
     steps:
       - name: checkout
@@ -123,7 +123,7 @@ jobs:
 
   build:
     name: check nightly
-    runs-on: [self-hosted, ubuntu-high-cpu]
+    runs-on: [ self-hosted, ubuntu-high-cpu ]
 
     steps:
       - name: checkout
@@ -149,7 +149,7 @@ jobs:
 
   build-stable:
     name: check stable
-    runs-on: [self-hosted, ubuntu-high-cpu]
+    runs-on: [ self-hosted, ubuntu-high-cpu ]
 
     steps:
       - name: checkout
@@ -198,7 +198,7 @@ jobs:
 
   test:
     name: test
-    runs-on: [self-hosted, ubuntu-high-cpu]
+    runs-on: [ self-hosted, ubuntu-high-cpu ]
 
     steps:
       - name: checkout

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -13,4 +13,7 @@
 # - the CI files in .github folder
 # - the Makefile in base_layer/key_manager/Makefile
 [toolchain]
-channel = "stable"
+# 1.78 causes a mempory alignment panic in the version of wasmer we use. For now we'll lock to 1.77.
+# https://github.com/wasmerio/wasmer/blob/2.3.0/lib/vm/src/instance/mod.rs#L968
+# Error: unsafe precondition(s) violated: ptr::copy_nonoverlapping requires that both pointer arguments are aligned and non-null and the specified memory ranges do not overlap
+channel = "1.77"


### PR DESCRIPTION
Description
---
Lock rust version to 1.77

Motivation and Context
---
Rust 1.78 causes a mempory alignment panic in the version of wasmer we use. For now we'll lock to 1.77.
https://github.com/wasmerio/wasmer/blob/2.3.0/lib/vm/src/instance/mod.rs#L968
Error: unsafe precondition(s) violated: ptr::copy_nonoverlapping requires that both pointer arguments are aligned and non-null and the specified memory ranges do not overlap

How Has This Been Tested?
---
CI

What process can a PR reviewer use to test or verify this change?
---
Wasm tests pass

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify