### PR TITLE
fix(docs): tari_template_lib resource builders not showing on rust docs

### DIFF
--- a/dan_layer/template_lib/src/resource/builder/mod.rs
+++ b/dan_layer/template_lib/src/resource/builder/mod.rs
@@ -20,9 +20,9 @@
 //   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //   USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-mod confidential;
-mod fungible;
-mod non_fungible;
+pub mod confidential;
+pub mod fungible;
+pub mod non_fungible;
 
 use crate::resource::builder::{
     confidential::ConfidentialResourceBuilder,


### PR DESCRIPTION
Description
---
Set to `pub` the visibility of resource builder modules in `tari_template_lib`

Motivation and Context
---
Currently `FungibleResourceBuilder`, `NonFungibleResourceBuilder` and `ConfidentialResourceBuilder` don't show up in `tari_template_lib` docs.

This happened because the visibility of the modules containing those structs was not public, so this PR sets the visibility to public.

How Has This Been Tested?
---
Manually by running `cargo doc --open` on the `tari_template_lib` crate

What process can a PR reviewer use to test or verify this change?
---
See previous section

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify