### PR TITLE
feat(testing): add option to compile templates in cargo workspace

### DIFF
--- a/dan_layer/engine/src/wasm/compile.rs
+++ b/dan_layer/engine/src/wasm/compile.rs
@@ -70,7 +70,15 @@ crate-type = ["cdylib", "lib"]
     compile_template(temp_dir.path(), features)
 }
 
+pub fn compile_template_with_custom_target_dir<P: AsRef<Path>>(package_dir: P, features: &[&str], target_dir: P) -> io::Result<WasmModule> {
+    compile_template_internal(package_dir, features, Some(target_dir))
+}
+
 pub fn compile_template<P: AsRef<Path>>(package_dir: P, features: &[&str]) -> io::Result<WasmModule> {
+    compile_template_internal(package_dir, features, None)
+}
+
+fn compile_template_internal<P: AsRef<Path>>(package_dir: P, features: &[&str], target_dir: Option<P>) -> io::Result<WasmModule> {
     if !package_dir.as_ref().exists() {
         return Err(io::Error::new(
             ErrorKind::NotFound,
@@ -124,12 +132,25 @@ pub fn compile_template<P: AsRef<Path>>(package_dir: P, features: &[&str]) -> io
     };
 
     // path of the wasm executable
-    let mut path = package_dir.as_ref().to_path_buf();
-    path.push("target");
-    path.push("wasm32-unknown-unknown");
-    path.push("release");
-    path.push(wasm_name);
-    path.set_extension("wasm");
+    let path = match target_dir {
+        None => {
+            let mut path = package_dir.as_ref().to_path_buf();
+            path.push("target");
+            path.push("wasm32-unknown-unknown");
+            path.push("release");
+            path.push(wasm_name);
+            path.set_extension("wasm");
+            path
+        }
+        Some(target_dir) => {
+            let mut path = target_dir.as_ref().to_path_buf();
+            path.push("wasm32-unknown-unknown");
+            path.push("release");
+            path.push(wasm_name);
+            path.set_extension("wasm");
+            path
+        }
+    };
 
     // return
     let code = fs::read(path)?;

--- a/dan_layer/engine/src/wasm/compile.rs
+++ b/dan_layer/engine/src/wasm/compile.rs
@@ -70,7 +70,11 @@ crate-type = ["cdylib", "lib"]
     compile_template(temp_dir.path(), features)
 }
 
-pub fn compile_template_with_custom_target_dir<P: AsRef<Path>>(package_dir: P, features: &[&str], target_dir: P) -> io::Result<WasmModule> {
+pub fn compile_template_with_custom_target_dir<P: AsRef<Path>>(
+    package_dir: P,
+    features: &[&str],
+    target_dir: P,
+) -> io::Result<WasmModule> {
     compile_template_internal(package_dir, features, Some(target_dir))
 }
 
@@ -78,7 +82,11 @@ pub fn compile_template<P: AsRef<Path>>(package_dir: P, features: &[&str]) -> io
     compile_template_internal(package_dir, features, None)
 }
 
-fn compile_template_internal<P: AsRef<Path>>(package_dir: P, features: &[&str], target_dir: Option<P>) -> io::Result<WasmModule> {
+fn compile_template_internal<P: AsRef<Path>>(
+    package_dir: P,
+    features: &[&str],
+    target_dir: Option<P>,
+) -> io::Result<WasmModule> {
     if !package_dir.as_ref().exists() {
         return Err(io::Error::new(
             ErrorKind::NotFound,
@@ -132,25 +140,18 @@ fn compile_template_internal<P: AsRef<Path>>(package_dir: P, features: &[&str], 
     };
 
     // path of the wasm executable
-    let path = match target_dir {
+    let mut path = match target_dir {
+        Some(target_dir) => target_dir.as_ref().to_path_buf(),
         None => {
             let mut path = package_dir.as_ref().to_path_buf();
             path.push("target");
-            path.push("wasm32-unknown-unknown");
-            path.push("release");
-            path.push(wasm_name);
-            path.set_extension("wasm");
             path
-        }
-        Some(target_dir) => {
-            let mut path = target_dir.as_ref().to_path_buf();
-            path.push("wasm32-unknown-unknown");
-            path.push("release");
-            path.push(wasm_name);
-            path.set_extension("wasm");
-            path
-        }
+        },
     };
+    path.push("wasm32-unknown-unknown");
+    path.push("release");
+    path.push(wasm_name);
+    path.set_extension("wasm");
 
     // return
     let code = fs::read(path)?;

--- a/dan_layer/template_test_tooling/src/package_builder.rs
+++ b/dan_layer/template_test_tooling/src/package_builder.rs
@@ -8,11 +8,13 @@ use std::{
 };
 
 use tari_dan_common_types::services::template_provider::TemplateProvider;
-use tari_dan_engine::wasm::compile::compile_template_with_custom_target_dir;
 use tari_dan_engine::{
     abi::TemplateDef,
     template::{LoadedTemplate, TemplateLoaderError, TemplateModuleLoader},
-    wasm::{compile::compile_template, WasmModule},
+    wasm::{
+        compile::{compile_template, compile_template_with_custom_target_dir},
+        WasmModule,
+    },
 };
 use tari_engine_types::hashing::hash_template_code;
 use tari_template_builtin::get_template_builtin;
@@ -54,7 +56,6 @@ impl Package {
 #[derive(Debug, Clone, Default)]
 pub struct PackageBuilder {
     templates: HashMap<TemplateAddress, LoadedTemplate>,
-
 }
 
 impl PackageBuilder {
@@ -68,14 +69,15 @@ impl PackageBuilder {
         self.add_template_with_features(path, &[], target_dir)
     }
 
-    pub fn add_template_with_features<P: AsRef<Path>>(&mut self, path: P, features: &[&str], target_dir: Option<P>) -> &mut Self {
+    pub fn add_template_with_features<P: AsRef<Path>>(
+        &mut self,
+        path: P,
+        features: &[&str],
+        target_dir: Option<P>,
+    ) -> &mut Self {
         let wasm = match target_dir {
-            None => {
-                compile_template(path, features).unwrap()
-            }
-            Some(target_dir) => {
-                compile_template_with_custom_target_dir(path, features, target_dir).unwrap()
-            }
+            None => compile_template(path, features).unwrap(),
+            Some(target_dir) => compile_template_with_custom_target_dir(path, features, target_dir).unwrap(),
         };
         let template_addr = hash_template_code(wasm.code());
         let wasm = wasm.load_template().unwrap();

--- a/dan_layer/template_test_tooling/src/package_builder.rs
+++ b/dan_layer/template_test_tooling/src/package_builder.rs
@@ -8,6 +8,7 @@ use std::{
 };
 
 use tari_dan_common_types::services::template_provider::TemplateProvider;
+use tari_dan_engine::wasm::compile::compile_template_with_custom_target_dir;
 use tari_dan_engine::{
     abi::TemplateDef,
     template::{LoadedTemplate, TemplateLoaderError, TemplateModuleLoader},
@@ -53,6 +54,7 @@ impl Package {
 #[derive(Debug, Clone, Default)]
 pub struct PackageBuilder {
     templates: HashMap<TemplateAddress, LoadedTemplate>,
+
 }
 
 impl PackageBuilder {
@@ -62,12 +64,19 @@ impl PackageBuilder {
         }
     }
 
-    pub fn add_template<P: AsRef<Path>>(&mut self, path: P) -> &mut Self {
-        self.add_template_with_features(path, &[])
+    pub fn add_template<P: AsRef<Path>>(&mut self, path: P, target_dir: Option<P>) -> &mut Self {
+        self.add_template_with_features(path, &[], target_dir)
     }
 
-    pub fn add_template_with_features<P: AsRef<Path>>(&mut self, path: P, features: &[&str]) -> &mut Self {
-        let wasm = compile_template(path, features).unwrap();
+    pub fn add_template_with_features<P: AsRef<Path>>(&mut self, path: P, features: &[&str], target_dir: Option<P>) -> &mut Self {
+        let wasm = match target_dir {
+            None => {
+                compile_template(path, features).unwrap()
+            }
+            Some(target_dir) => {
+                compile_template_with_custom_target_dir(path, features, target_dir).unwrap()
+            }
+        };
         let template_addr = hash_template_code(wasm.code());
         let wasm = wasm.load_template().unwrap();
         self.add_loaded_template(template_addr, wasm);

--- a/dan_layer/template_test_tooling/src/template_test.rs
+++ b/dan_layer/template_test_tooling/src/template_test.rs
@@ -70,7 +70,15 @@ pub struct TemplateTest {
 }
 
 impl TemplateTest {
-    pub fn new<I: IntoIterator<Item = P>, P: AsRef<Path>>(template_paths: I) -> Self {
+    pub fn new<I: IntoIterator<Item = P>, P: Clone + AsRef<Path>>(template_paths: I) -> Self {
+        Self::new_internal(template_paths, None)
+    }
+
+    pub fn new_with_shared_target_dir<I: IntoIterator<Item = P>, P: Clone + AsRef<Path>>(template_paths: I, target_dir: P) -> Self {
+        Self::new_internal(template_paths, Some(target_dir))
+    }
+
+    fn new_internal<I: IntoIterator<Item = P>, P: Clone + AsRef<Path>>(template_paths: I, target_dir: Option<P>) -> Self {
         let mut builder = Package::builder();
 
         // Add builtin templates
@@ -78,11 +86,11 @@ impl TemplateTest {
         builder.add_builtin_template(&ACCOUNT_NFT_TEMPLATE_ADDRESS);
 
         // Add the faucet template for fungible tokens
-        builder.add_template(concat!(env!("CARGO_MANIFEST_DIR"), "/templates/faucet"));
+        builder.add_template(concat!(env!("CARGO_MANIFEST_DIR"), "/templates/faucet"), None);
 
         // Add all of the templates specified in the argument
         for path in template_paths {
-            builder.add_template(path);
+            builder.add_template(path, target_dir.clone());
         }
 
         let package = builder.build();

--- a/dan_layer/template_test_tooling/src/template_test.rs
+++ b/dan_layer/template_test_tooling/src/template_test.rs
@@ -74,11 +74,17 @@ impl TemplateTest {
         Self::new_internal(template_paths, None)
     }
 
-    pub fn new_with_shared_target_dir<I: IntoIterator<Item = P>, P: Clone + AsRef<Path>>(template_paths: I, target_dir: P) -> Self {
+    pub fn new_with_shared_target_dir<I: IntoIterator<Item = P>, P: Clone + AsRef<Path>>(
+        template_paths: I,
+        target_dir: P,
+    ) -> Self {
         Self::new_internal(template_paths, Some(target_dir))
     }
 
-    fn new_internal<I: IntoIterator<Item = P>, P: Clone + AsRef<Path>>(template_paths: I, target_dir: Option<P>) -> Self {
+    fn new_internal<I: IntoIterator<Item = P>, P: Clone + AsRef<Path>>(
+        template_paths: I,
+        target_dir: Option<P>,
+    ) -> Self {
         let mut builder = Package::builder();
 
         // Add builtin templates


### PR DESCRIPTION
Description
---
Added an optional custom target directory, so compilation will work even with a cargo workspace project.

Motivation and Context
---
Compiling templates were only possible in a non-workspace cargo project, so if a template project is compiled in a different `target` directory (in workspace case in the root) then the compilation fails because it tried to load the wasm binary from the wrong place.

How Has This Been Tested?
---
Manually.

What process can a PR reviewer use to test or verify this change?
---


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to specify a custom target directory when compiling templates.
  - Introduced a new way to create template tests with a shared target directory.

- **Refactor**
  - Updated method signatures to support optional target directory parameters for template addition and testing.
  - Streamlined internal logic for template compilation and test initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->