### PR TITLE
feat(tari_swarm_daemon): link up wallet daemon and signaling server

### DIFF
--- a/applications/tari_swarm_daemon/src/main.rs
+++ b/applications/tari_swarm_daemon/src/main.rs
@@ -110,16 +110,6 @@ fn get_base_config(cli: &Cli) -> anyhow::Result<Config> {
             env: vec![],
         },
         ExecutableConfig {
-            instance_type: InstanceType::TariWalletDaemon,
-            execuable_path: Some("target/release/tari_wallet_daemon".into()),
-            compile: Some(CompileConfig {
-                working_dir: Some(".".into()),
-                package_name: "tari_dan_wallet_daemon".to_string(),
-                target_dir: None,
-            }),
-            env: vec![],
-        },
-        ExecutableConfig {
             instance_type: InstanceType::TariIndexer,
             execuable_path: Some("target/release/tari_indexer".into()),
             compile: Some(CompileConfig {
@@ -135,6 +125,16 @@ fn get_base_config(cli: &Cli) -> anyhow::Result<Config> {
             compile: Some(CompileConfig {
                 working_dir: Some(".".into()),
                 package_name: "tari_signaling_server".to_string(),
+                target_dir: None,
+            }),
+            env: vec![],
+        },
+        ExecutableConfig {
+            instance_type: InstanceType::TariWalletDaemon,
+            execuable_path: Some("target/release/tari_wallet_daemon".into()),
+            compile: Some(CompileConfig {
+                working_dir: Some(".".into()),
+                package_name: "tari_dan_wallet_daemon".to_string(),
                 target_dir: None,
             }),
             env: vec![],
@@ -156,8 +156,8 @@ fn get_base_config(cli: &Cli) -> anyhow::Result<Config> {
             .with_name("Validator node")
             .with_num_instances(1),
         InstanceConfig::new(InstanceType::TariIndexer).with_name("Indexer"),
-        InstanceConfig::new(InstanceType::TariWalletDaemon).with_name("Wallet Daemon"),
         InstanceConfig::new(InstanceType::TariSignalingServer).with_name("Signaling server"),
+        InstanceConfig::new(InstanceType::TariWalletDaemon).with_name("Wallet Daemon"),
     ];
 
     let base_dir = cli

--- a/applications/tari_swarm_daemon/src/process_definitions/context.rs
+++ b/applications/tari_swarm_daemon/src/process_definitions/context.rs
@@ -12,6 +12,7 @@ use crate::process_manager::{
     InstanceManager,
     MinoTariNodeProcess,
     MinoTariWalletProcess,
+    SignalingServerProcess,
 };
 
 pub struct ProcessContext<'a> {
@@ -90,5 +91,9 @@ impl<'a> ProcessContext<'a> {
 
     pub fn indexers(&self) -> impl Iterator<Item = &IndexerProcess> {
         self.instances.indexers()
+    }
+
+    pub fn signaling_servers(&self) -> impl Iterator<Item = &SignalingServerProcess> {
+        self.instances.signaling_servers()
     }
 }

--- a/applications/tari_swarm_daemon/src/process_definitions/wallet_daemon.rs
+++ b/applications/tari_swarm_daemon/src/process_definitions/wallet_daemon.rs
@@ -5,7 +5,7 @@ use anyhow::anyhow;
 use async_trait::async_trait;
 use tokio::process::Command;
 
-use crate::{process_definitions::{ProcessContext, ProcessDefinition}, process_manager::SignalingServerProcess};
+use crate::process_definitions::{ProcessContext, ProcessDefinition};
 
 #[derive(Debug, Default)]
 pub struct WalletDaemon;
@@ -50,7 +50,7 @@ impl ProcessDefinition for WalletDaemon {
             .arg(format!("--json-rpc-address={json_rpc_address}"))
             .arg(format!("--indexer-url={indexer_url}"))
             .arg(format!("--ui-connect-address={json_rpc_public_address}"))
-            .arg(format!("-pdan_wallet_daemon.http_ui_address={web_ui_address}"));    
+            .arg(format!("-pdan_wallet_daemon.http_ui_address={web_ui_address}"));
 
         // A signaling server is not required for startup of the wallet daemon,
         // but if it is available we want to set it up

--- a/applications/tari_swarm_daemon/src/process_definitions/wallet_daemon.rs
+++ b/applications/tari_swarm_daemon/src/process_definitions/wallet_daemon.rs
@@ -5,7 +5,7 @@ use anyhow::anyhow;
 use async_trait::async_trait;
 use tokio::process::Command;
 
-use crate::process_definitions::{ProcessContext, ProcessDefinition};
+use crate::{process_definitions::{ProcessContext, ProcessDefinition}, process_manager::SignalingServerProcess};
 
 #[derive(Debug, Default)]
 pub struct WalletDaemon;
@@ -50,7 +50,22 @@ impl ProcessDefinition for WalletDaemon {
             .arg(format!("--json-rpc-address={json_rpc_address}"))
             .arg(format!("--indexer-url={indexer_url}"))
             .arg(format!("--ui-connect-address={json_rpc_public_address}"))
-            .arg(format!("-pdan_wallet_daemon.http_ui_address={web_ui_address}"));
+            .arg(format!("-pdan_wallet_daemon.http_ui_address={web_ui_address}"));    
+
+        // A signaling server is not required for startup of the wallet daemon,
+        // but if it is available we want to set it up
+        let maybe_signaling_server = context.signaling_servers().next();
+        if let Some(signaling_server) = maybe_signaling_server {
+            let signaling_server_url = format!(
+                "{local_ip}:{}",
+                signaling_server
+                    .instance()
+                    .allocated_ports()
+                    .get("jrpc")
+                    .ok_or_else(|| anyhow!("Signaling server port not found"))?
+            );
+            command.arg(format!("--signaling-server-address={signaling_server_url}"));
+        }
 
         Ok(command)
     }

--- a/applications/tari_swarm_daemon/src/process_manager/instances/manager.rs
+++ b/applications/tari_swarm_daemon/src/process_manager/instances/manager.rs
@@ -211,13 +211,13 @@ impl InstanceManager {
             InstanceType::TariIndexer => {
                 self.indexers.insert(instance_id, IndexerProcess::new(instance));
             },
-            InstanceType::TariWalletDaemon => {
-                self.wallet_daemons
-                    .insert(instance_id, WalletDaemonProcess::new(instance));
-            },
             InstanceType::TariSignalingServer => {
                 self.signaling_servers
                     .insert(instance_id, SignalingServerProcess::new(instance));
+            },
+            InstanceType::TariWalletDaemon => {
+                self.wallet_daemons
+                    .insert(instance_id, WalletDaemonProcess::new(instance));
             },
         }
 
@@ -250,6 +250,10 @@ impl InstanceManager {
 
     pub fn indexers(&self) -> impl Iterator<Item = &IndexerProcess> + Sized {
         self.indexers.values()
+    }
+
+    pub fn signaling_servers(&self) -> impl Iterator<Item = &SignalingServerProcess> + Sized {
+        self.signaling_servers.values()
     }
 
     // pub fn wallet_daemons(&self) -> impl Iterator<Item = &WalletDaemonProcess> + Sized {
@@ -301,6 +305,7 @@ impl InstanceManager {
             .chain(self.minotari_miners.values_mut().map(|x| x.instance_mut()))
             .chain(self.validator_nodes.values_mut().map(|x| x.instance_mut()))
             .chain(self.indexers.values_mut().map(|x| x.instance_mut()))
+            .chain(self.signaling_servers.values_mut().map(|x| x.instance_mut()))
             .chain(self.wallet_daemons.values_mut().map(|x| x.instance_mut()))
     }
 
@@ -312,6 +317,7 @@ impl InstanceManager {
             .chain(self.minotari_miners.values().map(|x| x.instance()))
             .chain(self.validator_nodes.values().map(|x| x.instance()))
             .chain(self.indexers.values().map(|x| x.instance()))
+            .chain(self.signaling_servers.values().map(|x| x.instance()))
             .chain(self.wallet_daemons.values().map(|x| x.instance()))
     }
 

--- a/applications/tari_swarm_daemon/src/process_manager/processes/signaling_server.rs
+++ b/applications/tari_swarm_daemon/src/process_manager/processes/signaling_server.rs
@@ -12,12 +12,10 @@ impl SignalingServerProcess {
         Self { instance }
     }
 
-    #[allow(dead_code)]
     pub fn instance(&self) -> &Instance {
         &self.instance
     }
 
-    #[allow(dead_code)]
     pub fn instance_mut(&mut self) -> &mut Instance {
         &mut self.instance
     }


### PR DESCRIPTION
Description
---
Links up wallet daemon and signaling server in the `tari_swam` application

Motivation and Context
---
`tari_swarm_daemon` is a very useful tool to spawn a local Tari network for development purposes. But currently the wallet daemon process is not spawn with the signaling server address, which means that webRTC communication between web pages and the wallet daemon is not possible.  This PR makes the necessary changes to the `tari_swarm_daemon` to make this possible.

How Has This Been Tested?
---
Manually by running `tari_swarm_daemon` and connecting a site to the wallet daemon using `tari.js`

What process can a PR reviewer use to test or verify this change?
---
See previous section. Note that existing `tari_swarm` process directories (and config files) must be created fresh for this change to work.

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify