### PR TITLE
fix(wallet_jrpc_client): empty npm package when publishing

### DIFF
--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -20,10 +20,12 @@ jobs:
         with:
           node-version: "20"
       - run: npm ci
+      - run: npm run build
       - uses: JS-DevTools/npm-publish@v3
         with:
           token: ${{ secrets.NPM_TOKEN }}
           package: bindings
+          access: 'public'
 
   # Publish the Tari Wallet Daemon client to the NPM registry
   publish-wallet-daemon-client:
@@ -38,8 +40,10 @@ jobs:
         with:
           node-version: "20"
       - run: npm ci
+      - run: npm run build
       - uses: JS-DevTools/npm-publish@v3
         with:
           token: ${{ secrets.NPM_TOKEN }}
           package: clients/javascript/wallet_daemon_client
+          access: 'public'
       

--- a/applications/tari_dan_wallet_web_ui/package-lock.json
+++ b/applications/tari_dan_wallet_web_ui/package-lock.json
@@ -47,7 +47,7 @@
     },
     "../../clients/javascript/wallet_daemon_client": {
       "name": "@tari-project/wallet_jrpc_client",
-      "version": "1.0.7",
+      "version": "1.0.8",
       "license": "ISC",
       "dependencies": {
         "@tari-project/typescript-bindings": "1.0.3"

--- a/clients/javascript/wallet_daemon_client/package-lock.json
+++ b/clients/javascript/wallet_daemon_client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tari-project/wallet_jrpc_client",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tari-project/wallet_jrpc_client",
-      "version": "1.0.7",
+      "version": "1.0.8",
       "license": "ISC",
       "dependencies": {
         "@tari-project/typescript-bindings": "1.0.3"

--- a/clients/javascript/wallet_daemon_client/package.json
+++ b/clients/javascript/wallet_daemon_client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tari-project/wallet_jrpc_client",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Tari wallet JSON-RPC client library",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Description
---
* Added a `npm run build` step on npm publish ci jobs
* Bumped `wallet_jrpc_client` version to trigger a new npm publish

Motivation and Context
---
The CI job for publishing `wallet_jrpc_client` npm package did not include the `dist` folder where the actual code exists. To fix this, this PR runs a `npm run build` step before publishing to the npm registry to make sure the `dist` folder is created.

For safety we add it this too to the `typescript-bindings` ci job to prevent this problem in the future.

How Has This Been Tested?
---
Publishing first into a personal npm scope to test this behaviour

What process can a PR reviewer use to test or verify this change?
---
Does not apply

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify