### PR TITLE
fix(indexer): list_substates can also list nfts

### DIFF
--- a/applications/tari_indexer/src/substate_storage_sqlite/sqlite_substate_store_factory.rs
+++ b/applications/tari_indexer/src/substate_storage_sqlite/sqlite_substate_store_factory.rs
@@ -255,10 +255,7 @@ impl SubstateStoreReadTransaction for SqliteSubstateStoreReadTransaction<'_> {
         }
 
         if let Some(substate_type) = by_type {
-            let address_like = match substate_type {
-                SubstateType::NonFungible => format!("resource_% {}_%", substate_type.as_prefix_str()),
-                _ => format!("{}_%", substate_type.as_prefix_str()),
-            };
+            let address_like = format!("{}_%", substate_type.as_prefix_str());
             query = query.filter(substates::address.like(address_like));
         }
 


### PR DESCRIPTION
Description
---
fix(indexer): list_substates can also list nfts

Motivation and Context
---
A change in the nft address format caused the indexer not to be able to list nfts
ref #1080 

How Has This Been Tested?
---
Calling list_substates on the indexer with "NonFungible"

What process can a PR reviewer use to test or verify this change?
---


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified internal filtering logic for data queries by unifying the formatting approach. The update streamlines the process for constructing query filters, enhancing consistency in processing different types without changing public behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->