### PR TITLE
fix(indexer): sync templates from event scanner

### DIFF
--- a/applications/tari_indexer/src/bootstrap.rs
+++ b/applications/tari_indexer/src/bootstrap.rs
@@ -47,10 +47,11 @@ use tari_epoch_manager::service::{EpochManagerConfig, EpochManagerHandle};
 use tari_epoch_oracles::{base_layer::BaseLayerOracle, configured::ConfiguredEpochOracle, EpochOracle};
 use tari_networking::{MessagingMode, NetworkingHandle, RelayCircuitLimits, RelayReservationLimits, SwarmConfig};
 use tari_shutdown::ShutdownSignal;
-use tari_template_manager::implementation::TemplateManager;
+use tari_template_manager::{implementation::TemplateManager, interface::TemplateManagerHandle};
 use tari_validator_node_rpc::client::TariValidatorNodeRpcClientFactory;
 
 use crate::{
+    network_client::TariNetworkClient,
     substate_storage_sqlite::sqlite_substate_store_factory::SqliteSubstateStore,
     ApplicationConfig,
     IndexerEpochManagerSpec,
@@ -114,8 +115,6 @@ pub async fn spawn_services(
     // Connect to substate db
     let substate_store = SqliteSubstateStore::try_create(config.indexer.state_db_path())?;
 
-    // Epoch manager
-    let validator_node_client_factory = TariValidatorNodeRpcClientFactory::new(networking.clone());
     // Epoch event oracle
     let epoch_event_oracle = match config.epoch_oracle.oracle_type {
         EpochOracleType::BaseLayer => {
@@ -159,9 +158,13 @@ pub async fn spawn_services(
         shutdown.clone(),
     );
 
+    // Client factory
+    let validator_node_client_factory = TariValidatorNodeRpcClientFactory::new(networking.clone());
+    let network_client = TariNetworkClient::new(epoch_manager.clone(), validator_node_client_factory.clone());
+
     // Template manager
     let template_manager = TemplateManager::initialize(global_db.clone(), config.indexer.templates.clone())?;
-    let (_template_manager_service, _) = tari_template_manager::implementation::spawn(
+    let (template_manager_service, _) = tari_template_manager::implementation::spawn(
         template_manager.clone(),
         epoch_manager.clone(),
         validator_node_client_factory.clone(),
@@ -177,9 +180,11 @@ pub async fn spawn_services(
         networking,
         epoch_manager,
         validator_node_client_factory,
+        network_client,
         substate_store,
         global_db,
         template_manager,
+        template_manager_service,
     })
 }
 
@@ -189,8 +194,10 @@ pub struct Services {
     pub epoch_manager: EpochManagerHandle<PeerAddress>,
     pub validator_node_client_factory: TariValidatorNodeRpcClientFactory,
     pub substate_store: SqliteSubstateStore,
+    pub network_client: TariNetworkClient<EpochManagerHandle<PeerAddress>, TariValidatorNodeRpcClientFactory>,
     pub global_db: GlobalDb<SqliteGlobalDbAdapter<PeerAddress>>,
     pub template_manager: TemplateManager<PeerAddress>,
+    pub template_manager_service: TemplateManagerHandle,
 }
 
 fn ensure_directories_exist(config: &ApplicationConfig) -> io::Result<()> {

--- a/applications/tari_indexer/src/event_scanner.rs
+++ b/applications/tari_indexer/src/event_scanner.rs
@@ -34,6 +34,7 @@ use tari_engine_types::{
 };
 use tari_epoch_manager::{service::EpochManagerHandle, EpochManagerReader};
 use tari_template_lib::models::{EntityId, TemplateAddress};
+use tari_template_manager::interface::{TemplateChange, TemplateManagerHandle};
 use tari_validator_node_rpc::client::{TariValidatorNodeRpcClientFactory, ValidatorNodeClientFactory};
 
 use crate::{
@@ -87,6 +88,7 @@ pub struct EventScanner {
     epoch_manager: EpochManagerHandle<PeerAddress>,
     client_factory: TariValidatorNodeRpcClientFactory,
     substate_store: SqliteSubstateStore,
+    template_manager: TemplateManagerHandle,
     event_filters: Vec<EventFilter>,
 }
 
@@ -95,12 +97,14 @@ impl EventScanner {
         epoch_manager: EpochManagerHandle<PeerAddress>,
         client_factory: TariValidatorNodeRpcClientFactory,
         substate_store: SqliteSubstateStore,
+        template_manager: TemplateManagerHandle,
         event_filters: Vec<EventFilter>,
     ) -> Self {
         Self {
             epoch_manager,
             client_factory,
             substate_store,
+            template_manager,
             event_filters,
         }
     }
@@ -187,6 +191,29 @@ impl EventScanner {
                 );
                 self.store_events_in_db(&filtered_events, block_data.block.timestamp())?;
                 self.store_substates_in_db(&block_data.diff, block_data.block.timestamp())?;
+
+                let new_templates = block_data
+                    .diff
+                    .iter()
+                    .filter_map(|r| r.as_create())
+                    .filter_map(|create| {
+                        let value = create.substate.value().value()?;
+                        let template = value.as_template()?;
+                        let template_address = create
+                            .substate
+                            .substate_id()
+                            .as_template()
+                            .expect("Expected template substate ID");
+
+                        Some(TemplateChange::Add {
+                            template_address,
+                            author_public_key: template.author.clone(),
+                            binary_hash: template.binary_hash.into_array().into(),
+                            epoch,
+                        })
+                    })
+                    .collect();
+                self.template_manager.enqueue_template_changes(new_templates).await?;
             }
         }
 

--- a/applications/tari_indexer/src/json_rpc/handlers.rs
+++ b/applications/tari_indexer/src/json_rpc/handlers.rs
@@ -83,6 +83,7 @@ use crate::{
     bootstrap::Services,
     dry_run::processor::DryRunTransactionProcessor,
     json_rpc::error::internal_error,
+    network_client::NetworkClientError,
     substate_manager::SubstateManager,
     transaction_manager::{error::TransactionManagerError, TransactionManager},
 };
@@ -482,14 +483,16 @@ impl JsonRpcHandlers {
                 .autofill_transaction(request.transaction, request.required_substates)
                 .await
                 .map_err(|e| match e {
-                    TransactionManagerError::AllValidatorsFailed { .. } => JsonRpcResponse::error(
-                        answer_id,
-                        JsonRpcError::new(
-                            JsonRpcErrorReason::ApplicationError(400),
-                            format!("All validators failed: {}", e),
-                            json::Value::Null,
-                        ),
-                    ),
+                    TransactionManagerError::NetworkClientError(NetworkClientError::AllValidatorsFailed { .. }) => {
+                        JsonRpcResponse::error(
+                            answer_id,
+                            JsonRpcError::new(
+                                JsonRpcErrorReason::ApplicationError(400),
+                                format!("All validators failed: {}", e),
+                                json::Value::Null,
+                            ),
+                        )
+                    },
                     e => Self::internal_error(answer_id, e),
                 })?
         };
@@ -498,14 +501,16 @@ impl JsonRpcHandlers {
             .submit_transaction(transaction)
             .await
             .map_err(|e| match e {
-                TransactionManagerError::AllValidatorsFailed { .. } => JsonRpcResponse::error(
-                    answer_id,
-                    JsonRpcError::new(
-                        JsonRpcErrorReason::ApplicationError(400),
-                        format!("All validators failed: {}", e),
-                        json::Value::Null,
-                    ),
-                ),
+                TransactionManagerError::NetworkClientError(NetworkClientError::AllValidatorsFailed { .. }) => {
+                    JsonRpcResponse::error(
+                        answer_id,
+                        JsonRpcError::new(
+                            JsonRpcErrorReason::ApplicationError(400),
+                            format!("All validators failed: {}", e),
+                            json::Value::Null,
+                        ),
+                    )
+                },
                 e => Self::internal_error(answer_id, e),
             })?;
 
@@ -574,6 +579,7 @@ impl JsonRpcHandlers {
     pub async fn get_template_definition(&self, value: JsonRpcExtractor) -> JrpcResult {
         let answer_id = value.get_answer_id();
         let request: GetTemplateDefinitionRequest = value.parse_params()?;
+
         let template = self
             .template_manager
             .fetch_template(&request.template_address)

--- a/applications/tari_indexer/src/lib.rs
+++ b/applications/tari_indexer/src/lib.rs
@@ -37,6 +37,7 @@ mod event_data;
 mod event_manager;
 mod event_scanner;
 mod json_rpc;
+mod network_client;
 mod substate_manager;
 mod substate_storage_sqlite;
 mod transaction_manager;
@@ -122,11 +123,7 @@ pub async fn run_indexer(config: ApplicationConfig, mut shutdown_signal: Shutdow
         dan_layer_scanner.clone(),
         services.substate_store.clone(),
     ));
-    let transaction_manager = TransactionManager::new(
-        services.epoch_manager.clone(),
-        services.validator_node_client_factory.clone(),
-        dan_layer_scanner.clone(),
-    );
+    let transaction_manager = TransactionManager::new(services.network_client.clone(), dan_layer_scanner.clone());
 
     // dry run
     let dry_run_transaction_processor = DryRunTransactionProcessor::new(
@@ -187,6 +184,7 @@ pub async fn run_indexer(config: ApplicationConfig, mut shutdown_signal: Shutdow
         services.epoch_manager.clone(),
         services.validator_node_client_factory.clone(),
         services.substate_store.clone(),
+        services.template_manager_service.clone(),
         event_filters,
     );
 

--- a/applications/tari_indexer/src/network_client.rs
+++ b/applications/tari_indexer/src/network_client.rs
@@ -1,0 +1,194 @@
+//    Copyright 2025 The Tari Project
+//    SPDX-License-Identifier: BSD-3-Clause
+
+use std::{collections::HashSet, fmt::Display, future::Future};
+
+use log::{info, warn};
+use tari_dan_common_types::{
+    optional::IsNotFoundError,
+    NodeAddressable,
+    ShardGroup,
+    SubstateAddress,
+    ToSubstateAddress,
+};
+use tari_epoch_manager::{EpochManagerError, EpochManagerReader};
+use tari_transaction::{Transaction, TransactionId};
+use tari_validator_node_rpc::client::{ValidatorNodeClientFactory, ValidatorNodeRpcClient};
+
+const LOG_TARGET: &str = "tari::indexer::network_client";
+
+#[derive(Debug, Clone)]
+pub struct TariNetworkClient<TEpochManager, TClientFactory> {
+    epoch_manager: TEpochManager,
+    client_provider: TClientFactory,
+}
+
+impl<TAddr, TEpochManager, TClientFactory> TariNetworkClient<TEpochManager, TClientFactory>
+where
+    TAddr: NodeAddressable + 'static,
+    TEpochManager: EpochManagerReader<Addr = TAddr> + 'static,
+    TClientFactory: ValidatorNodeClientFactory<TAddr> + 'static,
+    <TClientFactory::Client as ValidatorNodeRpcClient<TAddr>>::Error: IsNotFoundError + 'static,
+{
+    pub fn new(epoch_manager: TEpochManager, client_provider: TClientFactory) -> Self {
+        Self {
+            epoch_manager,
+            client_provider,
+        }
+    }
+
+    pub async fn submit_transaction(&self, transaction: Transaction) -> Result<TransactionId, NetworkClientError> {
+        let tx_id = *transaction.id();
+
+        info!(
+            target: LOG_TARGET,
+            "Submitting transaction {} to the validator node", tx_id
+        );
+
+        // Ensure initial scanning has completed to ensure an accurate epoch
+        self.epoch_manager.wait_for_initial_scanning_to_complete().await?;
+
+        let involved = transaction
+            .all_inputs_iter()
+            // The version does not affect the shard group
+            .map(|i| i.or_zero_version().to_substate_address())
+            // NOTE: if I don't collect here, we get lifetime issues in the JSON-RPC handlers (Send impl not general enough).
+            // For uniqueness, it seems like a good idea to collect to a HashSet anyway.
+            .collect::<HashSet<_>>();
+        self.try_with_committee(involved, 2, |mut client| {
+            let transaction = transaction.clone();
+            async move { client.submit_transaction(transaction).await }
+        })
+        .await
+    }
+
+    #[allow(dead_code)]
+    pub async fn try_with_random_members<'a, F, T, E, TFut>(
+        &self,
+        num_to_query: usize,
+        shard_group: Option<ShardGroup>,
+        mut callback: F,
+    ) -> Result<T, NetworkClientError>
+    where
+        F: FnMut(TClientFactory::Client) -> TFut,
+        TFut: Future<Output = Result<T, E>> + 'a,
+        TClientFactory::Client: 'a,
+        T: 'static,
+        E: Display,
+    {
+        let epoch = self.epoch_manager.current_epoch().await?;
+        let mut attempted = vec![];
+
+        let mut last_error = None;
+        while attempted.len() < num_to_query {
+            let vn = self
+                .epoch_manager
+                .get_random_committee_member(epoch, shard_group, attempted.clone())
+                .await?;
+
+            let client = self.client_provider.create_client(&vn.address);
+            match callback(client).await {
+                Ok(ret) => {
+                    return Ok(ret);
+                },
+                Err(err) => {
+                    warn!(
+                        target: LOG_TARGET,
+                        "Request failed for validator '{}': {}", vn, err
+                    );
+                    last_error = Some(err.to_string());
+                },
+            }
+
+            attempted.push(vn.address);
+        }
+
+        Err(NetworkClientError::AllValidatorsFailed {
+            committee_size: attempted.len(),
+            last_error,
+        })
+    }
+
+    /// Fetches the committee members for the given shard and calls the given callback with each member until
+    /// the callback returns a `Ok` result. If the callback returns an `Err` result, the next committee member is
+    /// called.
+    pub async fn try_with_committee<'a, F, T, E, TFut, ISubstateAddr>(
+        &self,
+        substate_addresses: ISubstateAddr,
+        mut num_to_query: usize,
+        mut callback: F,
+    ) -> Result<T, NetworkClientError>
+    where
+        F: FnMut(TClientFactory::Client) -> TFut,
+        TFut: Future<Output = Result<T, E>> + 'a,
+        TClientFactory::Client: 'a,
+        T: 'static,
+        E: Display,
+        ISubstateAddr: IntoIterator<Item = SubstateAddress>,
+    {
+        let epoch = self.epoch_manager.current_epoch().await?;
+        // Get all unique members. The hashset already "shuffles" items owing to the random hash function.
+        let mut all_members = HashSet::new();
+        // TODO: suggest passing in the shard groups to try_with_committee. We need the NumPreshards and
+        // num_committees from the epoch manager to do so but this will also prevent us loading the same committees
+        // multiple times.
+        for substate_address in substate_addresses {
+            let committee = self
+                .epoch_manager
+                .get_committee_for_substate(epoch, substate_address)
+                .await?;
+            all_members.extend(committee.into_addresses());
+        }
+
+        let committee_size = all_members.len();
+        if committee_size == 0 {
+            return Err(NetworkClientError::NoCommitteeMembers);
+        }
+
+        let mut num_succeeded = 0;
+        let mut last_error = None;
+        let mut last_return = None;
+        for validator in all_members {
+            let client = self.client_provider.create_client(&validator);
+            match callback(client).await {
+                Ok(ret) => {
+                    num_to_query = num_to_query.saturating_sub(1);
+                    num_succeeded += 1;
+                    last_return = Some(ret);
+                    if num_to_query == 0 {
+                        break;
+                    }
+                },
+                Err(err) => {
+                    warn!(
+                        target: LOG_TARGET,
+                        "Request failed for validator '{}': {}", validator, err
+                    );
+                    last_error = Some(err.to_string());
+                },
+            }
+        }
+
+        if num_succeeded == 0 {
+            return Err(NetworkClientError::AllValidatorsFailed {
+                committee_size,
+                last_error,
+            });
+        }
+
+        Ok(last_return.expect("last_return must be Some if num_succeeded > 0"))
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum NetworkClientError {
+    #[error("Epoch manager error: {0}")]
+    EpochManagerError(#[from] EpochManagerError),
+    #[error("Rpc call failed for all ({committee_size}) validators: {}", .last_error.as_deref().unwrap_or("unknown"))]
+    AllValidatorsFailed {
+        committee_size: usize,
+        last_error: Option<String>,
+    },
+    #[error("No committee at present. Try again later")]
+    NoCommitteeMembers,
+}

--- a/applications/tari_indexer/src/transaction_manager/error.rs
+++ b/applications/tari_indexer/src/transaction_manager/error.rs
@@ -2,20 +2,14 @@
 //   SPDX-License-Identifier: BSD-3-Clause
 
 use tari_dan_common_types::optional::IsNotFoundError;
-use tari_epoch_manager::EpochManagerError;
 use tari_indexer_lib::{error::IndexerError, transaction_autofiller::TransactionAutofillerError};
+
+use crate::network_client::NetworkClientError;
 
 #[derive(Debug, thiserror::Error)]
 pub enum TransactionManagerError {
-    #[error("Epoch manager error: {0}")]
-    EpochManagerError(#[from] EpochManagerError),
-    #[error("Rpc call failed for all ({committee_size}) validators: {}", .last_error.as_deref().unwrap_or("unknown"))]
-    AllValidatorsFailed {
-        committee_size: usize,
-        last_error: Option<String>,
-    },
-    #[error("No committee at present. Try again later")]
-    NoCommitteeMembers,
+    #[error(transparent)]
+    NetworkClientError(#[from] NetworkClientError),
     #[error("{entity} not found: {key}")]
     NotFound { entity: &'static str, key: String },
     #[error(transparent)]

--- a/applications/tari_indexer/src/transaction_manager/mod.rs
+++ b/applications/tari_indexer/src/transaction_manager/mod.rs
@@ -22,13 +22,11 @@
 
 pub(crate) mod error;
 
-use std::{collections::HashSet, fmt::Display, future::Future, iter, sync::Arc};
+use std::{iter, sync::Arc};
 
-use log::*;
 use tari_dan_common_types::{
     optional::{IsNotFoundError, Optional},
     NodeAddressable,
-    SubstateAddress,
     SubstateRequirement,
     ToSubstateAddress,
 };
@@ -46,13 +44,10 @@ use tari_validator_node_rpc::client::{
     ValidatorNodeRpcClient,
 };
 
-use crate::transaction_manager::error::TransactionManagerError;
-
-const LOG_TARGET: &str = "tari::indexer::transaction_manager";
+use crate::{network_client::TariNetworkClient, transaction_manager::error::TransactionManagerError};
 
 pub struct TransactionManager<TEpochManager, TClientFactory, TSubstateCache> {
-    epoch_manager: TEpochManager,
-    client_provider: TClientFactory,
+    network_client: TariNetworkClient<TEpochManager, TClientFactory>,
     transaction_autofiller: TransactionAutofiller<TEpochManager, TClientFactory, TSubstateCache>,
 }
 
@@ -66,40 +61,18 @@ where
     TSubstateCache: SubstateCache + 'static,
 {
     pub fn new(
-        epoch_manager: TEpochManager,
-        client_provider: TClientFactory,
+        network_client: TariNetworkClient<TEpochManager, TClientFactory>,
         substate_scanner: Arc<SubstateScanner<TEpochManager, TClientFactory, TSubstateCache>>,
     ) -> Self {
         Self {
-            epoch_manager,
-            client_provider,
+            network_client,
             transaction_autofiller: TransactionAutofiller::new(substate_scanner),
         }
     }
 
     pub async fn submit_transaction(&self, transaction: Transaction) -> Result<TransactionId, TransactionManagerError> {
-        let tx_id = *transaction.id();
-
-        info!(
-            target: LOG_TARGET,
-            "Submitting transaction {} to the validator node", tx_id
-        );
-
-        // Ensure initial scanning has completed to ensure an accurate epoch
-        self.epoch_manager.wait_for_initial_scanning_to_complete().await?;
-
-        let involved = transaction
-            .all_inputs_iter()
-            // The version does not affect the shard group
-            .map(|i| i.or_zero_version().to_substate_address())
-            // NOTE: if I don't collect here, we get lifetime issues in the JSON-RPC handlers (Send impl not general enough).
-            // For uniqueness, it seems like a good idea to collect to a HashSet anyway.
-            .collect::<HashSet<_>>();
-        self.try_with_committee(involved, 2, |mut client| {
-            let transaction = transaction.clone();
-            async move { client.submit_transaction(transaction).await }
-        })
-        .await
+        let id = self.network_client.submit_transaction(transaction).await?;
+        Ok(id)
     }
 
     pub async fn autofill_transaction(
@@ -119,14 +92,15 @@ where
         transaction_id: TransactionId,
     ) -> Result<TransactionResultStatus, TransactionManagerError> {
         let transaction_substate_address = transaction_id.to_substate_address();
-        self.try_with_committee(iter::once(transaction_substate_address), 1, |mut client| async move {
-            client.get_finalized_transaction_result(transaction_id).await.optional()
-        })
-        .await?
-        .ok_or_else(|| TransactionManagerError::NotFound {
-            entity: "Transaction result",
-            key: transaction_id.to_string(),
-        })
+        self.network_client
+            .try_with_committee(iter::once(transaction_substate_address), 1, |mut client| async move {
+                client.get_finalized_transaction_result(transaction_id).await.optional()
+            })
+            .await?
+            .ok_or_else(|| TransactionManagerError::NotFound {
+                entity: "Transaction result",
+                key: transaction_id.to_string(),
+            })
     }
 
     pub async fn get_substate(
@@ -134,79 +108,12 @@ where
         substate_requirement: &SubstateRequirement,
     ) -> Result<SubstateResult, TransactionManagerError> {
         let address = substate_requirement.to_substate_address_zero_version();
-        self.try_with_committee(iter::once(address), 1, |mut client| async move {
-            client.get_substate(substate_requirement).await
-        })
-        .await
-    }
-
-    /// Fetches the committee members for the given shard and calls the given callback with each member until
-    /// the callback returns a `Ok` result. If the callback returns an `Err` result, the next committee member is
-    /// called.
-    async fn try_with_committee<'a, F, T, E, TFut, IShard>(
-        &self,
-        substate_addresses: IShard,
-        mut num_to_query: usize,
-        mut callback: F,
-    ) -> Result<T, TransactionManagerError>
-    where
-        F: FnMut(TClientFactory::Client) -> TFut,
-        TFut: Future<Output = Result<T, E>> + 'a,
-        TClientFactory::Client: 'a,
-        T: 'static,
-        E: Display,
-        IShard: IntoIterator<Item = SubstateAddress>,
-    {
-        let epoch = self.epoch_manager.current_epoch().await?;
-        // Get all unique members. The hashset already "shuffles" items owing to the random hash function.
-        let mut all_members = HashSet::new();
-        // TODO: suggest passing in the shard groups to try_with_committee. We need the NumPreshards and
-        // num_committees from the epoch manager to do so but this will also prevent us loading the same committees
-        // multiple times.
-        for substate_address in substate_addresses {
-            let committee = self
-                .epoch_manager
-                .get_committee_for_substate(epoch, substate_address)
-                .await?;
-            all_members.extend(committee.into_addresses());
-        }
-
-        let committee_size = all_members.len();
-        if committee_size == 0 {
-            return Err(TransactionManagerError::NoCommitteeMembers);
-        }
-
-        let mut num_succeeded = 0;
-        let mut last_error = None;
-        let mut last_return = None;
-        for validator in all_members {
-            let client = self.client_provider.create_client(&validator);
-            match callback(client).await {
-                Ok(ret) => {
-                    num_to_query = num_to_query.saturating_sub(1);
-                    num_succeeded += 1;
-                    last_return = Some(ret);
-                    if num_to_query == 0 {
-                        break;
-                    }
-                },
-                Err(err) => {
-                    warn!(
-                        target: LOG_TARGET,
-                        "Request failed for validator '{}': {}", validator, err
-                    );
-                    last_error = Some(err.to_string());
-                },
-            }
-        }
-
-        if num_succeeded == 0 {
-            return Err(TransactionManagerError::AllValidatorsFailed {
-                committee_size,
-                last_error,
-            });
-        }
-
-        Ok(last_return.expect("last_return must be Some if num_succeeded > 0"))
+        let result = self
+            .network_client
+            .try_with_committee(iter::once(address), 1, |mut client| async move {
+                client.get_substate(substate_requirement).await
+            })
+            .await?;
+        Ok(result)
     }
 }

--- a/dan_layer/engine/src/runtime/impl.rs
+++ b/dan_layer/engine/src/runtime/impl.rs
@@ -2333,6 +2333,7 @@ impl<TTemplateProvider: TemplateProvider<Template = LoadedTemplate>> RuntimeInte
     fn publish_template(&self, template: Vec<u8>) -> Result<(), RuntimeError> {
         self.invoke_modules_on_runtime_call("publish_template")?;
         self.tracker.write_with(|state| {
+            let template_byte_size = template.len();
             let binary_hash = hash_template_code(&template);
             let template_address = PublishedTemplateAddress::from_author_and_binary_hash(
                 &self.transaction_signer_public_key,
@@ -2349,6 +2350,17 @@ impl<TTemplateProvider: TemplateProvider<Template = LoadedTemplate>> RuntimeInte
             // Mark template substate as owned by current call stack
             let scope_mut = state.current_call_scope_mut()?;
             scope_mut.move_node_to_owned(&template_address.into())?;
+            // Publish template event
+            let mut metadata = Metadata::new();
+            metadata.insert("template_byte_size".to_string(), template_byte_size.to_string());
+            state.push_event(Event::std(
+                Some(template_address.into()),
+                template_address.as_hash(),
+                state.transaction_hash(),
+                "template",
+                "publish",
+                metadata,
+            ));
 
             Ok(())
         })

--- a/dan_layer/storage/src/consensus_models/substate.rs
+++ b/dan_layer/storage/src/consensus_models/substate.rs
@@ -431,6 +431,10 @@ impl SubstateData {
     pub fn to_value_hash(&self) -> FixedHash {
         self.value.to_value_hash(self.version)
     }
+
+    pub fn substate_id(&self) -> &SubstateId {
+        &self.substate_id
+    }
 }
 
 impl From<SubstateRecord> for SubstateData {

--- a/dan_layer/storage/src/global/models/validator_node.rs
+++ b/dan_layer/storage/src/global/models/validator_node.rs
@@ -1,10 +1,12 @@
 //   Copyright 2023 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
+use std::fmt::Display;
+
 use serde::{Deserialize, Serialize};
 use tari_common::configuration::Network;
 use tari_common_types::types::{FixedHash, PublicKey};
-use tari_dan_common_types::{vn_node_hash, Epoch, NodeAddressable, SubstateAddress};
+use tari_dan_common_types::{displayable::Displayable, vn_node_hash, Epoch, NodeAddressable, SubstateAddress};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ValidatorNode<TAddr> {
@@ -33,5 +35,19 @@ impl<TAddr> Eq for ValidatorNode<TAddr> {}
 impl<TAddr> std::hash::Hash for ValidatorNode<TAddr> {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.shard_key.hash(state);
+    }
+}
+
+impl<TAddr: NodeAddressable> Display for ValidatorNode<TAddr> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Validator(pk={}, shard_key={}, addr={}, start_epoch={}, end_epoch={})",
+            self.public_key,
+            self.shard_key,
+            self.address,
+            self.start_epoch,
+            self.end_epoch.display()
+        )
     }
 }

--- a/dan_layer/template_test_tooling/templates/faucet/Cargo.lock
+++ b/dan_layer/template_test_tooling/templates/faucet/Cargo.lock
@@ -424,7 +424,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_lib"
-version = "0.9.0"
+version = "0.8.2"
 dependencies = [
  "newtype-ops",
  "serde",


### PR DESCRIPTION
Description
---
fix(indexer): sync templates from event scanner

Motivation and Context
---
Templates published as substates were not downloaded. This PR enqueues templates for syncing when they are detected in the event scanner.
Fixes #1299 

How Has This Been Tested?
---
Manually new templates are synced

What process can a PR reviewer use to test or verify this change?
---
Call get template definition on the indexer after a new template is published

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify