### PR TITLE
fix(template): add full typename to invalid argument error

### DIFF
--- a/dan_layer/engine/tests/test.rs
+++ b/dan_layer/engine/tests/test.rs
@@ -384,7 +384,8 @@ mod errors {
         match result.finalize.result.full_reject().unwrap() {
             RejectReason::ExecutionFailure(message) => {
                 assert!(message.starts_with(
-                    "Panic! failed to decode argument at position 0 for function 'please_pass_invalid_args':"
+                    "Panic! failed to decode argument at position 0 (tari_template_lib::models::amount::Amount) for \
+                     function 'please_pass_invalid_args':"
                 ),);
             },
             reason => panic!("Unexpected failure reason: {}", reason),

--- a/dan_layer/template_abi/src/rust.rs
+++ b/dan_layer/template_abi/src/rust.rs
@@ -25,7 +25,7 @@ mod no_std {
     extern crate alloc;
 
     pub use alloc::{boxed, format, str, string, vec};
-    pub use core::{cmp, fmt, iter, mem, num, ops, ptr, slice, write, writeln};
+    pub use core::{any, cmp, fmt, iter, mem, num, ops, ptr, slice, write, writeln};
 
     pub mod collections {
         extern crate alloc;
@@ -41,7 +41,25 @@ pub use no_std::*;
 
 #[cfg(feature = "std")]
 mod rust_std {
-    pub use ::std::{boxed, cmp, fmt, format, io, iter, mem, num, ops, ptr, slice, str, string, vec, write, writeln};
+    pub use ::std::{
+        any,
+        boxed,
+        cmp,
+        fmt,
+        format,
+        io,
+        iter,
+        mem,
+        num,
+        ops,
+        ptr,
+        slice,
+        str,
+        string,
+        vec,
+        write,
+        writeln,
+    };
 
     pub mod collections {
         pub use ::std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};

--- a/dan_layer/template_lib/src/template_dependencies.rs
+++ b/dan_layer/template_lib/src/template_dependencies.rs
@@ -23,6 +23,6 @@
 //! Public types that are available to internal template code.
 
 pub use tari_bor::{decode, decode_exact, encode_with_len, from_value, serde};
-pub use tari_template_abi::{wrap_ptr, CallInfo};
+pub use tari_template_abi::{rust, wrap_ptr, CallInfo};
 
 pub use crate::{args::LogLevel, debug, engine, get_context as context, init_context, panic_hook::register_panic_hook};

--- a/dan_layer/template_macros/src/template/dispatcher.rs
+++ b/dan_layer/template_macros/src/template/dispatcher.rs
@@ -128,7 +128,7 @@ fn get_function_block(template_ident: &Ident, ast: FunctionAst) -> Expr {
                 args.push(parse_quote! { #arg_ident });
                 stmts.push(parse_quote! {
                     let #arg_ident = from_value::<#type_path>(&call_info.args[#i])
-                        .unwrap_or_else(|e| panic!("failed to decode argument at position {} for function '{}': {}", #i, #func_name, e));
+                        .unwrap_or_else(|e| panic!("failed to decode argument at position {} ({}) for function '{}': {}", #i, rust::any::type_name::<#type_path>(), #func_name, e));
                 })
             },
             TypeAst::Tuple { type_tuple, .. } => {


### PR DESCRIPTION
Description
---
fix(template): add full typename to invalid argument error

Motivation and Context
---
Adding the type name to the error message makes it easier to determine an issue with a transaction.
```
Panic! failed to decode argument at position 0 (tari_template_lib::models::amount::Amount) for  function 'please_pass_invalid_args':
```
How Has This Been Tested?
---
Updated exiting unit test

What process can a PR reviewer use to test or verify this change?
---
Pass an invalid argument into a template

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify