### PR TITLE
fix(swarm): ensure base path exists in init

### DIFF
--- a/applications/tari_swarm_daemon/src/main.rs
+++ b/applications/tari_swarm_daemon/src/main.rs
@@ -170,6 +170,8 @@ fn get_base_config(cli: &Cli) -> anyhow::Result<Config> {
         })
         .unwrap_or_else(|| std::env::current_dir().unwrap().join("data").join("swarm"));
 
+    fs::create_dir_all(&base_dir)?;
+
     Ok(Config {
         skip_registration: false,
         network: cli.common.network.unwrap_or(Network::LocalNet),


### PR DESCRIPTION
Description
---
fix(swarm): ensure base path exists in init

Motivation and Context
---
Base path must exist in init

How Has This Been Tested?
---

What process can a PR reviewer use to test or verify this change?
---


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify