### PR TITLE
feat(watcher): telegram alerting and automatically persist val node

### DIFF
--- a/applications/tari_watcher/README.md
+++ b/applications/tari_watcher/README.md
@@ -8,7 +8,7 @@
 
 ### Quickstart
 
-Initialize the project with `tari_watcher init` and start it with `tari_watcher run`. Edit the newly generated `config.toml` to enable notifications on channels such as Mattermost and Telegram.Make sure to have started up `tari_validator_node` once previously to have a node directory set up, default is `tari_validator_node -- -b data/vn1`.
+Initialize the project with `tari_watcher init` and start it with `tari_watcher run`. Edit the newly generated `config.toml` to enable notifications on Mattermost and Telegram. Make sure to have started up `tari_validator_node` once previously to have a node directory set up, default is `tari_validator_node -- -b data/vn1`.
 
 ### Setup
 
@@ -29,7 +29,7 @@ The default values used (see `constants.rs`) when running the project without an
 ```
 ├── alerting.rs     # channel notifier implementations
 ├── cli.rs          # cli and flags passed during bootup
-├── config.rs       # main config file creation 
+├── config.rs       # main config file creation
 ├── constants.rs    # various constants used as default values
 ├── helpers.rs      # common helper functions
 ├── logger.rs

--- a/applications/tari_watcher/src/alerting.rs
+++ b/applications/tari_watcher/src/alerting.rs
@@ -6,8 +6,6 @@ use reqwest::StatusCode;
 use serde_json::json;
 
 pub trait Alerting {
-    fn new(url: String, channel_id: String, credentials: String) -> Self;
-
     // Sends an alert message to the service
     async fn alert(&mut self, message: &str) -> Result<()>;
 
@@ -21,31 +19,31 @@ pub trait Alerting {
 
 pub struct MatterMostNotifier {
     // Mattermost server URL
-    server_url: String,
+    pub server_url: String,
     // Mattermost channel ID used for alerts
-    channel_id: String,
+    pub channel_id: String,
     // User token (retrieved after login)
-    credentials: String,
+    pub credentials: String,
     // Alerts sent since last reset
-    alerts_sent: u64,
+    pub alerts_sent: u64,
     // HTTP client
-    client: reqwest::Client,
+    pub client: reqwest::Client,
 }
 
 impl Alerting for MatterMostNotifier {
-    fn new(server_url: String, channel_id: String, credentials: String) -> Self {
-        Self {
-            server_url,
-            channel_id,
-            credentials,
-            alerts_sent: 0,
-            client: reqwest::Client::new(),
-        }
-    }
-
     async fn alert(&mut self, message: &str) -> Result<()> {
-        const LOGIN_ENDPOINT: &str = "/api/v4/posts";
-        let url = format!("{}{}", self.server_url, LOGIN_ENDPOINT);
+        if self.server_url.is_empty() {
+            bail!("Server URL field is empty");
+        }
+        if self.credentials.is_empty() {
+            bail!("Credentials field is empty");
+        }
+        if self.channel_id.is_empty() {
+            bail!("Channel ID is empty");
+        }
+
+        const POST_ENDPOINT: &str = "/api/v4/posts";
+        let url = format!("{}{}", self.server_url, POST_ENDPOINT);
         let req = json!({
             "channel_id": self.channel_id,
             "message": message,
@@ -73,7 +71,7 @@ impl Alerting for MatterMostNotifier {
             bail!("Server URL is empty");
         }
         if self.credentials.is_empty() {
-            bail!("Credentials are empty");
+            bail!("Credentials field is empty");
         }
 
         let url = format!("{}{}", self.server_url, PING_ENDPOINT);
@@ -83,6 +81,57 @@ impl Alerting for MatterMostNotifier {
             .header("Authorization", format!("Bearer {}", self.credentials))
             .send()
             .await?;
+
+        if resp.status() != StatusCode::OK {
+            bail!("Failed to ping, got response: {}", resp.status());
+        }
+
+        Ok(())
+    }
+
+    fn stats(&self) -> Result<u64> {
+        Ok(self.alerts_sent)
+    }
+}
+
+pub struct TelegramNotifier {
+    // Telegram bot token
+    pub bot_token: String,
+    // Telegram chat ID (either in @channel or number id format)
+    pub chat_id: String,
+    // Alerts sent since last reset
+    pub alerts_sent: u64,
+    // HTTP client
+    pub client: reqwest::Client,
+}
+
+impl Alerting for TelegramNotifier {
+    async fn alert(&mut self, message: &str) -> Result<()> {
+        let post_endpoint: &str = &format!("/bot{}/sendMessage", self.bot_token);
+        let url = format!("https://api.telegram.org{}", post_endpoint);
+        let req = json!({
+            "chat_id": self.chat_id,
+            "text": message,
+        });
+        let resp = self.client.post(&url).json(&req).send().await?;
+
+        if resp.status() != StatusCode::OK {
+            bail!("Failed to send alert, got response: {}", resp.status());
+        }
+
+        self.alerts_sent += 1;
+
+        Ok(())
+    }
+
+    async fn ping(&self) -> Result<()> {
+        let ping_endpoint: &str = &format!("/bot{}/getMe", self.bot_token);
+        if self.bot_token.is_empty() {
+            bail!("Bot token is empty");
+        }
+
+        let url = format!("https://api.telegram.org{}", ping_endpoint);
+        let resp = self.client.get(url.clone()).send().await?;
 
         if resp.status() != StatusCode::OK {
             bail!("Failed to ping, got response: {}", resp.status());

--- a/applications/tari_watcher/src/alerting.rs
+++ b/applications/tari_watcher/src/alerting.rs
@@ -107,6 +107,13 @@ pub struct TelegramNotifier {
 
 impl Alerting for TelegramNotifier {
     async fn alert(&mut self, message: &str) -> Result<()> {
+        if self.bot_token.is_empty() {
+            bail!("Bot token is empty");
+        }
+        if self.chat_id.is_empty() {
+            bail!("Chat ID is empty");
+        }
+
         let post_endpoint: &str = &format!("/bot{}/sendMessage", self.bot_token);
         let url = format!("https://api.telegram.org{}", post_endpoint);
         let req = json!({
@@ -125,11 +132,11 @@ impl Alerting for TelegramNotifier {
     }
 
     async fn ping(&self) -> Result<()> {
-        let ping_endpoint: &str = &format!("/bot{}/getMe", self.bot_token);
         if self.bot_token.is_empty() {
             bail!("Bot token is empty");
         }
 
+        let ping_endpoint: &str = &format!("/bot{}/getMe", self.bot_token);
         let url = format!("https://api.telegram.org{}", ping_endpoint);
         let resp = self.client.get(url.clone()).send().await?;
 

--- a/applications/tari_watcher/src/cli.rs
+++ b/applications/tari_watcher/src/cli.rs
@@ -56,11 +56,16 @@ pub struct InitArgs {
     #[clap(long)]
     /// Disable initial and auto registration of the validator node
     pub no_auto_register: bool,
+
+    #[clap(long)]
+    /// Disable auto restart of the validator node
+    pub no_auto_restart: bool,
 }
 
 impl InitArgs {
     pub fn apply(&self, config: &mut Config) {
         config.auto_register = !self.no_auto_register;
+        config.auto_restart = !self.no_auto_restart;
     }
 }
 

--- a/applications/tari_watcher/src/config.rs
+++ b/applications/tari_watcher/src/config.rs
@@ -12,7 +12,9 @@ use tokio::io::{self, AsyncWriteExt};
 use crate::{
     cli::Cli,
     constants::{
-        DEFAULT_BASE_NODE_GRPC_ADDRESS, DEFAULT_BASE_WALLET_GRPC_ADDRESS, DEFAULT_MINOTARI_MINER_BINARY_PATH,
+        DEFAULT_BASE_NODE_GRPC_ADDRESS,
+        DEFAULT_BASE_WALLET_GRPC_ADDRESS,
+        DEFAULT_MINOTARI_MINER_BINARY_PATH,
         DEFAULT_VALIDATOR_NODE_BINARY_PATH,
     },
 };
@@ -22,6 +24,9 @@ pub struct Config {
     /// Allow watcher to submit a new validator node registration transaction initially and before
     /// the current registration expires
     pub auto_register: bool,
+
+    /// Allow watcher to restart the validator node if it crashes and stops running
+    pub auto_restart: bool,
 
     /// The Minotari node gRPC address
     pub base_node_grpc_address: String,
@@ -156,6 +161,7 @@ pub fn get_base_config(cli: &Cli) -> anyhow::Result<Config> {
 
     Ok(Config {
         auto_register: true,
+        auto_restart: true,
         base_node_grpc_address: DEFAULT_BASE_NODE_GRPC_ADDRESS.to_string(),
         base_wallet_grpc_address: DEFAULT_BASE_WALLET_GRPC_ADDRESS.to_string(),
         base_dir: base_dir.to_path_buf(),

--- a/applications/tari_watcher/src/config.rs
+++ b/applications/tari_watcher/src/config.rs
@@ -12,9 +12,7 @@ use tokio::io::{self, AsyncWriteExt};
 use crate::{
     cli::Cli,
     constants::{
-        DEFAULT_BASE_NODE_GRPC_ADDRESS,
-        DEFAULT_BASE_WALLET_GRPC_ADDRESS,
-        DEFAULT_MINOTARI_MINER_BINARY_PATH,
+        DEFAULT_BASE_NODE_GRPC_ADDRESS, DEFAULT_BASE_WALLET_GRPC_ADDRESS, DEFAULT_MINOTARI_MINER_BINARY_PATH,
         DEFAULT_VALIDATOR_NODE_BINARY_PATH,
     },
 };
@@ -177,7 +175,7 @@ pub fn get_base_config(cli: &Cli) -> anyhow::Result<Config> {
             telegram: ChannelConfig {
                 name: "telegram".to_string(),
                 enabled: false,
-                server_url: "".to_string(),
+                server_url: "https://api.telegram.org".to_string(),
                 channel_id: "".to_string(),
                 credentials: "".to_string(),
             },

--- a/applications/tari_watcher/src/manager.rs
+++ b/applications/tari_watcher/src/manager.rs
@@ -5,7 +5,10 @@ use std::path::PathBuf;
 
 use log::*;
 use minotari_app_grpc::tari_rpc::{
-    self as grpc, ConsensusConstants, GetActiveValidatorNodesResponse, RegisterValidatorNodeResponse,
+    self as grpc,
+    ConsensusConstants,
+    GetActiveValidatorNodesResponse,
+    RegisterValidatorNodeResponse,
 };
 use tari_shutdown::{Shutdown, ShutdownSignal};
 use tokio::sync::{mpsc, oneshot};

--- a/applications/tari_watcher/src/process.rs
+++ b/applications/tari_watcher/src/process.rs
@@ -11,7 +11,6 @@ use tokio::{
     io::AsyncWriteExt,
     process::{Child, Command as TokioCommand},
     sync::mpsc::{self},
-    time::{sleep, Duration},
 };
 
 use crate::{
@@ -123,8 +122,6 @@ pub async fn spawn_validator_node_os(
     let tx_alert_clone_main = tx_alert.clone();
     let tx_restart_clone_main = tx_restart.clone();
     tokio::spawn(async move {
-        let mut restarted = false;
-
         loop {
             let child_res = spawn_child(
                 validator_node_path.clone(),
@@ -132,11 +129,6 @@ pub async fn spawn_validator_node_os(
                 base_dir.clone(),
             )
             .await;
-
-            if restarted {
-                // give it some time to clean up
-                sleep(Duration::from_secs(10)).await;
-            }
 
             match child_res {
                 Ok(child) => {
@@ -163,7 +155,6 @@ pub async fn spawn_validator_node_os(
                     }
 
                     info!("Received signal, preparing to restart validator node");
-                    restarted = true;
                 },
                 None => {
                     error!("Failed to receive restart signal, exiting");

--- a/applications/tari_watcher/src/process.rs
+++ b/applications/tari_watcher/src/process.rs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 use std::{path::PathBuf, process::Stdio};
+use tokio::process::Child;
+use tokio::time::{sleep, Duration};
 
 use anyhow::bail;
 use log::*;
@@ -58,7 +60,6 @@ async fn create_pid_file(path: PathBuf) -> anyhow::Result<()> {
 }
 
 pub struct ChildChannel {
-    pub pid: u32,
     pub rx_log: mpsc::Receiver<ProcessStatus>,
     pub tx_log: mpsc::Sender<ProcessStatus>,
     pub rx_alert: mpsc::Receiver<ProcessStatus>,
@@ -66,17 +67,15 @@ pub struct ChildChannel {
     pub cfg_alert: Channels,
 }
 
-pub async fn spawn_validator_node_os(
+async fn spawn_child(
     validator_node_path: PathBuf,
     validator_config_path: PathBuf,
     base_dir: PathBuf,
-    cfg_alert: Channels,
-) -> anyhow::Result<ChildChannel> {
+) -> anyhow::Result<Child> {
     let node_binary_path = base_dir.join(validator_node_path);
-    let mut vn_cfg_path = base_dir.join(validator_config_path);
-    let vn_cfg_str = vn_cfg_path.as_mut_os_str().to_str();
+    let vn_cfg_path = base_dir.join(validator_config_path);
     debug!("Using VN binary at: {}", node_binary_path.display());
-    debug!("Using VN config in directory: {}", vn_cfg_str.unwrap_or_default());
+    debug!("Using VN config in directory: {}", vn_cfg_path.display());
 
     let child = TokioCommand::new(node_binary_path.clone().into_os_string())
         .arg("-b")
@@ -90,15 +89,10 @@ pub async fn spawn_validator_node_os(
     let pid = child.id().expect("Failed to get PID for child process");
     info!("Spawned validator child process with id {}", pid);
 
-    if let Err(e) = create_pid_file(PathBuf::from(DEFAULT_VALIDATOR_PID_PATH)).await {
+    let path = base_dir.join(DEFAULT_VALIDATOR_PID_PATH);
+    if let Err(e) = create_pid_file(path.clone()).await {
         log::error!("Failed to create PID file when spawning node: {}", e);
     }
-
-    let path = base_dir.join(DEFAULT_VALIDATOR_PID_PATH);
-    debug!(
-        "Spawning validator node with process persisted at file: {}",
-        path.display()
-    );
 
     create_pid_file(path.clone()).await?;
 
@@ -110,12 +104,68 @@ pub async fn spawn_validator_node_os(
         .await?;
     file.write_all(pid.to_string().as_bytes()).await?;
 
+    Ok(child)
+}
+
+pub async fn spawn_validator_node_os(
+    validator_node_path: PathBuf,
+    validator_config_path: PathBuf,
+    base_dir: PathBuf,
+    cfg_alert: Channels,
+) -> anyhow::Result<ChildChannel> {
     let (tx_log, rx_log) = mpsc::channel(16);
     let (tx_alert, rx_alert) = mpsc::channel(16);
-    tokio::spawn(monitor_child(child, tx_log.clone(), tx_alert.clone()));
+    let (tx_restart, mut rx_restart) = mpsc::channel(1);
+
+    let tx_log_clone_main = tx_log.clone();
+    let tx_alert_clone_main = tx_alert.clone();
+    let tx_restart_clone_main = tx_restart.clone();
+    tokio::spawn(async move {
+        let mut restarted = false;
+
+        loop {
+            let child_res = spawn_child(
+                validator_node_path.clone(),
+                validator_config_path.clone(),
+                base_dir.clone(),
+            )
+            .await;
+
+            if restarted {
+                // give it some time to clean up
+                sleep(Duration::from_secs(10)).await;
+            }
+
+            match child_res {
+                Ok(child) => {
+                    let tx_log_monitor = tx_log_clone_main.clone();
+                    let tx_alert_monitor = tx_alert_clone_main.clone();
+                    let tx_restart_monitor = tx_restart_clone_main.clone();
+                    // spawn monitoring and handle logs and alerts
+                    tokio::spawn(async move {
+                        monitor_child(child, tx_log_monitor, tx_alert_monitor, tx_restart_monitor).await;
+                    });
+                },
+                Err(e) => {
+                    error!("Failed to spawn child process: {:?}", e);
+                },
+            }
+
+            // block channel until we receive a restart signal
+            match rx_restart.recv().await {
+                Some(_) => {
+                    info!("Received signal, restarting validator node");
+                    restarted = true;
+                },
+                None => {
+                    error!("Failed to receive restart signal, exiting");
+                    break;
+                },
+            }
+        }
+    });
 
     Ok(ChildChannel {
-        pid,
         rx_log,
         tx_log,
         tx_alert,
@@ -148,39 +198,24 @@ async fn check_existing_node_os(base_dir: PathBuf) -> Option<u32> {
     None
 }
 
-pub struct Process {
-    // Child process ID of the forked validator instance.
-    pid: Option<u32>,
-}
-
-impl Process {
-    pub fn new() -> Self {
-        Self { pid: None }
+pub async fn start_validator(
+    validator_path: PathBuf,
+    validator_config_path: PathBuf,
+    base_dir: PathBuf,
+    alerting_config: Channels,
+) -> Option<ChildChannel> {
+    let opt = check_existing_node_os(base_dir.clone()).await;
+    if let Some(pid) = opt {
+        info!("Picking up existing validator node process with id: {}", pid);
+        // todo: create new process status channel for picked up process
+        return None;
+    } else {
+        debug!("No existing validator node process found, spawn new one");
     }
 
-    pub async fn start_validator(
-        &mut self,
-        validator_path: PathBuf,
-        validator_config_path: PathBuf,
-        base_dir: PathBuf,
-        alerting_config: Channels,
-    ) -> Option<ChildChannel> {
-        let opt = check_existing_node_os(base_dir.clone()).await;
-        if let Some(pid) = opt {
-            info!("Picking up existing validator node process with id: {}", pid);
+    let cc = spawn_validator_node_os(validator_path, validator_config_path, base_dir, alerting_config)
+        .await
+        .ok()?;
 
-            self.pid = Some(pid);
-            // todo: create new process status channel for picked up process
-            return None;
-        } else {
-            debug!("No existing validator node process found, spawn new one");
-        }
-
-        let cc = spawn_validator_node_os(validator_path, validator_config_path, base_dir, alerting_config)
-            .await
-            .ok()?;
-        self.pid = Some(cc.pid);
-
-        Some(cc)
-    }
+    Some(cc)
 }


### PR DESCRIPTION
Description
---

* Add Telegram support for alerting on various events
* Add automatic restart of `tari_validator_node` if it crashes and configuration to disable

How Has This Been Tested?
---
Create TG channel and populate `credentials` (bot token) and `channel_id` in the config file. Go through previous steps of starting `tari_swarm_daemon` and have the `tari_watcher` register the node.

Look at the watcher logs for the spawned process pid, or use `ps aux | grep 'tari_validator_node'` and look for the process with the default VN folder, and call `kill -9 $PID`. This induces a crash of the node and if `auto_restart` is enabled, the `tari_watcher` will start a new validator node. It will keep the state of registry since before, as long as the `tari_watcher` does not exit, and send registration transaction as usual.