### PR TITLE
fix(template-manager): fix builtin check for exist with status

### DIFF
--- a/dan_layer/template_manager/src/implementation/manager.rs
+++ b/dan_layer/template_manager/src/implementation/manager.rs
@@ -142,6 +142,10 @@ impl<TAddr: NodeAddressable> TemplateManager<TAddr> {
         status: Option<TemplateStatus>,
     ) -> Result<bool, TemplateManagerError> {
         if self.builtin_templates.contains_key(address) {
+            if status.is_some_and(|s| !s.is_active()) {
+                return Ok(false);
+            }
+
             return Ok(true);
         }
         let mut tx = self.global_db.create_transaction()?;

--- a/integration_tests/tests/steps/wallet_daemon.rs
+++ b/integration_tests/tests/steps/wallet_daemon.rs
@@ -48,7 +48,7 @@ async fn when_i_claim_burn_via_wallet_daemon(
         proof.clone(),
         reciprocal_claim_public_key.clone(),
         wallet_daemon_name,
-        1000,
+        5000,
     )
     .await
     .unwrap();
@@ -97,7 +97,7 @@ async fn when_i_claim_burn_via_wallet_daemon_it_fails(
         proof.clone(),
         reciprocal_claim_public_key.clone(),
         wallet_daemon_name,
-        1000,
+        5000,
     )
     .await
     .unwrap_err();


### PR DESCRIPTION
Description
---
Fixes check for existance on template_exists when passing in a builtin template with a status

Motivation and Context
---
We validate that templates are not marked as invalid in the TemplateExists validation. If a builtin template address is passed in, it always returns true regardless of the queried status. This is not correct and has been corrected in this PR to return false if the status is not Active

How Has This Been Tested?
---
Existing tests

What process can a PR reviewer use to test or verify this change?
---
CI

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify