### PR TITLE
chore: wallet daemon and npm pain points

### DIFF
--- a/applications/tari_dan_wallet_daemon/src/config.rs
+++ b/applications/tari_dan_wallet_daemon/src/config.rs
@@ -83,7 +83,7 @@ impl Default for WalletDaemonConfig {
     fn default() -> Self {
         Self {
             override_from: None,
-            network: Default::default(),
+            network: Network::Igor,
             json_rpc_address: Some(SocketAddr::from(([127u8, 0, 0, 1], 9000))),
             ui_connect_address: None,
             signaling_server_address: Some(SocketAddr::from(([127u8, 0, 0, 1], 9100))),

--- a/applications/tari_dan_wallet_web_ui/src/Components/WalletConnectLink/WalletConnectLink.tsx
+++ b/applications/tari_dan_wallet_web_ui/src/Components/WalletConnectLink/WalletConnectLink.tsx
@@ -41,7 +41,7 @@ import { Core } from '@walletconnect/core'
 import { Web3Wallet } from '@walletconnect/web3wallet'
 import { accountsCreateFreeTestCoins, accountsGetBalances, accountsGetDefault, confidentialViewVaultBalance, keysCreate, substatesGet, substatesList, templatesGet, transactionsGetResult, transactionsSubmit } from "../../utils/json_rpc";
 
-const projectId: string | null = import.meta.env.VITE_WALLET_CONNECT_PROJECT_ID || null;
+const projectId: string = import.meta.env.VITE_WALLET_CONNECT_PROJECT_ID || "78f3485d08b9640a087cbcea000e1f8b";
 
 const ConnectorDialog = () => {
   const [page, setPage] = useState(1);
@@ -63,9 +63,6 @@ const ConnectorDialog = () => {
   const optionalPermissions: TariPermission[] = [];
 
   async function createWallet(): Promise<any| null> {
-    if (!projectId)
-      return null;
-
     const core = new Core({ projectId });
     const wallet = await Web3Wallet.init({
       core: core,

--- a/applications/tari_dan_wallet_web_ui/src/theme/LayoutMain.tsx
+++ b/applications/tari_dan_wallet_web_ui/src/theme/LayoutMain.tsx
@@ -184,7 +184,6 @@ export default function Layout() {
                 <Logo fill={theme.palette.text.primary} />
               </Link>
               <Stack direction="row" spacing={1}>
-                <ConnectorLink />
                 <WalletConnectLink />
               </Stack>
             </Box>

--- a/bindings/package-lock.json
+++ b/bindings/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tari-project/typescript-bindings",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tari-project/typescript-bindings",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "ISC",
       "devDependencies": {
         "shx": "^0.3.4",

--- a/bindings/package.json
+++ b/bindings/package.json
@@ -1,7 +1,15 @@
 {
   "name": "@tari-project/typescript-bindings",
-  "version": "1.4.0",
-  "description": "",
+  "version": "1.4.1",
+  "description": "TypeScript types synchronized to the Tari Ootle Rust codebase",
+  "homepage": "https://github.com/tari-project/tari-dan#readme",
+  "bugs": {
+    "url": "https://github.com/tari-project/tari-dan/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tari-project/tari-dan.git"
+  },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "publishConfig": {

--- a/clients/javascript/wallet_daemon_client/package-lock.json
+++ b/clients/javascript/wallet_daemon_client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tari-project/wallet_jrpc_client",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tari-project/wallet_jrpc_client",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "ISC",
       "dependencies": {
         "@tari-project/typescript-bindings": "^1.4.0"

--- a/clients/javascript/wallet_daemon_client/package.json
+++ b/clients/javascript/wallet_daemon_client/package.json
@@ -1,7 +1,15 @@
 {
   "name": "@tari-project/wallet_jrpc_client",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Tari wallet JSON-RPC client library",
+  "homepage": "https://github.com/tari-project/tari-dan#readme",
+  "bugs": {
+    "url": "https://github.com/tari-project/tari-dan/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tari-project/tari-dan.git"
+  },
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
Description
---
* In the wallet daemon
    * Removed the old Tari connector button (deprecated), leaving only the WalletConnect option. This is to avoid user confusion.
    * Hardcoded the WalletConnect ProjectId as default, to make wallet daemon binaries automatically use it without needing to specify it in the envvars (it can still be overridden in the envvars if needed).
    * Make `Igor` the default network if no network is specified from CLI 
* Adding metadata (repository, homepage and issues) to the npm packages (`typescript-bindings`, `wallet_jrpc_client`) so they are linked back from the npm registry. Bumped the version number to trigger a npm publish.

Motivation and Context
---
We identified some pain points for users/developers related to wallet daemon and npm packages.

How Has This Been Tested?
---
* Manually by starting a new localnet with tari spawn and connect with walletconnect
* For the default network value, spawned a wallet daemon directly from CLI and inspected the logs

What process can a PR reviewer use to test or verify this change?
---
See previous section

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify