### PR TITLE
feat(consensus): proposed block parked and ready event

### DIFF
--- a/applications/tari_validator_node/src/dan_node.rs
+++ b/applications/tari_validator_node/src/dan_node.rs
@@ -87,6 +87,8 @@ impl DanNode {
     }
 
     async fn handle_hotstuff_event(&self, event: HotstuffEvent) -> Result<(), anyhow::Error> {
+        info!(target: LOG_TARGET, "🔥 consensus event: {event}");
+
         let HotstuffEvent::BlockCommitted { block_id, .. } = event else {
             return Ok(());
         };

--- a/dan_layer/consensus/src/hotstuff/event.rs
+++ b/dan_layer/consensus/src/hotstuff/event.rs
@@ -2,14 +2,22 @@
 //    SPDX-License-Identifier: BSD-3-Clause
 
 use tari_dan_common_types::NodeHeight;
-use tari_dan_storage::consensus_models::BlockId;
+use tari_dan_storage::consensus_models::{BlockId, LeafBlock};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, thiserror::Error)]
 pub enum HotstuffEvent {
-    /// A block has been committed
+    #[error("Block {block_id} has been committed at height {height}")]
     BlockCommitted { block_id: BlockId, height: NodeHeight },
-    /// A critical failure occurred in consensus
+    #[error("Consensus failure: {message}")]
     Failure { message: String },
-    /// A leader has timed out
+    #[error("Leader timeout: new height {new_height}")]
     LeaderTimeout { new_height: NodeHeight },
+    #[error("Block {block} has been parked ({num_missing_txs} missing, {num_awaiting_txs} awaiting execution)")]
+    ProposedBlockParked {
+        block: LeafBlock,
+        num_missing_txs: usize,
+        num_awaiting_txs: usize,
+    },
+    #[error("Parked block {block} is ready")]
+    ParkedBlockReady { block: LeafBlock },
 }

--- a/dan_layer/consensus/src/hotstuff/worker.rs
+++ b/dan_layer/consensus/src/hotstuff/worker.rs
@@ -135,6 +135,7 @@ impl<TConsensusSpec: ConsensusSpec> HotstuffWorker<TConsensusSpec> {
                 signing_service.clone(),
                 outbound_messaging.clone(),
                 transaction_pool.clone(),
+                tx_events.clone(),
             ),
 
             on_next_sync_view: OnNextSyncViewHandler::new(

--- a/dan_layer/consensus_tests/src/support/harness.rs
+++ b/dan_layer/consensus_tests/src/support/harness.rs
@@ -162,8 +162,8 @@ impl Test {
             match event {
                 HotstuffEvent::BlockCommitted { block_id, height } => return (address, block_id, height),
                 HotstuffEvent::Failure { message } => panic!("[{}] Consensus failure: {}", address, message),
-                HotstuffEvent::LeaderTimeout { new_height } => {
-                    log::info!("[{address}] Leader timeout. New height {new_height}");
+                other => {
+                    log::info!("[{}] Ignoring event: {:?}", address, other);
                     continue;
                 },
             }


### PR DESCRIPTION
Description
---
Adds ProposedBlockParked and ParkedBlockReady events to consensus

Motivation and Context
---
Notifies event consumers of a proposed block that needs to be parked or has been unparked. 
Currently this is simply logged but further tracking features may be implemented for these events.

How Has This Been Tested?
---
Manually

What process can a PR reviewer use to test or verify this change?
---
Check logs for parked blocks

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify