### PR TITLE
fix(consensus): deferred execution fixes

### DIFF
--- a/applications/tari_validator_node/src/p2p/services/mempool/executor.rs
+++ b/applications/tari_validator_node/src/p2p/services/mempool/executor.rs
@@ -62,10 +62,10 @@ where
 
     if !foreign.is_empty() {
         info!(target: LOG_TARGET, "Unable to execute transaction {} in the mempool because it has foreign inputs: {:?}", transaction.id(), foreign);
-        return Ok(Err(MempoolError::MustDeferExecution {
+        return Err(MempoolError::MustDeferExecution {
             local_substates,
             foreign_substates: foreign,
-        }));
+        });
     }
 
     info!(target: LOG_TARGET, "🎱 Transaction {} resolved local inputs = [{}]", transaction.id(), local_substates.keys().map(|addr| addr.to_string()).collect::<Vec<_>>().join(", "));

--- a/dan_layer/common_types/src/committee.rs
+++ b/dan_layer/common_types/src/committee.rs
@@ -237,10 +237,10 @@ impl CommitteeInfo {
     }
 
     /// Calculates the number of distinct shards for a given shard set
-    pub fn count_distinct_shards<'a, I: IntoIterator<Item = &'a SubstateAddress>>(&self, shards: I) -> usize {
+    pub fn count_distinct_shards<B: Borrow<SubstateAddress>, I: IntoIterator<Item = B>>(&self, shards: I) -> usize {
         shards
             .into_iter()
-            .map(|shard| shard.to_shard(self.num_committees))
+            .map(|shard| shard.borrow().to_shard(self.num_committees))
             .collect::<std::collections::HashSet<_>>()
             .len()
     }

--- a/dan_layer/consensus/src/hotstuff/substate_store/error.rs
+++ b/dan_layer/consensus/src/hotstuff/substate_store/error.rs
@@ -38,6 +38,8 @@ pub enum SubstateStoreError {
 
     #[error(transparent)]
     StoreError(#[from] StorageError),
+    #[error(transparent)]
+    StateTreeError(#[from] tari_state_tree::StateTreeError),
 }
 
 impl IsNotFoundError for SubstateStoreError {

--- a/dan_layer/storage/src/consensus_models/transaction.rs
+++ b/dan_layer/storage/src/consensus_models/transaction.rs
@@ -9,7 +9,7 @@ use tari_engine_types::commit_result::{ExecuteResult, FinalizeResult, RejectReas
 use tari_transaction::{Transaction, TransactionId, VersionedSubstateId};
 
 use crate::{
-    consensus_models::{Decision, ExecutedTransaction, TransactionAtom, VersionedSubstateIdLockIntent},
+    consensus_models::{BlockId, Decision, ExecutedTransaction, TransactionAtom, VersionedSubstateIdLockIntent},
     Ordering,
     StateStoreReadTransaction,
     StateStoreWriteTransaction,
@@ -236,13 +236,13 @@ impl TransactionRecord {
         tx.transactions_get_paginated(limit, offset, ordering)
     }
 
-    pub fn finalize_all<'a, TTx, I>(tx: &mut TTx, transactions: I) -> Result<(), StorageError>
+    pub fn finalize_all<'a, TTx, I>(tx: &mut TTx, block_id: BlockId, transactions: I) -> Result<(), StorageError>
     where
         TTx: StateStoreWriteTransaction + Deref,
         TTx::Target: StateStoreReadTransaction,
         I: IntoIterator<Item = &'a TransactionAtom>,
     {
-        tx.transactions_finalize_all(transactions)
+        tx.transactions_finalize_all(block_id, transactions)
     }
 }
 

--- a/dan_layer/storage/src/consensus_models/transaction_execution.rs
+++ b/dan_layer/storage/src/consensus_models/transaction_execution.rs
@@ -74,6 +74,15 @@ impl TransactionExecution {
     pub fn to_initial_evidence(&self) -> Evidence {
         Evidence::from_inputs_and_outputs(self.transaction_id, &self.resolved_inputs, &self.resulting_outputs)
     }
+
+    pub fn transaction_fee(&self) -> u64 {
+        self.result
+            .finalize
+            .fee_receipt
+            .total_fees_paid()
+            .as_u64_checked()
+            .unwrap()
+    }
 }
 
 impl TransactionExecution {

--- a/dan_layer/storage/src/consensus_models/transaction_pool.rs
+++ b/dan_layer/storage/src/consensus_models/transaction_pool.rs
@@ -248,6 +248,20 @@ impl<TStateStore: StateStore> TransactionPool<TStateStore> {
     ) -> Result<Vec<TransactionAtom>, TransactionPoolError> {
         TransactionPoolRecord::remove_all(tx, tx_ids)
     }
+
+    pub fn remove(
+        &self,
+        tx: &mut TStateStore::WriteTransaction<'_>,
+        id: TransactionId,
+    ) -> Result<TransactionAtom, TransactionPoolError> {
+        let atom = TransactionPoolRecord::remove_all(tx, &[id])?.pop().ok_or_else(|| {
+            TransactionPoolError::StorageError(StorageError::NotFound {
+                item: "TransactionPoolRecord".to_string(),
+                key: id.to_string(),
+            })
+        })?;
+        Ok(atom)
+    }
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -403,6 +417,11 @@ impl TransactionPoolRecord {
 
     pub fn set_initial_evidence(&mut self, evidence: Evidence) -> &mut Self {
         self.atom.evidence = evidence;
+        self
+    }
+
+    pub fn set_transaction_fee(&mut self, transaction_fee: u64) -> &mut Self {
+        self.atom.transaction_fee = transaction_fee;
         self
     }
 

--- a/dan_layer/storage/src/state_store/mod.rs
+++ b/dan_layer/storage/src/state_store/mod.rs
@@ -324,6 +324,7 @@ pub trait StateStoreWriteTransaction {
 
     fn transactions_finalize_all<'a, I: IntoIterator<Item = &'a TransactionAtom>>(
         &mut self,
+        block_id: BlockId,
         transaction: I,
     ) -> Result<(), StorageError>;
     // -------------------------------- Transaction Executions -------------------------------- //


### PR DESCRIPTION
Description
---
- fix incorrect transaction fee after execution
- fix incorrect resolved substates for rejected transations
- calculate merkle root for block after all executions for a block are complete
- commit JMT diff as part of block changeset
- fix deferred transaction finalization 
- fix mempool marks transaction as deferred and sends to consensus instead of ABORTing deferred transactions immediately

Motivation and Context
---
Number of omissions and bugs in deferred transaction execution are fixed in the PR.

How Has This Been Tested?
---
Manually, commenting out code in the wallet daemon and mempool that fills or resolves inputs for a transaction and use unversioned inputs. The results in deferred execution which succeeds after this PR. Tested creating an account and transferring. Also tested concurrent local-only conflicting transactions, the second transaction was aborted due to a lock conflict, this still needs to be investigated. 

What process can a PR reviewer use to test or verify this change?
---
It's currently not possible to directly test this on a single-shard network without forcing transactions to be deferred in code. Mutlishard deferred is not currently supported because we cannot resolve foreign inputs. 

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify