### PR TITLE
feat: template upload endpoint update

### DIFF
--- a/applications/tari_swarm_daemon/Cargo.toml
+++ b/applications/tari_swarm_daemon/Cargo.toml
@@ -44,7 +44,7 @@ tokio = { workspace = true, features = ["rt-multi-thread", "macros", "signal", "
 toml = "0.8.12"
 tonic = { workspace = true }
 tower-http = { workspace = true, features = ["fs", "cors"] }
-url = { workspace = true }
+url = { workspace = true, features = ["default", "serde"] }
 
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.28.0", default-features = false, features = ["signal"] }

--- a/applications/tari_swarm_daemon/src/webserver/server.rs
+++ b/applications/tari_swarm_daemon/src/webserver/server.rs
@@ -132,16 +132,16 @@ async fn call_handler<H, TReq, TResp>(
 where
     TReq: DeserializeOwned,
     TResp: Serialize,
-    H: for<'a> JrpcHandler<'a, TReq, Response = TResp>,
+    H: for<'a> JrpcHandler<'a, TReq, Response=TResp>,
 {
     let answer_id = value.get_answer_id();
     let params = value.parse_params().inspect_err(|e| match &e.result {
         JsonRpcAnswer::Result(_) => {
             unreachable!("parse_params() error should not return a result")
-        },
+        }
         JsonRpcAnswer::Error(e) => {
             warn!(target: LOG_TARGET, "🌐 JSON-RPC params error: {}", e);
-        },
+        }
     })?;
     let resp = handler
         .handle(&context, params)

--- a/applications/tari_swarm_daemon/src/webserver/server.rs
+++ b/applications/tari_swarm_daemon/src/webserver/server.rs
@@ -132,16 +132,16 @@ async fn call_handler<H, TReq, TResp>(
 where
     TReq: DeserializeOwned,
     TResp: Serialize,
-    H: for<'a> JrpcHandler<'a, TReq, Response=TResp>,
+    H: for<'a> JrpcHandler<'a, TReq, Response = TResp>,
 {
     let answer_id = value.get_answer_id();
     let params = value.parse_params().inspect_err(|e| match &e.result {
         JsonRpcAnswer::Result(_) => {
             unreachable!("parse_params() error should not return a result")
-        }
+        },
         JsonRpcAnswer::Error(e) => {
             warn!(target: LOG_TARGET, "🌐 JSON-RPC params error: {}", e);
-        }
+        },
     })?;
     let resp = handler
         .handle(&context, params)

--- a/applications/tari_swarm_daemon/src/webserver/templates.rs
+++ b/applications/tari_swarm_daemon/src/webserver/templates.rs
@@ -4,12 +4,7 @@
 use std::{io, sync::Arc};
 
 use axum::extract::Query;
-use axum::{
-    extract::{multipart::MultipartError, Multipart},
-    http::StatusCode,
-    response::IntoResponse,
-    Extension,
-};
+use axum::{extract::{multipart::MultipartError, Multipart}, http::StatusCode, response::IntoResponse, Extension, Json};
 use log::{error, info};
 use serde::{Deserialize, Serialize};
 use tari_crypto::tari_utilities::hex;
@@ -25,30 +20,48 @@ fn register_template_default() -> bool {
 }
 
 #[derive(Deserialize)]
-struct UploadQueryParams {
+pub struct UploadQueryParams {
     #[serde(default = "register_template_default")]
     register_template: bool,
 }
 
-#[derive(Serialize)]
-struct UploadResponse {
+#[derive(Serialize, Deserialize)]
+pub struct UploadResponse {
     success: bool,
     template_url: Option<Url>,
     error: String,
 }
 
-pub async fn upload(
-    Extension(context): Extension<Arc<HandlerContext>>,
-    mut value: Multipart,
-    query_params: Query<UploadQueryParams>,
-) -> Result<UploadResponse, UploadError> {
-    let Some(field) = value.next_field().await? else {
-        error!("🌐 Upload template: no field found");
-        return Ok(UploadResponse {
+impl UploadResponse {
+    pub fn success(template_url: Url) -> Self {
+        Self {
+            success: true,
+            template_url: Some(template_url),
+            error: String::new(),
+        }
+    }
+
+    pub fn failure(error: String) -> Self {
+        Self {
             success: false,
             template_url: None,
-            error: "No multipart file field found".to_string(),
-        });
+            error,
+        }
+    }
+}
+
+pub async fn upload(
+    Extension(context): Extension<Arc<HandlerContext>>,
+    query_params: Query<UploadQueryParams>,
+    mut value: Multipart,
+) -> Result<Json<UploadResponse>, UploadError> {
+    let Some(field) = value.next_field().await? else {
+        error!("🌐 Upload template: no field found");
+        return Ok(
+            Json(
+                UploadResponse::failure("No multipart file field found".to_string())
+            )
+        );
     };
 
     let name = field.file_name().unwrap_or("unnamed-template").to_string();
@@ -76,17 +89,17 @@ pub async fn upload(
             name,
             version: 0,
             contents_hash: hash,
-            contents_url: template_url,
+            contents_url: template_url.clone(),
         };
 
         return match context.process_manager().register_template(data).await {
             Ok(()) => {
                 info!("🌐 Registered template");
-                Ok(UploadResponse {
-                    success: true,
-                    template_url: Some(template_url.clone()),
-                    error: String::new(),
-                })
+                Ok(
+                    Json(
+                        UploadResponse::success(template_url)
+                    )
+                )
             }
             Err(err) => {
                 error!("🌐 Registering template failed: {}", err);
@@ -95,7 +108,11 @@ pub async fn upload(
         };
     }
 
-    Ok(UploadResponse { template_url })
+    Ok(
+        Json(
+            UploadResponse::success(template_url)
+        )
+    )
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/applications/tari_swarm_daemon/src/webserver/templates.rs
+++ b/applications/tari_swarm_daemon/src/webserver/templates.rs
@@ -3,8 +3,13 @@
 
 use std::{io, sync::Arc};
 
-use axum::extract::Query;
-use axum::{extract::{multipart::MultipartError, Multipart}, http::StatusCode, response::IntoResponse, Extension, Json};
+use axum::{
+    extract::{multipart::MultipartError, Multipart, Query},
+    http::StatusCode,
+    response::IntoResponse,
+    Extension,
+    Json,
+};
 use log::{error, info};
 use serde::{Deserialize, Serialize};
 use tari_crypto::tari_utilities::hex;
@@ -82,7 +87,7 @@ pub async fn upload(
         context.config().webserver.bind_address.port(),
         dest_file
     ))
-        .unwrap();
+    .unwrap();
 
     if query_params.register_template {
         let data = TemplateData {
@@ -95,24 +100,16 @@ pub async fn upload(
         return match context.process_manager().register_template(data).await {
             Ok(()) => {
                 info!("🌐 Registered template");
-                Ok(
-                    Json(
-                        UploadResponse::success(template_url)
-                    )
-                )
-            }
+                Ok(Json(UploadResponse::success(template_url)))
+            },
             Err(err) => {
                 error!("🌐 Registering template failed: {}", err);
                 Err(err.into())
-            }
+            },
         };
     }
 
-    Ok(
-        Json(
-            UploadResponse::success(template_url)
-        )
-    )
+    Ok(Json(UploadResponse::success(template_url)))
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -141,7 +138,7 @@ impl IntoResponse for UploadError {
             UploadError::MultiPartError(err) => err.into_response(),
             UploadError::Other(err) => {
                 (StatusCode::INTERNAL_SERVER_ERROR, format!("Upload error: {}", err)).into_response()
-            }
+            },
         }
     }
 }

--- a/applications/tari_swarm_daemon/src/webserver/templates.rs
+++ b/applications/tari_swarm_daemon/src/webserver/templates.rs
@@ -3,6 +3,7 @@
 
 use std::{io, sync::Arc};
 
+use axum::extract::Query;
 use axum::{
     extract::{multipart::MultipartError, Multipart},
     http::StatusCode,
@@ -10,6 +11,7 @@ use axum::{
     Extension,
 };
 use log::{error, info};
+use serde::{Deserialize, Serialize};
 use tari_crypto::tari_utilities::hex;
 use tari_dan_engine::wasm::WasmModule;
 use tari_engine_types::calculate_template_binary_hash;
@@ -18,14 +20,35 @@ use url::Url;
 
 use crate::{process_manager::TemplateData, webserver::context::HandlerContext};
 
+fn register_template_default() -> bool {
+    true
+}
+
+#[derive(Deserialize)]
+struct UploadQueryParams {
+    #[serde(default = "register_template_default")]
+    register_template: bool,
+}
+
+#[derive(Serialize)]
+struct UploadResponse {
+    success: bool,
+    template_url: Option<Url>,
+    error: String,
+}
+
 pub async fn upload(
     Extension(context): Extension<Arc<HandlerContext>>,
     mut value: Multipart,
-) -> Result<(), UploadError> {
+    query_params: Query<UploadQueryParams>,
+) -> Result<UploadResponse, UploadError> {
     let Some(field) = value.next_field().await? else {
         error!("🌐 Upload template: no field found");
-        // TODO: return error
-        return Ok(());
+        return Ok(UploadResponse {
+            success: false,
+            template_url: None,
+            error: "No multipart file field found".to_string(),
+        });
     };
 
     let name = field.file_name().unwrap_or("unnamed-template").to_string();
@@ -41,28 +64,38 @@ pub async fn upload(
     file.write_all(&bytes).await?;
     info!("🌐 Upload template {} bytes", bytes.len());
 
-    let data = TemplateData {
-        name,
-        version: 0,
-        contents_hash: hash,
-        contents_url: Url::parse(&format!(
-            "http://localhost:{}/templates/{}",
-            context.config().webserver.bind_address.port(),
-            dest_file
-        ))
-        .unwrap(),
-    };
+    let template_url = Url::parse(&format!(
+        "http://localhost:{}/templates/{}",
+        context.config().webserver.bind_address.port(),
+        dest_file
+    ))
+        .unwrap();
 
-    match context.process_manager().register_template(data).await {
-        Ok(()) => {
-            info!("🌐 Registered template");
-            Ok(())
-        },
-        Err(err) => {
-            error!("🌐 Registering template failed: {}", err);
-            Err(err.into())
-        },
+    if query_params.register_template {
+        let data = TemplateData {
+            name,
+            version: 0,
+            contents_hash: hash,
+            contents_url: template_url,
+        };
+
+        return match context.process_manager().register_template(data).await {
+            Ok(()) => {
+                info!("🌐 Registered template");
+                Ok(UploadResponse {
+                    success: true,
+                    template_url: Some(template_url.clone()),
+                    error: String::new(),
+                })
+            }
+            Err(err) => {
+                error!("🌐 Registering template failed: {}", err);
+                Err(err.into())
+            }
+        };
     }
+
+    Ok(UploadResponse { template_url })
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -91,7 +124,7 @@ impl IntoResponse for UploadError {
             UploadError::MultiPartError(err) => err.into_response(),
             UploadError::Other(err) => {
                 (StatusCode::INTERNAL_SERVER_ERROR, format!("Upload error: {}", err)).into_response()
-            },
+            }
         }
     }
 }


### PR DESCRIPTION
Description
---
Now template upload endpoint can just upload the template and nothing else.
Also now it returns the uploaded template's URL.

Motivation and Context
---

How Has This Been Tested?
---

What process can a PR reviewer use to test or verify this change?
---


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify