### PR TITLE
fix(wallet)!: ensure L1/L2 parity with claim signature

### DIFF
--- a/applications/tari_swarm_daemon/src/config.rs
+++ b/applications/tari_swarm_daemon/src/config.rs
@@ -258,4 +258,16 @@ impl CompileConfig {
     pub fn working_dir(&self) -> PathBuf {
         self.working_dir.clone().unwrap_or_else(|| PathBuf::from("."))
     }
+
+    pub fn bin_path(&self) -> PathBuf {
+        add_ext(self.working_dir().join(self.target_dir()).join(&self.package_name))
+    }
+}
+
+fn add_ext(path: PathBuf) -> PathBuf {
+    if cfg!(windows) {
+        path.with_extension("exe")
+    } else {
+        path
+    }
 }

--- a/applications/tari_swarm_daemon/src/process_manager/executables/manager.rs
+++ b/applications/tari_swarm_daemon/src/process_manager/executables/manager.rs
@@ -1,11 +1,7 @@
 //   Copyright 2024 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use std::{
-    env,
-    io,
-    path::{Path, PathBuf},
-};
+use std::{env, io, path::Path};
 
 use anyhow::{anyhow, Context};
 use futures::{stream::FuturesUnordered, StreamExt};
@@ -86,14 +82,11 @@ impl ExecutableManager {
                 .as_ref()
                 .expect("BUG: Compiled but compile config was None");
 
-            let bin_path = compile
-                .working_dir()
-                .join(compile.target_dir())
-                .join(&compile.package_name);
+            let bin_path = compile.bin_path();
 
             self.prepared.push(Executable {
                 instance_type: exec.instance_type,
-                path: add_ext(&bin_path),
+                path: bin_path,
                 env: exec.env.clone(),
             })
         }
@@ -140,12 +133,7 @@ impl ExecutableManager {
             {
                 &self.prepared[i]
             } else {
-                let bin_path = add_ext(
-                    compile
-                        .working_dir()
-                        .join(compile.target_dir())
-                        .join(&compile.package_name),
-                );
+                let bin_path = compile.bin_path();
                 self.prepared.push(Executable {
                     instance_type,
                     path: bin_path.canonicalize().with_context(|| {
@@ -194,15 +182,5 @@ pub struct Executables<'a> {
 impl Executables<'_> {
     pub fn get(&self, instance_type: InstanceType) -> Option<&Executable> {
         self.executables.iter().find(|e| e.instance_type == instance_type)
-    }
-}
-
-fn add_ext<P: AsRef<Path>>(path: P) -> PathBuf {
-    let path = path.as_ref().to_path_buf();
-
-    if cfg!(windows) {
-        path.with_extension("exe")
-    } else {
-        path
     }
 }

--- a/applications/tari_swarm_daemon/src/process_manager/manager.rs
+++ b/applications/tari_swarm_daemon/src/process_manager/manager.rs
@@ -440,7 +440,6 @@ impl ProcessManager {
         serde_json::to_writer_pretty(&mut file, &proof)?;
 
         info!("🔥 Burned {amount} Tari to account {account_name}");
-        self.mine(10).await?;
         Ok(file_name)
     }
 

--- a/dan_layer/engine/src/runtime/error.rs
+++ b/dan_layer/engine/src/runtime/error.rs
@@ -167,8 +167,8 @@ pub enum RuntimeError {
     InvalidMethodAccessRule { template_name: String, details: String },
     #[error("Runtime module error: {0}")]
     ModuleError(#[from] RuntimeModuleError),
-    #[error("Invalid claiming signature")]
-    InvalidClaimingSignature,
+    #[error("Invalid claiming signature: {details}")]
+    InvalidClaimingSignature { details: String },
     #[error("Invalid range proof")]
     InvalidRangeProof,
     #[error("Invalid substate type")]

--- a/dan_layer/engine/src/runtime/impl.rs
+++ b/dan_layer/engine/src/runtime/impl.rs
@@ -2299,25 +2299,33 @@ impl<TTemplateProvider: TemplateProvider<Template = LoadedTemplate>> RuntimeInte
         // 1. Must exist
         let unclaimed_output = self.tracker.take_unclaimed_confidential_output(output_address)?;
         // 2. owner_sig must be valid
+        // NOTE: .as_bytes() used because the tari_crypto borsh implementations serialize as variable length bytes
+        // (always 32)
         let message = ownership_proof_hasher64(self.network)
-            .chain(proof_of_knowledge.public_nonce())
-            .chain(&unclaimed_output.commitment)
-            .chain(&self.transaction_signer_public_key)
+            .chain(&proof_of_knowledge.public_nonce().as_bytes())
+            .chain(&unclaimed_output.commitment.as_bytes())
+            .chain(&self.transaction_signer_public_key.as_bytes())
             .finalize();
 
         let commitment = PedersenCommitment::try_from_byte_type(&unclaimed_output.commitment).map_err(|e| {
             warn!(target: LOG_TARGET, "Claim burn failed - malformed commitment: {}", e);
-            RuntimeError::InvalidClaimingSignature
+            RuntimeError::InvalidClaimingSignature {
+                details: "malformed commitment".to_string(),
+            }
         })?;
 
         let proof_of_knowledge = CommitmentSignature::try_from_byte_type(&proof_of_knowledge).map_err(|e| {
             warn!(target: LOG_TARGET, "Claim burn failed - malformed proof of knowledge: {}", e);
-            RuntimeError::InvalidClaimingSignature
+            RuntimeError::InvalidClaimingSignature {
+                details: "malformed proof of knowledge".to_string(),
+            }
         })?;
 
         if !proof_of_knowledge.verify_challenge(&commitment, &message, get_commitment_factory()) {
-            warn!(target: LOG_TARGET, "Claim burn failed - Invalid signature");
-            return Err(RuntimeError::InvalidClaimingSignature);
+            warn!(target: LOG_TARGET, "Claim burn failed - signature verification failed");
+            return Err(RuntimeError::InvalidClaimingSignature {
+                details: "signature verification failed".to_string(),
+            });
         }
 
         // 3. range_proof must be valid

--- a/dan_layer/engine_types/src/confidential/claim.rs
+++ b/dan_layer/engine_types/src/confidential/claim.rs
@@ -5,18 +5,22 @@ use serde::{Deserialize, Serialize};
 use tari_template_lib::{
     models::{ConfidentialWithdrawProof, UnclaimedConfidentialOutputAddress},
     prelude::RistrettoPublicKeyBytes,
-    types::crypto::CommitmentSignatureBytes,
+    types::{crypto::CommitmentSignatureBytes, serde_helpers},
 };
-#[cfg(feature = "ts")]
-use ts_rs::TS;
 
 #[derive(Debug, Clone, Deserialize, Serialize, Eq, PartialEq)]
-#[cfg_attr(feature = "ts", derive(TS), ts(export, export_to = "../../bindings/src/types/"))]
+#[cfg_attr(
+    feature = "ts",
+    derive(ts_rs::TS),
+    ts(export, export_to = "../../bindings/src/types/")
+)]
 pub struct ConfidentialClaim {
     #[cfg_attr(feature = "ts", ts(type = "string"))]
     pub public_key: RistrettoPublicKeyBytes,
     #[cfg_attr(feature = "ts", ts(type = "string"))]
     pub output_address: UnclaimedConfidentialOutputAddress,
+    #[cfg_attr(feature = "ts", ts(type = "string"))]
+    #[serde(with = "serde_helpers::dynamic_hex")]
     pub range_proof: Vec<u8>,
     #[cfg_attr(feature = "ts", ts(type = "string"))]
     pub proof_of_knowledge: CommitmentSignatureBytes,

--- a/dan_layer/template_lib/src/models/confidential_proof.rs
+++ b/dan_layer/template_lib/src/models/confidential_proof.rs
@@ -26,6 +26,8 @@ pub struct ConfidentialOutputStatement {
     pub change_statement: Option<ConfidentialStatement>,
     /// Bulletproof range proof for the output and change commitments proving that values are in the range
     /// [minimum_value_promise, 2^64)
+    #[cfg_attr(feature = "ts", ts(type = "string"))]
+    #[serde(with = "serde_helpers::dynamic_hex")]
     pub range_proof: Vec<u8>,
     /// The amount of revealed funds to output
     pub output_revealed_amount: Amount,


### PR DESCRIPTION
Description
---
Updates the claim burn signature to the latest on feature-dan2 since #1384 
Adds a significantly more efficient cbor encoding for the RangeProofs
Uses a hex encoding for rangeproofs represented in JSON.

Motivation and Context
---
Tari crypto Borsh serialisation implements the borsh encoding by encoding a byte slice. This slice is always 32 bytes; however, a slice's encoding is variable length.
This PR updates the signature message to encode in this way.

A more efficient cbor encoding for the rangeproof is also implemented, as well as a hex encoding for JSON.

How Has This Been Tested?
---
Manually, cucumber

What process can a PR reviewer use to test or verify this change?
---
Burn and claim funds


Breaking Changes
---

- [ ] None
- [x] Requires data directory to be deleted
- [ ] Other - Please specify

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced improved executable handling for robust cross-platform support.
  - Enhanced confidential transaction security by adding range proof details for improved verification.

- **Bug Fixes**
  - Removed an automatic block processing step following fund burns for more predictable wallet behavior.
  - Refined error reporting to provide clearer context during signature validation issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->