### PR TITLE
fix(mempool): insert transaction for failed before validation

### DIFF
--- a/applications/tari_validator_node/src/p2p/services/mempool/service.rs
+++ b/applications/tari_validator_node/src/p2p/services/mempool/service.rs
@@ -315,7 +315,7 @@ where
             self.state_store.with_write_tx(|tx| {
                 TransactionRecord::new(transaction)
                     .set_abort(format!("Mempool validation failed: {e}"))
-                    .update(tx)
+                    .insert(tx)
             })?;
 
             #[cfg(feature = "metrics")]

--- a/applications/tari_validator_node/src/p2p/services/mempool/validators/after/has_involved_shards.rs
+++ b/applications/tari_validator_node/src/p2p/services/mempool/validators/after/has_involved_shards.rs
@@ -26,7 +26,7 @@ impl Validator<ExecutedTransaction> for HasInvolvedShards {
 
     async fn validate(&self, executed: &ExecutedTransaction) -> Result<(), Self::Error> {
         if executed.num_inputs_and_outputs() == 0 {
-            debug!(target: LOG_TARGET, "HasInvolvedShards - FAIL: No input or output shards");
+            warn!(target: LOG_TARGET, "HasInvolvedShards - FAIL: No input or output shards");
             return Err(MempoolError::NoInvolvedShards {
                 transaction_id: *executed.id(),
             });

--- a/applications/tari_validator_node/src/p2p/services/mempool/validators/before/epoch_range.rs
+++ b/applications/tari_validator_node/src/p2p/services/mempool/validators/before/epoch_range.rs
@@ -2,11 +2,14 @@
 //    SPDX-License-Identifier: BSD-3-Clause
 
 use async_trait::async_trait;
+use log::warn;
 use tari_dan_common_types::NodeAddressable;
 use tari_epoch_manager::{base_layer::EpochManagerHandle, EpochManagerReader};
 use tari_transaction::Transaction;
 
 use crate::p2p::services::mempool::{MempoolError, Validator};
+
+const LOG_TARGET: &str = "tari::dan::mempool::validators::epoch_range";
 
 #[derive(Debug)]
 pub struct EpochRangeValidator<TAddr> {
@@ -27,6 +30,7 @@ impl<TAddr: NodeAddressable> Validator<Transaction> for EpochRangeValidator<TAdd
         let current_epoch = self.epoch_manager.current_epoch().await?;
         if let Some(min_epoch) = transaction.min_epoch() {
             if current_epoch < min_epoch {
+                warn!(target: LOG_TARGET, "EpochRangeValidator - FAIL: Current epoch {current_epoch} less than minimum epoch {min_epoch}.");
                 return Err(MempoolError::CurrentEpochLessThanMinimum {
                     current_epoch,
                     min_epoch,
@@ -36,6 +40,7 @@ impl<TAddr: NodeAddressable> Validator<Transaction> for EpochRangeValidator<TAdd
 
         if let Some(max_epoch) = transaction.max_epoch() {
             if current_epoch > max_epoch {
+                warn!(target: LOG_TARGET, "EpochRangeValidator - FAIL: Current epoch {current_epoch} greater than maximum epoch {max_epoch}.");
                 return Err(MempoolError::CurrentEpochGreaterThanMaximum {
                     current_epoch,
                     max_epoch,

--- a/applications/tari_validator_node/src/p2p/services/mempool/validators/before/fee.rs
+++ b/applications/tari_validator_node/src/p2p/services/mempool/validators/before/fee.rs
@@ -2,9 +2,12 @@
 //    SPDX-License-Identifier: BSD-3-Clause
 
 use async_trait::async_trait;
+use log::warn;
 use tari_transaction::Transaction;
 
 use crate::p2p::services::mempool::{MempoolError, Validator};
+
+const LOG_TARGET: &str = "tari::dan::mempool::validators::fee";
 
 #[derive(Debug)]
 pub struct FeeTransactionValidator;
@@ -15,6 +18,7 @@ impl Validator<Transaction> for FeeTransactionValidator {
 
     async fn validate(&self, transaction: &Transaction) -> Result<(), MempoolError> {
         if transaction.fee_instructions().is_empty() {
+            warn!(target: LOG_TARGET, "FeeTransactionValidator - FAIL: No fee instructions");
             return Err(MempoolError::NoFeeInstructions);
         }
         Ok(())

--- a/applications/tari_validator_node/src/p2p/services/mempool/validators/before/has_inputs.rs
+++ b/applications/tari_validator_node/src/p2p/services/mempool/validators/before/has_inputs.rs
@@ -36,7 +36,7 @@ impl Validator<Transaction> for HasInputs {
                 return Ok(());
             }
 
-            debug!(target: LOG_TARGET, "HasInputs - FAIL: No input shards");
+            warn!(target: LOG_TARGET, "HasInputs - FAIL: No input shards");
             return Err(MempoolError::NoInputs {
                 transaction_id: *transaction.id(),
             });

--- a/applications/tari_validator_node/src/p2p/services/mempool/validators/before/signature.rs
+++ b/applications/tari_validator_node/src/p2p/services/mempool/validators/before/signature.rs
@@ -2,9 +2,12 @@
 //    SPDX-License-Identifier: BSD-3-Clause
 
 use async_trait::async_trait;
+use log::warn;
 use tari_transaction::Transaction;
 
 use crate::p2p::services::mempool::{MempoolError, Validator};
+
+const LOG_TARGET: &str = "tari::dan::mempool::validators::signature";
 
 #[derive(Debug)]
 pub struct TransactionSignatureValidator;
@@ -15,6 +18,7 @@ impl Validator<Transaction> for TransactionSignatureValidator {
 
     async fn validate(&self, transaction: &Transaction) -> Result<(), MempoolError> {
         if !transaction.signature().verify(&transaction.into()) {
+            warn!(target: LOG_TARGET, "TransactionSignatureValidator - FAIL: Invalid signature");
             return Err(MempoolError::InvalidSignature);
         }
 

--- a/applications/tari_validator_node/src/p2p/services/mempool/validators/before/template_exists.rs
+++ b/applications/tari_validator_node/src/p2p/services/mempool/validators/before/template_exists.rs
@@ -2,12 +2,15 @@
 //    SPDX-License-Identifier: BSD-3-Clause
 
 use async_trait::async_trait;
+use log::warn;
 use tari_dan_app_utilities::template_manager::{implementation::TemplateManager, interface::TemplateManagerError};
 use tari_dan_common_types::NodeAddressable;
 use tari_engine_types::instruction::Instruction;
 use tari_transaction::Transaction;
 
 use crate::p2p::services::mempool::{MempoolError, Validator};
+
+const LOG_TARGET: &str = "tari::dan::mempool::validators::template_exists";
 
 #[derive(Debug)]
 pub struct TemplateExistsValidator<TAddr> {
@@ -33,11 +36,12 @@ impl<TAddr: NodeAddressable> Validator<Transaction> for TemplateExistsValidator<
                     match template_exists {
                         Err(e) => return Err(MempoolError::InvalidTemplateAddress(e)),
                         Ok(false) => {
+                            warn!(target: LOG_TARGET, "TemplateExistsValidator - FAIL: Template not found");
                             return Err(MempoolError::InvalidTemplateAddress(
                                 TemplateManagerError::TemplateNotFound {
                                     address: *template_address,
                                 },
-                            ))
+                            ));
                         },
                         _ => continue,
                     }


### PR DESCRIPTION
Description
---

Insert transaction in database if before-execution validations fail

Motivation and Context
---

This case will cause the error: `Storage Error: Not found: item: transaction`.

We insert to allow submitters to later request this result. We might want to return this validation result to the caller and not persist the transaction.

How Has This Been Tested?
---
Not tested

What process can a PR reviewer use to test or verify this change?
---


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify