### PR TITLE
fix(swarm): reuse allocated ports after restart

### DIFF
--- a/applications/tari_indexer/src/event_scanner.rs
+++ b/applications/tari_indexer/src/event_scanner.rs
@@ -274,7 +274,7 @@ impl EventScanner {
                     module_name,
                     timestamp: transaction.timestamp as i64,
                 };
-                info!(
+                debug!(
                     target: LOG_TARGET,
                     "Saving substate: {:?}",
                     substate_row

--- a/applications/tari_swarm_daemon/src/process_definitions/context.rs
+++ b/applications/tari_swarm_daemon/src/process_definitions/context.rs
@@ -70,7 +70,7 @@ impl<'a> ProcessContext<'a> {
     }
 
     pub async fn get_free_port(&mut self, name: &'static str) -> anyhow::Result<u16> {
-        Ok(self.port_allocator.next_port(name).await)
+        Ok(self.port_allocator.get_or_next_port(name).await)
     }
 
     pub fn local_ip(&self) -> &IpAddr {

--- a/applications/tari_swarm_daemon/src/process_manager/port_allocator.rs
+++ b/applications/tari_swarm_daemon/src/process_manager/port_allocator.rs
@@ -52,7 +52,10 @@ impl AllocatedPorts {
         self.ports[name]
     }
 
-    pub async fn next_port(&mut self, name: &'static str) -> u16 {
+    pub async fn get_or_next_port(&mut self, name: &'static str) -> u16 {
+        if let Some(port) = self.ports.get(name) {
+            return *port;
+        }
         loop {
             let port = self.current_port;
             self.current_port += 1;

--- a/utilities/tariswap_test_bench/templates/tariswap/Cargo.toml
+++ b/utilities/tariswap_test_bench/templates/tariswap/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tari_template_abi = { path = "../../../../template_abi" }
-tari_template_lib = { path = "../../../../template_lib" }
+tari_template_abi = { path = "../../../../dan_layer/template_abi" }
+tari_template_lib = { path = "../../../../dan_layer/template_lib" }
 
 [lib]
 crate-type = ["cdylib", "lib"]


### PR DESCRIPTION
Description
---
uses previously allocated ports when restarting an instance

Motivation and Context
---
If an instance was stopped and started, it would receive new ports, causing other instances that may depend on the previous ports to break. This PR reuses the previously assigned ports for the instance on restart.

How Has This Been Tested?
---
Manually 

What process can a PR reviewer use to test or verify this change?
---
Click stop then start on an instance, ports should remain the same.

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify