### PR TITLE
fix(engine)!: uuid duplication on the same EntityId

### DIFF
--- a/dan_layer/engine/tests/account_nfts.rs
+++ b/dan_layer/engine/tests/account_nfts.rs
@@ -1,10 +1,10 @@
 //   Copyright 2023 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use tari_engine_types::instruction::Instruction;
+use tari_engine_types::{commit_result::ExecuteResult, instruction::Instruction};
 use tari_template_lib::{
     args,
-    models::{ComponentAddress, NonFungibleId},
+    models::{ComponentAddress, NonFungibleAddress, NonFungibleId, TemplateAddress},
     prelude::Metadata,
     resource::TOKEN_SYMBOL,
 };
@@ -12,23 +12,17 @@ use tari_template_test_tooling::TemplateTest;
 
 #[test]
 fn basic_nft_mint() {
+    // setup the test
     let mut account_nft_template_test = TemplateTest::new::<_, &str>([]);
 
-    let account_nft_template = account_nft_template_test.get_template_address("AccountNonFungible");
-
+    // create a user account
     let (owner_component_address, owner_token, _) = account_nft_template_test.create_funded_account();
 
-    let result = account_nft_template_test
-        .execute_and_commit(
-            vec![Instruction::CallFunction {
-                template_address: account_nft_template,
-                function: "create".to_string(),
-                args: args![owner_token],
-            }],
-            vec![],
-        )
-        .unwrap();
+    // get the AccountNft template address
+    let account_nft_template = account_nft_template_test.get_template_address("AccountNonFungible");
 
+    // create the AccountNft component associated with the user account
+    let result = create_nft_component(&mut account_nft_template_test, account_nft_template, owner_token.clone());
     assert!(result.finalize.result.is_accept());
     let nft_component_address: ComponentAddress = result.finalize.execution_results[0].decode().unwrap();
 
@@ -45,17 +39,65 @@ fn basic_nft_mint() {
 
     assert!(result.finalize.is_accept());
 
+    // mint a new AccountNft
     let mut metadata = Metadata::new();
-
     metadata.insert(TOKEN_SYMBOL.to_string(), "ACCNFT".to_string());
     metadata.insert("name".to_string(), "my_custom_nft".to_string());
     metadata.insert("brightness".to_string(), "100".to_string());
 
-    let result = account_nft_template_test
+    let result = mint_account_nft(&mut account_nft_template_test, nft_component_address, owner_component_address, owner_token.clone(), metadata);
+    assert!(result.finalize.result.is_accept());
+
+    let bucket_nfts = result.finalize.execution_results[2]
+        .decode::<Vec<NonFungibleId>>()
+        .unwrap();
+    assert_eq!(bucket_nfts.len(), 1);
+}
+
+#[test]
+fn mint_multiple_times() {
+    // setup the test
+    let mut account_nft_template_test = TemplateTest::new::<_, &str>([]);
+
+    // create a user account
+    let (owner_component_address, owner_token, _) = account_nft_template_test.create_funded_account();
+
+    // get the AccountNft template address
+    let account_nft_template = account_nft_template_test.get_template_address("AccountNonFungible");
+
+    // create the account nft component
+    let result = create_nft_component(&mut account_nft_template_test, account_nft_template, owner_token.clone());
+    assert!(result.finalize.result.is_accept());
+    let nft_component_address: ComponentAddress = result.finalize.execution_results[0].decode().unwrap();
+
+    // mint one nft
+    let result = mint_account_nft(&mut account_nft_template_test, nft_component_address, owner_component_address, owner_token.clone(), Metadata::new());
+    assert!(result.finalize.result.is_accept());
+
+    // mint a second nft
+    let result = mint_account_nft(&mut account_nft_template_test, nft_component_address, owner_component_address, owner_token.clone(), Metadata::new());
+    assert!(result.finalize.result.is_accept());
+}
+
+fn create_nft_component(test: &mut TemplateTest, nft_template: TemplateAddress, owner_token: NonFungibleAddress) -> ExecuteResult {
+    test
+        .execute_and_commit(
+            vec![Instruction::CallFunction {
+                template_address: nft_template,
+                function: "create".to_string(),
+                args: args![owner_token],
+            }],
+            vec![],
+        )
+        .unwrap()
+}
+
+fn mint_account_nft(test: &mut TemplateTest, nft_component: ComponentAddress, account: ComponentAddress, owner_token: NonFungibleAddress, metadata: Metadata) -> ExecuteResult {
+    test
         .execute_and_commit(
             vec![
                 Instruction::CallMethod {
-                    component_address: nft_component_address,
+                    component_address: nft_component,
                     method: "mint".to_string(),
                     args: args![metadata],
                 },
@@ -63,24 +105,17 @@ fn basic_nft_mint() {
                     key: b"my_nft".to_vec(),
                 },
                 Instruction::CallFunction {
-                    template_address: account_nft_template_test.get_template_address("Account"),
+                    template_address: test.get_template_address("Account"),
                     function: "get_non_fungible_ids_for_bucket".to_string(),
                     args: args![Variable("my_nft")],
                 },
                 Instruction::CallMethod {
-                    component_address: owner_component_address,
+                    component_address: account,
                     method: "deposit".to_string(),
                     args: args![Variable("my_nft")],
                 },
             ],
             vec![owner_token],
         )
-        .unwrap();
-
-    assert!(result.finalize.result.is_accept());
-
-    let bucket_nfts = result.finalize.execution_results[2]
-        .decode::<Vec<NonFungibleId>>()
-        .unwrap();
-    assert_eq!(bucket_nfts.len(), 1);
+        .unwrap()
 }

--- a/dan_layer/engine/tests/account_nfts.rs
+++ b/dan_layer/engine/tests/account_nfts.rs
@@ -22,7 +22,11 @@ fn basic_nft_mint() {
     let account_nft_template = account_nft_template_test.get_template_address("AccountNonFungible");
 
     // create the AccountNft component associated with the user account
-    let result = create_nft_component(&mut account_nft_template_test, account_nft_template, owner_token.clone());
+    let result = create_nft_component(
+        &mut account_nft_template_test,
+        account_nft_template,
+        owner_token.clone(),
+    );
     assert!(result.finalize.result.is_accept());
     let nft_component_address: ComponentAddress = result.finalize.execution_results[0].decode().unwrap();
 
@@ -45,7 +49,13 @@ fn basic_nft_mint() {
     metadata.insert("name".to_string(), "my_custom_nft".to_string());
     metadata.insert("brightness".to_string(), "100".to_string());
 
-    let result = mint_account_nft(&mut account_nft_template_test, nft_component_address, owner_component_address, owner_token.clone(), metadata);
+    let result = mint_account_nft(
+        &mut account_nft_template_test,
+        nft_component_address,
+        owner_component_address,
+        owner_token.clone(),
+        metadata,
+    );
     assert!(result.finalize.result.is_accept());
 
     let bucket_nfts = result.finalize.execution_results[2]
@@ -66,56 +76,80 @@ fn mint_multiple_times() {
     let account_nft_template = account_nft_template_test.get_template_address("AccountNonFungible");
 
     // create the account nft component
-    let result = create_nft_component(&mut account_nft_template_test, account_nft_template, owner_token.clone());
+    let result = create_nft_component(
+        &mut account_nft_template_test,
+        account_nft_template,
+        owner_token.clone(),
+    );
     assert!(result.finalize.result.is_accept());
     let nft_component_address: ComponentAddress = result.finalize.execution_results[0].decode().unwrap();
 
     // mint one nft
-    let result = mint_account_nft(&mut account_nft_template_test, nft_component_address, owner_component_address, owner_token.clone(), Metadata::new());
+    let result = mint_account_nft(
+        &mut account_nft_template_test,
+        nft_component_address,
+        owner_component_address,
+        owner_token.clone(),
+        Metadata::new(),
+    );
     assert!(result.finalize.result.is_accept());
 
     // mint a second nft
-    let result = mint_account_nft(&mut account_nft_template_test, nft_component_address, owner_component_address, owner_token.clone(), Metadata::new());
+    let result = mint_account_nft(
+        &mut account_nft_template_test,
+        nft_component_address,
+        owner_component_address,
+        owner_token.clone(),
+        Metadata::new(),
+    );
     assert!(result.finalize.result.is_accept());
 }
 
-fn create_nft_component(test: &mut TemplateTest, nft_template: TemplateAddress, owner_token: NonFungibleAddress) -> ExecuteResult {
-    test
-        .execute_and_commit(
-            vec![Instruction::CallFunction {
-                template_address: nft_template,
-                function: "create".to_string(),
-                args: args![owner_token],
-            }],
-            vec![],
-        )
-        .unwrap()
+fn create_nft_component(
+    test: &mut TemplateTest,
+    nft_template: TemplateAddress,
+    owner_token: NonFungibleAddress,
+) -> ExecuteResult {
+    test.execute_and_commit(
+        vec![Instruction::CallFunction {
+            template_address: nft_template,
+            function: "create".to_string(),
+            args: args![owner_token],
+        }],
+        vec![],
+    )
+    .unwrap()
 }
 
-fn mint_account_nft(test: &mut TemplateTest, nft_component: ComponentAddress, account: ComponentAddress, owner_token: NonFungibleAddress, metadata: Metadata) -> ExecuteResult {
-    test
-        .execute_and_commit(
-            vec![
-                Instruction::CallMethod {
-                    component_address: nft_component,
-                    method: "mint".to_string(),
-                    args: args![metadata],
-                },
-                Instruction::PutLastInstructionOutputOnWorkspace {
-                    key: b"my_nft".to_vec(),
-                },
-                Instruction::CallFunction {
-                    template_address: test.get_template_address("Account"),
-                    function: "get_non_fungible_ids_for_bucket".to_string(),
-                    args: args![Variable("my_nft")],
-                },
-                Instruction::CallMethod {
-                    component_address: account,
-                    method: "deposit".to_string(),
-                    args: args![Variable("my_nft")],
-                },
-            ],
-            vec![owner_token],
-        )
-        .unwrap()
+fn mint_account_nft(
+    test: &mut TemplateTest,
+    nft_component: ComponentAddress,
+    account: ComponentAddress,
+    owner_token: NonFungibleAddress,
+    metadata: Metadata,
+) -> ExecuteResult {
+    test.execute_and_commit(
+        vec![
+            Instruction::CallMethod {
+                component_address: nft_component,
+                method: "mint".to_string(),
+                args: args![metadata],
+            },
+            Instruction::PutLastInstructionOutputOnWorkspace {
+                key: b"my_nft".to_vec(),
+            },
+            Instruction::CallFunction {
+                template_address: test.get_template_address("Account"),
+                function: "get_non_fungible_ids_for_bucket".to_string(),
+                args: args![Variable("my_nft")],
+            },
+            Instruction::CallMethod {
+                component_address: account,
+                method: "deposit".to_string(),
+                args: args![Variable("my_nft")],
+            },
+        ],
+        vec![owner_token],
+    )
+    .unwrap()
 }

--- a/dan_layer/engine_types/src/id_provider.rs
+++ b/dan_layer/engine_types/src/id_provider.rs
@@ -90,6 +90,7 @@ impl<'a> IdProvider<'a> {
     pub fn new_uuid(&self) -> Result<[u8; 32], IdProviderError> {
         let n = self.object_ids.next_uuid_id();
         let id = hasher32(EngineHashDomainLabel::UuidOutput)
+            .chain(&self.transaction_hash)
             .chain(&self.entity_id)
             .chain(&n)
             .result();

--- a/dan_layer/template_test_tooling/templates/faucet/Cargo.lock
+++ b/dan_layer/template_test_tooling/templates/faucet/Cargo.lock
@@ -376,7 +376,7 @@ dependencies = [
 
 [[package]]
 name = "tari_bor"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "ciborium",
  "ciborium-io",
@@ -385,7 +385,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_abi"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "serde",
  "tari_bor",
@@ -393,7 +393,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_lib"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "newtype-ops",
  "serde",
@@ -405,7 +405,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_macros"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
Description
---
* Updated the `new_uuid` implementation to include the `transaction_hash`
* New unit test to reproduce the issue
* Clened the `account_nfts` test code

Motivation and Context
---
The engine implementation of the `new_uuid` function, used when generating a random id (e.g. non fungibles), does cause a duplication id issue on objects generated inside the scope of the same EntityId.

This happens because the `new_uuid` only uses a the `entity_id` and a increasing integer to generate a new random uuid. On separated transactions that generate random uuids in the same EntityId this can end up in a duplication.

This PR adds the `transaction_hash` to to the `new_uuid` generation, avoiding separated transactions to  generate the same uuids even if the EntityId is the same.

How Has This Been Tested?
---
New `engine` unit test `mint_multiple_times` that reproduces the problem. With the fix the new test pass.

What process can a PR reviewer use to test or verify this change?
---
See previous section

Breaking Changes
---

- [ ] None
- [ ] Requires data directory to be deleted
- [x] **BREAKING CHANGE**: consensus change on engine uuid generation, so VNs without this change will not reach consensus with VNs that have this change.