### PR TITLE
fix(indexer): reuse validator RPC sessions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9995,6 +9995,7 @@ dependencies = [
  "tari_rpc_macros",
  "tari_transaction",
  "thiserror",
+ "tokio",
 ]
 
 [[package]]

--- a/dan_layer/consensus/src/hotstuff/on_propose.rs
+++ b/dan_layer/consensus/src/hotstuff/on_propose.rs
@@ -113,7 +113,7 @@ where TConsensusSpec: ConsensusSpec
                     if let Some(next_block) = self.store.with_read_tx(|tx| last_proposed.get_block(tx)).optional()? {
                         info!(
                             target: LOG_TARGET,
-                            "🌿 RE-BROADCASTING locally block {}({}) to {} validators. {} command(s), justify: {} ({}), parent: {}",
+                            "🌿 RE-BROADCASTING local block {}({}) to {} validators. {} command(s), justify: {} ({}), parent: {}",
                             next_block.id(),
                             next_block.height(),
                             local_committee.len(),

--- a/dan_layer/validator_node_rpc/Cargo.toml
+++ b/dan_layer/validator_node_rpc/Cargo.toml
@@ -23,6 +23,7 @@ async-trait = { workspace = true }
 prost = { workspace = true }
 serde = { workspace = true, default-features = true }
 thiserror = { workspace = true }
+tokio = { workspace = true, default-features = false, features = ["sync"] }
 
 [build-dependencies]
 proto_builder = { workspace = true }

--- a/networking/rpc_framework/src/lib.rs
+++ b/networking/rpc_framework/src/lib.rs
@@ -30,7 +30,7 @@
 
 /// Maximum frame size of each RPC message. This is enforced in tokio's length delimited codec.
 /// This can be thought of as the hard limit on message size.
-pub const RPC_MAX_FRAME_SIZE: usize = 3 * 1024 * 1024; // 3 MiB
+pub const RPC_MAX_FRAME_SIZE: usize = 6 * 1024 * 1024; // 3 MiB
 
 /// The maximum request payload size
 const fn max_request_size() -> usize {

--- a/networking/rpc_framework/src/lib.rs
+++ b/networking/rpc_framework/src/lib.rs
@@ -30,7 +30,7 @@
 
 /// Maximum frame size of each RPC message. This is enforced in tokio's length delimited codec.
 /// This can be thought of as the hard limit on message size.
-pub const RPC_MAX_FRAME_SIZE: usize = 6 * 1024 * 1024; // 3 MiB
+pub const RPC_MAX_FRAME_SIZE: usize = 6 * 1024 * 1024; // 6 MiB
 
 /// The maximum request payload size
 const fn max_request_size() -> usize {


### PR DESCRIPTION
Description
---
caches and reuses validator RPC sessions

Motivation and Context
---
When submitting many transactions through the indexer (using tariswap test) new RPC sessions would hit the session limit. This PR keeps hold of RPC sessions and reuses them (requests are queued) instead of creating new sessions.

How Has This Been Tested?
---
Tariswap test works.

What process can a PR reviewer use to test or verify this change?
---
Tariswap test (`utilities/tariswap_test_bench`)

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify