### PR TITLE
fix(wallet): update indexer port

### DIFF
--- a/applications/tari_dan_app_utilities/config_presets/e_dan_wallet_daemon.toml
+++ b/applications/tari_dan_app_utilities/config_presets/e_dan_wallet_daemon.toml
@@ -16,4 +16,4 @@
 # indexer_json_rpc_url = "http://127.0.0.1:18200/json_rpc"
 [igor.dan_wallet_daemon]
 # Indexer JSON-RPC url for Igor.
-indexer_json_rpc_url = "http://18.217.22.26:12006/json_rpc"
+indexer_json_rpc_url = "http://18.217.22.26:12008/json_rpc"


### PR DESCRIPTION
Description
---
Indexer is running on port 12008


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the port number for the indexer service in the wallet daemon configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->