### PR TITLE
feat(state-tree)!: implement verify for Merkle in/exclusion proofs

### DIFF
--- a/applications/tari_swarm_daemon/src/main.rs
+++ b/applications/tari_swarm_daemon/src/main.rs
@@ -197,7 +197,8 @@ async fn start(cli: &Cli) -> anyhow::Result<()> {
     let lock_file = config.base_dir.join("tari_swarm.pid");
     let _pid = lockfile::Lockfile::create(&lock_file).with_context(|| {
         anyhow!(
-            "Failed to acquire lockfile at {}. Is another instance already running?",
+            "Failed to acquire lockfile at '{}'. Is another instance already running? If not, swarm may have \
+             previously crashed and you may remove the lockfile.",
             lock_file.display()
         )
     })?;

--- a/dan_layer/rpc_state_sync/src/manager.rs
+++ b/dan_layer/rpc_state_sync/src/manager.rs
@@ -207,11 +207,11 @@ where TConsensusSpec: ConsensusSpec<Addr = PeerAddress>
 
                     let change = match &transition.update {
                         SubstateUpdate::Create(create) => SubstateTreeChange::Up {
-                            id: create.substate.substate_id.clone(),
+                            id: create.substate.to_versioned_substate_id(),
                             value_hash: hash_substate(&create.substate.substate_value, create.substate.version),
                         },
                         SubstateUpdate::Destroy(destroy) => SubstateTreeChange::Down {
-                            id: destroy.substate_id.clone(),
+                            id: destroy.to_versioned_substate_id()
                         },
                     };
 

--- a/dan_layer/state_tree/src/bit_iter.rs
+++ b/dan_layer/state_tree/src/bit_iter.rs
@@ -1,0 +1,54 @@
+//   Copyright 2024 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+use std::ops::Range;
+
+/// An iterator over a hash value that generates one bit for each iteration.
+pub struct BitIterator<'a> {
+    /// The reference to the bytes that represent the `HashValue`.
+    bytes: &'a [u8],
+    pos: Range<usize>,
+    // invariant hash_bytes.len() == HashValue::LENGTH;
+    // invariant pos.end == hash_bytes.len() * 8;
+}
+
+impl<'a> BitIterator<'a> {
+    /// Constructs a new `BitIterator` using given `HashValue`.
+    pub fn new(bytes: &'a [u8]) -> Self {
+        BitIterator {
+            bytes,
+            pos: 0..bytes.len() * 8,
+        }
+    }
+
+    /// Returns the `index`-th bit in the bytes.
+    fn get_bit(&self, index: usize) -> bool {
+        // MIRAI annotations - important?
+        // assume!(index < self.pos.end); // assumed precondition
+        // assume!(self.hash_bytes.len() == 32); // invariant
+        // assume!(self.pos.end == self.hash_bytes.len() * 8); // invariant
+        let pos = index / 8;
+        let bit = 7 - index % 8;
+        (self.bytes[pos] >> bit) & 1 != 0
+    }
+}
+
+impl<'a> Iterator for BitIterator<'a> {
+    type Item = bool;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.pos.next().map(|x| self.get_bit(x))
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.pos.size_hint()
+    }
+}
+
+impl<'a> DoubleEndedIterator for BitIterator<'a> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.pos.next_back().map(|x| self.get_bit(x))
+    }
+}
+
+impl<'a> ExactSizeIterator for BitIterator<'a> {}

--- a/dan_layer/state_tree/src/jellyfish/error.rs
+++ b/dan_layer/state_tree/src/jellyfish/error.rs
@@ -1,0 +1,30 @@
+//   Copyright 2024 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+use crate::{Hash, LeafKey};
+
+#[derive(Debug, thiserror::Error)]
+pub enum JmtProofVerifyError {
+    #[error("Sparse Merkle Tree proof has more than 256 ({num_siblings}) siblings.")]
+    TooManySiblings { num_siblings: usize },
+    #[error("Keys do not match. Key in proof: {actual_key}. Expected key: {expected_key}.")]
+    KeyMismatch { actual_key: LeafKey, expected_key: LeafKey },
+    #[error("Value hashes do not match. Value hash in proof: {actual}. Expected value hash: {expected}.")]
+    ValueMismatch { actual: Hash, expected: Hash },
+    #[error("Expected inclusion proof. Found non-inclusion proof.")]
+    ExpectedInclusionProof,
+    #[error("Expected non-inclusion proof, but key exists in proof.")]
+    ExpectedNonInclusionProof,
+    #[error(
+        "Key would not have ended up in the subtree where the provided key in proof is the only existing  key, if it \
+         existed. So this is not a valid non-inclusion proof."
+    )]
+    InvalidNonInclusionProof,
+    #[error(
+        "Root hashes do not match. Actual root hash: {actual_root_hash}. Expected root hash: {expected_root_hash}."
+    )]
+    RootHashMismatch {
+        actual_root_hash: Hash,
+        expected_root_hash: Hash,
+    },
+}

--- a/dan_layer/state_tree/src/jellyfish/mod.rs
+++ b/dan_layer/state_tree/src/jellyfish/mod.rs
@@ -10,6 +10,7 @@ pub use tree::*;
 mod types;
 pub use types::*;
 
+mod error;
 mod store;
 
 pub use store::*;

--- a/dan_layer/state_tree/src/jellyfish/tree.rs
+++ b/dan_layer/state_tree/src/jellyfish/tree.rs
@@ -375,7 +375,7 @@ impl<'a, R: 'a + TreeStoreReader<P>, P: Clone> JellyfishMerkleTree<'a, R, P> {
 
         if kvs.len() == 1 && kvs[0].0 == existing_leaf_key {
             if let (key, Some((value_hash, payload))) = kvs[0] {
-                let new_leaf_node = Node::new_leaf(key.clone(), *value_hash, payload.clone(), version);
+                let new_leaf_node = Node::new_leaf(*key, *value_hash, payload.clone(), version);
                 Ok(Some(new_leaf_node))
             } else {
                 Ok(None)
@@ -454,7 +454,7 @@ impl<'a, R: 'a + TreeStoreReader<P>, P: Clone> JellyfishMerkleTree<'a, R, P> {
     ) -> Result<Option<Node<P>>, JmtStorageError> {
         if kvs.len() == 1 {
             if let (key, Some((value_hash, payload))) = kvs[0] {
-                let new_leaf_node = Node::new_leaf(key.clone(), *value_hash, payload.clone(), version);
+                let new_leaf_node = Node::new_leaf(*key, *value_hash, payload.clone(), version);
                 Ok(Some(new_leaf_node))
             } else {
                 Ok(None)

--- a/dan_layer/state_tree/src/key_mapper.rs
+++ b/dan_layer/state_tree/src/key_mapper.rs
@@ -1,7 +1,7 @@
 //   Copyright 2024 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use tari_engine_types::substate::SubstateId;
+use tari_dan_common_types::VersionedSubstateId;
 
 use crate::{jellyfish::LeafKey, Hash};
 
@@ -11,8 +11,8 @@ pub trait DbKeyMapper<T> {
 
 pub struct SpreadPrefixKeyMapper;
 
-impl DbKeyMapper<SubstateId> for SpreadPrefixKeyMapper {
-    fn map_to_leaf_key(id: &SubstateId) -> LeafKey {
+impl DbKeyMapper<VersionedSubstateId> for SpreadPrefixKeyMapper {
+    fn map_to_leaf_key(id: &VersionedSubstateId) -> LeafKey {
         let hash = crate::jellyfish::jmt_node_hash(id);
         LeafKey::new(hash)
     }

--- a/dan_layer/state_tree/src/lib.rs
+++ b/dan_layer/state_tree/src/lib.rs
@@ -12,5 +12,7 @@ pub mod memory_store;
 mod staged_store;
 pub use staged_store::*;
 
+mod bit_iter;
 mod tree;
+
 pub use tree::*;

--- a/dan_layer/storage/src/consensus_models/substate.rs
+++ b/dan_layer/storage/src/consensus_models/substate.rs
@@ -344,6 +344,12 @@ pub struct SubstateDestroyedProof {
     pub destroyed_by_transaction: TransactionId,
 }
 
+impl SubstateDestroyedProof {
+    pub fn to_versioned_substate_id(&self) -> VersionedSubstateId {
+        VersionedSubstateId::new(self.substate_id.clone(), self.version)
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct SubstateData {
     pub substate_id: SubstateId,
@@ -353,6 +359,10 @@ pub struct SubstateData {
 }
 
 impl SubstateData {
+    pub fn to_versioned_substate_id(&self) -> VersionedSubstateId {
+        VersionedSubstateId::new(self.substate_id.clone(), self.version)
+    }
+
     pub fn into_substate(self) -> Substate {
         Substate::new(self.version, self.substate_value)
     }

--- a/dan_layer/storage/src/consensus_models/substate_change.rs
+++ b/dan_layer/storage/src/consensus_models/substate_change.rs
@@ -146,12 +146,10 @@ impl From<&SubstateChange> for SubstateTreeChange {
     fn from(value: &SubstateChange) -> Self {
         match value {
             SubstateChange::Up { id, substate, .. } => SubstateTreeChange::Up {
-                id: id.substate_id().clone(),
+                id: id.clone(),
                 value_hash: substate.to_value_hash(),
             },
-            SubstateChange::Down { id, .. } => SubstateTreeChange::Down {
-                id: id.substate_id().clone(),
-            },
+            SubstateChange::Down { id, .. } => SubstateTreeChange::Down { id: id.clone() },
         }
     }
 }

--- a/integration_tests/tests/features/eviction.feature
+++ b/integration_tests/tests/features/eviction.feature
@@ -6,7 +6,6 @@
 Feature: Eviction scenarios
 
   @flaky
-  @doit
   Scenario: Offline validator gets evicted
     # Initialize a base node, wallet, miner and several VNs
     Given a base node BASE


### PR DESCRIPTION
Description
---
feat(state-tree): implement verify for Merkle in/exclusion proofs
fix(consensus)!: include substate version in JMT node hashes

Motivation and Context
---
Implement inclusion and exclusion proofs for JMT. This is useful for command inclusion proofs e.g. eviction proof as well as inclusion proofs for substates.

Usage:

```rust
let (key, proof_value, proof) = tree.get_proof(current_version, &substate_id).unwrap();
let value_hash = hash_substate(substate);
proof.verify_inclusion(&root_hash, &key, &value_hash).unwrap();
proof.verify_exclusion(&root_hash, &some_non_existing_key).unwrap();
```

How Has This Been Tested?
---
Unit tests, manually

What process can a PR reviewer use to test or verify this change?
---


Breaking Changes
---

- [ ] None
- [x] Requires data directory to be deleted
- [ ] Other - Please specify

BREAKING CHANGE: substate changes for JMT state tree include the substate version in the key hash