### PR TITLE
fix(swarm): use host envs when compiling

### DIFF
--- a/applications/tari_swarm_daemon/src/main.rs
+++ b/applications/tari_swarm_daemon/src/main.rs
@@ -170,7 +170,7 @@ fn get_base_config(cli: &Cli) -> anyhow::Result<Config> {
         })
         .unwrap_or_else(|| std::env::current_dir().unwrap().join("data").join("swarm"));
 
-    fs::create_dir_all(&base_dir)?;
+    std::fs::create_dir_all(&base_dir)?;
 
     Ok(Config {
         skip_registration: false,

--- a/applications/tari_swarm_daemon/src/process_manager/executables/manager.rs
+++ b/applications/tari_swarm_daemon/src/process_manager/executables/manager.rs
@@ -2,6 +2,7 @@
 //   SPDX-License-Identifier: BSD-3-Clause
 
 use std::{
+    env,
     io,
     path::{Path, PathBuf},
 };
@@ -169,6 +170,8 @@ impl ExecutableManager {
 fn cargo_build<P: AsRef<Path>>(working_dir: P, package: &str) -> io::Result<Child> {
     Command::new("cargo")
         .args(["build", "--release", "--bin", package])
+        // Ensure host environment vars are available
+        .envs(env::vars())
         .current_dir(working_dir)
         .kill_on_drop(true)
         .spawn()


### PR DESCRIPTION
Description
---
fix(swarm): use host envs when compiling

Motivation and Context
---
Some dependencies may require the host environment when compiling 

How Has This Been Tested?
---
Swarm compiles successfully 

What process can a PR reviewer use to test or verify this change?
---


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify