### PR TITLE
fix(tari_validator_node_web_ui): missing templates on template list

### DIFF
--- a/applications/tari_validator_node_web_ui/src/routes/VN/Components/Templates.tsx
+++ b/applications/tari_validator_node_web_ui/src/routes/VN/Components/Templates.tsx
@@ -52,7 +52,9 @@ function Templates() {
   const [lastSort, setLastSort] = useState({ column: "", order: -1 });
 
   useEffect(() => {
-    getTemplates({ limit: 10 }).then((response) => {
+    // TODO: proper pagination with limit+offset. It would require changes in VN backend (and clients) to add the offset parameter
+    //       for now, limit=0 makes the backend return all templates
+    getTemplates({ limit: 0 }).then((response) => {
       setTemplates(response.templates.slice());
     });
   }, []);


### PR DESCRIPTION
Description
---
Set `limit` as `0` when fetching templates from the VN JRPC API, which makes it return all templates

Motivation and Context
---
The list of templates in the VN UI does not show any new templates past 10 (+3 including builtin template).

This PR is a quick fix to ignore the limit and show all templates. In the future we would want proper pagination by updating the VN JRPC API to accept an `offset` parameter

How Has This Been Tested?
---
Locally:
* Starting a new localnet with tari_spawn
* Deployed more than 10 different templates
* Checking that all appear on the listing

What process can a PR reviewer use to test or verify this change?
---
See previous section

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify