### PR TITLE
fix(wallet-daemon): authored templates are not saved always to local DB

### DIFF
--- a/applications/tari_dan_wallet_daemon/src/services/template_monitor.rs
+++ b/applications/tari_dan_wallet_daemon/src/services/template_monitor.rs
@@ -63,6 +63,9 @@ where
                 Ok(template_def) => Some(template_def),
                 Err(error) => {
                     error!(target: LOG_TARGET, "Failed to fetch template definition: {}, retry...", error);
+                    if self.shutdown_signal.is_triggered() {
+                        return Err(anyhow!("shutdown during fetch template definition"));
+                    }
                     tokio::time::sleep(current_wait_time).await;
                     if current_wait_time < max_wait_time {
                         current_wait_time = current_wait_time.add(wait_step);

--- a/applications/tari_dan_wallet_daemon/src/services/template_monitor.rs
+++ b/applications/tari_dan_wallet_daemon/src/services/template_monitor.rs
@@ -1,22 +1,26 @@
 // Copyright 2025 The Tari Project
 // SPDX-License-Identifier: BSD-3-Clause
 
+use std::{ops::Add, time::Duration};
+
+use anyhow::anyhow;
 use log::error;
 use tari_common_types::types::PublicKey;
 use tari_dan_common_types::optional::IsNotFoundError;
 use tari_dan_wallet_sdk::{
-    apis::key_manager,
+    apis::{key_manager, transaction::TransactionApiError},
     models::TransactionStatus,
     network::WalletNetworkInterface,
     storage::WalletStore,
     DanWalletSdk,
 };
-use tari_engine_types::commit_result::TransactionResult;
+use tari_engine_types::{commit_result::TransactionResult, TemplateAddress};
 use tari_shutdown::ShutdownSignal;
+use tari_template_abi::TemplateDef;
 
 use crate::{notify::Notify, services::WalletEvent};
 
-const LOG_TARGET: &str = "tari::dan::wallet_daemon::template_monitor";
+const LOG_TARGET: &str = "tari::dan_wallet_daemon::services::template_monitor";
 
 pub struct TemplateMonitor<TStore, TNetworkInterface> {
     notify: Notify<WalletEvent>,
@@ -42,6 +46,35 @@ where
         }
     }
 
+    /// Fetching template definition with retry.
+    async fn fetch_template_definition(&self, template_address: TemplateAddress) -> anyhow::Result<TemplateDef> {
+        let min_wait_time = Duration::from_millis(100);
+        let max_wait_time = Duration::from_secs(5);
+        let wait_step = Duration::from_millis(100);
+        let mut current_wait_time = min_wait_time;
+        let mut template_definition = None;
+        let network_interface = self.wallet_sdk.get_network_interface();
+        while template_definition.is_none() {
+            template_definition = match network_interface
+                .fetch_template_definition(template_address)
+                .await
+                .map_err(|error| TransactionApiError::NetworkInterfaceError(format!("{}", error)))
+            {
+                Ok(template_def) => Some(template_def),
+                Err(error) => {
+                    error!(target: LOG_TARGET, "Failed to fetch template definition: {}, retry...", error);
+                    tokio::time::sleep(current_wait_time).await;
+                    if current_wait_time < max_wait_time {
+                        current_wait_time = current_wait_time.add(wait_step);
+                    }
+                    None
+                },
+            };
+        }
+
+        template_definition.ok_or(anyhow!("Could not fetch template definition"))
+    }
+
     async fn handle_wallet_event(&self, event: WalletEvent) -> anyhow::Result<()> {
         if let WalletEvent::TransactionFinalized(event) = event {
             if matches!(event.status, TransactionStatus::Accepted) {
@@ -57,10 +90,11 @@ where
                         None
                     });
                     for (key_index, template_addr) in templates_iter {
+                        let template_definition = self.fetch_template_definition(template_addr.as_hash()).await?;
                         if let Err(error) = self
                             .wallet_sdk
                             .template_api()
-                            .add_authored_template(key_index, template_addr.as_hash())
+                            .add_authored_template(key_index, template_addr.as_hash(), template_definition)
                             .await
                         {
                             error!(target: LOG_TARGET, "Error saving template to authored ({template_addr:?}): {}", error);

--- a/dan_layer/wallet/sdk/src/apis/template.rs
+++ b/dan_layer/wallet/sdk/src/apis/template.rs
@@ -1,32 +1,24 @@
 // Copyright 2025 The Tari Project
 // SPDX-License-Identifier: BSD-3-Clause
 
-use tari_dan_common_types::optional::IsNotFoundError;
 use tari_engine_types::TemplateAddress;
+use tari_template_abi::TemplateDef;
 
 use crate::{
     apis::transaction::TransactionApiError,
     models::AuthoredTemplateModel,
-    network::WalletNetworkInterface,
     storage::{WalletStorageError, WalletStore, WalletStoreReader, WalletStoreWriter},
 };
 
-pub struct TemplateApi<'a, TStore, TNetworkInterface> {
+pub struct TemplateApi<'a, TStore> {
     store: &'a TStore,
-    network_interface: &'a TNetworkInterface,
 }
 
-impl<'a, TStore, TNetworkInterface> TemplateApi<'a, TStore, TNetworkInterface>
-where
-    TStore: WalletStore,
-    TNetworkInterface: WalletNetworkInterface,
-    TNetworkInterface::Error: IsNotFoundError,
+impl<'a, TStore> TemplateApi<'a, TStore>
+where TStore: WalletStore
 {
-    pub fn new(store: &'a TStore, network_interface: &'a TNetworkInterface) -> Self {
-        Self {
-            store,
-            network_interface,
-        }
+    pub fn new(store: &'a TStore) -> Self {
+        Self { store }
     }
 
     /// Adds a new template to the list of known templates authored by an owned account.
@@ -35,6 +27,7 @@ where
         &self,
         key_index: u64,
         template_address: TemplateAddress,
+        template_definition: TemplateDef,
     ) -> Result<(), TransactionApiError> {
         // check if we already have this template
         if self.store.with_read_tx(|tx| {
@@ -46,12 +39,6 @@ where
             return Ok(());
         };
 
-        // save new template
-        let template_definition = self
-            .network_interface
-            .fetch_template_definition(template_address)
-            .await
-            .map_err(|error| TransactionApiError::NetworkInterfaceError(format!("{}", error)))?;
         self.store.with_write_tx(|tx| {
             tx.authored_templates_insert(AuthoredTemplateModel::new(
                 key_index,

--- a/dan_layer/wallet/sdk/src/sdk.rs
+++ b/dan_layer/wallet/sdk/src/sdk.rs
@@ -137,8 +137,8 @@ where
         NonFungibleTokensApi::new(&self.store)
     }
 
-    pub fn template_api(&self) -> TemplateApi<'_, TStore, TNetworkInterface> {
-        TemplateApi::new(&self.store, &self.network_interface)
+    pub fn template_api(&self) -> TemplateApi<'_, TStore> {
+        TemplateApi::new(&self.store)
     }
 
     fn get_or_create_cipher_seed(store: &TStore) -> Result<CipherSeed, WalletSdkError> {


### PR DESCRIPTION
Description
---
I implemented a simple retry mechanism to try to fetch template definition (with increasing wait time to not spam indexer) for a new template published in a transaction.

Motivation and Context
---
It is not guaranteed that when we receive an event for a transaction that contains a published template that we have the template available on indexer. Because of this, new authored templates were not always showing on UI (and also saved to local DB).

Closes https://github.com/tari-project/tari-dan/issues/1323

How Has This Been Tested?
---
1. Started a fresh swarm with 10 nodes for having a longer time while templates are synchronized
2. Create an account
3. Open in another window the templates in wallet daemon UI
4. Publish a template
5. Wait for wallet daemon UI to be updated

What process can a PR reviewer use to test or verify this change?
---


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced wallet event processing by adding asynchronous template fetching with robust retry and error handling for improved reliability.

- **Refactor**
  - Streamlined template management by simplifying dependencies and reducing configuration complexity for easier integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->