### PR TITLE
feat(db-inspector): basic server pagination and key query

### DIFF
--- a/utilities/db_inspector/src/webserver/error.rs
+++ b/utilities/db_inspector/src/webserver/error.rs
@@ -6,6 +6,7 @@ use axum::{
     response::{IntoResponse, Response},
     Json,
 };
+use log::error;
 use serde::Serialize;
 use tari_state_store_rocksdb::error::RocksDbStorageError;
 
@@ -40,6 +41,8 @@ impl WebError {
 
 impl IntoResponse for WebError {
     fn into_response(self) -> Response {
+        error!("WebError({}): {}", self.code, self.message);
+
         (
             StatusCode::from_u16(self.code).expect("invalid status code"),
             Json(self),

--- a/utilities/db_inspector/src/webserver/handlers/block_diff.rs
+++ b/utilities/db_inspector/src/webserver/handlers/block_diff.rs
@@ -40,8 +40,11 @@ pub async fn list(
     } else {
         Ordering::Descending
     };
+
+    let page_size = req.limit.unwrap_or(1_000);
+    let skip = req.page.unwrap_or(0) * page_size;
     let iter = cf.iterator(ordering, OPERATION);
-    for result in iter.take(req.limit.unwrap_or(1_000_000)) {
+    for result in iter.skip(skip).take(page_size) {
         let (id, data) = result?;
         let encoded_key = cf.encode_key(&id);
         table.add_row(json!({

--- a/utilities/db_inspector/src/webserver/handlers/blocks.rs
+++ b/utilities/db_inspector/src/webserver/handlers/blocks.rs
@@ -8,6 +8,7 @@ use axum::{
     Extension,
     Json,
 };
+use log::warn;
 use serde_json::json;
 use tari_dan_common_types::Epoch;
 use tari_dan_storage::Ordering;
@@ -46,9 +47,14 @@ pub async fn list(
     } else {
         Ordering::Descending
     };
-    // let ((epoch, height, block_id), _) = query_cf.query_last(OPERATION)?;
+    if req.query_prefix_hex.is_some() {
+        warn!("The start parameter is not supported for blocks");
+    }
+
+    let page_size = req.limit.unwrap_or(1_000);
+    let skip = req.page.unwrap_or(0) * page_size;
     let iter = query_cf.query_end_range_key_iterator(ordering, &Epoch::max());
-    for result in iter.take(req.limit.unwrap_or(1_000_000)) {
+    for result in iter.skip(skip).take(page_size) {
         let (_, _, block_id) = result?;
         let block = cf.get(&block_id, OPERATION)?;
         let mut flags = Vec::new();

--- a/utilities/db_inspector/src/webserver/handlers/state_transitions.rs
+++ b/utilities/db_inspector/src/webserver/handlers/state_transitions.rs
@@ -16,7 +16,7 @@ use tari_state_store_rocksdb::models;
 use crate::webserver::{
     context::HandlerContext,
     error::WebError,
-    handlers::types::{Column, TableRequest, TableResponse},
+    handlers::types::{decode_hex_prefix, Column, TableRequest, TableResponse},
 };
 
 pub async fn list(
@@ -38,14 +38,24 @@ pub async fn list(
     let tx = db.read_only_context();
 
     let cf = tx.cf(models::state_transition::StateTransitionModel)?;
+
     let substate_cf = tx.cf(models::substate::SubstateModel)?;
     let ordering = if req.asc {
         Ordering::Ascending
     } else {
         Ordering::Descending
     };
-    let iter = cf.iterator(ordering, OPERATION);
-    for result in iter.take(req.limit.unwrap_or(1_000_000)) {
+    let iter = if let Some(prefix_hex) = req.query_prefix_hex.as_ref() {
+        let key_prefix = decode_hex_prefix(prefix_hex)?;
+        cf.range_iterator(ordering, key_prefix.as_slice()..)
+    } else {
+        let empty = Vec::<u8>::new();
+        cf.range_iterator(ordering, empty.as_slice()..)
+    };
+
+    let page_size = req.limit.unwrap_or(1_000);
+    let skip = req.page.unwrap_or(0) * page_size;
+    for result in iter.skip(skip).take(page_size) {
         let (id, data) = result?;
         let encoded_key = cf.encode_key(&id);
         let substate = substate_cf.get(&data.substate_address, OPERATION).optional()?;

--- a/utilities/db_inspector/src/webserver/handlers/tables.rs
+++ b/utilities/db_inspector/src/webserver/handlers/tables.rs
@@ -18,7 +18,7 @@ use tari_state_store_rocksdb::{codecs::DbCodec, models, traits::Cf};
 use crate::webserver::{
     context::HandlerContext,
     error::WebError,
-    handlers::types::{Column, TableRequest, TableResponse},
+    handlers::types::{decode_hex_prefix, Column, TableRequest, TableResponse},
 };
 
 pub fn list<CF, F, B, S>(cf: F) -> impl Handler<(), S, B>
@@ -46,8 +46,18 @@ where
                 } else {
                     Ordering::Descending
                 };
-                let iter = cf.iterator(ordering, OPERATION);
-                for result in iter.take(req.limit.unwrap_or(1_000_000)) {
+                let iter = if let Some(prefix_hex) = req.query_prefix_hex.as_ref() {
+                    let key_prefix = decode_hex_prefix(prefix_hex)?;
+                    cf.range_iterator(ordering, key_prefix.as_slice()..)
+                } else {
+                    let empty = Vec::<u8>::new();
+                    cf.range_iterator(ordering, empty.as_slice()..)
+                };
+
+                let page_size = req.limit.unwrap_or(1_000);
+                let skip = req.page.unwrap_or(0) * page_size;
+
+                for result in iter.skip(skip).take(page_size) {
                     let (key, value) = result?;
                     let mut value =
                         serde_json::to_value(value).map_err(|e| anyhow!("Failed to serialize value: {}", e))?;

--- a/utilities/db_inspector/src/webserver/handlers/types.rs
+++ b/utilities/db_inspector/src/webserver/handlers/types.rs
@@ -4,8 +4,12 @@
 use serde::{Deserialize, Serialize};
 use serde_json as json;
 
+use crate::webserver::error::WebError;
+
 #[derive(Debug, Clone, Deserialize)]
 pub struct TableRequest {
+    pub query_prefix_hex: Option<String>,
+    pub page: Option<usize>,
     pub limit: Option<usize>,
     #[serde(default)]
     pub asc: bool,
@@ -70,5 +74,17 @@ impl TableResponse {
 macro_rules! row {
     ($($s:expr),*$(,)?) => {
         vec![$(::serde_json::to_value(&$s).unwrap()),*]
+    }
+}
+
+pub fn decode_hex_prefix(prefix_hex: &str) -> Result<Vec<u8>, WebError> {
+    if prefix_hex.len() % 2 == 0 {
+        hex::decode(prefix_hex)
+            .map_err(|e| WebError::bad_request(format!("Failed to decode hex prefix: {}. Error: {}", prefix_hex, e)))
+    } else {
+        let mut p = prefix_hex.to_string();
+        p.push('0');
+        hex::decode(p)
+            .map_err(|e| WebError::bad_request(format!("Failed to decode hex prefix: {}. Error: {}", prefix_hex, e)))
     }
 }

--- a/utilities/db_inspector/web_ui/src/client.ts
+++ b/utilities/db_inspector/web_ui/src/client.ts
@@ -3,7 +3,7 @@
 
 const URL = import.meta.env.VITE_API_ADDRESS || "http://localhost:9090/api";
 
-type Params = { [key: string]: string | number | boolean | null };
+export type Params = { [key: string]: string | number | boolean | null };
 
 function getUrl(entity: string, params: Params = {}) {
   function toQueryString(params: Params): string {

--- a/utilities/db_inspector/web_ui/src/routes/InspectCf.tsx
+++ b/utilities/db_inspector/web_ui/src/routes/InspectCf.tsx
@@ -1,13 +1,14 @@
 //   Copyright 2025 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-import { Box, Button, Divider, Grid, Typography } from "@mui/material";
+import { Box, Button, Divider, Grid, TextField, Typography } from "@mui/material";
 import { useTheme } from "@mui/material/styles";
 import { client } from "../store/databases.ts";
 import { Link as RouterLink, useParams } from "react-router-dom";
-import { DataGrid, GridColDef } from "@mui/x-data-grid";
-import { useEffect, useState } from "react";
+import { DataGrid, GridColDef, GridPaginationModel } from "@mui/x-data-grid";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Refresh } from "@mui/icons-material";
+import { Params } from "../client.ts";
 
 
 type Row = Record<string, string | object>;
@@ -20,6 +21,11 @@ interface Column {
 interface ColumnFamilyData {
   columns: Column[];
   rows: Row[];
+  total_entries: number;
+}
+
+interface PaginationModel extends GridPaginationModel {
+  query?: string;
 }
 
 function estimateWidth(labelLength: number, data: Row[], getter: (row: Row) => any): number {
@@ -73,17 +79,37 @@ export default function InspectCf() {
   const theme = useTheme();
   const { dbName, cfName } = useParams();
   const [data, setData] = useState<ColumnFamilyData | null>(null);
+  const [pagination, setPagination] = useState<PaginationModel>({ page: 0, pageSize: 20 });
   const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
 
   const fetch = () => {
-    client.listCfItems(dbName!, cfName!, { limit: 500 }).then((res) => {
+    setError(null);
+    setIsLoading(true);
+
+    const query = { limit: pagination.pageSize, page: pagination.page, query_prefix_hex: pagination.query || "" };
+    client.listCfItems(dbName!, cfName!, query as Params).then((res) => {
       setData(res);
     }).catch((err) => {
       setError(err.message);
+    }).finally(() => {
+      setIsLoading(false);
     });
   };
 
-  useEffect(fetch, [dbName, cfName]);
+  useEffect(fetch, [dbName, cfName, pagination]);
+
+  const columns = data ? generateColumns(data) : [];
+  // Following lines are here to prevent `rowCount` from being undefined during the loading
+  const rowCountRef = useRef(data?.total_entries || 0);
+
+  const rowCount = useMemo(() => {
+    if (data?.total_entries !== undefined) {
+      rowCountRef.current = data.total_entries;
+    }
+    return rowCountRef.current;
+  }, [data?.total_entries]);
+
 
   if (error) {
     return (
@@ -115,13 +141,6 @@ export default function InspectCf() {
     );
   }
 
-  if (!data) {
-    return <div>Loading...</div>;
-  }
-
-
-  const columns = generateColumns(data);
-
   return (
     <>
       <Grid size={{ xs: 12, md: 12, lg: 12 }}>
@@ -149,6 +168,23 @@ export default function InspectCf() {
             >
               <Refresh />
             </Button>
+            <TextField
+              variant="outlined"
+              size="small"
+              label="Prefix key query"
+              style={{ marginLeft: theme.spacing(2) }}
+              onChange={(e) => setPagination({ ...pagination, page: 0, query: e.target.value })}
+              value={pagination.query || ""}
+              placeholder="Enter a key prefix in hex"
+            />
+            <Button
+              variant="outlined"
+              color="secondary"
+              onClick={() => setPagination({ ...pagination, page: 0, query: "" })}
+              style={{ marginLeft: theme.spacing(2) }}
+            >
+              Clear
+            </Button>
           </Typography>
         </Box>
         <Divider />
@@ -156,15 +192,19 @@ export default function InspectCf() {
 
       <Grid container spacing={3}>
         <DataGrid
-          rows={data.rows}
+          rows={data?.rows || []}
           columns={columns}
+          loading={isLoading}
+          rowCount={rowCount}
           initialState={{
             pagination: {
               paginationModel: {
-                pageSize: 20,
+                pageSize: pagination.pageSize,
               },
             },
           }}
+          paginationMode="server"
+          onPaginationModelChange={setPagination}
           sortingOrder={["desc", "asc", null]}
           checkboxSelection
         />


### PR DESCRIPTION
Description
---
feat(db-inspector): basic server pagination and key query

Motivation and Context
---
Previously only first (by key) 500 records are shown. This PR allows pagination. 
Basical ability to query for a specific key

How Has This Been Tested?
---
Manually

What process can a PR reviewer use to test or verify this change?
---
` cargo run --bin db_inspector --release`

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced server-side pagination and prefix-based filtering for data tables in the web UI, allowing users to navigate large datasets more efficiently and filter entries by key prefix.
  - Added UI controls for entering and clearing hex prefix queries in data table views.

- **Improvements**
  - Default page size for data retrieval is now reduced for better performance.
  - Enhanced error logging for web errors to aid in troubleshooting.
  - Improved loading and error handling in the data grid for a smoother user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->