### PR TITLE
fix: cucumber test for events, remove resource event

### DIFF
--- a/dan_layer/engine/src/runtime/error.rs
+++ b/dan_layer/engine/src/runtime/error.rs
@@ -244,8 +244,8 @@ pub enum RuntimeError {
     #[error("Address allocation type mismatch: {address}")]
     AddressAllocationTypeMismatch { address: SubstateId },
 
-    #[error("Invalid event topic {topic}")]
-    InvalidEventTopic { topic: String },
+    #[error("Invalid event topic '{topic}': 'std' prefix is reserved for built-in events")]
+    InvalidEventTopicStdPrefix { topic: String },
 
     #[error("Numeric conversion error: {details}")]
     NumericConversionError { details: String },

--- a/dan_layer/engine/src/runtime/tracker.rs
+++ b/dan_layer/engine/src/runtime/tracker.rs
@@ -196,11 +196,12 @@ impl StateTracker {
 
             state.new_substate(substate_id.clone(), SubstateValue::Component(component))?;
 
-            state.push_event(Event::new(
+            state.push_event(Event::std(
                 Some(substate_id),
                 template_address,
                 state.transaction_hash(),
-                "component-created".to_string(),
+                "component",
+                "created",
                 Metadata::from([("module_name".to_string(), module_name)]),
             ));
 

--- a/dan_layer/engine/src/runtime/working_state.rs
+++ b/dan_layer/engine/src/runtime/working_state.rs
@@ -203,11 +203,12 @@ impl WorkingState {
 
         // add event to indicate that there is a change in component
         let (template_address, module_name) = self.current_template().map(|(addr, name)| (*addr, name.to_string()))?;
-        self.push_event(Event::new(
+        self.push_event(Event::std(
             Some(locked.address().clone()),
             template_address,
             self.transaction_hash(),
-            "std.component.updated".to_string(),
+            "component",
+            "updated",
             tari_template_lib::models::Metadata::from([("module_name".to_string(), module_name)]),
         ));
 

--- a/dan_layer/engine/tests/events.rs
+++ b/dan_layer/engine/tests/events.rs
@@ -49,7 +49,7 @@ fn cannot_use_standard_topic() {
             .build_and_seal(&private_key),
         [].into(),
     );
-    assert_reject_reason(reason, RuntimeError::InvalidEventTopic {
+    assert_reject_reason(reason, RuntimeError::InvalidEventTopicStdPrefix {
         topic: invalid_topic.to_owned(),
     });
 }

--- a/dan_layer/engine_types/src/events.rs
+++ b/dan_layer/engine_types/src/events.rs
@@ -32,6 +32,13 @@ use ts_rs::TS;
 
 use crate::{serde_with, substate::SubstateId};
 
+// Topics for builtin events emitted by the engine
+const STANDARD_TOPIC_PREFIX: &str = "std.";
+
+fn std_event(object_name: &str, action_name: &str) -> String {
+    format!("{}{}.{}", STANDARD_TOPIC_PREFIX, object_name, action_name)
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[cfg_attr(feature = "ts", derive(TS), ts(export, export_to = "../../bindings/src/types/"))]
 pub struct Event {
@@ -63,6 +70,27 @@ impl Event {
             topic,
             payload,
         }
+    }
+
+    pub fn std(
+        substate_id: Option<SubstateId>,
+        template_address: TemplateAddress,
+        tx_hash: Hash,
+        object_name: &str,
+        action_name: &str,
+        payload: Metadata,
+    ) -> Self {
+        Self::new(
+            substate_id,
+            template_address,
+            tx_hash,
+            std_event(object_name, action_name),
+            payload,
+        )
+    }
+
+    pub fn topic_has_std_prefix<T: AsRef<str>>(topic: T) -> bool {
+        topic.as_ref().starts_with(STANDARD_TOPIC_PREFIX)
     }
 
     pub fn substate_id(&self) -> Option<&SubstateId> {

--- a/dan_layer/template_lib/src/models/metadata.rs
+++ b/dan_layer/template_lib/src/models/metadata.rs
@@ -106,6 +106,14 @@ impl IntoIterator for Metadata {
     }
 }
 
+impl<K: ToString, V: Into<String>> FromIterator<(K, V)> for Metadata {
+    fn from_iter<I: IntoIterator<Item = (K, V)>>(iter: I) -> Self {
+        Self(BorTag::new(
+            iter.into_iter().map(|(k, v)| (k.to_string(), v.into())).collect(),
+        ))
+    }
+}
+
 impl Default for Metadata {
     fn default() -> Self {
         Self::new()

--- a/integration_tests/tests/features/indexer.feature
+++ b/integration_tests/tests/features/indexer.feature
@@ -82,7 +82,7 @@ Feature: Indexer node
 #    Then the indexer IDX returns 6 non fungibles for resource NFT/resources/0
 
     # Scan the network for the event emitted on ACC creation
-    When indexer IDX scans the network events for account ACC with topics component-created,pay_fee,pay_fee,pay_fee,pay_fee,pay_fee,pay_fee,pay_fee,deposit,component-created,pay_fee,pay_fee,deposit,deposit,deposit,deposit,deposit,deposit
+    When indexer IDX scans the network events for account ACC with topics std.component.created,pay_fee,pay_fee,pay_fee,pay_fee,pay_fee,pay_fee,pay_fee,deposit,std.component.updated,std.component.created,pay_fee,pay_fee,deposit,std.component.updated,deposit,deposit,deposit,deposit,deposit
 
   Scenario: Indexer GraphQL requests work
     # Initialize a base node, wallet, miner and VN
@@ -121,10 +121,10 @@ Feature: Indexer node
 
     ##### Scenario
     # Scan the network for the event emitted on ACC_1 creation
-    When indexer IDX scans the network events for account ACC_1 with topics component-created,pay_fee,component-created,pay_fee
+    When indexer IDX scans the network events for account ACC_1 with topics std.component.created,pay_fee,std.component.created,pay_fee
 
     # Scan the network for the event emitted on ACC_2 creation
-    When indexer IDX scans the network events for account ACC_2 with topics component-created,pay_fee,component-created,pay_fee
+    When indexer IDX scans the network events for account ACC_2 with topics std.component.created,pay_fee,std.component.created,pay_fee
 
   Scenario: Indexer GraphQL filtering and pagination of events
 


### PR DESCRIPTION
Description
---
fix: failing cucumber
remove resource events for every vault withdraw/deposit

Motivation and Context
---
When a vault deposit/withdraw occurs we used to emit an event for the resource. This results in extra data that may not be useful. If we do need this, we should perhaps make it an option on the resource. For the time being, it's easier to add something later when we know that we need it and nothing currently relies on it, than to remove it later and hope that it doesn't break anything, so it is removed here. It is worth noting that an indexer can locally infer this event based on the vault event, thereby still allowing deposits by resource to be searched.

How Has This Been Tested?
---
CI

What process can a PR reviewer use to test or verify this change?
---


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify