### PR TITLE
fix(mempool): provide finalize result for invalid transactions

### DIFF
--- a/applications/tari_validator_node/src/p2p/services/mempool/service.rs
+++ b/applications/tari_validator_node/src/p2p/services/mempool/service.rs
@@ -105,7 +105,7 @@ where TValidator: Validator<Transaction, Context = (), Error = TransactionValida
                         info!(target: LOG_TARGET, "Mempool service subscribing transaction messages for {shard_group} in {epoch}");
                         self.gossip.subscribe(shard_group).await?;
                     } else {
-                        info!(target: LOG_TARGET, "Not registered for epoch {epoch}, unsubscribing from gossip");
+                        info!(target: LOG_TARGET, "Not registered for epoch {epoch}, unsubscribing from gossip if necessary");
                         self.gossip.unsubscribe().await?;
                     }
                 },
@@ -227,7 +227,7 @@ where TValidator: Validator<Transaction, Context = (), Error = TransactionValida
             let transaction_id = *transaction.id();
             self.state_store.with_write_tx(|tx| {
                 TransactionRecord::new(transaction)
-                    .abort(RejectReason::InvalidTransaction(format!(
+                    .abort_and_finalize(RejectReason::InvalidTransaction(format!(
                         "Mempool validation failed: {e}"
                     )))
                     .insert(tx)

--- a/dan_layer/storage/src/consensus_models/transaction.rs
+++ b/dan_layer/storage/src/consensus_models/transaction.rs
@@ -175,6 +175,21 @@ impl TransactionRecord {
         self
     }
 
+    pub fn abort_and_finalize(&mut self, reason: RejectReason) -> &mut Self {
+        self.abort(reason.clone());
+        let exec_result = self.execution_result.as_ref().filter(|r| r.finalize.result.is_reject());
+        let execution_time = exec_result.as_ref().map(|r| r.execution_time).unwrap_or_default();
+        self.final_decision = Some(Decision::Abort(AbortReason::from(&reason)));
+        self.finalized_time = Some(execution_time);
+        self.execution_result = Some(ExecuteResult {
+            finalize: exec_result
+                .map(|r| r.finalize.clone())
+                .unwrap_or_else(|| FinalizeResult::new_rejected(self.transaction.id().into_array().into(), reason)),
+            execution_time,
+        });
+        self
+    }
+
     pub fn is_involved_in_inputs(&self, local_committee_info: &CommitteeInfo) -> bool {
         self.transaction
             .all_inputs_iter()


### PR DESCRIPTION
Description
---
fix(mempool): provide finalize result for invalid transactions

Motivation and Context
---
If an invalid transaction is submitted to the mempool, the final execution result is not set. This causes the queried result of the transaction to still be pending. This PR creates an execution result for the invalid transaction.

How Has This Been Tested?
---
Submitting a transaction that calls a non-existant template.

What process can a PR reviewer use to test or verify this change?
---
As above

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an enhanced transaction finalization mechanism that provides more consistent handling of failed validations, ensuring improved management of error states.
- **Refactor**
  - Refined system logging to offer clearer, more nuanced operational feedback during runtime processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->