### PR TITLE
fix: syncing from epoch 0 before consensus has started

### DIFF
--- a/applications/tari_swarm_daemon/src/config.rs
+++ b/applications/tari_swarm_daemon/src/config.rs
@@ -147,6 +147,10 @@ impl InstanceType {
             InstanceType::TariValidatorNode | InstanceType::TariIndexer | InstanceType::TariWalletDaemon
         )
     }
+
+    pub fn is_miner(self) -> bool {
+        matches!(self, InstanceType::MinoTariMiner)
+    }
 }
 
 impl Display for InstanceType {

--- a/applications/tari_swarm_daemon/src/process_manager/manager.rs
+++ b/applications/tari_swarm_daemon/src/process_manager/manager.rs
@@ -80,7 +80,7 @@ impl ProcessManager {
         for instance in self
             .instance_manager
             .instances_mut()
-            .filter(|i| !i.instance_type().is_tari_node())
+            .filter(|i| !i.instance_type().is_tari_node() && !i.instance_type().is_miner())
         {
             if let Some(status) = instance.check_running()? {
                 return Err(anyhow!(

--- a/dan_layer/rpc_state_sync/src/manager.rs
+++ b/dan_layer/rpc_state_sync/src/manager.rs
@@ -41,6 +41,7 @@ use tari_dan_storage::{
 };
 use tari_engine_types::substate::hash_substate;
 use tari_epoch_manager::EpochManagerReader;
+use tari_rpc_framework::RpcError;
 use tari_state_tree::{
     memory_store::MemoryTreeStore,
     Hash,
@@ -107,6 +108,7 @@ where TConsensusSpec: ConsensusSpec<Addr = PeerAddress>
                 Ok(cp) => Ok(Some(cp)),
                 Err(err) => Err(CommsRpcConsensusSyncError::InvalidResponse(err)),
             },
+            Err(RpcError::RequestFailed(err)) if err.is_not_found() => Ok(None),
             Ok(GetCheckpointResponse { checkpoint: None }) => Ok(None),
             Err(err) => Err(err.into()),
         }


### PR DESCRIPTION
Description
---

Motivation and Context
---
Swarm will sometimes fail to start because syncing from epoch 0 will fail when starting a new network.

How Has This Been Tested?
---

What process can a PR reviewer use to test or verify this change?
---


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify