### PR TITLE
feat(wallet-daemon): add method to list nft

### DIFF
--- a/applications/tari_dan_wallet_web_ui/src/Components/WalletConnectLink/WalletConnectLink.tsx
+++ b/applications/tari_dan_wallet_web_ui/src/Components/WalletConnectLink/WalletConnectLink.tsx
@@ -39,7 +39,7 @@ import { useTheme } from "@mui/material/styles";
 import { TariPermission, TariPermissionKeyList, TariPermissionTransactionGet, TariPermissionTransactionSend } from "../../utils/tari_permissions";
 import { Core } from '@walletconnect/core'
 import { Web3Wallet } from '@walletconnect/web3wallet'
-import { accountsCreateFreeTestCoins, accountsGetBalances, accountsGetDefault, confidentialViewVaultBalance, keysCreate, substatesGet, substatesList, templatesGet, transactionsGetResult, transactionsSubmit } from "../../utils/json_rpc";
+import { accountsCreateFreeTestCoins, accountsGetBalances, accountsGetDefault, confidentialViewVaultBalance, keysCreate, nftList, substatesGet, substatesList, templatesGet, transactionsGetResult, transactionsSubmit } from "../../utils/json_rpc";
 
 const projectId: string = import.meta.env.VITE_WALLET_CONNECT_PROJECT_ID || "78f3485d08b9640a087cbcea000e1f8b";
 
@@ -147,6 +147,8 @@ const ConnectorDialog = () => {
         return accountsCreateFreeTestCoins(params);
       case "tari_listSubstates":
         return substatesList(params);
+      case "tari_getNftsList":
+        return nftList(params);
       default:
         throw new Error("Invalid method")
     }

--- a/clients/javascript/wallet_daemon_client/src/index.ts
+++ b/clients/javascript/wallet_daemon_client/src/index.ts
@@ -287,6 +287,9 @@ export class WalletDaemonClient {
 
 
   public substatesGet(params: SubstatesGetRequest): Promise<SubstatesGetResponse> {
+    // TODO: fix error if param type is `substate_id: Substate_id`
+    // `substateIdToString(substateId)` doesn't solve the issue
+    // possible tested fix is to change param type: `substate_id: string`
     return this.__invokeRpc("substates.get", params);
   }
 


### PR DESCRIPTION
Description
---
Add `tari_getNftsList`method which enables fetching account's nfts.
Also add the note for `substatesGet` type error.

Motivation and Context
---
Using `tari.js` providers this method was missing for the provider.

How Has This Been Tested?
---
Manually using `WalletConnect` provider and `Hello-Ootle` tapplet while working on [tari-js PR](https://github.com/tari-project/tari.js/pull/52)

What process can a PR reviewer use to test or verify this change?
---


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the wallet connection interface to support NFT list retrieval, offering a streamlined experience for managing digital collectibles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->