### PR TITLE
fix(ci): remove build step when publishing typescript-bindings

### DIFF
--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -20,7 +20,6 @@ jobs:
         with:
           node-version: "20"
       - run: npm ci
-      - run: npm run build
       - uses: JS-DevTools/npm-publish@v3
         with:
           token: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Description
---
Removed the `npm build` step on `typescript-bindings` npm publish CI job

Motivation and Context
---
On https://github.com/tari-project/tari-dan/pull/1093 we introduced a step to build the npm package for both `wallet_jrpc_client` and `typescript-bindings`.

We shouldn't include that step for `typescript-bindings` as we can assume it's already built (there are checks for that) and the build runs a custom script that builds all of the rust project using cargo.

So this PR removes the `npm build` step on `typescript-bindings` npm publish CI job. We only need it for `wallet_jrpc_client` 

How Has This Been Tested?
---
Does not apply

What process can a PR reviewer use to test or verify this change?
---
Does not apply

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify