### PR TITLE
chore!: renaming and hasher documentation

### DIFF
--- a/applications/tari_validator_node/src/consensus/signature_service.rs
+++ b/applications/tari_validator_node/src/consensus/signature_service.rs
@@ -36,7 +36,7 @@ impl VoteSignatureService for TariSignatureService {
         block_id: &BlockId,
         decision: &QuorumDecision,
     ) -> bool {
-        let challenge = self.create_challenge(leaf_hash, block_id, decision);
-        signature.verify(challenge)
+        let message = self.create_message(leaf_hash, block_id, decision);
+        signature.verify(message)
     }
 }

--- a/dan_layer/common_types/src/hasher.rs
+++ b/dan_layer/common_types/src/hasher.rs
@@ -11,10 +11,18 @@ use tari_bor::encode_into;
 use tari_common_types::types::FixedHash;
 use tari_crypto::hashing::DomainSeparation;
 
+/// Create a new `TariHasher` using a given domain-separated hasher and label.
+/// This is just a wrapper,
 pub fn tari_hasher<D: DomainSeparation>(label: &'static str) -> TariHasher {
     TariHasher::new_with_label::<D>(label)
 }
 
+/// A domain-separated hasher that uses CBOR internally to ensure hashing is canonical.
+///
+/// The hasher produces 32 bytes of output using the `Blake2b` hash function.
+///
+/// This assumes that any input type supports `Serialize` canonically; that is, two different values of the same type
+/// must serialize distinctly.
 #[derive(Debug, Clone)]
 pub struct TariHasher {
     hasher: Blake2b<U32>,
@@ -28,6 +36,8 @@ impl TariHasher {
     }
 
     pub fn update<T: Serialize + ?Sized>(&mut self, data: &T) {
+        // Update the hasher using the CBOR encoding of the input, which is assumed to be canonical.
+        //
         // Binary encoding does not make any contract to say that if the writer is infallible (as it is here) then
         // encoding in infallible. However this should be the case. Since it is very unergonomic to return an
         // error in hash chain functions, and therefore all usages of the hasher, we assume all types implement

--- a/dan_layer/consensus/src/block_validations.rs
+++ b/dan_layer/consensus/src/block_validations.rs
@@ -169,7 +169,7 @@ pub async fn check_quorum_certificate<TConsensusSpec: ConsensusSpec>(
     }
 
     for (sign, leaf) in qc.signatures().iter().zip(vns.iter()) {
-        let challenge = vote_signing_service.create_challenge(leaf, qc.block_id(), &qc.decision());
+        let challenge = vote_signing_service.create_message(leaf, qc.block_id(), &qc.decision());
         if !sign.verify(challenge) {
             return Err(ProposalValidationError::QCInvalidSignature { qc: qc.clone() }.into());
         }

--- a/dan_layer/consensus/src/traits/signing_service.rs
+++ b/dan_layer/consensus/src/traits/signing_service.rs
@@ -12,12 +12,7 @@ pub trait ValidatorSignatureService {
 }
 
 pub trait VoteSignatureService: ValidatorSignatureService {
-    fn create_challenge(
-        &self,
-        voter_leaf_hash: &FixedHash,
-        block_id: &BlockId,
-        decision: &QuorumDecision,
-    ) -> FixedHash {
+    fn create_message(&self, voter_leaf_hash: &FixedHash, block_id: &BlockId, decision: &QuorumDecision) -> FixedHash {
         vote_signature_hasher()
             .chain(voter_leaf_hash)
             .chain(block_id)
@@ -26,8 +21,8 @@ pub trait VoteSignatureService: ValidatorSignatureService {
     }
 
     fn sign_vote(&self, leaf_hash: &FixedHash, block_id: &BlockId, decision: &QuorumDecision) -> ValidatorSignature {
-        let challenge = self.create_challenge(leaf_hash, block_id, decision);
-        let signature = self.sign(challenge);
+        let message = self.create_message(leaf_hash, block_id, decision);
+        let signature = self.sign(message);
         ValidatorSignature::new(self.public_key().clone(), signature)
     }
 


### PR DESCRIPTION
Description
---
Updates the documentation for `TariHasher`. Does some renaming relating to hasher outputs.

Motivation and Context
---
The `TariHasher` type has minimal documentation. Because it uses CBOR encoding under the hood to help ensure canonical hasher input, it may be useful to describe its design intent and requirements on input data. This PR adds such documentation.

Separately, one use of the hasher functionality is to [produce vote signature messages](https://github.com/tari-project/tari-dan/blob/9db28d44b9bc328d8523e2665dab4f94e8d53813/dan_layer/consensus/src/traits/signing_service.rs#L21-L25). The naming used suggests this value is a signature challenge, which is not the case. This PR does some renaming to clarify this.

How Has This Been Tested?
---
Existing tests pass.

What process can a PR reviewer use to test or verify this change?
---
Confirm that the updated documentation is accurate, and that the renaming was done correctly.

BREAKING CHANGE: Changes the `VoteSignatureService` public trait API via a rename.