### PR TITLE
feat(consensus): skip to local accept phase for aborted transactions

### DIFF
--- a/applications/tari_validator_node_web_ui/src/routes/Transactions/TransactionDetails.tsx
+++ b/applications/tari_validator_node_web_ui/src/routes/Transactions/TransactionDetails.tsx
@@ -22,7 +22,6 @@
 
 import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
-// import { transactionsGet } from '../../utils/json_rpc';
 import { Accordion, AccordionDetails, AccordionSummary } from "../../Components/Accordion";
 import { Alert, Button, Fade, Grid, Table, TableBody, TableCell, TableContainer, TableRow } from "@mui/material";
 import Typography from "@mui/material/Typography";
@@ -30,7 +29,6 @@ import { DataTableCell, StyledPaper } from "../../Components/StyledComponents";
 import PageHeading from "../../Components/PageHeading";
 import Events from "./Events";
 import Logs from "./Logs";
-import FeeInstructions from "./FeeInstructions";
 import Instructions from "./Instructions";
 import Substates from "./Substates";
 import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";

--- a/dan_layer/common_types/src/versioned_substate_id.rs
+++ b/dan_layer/common_types/src/versioned_substate_id.rs
@@ -175,6 +175,49 @@ impl Borrow<SubstateId> for SubstateRequirement {
     }
 }
 
+#[derive(Debug, Clone, Copy)]
+pub struct SubstateRequirementRef<'a> {
+    pub substate_id: &'a SubstateId,
+    pub version: Option<u32>,
+}
+
+impl<'a> SubstateRequirementRef<'a> {
+    pub fn new(substate_id: &'a SubstateId, version: Option<u32>) -> Self {
+        Self { substate_id, version }
+    }
+
+    pub fn to_owned(&self) -> SubstateRequirement {
+        SubstateRequirement::new(self.substate_id.clone(), self.version)
+    }
+}
+
+impl<'a> From<&'a VersionedSubstateId> for SubstateRequirementRef<'a> {
+    fn from(value: &'a VersionedSubstateId) -> Self {
+        Self {
+            substate_id: &value.substate_id,
+            version: Some(value.version),
+        }
+    }
+}
+
+impl<'a> From<&'a SubstateRequirement> for SubstateRequirementRef<'a> {
+    fn from(value: &'a SubstateRequirement) -> Self {
+        Self {
+            substate_id: &value.substate_id,
+            version: value.version,
+        }
+    }
+}
+
+impl<'a> From<VersionedSubstateIdRef<'a>> for SubstateRequirementRef<'a> {
+    fn from(value: VersionedSubstateIdRef<'a>) -> Self {
+        Self {
+            substate_id: value.substate_id,
+            version: Some(value.version),
+        }
+    }
+}
+
 #[derive(Debug, thiserror::Error)]
 #[error("Failed to parse substate requirement {0}")]
 pub struct SubstateRequirementParseError(String);

--- a/dan_layer/consensus/src/hotstuff/on_propose.rs
+++ b/dan_layer/consensus/src/hotstuff/on_propose.rs
@@ -301,6 +301,10 @@ where TConsensusSpec: ConsensusSpec
             ),
             // Leader thinks all local nodes have prepared
             TransactionPoolStage::Prepared => {
+                if tx_rec.current_decision().is_abort() {
+                    let atom = tx_rec.get_current_transaction_atom();
+                    return Ok(Some(Command::LocalAccept(atom)));
+                }
                 if tx_rec
                     .evidence()
                     .is_committee_output_only(local_committee_info.shard_group())

--- a/dan_layer/storage/src/consensus_models/evidence.rs
+++ b/dan_layer/storage/src/consensus_models/evidence.rs
@@ -138,6 +138,12 @@ impl Evidence {
             .all(|e| e.is_prepare_justified() || e.is_accept_justified())
     }
 
+    pub fn some_shard_groups_prepared(&self) -> bool {
+        self.evidence
+            .values()
+            .any(|e| e.is_prepare_justified() || e.is_accept_justified())
+    }
+
     pub fn all_input_shard_groups_prepared(&self) -> bool {
         self.evidence
             .values()


### PR DESCRIPTION
Description
---
feat(consensus): skip to local accept phase for aborted transactions
Missing consensus-level  transaction validators 
Additional atom checks in LocalAccept

Motivation and Context
---
Since aborted transactions do not lock or pledge inputs, they can proceed directly to Accept phase
This removes the need for 2 cross-shard exchanges.

How Has This Been Tested?
---
Still testing

What process can a PR reviewer use to test or verify this change?
---


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify