### PR TITLE
fix(wallet_web_ui): invalid resource error on transfers

### DIFF
--- a/applications/tari_dan_wallet_web_ui/src/routes/AssetVault/Components/SendMoney.tsx
+++ b/applications/tari_dan_wallet_web_ui/src/routes/AssetVault/Components/SendMoney.tsx
@@ -44,7 +44,7 @@ import {
 } from "@tari-project/typescript-bindings";
 import InputLabel from "@mui/material/InputLabel";
 
-const XTR2 = "resource_01010101010101010101010101010101010101010101010101010101";
+const XTR2 = "resource_0101010101010101010101010101010101010101010101010101010101010101";
 
 export default function SendMoney() {
   const [open, setOpen] = useState(false);


### PR DESCRIPTION
Description
---
Fixed the default XTR resource address in the wallet web ui

Motivation and Context
---
Recently we changed the format of resource and component addresses, being now a bit longer. The wallet web ui still got a constant for the XTR resource with the old format, causing problems when doing transfers. This PR fixes it.

How Has This Been Tested?
---
Manually by launching a local network with `tari_swarm`, creating accounts and doing transfers

What process can a PR reviewer use to test or verify this change?
---
See previous section

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify