### PR TITLE
feat(peersync)!: push local peer record to connected peer on change

### DIFF
--- a/applications/tari_indexer/log4rs_sample.yml
+++ b/applications/tari_indexer/log4rs_sample.yml
@@ -72,6 +72,23 @@ appenders:
     encoder:
       pattern: "{d(%Y-%m-%d %H:%M:%S.%f)} [{t}] [{X(node-public-key)},{X(node-id)}] {l:5} {m} // {f}:{L}{n}"
 
+  # An appender named "libp2p" that writes to a file with a custom pattern encoder
+  libp2p:
+    kind: rolling_file
+    path: "{{log_dir}}/log/indexer/libp2p.log"
+    policy:
+      kind: compound
+      trigger:
+        kind: size
+        limit: 10mb
+      roller:
+        kind: fixed_window
+        base: 1
+        count: 5
+        pattern: "{{log_dir}}/log/indexer/libp2p.{}.log"
+    encoder:
+      pattern: "{d(%Y-%m-%d %H:%M:%S.%f)} [{t}] [Thread:{I}] {l:5} {m}{n} // {f}:{L} "
+
   # An appender named "other" that writes to a file with a custom pattern encoder
   other:
     kind: rolling_file
@@ -124,13 +141,7 @@ loggers:
       - stdout
     additive: false
 
-  # Route log events sent to the "comms" logger to the "network" appender
-  comms:
-    level: debug
-    appenders:
-      - network
-
-    # Route log events sent to the "yamux" logger to the "network" appender
+  # Route log events sent to the "yamux" logger to the "network" appender
   yamux:
     level: info
     appenders:
@@ -151,4 +162,85 @@ loggers:
     level: info
     appenders:
       - other
+    additive: false
+  # libp2p
+  libp2p_identify:
+    level: debug
+    appenders:
+      - libp2p
+    additive: false
+  libp2p_noise:
+    level: debug
+    appenders:
+      - libp2p
+    additive: false
+  libp2p_peersync:
+    level: debug
+    appenders:
+      - libp2p
+    additive: false
+  libp2p_gossipsub:
+    level: info
+    appenders:
+      - libp2p
+    additive: false
+  quinn:
+    level: info
+    appenders:
+      - libp2p
+    additive: false
+  quinn_proto:
+    level: info
+    appenders:
+      - libp2p
+    additive: false
+  libp2p_core:
+    level: info
+    appenders:
+      - libp2p
+    additive: false
+  libp2p_mdns:
+    level: debug
+    appenders:
+      - libp2p
+    additive: false
+  libp2p_swarm:
+    level: debug
+    appenders:
+      - libp2p
+    additive: false
+  hickory_proto:
+    level: info
+    appenders:
+      - libp2p
+    additive: false
+  multistream_select:
+    level: info
+    appenders:
+      - libp2p
+    additive: false
+  libp2p_tcp:
+    level: debug
+    appenders:
+      - libp2p
+    additive: false
+  libp2p_quic:
+    level: debug
+    appenders:
+      - libp2p
+    additive: false
+  libp2p_kad:
+    level: debug
+    appenders:
+      - libp2p
+    additive: false
+  libp2p_ping:
+    level: debug
+    appenders:
+      - libp2p
+    additive: false
+  libp2p_messaging:
+    level: debug
+    appenders:
+      - libp2p
     additive: false

--- a/applications/tari_validator_node/log4rs_sample.yml
+++ b/applications/tari_validator_node/log4rs_sample.yml
@@ -89,6 +89,23 @@ appenders:
     encoder:
       pattern: "{d(%Y-%m-%d %H:%M:%S.%f)} [{t}] [{X(node-public-key)},{X(node-id)}] {l:5} {m} // {f}:{L}{n}"
 
+  # An appender named "libp2p" that writes to a file with a custom pattern encoder
+  libp2p:
+    kind: rolling_file
+    path: "{{log_dir}}/log/validator-node/libp2p.log"
+    policy:
+      kind: compound
+      trigger:
+        kind: size
+        limit: 10mb
+      roller:
+        kind: fixed_window
+        base: 1
+        count: 5
+        pattern: "{{log_dir}}/log/validator-node/libp2p.{}.log"
+    encoder:
+      pattern: "{d(%Y-%m-%d %H:%M:%S.%f)} [{t}] [Thread:{I}] {l:5} {m}{n} // {f}:{L} "
+
 
   # An appender named "other" that writes to a file with a custom pattern encoder
   other:
@@ -195,4 +212,85 @@ loggers:
     level: info
     appenders:
       - other
+    additive: false
+  # libp2p
+  libp2p_identify:
+    level: debug
+    appenders:
+      - libp2p
+    additive: false
+  libp2p_noise:
+    level: debug
+    appenders:
+      - libp2p
+    additive: false
+  libp2p_peersync:
+    level: debug
+    appenders:
+      - libp2p
+    additive: false
+  libp2p_gossipsub:
+    level: info
+    appenders:
+      - libp2p
+    additive: false
+  quinn:
+    level: info
+    appenders:
+      - libp2p
+    additive: false
+  quinn_proto:
+    level: info
+    appenders:
+      - libp2p
+    additive: false
+  libp2p_core:
+    level: info
+    appenders:
+      - libp2p
+    additive: false
+  libp2p_mdns:
+    level: debug
+    appenders:
+      - libp2p
+    additive: false
+  libp2p_swarm:
+    level: debug
+    appenders:
+      - libp2p
+    additive: false
+  hickory_proto:
+    level: info
+    appenders:
+      - libp2p
+    additive: false
+  multistream_select:
+    level: info
+    appenders:
+      - libp2p
+    additive: false
+  libp2p_tcp:
+    level: debug
+    appenders:
+      - libp2p
+    additive: false
+  libp2p_quic:
+    level: debug
+    appenders:
+      - libp2p
+    additive: false
+  libp2p_kad:
+    level: debug
+    appenders:
+      - libp2p
+    additive: false
+  libp2p_ping:
+    level: debug
+    appenders:
+      - libp2p
+    additive: false
+  libp2p_messaging:
+    level: debug
+    appenders:
+      - libp2p
     additive: false

--- a/networking/core/src/worker.rs
+++ b/networking/core/src/worker.rs
@@ -565,14 +565,15 @@ where
             Autonat(event) => {
                 self.on_autonat_event(event)?;
             },
-            PeerSync(peersync::Event::LocalPeerRecordUpdated { record }) => {
-                info!(target: LOG_TARGET, "🧑‍🧑‍🧒‍🧒 Local peer record updated: {:?} announce enabled = {}, has_sent_announce = {}",record, self.config.announce, self.has_sent_announce);
-                if self.config.announce && !self.has_sent_announce && record.is_signed() {
+            PeerSync(peersync::Event::LocalPeerRecordUpdated) => {
+                if self.config.announce && !self.has_sent_announce {
+                    let record = self.swarm.behaviour().peer_sync.local_peer_record();
                     info!(target: LOG_TARGET, "📣 Sending local peer announce with {} address(es)", record.addresses().len());
+                    let proto_rec = record.encode_to_proto()?;
                     self.swarm
                         .behaviour_mut()
                         .gossipsub
-                        .publish(IdentTopic::new(PEER_ANNOUNCE_TOPIC), record.encode_to_proto()?)?;
+                        .publish(IdentTopic::new(PEER_ANNOUNCE_TOPIC), proto_rec)?;
                     self.has_sent_announce = true;
                 }
             },

--- a/networking/core/src/worker.rs
+++ b/networking/core/src/worker.rs
@@ -404,6 +404,7 @@ where
                 peer_id,
                 endpoint,
                 cause,
+                connection_id,
                 ..
             } => {
                 info!(target: LOG_TARGET, "🔌 Connection closed: peer_id={}, endpoint={:?}, cause={:?}", peer_id, endpoint, cause);
@@ -419,6 +420,12 @@ where
                     },
                 }
                 shrink_hashmap_if_required(&mut self.active_connections);
+                if let Some(selected) = self.relays.selected_relay() {
+                    if selected.circuit_connection_id == Some(connection_id) {
+                        // Our selected relay has disconnected, attempt to reserve another
+                        self.attempt_relay_reservation();
+                    }
+                }
             },
             SwarmEvent::OutgoingConnectionError {
                 peer_id: Some(peer_id),
@@ -502,7 +509,7 @@ where
                 connection_id,
             }) => {
                 info!(target: LOG_TARGET, "👋 Received identify from {} with {} addresses (id={connection_id})", peer_id, info.listen_addrs.len());
-                self.on_peer_identified(peer_id, info)?;
+                self.on_peer_identified(connection_id, peer_id, info)?;
             },
             Identify(event) => {
                 debug!(target: LOG_TARGET, "ℹ️ Identify event: {:?}", event);
@@ -743,7 +750,7 @@ where
 
         if let Some(relay) = self.relays.selected_relay_mut() {
             if endpoint.is_dialer() && relay.peer_id == peer_id {
-                relay.dialled_address = Some(endpoint.get_remote_address().clone());
+                relay.remote_address = Some(endpoint.get_remote_address().clone());
             }
         }
 
@@ -771,7 +778,12 @@ where
         Ok(())
     }
 
-    fn on_peer_identified(&mut self, peer_id: PeerId, info: identify::Info) -> Result<(), NetworkingError> {
+    fn on_peer_identified(
+        &mut self,
+        connection_id: ConnectionId,
+        peer_id: PeerId,
+        info: identify::Info,
+    ) -> Result<(), NetworkingError> {
         if !self.config.swarm.protocol_version.is_compatible(&info.protocol_version) {
             info!(target: LOG_TARGET, "🚨 Peer {} is using an incompatible protocol version: {}. Our version {}", peer_id, info.protocol_version, self.config.swarm.protocol_version);
             // Error can be ignored as the docs indicate that an error only occurs if there was no connection to the
@@ -815,6 +827,9 @@ where
                     // Otherwise, if the peer advertises as a relay we'll add them
                     info!(target: LOG_TARGET, "📡 Adding peer {peer_id} {address} as a relay");
                     self.relays.add_possible_relay(peer_id, address.clone());
+                    if !self.relays.has_active_relay() {
+                        self.relays.set_relay_peer(peer_id, Some(address.clone()));
+                    }
                 } else {
                     // Nothing to do
                 }
@@ -824,7 +839,7 @@ where
         // If this peer is the selected relay that was dialled previously, listen on the circuit address
         // Note we only select a relay if autonat says we are not publicly accessible.
         if is_relay {
-            self.establish_relay_circuit_on_connect(&peer_id);
+            self.establish_relay_circuit_on_connect(&peer_id, connection_id);
         }
 
         self.publish_event(NetworkingEvent::NewIdentifiedPeer {
@@ -848,7 +863,7 @@ where
 
     /// Establishes a relay circuit for the given peer if it is the selected relay peer. Returns true if the circuit
     /// was established from this call.
-    fn establish_relay_circuit_on_connect(&mut self, peer_id: &PeerId) -> bool {
+    fn establish_relay_circuit_on_connect(&mut self, peer_id: &PeerId, connection_id: ConnectionId) -> bool {
         let Some(relay) = self.relays.selected_relay() else {
             return false;
         };
@@ -859,12 +874,12 @@ where
         }
 
         // If we've already established a circuit with the relay, there's nothing to do here
-        if relay.is_circuit_established {
+        if relay.has_circuit() {
             return false;
         }
 
         // Check if we've got a confirmed address for the relay
-        let Some(dialled_address) = relay.dialled_address.as_ref() else {
+        let Some(dialled_address) = relay.remote_address.as_ref() else {
             return false;
         };
 
@@ -881,7 +896,7 @@ where
                     // unreachable
                     return false;
                 };
-                relay_mut.is_circuit_established = true;
+                relay_mut.circuit_connection_id = Some(connection_id);
                 true
             },
             Err(e) => {

--- a/networking/core/src/worker.rs
+++ b/networking/core/src/worker.rs
@@ -686,8 +686,12 @@ where
         use autonat::Event::*;
         match event {
             StatusChanged { old, new } => {
-                if let Some(public_address) = self.swarm.behaviour().autonat.public_address() {
+                if let Some(public_address) = self.swarm.behaviour().autonat.public_address().cloned() {
                     info!(target: LOG_TARGET, "🌍️ Autonat: Our public address is {public_address}");
+                    self.swarm
+                        .behaviour_mut()
+                        .peer_sync
+                        .add_known_local_public_addresses(vec![public_address]);
                 }
 
                 // If we are/were "Private", let's establish a relay reservation with a known relay

--- a/networking/libp2p-peersync/proto/messages.proto
+++ b/networking/libp2p-peersync/proto/messages.proto
@@ -3,30 +3,37 @@
 
 syntax = "proto3";
 
+message Message {
+  oneof payload {
+    SignedPeerRecord LocalRecord = 1;
+    WantPeers WantPeers = 2;
+  }
+}
+
 // A want request for peers
 message WantPeers {
-    // Requested peers
-    repeated bytes want_peer_ids = 1;
+  // Requested peers
+  repeated bytes want_peer_ids = 1;
 }
 
 // Response to a want request. This response is streamed back to the requester.
 message WantPeerResponse {
-    // A peer that was requested.
-    SignedPeerRecord peer = 1;
+  // A peer that was requested.
+  SignedPeerRecord peer = 1;
 }
 
 message SignedPeerRecord {
-    // The addresses of the peer
-    repeated bytes addresses = 1;
-    // The Unix epoch based timestamp when this peer record was signed
-    uint64 ts_updated_at = 2;
-    // The signature that signs the peer record (addresses | ts_updated_at)
-    PeerSignature signature = 3;
+  // The addresses of the peer
+  repeated bytes addresses = 1;
+  // The Unix epoch based timestamp when this peer record was signed
+  uint64 ts_updated_at = 2;
+  // The signature that signs the peer record (addresses | ts_updated_at)
+  PeerSignature signature = 3;
 }
 
 message PeerSignature {
-    // The public key of the peer
-    bytes public_key = 1;
-    // The signature that signs the peer record (addresses | ts_updated_at)
-    bytes signature = 2;
+  // The public key of the peer
+  bytes public_key = 1;
+  // The signature that signs the peer record (addresses | ts_updated_at)
+  bytes signature = 2;
 }

--- a/networking/libp2p-peersync/src/behaviour.rs
+++ b/networking/libp2p-peersync/src/behaviour.rs
@@ -113,11 +113,14 @@ where TPeerStore: PeerStore
             return;
         }
 
+        let mut is_any_new = false;
         for addr in addrs {
-            self.local_peer_record.add_address(addr.clone());
+            is_any_new |= self.local_peer_record.add_address(addr.clone());
         }
 
-        self.handle_update_local_record();
+        if is_any_new {
+            self.handle_update_local_record();
+        }
     }
 
     pub async fn want_peers<I: IntoIterator<Item = PeerId>>(&mut self, peers: I) -> Result<(), Error> {
@@ -263,14 +266,18 @@ where TPeerStore: PeerStore
             FromSwarm::ConnectionClosed(connection_closed) => self.on_connection_closed(connection_closed),
             FromSwarm::AddressChange(_) => {},
             FromSwarm::ExternalAddrConfirmed(addr_confirmed) => {
-                self.local_peer_record.add_address(addr_confirmed.addr.clone());
-                self.handle_update_local_record()
+                if self.local_peer_record.add_address(addr_confirmed.addr.clone()) {
+                    self.handle_update_local_record();
+                    self.pending_events
+                        .push_back(ToSwarm::GenerateEvent(Event::LocalPeerRecordUpdated));
+                }
             },
             FromSwarm::ExternalAddrExpired(addr_expired) => {
-                self.local_peer_record.remove_address(addr_expired.addr);
-                self.handle_update_local_record();
-                self.pending_events
-                    .push_back(ToSwarm::GenerateEvent(Event::LocalPeerRecordUpdated));
+                if self.local_peer_record.remove_address(addr_expired.addr) {
+                    self.handle_update_local_record();
+                    self.pending_events
+                        .push_back(ToSwarm::GenerateEvent(Event::LocalPeerRecordUpdated));
+                }
             },
             _ => {},
         }
@@ -309,18 +316,6 @@ where TPeerStore: PeerStore
 
     fn poll(&mut self, cx: &mut Context<'_>) -> Poll<ToSwarm<Self::ToSwarm, THandlerInEvent<Self>>> {
         if let Some(event) = self.pending_events.pop_front() {
-            //     if let
-            //         ToSwarm::GenerateEvent(event) =
-            //         &event {
-            //         match event {
-            //             Event::InboundFailure { peer_id, .. } => {}
-            //             Event::OutboundFailure { peer_id, .. } => {}
-            //             Event::InboundStreamInterrupted { peer_id,  .. } => {}
-            //             Event::OutboundStreamInterrupted { peer_id, .. } => {}
-            //             Event::ResponseStreamComplete { peer_id, .. } => {}
-            //             Event::Error(_) => {}
-            //         }
-            //     }
             return Poll::Ready(event);
         }
         if self.pending_events.capacity() > EMPTY_QUEUE_SHRINK_THRESHOLD {

--- a/networking/libp2p-peersync/src/behaviour.rs
+++ b/networking/libp2p-peersync/src/behaviour.rs
@@ -13,8 +13,6 @@ use libp2p::{
     futures::executor::block_on,
     identity::Keypair,
     swarm::{
-        behaviour::ExternalAddrConfirmed,
-        AddressChange,
         ConnectionClosed,
         ConnectionDenied,
         ConnectionId,
@@ -34,7 +32,7 @@ use libp2p::{
 use crate::{
     error::Error,
     event::Event,
-    handler::Handler,
+    handler::{Handler, HandlerAction},
     store::PeerStore,
     Config,
     LocalPeerRecord,
@@ -72,7 +70,7 @@ where TPeerStore: PeerStore
         Self::with_custom_protocol(keypair, DEFAULT_PROTOCOL_NAME, store, config)
     }
 
-    pub fn with_custom_protocol(
+    fn with_custom_protocol(
         keypair: Keypair,
         protocol: StreamProtocol,
         peer_store: TPeerStore,
@@ -88,7 +86,7 @@ where TPeerStore: PeerStore
             active_outbound_connections: HashMap::new(),
             remaining_want_peers: HashSet::new(),
             pending_syncs: VecDeque::new(),
-            pending_tasks: futures_bounded::FuturesSet::new(Duration::from_secs(1000), 1024),
+            pending_tasks: futures_bounded::FuturesSet::new(Duration::from_secs(30), 1024),
             sync_semaphore: Arc::new(async_semaphore::Semaphore::new(1)),
         }
     }
@@ -104,6 +102,10 @@ where TPeerStore: PeerStore
             .put_if_newer(peer)
             .await
             .map_err(|e| Error::StoreError(e.to_string()))
+    }
+
+    pub fn local_peer_record(&self) -> &LocalPeerRecord {
+        &self.local_peer_record
     }
 
     pub fn add_known_local_public_addresses(&mut self, addrs: Vec<Multiaddr>) {
@@ -151,7 +153,7 @@ where TPeerStore: PeerStore
                 self.pending_events.push_back(ToSwarm::NotifyHandler {
                     peer_id: *peer_id,
                     handler: NotifyHandler::One(*conn_id),
-                    event: list.clone(),
+                    event: HandlerAction::WantPeers(list.clone()),
                 });
             }
         }
@@ -174,31 +176,14 @@ where TPeerStore: PeerStore
         }
     }
 
-    fn on_address_change(&mut self, _address_change: AddressChange) {}
-
-    fn on_external_addr_confirmed(&mut self, addr_confirmed: ExternalAddrConfirmed) {
-        self.local_peer_record.add_address(addr_confirmed.addr.clone());
-        self.handle_update_local_record()
-    }
-
     fn handle_update_local_record(&mut self) {
         let store = self.peer_store.clone();
         let local_peer_record = self.local_peer_record.clone();
-        if !local_peer_record.is_signed() {
-            return;
-        }
-        let peer_rec = match local_peer_record.clone().try_into() {
-            Ok(peer_rec) => peer_rec,
-            Err(err) => {
-                tracing::error!("Failed to convert local peer record to signed peer record: {}", err);
-                return;
-            },
-        };
+        let local_peer_rec = SignedPeerRecord::from(local_peer_record);
+        let local_rec = Arc::new(local_peer_rec.clone());
         let task = async move {
-            match store.put(peer_rec).await {
-                Ok(_) => Event::LocalPeerRecordUpdated {
-                    record: local_peer_record,
-                },
+            match store.put(local_peer_rec).await {
+                Ok(_) => Event::LocalPeerRecordUpdated,
                 Err(err) => {
                     tracing::error!("Failed to add local peer record to store: {}", err);
                     Event::Error(Error::StoreError(err.to_string()))
@@ -206,7 +191,16 @@ where TPeerStore: PeerStore
             }
         };
         match self.pending_tasks.try_push(task) {
-            Ok(()) => {},
+            Ok(()) => {
+                self.pending_events.reserve(self.active_outbound_connections.len());
+                for (peer_id, conn_id) in &self.active_outbound_connections {
+                    self.pending_events.push_back(ToSwarm::NotifyHandler {
+                        peer_id: *peer_id,
+                        handler: NotifyHandler::One(*conn_id),
+                        event: HandlerAction::PushLocalRecord(local_rec.clone()),
+                    });
+                }
+            },
             Err(_) => {
                 self.pending_events.push_back(ToSwarm::GenerateEvent(Event::Error(
                     Error::ExceededMaxNumberOfPendingTasks,
@@ -225,17 +219,18 @@ where TPeerStore: PeerStore
     fn handle_established_inbound_connection(
         &mut self,
         _connection_id: ConnectionId,
-        peer: PeerId,
+        peer_id: PeerId,
         _local_addr: &Multiaddr,
         _remote_addr: &Multiaddr,
     ) -> Result<THandler<Self>, ConnectionDenied> {
         let handler = Handler::new(
-            peer,
+            peer_id,
             self.peer_store.clone(),
             self.protocol.clone(),
             &self.config,
             self.remaining_want_peers.clone(),
             self.sync_semaphore.clone(),
+            None,
         );
         Ok(handler)
     }
@@ -248,6 +243,7 @@ where TPeerStore: PeerStore
         _role_override: Endpoint,
         _port_use: PortUse,
     ) -> Result<THandler<Self>, ConnectionDenied> {
+        tracing::debug!("outbound connection to peer {}", peer);
         let handler = Handler::new(
             peer,
             self.peer_store.clone(),
@@ -255,6 +251,7 @@ where TPeerStore: PeerStore
             &self.config,
             self.remaining_want_peers.clone(),
             self.sync_semaphore.clone(),
+            Some(Arc::new(self.local_peer_record.clone().into())),
         );
         self.active_outbound_connections.insert(peer, connection_id);
         Ok(handler)
@@ -264,16 +261,16 @@ where TPeerStore: PeerStore
         match event {
             FromSwarm::ConnectionEstablished(_) => {},
             FromSwarm::ConnectionClosed(connection_closed) => self.on_connection_closed(connection_closed),
-            FromSwarm::AddressChange(address_change) => self.on_address_change(address_change),
+            FromSwarm::AddressChange(_) => {},
             FromSwarm::ExternalAddrConfirmed(addr_confirmed) => {
-                self.on_external_addr_confirmed(addr_confirmed);
+                self.local_peer_record.add_address(addr_confirmed.addr.clone());
+                self.handle_update_local_record()
             },
             FromSwarm::ExternalAddrExpired(addr_expired) => {
                 self.local_peer_record.remove_address(addr_expired.addr);
+                self.handle_update_local_record();
                 self.pending_events
-                    .push_back(ToSwarm::GenerateEvent(Event::LocalPeerRecordUpdated {
-                        record: self.local_peer_record.clone(),
-                    }));
+                    .push_back(ToSwarm::GenerateEvent(Event::LocalPeerRecordUpdated));
             },
             _ => {},
         }
@@ -302,7 +299,7 @@ where TPeerStore: PeerStore
             },
             Event::InboundStreamInterrupted { .. } => {},
             Event::OutboundStreamInterrupted { .. } => {},
-            Event::ResponseStreamComplete { .. } => {},
+            Event::InboundRequestCompleted { .. } => {},
             Event::LocalPeerRecordUpdated { .. } => {},
             Event::Error(_) => {},
         }

--- a/networking/libp2p-peersync/src/event.rs
+++ b/networking/libp2p-peersync/src/event.rs
@@ -3,7 +3,7 @@
 
 use libp2p::PeerId;
 
-use crate::{error::Error, LocalPeerRecord};
+use crate::error::Error;
 
 #[derive(Debug)]
 pub enum Event {
@@ -25,13 +25,11 @@ pub enum Event {
     OutboundStreamInterrupted {
         peer_id: PeerId,
     },
-    ResponseStreamComplete {
+    InboundRequestCompleted {
         peer_id: PeerId,
         peers_sent: usize,
         requested: usize,
     },
-    LocalPeerRecordUpdated {
-        record: LocalPeerRecord,
-    },
+    LocalPeerRecordUpdated,
     Error(Error),
 }

--- a/networking/libp2p-peersync/src/lib.rs
+++ b/networking/libp2p-peersync/src/lib.rs
@@ -35,4 +35,4 @@ pub use event::*;
 pub use peer_record::*;
 
 /// The maximum message size permitted for peer messages
-pub(crate) const MAX_MESSAGE_SIZE: usize = 1024;
+pub(crate) const MAX_MESSAGE_SIZE: usize = 3 * 1024;

--- a/networking/libp2p-peersync/src/outbound_task.rs
+++ b/networking/libp2p-peersync/src/outbound_task.rs
@@ -10,86 +10,116 @@ use libp2p::{
 
 use crate::{behaviour::WantList, handler::FramedOutbound, proto, store::PeerStore, Error, Event, SignedPeerRecord};
 
-pub async fn outbound_sync_task<TPeerStore: PeerStore>(
+pub async fn outbound_request_want_list_task<TPeerStore: PeerStore>(
     peer_id: PeerId,
     mut framed: FramedOutbound,
     store: TPeerStore,
     want_list: Arc<WantList>,
+    local_peer_record: Option<Arc<SignedPeerRecord>>,
 ) -> Event {
-    tracing::debug!("Starting outbound protocol sync with peer {}", peer_id);
-    outbound_sync_task_inner(peer_id, &mut framed, store, want_list)
+    tracing::debug!("Starting outbound protocol with peer {}", peer_id);
+    outbound_request_want_list_task_inner(peer_id, &mut framed, store, want_list, local_peer_record.as_deref())
         .await
         .unwrap_or_else(Event::Error)
 }
 
-async fn outbound_sync_task_inner<TPeerStore: PeerStore>(
-    from_peer: PeerId,
+async fn outbound_request_want_list_task_inner<TPeerStore: PeerStore>(
+    peer_id: PeerId,
     framed: &mut FramedOutbound,
     store: TPeerStore,
     want_list: Arc<WantList>,
+    local_peer_record: Option<&SignedPeerRecord>,
 ) -> Result<Event, Error> {
-    {
+    if let Some(local_peer_record) = local_peer_record {
+        tracing::debug!("Sending updated local peer record to peer {}", peer_id);
+        let msg = proto::SignedPeerRecord::from(local_peer_record);
+        framed.send(msg.into()).await.map_err(|e| Error::CodecError(e.into()))?;
+    }
+
+    if want_list.is_empty() {
+        tracing::debug!("[peer_id={peer_id}] Empty want list. Protocol complete");
+        // Nothing further to do, let the peer know
         framed
-            .send(proto::WantPeers {
-                want_peer_ids: want_list.iter().map(|p| p.to_bytes()).collect(),
+            .send(proto::Message {
+                payload: proto::mod_Message::OneOfpayload::None,
             })
             .await
             .map_err(|e| Error::CodecError(e.into()))?;
-        tracing::debug!("Sent want list to peer {}", from_peer);
+        return Ok(Event::InboundRequestCompleted {
+            peer_id,
+            peers_sent: 1,
+            requested: 0,
+        });
+    }
 
-        let mut new_peers = 0;
-        while let Some(msg) = framed.next().await {
-            if new_peers + 1 > want_list.len() {
-                return Err(Error::InvalidMessage {
-                    peer_id: from_peer,
-                    details: format!("Peer {from_peer} sent us more peers than we requested"),
-                });
+    framed
+        .send(
+            proto::WantPeers {
+                want_peer_ids: want_list.iter().map(|p| p.to_bytes()).collect(),
             }
+            .into(),
+        )
+        .await
+        .map_err(|e| Error::CodecError(e.into()))?;
+    tracing::debug!("Sent want list (size={}) to peer {}", want_list.len(), peer_id);
 
-            match msg {
-                Ok(msg) => {
-                    let Some(peer) = msg.peer else {
-                        return Err(Error::InvalidMessage {
-                            peer_id: from_peer,
-                            details: "empty message".to_string(),
-                        });
-                    };
-
-                    let rec = match SignedPeerRecord::try_from(peer) {
-                        Ok(rec) => rec,
-                        Err(e) => {
-                            return Err(Error::InvalidMessage {
-                                peer_id: from_peer,
-                                details: e.to_string(),
-                            });
-                        },
-                    };
-
-                    if !want_list.contains(&rec.to_peer_id()) {
-                        return Err(Error::InvalidMessage {
-                            peer_id: from_peer,
-                            details: format!("Peer {from_peer} sent us a peer we didnt request"),
-                        });
-                    }
-
-                    new_peers += 1;
-
-                    store
-                        .put_if_newer(rec)
-                        .await
-                        .map_err(|err| Error::StoreError(err.to_string()))?;
-                },
-                Err(e) => {
-                    let e = io::Error::from(e);
-                    if e.kind() == io::ErrorKind::UnexpectedEof {
-                        return Ok(Event::OutboundStreamInterrupted { peer_id: from_peer });
-                    } else {
-                        return Err(Error::CodecError(e));
-                    }
-                },
-            }
+    let mut new_peers = 0;
+    while let Some(msg) = framed.next().await {
+        if new_peers + 1 > want_list.len() {
+            return Err(Error::InvalidMessage {
+                peer_id,
+                details: format!("Peer {peer_id} sent us more peers than we requested"),
+            });
         }
 
-        Ok(Event::PeerBatchReceived { from_peer, new_peers })
+        match msg {
+            Ok(msg) => {
+                let Some(peer) = msg.peer else {
+                    return Err(Error::InvalidMessage {
+                        peer_id,
+                        details: "empty message".to_string(),
+                    });
+                };
+
+                let rec = match SignedPeerRecord::try_from(peer) {
+                    Ok(rec) => rec,
+                    Err(e) => {
+                        return Err(Error::InvalidMessage {
+                            peer_id,
+                            details: e.to_string(),
+                        });
+                    },
+                };
+
+                if !want_list.contains(&rec.to_peer_id()) {
+                    return Err(Error::InvalidMessage {
+                        peer_id,
+                        details: format!("Peer {peer_id} sent us a peer we didnt request"),
+                    });
+                }
+
+                new_peers += 1;
+
+                store
+                    .put_if_newer(rec)
+                    .await
+                    .map_err(|err| Error::StoreError(err.to_string()))?;
+            },
+            Err(e) => {
+                let e = io::Error::from(e);
+                if e.kind() == io::ErrorKind::UnexpectedEof {
+                    return Ok(Event::OutboundStreamInterrupted { peer_id });
+                } else {
+                    return Err(Error::CodecError(e));
+                }
+            },
+        }
     }
+
+    tracing::debug!("Received {} new peers from {}", new_peers, peer_id);
+
+    Ok(Event::PeerBatchReceived {
+        from_peer: peer_id,
+        new_peers,
+    })
 }

--- a/networking/libp2p-peersync/src/peer_record.rs
+++ b/networking/libp2p-peersync/src/peer_record.rs
@@ -124,14 +124,21 @@ impl LocalPeerRecord {
         self.keypair.public().to_peer_id()
     }
 
-    pub fn add_address(&mut self, address: Multiaddr) {
-        self.addresses.insert(address);
-        self.sign();
+    pub fn add_address(&mut self, address: Multiaddr) -> bool {
+        if self.addresses.insert(address) {
+            // Sign only if the address was not already there
+            self.sign();
+            return true;
+        }
+        false
     }
 
-    pub fn remove_address(&mut self, address: &Multiaddr) {
-        self.addresses.remove(address);
-        self.sign();
+    pub fn remove_address(&mut self, address: &Multiaddr) -> bool {
+        if self.addresses.remove(address) {
+            self.sign();
+            return true;
+        }
+        false
     }
 
     pub fn addresses(&self) -> &HashSet<Multiaddr> {

--- a/networking/libp2p-peersync/src/peer_record.rs
+++ b/networking/libp2p-peersync/src/peer_record.rs
@@ -69,25 +69,33 @@ impl TryFrom<proto::SignedPeerRecord> for SignedPeerRecord {
     }
 }
 
-impl From<SignedPeerRecord> for proto::SignedPeerRecord {
-    fn from(value: SignedPeerRecord) -> Self {
+impl From<&SignedPeerRecord> for proto::SignedPeerRecord {
+    fn from(value: &SignedPeerRecord) -> Self {
         Self {
-            addresses: value.addresses.into_iter().map(|a| a.to_vec()).collect(),
+            addresses: value.addresses.iter().map(|a| a.to_vec()).collect(),
             ts_updated_at: value.updated_at.as_secs(),
-            signature: Some(value.signature.into()),
+            signature: Some(proto::PeerSignature::from(value.signature.clone())),
         }
     }
 }
 
-impl TryFrom<LocalPeerRecord> for SignedPeerRecord {
-    type Error = Error;
+impl From<SignedPeerRecord> for proto::SignedPeerRecord {
+    fn from(value: SignedPeerRecord) -> Self {
+        Self {
+            addresses: value.addresses.iter().map(|a| a.to_vec()).collect(),
+            ts_updated_at: value.updated_at.as_secs(),
+            signature: Some(proto::PeerSignature::from(value.signature)),
+        }
+    }
+}
 
-    fn try_from(value: LocalPeerRecord) -> Result<Self, Self::Error> {
-        Ok(Self {
+impl From<LocalPeerRecord> for SignedPeerRecord {
+    fn from(value: LocalPeerRecord) -> Self {
+        Self {
             addresses: value.addresses.into_iter().collect(),
             updated_at: value.updated_at,
-            signature: value.signature.ok_or_else(|| Error::LocalPeerNotSigned)?,
-        })
+            signature: value.signature,
+        }
     }
 }
 
@@ -96,16 +104,19 @@ pub struct LocalPeerRecord {
     keypair: Arc<identity::Keypair>,
     addresses: HashSet<Multiaddr>,
     updated_at: Duration,
-    signature: Option<PeerSignature>,
+    signature: PeerSignature,
 }
 
 impl LocalPeerRecord {
     pub fn new(keypair: Arc<identity::Keypair>) -> Self {
+        let updated_at = epoch_time_now();
+        let addresses = HashSet::new();
+        let signature = sign_peer_rec(&keypair, &addresses, &updated_at);
         Self {
             keypair,
-            addresses: HashSet::new(),
-            updated_at: epoch_time_now(),
-            signature: None,
+            addresses,
+            updated_at,
+            signature,
         }
     }
 
@@ -127,18 +138,13 @@ impl LocalPeerRecord {
         &self.addresses
     }
 
-    pub fn is_signed(&self) -> bool {
-        self.signature.is_some()
-    }
-
     pub fn encode_to_proto(&self) -> Result<BytesMut, Error> {
-        SignedPeerRecord::try_from(self.clone())?.encode_to_proto()
+        SignedPeerRecord::from(self.clone()).encode_to_proto()
     }
 
     fn sign(&mut self) {
         self.updated_at = epoch_time_now();
-        let msg = peer_signature_challenge(&self.addresses, &self.updated_at);
-        self.signature = Some(PeerSignature::sign(&self.keypair, &msg));
+        self.signature = sign_peer_rec(&self.keypair, &self.addresses, &self.updated_at);
     }
 }
 
@@ -187,6 +193,11 @@ impl TryFrom<proto::PeerSignature> for PeerSignature {
             signature: value.signature,
         })
     }
+}
+
+fn sign_peer_rec(keypair: &identity::Keypair, addresses: &HashSet<Multiaddr>, updated_at: &Duration) -> PeerSignature {
+    let msg = peer_signature_challenge(addresses, updated_at);
+    PeerSignature::sign(keypair, &msg)
 }
 
 fn peer_signature_challenge<'a, I: IntoIterator<Item = &'a Multiaddr>>(

--- a/networking/libp2p-peersync/src/proto.rs
+++ b/networking/libp2p-peersync/src/proto.rs
@@ -4,3 +4,19 @@
 include!(concat!(env!("OUT_DIR"), "/proto/mod.rs"));
 
 pub use messages::*;
+
+impl From<WantPeers> for Message {
+    fn from(value: WantPeers) -> Self {
+        Self {
+            payload: mod_Message::OneOfpayload::WantPeers(value),
+        }
+    }
+}
+
+impl From<SignedPeerRecord> for Message {
+    fn from(value: SignedPeerRecord) -> Self {
+        Self {
+            payload: mod_Message::OneOfpayload::LocalRecord(value),
+        }
+    }
+}


### PR DESCRIPTION
Description
---
feat(peersync)!: push local peer record to connected peer on change
Add libp2p logs to log4rs

Motivation and Context
---
Connected peers should have an up-to-date and shareable address record for peers they are connected to. This PR adds this to the peer sync protocol.

How Has This Been Tested?
---
Manually - looked at logs to observe it working

What process can a PR reviewer use to test or verify this change?
---
Given node A connected to node B prior, a node C can request node B from Node A and always get a response.

Breaking Changes
---

- [ ] None
- [ ] Requires data directory to be deleted
- [x] Other - Please specify

BREAKING CHANGE: peer sync protocol is not compatible with previous versions