### PR TITLE
fix(sync)!: validate checkpoint merkle root

### DIFF
--- a/applications/tari_dan_app_utilities/src/consensus_constants.rs
+++ b/applications/tari_dan_app_utilities/src/consensus_constants.rs
@@ -42,7 +42,7 @@ impl ConsensusConstants {
             committee_size: 7,
             max_base_layer_blocks_ahead: 5,
             max_base_layer_blocks_behind: 5,
-            num_preshards: NumPreshards::SixtyFour,
+            num_preshards: NumPreshards::P64,
             pacemaker_max_base_time: Duration::from_secs(10),
         }
     }

--- a/dan_layer/common_types/src/hashing.rs
+++ b/dan_layer/common_types/src/hashing.rs
@@ -36,10 +36,6 @@ pub fn block_hasher() -> TariHasher {
     dan_hasher("Block")
 }
 
-pub fn state_root_hasher() -> TariHasher {
-    dan_hasher("JmtStateRoots")
-}
-
 pub fn quorum_certificate_hasher() -> TariHasher {
     dan_hasher("QuorumCertificate")
 }

--- a/dan_layer/common_types/src/num_preshards.rs
+++ b/dan_layer/common_types/src/num_preshards.rs
@@ -12,26 +12,26 @@ use serde::{Deserialize, Serialize};
 )]
 #[derive(Clone, Debug, Copy, Hash, PartialEq, Eq, Serialize, Deserialize)]
 pub enum NumPreshards {
-    One = 1,
-    Two = 2,
-    Four = 4,
-    Eight = 8,
-    Sixteen = 16,
-    ThirtyTwo = 32,
-    SixtyFour = 64,
-    OneTwentyEight = 128,
-    TwoFiftySix = 256,
+    P1 = 1,
+    P2 = 2,
+    P4 = 4,
+    P8 = 8,
+    P16 = 16,
+    P32 = 32,
+    P64 = 64,
+    P128 = 128,
+    P256 = 256,
 }
 
 impl NumPreshards {
-    pub const MAX: Self = Self::TwoFiftySix;
+    pub const MAX: Self = Self::P256;
 
     pub fn as_u32(self) -> u32 {
         self as u32
     }
 
     pub fn is_one(self) -> bool {
-        self == Self::One
+        self == Self::P1
     }
 }
 
@@ -40,15 +40,15 @@ impl TryFrom<u32> for NumPreshards {
 
     fn try_from(value: u32) -> Result<Self, Self::Error> {
         match value {
-            1 => Ok(Self::One),
-            2 => Ok(Self::Two),
-            4 => Ok(Self::Four),
-            8 => Ok(Self::Eight),
-            16 => Ok(Self::Sixteen),
-            32 => Ok(Self::ThirtyTwo),
-            64 => Ok(Self::SixtyFour),
-            128 => Ok(Self::OneTwentyEight),
-            256 => Ok(Self::TwoFiftySix),
+            1 => Ok(Self::P1),
+            2 => Ok(Self::P2),
+            4 => Ok(Self::P4),
+            8 => Ok(Self::P8),
+            16 => Ok(Self::P16),
+            32 => Ok(Self::P32),
+            64 => Ok(Self::P64),
+            128 => Ok(Self::P128),
+            256 => Ok(Self::P256),
             _ => Err(InvalidNumPreshards(value)),
         }
     }

--- a/dan_layer/common_types/src/shard_group.rs
+++ b/dan_layer/common_types/src/shard_group.rs
@@ -142,7 +142,7 @@ mod tests {
     #[test]
     fn to_substate_address_range() {
         let sg = ShardGroup::new(0, 63);
-        let range = sg.to_substate_address_range(NumPreshards::SixtyFour);
+        let range = sg.to_substate_address_range(NumPreshards::P64);
         assert_eq!(*range.start(), SubstateAddress::zero());
         assert_eq!(*range.end(), SubstateAddress::max());
     }

--- a/dan_layer/common_types/src/substate_address.rs
+++ b/dan_layer/common_types/src/substate_address.rs
@@ -305,20 +305,20 @@ mod tests {
     #[test]
     fn to_committee_shard_and_shard_range_match() {
         let address = address_at(1, 8);
-        let shard = address.to_shard(NumPreshards::Eight);
+        let shard = address.to_shard(NumPreshards::P8);
         assert_eq!(shard, 1);
 
-        let range = Shard::from(0).to_substate_address_range(NumPreshards::Two);
+        let range = Shard::from(0).to_substate_address_range(NumPreshards::P2);
         assert_range(range, SubstateAddress::zero()..address_at(1, 2));
-        let range = Shard::from(1).to_substate_address_range(NumPreshards::Two);
+        let range = Shard::from(1).to_substate_address_range(NumPreshards::P2);
         assert_range(range, address_at(1, 2)..=SubstateAddress::max());
 
         for n in 0..7 {
-            let range = Shard::from(n).to_substate_address_range(NumPreshards::Eight);
+            let range = Shard::from(n).to_substate_address_range(NumPreshards::P8);
             assert_range(range, address_at(n, 8)..address_at(n + 1, 8));
         }
 
-        let range = Shard::from(7).to_substate_address_range(NumPreshards::Eight);
+        let range = Shard::from(7).to_substate_address_range(NumPreshards::P8);
         assert_range(range, address_at(7, 8)..=address_at(8, 8));
     }
 
@@ -381,28 +381,28 @@ mod tests {
 
     #[test]
     fn to_shard() {
-        let shard = SubstateAddress::zero().to_shard(NumPreshards::Two);
+        let shard = SubstateAddress::zero().to_shard(NumPreshards::P2);
         assert_eq!(shard, 0);
-        let shard = address_at(1, 2).to_shard(NumPreshards::Two);
+        let shard = address_at(1, 2).to_shard(NumPreshards::P2);
         assert_eq!(shard, 1);
-        let shard = plus_one(address_at(1, 2)).to_shard(NumPreshards::Two);
+        let shard = plus_one(address_at(1, 2)).to_shard(NumPreshards::P2);
         assert_eq!(shard, 1);
-        let shard = SubstateAddress::max().to_shard(NumPreshards::Two);
+        let shard = SubstateAddress::max().to_shard(NumPreshards::P2);
         assert_eq!(shard, 1);
 
         for i in 0..=32 {
-            let shard = divide_shard_space(i, 32).to_shard(NumPreshards::One);
+            let shard = divide_shard_space(i, 32).to_shard(NumPreshards::P1);
             assert_eq!(shard, 0);
         }
 
         // 2 shards, exactly half of the physical shard space
         for i in 0..=8 {
-            let shard = divide_shard_space(i, 16).to_shard(NumPreshards::Two);
+            let shard = divide_shard_space(i, 16).to_shard(NumPreshards::P2);
             assert_eq!(shard, 0, "{shard} is not 0 for i: {i}");
         }
 
         for i in 9..16 {
-            let shard = divide_shard_space(i, 16).to_shard(NumPreshards::Two);
+            let shard = divide_shard_space(i, 16).to_shard(NumPreshards::P2);
             assert_eq!(shard, 1, "{shard} is not 1 for i: {i}");
         }
 
@@ -423,7 +423,7 @@ mod tests {
             }
         }
 
-        let shard = divide_floor(SubstateAddress::max(), 2).to_shard(NumPreshards::TwoFiftySix);
+        let shard = divide_floor(SubstateAddress::max(), 2).to_shard(NumPreshards::P256);
         assert_eq!(shard, 128);
     }
 
@@ -503,56 +503,56 @@ mod tests {
 
         #[test]
         fn it_returns_the_correct_shard_group() {
-            let group = SubstateAddress::zero().to_shard_group(NumPreshards::Four, 2);
+            let group = SubstateAddress::zero().to_shard_group(NumPreshards::P4, 2);
             assert_eq!(group.as_range(), Shard::from(0)..=Shard::from(1));
 
-            let group = plus_one(address_at(0, 4)).to_shard_group(NumPreshards::Four, 2);
+            let group = plus_one(address_at(0, 4)).to_shard_group(NumPreshards::P4, 2);
             assert_eq!(group.as_range(), Shard::from(0)..=Shard::from(1));
 
-            let group = address_at(1, 4).to_shard_group(NumPreshards::Four, 2);
+            let group = address_at(1, 4).to_shard_group(NumPreshards::P4, 2);
             assert_eq!(group.as_range(), Shard::from(0)..=Shard::from(1));
 
-            let group = address_at(2, 4).to_shard_group(NumPreshards::Four, 2);
+            let group = address_at(2, 4).to_shard_group(NumPreshards::P4, 2);
             assert_eq!(group.as_range(), Shard::from(2)..=Shard::from(3));
 
-            let group = address_at(3, 4).to_shard_group(NumPreshards::Four, 2);
+            let group = address_at(3, 4).to_shard_group(NumPreshards::P4, 2);
             assert_eq!(group.as_range(), Shard::from(2)..=Shard::from(3));
 
-            let group = SubstateAddress::max().to_shard_group(NumPreshards::Four, 2);
+            let group = SubstateAddress::max().to_shard_group(NumPreshards::P4, 2);
             assert_eq!(group.as_range(), Shard::from(2)..=Shard::from(3));
 
-            let group = minus_one(address_at(1, 64)).to_shard_group(NumPreshards::SixtyFour, 16);
+            let group = minus_one(address_at(1, 64)).to_shard_group(NumPreshards::P64, 16);
             assert_eq!(group.as_range(), Shard::from(0)..=Shard::from(3));
-            let group = address_at(4, 64).to_shard_group(NumPreshards::SixtyFour, 16);
+            let group = address_at(4, 64).to_shard_group(NumPreshards::P64, 16);
             assert_eq!(group.as_range(), Shard::from(4)..=Shard::from(7));
 
-            let group = address_at(8, 64).to_shard_group(NumPreshards::SixtyFour, 2);
+            let group = address_at(8, 64).to_shard_group(NumPreshards::P64, 2);
             assert_eq!(group.as_range(), Shard::from(0)..=Shard::from(31));
-            let group = address_at(5, 8).to_shard_group(NumPreshards::SixtyFour, 2);
+            let group = address_at(5, 8).to_shard_group(NumPreshards::P64, 2);
             assert_eq!(group.as_range(), Shard::from(32)..=Shard::from(63));
 
             // On boundary
-            let group = address_at(0, 8).to_shard_group(NumPreshards::SixtyFour, 2);
+            let group = address_at(0, 8).to_shard_group(NumPreshards::P64, 2);
             assert_eq!(group.as_range(), Shard::from(0)..=Shard::from(31));
-            let group = address_at(4, 8).to_shard_group(NumPreshards::SixtyFour, 2);
+            let group = address_at(4, 8).to_shard_group(NumPreshards::P64, 2);
             assert_eq!(group.as_range(), Shard::from(32)..=Shard::from(63));
 
-            let group = address_at(8, 8).to_shard_group(NumPreshards::SixtyFour, 2);
+            let group = address_at(8, 8).to_shard_group(NumPreshards::P64, 2);
             assert_eq!(group.as_range(), Shard::from(32)..=Shard::from(63));
 
-            let group = plus_one(address_at(3, 64)).to_shard_group(NumPreshards::SixtyFour, 32);
+            let group = plus_one(address_at(3, 64)).to_shard_group(NumPreshards::P64, 32);
             assert_eq!(group.as_range(), Shard::from(2)..=Shard::from(3));
 
-            let group = plus_one(address_at(3, 64)).to_shard_group(NumPreshards::SixtyFour, 32);
+            let group = plus_one(address_at(3, 64)).to_shard_group(NumPreshards::P64, 32);
             assert_eq!(group.as_range(), Shard::from(2)..=Shard::from(3));
 
-            let group = address_at(16, 64).to_shard_group(NumPreshards::SixtyFour, 32);
+            let group = address_at(16, 64).to_shard_group(NumPreshards::P64, 32);
             assert_eq!(group.as_range(), Shard::from(16)..=Shard::from(17));
 
-            let group = minus_one(address_at(1, 4)).to_shard_group(NumPreshards::SixtyFour, 64);
+            let group = minus_one(address_at(1, 4)).to_shard_group(NumPreshards::P64, 64);
             assert_eq!(group.as_range(), Shard::from(16)..=Shard::from(16));
 
-            let group = address_at(66, 256).to_shard_group(NumPreshards::SixtyFour, 16);
+            let group = address_at(66, 256).to_shard_group(NumPreshards::P64, 16);
             assert_eq!(group.as_range(), Shard::from(16)..=Shard::from(19));
         }
 
@@ -588,66 +588,66 @@ mod tests {
         fn it_returns_the_correct_shard_group_for_odd_num_committees() {
             // All shard groups except the last have 3 shards each
 
-            let group = address_at(0, 64).to_shard_group(NumPreshards::SixtyFour, 3);
+            let group = address_at(0, 64).to_shard_group(NumPreshards::P64, 3);
             // First shard group gets an extra shard to cover the remainder
             assert_eq!(group.as_range(), Shard::from(0)..=Shard::from(21));
             assert_eq!(group.len(), 22);
-            let group = address_at(31, 64).to_shard_group(NumPreshards::SixtyFour, 3);
+            let group = address_at(31, 64).to_shard_group(NumPreshards::P64, 3);
             assert_eq!(group.as_range(), Shard::from(22)..=Shard::from(42));
             assert_eq!(group.len(), 21);
-            let group = address_at(50, 64).to_shard_group(NumPreshards::SixtyFour, 3);
+            let group = address_at(50, 64).to_shard_group(NumPreshards::P64, 3);
             assert_eq!(group.as_range(), Shard::from(43)..=Shard::from(63));
             assert_eq!(group.len(), 21);
 
-            let group = address_at(3, 64).to_shard_group(NumPreshards::SixtyFour, 7);
+            let group = address_at(3, 64).to_shard_group(NumPreshards::P64, 7);
             assert_eq!(group.as_range(), Shard::from(0)..=Shard::from(9));
             assert_eq!(group.len(), 10);
-            let group = address_at(11, 64).to_shard_group(NumPreshards::SixtyFour, 7);
+            let group = address_at(11, 64).to_shard_group(NumPreshards::P64, 7);
             assert_eq!(group.as_range(), Shard::from(10)..=Shard::from(18));
             assert_eq!(group.len(), 9);
-            let group = address_at(22, 64).to_shard_group(NumPreshards::SixtyFour, 7);
+            let group = address_at(22, 64).to_shard_group(NumPreshards::P64, 7);
             assert_eq!(group.as_range(), Shard::from(19)..=Shard::from(27));
             assert_eq!(group.len(), 9);
-            let group = address_at(60, 64).to_shard_group(NumPreshards::SixtyFour, 7);
+            let group = address_at(60, 64).to_shard_group(NumPreshards::P64, 7);
             assert_eq!(group.as_range(), Shard::from(55)..=Shard::from(63));
             assert_eq!(group.len(), 9);
-            let group = address_at(64, 64).to_shard_group(NumPreshards::SixtyFour, 7);
+            let group = address_at(64, 64).to_shard_group(NumPreshards::P64, 7);
             assert_eq!(group.as_range(), Shard::from(55)..=Shard::from(63));
             assert_eq!(group.len(), 9);
-            let group = SubstateAddress::zero().to_shard_group(NumPreshards::Eight, 3);
+            let group = SubstateAddress::zero().to_shard_group(NumPreshards::P8, 3);
             assert_eq!(group.as_range(), Shard::from(0)..=Shard::from(2));
 
-            let group = address_at(1, 8).to_shard_group(NumPreshards::Eight, 3);
+            let group = address_at(1, 8).to_shard_group(NumPreshards::P8, 3);
             assert_eq!(group.as_range(), Shard::from(0)..=Shard::from(2));
 
-            let group = address_at(1, 8).to_shard_group(NumPreshards::Eight, 3);
+            let group = address_at(1, 8).to_shard_group(NumPreshards::P8, 3);
             assert_eq!(group.as_range(), Shard::from(0)..=Shard::from(2));
 
-            let group = address_at(3, 8).to_shard_group(NumPreshards::Eight, 3);
+            let group = address_at(3, 8).to_shard_group(NumPreshards::P8, 3);
             assert_eq!(group.as_range(), Shard::from(3)..=Shard::from(5));
 
-            let group = address_at(4, 8).to_shard_group(NumPreshards::Eight, 3);
+            let group = address_at(4, 8).to_shard_group(NumPreshards::P8, 3);
             assert_eq!(group.as_range(), Shard::from(3)..=Shard::from(5));
 
-            let group = address_at(5, 8).to_shard_group(NumPreshards::Eight, 3);
+            let group = address_at(5, 8).to_shard_group(NumPreshards::P8, 3);
             assert_eq!(group.as_range(), Shard::from(3)..=Shard::from(5));
             //
-            let group = address_at(6, 8).to_shard_group(NumPreshards::Eight, 3);
+            let group = address_at(6, 8).to_shard_group(NumPreshards::P8, 3);
             assert_eq!(group.as_range(), Shard::from(6)..=Shard::from(7));
 
-            let group = address_at(7, 8).to_shard_group(NumPreshards::Eight, 3);
+            let group = address_at(7, 8).to_shard_group(NumPreshards::P8, 3);
             assert_eq!(group.as_range(), Shard::from(6)..=Shard::from(7));
-            let group = address_at(8, 8).to_shard_group(NumPreshards::Eight, 3);
+            let group = address_at(8, 8).to_shard_group(NumPreshards::P8, 3);
             assert_eq!(group.as_range(), Shard::from(6)..=Shard::from(7));
 
             // Committee = 5
-            let group = address_at(4, 8).to_shard_group(NumPreshards::Eight, 5);
+            let group = address_at(4, 8).to_shard_group(NumPreshards::P8, 5);
             assert_eq!(group.as_range(), Shard::from(4)..=Shard::from(5));
 
-            let group = address_at(7, 8).to_shard_group(NumPreshards::Eight, 5);
+            let group = address_at(7, 8).to_shard_group(NumPreshards::P8, 5);
             assert_eq!(group.as_range(), Shard::from(7)..=Shard::from(7));
 
-            let group = address_at(8, 8).to_shard_group(NumPreshards::Eight, 5);
+            let group = address_at(8, 8).to_shard_group(NumPreshards::P8, 5);
             assert_eq!(group.as_range(), Shard::from(7)..=Shard::from(7));
         }
     }
@@ -657,17 +657,17 @@ mod tests {
 
         #[test]
         fn it_works() {
-            let range = ShardGroup::new(0, 9).to_substate_address_range(NumPreshards::Sixteen);
+            let range = ShardGroup::new(0, 9).to_substate_address_range(NumPreshards::P16);
             assert_range(range, SubstateAddress::zero()..address_at(10, 16));
 
-            let range = ShardGroup::new(1, 15).to_substate_address_range(NumPreshards::Sixteen);
+            let range = ShardGroup::new(1, 15).to_substate_address_range(NumPreshards::P16);
             // Last shard always includes SubstateAddress::max
             assert_range(range, address_at(1, 16)..=address_at(16, 16));
 
-            let range = ShardGroup::new(1, 8).to_substate_address_range(NumPreshards::Sixteen);
+            let range = ShardGroup::new(1, 8).to_substate_address_range(NumPreshards::P16);
             assert_range(range, address_at(1, 16)..address_at(9, 16));
 
-            let range = ShardGroup::new(8, 15).to_substate_address_range(NumPreshards::Sixteen);
+            let range = ShardGroup::new(8, 15).to_substate_address_range(NumPreshards::P16);
             assert_range(range, address_at(8, 16)..=address_at(16, 16));
         }
     }

--- a/dan_layer/consensus/src/hotstuff/block_change_set.rs
+++ b/dan_layer/consensus/src/hotstuff/block_change_set.rs
@@ -11,7 +11,7 @@ use tari_dan_storage::{
         BlockDiff,
         LeafBlock,
         LockedSubstate,
-        PendingStateTreeDiff,
+        PendingShardStateTreeDiff,
         QuorumDecision,
         SubstateChange,
         SubstateRecord,
@@ -62,9 +62,9 @@ impl ProposedBlockChangeSet {
     pub fn no_vote(mut self) -> Self {
         self.quorum_decision = None;
         self.block_diff = Vec::new();
-        self.transaction_changes.clear();
-        self.state_tree_diffs.clear();
-        self.substate_locks.clear();
+        self.transaction_changes = IndexMap::new();
+        self.state_tree_diffs = IndexMap::new();
+        self.substate_locks = IndexMap::new();
         self
     }
 
@@ -142,8 +142,9 @@ impl ProposedBlockChangeSet {
         block_diff.insert(tx)?;
 
         // Store the tree diffs for each effected shard
-        for (shard, diff) in self.state_tree_diffs {
-            PendingStateTreeDiff::create(tx, *self.block.block_id(), shard, diff)?;
+        let shard_tree_diffs = self.state_tree_diffs;
+        for (shard, diff) in shard_tree_diffs {
+            PendingShardStateTreeDiff::create(tx, *self.block.block_id(), shard, diff)?;
         }
 
         // Save locks

--- a/dan_layer/consensus/src/hotstuff/on_propose.rs
+++ b/dan_layer/consensus/src/hotstuff/on_propose.rs
@@ -28,7 +28,7 @@ use tari_dan_storage::{
         LastProposed,
         LeafBlock,
         LockedBlock,
-        PendingStateTreeDiff,
+        PendingShardStateTreeDiff,
         QuorumCertificate,
         SubstateChange,
         SubstateLockFlag,
@@ -515,13 +515,16 @@ where TConsensusSpec: ConsensusSpec
             commands.iter().map(|c| c.to_string()).collect::<Vec<_>>().join(",")
         );
 
-        let pending_tree_diffs = PendingStateTreeDiff::get_all_up_to_commit_block(tx, high_qc.block_id())?;
+        let pending_tree_diffs = PendingShardStateTreeDiff::get_all_up_to_commit_block(tx, high_qc.block_id())?;
 
         let (state_root, _) = calculate_state_merkle_root(
             tx,
             local_committee_info.shard_group(),
             pending_tree_diffs,
-            substate_store.diff(),
+            substate_store
+                .diff()
+                .iter()
+                .filter(|ch| local_committee_info.shard_group().contains(&ch.shard())),
         )?;
 
         let non_local_shards = get_non_local_shards(substate_store.diff(), local_committee_info);

--- a/dan_layer/consensus/src/hotstuff/substate_store/mod.rs
+++ b/dan_layer/consensus/src/hotstuff/substate_store/mod.rs
@@ -3,10 +3,10 @@
 
 mod error;
 mod pending_store;
+mod shard_state_store;
 mod sharded_state_tree;
-mod sharded_store;
 
 pub use error::*;
 pub use pending_store::*;
+pub use shard_state_store::*;
 pub use sharded_state_tree::*;
-pub use sharded_store::*;

--- a/dan_layer/consensus/src/hotstuff/substate_store/shard_state_store.rs
+++ b/dan_layer/consensus/src/hotstuff/substate_store/shard_state_store.rs
@@ -75,7 +75,7 @@ impl<'a, TTx: StateStoreWriteTransaction> TreeStoreWriter<Version> for ShardScop
 
     fn record_stale_tree_node(&mut self, node: StaleTreeNode) -> Result<(), tari_state_tree::JmtStorageError> {
         self.tx
-            .state_tree_nodes_mark_stale_tree_node(self.shard, node)
+            .state_tree_nodes_record_stale_tree_node(self.shard, node)
             .map_err(|e| tari_state_tree::JmtStorageError::UnexpectedError(e.to_string()))
     }
 }

--- a/dan_layer/consensus/src/hotstuff/substate_store/sharded_state_tree.rs
+++ b/dan_layer/consensus/src/hotstuff/substate_store/sharded_state_tree.rs
@@ -5,15 +5,17 @@ use std::collections::HashMap;
 
 use indexmap::IndexMap;
 use log::debug;
-use tari_dan_common_types::{hashing::state_root_hasher, shard::Shard};
+use tari_dan_common_types::{shard::Shard, ShardGroup};
 use tari_dan_storage::{
-    consensus_models::{PendingStateTreeDiff, VersionedStateHashTreeDiff},
+    consensus_models::{PendingShardStateTreeDiff, VersionedStateHashTreeDiff},
     StateStoreReadTransaction,
     StateStoreWriteTransaction,
 };
 use tari_state_tree::{
+    memory_store::MemoryTreeStore,
     Hash,
     JmtStorageError,
+    RootStateTree,
     SpreadPrefixStateTree,
     StagedTreeStore,
     StateHashTreeDiff,
@@ -21,16 +23,17 @@ use tari_state_tree::{
     SubstateTreeChange,
     TreeStoreWriter,
     Version,
+    SPARSE_MERKLE_PLACEHOLDER_HASH,
 };
 
-use crate::hotstuff::substate_store::sharded_store::{ShardScopedTreeStoreReader, ShardScopedTreeStoreWriter};
+use crate::hotstuff::substate_store::shard_state_store::{ShardScopedTreeStoreReader, ShardScopedTreeStoreWriter};
 
 const LOG_TARGET: &str = "tari::dan::consensus::sharded_state_tree";
 
 pub struct ShardedStateTree<TTx> {
     tx: TTx,
-    pending_diffs: HashMap<Shard, Vec<PendingStateTreeDiff>>,
-    sharded_tree_diffs: IndexMap<Shard, VersionedStateHashTreeDiff>,
+    pending_diffs: HashMap<Shard, Vec<PendingShardStateTreeDiff>>,
+    shard_tree_diffs: IndexMap<Shard, VersionedStateHashTreeDiff>,
 }
 
 impl<TTx> ShardedStateTree<TTx> {
@@ -38,11 +41,11 @@ impl<TTx> ShardedStateTree<TTx> {
         Self {
             tx,
             pending_diffs: HashMap::new(),
-            sharded_tree_diffs: IndexMap::new(),
+            shard_tree_diffs: IndexMap::new(),
         }
     }
 
-    pub fn with_pending_diffs(self, pending_diffs: HashMap<Shard, Vec<PendingStateTreeDiff>>) -> Self {
+    pub fn with_pending_diffs(self, pending_diffs: HashMap<Shard, Vec<PendingShardStateTreeDiff>>) -> Self {
         Self { pending_diffs, ..self }
     }
 
@@ -69,25 +72,20 @@ impl<TTx: StateStoreReadTransaction> ShardedStateTree<&TTx> {
         let maybe_version = self
             .tx
             .state_tree_versions_get_latest(shard)
-            .map_err(|e| StateTreeError::StorageError(JmtStorageError::UnexpectedError(e.to_string())))?;
+            .map_err(|e| StateTreeError::JmtStorageError(JmtStorageError::UnexpectedError(e.to_string())))?;
         Ok(maybe_version)
     }
 
-    pub fn into_versioned_tree_diffs(self) -> IndexMap<Shard, VersionedStateHashTreeDiff> {
-        self.sharded_tree_diffs
+    pub fn into_shard_tree_diffs(self) -> IndexMap<Shard, VersionedStateHashTreeDiff> {
+        self.shard_tree_diffs
     }
 
     pub fn put_substate_tree_changes(
         &mut self,
+        shard_group: ShardGroup,
         changes: IndexMap<Shard, Vec<SubstateTreeChange>>,
     ) -> Result<Hash, StateTreeError> {
-        // This is here so that the state merkle root is all zeros for no changes (instead of being
-        // state_root_hasher().result()).
-        if changes.is_empty() {
-            return Ok(Hash::zero());
-        }
-
-        let mut state_roots = state_root_hasher();
+        let mut shard_state_roots = HashMap::with_capacity(changes.len());
         for (shard, changes) in changes {
             let current_version = self.get_current_version(shard)?;
             let next_version = current_version.unwrap_or(0) + 1;
@@ -97,34 +95,74 @@ impl<TTx: StateStoreReadTransaction> ShardedStateTree<&TTx> {
             // Staged store that tracks changes to the state tree
             let mut store = StagedTreeStore::new(&scoped_store);
             // Apply pending (not yet committed) diffs to the staged store
-            if let Some(diffs) = self.pending_diffs.remove(&shard) {
+            if let Some(diffs) = self.pending_diffs.get(&shard) {
                 debug!(target: LOG_TARGET, "Applying {num_diffs} pending diff(s) to shard {shard} (version={version})", num_diffs = diffs.len(), version = diffs.last().map(|d| d.version).unwrap_or(0));
                 for diff in diffs {
-                    store.apply_pending_diff(diff.diff);
+                    store.apply_pending_diff(diff.diff.clone());
                 }
             }
 
             // Apply state updates to the state tree that is backed by the staged shard-scoped store
             let mut state_tree = SpreadPrefixStateTree::new(&mut store);
             debug!(target: LOG_TARGET, "v{next_version} contains {} tree change(s) for shard {shard}", changes.len());
-            let state_root = state_tree.put_substate_changes(current_version, next_version, changes)?;
-            state_roots.update(&state_root);
-            self.sharded_tree_diffs
+            let shard_state_hash = state_tree.put_substate_changes(current_version, next_version, changes)?;
+            shard_state_roots.insert(shard, shard_state_hash);
+            self.shard_tree_diffs
                 .insert(shard, VersionedStateHashTreeDiff::new(next_version, store.into_diff()));
         }
 
-        // TODO: use a Merkle tree to generate a root for these hashes
-        Ok(state_roots.result())
+        let root_hash = self.get_shard_group_root(shard_group, shard_state_roots)?;
+        Ok(root_hash)
+    }
+
+    fn get_shard_group_root(
+        &self,
+        shard_group: ShardGroup,
+        mut shard_state_roots: HashMap<Shard, Hash>,
+    ) -> Result<Hash, StateTreeError> {
+        let mut mem_store = MemoryTreeStore::new();
+        let mut root_tree = RootStateTree::new(&mut mem_store);
+        let mut hashes = Vec::with_capacity(shard_group.len());
+        for shard in shard_group.shard_iter() {
+            match shard_state_roots.remove(&shard) {
+                Some(r) => hashes.push(r),
+                None => {
+                    let hash = self.get_state_root_for_shard(shard)?;
+                    hashes.push(hash);
+                },
+            };
+        }
+        root_tree.put_root_hash_changes(None, 1, hashes)
+    }
+
+    fn get_state_root_for_shard(&self, shard: Shard) -> Result<Hash, StateTreeError> {
+        let Some(version) = self.get_current_version(shard)? else {
+            // At v0 there have been no state changes
+            return Ok(SPARSE_MERKLE_PLACEHOLDER_HASH);
+        };
+
+        let scoped_store = ShardScopedTreeStoreReader::new(self.tx, shard);
+        let mut store = StagedTreeStore::new(&scoped_store);
+        if let Some(diffs) = self.pending_diffs.get(&shard) {
+            for diff in diffs {
+                store.apply_pending_diff(diff.diff.clone());
+            }
+        }
+        let state_tree = SpreadPrefixStateTree::new(&mut store);
+
+        let root_hash = state_tree.get_root_hash(version)?;
+        Ok(root_hash)
     }
 }
 
 impl<TTx: StateStoreWriteTransaction> ShardedStateTree<&mut TTx> {
-    pub fn commit_diffs(&mut self, diffs: IndexMap<Shard, Vec<PendingStateTreeDiff>>) -> Result<(), StateTreeError> {
+    pub fn commit_diffs(
+        &mut self,
+        diffs: IndexMap<Shard, Vec<PendingShardStateTreeDiff>>,
+    ) -> Result<(), StateTreeError> {
         for (shard, pending_diffs) in diffs {
             for pending_diff in pending_diffs {
-                let version = pending_diff.version;
-                let diff = pending_diff.diff;
-                self.commit_diff(shard, version, diff)?;
+                self.commit_diff(shard, pending_diff.version, pending_diff.diff)?;
             }
         }
 
@@ -135,7 +173,7 @@ impl<TTx: StateStoreWriteTransaction> ShardedStateTree<&mut TTx> {
         &mut self,
         shard: Shard,
         version: Version,
-        diff: StateHashTreeDiff,
+        diff: StateHashTreeDiff<Version>,
     ) -> Result<(), StateTreeError> {
         let mut store = ShardScopedTreeStoreWriter::new(self.tx, shard);
 

--- a/dan_layer/consensus_tests/src/support/mod.rs
+++ b/dan_layer/consensus_tests/src/support/mod.rs
@@ -4,7 +4,7 @@
 // TODO: use all functions
 // #![allow(dead_code)]
 
-pub const TEST_NUM_PRESHARDS: NumPreshards = NumPreshards::SixtyFour;
+pub const TEST_NUM_PRESHARDS: NumPreshards = NumPreshards::P64;
 
 mod address;
 mod epoch_manager;

--- a/dan_layer/p2p/proto/rpc.proto
+++ b/dan_layer/p2p/proto/rpc.proto
@@ -231,6 +231,7 @@ message GetCheckpointResponse {
 message EpochCheckpoint {
   tari.dan.consensus.Block block = 1;
   repeated tari.dan.consensus.QuorumCertificate qcs = 2;
+  map<uint32, bytes> shard_roots = 3;
 }
 
 message SyncStateRequest {

--- a/dan_layer/rpc_state_sync/src/error.rs
+++ b/dan_layer/rpc_state_sync/src/error.rs
@@ -8,7 +8,7 @@ use tari_dan_storage::{
 };
 use tari_epoch_manager::EpochManagerError;
 use tari_rpc_framework::{RpcError, RpcStatus};
-use tari_state_tree::JmtStorageError;
+use tari_state_tree::{Hash, JmtStorageError};
 use tari_validator_node_rpc::ValidatorNodeRpcClientError;
 
 #[derive(Debug, thiserror::Error)]
@@ -33,6 +33,8 @@ pub enum CommsRpcConsensusSyncError {
     ProposalValidationError(#[from] ProposalValidationError),
     #[error("State tree error: {0}")]
     StateTreeError(#[from] tari_state_tree::StateTreeError),
+    #[error("State root mismatch. Expected: {expected}, actual: {actual}")]
+    StateRootMismatch { expected: Hash, actual: Hash },
 }
 
 impl CommsRpcConsensusSyncError {

--- a/dan_layer/state_store_sqlite/migrations/2023-06-08-091819_create_state_store/up.sql
+++ b/dan_layer/state_store_sqlite/migrations/2023-06-08-091819_create_state_store/up.sql
@@ -359,22 +359,6 @@ create table state_tree_shard_versions
     created_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
-CREATE TABLE shard_group_state_tree
-(
-    id       integer not NULL primary key AUTOINCREMENT,
-    epoch    bigint  not NULL,
-    key      text    not NULL,
-    node     text    not NULL,
-    is_stale boolean not null default '0'
-);
-
--- Scoping by shard
-CREATE INDEX shard_group_state_tree_idx_shard_key on shard_group_state_tree (epoch) WHERE is_stale = false;
--- Duplicate keys are not allowed
-CREATE UNIQUE INDEX shard_group_state_tree_uniq_idx_key on shard_group_state_tree (epoch, key) WHERE is_stale = false;
--- filtering out or by is_stale is used in every query
-CREATE INDEX shard_group_state_tree_idx_is_stale on shard_group_state_tree (is_stale);
-
 -- One entry per shard
 CREATE UNIQUE INDEX state_tree_uniq_shard_versions_shard on state_tree_shard_versions (shard);
 
@@ -391,6 +375,17 @@ CREATE TABLE pending_state_tree_diffs
 );
 
 CREATE UNIQUE INDEX pending_state_tree_diffs_uniq_idx_block_id_shard on pending_state_tree_diffs (block_id, shard);
+
+
+CREATE TABLE epoch_checkpoints
+(
+    id              integer   not NULL primary key AUTOINCREMENT,
+    epoch           bigint    not NULL,
+    commit_block    text      not NULL,
+    qcs             text      not NULL,
+    shard_roots     text      not NULL,
+    created_at      timestamp not NULL DEFAULT CURRENT_TIMESTAMP
+);
 
 -- An append-only store of state transitions
 CREATE TABLE state_transitions

--- a/dan_layer/state_store_sqlite/src/schema.rs
+++ b/dan_layer/state_store_sqlite/src/schema.rs
@@ -43,6 +43,17 @@ diesel::table! {
 }
 
 diesel::table! {
+    epoch_checkpoints (id) {
+        id -> Integer,
+        epoch -> BigInt,
+        commit_block -> Text,
+        qcs -> Text,
+        shard_roots -> Text,
+        created_at -> Timestamp,
+    }
+}
+
+diesel::table! {
     foreign_proposals (id) {
         id -> Integer,
         shard_group -> Integer,
@@ -382,6 +393,7 @@ diesel::table! {
 diesel::allow_tables_to_appear_in_same_query!(
     block_diffs,
     blocks,
+    epoch_checkpoints,
     foreign_proposals,
     foreign_receive_counters,
     foreign_send_counters,

--- a/dan_layer/state_store_sqlite/src/sql_models/epoch_checkpoint.rs
+++ b/dan_layer/state_store_sqlite/src/sql_models/epoch_checkpoint.rs
@@ -1,0 +1,30 @@
+//   Copyright 2024 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+use diesel::Queryable;
+use tari_dan_storage::{consensus_models, StorageError};
+use time::PrimitiveDateTime;
+
+use crate::serialization::deserialize_json;
+
+#[derive(Debug, Clone, Queryable)]
+pub struct EpochCheckpoint {
+    pub id: i32,
+    pub epoch: i64,
+    pub commit_block: String,
+    pub qcs: String,
+    pub shard_roots: String,
+    pub created_at: PrimitiveDateTime,
+}
+
+impl TryFrom<EpochCheckpoint> for consensus_models::EpochCheckpoint {
+    type Error = StorageError;
+
+    fn try_from(value: EpochCheckpoint) -> Result<Self, Self::Error> {
+        let commit_block = deserialize_json(&value.commit_block)?;
+        let qcs = deserialize_json(&value.qcs)?;
+        let shard_roots = deserialize_json(&value.shard_roots)?;
+
+        Ok(Self::new(commit_block, qcs, shard_roots))
+    }
+}

--- a/dan_layer/state_store_sqlite/src/sql_models/mod.rs
+++ b/dan_layer/state_store_sqlite/src/sql_models/mod.rs
@@ -4,6 +4,7 @@
 mod block;
 mod block_diff;
 mod bookkeeping;
+mod epoch_checkpoint;
 mod leaf_block;
 mod pending_state_tree_diff;
 mod quorum_certificate;
@@ -18,6 +19,7 @@ mod vote;
 pub use block::*;
 pub use block_diff::*;
 pub use bookkeeping::*;
+pub use epoch_checkpoint::*;
 pub use leaf_block::*;
 pub use pending_state_tree_diff::*;
 pub use quorum_certificate::*;

--- a/dan_layer/state_store_sqlite/src/sql_models/pending_state_tree_diff.rs
+++ b/dan_layer/state_store_sqlite/src/sql_models/pending_state_tree_diff.rs
@@ -18,7 +18,7 @@ pub struct PendingStateTreeDiff {
     pub created_at: PrimitiveDateTime,
 }
 
-impl TryFrom<PendingStateTreeDiff> for consensus_models::PendingStateTreeDiff {
+impl TryFrom<PendingStateTreeDiff> for consensus_models::PendingShardStateTreeDiff {
     type Error = StorageError;
 
     fn try_from(value: PendingStateTreeDiff) -> Result<Self, Self::Error> {

--- a/dan_layer/state_store_sqlite/tests/tests.rs
+++ b/dan_layer/state_store_sqlite/tests/tests.rs
@@ -47,7 +47,7 @@ mod confirm_all_transitions {
         let atom3 = create_tx_atom();
 
         let network = Default::default();
-        let zero_block = Block::zero_block(network, NumPreshards::SixtyFour);
+        let zero_block = Block::zero_block(network, NumPreshards::P64);
         zero_block.insert(&mut tx).unwrap();
         let block1 = Block::new(
             network,
@@ -55,7 +55,7 @@ mod confirm_all_transitions {
             zero_block.justify().clone(),
             NodeHeight(1),
             Epoch(0),
-            ShardGroup::all_shards(NumPreshards::SixtyFour),
+            ShardGroup::all_shards(NumPreshards::P64),
             Default::default(),
             // Need to have a command in, otherwise this block will not be included internally in the query because it
             // cannot cause a state change without any commands

--- a/dan_layer/state_tree/src/error.rs
+++ b/dan_layer/state_tree/src/error.rs
@@ -1,10 +1,21 @@
 //   Copyright 2024 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
+use tari_dan_common_types::optional::IsNotFoundError;
+
 use crate::jellyfish::JmtStorageError;
 
 #[derive(Debug, thiserror::Error)]
 pub enum StateTreeError {
-    #[error("Storage error: {0}")]
-    StorageError(#[from] JmtStorageError),
+    #[error("JMT Storage error: {0}")]
+    JmtStorageError(#[from] JmtStorageError),
+}
+
+impl IsNotFoundError for StateTreeError {
+    fn is_not_found_error(&self) -> bool {
+        #[allow(clippy::single_match)]
+        match self {
+            StateTreeError::JmtStorageError(err) => err.is_not_found_error(),
+        }
+    }
 }

--- a/dan_layer/state_tree/src/jellyfish/store.rs
+++ b/dan_layer/state_tree/src/jellyfish/store.rs
@@ -3,10 +3,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    jellyfish::{JmtStorageError, Node, NodeKey},
-    Version,
-};
+use crate::jellyfish::{JmtStorageError, Node, NodeKey};
 
 /// Implementers are able to read nodes from a tree store.
 pub trait TreeStoreReader<P> {
@@ -52,26 +49,26 @@ impl StaleTreeNode {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum TreeNode {
-    V1(Node<Version>),
+pub enum TreeNode<P> {
+    V1(Node<P>),
 }
 
-impl TreeNode {
-    pub fn new_latest(node: Node<Version>) -> Self {
+impl<P> TreeNode<P> {
+    pub fn new_latest(node: Node<P>) -> Self {
         Self::new_v1(node)
     }
 
-    pub fn new_v1(node: Node<Version>) -> Self {
+    pub fn new_v1(node: Node<P>) -> Self {
         Self::V1(node)
     }
 
-    pub fn as_node(&self) -> &Node<Version> {
+    pub fn as_node(&self) -> &Node<P> {
         match self {
             Self::V1(node) => node,
         }
     }
 
-    pub fn into_node(self) -> Node<Version> {
+    pub fn into_node(self) -> Node<P> {
         match self {
             Self::V1(node) => node,
         }

--- a/dan_layer/state_tree/src/jellyfish/types.rs
+++ b/dan_layer/state_tree/src/jellyfish/types.rs
@@ -702,17 +702,18 @@ pub struct LeafKey {
     /// becomes unspecified.
     /// All leaf keys must be evenly distributed across their space - otherwise the tree's
     /// performance degrades.
+    /// TARI: always a hash, so replaced heap-allocated Vec<u8> with a Hash
     #[serde(with = "serde_with::hex")]
-    pub bytes: Vec<u8>,
+    pub bytes: Hash,
 }
 
 impl LeafKey {
-    pub fn new(bytes: Vec<u8>) -> Self {
+    pub fn new(bytes: Hash) -> Self {
         Self { bytes }
     }
 
     pub fn as_ref(&self) -> LeafKeyRef<'_> {
-        LeafKeyRef::new(&self.bytes)
+        LeafKeyRef::new(self.bytes.as_slice())
     }
 }
 
@@ -736,7 +737,7 @@ impl<'a> LeafKeyRef<'a> {
 
 impl PartialEq<LeafKey> for LeafKeyRef<'_> {
     fn eq(&self, other: &LeafKey) -> bool {
-        self.bytes == other.bytes
+        self.bytes == other.bytes.as_slice()
     }
 }
 

--- a/dan_layer/state_tree/src/key_mapper.rs
+++ b/dan_layer/state_tree/src/key_mapper.rs
@@ -3,17 +3,25 @@
 
 use tari_engine_types::substate::SubstateId;
 
-use crate::jellyfish::LeafKey;
+use crate::{jellyfish::LeafKey, Hash};
 
-pub trait DbKeyMapper {
-    fn map_to_leaf_key(id: &SubstateId) -> LeafKey;
+pub trait DbKeyMapper<T> {
+    fn map_to_leaf_key(id: &T) -> LeafKey;
 }
 
 pub struct SpreadPrefixKeyMapper;
 
-impl DbKeyMapper for SpreadPrefixKeyMapper {
+impl DbKeyMapper<SubstateId> for SpreadPrefixKeyMapper {
     fn map_to_leaf_key(id: &SubstateId) -> LeafKey {
         let hash = crate::jellyfish::jmt_node_hash(id);
-        LeafKey::new(hash.to_vec())
+        LeafKey::new(hash)
+    }
+}
+
+pub struct HashIdentityKeyMapper;
+
+impl DbKeyMapper<Hash> for HashIdentityKeyMapper {
+    fn map_to_leaf_key(hash: &Hash) -> LeafKey {
+        LeafKey::new(*hash)
     }
 }

--- a/dan_layer/state_tree/src/memory_store.rs
+++ b/dan_layer/state_tree/src/memory_store.rs
@@ -1,26 +1,17 @@
 //   Copyright 2024 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use std::{collections::HashMap, fmt};
+use std::{collections::HashMap, fmt, fmt::Debug};
 
-use crate::jellyfish::{
-    JmtStorageError,
-    Node,
-    NodeKey,
-    StaleTreeNode,
-    TreeNode,
-    TreeStoreReader,
-    TreeStoreWriter,
-    Version,
-};
+use crate::jellyfish::{JmtStorageError, Node, NodeKey, StaleTreeNode, TreeNode, TreeStoreReader, TreeStoreWriter};
 
 #[derive(Debug, Default)]
-pub struct MemoryTreeStore {
-    pub nodes: HashMap<NodeKey, TreeNode>,
+pub struct MemoryTreeStore<P> {
+    pub nodes: HashMap<NodeKey, TreeNode<P>>,
     pub stale_nodes: Vec<StaleTreeNode>,
 }
 
-impl MemoryTreeStore {
+impl<P> MemoryTreeStore<P> {
     pub fn new() -> Self {
         Self {
             nodes: HashMap::new(),
@@ -35,8 +26,8 @@ impl MemoryTreeStore {
     }
 }
 
-impl TreeStoreReader<Version> for MemoryTreeStore {
-    fn get_node(&self, key: &NodeKey) -> Result<Node<Version>, JmtStorageError> {
+impl<P: Clone> TreeStoreReader<P> for MemoryTreeStore<P> {
+    fn get_node(&self, key: &NodeKey) -> Result<Node<P>, JmtStorageError> {
         self.nodes
             .get(key)
             .map(|node| node.clone().into_node())
@@ -44,8 +35,8 @@ impl TreeStoreReader<Version> for MemoryTreeStore {
     }
 }
 
-impl TreeStoreWriter<Version> for MemoryTreeStore {
-    fn insert_node(&mut self, key: NodeKey, node: Node<Version>) -> Result<(), JmtStorageError> {
+impl<P> TreeStoreWriter<P> for MemoryTreeStore<P> {
+    fn insert_node(&mut self, key: NodeKey, node: Node<P>) -> Result<(), JmtStorageError> {
         let node = TreeNode::new_latest(node);
         self.nodes.insert(key, node);
         Ok(())
@@ -57,7 +48,7 @@ impl TreeStoreWriter<Version> for MemoryTreeStore {
     }
 }
 
-impl fmt::Display for MemoryTreeStore {
+impl<P: Debug> fmt::Display for MemoryTreeStore<P> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f, "MemoryTreeStore")?;
         writeln!(f, "  Nodes:")?;

--- a/dan_layer/state_tree/tests/test.rs
+++ b/dan_layer/state_tree/tests/test.rs
@@ -95,12 +95,23 @@ fn hash_computed_consistently_after_adding_higher_tier_sibling() {
 #[test]
 fn hash_allows_putting_in_same_version() {
     let mut tester_1 = HashTreeTester::new_empty();
-    tester_1.put_substate_changes(vec![change(1, Some(30))]);
-    tester_1.put_substate_changes(vec![change(2, Some(31))]);
-    // Append another change to the same version
-    let hash_1 = tester_1.put_changes_at_version(vec![change(3, Some(32))]);
+    tester_1.put_changes_at_version(None, 1, vec![change(1, Some(30))]);
+    tester_1.put_changes_at_version(Some(1), 1, vec![change(2, Some(31))]);
+    tester_1.put_changes_at_version(Some(1), 1, vec![change(3, Some(32))]);
+    tester_1.put_changes_at_version(Some(1), 1, vec![change(4, Some(33))]);
+    tester_1.put_changes_at_version(Some(1), 1, vec![change(5, Some(34))]);
+    let hash_1 = tester_1.put_changes_at_version(Some(1), 1, vec![change(6, Some(35))]);
     let mut tester_2 = HashTreeTester::new_empty();
-    let hash_2 = tester_2.put_substate_changes(vec![change(1, Some(30)), change(2, Some(31)), change(3, Some(32))]);
+    tester_2.put_changes_at_version(None, 1, vec![
+        change(1, Some(30)),
+        change(2, Some(31)),
+        change(3, Some(32)),
+    ]);
+    let hash_2 = tester_2.put_changes_at_version(Some(1), 2, vec![
+        change(4, Some(33)),
+        change(5, Some(34)),
+        change(6, Some(35)),
+    ]);
     assert_eq!(hash_1, hash_2);
 }
 

--- a/dan_layer/storage/src/consensus_models/block.rs
+++ b/dan_layer/storage/src/consensus_models/block.rs
@@ -534,6 +534,14 @@ impl Block {
         )
     }
 
+    pub fn get_last_n_in_epoch<TTx: StateStoreReadTransaction + ?Sized>(
+        tx: &TTx,
+        n: usize,
+        epoch: Epoch,
+    ) -> Result<Vec<Self>, StorageError> {
+        tx.blocks_get_last_n_in_epoch(n, epoch)
+    }
+
     pub fn exists<TTx: StateStoreReadTransaction + ?Sized>(&self, tx: &TTx) -> Result<bool, StorageError> {
         Self::record_exists(tx, self.id())
     }

--- a/dan_layer/storage/src/consensus_models/state_tree_diff.rs
+++ b/dan_layer/storage/src/consensus_models/state_tree_diff.rs
@@ -13,18 +13,18 @@ use tari_state_tree::{StateHashTreeDiff, Version};
 use crate::{consensus_models::BlockId, StateStoreReadTransaction, StateStoreWriteTransaction, StorageError};
 
 #[derive(Debug, Clone, Default)]
-pub struct PendingStateTreeDiff {
+pub struct PendingShardStateTreeDiff {
     pub version: Version,
-    pub diff: StateHashTreeDiff,
+    pub diff: StateHashTreeDiff<Version>,
 }
 
-impl PendingStateTreeDiff {
-    pub fn load(version: Version, diff: StateHashTreeDiff) -> Self {
+impl PendingShardStateTreeDiff {
+    pub fn load(version: Version, diff: StateHashTreeDiff<Version>) -> Self {
         Self { version, diff }
     }
 }
 
-impl PendingStateTreeDiff {
+impl PendingShardStateTreeDiff {
     /// Returns all pending state tree diffs from the last committed block (exclusive) to the given block (inclusive).
     pub fn get_all_up_to_commit_block<TTx>(
         tx: &TTx,
@@ -54,24 +54,18 @@ impl PendingStateTreeDiff {
         TTx: Deref + StateStoreWriteTransaction,
         TTx::Target: StateStoreReadTransaction,
     {
-        // if tx.pending_state_tree_diffs_exists_for_block(&block_id)? {
-        //     Ok(false)
-        // } else {
-        tx.pending_state_tree_diffs_insert(block_id, shard, diff)?;
-        // Ok(true)
-        // }
-        Ok(())
+        tx.pending_state_tree_diffs_insert(block_id, shard, diff)
     }
 }
 
 #[derive(Debug, Clone)]
 pub struct VersionedStateHashTreeDiff {
     pub version: Version,
-    pub diff: StateHashTreeDiff,
+    pub diff: StateHashTreeDiff<Version>,
 }
 
 impl VersionedStateHashTreeDiff {
-    pub fn new(version: Version, diff: StateHashTreeDiff) -> Self {
+    pub fn new(version: Version, diff: StateHashTreeDiff<Version>) -> Self {
         Self { version, diff }
     }
 }


### PR DESCRIPTION
Description
---
fix(sync): validate checkpoint merkle root
Rename NumPreshard variants (https://github.com/tari-project/tari-dan/pull/1092#discussion_r1701642796)

Motivation and Context
---
Validates the checkpoint blocks merkle root against the synced state so that the validator can be sure they have the correct state. Note that block and QC signatures are not currently validated pending a refactor in the validations. 

How Has This Been Tested?
---
Manually, submitting transactions, mining to next epoch, submitting more transactions, deleting data of one VN and resyncing. 

What process can a PR reviewer use to test or verify this change?
---
As above

Breaking Changes
---

- [ ] None
- [ ] Requires data directory to be deleted
- [x] Other - Please specify

BREAKING CHANGE: the merkle root construction differs slightly from current development branch