### PR TITLE
feat(swarm): allow custom listen IP configuration

### DIFF
--- a/applications/tari_swarm_daemon/src/config.rs
+++ b/applications/tari_swarm_daemon/src/config.rs
@@ -89,7 +89,8 @@ pub struct InstanceConfig {
     pub name: String,
     pub instance_type: InstanceType,
     pub num_instances: u32,
-    pub extra_args: HashMap<String, String>,
+    #[serde(alias = "extra_args")]
+    pub settings: HashMap<String, String>,
 }
 
 impl InstanceConfig {
@@ -98,7 +99,7 @@ impl InstanceConfig {
             name: instance_type.to_string(),
             instance_type,
             num_instances: 1,
-            extra_args: HashMap::new(),
+            settings: HashMap::new(),
         }
     }
 
@@ -107,8 +108,8 @@ impl InstanceConfig {
         self
     }
 
-    pub fn with_arg<K: Into<String>, V: ToString>(mut self, key: K, value: V) -> Self {
-        self.extra_args.insert(key.into(), value.to_string());
+    pub fn with_setting<K: Into<String>, V: ToString>(mut self, key: K, value: V) -> Self {
+        self.settings.insert(key.into(), value.to_string());
         self
     }
 

--- a/applications/tari_swarm_daemon/src/logger.rs
+++ b/applications/tari_swarm_daemon/src/logger.rs
@@ -1,0 +1,66 @@
+//    Copyright 2024 The Tari Project
+//    SPDX-License-Identifier: BSD-3-Clause
+
+use fern::FormatCallback;
+
+pub fn init_logger() -> Result<(), log::SetLoggerError> {
+    fn should_skip(target: &str) -> bool {
+        const SKIP: [&str; 3] = ["hyper::", "h2::", "tower::"];
+        SKIP.iter().any(|s| target.starts_with(s))
+    }
+
+    let colors = fern::colors::ColoredLevelConfig::new().info(fern::colors::Color::Green);
+    fern::Dispatch::new()
+        .format(move |out, message, record| {
+            if should_skip(record.target()) {
+                return;
+            }
+
+            let fallback =   |out: FormatCallback<'_>|  out.finish(format_args!(
+                "{} {} {}",
+                humantime::format_rfc3339(std::time::SystemTime::now()),
+                colors.color(record.level()),
+                message
+            ));
+
+            // Example: [Validator node-#1] 12:55 INFO Received vote for block #NodeHeight(88) d9abc7b1bb66fd912848f5bc4e5a69376571237e3243dc7f6a91db02bb5cf37c from a08cf5038e8e3cda8e3716c79f769cd42fad05f7110628efb5be6a40e28bc94c (4 of 3)
+            // Implement a naive parsing of the log message to extract the target, level and the log message from each running process
+            let message_str = message.to_string();
+            let Some((target, rest)) = message_str.split_once( ']') else {
+                fallback(out);
+                return;
+            };
+
+            let mut parts = rest.trim().splitn(3, ' ');
+
+            // Skip the time
+            if parts.next().is_none() {
+                fallback(out);
+                return;
+            }
+
+            let Some(level) = parts.next()
+                .and_then(|s| s.parse().ok())
+                .map(|l| colors.color(l)) else {
+                fallback(out);
+                return;
+            };
+
+            let Some(log) = parts.next() else {
+                fallback(out);
+                return;
+            };
+
+            out.finish(format_args!(
+                "{} {}] {} {}",
+                humantime::format_rfc3339(std::time::SystemTime::now()),
+                target,
+                level,
+                log
+            ))
+        })
+        .level(log::LevelFilter::Debug)
+        .chain(std::io::stdout())
+        // .chain(fern::log_file("output.log").unwrap())
+        .apply()
+}

--- a/applications/tari_swarm_daemon/src/main.rs
+++ b/applications/tari_swarm_daemon/src/main.rs
@@ -151,7 +151,7 @@ fn get_base_config(cli: &Cli) -> anyhow::Result<Config> {
         // Let's mine 10 blocks on startup by default.
         InstanceConfig::new(InstanceType::MinoTariMiner)
             .with_name("Minotari Miner")
-            .with_arg("max_blocks", "10"),
+            .with_setting("max_blocks", "10"),
         InstanceConfig::new(InstanceType::TariValidatorNode)
             .with_name("Validator node")
             .with_num_instances(1),

--- a/applications/tari_swarm_daemon/src/process_definitions/context.rs
+++ b/applications/tari_swarm_daemon/src/process_definitions/context.rs
@@ -23,7 +23,7 @@ pub struct ProcessContext<'a> {
     listen_ip: IpAddr,
     port_allocator: &'a mut AllocatedPorts,
     instances: &'a InstanceManager,
-    args: &'a HashMap<String, String>,
+    settings: &'a HashMap<String, String>,
 }
 
 impl<'a> ProcessContext<'a> {
@@ -35,7 +35,7 @@ impl<'a> ProcessContext<'a> {
         listen_ip: IpAddr,
         port_allocator: &'a mut AllocatedPorts,
         instances: &'a InstanceManager,
-        args: &'a HashMap<String, String>,
+        settings: &'a HashMap<String, String>,
     ) -> Self {
         Self {
             instance_id,
@@ -45,7 +45,7 @@ impl<'a> ProcessContext<'a> {
             listen_ip,
             port_allocator,
             instances,
-            args,
+            settings,
         }
     }
 
@@ -65,8 +65,8 @@ impl<'a> ProcessContext<'a> {
         self.network
     }
 
-    pub fn get_arg(&self, key: &str) -> Option<&String> {
-        self.args.get(key)
+    pub fn get_setting(&self, key: &str) -> Option<&String> {
+        self.settings.get(key)
     }
 
     pub async fn get_free_port(&mut self, name: &'static str) -> anyhow::Result<u16> {

--- a/applications/tari_swarm_daemon/src/process_definitions/context.rs
+++ b/applications/tari_swarm_daemon/src/process_definitions/context.rs
@@ -20,7 +20,7 @@ pub struct ProcessContext<'a> {
     bin: &'a PathBuf,
     base_path: PathBuf,
     network: Network,
-    local_ip: IpAddr,
+    listen_ip: IpAddr,
     port_allocator: &'a mut AllocatedPorts,
     instances: &'a InstanceManager,
     args: &'a HashMap<String, String>,
@@ -32,7 +32,7 @@ impl<'a> ProcessContext<'a> {
         bin: &'a PathBuf,
         base_path: PathBuf,
         network: Network,
-        local_ip: IpAddr,
+        listen_ip: IpAddr,
         port_allocator: &'a mut AllocatedPorts,
         instances: &'a InstanceManager,
         args: &'a HashMap<String, String>,
@@ -42,7 +42,7 @@ impl<'a> ProcessContext<'a> {
             bin,
             base_path,
             network,
-            local_ip,
+            listen_ip,
             port_allocator,
             instances,
             args,
@@ -73,8 +73,8 @@ impl<'a> ProcessContext<'a> {
         Ok(self.port_allocator.get_or_next_port(name).await)
     }
 
-    pub fn local_ip(&self) -> &IpAddr {
-        &self.local_ip
+    pub fn listen_ip(&self) -> &IpAddr {
+        &self.listen_ip
     }
 
     pub fn environment(&self) -> Vec<(&str, &str)> {

--- a/applications/tari_swarm_daemon/src/process_definitions/indexer.rs
+++ b/applications/tari_swarm_daemon/src/process_definitions/indexer.rs
@@ -24,11 +24,11 @@ impl ProcessDefinition for Indexer {
         let mut command = Command::new(context.bin());
         let jrpc_port = context.get_free_port("jrpc").await?;
         let web_ui_port = context.get_free_port("web").await?;
-        let local_ip = context.local_ip();
+        let listen_ip = context.listen_ip();
 
-        let json_rpc_public_address = format!("{local_ip}:{jrpc_port}");
-        let json_rpc_address = format!("{local_ip}:{jrpc_port}");
-        let web_ui_address = format!("{local_ip}:{web_ui_port}");
+        let json_rpc_public_address = format!("{listen_ip}:{jrpc_port}");
+        let json_rpc_address = format!("{listen_ip}:{jrpc_port}");
+        let web_ui_address = format!("{listen_ip}:{web_ui_port}");
 
         let base_node = context
             .minotari_nodes()
@@ -39,7 +39,7 @@ impl ProcessDefinition for Indexer {
             .instance()
             .allocated_ports()
             .get("grpc")
-            .map(|port| format!("{local_ip}:{port}"))
+            .map(|port| format!("{listen_ip}:{port}"))
             .ok_or_else(|| anyhow!("grpc port not found for base node"))?;
 
         command

--- a/applications/tari_swarm_daemon/src/process_definitions/minotari_miner.rs
+++ b/applications/tari_swarm_daemon/src/process_definitions/minotari_miner.rs
@@ -24,7 +24,7 @@ impl MinotariMiner {
 impl ProcessDefinition for MinotariMiner {
     async fn get_command(&self, context: ProcessContext<'_>) -> anyhow::Result<Command> {
         let mut command = Command::new(context.bin());
-        let local_ip = context.local_ip();
+        let listen_ip = context.listen_ip();
         let base_node = context
             .minotari_nodes()
             .next()
@@ -60,7 +60,7 @@ impl ProcessDefinition for MinotariMiner {
             .arg(format!("--max-blocks={max_blocks}"))
             .arg(format!("-pminer.wallet_payment_address={wallet_payment_address}"))
             .arg(format!(
-                "-pminer.base_node_grpc_address=/ip4/{local_ip}/tcp/{base_node_grpc_port}",
+                "-pminer.base_node_grpc_address=/ip4/{listen_ip}/tcp/{base_node_grpc_port}",
             ))
             .arg("-pminer.num_mining_threads=1");
 

--- a/applications/tari_swarm_daemon/src/process_definitions/minotari_miner.rs
+++ b/applications/tari_swarm_daemon/src/process_definitions/minotari_miner.rs
@@ -44,7 +44,7 @@ impl ProcessDefinition for MinotariMiner {
             TariAddress::from_bytes(&address).expect("Invalid public key returned from console wallet");
 
         let max_blocks = context
-            .get_arg("max_blocks")
+            .get_setting("max_blocks")
             .map(|s| u64::from_str(s))
             .transpose()
             .context("max_blocks is not a u64")?

--- a/applications/tari_swarm_daemon/src/process_definitions/minotari_node.rs
+++ b/applications/tari_swarm_daemon/src/process_definitions/minotari_node.rs
@@ -24,9 +24,9 @@ impl ProcessDefinition for MinotariNode {
         let mut command = Command::new(context.bin());
         let p2p_port = context.get_free_port("p2p").await?;
         let grpc_port = context.get_free_port("grpc").await?;
-        let local_ip = context.local_ip();
+        let listen_ip = context.listen_ip();
 
-        let public_address = format!("/ip4/{local_ip}/tcp/{p2p_port}");
+        let public_address = format!("/ip4/{listen_ip}/tcp/{p2p_port}");
 
         let base_nodes = context.minotari_nodes();
         let mut base_node_addresses = Vec::new();
@@ -47,7 +47,7 @@ impl ProcessDefinition for MinotariNode {
                 "-pbase_node.p2p.transport.tcp.listener_address={public_address}"
             ))
             .arg(format!("-pbase_node.p2p.public_addresses={public_address}"))
-            .arg(format!("-pbase_node.grpc_address=/ip4/{local_ip}/tcp/{grpc_port}"))
+            .arg(format!("-pbase_node.grpc_address=/ip4/{listen_ip}/tcp/{grpc_port}"))
             .args([
                 "--non-interactive",
                 "--enable-grpc",

--- a/applications/tari_swarm_daemon/src/process_definitions/minotari_wallet.rs
+++ b/applications/tari_swarm_daemon/src/process_definitions/minotari_wallet.rs
@@ -25,9 +25,9 @@ impl ProcessDefinition for MinotariWallet {
         let mut command = Command::new(context.bin());
         let p2p_port = context.get_free_port("p2p").await?;
         let grpc_port = context.get_free_port("grpc").await?;
-        let local_ip = context.local_ip();
+        let listen_ip = context.listen_ip();
 
-        let public_address = format!("/ip4/{local_ip}/tcp/{p2p_port}");
+        let public_address = format!("/ip4/{listen_ip}/tcp/{p2p_port}");
 
         let base_nodes = context.minotari_nodes().collect::<Vec<_>>();
 
@@ -55,7 +55,7 @@ impl ProcessDefinition for MinotariWallet {
             .arg("-pwallet.p2p.transport.type=tcp")
             .arg(format!("-pwallet.p2p.transport.tcp.listener_address={public_address}"))
             .arg(format!("-pwallet.p2p.public_addresses={public_address}"))
-            .arg(format!("-pwallet.grpc_address=/ip4/{local_ip}/tcp/{grpc_port}"))
+            .arg(format!("-pwallet.grpc_address=/ip4/{listen_ip}/tcp/{grpc_port}"))
             .args(["--non-interactive", "-pwallet.p2p.allow_test_addresses=true"])
             .arg(format!(
                 "-p{}.p2p.seeds.peer_seeds={}",

--- a/applications/tari_swarm_daemon/src/process_definitions/signaling_server.rs
+++ b/applications/tari_swarm_daemon/src/process_definitions/signaling_server.rs
@@ -20,8 +20,8 @@ impl ProcessDefinition for SignalingServer {
     async fn get_command(&self, mut context: ProcessContext<'_>) -> anyhow::Result<Command> {
         let mut command = Command::new(context.bin());
         let jrpc_port = context.get_free_port("jrpc").await?;
-        let local_ip = context.local_ip();
-        let listen_addr = format!("{local_ip}:{jrpc_port}");
+        let listen_ip = context.listen_ip();
+        let listen_addr = format!("{listen_ip}:{jrpc_port}");
 
         command
             .arg("-b")

--- a/applications/tari_swarm_daemon/src/process_definitions/validator_node.rs
+++ b/applications/tari_swarm_daemon/src/process_definitions/validator_node.rs
@@ -25,11 +25,11 @@ impl ProcessDefinition for ValidatorNode {
         let mut command = Command::new(context.bin());
         let jrpc_port = context.get_free_port("jrpc").await?;
         let web_ui_port = context.get_free_port("web").await?;
-        let local_ip = context.local_ip();
+        let listen_ip = context.listen_ip();
 
-        let json_rpc_public_address = format!("{local_ip}:{jrpc_port}");
-        let json_rpc_address = format!("{local_ip}:{jrpc_port}");
-        let web_ui_address = format!("{local_ip}:{web_ui_port}");
+        let json_rpc_public_address = format!("{listen_ip}:{jrpc_port}");
+        let json_rpc_address = format!("{listen_ip}:{jrpc_port}");
+        let web_ui_address = format!("{listen_ip}:{web_ui_port}");
 
         let base_node = context
             .minotari_nodes()
@@ -40,7 +40,7 @@ impl ProcessDefinition for ValidatorNode {
             .instance()
             .allocated_ports()
             .get("grpc")
-            .map(|port| format!("{local_ip}:{port}"))
+            .map(|port| format!("{listen_ip}:{port}"))
             .ok_or_else(|| anyhow!("grpc port not found for base node"))?;
 
         debug!(

--- a/applications/tari_swarm_daemon/src/process_definitions/wallet_daemon.rs
+++ b/applications/tari_swarm_daemon/src/process_definitions/wallet_daemon.rs
@@ -24,18 +24,18 @@ impl ProcessDefinition for WalletDaemon {
         let mut command = Command::new(context.bin());
         let jrpc_port = context.get_free_port("jrpc").await?;
         let web_ui_port = context.get_free_port("web").await?;
-        let local_ip = context.local_ip();
+        let listen_ip = context.listen_ip();
 
-        let json_rpc_public_address = format!("{local_ip}:{jrpc_port}");
-        let json_rpc_address = format!("{local_ip}:{jrpc_port}");
-        let web_ui_address = format!("{local_ip}:{web_ui_port}");
+        let json_rpc_public_address = format!("{listen_ip}:{jrpc_port}");
+        let json_rpc_address = format!("{listen_ip}:{jrpc_port}");
+        let web_ui_address = format!("{listen_ip}:{web_ui_port}");
 
         let indexer = context
             .indexers()
             .next()
             .ok_or_else(|| anyhow!("Indexer should be started before wallet daemon"))?;
         let indexer_url = format!(
-            "http://{local_ip}:{}",
+            "http://{listen_ip}:{}",
             indexer
                 .instance()
                 .allocated_ports()
@@ -59,7 +59,7 @@ impl ProcessDefinition for WalletDaemon {
         let maybe_signaling_server = context.signaling_servers().next();
         if let Some(signaling_server) = maybe_signaling_server {
             let signaling_server_url = format!(
-                "{local_ip}:{}",
+                "{listen_ip}:{}",
                 signaling_server
                     .instance()
                     .allocated_ports()

--- a/applications/tari_swarm_daemon/src/process_manager/instances/instance.rs
+++ b/applications/tari_swarm_daemon/src/process_manager/instances/instance.rs
@@ -16,7 +16,7 @@ pub struct Instance {
     child: Child,
     allocated_ports: AllocatedPorts,
     base_path: PathBuf,
-    extra_args: HashMap<String, String>,
+    settings: HashMap<String, String>,
     is_running: bool,
 }
 
@@ -28,7 +28,7 @@ impl Instance {
         child: Child,
         allocated_ports: AllocatedPorts,
         base_path: PathBuf,
-        extra_args: HashMap<String, String>,
+        settings: HashMap<String, String>,
     ) -> Self {
         Self {
             id,
@@ -37,7 +37,7 @@ impl Instance {
             child,
             allocated_ports,
             base_path,
-            extra_args,
+            settings,
             is_running: true,
         }
     }
@@ -70,8 +70,8 @@ impl Instance {
         &self.base_path
     }
 
-    pub fn extra_args(&self) -> &HashMap<String, String> {
-        &self.extra_args
+    pub fn settings(&self) -> &HashMap<String, String> {
+        &self.settings
     }
 
     pub fn is_running(&self) -> bool {

--- a/applications/tari_swarm_daemon/src/process_manager/instances/manager.rs
+++ b/applications/tari_swarm_daemon/src/process_manager/instances/manager.rs
@@ -162,10 +162,10 @@ impl InstanceManager {
         self.port_allocator.register(instance_id, allocated_ports.clone());
 
         if let Some(stdout) = child.stdout.take() {
-            forward_logs(stdout_log_path, stdout, format!("{instance_type}#{instance_id}"));
+            forward_logs(stdout_log_path, stdout, instance_name.clone());
         }
         if let Some(stderr) = child.stderr.take() {
-            forward_logs(stderr_log_path, stderr, format!("{instance_type}#{instance_id}"));
+            forward_logs(stderr_log_path, stderr, instance_name.clone());
         }
 
         let mut instance = Instance::new_started(


### PR DESCRIPTION
Description
---
Allows user to specify `listen_ip` in extra args for the instance to override the IP address used for listeners (JSON-rpc, web etc)
Log target for stdout output of all instances uses the instance name to be consistent with the web UI
Greatly improve instance log output

Motivation and Context
---
This feature has been requested for use with docker.

extra_args is not named well and has been renamed to `settings`. extra_args is still accepted for backwards compatibilty

How Has This Been Tested?
---
By adding `listen_ip = "0.0.0.0"` to extra_args for the validator node.

What process can a PR reviewer use to test or verify this change?
---
As above, works with all instances that have listeners

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify