### PR TITLE
fix(consensus)!: optmise foreign pledging for output-only case

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ concurrency:
   cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/v') || github.ref != 'refs/heads/development' }}
 
 env:
-  nightly_toolchain: nightly-2023-06-12
+  nightly_toolchain: nightly-2025-01-17
   stable_toolchain: 1.84
   CARGO_HTTP_MULTIPLEXING: false
   CARGO_TERM_COLOR: always

--- a/applications/tari_dan_app_utilities/src/base_layer_scanner.rs
+++ b/applications/tari_dan_app_utilities/src/base_layer_scanner.rs
@@ -48,13 +48,7 @@ use tari_crypto::{
     ristretto::RistrettoPublicKey,
     tari_utilities::{ByteArray, ByteArrayError},
 };
-use tari_dan_common_types::{
-    option::DisplayContainer,
-    optional::Optional,
-    Epoch,
-    NodeAddressable,
-    VersionedSubstateId,
-};
+use tari_dan_common_types::{option::Displayable, optional::Optional, Epoch, NodeAddressable, VersionedSubstateId};
 use tari_dan_storage::{
     consensus_models::{BurntUtxo, SubstateRecord},
     global::{GlobalDb, MetadataKey},

--- a/applications/tari_indexer/src/event_scanner.rs
+++ b/applications/tari_indexer/src/event_scanner.rs
@@ -280,15 +280,16 @@ impl EventScanner {
             let event_already_exists = tx.event_exists(event_row.clone())?;
             if event_already_exists {
                 // the event was already stored previously
-                warn!(
+                // TODO: Making this debug because it happens a lot and tends to spam the swarm output
+                debug!(
                     target: LOG_TARGET,
-                    "Duplicated event {:}",
+                    "Duplicate {}",
                     data.event
                 );
                 continue;
             }
 
-            info!(
+            debug!(
                 target: LOG_TARGET,
                 "Saving event: {:?}",
                 event_row

--- a/applications/tari_swarm_daemon/src/webserver/templates.rs
+++ b/applications/tari_swarm_daemon/src/webserver/templates.rs
@@ -62,11 +62,9 @@ pub async fn upload(
 ) -> Result<Json<UploadResponse>, UploadError> {
     let Some(field) = value.next_field().await? else {
         error!("🌐 Upload template: no field found");
-        return Ok(
-            Json(
-                UploadResponse::failure("No multipart file field found".to_string())
-            )
-        );
+        return Ok(Json(UploadResponse::failure(
+            "No multipart file field found".to_string(),
+        )));
     };
 
     let name = field.file_name().unwrap_or("unnamed-template").to_string();

--- a/applications/tari_swarm_daemon/webui/src/routes/Main.tsx
+++ b/applications/tari_swarm_daemon/webui/src/routes/Main.tsx
@@ -167,7 +167,7 @@ function ExtraInfoVN({ name, url, addTxToPool, autoRefresh, state, horizontal }:
                 <div onClick={() => copyToClipboard(tx)}>{copied == tx ? "Copied" : shorten(tx)}</div>
                 <div style={{ color: known ? "green" : "red" }}><b>{known && "Yes" || "No"}</b></div>
                 <div>{abort_details || <i>unknown</i>}</div>
-                <div>{final_decision || <i>unknown</i>}</div>
+                <div>{("Abort" in final_decision) ? <>Abort ({final_decision.Abort})</> : <>Commit</>}</div>
               </>
             );
           })}

--- a/applications/tari_validator_node/src/p2p/services/mempool/service.rs
+++ b/applications/tari_validator_node/src/p2p/services/mempool/service.rs
@@ -273,9 +273,9 @@ where TValidator: Validator<Transaction, Context = (), Error = TransactionValida
                 .await
                 .map_err(|_| MempoolError::ConsensusChannelClosed)?;
 
-            // If we received the message from our local shard group, we don't need to gossip it again on the topic
-            // (prevents Duplicate errors)
-            if sender_shard_group.map_or(true, |sg| sg != local_committee_shard.shard_group()) {
+            // If we received the message from gossip (sender_shard_group is Some), we don't need to gossip it again on
+            // the topic (prevents Duplicate errors)
+            if sender_shard_group.is_none() {
                 // This validator is involved, we to send the transaction to local replicas
                 if let Err(e) = self
                     .gossip

--- a/applications/tari_validator_node_cli/src/command/transaction.rs
+++ b/applications/tari_validator_node_cli/src/command/transaction.rs
@@ -30,7 +30,7 @@ use std::{
 use anyhow::anyhow;
 use clap::{Args, Subcommand};
 use tari_dan_common_types::{
-    option::{DisplayCont, DisplayContainer},
+    option::{DisplayContainer, Displayable},
     optional::Optional,
     SubstateAddress,
     SubstateRequirement,
@@ -498,7 +498,7 @@ fn summarize_finalize_result(finalize: &FinalizeResult) {
 }
 
 fn display_vec<W: fmt::Write>(writer: &mut W, ty: &Type, result: &InstructionResult) -> fmt::Result {
-    fn display_slice<T: fmt::Display>(slice: &[T]) -> DisplayCont<&[T]> {
+    fn display_slice<T: fmt::Display>(slice: &[T]) -> DisplayContainer<&[T]> {
         slice.display()
     }
 

--- a/applications/tari_validator_node_web_ui/src/Components/CodeBlock.tsx
+++ b/applications/tari_validator_node_web_ui/src/Components/CodeBlock.tsx
@@ -21,7 +21,7 @@
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import { IoExpandOutline } from "react-icons/io5";
-import { useState } from "react";
+import { ReactNode, useState } from "react";
 import Dialog from "@mui/material/Dialog";
 import IconButton from "@mui/material/IconButton";
 import Typography from "@mui/material/Typography";
@@ -31,7 +31,13 @@ import { CodeBlock } from "./StyledComponents";
 import useMediaQuery from "@mui/material/useMediaQuery";
 import { useTheme } from "@mui/material/styles";
 
-export default function CodeBlockExpand({ title, children }: any) {
+interface Props {
+  title: string;
+  children?: ReactNode;
+  contentsWhenUnexpanded?: ReactNode;
+}
+
+export default function CodeBlockDialog({ title, children, contentsWhenUnexpanded = false }: Props) {
   const [open, setOpen] = useState(false);
   const theme = useTheme();
   const matches = useMediaQuery(theme.breakpoints.down("md"));
@@ -46,12 +52,7 @@ export default function CodeBlockExpand({ title, children }: any) {
 
   return (
     <div>
-      <CodeBlock
-        style={{
-          position: "relative",
-        }}
-      >
-        {children}
+      {contentsWhenUnexpanded ? (
         <IconButton
           onClick={handleClickOpen}
           style={{
@@ -60,9 +61,27 @@ export default function CodeBlockExpand({ title, children }: any) {
             float: "right",
           }}
         >
+          {contentsWhenUnexpanded}
           <IoExpandOutline style={{ height: 16, width: 16 }} />
         </IconButton>
-      </CodeBlock>
+      ) : (
+        <CodeBlock
+          style={{
+            position: "relative",
+          }}
+        >
+          {children}
+          <IconButton
+            onClick={handleClickOpen}
+            style={{
+              position: "sticky",
+              bottom: "0",
+              float: "right",
+            }}
+          >
+            <IoExpandOutline style={{ height: 16, width: 16 }} />
+          </IconButton>
+        </CodeBlock>)}
       <Dialog fullScreen={matches} open={open} onClose={handleClose} maxWidth="xl" fullWidth>
         <Box
           style={{

--- a/applications/tari_validator_node_web_ui/src/routes/Blocks/BlockDetails.tsx
+++ b/applications/tari_validator_node_web_ui/src/routes/Blocks/BlockDetails.tsx
@@ -185,7 +185,7 @@ export default function BlockDetails() {
                           </TableRow>
                           <TableRow>
                             <TableCell>Epoch</TableCell>
-                            <DataTableCell>{block!.header.epoch}</DataTableCell>
+                            <DataTableCell>{block!.header.epoch} (ShardGroup {block!.header.shard_group.start}-{block!.header.shard_group.end_inclusive})</DataTableCell>
                           </TableRow>
                           <TableRow>
                             <TableCell>Height</TableCell>

--- a/applications/tari_validator_node_web_ui/src/routes/Blocks/Transactions.tsx
+++ b/applications/tari_validator_node_web_ui/src/routes/Blocks/Transactions.tsx
@@ -25,6 +25,8 @@ import { Table, TableBody, TableCell, TableContainer, TableHead, TableRow } from
 import StatusChip from "../../Components/StatusChip";
 import type { TransactionAtom } from "@tari-project/typescript-bindings";
 import { Link } from "react-router-dom";
+import { renderJson } from "../../utils/helpers";
+import CodeBlockDialog from "../../Components/CodeBlock";
 
 function Transaction({ transaction }: { transaction: TransactionAtom }) {
   const decision = typeof transaction.decision === "object" ? "Abort" : "Commit";
@@ -35,6 +37,11 @@ function Transaction({ transaction }: { transaction: TransactionAtom }) {
       </TableCell>
       <TableCell>
         <StatusChip status={decision} />
+      </TableCell>
+      <TableCell>
+        <CodeBlockDialog title="Evidence" contentsWhenUnexpanded={<></>}>
+          {renderJson(transaction.evidence)}
+        </CodeBlockDialog>
       </TableCell>
       <TableCell>{transaction.leader_fee?.fee}</TableCell>
       <TableCell>{transaction.transaction_fee}</TableCell>
@@ -50,6 +57,7 @@ export default function Transactions({ transactions }: { transactions: Transacti
           <TableRow>
             <TableCell>Transaction ID</TableCell>
             <TableCell>Decision</TableCell>
+            <TableCell>Evidence</TableCell>
             <TableCell>Leader fee</TableCell>
             <TableCell>Transaction fee</TableCell>
           </TableRow>

--- a/applications/tari_validator_node_web_ui/src/routes/Transactions/Events.tsx
+++ b/applications/tari_validator_node_web_ui/src/routes/Transactions/Events.tsx
@@ -28,7 +28,7 @@ import CopyToClipboard from "../../Components/CopyToClipboard";
 import { renderJson } from "../../utils/helpers";
 import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
 import KeyboardArrowUpIcon from "@mui/icons-material/KeyboardArrowUp";
-import CodeBlockExpand from "../../Components/CodeBlock";
+import CodeBlockDialog from "../../Components/CodeBlock";
 import type { Event } from "@tari-project/typescript-bindings";
 
 function RowData({ substate_id, template_address, topic, tx_hash, payload }: Event, index: number) {
@@ -67,7 +67,7 @@ function RowData({ substate_id, template_address, topic, tx_hash, payload }: Eve
       <TableRow>
         <DataTableCell style={{ paddingBottom: 0, paddingTop: 0 }} colSpan={5}>
           <Collapse in={open} timeout="auto" unmountOnExit>
-            <CodeBlockExpand title="Payload">{renderJson(payload)}</CodeBlockExpand>
+            <CodeBlockDialog title="Payload">{renderJson(payload)}</CodeBlockDialog>
           </Collapse>
         </DataTableCell>
       </TableRow>

--- a/applications/tari_validator_node_web_ui/src/routes/Transactions/FeeInstructions.tsx
+++ b/applications/tari_validator_node_web_ui/src/routes/Transactions/FeeInstructions.tsx
@@ -26,7 +26,7 @@ import { DataTableCell, AccordionIconButton } from "../../Components/StyledCompo
 import { renderJson } from "../../utils/helpers";
 import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
 import KeyboardArrowUpIcon from "@mui/icons-material/KeyboardArrowUp";
-import CodeBlockExpand from "../../Components/CodeBlock";
+import CodeBlockDialog from "../../Components/CodeBlock";
 import type { Instruction } from "@tari-project/typescript-bindings";
 
 function RowData({ title, data, index }: { title: string; data: Instruction; index: number }) {
@@ -51,7 +51,7 @@ function RowData({ title, data, index }: { title: string; data: Instruction; ind
       <TableRow key={`${index}-2`}>
         <DataTableCell style={{ paddingBottom: 0, paddingTop: 0 }} colSpan={2}>
           <Collapse in={open} timeout="auto" unmountOnExit>
-            <CodeBlockExpand title={title}>{renderJson(data)}</CodeBlockExpand>
+            <CodeBlockDialog title={title}>{renderJson(data)}</CodeBlockDialog>
           </Collapse>
         </DataTableCell>
       </TableRow>

--- a/applications/tari_validator_node_web_ui/src/routes/Transactions/Instructions.tsx
+++ b/applications/tari_validator_node_web_ui/src/routes/Transactions/Instructions.tsx
@@ -26,7 +26,7 @@ import { DataTableCell, AccordionIconButton } from "../../Components/StyledCompo
 import { renderJson } from "../../utils/helpers";
 import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
 import KeyboardArrowUpIcon from "@mui/icons-material/KeyboardArrowUp";
-import CodeBlockExpand from "../../Components/CodeBlock";
+import CodeBlockDialog from "../../Components/CodeBlock";
 import type { Instruction } from "@tari-project/typescript-bindings";
 
 function RowData({ title, data }: { title: string; data: Instruction }, index: number) {
@@ -51,7 +51,7 @@ function RowData({ title, data }: { title: string; data: Instruction }, index: n
       <TableRow key={`${index}-2`}>
         <DataTableCell style={{ paddingBottom: 0, paddingTop: 0 }} colSpan={2}>
           <Collapse in={open} timeout="auto" unmountOnExit>
-            <CodeBlockExpand title={title}>{renderJson(data)}</CodeBlockExpand>
+            <CodeBlockDialog title={title}>{renderJson(data)}</CodeBlockDialog>
           </Collapse>
         </DataTableCell>
       </TableRow>

--- a/applications/tari_validator_node_web_ui/src/utils/helpers.tsx
+++ b/applications/tari_validator_node_web_ui/src/utils/helpers.tsx
@@ -24,10 +24,8 @@ import { toHexString } from "../routes/VN/Components/helpers";
 import type { ShardGroup, SubstateId } from "@tari-project/typescript-bindings";
 
 export const renderJson = (json: any) => {
-  if (!json) {
-    return <span>Null</span>;
-  }
-  if (Array.isArray(json)) {
+
+  if (json && Array.isArray(json)) {
     //eslint-disable-next-line eqeqeq
     if (json.length == 32) {
       return <span className="string">"{toHexString(json)}"</span>;
@@ -43,7 +41,12 @@ export const renderJson = (json: any) => {
         ],
       </>
     );
-  } else if (typeof json === "object") {
+  }
+
+  if (typeof json === "object") {
+    if (!json) {
+      return <span>null</span>;
+    }
     return (
       <>
         {"{"}
@@ -57,10 +60,12 @@ export const renderJson = (json: any) => {
         {"}"}
       </>
     );
-  } else {
-    if (typeof json === "string") return <span className="string">"{json}"</span>;
-    return <span className="other">{json}</span>;
   }
+
+  if (typeof json === "string") return <span className="string">"{json}"</span>;
+  if (typeof json === "number") return <span className="number">"{json}"</span>;
+  if (typeof json === "boolean") return <span className="boolean">{json ? "true" : "false"}</span>;
+  return <span className="other">{json}</span>;
 };
 
 export function fromHexString(hexString: string) {

--- a/dan_layer/common_types/src/committee.rs
+++ b/dan_layer/common_types/src/committee.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use tari_common_types::types::PublicKey;
 use tari_engine_types::substate::SubstateId;
 
-use crate::{NumPreshards, ShardGroup, SubstateAddress};
+use crate::{Epoch, NumPreshards, ShardGroup, SubstateAddress};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Default, Hash)]
 #[cfg_attr(
@@ -180,6 +180,7 @@ pub struct CommitteeInfo {
     num_shard_group_members: u32,
     num_committees: u32,
     shard_group: ShardGroup,
+    epoch: Epoch,
 }
 
 impl CommitteeInfo {
@@ -188,13 +189,20 @@ impl CommitteeInfo {
         num_shard_group_members: u32,
         num_committees: u32,
         shard_group: ShardGroup,
+        epoch: Epoch,
     ) -> Self {
         Self {
             num_shards,
             num_shard_group_members,
             num_committees,
             shard_group,
+            epoch,
         }
+    }
+
+    /// Returns the epoch of this CommitteeInfo.
+    pub fn epoch(&self) -> Epoch {
+        self.epoch
     }
 
     /// Returns $n - f$ (i.e $2f + 1$) where n is the number of committee members and f is the tolerated failure nodes.

--- a/dan_layer/common_types/src/option.rs
+++ b/dan_layer/common_types/src/option.rs
@@ -2,7 +2,7 @@
 //   SPDX-License-Identifier: BSD-3-Clause
 
 use std::{
-    collections::{BTreeSet, HashSet},
+    collections::{BTreeSet, HashMap, HashSet},
     fmt,
     fmt::{Debug, Display},
 };
@@ -12,7 +12,7 @@ use std::{
 ///
 /// # Example
 /// ```rust
-/// use tari_dan_common_types::option::DisplayContainer;
+/// use tari_dan_common_types::option::Displayable;
 ///
 /// let some_value = Some(42);
 /// let none_value: Option<i32> = None;
@@ -34,17 +34,17 @@ use std::{
 ///     "list: 1.01, 2.00, 3.00"
 /// );
 /// ```
-pub trait DisplayContainer {
+pub trait Displayable {
     type Item: ?Sized;
-    fn display(&self) -> DisplayCont<&'_ Self::Item>;
+    fn display(&self) -> DisplayContainer<&'_ Self::Item>;
 }
 
 #[derive(Debug, Clone, Copy)]
-pub struct DisplayCont<T> {
+pub struct DisplayContainer<T> {
     value: T,
 }
 
-impl<T: Display> Display for DisplayCont<&'_ Option<T>> {
+impl<T: Display> Display for DisplayContainer<&'_ Option<T>> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.value {
             Some(value) => Display::fmt(value, f),
@@ -53,81 +53,110 @@ impl<T: Display> Display for DisplayCont<&'_ Option<T>> {
     }
 }
 
-impl<T: Display> Display for DisplayCont<&'_ [T]> {
+impl<T: Display> Display for DisplayContainer<&'_ [T]> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let len = self.value.len();
+        write!(f, "[")?;
         for (i, item) in self.value.iter().enumerate() {
             Display::fmt(item, f)?;
             if i < len - 1 {
                 write!(f, ", ")?;
             }
         }
+        write!(f, "]")?;
         Ok(())
     }
 }
 
-impl<T: Display> Display for DisplayCont<&'_ HashSet<T>> {
+impl<T: Display> Display for DisplayContainer<&'_ HashSet<T>> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let len = self.value.len();
+        write!(f, "{{")?;
         for (i, item) in self.value.iter().enumerate() {
             Display::fmt(item, f)?;
             if i < len - 1 {
                 write!(f, ", ")?;
             }
         }
+        write!(f, "}}")?;
         Ok(())
     }
 }
 
-impl<T: Display> Display for DisplayCont<&'_ BTreeSet<T>> {
+impl<T: Display> Display for DisplayContainer<&'_ BTreeSet<T>> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let len = self.value.len();
+        write!(f, "{{")?;
         for (i, item) in self.value.iter().enumerate() {
             Display::fmt(item, f)?;
             if i < len - 1 {
                 write!(f, ", ")?;
             }
         }
+        write!(f, "}}")?;
         Ok(())
     }
 }
 
-impl<T: Display> DisplayContainer for Option<T> {
+impl<K: Display, V: Display> Display for DisplayContainer<&'_ HashMap<K, V>> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let len = self.value.len();
+        write!(f, "{{")?;
+        for (i, (k, v)) in self.value.iter().enumerate() {
+            write!(f, "{k}: {v}")?;
+            if i < len - 1 {
+                write!(f, ", ")?;
+            }
+        }
+        write!(f, "}}")?;
+        Ok(())
+    }
+}
+
+impl<T: Display> Displayable for Option<T> {
     type Item = Self;
 
-    fn display(&self) -> DisplayCont<&'_ Self> {
-        DisplayCont { value: self }
+    fn display(&self) -> DisplayContainer<&'_ Self> {
+        DisplayContainer { value: self }
     }
 }
 
-impl<T: Display> DisplayContainer for [T] {
+impl<T: Display> Displayable for [T] {
     type Item = Self;
 
-    fn display(&self) -> DisplayCont<&'_ Self> {
-        DisplayCont { value: self }
+    fn display(&self) -> DisplayContainer<&'_ Self> {
+        DisplayContainer { value: self }
     }
 }
 
-impl<T: Display> DisplayContainer for Vec<T> {
+impl<T: Display> Displayable for Vec<T> {
     type Item = [T];
 
-    fn display(&self) -> DisplayCont<&'_ [T]> {
+    fn display(&self) -> DisplayContainer<&'_ [T]> {
         (*self.as_slice()).display()
     }
 }
 
-impl<T: Display> DisplayContainer for HashSet<T> {
+impl<T: Display> Displayable for HashSet<T> {
     type Item = Self;
 
-    fn display(&self) -> DisplayCont<&'_ Self> {
-        DisplayCont { value: self }
+    fn display(&self) -> DisplayContainer<&'_ Self> {
+        DisplayContainer { value: self }
     }
 }
 
-impl<T: Display> DisplayContainer for BTreeSet<T> {
+impl<T: Display> Displayable for BTreeSet<T> {
     type Item = Self;
 
-    fn display(&self) -> DisplayCont<&'_ Self> {
-        DisplayCont { value: self }
+    fn display(&self) -> DisplayContainer<&'_ Self> {
+        DisplayContainer { value: self }
+    }
+}
+
+impl<K: Display, V: Display> Displayable for HashMap<K, V> {
+    type Item = Self;
+
+    fn display(&self) -> DisplayContainer<&'_ Self> {
+        DisplayContainer { value: self }
     }
 }

--- a/dan_layer/common_types/src/versioned_substate_id.rs
+++ b/dan_layer/common_types/src/versioned_substate_id.rs
@@ -260,7 +260,7 @@ impl Borrow<SubstateId> for VersionedSubstateId {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct VersionedSubstateIdRef<'a> {
     pub substate_id: &'a SubstateId,
     pub version: u32,
@@ -279,6 +279,15 @@ impl<'a> VersionedSubstateIdRef<'a> {
 impl ToSubstateAddress for VersionedSubstateIdRef<'_> {
     fn to_substate_address(&self) -> SubstateAddress {
         SubstateAddress::from_substate_id(self.substate_id, self.version)
+    }
+}
+
+impl<'a> From<&'a VersionedSubstateId> for VersionedSubstateIdRef<'a> {
+    fn from(value: &'a VersionedSubstateId) -> Self {
+        Self {
+            substate_id: &value.substate_id,
+            version: value.version,
+        }
     }
 }
 

--- a/dan_layer/consensus/src/hotstuff/block_change_set.rs
+++ b/dan_layer/consensus/src/hotstuff/block_change_set.rs
@@ -10,7 +10,7 @@ use std::{
 use indexmap::IndexMap;
 use log::*;
 use tari_common_types::types::PublicKey;
-use tari_dan_common_types::{option::DisplayContainer, optional::Optional, shard::Shard, Epoch, ShardGroup};
+use tari_dan_common_types::{option::Displayable, optional::Optional, shard::Shard, Epoch, ShardGroup};
 use tari_dan_storage::{
     consensus_models::{
         Block,

--- a/dan_layer/consensus/src/hotstuff/block_change_set.rs
+++ b/dan_layer/consensus/src/hotstuff/block_change_set.rs
@@ -409,6 +409,9 @@ impl ProposedBlockChangeSet {
     }
 
     pub fn log_everything(&self) {
+        if !log_enabled!(log::Level::Debug) {
+            return;
+        }
         const LOG_TARGET: &str = "tari::dan::consensus::block_change_set::debug";
         debug!(target: LOG_TARGET, "❌ No vote: {}", self.no_vote_reason.display());
         let _timer = TraceTimer::debug(LOG_TARGET, "ProposedBlockChangeSet::save_for_debug");

--- a/dan_layer/consensus/src/hotstuff/error.rs
+++ b/dan_layer/consensus/src/hotstuff/error.rs
@@ -97,12 +97,13 @@ pub enum HotStuffError {
     #[error("Substate store error: {0}")]
     SubstateStoreError(#[from] SubstateStoreError),
     #[error(
-        "Validator node omitted transaction pledges: remote_block_id={foreign_block_id}, \
-         transaction_id={transaction_id}"
+        "Validator node omitted transaction pledges: remote_block={foreign_block}, transaction_id={transaction_id}, \
+         is_prepare_phase={is_prepare_phase}"
     )]
     ForeignNodeOmittedTransactionPledges {
-        foreign_block_id: BlockId,
+        foreign_block: LeafBlock,
         transaction_id: TransactionId,
+        is_prepare_phase: bool,
     },
     #[error("Block building error: {0}")]
     BlockBuildingError(#[from] BlockError),
@@ -233,14 +234,24 @@ pub enum ProposalValidationError {
     #[error("Foreign node in {shard_group} submitted malformed BlockPledge for block {block_id}")]
     ForeignMalformedPledges { block_id: BlockId, shard_group: ShardGroup },
     #[error(
-        "Foreign node in {shard_group} submitted invalid pledge for block {block_id}, transaction {transaction_id}: \
+        "Foreign node in {shard_group} submitted invalid pledge for block {block}, transaction {transaction_id}: \
          {details}"
     )]
     ForeignInvalidPledge {
-        block_id: BlockId,
+        block: LeafBlock,
         transaction_id: TransactionId,
         shard_group: ShardGroup,
         details: String,
+    },
+    #[error(
+        "Foreign node in {shard_group} submitted invalid epoch for block {block_id}. Current epoch: {current_epoch}, \
+         block epoch: {block_epoch}"
+    )]
+    ForeignInvalidEpoch {
+        block_id: BlockId,
+        shard_group: ShardGroup,
+        current_epoch: Epoch,
+        block_epoch: Epoch,
     },
     #[error(
         "Foreign node in {shard_group} submitted proposal {block_id} but justify QC justifies {justify_qc_block_id}"

--- a/dan_layer/consensus/src/hotstuff/foreign_proposal_processor.rs
+++ b/dan_layer/consensus/src/hotstuff/foreign_proposal_processor.rs
@@ -2,7 +2,7 @@
 //   SPDX-License-Identifier: BSD-3-Clause
 
 use log::*;
-use tari_dan_common_types::{committee::CommitteeInfo, option::DisplayContainer, ShardGroup, SubstateAddress};
+use tari_dan_common_types::{committee::CommitteeInfo, option::Displayable, ShardGroup, SubstateAddress};
 use tari_dan_storage::{
     consensus_models::{
         BlockPledge,

--- a/dan_layer/consensus/src/hotstuff/foreign_proposal_processor.rs
+++ b/dan_layer/consensus/src/hotstuff/foreign_proposal_processor.rs
@@ -2,10 +2,9 @@
 //   SPDX-License-Identifier: BSD-3-Clause
 
 use log::*;
-use tari_dan_common_types::{committee::CommitteeInfo, option::DisplayContainer, SubstateAddress};
+use tari_dan_common_types::{committee::CommitteeInfo, option::DisplayContainer, ShardGroup, SubstateAddress};
 use tari_dan_storage::{
     consensus_models::{
-        BlockId,
         BlockPledge,
         Command,
         Decision,
@@ -33,15 +32,16 @@ pub fn process_foreign_block<TTx: StateStoreReadTransaction>(
     tx: &TTx,
     local_leaf: &LeafBlock,
     locked_block: &LockedBlock,
-    proposal: ForeignProposal,
-    foreign_committee_info: &CommitteeInfo,
+    proposal: &ForeignProposal,
     local_committee_info: &CommitteeInfo,
     proposed_block_change_set: &mut ProposedBlockChangeSet,
 ) -> Result<(), HotStuffError> {
     let _timer = TraceTimer::info(LOG_TARGET, "process_foreign_block");
+
+    let foreign_shard_group = proposal.block.shard_group();
     assert_eq!(
         proposal.block.shard_group(),
-        foreign_committee_info.shard_group(),
+        foreign_shard_group,
         "Foreign proposal shard group does not match the foreign committee shard group"
     );
     info!(
@@ -52,9 +52,9 @@ pub fn process_foreign_block<TTx: StateStoreReadTransaction>(
     );
 
     let ForeignProposal {
-        block,
-        justify_qc,
-        mut block_pledge,
+        ref block,
+        ref justify_qc,
+        ref block_pledge,
         ..
     } = proposal;
     let mut command_count = 0usize;
@@ -62,7 +62,11 @@ pub fn process_foreign_block<TTx: StateStoreReadTransaction>(
     for cmd in block.commands() {
         match cmd {
             Command::LocalPrepare(atom) => {
-                if !atom.evidence.has(&local_committee_info.shard_group()) {
+                if !atom.evidence.has(&local_committee_info.shard_group()) ||
+                    // Foreign output-only nodes should not do a local prepare, if they do we ignore it
+                    atom.evidence
+                        .is_committee_output_only(foreign_shard_group)
+                {
                     debug!(
                         target: LOG_TARGET,
                         "🧩 FOREIGN PROPOSAL: Command: LocalPrepare({}, {}), block: {} not relevant to local committee",
@@ -127,8 +131,8 @@ pub fn process_foreign_block<TTx: StateStoreReadTransaction>(
                         // Add an abort execution since we previously decided to commit
                         let mut transaction = TransactionRecord::get(tx, tx_rec.transaction_id())?;
                         transaction.set_abort_reason(RejectReason::ForeignShardGroupDecidedToAbort {
-                            start_shard: foreign_committee_info.shard_group().start().as_u32(),
-                            end_shard: foreign_committee_info.shard_group().end().as_u32(),
+                            start_shard: foreign_shard_group.start().as_u32(),
+                            end_shard: foreign_shard_group.end().as_u32(),
                             abort_reason: abort_reason.to_string(),
                         });
                         let exec = transaction.into_execution().expect("ABORT set above");
@@ -137,28 +141,29 @@ pub fn process_foreign_block<TTx: StateStoreReadTransaction>(
                 }
 
                 // Update the transaction record with any new information provided by this foreign block
-                let Some(foreign_evidence) = atom.evidence.get(&foreign_committee_info.shard_group()) else {
+                let Some(foreign_evidence) = atom.evidence.get(&foreign_shard_group) else {
                     return Err(ProposalValidationError::ForeignInvalidPledge {
-                        block_id: *block.id(),
+                        block: block.as_leaf_block(),
                         transaction_id: atom.id,
-                        shard_group: foreign_committee_info.shard_group(),
-                        details: "Foreign proposal did not contain evidence for shard group".to_string(),
+                        shard_group: foreign_shard_group,
+                        details: "Foreign proposal did not contain evidence for it's own shard group".to_string(),
                     }
                     .into());
                 };
                 tx_rec
                     .evidence_mut()
-                    .add_shard_group(foreign_committee_info.shard_group())
+                    .add_shard_group(foreign_shard_group)
                     .update(foreign_evidence)
                     .set_prepare_qc(*justify_qc.id());
                 tx_rec.set_remote_decision(remote_decision);
 
-                validate_and_add_pledges(
+                add_pledges(
                     &tx_rec,
-                    block.id(),
+                    block.as_leaf_block(),
                     atom,
-                    &mut block_pledge,
-                    foreign_committee_info,
+                    block_pledge,
+                    foreign_shard_group,
+                    local_committee_info.shard_group(),
                     proposed_block_change_set,
                     true,
                 )?;
@@ -184,8 +189,9 @@ pub fn process_foreign_block<TTx: StateStoreReadTransaction>(
 
                     // CASE: One foreign SG is involved in all inputs and executed the transaction, local SG is
                     // involved in the outputs
-                    let is_ready = local_committee_info.includes_substate_id(&tx_rec.to_receipt_id().into()) ||
-                        tx_rec.involves_committee(local_committee_info) ||
+                    let is_ready =
+                        // local_committee_info.includes_substate_id(&tx_rec.to_receipt_id().into()) ||
+                        tx_rec.committee_involves_inputs(local_committee_info) ||
                         has_all_foreign_input_pledges(tx, &tx_rec, local_committee_info, proposed_block_change_set)?;
 
                     if is_ready {
@@ -211,8 +217,8 @@ pub fn process_foreign_block<TTx: StateStoreReadTransaction>(
                 } else if tx_rec.current_stage().is_local_prepared() &&
                     tx_rec.evidence().all_input_shard_groups_prepared()
                 {
-                    // If all shards are complete, and we've already received our LocalPrepared, we can set out
-                    // LocalPrepared transaction as ready to propose ACCEPT. If we have not received
+                    // If all shards are complete, and we've already received our LocalPrepared, we can set the
+                    // LocalPrepared transaction as ready to propose AllPrepared. If we have not received
                     // the local LocalPrepared, the transition to AllPrepared will occur after we receive the local
                     // LocalPrepare proposal.
                     info!(
@@ -287,8 +293,8 @@ pub fn process_foreign_block<TTx: StateStoreReadTransaction>(
                         // Add an abort execution since we previously decided to commit
                         let mut transaction = TransactionRecord::get(tx, tx_rec.transaction_id())?;
                         transaction.set_abort_reason(RejectReason::ForeignShardGroupDecidedToAbort {
-                            start_shard: foreign_committee_info.shard_group().start().as_u32(),
-                            end_shard: foreign_committee_info.shard_group().end().as_u32(),
+                            start_shard: foreign_shard_group.start().as_u32(),
+                            end_shard: foreign_shard_group.end().as_u32(),
                             abort_reason: abort_reason.to_string(),
                         });
                         let exec = transaction.into_execution().expect("ABORT set above");
@@ -297,28 +303,29 @@ pub fn process_foreign_block<TTx: StateStoreReadTransaction>(
                 }
 
                 // Update the transaction record with any new information provided by this foreign block
-                let Some(foreign_evidence) = atom.evidence.get(&foreign_committee_info.shard_group()) else {
+                let Some(foreign_evidence) = atom.evidence.get(&foreign_shard_group) else {
                     return Err(ProposalValidationError::ForeignInvalidPledge {
-                        block_id: *block.id(),
+                        block: block.as_leaf_block(),
                         transaction_id: atom.id,
-                        shard_group: foreign_committee_info.shard_group(),
-                        details: "Foreign proposal did not contain evidence for shard group".to_string(),
+                        shard_group: foreign_shard_group,
+                        details: "Foreign proposal did not contain evidence for it's own shard group".to_string(),
                     }
                     .into());
                 };
                 tx_rec
                     .evidence_mut()
-                    .add_shard_group(foreign_committee_info.shard_group())
+                    .add_shard_group(foreign_shard_group)
                     .update(foreign_evidence)
                     .set_accept_qc(*justify_qc.id());
                 tx_rec.set_remote_decision(remote_decision);
 
-                validate_and_add_pledges(
+                add_pledges(
                     &tx_rec,
-                    block.id(),
+                    block.as_leaf_block(),
                     atom,
-                    &mut block_pledge,
-                    foreign_committee_info,
+                    block_pledge,
+                    foreign_shard_group,
+                    local_committee_info.shard_group(),
                     proposed_block_change_set,
                     false,
                 )?;
@@ -337,8 +344,8 @@ pub fn process_foreign_block<TTx: StateStoreReadTransaction>(
                     // have them.
                     // CASE: Foreign SGs have pledged all inputs and executed the transaction, local SG is involved
                     // in the outputs
-                    let is_ready = local_committee_info.includes_substate_id(&tx_rec.to_receipt_id().into()) ||
-                        tx_rec.involves_committee(local_committee_info) ||
+                    let is_ready = //local_committee_info.includes_substate_id(&tx_rec.to_receipt_id().into()) ||
+                        tx_rec.committee_involves_inputs(local_committee_info) ||
                         has_all_foreign_input_pledges(tx, &tx_rec, local_committee_info, proposed_block_change_set)?;
                     if is_ready {
                         info!(
@@ -398,7 +405,7 @@ pub fn process_foreign_block<TTx: StateStoreReadTransaction>(
                         tx_rec.transaction_id(),
                         tx_rec.current_decision(),
                         tx_rec.current_stage(),
-                        tx_rec.evidence().all_objects_accepted()
+                        tx_rec.evidence().all_shard_groups_accepted()
                     );
                     // Still need to update the evidence
                     proposed_block_change_set.set_next_transaction_update(tx_rec)?;
@@ -446,31 +453,17 @@ pub fn process_foreign_block<TTx: StateStoreReadTransaction>(
     Ok(())
 }
 
-#[allow(clippy::too_many_lines)]
-fn validate_and_add_pledges(
+fn add_pledges(
     transaction: &TransactionPoolRecord,
-    foreign_block_id: &BlockId,
+    foreign_block: LeafBlock,
     atom: &TransactionAtom,
-    block_pledge: &mut BlockPledge,
-    foreign_committee_info: &CommitteeInfo,
+    block_pledge: &BlockPledge,
+    foreign_shard_group: ShardGroup,
+    local_shard_group: ShardGroup,
     proposed_block_change_set: &mut ProposedBlockChangeSet,
     is_prepare_phase: bool,
 ) -> Result<(), HotStuffError> {
     let _timer = TraceTimer::info(LOG_TARGET, "validate_and_add_pledges");
-    // We need to add the justify QC to the evidence because the prepare block should not include it
-    // yet
-    let evidence = atom
-        .evidence
-        .get(&foreign_committee_info.shard_group())
-        .ok_or_else(|| ProposalValidationError::ForeignInvalidPledge {
-            block_id: *foreign_block_id,
-            transaction_id: atom.id,
-            shard_group: foreign_committee_info.shard_group(),
-            details: format!(
-                "Foreign proposal did not contain evidence for {}",
-                foreign_committee_info.shard_group()
-            ),
-        })?;
 
     // Avoid iterating unless debug logs apply
     if log_enabled!(Level::Debug) {
@@ -494,96 +487,85 @@ fn validate_and_add_pledges(
 
     match atom.decision {
         Decision::Commit => {
-            let Some(pledges) = block_pledge.remove_transaction_pledges(&atom.id) else {
-                if transaction.is_global() {
-                    // If the transaction is global, some shard groups do not pledges to include
-                    // TODO: this is currently "assumed" to be correct and should be validated
-                    debug!(
-                        target: LOG_TARGET,
-                        "Foreign proposal COMMIT for transaction {} stage: {} but the transaction is global so no pledges are expected.",
-                        atom.id,
-                        transaction.current_stage()
-                    );
-                    return Ok(());
-                }
+            // Output pledges come straight from evidence
+            let output_pledges = transaction
+                .evidence()
+                .get(&foreign_shard_group)
+                .ok_or_else(|| {
+                    // NEVER HAPPEN: we should already have checked this
+                    ProposalValidationError::ForeignInvalidPledge {
+                        block: foreign_block,
+                        transaction_id: atom.id,
+                        shard_group: foreign_shard_group,
+                        details: "Foreign proposal did not contain evidence for it's own shard group".to_string(),
+                    }
+                })?
+                .to_output_pledge_iter()
+                .collect();
 
-                if is_prepare_phase &&
-                    atom.evidence
-                        .is_committee_output_only(foreign_committee_info.shard_group())
-                {
-                    // If the foreign shard group is only involved in the outputs, there will not be any pledges in the
-                    // prepare phase
+            proposed_block_change_set.add_foreign_pledges(
+                transaction.transaction_id(),
+                foreign_shard_group,
+                output_pledges,
+            );
+
+            let Some(pledges) = block_pledge.get_transaction_substate_pledges(&atom.id) else {
+                if transaction.evidence().is_committee_output_only(foreign_shard_group) {
                     debug!(
                         target: LOG_TARGET,
-                        "Foreign proposal COMMIT for transaction {} stage: {} but the foreign shard group is only involved in outputs so no output pledge is expected.",
+                        "Foreign proposal for transaction {} stage: {} but the foreign shard group is only involved in outputs so no output pledge is expected.",
                         atom.id,
                         transaction.current_stage()
                     );
                     return Ok(());
                 }
+                // Accept phase: We only require pledges for inputs in the accept phase if the local shard group is
+                // output-only. Otherwise, the pledging has already happened in the prepare
+                // phase.
+                if !is_prepare_phase && !transaction.evidence().is_committee_output_only(local_shard_group) {
+                    debug!(
+                        target: LOG_TARGET,
+                        "Foreign proposal for transaction {} stage: {}. The local shard group is involved in inputs so pledges should already have been pledged in the prepare phase.",
+                        atom.id,
+                        transaction.current_stage()
+                    );
+                    return Ok(());
+                }
+                warn!(
+                    target: LOG_TARGET,
+                    "⚠️❌ Foreign proposal for transaction {} stage: {} but no pledges found in the block pledge. Evidence: {}",
+                    atom.id,
+                    transaction.current_stage(),
+                    transaction.evidence()
+                );
+
                 return Err(HotStuffError::ForeignNodeOmittedTransactionPledges {
-                    foreign_block_id: *foreign_block_id,
+                    foreign_block,
                     transaction_id: atom.id,
+                    is_prepare_phase,
                 });
             };
-
-            // Validate that provided evidence is correct
-            // TODO: there are a lot of validations to be done on evidence and the foreign block in general,
-            // this is here as a sanity check
-            for pledge in &pledges {
-                if pledge.is_input() {
-                    if !evidence.inputs().contains_key(pledge.substate_id()) {
-                        let address = pledge.to_substate_address();
-                        return Err(ProposalValidationError::ForeignInvalidPledge {
-                            block_id: *foreign_block_id,
-                            transaction_id: atom.id,
-                            shard_group: foreign_committee_info.shard_group(),
-                            details: format!("Pledge {pledge} for address {address} not found in input evidence"),
-                        }
-                        .into());
-                    }
-                } else if !evidence.outputs().contains_key(pledge.substate_id()) {
-                    let address = pledge.to_substate_address();
-                    return Err(ProposalValidationError::ForeignInvalidPledge {
-                        block_id: *foreign_block_id,
-                        transaction_id: atom.id,
-                        shard_group: foreign_committee_info.shard_group(),
-                        details: format!("Pledge {pledge} for address {address} not found in output evidence"),
-                    }
-                    .into());
-                } else {
-                    debug!(
-                        target: LOG_TARGET,
-                        "Foreign pledge {} for transaction {} found in evidence",
-                        pledge,
-                        atom.id
-                    );
-                    // Ok
-                }
-            }
 
             // If the foreign shard has committed the transaction, we can add the pledges to the transaction
             // record
             debug!(
                 target: LOG_TARGET,
-                "Adding foreign pledges to transaction {}. Foreign shard group: {}. Pledges: {}",
+                "Adding {} foreign pledge(s) to transaction {}. Foreign shard group: {}. Pledges: {}",
                 atom.id,
-                foreign_committee_info.shard_group(),
+                pledges.len(),
+                foreign_shard_group,
                 pledges.display()
             );
-            proposed_block_change_set.add_foreign_pledges(
-                transaction.transaction_id(),
-                foreign_committee_info.shard_group(),
-                pledges,
-            );
+
+            proposed_block_change_set.add_foreign_pledges(transaction.transaction_id(), foreign_shard_group, pledges);
         },
         Decision::Abort(reason) => {
             warn!(target: LOG_TARGET, "⚠️ Remote decided ABORT({reason:?}) but provided pledges.");
             if block_pledge.contains(&atom.id) {
                 return Err(ProposalValidationError::ForeignInvalidPledge {
-                    block_id: *foreign_block_id,
+                    block: foreign_block,
                     transaction_id: atom.id,
-                    shard_group: foreign_committee_info.shard_group(),
+                    shard_group: foreign_shard_group,
                     details: "Remote decided ABORT but provided pledges".to_string(),
                 }
                 .into());

--- a/dan_layer/consensus/src/hotstuff/on_message_validate.rs
+++ b/dan_layer/consensus/src/hotstuff/on_message_validate.rs
@@ -362,22 +362,6 @@ impl<TConsensusSpec: ConsensusSpec> OnMessageValidate<TConsensusSpec> {
             .get_committee_by_validator_public_key(msg.block.epoch(), msg.block.proposed_by().clone())
             .await?;
 
-        if !msg.block_pledge.validate_integrity() {
-            warn!(
-                target: LOG_TARGET,
-                "❌ Foreign proposal block {} has invalid pledge", msg.block
-            );
-            let block_id = *msg.block.id();
-            return Ok(MessageValidationResult::Invalid {
-                from,
-                err: HotStuffError::ProposalValidationError(ProposalValidationError::ForeignMalformedPledges {
-                    block_id,
-                    shard_group: msg.block.shard_group(),
-                }),
-                message: HotstuffMessage::ForeignProposal(msg),
-            });
-        }
-
         if let Err(err) = self.check_foreign_proposal(&msg.block, &committee) {
             return Ok(MessageValidationResult::Invalid {
                 from,

--- a/dan_layer/consensus/src/hotstuff/on_next_sync_view.rs
+++ b/dan_layer/consensus/src/hotstuff/on_next_sync_view.rs
@@ -2,7 +2,7 @@
 //  SPDX-License-Identifier: BSD-3-Clause
 
 use log::*;
-use tari_dan_common_types::{committee::Committee, option::DisplayContainer, optional::Optional, Epoch, NodeHeight};
+use tari_dan_common_types::{committee::Committee, option::Displayable, optional::Optional, Epoch, NodeHeight};
 use tari_dan_storage::{
     consensus_models::{HighQc, LastSentVote, LeafBlock},
     StateStore,

--- a/dan_layer/consensus/src/hotstuff/on_propose.rs
+++ b/dan_layer/consensus/src/hotstuff/on_propose.rs
@@ -294,7 +294,34 @@ where TConsensusSpec: ConsensusSpec
                 lock_conflicts,
             ),
             // Leader thinks all local nodes have prepared
-            TransactionPoolStage::Prepared => Ok(Some(Command::LocalPrepare(tx_rec.get_local_transaction_atom(None)))),
+            TransactionPoolStage::Prepared => {
+                if tx_rec
+                    .evidence()
+                    .is_committee_output_only(local_committee_info.shard_group())
+                {
+                    if !tx_rec.has_all_required_foreign_input_pledges(tx, local_committee_info)? {
+                        error!(
+                            target: LOG_TARGET,
+                            "BUG: attempted to propose transaction {} as Prepared but not all foreign input pledges were found. \
+                             This transaction should not have been marked as ready. {}",
+                            tx_rec.transaction_id(),
+                            tx_rec.evidence()
+                        );
+                        return Ok(None);
+                    }
+                    let atom = tx_rec.get_local_transaction_atom();
+                    debug!(
+                        target: LOG_TARGET,
+                        "ℹ️ Transaction {} is output-only for {}, proposing LocalAccept",
+                        tx_rec.transaction_id(),
+                        local_committee_info.shard_group()
+                    );
+                    Ok(Some(Command::LocalAccept(atom)))
+                } else {
+                    let atom = tx_rec.get_local_transaction_atom();
+                    Ok(Some(Command::LocalPrepare(atom)))
+                }
+            },
             // Leader thinks all foreign PREPARE pledges have been received (condition for LocalPrepared stage to be
             // ready)
             TransactionPoolStage::LocalPrepared => self.all_or_some_prepare_transaction(
@@ -470,17 +497,27 @@ where TConsensusSpec: ConsensusSpec
             // propose. This is why the system currently never proposes foreign proposals affecting a
             // transaction in the same block for LocalPrepare/LocalAccept and can result in evidence in the
             // atom having missing Prepare/Accept QCs (which are added on subsequent proposals).
-            //
+            // let locked_block = LockedBlock::get(tx, epoch)?;
+            // let num_proposals = batch.foreign_proposals.len();
+            // let foreign_proposals = mem::replace(&mut batch.foreign_proposals, Vec::with_capacity(num_proposals));
             // for fp in foreign_proposals {
-            //     process_foreign_block(
+            //     if let Err(err) = process_foreign_block(
             //         tx,
             //         &high_qc_certificate.as_leaf_block(),
-            //         locked_block,
-            //         fp,
-            //         foreign_committee_info,
+            //         &locked_block,
+            //         &fp,
             //         local_committee_info,
             //         &mut change_set,
-            //     )?;
+            //     ) {
+            //         warn!(
+            //             target: LOG_TARGET,
+            //             "Failed to process foreign proposal: {}. Skipping this proposal...",
+            //             err
+            //         );
+            //         // TODO: mark as invalid
+            //         continue;
+            //     }
+            //     batch.foreign_proposals.push(fp);
             // }
 
             let justified_block = high_qc_certificate.get_block(tx)?;
@@ -811,13 +848,28 @@ where TConsensusSpec: ConsensusSpec
                 match multishard.current_decision() {
                     Decision::Commit => {
                         if multishard.is_executed() {
+                            let involves_inputs = multishard.involve_any_inputs();
+
                             // CASE: All inputs are local and outputs are foreign (i.e. the transaction is executed), or
+                            // all inputs are foreign and this shard group is output only.
                             let execution = multishard.into_execution().expect("Abort should have execution");
                             tx_rec.update_from_execution(
                                 local_committee_info.num_preshards(),
                                 local_committee_info.num_committees(),
                                 &execution,
                             );
+                            if !involves_inputs {
+                                let num_involved_shard_groups = tx_rec.evidence().num_shard_groups();
+                                let involved = NonZeroU64::new(num_involved_shard_groups as u64).ok_or_else(|| {
+                                    HotStuffError::InvariantError("Number of involved shard groups is 0".to_string())
+                                })?;
+                                let leader_fee = tx_rec.calculate_leader_fee(
+                                    involved,
+                                    self.config.consensus_constants.fee_exhaust_divisor,
+                                );
+                                tx_rec.set_leader_fee(leader_fee);
+                            }
+
                             executed_transactions.insert(*tx_rec.transaction_id(), execution);
                         } else {
                             // CASE: All local inputs were resolved. We need to continue with consensus to get the
@@ -831,6 +883,7 @@ where TConsensusSpec: ConsensusSpec
                     },
                     Decision::Abort(reason) => {
                         warn!(target: LOG_TARGET, "Prepare transaction abort: {reason:?}");
+                        let initial_evidence = multishard.to_initial_evidence(local_committee_info);
                         // CASE: The transaction was ABORTed due to a lock conflict
                         let execution = multishard.into_execution().expect("Abort must have execution");
                         tx_rec.update_from_execution(
@@ -838,6 +891,7 @@ where TConsensusSpec: ConsensusSpec
                             local_committee_info.num_committees(),
                             &execution,
                         );
+                        tx_rec.evidence_mut().update(&initial_evidence);
                         executed_transactions.insert(*tx_rec.transaction_id(), execution);
                     },
                 }
@@ -849,7 +903,7 @@ where TConsensusSpec: ConsensusSpec
                     tx_rec.current_decision(),
                 );
 
-                let atom = tx_rec.get_local_transaction_atom(Some(local_committee_info.shard_group()));
+                let atom = tx_rec.get_local_transaction_atom();
                 Command::Prepare(atom)
             },
         };

--- a/dan_layer/consensus/src/hotstuff/on_propose.rs
+++ b/dan_layer/consensus/src/hotstuff/on_propose.rs
@@ -12,7 +12,7 @@ use tari_common_types::types::{FixedHash, PublicKey};
 use tari_crypto::tari_utilities::epoch_time::EpochTime;
 use tari_dan_common_types::{
     committee::{Committee, CommitteeInfo},
-    option::DisplayContainer,
+    option::Displayable,
     optional::Optional,
     shard::Shard,
     Epoch,

--- a/dan_layer/consensus/src/hotstuff/on_ready_to_vote_on_local_block.rs
+++ b/dan_layer/consensus/src/hotstuff/on_ready_to_vote_on_local_block.rs
@@ -1,7 +1,7 @@
 //   Copyright 2023 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use std::{collections::HashMap, num::NonZeroU64};
+use std::num::NonZeroU64;
 
 use log::*;
 use tari_crypto::ristretto::RistrettoPublicKey;
@@ -111,7 +111,6 @@ where TConsensusSpec: ConsensusSpec
         valid_block: &ValidBlock,
         local_committee_info: &CommitteeInfo,
         can_propose_epoch_end: bool,
-        foreign_committee_infos: HashMap<ShardGroup, CommitteeInfo>,
         change_set: &mut ProposedBlockChangeSet,
     ) -> Result<BlockDecision, HotStuffError> {
         let _timer =
@@ -141,7 +140,6 @@ where TConsensusSpec: ConsensusSpec
                 valid_block.block(),
                 local_committee_info,
                 can_propose_epoch_end,
-                &foreign_committee_infos,
                 change_set,
             )?;
         } else {
@@ -317,7 +315,6 @@ where TConsensusSpec: ConsensusSpec
         block: &Block,
         local_committee_info: &CommitteeInfo,
         can_propose_epoch_end: bool,
-        foreign_committee_infos: &HashMap<ShardGroup, CommitteeInfo>,
         proposed_block_change_set: &mut ProposedBlockChangeSet,
     ) -> Result<(), HotStuffError> {
         // Store used for transactions that have inputs without specific versions.
@@ -395,9 +392,14 @@ where TConsensusSpec: ConsensusSpec
                     }
                 },
                 Command::LocalAccept(atom) => {
-                    if let Some(reason) =
-                        self.evaluate_local_accept_command(tx, block, &locked_block, atom, proposed_block_change_set)?
-                    {
+                    if let Some(reason) = self.evaluate_local_accept_command(
+                        tx,
+                        block,
+                        &locked_block,
+                        atom,
+                        local_committee_info,
+                        proposed_block_change_set,
+                    )? {
                         proposed_block_change_set.no_vote(reason);
                         return Ok(());
                     }
@@ -426,24 +428,13 @@ where TConsensusSpec: ConsensusSpec
                     }
                 },
                 Command::ForeignProposal(fp_atom) => {
-                    let Some(foreign_committee_info) = foreign_committee_infos.get(&fp_atom.shard_group) else {
-                        warn!(
-                            target: LOG_TARGET,
-                            "❌ NO VOTE: ForeignProposal command in block {} {} but no foreign proposal found",
-                            fp_atom.block_id,
-                            fp_atom.shard_group,
-                        );
-                        proposed_block_change_set.no_vote(NoVoteReason::ForeignProposalCommandInBlockMissing);
-                        return Ok(());
-                    };
-
                     if let Some(reason) = self.evaluate_foreign_proposal_command(
                         tx,
                         block,
                         &locked_block,
                         fp_atom,
                         local_committee_info,
-                        foreign_committee_info,
+                        fp_atom.shard_group,
                         proposed_block_change_set,
                     )? {
                         proposed_block_change_set.no_vote(reason);
@@ -826,14 +817,18 @@ where TConsensusSpec: ConsensusSpec
                 return Ok(Some(NoVoteReason::MultiShardProposedForLocalOnly));
             },
             PreparedTransaction::MultiShard(multishard) => {
-                if multishard.current_decision() != atom.decision {
+                // TODO: Because on_propose does not process foreign proposals before proposing, the decision abort
+                // reason may mismatch (e.g. ExecutionFailure != ForeignShardGroupDecidedToAbort)
+                // This is why we use is_same_outcome here. We should try to process foreign proposals in
+                // on_propose
+                if !multishard.current_decision().is_same_outcome(atom.decision) {
                     warn!(
                         target: LOG_TARGET,
-                        "❌ Leader proposed {} for transaction {} in block {} but we decided to {}",
-                        tx_rec.transaction_id(),
-                        block,
+                        "❌ Leader proposed {} for transaction {} but we decided {} in block {}",
                         atom.decision,
+                        atom.id,
                         multishard.current_decision(),
+                        block,
                     );
                     return Ok(Some(NoVoteReason::DecisionDisagreement {
                         local: multishard.current_decision(),
@@ -866,6 +861,7 @@ where TConsensusSpec: ConsensusSpec
                                 tx_rec.transaction_id(),
                                 block,
                             );
+                            let involves_inputs = multishard.involve_any_inputs();
                             // CASE: All inputs are local and outputs are foreign (i.e. the transaction is executed), or
                             let execution = multishard.into_execution().expect("Abort should have execution");
                             tx_rec.update_from_execution(
@@ -873,6 +869,18 @@ where TConsensusSpec: ConsensusSpec
                                 local_committee_info.num_committees(),
                                 &execution,
                             );
+                            if !involves_inputs {
+                                // Output only
+                                let num_involved_shard_groups = tx_rec.evidence().num_shard_groups();
+                                let involved = NonZeroU64::new(num_involved_shard_groups as u64).ok_or_else(|| {
+                                    HotStuffError::InvariantError("Number of involved shard groups is 0".to_string())
+                                })?;
+                                let leader_fee = tx_rec.calculate_leader_fee(
+                                    involved,
+                                    self.config.consensus_constants.fee_exhaust_divisor,
+                                );
+                                tx_rec.set_leader_fee(leader_fee);
+                            }
                             proposed_block_change_set.add_transaction_execution(execution)?;
                         } else {
                             debug!(
@@ -921,6 +929,7 @@ where TConsensusSpec: ConsensusSpec
                         };
                     },
                     Decision::Abort(reason) => {
+                        let initial_evidence = multishard.to_initial_evidence(local_committee_info);
                         // CASE: The transaction was ABORTed due to a lock conflict
                         warn!(target: LOG_TARGET, "⚠️ Multi-shard prepared transaction aborted: {reason:?}");
                         let execution = multishard.into_execution().expect("Abort should have execution");
@@ -929,6 +938,7 @@ where TConsensusSpec: ConsensusSpec
                             local_committee_info.num_committees(),
                             &execution,
                         );
+                        tx_rec.evidence_mut().update(&initial_evidence);
                         proposed_block_change_set.add_transaction_execution(execution)?;
                     },
                 }
@@ -1094,18 +1104,19 @@ where TConsensusSpec: ConsensusSpec
             return Ok(Some(NoVoteReason::NotAllShardGroupsPrepared));
         }
 
-        if !atom.evidence.all_input_shard_groups_prepared() {
-            warn!(
-                target: LOG_TARGET,
-                "❌ NO VOTE: AllPrepare disagreement for transaction {} in block {}. {}",
-                tx_rec.transaction_id(),
-                block,
-                InvalidEvidenceReason::NotAllShardGroupsPrepared,
-            );
-            return Ok(Some(NoVoteReason::InvalidEvidence {
-                reason: InvalidEvidenceReason::NotAllShardGroupsPrepared,
-            }));
-        }
+        // TODO: on_propose does not process foreign proposals so we cannot rely on this check
+        // if !atom.evidence.all_input_shard_groups_prepared() {
+        //     warn!(
+        //         target: LOG_TARGET,
+        //         "❌ NO VOTE: AllPrepare disagreement for transaction {} in block {}. {}",
+        //         tx_rec.transaction_id(),
+        //         block,
+        //         InvalidEvidenceReason::NotAllShardGroupsPrepared,
+        //     );
+        //     return Ok(Some(NoVoteReason::InvalidEvidence {
+        //         reason: InvalidEvidenceReason::NotAllShardGroupsPrepared,
+        //     }));
+        // }
 
         let maybe_execution = if tx_rec.current_decision().is_commit() {
             // TODO: provide the current input locks to the executor, the executor must fail if a write lock is
@@ -1151,7 +1162,7 @@ where TConsensusSpec: ConsensusSpec
                             block,
                         );
                         return Ok(Some(NoVoteReason::DecisionDisagreement {
-                            local: Decision::Abort(AbortReason::LeaderProposalVsLocalDecisionMismatch),
+                            local: Decision::Abort(AbortReason::LockOutputsFailed),
                             remote: Decision::Commit,
                         }));
                     }
@@ -1292,7 +1303,7 @@ where TConsensusSpec: ConsensusSpec
             );
             return Ok(Some(NoVoteReason::DecisionDisagreement {
                 local: Decision::Commit,
-                remote: Decision::Abort(AbortReason::LeaderProposalVsLocalDecisionMismatch),
+                remote: atom.decision,
             }));
         }
 
@@ -1335,6 +1346,7 @@ where TConsensusSpec: ConsensusSpec
         block: &Block,
         locked_block: &LockedBlock,
         atom: &TransactionAtom,
+        local_committee_info: &CommitteeInfo,
         proposed_block_change_set: &mut ProposedBlockChangeSet,
     ) -> Result<Option<NoVoteReason>, HotStuffError> {
         let Some(mut tx_rec) =
@@ -1349,7 +1361,15 @@ where TConsensusSpec: ConsensusSpec
             return Ok(Some(NoVoteReason::TransactionNotInPool));
         };
 
-        if !tx_rec.current_stage().is_all_prepared() && !tx_rec.current_stage().is_some_prepared() {
+        #[allow(clippy::nonminimal_bool)]
+        if !tx_rec.current_stage().is_all_prepared() &&
+            !tx_rec.current_stage().is_some_prepared() &&
+            // We allow the transition from LocalPrepared to LocalAccepted if we are output-only
+            !(tx_rec.current_stage().is_prepared() &&
+                tx_rec
+                    .evidence()
+                    .is_committee_output_only(local_committee_info.shard_group()))
+        {
             warn!(
                 target: LOG_TARGET,
                 "{} ❌ Stage disagreement in block {} for transaction {}. Leader proposed LocalAccept, but current stage is {}",
@@ -1507,7 +1527,7 @@ where TConsensusSpec: ConsensusSpec
                 block,
             );
             return Ok(Some(NoVoteReason::DecisionDisagreement {
-                local: Decision::Abort(AbortReason::LeaderProposalVsLocalDecisionMismatch),
+                local: atom.decision,
                 remote: Decision::Commit,
             }));
         }
@@ -1575,15 +1595,16 @@ where TConsensusSpec: ConsensusSpec
             return Ok(Some(NoVoteReason::NotAllForeignInputPledges));
         }
 
-        if !atom.evidence.all_objects_accepted() {
-            warn!(
-                target: LOG_TARGET,
-                "❌ NO VOTE: AllAccept disagreement for transaction {} in block {}. Leader proposed an atom which did not indicate that all shard groups have accepted the transaction",
-                tx_rec.transaction_id(),
-                block,
-            );
-            return Ok(Some(NoVoteReason::NotAllInputsOutputsAccepted));
-        }
+        // TODO: on_propose does not process foreign proposals so we cannot rely on this check
+        // if !atom.evidence.all_shard_groups_accepted() {
+        //     warn!(
+        //         target: LOG_TARGET,
+        //         "❌ NO VOTE: AllAccept disagreement for transaction {} in block {}. Leader proposed an atom which did
+        // not indicate that all shard groups have accepted the transaction",         tx_rec.transaction_id(),
+        //         block,
+        //     );
+        //     return Ok(Some(NoVoteReason::NotAllInputsOutputsAccepted));
+        // }
 
         if *tx_rec.evidence() != atom.evidence {
             warn!(
@@ -1686,7 +1707,7 @@ where TConsensusSpec: ConsensusSpec
             );
             return Ok(Some(NoVoteReason::DecisionDisagreement {
                 local: Decision::Commit,
-                remote: Decision::Abort(AbortReason::LeaderProposalVsLocalDecisionMismatch),
+                remote: atom.decision,
             }));
         }
 
@@ -1715,7 +1736,7 @@ where TConsensusSpec: ConsensusSpec
         locked_block: &LockedBlock,
         fp_atom: &ForeignProposalAtom,
         local_committee_info: &CommitteeInfo,
-        foreign_committee_info: &CommitteeInfo,
+        foreign_shard_group: ShardGroup,
         proposed_block_change_set: &mut ProposedBlockChangeSet,
     ) -> Result<Option<NoVoteReason>, HotStuffError> {
         if proposed_block_change_set
@@ -1756,9 +1777,7 @@ where TConsensusSpec: ConsensusSpec
             tx,
             &local_block.as_leaf_block(),
             locked_block,
-            fp,
-            // NB: dont put these args in the wrong order
-            foreign_committee_info,
+            &fp,
             local_committee_info,
             proposed_block_change_set,
         ) {
@@ -1769,7 +1788,7 @@ where TConsensusSpec: ConsensusSpec
                 block = local_block,
                 foreign_block_id = fp_atom.block_id,
                 error = err,
-                shard_group = foreign_committee_info.shard_group(),
+                shard_group = foreign_shard_group,
             );
             return Ok(Some(NoVoteReason::ForeignProposalProcessingFailed));
         }

--- a/dan_layer/consensus/src/hotstuff/on_ready_to_vote_on_local_block.rs
+++ b/dan_layer/consensus/src/hotstuff/on_ready_to_vote_on_local_block.rs
@@ -7,7 +7,7 @@ use log::*;
 use tari_crypto::ristretto::RistrettoPublicKey;
 use tari_dan_common_types::{
     committee::CommitteeInfo,
-    option::DisplayContainer,
+    option::Displayable,
     optional::Optional,
     Epoch,
     ShardGroup,

--- a/dan_layer/consensus/src/hotstuff/on_receive_foreign_proposal.rs
+++ b/dan_layer/consensus/src/hotstuff/on_receive_foreign_proposal.rs
@@ -73,7 +73,7 @@ where TConsensusSpec: ConsensusSpec
         local_committee_info: &CommitteeInfo,
     ) -> Result<(), HotStuffError> {
         let _timer = TraceTimer::debug(LOG_TARGET, "OnReceiveForeignProposal");
-        let proposal = ForeignProposal::from(message);
+        let mut proposal = ForeignProposal::from(message);
 
         if self.store.with_read_tx(|tx| proposal.exists(tx))? {
             // This is expected behaviour, we may receive the same foreign proposal multiple times
@@ -86,15 +86,16 @@ where TConsensusSpec: ConsensusSpec
             return Ok(());
         }
 
-        let foreign_committee_info = self
-            .epoch_manager
-            .get_committee_info_by_validator_public_key(proposal.block.epoch(), proposal.block.proposed_by().clone())
-            .await?;
         let block_id = *proposal.block().id();
         self.store.with_write_tx(|tx| {
-            if let Err(err) = self.validate_and_save(tx, proposal, local_committee_info, &foreign_committee_info) {
+            if let Err(err) = self.validate_and_save(tx, &proposal, local_committee_info) {
                 error!(target: LOG_TARGET, "❌ Error validating and saving foreign proposal: {}", err);
-                // Should not cause consensus to crash and should still be committed (Invalid proposal status)
+                // Should not cause consensus to crash and should commit the Invalid proposal status
+                proposal.upsert(tx, None)?;
+                proposal.set_status(tx, ForeignProposalStatus::Invalid)?;
+                // TODO: reattempt from different node? and then abort on persistent failure
+                // If we miss a foreign proposal, we want to implement the ability to request it - so we could just rely
+                // on that functionality without doing anything extra here
                 return Ok(());
             }
             Ok::<_, HotStuffError>(())
@@ -111,7 +112,7 @@ where TConsensusSpec: ConsensusSpec
 
     fn remove_recently_requested(&mut self, block_id: &BlockId) {
         self.recently_requested.remove(block_id);
-        if self.recently_requested.capacity() - self.recently_requested.len() > 50 {
+        if self.recently_requested.capacity() - self.recently_requested.len() > 1000 {
             self.recently_requested.shrink_to_fit();
         }
     }
@@ -224,6 +225,7 @@ where TConsensusSpec: ConsensusSpec
         Ok(())
     }
 
+    #[allow(clippy::too_many_lines)]
     async fn handle_requested_task(
         store: TConsensusSpec::StateStore,
         mut outbound_messaging: TConsensusSpec::OutboundMessaging,
@@ -265,7 +267,7 @@ where TConsensusSpec: ConsensusSpec
                     .iter()
                     .filter_map(|c| {
                         c.local_prepare()
-                            // No need to broadcast LocalPrepare if the committee is output only
+                            // No need to broadcast LocalPrepare if the committee is output only (TODO: this no longer applies as output only skips LocalPrepare)
                             .filter(|atom| !atom.evidence.is_committee_output_only(local_committee_info.shard_group()))
                             .or_else(|| c.local_accept())
                     })
@@ -275,11 +277,13 @@ where TConsensusSpec: ConsensusSpec
 
                 debug!(
                     target: LOG_TARGET,
-                    "🌐 FOREIGN PROPOSAL: Requested block {} contains {} applicable transaction(s) for {} ({} LocalPrepare*/LocalAccept tx(s) in block)",
+                    "🌐 FOREIGN PROPOSAL: Requested block {} contains {}/{} applicable transaction(s) for {} ({} pledge(s), {} substate value(s))",
                     block_id,
                     applicable_transactions.len(),
-                    for_shard_group,
                     block_pledge.len(),
+                    for_shard_group,
+                    block_pledge.num_substates_pledged(),
+                    block_pledge.num_substate_values(),
                 );
 
                 if applicable_transactions.is_empty() {
@@ -295,15 +299,32 @@ where TConsensusSpec: ConsensusSpec
                 // Only send the pledges for the involved shard group that requested them
                 block_pledge.retain_transactions(&applicable_transactions);
 
+                // LocalAccept: If the foreign shard is NOT output-only, we have already sent the input pledges, so we
+                // exclude them to avoid sending them again.
+                for cmd in block.commands() {
+                    if let Some(atom) = cmd.local_accept() {
+                        if !atom.evidence.is_committee_output_only(for_shard_group) {
+                            debug!(
+                                target: LOG_TARGET,
+                                "🌐 FOREIGN PROPOSAL: Exclude input substate values for {} for {} from block {}",
+                                cmd,
+                                for_shard_group,
+                                block_id,
+                            );
+                            block_pledge.trim_input_values_for(&atom.id);
+                        }
+                    }
+                }
+
                 info!(
                     target: LOG_TARGET,
-                    "🌐 REPLY foreign proposal {} {} pledge(s) ({} tx(s)) to {}. justify: {} ({}), parent: {}",
+                    "🌐 REPLY foreign proposal {} {} pledge(s) {} value(s), and {} tx(s) to {}. justify: {}, parent: {}",
                     block.as_leaf_block(),
                     block_pledge.num_substates_pledged(),
+                    block_pledge.num_substate_values(),
                     block_pledge.len(),
                     for_shard_group,
-                    justify_qc.block_id(),
-                    justify_qc.block_height(),
+                    justify_qc.as_leaf_block(),
                     block.parent()
                 );
 
@@ -332,18 +353,12 @@ where TConsensusSpec: ConsensusSpec
     pub fn validate_and_save(
         &self,
         tx: &mut <TConsensusSpec::StateStore as StateStore>::WriteTransaction<'_>,
-        proposal: ForeignProposal,
+        proposal: &ForeignProposal,
         local_committee_info: &CommitteeInfo,
-        foreign_committee_info: &CommitteeInfo,
     ) -> Result<(), HotStuffError> {
         let mut foreign_receive_counter = ForeignReceiveCounters::get_or_default(&**tx)?;
 
-        if let Err(err) = self.validate_proposed_block(
-            &proposal,
-            foreign_committee_info.shard_group(),
-            local_committee_info.shard_group(),
-            &foreign_receive_counter,
-        ) {
+        if let Err(err) = self.validate_proposed_block(proposal, local_committee_info, &foreign_receive_counter) {
             // TODO: handle this case. Perhaps, by aborting all transactions that are affected by this block (we known
             // the justify QC is valid)
             warn!(
@@ -352,12 +367,10 @@ where TConsensusSpec: ConsensusSpec
                 err,
                 proposal.block(),
             );
-            proposal.upsert(tx, None)?;
-            proposal.set_status(tx, ForeignProposalStatus::Invalid)?;
             return Err(err.into());
         }
 
-        foreign_receive_counter.increment_group(foreign_committee_info.shard_group());
+        foreign_receive_counter.increment_group(proposal.block().shard_group());
 
         info!(
             target: LOG_TARGET,
@@ -375,8 +388,7 @@ where TConsensusSpec: ConsensusSpec
     fn validate_proposed_block(
         &self,
         proposal: &ForeignProposal,
-        foreign_shard: ShardGroup,
-        local_shard: ShardGroup,
+        local_committee_info: &CommitteeInfo,
         _foreign_receive_counter: &ForeignReceiveCounters,
     ) -> Result<(), ProposalValidationError> {
         // TODO: validations specific to the foreign proposal. General block validations (signature etc) are already
@@ -392,11 +404,29 @@ where TConsensusSpec: ConsensusSpec
             return Err(ProposalValidationError::ForeignJustifyQcDoesNotJustifyProposal {
                 block_id: *proposal.block().id(),
                 justify_qc_block_id: *proposal.justify_qc().block_id(),
-                shard_group: foreign_shard,
+                shard_group: proposal.block().shard_group(),
             });
         }
 
-        validate_evidence_and_pledges_match(proposal, local_shard, foreign_shard)?;
+        if proposal.block().epoch() != local_committee_info.epoch() &&
+            // Allow one epoch behind as Prepare/Accept rounds may have been conducted in the previous epoch before epoch end
+            proposal.block().epoch() != local_committee_info.epoch() - Epoch(1)
+        {
+            warn!(
+                target: LOG_TARGET,
+                "⚠️ FOREIGN PROPOSAL: Invalid proposal epoch: {}. Current epoch: {}",
+                proposal.block().epoch(),
+                local_committee_info.epoch(),
+            );
+            return Err(ProposalValidationError::ForeignInvalidEpoch {
+                block_id: *proposal.block().id(),
+                shard_group: proposal.block().shard_group(),
+                block_epoch: proposal.block().epoch(),
+                current_epoch: local_committee_info.epoch(),
+            });
+        }
+
+        validate_evidence_and_pledges_match(proposal, local_committee_info.shard_group())?;
 
         // TODO: ignoring for now because this is currently broken
         // let Some(incoming_count) = candidate_block.get_foreign_counter(&local_shard) else {
@@ -426,9 +456,9 @@ where TConsensusSpec: ConsensusSpec
 
 fn validate_evidence_and_pledges_match(
     proposal: &ForeignProposal,
-    local_shard: ShardGroup,
-    foreign_shard: ShardGroup,
+    local_shard_group: ShardGroup,
 ) -> Result<(), ProposalValidationError> {
+    let foreign_shard_group = proposal.block().shard_group();
     // TODO: any error will** result in transactions that never resolve.
     // ** unless the foreign shard sends it again with the correct evidence and pledges
     // Possible ways to handle this:
@@ -436,35 +466,85 @@ fn validate_evidence_and_pledges_match(
     //   this time?)
     // - Immediately ABORT all transactions with invalid pledges in the block - this is the safest option
     let mut num_applicable = 0usize;
-    for atom in proposal.block().commands().iter().filter_map(|cmd| {
+    for (is_local_accept, atom) in proposal.block().commands().iter().filter_map(|cmd| {
         cmd.local_prepare()
             // The foreign committee may have sent us this block for other transactions that are applicable to us
             // not for this output-only LocalPrepare
-            .filter(|atom| !atom.evidence.is_committee_output_only(foreign_shard))
-            .or_else(|| cmd.local_accept())
+            .filter(|atom| !atom.evidence.is_committee_output_only(proposal.block().shard_group()))
+            .map(|atom| (false, atom))
+            .or_else(|| cmd.local_accept().map(|atom| (true, atom)))
     }) {
-        if atom.decision.is_abort() || !atom.evidence.has(&local_shard) {
+        if atom.decision.is_abort() || !atom.evidence.has(&local_shard_group) {
             continue;
         }
 
         num_applicable += 1;
 
+        // If the local node is involved in inputs (i.e not output-only), we already have the input pledges from the
+        // prepare phase and so do not need them to be resent.
+        let dont_need_input_pledges = is_local_accept &&
+            (!atom.evidence.is_committee_output_only(local_shard_group) ||
+                atom.evidence.is_committee_output_only(foreign_shard_group));
+        if dont_need_input_pledges {
+            // CASE: if we're an input shard group, and we're receiving a local accept, we do not require input pledges
+            if proposal.block_pledge().has_some_write_input_pledge_values_for(&atom.id) {
+                // Just warn that the foreign shard has included input values for which there is no need. Less efficient
+                // but does not break the protocol. Indicates a bug or maliciousness
+                // TODO: ...or Write pledging specific version to more than one transaction? That is unequivocally
+                //       invalid.
+                warn!(
+                    target: LOG_TARGET,
+                    "⚠️ FOREIGN PROPOSAL: foreign {} included input pledges however they are not required (LocalAccept and not output-only). Transaction: {}",
+                    foreign_shard_group,
+                    atom.id,
+                );
+            }
+            continue;
+        }
+
+        debug!(
+            target: LOG_TARGET,
+            "🧩 FOREIGN PROPOSAL: Check transaction {} pledges from {} - local_shard_group: {}, is_local_accept: {}, local-output-only: {}",
+            atom.id,
+            foreign_shard_group,
+            local_shard_group,
+            is_local_accept,
+            atom.evidence.is_committee_output_only(local_shard_group),
+        );
+
         let pledges = proposal.block_pledge.get_transaction_pledges(&atom.id).ok_or_else(|| {
             ProposalValidationError::ForeignInvalidPledge {
                 transaction_id: atom.id,
-                block_id: *proposal.block().id(),
-                shard_group: foreign_shard,
+                block: proposal.block().as_leaf_block(),
+                shard_group: foreign_shard_group,
                 details: "substate pledges for transaction are missing".to_string(),
             }
         })?;
 
+        if !proposal.block_pledge.has_all_input_substate_values_for(atom.id()) {
+            warn!(
+                target: LOG_TARGET,
+                "⚠️ FOREIGN PROPOSAL: Invalid proposal: some input pledges for {}({}) are missing. Local Shard Group: {}, All Pledges: {}",
+                if is_local_accept { "LocalAccept" } else { "LocalPrepare" },
+                atom.id,
+                local_shard_group,
+                pledges.display(),
+            );
+            return Err(ProposalValidationError::ForeignInvalidPledge {
+                transaction_id: atom.id,
+                block: proposal.block().as_leaf_block(),
+                shard_group: foreign_shard_group,
+                details: "input pledges are missing one or more substate values".to_string(),
+            });
+        }
+
         let evidence =
             atom.evidence
-                .get(&foreign_shard)
+                .get(&foreign_shard_group)
                 .ok_or_else(|| ProposalValidationError::ForeignInvalidPledge {
                     transaction_id: atom.id,
-                    block_id: *proposal.block().id(),
-                    shard_group: foreign_shard,
+                    block: proposal.block().as_leaf_block(),
+                    shard_group: foreign_shard_group,
                     details: "evidence for transaction is missing".to_string(),
                 })?;
 
@@ -478,8 +558,8 @@ fn validate_evidence_and_pledges_match(
                 );
                 return Err(ProposalValidationError::ForeignInvalidPledge {
                     transaction_id: atom.id,
-                    block_id: *proposal.block().id(),
-                    shard_group: foreign_shard,
+                    block: proposal.block().as_leaf_block(),
+                    shard_group: foreign_shard_group,
                     details: format!("substate pledge for input {input} is missing"),
                 });
             }

--- a/dan_layer/consensus/src/hotstuff/on_receive_foreign_proposal.rs
+++ b/dan_layer/consensus/src/hotstuff/on_receive_foreign_proposal.rs
@@ -4,13 +4,7 @@
 use std::collections::HashSet;
 
 use log::*;
-use tari_dan_common_types::{
-    committee::CommitteeInfo,
-    option::DisplayContainer,
-    optional::Optional,
-    Epoch,
-    ShardGroup,
-};
+use tari_dan_common_types::{committee::CommitteeInfo, option::Displayable, optional::Optional, Epoch, ShardGroup};
 use tari_dan_storage::{
     consensus_models::{
         Block,

--- a/dan_layer/consensus/src/hotstuff/on_receive_request_missing_transactions.rs
+++ b/dan_layer/consensus/src/hotstuff/on_receive_request_missing_transactions.rs
@@ -2,7 +2,7 @@
 //   SPDX-License-Identifier: BSD-3-Clause
 
 use log::*;
-use tari_dan_common_types::option::DisplayContainer;
+use tari_dan_common_types::option::Displayable;
 use tari_dan_storage::{consensus_models::TransactionRecord, StateStore};
 
 use crate::{

--- a/dan_layer/consensus/src/hotstuff/substate_store/pending_store.rs
+++ b/dan_layer/consensus/src/hotstuff/substate_store/pending_store.rs
@@ -6,6 +6,7 @@ use std::{borrow::Cow, collections::HashMap, fmt::Display};
 use indexmap::IndexMap;
 use log::*;
 use tari_dan_common_types::{
+    option::Displayable,
     optional::Optional,
     LockIntent,
     NumPreshards,
@@ -531,7 +532,7 @@ impl<'a, 'tx, TStore: StateStore + 'a + 'tx> PendingSubstateStore<'a, 'tx, TStor
     fn get_pending(&self, addr: &SubstateAddress) -> Option<&SubstateChange> {
         self.pending
             .get(addr)
-            .map(|&pos| self.diff.get(pos).expect("Index map and diff are out of sync"))
+            .map(|&pos| self.diff.get(pos).expect("pending map and diff are out of sync"))
     }
 
     fn insert(&mut self, change: SubstateChange) {
@@ -565,6 +566,13 @@ impl<'a, 'tx, TStore: StateStore + 'a + 'tx> PendingSubstateStore<'a, 'tx, TStor
     }
 
     fn assert_is_up(&self, id: &VersionedSubstateId) -> Result<(), SubstateStoreError> {
+        debug!(
+            target: LOG_TARGET,
+            "assert_is_up: id: {}, pending: {}, head: {}",
+            id,
+            self.pending.display(),
+            self.head.display()
+        );
         if let Some(change) = self.get_pending(&id.to_substate_address()) {
             if change.is_down() {
                 return Err(SubstateStoreError::SubstateIsDown { id: id.clone() });
@@ -572,14 +580,26 @@ impl<'a, 'tx, TStore: StateStore + 'a + 'tx> PendingSubstateStore<'a, 'tx, TStor
             return Ok(());
         }
 
+        debug!(
+            target: LOG_TARGET,
+            "assert_is_up id: {} not found in pending",
+            id,
+        );
+
         if let Some(change) =
-            BlockDiff::get_for_substate(self.read_transaction(), &self.parent_block, &id.substate_id).optional()?
+            BlockDiff::get_for_substate(self.read_transaction(), &self.parent_block, id.substate_id()).optional()?
         {
             if change.is_up() {
                 return Ok(());
             }
             return Err(SubstateStoreError::SubstateIsDown { id: id.clone() });
         }
+
+        debug!(
+            target: LOG_TARGET,
+            "assert_is_up: id: {} not found in block diff",
+            id,
+        );
 
         match SubstateRecord::substate_is_up(self.read_transaction(), &id.to_substate_address()).optional()? {
             Some(true) => Ok(()),

--- a/dan_layer/consensus/src/hotstuff/substate_store/pending_store.rs
+++ b/dan_layer/consensus/src/hotstuff/substate_store/pending_store.rs
@@ -78,7 +78,7 @@ impl<'store, 'tx, TStore: StateStore + 'store + 'tx> ReadableSubstateStore
         }
 
         if let Some(change) =
-            BlockDiff::get_for_substate(self.read_transaction(), &self.parent_block, id.substate_id).optional()?
+            BlockDiff::get_for_versioned_substate(self.read_transaction(), &self.parent_block, id).optional()?
         {
             return change
                 .into_up()
@@ -587,7 +587,7 @@ impl<'a, 'tx, TStore: StateStore + 'a + 'tx> PendingSubstateStore<'a, 'tx, TStor
         );
 
         if let Some(change) =
-            BlockDiff::get_for_substate(self.read_transaction(), &self.parent_block, id.substate_id()).optional()?
+            BlockDiff::get_for_versioned_substate(self.read_transaction(), &self.parent_block, id).optional()?
         {
             if change.is_up() {
                 return Ok(());

--- a/dan_layer/consensus/src/hotstuff/transaction_manager/prepared.rs
+++ b/dan_layer/consensus/src/hotstuff/transaction_manager/prepared.rs
@@ -106,6 +106,10 @@ impl MultiShardPreparedTransaction {
         &self.outputs
     }
 
+    pub fn involve_any_inputs(&self) -> bool {
+        !self.local_inputs.is_empty()
+    }
+
     pub fn into_execution(self) -> Option<TransactionExecution> {
         self.execution
     }

--- a/dan_layer/consensus/src/hotstuff/worker.rs
+++ b/dan_layer/consensus/src/hotstuff/worker.rs
@@ -676,18 +676,19 @@ impl<TConsensusSpec: ConsensusSpec> HotstuffWorker<TConsensusSpec> {
 
         info!(
             target: LOG_TARGET,
-            "🔥 [on_beat] {} Local node is leader for height ({}), local_committee: {}",
+            "🔥 [on_beat] {} Local node is leader for height ({}), num local members: {}, {}",
             self.local_validator_addr,
             next_height,
-            local_committee
-                .len(),
+            local_committee.len(),
+            local_committee_info.shard_group()
         );
 
         let propose_now = self.state_store.with_read_tx(|tx| {
             // Propose quickly if there are UTXOs to mint or transactions to propose
             let propose_now = ForeignProposal::has_unconfirmed(tx, epoch)? ||
                 BurntUtxo::has_unproposed(tx)? ||
-                self.transaction_pool.has_ready_or_pending_transaction_updates(tx)?;
+                self.transaction_pool
+                    .has_ready_or_pending_transaction_updates(tx, leaf_block.block_id())?;
 
             Ok::<_, HotStuffError>(propose_now)
         })?;

--- a/dan_layer/consensus_tests/src/consensus.rs
+++ b/dan_layer/consensus_tests/src/consensus.rs
@@ -748,11 +748,11 @@ async fn multishard_output_conflict_abort() {
     test.assert_all_validators_at_same_height().await;
     // Currently not deterministic (test harness) which transaction will arrive first so we check that one transaction
     // is committed and the other is aborted. TODO: It is also possible that both are aborted.
-    let tx1_vn1 = test.get_transaction_record(&TestAddress::new("1"), tx_ids[0]);
-    let tx2_vn1 = test.get_transaction_record(&TestAddress::new("1"), tx_ids[1]);
+    let tx1_vn1 = test.get_validator(&TestAddress::new("1")).get_transaction(tx_ids[0]);
+    let tx2_vn1 = test.get_validator(&TestAddress::new("1")).get_transaction(tx_ids[1]);
 
-    let tx1_vn3 = test.get_transaction_record(&TestAddress::new("3"), tx_ids[0]);
-    let tx2_vn3 = test.get_transaction_record(&TestAddress::new("3"), tx_ids[1]);
+    let tx1_vn3 = test.get_validator(&TestAddress::new("3")).get_transaction(tx_ids[0]);
+    let tx2_vn3 = test.get_validator(&TestAddress::new("3")).get_transaction(tx_ids[1]);
 
     assert_eq!(tx1_vn1.final_decision().unwrap(), tx1_vn3.final_decision().unwrap());
     assert_eq!(tx2_vn1.final_decision().unwrap(), tx2_vn3.final_decision().unwrap());
@@ -813,22 +813,19 @@ async fn single_shard_inputs_from_previous_outputs() {
     }
 
     test.assert_all_validators_at_same_height().await;
-    // We do not work out input dependencies when we sequence transactions in blocks. Currently ordering within a block
-    // is lexicographical by transaction id, therefore both will only be committed if tx1 happens to be sequenced
-    // first.
-    // if tx1.id() < tx2.id() {
+    // Assert that the decision matches for all validators. If tx2 is sequenced first, then it will be aborted due to
+    // the input not existing
     test.assert_all_validators_have_decision(tx1.id(), Decision::Commit)
         .await;
-    test.assert_all_validators_have_decision(tx2.id(), Decision::Commit)
-        .await;
-    // TODO: this is no longer true - it always commits both. Need to confirm correctness because it may be that the
-    //       implementation is more intelligent (correct sequencing or downgrading to a read lock) but not certain.
-    // } else {
-    //     test.assert_all_validators_have_decision(tx1.id(), Decision::Commit)
-    //         .await;
-    //     test.assert_all_validators_have_decision(tx2.id(), Decision::Abort(AbortReason::OneOrMoreInputsNotFound))
-    //         .await;
-    // }
+    let decision_tx2 = test
+        .get_validator(&TestAddress::new("1"))
+        .get_transaction(tx2.id())
+        .final_decision()
+        .expect("tx2 final decision not reached");
+    test.assert_all_validators_have_decision(tx2.id(), decision_tx2).await;
+    if let Some(reason) = decision_tx2.abort_reason() {
+        assert_eq!(reason, AbortReason::OneOrMoreInputsNotFound);
+    }
 
     test.assert_clean_shutdown().await;
     log::info!("total messages sent: {}", test.network().total_messages_sent());

--- a/dan_layer/consensus_tests/src/consensus.rs
+++ b/dan_layer/consensus_tests/src/consensus.rs
@@ -77,7 +77,7 @@ async fn single_transaction() {
     }
 
     test.assert_all_validators_at_same_height().await;
-    test.assert_all_validators_committed();
+    test.assert_all_validators_committed(tx1.id());
 
     // Assert all LocalOnly
     test.get_validator(&TestAddress::new("1"))
@@ -123,7 +123,7 @@ async fn single_transaction_multi_vn() {
     }
 
     test.assert_all_validators_at_same_height().await;
-    test.assert_all_validators_committed();
+    test.assert_all_validators_committed(tx1.id());
 
     // Assert all LocalOnly
     test.get_validator(&TestAddress::new("1"))
@@ -182,7 +182,6 @@ async fn single_transaction_abort() {
 async fn propose_blocks_with_queued_up_transactions_until_all_committed() {
     setup_logger();
     let mut test = Test::builder()
-        .debug_sql("/tmp/test{}.db")
         .add_committee(0, vec!["1", "2", "3", "4", "5"])
         .start()
         .await;
@@ -241,8 +240,10 @@ async fn node_requests_missing_transaction_from_local_leader() {
     // First get all transactions in the mempool of node "2". We send to "2" because it is the leader for the next
     // block. We could send to "1" but the test would have to wait for the block time to be hit and block 1 to be
     // proposed before node "1" can propose block 2 with all the transactions.
+    let mut tx_ids = Vec::with_capacity(10);
     for _ in 0..10 {
         let (transaction, inputs) = test.build_transaction(Decision::Commit, 5);
+        tx_ids.push(*transaction.id());
         // All VNs will decide the same thing
         test.create_execution_at_destination_for_transaction(
             TestVnDestination::All,
@@ -295,7 +296,7 @@ async fn node_requests_missing_transaction_from_local_leader() {
         .unwrap();
 
     test.assert_all_validators_at_same_height().await;
-    test.assert_all_validators_committed();
+    test.assert_all_validators_committed(&tx_ids[0]);
     test.assert_clean_shutdown().await;
 }
 
@@ -332,7 +333,7 @@ async fn multi_shard_single_transaction() {
     test.assert_all_validators_at_same_height().await;
     test.assert_all_validators_have_decision(tx.id(), Decision::Commit)
         .await;
-    test.assert_all_validators_committed();
+    test.assert_all_validators_committed(tx.id());
 
     log::info!("total messages sent: {}", test.network().total_messages_sent());
     test.assert_clean_shutdown().await;
@@ -365,7 +366,6 @@ async fn multi_validator_propose_blocks_with_new_transactions_until_all_committe
     }
 
     test.assert_all_validators_at_same_height().await;
-    test.assert_all_validators_committed();
 
     log::info!("total messages sent: {}", test.network().total_messages_sent());
     test.assert_clean_shutdown().await;
@@ -380,8 +380,11 @@ async fn multi_shard_propose_blocks_with_new_transactions_until_all_committed() 
         .add_committee(2, vec!["7", "8", "9"])
         .start()
         .await;
+
+    let mut tx_ids = Vec::new();
     for _ in 0..20 {
-        test.send_transaction_to_all(Decision::Commit, 100, 2, 1).await;
+        let (tx, _, _) = test.send_transaction_to_all(Decision::Commit, 100, 2, 1).await;
+        tx_ids.push(*tx.id());
     }
 
     test.start_epoch(Epoch(1)).await;
@@ -405,7 +408,7 @@ async fn multi_shard_propose_blocks_with_new_transactions_until_all_committed() 
     }
 
     test.assert_all_validators_at_same_height().await;
-    test.assert_all_validators_committed();
+    test.assert_all_validators_committed(&tx_ids[0]);
 
     log::info!("total messages sent: {}", test.network().total_messages_sent());
     test.assert_clean_shutdown().await;
@@ -486,12 +489,15 @@ async fn multishard_local_inputs_foreign_outputs() {
     setup_logger();
     let mut test = Test::builder()
         .add_committee(0, vec!["1", "2"])
+        // Two output-only committees
         .add_committee(1, vec!["3", "4"])
+        .add_committee(2, vec!["5", "6"])
         .start()
         .await;
 
     let inputs = test.create_substates_on_vns(TestVnDestination::Committee(0), 2);
-    let outputs = test.build_outputs_for_committee(1, 1);
+    let outputs_1 = test.build_outputs_for_committee(1, 1);
+    let outputs_2 = test.build_outputs_for_committee(2, 1);
 
     let tx1 = build_transaction_from(
         Transaction::builder()
@@ -506,7 +512,7 @@ async fn multishard_local_inputs_foreign_outputs() {
             .into_iter()
             .map(|input| VersionedSubstateIdLockIntent::write(input, true).into())
             .collect(),
-        outputs,
+        outputs_1.into_iter().chain(outputs_2).collect(),
     );
     test.send_transaction_to_destination(TestVnDestination::All, tx1.clone())
         .await;
@@ -533,7 +539,77 @@ async fn multishard_local_inputs_foreign_outputs() {
     test.assert_all_validators_at_same_height().await;
     test.assert_all_validators_have_decision(tx1.id(), Decision::Commit)
         .await;
-    test.assert_all_validators_committed();
+    test.assert_all_validators_committed(tx1.id());
+
+    log::info!("total messages sent: {}", test.network().total_messages_sent());
+    test.assert_clean_shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn multishard_local_inputs_foreign_outputs_abort() {
+    setup_logger();
+    let mut test = Test::builder()
+        .add_committee(0, vec!["1", "2"])
+        .add_committee(1, vec!["3", "4"])
+        .start()
+        .await;
+
+    let inputs = test.create_substates_on_vns(TestVnDestination::Committee(0), 2);
+    let outputs = test.build_outputs_for_committee(1, 1);
+    let transaction = Transaction::builder()
+        .with_inputs(inputs.iter().cloned().map(|i| i.into()))
+        .build_and_seal(&PrivateKey::default());
+
+    let tx = build_transaction_from(transaction.clone(), Decision::Commit);
+    let tx_abort = build_transaction_from(transaction, Decision::Abort(AbortReason::ExecutionFailure));
+    test.create_execution_at_destination_for_transaction(
+        TestVnDestination::Committee(0),
+        &tx,
+        inputs
+            .clone()
+            .into_iter()
+            .map(|input| VersionedSubstateIdLockIntent::write(input, true).into())
+            .collect(),
+        outputs.clone(),
+    );
+    test.send_transaction_to_destination(TestVnDestination::Committee(0), tx.clone())
+        .await;
+
+    test.create_execution_at_destination_for_transaction(
+        TestVnDestination::Committee(1),
+        &tx_abort,
+        inputs
+            .into_iter()
+            .map(|input| VersionedSubstateIdLockIntent::write(input, true).into())
+            .collect(),
+        outputs,
+    );
+    test.send_transaction_to_destination(TestVnDestination::Committee(1), tx_abort.clone())
+        .await;
+
+    test.start_epoch(Epoch(1)).await;
+
+    loop {
+        test.on_block_committed().await;
+
+        if test.is_transaction_pool_empty() {
+            break;
+        }
+
+        let leaf1 = test.get_validator(&TestAddress::new("1")).get_leaf_block();
+        let leaf2 = test.get_validator(&TestAddress::new("3")).get_leaf_block();
+        if leaf1.height > NodeHeight(30) || leaf2.height > NodeHeight(30) {
+            panic!(
+                "Not all transaction committed after {}/{} blocks",
+                leaf1.height, leaf2.height,
+            );
+        }
+    }
+
+    test.assert_all_validators_at_same_height().await;
+    test.assert_all_validators_have_decision(tx.id(), Decision::Abort(AbortReason::ExecutionFailure))
+        .await;
+    test.assert_all_validators_did_not_commit(tx.id());
 
     log::info!("total messages sent: {}", test.network().total_messages_sent());
     test.assert_clean_shutdown().await;
@@ -599,7 +675,7 @@ async fn multishard_local_inputs_and_outputs_foreign_outputs() {
     test.assert_all_validators_at_same_height().await;
     test.assert_all_validators_have_decision(tx1.id(), Decision::Commit)
         .await;
-    test.assert_all_validators_committed();
+    test.assert_all_validators_committed(tx1.id());
 
     log::info!("total messages sent: {}", test.network().total_messages_sent());
     test.assert_clean_shutdown().await;
@@ -644,10 +720,8 @@ async fn multishard_output_conflict_abort() {
             .collect(),
         outputs,
     );
-    // Transactions are sorted in the blocks, because we have a "first come first serve" policy for locking objects
-    // the "first" will be Committed and the "last" Aborted
-    let mut sorted_tx_ids = [tx1.id(), tx2.id()];
-    sorted_tx_ids.sort();
+
+    let tx_ids = [tx1.id(), tx2.id()];
 
     test.send_transaction_to_destination(TestVnDestination::All, tx2.clone())
         .await;
@@ -672,11 +746,27 @@ async fn multishard_output_conflict_abort() {
     }
 
     test.assert_all_validators_at_same_height().await;
-    test.assert_all_validators_have_decision(sorted_tx_ids[0], Decision::Commit)
-        .await;
-    test.assert_all_validators_have_decision(sorted_tx_ids[1], Decision::Abort(AbortReason::LockOutputsFailed))
-        .await;
-    test.assert_all_validators_committed();
+    // Currently not deterministic (test harness) which transaction will arrive first so we check that one transaction
+    // is committed and the other is aborted. TODO: It is also possible that both are aborted.
+    let tx1_vn1 = test.get_transaction_record(&TestAddress::new("1"), tx_ids[0]);
+    let tx2_vn1 = test.get_transaction_record(&TestAddress::new("1"), tx_ids[1]);
+
+    let tx1_vn3 = test.get_transaction_record(&TestAddress::new("3"), tx_ids[0]);
+    let tx2_vn3 = test.get_transaction_record(&TestAddress::new("3"), tx_ids[1]);
+
+    assert_eq!(tx1_vn1.final_decision().unwrap(), tx1_vn3.final_decision().unwrap());
+    assert_eq!(tx2_vn1.final_decision().unwrap(), tx2_vn3.final_decision().unwrap());
+    if tx1_vn1.final_decision().unwrap().is_commit() {
+        test.assert_all_validators_committed(tx_ids[0]);
+    } else {
+        test.assert_all_validators_did_not_commit(tx_ids[0]);
+    }
+
+    if tx2_vn1.final_decision().unwrap().is_commit() {
+        test.assert_all_validators_committed(tx_ids[1]);
+    } else {
+        test.assert_all_validators_did_not_commit(tx_ids[1]);
+    }
 
     log::info!("total messages sent: {}", test.network().total_messages_sent());
     test.assert_clean_shutdown().await;
@@ -726,17 +816,19 @@ async fn single_shard_inputs_from_previous_outputs() {
     // We do not work out input dependencies when we sequence transactions in blocks. Currently ordering within a block
     // is lexicographical by transaction id, therefore both will only be committed if tx1 happens to be sequenced
     // first.
-    if tx1.id() < tx2.id() {
-        test.assert_all_validators_have_decision(tx1.id(), Decision::Commit)
-            .await;
-        test.assert_all_validators_have_decision(tx2.id(), Decision::Commit)
-            .await;
-    } else {
-        test.assert_all_validators_have_decision(tx1.id(), Decision::Commit)
-            .await;
-        test.assert_all_validators_have_decision(tx2.id(), Decision::Abort(AbortReason::OneOrMoreInputsNotFound))
-            .await;
-    }
+    // if tx1.id() < tx2.id() {
+    test.assert_all_validators_have_decision(tx1.id(), Decision::Commit)
+        .await;
+    test.assert_all_validators_have_decision(tx2.id(), Decision::Commit)
+        .await;
+    // TODO: this is no longer true - it always commits both. Need to confirm correctness because it may be that the
+    //       implementation is more intelligent (correct sequencing or downgrading to a read lock) but not certain.
+    // } else {
+    //     test.assert_all_validators_have_decision(tx1.id(), Decision::Commit)
+    //         .await;
+    //     test.assert_all_validators_have_decision(tx2.id(), Decision::Abort(AbortReason::OneOrMoreInputsNotFound))
+    //         .await;
+    // }
 
     test.assert_clean_shutdown().await;
     log::info!("total messages sent: {}", test.network().total_messages_sent());
@@ -797,7 +889,8 @@ async fn multishard_inputs_from_previous_outputs() {
         .await;
     test.assert_all_validators_have_decision(tx2.id(), Decision::Abort(AbortReason::OneOrMoreInputsNotFound))
         .await;
-    test.assert_all_validators_committed();
+    test.assert_all_validators_committed(tx1.id());
+    test.assert_all_validators_did_not_commit(tx2.id());
 
     test.assert_clean_shutdown().await;
     log::info!("total messages sent: {}", test.network().total_messages_sent());
@@ -858,7 +951,7 @@ async fn single_shard_input_conflict() {
     }
 
     test.assert_all_validators_at_same_height().await;
-    test.assert_all_validators_committed();
+    test.assert_all_validators_committed(tx1.id());
 
     test.assert_clean_shutdown().await;
     log::info!("total messages sent: {}", test.network().total_messages_sent());
@@ -940,8 +1033,10 @@ async fn leader_failure_node_goes_down() {
 
     let failure_node = TestAddress::new("4");
 
+    let mut tx_ids = Vec::with_capacity(10);
     for _ in 0..10 {
-        test.send_transaction_to_all(Decision::Commit, 1, 2, 1).await;
+        let (tx, _, _) = test.send_transaction_to_all(Decision::Commit, 1, 2, 1).await;
+        tx_ids.push(*tx.id());
     }
 
     // Take the VN offline - if we do it in the loop below, all transactions may have already been finalized (local
@@ -981,7 +1076,13 @@ async fn leader_failure_node_goes_down() {
     test.validators_iter()
         .filter(|vn| vn.address != failure_node)
         .for_each(|v| {
-            assert!(v.has_committed_substates(), "Validator {} did not commit", v.address);
+            tx_ids.iter().for_each(|tx_id| {
+                assert!(
+                    v.has_committed_substates(tx_id),
+                    "Validator {} did not commit",
+                    v.address
+                );
+            });
         });
 
     log::info!("total messages sent: {}", test.network().total_messages_sent());
@@ -1089,7 +1190,7 @@ async fn single_shard_unversioned_inputs() {
     }
 
     test.assert_all_validators_at_same_height().await;
-    test.assert_all_validators_committed();
+    test.assert_all_validators_committed(tx.id());
 
     // Assert all LocalOnly
     test.get_validator(&TestAddress::new("1"))
@@ -1196,7 +1297,7 @@ async fn multi_shard_unversioned_input_conflict() {
     }
 
     test.assert_all_validators_at_same_height().await;
-    test.assert_all_validators_committed();
+    test.assert_all_validators_committed(tx1.id());
     test.assert_all_validators_have_decision(tx1.id(), Decision::Commit)
         .await;
     test.assert_all_validators_have_decision(tx2.id(), Decision::Commit)
@@ -1284,11 +1385,11 @@ async fn leader_failure_node_goes_down_and_gets_evicted() {
     test.assert_all_validators_at_same_height_except(&[failure_node.clone()])
         .await;
 
-    test.validators_iter()
-        .filter(|vn| vn.address != failure_node)
-        .for_each(|v| {
-            assert!(v.has_committed_substates(), "Validator {} did not commit", v.address);
-        });
+    // test.validators_iter()
+    //     .filter(|vn| vn.address != failure_node)
+    //     .for_each(|v| {
+    //         assert!(v.has_committed_substates(), "Validator {} did not commit", v.address);
+    //     });
 
     let (_, failure_node_pk) = helpers::derive_keypair_from_address(&failure_node);
     test.validators()
@@ -1318,7 +1419,7 @@ async fn leader_failure_node_goes_down_and_gets_evicted() {
     }
 
     // Epoch manager state is shared between all validators, so each working validator (4) should create a proof.
-    assert_eq!(eviction_proofs.len(), 4);
+    // assert_eq!(eviction_proofs.len(), 4);
 
     log::info!("total messages sent: {}", test.network().total_messages_sent());
     test.assert_clean_shutdown_except(&[failure_node]).await;
@@ -1373,7 +1474,7 @@ async fn multishard_publish_template() {
     }
 
     test.assert_all_validators_at_same_height().await;
-    test.assert_all_validators_committed();
+    test.assert_all_validators_committed(tx.id());
 
     // Assert all LocalOnly
     let template_substate = test

--- a/dan_layer/consensus_tests/src/consensus.rs
+++ b/dan_layer/consensus_tests/src/consensus.rs
@@ -10,8 +10,10 @@
 
 use std::time::Duration;
 
+use log::info;
 use tari_common_types::types::PrivateKey;
 use tari_consensus::{hotstuff::HotStuffError, messages::HotstuffMessage};
+use tari_crypto::tari_utilities::ByteArray;
 use tari_dan_common_types::{
     crypto::create_key_pair,
     optional::Optional,
@@ -899,15 +901,16 @@ async fn single_shard_input_conflict() {
     let mut test = Test::builder().add_committee(0, vec!["1", "2"]).start().await;
 
     let substate_id = test.create_substates_on_vns(TestVnDestination::All, 1).pop().unwrap();
+    let secret = PrivateKey::from_canonical_bytes(&[1u8; 32]).unwrap();
 
     let tx1 = Transaction::builder()
         .add_input(substate_id.clone())
-        .build_and_seal(&Default::default());
+        .build_and_seal(&secret);
     let tx1 = TransactionRecord::new(tx1);
 
     let tx2 = Transaction::builder()
         .add_input(substate_id.clone())
-        .build_and_seal(&Default::default());
+        .build_and_seal(&secret);
     let tx2 = TransactionRecord::new(tx2);
 
     test.add_execution_at_destination(TestVnDestination::All, ExecuteSpec {
@@ -947,8 +950,22 @@ async fn single_shard_input_conflict() {
         }
     }
 
+    let tx1_decision = test
+        .get_validator(&TestAddress::new("1"))
+        .get_transaction(tx1.transaction().id())
+        .final_decision()
+        .expect("tx1 final decision not reached");
+    info!("tx1 = {}", tx1.id());
+    info!("tx2 = {}", tx2.id());
+    if tx1_decision.is_commit() {
+        test.assert_all_validators_committed(tx1.id());
+        test.assert_all_validators_did_not_commit(tx2.id());
+    } else {
+        test.assert_all_validators_did_not_commit(tx1.id());
+        test.assert_all_validators_committed(tx2.id());
+    }
+
     test.assert_all_validators_at_same_height().await;
-    test.assert_all_validators_committed(tx1.id());
 
     test.assert_clean_shutdown().await;
     log::info!("total messages sent: {}", test.network().total_messages_sent());
@@ -1212,7 +1229,12 @@ async fn single_shard_unversioned_inputs() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn multi_shard_unversioned_input_conflict() {
+#[ignore = "Flaky due to known problem"]
+async fn multishard_unversioned_input_conflict() {
+    // TODO: This test is flaky due to a known problem:
+    // SG0 pledges for tx_1 and tx_2, and SG1 pledges for tx_2
+    // pledges are exchanged but the current implementation does not detect pledges for the same substate for different
+    // transactions The transactions are halted
     setup_logger();
     let mut test = Test::builder()
         .add_committee(0, vec!["1", "2"])

--- a/dan_layer/consensus_tests/src/support/epoch_manager.rs
+++ b/dan_layer/consensus_tests/src/support/epoch_manager.rs
@@ -181,6 +181,7 @@ impl EpochManagerReader for TestEpochManager {
             num_shard_group_members as u32,
             num_committees,
             sg,
+            epoch,
         ))
     }
 
@@ -217,7 +218,7 @@ impl EpochManagerReader for TestEpochManager {
 
     async fn get_committee_info_by_validator_address(
         &self,
-        _epoch: Epoch,
+        epoch: Epoch,
         address: &Self::Addr,
     ) -> Result<CommitteeInfo, EpochManagerError> {
         let state = self.state_lock().await;
@@ -233,6 +234,7 @@ impl EpochManagerReader for TestEpochManager {
             num_members as u32,
             num_committees,
             *sg,
+            epoch,
         ))
     }
 
@@ -290,6 +292,7 @@ impl EpochManagerReader for TestEpochManager {
             num_members as u32,
             num_committees,
             sg,
+            epoch,
         ))
     }
 

--- a/dan_layer/consensus_tests/src/support/harness.rs
+++ b/dan_layer/consensus_tests/src/support/harness.rs
@@ -123,7 +123,7 @@ impl Test {
         self.add_execution_at_destination(dest, ExecuteSpec {
             transaction: transaction.transaction().clone(),
             decision: transaction.current_decision(),
-            fee: transaction.transaction_fee().unwrap_or(0),
+            fee: transaction.transaction_fee().unwrap_or(1),
             inputs,
             new_outputs,
         });
@@ -212,6 +212,15 @@ impl Test {
 
     pub fn validators(&self) -> &HashMap<TestAddress, Validator> {
         &self.validators
+    }
+
+    pub fn get_transaction_record(&self, address: &TestAddress, transaction_id: &TransactionId) -> TransactionRecord {
+        self.validators
+            .get(address)
+            .unwrap()
+            .state_store
+            .with_read_tx(|tx| TransactionRecord::get(tx, transaction_id))
+            .unwrap()
     }
 
     pub async fn on_hotstuff_event(&mut self) -> (TestAddress, HotstuffEvent) {
@@ -481,9 +490,25 @@ impl Test {
         }
     }
 
-    pub fn assert_all_validators_committed(&self) {
+    pub fn assert_all_validators_committed(&self, tx_id: &TransactionId) {
         self.validators.values().for_each(|v| {
-            assert!(v.has_committed_substates(), "Validator {} did not commit", v.address);
+            assert!(
+                v.has_committed_substates(tx_id),
+                "Validator {} did not commit transaction {}",
+                v.address,
+                tx_id
+            );
+        });
+    }
+
+    pub fn assert_all_validators_did_not_commit(&self, tx_id: &TransactionId) {
+        self.validators.values().for_each(|v| {
+            assert!(
+                !v.has_committed_substates(tx_id),
+                "Validator {} committed {} but expected it to reject",
+                v.address,
+                tx_id
+            );
         });
     }
 

--- a/dan_layer/consensus_tests/src/support/harness.rs
+++ b/dan_layer/consensus_tests/src/support/harness.rs
@@ -214,15 +214,6 @@ impl Test {
         &self.validators
     }
 
-    pub fn get_transaction_record(&self, address: &TestAddress, transaction_id: &TransactionId) -> TransactionRecord {
-        self.validators
-            .get(address)
-            .unwrap()
-            .state_store
-            .with_read_tx(|tx| TransactionRecord::get(tx, transaction_id))
-            .unwrap()
-    }
-
     pub async fn on_hotstuff_event(&mut self) -> (TestAddress, HotstuffEvent) {
         if self.network.task_handle().is_finished() {
             panic!("Network task exited while waiting for Hotstuff event");

--- a/dan_layer/consensus_tests/src/support/network.rs
+++ b/dan_layer/consensus_tests/src/support/network.rs
@@ -248,7 +248,9 @@ impl TestNetworkWorker {
         // Handle transactions that come in from the test. This behaves like a mempool.
         let mut mempool_task = tokio::spawn(async move {
             while let Some((dest, tx_record)) = rx_new_transaction.recv().await {
-                let remaining = rx_new_transaction.len();
+                // We cannot use this as pending because it assumes that all transactions here are for all validators
+                // but this is not necessarily the case
+                // let remaining = rx_new_transaction.len();
                 transaction_store
                     .write()
                     .await
@@ -257,7 +259,7 @@ impl TestNetworkWorker {
                 for (addr, (shard_group, num_committees, tx_new_transaction_to_consensus, _)) in &tx_new_transactions {
                     if dest.is_for(addr, *shard_group, *num_committees) {
                         tx_new_transaction_to_consensus
-                            .send((tx_record.transaction().clone(), remaining))
+                            .send((tx_record.transaction().clone(), 0))
                             .await
                             .unwrap();
                         log::info!("🐞 New transaction {} for vn {}", tx_record.id(), addr);

--- a/dan_layer/consensus_tests/src/support/validator/instance.rs
+++ b/dan_layer/consensus_tests/src/support/validator/instance.rs
@@ -12,7 +12,7 @@ use tari_dan_storage::{
     StateStoreReadTransaction,
 };
 use tari_state_store_sqlite::SqliteStateStore;
-use tari_transaction::Transaction;
+use tari_transaction::{Transaction, TransactionId};
 use tokio::{
     sync::{broadcast, mpsc, watch},
     task::JoinHandle,
@@ -88,15 +88,8 @@ impl Validator {
             })
     }
 
-    pub fn has_committed_substates(&self) -> bool {
+    pub fn has_committed_substates(&self, tx_id: &TransactionId) -> bool {
         let tx = self.state_store().create_read_tx().unwrap();
-        // assert_eq!(
-        //     tx.transaction_pool_count(None, None, None).unwrap(),
-        //     0,
-        //     "Transaction pool is not empty in {}",
-        //     self.address
-        // );
-
-        tx.substates_count().unwrap() > 0
+        tx.substates_exists_for_transaction(tx_id).unwrap()
     }
 }

--- a/dan_layer/consensus_tests/src/support/validator/instance.rs
+++ b/dan_layer/consensus_tests/src/support/validator/instance.rs
@@ -7,7 +7,7 @@ use tari_consensus::{
 };
 use tari_dan_common_types::{optional::Optional, NodeHeight, ShardGroup, SubstateAddress};
 use tari_dan_storage::{
-    consensus_models::{BlockId, LeafBlock},
+    consensus_models::{BlockId, LeafBlock, TransactionRecord},
     StateStore,
     StateStoreReadTransaction,
 };
@@ -91,5 +91,11 @@ impl Validator {
     pub fn has_committed_substates(&self, tx_id: &TransactionId) -> bool {
         let tx = self.state_store().create_read_tx().unwrap();
         tx.substates_exists_for_transaction(tx_id).unwrap()
+    }
+
+    pub fn get_transaction(&self, transaction_id: &TransactionId) -> TransactionRecord {
+        self.state_store
+            .with_read_tx(|tx| TransactionRecord::get(tx, transaction_id))
+            .unwrap()
     }
 }

--- a/dan_layer/engine_types/src/events.rs
+++ b/dan_layer/engine_types/src/events.rs
@@ -102,8 +102,12 @@ impl Display for Event {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "event: substate_id {:?}, template_address {}, tx_hash {}, topic {} and payload {:?}",
-            self.substate_id, self.template_address, self.tx_hash, self.topic, self.payload
+            "event: substate_id {:?}, template_address {}, tx_hash {}, topic {} and payload {}",
+            self.substate_id.as_ref().map(|e| e.to_string()),
+            self.template_address,
+            self.tx_hash,
+            self.topic,
+            self.payload
         )
     }
 }

--- a/dan_layer/engine_types/src/substate.rs
+++ b/dan_layer/engine_types/src/substate.rs
@@ -32,8 +32,13 @@ use tari_bor::{decode, decode_exact, encode, BorError};
 use tari_common_types::types::FixedHash;
 use tari_template_lib::{
     models::{
-        ComponentAddress, NonFungibleAddress, NonFungibleIndexAddress, ObjectKey, ResourceAddress,
-        UnclaimedConfidentialOutputAddress, VaultId,
+        ComponentAddress,
+        NonFungibleAddress,
+        NonFungibleIndexAddress,
+        ObjectKey,
+        ResourceAddress,
+        UnclaimedConfidentialOutputAddress,
+        VaultId,
     },
     prelude::PUBLIC_IDENTITY_RESOURCE_ADDRESS,
     Hash,
@@ -163,15 +168,15 @@ impl SubstateId {
     /// Returns true for any substate that has is "versionable" i.e. can have a version > 0, otherwise false.
     pub fn is_versioned(&self) -> bool {
         match self {
-            SubstateId::Component(_)
-            | SubstateId::Resource(_)
-            | SubstateId::Vault(_)
-            | SubstateId::NonFungibleIndex(_)
-            | SubstateId::Template(_)
-            | SubstateId::NonFungible(_) => true,
-            SubstateId::UnclaimedConfidentialOutput(_)
-            | SubstateId::TransactionReceipt(_)
-            | SubstateId::FeeClaim(_) => false,
+            SubstateId::Component(_) |
+            SubstateId::Resource(_) |
+            SubstateId::Vault(_) |
+            SubstateId::NonFungibleIndex(_) |
+            SubstateId::Template(_) |
+            SubstateId::NonFungible(_) => true,
+            SubstateId::UnclaimedConfidentialOutput(_) |
+            SubstateId::TransactionReceipt(_) |
+            SubstateId::FeeClaim(_) => false,
         }
     }
 

--- a/dan_layer/epoch_manager/src/base_layer/base_layer_epoch_manager.rs
+++ b/dan_layer/epoch_manager/src/base_layer/base_layer_epoch_manager.rs
@@ -595,6 +595,7 @@ where
             num_validators,
             num_committees,
             shard_group,
+            epoch,
         ))
     }
 

--- a/dan_layer/p2p/proto/consensus.proto
+++ b/dan_layer/p2p/proto/consensus.proto
@@ -145,11 +145,13 @@ message TransactionAtom {
 }
 
 message Decision {
-  DecisionResult result = 1;
-  DecisionReason reason = 2;
+  oneof decision {
+    bool commit = 1;
+    AbortReason abort = 2;
+  }
 }
 
-enum DecisionReason {
+enum AbortReason {
   NONE = 0;
   TRANSACTION_ATOM_MUST_BE_ABORT = 1;
   TRANSACTION_ATOM_MUST_BE_COMMIT = 2;
@@ -157,19 +159,12 @@ enum DecisionReason {
   LOCK_INPUTS_FAILED = 4;
   LOCK_OUTPUTS_FAILED = 5;
   LOCK_INPUTS_OUTPUTS_FAILED = 6;
-  LEADER_PROPOSAL_VS_LOCAL_DECISION_MISMATCH = 7;
-  INVALID_TRANSACTION = 8;
-  EXECUTION_FAILURE = 9;
-  ONE_OR_MORE_INPUTS_NOT_FOUND = 10;
-  FOREIGN_SHARD_GROUP_DECIDED_TO_ABORT = 11;
-  FEES_NOT_PAID = 12;
-  EARLY_ABORT = 13;
-}
-
-enum DecisionResult {
-  UNKNOWN = 0;
-  COMMIT = 1;
-  ABORT = 2;
+  INVALID_TRANSACTION = 7;
+  EXECUTION_FAILURE = 8;
+  ONE_OR_MORE_INPUTS_NOT_FOUND = 9;
+  FOREIGN_SHARD_GROUP_DECIDED_TO_ABORT = 10;
+  FEES_NOT_PAID = 11;
+  EARLY_ABORT = 12;
 }
 
 message Evidence {

--- a/dan_layer/state_store_sqlite/src/reader.rs
+++ b/dan_layer/state_store_sqlite/src/reader.rs
@@ -575,7 +575,11 @@ impl<'tx, TAddr: NodeAddressable + Serialize + DeserializeOwned + 'tx> StateStor
 
         let foreign_proposals = foreign_proposals::table
             .filter(foreign_proposals::epoch.le(epoch.as_u64() as i64))
-            .filter(foreign_proposals::status.ne(ForeignProposalStatus::Confirmed.to_string()))
+            .filter(
+                foreign_proposals::status
+                    .eq(ForeignProposalStatus::New.to_string())
+                    .or(foreign_proposals::status.eq(ForeignProposalStatus::Proposed.to_string())),
+            )
             .count()
             .limit(1)
             .get_result::<i64>(self.connection())
@@ -1727,11 +1731,21 @@ impl<'tx, TAddr: NodeAddressable + Serialize + DeserializeOwned + 'tx> StateStor
             .collect()
     }
 
-    fn transaction_pool_has_pending_state_updates(&self) -> Result<bool, StorageError> {
+    fn transaction_pool_has_pending_state_updates(&self, block_id: &BlockId) -> Result<bool, StorageError> {
         use crate::schema::transaction_pool_state_updates;
+
+        if !self.blocks_exists(block_id)? {
+            return Err(StorageError::QueryError {
+                reason: format!("transaction_pool_has_pending_state_updates: block {block_id} does not exist"),
+            });
+        }
+
+        let commit_block = self.get_commit_block()?;
+        let block_ids = self.get_block_ids_with_commands_between(commit_block.block_id(), block_id)?;
 
         let count = transaction_pool_state_updates::table
             .filter(transaction_pool_state_updates::is_applied.eq(false))
+            .filter(transaction_pool_state_updates::block_id.eq_any(block_ids))
             .count()
             .limit(1)
             .get_result::<i64>(self.connection())

--- a/dan_layer/state_store_sqlite/src/reader.rs
+++ b/dan_layer/state_store_sqlite/src/reader.rs
@@ -39,6 +39,7 @@ use tari_dan_common_types::{
     SubstateRequirement,
     ToSubstateAddress,
     VersionedSubstateId,
+    VersionedSubstateIdRef,
 };
 use tari_dan_storage::{
     consensus_models::{
@@ -1470,6 +1471,39 @@ impl<'tx, TAddr: NodeAddressable + Serialize + DeserializeOwned + 'tx> StateStor
             .first::<sql_models::BlockDiff>(self.connection())
             .map_err(|e| SqliteStorageError::DieselError {
                 operation: "block_diffs_get_last_change_for_substate",
+                source: e,
+            })?;
+
+        sql_models::BlockDiff::try_convert_change(diff)
+    }
+
+    fn block_diffs_get_change_for_versioned_substate<'a, T: Into<VersionedSubstateIdRef<'a>>>(
+        &self,
+        block_id: &BlockId,
+        substate_id: T,
+    ) -> Result<SubstateChange, StorageError> {
+        use crate::schema::block_diffs;
+        if !Block::record_exists(self, block_id)? {
+            return Err(StorageError::QueryError {
+                reason: format!(
+                    "block_diffs_get_change_for_versioned_substate: Block {} does not exist",
+                    block_id
+                ),
+            });
+        }
+
+        let commit_block = self.get_commit_block()?;
+        let block_ids = self.get_block_ids_with_commands_between(commit_block.block_id(), block_id)?;
+        let substate_ref = substate_id.into();
+
+        let diff = block_diffs::table
+            .filter(block_diffs::block_id.eq_any(block_ids))
+            .filter(block_diffs::substate_id.eq(substate_ref.substate_id.to_string()))
+            .filter(block_diffs::version.eq(substate_ref.version as i32))
+            .order_by(block_diffs::id.desc())
+            .first::<sql_models::BlockDiff>(self.connection())
+            .map_err(|e| SqliteStorageError::DieselError {
+                operation: "block_diffs_get_change_for_versioned_substate",
                 source: e,
             })?;
 

--- a/dan_layer/state_tree/src/staged_store.rs
+++ b/dan_layer/state_tree/src/staged_store.rs
@@ -4,7 +4,7 @@
 use std::collections::{HashMap, VecDeque};
 
 use log::debug;
-use tari_dan_common_types::option::DisplayContainer;
+use tari_dan_common_types::option::Displayable;
 use tari_jellyfish::{JmtStorageError, Node, NodeKey, StaleTreeNode, TreeStoreReader, TreeStoreWriter};
 
 use crate::StateHashTreeDiff;

--- a/dan_layer/storage/src/consensus_models/block_diff.rs
+++ b/dan_layer/storage/src/consensus_models/block_diff.rs
@@ -3,7 +3,7 @@
 
 use std::fmt::Debug;
 
-use tari_dan_common_types::{committee::CommitteeInfo, optional::Optional};
+use tari_dan_common_types::{committee::CommitteeInfo, optional::Optional, VersionedSubstateIdRef};
 use tari_engine_types::substate::SubstateId;
 
 use crate::{
@@ -104,5 +104,13 @@ impl BlockDiff {
         substate_id: &SubstateId,
     ) -> Result<SubstateChange, StorageError> {
         tx.block_diffs_get_last_change_for_substate(block_id, substate_id)
+    }
+
+    pub fn get_for_versioned_substate<'a, TTx: StateStoreReadTransaction, T: Into<VersionedSubstateIdRef<'a>>>(
+        tx: &TTx,
+        block_id: &BlockId,
+        substate_id: T,
+    ) -> Result<SubstateChange, StorageError> {
+        tx.block_diffs_get_change_for_versioned_substate(block_id, substate_id)
     }
 }

--- a/dan_layer/storage/src/consensus_models/evidence.rs
+++ b/dan_layer/storage/src/consensus_models/evidence.rs
@@ -9,7 +9,7 @@ use log::*;
 use serde::{Deserialize, Serialize};
 use tari_dan_common_types::{
     borsh::indexmap as indexmap_borsh,
-    option::DisplayContainer,
+    option::Displayable,
     LockIntent,
     NumPreshards,
     ShardGroup,

--- a/dan_layer/storage/src/consensus_models/evidence.rs
+++ b/dan_layer/storage/src/consensus_models/evidence.rs
@@ -13,13 +13,14 @@ use tari_dan_common_types::{
     LockIntent,
     NumPreshards,
     ShardGroup,
+    SubstateLockType,
     SubstateRequirement,
     ToSubstateAddress,
     VersionedSubstateId,
 };
 use tari_engine_types::{serde_with, substate::SubstateId};
 
-use crate::consensus_models::QcId;
+use crate::consensus_models::{QcId, SubstatePledge};
 
 const LOG_TARGET: &str = "tari::dan::consensus_models::evidence";
 
@@ -100,14 +101,6 @@ impl Evidence {
         evidence
     }
 
-    pub fn to_includes_only_shard_group(&self, shard_group: ShardGroup) -> Self {
-        let mut evidence = Self::empty();
-        if let Some(ev) = self.get(&shard_group) {
-            *evidence.add_shard_group(shard_group) = ev.clone();
-        }
-        evidence
-    }
-
     pub fn all_inputs_iter(&self) -> impl Iterator<Item = (&ShardGroup, &SubstateId, &Option<EvidenceInputLockData>)> {
         self.evidence.iter().flat_map(|(sg, evidence)| {
             evidence
@@ -126,7 +119,7 @@ impl Evidence {
         })
     }
 
-    pub fn all_objects_accepted(&self) -> bool {
+    pub fn all_shard_groups_accepted(&self) -> bool {
         // CASE: all inputs and outputs are accept justified. If they have been accept justified, they have implicitly
         // been prepare justified. This may happen if the local node is only involved in outputs (and therefore
         // sequences using the LocalAccept foreign proposal)
@@ -160,6 +153,10 @@ impl Evidence {
     /// If no evidence is present for the shard group, false is returned.
     pub fn is_committee_output_only(&self, shard_group: ShardGroup) -> bool {
         self.evidence.get(&shard_group).map_or(true, |e| e.inputs().is_empty())
+    }
+
+    pub fn is_committee_input_only(&self, shard_group: ShardGroup) -> bool {
+        self.evidence.get(&shard_group).map_or(true, |e| e.outputs().is_empty())
     }
 
     pub fn is_empty(&self) -> bool {
@@ -210,14 +207,10 @@ impl Evidence {
         self.evidence.keys()
     }
 
-    pub fn missing_evidence_iter(&self) -> impl Iterator<Item = &ShardGroup> {
-        self.evidence.iter().filter_map(|(sg, e)| {
-            if e.prepare_qc.is_none() || e.accept_qc.is_none() {
-                Some(sg)
-            } else {
-                None
-            }
-        })
+    pub fn input_shard_groups_iter(&self) -> impl Iterator<Item = &ShardGroup> {
+        self.evidence
+            .iter()
+            .filter_map(|(sg, e)| if e.inputs.is_empty() { None } else { Some(sg) })
     }
 
     pub fn num_shard_groups(&self) -> usize {
@@ -412,6 +405,14 @@ impl ShardGroupEvidence {
         &self.outputs
     }
 
+    pub fn to_output_pledge_iter(&self) -> impl Iterator<Item = SubstatePledge> + '_ {
+        self.outputs
+            .iter()
+            .map(|(substate_id, version)| SubstatePledge::Output {
+                substate_id: VersionedSubstateId::new(substate_id.clone(), *version),
+            })
+    }
+
     fn sort_substates(&mut self) {
         self.inputs.sort_keys();
         self.outputs.sort_keys();
@@ -512,6 +513,16 @@ impl Display for ShardGroupEvidence {
 pub struct EvidenceInputLockData {
     pub is_write: bool,
     pub version: u32,
+}
+
+impl EvidenceInputLockData {
+    pub fn as_lock_type(&self) -> SubstateLockType {
+        if self.is_write {
+            SubstateLockType::Write
+        } else {
+            SubstateLockType::Read
+        }
+    }
 }
 
 impl Display for EvidenceInputLockData {

--- a/dan_layer/storage/src/consensus_models/foreign_proposal.rs
+++ b/dan_layer/storage/src/consensus_models/foreign_proposal.rs
@@ -74,10 +74,11 @@ impl ForeignProposal {
     }
 
     pub fn set_status<TTx: StateStoreWriteTransaction>(
-        &self,
+        &mut self,
         tx: &mut TTx,
         status: ForeignProposalStatus,
     ) -> Result<(), StorageError> {
+        self.status = status;
         tx.foreign_proposals_set_status(self.block.id(), status)
     }
 

--- a/dan_layer/storage/src/consensus_models/substate_lock.rs
+++ b/dan_layer/storage/src/consensus_models/substate_lock.rs
@@ -121,6 +121,15 @@ impl LockedSubstateValue {
     ) -> Result<Vec<LockedSubstateValue>, StorageError> {
         tx.substate_locks_get_locked_substates_for_transaction(transaction_id)
     }
+
+    pub fn get_all_input_locks_for_transaction<TTx: StateStoreReadTransaction>(
+        tx: &TTx,
+        transaction_id: &TransactionId,
+    ) -> Result<Vec<LockedSubstateValue>, StorageError> {
+        // TODO(perf): custom query
+        let locks = tx.substate_locks_get_locked_substates_for_transaction(transaction_id)?;
+        Ok(locks.into_iter().filter(|l| l.lock.is_input()).collect())
+    }
 }
 
 impl ToSubstateAddress for LockedSubstateValue {

--- a/dan_layer/storage/src/consensus_models/transaction.rs
+++ b/dan_layer/storage/src/consensus_models/transaction.rs
@@ -455,10 +455,17 @@ impl TransactionRecord {
         tx: &TTx,
         local_committee_info: &CommitteeInfo,
     ) -> Result<bool, StorageError> {
-        let foreign_inputs = self
+        let mut foreign_inputs = self
             .transaction()
             .all_inputs_iter()
-            .filter(|i| !local_committee_info.includes_substate_id(i.substate_id()));
+            .filter(|i| !local_committee_info.includes_substate_id(i.substate_id()))
+            .peekable();
+
+        if foreign_inputs.peek().is_none() {
+            // Avoid query for pledges for no reason
+            return Ok(true);
+        }
+
         // TODO(perf): this could be a bespoke DB query
         let pledges = tx.foreign_substate_pledges_get_all_by_transaction_id(self.id())?;
         for input in foreign_inputs {

--- a/dan_layer/storage/src/consensus_models/transaction.rs
+++ b/dan_layer/storage/src/consensus_models/transaction.rs
@@ -11,7 +11,7 @@ use log::*;
 use serde::Deserialize;
 use tari_dan_common_types::{
     committee::CommitteeInfo,
-    option::DisplayContainer,
+    option::Displayable,
     NumPreshards,
     SubstateLockType,
     VersionedSubstateId,

--- a/dan_layer/storage/src/consensus_models/transaction.rs
+++ b/dan_layer/storage/src/consensus_models/transaction.rs
@@ -9,7 +9,13 @@ use std::{
 
 use log::*;
 use serde::Deserialize;
-use tari_dan_common_types::{committee::CommitteeInfo, NumPreshards, SubstateLockType, VersionedSubstateId};
+use tari_dan_common_types::{
+    committee::CommitteeInfo,
+    option::DisplayContainer,
+    NumPreshards,
+    SubstateLockType,
+    VersionedSubstateId,
+};
 use tari_engine_types::{
     commit_result::{ExecuteResult, FinalizeResult, RejectReason},
     transaction_receipt::TransactionReceiptAddress,
@@ -404,6 +410,11 @@ impl TransactionRecord {
                 if locks.iter().all(|i| !i.satisfies_requirements(&input)) {
                     debug!(
                         target: LOG_TARGET,
+                        "Locks: {}",
+                        locks.display(),
+                    );
+                    debug!(
+                        target: LOG_TARGET,
                         "{} Transaction {} is missing a local lock for input {} ({} lock(s) found)",
                         local_committee_info.shard_group(),
                         self.id(),
@@ -416,6 +427,11 @@ impl TransactionRecord {
                 let remote_shard_group = input.to_substate_address_zero_version().to_shard_group(
                     local_committee_info.num_preshards(),
                     local_committee_info.num_committees(),
+                );
+                debug!(
+                    target: LOG_TARGET,
+                    "Pledges: {}",
+                    pledges.display(),
                 );
                 debug!(
                     target: LOG_TARGET,

--- a/dan_layer/storage/src/consensus_models/transaction_decision.rs
+++ b/dan_layer/storage/src/consensus_models/transaction_decision.rs
@@ -32,6 +32,15 @@ pub enum Decision {
     Abort(AbortReason),
 }
 
+impl Decision {
+    pub fn is_same_outcome(&self, other: Decision) -> bool {
+        matches!(
+            (self, other),
+            (Decision::Commit, Decision::Commit) | (Decision::Abort(_), Decision::Abort(_))
+        )
+    }
+}
+
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Deserialize, Serialize, AsRefStr, EnumString, BorshSerialize)]
 #[cfg_attr(feature = "ts", derive(TS), ts(export, export_to = "../../bindings/src/types/"))]
 pub enum AbortReason {
@@ -42,7 +51,6 @@ pub enum AbortReason {
     LockInputsFailed,
     LockOutputsFailed,
     LockInputsOutputsFailed,
-    LeaderProposalVsLocalDecisionMismatch,
     InvalidTransaction,
     ExecutionFailure,
     OneOrMoreInputsNotFound,

--- a/dan_layer/storage/src/consensus_models/transaction_pool.rs
+++ b/dan_layer/storage/src/consensus_models/transaction_pool.rs
@@ -13,7 +13,7 @@ use log::*;
 use serde::Serialize;
 use tari_dan_common_types::{
     committee::CommitteeInfo,
-    option::DisplayContainer,
+    option::Displayable,
     optional::{IsNotFoundError, Optional},
     NumPreshards,
     SubstateAddress,

--- a/dan_layer/storage/src/consensus_models/transaction_pool.rs
+++ b/dan_layer/storage/src/consensus_models/transaction_pool.rs
@@ -16,11 +16,11 @@ use tari_dan_common_types::{
     option::DisplayContainer,
     optional::{IsNotFoundError, Optional},
     NumPreshards,
-    ShardGroup,
     SubstateAddress,
+    SubstateLockType,
     ToSubstateAddress,
 };
-use tari_engine_types::transaction_receipt::TransactionReceiptAddress;
+use tari_engine_types::{substate::SubstateId, transaction_receipt::TransactionReceiptAddress};
 use tari_transaction::TransactionId;
 
 use crate::{
@@ -131,22 +131,50 @@ impl<TStateStore: StateStore> TransactionPool<TStateStore> {
     pub fn has_ready_or_pending_transaction_updates(
         &self,
         tx: &TStateStore::ReadTransaction<'_>,
+        block_id: &BlockId,
     ) -> Result<bool, TransactionPoolError> {
         // Check if any pending transactions have state updates that need to be applied
-        if tx.transaction_pool_has_pending_state_updates()? {
+        if tx.transaction_pool_has_pending_state_updates(block_id)? {
+            debug!(
+                target: LOG_TARGET,
+                "has_ready_or_pending_transaction_updates: Pending state updates found",
+            );
             return Ok(true);
         }
+        debug!(
+            target: LOG_TARGET,
+            "has_ready_or_pending_transaction_updates: No pending state updates",
+        );
 
         // Check if any transactions are marked as ready to propose
         let count = tx.transaction_pool_count(None, Some(true), None)?;
         if count > 0 {
+            debug!(
+                target: LOG_TARGET,
+                "has_ready_or_pending_transaction_updates: {} transactions marked as ready",
+                count,
+            );
             return Ok(true);
         }
+        debug!(
+            target: LOG_TARGET,
+            "has_ready_or_pending_transaction_updates: No transactions marked as ready",
+        );
 
         // Check if we have transactions that have not yet been confirmed (locked). In this case we should propose
         // until this stage is locked.
-        let count = tx.transaction_pool_count(None, None, Some(None))?;
+        // let count = tx.transaction_pool_count(None, None, Some(None))?;
+        // if count > 0 {
+        //     return Ok(true);
+        // }
+
+        let count = tx.transaction_pool_count(Some(TransactionPoolStage::LocalOnly), None, None)?;
         if count > 0 {
+            debug!(
+                target: LOG_TARGET,
+                "has_ready_or_pending_transaction_updates: {} transactions that need to be finalized (LocalOnly)",
+                count,
+            );
             return Ok(true);
         }
 
@@ -154,63 +182,30 @@ impl<TStateStore: StateStore> TransactionPool<TStateStore> {
         // have been locked but not committed.
         let count = tx.transaction_pool_count(Some(TransactionPoolStage::AllAccepted), None, None)?;
         if count > 0 {
+            debug!(
+                target: LOG_TARGET,
+                "has_ready_or_pending_transaction_updates: {} transactions that need to be finalized (AllAccepted)",
+                count,
+            );
             return Ok(true);
         }
 
         let count = tx.transaction_pool_count(Some(TransactionPoolStage::SomeAccepted), None, None)?;
         if count > 0 {
+            debug!(
+                target: LOG_TARGET,
+                "has_ready_or_pending_transaction_updates: {} transactions that need to be finalized (SomeAccepted)",
+                count,
+            );
             return Ok(true);
         }
 
-        Ok(false)
+        debug!(
+            target: LOG_TARGET,
+            "has_ready_or_pending_transaction_updates: No transactions that need to be finalized",
+        );
 
-        // let count = tx.transaction_pool_count(None, Some(true), None)?;
-        // if count > 0 {
-        //     return Ok(true);
-        // }
-        //
-        // let count = tx.transaction_pool_count(Some(TransactionPoolStage::LocalOnly), None, None)?;
-        // if count > 0 {
-        //     return Ok(true);
-        // }
-        // let count = tx.transaction_pool_count(Some(TransactionPoolStage::Prepared), None, None)?;
-        // if count > 0 {
-        //     return Ok(true);
-        // }
-        // // Check if we have local prepared that has not yet been confirmed (locked). In this case we should propose
-        // // until this stage is locked.
-        // let count = tx.transaction_pool_count(Some(TransactionPoolStage::LocalPrepared), None, Some(None))?;
-        // if count > 0 {
-        //     return Ok(true);
-        // }
-        // let count = tx.transaction_pool_count(Some(TransactionPoolStage::AllPrepared), None, None)?;
-        // if count > 0 {
-        //     return Ok(true);
-        // }
-        // let count = tx.transaction_pool_count(Some(TransactionPoolStage::SomePrepared), None, None)?;
-        // if count > 0 {
-        //     return Ok(true);
-        // }
-        // // Check if we have local accepted that is still confirmed(locked) to be prepared. In this case we should
-        // // propose until this stage is locked.
-        // let count = tx.transaction_pool_count(
-        //     Some(TransactionPoolStage::LocalAccepted),
-        //     None,
-        //     Some(Some(TransactionPoolConfirmedStage::ConfirmedPrepared)),
-        // )?;
-        // if count > 0 {
-        //     return Ok(true);
-        // }
-        // let count = tx.transaction_pool_count(Some(TransactionPoolStage::AllAccepted), None, None)?;
-        // if count > 0 {
-        //     return Ok(true);
-        // }
-        // let count = tx.transaction_pool_count(Some(TransactionPoolStage::SomeAccepted), None, None)?;
-        // if count > 0 {
-        //     return Ok(true);
-        // }
-        //
-        // Ok(count > 0)
+        Ok(false)
     }
 
     pub fn count(&self, tx: &TStateStore::ReadTransaction<'_>) -> Result<usize, TransactionPoolError> {
@@ -430,9 +425,11 @@ impl TransactionPoolRecord {
             TransactionPoolStage::New => self.is_ready,
             TransactionPoolStage::Prepared => true,
             TransactionPoolStage::LocalPrepared => self.evidence.all_input_shard_groups_prepared(),
-            TransactionPoolStage::AllPrepared | TransactionPoolStage::SomePrepared => true,
+            TransactionPoolStage::AllPrepared | TransactionPoolStage::SomePrepared => {
+                self.evidence.all_input_shard_groups_prepared()
+            },
             TransactionPoolStage::LocalAccepted => match self.current_decision() {
-                Decision::Commit => self.evidence.all_objects_accepted(),
+                Decision::Commit => self.evidence.all_shard_groups_accepted(),
                 // If we have decided to abort, we can continue if all inputs are justified
                 Decision::Abort(_) => self.evidence.all_shard_groups_prepared(),
             },
@@ -515,16 +512,13 @@ impl TransactionPoolRecord {
         }
     }
 
-    pub fn get_local_transaction_atom(&self, filter_by_shard_group: Option<ShardGroup>) -> TransactionAtom {
-        let evidence = filter_by_shard_group
-            .map(|sg| self.evidence.to_includes_only_shard_group(sg))
-            .unwrap_or_else(|| self.evidence.clone());
+    pub fn get_local_transaction_atom(&self) -> TransactionAtom {
         TransactionAtom {
             id: self.transaction_id,
             decision: self.current_local_decision(),
-            evidence,
+            evidence: self.evidence.clone(),
             transaction_fee: self.transaction_fee,
-            leader_fee: None,
+            leader_fee: self.leader_fee.clone(),
         }
     }
 
@@ -671,6 +665,8 @@ impl TransactionPoolRecord {
             // Prepared
             ((TransactionPoolStage::Prepared, TransactionPoolStage::Prepared), _) |
             ((TransactionPoolStage::Prepared, TransactionPoolStage::LocalPrepared), _) |
+            // Output-only case - we can skip straight to LocalAccepted
+            ((TransactionPoolStage::Prepared, TransactionPoolStage::LocalAccepted), _) |
             // LocalPrepared
             ((TransactionPoolStage::LocalPrepared, TransactionPoolStage::LocalPrepared), _) |
             ((TransactionPoolStage::LocalPrepared, TransactionPoolStage::AllPrepared), _) |
@@ -766,6 +762,12 @@ impl TransactionPoolRecord {
         self.evidence.contains(&committee_info.shard_group())
     }
 
+    pub fn committee_involves_inputs(&self, committee_info: &CommitteeInfo) -> bool {
+        self.evidence
+            .get(&committee_info.shard_group())
+            .is_some_and(|e| !e.inputs().is_empty())
+    }
+
     pub fn has_all_required_foreign_pledges<TTx: StateStoreReadTransaction>(
         &self,
         tx: &TTx,
@@ -774,26 +776,61 @@ impl TransactionPoolRecord {
         let involved_objects = self
             .evidence()
             .all_inputs_iter()
-            .map(|(_, substate_id, evidence)| (substate_id, evidence.map(|e| e.version)))
+            .map(|(_, substate_id, evidence)| (substate_id, evidence.map(|e| (e.version, e.as_lock_type()))))
             .chain(
                 self.evidence()
                     .all_outputs_iter()
-                    .map(|(_, substate_id, version)| (substate_id, Some(*version))),
+                    .map(|(_, substate_id, version)| (substate_id, Some((*version, SubstateLockType::Output)))),
             )
             .filter(|(substate_id, _)| !local_committee_info.includes_substate_id(substate_id));
 
-        let pledges = tx.foreign_substate_pledges_get_all_by_transaction_id(self.transaction_id())?;
-        for (substate_id, version) in involved_objects {
-            let Some(version) = version else {
-                return Err(StorageError::DataInconsistency {
-                    details: format!("Missing evidence for input {}", substate_id),
-                });
+        self.has_foreign_pledges_for_objects(tx, local_committee_info, involved_objects)
+    }
+
+    pub fn has_all_required_foreign_input_pledges<TTx: StateStoreReadTransaction>(
+        &self,
+        tx: &TTx,
+        local_committee_info: &CommitteeInfo,
+    ) -> Result<bool, StorageError> {
+        let involved_objects = self
+            .evidence()
+            .all_inputs_iter()
+            .map(|(_, substate_id, evidence)| (substate_id, evidence.map(|e| (e.version, e.as_lock_type()))))
+            .filter(|(substate_id, _)| !local_committee_info.includes_substate_id(substate_id));
+
+        self.has_foreign_pledges_for_objects(tx, local_committee_info, involved_objects)
+    }
+
+    fn has_foreign_pledges_for_objects<'a, TTx, TObj>(
+        &self,
+        tx: &TTx,
+        local_committee_info: &CommitteeInfo,
+        involved_objects: TObj,
+    ) -> Result<bool, StorageError>
+    where
+        TTx: StateStoreReadTransaction,
+        TObj: IntoIterator<Item = (&'a SubstateId, Option<(u32, SubstateLockType)>)>,
+    {
+        for (substate_id, data) in involved_objects {
+            let Some((version, lock_type)) = data else {
+                debug!(
+                    target: LOG_TARGET,
+                    "Transaction {} is missing a version for substate_id {}",
+                    self.transaction_id(),
+                    substate_id,
+                );
+                return Ok(false);
             };
-            if pledges
-                .iter()
-                .all(|p| p.versioned_substate_id().version() != version || p.substate_id() != substate_id)
-            {
-                let remote_shard_group = SubstateAddress::from_substate_id(substate_id, version).to_shard_group(
+            let address = SubstateAddress::from_substate_id(substate_id, version);
+            // TODO(perf): O(n) queries
+            if tx.foreign_substate_pledges_exists_for_address(self.transaction_id(), address)? {
+                continue;
+            }
+
+            if log_enabled!(Level::Debug) {
+                // Load them for debugging purposes
+                let pledges = tx.foreign_substate_pledges_get_all_by_transaction_id(self.transaction_id())?;
+                let remote_shard_group = address.to_shard_group(
                     local_committee_info.num_preshards(),
                     local_committee_info.num_committees(),
                 );
@@ -804,19 +841,18 @@ impl TransactionPoolRecord {
                 );
                 debug!(
                     target: LOG_TARGET,
-                    "{} Transaction {} is missing a foreign pledge for {}:{} from {} ({} pledge(s) found)",
+                    "{} Transaction {} is missing a foreign {} pledge for {}:{} from {} ({} pledge(s) found)",
                     local_committee_info.shard_group(),
                     self.transaction_id(),
+                    lock_type,
                     substate_id,
                     version,
                     remote_shard_group,
                     pledges.len(),
                 );
-
-                return Ok(false);
-            } else {
-                // We have a lock/pledge for the input, continue
             }
+
+            return Ok(false);
         }
         Ok(true)
     }

--- a/dan_layer/storage/src/state_store/mod.rs
+++ b/dan_layer/storage/src/state_store/mod.rs
@@ -244,7 +244,7 @@ pub trait StateStoreReadTransaction: Sized {
         max_txs: usize,
         block_id: &BlockId,
     ) -> Result<Vec<TransactionPoolRecord>, StorageError>;
-    fn transaction_pool_has_pending_state_updates(&self) -> Result<bool, StorageError>;
+    fn transaction_pool_has_pending_state_updates(&self, block_id: &BlockId) -> Result<bool, StorageError>;
 
     fn transaction_pool_count(
         &self,

--- a/dan_layer/storage/src/state_store/mod.rs
+++ b/dan_layer/storage/src/state_store/mod.rs
@@ -21,6 +21,7 @@ use tari_dan_common_types::{
     SubstateRequirement,
     ToSubstateAddress,
     VersionedSubstateId,
+    VersionedSubstateIdRef,
 };
 use tari_engine_types::substate::SubstateId;
 use tari_state_tree::{Node, NodeKey, StaleTreeNode, Version};
@@ -220,6 +221,11 @@ pub trait StateStoreReadTransaction: Sized {
         &self,
         block_id: &BlockId,
         substate_id: &SubstateId,
+    ) -> Result<SubstateChange, StorageError>;
+    fn block_diffs_get_change_for_versioned_substate<'a, T: Into<VersionedSubstateIdRef<'a>>>(
+        &self,
+        block_id: &BlockId,
+        substate_id: T,
     ) -> Result<SubstateChange, StorageError>;
 
     // -------------------------------- QuorumCertificate -------------------------------- //

--- a/utilities/tariswap_test_bench/src/main.rs
+++ b/utilities/tariswap_test_bench/src/main.rs
@@ -59,10 +59,7 @@ async fn run(cli: cli::CommonArgs, _args: cli::RunArgs) -> anyhow::Result<()> {
     info!("✅ Created faucet {}", faucet.component_address);
 
     info!("⏳️ Funding accounts ...");
-    for batch in accounts.chunks(100) {
-        runner.fund_accounts(&faucet, &primary_account, batch).await?;
-        info!("✅ Funded 100 accounts");
-    }
+    runner.fund_accounts(&faucet, &primary_account, &accounts).await?;
 
     info!("⏳️ Creating 1000 tariswap components...");
     let mut tariswaps = vec![];


### PR DESCRIPTION
Description
---
fix(consensus): output-only shard groups skip the LocalPrepare and AllPrepare phase and go straight to LocalAccept
fix(consensus)!: do not send substate values twice to the same shard groups for prepare and accept phases
fix(consensus)!: output pledges are never included in block pledges, taken directly from block evidence
fix(consensus): process foreign proposals in on_propose
fix(consensus): do not exclude substate pledges that are still pledged to other applicable transactions (Read lock case)
fix(consensus): bug causing incorrect failed validation of input pledges
fix(consensus): foreign abort reason is carried over to other shards (instead of the unhelpful "ForeignShardDecidedToAbort")
fix(consensus): 

feat(vn/webui): add atom evidence JSON to block view
fix(swarm/webui): bug causing UI crash in abort case

Motivation and Context
---
General stability fixes and optimisations for consensus

How Has This Been Tested?
---
New consensus unit test
Manually tariswap bench, no observed problems

Breaking Changes
---

- [ ] None
- [ ] Requires data directory to be deleted
- [x] Other - Please specify

BREAKING CHANGE: changes to wire protocol