### PR TITLE
fix: set versions for template wasm independently

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10533,7 +10533,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_lib"
-version = "0.9.0"
+version = "0.8.2"
 dependencies = [
  "borsh",
  "newtype-ops",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,7 @@ tari_rpc_macros = { path = "networking/rpc_macros" }
 tari_state_store_sqlite = { path = "dan_layer/state_store_sqlite" }
 tari_state_tree = { path = "dan_layer/state_tree" }
 tari_swarm = { path = "networking/swarm" }
-tari_template_abi = { version = "0.8", path = "dan_layer/template_abi" }
+tari_template_abi = { version = "0.8.2", path = "dan_layer/template_abi" }
 tari_template_builtin = { path = "dan_layer/template_builtin" }
 tari_template_lib = { path = "dan_layer/template_lib" }
 tari_template_macros = { version = "0.8", path = "dan_layer/template_macros" }

--- a/dan_layer/engine/src/wasm/process.rs
+++ b/dan_layer/engine/src/wasm/process.rs
@@ -59,7 +59,8 @@ use crate::{
 };
 
 const LOG_TARGET: &str = "tari::dan::engine::wasm::process";
-pub const ENGINE_TARI_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+const MINIMUM_SUPPORTED_TEMPLATE_LIB_VERSION: &str = "0.8.0";
 
 pub struct WasmProcess {
     module: LoadedWasmTemplate,
@@ -101,7 +102,7 @@ impl WasmProcess {
         store: &mut S,
         val: &T,
     ) -> Result<AllocPtr, WasmExecutionError> {
-        let len = encoded_len(val).unwrap();
+        let len = encoded_len(val)?;
         let len = u32::try_from(len).map_err(|_| WasmExecutionError::MemoryAllocationTooLarge)?;
 
         let ptr = self.env.alloc(store, len)?;
@@ -109,7 +110,7 @@ impl WasmProcess {
             return Err(WasmExecutionError::MemoryAllocationFailed);
         }
         let mut writer = self.env.memory_writer(store, ptr)?;
-        encode_into_writer(val, &mut writer).unwrap();
+        encode_into_writer(val, &mut writer)?;
 
         Ok(AllocPtr::new(ptr.offset(), len))
     }
@@ -241,12 +242,12 @@ impl WasmProcess {
     fn validate_template_tari_version(module: &LoadedWasmTemplate) -> Result<(), WasmExecutionError> {
         let template_tari_version = module.template_def().tari_version();
 
-        if are_versions_compatible(template_tari_version, ENGINE_TARI_VERSION)? {
+        if are_versions_compatible(template_tari_version, MINIMUM_SUPPORTED_TEMPLATE_LIB_VERSION)? {
             log::debug!(target: LOG_TARGET, "The Tari version in the template WASM (\"{}\") is compatible with the one used in the engine", template_tari_version);
         } else {
-            log::error!(target: LOG_TARGET, "The Tari version in the template WASM (\"{}\") is incompatible with the one used in the engine (\"{}\")", template_tari_version, ENGINE_TARI_VERSION);
+            log::error!(target: LOG_TARGET, "The Tari version in the template WASM (\"{}\") is incompatible with the one used in the engine (\"{}\")", template_tari_version, MINIMUM_SUPPORTED_TEMPLATE_LIB_VERSION);
             return Err(WasmExecutionError::TemplateVersionMismatch {
-                engine_version: ENGINE_TARI_VERSION.to_owned(),
+                engine_version: MINIMUM_SUPPORTED_TEMPLATE_LIB_VERSION.to_owned(),
                 template_version: template_tari_version.to_owned(),
             });
         }

--- a/dan_layer/template_abi/Cargo.toml
+++ b/dan_layer/template_abi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_template_abi"
 description = "Defines the low-level Tari engine ABI for WASM targets"
-version.workspace = true
+version = "0.8.2"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true
@@ -9,10 +9,7 @@ license.workspace = true
 
 [dependencies]
 tari_bor = { workspace = true, default-features = false }
-serde = { workspace = true, default-features = false, features = [
-  "alloc",
-  "derive",
-] }
+serde = { workspace = true, default-features = false, features = ["alloc", "derive"] }
 hashbrown = { workspace = true, optional = true }
 ts-rs = { workspace = true, optional = true }
 

--- a/dan_layer/template_lib/Cargo.toml
+++ b/dan_layer/template_lib/Cargo.toml
@@ -1,8 +1,7 @@
 [package]
 name = "tari_template_lib"
 description = "Tari template library provides abstrations that interface with the Tari validator engine"
-# template_lib has an independent version from the rest of the crates so that general releases don't always break previous templates.
-version = "0.9.0"
+version = "0.8.2"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/dan_layer/template_macros/Cargo.toml
+++ b/dan_layer/template_macros/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "tari_template_macros"
 description = "Tari template macro"
-version.workspace = true
+# This crate has an independent version from the rest of the crates so that general releases don't always break previous templates.
+version = "0.8.2"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/dan_layer/template_test_tooling/Cargo.toml
+++ b/dan_layer/template_test_tooling/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_template_test_tooling"
 description = "Test tooling for Tari template development"
-version.workspace = true
+version = "0.8.2"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true


### PR DESCRIPTION
Description
---
fix: set versions for template wasm independently

Motivation and Context
---
Template wasm version is set by the template_macros crate, not the template_lib crate. I've updated the engine to hard code a minimal compatible version so that if we update the workspace version this does not break wasm templates.

How Has This Been Tested?
---

What process can a PR reviewer use to test or verify this change?
---


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify