### PR TITLE
fix: minor improvements to template lib and test tooling

### DIFF
--- a/clients/validator_node_client/Cargo.toml
+++ b/clients/validator_node_client/Cargo.toml
@@ -17,7 +17,7 @@ tari_dan_storage = { workspace = true }
 
 reqwest = { workspace = true, features = ["json"] }
 multiaddr = { workspace = true }
-serde = { workspace = true, default-features = true }
+serde = { workspace = true, default-features = true, features = ["rc"] }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 ts-rs = { workspace = true, optional = true }

--- a/dan_layer/engine/src/runtime/actions.rs
+++ b/dan_layer/engine/src/runtime/actions.rs
@@ -6,12 +6,16 @@ use std::fmt::{Display, Formatter};
 use tari_template_lib::{
     args::{ComponentAction, VaultAction},
     auth::ResourceAuthAction,
+    models::ComponentAddress,
 };
 
 #[derive(Debug, Clone)]
 pub enum ActionIdent {
     Native(NativeAction),
-    ComponentCallMethod { method: String },
+    ComponentCallMethod {
+        component_address: ComponentAddress,
+        method: String,
+    },
 }
 
 impl From<NativeAction> for ActionIdent {
@@ -42,8 +46,11 @@ impl Display for ActionIdent {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             ActionIdent::Native(native_fn) => write!(f, "native.{}", native_fn),
-            ActionIdent::ComponentCallMethod { method } => {
-                write!(f, "call component method '{}'", method)
+            ActionIdent::ComponentCallMethod {
+                component_address,
+                method,
+            } => {
+                write!(f, "call component method '{method}' on {component_address}")
             },
         }
     }

--- a/dan_layer/engine/tests/access_rules.rs
+++ b/dan_layer/engine/tests/access_rules.rs
@@ -92,6 +92,7 @@ mod component_access_rules {
         );
 
         assert_access_denied_for_action(reason, ActionIdent::ComponentCallMethod {
+            component_address,
             method: "set_value".to_string(),
         });
     }
@@ -137,6 +138,7 @@ mod component_access_rules {
         );
 
         assert_access_denied_for_action(reason, ActionIdent::ComponentCallMethod {
+            component_address,
             method: "set_value".to_string(),
         });
 

--- a/dan_layer/engine/tests/account.rs
+++ b/dan_layer/engine/tests/account.rs
@@ -41,8 +41,8 @@ fn basic_faucet_transfer() {
         .unwrap();
 
     // Create sender and receiver accounts
-    let (sender_address, sender_proof, _) = template_test.create_owned_account();
-    let (receiver_address, _, _) = template_test.create_owned_account();
+    let (sender_address, sender_proof, _) = template_test.create_funded_account();
+    let (receiver_address, _, _) = template_test.create_funded_account();
 
     let _result = template_test
         .execute_and_commit(
@@ -128,7 +128,7 @@ fn withdraw_from_account_prevented() {
         .unwrap();
 
     // Create sender and receiver accounts
-    let (source_account, _, _) = template_test.create_owned_account();
+    let (source_account, _, _) = template_test.create_funded_account();
 
     let _result = template_test
         .execute_and_commit_manifest(
@@ -147,7 +147,7 @@ fn withdraw_from_account_prevented() {
         )
         .unwrap();
 
-    let (dest_address, non_owning_token, non_owning_key) = template_test.create_owned_account();
+    let (dest_address, non_owning_token, non_owning_key) = template_test.create_funded_account();
 
     let reason = template_test.execute_expect_failure(
         Transaction::builder()
@@ -161,6 +161,7 @@ fn withdraw_from_account_prevented() {
     );
 
     assert_access_denied_for_action(reason, ActionIdent::ComponentCallMethod {
+        component_address: source_account,
         method: "withdraw".to_string(),
     });
 
@@ -190,7 +191,7 @@ fn attempt_to_overwrite_account() {
     let mut template_test = TemplateTest::new::<_, &str>([]);
 
     // Create initial account with faucet funds
-    let (source_account, source_account_proof, source_account_sk) = template_test.create_owned_account();
+    let (source_account, source_account_proof, source_account_sk) = template_test.create_funded_account();
     let source_account_pk = RistrettoPublicKey::from_secret_key(&source_account_sk);
 
     let overwriting_tx = template_test.execute_expect_failure(

--- a/dan_layer/engine/tests/account_nfts.rs
+++ b/dan_layer/engine/tests/account_nfts.rs
@@ -16,7 +16,7 @@ fn basic_nft_mint() {
 
     let account_nft_template = account_nft_template_test.get_template_address("AccountNonFungible");
 
-    let (owner_component_address, owner_token, _) = account_nft_template_test.create_owned_account();
+    let (owner_component_address, owner_token, _) = account_nft_template_test.create_funded_account();
 
     let result = account_nft_template_test
         .execute_and_commit(

--- a/dan_layer/engine/tests/composability.rs
+++ b/dan_layer/engine/tests/composability.rs
@@ -242,7 +242,7 @@ fn it_allows_method_to_function_calls() {
 fn it_fails_on_invalid_calls() {
     let mut test = setup();
     let components = initialize_composability(&mut test);
-    let (_, _, private_key) = test.template_test.create_owned_account();
+    let (_, _, private_key) = test.template_test.create_funded_account();
 
     // the "invalid_state_call" method tries to call a non-existent method in the inner state component
     let result = test
@@ -298,6 +298,7 @@ fn it_does_not_propagate_permissions() {
 
     // We expect the component call to withdraw to fail with AccessDenied.
     assert_access_denied_for_action(reason, ActionIdent::ComponentCallMethod {
+        component_address: victim_account,
         method: "withdraw".to_string(),
     });
 }
@@ -331,7 +332,7 @@ fn it_allows_multiple_recursion_levels() {
 #[test]
 fn it_fails_when_surpassing_recursion_limit() {
     let mut test = setup();
-    let (_, _, private_key) = test.template_test.create_owned_account();
+    let (_, _, private_key) = test.template_test.create_funded_account();
     let max_call_depth = MAX_CALL_DEPTH;
 
     // innermost composability component

--- a/dan_layer/engine/tests/confidential.rs
+++ b/dan_layer/engine/tests/confidential.rs
@@ -97,8 +97,8 @@ fn transfer_confidential_amounts_between_accounts() {
     let (mut template_test, faucet, faucet_resx) = setup(confidential_proof, None);
 
     // Create an account
-    let (account1, owner1, _k) = template_test.create_owned_account();
-    let (account2, _owner2, _k) = template_test.create_owned_account();
+    let (account1, owner1, _k) = template_test.create_funded_account();
+    let (account2, _owner2, _k) = template_test.create_funded_account();
 
     // Create proof for transfer
     let proof = generate_withdraw_proof(&faucet_mask, Amount(1000), Some(Amount(99_000)), Amount(0));
@@ -179,7 +179,7 @@ fn transfer_confidential_fails_with_invalid_balance() {
     let (mut template_test, faucet, _faucet_resx) = setup(confidential_proof, None);
 
     // Create an account
-    let (account1, _owner1, _k) = template_test.create_owned_account();
+    let (account1, _owner1, _k) = template_test.create_funded_account();
 
     // Create proof for transfer
     let proof = generate_withdraw_proof(&faucet_mask, Amount(1001), Some(Amount(99_000)), Amount(0));
@@ -211,8 +211,8 @@ fn reveal_confidential_and_transfer() {
     let (mut template_test, faucet, faucet_resx) = setup(confidential_proof, None);
 
     // Create an account
-    let (account1, owner1, _k) = template_test.create_owned_account();
-    let (account2, owner2, _k) = template_test.create_owned_account();
+    let (account1, owner1, _k) = template_test.create_funded_account();
+    let (account2, owner2, _k) = template_test.create_funded_account();
 
     // Create proof for transfer
 
@@ -284,8 +284,8 @@ fn attempt_to_reveal_with_unbalanced_proof() {
     let (mut template_test, faucet, faucet_resx) = setup(confidential_proof, None);
 
     // Create an account
-    let (account1, owner1, _k) = template_test.create_owned_account();
-    let (account2, _owner2, _k) = template_test.create_owned_account();
+    let (account1, owner1, _k) = template_test.create_funded_account();
+    let (account2, _owner2, _k) = template_test.create_funded_account();
 
     // Create proof for transfer
 
@@ -337,7 +337,7 @@ fn multi_commitment_join() {
     let (mut template_test, faucet, faucet_resx) = setup(confidential_proof, None);
 
     // Create an account
-    let (account1, owner1, _k) = template_test.create_owned_account();
+    let (account1, owner1, _k) = template_test.create_funded_account();
 
     // Create proof for transfer
 

--- a/dan_layer/engine/tests/events.rs
+++ b/dan_layer/engine/tests/events.rs
@@ -41,7 +41,7 @@ fn basic_emit_event() {
 fn cannot_use_standard_topic() {
     let mut template_test = TemplateTest::new(vec!["tests/templates/events"]);
     let event_emitter_template = template_test.get_template_address("EventEmitter");
-    let (_, _, private_key) = template_test.create_owned_account();
+    let (_, _, private_key) = template_test.create_funded_account();
     let invalid_topic = "std.mytopic";
     let reason = template_test.execute_expect_failure(
         Transaction::builder()
@@ -82,8 +82,8 @@ fn builtin_vault_events() {
         .unwrap();
 
     // Create sender and receiver accounts
-    let (sender_address, sender_proof, _) = template_test.create_owned_account();
-    let (receiver_address, _, _) = template_test.create_owned_account();
+    let (sender_address, sender_proof, _) = template_test.create_funded_account();
+    let (receiver_address, _, _) = template_test.create_funded_account();
     template_test
         .execute_and_commit(
             vec![

--- a/dan_layer/engine/tests/fees.rs
+++ b/dan_layer/engine/tests/fees.rs
@@ -16,7 +16,7 @@ use tari_transaction::Transaction;
 fn deducts_fees_from_payments_and_refunds_the_rest() {
     let mut test = TemplateTest::new(["tests/templates/state"]);
 
-    let (account, owner_token, private_key) = test.create_owned_account();
+    let (account, owner_token, private_key) = test.create_funded_account();
     let orig_balance: Amount = test.call_method(account, "balance", args![CONFIDENTIAL_TARI_RESOURCE_ADDRESS], vec![]);
 
     test.enable_fees();
@@ -44,7 +44,7 @@ fn deducts_fees_from_payments_and_refunds_the_rest() {
 fn deducts_fees_when_transaction_fails() {
     let mut test = TemplateTest::new(["tests/templates/state"]);
 
-    let (account, owner_token, private_key) = test.create_owned_account();
+    let (account, owner_token, private_key) = test.create_funded_account();
     let orig_balance: Amount = test.call_method(account, "balance", args![CONFIDENTIAL_TARI_RESOURCE_ADDRESS], vec![]);
 
     test.enable_fees();
@@ -120,7 +120,7 @@ fn another_account_pays_partially_for_fees() {
     let mut test = TemplateTest::new(iter::empty::<&str>());
 
     let (account, owner_token, private_key) = test.create_empty_account();
-    let (account_fee, owner_token_fee, _) = test.create_owned_account();
+    let (account_fee, owner_token_fee, _) = test.create_funded_account();
     let orig_balance: Amount = test.call_method(
         account_fee,
         "balance",
@@ -167,7 +167,7 @@ fn another_account_pays_partially_for_fees() {
 fn failed_fee_transaction() {
     let mut test = TemplateTest::new(["tests/templates/state"]);
 
-    let (account, owner_token, private_key) = test.create_owned_account();
+    let (account, owner_token, private_key) = test.create_funded_account();
     let initial_balance: Amount =
         test.call_method(account, "balance", args![CONFIDENTIAL_TARI_RESOURCE_ADDRESS], vec![]);
 
@@ -201,8 +201,8 @@ fn failed_fee_transaction() {
 fn fail_partial_paid_fees() {
     let mut test = TemplateTest::new(["tests/templates/state"]);
 
-    let (account, owner_token, private_key) = test.create_owned_account();
-    let (account2, owner_token2, _) = test.create_owned_account();
+    let (account, owner_token, private_key) = test.create_funded_account();
+    let (account2, owner_token2, _) = test.create_funded_account();
     let orig_balance: Amount = test.call_method(account, "balance", args![CONFIDENTIAL_TARI_RESOURCE_ADDRESS], vec![]);
     println!("{:?}", orig_balance);
     test.enable_fees();
@@ -239,8 +239,8 @@ fn fail_partial_paid_fees() {
 fn fail_pay_less_fees_than_fee_transaction() {
     let mut test = TemplateTest::new(["tests/templates/state"]);
 
-    let (account, owner_token, private_key) = test.create_owned_account();
-    let (account2, owner_token2, _) = test.create_owned_account();
+    let (account, owner_token, private_key) = test.create_funded_account();
+    let (account2, owner_token2, _) = test.create_funded_account();
     let orig_balance: Amount = test.call_method(account, "balance", args![CONFIDENTIAL_TARI_RESOURCE_ADDRESS], vec![]);
     let state: ComponentAddress = test.call_function("State", "new", args![], vec![]);
 
@@ -302,8 +302,8 @@ fn fail_pay_less_fees_than_fee_transaction() {
 fn fail_pay_too_little_no_fee_instruction() {
     let mut test = TemplateTest::new(iter::empty::<&str>());
 
-    let (account, owner_token, private_key) = test.create_owned_account();
-    let (account2, owner_token2, _) = test.create_owned_account();
+    let (account, owner_token, private_key) = test.create_funded_account();
+    let (account2, owner_token2, _) = test.create_funded_account();
     let orig_balance: Amount = test.call_method(account, "balance", args![CONFIDENTIAL_TARI_RESOURCE_ADDRESS], vec![]);
 
     test.enable_fees();
@@ -336,8 +336,8 @@ fn fail_pay_too_little_no_fee_instruction() {
 fn success_pay_fee_in_main_instructions() {
     let mut test = TemplateTest::new(iter::empty::<&str>());
 
-    let (account, owner_token, private_key) = test.create_owned_account();
-    let (account2, owner_token2, _) = test.create_owned_account();
+    let (account, owner_token, private_key) = test.create_funded_account();
+    let (account2, owner_token2, _) = test.create_funded_account();
     let orig_balance: Amount = test.call_method(account, "balance", args![CONFIDENTIAL_TARI_RESOURCE_ADDRESS], vec![]);
 
     test.enable_fees();

--- a/dan_layer/engine/tests/shenanigans.rs
+++ b/dan_layer/engine/tests/shenanigans.rs
@@ -122,7 +122,7 @@ fn it_rejects_unknown_substate_addresses() {
 fn it_rejects_references_to_buckets_that_arent_in_scope() {
     let mut test = TemplateTest::new(["tests/templates/shenanigans"]);
     let template_addr = test.get_template_address("Shenanigans");
-    let (account, owner_token, owner_key) = test.create_owned_account();
+    let (account, owner_token, owner_key) = test.create_funded_account();
 
     let result = test.execute_expect_success(
         Transaction::builder()
@@ -170,7 +170,7 @@ fn it_rejects_double_ownership_of_vault() {
 fn it_prevents_access_to_vault_id_in_component_context() {
     let mut test = TemplateTest::new(["tests/templates/shenanigans"]);
     let template_addr = test.get_template_address("Shenanigans");
-    let (account, _, _) = test.create_owned_account();
+    let (account, _, _) = test.create_funded_account();
 
     let vault_id = {
         let component = test.read_only_state_store().get_component(account).unwrap();
@@ -209,7 +209,7 @@ fn it_prevents_access_to_vault_id_in_component_context() {
 fn it_prevents_access_to_out_of_scope_component() {
     let mut test = TemplateTest::new(["tests/templates/shenanigans"]);
     let template_addr = test.get_template_address("Shenanigans");
-    let (account, _, _) = test.create_owned_account();
+    let (account, _, _) = test.create_funded_account();
 
     let result = test.execute_expect_success(
         Transaction::builder()
@@ -242,7 +242,7 @@ fn it_prevents_access_to_out_of_scope_component() {
 fn it_disallows_calls_on_vaults_that_are_not_owned_by_current_component() {
     let mut test = TemplateTest::new(["tests/templates/shenanigans"]);
     let template_addr = test.get_template_address("Shenanigans");
-    let (victim, _, _) = test.create_owned_account();
+    let (victim, _, _) = test.create_funded_account();
     let (attacker, _, _) = test.create_empty_account();
 
     let vault_id = {
@@ -274,7 +274,7 @@ fn it_disallows_calls_on_vaults_that_are_not_owned_by_current_component() {
 fn it_disallows_vault_access_if_vault_is_not_owned() {
     let mut test = TemplateTest::new(["tests/templates/shenanigans"]);
     let template_addr = test.get_template_address("Shenanigans");
-    let (victim, _, _) = test.create_owned_account();
+    let (victim, _, _) = test.create_funded_account();
 
     let vault_id = {
         let component = test.read_only_state_store().get_component(victim).unwrap();

--- a/dan_layer/engine/tests/tariswap.rs
+++ b/dan_layer/engine/tests/tariswap.rs
@@ -28,7 +28,7 @@ fn setup(fee: u16) -> TariSwapTest {
 
     let (tariswap, lp_resource) = create_tariswap_component(&mut template_test, a_resource, b_resource, fee);
 
-    let (account_address, account_proof, _) = template_test.create_owned_account();
+    let (account_address, account_proof, _) = template_test.create_funded_account();
     fund_account(&mut template_test, account_address, a_faucet);
     fund_account(&mut template_test, account_address, b_faucet);
 

--- a/dan_layer/engine/tests/test.rs
+++ b/dan_layer/engine/tests/test.rs
@@ -493,7 +493,7 @@ mod basic_nft {
     ) {
         let mut template_test = TemplateTest::new(vec!["tests/templates/nft/basic_nft"]);
 
-        let (account_address, owner_token, _) = template_test.create_owned_account();
+        let (account_address, owner_token, _) = template_test.create_funded_account();
         let nft_component: ComponentAddress = template_test.call_function("SparkleNft", "new", args![], vec![]);
 
         let nft_resx = template_test.get_previous_output_address(SubstateType::Resource);
@@ -947,7 +947,7 @@ mod emoji_id {
         let mut template_test = TemplateTest::new(vec!["tests/templates/nft/emoji_id"]);
 
         // create an account
-        let (account_address, owner_proof, _) = template_test.create_owned_account();
+        let (account_address, owner_proof, _) = template_test.create_funded_account();
 
         // create a fungible token faucet, we are going to use those tokens as payments
         // TODO: use Thaums instead when they're implemented
@@ -1096,7 +1096,7 @@ mod tickets {
         let mut template_test = TemplateTest::new(vec!["tests/templates/nft/tickets"]);
 
         // create an account
-        let (account_address, owner_proof, secret) = template_test.create_owned_account();
+        let (account_address, owner_proof, secret) = template_test.create_funded_account();
 
         // create a fungible token faucet, we are going to use those tokens as payments
         // TODO: use Thaums instead when they're implemented
@@ -1236,7 +1236,7 @@ mod nft_indexes {
     ) {
         let mut template_test = TemplateTest::new(vec!["tests/templates/nft/nft_list"]);
 
-        let (account_address, owner_token, _) = template_test.create_owned_account();
+        let (account_address, owner_token, _) = template_test.create_funded_account();
         let nft_component: ComponentAddress = template_test.call_function("SparkleNft", "new", args![], vec![]);
 
         let nft_resx = template_test.get_previous_output_address(SubstateType::Resource);

--- a/dan_layer/engine_types/src/commit_result.rs
+++ b/dan_layer/engine_types/src/commit_result.rs
@@ -22,7 +22,7 @@
 
 use std::fmt::{self, Display, Formatter};
 
-use serde::{Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use tari_template_lib::Hash;
 #[cfg(feature = "ts")]
 use ts_rs::TS;
@@ -100,6 +100,15 @@ impl ExecuteResult {
         let receipt = &self.finalize.fee_receipt;
         assert!(receipt.is_paid_in_full(), "Fees not paid in full");
         receipt
+    }
+
+    pub fn expect_return<T: DeserializeOwned>(&self, index: usize) -> T {
+        self.finalize
+            .execution_results
+            .get(index)
+            .expect("No return value at index")
+            .decode()
+            .expect("Failed to decode return value")
     }
 }
 

--- a/dan_layer/template_lib/src/component/instance.rs
+++ b/dan_layer/template_lib/src/component/instance.rs
@@ -17,7 +17,7 @@ pub struct ComponentBuilder<T> {
     address_allocation: Option<AddressAllocation<ComponentAddress>>,
 }
 
-impl<T: serde::Serialize> ComponentBuilder<T> {
+impl<T> ComponentBuilder<T> {
     /// Returns a new component builder for the specified data
     fn new(component: T) -> Self {
         Self {
@@ -46,7 +46,9 @@ impl<T: serde::Serialize> ComponentBuilder<T> {
         self.access_rules = access_rules;
         self
     }
+}
 
+impl<T: serde::Serialize> ComponentBuilder<T> {
     /// Creates the new component and returns it
     pub fn create(self) -> Component<T> {
         let address = engine().create_component(

--- a/dan_layer/template_lib/src/models/bucket.rs
+++ b/dan_layer/template_lib/src/models/bucket.rs
@@ -213,4 +213,12 @@ impl Bucket {
         resp.decode()
             .expect("count_confidential_commitments returned invalid u32")
     }
+
+    pub fn assert_contains_no_confidential_funds(&self) {
+        let count = self.count_confidential_commitments();
+        assert_eq!(
+            count, 0,
+            "Expected bucket to have no confidential commitments, but found {count}",
+        );
+    }
 }

--- a/dan_layer/template_lib/src/models/resource.rs
+++ b/dan_layer/template_lib/src/models/resource.rs
@@ -30,7 +30,7 @@ use tari_template_abi::rust::{
 use ts_rs::TS;
 
 use super::{BinaryTag, EntityId, KeyParseError, ObjectKey};
-use crate::newtype_struct_serde_impl;
+use crate::{newtype_struct_serde_impl, prelude::CONFIDENTIAL_TARI_RESOURCE_ADDRESS};
 
 const TAG: u64 = BinaryTag::ResourceAddress.as_u64();
 
@@ -55,6 +55,10 @@ impl ResourceAddress {
 
     pub fn as_entity_id(&self) -> EntityId {
         self.as_object_key().as_entity_id()
+    }
+
+    pub fn is_tari(&self) -> bool {
+        *self == CONFIDENTIAL_TARI_RESOURCE_ADDRESS
     }
 }
 

--- a/dan_layer/template_lib/src/resource/builder/confidential.rs
+++ b/dan_layer/template_lib/src/resource/builder/confidential.rs
@@ -115,14 +115,14 @@ impl ConfidentialResourceBuilder {
     /// Specify a hook method that will be called to authorize actions on the resource.
     /// The signature of the method must be `fn(action: ResourceAuthAction, caller: CallerContext)`.
     /// The method should panic to deny the action.
-    /// The resource will fail to build if the component's template does not have a method with the specified signature.
+    /// The resource will fail to build if the component's template does not have a method with the correct signature.
     /// Hooks are only run when the resource is acted on by an external component.
     ///
     /// ## Examples
     ///
     /// Building a resource with a hook from within a component
     /// ```rust
-    /// use tari_template_lib::{caller_context::CallerContext, prelude::ResourceBuilder};
+    /// # use tari_template_lib::{caller_context::CallerContext, prelude::ResourceBuilder};
     /// ResourceBuilder::confidential()
     ///     .with_authorization_hook(CallerContext::current_component_address(), "my_hook")
     ///     .build();
@@ -131,7 +131,7 @@ impl ConfidentialResourceBuilder {
     /// Building a resource with a hook in a static template function. The address is allocated beforehand.
     ///
     /// ```rust
-    /// use tari_template_lib::{caller_context::CallerContext, prelude::ResourceBuilder};
+    /// # use tari_template_lib::{caller_context::CallerContext, prelude::ResourceBuilder};
     /// let alloc = CallerContext::allocate_component_address();
     /// ResourceBuilder::confidential()
     ///     .with_authorization_hook(*alloc.address(), "my_hook")

--- a/dan_layer/template_test_tooling/src/template_test.rs
+++ b/dan_layer/template_test_tooling/src/template_test.rs
@@ -233,7 +233,7 @@ impl TemplateTest {
             .unwrap()
             .get_value(path)
             .unwrap()
-            .unwrap()
+            .unwrap_or_else(|| panic!("Expected component to have value at '{path}' but no value was found"))
     }
 
     pub fn default_signing_key(&self) -> &RistrettoSecretKey {
@@ -397,7 +397,15 @@ impl TemplateTest {
         (component, owner_proof, secret_key)
     }
 
+    #[deprecated(
+        since = "0.1.0",
+        note = "Please use create_funded_account instead. This method will be removed."
+    )]
     pub fn create_owned_account(&mut self) -> (ComponentAddress, NonFungibleAddress, RistrettoSecretKey) {
+        self.create_funded_account()
+    }
+
+    pub fn create_funded_account(&mut self) -> (ComponentAddress, NonFungibleAddress, RistrettoSecretKey) {
         let (owner_proof, public_key, secret_key) = self.create_owner_proof();
         let old_fail_fees = self.enable_fees;
         self.enable_fees = false;

--- a/dan_layer/template_test_tooling/templates/faucet/Cargo.lock
+++ b/dan_layer/template_test_tooling/templates/faucet/Cargo.lock
@@ -376,7 +376,7 @@ dependencies = [
 
 [[package]]
 name = "tari_bor"
-version = "0.5.3"
+version = "0.6.0"
 dependencies = [
  "ciborium",
  "ciborium-io",
@@ -385,7 +385,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_abi"
-version = "0.5.3"
+version = "0.6.0"
 dependencies = [
  "serde",
  "tari_bor",
@@ -393,7 +393,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_lib"
-version = "0.5.3"
+version = "0.6.0"
 dependencies = [
  "newtype-ops",
  "serde",
@@ -405,7 +405,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_macros"
-version = "0.5.3"
+version = "0.6.0"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
Description
---
minor ergonomic improvements to test tooling
add missing serde feature to validator_node_client crate
better access denied message for component access rules
better error message for failed `extract_component_value` (previously unwrap on None)
deprecate `create_owned_account` in favour of `create_funded_account`
add `assert_contains_no_confidential_funds` method to Bucket
return_value accessor for test transaction  results

Motivation and Context
---
Minor clarity and ergonomics changes for template testing.
The missing serde "rc" feature caused compile to fail for `transaction_submitter`

How Has This Been Tested?
---
Existing tests

What process can a PR reviewer use to test or verify this change?
---
CI

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify