### PR TITLE
fix(template-lib)!: improve initial supply api resource builder

### DIFF
--- a/applications/tari_validator_node/src/bootstrap.rs
+++ b/applications/tari_validator_node/src/bootstrap.rs
@@ -485,7 +485,7 @@ where
     let substate_id = SubstateId::Resource(CONFIDENTIAL_TARI_RESOURCE_ADDRESS);
     let substate_address = SubstateAddress::from_substate_id(&substate_id, 0);
     let mut metadata = Metadata::new();
-    metadata.insert(TOKEN_SYMBOL, "tXTR2".to_string());
+    metadata.insert(TOKEN_SYMBOL, "tXTR".to_string());
     if !SubstateRecord::exists(&**tx, &substate_address)? {
         SubstateRecord {
             substate_id,

--- a/dan_layer/engine/src/bootstrap.rs
+++ b/dan_layer/engine/src/bootstrap.rs
@@ -40,7 +40,7 @@ pub fn bootstrap_state<T: StateWriter>(state_db: &mut T) -> Result<(), StateStor
     let address = SubstateId::Resource(CONFIDENTIAL_TARI_RESOURCE_ADDRESS);
     let mut metadata = Metadata::new();
     // TODO: decide on symbol for L2 tari
-    metadata.insert(TOKEN_SYMBOL, "tXTR2".to_string());
+    metadata.insert(TOKEN_SYMBOL, "tXTR".to_string());
     state_db.set_state(
         &address,
         Substate::new(

--- a/dan_layer/engine/src/runtime/impl.rs
+++ b/dan_layer/engine/src/runtime/impl.rs
@@ -83,7 +83,7 @@ use tari_template_lib::{
         WorkspaceAction,
     },
     auth::{AuthHook, AuthHookCaller, ComponentAccessRules, OwnerRule, ResourceAccessRules, ResourceAuthAction},
-    constants::{CONFIDENTIAL_TARI_RESOURCE_ADDRESS, XTR2},
+    constants::{CONFIDENTIAL_TARI_RESOURCE_ADDRESS, XTR},
     crypto::RistrettoPublicKeyBytes,
     models::{
         Amount,
@@ -1390,7 +1390,7 @@ impl<TTemplateProvider: TemplateProvider<Template = LoadedTemplate>> RuntimeInte
                 self.tracker.write_with(|state| {
                     let vault_lock = state.lock_substate(&SubstateId::Vault(vault_id), LockFlag::Write)?;
                     let resource_address = *state.get_vault(&vault_lock)?.resource_address();
-                    if resource_address != XTR2 {
+                    if resource_address != XTR {
                         return Err(RuntimeError::InvalidArgument {
                             argument: "vault_ref",
                             reason: format!(
@@ -1399,7 +1399,7 @@ impl<TTemplateProvider: TemplateProvider<Template = LoadedTemplate>> RuntimeInte
                             ),
                         });
                     }
-                    let resource_lock = state.lock_substate(&SubstateId::Resource(XTR2), LockFlag::Read)?;
+                    let resource_lock = state.lock_substate(&SubstateId::Resource(XTR), LockFlag::Read)?;
                     let resource = state.get_resource(&resource_lock)?;
 
                     state.authorization().check_resource_access_rules(
@@ -1411,7 +1411,7 @@ impl<TTemplateProvider: TemplateProvider<Template = LoadedTemplate>> RuntimeInte
 
                     let vault_mut = state.get_vault_mut(&vault_lock)?;
 
-                    let mut container = ResourceContainer::confidential(XTR2, None, Amount::zero());
+                    let mut container = ResourceContainer::confidential(XTR, None, Amount::zero());
                     if !arg.amount.is_zero() {
                         let withdrawn = vault_mut.withdraw(arg.amount)?;
                         container.deposit(withdrawn)?;

--- a/dan_layer/engine/src/runtime/impl.rs
+++ b/dan_layer/engine/src/runtime/impl.rs
@@ -1676,6 +1676,20 @@ impl<TTemplateProvider: TemplateProvider<Template = LoadedTemplate>> RuntimeInte
                     Ok(InvokeResult::encode(&bucket_id)?)
                 })
             },
+            BucketAction::Join => {
+                let bucket_id = bucket_ref.bucket_id().ok_or_else(|| RuntimeError::InvalidArgument {
+                    argument: "bucket_ref",
+                    reason: "Join bucket action requires a bucket id".to_string(),
+                })?;
+                let other_bucket_id = args.assert_one_arg()?;
+
+                self.tracker.write_with(|state| {
+                    let other_bucket = state.take_bucket(other_bucket_id)?;
+                    let bucket = state.get_bucket_mut(bucket_id)?;
+                    bucket.join(other_bucket)?;
+                    Ok(InvokeResult::encode(&bucket_id)?)
+                })
+            },
             BucketAction::RevealConfidential => {
                 let bucket_id = bucket_ref.bucket_id().ok_or_else(|| RuntimeError::InvalidArgument {
                     argument: "bucket_ref",

--- a/dan_layer/engine/src/runtime/scope.rs
+++ b/dan_layer/engine/src/runtime/scope.rs
@@ -6,7 +6,7 @@ use std::fmt::Display;
 use indexmap::IndexSet;
 use tari_engine_types::{indexed_value::IndexedWellKnownTypes, lock::LockId, substate::SubstateId, TemplateAddress};
 use tari_template_lib::{
-    constants::XTR2,
+    constants::XTR,
     models::{BucketId, EntityId, ProofId},
     prelude::PUBLIC_IDENTITY_RESOURCE_ADDRESS,
 };
@@ -80,8 +80,8 @@ impl CallScope {
 
     pub fn is_substate_in_scope(&self, address: &SubstateId) -> bool {
         // TODO: Hacky
-        // If the address is the XTR2 resource, it is always in scope
-        if *address == XTR2 {
+        // If the address is the XTR resource, it is always in scope
+        if *address == XTR {
             return true;
         }
 

--- a/dan_layer/engine/tests/resource.rs
+++ b/dan_layer/engine/tests/resource.rs
@@ -1,0 +1,27 @@
+//   Copyright 2024 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+use tari_template_lib::{args, models::ComponentAddress};
+use tari_template_test_tooling::{support::confidential::generate_confidential_proof, TemplateTest};
+
+#[test]
+fn fungible_join() {
+    let mut test = TemplateTest::new(vec!["tests/templates/resource"]);
+    let component: ComponentAddress = test.call_function("ResourceTest", "new", args![], vec![]);
+    test.call_method::<()>(component, "fungible_join", args![], vec![]);
+}
+
+#[test]
+fn non_fungible_join() {
+    let mut test = TemplateTest::new(vec!["tests/templates/resource"]);
+    let component: ComponentAddress = test.call_function("ResourceTest", "new", args![], vec![]);
+    test.call_method::<()>(component, "non_fungible_join", args![], vec![]);
+}
+
+#[test]
+fn confidential_join() {
+    let mut test = TemplateTest::new(vec!["tests/templates/resource"]);
+    let component: ComponentAddress = test.call_function("ResourceTest", "new", args![], vec![]);
+    let (output, _, _) = generate_confidential_proof(1000.into(), None);
+    test.call_method::<()>(component, "confidential_join", args![output], vec![]);
+}

--- a/dan_layer/engine/tests/shenanigans.rs
+++ b/dan_layer/engine/tests/shenanigans.rs
@@ -6,7 +6,7 @@ use tari_engine_types::{indexed_value::IndexedWellKnownTypes, resource_container
 use tari_template_lib::{
     args,
     args::VaultAction,
-    constants::XTR2,
+    constants::XTR,
     models::{Amount, ComponentAddress, ResourceAddress},
     prelude::ResourceType,
 };
@@ -138,7 +138,7 @@ fn it_rejects_references_to_buckets_that_arent_in_scope() {
 
     let reason = test.execute_expect_failure(
         Transaction::builder()
-            .call_method(account, "withdraw", args![XTR2, Amount(1000)])
+            .call_method(account, "withdraw", args![XTR, Amount(1000)])
             .put_last_instruction_output_on_workspace("bucket")
             .call_method(shenanigans, "take_bucket_zero", args![])
             .sign(&owner_key)

--- a/dan_layer/engine/tests/templates/access_rules/src/lib.rs
+++ b/dan_layer/engine/tests/templates/access_rules/src/lib.rs
@@ -9,9 +9,12 @@ pub fn create_badge_resource(recall_rule: AccessRule) -> Bucket {
     let mut metadata = Metadata::new();
     metadata.insert("colour", "blue");
     ResourceBuilder::non_fungible()
-        .mint_many_with(BADGE_NAMES, |name| (NonFungibleId::from_string(name), (&metadata, &())))
         .recallable(recall_rule)
-        .build_bucket()
+        .initial_supply_with_data(
+            BADGE_NAMES
+                .into_iter()
+                .map(|name| (NonFungibleId::from_string(name), (&metadata, &()))),
+        )
 }
 
 #[template]
@@ -36,8 +39,7 @@ mod access_rules_template {
             let tokens = ResourceBuilder::fungible()
                 .with_owner_rule(owner_rule.clone())
                 .with_access_rules(resource_rules)
-                .initial_supply(1000)
-                .build_bucket();
+                .initial_supply(1000);
 
             let badges = create_badge_resource(recall_rule);
 
@@ -56,7 +58,7 @@ mod access_rules_template {
         pub fn default_rules() -> Component<AccessRulesTest> {
             let badges = create_badge_resource(AccessRule::DenyAll);
 
-            let tokens = ResourceBuilder::fungible().initial_supply(1000).build_bucket();
+            let tokens = ResourceBuilder::fungible().initial_supply(1000);
 
             Component::create(Self {
                 value: 0,
@@ -73,9 +75,8 @@ mod access_rules_template {
             let address_alloc = CallerContext::allocate_component_address();
 
             let tokens = ResourceBuilder::fungible()
-                .initial_supply(1000)
                 .with_authorization_hook(*address_alloc.address(), hook)
-                .build_bucket();
+                .initial_supply(1000);
 
             Component::new(Self {
                 value: 0,
@@ -95,12 +96,11 @@ mod access_rules_template {
             let address_alloc = CallerContext::allocate_component_address();
 
             let tokens = ResourceBuilder::fungible()
-                .initial_supply(1000)
                 .with_authorization_hook(
                     *address_alloc.address(),
                     "malicious_auth_hook_set_state_on_another_component",
                 )
-                .build_bucket();
+                .initial_supply(1000);
 
             Component::new(Self {
                 value: 0,
@@ -119,7 +119,6 @@ mod access_rules_template {
 
             let badge_resource = badges.resource_address();
             let tokens = ResourceBuilder::fungible()
-                .initial_supply(1000)
                 .mintable(AccessRule::Restricted(RestrictedAccessRule::Require(
                     RequireRule::Require(
                         NonFungibleAddress::new(badge_resource, NonFungibleId::from_string("mint")).into(),
@@ -140,7 +139,7 @@ mod access_rules_template {
                         NonFungibleAddress::new(badge_resource, NonFungibleId::from_string("deposit")).into(),
                     ),
                 )))
-                .build_bucket();
+                .initial_supply(1000);
 
             Component::new(Self {
                 value: 0,
@@ -158,7 +157,6 @@ mod access_rules_template {
 
             let badge_resource = badges.resource_address();
             let tokens = ResourceBuilder::fungible()
-                .initial_supply(1000)
                 .mintable(AccessRule::Restricted(RestrictedAccessRule::Require(
                     RequireRule::Require(badge_resource.into()),
                 )))
@@ -171,7 +169,7 @@ mod access_rules_template {
                 .depositable(AccessRule::Restricted(RestrictedAccessRule::Require(
                     RequireRule::Require(badge_resource.into()),
                 )))
-                .build_bucket();
+                .initial_supply(1000);
 
             Component::new(Self {
                 value: 0,
@@ -189,13 +187,12 @@ mod access_rules_template {
 
             let allocation = CallerContext::allocate_component_address();
             let tokens = ResourceBuilder::fungible()
-                .initial_supply(1000)
                 .mintable(AccessRule::Restricted(RestrictedAccessRule::Require(
                     RequireRule::Require(allocation.address().clone().into()),
                 )))
                 // Only access rules apply, this just makes the test simpler because we do not need to change the transaction signer
                 .with_owner_rule(OwnerRule::None)
-                .build_bucket();
+                .initial_supply(1000);
 
             Component::new(Self {
                 value: 0,

--- a/dan_layer/engine/tests/templates/confidential/faucet/src/lib.rs
+++ b/dan_layer/engine/tests/templates/confidential/faucet/src/lib.rs
@@ -34,8 +34,7 @@ mod faucet_template {
         pub fn mint(confidential_proof: ConfidentialOutputStatement) -> Component<Self> {
             let coins = ResourceBuilder::confidential()
                 .mintable(AccessRule::AllowAll)
-                .initial_supply(confidential_proof)
-                .build_bucket();
+                .initial_supply(confidential_proof);
 
             Component::new(Self {
                 vault: Vault::from_bucket(coins),
@@ -50,9 +49,8 @@ mod faucet_template {
         ) -> Component<Self> {
             let coins = ResourceBuilder::confidential()
                 .mintable(AccessRule::AllowAll)
-                .initial_supply(confidential_proof)
                 .with_view_key(view_key)
-                .build_bucket();
+                .initial_supply(confidential_proof);
 
             Component::new(Self {
                 vault: Vault::from_bucket(coins),

--- a/dan_layer/engine/tests/templates/nft/airdrop/src/lib.rs
+++ b/dan_layer/engine/tests/templates/nft/airdrop/src/lib.rs
@@ -37,8 +37,7 @@ mod airdrop_template {
         pub fn new() -> Component<Self> {
             let bucket = ResourceBuilder::non_fungible()
                 .with_token_symbol("AIR")
-                .mint_many_with(1..=100, |n| (NonFungibleId::from_u32(n), (&(), &())))
-                .build_bucket();
+                .initial_supply((1..=100).map(NonFungibleId::from_u32));
 
             Component::new(Self {
                 allow_list: HashSet::new(),

--- a/dan_layer/engine/tests/templates/nft/basic_nft/src/lib.rs
+++ b/dan_layer/engine/tests/templates/nft/basic_nft/src/lib.rs
@@ -39,17 +39,16 @@ mod sparkle_nft_template {
         pub fn new() -> Component<Self> {
             // Create the non-fungible resource with 1 token (optional)
             let tokens = [
-                (NonFungibleId::from_u32(1), (&(), &())),
-                (NonFungibleId::from_u64(u64::MAX), (&(), &())),
-                (NonFungibleId::from_string("Sparkle1"), (&(), &())),
-                (NonFungibleId::from_u256([0u8; 32]), (&(), &())),
+                NonFungibleId::from_u32(1),
+                NonFungibleId::from_u64(u64::MAX),
+                NonFungibleId::from_string("Sparkle1"),
+                NonFungibleId::from_u256([0u8; 32]),
             ];
             let bucket = ResourceBuilder::non_fungible().with_token_symbol("SPKL")
-                .with_non_fungibles(tokens)
                 // Allow minting and burning for tests
                 .mintable(AccessRule::AllowAll)
                 .burnable(AccessRule::AllowAll)
-                .build_bucket();
+                .initial_supply(tokens);
 
             Component::new(Self {
                 address: bucket.resource_address(),

--- a/dan_layer/engine/tests/templates/recall/src/lib.rs
+++ b/dan_layer/engine/tests/templates/recall/src/lib.rs
@@ -19,21 +19,19 @@ mod template {
             confidential_supply: ConfidentialOutputStatement,
         ) -> (Component<Self>, ResourceAddress, ResourceAddress, ResourceAddress) {
             let fungible = ResourceBuilder::fungible()
-                .initial_supply(Amount(1_000_000))
                 .recallable(AccessRule::AllowAll)
-                .build_bucket();
+                .initial_supply(Amount(1_000_000));
+
             let fungible_resource = fungible.resource_address();
 
             let non_fungible = ResourceBuilder::non_fungible()
-                .mint_many_with(1..=10, |n| (NonFungibleId::from_u32(n), (&(), &())))
                 .recallable(AccessRule::AllowAll)
-                .build_bucket();
+                .initial_supply((1..=10).map(NonFungibleId::from_u32));
             let non_fungible_resource = non_fungible.resource_address();
 
             let confidential = ResourceBuilder::confidential()
-                .initial_supply(confidential_supply)
                 .recallable(AccessRule::AllowAll)
-                .build_bucket();
+                .initial_supply(confidential_supply);
             let confidential_resource = confidential.resource_address();
 
             let component = Component::new(Self {

--- a/dan_layer/engine/tests/templates/resource/Cargo.toml
+++ b/dan_layer/engine/tests/templates/resource/Cargo.toml
@@ -1,0 +1,14 @@
+[workspace]
+[package]
+name = "hello_world"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+tari_template_lib = { path = "../../../../template_lib" }
+
+
+[lib]
+crate-type = ["cdylib", "lib"]

--- a/dan_layer/engine/tests/templates/resource/src/lib.rs
+++ b/dan_layer/engine/tests/templates/resource/src/lib.rs
@@ -1,0 +1,84 @@
+//  Copyright 2022. The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use tari_template_lib::prelude::*;
+
+#[template]
+mod template {
+    use super::*;
+
+    pub struct ResourceTest {
+        fungible: Vault,
+        non_fungible: Vault,
+        confidential: Vault,
+    }
+
+    impl ResourceTest {
+        pub fn new() -> Component<Self> {
+            let fungible = ResourceBuilder::fungible().initial_supply(1000);
+            let non_fungible = ResourceBuilder::non_fungible()
+                .initial_supply([NonFungibleId::from_u64(1), NonFungibleId::from_u64(2)]);
+            let confidential = ResourceBuilder::confidential()
+                .mintable(AccessRule::AllowAll)
+                .initial_supply(ConfidentialOutputStatement::mint_revealed(1000));
+
+            Component::new(Self {
+                fungible: Vault::from_bucket(fungible),
+                non_fungible: Vault::from_bucket(non_fungible),
+                confidential: Vault::from_bucket(confidential),
+            })
+            .with_access_rules(AccessRules::allow_all())
+            .create()
+        }
+
+        pub fn fungible_join(&self) {
+            let b1 = self.fungible.withdraw(10);
+            let b2 = self.fungible.withdraw(900);
+            let joined = b1.join(b2);
+            assert_eq!(joined.amount(), 910);
+            self.fungible.deposit(joined);
+        }
+
+        pub fn non_fungible_join(&self) {
+            let b1 = self.non_fungible.withdraw_non_fungible(NonFungibleId::from_u64(1));
+            let b2 = self.non_fungible.withdraw_non_fungible(NonFungibleId::from_u64(2));
+            let joined = b1.join(b2);
+            assert_eq!(joined.amount(), 2);
+            self.non_fungible.deposit(joined);
+        }
+
+        pub fn confidential_join(&self, output: ConfidentialOutputStatement) {
+            let commitments = ResourceManager::get(self.confidential.resource_address()).mint_confidential(output);
+            let b1 = self
+                .confidential
+                .withdraw_confidential(ConfidentialWithdrawProof::revealed_withdraw(10));
+            let b2 = self
+                .confidential
+                .withdraw_confidential(ConfidentialWithdrawProof::revealed_withdraw(900));
+            let joined = b1.join(b2);
+            let joined = joined.join(commitments);
+            assert_eq!(joined.amount(), 910);
+            self.confidential.deposit(joined);
+            assert_eq!(self.confidential.commitment_count(), 1);
+        }
+    }
+}

--- a/dan_layer/engine_types/src/bucket.rs
+++ b/dan_layer/engine_types/src/bucket.rs
@@ -92,6 +92,10 @@ impl Bucket {
         self.resource_container.withdraw_confidential(proof, view_key)
     }
 
+    pub fn join(&mut self, other: Bucket) -> Result<(), ResourceError> {
+        self.resource_container.deposit(other.resource_container)
+    }
+
     pub fn reveal_confidential(
         &mut self,
         proof: ConfidentialWithdrawProof,

--- a/dan_layer/template_lib/src/args/types.rs
+++ b/dan_layer/template_lib/src/args/types.rs
@@ -423,6 +423,7 @@ pub enum BucketAction {
     GetAmount,
     Take,
     TakeConfidential,
+    Join,
     RevealConfidential,
     Burn,
     CreateProof,

--- a/dan_layer/template_lib/src/constants.rs
+++ b/dan_layer/template_lib/src/constants.rs
@@ -18,4 +18,4 @@ pub const CONFIDENTIAL_TARI_RESOURCE_ADDRESS: ResourceAddress =
     ResourceAddress::new(ObjectKey::from_array([1u8; ObjectKey::LENGTH]));
 
 /// Shorthand version of the `CONFIDENTIAL_TARI_RESOURCE_ADDRESS` constant
-pub const XTR2: ResourceAddress = CONFIDENTIAL_TARI_RESOURCE_ADDRESS;
+pub const XTR: ResourceAddress = CONFIDENTIAL_TARI_RESOURCE_ADDRESS;

--- a/dan_layer/template_lib/src/models/amount.rs
+++ b/dan_layer/template_lib/src/models/amount.rs
@@ -180,6 +180,21 @@ impl PartialEq<u64> for Amount {
     }
 }
 
+impl PartialEq<i32> for Amount {
+    fn eq(&self, other: &i32) -> bool {
+        i32::try_from(self.0).map_or(false, |v| v == *other)
+    }
+}
+
+impl PartialEq<u32> for Amount {
+    fn eq(&self, other: &u32) -> bool {
+        if self.is_negative() {
+            return false;
+        }
+        u32::try_from(self.0).map_or(false, |v| v == *other)
+    }
+}
+
 impl PartialOrd<u64> for Amount {
     fn partial_cmp(&self, other: &u64) -> Option<cmp::Ordering> {
         match i64::try_from(*other) {

--- a/dan_layer/template_lib/src/models/bucket.rs
+++ b/dan_layer/template_lib/src/models/bucket.rs
@@ -145,6 +145,18 @@ impl Bucket {
         (new_bucket, self)
     }
 
+    /// Joins the bucket with another of the same resource type, returning a new joined bucket with the value of both.
+    /// Will panic if the other bucket is not of the same resource type.
+    pub fn join(self, other: Bucket) -> Self {
+        let resp: InvokeResult = call_engine(EngineOp::BucketInvoke, &BucketInvokeArg {
+            bucket_ref: BucketRef::Ref(self.id),
+            action: BucketAction::Join,
+            args: invoke_args![other.id],
+        });
+
+        resp.decode().expect("Bucket join returned invalid result")
+    }
+
     /// Returns how many tokens this bucket holds
     pub fn amount(&self) -> Amount {
         let resp: InvokeResult = call_engine(EngineOp::BucketInvoke, &BucketInvokeArg {

--- a/dan_layer/template_lib/src/models/confidential_proof.rs
+++ b/dan_layer/template_lib/src/models/confidential_proof.rs
@@ -31,12 +31,12 @@ pub struct ConfidentialOutputStatement {
 
 impl ConfidentialOutputStatement {
     /// Creates an output proof for minting which only mints a revealed amount.
-    pub fn mint_revealed(amount: Amount) -> Self {
+    pub fn mint_revealed<T: Into<Amount>>(amount: T) -> Self {
         Self {
             output_statement: None,
             change_statement: None,
             range_proof: vec![],
-            output_revealed_amount: amount,
+            output_revealed_amount: amount.into(),
             change_revealed_amount: Amount::zero(),
         }
     }
@@ -145,11 +145,12 @@ pub struct ConfidentialWithdrawProof {
 
 impl ConfidentialWithdrawProof {
     /// Creates a withdrawal proof for revealed funds of a specific amount
-    pub fn revealed_withdraw(amount: Amount) -> Self {
+    pub fn revealed_withdraw<T: Into<Amount>>(amount: T) -> Self {
         // There are no confidential inputs or outputs (this amounts to the same thing as a Fungible resource transfer)
         // So signature s = 0 + e.x where x is a 0 excess, is valid.
         let balance_proof = BalanceProofSignature::try_from_parts(&[0u8; 32], &[0u8; 32]).unwrap();
 
+        let amount = amount.into();
         Self {
             inputs: vec![],
             input_revealed_amount: amount,

--- a/dan_layer/template_lib/src/models/non_fungible.rs
+++ b/dan_layer/template_lib/src/models/non_fungible.rs
@@ -9,8 +9,6 @@ use tari_template_abi::{
     rust::{fmt, fmt::Display, str::FromStr, write},
     EngineOp,
 };
-#[cfg(feature = "ts")]
-use ts_rs::TS;
 
 use super::BinaryTag;
 use crate::{
@@ -27,7 +25,11 @@ const DELIM: char = ':';
 /// The unique identification of a non-fungible token inside it's parent resource
 #[serde_as]
 #[derive(Debug, Clone, Ord, PartialOrd, PartialEq, Eq, Serialize, Deserialize, Hash)]
-#[cfg_attr(feature = "ts", derive(TS), ts(export, export_to = "../../bindings/src/types/"))]
+#[cfg_attr(
+    feature = "ts",
+    derive(ts_rs::TS),
+    ts(export, export_to = "../../bindings/src/types/")
+)]
 pub enum NonFungibleId {
     U256(#[serde_as(as = "serde_with::Bytes")] [u8; 32]),
     String(String),
@@ -203,12 +205,20 @@ const TAG: u64 = BinaryTag::NonFungibleAddress.as_u64();
 
 /// The unique identifier of a non-fungible index in the Tari network
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, PartialOrd, Ord)]
-#[cfg_attr(feature = "ts", derive(TS), ts(export, export_to = "../../bindings/src/types/"))]
+#[cfg_attr(
+    feature = "ts",
+    derive(ts_rs::TS),
+    ts(export, export_to = "../../bindings/src/types/")
+)]
 pub struct NonFungibleAddress(#[cfg_attr(feature = "ts", ts(type = "string"))] BorTag<NonFungibleAddressContents, TAG>);
 
 /// Data used to build a `NonFungibleAddress`
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, PartialOrd, Ord)]
-#[cfg_attr(feature = "ts", derive(TS), ts(export, export_to = "../../bindings/src/types/"))]
+#[cfg_attr(
+    feature = "ts",
+    derive(ts_rs::TS),
+    ts(export, export_to = "../../bindings/src/types/")
+)]
 pub struct NonFungibleAddressContents {
     resource_address: ResourceAddress,
     id: NonFungibleId,

--- a/dan_layer/template_lib/src/models/vault.rs
+++ b/dan_layer/template_lib/src/models/vault.rs
@@ -195,11 +195,11 @@ impl Vault {
     }
 
     /// Withdraw an `amount` of tokens from the vault into a new bucket.
-    pub fn withdraw(&self, amount: Amount) -> Bucket {
+    pub fn withdraw<T: Into<Amount>>(&self, amount: T) -> Bucket {
         let resp: InvokeResult = call_engine(EngineOp::VaultInvoke, &VaultInvokeArg {
             vault_ref: self.vault_ref(),
             action: VaultAction::Withdraw,
-            args: invoke_args![VaultWithdrawArg::Fungible { amount }],
+            args: invoke_args![VaultWithdrawArg::Fungible { amount: amount.into() }],
         });
 
         resp.decode().expect("failed to decode Bucket")

--- a/dan_layer/template_lib/src/prelude.rs
+++ b/dan_layer/template_lib/src/prelude.rs
@@ -34,7 +34,7 @@ pub use crate::{
     caller_context::CallerContext,
     component::{Component, ComponentManager},
     consensus::Consensus,
-    constants::{CONFIDENTIAL_TARI_RESOURCE_ADDRESS, PUBLIC_IDENTITY_RESOURCE_ADDRESS, XTR2},
+    constants::{CONFIDENTIAL_TARI_RESOURCE_ADDRESS, PUBLIC_IDENTITY_RESOURCE_ADDRESS, XTR},
     crypto::{PedersonCommitmentBytes, RistrettoPublicKeyBytes},
     debug,
     error,

--- a/dan_layer/template_test_tooling/templates/faucet/src/lib.rs
+++ b/dan_layer/template_test_tooling/templates/faucet/src/lib.rs
@@ -38,8 +38,7 @@ mod faucet_template {
         pub fn mint_with_symbol(initial_supply: Amount, symbol: String) -> Component<Self> {
             let coins = ResourceBuilder::fungible()
                 .with_token_symbol(symbol)
-                .initial_supply(initial_supply)
-                .build_bucket();
+                .initial_supply(initial_supply);
 
             Component::new(Self {
                 vault: Vault::from_bucket(coins),

--- a/integration_tests/src/templates/basic_nft/Cargo.toml
+++ b/integration_tests/src/templates/basic_nft/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tari_template_lib = {path="../../../../dan_layer/template_lib"}
+tari_template_lib = { path = "../../../../dan_layer/template_lib" }
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"] }
 
 [profile.release]

--- a/integration_tests/src/templates/basic_nft/src/lib.rs
+++ b/integration_tests/src/templates/basic_nft/src/lib.rs
@@ -58,7 +58,7 @@ mod sparkle_nft_template {
                 // AllowAll makes testing easier
                 .mintable(AccessRule::AllowAll)
                 .burnable(AccessRule::AllowAll)
-                .build_bucket();
+                .initial_supply_with_data(Some((nft, (&(), &empty))));
 
             Component::new(Self {
                 resource_address: bucket.resource_address(),

--- a/integration_tests/src/templates/basic_nft/src/lib.rs
+++ b/integration_tests/src/templates/basic_nft/src/lib.rs
@@ -36,7 +36,8 @@ mod sparkle_nft_template {
 
     impl SparkleNft {
         pub fn new() -> Component<Self> {
-            let resource_address = ResourceBuilder::non_fungible().with_token_symbol("SPKL")
+            let resource_address = ResourceBuilder::non_fungible()
+                .with_token_symbol("SPKL")
                 // AllowAll makes testing easier
                 .mintable(AccessRule::AllowAll)
                 .burnable(AccessRule::AllowAll)
@@ -53,8 +54,8 @@ mod sparkle_nft_template {
 
         pub fn new_with_initial_nft(nft: NonFungibleId) -> Component<Self> {
             let empty = Metadata::new();
-            let bucket = ResourceBuilder::non_fungible().with_token_symbol("SPKL")
-                .with_non_fungibles(Some((nft, (&(), &empty))))
+            let bucket = ResourceBuilder::non_fungible()
+                .with_token_symbol("SPKL")
                 // AllowAll makes testing easier
                 .mintable(AccessRule::AllowAll)
                 .burnable(AccessRule::AllowAll)
@@ -85,7 +86,7 @@ mod sparkle_nft_template {
             immutable_data.insert("name", name).insert("image_url", url);
 
             // Mint the NFT, this will fail if the token ID already exists
-            let mut res_manager = ResourceManager::get(self.resource_address);
+            let res_manager = ResourceManager::get(self.resource_address);
             res_manager.mint_non_fungible(id.clone(), &immutable_data, &Sparkle { brightness: 0 })
         }
 
@@ -108,7 +109,7 @@ mod sparkle_nft_template {
             nft.set_mutable_data(&data);
         }
 
-        pub fn burn(&mut self, mut bucket: Bucket) {
+        pub fn burn(&mut self, bucket: Bucket) {
             // this check is actually not needed, but with it we cover the "bucket.resource_type" method
             assert!(
                 bucket.resource_type() == ResourceType::NonFungible,

--- a/integration_tests/src/templates/counter/Cargo.toml
+++ b/integration_tests/src/templates/counter/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tari_template_lib = {path="../../../../dan_layer/template_lib"}
+tari_template_lib = { path = "../../../../dan_layer/template_lib" }
 
 [profile.release]
 opt-level = 's'     # Optimize for size.

--- a/integration_tests/src/templates/faucet/Cargo.toml
+++ b/integration_tests/src/templates/faucet/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tari_template_lib = {path="../../../../dan_layer/template_lib"}
+tari_template_lib = { path = "../../../../dan_layer/template_lib" }
 
 [profile.release]
 opt-level = 's'     # Optimize for size.

--- a/integration_tests/src/templates/faucet/src/lib.rs
+++ b/integration_tests/src/templates/faucet/src/lib.rs
@@ -34,8 +34,7 @@ mod faucet_template {
         pub fn mint(initial_supply: Amount) -> Component<Self> {
             let coins = ResourceBuilder::fungible()
                 .with_token_symbol("FAUCET")
-                .initial_supply(initial_supply)
-                .build_bucket();
+                .initial_supply(initial_supply);
 
             Component::new(Self {
                 vault: Vault::from_bucket(coins),
@@ -52,6 +51,5 @@ mod faucet_template {
             debug!("Withdrawing {} coins from faucet", amount);
             self.vault.withdraw(amount)
         }
-
     }
 }

--- a/integration_tests/src/templates/fees/Cargo.toml
+++ b/integration_tests/src/templates/fees/Cargo.toml
@@ -18,10 +18,3 @@ strip = "debuginfo" # Strip debug info.
 
 [lib]
 crate-type = ["cdylib", "lib"]
-
-[dev-dependencies]
-tari_dan_engine = { path = "../../../../dan_layer/engine" }
-tari_dan_common_types = { path = "../../../../dan_layer/common_types" }
-
-tari_crypto = { workspace = true }
-tari_common_types = { git = "https://github.com/tari-project/tari.git", branch = "feature-dan2", package = "tari_common_types" }

--- a/utilities/tariswap_test_bench/src/accounts.rs
+++ b/utilities/tariswap_test_bench/src/accounts.rs
@@ -112,9 +112,9 @@ impl Runner {
                     revealed_amount: 1_000_000.into(),
                     output: None,
                 })
-                .put_last_instruction_output_on_workspace("xtr2")
+                .put_last_instruction_output_on_workspace("xtr")
                 .call_method(account.address.as_component_address().unwrap(), "deposit", args![
-                    Workspace("xtr2")
+                    Workspace("xtr")
                 ]);
         }
 

--- a/utilities/tariswap_test_bench/src/tariswap.rs
+++ b/utilities/tariswap_test_bench/src/tariswap.rs
@@ -6,7 +6,7 @@ use tari_dan_wallet_sdk::{apis::key_manager::TRANSACTION_BRANCH, models::Account
 use tari_template_lib::{
     args,
     models::{Amount, ComponentAddress},
-    prelude::XTR2,
+    prelude::XTR,
 };
 use tari_transaction::{SubstateRequirement, Transaction};
 
@@ -30,7 +30,7 @@ impl Runner {
         );
         for _ in 0..num_tariswaps {
             builder = builder.call_function(self.tariswap_template.address, "new", args![
-                XTR2,
+                XTR,
                 faucet.resource_address,
                 Amount(1)
             ]);
@@ -67,11 +67,11 @@ impl Runner {
                 let transaction = Transaction::builder()
                     .with_inputs(vec![
                         SubstateRequirement::new(faucet.resource_address.into(), Some(0)),
-                        SubstateRequirement::new(XTR2.into(), Some(0)),
+                        SubstateRequirement::new(XTR.into(), Some(0)),
                     ])
                     .fee_transaction_pay_from_component(account.address.as_component_address().unwrap(), Amount(1000))
                     .call_method(account.address.as_component_address().unwrap(), "withdraw", args![
-                        XTR2, amount_a
+                        XTR, amount_a
                     ])
                     .put_last_instruction_output_on_workspace("a")
                     .call_method(account.address.as_component_address().unwrap(), "withdraw", args![
@@ -113,7 +113,7 @@ impl Runner {
         let key = self.sdk.key_manager_api().derive_key(TRANSACTION_BRANCH, 0)?;
 
         let mut tx_ids = vec![];
-        // Swap XTR2 for faucet
+        // Swap XTR for faucet
         // Batch these otherwise we can break consensus (proposed with locked object)
         for i in 0..5 {
             for (i, account) in accounts.iter().enumerate().skip(i * 200).take(200) {
@@ -122,15 +122,15 @@ impl Runner {
                     // Use resources as input refs to allow concurrent access.
                     .with_inputs(vec![
                         SubstateRequirement::new(faucet.resource_address.into(), Some(0)),
-                        SubstateRequirement::new(XTR2.into(), Some(0)),
+                        SubstateRequirement::new(XTR.into(), Some(0)),
                     ])
                     .fee_transaction_pay_from_component(account.address.as_component_address().unwrap(), Amount(1000))
-                    .call_method(tariswap.component_address, "get_pool_balance", args![ XTR2, ])
+                    .call_method(tariswap.component_address, "get_pool_balance", args![ XTR, ])
                     .call_method(tariswap.component_address, "get_pool_balance", args![ faucet.resource_address, ])
-                    .call_method(tariswap.component_address, "get_pool_ratio", args![XTR2, Amount(1000)])
+                    .call_method(tariswap.component_address, "get_pool_ratio", args![XTR, Amount(1000)])
                     .call_method(tariswap.component_address, "get_pool_ratio", args![faucet.resource_address, Amount(1000)])
                     .call_method(account.address.as_component_address().unwrap(), "withdraw", args![
-                    XTR2, amount_a_for_b
+                    XTR, amount_a_for_b
                 ])
                     .put_last_instruction_output_on_workspace("a")
                     .call_method(tariswap.component_address, "swap", args![
@@ -155,14 +155,14 @@ impl Runner {
                 let ratio_b = result.execution_results[3].decode::<Amount>()?;
                 let amount_swapped = amount_a_for_b.value() as f64 * (ratio_b.value() as f64 / 1000.0);
                 log::info!(
-                    "Swap {n} for {amount_a_for_b} XTR2 -> {amount_swapped} FAUCET @ {ratio_a}:{ratio_b} | pool \
-                     liquidity: {balance_a} XTR2 {balance_b} FAUCET",
+                    "Swap {n} for {amount_a_for_b} XTR -> {amount_swapped} FAUCET @ {ratio_a}:{ratio_b} | pool \
+                     liquidity: {balance_a} XTR {balance_b} FAUCET",
                     n = (i + 1) * (j + 1)
                 );
             }
         }
 
-        // Swap faucet for XTR2
+        // Swap faucet for XTR
         for i in 0..5 {
             for (i, account) in accounts.iter().enumerate().skip(i * 200).take(200) {
                 let tariswap = &tariswaps[i % tariswaps.len()];
@@ -170,12 +170,12 @@ impl Runner {
                     // Use resources as input refs to allow concurrent access.
                     .with_inputs(vec![
                         SubstateRequirement::new(faucet.resource_address.into(), Some(0)),
-                        SubstateRequirement::new(XTR2.into(), Some(0)),
+                        SubstateRequirement::new(XTR.into(), Some(0)),
                     ])
                     .fee_transaction_pay_from_component(account.address.as_component_address().unwrap(), Amount(1000))
-                    .call_method(tariswap.component_address, "get_pool_balance", args![XTR2])
+                    .call_method(tariswap.component_address, "get_pool_balance", args![XTR])
                     .call_method(tariswap.component_address, "get_pool_balance", args![faucet.resource_address])
-                    .call_method(tariswap.component_address, "get_pool_ratio", args![XTR2, Amount(1000)])
+                    .call_method(tariswap.component_address, "get_pool_ratio", args![XTR, Amount(1000)])
                     .call_method(tariswap.component_address, "get_pool_ratio", args![faucet.resource_address, Amount(1000)])
                     .call_method(account.address.as_component_address().unwrap(), "withdraw", args![
                         faucet.resource_address, amount_b_for_a
@@ -183,7 +183,7 @@ impl Runner {
                     .put_last_instruction_output_on_workspace("b")
                     .call_method(tariswap.component_address, "swap", args![
                         Workspace("b"),
-                        XTR2,
+                        XTR,
                     ])
                     .put_last_instruction_output_on_workspace("swapped")
                     .call_method(account.address.as_component_address().unwrap(), "deposit", args![
@@ -203,8 +203,8 @@ impl Runner {
                 let ratio_b = result.execution_results[3].decode::<Amount>()?;
                 let amount_swapped = amount_b_for_a.value() as f64 * (ratio_a.value() as f64 / 1000.0);
                 log::info!(
-                    "Swap {n} for {amount_b_for_a} FAUCET -> {amount_swapped} XTR2 @ {ratio_b}:{ratio_a} | pool \
-                     liquidity: {balance_a} XTR2 {balance_b} FAUCET",
+                    "Swap {n} for {amount_b_for_a} FAUCET -> {amount_swapped} XTR @ {ratio_b}:{ratio_a} | pool \
+                     liquidity: {balance_a} XTR {balance_b} FAUCET",
                     n = (i + 1) * (j + 1) * 2
                 );
             }


### PR DESCRIPTION
Description
---
Improve API for resource builder with initial supply.
Rename XTR2 constant to XTR
Add `Bucket::join`

Motivation and Context
---

Previously if you provided an initial supply for the resource builder and called `build()` a panic would occur.
This PR changes `initial_supply` to immediately build and return the bucket preventing the user from making the above error at compile time.

Previous API: 
```rust
let bucket = ResourceBuilder::fungible().initial_supply(1000).build_bucket()
```
```rust
// will panic at runtime
let bucket = ResourceBuilder::fungible().build_bucket()
```
New API:
```rust
let bucket = ResourceBuilder::fungible().initial_supply(1000);

let bucket = ResourceBuilder::non_fungible()
       .initial_supply((1..=100).map(NonFungibleId::from_u32));

let confidential = ResourceBuilder::confidential()
       .initial_supply(confidential_supply);
```

How Has This Been Tested?
---
Existing engine tests updated

What process can a PR reviewer use to test or verify this change?
---
Update existing templates to use the new API

Breaking Changes
---

- [ ] None
- [ ] Requires data directory to be deleted
- [x] Other - Please specify

BREAKING CHANGE: templates that previously built resources with initial supply will no longer compile. The ABI for buckets adds `Join`. Since the integer representation of the ops shifts by 1 after `Join` some bucket operations will be invalid on previous WASM. i.e. WASM needs to be recompiled.