### PR TITLE
chore: add github workflow for npm publish

### DIFF
--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -3,18 +3,9 @@
 # See https://github.com/marketplace/actions/npm-publish for more information
 name: Publish Packages to npmjs
 
-# TODO: after confirming that the action works, set the trigger on "development" branch commits instead of PRs 
-# on:
-#   push:
-#     branches: development
-
 on:
-  pull_request:
-    types:
-      - opened
-      - reopened
-      - edited
-      - synchronize
+  push:
+    branches: development
 
 jobs:
   # Publish the TypeScript bindings to the NPM registry

--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -29,7 +29,6 @@ jobs:
         with:
           node-version: "20"
       - run: npm ci
-      - run: npm test
       - uses: JS-DevTools/npm-publish@v3
         id: publish
         with:

--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -1,0 +1,50 @@
+---
+# Publishing all NPM packages to the npm registry when the version number changes
+# See https://github.com/marketplace/actions/npm-publish for more information
+name: Publish Packages to npmjs
+
+on:
+  push:
+    branches: development
+
+jobs:
+  # Publish the TypeScript bindings to the NPM registry
+  publish-typescript-bindings:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./bindings
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "20"
+      - run: npm ci
+      - run: npm test
+      - uses: JS-DevTools/npm-publish@v3
+        id: publish
+        with:
+          token: ${{ secrets.NPM_TOKEN }}
+      - if: ${{ steps.publish.outputs.type }}
+        run: echo "Published to NPM registry '${{ steps.publish.outputs.name }}' version '${{ steps.publish.outputs.version }}'"
+
+  # Publish the Tari Wallet Daemon client to the NPM registry
+  publish-wallet-daemon-client:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./clients/javascript/wallet_daemon_client
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "20"
+      - run: npm ci
+      - run: npm test
+      - uses: JS-DevTools/npm-publish@v3
+        id: publish
+        with:
+          token: ${{ secrets.NPM_TOKEN }}
+      - if: ${{ steps.publish.outputs.type }}
+        run: echo "Published to NPM registry '${{ steps.publish.outputs.name }}' version '${{ steps.publish.outputs.version }}'"
+      

--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -3,9 +3,18 @@
 # See https://github.com/marketplace/actions/npm-publish for more information
 name: Publish Packages to npmjs
 
+# TODO: after confirming that the action works, set the trigger on "development" branch commits instead of PRs 
+# on:
+#   push:
+#     branches: development
+
 on:
-  push:
-    branches: development
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - edited
+      - synchronize
 
 jobs:
   # Publish the TypeScript bindings to the NPM registry

--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -48,7 +48,6 @@ jobs:
         with:
           node-version: "20"
       - run: npm ci
-      - run: npm test
       - uses: JS-DevTools/npm-publish@v3
         id: publish
         with:


### PR DESCRIPTION
Description
---
Added a new github CI action to automatically publish to npm registry on every version change::
* TypeScript bindings
* Wallet daemon client

Motivation and Context
---
The `typescript-bindings` and the `wallet-daemon-client` npm packages are used by multiple projects. We want to automatically publish their latest versions to the [NPM registry](https://www.npmjs.com/) when the package versions increases. This way dependent projects can directly include the npm dependency for them.

How Has This Been Tested?
---
In progress

What process can a PR reviewer use to test or verify this change?
---
Testing in progress

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify