### PR TITLE
fix(walletd): use transactions.inputs field

### DIFF
--- a/clients/wallet_daemon_client/src/types.rs
+++ b/clients/wallet_daemon_client/src/types.rs
@@ -102,12 +102,12 @@ pub struct TransactionSubmitRequest {
     pub transaction: Option<UnsignedTransaction>,
     #[cfg_attr(feature = "ts", ts(type = "number | null"))]
     pub signing_key_index: Option<u64>,
-    pub inputs: Vec<SubstateRequirement>,
     pub override_inputs: bool,
     pub is_dry_run: bool,
     #[cfg_attr(feature = "ts", ts(type = "Array<number>"))]
     pub proof_ids: Vec<ConfidentialProofId>,
     // TODO: remove the following fields
+    pub inputs: Vec<SubstateRequirement>,
     pub fee_instructions: Vec<Instruction>,
     pub instructions: Vec<Instruction>,
     pub min_epoch: Option<Epoch>,


### PR DESCRIPTION
Description
---
Use previously unused field in TransactionSubmitRequest

Motivation and Context
---
`transaction.inputs` in  TransactionSubmitRequest was unused

How Has This Been Tested?
---
Existing tests

What process can a PR reviewer use to test or verify this change?
---
Submit transaction using `transaction.input` field.

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify