### PR TITLE
fix: remove epoch manager calls from consensus gossipsub

### DIFF
--- a/applications/tari_indexer/src/lib.rs
+++ b/applications/tari_indexer/src/lib.rs
@@ -96,12 +96,7 @@ pub async fn run_indexer(config: ApplicationConfig, mut shutdown_signal: Shutdow
     )
     .await?;
 
-    let mut epoch_manager_events = services.epoch_manager.subscribe().await.map_err(|e| {
-        ExitError::new(
-            ExitCode::ConfigError,
-            format!("Epoch manager crashed on startup: {}", e),
-        )
-    })?;
+    let mut epoch_manager_events = services.epoch_manager.subscribe();
 
     let substate_cache_dir = config.common.base_path.join("substate_cache");
     let substate_cache = SubstateFileCache::new(substate_cache_dir)

--- a/applications/tari_validator_node/src/bootstrap.rs
+++ b/applications/tari_validator_node/src/bootstrap.rs
@@ -76,7 +76,10 @@ use tari_engine_types::{
     substate::{SubstateId, SubstateValue},
     vault::Vault,
 };
-use tari_epoch_manager::base_layer::{EpochManagerConfig, EpochManagerHandle};
+use tari_epoch_manager::{
+    base_layer::{EpochManagerConfig, EpochManagerHandle},
+    EpochManagerReader,
+};
 use tari_indexer_lib::substate_scanner::SubstateScanner;
 use tari_networking::{MessagingMode, NetworkingHandle, RelayCircuitLimits, RelayReservationLimits, SwarmConfig};
 use tari_rpc_framework::RpcServer;
@@ -250,8 +253,11 @@ pub async fn spawn_services(
     };
 
     // Consensus gossip
-    let (consensus_gossip_service, join_handle, rx_consensus_gossip_messages) =
-        consensus_gossip::spawn(epoch_manager.clone(), networking.clone(), rx_consensus_gossip_messages);
+    let (consensus_gossip_service, join_handle, rx_consensus_gossip_messages) = consensus_gossip::spawn(
+        epoch_manager.subscribe(),
+        networking.clone(),
+        rx_consensus_gossip_messages,
+    );
     handles.push(join_handle);
 
     // Messaging

--- a/applications/tari_validator_node/src/dan_node.rs
+++ b/applications/tari_validator_node/src/dan_node.rs
@@ -42,7 +42,7 @@ impl DanNode {
 
     pub async fn start(mut self, mut shutdown: ShutdownSignal) -> Result<(), anyhow::Error> {
         let mut hotstuff_events = self.services.consensus_handle.subscribe_to_hotstuff_events();
-        let mut epoch_manager_events = self.services.epoch_manager.subscribe().await?;
+        let mut epoch_manager_events = self.services.epoch_manager.subscribe();
 
         // if let Err(err) = self.dial_local_shard_peers().await {
         //     error!(target: LOG_TARGET, "Failed to dial local shard peers: {}", err);

--- a/applications/tari_validator_node/src/p2p/services/consensus_gossip/error.rs
+++ b/applications/tari_validator_node/src/p2p/services/consensus_gossip/error.rs
@@ -22,9 +22,7 @@
 
 use tari_epoch_manager::EpochManagerError;
 use tari_networking::NetworkingError;
-use tokio::sync::{mpsc, oneshot};
-
-use super::ConsensusGossipRequest;
+use tokio::sync::oneshot;
 
 #[derive(thiserror::Error, Debug)]
 pub enum ConsensusGossipError {
@@ -36,12 +34,6 @@ pub enum ConsensusGossipError {
     RequestCancelled,
     #[error("Network error: {0}")]
     NetworkingError(#[from] NetworkingError),
-}
-
-impl From<mpsc::error::SendError<ConsensusGossipRequest>> for ConsensusGossipError {
-    fn from(_: mpsc::error::SendError<ConsensusGossipRequest>) -> Self {
-        Self::RequestCancelled
-    }
 }
 
 impl From<oneshot::error::RecvError> for ConsensusGossipError {

--- a/applications/tari_validator_node/src/p2p/services/consensus_gossip/mod.rs
+++ b/applications/tari_validator_node/src/p2p/services/consensus_gossip/mod.rs
@@ -24,7 +24,7 @@ mod error;
 pub use error::*;
 
 mod handle;
-pub use handle::{ConsensusGossipHandle, ConsensusGossipRequest};
+pub use handle::ConsensusGossipHandle;
 
 mod initializer;
 pub use initializer::spawn;

--- a/applications/tari_validator_node/src/p2p/services/consensus_gossip/service.rs
+++ b/applications/tari_validator_node/src/p2p/services/consensus_gossip/service.rs
@@ -20,28 +20,24 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::fmt::Display;
-
 use libp2p::{gossipsub, PeerId};
 use log::*;
-use tari_consensus::messages::HotstuffMessage;
-use tari_dan_common_types::{Epoch, PeerAddress, ShardGroup};
+use tari_dan_common_types::ShardGroup;
 use tari_dan_p2p::{proto, TariMessagingSpec};
-use tari_epoch_manager::{base_layer::EpochManagerHandle, EpochManagerEvent, EpochManagerReader};
+use tari_epoch_manager::EpochManagerEvent;
 use tari_networking::{NetworkingHandle, NetworkingService};
 use tari_swarm::messaging::{prost::ProstCodec, Codec};
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::{broadcast, mpsc};
 
-use super::{ConsensusGossipError, ConsensusGossipRequest};
+use super::ConsensusGossipError;
 
 const LOG_TARGET: &str = "tari::validator_node::consensus_gossip::service";
 
 pub const TOPIC_PREFIX: &str = "consensus";
 
 #[derive(Debug)]
-pub(super) struct ConsensusGossipService<TAddr> {
-    requests: mpsc::Receiver<ConsensusGossipRequest>,
-    epoch_manager: EpochManagerHandle<TAddr>,
+pub(super) struct ConsensusGossipService {
+    epoch_manager_events: broadcast::Receiver<EpochManagerEvent>,
     is_subscribed: Option<ShardGroup>,
     networking: NetworkingHandle<TariMessagingSpec>,
     codec: ProstCodec<proto::consensus::HotStuffMessage>,
@@ -49,17 +45,15 @@ pub(super) struct ConsensusGossipService<TAddr> {
     tx_consensus_gossip: mpsc::Sender<(PeerId, proto::consensus::HotStuffMessage)>,
 }
 
-impl ConsensusGossipService<PeerAddress> {
+impl ConsensusGossipService {
     pub fn new(
-        requests: mpsc::Receiver<ConsensusGossipRequest>,
-        epoch_manager: EpochManagerHandle<PeerAddress>,
+        epoch_manager_events: broadcast::Receiver<EpochManagerEvent>,
         networking: NetworkingHandle<TariMessagingSpec>,
         rx_gossip: mpsc::UnboundedReceiver<(PeerId, gossipsub::Message)>,
         tx_consensus_gossip: mpsc::Sender<(PeerId, proto::consensus::HotStuffMessage)>,
     ) -> Self {
         Self {
-            requests,
-            epoch_manager,
+            epoch_manager_events,
             is_subscribed: None,
             networking,
             codec: ProstCodec::default(),
@@ -69,24 +63,16 @@ impl ConsensusGossipService<PeerAddress> {
     }
 
     pub async fn run(mut self) -> anyhow::Result<()> {
-        let mut events = self.epoch_manager.subscribe().await?;
-
         loop {
             tokio::select! {
-                Some(req) = self.requests.recv() => self.handle_request(req).await,
                 Some(msg) = self.rx_gossip.recv() => {
                     if let Err(err) = self.handle_incoming_gossip_message(msg).await {
                         warn!(target: LOG_TARGET, "Consensus gossip service error: {}", err);
                     }
                 },
-                Ok(event) = events.recv() => {
-                    if let EpochManagerEvent::EpochChanged(epoch) = event {
-                        if self.epoch_manager.is_this_validator_registered_for_epoch(epoch).await?{
-                            info!(target: LOG_TARGET, "Consensus gossip service subscribing messages for epoch {}", epoch);
-                            self.subscribe(epoch).await?;
-
-                            // TODO: unsubscribe older epoch shards?
-                        }
+                Ok(event) = self.epoch_manager_events.recv() => {
+                    if let EpochManagerEvent::ThisValidatorIsRegistered{shard_group, ..} = event {
+                        self.subscribe(shard_group).await?;
                     }
                 },
                 else => {
@@ -99,21 +85,6 @@ impl ConsensusGossipService<PeerAddress> {
         self.unsubscribe().await?;
 
         Ok(())
-    }
-
-    async fn handle_request(&mut self, request: ConsensusGossipRequest) {
-        match request {
-            ConsensusGossipRequest::Multicast {
-                shard_group,
-                message,
-                reply,
-            } => {
-                handle(reply, self.multicast(shard_group, message).await);
-            },
-            ConsensusGossipRequest::GetLocalShardGroup { reply } => {
-                handle(reply, self.get_local_shard_group().await);
-            },
-        }
     }
 
     async fn handle_incoming_gossip_message(
@@ -136,12 +107,10 @@ impl ConsensusGossipService<PeerAddress> {
         Ok(())
     }
 
-    async fn subscribe(&mut self, epoch: Epoch) -> Result<(), ConsensusGossipError> {
-        let committee_shard = self.epoch_manager.get_local_committee_info(epoch).await?;
-        let shard_group = committee_shard.shard_group();
-
+    async fn subscribe(&mut self, shard_group: ShardGroup) -> Result<(), ConsensusGossipError> {
         match self.is_subscribed {
             Some(sg) if sg == shard_group => {
+                debug!(target: LOG_TARGET, "🌬️ Consensus gossip already subscribed to messages for {shard_group}");
                 return Ok(());
             },
             Some(_) => {
@@ -150,9 +119,10 @@ impl ConsensusGossipService<PeerAddress> {
             None => {},
         }
 
+        info!(target: LOG_TARGET, "🌬️ Consensus gossip service subscribing messages for {shard_group}");
         let topic = shard_group_to_topic(shard_group);
         self.networking.subscribe_topic(topic).await?;
-        self.is_subscribed = Some(committee_shard.shard_group());
+        self.is_subscribed = Some(shard_group);
 
         Ok(())
     }
@@ -166,74 +136,13 @@ impl ConsensusGossipService<PeerAddress> {
 
         Ok(())
     }
-
-    pub async fn multicast(
-        &mut self,
-        shard_group: ShardGroup,
-        message: HotstuffMessage,
-    ) -> Result<(), ConsensusGossipError> {
-        // if we are alone in the local shard group, no need to broadcast
-        if self.num_shard_group_members().await? < 2 {
-            return Ok(());
-        }
-
-        let topic = shard_group_to_topic(shard_group);
-
-        debug!(
-            target: LOG_TARGET,
-            "multicast: topic: {}", topic,
-        );
-
-        let message = proto::consensus::HotStuffMessage::from(&message);
-        let mut buf = Vec::with_capacity(1024);
-        self.codec
-            .encode_to(&mut buf, message)
-            .await
-            .map_err(|e| ConsensusGossipError::InvalidMessage(e.into()))?;
-
-        self.networking.publish_gossip(topic, buf).await?;
-
-        Ok(())
-    }
-
-    async fn num_shard_group_members(&self) -> Result<u32, ConsensusGossipError> {
-        let epoch = self.epoch_manager.current_epoch().await?;
-
-        if self.epoch_manager.is_this_validator_registered_for_epoch(epoch).await? {
-            let committee_shard = self.epoch_manager.get_local_committee_info(epoch).await?;
-            return Ok(committee_shard.num_shard_group_members());
-        }
-
-        // default value if the VN is not registered
-        Ok(0)
-    }
-
-    pub async fn get_local_shard_group(&self) -> Result<Option<ShardGroup>, ConsensusGossipError> {
-        let epoch = self.epoch_manager.current_epoch().await?;
-
-        if !self.epoch_manager.is_this_validator_registered_for_epoch(epoch).await? {
-            return Ok(None);
-        }
-
-        let committee_shard = self.epoch_manager.get_local_committee_info(epoch).await?;
-        Ok(Some(committee_shard.shard_group()))
-    }
 }
 
-fn shard_group_to_topic(shard_group: ShardGroup) -> String {
+pub(super) fn shard_group_to_topic(shard_group: ShardGroup) -> String {
     format!(
         "{}-{}-{}",
         TOPIC_PREFIX,
         shard_group.start().as_u32(),
         shard_group.end().as_u32()
     )
-}
-
-fn handle<T, E: Display>(reply: oneshot::Sender<Result<T, E>>, result: Result<T, E>) {
-    if let Err(ref e) = result {
-        error!(target: LOG_TARGET, "Request failed with error: {}", e);
-    }
-    if reply.send(result).is_err() {
-        error!(target: LOG_TARGET, "Requester abandoned request");
-    }
 }

--- a/applications/tari_validator_node/src/p2p/services/mempool/service.rs
+++ b/applications/tari_validator_node/src/p2p/services/mempool/service.rs
@@ -90,7 +90,7 @@ where TValidator: Validator<Transaction, Context = (), Error = TransactionValida
     }
 
     pub async fn run(mut self) -> anyhow::Result<()> {
-        let mut events = self.epoch_manager.subscribe().await?;
+        let mut events = self.epoch_manager.subscribe();
 
         loop {
             tokio::select! {

--- a/applications/tari_validator_node/src/p2p/services/messaging/outbound.rs
+++ b/applications/tari_validator_node/src/p2p/services/messaging/outbound.rs
@@ -80,7 +80,7 @@ impl<TMsgLogger: MessageLogger + Send> tari_consensus::traits::OutboundMessaging
             .map_err(|_| OutboundMessagingError::FailedToEnqueueMessage {
                 reason: "loopback sender closed".to_string(),
             })?;
-        return Ok(());
+        Ok(())
     }
 
     async fn send<T: Into<HotstuffMessage> + Send>(
@@ -110,16 +110,6 @@ impl<TMsgLogger: MessageLogger + Send> tari_consensus::traits::OutboundMessaging
         T: Into<HotstuffMessage> + Send,
     {
         let message = message.into();
-
-        // send it once to ourselves
-        let local_shard_group = self
-            .consensus_gossip
-            .get_local_shard_group()
-            .await
-            .map_err(OutboundMessagingError::from_error)?;
-        if local_shard_group == Some(shard_group) {
-            self.send_self(message.clone()).await?;
-        }
 
         self.consensus_gossip
             .multicast(shard_group, message)

--- a/dan_layer/consensus/src/hotstuff/on_receive_local_proposal.rs
+++ b/dan_layer/consensus/src/hotstuff/on_receive_local_proposal.rs
@@ -914,6 +914,9 @@ async fn broadcast_foreign_proposal_if_required<TConsensusSpec: ConsensusSpec>(
             shard_group,
         );
 
+        // TODO: This message can be much larger than the default maximum for gossipsub (16KiB) For now, the limit is
+        //       increased. We also need to allow committees that are stuck on LocalAccept/LocalPrepare to request the
+        //       foreign proposal through messaging.
         outbound_messaging
             .multicast(
                 shard_group,

--- a/dan_layer/consensus/src/hotstuff/state_machine/idle.rs
+++ b/dan_layer/consensus/src/hotstuff/state_machine/idle.rs
@@ -33,7 +33,7 @@ where TSpec: ConsensusSpec
         context: &mut ConsensusWorkerContext<TSpec>,
     ) -> Result<ConsensusStateEvent, HotStuffError> {
         // Subscribe before checking if we're registered to eliminate the chance that we miss the epoch event
-        let mut epoch_events = context.epoch_manager.subscribe().await?;
+        let mut epoch_events = context.epoch_manager.subscribe();
         context.epoch_manager.wait_for_initial_scanning_to_complete().await?;
         let current_epoch = context.epoch_manager.current_epoch().await?;
         if self.is_registered_for_epoch(context, current_epoch).await? {

--- a/dan_layer/consensus/src/hotstuff/worker.rs
+++ b/dan_layer/consensus/src/hotstuff/worker.rs
@@ -258,7 +258,7 @@ impl<TConsensusSpec: ConsensusSpec> HotstuffWorker<TConsensusSpec> {
         let mut on_force_beat = self.pacemaker.get_on_force_beat();
         let mut on_leader_timeout = self.pacemaker.get_on_leader_timeout();
 
-        let mut epoch_manager_events = self.epoch_manager.subscribe().await?;
+        let mut epoch_manager_events = self.epoch_manager.subscribe();
 
         let mut prev_height = self.pacemaker.current_view().get_height();
         let current_epoch = self.pacemaker.current_view().get_epoch();

--- a/dan_layer/consensus_tests/src/support/epoch_manager.rs
+++ b/dan_layer/consensus_tests/src/support/epoch_manager.rs
@@ -149,8 +149,8 @@ impl TestEpochManager {
 impl EpochManagerReader for TestEpochManager {
     type Addr = TestAddress;
 
-    async fn subscribe(&self) -> Result<broadcast::Receiver<EpochManagerEvent>, EpochManagerError> {
-        Ok(self.tx_epoch_events.subscribe())
+    fn subscribe(&self) -> broadcast::Receiver<EpochManagerEvent> {
+        self.tx_epoch_events.subscribe()
     }
 
     async fn get_committee_for_substate(

--- a/dan_layer/epoch_manager/src/base_layer/base_layer_epoch_manager.rs
+++ b/dan_layer/epoch_manager/src/base_layer/base_layer_epoch_manager.rs
@@ -152,6 +152,7 @@ impl<TAddr: NodeAddressable + DerivableFromPublicKey>
         if let Some(vn) = vns.iter().find(|vn| vn.public_key == self.node_public_key) {
             self.publish_event(EpochManagerEvent::ThisValidatorIsRegistered {
                 epoch,
+                shard_group: vn.shard_key.to_shard_group(self.config.num_preshards, num_committees),
                 shard_key: vn.shard_key,
             });
         }

--- a/dan_layer/epoch_manager/src/base_layer/types.rs
+++ b/dan_layer/epoch_manager/src/base_layer/types.rs
@@ -13,9 +13,9 @@ use tari_dan_common_types::{
     SubstateAddress,
 };
 use tari_dan_storage::global::models::ValidatorNode;
-use tokio::sync::{broadcast, oneshot};
+use tokio::sync::oneshot;
 
-use crate::{error::EpochManagerError, EpochManagerEvent};
+use crate::error::EpochManagerError;
 
 type Reply<T> = oneshot::Sender<Result<T, EpochManagerError>>;
 
@@ -92,9 +92,6 @@ pub enum EpochManagerRequest<TAddr> {
     GetValidatorNodesPerEpoch {
         epoch: Epoch,
         reply: Reply<Vec<ValidatorNode<TAddr>>>,
-    },
-    Subscribe {
-        reply: Reply<broadcast::Receiver<EpochManagerEvent>>,
     },
     NotifyScanningComplete {
         reply: Reply<()>,

--- a/dan_layer/epoch_manager/src/event.rs
+++ b/dan_layer/epoch_manager/src/event.rs
@@ -1,10 +1,14 @@
 //    Copyright 2023 The Tari Project
 //    SPDX-License-Identifier: BSD-3-Clause
 
-use tari_dan_common_types::{Epoch, SubstateAddress};
+use tari_dan_common_types::{Epoch, ShardGroup, SubstateAddress};
 
 #[derive(Debug, Clone)]
 pub enum EpochManagerEvent {
     EpochChanged(Epoch),
-    ThisValidatorIsRegistered { epoch: Epoch, shard_key: SubstateAddress },
+    ThisValidatorIsRegistered {
+        epoch: Epoch,
+        shard_group: ShardGroup,
+        shard_key: SubstateAddress,
+    },
 }

--- a/dan_layer/epoch_manager/src/traits.rs
+++ b/dan_layer/epoch_manager/src/traits.rs
@@ -40,7 +40,7 @@ use crate::{EpochManagerError, EpochManagerEvent};
 pub trait EpochManagerReader: Send + Sync {
     type Addr: NodeAddressable;
 
-    async fn subscribe(&self) -> Result<broadcast::Receiver<EpochManagerEvent>, EpochManagerError>;
+    fn subscribe(&self) -> broadcast::Receiver<EpochManagerEvent>;
 
     async fn wait_for_initial_scanning_to_complete(&self) -> Result<(), EpochManagerError>;
 

--- a/networking/swarm/src/config.rs
+++ b/networking/swarm/src/config.rs
@@ -40,8 +40,9 @@ impl Default for Config {
             relay_reservation_limits: RelayReservationLimits::default(),
             // This is the default for identify
             identify_interval: Duration::from_secs(5 * 60),
-            // 128k, double the libp2p default
-            gossip_sub_max_message_size: 128 * 1024,
+            // 1MiB, 64 times the libp2p default
+            // TODO: change this to a lower limit when foreign proposal messages are smaller
+            gossip_sub_max_message_size: 1024 * 1024,
         }
     }
 }


### PR DESCRIPTION
Description
---
fix: remove epoch manager calls from consensus gossipsub

Motivation and Context
---
Several epoch manager calls were used for message broadcasts, however, all required info obtained from these calls is already available at the consensus level, this PR removes the epoch manager dependency from consensus gossip only using the epoch manager events receiver.

Also directly encode and send the gossip message in the handle instead of first routing the message through the consensus gossip service and then to networking. The consensus gossip service is only responsible for ensuring that the node is subscribed to the correct shard group topic. 

Increased gossipsub message limit to 1MiB to account for large foreign proposal messages which were rejected when testing. This is temporary and improvements to the protocol should allow us to reduce this.

How Has This Been Tested?
---
Manually

What process can a PR reviewer use to test or verify this change?
---
Slight and certainly unobservable performance improvements, this is a simplification PR

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify