### PR TITLE
chore: set npm access public

### DIFF
--- a/bindings/package.json
+++ b/bindings/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.3",
   "description": "",
   "main": "index.ts",
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "sh build.sh && tsc",
     "tsc": "tsc"

--- a/clients/javascript/wallet_daemon_client/package.json
+++ b/clients/javascript/wallet_daemon_client/package.json
@@ -2,6 +2,9 @@
   "name": "@tari-project/wallet_jrpc_client",
   "version": "1.0.7",
   "description": "Tari wallet JSON-RPC client library",
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "tsc",
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
Description
---
Set the `publishConfig` access to `public` for npm packages

Motivation and Context
---
Fixes `Error 402 while publishing package`

How Has This Been Tested?
---
Does not apply

What process can a PR reviewer use to test or verify this change?
---
Does not apply

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify