### PR TITLE
fix(consensus): correctly handle conflicting outputs for transaction

### DIFF
--- a/dan_layer/consensus/src/hotstuff/substate_store/error.rs
+++ b/dan_layer/consensus/src/hotstuff/substate_store/error.rs
@@ -12,8 +12,6 @@ pub enum SubstateStoreError {
     SubstateNotFound { id: VersionedSubstateId },
     #[error("Substate {id} is DOWN")]
     SubstateIsDown { id: VersionedSubstateId },
-    #[error("Expected substate {id} to not exist but it was found")]
-    ExpectedSubstateNotExist { id: VersionedSubstateId },
     #[error("Expected substate {id} to be DOWN but it was UP")]
     ExpectedSubstateDown { id: VersionedSubstateId },
 
@@ -56,6 +54,8 @@ pub enum LockFailedError {
         substate_id: VersionedSubstateId,
         conflict: LockConflict,
     },
+    #[error("Substate {id} is already UP and conflicts with an existing output")]
+    SubstateIsUp { id: VersionedSubstateId },
 }
 
 impl LockFailedError {


### PR DESCRIPTION
Description
---
fix(consensus): correctly handle conflicting outputs for transaction

Motivation and Context
---
A transaction producing a duplicate output would cause consensus to crash. This PR fixes this and results in transaction rejection.

How Has This Been Tested?
---
Not tested

What process can a PR reviewer use to test or verify this change?
---


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify