### PR TITLE
ci(fix): add env RUSTUP_PERMIT_COPY_RENAME to fix cross-device link errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,8 @@ jobs:
   build-stable:
     name: check stable
     runs-on: [ self-hosted, ubuntu-high-cpu ]
+    env:
+      RUSTUP_PERMIT_COPY_RENAME: true
 
     steps:
       - name: checkout


### PR DESCRIPTION
Description
add env RUSTUP_PERMIT_COPY_RENAME to fix cross-device link errors

Motivation and Context
Enable CI testing for stable

How Has This Been Tested?
---

What process can a PR reviewer use to test or verify this change?
---


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify