### PR TITLE
fix(consensus)!: set substate version when mutating vn fee pool

### DIFF
--- a/dan_layer/common_types/src/versioned_substate_id.rs
+++ b/dan_layer/common_types/src/versioned_substate_id.rs
@@ -346,6 +346,10 @@ impl VersionedSubstateId {
         Self::new(self.substate_id.clone(), self.version + 1)
     }
 
+    pub fn into_next_version(self) -> Self {
+        Self::new(self.substate_id, self.version + 1)
+    }
+
     pub fn as_ref(&self) -> VersionedSubstateIdRef {
         VersionedSubstateIdRef {
             substate_id: &self.substate_id,

--- a/dan_layer/consensus/src/hotstuff/block_change_set.rs
+++ b/dan_layer/consensus/src/hotstuff/block_change_set.rs
@@ -535,7 +535,7 @@ mod tests {
     fn check_max_mem_usage() {
         let sz = size_of::<ProposedBlockChangeSet>();
         eprintln!("ProposedBlockChangeSet: {}", sz);
-        const TARGET_MAX_MEM_USAGE: usize = 20_056_000;
+        const TARGET_MAX_MEM_USAGE: usize = 19_896_000;
         let mem_block_diff = size_of::<SubstateChange>() * MEM_MAX_BLOCK_DIFF_CHANGES;
         eprintln!("mem_block_diff: {}MiB", mem_block_diff / 1024 / 1024);
         let mem_state_tree_diffs =

--- a/dan_layer/consensus/src/hotstuff/on_propose.rs
+++ b/dan_layer/consensus/src/hotstuff/on_propose.rs
@@ -2,7 +2,7 @@
 //   SPDX-License-Identifier: BSD-3-Clause
 
 use std::{
-    collections::{BTreeSet, HashMap, HashSet},
+    collections::{BTreeSet, HashMap},
     fmt::Display,
     num::NonZeroU64,
 };
@@ -14,11 +14,10 @@ use tari_dan_common_types::{
     committee::{Committee, CommitteeInfo},
     displayable::Displayable,
     optional::Optional,
-    shard::Shard,
     Epoch,
     ExtraData,
     NodeHeight,
-    VersionedSubstateId,
+    SubstateAddress,
 };
 use tari_dan_storage::{
     consensus_models::{
@@ -543,10 +542,11 @@ where TConsensusSpec: ConsensusSpec
 
         // This relies on the UTXO commands being ordered after transaction commands
         for (commitment, output) in batch.burnt_utxos {
-            let id = VersionedSubstateId::new(commitment, 0);
-            let shard = id.to_shard(local_committee_info.num_preshards());
+            let substate_id = commitment.into();
+            let addr = SubstateAddress::from_substate_id(&substate_id, 0);
+            let shard = addr.to_shard(local_committee_info.num_preshards());
             let change = SubstateChange::Up {
-                id,
+                id: substate_id,
                 shard,
                 substate: Substate::new(0, output),
             };
@@ -559,11 +559,6 @@ where TConsensusSpec: ConsensusSpec
             "command(s) for next block: [{}]",
             commands.display()
         );
-
-        let timer = TraceTimer::info(LOG_TARGET, "Propose calculate state root");
-
-        let pending_tree_diffs =
-            PendingShardStateTreeDiff::get_all_up_to_commit_block(tx, start_of_chain_block.block_id())?;
 
         // Add proposer fee substate
         if total_leader_fee > 0 {
@@ -583,6 +578,9 @@ where TConsensusSpec: ConsensusSpec
             )?;
         }
 
+        let timer = TraceTimer::info(LOG_TARGET, "Propose calculate state root");
+        let pending_tree_diffs =
+            PendingShardStateTreeDiff::get_all_up_to_commit_block(tx, start_of_chain_block.block_id())?;
         let (state_root, _) = calculate_state_merkle_root(
             tx,
             local_committee_info.shard_group(),
@@ -594,12 +592,13 @@ where TConsensusSpec: ConsensusSpec
         )?;
         timer.done();
 
-        let non_local_shards = get_non_local_shards(substate_store.diff(), local_committee_info);
-
         let foreign_counters = ForeignSendCounters::get_or_default(tx, parent_block.block_id())?;
-        let foreign_indexes = non_local_shards
+        let foreign_indexes = substate_store
+            .diff()
             .iter()
-            .map(|shard| (*shard, foreign_counters.get_count(*shard) + 1))
+            .map(|change| change.shard())
+            .filter(|shard| !local_committee_info.shard_group().contains(shard))
+            .map(|shard| (shard, foreign_counters.get_count(shard) + 1))
             .collect();
 
         let mut header = BlockHeader::create(
@@ -1096,19 +1095,6 @@ where TConsensusSpec: ConsensusSpec
 
         Ok(executed.into_execution())
     }
-}
-
-pub fn get_non_local_shards<'a, I: IntoIterator<Item = &'a SubstateChange>>(
-    diff: I,
-    local_committee_info: &CommitteeInfo,
-) -> HashSet<Shard> {
-    diff.into_iter()
-        .map(|ch| {
-            ch.versioned_substate_id()
-                .to_shard(local_committee_info.num_preshards())
-        })
-        .filter(|shard| !local_committee_info.shard_group().contains(shard))
-        .collect()
 }
 
 #[derive(Default)]

--- a/dan_layer/consensus/src/hotstuff/on_ready_to_vote_on_local_block.rs
+++ b/dan_layer/consensus/src/hotstuff/on_ready_to_vote_on_local_block.rs
@@ -5,7 +5,7 @@ use std::num::NonZeroU64;
 
 use log::*;
 use tari_crypto::ristretto::RistrettoPublicKey;
-use tari_dan_common_types::{committee::CommitteeInfo, optional::Optional, Epoch, ShardGroup, VersionedSubstateId};
+use tari_dan_common_types::{committee::CommitteeInfo, optional::Optional, Epoch, ShardGroup, SubstateAddress};
 use tari_dan_storage::{
     consensus_models::{
         AbortReason,
@@ -1529,10 +1529,11 @@ where TConsensusSpec: ConsensusSpec
             );
             return Ok(Some(NoVoteReason::MintConfidentialOutputUnknown));
         };
-        let id = VersionedSubstateId::new(atom.commitment, 0);
-        let shard = id.to_shard(local_committee_info.num_preshards());
+        let substate_id = atom.commitment.into();
+        let addr = SubstateAddress::from_substate_id(&substate_id, 0);
+        let shard = addr.to_shard(local_committee_info.num_preshards());
         let change = SubstateChange::Up {
-            id,
+            id: substate_id,
             shard,
             substate: Substate::new(0, output),
         };

--- a/dan_layer/consensus/src/hotstuff/substate_store/pending_store.rs
+++ b/dan_layer/consensus/src/hotstuff/substate_store/pending_store.rs
@@ -83,7 +83,7 @@ impl<'a, 'tx, TStore: StateStore + 'a> PendingSubstateStore<'a, 'tx, TStore> {
             });
         }
         Ok(SubstateChange::Up {
-            id: VersionedSubstateId::new(id.clone(), substate.version()),
+            id: id.clone(),
             shard: substate.created_by_shard,
             substate: substate
                 .into_substate()
@@ -114,7 +114,7 @@ impl<'a, 'tx, TStore: StateStore + 'a> PendingSubstateStore<'a, 'tx, TStore> {
                     let up = SubstateChange::Up {
                         shard: id.to_shard(num_preshards),
                         substate: Substate::new(next_id.version(), value),
-                        id: next_id,
+                        id: next_id.into_substate_id(),
                     };
                     self.put(up)?;
                 },
@@ -124,37 +124,36 @@ impl<'a, 'tx, TStore: StateStore + 'a> PendingSubstateStore<'a, 'tx, TStore> {
 
         let Some(change) = self.get_latest_change_from_store(substate_id).optional()? else {
             let value = creator(None)?;
-            let id = VersionedSubstateId::new(substate_id.clone(), 0);
+            let id = SubstateAddress::from_substate_id(substate_id, 0);
             let up = SubstateChange::Up {
                 shard: id.to_shard(num_preshards),
-                substate: Substate::new(id.version(), value),
-                id,
+                substate: Substate::new(0, value),
+                id: substate_id.clone(),
             };
             self.put(up)?;
             return Ok(());
         };
         match change {
             SubstateChange::Up {
-                mut substate,
-                id,
-                shard,
-                ..
+                substate, id, shard, ..
             } => {
-                updater(substate.substate_value_mut())?;
-                self.put(SubstateChange::Down { id: id.clone(), shard })?;
-                self.put(SubstateChange::Up {
-                    id: id.to_next_version(),
+                self.insert(SubstateChange::Down {
+                    id: VersionedSubstateId::new(id.clone(), substate.version()),
                     shard,
-                    substate,
-                })?;
+                });
+                let next_version = substate.version() + 1;
+                let mut substate_value = substate.into_substate_value();
+                updater(&mut substate_value)?;
+                let substate = Substate::new(next_version, substate_value);
+                self.insert(SubstateChange::Up { id, shard, substate });
             },
             SubstateChange::Down { id, .. } => {
                 let value = creator(Some(id.as_ref()))?;
-                let next_id = id.to_next_version();
+                let next_id = id.into_next_version();
                 let up = SubstateChange::Up {
-                    shard: id.to_shard(self.num_preshards),
+                    shard: next_id.to_shard(self.num_preshards),
                     substate: Substate::new(next_id.version(), value),
-                    id: next_id,
+                    id: next_id.into_substate_id(),
                 };
                 self.put(up)?;
             },
@@ -175,7 +174,7 @@ impl<'store, 'tx, TStore: StateStore + 'store + 'tx> ReadableSubstateStore
                 .up_substate()
                 .cloned()
                 .ok_or_else(|| SubstateStoreError::SubstateIsDown {
-                    id: change.versioned_substate_id().clone(),
+                    id: change.versioned_substate_id().to_owned(),
                 });
         }
 
@@ -202,9 +201,9 @@ impl<'store, 'tx, TStore: StateStore + 'store + 'tx> ReadableSubstateStore
 impl<'a, 'tx, TStore: StateStore + 'a + 'tx> WriteableSubstateStore for PendingSubstateStore<'a, 'tx, TStore> {
     fn put(&mut self, change: SubstateChange) -> Result<(), Self::Error> {
         match &change {
-            SubstateChange::Up { id, .. } => {
-                if let Some(v) = id.to_previous_version() {
-                    self.assert_is_down(&v)?;
+            SubstateChange::Up { id, substate, .. } => {
+                if let Some(v) = substate.previous_version() {
+                    self.assert_is_down(VersionedSubstateIdRef::new(id, v))?;
                 }
             },
             SubstateChange::Down { id, .. } => {
@@ -234,11 +233,11 @@ impl<'a, 'tx, TStore: StateStore + 'a + 'tx> WriteableSubstateStore for PendingS
             if id.is_validator_fee_pool() {
                 continue;
             }
-            let id = VersionedSubstateId::new(id.clone(), substate.version());
-            let shard = id.to_shard(self.num_preshards);
+            let addr = SubstateAddress::from_substate_id(id, substate.version());
+            let shard = addr.to_shard(self.num_preshards);
             debug!(target: LOG_TARGET, "🔼️ Up: {id} {shard} value hash: {}", substate.to_value_hash());
             self.put(SubstateChange::Up {
-                id,
+                id: id.clone(),
                 shard,
                 substate: substate.clone(),
             })?;
@@ -753,10 +752,10 @@ impl<'store, 'tx, TStore: StateStore + 'store + 'tx> PendingSubstateStore<'store
         }
     }
 
-    fn assert_is_down(&self, id: &VersionedSubstateId) -> Result<(), SubstateStoreError> {
+    fn assert_is_down(&self, id: VersionedSubstateIdRef<'_>) -> Result<(), SubstateStoreError> {
         if let Some(change) = self.get_pending(&id.to_substate_address()) {
             if change.is_up() {
-                return Err(SubstateStoreError::ExpectedSubstateDown { id: id.clone() });
+                return Err(SubstateStoreError::ExpectedSubstateDown { id: id.to_owned() });
             }
             return Ok(());
         }
@@ -765,7 +764,7 @@ impl<'store, 'tx, TStore: StateStore + 'store + 'tx> PendingSubstateStore<'store
             BlockDiff::get_for_versioned_substate(self.read_transaction(), &self.parent_block, id).optional()?
         {
             if change.is_up() {
-                return Err(SubstateStoreError::ExpectedSubstateDown { id: id.clone() });
+                return Err(SubstateStoreError::ExpectedSubstateDown { id: id.to_owned() });
             }
             return Ok(());
         }
@@ -773,10 +772,10 @@ impl<'store, 'tx, TStore: StateStore + 'store + 'tx> PendingSubstateStore<'store
         let address = id.to_substate_address();
         let Some(is_up) = SubstateRecord::substate_is_up(self.read_transaction(), &address).optional()? else {
             debug!(target: LOG_TARGET, "Expected substate {} to be DOWN but it does not exist", address);
-            return Err(SubstateStoreError::SubstateNotFound { id: id.clone() });
+            return Err(SubstateStoreError::SubstateNotFound { id: id.to_owned() });
         };
         if is_up {
-            return Err(SubstateStoreError::ExpectedSubstateDown { id: id.clone() });
+            return Err(SubstateStoreError::ExpectedSubstateDown { id: id.to_owned() });
         }
 
         Ok(())

--- a/dan_layer/consensus_tests/src/consensus.rs
+++ b/dan_layer/consensus_tests/src/consensus.rs
@@ -20,10 +20,9 @@ use tari_dan_common_types::{
     optional::Optional,
     Epoch,
     NodeHeight,
+    SubstateAddress,
     SubstateLockType,
     SubstateRequirement,
-    ToSubstateAddress,
-    VersionedSubstateId,
 };
 use tari_dan_storage::{
     consensus_models::{AbortReason, Command, Decision, SubstateRecord, TransactionRecord},
@@ -49,6 +48,7 @@ use crate::support::{
     Test,
     TestAddress,
     TestVnDestination,
+    TEST_NUM_PRESHARDS,
 };
 
 // Although these tests will pass with a single thread, we enable multi-threaded mode so that any unhandled race
@@ -1547,11 +1547,27 @@ async fn multishard_publish_template() {
     test.assert_all_validators_committed(tx.id());
 
     // Assert all have the template
-    let template_substate = test
-        .get_validator(&TestAddress::new("1"))
-        .state_store
-        .with_read_tx(|tx| SubstateRecord::get(tx, &VersionedSubstateId::new(template_id, 0).to_substate_address()))
+    let address = SubstateAddress::from_substate_id(&template_id.into(), 0);
+    // Figure out which VN is responsible for the template substate
+    let shard = address.to_shard(TEST_NUM_PRESHARDS);
+    let vn_addr = test
+        .num_preshards()
+        .all_shard_groups_iter(test.num_committees())
+        .enumerate()
+        .find_map(|(i, sg)| {
+            if sg.contains(&shard) {
+                Some(TestAddress::new(((i + 1) * 2).to_string()))
+            } else {
+                None
+            }
+        })
         .unwrap();
+
+    let template_substate = test
+        .get_validator(&vn_addr)
+        .state_store
+        .with_read_tx(|tx| SubstateRecord::get(tx, &address))
+        .unwrap_or_else(|e| panic!("Failed to get template substate from {vn_addr}: {e}"));
     let binary_hash = template_substate
         .substate_value
         .unwrap()

--- a/dan_layer/consensus_tests/src/state_tree.rs
+++ b/dan_layer/consensus_tests/src/state_tree.rs
@@ -24,6 +24,8 @@ async fn check_state_transitions() {
         .add_committee(0, vec!["1"])
         .start()
         .await;
+    let _ignore = test.send_transaction_to_all(Decision::Commit, 100, 1, 10).await;
+    let _ignore = test.send_transaction_to_all(Decision::Commit, 200, 1, 1).await;
     let _ignore = test.send_transaction_to_all(Decision::Commit, 1, 1, 1).await;
     test.start_epoch(Epoch(1)).await;
 

--- a/dan_layer/consensus_tests/src/substate_store.rs
+++ b/dan_layer/consensus_tests/src/substate_store.rs
@@ -44,7 +44,7 @@ fn it_allows_substate_up_for_v0() {
     // Cannot put version 1
     store
         .put(SubstateChange::Up {
-            id: VersionedSubstateId::new(id.clone(), 1),
+            id: id.clone(),
             shard: Shard::first(),
             substate: Substate::new(1, value.clone()),
         })
@@ -52,7 +52,7 @@ fn it_allows_substate_up_for_v0() {
 
     store
         .put(SubstateChange::Up {
-            id: VersionedSubstateId::new(id.clone(), 0),
+            id: id.clone(),
             shard: Shard::first(),
             substate: Substate::new(0, value),
         })
@@ -82,11 +82,12 @@ fn it_allows_down_then_up() {
         })
         .unwrap();
 
+    let next_version = id.to_next_version();
     store
         .put(SubstateChange::Up {
-            id: id.to_next_version(),
+            id: next_version.substate_id().clone(),
             shard: Shard::first(),
-            substate: new_substate(1, 1),
+            substate: new_substate(1, next_version.version()),
         })
         .unwrap();
 
@@ -106,9 +107,9 @@ fn it_fails_if_previous_version_is_not_down() {
     let mut store = create_pending_store(&tx);
     let err = store
         .put(SubstateChange::Up {
-            id: id.to_next_version(),
+            id: id.substate_id().clone(),
             shard: Shard::first(),
-            substate: new_substate(1, 1),
+            substate: new_substate(1, id.version() + 1),
         })
         .unwrap_err();
 

--- a/dan_layer/consensus_tests/src/support/harness.rs
+++ b/dan_layer/consensus_tests/src/support/harness.rs
@@ -4,6 +4,7 @@
 use std::{
     collections::{hash_map, HashMap, HashSet},
     fmt::Display,
+    fs,
     time::Duration,
 };
 
@@ -560,6 +561,7 @@ impl Test {
 pub struct TestBuilder {
     committees: HashMap<u32, Committee<TestAddress>>,
     sql_address: String,
+    rocks_path: Option<String>,
     timeout: Option<Duration>,
     debug_sql_file: Option<String>,
     message_filter: Option<MessageFilter>,
@@ -575,6 +577,7 @@ impl TestBuilder {
             sql_address: ":memory:".to_string(),
             timeout: Some(Duration::from_secs(10)),
             debug_sql_file: None,
+            rocks_path: None,
             message_filter: None,
             failure_nodes: Vec::new(),
             claim_keys: None,
@@ -616,6 +619,12 @@ impl TestBuilder {
     #[allow(dead_code)]
     pub fn with_sql_url<T: Into<String>>(mut self, sql_address: T) -> Self {
         self.sql_address = sql_address.into();
+        self
+    }
+
+    #[allow(dead_code)]
+    pub fn with_rocks_path<T: Into<String>>(mut self, path: T) -> Self {
+        self.rocks_path = Some(path.into());
         self
     }
 
@@ -662,6 +671,7 @@ impl TestBuilder {
         leader_strategy: &RoundRobinLeaderStrategy,
         epoch_manager: &TestEpochManager,
         sql_address: String,
+        rocks_path_override: Option<String>,
         config: HotstuffConfig,
         failure_nodes: &[TestAddress],
         shutdown_signal: ShutdownSignal,
@@ -681,10 +691,22 @@ impl TestBuilder {
             })
             .map(|(vn, shard_group)| {
                 let sql_address = sql_address.replace("{}", vn.address.as_str());
+                let rocks_path_override = rocks_path_override
+                    .as_ref()
+                    .map(|path| path.replace("{}", vn.address.as_str()));
+
+                if let Some(ref rocks_path) = rocks_path_override {
+                    if fs::exists(rocks_path).unwrap() {
+                        log::info!("Removing existing rocks path {}", rocks_path);
+                        let _ignore = fs::remove_dir_all(rocks_path);
+                    }
+                    fs::create_dir_all(rocks_path).unwrap();
+                }
                 let (sk, pk) = helpers::derive_keypair_from_address(&vn.address);
 
                 let (channels, validator) = Validator::builder()
                     .with_sql_url(sql_address)
+                    .with_rocks_override_path(rocks_path_override)
                     .with_config(config.clone())
                     .with_address_and_secret_key(vn.address.clone(), sk)
                     .with_shard(vn.shard_key)
@@ -728,6 +750,7 @@ impl TestBuilder {
             &leader_strategy,
             &epoch_manager,
             self.sql_address,
+            self.rocks_path,
             self.config,
             &self.failure_nodes,
             shutdown.to_signal(),

--- a/dan_layer/consensus_tests/src/support/validator/builder.rs
+++ b/dan_layer/consensus_tests/src/support/validator/builder.rs
@@ -1,6 +1,8 @@
 //   Copyright 2023 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
+use std::path::{Path, PathBuf};
+
 use tari_common_types::types::PrivateKey;
 use tari_consensus::{
     hotstuff::{ConsensusCurrentState, ConsensusWorker, ConsensusWorkerContext, HotstuffConfig, HotstuffWorker},
@@ -39,7 +41,9 @@ pub struct ValidatorBuilder {
     pub shard_group: ShardGroup,
     pub sql_url: String,
     #[allow(dead_code)]
-    pub rocks_path: TempDir,
+    pub rocks_tmp_path: TempDir,
+    #[allow(dead_code)]
+    pub rocks_override_path: Option<PathBuf>,
     pub leader_strategy: RoundRobinLeaderStrategy,
     pub num_committees: u32,
     pub epoch_manager: Option<TestEpochManager>,
@@ -58,7 +62,8 @@ impl ValidatorBuilder {
             num_committees: 0,
             shard_group: ShardGroup::all_shards(TEST_NUM_PRESHARDS),
             sql_url: ":memory".to_string(),
-            rocks_path: tempfile::tempdir().unwrap(),
+            rocks_override_path: None,
+            rocks_tmp_path: tempfile::tempdir().unwrap(),
             leader_strategy: RoundRobinLeaderStrategy::new(),
             epoch_manager: None,
             transaction_executions: TestExecutionSpecStore::new(),
@@ -103,6 +108,11 @@ impl ValidatorBuilder {
         self
     }
 
+    pub fn with_rocks_override_path<P: AsRef<Path>>(&mut self, path: Option<P>) -> &mut Self {
+        self.rocks_override_path = path.as_ref().map(|p| p.as_ref().to_path_buf());
+        self
+    }
+
     pub fn with_leader_strategy(&mut self, leader_strategy: RoundRobinLeaderStrategy) -> &mut Self {
         self.leader_strategy = leader_strategy;
         self
@@ -137,7 +147,15 @@ impl ValidatorBuilder {
         let inbound_messaging = TestInboundMessaging::new(self.address.clone(), rx_hs_message, rx_loopback);
 
         #[cfg(not(feature = "sqlite_backend"))]
-        let store = TestStore::open(&self.rocks_path).unwrap();
+        let store = {
+            let rocks_path = self
+                .rocks_override_path
+                .as_ref()
+                .map(|p| p.as_path())
+                .unwrap_or_else(|| self.rocks_tmp_path.path());
+            log::info!("Rocksdb path {}", rocks_path.display());
+            TestStore::open(rocks_path).unwrap()
+        };
         #[cfg(feature = "sqlite_backend")]
         let store = TestStore::connect(&self.sql_url).unwrap();
         let signing_service = TestVoteSignatureService::new(self.address.clone());

--- a/dan_layer/engine_types/src/substate.rs
+++ b/dan_layer/engine_types/src/substate.rs
@@ -104,6 +104,10 @@ impl Substate {
     pub fn to_value_hash(&self) -> FixedHash {
         hash_substate(self.substate_value(), self.version)
     }
+
+    pub fn previous_version(&self) -> Option<u32> {
+        self.version.checked_sub(1)
+    }
 }
 
 pub fn hash_substate(substate: &SubstateValue, version: u32) -> FixedHash {

--- a/dan_layer/state_store_rocksdb/src/cf_api.rs
+++ b/dan_layer/state_store_rocksdb/src/cf_api.rs
@@ -62,7 +62,7 @@ impl<'db, DB, CF: Cf> CfContext<'db, DB, CF> {
 }
 
 impl<CF: Cf, DB: RocksReader> CfContext<'_, DB, CF> {
-    fn encode_key(&self, key: &CF::Key) -> EncodeVec {
+    pub fn encode_key(&self, key: &CF::Key) -> EncodeVec {
         self.key_codec.encode(key).unwrap_or_else(|e| {
             panic!(
                 "database corruption: key encoding failed for CF[{}], key type {}: {}",

--- a/dan_layer/state_store_rocksdb/src/codecs/block_diff.rs
+++ b/dan_layer/state_store_rocksdb/src/codecs/block_diff.rs
@@ -52,6 +52,7 @@ impl DbCodec<BlockDiffKey> for BlockIdSubstateIdVersionCodec {
     }
 }
 
+/// Codec for the BlockDiffKey. Encodes in substate_id, block_id, and version order.
 #[derive(Default)]
 pub struct BlockDiffKeyCodec {
     substate_id_codec: SubstateIdCodec,

--- a/dan_layer/state_store_sqlite/src/sql_models/block_diff.rs
+++ b/dan_layer/state_store_sqlite/src/sql_models/block_diff.rs
@@ -40,7 +40,6 @@ impl BlockDiff {
         let substate_id = SubstateId::from_str(&d.substate_id).map_err(|err| StorageError::DataInconsistency {
             details: format!("Invalid substate id {}: {}", d.substate_id, err),
         })?;
-        let id = VersionedSubstateId::new(substate_id, d.version as u32);
         let shard = Shard::from(d.shard as u32);
         match d.change.as_str() {
             "Up" => {
@@ -48,12 +47,15 @@ impl BlockDiff {
                     details: "Block diff change type is Up but state is missing".to_string(),
                 })?;
                 Ok(consensus_models::SubstateChange::Up {
-                    id,
+                    id: substate_id,
                     shard,
                     substate: deserialize_json(&state)?,
                 })
             },
-            "Down" => Ok(consensus_models::SubstateChange::Down { id, shard }),
+            "Down" => Ok(consensus_models::SubstateChange::Down {
+                id: VersionedSubstateId::new(substate_id, d.version as u32),
+                shard,
+            }),
             _ => Err(StorageError::DataInconsistency {
                 details: format!("Invalid block diff change type: {}", d.change),
             }),

--- a/dan_layer/state_store_tests/src/block_diffs.rs
+++ b/dan_layer/state_store_tests/src/block_diffs.rs
@@ -46,10 +46,9 @@ fn block_diffs_operations(db: impl StateStore) {
     let block_id9 = *block9.id();
     let substate_id = create_random_substate_id();
     let version = 0;
-    let versioned_substate_id = VersionedSubstateId::new(substate_id.clone(), version);
     let substate_record = build_substate_record(&substate_id, version);
     let change = SubstateChange::Up {
-        id: versioned_substate_id.clone(),
+        id: substate_id.clone(),
         shard: block9.shard_group().start(),
         substate: Substate::new(version, substate_record.substate_value.clone().unwrap()),
     };
@@ -57,13 +56,14 @@ fn block_diffs_operations(db: impl StateStore) {
     let value2 = build_substate_value(Some(
         substate_record.substate_value().unwrap().component().unwrap().entity_id,
     ));
+    let versioned_substate_id = VersionedSubstateId::new(substate_id.clone(), version);
     let changes = &[
         SubstateChange::Down {
             id: versioned_substate_id.clone(),
             shard: block9.shard_group().end(),
         },
         SubstateChange::Up {
-            id: versioned_substate_id.to_next_version(),
+            id: substate_id.clone(),
             shard: block9.shard_group().end(),
             substate: Substate::new(version + 1, value2.clone()),
         },
@@ -79,7 +79,7 @@ fn block_diffs_operations(db: impl StateStore) {
         .unwrap();
     match &change {
         SubstateChange::Up { id, shard, substate } => {
-            assert_eq!(*id, versioned_substate_id.to_next_version());
+            assert_eq!(id, versioned_substate_id.substate_id());
             assert_eq!(*shard, block9.shard_group().end());
             assert_eq!(substate.version(), version + 1);
             assert_eq!(substate.to_value_hash(), hash_substate(&value2, version + 1));

--- a/dan_layer/storage/src/consensus_models/block.rs
+++ b/dan_layer/storage/src/consensus_models/block.rs
@@ -656,9 +656,9 @@ impl Block {
         for change in changes {
             match change {
                 SubstateChange::Up { id, shard, substate } => {
-                    let version = id.version();
+                    let version = substate.version();
                     SubstateRecord::new(
-                        id.into_substate_id(),
+                        id,
                         version,
                         substate.into_substate_value(),
                         shard,

--- a/dan_layer/storage/src/consensus_models/block_diff.rs
+++ b/dan_layer/storage/src/consensus_models/block_diff.rs
@@ -3,7 +3,7 @@
 
 use std::fmt::Debug;
 
-use tari_dan_common_types::{committee::CommitteeInfo, optional::Optional, VersionedSubstateIdRef};
+use tari_dan_common_types::{committee::CommitteeInfo, VersionedSubstateIdRef};
 use tari_engine_types::substate::SubstateId;
 
 use crate::{
@@ -70,28 +70,7 @@ impl BlockDiff {
     }
 
     pub fn remove<TTx: StateStoreWriteTransaction>(&self, tx: &mut TTx) -> Result<(), StorageError> {
-        if Self::remove_any(tx, Some(self.block_id))? == 0 {
-            return Err(StorageError::NotFound {
-                item: "BlockDiff (remove)",
-                key: self.block_id.to_string(),
-            });
-        }
-        Ok(())
-    }
-
-    pub fn remove_any<TTx, I>(tx: &mut TTx, block_ids: I) -> Result<usize, StorageError>
-    where
-        TTx: StateStoreWriteTransaction,
-        I: IntoIterator<Item = BlockId>,
-    {
-        // TODO(perf): bulk remove
-        let mut removed = 0usize;
-        for block_id in block_ids {
-            if tx.block_diffs_remove(&block_id).optional()?.is_some() {
-                removed += 1;
-            }
-        }
-        Ok(removed)
+        tx.block_diffs_remove(&self.block_id)
     }
 
     pub fn get_last_change_for_substate<TTx: StateStoreReadTransaction>(

--- a/dan_layer/storage/src/consensus_models/substate_change.rs
+++ b/dan_layer/storage/src/consensus_models/substate_change.rs
@@ -4,14 +4,20 @@
 use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
-use tari_dan_common_types::{shard::Shard, SubstateAddress, ToSubstateAddress, VersionedSubstateId};
+use tari_dan_common_types::{
+    shard::Shard,
+    SubstateAddress,
+    ToSubstateAddress,
+    VersionedSubstateId,
+    VersionedSubstateIdRef,
+};
 use tari_engine_types::substate::{Substate, SubstateId};
 use tari_state_tree::SubstateTreeChange;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum SubstateChange {
     Up {
-        id: VersionedSubstateId,
+        id: SubstateId,
         shard: Shard,
         substate: Substate,
     },
@@ -24,20 +30,23 @@ pub enum SubstateChange {
 impl SubstateChange {
     pub fn to_substate_address(&self) -> SubstateAddress {
         match self {
-            SubstateChange::Up { id, .. } => id.to_substate_address(),
+            SubstateChange::Up { id, substate, .. } => SubstateAddress::from_substate_id(id, substate.version()),
             SubstateChange::Down { id, .. } => id.to_substate_address(),
         }
     }
 
-    pub fn versioned_substate_id(&self) -> &VersionedSubstateId {
+    pub fn versioned_substate_id(&self) -> VersionedSubstateIdRef<'_> {
         match self {
-            SubstateChange::Up { id, .. } => id,
-            SubstateChange::Down { id, .. } => id,
+            SubstateChange::Up { id, substate, .. } => VersionedSubstateIdRef::new(id, substate.version()),
+            SubstateChange::Down { id, .. } => id.as_ref(),
         }
     }
 
     pub fn substate_id(&self) -> &SubstateId {
-        self.versioned_substate_id().substate_id()
+        match self {
+            SubstateChange::Up { id, .. } => id,
+            SubstateChange::Down { id, .. } => id.substate_id(),
+        }
     }
 
     pub fn version(&self) -> u32 {
@@ -92,7 +101,14 @@ impl Display for SubstateChange {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             SubstateChange::Up { id, shard, substate } => {
-                write!(f, "Up: {}, {}, substate hash: {}", id, shard, substate.to_value_hash())
+                write!(
+                    f,
+                    "Up: {}v{}, {}, substate hash: {}",
+                    id,
+                    substate.version(),
+                    shard,
+                    substate.to_value_hash()
+                )
             },
             SubstateChange::Down { id, shard } => write!(f, "Down: {}, {}", id, shard),
         }
@@ -103,7 +119,7 @@ impl From<&SubstateChange> for SubstateTreeChange {
     fn from(value: &SubstateChange) -> Self {
         match value {
             SubstateChange::Up { id, substate, .. } => SubstateTreeChange::Up {
-                id: id.clone(),
+                id: VersionedSubstateId::new(id.clone(), substate.version()),
                 value_hash: substate.to_value_hash(),
             },
             SubstateChange::Down { id, .. } => SubstateTreeChange::Down { id: id.clone() },

--- a/utilities/db_inspector/src/webserver/handlers/block_diff.rs
+++ b/utilities/db_inspector/src/webserver/handlers/block_diff.rs
@@ -1,0 +1,60 @@
+//   Copyright 2025 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+use std::sync::Arc;
+
+use axum::{
+    extract::{Path, Query},
+    Extension,
+    Json,
+};
+use serde_json::json;
+use tari_dan_storage::Ordering;
+use tari_state_store_rocksdb::models;
+
+use crate::webserver::{
+    context::HandlerContext,
+    error::WebError,
+    handlers::types::{Column, TableRequest, TableResponse},
+};
+
+pub async fn list(
+    Extension(context): Extension<Arc<HandlerContext>>,
+    Path(db_name): Path<String>,
+    Query(req): Query<TableRequest>,
+) -> Result<Json<TableResponse>, WebError> {
+    const OPERATION: &str = "list_state_transitions";
+    let db = context.open_db(&db_name)?;
+    let mut table = TableResponse::new([
+        Column::new("block_id", "Block Id"),
+        Column::new("shard", "Shard"),
+        Column::new("substate_id", "Substate ID"),
+        Column::new("version", "Version"),
+        Column::new("substate", "Substate"),
+    ]);
+    let tx = db.read_only_context();
+
+    let cf = tx.cf(models::block_diff::BlockDiffModel)?;
+    let ordering = if req.asc {
+        Ordering::Ascending
+    } else {
+        Ordering::Descending
+    };
+    let iter = cf.iterator(ordering, OPERATION);
+    for result in iter.take(req.limit.unwrap_or(1_000_000)) {
+        let (id, data) = result?;
+        let encoded_key = cf.encode_key(&id);
+        table.add_row(json!({
+            "id": hex::encode(encoded_key),
+            "block_id": id.block_id,
+            "substate_id": id.substate_id,
+            "version": id.version,
+            "shard": data.shard(),
+            "substate": data.substate(),
+        }));
+    }
+    let total = cf.count(OPERATION)?;
+    table.set_total_entries(total);
+
+    Ok(Json(table))
+}

--- a/utilities/db_inspector/src/webserver/handlers/mod.rs
+++ b/utilities/db_inspector/src/webserver/handlers/mod.rs
@@ -1,6 +1,7 @@
 //   Copyright 2025 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
+pub mod block_diff;
 pub mod blocks;
 pub mod bookkeeping;
 pub mod databases;

--- a/utilities/db_inspector/src/webserver/server.rs
+++ b/utilities/db_inspector/src/webserver/server.rs
@@ -47,6 +47,10 @@ pub async fn run(context: HandlerContext) -> anyhow::Result<()> {
         get(handlers::blocks::list),
     )
         .route(
+            "/databases/:db_name/column-families/block_diff",
+            get(handlers::block_diff::list),
+        )
+        .route(
             "/databases/:db_name/column-families/bookkeeping",
             get(handlers::bookkeeping::list),
         );
@@ -62,7 +66,7 @@ pub async fn run(context: HandlerContext) -> anyhow::Result<()> {
         models::foreign_proposal::EpochIndex,
         models::foreign_proposal::UnconfirmedIndex,
         models::block::EpochHeightIndex,
-        models::block_diff::BlockDiffModel,
+        // models::block_diff::BlockDiffModel,
         models::block_diff::SubstateIdIndex,
         models::quorum_certificate::QuorumCertificateModel,
         models::quorum_certificate::QuorumCertificateBlockIndex,


### PR DESCRIPTION
Description
---
fix(consensus): set substate version when mutating vn fee pool
fix(db-inspector): add specialized implementation for block_diff column family

Motivation and Context
---
The substate version was not updated when calling `update_in_place` and mutating an existing UP change in a previous block. This manifested in new validators being unable to sync due to JMT Merkle root mismatch.

How Has This Been Tested?
---
Existing tests, manually syncing new VNs

What process can a PR reviewer use to test or verify this change?
---
Click 'Add VN' in swarm and mine the new NV in, VN should sync and start consensus

Breaking Changes
---

- [ ] None
- [x] Requires data directory to be deleted
- [ ] Other - Please specify

BREAKING CHANGE: simplified SubstateChange a little, which is not compatible with previous DBs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added a new HTTP endpoint to inspect block diffs in the database inspector web interface, allowing users to view detailed block diff information.

- **Bug Fixes**
  - Improved consistency and clarity in how substate IDs and versions are handled across substate changes, storage, and consensus logic.

- **Documentation**
  - Added and updated documentation comments for improved clarity.

- **Refactor**
  - Simplified and unified substate versioning logic, reducing unnecessary cloning and improving performance.
  - Adjusted test harnesses to support configurable RocksDB paths for easier test setup and cleanup.
  - Streamlined shard filtering and substate address derivations in consensus logic.
  - Updated substate ID and version handling in multiple modules for better correctness and consistency.
  - Removed deprecated bulk removal logic in block diffs storage.
  - Enhanced shard and substate address calculations for mint confidential output and proposal processing.

- **Tests**
  - Enhanced test coverage and updated tests to reflect changes in substate version handling.
  - Improved test transaction flows and validator setup for robustness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->