### PR TITLE
feat(wallet_daemon_client): add dry run request

### DIFF
--- a/applications/tari_dan_wallet_web_ui/package-lock.json
+++ b/applications/tari_dan_wallet_web_ui/package-lock.json
@@ -52,7 +52,7 @@
     },
     "../../clients/javascript/wallet_daemon_client": {
       "name": "@tari-project/wallet_jrpc_client",
-      "version": "1.5.3",
+      "version": "1.5.4",
       "license": "ISC",
       "dependencies": {
         "@tari-project/typescript-bindings": "^1.5.3"

--- a/clients/javascript/wallet_daemon_client/package-lock.json
+++ b/clients/javascript/wallet_daemon_client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tari-project/wallet_jrpc_client",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tari-project/wallet_jrpc_client",
-      "version": "1.5.3",
+      "version": "1.5.4",
       "license": "ISC",
       "dependencies": {
         "@tari-project/typescript-bindings": "^1.5.3"

--- a/clients/javascript/wallet_daemon_client/package.json
+++ b/clients/javascript/wallet_daemon_client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tari-project/wallet_jrpc_client",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "description": "Tari wallet JSON-RPC client library",
   "homepage": "https://github.com/tari-project/tari-dan#readme",
   "bugs": {

--- a/clients/javascript/wallet_daemon_client/src/index.ts
+++ b/clients/javascript/wallet_daemon_client/src/index.ts
@@ -84,6 +84,8 @@ import type {
   WebauthnStartRegisterResponse,
   WebRtcStartRequest,
   WebRtcStartResponse,
+  TransactionSubmitDryRunRequest,
+  TransactionSubmitDryRunResponse,
 } from "@tari-project/typescript-bindings";
 import { FetchRpcTransport, RpcTransport } from "./transports";
 
@@ -194,6 +196,10 @@ export class WalletDaemonClient {
 
   public submitTransaction(params: TransactionSubmitRequest): Promise<TransactionSubmitResponse> {
     return this.__invokeRpc("transactions.submit", params);
+  }
+
+  public submitTransactionDryRun(params: TransactionSubmitDryRunRequest): Promise<TransactionSubmitDryRunResponse> {
+    return this.__invokeRpc("transactions.submit_dry_run", params);
   }
 
   public submitTransactionManifest(params: TransactionSubmitManifestRequest): Promise<TransactionSubmitManifestResponse> {


### PR DESCRIPTION
Description
---
Adds **dry run** command.

Motivation and Context
---

`tari.js` depends on this library to send requests via wallet daemon.
It is missing **dry run** of a transaction.

How Has This Been Tested?
---

I have not tested this, just verified, that it builds.
I will write test in `tari.js`, since it has integrated test suite.

What process can a PR reviewer use to test or verify this change?
---

I do not have an easy way to test this.

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a transaction dry-run feature, allowing users to simulate and review transactions before final submission.

- **Chores**
  - Updated the package version from 1.5.3 to 1.5.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->