### PR TITLE
fix(engine)!: allow multiple create components in one call

### DIFF
--- a/applications/tari_dan_wallet_daemon/src/handlers/accounts.rs
+++ b/applications/tari_dan_wallet_daemon/src/handlers/accounts.rs
@@ -23,7 +23,7 @@ use tari_dan_wallet_sdk::{
 };
 use tari_dan_wallet_storage_sqlite::SqliteWalletStore;
 use tari_engine_types::{
-    component::new_account_address_from_parts,
+    component::new_component_address_from_public_key,
     confidential::ConfidentialClaim,
     instruction::Instruction,
     substate::{Substate, SubstateId},
@@ -834,7 +834,7 @@ fn get_or_create_account<T: WalletStore>(
                 .unwrap_or_else(|| sdk.key_manager_api().next_key(key_manager::TRANSACTION_BRANCH))?;
             let account_pk = PublicKey::from_secret_key(&account_secret_key.key);
 
-            let account_address = new_account_address_from_parts(&ACCOUNT_TEMPLATE_ADDRESS, &account_pk);
+            let account_address = new_component_address_from_public_key(&ACCOUNT_TEMPLATE_ADDRESS, &account_pk);
 
             // We have no involved substate addresses, so we need to add an output
             (account_address.into(), account_secret_key, Some(name.to_string()))
@@ -882,7 +882,7 @@ pub async fn handle_transfer(
     let mut fee_instructions = vec![];
 
     let destination_account_address =
-        new_account_address_from_parts(&ACCOUNT_TEMPLATE_ADDRESS, &req.destination_public_key);
+        new_component_address_from_public_key(&ACCOUNT_TEMPLATE_ADDRESS, &req.destination_public_key);
     let existing_account = sdk
         .substate_api()
         .scan_for_substate(&SubstateId::Component(destination_account_address), None)

--- a/dan_layer/engine/src/runtime/mod.rs
+++ b/dan_layer/engine/src/runtime/mod.rs
@@ -168,7 +168,7 @@ pub trait RuntimeInterface: Send + Sync {
     fn reset_to_fee_checkpoint(&self) -> Result<(), RuntimeError>;
     fn finalize(&self) -> Result<FinalizeResult, RuntimeError>;
 
-    fn caller_context_invoke(&self, action: CallerContextAction) -> Result<InvokeResult, RuntimeError>;
+    fn caller_context_invoke(&self, action: CallerContextAction, args: EngineArgs) -> Result<InvokeResult, RuntimeError>;
 
     fn call_invoke(&self, action: CallAction, args: EngineArgs) -> Result<InvokeResult, RuntimeError>;
 

--- a/dan_layer/engine/src/runtime/mod.rs
+++ b/dan_layer/engine/src/runtime/mod.rs
@@ -168,7 +168,11 @@ pub trait RuntimeInterface: Send + Sync {
     fn reset_to_fee_checkpoint(&self) -> Result<(), RuntimeError>;
     fn finalize(&self) -> Result<FinalizeResult, RuntimeError>;
 
-    fn caller_context_invoke(&self, action: CallerContextAction, args: EngineArgs) -> Result<InvokeResult, RuntimeError>;
+    fn caller_context_invoke(
+        &self,
+        action: CallerContextAction,
+        args: EngineArgs,
+    ) -> Result<InvokeResult, RuntimeError>;
 
     fn call_invoke(&self, action: CallAction, args: EngineArgs) -> Result<InvokeResult, RuntimeError>;
 

--- a/dan_layer/engine/src/runtime/tracker.rs
+++ b/dan_layer/engine/src/runtime/tracker.rs
@@ -166,9 +166,7 @@ impl StateTracker {
                     addr.try_into()
                         .map_err(|address| RuntimeError::AddressAllocationTypeMismatch { address })?
                 },
-                None => state
-                    .id_provider()?
-                    .new_component_address(template_address, owner_key)?,
+                None => state.id_provider()?.new_component_address(template_address, None)?,
             };
 
             let component = ComponentBody { state: component_state };

--- a/dan_layer/engine/src/transaction/processor.rs
+++ b/dan_layer/engine/src/transaction/processor.rs
@@ -29,6 +29,7 @@ use tari_common_types::types::PublicKey;
 use tari_dan_common_types::{services::template_provider::TemplateProvider, Epoch};
 use tari_engine_types::{
     commit_result::{ExecuteResult, FinalizeResult, RejectReason, TransactionResult},
+    component::new_component_address_from_public_key,
     entity_id_provider::EntityIdProvider,
     indexed_value::{IndexedValue, IndexedWellKnownTypes},
     instruction::Instruction,
@@ -307,9 +308,9 @@ impl<TTemplateProvider: TemplateProvider<Template = LoadedTemplate> + 'static> T
             }
         })?;
         let owner_pk = RistrettoPublicKeyBytes::from_bytes(owner_public_key.as_bytes()).unwrap();
-        let owner_token = NonFungibleAddress::from_public_key(owner_pk);
+        let account_address = new_component_address_from_public_key(&ACCOUNT_TEMPLATE_ADDRESS, owner_public_key);
 
-        let mut args = args![owner_token];
+        let mut args = args![NonFungibleAddress::from_public_key(owner_pk)];
         if let Some(workspace_bucket) = workspace_bucket {
             args.push(arg![Workspace(workspace_bucket)]);
         }
@@ -324,7 +325,7 @@ impl<TTemplateProvider: TemplateProvider<Template = LoadedTemplate> + 'static> T
             template_address: ACCOUNT_TEMPLATE_ADDRESS,
             module_name: template.template_name().to_string(),
             arg_scope,
-            entity_id: owner_pk.as_hash().leading_bytes().into(),
+            entity_id: account_address.entity_id(),
         })?;
 
         let result = Self::invoke_template(template, template_provider, runtime.clone(), function_def, args)?;

--- a/dan_layer/engine/src/wasm/process.rs
+++ b/dan_layer/engine/src/wasm/process.rs
@@ -150,7 +150,9 @@ impl WasmProcess {
                 env.state().interface().consensus_invoke(arg.action)
             }),
             EngineOp::CallerContextInvoke => Self::handle(env, arg, |env, arg: CallerContextInvokeArg| {
-                env.state().interface().caller_context_invoke(arg.action)
+                env.state()
+                    .interface()
+                    .caller_context_invoke(arg.action, arg.args.into())
             }),
             EngineOp::GenerateRandomInvoke => Self::handle(env, arg, |env, arg: GenerateRandomInvokeArg| {
                 env.state().interface().generate_random_invoke(arg.action)

--- a/dan_layer/engine/tests/templates/access_rules/src/lib.rs
+++ b/dan_layer/engine/tests/templates/access_rules/src/lib.rs
@@ -72,7 +72,7 @@ mod access_rules_template {
         pub fn with_auth_hook(allowed: bool, hook: String) -> Component<AccessRulesTest> {
             let badges = create_badge_resource(AccessRule::DenyAll);
 
-            let address_alloc = CallerContext::allocate_component_address();
+            let address_alloc = CallerContext::allocate_component_address(None);
 
             let tokens = ResourceBuilder::fungible()
                 .with_authorization_hook(*address_alloc.address(), hook)
@@ -93,7 +93,7 @@ mod access_rules_template {
         pub fn with_auth_hook_attack_component(component_address: ComponentAddress) -> Component<AccessRulesTest> {
             let badges = create_badge_resource(AccessRule::DenyAll);
 
-            let address_alloc = CallerContext::allocate_component_address();
+            let address_alloc = CallerContext::allocate_component_address(None);
 
             let tokens = ResourceBuilder::fungible()
                 .with_authorization_hook(
@@ -185,7 +185,7 @@ mod access_rules_template {
         pub fn resource_actions_restricted_to_component() -> Component<AccessRulesTest> {
             let badges = create_badge_resource(AccessRule::AllowAll);
 
-            let allocation = CallerContext::allocate_component_address();
+            let allocation = CallerContext::allocate_component_address(None);
             let tokens = ResourceBuilder::fungible()
                 .mintable(AccessRule::Restricted(RestrictedAccessRule::Require(
                     RequireRule::Require(allocation.address().clone().into()),

--- a/dan_layer/engine/tests/templates/address_allocation/src/lib.rs
+++ b/dan_layer/engine/tests/templates/address_allocation/src/lib.rs
@@ -11,7 +11,7 @@ mod template {
 
     impl AddressAllocationTest {
         pub fn create() -> (Component<Self>, ComponentAddress) {
-            let allocation = CallerContext::allocate_component_address();
+            let allocation = CallerContext::allocate_component_address(None);
             let address = allocation.address().clone();
             (
                 Component::new(Self {}).with_address_allocation(allocation).create(),
@@ -20,7 +20,7 @@ mod template {
         }
 
         pub fn drop_allocation() {
-            let _allocation = CallerContext::allocate_component_address();
+            let _allocation = CallerContext::allocate_component_address(None);
         }
     }
 }

--- a/dan_layer/engine/tests/templates/state/src/lib.rs
+++ b/dan_layer/engine/tests/templates/state/src/lib.rs
@@ -37,6 +37,14 @@ mod state_template {
                 .create()
         }
 
+        pub fn create_multiple(n: u32) {
+            (0..n).for_each(|i| {
+                Component::new(Self { value: i })
+                    .with_access_rules(AccessRules::new().default(AccessRule::AllowAll))
+                    .create();
+            });
+        }
+
         pub fn restricted() -> Component<Self> {
             Component::new(Self { value: 0 })
                 .with_access_rules(

--- a/dan_layer/engine/tests/test.rs
+++ b/dan_layer/engine/tests/test.rs
@@ -157,7 +157,7 @@ fn test_buggy_template() {
         .unwrap_err();
     assert!(matches!(
         err,
-        TemplateLoaderError::WasmModuleError(WasmExecutionError::MemoryPointerOutOfRange { .. })
+        TemplateLoaderError::WasmModuleError(WasmExecutionError::AbiDecodeError { .. })
     ));
 
     let err = compile_template("tests/templates/buggy", &["unexpected_export_function"])

--- a/dan_layer/engine_types/src/component.rs
+++ b/dan_layer/engine_types/src/component.rs
@@ -25,11 +25,9 @@ use tari_common_types::types::PublicKey;
 use tari_template_lib::{
     auth::{ComponentAccessRules, OwnerRule, Ownership},
     crypto::RistrettoPublicKeyBytes,
-    models::{ComponentKey, EntityId, ObjectKey, TemplateAddress},
+    models::{EntityId, ObjectKey, TemplateAddress},
     prelude::ComponentAddress,
-    Hash,
 };
-use tari_utilities::ByteArray;
 #[cfg(feature = "ts")]
 use ts_rs::TS;
 
@@ -42,17 +40,17 @@ use crate::{
 
 /// Derives a component address.
 ///
-/// This can be used to derive the component address from a public key if the component sets OwnerRule::OwnedBySigner or
-/// OwnerRule::ByPublicKey
-pub fn new_account_address_from_parts(template_address: &TemplateAddress, public_key: &PublicKey) -> ComponentAddress {
+/// This can be used to derive the component address from a public key if the component sets public_key_address in the
+/// component builder.
+pub fn new_component_address_from_public_key(
+    template_address: &TemplateAddress,
+    public_key: &PublicKey,
+) -> ComponentAddress {
     let address = hasher32(EngineHashDomainLabel::ComponentAddress)
         .chain(template_address)
         .chain(public_key)
         .result();
-    let key = ObjectKey::new(
-        EntityId::from_array(Hash::try_from(public_key.as_bytes()).unwrap().leading_bytes()),
-        ComponentKey::new(address.trailing_bytes()),
-    );
+    let key = ObjectKey::from_array(address.leading_bytes());
     ComponentAddress::new(key)
 }
 

--- a/dan_layer/template_builtin/templates/account/src/lib.rs
+++ b/dan_layer/template_builtin/templates/account/src/lib.rs
@@ -67,6 +67,7 @@ mod account_template {
 
             Component::new(Self { vaults })
                 .with_access_rules(rules)
+                .with_public_key_address(public_key)
                 .with_owner_rule(OwnerRule::ByPublicKey(public_key))
                 .create()
         }

--- a/dan_layer/template_lib/src/args/types.rs
+++ b/dan_layer/template_lib/src/args/types.rs
@@ -507,6 +507,7 @@ pub enum GenerateRandomAction {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CallerContextInvokeArg {
     pub action: CallerContextAction,
+    pub args: Vec<Vec<u8>>,
 }
 
 /// The possible actions that can be performed related to the caller context

--- a/dan_layer/template_lib/src/caller_context.rs
+++ b/dan_layer/template_lib/src/caller_context.rs
@@ -19,6 +19,7 @@ impl CallerContext {
     pub fn transaction_signer_public_key() -> RistrettoPublicKeyBytes {
         let resp: InvokeResult = call_engine(EngineOp::CallerContextInvoke, &CallerContextInvokeArg {
             action: CallerContextAction::GetCallerPublicKey,
+            args: invoke_args![],
         });
 
         resp.decode().expect("Failed to decode PublicKey")
@@ -29,6 +30,7 @@ impl CallerContext {
     pub fn current_component_address() -> ComponentAddress {
         let resp: InvokeResult = call_engine(EngineOp::CallerContextInvoke, &CallerContextInvokeArg {
             action: CallerContextAction::GetComponentAddress,
+            args: invoke_args![],
         });
 
         resp.decode::<Option<ComponentAddress>>()
@@ -36,9 +38,12 @@ impl CallerContext {
             .expect("Not in a component instance context")
     }
 
-    pub fn allocate_component_address() -> AddressAllocation<ComponentAddress> {
+    pub fn allocate_component_address(
+        public_key_address: Option<RistrettoPublicKeyBytes>,
+    ) -> AddressAllocation<ComponentAddress> {
         let resp: InvokeResult = call_engine(EngineOp::CallerContextInvoke, &CallerContextInvokeArg {
             action: CallerContextAction::AllocateNewComponentAddress,
+            args: invoke_args![public_key_address],
         });
 
         resp.decode()

--- a/dan_layer/wallet/sdk/src/apis/confidential_transfer.rs
+++ b/dan_layer/wallet/sdk/src/apis/confidential_transfer.rs
@@ -10,7 +10,7 @@ use tari_common_types::types::{PrivateKey, PublicKey};
 use tari_crypto::keys::PublicKey as _;
 use tari_dan_common_types::optional::{IsNotFoundError, Optional};
 use tari_dan_wallet_crypto::{ConfidentialOutputMaskAndValue, ConfidentialProofStatement};
-use tari_engine_types::{component::new_account_address_from_parts, substate::SubstateId};
+use tari_engine_types::{component::new_component_address_from_public_key, substate::SubstateId};
 use tari_template_builtin::ACCOUNT_TEMPLATE_ADDRESS;
 use tari_template_lib::{
     args,
@@ -209,7 +209,7 @@ where
         &self,
         destination_pk: &PublicKey,
     ) -> Result<(VersionedSubstateId, bool), ConfidentialTransferApiError> {
-        let account_component = new_account_address_from_parts(&ACCOUNT_TEMPLATE_ADDRESS, destination_pk);
+        let account_component = new_component_address_from_public_key(&ACCOUNT_TEMPLATE_ADDRESS, destination_pk);
         match self
             .substate_api
             .scan_for_substate(&account_component.into(), None)

--- a/utilities/tariswap_test_bench/src/accounts.rs
+++ b/utilities/tariswap_test_bench/src/accounts.rs
@@ -5,7 +5,7 @@ use std::ops::RangeInclusive;
 
 use tari_crypto::{keys::PublicKey as _, ristretto::RistrettoPublicKey};
 use tari_dan_wallet_sdk::{apis::key_manager::TRANSACTION_BRANCH, models::Account};
-use tari_engine_types::component::new_account_address_from_parts;
+use tari_engine_types::component::new_component_address_from_public_key;
 use tari_template_builtin::ACCOUNT_TEMPLATE_ADDRESS;
 use tari_template_lib::{args, models::Amount};
 use tari_transaction::{Instruction, Transaction};
@@ -17,7 +17,7 @@ impl Runner {
         let key = self.sdk.key_manager_api().derive_key(TRANSACTION_BRANCH, 0)?;
         let owner_public_key = RistrettoPublicKey::from_secret_key(&key.key);
 
-        let account_address = new_account_address_from_parts(&ACCOUNT_TEMPLATE_ADDRESS, &owner_public_key);
+        let account_address = new_component_address_from_public_key(&ACCOUNT_TEMPLATE_ADDRESS, &owner_public_key);
 
         let transaction = Transaction::builder()
             .with_fee_instructions_builder(|builder| {

--- a/utilities/transaction_generator/src/transaction_builders/free_coins.rs
+++ b/utilities/transaction_generator/src/transaction_builders/free_coins.rs
@@ -3,7 +3,7 @@
 
 use rand::rngs::OsRng;
 use tari_crypto::{keys::PublicKey, ristretto::RistrettoPublicKey};
-use tari_engine_types::{component::new_account_address_from_parts, instruction::Instruction};
+use tari_engine_types::{component::new_component_address_from_public_key, instruction::Instruction};
 use tari_template_builtin::ACCOUNT_TEMPLATE_ADDRESS;
 use tari_template_lib::{args, models::Amount};
 use tari_transaction::Transaction;
@@ -11,7 +11,7 @@ use tari_transaction::Transaction;
 pub fn builder(_: u64) -> Transaction {
     let (signer_secret_key, signer_public_key) = RistrettoPublicKey::random_keypair(&mut OsRng);
 
-    let account_address = new_account_address_from_parts(&ACCOUNT_TEMPLATE_ADDRESS, &signer_public_key);
+    let account_address = new_component_address_from_public_key(&ACCOUNT_TEMPLATE_ADDRESS, &signer_public_key);
 
     Transaction::builder()
         .with_fee_instructions_builder(|builder| {


### PR DESCRIPTION
Description
---
- assigns a unique component address for each call to create_component 
- formalises component addresses using a public key 
- adds `.with_public_key_address` to component builder
- adds new test for multiple component creation
- use `with_public_key_address` in account template
- simplified the component address from public key derivation.

Motivation and Context
---

Previously you could not create multiple components in one call without explicitly allocating an address.
This PR changes the default behaviour to generate a unique address, thereby fixing the bug when creating multiple components in a single call. 
Some components need the address to be derived ahead of time using a public key can do this by optionally specifying a public key address on the component.

How Has This Been Tested?
---
New multiple component creation test. Existing account tests. Manually

What process can a PR reviewer use to test or verify this change?
---
Use a template that creates multiple components. Create an account that does not exist for another public key.

Breaking Changes
---

- [ ] None
- [ ] Requires data directory to be deleted
- [x] Other - Please specify

BREAKING CHANGE: caller context calls have an additional `arg` field, so templates using these need to be recompiled.