### PR TITLE
fix: increase gossip message size limit to 128k

### DIFF
--- a/networking/swarm/src/behaviour.rs
+++ b/networking/swarm/src/behaviour.rs
@@ -85,6 +85,7 @@ where
 
             // Gossipsub
             let gossipsub_config = gossipsub::ConfigBuilder::default()
+                .max_transmit_size(config.gossip_sub_max_message_size)
                 .validation_mode(gossipsub::ValidationMode::Strict) // This sets the kind of message validation. The default is Strict (enforce message signing)
                 .validate_messages()
                 .message_id_fn(get_message_id) // content-address messages. No two messages of the same content will be propagated.

--- a/networking/swarm/src/config.rs
+++ b/networking/swarm/src/config.rs
@@ -21,6 +21,7 @@ pub struct Config {
     pub relay_circuit_limits: RelayCircuitLimits,
     pub relay_reservation_limits: RelayReservationLimits,
     pub identify_interval: Duration,
+    pub gossip_sub_max_message_size: usize,
 }
 
 impl Default for Config {
@@ -39,6 +40,8 @@ impl Default for Config {
             relay_reservation_limits: RelayReservationLimits::default(),
             // This is the default for identify
             identify_interval: Duration::from_secs(5 * 60),
+            // 128k, double the libp2p default
+            gossip_sub_max_message_size: 128 * 1024,
         }
     }
 }


### PR DESCRIPTION
Description
---
fix: increase gossip message size limit to 128k

Motivation and Context
---
Some transactions being propagated were bigger than 64k (previous limit)

How Has This Been Tested?
---
tariswap test

What process can a PR reviewer use to test or verify this change?
---
tariswap test

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify