### PR TITLE
fix(template): fix log macros

### DIFF
--- a/dan_layer/engine/tests/templates/access_rules/src/lib.rs
+++ b/dan_layer/engine/tests/templates/access_rules/src/lib.rs
@@ -42,6 +42,7 @@ mod access_rules_template {
                 .initial_supply(1000);
 
             let badges = create_badge_resource(recall_rule);
+            info!("Badges resource address: {}", badges.resource_address());
 
             Component::new(Self {
                 value: 0,
@@ -94,6 +95,8 @@ mod access_rules_template {
             let badges = create_badge_resource(rule!(deny_all));
 
             let address_alloc = CallerContext::allocate_component_address(None);
+            let id = address_alloc.id();
+            info!("Allocated address: {id}");
 
             let tokens = ResourceBuilder::fungible()
                 .with_authorization_hook(
@@ -119,14 +122,22 @@ mod access_rules_template {
 
             let badge_resource = badges.resource_address();
             let tokens = ResourceBuilder::fungible()
-                .mintable(rule!(non_fungible(
-                    NonFungibleAddress::new(badge_resource, NonFungibleId::from_string("mint")))))
-                .burnable(rule!(non_fungible(
-                    NonFungibleAddress::new(badge_resource, NonFungibleId::from_string("burn")))))
-                .withdrawable(rule!(non_fungible(
-                    NonFungibleAddress::new(badge_resource, NonFungibleId::from_string("withdraw")))))
-                .depositable(rule!(non_fungible(
-                    NonFungibleAddress::new(badge_resource, NonFungibleId::from_string("deposit")))))
+                .mintable(rule!(non_fungible(NonFungibleAddress::new(
+                    badge_resource,
+                    NonFungibleId::from_string("mint")
+                ))))
+                .burnable(rule!(non_fungible(NonFungibleAddress::new(
+                    badge_resource,
+                    NonFungibleId::from_string("burn")
+                ))))
+                .withdrawable(rule!(non_fungible(NonFungibleAddress::new(
+                    badge_resource,
+                    NonFungibleId::from_string("withdraw")
+                ))))
+                .depositable(rule!(non_fungible(NonFungibleAddress::new(
+                    badge_resource,
+                    NonFungibleId::from_string("deposit")
+                ))))
                 .initial_supply(1000);
 
             Component::new(Self {

--- a/dan_layer/template_lib/src/macros.rs
+++ b/dan_layer/template_lib/src/macros.rs
@@ -20,10 +20,10 @@ macro_rules! debug {
 #[macro_export]
 macro_rules! log {
     ($lvl:expr, $fmt:expr) => {
-        $crate::engine::engine().emit_log($lvl, $fmt)
+        $crate::engine().emit_log($lvl, format!($fmt))
     };
     ($lvl:expr, $fmt:expr, $($args:tt)*) => {
-        $crate::engine::engine().emit_log($lvl, format!($fmt, $($args)*))
+        $crate::engine().emit_log($lvl, format!($fmt, $($args)*))
     };
 }
 
@@ -31,10 +31,10 @@ macro_rules! log {
 #[macro_export]
 macro_rules! info {
     ($fmt:expr) => {
-        $crate::macros::log!($crate::args::LogLevel::Info, $fmt)
+        $crate::log!($crate::args::LogLevel::Info, $fmt)
     };
     ($fmt:expr, $($args:tt)*) => {
-        $crate::macros::log!($crate::args::LogLevel::Info, $fmt, $($args)*)
+        $crate::log!($crate::args::LogLevel::Info, $fmt, $($args)*)
     };
 }
 
@@ -42,10 +42,10 @@ macro_rules! info {
 #[macro_export]
 macro_rules! warn {
     ($fmt:expr) => {
-        $crate::macros::log!($crate::args::LogLevel::Warn, $fmt)
+        $crate::log!($crate::args::LogLevel::Warn, $fmt)
     };
     ($fmt:expr, $($args:tt)*) => {
-        $crate::macros::log!($crate::args::LogLevel::Warn, $fmt, $($args)*)
+        $crate::log!($crate::args::LogLevel::Warn, $fmt, $($args)*)
     };
 }
 
@@ -53,9 +53,9 @@ macro_rules! warn {
 #[macro_export]
 macro_rules! error {
     ($fmt:expr) => {
-        $crate::macros::log!($crate::args::LogLevel::Error, $fmt)
+        $crate::log!($crate::args::LogLevel::Error, $fmt)
     };
     ($fmt:expr, $($args:tt)*) => {
-        $crate::macros::log!($crate::args::LogLevel::Error, $fmt, $($args)*)
+        $crate::log!($crate::args::LogLevel::Error, $fmt, $($args)*)
     };
 }

--- a/dan_layer/template_test_tooling/templates/faucet/Cargo.lock
+++ b/dan_layer/template_test_tooling/templates/faucet/Cargo.lock
@@ -407,7 +407,7 @@ dependencies = [
 
 [[package]]
 name = "tari_bor"
-version = "0.8.0"
+version = "0.8.2"
 dependencies = [
  "ciborium",
  "ciborium-io",
@@ -416,7 +416,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_abi"
-version = "0.8.0"
+version = "0.8.2"
 dependencies = [
  "serde",
  "tari_bor",
@@ -436,7 +436,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_macros"
-version = "0.8.0"
+version = "0.8.2"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
Description
---
fixes `info!`, `warn!` and `error!` macros compile errors
Support "inline" syntax for macros `info!("format {this}")`

Motivation and Context
---
Uses publicly-accessible modules in the macro-generated code.

How Has This Been Tested?
---
Added log calls to access rules unit tests

What process can a PR reviewer use to test or verify this change?
---
Use the log macros in templates

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify