### PR TITLE
fix(consensus)!: remove unnecessary commands and tx phases

### DIFF
--- a/dan_layer/consensus/src/hotstuff/foreign_proposal_processor.rs
+++ b/dan_layer/consensus/src/hotstuff/foreign_proposal_processor.rs
@@ -526,7 +526,7 @@ pub fn process_foreign_block<TStore: StateStore>(
                 } else {
                     info!(
                         target: LOG_TARGET,
-                        "🧩 FOREIGN PROPOSAL: Transaction is NOT ready for ALL_ACCEPT({}, {}) Local Stage: {}, All Justified: {}. Waiting for local or foreign proposal.",
+                        "🧩 FOREIGN PROPOSAL: Transaction is NOT ready for AllAccept({}, {}) Local Stage: {}, All Justified: {}. Waiting for local or foreign proposal.",
                         tx_rec.transaction_id(),
                         tx_rec.current_decision(),
                         tx_rec.current_stage(),
@@ -548,9 +548,6 @@ pub fn process_foreign_block<TStore: StateStore>(
             // TODO(perf): Can we find a way to exclude these unused commands to reduce message size?
             Command::AllAccept(_) |
             Command::SomeAccept(_) |
-            Command::AllPrepare(_) |
-            Command::SomePrepare(_) |
-            Command::Prepare(_) |
             Command::LocalOnly(_) |
             Command::ForeignProposal(_) |
             Command::EvictNode(_) |

--- a/dan_layer/consensus/src/hotstuff/on_propose.rs
+++ b/dan_layer/consensus/src/hotstuff/on_propose.rs
@@ -79,7 +79,7 @@ use crate::{
     traits::{ConsensusSpec, OutboundMessaging, ValidatorSignatureService, WriteableSubstateStore},
 };
 
-const LOG_TARGET: &str = "tari::dan::consensus::hotstuff::on_local_propose";
+const LOG_TARGET: &str = "tari::dan::consensus::hotstuff::on_propose";
 
 struct NextBlock {
     block: Block,
@@ -289,6 +289,7 @@ where TConsensusSpec: ConsensusSpec
     ) -> Result<Option<Command>, HotStuffError> {
         match tx_rec.current_stage() {
             TransactionPoolStage::New => self.prepare_transaction(
+                tx,
                 start_of_chain_id,
                 &mut tx_rec,
                 local_committee_info,
@@ -296,11 +297,9 @@ where TConsensusSpec: ConsensusSpec
                 executed_transactions,
                 lock_conflicts,
             ),
-            // Leader thinks all local nodes have prepared
-            TransactionPoolStage::Prepared => self.local_prepare_transaction(tx, local_committee_info, &tx_rec),
             // Leader thinks all foreign PREPARE pledges have been received (condition for LocalPrepared stage to be
             // ready)
-            TransactionPoolStage::LocalPrepared => self.all_or_some_prepare_transaction(
+            TransactionPoolStage::LocalPrepared => self.local_accept_transaction(
                 tx,
                 start_of_chain_id,
                 local_committee_info,
@@ -309,13 +308,6 @@ where TConsensusSpec: ConsensusSpec
                 executed_transactions,
             ),
 
-            // Leader thinks that all local nodes agree that all shard groups have prepared, we are ready to accept
-            // locally
-            TransactionPoolStage::AllPrepared => Ok(Some(Command::LocalAccept(
-                self.get_transaction_atom_with_leader_fee(&mut tx_rec)?,
-            ))),
-            // Leader thinks local nodes are ready to accept an ABORT
-            TransactionPoolStage::SomePrepared => Ok(Some(Command::LocalAccept(tx_rec.get_current_transaction_atom()))),
             // Leader thinks that all foreign ACCEPT pledges have been received and, we are ready to accept the result
             // (COMMIT/ABORT)
             TransactionPoolStage::LocalAccepted => {
@@ -735,6 +727,7 @@ where TConsensusSpec: ConsensusSpec
     #[allow(clippy::too_many_lines)]
     fn prepare_transaction(
         &self,
+        tx: &<TConsensusSpec::StateStore as StateStore>::ReadTransaction<'_>,
         parent_block: &LeafBlock,
         tx_rec: &mut TransactionPoolRecord,
         local_committee_info: &CommitteeInfo,
@@ -784,7 +777,7 @@ where TConsensusSpec: ConsensusSpec
             return Ok(None);
         }
 
-        let command = match prepared {
+        match prepared {
             PreparedTransaction::LocalOnly(local) => match *local {
                 LocalPreparedTransaction::Accept { execution, .. } => {
                     tx_rec
@@ -830,7 +823,7 @@ where TConsensusSpec: ConsensusSpec
                     executed_transactions.insert(*tx_rec.transaction_id(), execution);
 
                     let atom = tx_rec.get_current_transaction_atom();
-                    Command::LocalOnly(atom)
+                    Ok(Some(Command::LocalOnly(atom)))
                 },
                 LocalPreparedTransaction::EarlyAbort { execution } => {
                     info!(
@@ -847,7 +840,7 @@ where TConsensusSpec: ConsensusSpec
                         ));
                     executed_transactions.insert(*tx_rec.transaction_id(), execution);
                     let atom = tx_rec.get_current_transaction_atom();
-                    Command::LocalOnly(atom)
+                    Ok(Some(Command::LocalOnly(atom)))
                 },
             },
 
@@ -903,53 +896,43 @@ where TConsensusSpec: ConsensusSpec
                     tx_rec.current_decision(),
                 );
 
-                let atom = tx_rec.get_local_transaction_atom();
-                Command::Prepare(atom)
+                if tx_rec.current_decision().is_abort() {
+                    let atom = tx_rec.get_current_transaction_atom();
+                    return Ok(Some(Command::LocalAccept(atom)));
+                }
+                if tx_rec
+                    .evidence()
+                    .is_committee_output_only(local_committee_info.shard_group())
+                {
+                    // No prepare phase needed for output-only transactions. All foreign shards have prepared inputs
+                    // and the output shard groups need to execute and accept outputs.
+                    if !tx_rec.has_all_required_foreign_input_pledges(tx, local_committee_info)? {
+                        error!(
+                            target: LOG_TARGET,
+                            "BUG: attempted to propose transaction {} as LocalPrepared but not all foreign input pledges were found. \
+                             This transaction should not have been marked as ready. {}",
+                            tx_rec.transaction_id(),
+                            tx_rec.evidence()
+                        );
+                        return Ok(None);
+                    }
+                    let atom = tx_rec.get_local_transaction_atom();
+                    debug!(
+                        target: LOG_TARGET,
+                        "ℹ️ Transaction {} is output-only for {}, proposing LocalAccept",
+                        tx_rec.transaction_id(),
+                        local_committee_info.shard_group()
+                    );
+                    Ok(Some(Command::LocalAccept(atom)))
+                } else {
+                    let atom = tx_rec.get_current_transaction_atom();
+                    Ok(Some(Command::LocalPrepare(atom)))
+                }
             },
-        };
-
-        Ok(Some(command))
-    }
-
-    fn local_prepare_transaction(
-        &self,
-        tx: &<TConsensusSpec::StateStore as StateStore>::ReadTransaction<'_>,
-        local_committee_info: &CommitteeInfo,
-        tx_rec: &TransactionPoolRecord,
-    ) -> Result<Option<Command>, HotStuffError> {
-        if tx_rec.current_decision().is_abort() {
-            let atom = tx_rec.get_current_transaction_atom();
-            return Ok(Some(Command::LocalAccept(atom)));
-        }
-        if tx_rec
-            .evidence()
-            .is_committee_output_only(local_committee_info.shard_group())
-        {
-            if !tx_rec.has_all_required_foreign_input_pledges(tx, local_committee_info)? {
-                error!(
-                    target: LOG_TARGET,
-                    "BUG: attempted to propose transaction {} as Prepared but not all foreign input pledges were found. \
-                     This transaction should not have been marked as ready. {}",
-                    tx_rec.transaction_id(),
-                    tx_rec.evidence()
-                );
-                return Ok(None);
-            }
-            let atom = tx_rec.get_local_transaction_atom();
-            debug!(
-                target: LOG_TARGET,
-                "ℹ️ Transaction {} is output-only for {}, proposing LocalAccept",
-                tx_rec.transaction_id(),
-                local_committee_info.shard_group()
-            );
-            Ok(Some(Command::LocalAccept(atom)))
-        } else {
-            let atom = tx_rec.get_local_transaction_atom();
-            Ok(Some(Command::LocalPrepare(atom)))
         }
     }
 
-    fn all_or_some_prepare_transaction(
+    fn local_accept_transaction(
         &self,
         tx: &<TConsensusSpec::StateStore as StateStore>::ReadTransaction<'_>,
         parent_block: &LeafBlock,
@@ -960,7 +943,7 @@ where TConsensusSpec: ConsensusSpec
     ) -> Result<Option<Command>, HotStuffError> {
         // Only set to abort if either the local or one or more foreign shards decided to ABORT
         if tx_rec.current_decision().is_abort() {
-            return Ok(Some(Command::SomePrepare(tx_rec.get_current_transaction_atom())));
+            return Ok(Some(Command::LocalAccept(tx_rec.get_current_transaction_atom())));
         }
 
         let transaction = TransactionRecord::get(tx, tx_rec.transaction_id())?;
@@ -1001,7 +984,7 @@ where TConsensusSpec: ConsensusSpec
             );
 
             executed_transactions.insert(*tx_rec.transaction_id(), execution);
-            return Ok(Some(Command::AllPrepare(tx_rec.get_current_transaction_atom())));
+            return Ok(Some(Command::LocalAccept(tx_rec.get_current_transaction_atom())));
         }
 
         tx_rec.update_from_execution(
@@ -1009,11 +992,11 @@ where TConsensusSpec: ConsensusSpec
             local_committee_info.num_committees(),
             &execution,
         );
-
         executed_transactions.insert(*tx_rec.transaction_id(), execution);
         // If we locally decided to ABORT, we are still saying that we think all prepared and, after execution decide to
         // ABORT. When we enter the acceptance phase, we will propose SomeAccept for this case.
-        Ok(Some(Command::AllPrepare(tx_rec.get_current_transaction_atom())))
+        let atom = self.get_transaction_atom_with_leader_fee(tx_rec)?;
+        Ok(Some(Command::LocalAccept(atom)))
     }
 
     fn accept_transaction(

--- a/dan_layer/consensus/src/hotstuff/on_ready_to_vote_on_local_block.rs
+++ b/dan_layer/consensus/src/hotstuff/on_ready_to_vote_on_local_block.rs
@@ -5,14 +5,7 @@ use std::num::NonZeroU64;
 
 use log::*;
 use tari_crypto::ristretto::RistrettoPublicKey;
-use tari_dan_common_types::{
-    committee::CommitteeInfo,
-    displayable::Displayable,
-    optional::Optional,
-    Epoch,
-    ShardGroup,
-    VersionedSubstateId,
-};
+use tari_dan_common_types::{committee::CommitteeInfo, optional::Optional, Epoch, ShardGroup, VersionedSubstateId};
 use tari_dan_storage::{
     consensus_models::{
         AbortReason,
@@ -349,20 +342,6 @@ where TConsensusSpec: ConsensusSpec
                         return Ok(());
                     }
                 },
-                Command::Prepare(atom) => {
-                    if let Some(reason) = self.evaluate_prepare_command(
-                        tx,
-                        block,
-                        &locked_block,
-                        atom,
-                        local_committee_info,
-                        &mut substate_store,
-                        proposed_block_change_set,
-                    )? {
-                        proposed_block_change_set.no_vote(reason);
-                        return Ok(());
-                    }
-                },
                 Command::LocalPrepare(atom) => {
                     if let Some(reason) = self.evaluate_local_prepare_command(
                         tx,
@@ -370,31 +349,9 @@ where TConsensusSpec: ConsensusSpec
                         &locked_block,
                         atom,
                         local_committee_info,
-                        proposed_block_change_set,
-                    )? {
-                        proposed_block_change_set.no_vote(reason);
-                        return Ok(());
-                    }
-                },
-                Command::AllPrepare(atom) => {
-                    // Execute here
-                    if let Some(reason) = self.evaluate_all_prepare_command(
-                        tx,
-                        block,
-                        &locked_block,
-                        atom,
-                        local_committee_info,
                         &mut substate_store,
                         proposed_block_change_set,
                     )? {
-                        proposed_block_change_set.no_vote(reason);
-                        return Ok(());
-                    }
-                },
-                Command::SomePrepare(atom) => {
-                    if let Some(reason) =
-                        self.evaluate_some_prepare_command(tx, block, &locked_block, atom, proposed_block_change_set)?
-                    {
                         proposed_block_change_set.no_vote(reason);
                         return Ok(());
                     }
@@ -406,6 +363,7 @@ where TConsensusSpec: ConsensusSpec
                         &locked_block,
                         atom,
                         local_committee_info,
+                        &mut substate_store,
                         proposed_block_change_set,
                     )? {
                         proposed_block_change_set.no_vote(reason);
@@ -777,29 +735,16 @@ where TConsensusSpec: ConsensusSpec
     }
 
     #[allow(clippy::too_many_lines)]
-    fn evaluate_prepare_command(
+    fn initial_prepare_multishard(
         &self,
-        tx: &<TConsensusSpec::StateStore as StateStore>::ReadTransaction<'_>,
+        tx_rec: &mut TransactionPoolRecord,
         block: &Block,
-        locked_block: &LockedBlock,
         atom: &TransactionAtom,
         local_committee_info: &CommitteeInfo,
         substate_store: &mut PendingSubstateStore<TConsensusSpec::StateStore>,
         proposed_block_change_set: &mut ProposedBlockChangeSet,
     ) -> Result<Option<NoVoteReason>, HotStuffError> {
         let _timer = TraceTimer::info(LOG_TARGET, "Evaluate Prepare command");
-        let Some(mut tx_rec) = proposed_block_change_set
-            .get_transaction(tx, locked_block, &block.as_leaf_block(), atom.id())
-            .optional()?
-        else {
-            warn!(
-                target: LOG_TARGET,
-                "⚠️ Local proposal received ({}) for transaction {} which is not in the pool. This is likely a previous transaction that has been re-proposed. Not voting on block.",
-                block,
-                atom.id(),
-            );
-            return Ok(Some(NoVoteReason::TransactionNotInPool));
-        };
 
         info!(
             target: LOG_TARGET,
@@ -824,7 +769,7 @@ where TConsensusSpec: ConsensusSpec
 
         let prepared = self
             .transaction_manager
-            .prepare(substate_store, local_committee_info, block.epoch(), &tx_rec, block.id())
+            .prepare(substate_store, local_committee_info, block.epoch(), tx_rec, block.id())
             .map_err(|e| HotStuffError::TransactionExecutorError(e.to_string()))?;
 
         if !prepared.is_involved(local_committee_info) {
@@ -863,22 +808,6 @@ where TConsensusSpec: ConsensusSpec
                         remote: atom.decision,
                     }));
                 }
-
-                if !atom.evidence.contains(&local_committee_info.shard_group()) {
-                    warn!(
-                        target: LOG_TARGET,
-                        "❌ Prepare command for transaction {} has invalid evidence {} missing local shard group {}
-                    in {}",         tx_rec.transaction_id(),
-                        atom.evidence,
-                        local_committee_info.shard_group(),
-                        block,
-                    );
-                    return Ok(Some(NoVoteReason::InvalidEvidence {
-                        reason: InvalidEvidenceReason::MissingInvolvedShardGroup {
-                            shard_group: local_committee_info.shard_group(),
-                        },
-                    }));
-                };
 
                 // TODO: this is kinda hacky - we may not be involved in the transaction after ABORT execution,
                 // but this would be invalid so we ensure that we are added to evidence. Ideally, we wouldn't
@@ -933,42 +862,8 @@ where TConsensusSpec: ConsensusSpec
                         tx_rec.set_evidence(evidence);
                     },
                 }
-
-                // Check the local evidence only since in this phase that is all that should be included.
-                // Aside from data reduction, on_propose may propose a foreign proposal that updates the
-                // evidence in the same block. However, because on_propose does not
-                // include the evidence from the foreign proposal since it is processed here for the proposer,
-                // foreign shard evidence will mismatch in this case.
-                if atom.evidence.get(&local_committee_info.shard_group()) !=
-                    tx_rec.evidence().get(&local_committee_info.shard_group())
-                {
-                    warn!(
-                        target: LOG_TARGET,
-                        "❌ Prepare command for transaction {} has invalid evidence in {}",
-                        tx_rec.transaction_id(),
-                        block,
-                    );
-                    warn!(
-                        target: LOG_TARGET,
-                        "❌ Prepare command evidence {} {}",
-                        local_committee_info.shard_group(),
-                        atom.evidence.get(&local_committee_info.shard_group()).display()
-                    );
-                    warn!(
-                        target: LOG_TARGET,
-                        "❌ local evidence {} {}",
-                        local_committee_info.shard_group(),
-                        tx_rec.evidence().get(&local_committee_info.shard_group()).display()
-                    );
-                    return Ok(Some(NoVoteReason::InvalidEvidence {
-                        reason: InvalidEvidenceReason::MismatchedEvidence,
-                    }));
-                }
             },
         }
-
-        tx_rec.set_next_stage(TransactionPoolStage::Prepared)?;
-        proposed_block_change_set.set_next_transaction_update(tx_rec)?;
 
         Ok(None)
     }
@@ -980,6 +875,7 @@ where TConsensusSpec: ConsensusSpec
         locked_block: &LockedBlock,
         atom: &TransactionAtom,
         local_committee_info: &CommitteeInfo,
+        substate_store: &mut PendingSubstateStore<TConsensusSpec::StateStore>,
         proposed_block_change_set: &mut ProposedBlockChangeSet,
     ) -> Result<Option<NoVoteReason>, HotStuffError> {
         let Some(mut tx_rec) = proposed_block_change_set
@@ -995,7 +891,7 @@ where TConsensusSpec: ConsensusSpec
             return Ok(Some(NoVoteReason::TransactionNotInPool));
         };
 
-        if !tx_rec.current_stage().is_prepared() {
+        if !tx_rec.current_stage().is_new() {
             warn!(
                 target: LOG_TARGET,
                 "{} ❌ LocalPrepare Stage disagreement in block {} for transaction {}. Leader proposed LocalPrepare, but local stage is {}",
@@ -1005,26 +901,20 @@ where TConsensusSpec: ConsensusSpec
                 tx_rec.current_stage()
             );
             return Ok(Some(NoVoteReason::StageDisagreement {
-                expected: TransactionPoolStage::Prepared,
+                expected: TransactionPoolStage::New,
                 stage: tx_rec.current_stage(),
             }));
         }
-        // We check that the leader decision is the same as our local decision.
-        // We disregard the remote decision because not all validators may have received the foreign
-        // LocalPrepared yet. We will never accept a decision disagreement for the Accept command.
-        if tx_rec.current_local_decision() != atom.decision {
-            warn!(
-                target: LOG_TARGET,
-                "❌ LocalPrepared decision disagreement for transaction {} in block {}. Leader proposed {}, we decided {}",
-                tx_rec.transaction_id(),
-                block,
-                atom.decision,
-                tx_rec.current_local_decision()
-            );
-            return Ok(Some(NoVoteReason::DecisionDisagreement {
-                local: tx_rec.current_local_decision(),
-                remote: atom.decision,
-            }));
+
+        if let Some(reason) = self.initial_prepare_multishard(
+            &mut tx_rec,
+            block,
+            atom,
+            local_committee_info,
+            substate_store,
+            proposed_block_change_set,
+        )? {
+            return Ok(Some(reason));
         }
 
         if tx_rec.transaction_fee() != atom.transaction_fee {
@@ -1062,7 +952,7 @@ where TConsensusSpec: ConsensusSpec
     }
 
     #[allow(clippy::too_many_lines)]
-    fn evaluate_all_prepare_command(
+    fn evaluate_local_accept_command(
         &self,
         tx: &<TConsensusSpec::StateStore as StateStore>::ReadTransaction<'_>,
         block: &Block,
@@ -1072,7 +962,6 @@ where TConsensusSpec: ConsensusSpec
         substate_store: &mut PendingSubstateStore<TConsensusSpec::StateStore>,
         proposed_block_change_set: &mut ProposedBlockChangeSet,
     ) -> Result<Option<NoVoteReason>, HotStuffError> {
-        let _timer = TraceTimer::info(LOG_TARGET, "Evaluate AllPrepare command (execute)");
         let Some(mut tx_rec) = proposed_block_change_set
             .get_transaction(tx, locked_block, &block.as_leaf_block(), atom.id())
             .optional()?
@@ -1086,65 +975,53 @@ where TConsensusSpec: ConsensusSpec
             return Ok(Some(NoVoteReason::TransactionNotInPool));
         };
 
-        if !tx_rec.current_stage().is_local_prepared() {
-            warn!(
-                target: LOG_TARGET,
-                "{} ❌ Stage disagreement in block {} for transaction {}. Leader proposed AllPrepare, but current stage is {}",
-                self.local_validator_pk,
+        if tx_rec.current_stage().is_new() {
+            // CASE: This was supposedly sequenced because we are aborting or because we are an output-only shardgroup
+            if let Some(reason) = self.initial_prepare_multishard(
+                &mut tx_rec,
                 block,
-                tx_rec.transaction_id(),
-                tx_rec.current_stage()
-            );
-            return Ok(Some(NoVoteReason::StageDisagreement {
-                expected: TransactionPoolStage::LocalPrepared,
-                stage: tx_rec.current_stage(),
-            }));
-        }
+                atom,
+                local_committee_info,
+                substate_store,
+                proposed_block_change_set,
+            )? {
+                return Ok(Some(reason));
+            }
+            if !tx_rec.current_decision().is_abort() &&
+                !tx_rec
+                    .evidence()
+                    .is_committee_output_only(local_committee_info.shard_group())
+            {
+                warn!(
+                    target: LOG_TARGET,
+                    "❌ LocalAccept: transaction {} in block {} is not output-only",
+                    tx_rec.transaction_id(),
+                    block,
+                );
+                return Ok(Some(NoVoteReason::OutputOnlyDisagreement {
+                    transaction_id: *tx_rec.transaction_id(),
+                    shard_group: local_committee_info.shard_group(),
+                    command: "LocalAccept",
+                    stage: tx_rec.current_stage(),
+                }));
+            }
+        } else if tx_rec.current_decision().is_commit() {
+            // CASE: We are in the LocalPrepared stage, and want to proceed to LocalAccept
 
-        // If we've already decided to abort, we cannot change to commit in LocalPrepared phase so proposing AllPrepared
-        // is invalid
-        if tx_rec.current_decision().is_abort() && atom.decision.is_commit() {
-            warn!(
-                target: LOG_TARGET,
-                "❌ NO VOTE AllPrepare: decision disagreement for transaction {} in block {}. Leader proposed {}, we decided {}",
-                tx_rec.transaction_id(),
-                block,
-                atom.decision,
-                tx_rec.current_decision()
-            );
-            return Ok(Some(NoVoteReason::DecisionDisagreement {
-                local: tx_rec.current_decision(),
-                remote: atom.decision,
-            }));
-        }
-
-        if !tx_rec.evidence().all_input_shard_groups_prepared() {
-            warn!(
-                target: LOG_TARGET,
-                "❌ NO VOTE: AllPrepare disagreement for transaction {} in block {}. Leader proposed that all shard groups have prepared, but this is not the case",
-                tx_rec.transaction_id(),
-                block,
-            );
-            return Ok(Some(NoVoteReason::NotAllShardGroupsPrepared));
-        }
-
-        // TODO: on_propose does not process foreign proposals so we cannot rely on this check
-        // if !atom.evidence.all_input_shard_groups_prepared() {
-        //     warn!(
-        //         target: LOG_TARGET,
-        //         "❌ NO VOTE: AllPrepare disagreement for transaction {} in block {}. {}",
-        //         tx_rec.transaction_id(),
-        //         block,
-        //         InvalidEvidenceReason::NotAllShardGroupsPrepared,
-        //     );
-        //     return Ok(Some(NoVoteReason::InvalidEvidence {
-        //         reason: InvalidEvidenceReason::NotAllShardGroupsPrepared,
-        //     }));
-        // }
-
-        let maybe_execution = if tx_rec.current_decision().is_commit() {
-            // TODO: provide the current input locks to the executor, the executor must fail if a write lock is
-            // requested for a read-locked substate.
+            if !tx_rec.current_stage().is_local_prepared() {
+                warn!(
+                    target: LOG_TARGET,
+                    "❌ LocalAccept: transaction {} in block {} is not in COMMITTED LocalPrepared stage (committed stage: {}, current stage: {})",
+                    tx_rec.transaction_id(),
+                    block,
+                    tx_rec.committed_stage(),
+                    tx_rec.current_stage(),
+                );
+                return Ok(Some(NoVoteReason::StageDisagreement {
+                    expected: TransactionPoolStage::LocalPrepared,
+                    stage: tx_rec.current_stage(),
+                }));
+            }
 
             let transaction = tx_rec.get_transaction(tx)?;
             if !transaction.has_all_required_input_pledges(tx, local_committee_info)? {
@@ -1201,9 +1078,10 @@ where TConsensusSpec: ConsensusSpec
 
                     execution.set_abort_reason(RejectReason::FailedToLockOutputs(err.to_string()));
 
-                    tx_rec.set_local_decision(Decision::Abort(AbortReason::LockOutputsFailed));
-                    tx_rec.set_transaction_fee(0);
-                    tx_rec.set_next_stage(TransactionPoolStage::AllPrepared)?;
+                    tx_rec
+                        .set_local_decision(Decision::Abort(AbortReason::LockOutputsFailed))
+                        .set_transaction_fee(0)
+                        .set_next_stage(TransactionPoolStage::LocalAccepted)?;
 
                     proposed_block_change_set
                         .set_next_transaction_update(tx_rec)?
@@ -1213,233 +1091,16 @@ where TConsensusSpec: ConsensusSpec
                 }
             }
 
-            Some(execution)
-        } else {
-            // If we already locally decided to abort, there is no purpose in executing the transaction
-            None
-        };
-
-        // We check that the leader decision is the same as our local decision.
-        if tx_rec.current_decision() != atom.decision {
-            warn!(
+            info!(
                 target: LOG_TARGET,
-                "❌ NO VOTE AllAccept: decision disagreement for transaction {} (after execute) in block {}. Leader proposed {}, we decided {}",
+                "👨‍🔧 LocalAccept: Executed transaction {} in block {} with decision {}",
                 tx_rec.transaction_id(),
                 block,
-                atom.decision,
-                tx_rec.current_decision()
+                execution.decision()
             );
-            return Ok(Some(NoVoteReason::DecisionDisagreement {
-                local: tx_rec.current_decision(),
-                remote: atom.decision,
-            }));
-        }
-
-        if tx_rec.transaction_fee() != atom.transaction_fee {
-            warn!(
-                target: LOG_TARGET,
-                "❌ NO VOTE AllAccept: transaction fee disagreement tx {} in block {}. Leader proposed {}, we calculated {}",
-                tx_rec.transaction_id(),
-                block,
-                atom.transaction_fee,
-                tx_rec.transaction_fee()
-            );
-            return Ok(Some(NoVoteReason::FeeDisagreement));
-        }
-
-        if tx_rec.transaction_fee() != atom.transaction_fee {
-            warn!(
-                target: LOG_TARGET,
-                "❌ AllPrepare transaction fee disagreement tx {} in block {}. Leader proposed {}, we calculated {}",
-                tx_rec.transaction_id(),
-                block,
-                atom.transaction_fee,
-                tx_rec.transaction_fee()
-            );
-            return Ok(Some(NoVoteReason::FeeDisagreement));
-        }
-
-        if !tx_rec.evidence().eq_pledges(&atom.evidence) {
-            warn!(
-                target: LOG_TARGET,
-                "❌ AllPrepare evidence disagreement tx {} in block {}. Leader proposed {}, we calculated {}",
-                tx_rec.transaction_id(),
-                block,
-                atom.evidence,
-                tx_rec.evidence()
-            );
-            return Ok(Some(NoVoteReason::InvalidEvidence {
-                reason: InvalidEvidenceReason::MismatchedEvidence,
-            }));
-        }
-
-        // maybe_execution is only None if the transaction is not committed
-        if let Some(execution) = maybe_execution {
             proposed_block_change_set.add_transaction_execution(execution)?;
-        }
-
-        tx_rec.set_next_stage(TransactionPoolStage::AllPrepared)?;
-        proposed_block_change_set.set_next_transaction_update(tx_rec)?;
-
-        Ok(None)
-    }
-
-    fn evaluate_some_prepare_command(
-        &self,
-        tx: &<TConsensusSpec::StateStore as StateStore>::ReadTransaction<'_>,
-        block: &Block,
-        locked_block: &LockedBlock,
-        atom: &TransactionAtom,
-        proposed_block_change_set: &mut ProposedBlockChangeSet,
-    ) -> Result<Option<NoVoteReason>, HotStuffError> {
-        if atom.decision.is_commit() {
-            warn!(
-                target: LOG_TARGET,
-                "❌ SomePrepare command received for block {} but requires that the transaction is ABORT",
-                block.id(),
-            );
-            return Ok(Some(NoVoteReason::DecisionDisagreement {
-                local: Decision::Abort(AbortReason::TransactionAtomMustBeAbort),
-                remote: Decision::Commit,
-            }));
-        }
-
-        let Some(mut tx_rec) = proposed_block_change_set
-            .get_transaction(tx, locked_block, &block.as_leaf_block(), atom.id())
-            .optional()?
-        else {
-            warn!(
-                target: LOG_TARGET,
-                "⚠️ Local proposal received ({}) for transaction {} which is not in the pool. This is likely a previous transaction that has been re-proposed. Not voting on block.",
-                block,
-                atom.id(),
-            );
-            return Ok(Some(NoVoteReason::TransactionNotInPool));
-        };
-
-        // If the local node would decide SomePrepare too, we should have already ABORTed due to foreign prepare abort
-        // or local input lock conflict
-        if tx_rec.current_decision().is_commit() {
-            warn!(
-                target: LOG_TARGET,
-                "❌ SomePrepare decision disagreement for transaction {} in block {}. Leader proposed ABORT, we decided COMMIT",
-                tx_rec.transaction_id(),
-                block,
-            );
-            return Ok(Some(NoVoteReason::DecisionDisagreement {
-                local: Decision::Commit,
-                remote: atom.decision,
-            }));
-        }
-
-        if !tx_rec.current_stage().is_local_prepared() {
-            warn!(
-                target: LOG_TARGET,
-                "{} ❌ Stage disagreement in block {} for transaction {}. Leader proposed SomePrepare, but local stage is {}",
-                self.local_validator_pk,
-                block,
-                tx_rec.transaction_id(),
-                tx_rec.current_stage()
-            );
-            return Ok(Some(NoVoteReason::StageDisagreement {
-                expected: TransactionPoolStage::LocalPrepared,
-                stage: tx_rec.current_stage(),
-            }));
-        }
-
-        if tx_rec.transaction_fee() != atom.transaction_fee {
-            warn!(
-                target: LOG_TARGET,
-                "❌ SomePrepare transaction fee disagreement tx {} in block {}. Leader proposed {}, we calculated {}",
-                tx_rec.transaction_id(),
-                block,
-                atom.transaction_fee,
-                tx_rec.transaction_fee()
-            );
-            return Ok(Some(NoVoteReason::FeeDisagreement));
-        }
-
-        tx_rec.set_next_stage(TransactionPoolStage::SomePrepared)?;
-        proposed_block_change_set.set_next_transaction_update(tx_rec)?;
-
-        Ok(None)
-    }
-
-    #[allow(clippy::too_many_lines)]
-    fn evaluate_local_accept_command(
-        &self,
-        tx: &<TConsensusSpec::StateStore as StateStore>::ReadTransaction<'_>,
-        block: &Block,
-        locked_block: &LockedBlock,
-        atom: &TransactionAtom,
-        local_committee_info: &CommitteeInfo,
-        proposed_block_change_set: &mut ProposedBlockChangeSet,
-    ) -> Result<Option<NoVoteReason>, HotStuffError> {
-        let Some(mut tx_rec) = proposed_block_change_set
-            .get_transaction(tx, locked_block, &block.as_leaf_block(), atom.id())
-            .optional()?
-        else {
-            warn!(
-                target: LOG_TARGET,
-                "⚠️ Local proposal received ({}) for transaction {} which is not in the pool. This is likely a previous transaction that has been re-proposed. Not voting on block.",
-                block,
-                atom.id(),
-            );
-            return Ok(Some(NoVoteReason::TransactionNotInPool));
-        };
-
-        // We check that the leader decision is the same as our local decision.
-        // We disregard the remote decision because not all validators may have received the foreign
-        // LocalPrepared yet. We will never accept a decision disagreement for the Accept command.
-        if tx_rec.current_decision() != atom.decision {
-            warn!(
-                target: LOG_TARGET,
-                "❌ NO VOTE LocalAccept: decision disagreement for transaction {} in block {}. Leader proposed {}, we decided {}",
-                tx_rec.transaction_id(),
-                block,
-                atom.decision,
-                tx_rec.current_decision()
-            );
-            return Ok(Some(NoVoteReason::DecisionDisagreement {
-                local: tx_rec.current_decision(),
-                remote: atom.decision,
-            }));
-        }
-
-        let is_applicable_stage = match tx_rec.current_decision() {
-            Decision::Commit => {
-                // Commit. AllPrepared, or from Prepared directly if we are output-only (which only has Accept phase)
-                tx_rec.current_stage().is_all_prepared() ||
-                    (tx_rec.current_stage().is_prepared() &&
-                        tx_rec
-                            .evidence()
-                            .is_committee_output_only(local_committee_info.shard_group()))
-            },
-            Decision::Abort(_) => {
-                // Abort. AllPrepared (aborted after executing) or SomePrepared (aborted before executing). We allow the
-                // transition from Prepared to LocalAccepted if ABORT, or we are output-only
-                tx_rec.current_stage().is_all_prepared() ||
-                    tx_rec.current_stage().is_some_prepared() ||
-                    (tx_rec.current_stage().is_prepared() ||
-                        tx_rec
-                            .evidence()
-                            .is_committee_output_only(local_committee_info.shard_group()))
-            },
-        };
-
-        if !is_applicable_stage {
-            let is_output_only = tx_rec
-                .evidence()
-                .is_committee_output_only(local_committee_info.shard_group());
-            let reason = NoVoteReason::StageTransitionNotApplicable {
-                current: tx_rec.current_stage(),
-                next: TransactionPoolStage::LocalAccepted,
-                is_output_only,
-                decision: tx_rec.current_decision(),
-            };
-
-            warn!(target: LOG_TARGET, "❌ {reason} in {block}");
-            return Ok(Some(reason));
+        } else {
+            // Abort - nothing to do here
         }
 
         if tx_rec.transaction_fee() != atom.transaction_fee {
@@ -1957,16 +1618,18 @@ where TConsensusSpec: ConsensusSpec
             new_locked_block,
         );
 
-        // Release all locks for SomePrepare transactions since these can never be committed
-        SubstateRecord::unlock_all(tx, new_locked_block.all_some_prepare().map(|t| &t.id))?;
+        // Release all locks for Aborted transactions since these can never be committed after accept
+        SubstateRecord::unlock_all(
+            tx,
+            new_locked_block
+                .all_local_accept()
+                .filter(|a| a.decision.is_abort())
+                .map(|t| &t.id),
+        )?;
 
         // Remove the chains that are no longer in this block's chain
         // This will also release any locks for blocks that no longer apply
         new_locked_block.remove_parallel_chains(tx)?;
-
-        // This moves the stage update from pending to current for all transactions on the locked block
-        self.transaction_pool
-            .confirm_all_transitions(tx, &new_locked_block.as_locked_block())?;
 
         Ok(())
     }
@@ -1997,6 +1660,10 @@ where TConsensusSpec: ConsensusSpec
             target: LOG_TARGET,
             "🌳 Committing block {} with {} substate change(s)", block, diff.len()
         );
+
+        // This moves the stage update from pending to current for all transactions on the commit block
+        self.transaction_pool
+            .confirm_all_transitions(tx, &block.as_leaf_block())?;
 
         for atom in block.all_foreign_proposals() {
             // TODO: we need to keep these ATM to send them if a node needs to catch up

--- a/dan_layer/engine_types/src/substate.rs
+++ b/dan_layer/engine_types/src/substate.rs
@@ -356,6 +356,11 @@ impl From<ValidatorFeePoolAddress> for SubstateId {
     }
 }
 
+impl AsRef<SubstateId> for SubstateId {
+    fn as_ref(&self) -> &SubstateId {
+        self
+    }
+}
 #[derive(Debug, thiserror::Error)]
 #[error("Could not convert substate ID variant '{substate_id}' to {expected}")]
 pub struct InvalidSubstateIdVariant {

--- a/dan_layer/p2p/proto/consensus.proto
+++ b/dan_layer/p2p/proto/consensus.proto
@@ -112,18 +112,15 @@ message LeaderFee {
 message Command {
   oneof command {
     TransactionAtom local_only = 1;
-    TransactionAtom prepare = 2;
-    TransactionAtom local_prepare = 3;
-    TransactionAtom all_prepare = 4;
-    TransactionAtom some_prepare = 5;
-    TransactionAtom local_accept = 6;
-    TransactionAtom all_accept = 7;
-    TransactionAtom some_accept = 8;
+    TransactionAtom local_prepare = 2;
+    TransactionAtom local_accept = 3;
+    TransactionAtom all_accept = 4;
+    TransactionAtom some_accept = 5;
 
-    ForeignProposalAtom foreign_proposal = 9;
-    MintConfidentialOutputAtom mint_confidential_output = 10;
-    EvictNodeAtom evict_node = 11;
-    bool end_epoch = 12;
+    ForeignProposalAtom foreign_proposal = 6;
+    MintConfidentialOutputAtom mint_confidential_output = 7;
+    EvictNodeAtom evict_node = 8;
+    bool end_epoch = 9;
   }
 }
 

--- a/dan_layer/p2p/src/conversions/consensus.rs
+++ b/dan_layer/p2p/src/conversions/consensus.rs
@@ -562,10 +562,7 @@ impl From<&Command> for proto::consensus::Command {
     fn from(value: &Command) -> Self {
         let command = match value {
             Command::LocalOnly(tx) => proto::consensus::command::Command::LocalOnly(tx.into()),
-            Command::Prepare(tx) => proto::consensus::command::Command::Prepare(tx.into()),
             Command::LocalPrepare(tx) => proto::consensus::command::Command::LocalPrepare(tx.into()),
-            Command::AllPrepare(tx) => proto::consensus::command::Command::AllPrepare(tx.into()),
-            Command::SomePrepare(tx) => proto::consensus::command::Command::SomePrepare(tx.into()),
             Command::LocalAccept(tx) => proto::consensus::command::Command::LocalAccept(tx.into()),
             Command::AllAccept(tx) => proto::consensus::command::Command::AllAccept(tx.into()),
             Command::SomeAccept(tx) => proto::consensus::command::Command::SomeAccept(tx.into()),
@@ -590,10 +587,7 @@ impl TryFrom<proto::consensus::Command> for Command {
         let command = value.command.ok_or_else(|| anyhow!("Command is missing"))?;
         Ok(match command {
             proto::consensus::command::Command::LocalOnly(tx) => Command::LocalOnly(tx.try_into()?),
-            proto::consensus::command::Command::Prepare(tx) => Command::Prepare(tx.try_into()?),
             proto::consensus::command::Command::LocalPrepare(tx) => Command::LocalPrepare(tx.try_into()?),
-            proto::consensus::command::Command::AllPrepare(tx) => Command::AllPrepare(tx.try_into()?),
-            proto::consensus::command::Command::SomePrepare(tx) => Command::SomePrepare(tx.try_into()?),
             proto::consensus::command::Command::LocalAccept(tx) => Command::LocalAccept(tx.try_into()?),
             proto::consensus::command::Command::AllAccept(tx) => Command::AllAccept(tx.try_into()?),
             proto::consensus::command::Command::SomeAccept(tx) => Command::SomeAccept(tx.try_into()?),

--- a/dan_layer/state_store_sqlite/src/writer.rs
+++ b/dan_layer/state_store_sqlite/src/writer.rs
@@ -1247,11 +1247,11 @@ impl<'tx, TAddr: NodeAddressable + 'tx> StateStoreWriteTransaction for SqliteSta
         txs.into_iter().map(|tx| tx.try_convert(None)).collect()
     }
 
-    fn transaction_pool_confirm_all_transitions(&mut self, new_locked_block: &LockedBlock) -> Result<(), StorageError> {
+    fn transaction_pool_confirm_all_transitions(&mut self, block: &LeafBlock) -> Result<(), StorageError> {
         use crate::schema::{transaction_pool, transaction_pool_state_updates};
 
         let updates = transaction_pool_state_updates::table
-            .filter(transaction_pool_state_updates::block_id.eq(serialize_hex(new_locked_block.block_id())))
+            .filter(transaction_pool_state_updates::block_id.eq(serialize_hex(block.block_id())))
             .filter(transaction_pool_state_updates::is_applied.eq(false))
             .get_results::<sql_models::TransactionPoolStateUpdate>(self.connection())
             .map_err(|e| SqliteStorageError::DieselError {
@@ -1261,12 +1261,12 @@ impl<'tx, TAddr: NodeAddressable + 'tx> StateStoreWriteTransaction for SqliteSta
 
         debug!(
             target: LOG_TARGET,
-            "transaction_pool_confirm_all_transitions: new_locked_block={}, {} updates",  new_locked_block, updates.len()
+            "transaction_pool_confirm_all_transitions: new_locked_block={}, {} updates",  block, updates.len()
         );
 
         diesel::update(transaction_pool_state_updates::table)
             .filter(transaction_pool_state_updates::id.eq_any(updates.iter().map(|u| u.id)))
-            .filter(transaction_pool_state_updates::block_height.le(new_locked_block.height().as_u64() as i64))
+            .filter(transaction_pool_state_updates::block_height.le(block.height().as_u64() as i64))
             .set(transaction_pool_state_updates::is_applied.eq(true))
             .execute(self.connection())
             .map_err(|e| SqliteStorageError::DieselError {

--- a/dan_layer/state_store_sqlite/tests/tests.rs
+++ b/dan_layer/state_store_sqlite/tests/tests.rs
@@ -60,7 +60,7 @@ mod confirm_all_transitions {
             Default::default(),
             // Need to have a command in, otherwise this block will not be included internally in the query because it
             // cannot cause a state change without any commands
-            [Command::Prepare(atom1.clone())].into_iter().collect(),
+            [Command::LocalPrepare(atom1.clone())].into_iter().collect(),
             Default::default(),
             Default::default(),
             Default::default(),
@@ -100,11 +100,10 @@ mod confirm_all_transitions {
             .unwrap()
             .clone();
 
-        tx_1.set_next_stage(TransactionPoolStage::Prepared).unwrap();
         tx_1.set_next_stage(TransactionPoolStage::LocalPrepared).unwrap();
 
-        tx_2.set_next_stage(TransactionPoolStage::Prepared).unwrap();
-        tx_3.set_next_stage(TransactionPoolStage::Prepared).unwrap();
+        tx_2.set_next_stage(TransactionPoolStage::LocalPrepared).unwrap();
+        tx_3.set_next_stage(TransactionPoolStage::LocalPrepared).unwrap();
 
         tx.transaction_pool_add_pending_update(&block_id, &TransactionPoolStatusUpdate::new(tx_1, true))
             .unwrap();
@@ -123,9 +122,9 @@ mod confirm_all_transitions {
             .transaction_pool_get_for_blocks(zero_block.id(), &block_id, &atom2.id)
             .unwrap();
         assert!(rec.committed_stage().is_new());
-        assert!(rec.pending_stage().unwrap().is_prepared());
+        assert!(rec.pending_stage().unwrap().is_local_prepared());
 
-        tx.transaction_pool_confirm_all_transitions(&block1.as_locked_block())
+        tx.transaction_pool_confirm_all_transitions(&block1.as_leaf_block())
             .unwrap();
 
         let rec = tx
@@ -137,13 +136,13 @@ mod confirm_all_transitions {
         let rec = tx
             .transaction_pool_get_for_blocks(zero_block.id(), &block_id, &atom2.id)
             .unwrap();
-        assert_eq!(rec.committed_stage(), TransactionPoolStage::Prepared);
+        assert_eq!(rec.committed_stage(), TransactionPoolStage::LocalPrepared);
         assert_eq!(rec.pending_stage(), None);
 
         let rec = tx
             .transaction_pool_get_for_blocks(zero_block.id(), &block_id, &atom3.id)
             .unwrap();
-        assert_eq!(rec.committed_stage(), TransactionPoolStage::Prepared);
+        assert_eq!(rec.committed_stage(), TransactionPoolStage::LocalPrepared);
         assert_eq!(rec.pending_stage(), None);
 
         tx.rollback().unwrap();

--- a/dan_layer/storage/src/consensus_models/block.rs
+++ b/dan_layer/storage/src/consensus_models/block.rs
@@ -323,8 +323,8 @@ impl Block {
         self.commands.iter().filter_map(|c| c.mint_confidential_output())
     }
 
-    pub fn all_some_prepare(&self) -> impl Iterator<Item = &TransactionAtom> + '_ {
-        self.commands.iter().filter_map(|c| c.some_prepare())
+    pub fn all_local_accept(&self) -> impl Iterator<Item = &TransactionAtom> + '_ {
+        self.commands.iter().filter_map(|c| c.local_accept())
     }
 
     pub fn command_count(&self) -> usize {

--- a/dan_layer/storage/src/consensus_models/command.rs
+++ b/dan_layer/storage/src/consensus_models/command.rs
@@ -96,14 +96,9 @@ pub enum Command {
     /// Request validators to prepare a local-only transaction
     LocalOnly(TransactionAtom),
     /// Request validators to prepare a transaction.
-    Prepare(TransactionAtom),
-    /// Request validators to agree that the transaction was prepared by all local validators.
     LocalPrepare(TransactionAtom),
-    /// Request validators to agree that all involved shard groups prepared the transaction.
-    AllPrepare(TransactionAtom),
-    /// Request validators to agree that one or more involved shard groups did not prepare the transaction.
-    SomePrepare(TransactionAtom),
-    /// Request validators to accept (i.e. accept COMMIT/ABORT decision) a transaction. All foreign inputs are received
+    /// Request validators to  agree that all involved shard groups prepared the transaction and
+    /// accept (i.e. accept COMMIT/ABORT decision) a transaction. All foreign inputs are received
     /// and the transaction is executed with the same decision.
     LocalAccept(TransactionAtom),
     /// Request validators to agree that all involved shard groups agreed to ACCEPT the transaction.
@@ -132,10 +127,7 @@ enum CommandOrdering<'a> {
 impl Command {
     pub fn transaction(&self) -> Option<&TransactionAtom> {
         match self {
-            Command::Prepare(tx) |
             Command::LocalPrepare(tx) |
-            Command::AllPrepare(tx) |
-            Command::SomePrepare(tx) |
             Command::LocalAccept(tx) |
             Command::AllAccept(tx) |
             Command::SomeAccept(tx) |
@@ -149,10 +141,7 @@ impl Command {
 
     fn as_ordering(&self) -> CommandOrdering<'_> {
         match self {
-            Command::Prepare(tx) |
             Command::LocalPrepare(tx) |
-            Command::AllPrepare(tx) |
-            Command::SomePrepare(tx) |
             Command::LocalAccept(tx) |
             Command::AllAccept(tx) |
             Command::SomeAccept(tx) |
@@ -178,23 +167,9 @@ impl Command {
         }
     }
 
-    pub fn prepare(&self) -> Option<&TransactionAtom> {
-        match self {
-            Command::Prepare(tx) => Some(tx),
-            _ => None,
-        }
-    }
-
     pub fn local_prepare(&self) -> Option<&TransactionAtom> {
         match self {
             Command::LocalPrepare(tx) => Some(tx),
-            _ => None,
-        }
-    }
-
-    pub fn some_prepare(&self) -> Option<&TransactionAtom> {
-        match self {
-            Command::SomePrepare(tx) => Some(tx),
             _ => None,
         }
     }
@@ -297,10 +272,7 @@ impl Display for Command {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             Command::LocalOnly(tx) => write!(f, "LocalOnly({}, {})", tx.id, tx.decision),
-            Command::Prepare(tx) => write!(f, "Prepare({}, {})", tx.id, tx.decision),
             Command::LocalPrepare(tx) => write!(f, "LocalPrepare({}, {})", tx.id, tx.decision),
-            Command::AllPrepare(tx) => write!(f, "AllPrepared({}, {})", tx.id, tx.decision),
-            Command::SomePrepare(tx) => write!(f, "SomePrepared({}, {})", tx.id, tx.decision),
             Command::LocalAccept(tx) => write!(f, "LocalAccept({}, {})", tx.id, tx.decision),
             Command::AllAccept(tx) => write!(f, "AllAccept({}, {})", tx.id, tx.decision),
             Command::SomeAccept(tx) => write!(f, "SomeAccept({}, {})", tx.id, tx.decision),
@@ -375,7 +347,7 @@ mod tests {
                 block_id: BlockId::zero(),
                 shard_group: ShardGroup::new(0, 64),
             }),
-            Command::Prepare(TransactionAtom {
+            Command::LocalPrepare(TransactionAtom {
                 id: TransactionId::default(),
                 decision: Decision::Commit,
                 evidence: Evidence::default(),

--- a/dan_layer/storage/src/consensus_models/no_vote.rs
+++ b/dan_layer/storage/src/consensus_models/no_vote.rs
@@ -2,6 +2,7 @@
 //   SPDX-License-Identifier: BSD-3-Clause
 
 use tari_dan_common_types::ShardGroup;
+use tari_transaction::TransactionId;
 
 use crate::consensus_models::{Decision, TransactionPoolStage};
 
@@ -20,6 +21,16 @@ pub enum NoVoteReason {
         next: TransactionPoolStage,
         is_output_only: bool,
         decision: Decision,
+    },
+    #[error(
+        "Output only disagreement for local {shard_group}. Transaction ID: {transaction_id}, Stage: {stage}, Command: \
+         {command}"
+    )]
+    OutputOnlyDisagreement {
+        transaction_id: TransactionId,
+        shard_group: ShardGroup,
+        stage: TransactionPoolStage,
+        command: &'static str,
     },
     #[error("The transaction is not in the pool")]
     TransactionNotInPool,
@@ -91,6 +102,7 @@ impl NoVoteReason {
             Self::AlreadyVotedAtHeight => "ShouldNotVote",
             Self::StageDisagreement { .. } => "StageDisagreement",
             Self::StageTransitionNotApplicable { .. } => "StageTransitionNotApplicable",
+            Self::OutputOnlyDisagreement { .. } => "OutputOnlyDisagreement",
             Self::TransactionNotInPool => "TransactionNotInPool",
             Self::DecisionDisagreement { .. } => "DecisionDisagreement",
             Self::FeeDisagreement => "FeeDisagreement",

--- a/dan_layer/storage/src/consensus_models/transaction_pool.rs
+++ b/dan_layer/storage/src/consensus_models/transaction_pool.rs
@@ -215,9 +215,9 @@ impl<TStateStore: StateStore> TransactionPool<TStateStore> {
     pub fn confirm_all_transitions(
         &self,
         tx: &mut TStateStore::WriteTransaction<'_>,
-        locked_block: &LockedBlock,
+        block: &LeafBlock,
     ) -> Result<(), TransactionPoolError> {
-        tx.transaction_pool_confirm_all_transitions(locked_block)?;
+        tx.transaction_pool_confirm_all_transitions(block)?;
         Ok(())
     }
 
@@ -240,16 +240,11 @@ impl<TStateStore: StateStore> TransactionPool<TStateStore> {
 pub enum TransactionPoolStage {
     /// Transaction has just come in and has never been proposed
     New,
-    /// Transaction is prepared in response to a Prepare command, but we do not yet have confirmation that the rest of
-    /// the local committee has prepared.
-    Prepared,
-    /// We have proof that all local committees have prepared the transaction
+    /// Transaction is prepared in response to a LocalPrepare command. We have proof that all local committees have
+    /// prepared the transaction
     LocalPrepared,
-    /// All involved shard groups have prepared and all have pledged their local inputs
-    AllPrepared,
-    /// Some involved shard groups have prepared but one or more did not successfully pledge their local inputs
-    SomePrepared,
-    /// The local shard group has accepted the transaction
+    /// All (Commit), Some or None (Abort) of involved shard groups have prepared and all have pledged their local
+    /// inputs The local shard group should accept the transaction
     LocalAccepted,
     /// All involved shard groups have accepted the transaction
     AllAccepted,
@@ -268,24 +263,12 @@ impl TransactionPoolStage {
         matches!(self, Self::LocalOnly)
     }
 
-    pub fn is_prepared(&self) -> bool {
-        matches!(self, Self::Prepared)
-    }
-
     pub fn is_local_prepared(&self) -> bool {
         matches!(self, Self::LocalPrepared)
     }
 
     pub fn is_local_accepted(&self) -> bool {
         matches!(self, Self::LocalAccepted)
-    }
-
-    pub fn is_some_prepared(&self) -> bool {
-        matches!(self, Self::SomePrepared)
-    }
-
-    pub fn is_all_prepared(&self) -> bool {
-        matches!(self, Self::AllPrepared)
     }
 
     pub fn is_all_accepted(&self) -> bool {
@@ -313,10 +296,7 @@ impl FromStr for TransactionPoolStage {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "New" => Ok(TransactionPoolStage::New),
-            "Prepared" => Ok(TransactionPoolStage::Prepared),
             "LocalPrepared" => Ok(TransactionPoolStage::LocalPrepared),
-            "SomePrepared" => Ok(TransactionPoolStage::SomePrepared),
-            "AllPrepared" => Ok(TransactionPoolStage::AllPrepared),
             "LocalAccepted" => Ok(TransactionPoolStage::LocalAccepted),
             "AllAccepted" => Ok(TransactionPoolStage::AllAccepted),
             "SomeAccepted" => Ok(TransactionPoolStage::SomeAccepted),
@@ -422,13 +402,10 @@ impl TransactionPoolRecord {
     fn can_continue_to(&self, stage: TransactionPoolStage) -> bool {
         match stage {
             TransactionPoolStage::New => self.is_ready,
-            TransactionPoolStage::Prepared => true,
             TransactionPoolStage::LocalPrepared => match self.current_decision() {
                 Decision::Commit => self.evidence.all_input_shard_groups_prepared(),
                 Decision::Abort(_) => self.evidence.some_shard_groups_prepared(),
             },
-            TransactionPoolStage::AllPrepared => self.evidence.all_input_shard_groups_prepared(),
-            TransactionPoolStage::SomePrepared => self.evidence.some_shard_groups_prepared(),
             TransactionPoolStage::LocalAccepted => match self.current_decision() {
                 Decision::Commit => self.evidence.all_shard_groups_accepted(),
                 // If we have decided to abort, we can continue if any foreign shard or locally has prepared
@@ -664,23 +641,13 @@ impl TransactionPoolRecord {
         // Check that only permitted stage transactions are performed
         match ((self.current_stage(), pending_stage), is_ready) {
             ((TransactionPoolStage::New, TransactionPoolStage::New), true) |
-            ((TransactionPoolStage::New, TransactionPoolStage::Prepared), true) |
+            ((TransactionPoolStage::New, TransactionPoolStage::LocalPrepared), _) |
             ((TransactionPoolStage::New, TransactionPoolStage::LocalOnly), false) |
-            // Prepared
-            ((TransactionPoolStage::Prepared, TransactionPoolStage::Prepared), _) |
-            ((TransactionPoolStage::Prepared, TransactionPoolStage::LocalPrepared), _) |
             // Output-only case - we can skip straight to LocalAccepted
-            ((TransactionPoolStage::Prepared, TransactionPoolStage::LocalAccepted), _) |
+            ((TransactionPoolStage::New, TransactionPoolStage::LocalAccepted), _) |
             // LocalPrepared
             ((TransactionPoolStage::LocalPrepared, TransactionPoolStage::LocalPrepared), _) |
-            ((TransactionPoolStage::LocalPrepared, TransactionPoolStage::AllPrepared), _) |
-            ((TransactionPoolStage::LocalPrepared, TransactionPoolStage::SomePrepared), _) |
-            // AllPrepared
-            ((TransactionPoolStage::AllPrepared, TransactionPoolStage::AllPrepared), _) |
-            ((TransactionPoolStage::AllPrepared, TransactionPoolStage::LocalAccepted), _) |
-            // SomePrepared
-            ((TransactionPoolStage::SomePrepared, TransactionPoolStage::SomePrepared), _) |
-            ((TransactionPoolStage::SomePrepared, TransactionPoolStage::LocalAccepted), _) |
+            ((TransactionPoolStage::LocalPrepared, TransactionPoolStage::LocalAccepted), _) |
             // LocalAccepted
             ((TransactionPoolStage::LocalAccepted, TransactionPoolStage::LocalAccepted), _) |
             ((TransactionPoolStage::LocalAccepted, TransactionPoolStage::AllAccepted), false) |
@@ -900,12 +867,7 @@ mod tests {
 
         #[test]
         fn it_is_ordered_correctly() {
-            assert!(TransactionPoolStage::New < TransactionPoolStage::Prepared);
-            assert!(TransactionPoolStage::Prepared < TransactionPoolStage::LocalPrepared);
-            assert!(TransactionPoolStage::LocalPrepared < TransactionPoolStage::AllPrepared);
-            assert!(TransactionPoolStage::LocalPrepared < TransactionPoolStage::SomePrepared);
-            assert!(TransactionPoolStage::AllPrepared < TransactionPoolStage::LocalAccepted);
-            assert!(TransactionPoolStage::SomePrepared < TransactionPoolStage::LocalAccepted);
+            assert!(TransactionPoolStage::New < TransactionPoolStage::LocalPrepared);
             assert!(TransactionPoolStage::LocalAccepted < TransactionPoolStage::AllAccepted);
             assert!(TransactionPoolStage::LocalAccepted < TransactionPoolStage::SomeAccepted);
         }

--- a/dan_layer/storage/src/state_store/mod.rs
+++ b/dan_layer/storage/src/state_store/mod.rs
@@ -493,7 +493,7 @@ pub trait StateStoreWriteTransaction {
         &mut self,
         transaction_ids: I,
     ) -> Result<Vec<TransactionPoolRecord>, StorageError>;
-    fn transaction_pool_confirm_all_transitions(&mut self, new_locked_block: &LockedBlock) -> Result<(), StorageError>;
+    fn transaction_pool_confirm_all_transitions(&mut self, block: &LeafBlock) -> Result<(), StorageError>;
     fn transaction_pool_state_updates_remove_any_by_block_id(&mut self, block_id: &BlockId)
         -> Result<(), StorageError>;
 


### PR DESCRIPTION
Description
---
Removes `Prepare`, `SomePrepare`, and `AllPrepare` commands and their respective transaction phases.

Motivation and Context
---
Closes #1314 

Reduces the number of rounds and blocks required to reach consensus in the multishard context

How Has This Been Tested?
---
Existing tests and manually

What process can a PR reviewer use to test or verify this change?
---
Everything works as before

Breaking Changes
---

- [ ] None
- [x] Requires data directory to be deleted
- [ ] Other - Please specify

BREAKING CHANGE: consensus protocol changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined command processing and transaction state transitions for a simpler, more consistent workflow.
  - Improved logging messages and protocol definitions to enhance clarity and system stability.
- **New Features**
  - Introduced an enhanced method for local transaction acceptance.
  - Expanded error reporting to better capture output discrepancies.
- **Tests**
  - Updated test scenarios to align with the revised transaction states and processing logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->