### PR TITLE
feat: add VN command to compact the database

### DIFF
--- a/applications/tari_dan_wallet_daemon/build.rs
+++ b/applications/tari_dan_wallet_daemon/build.rs
@@ -24,7 +24,7 @@ use std::{env, fs, process::Command};
 
 const NPM_COMMANDS: &[(&str, &[&str])] = &[
     ("../../bindings", &["install"]),
-    ("../../bindings", &["run", "build-dist"]),
+    ("../../bindings", &["run", "build-dev"]),
     ("../../clients/javascript/wallet_daemon_client", &["install"]),
     ("../../clients/javascript/wallet_daemon_client", &["run", "build"]),
     ("./web_ui", &["install"]),

--- a/applications/tari_validator_node/src/cli.rs
+++ b/applications/tari_validator_node/src/cli.rs
@@ -59,6 +59,8 @@ pub struct Cli {
     /// FOR DEBUGGING PURPOSES ONLY
     #[clap(long, short = 'd')]
     pub debug_templates: Vec<String>,
+    #[clap(subcommand)]
+    pub command: Option<Subcommand>,
 }
 
 impl ConfigOverrideProvider for Cli {
@@ -112,4 +114,12 @@ impl ConfigOverrideProvider for Cli {
         }
         overrides
     }
+}
+
+#[derive(clap::Subcommand, Debug)]
+pub enum Subcommand {
+    /// Start the validator node
+    Start,
+    /// Compact the database and exit
+    CompactDb,
 }

--- a/applications/tari_validator_node/src/consensus/mod.rs
+++ b/applications/tari_validator_node/src/consensus/mod.rs
@@ -36,7 +36,7 @@ mod leader_selection;
 #[cfg(feature = "metrics")]
 pub mod metrics;
 mod signature_service;
-pub(crate) mod spec;
+pub mod spec;
 
 pub use block_transaction_executor::*;
 pub use handle::*;

--- a/applications/tari_validator_node/src/lib.rs
+++ b/applications/tari_validator_node/src/lib.rs
@@ -21,9 +21,8 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 mod bootstrap;
-pub mod cli;
 mod config;
-mod consensus;
+pub mod consensus;
 mod dan_node;
 mod dry_run_transaction_processor;
 mod event_subscription;

--- a/applications/tari_validator_node/src/main.rs
+++ b/applications/tari_validator_node/src/main.rs
@@ -26,18 +26,17 @@ use std::{fs, panic, process};
 
 use clap::Parser;
 use log::*;
-use tari_common::{
-    exit_codes::{ExitCode, ExitError},
-    initialize_logging,
-};
+use tari_common::initialize_logging;
 use tari_dan_app_utilities::configuration::load_configuration;
 use tari_shutdown::Shutdown;
-use tari_validator_node::{cli::Cli, run_validator_node, ApplicationConfig};
+use tari_validator_node::{run_validator_node, ApplicationConfig};
+
+use crate::cli::Cli;
 
 const LOG_TARGET: &str = "tari::validator_node::app";
 
 #[tokio::main]
-async fn main() {
+async fn main() -> anyhow::Result<()> {
     // Uncomment to enable tokio tracing via tokio-console
     // console_subscriber::init();
 
@@ -49,25 +48,9 @@ async fn main() {
         process::exit(1);
     }));
 
-    if let Err(err) = main_inner().await {
-        let exit_code = err.exit_code;
-        eprintln!("{:?}", err);
-        error!(
-            target: LOG_TARGET,
-            "Exiting with code ({}) {:?}: {}",
-            exit_code as i32,
-            exit_code,
-            err.details.unwrap_or_default()
-        );
-        process::exit(exit_code as i32);
-    }
-}
-
-async fn main_inner() -> Result<(), ExitError> {
     let cli = Cli::parse();
     let config_path = cli.common.config_path();
-    let cfg = load_configuration(config_path, true, &cli, cli.common.network)
-        .map_err(|e| ExitError::new(ExitCode::ConfigError, e))?;
+    let cfg = load_configuration(config_path, true, &cli, cli.common.network)?;
     let config = ApplicationConfig::load_from(&cfg)?;
 
     // Remove the pid file if it exists
@@ -80,18 +63,27 @@ async fn main_inner() -> Result<(), ExitError> {
         eprintln!("{}", e);
     }
 
-    let shutdown = Shutdown::new();
-    match run_validator_node(config, shutdown).await {
-        Ok(_) => info!(target: LOG_TARGET, "Validator node shutdown successfully"),
-        Err(e) => match e.downcast() {
-            Ok(exit_error) => {
-                error!(target: LOG_TARGET, "Validator node shutdown with an error: {:?}", exit_error);
-                return Err(exit_error);
-            },
-            Err(e) => {
-                error!(target: LOG_TARGET, "Validator node shutdown with an error: {:?}", e);
-                return Err(ExitError::new(ExitCode::UnknownError, e));
-            },
+    match cli.command {
+        Some(cli::Subcommand::CompactDb) => {
+            let timer = std::time::Instant::now();
+            #[cfg(feature = "sqlite_backend")]
+            info!("sqlite backend does not support compaction");
+            #[cfg(not(feature = "sqlite_backend"))]
+            tari_validator_node::consensus::spec::ValidatorNodeStateStore::compact_all(
+                &config.validator_node.state_db_path,
+            )?;
+
+            info!(
+                target: LOG_TARGET,
+                "Compacted state database in {:.2?}",
+                timer.elapsed()
+            );
+            return Ok(());
+        },
+        Some(cli::Subcommand::Start) | None => {
+            let shutdown = Shutdown::new();
+            run_validator_node(config, shutdown).await?;
+            info!(target: LOG_TARGET, "Validator node shutdown successfully");
         },
     }
 

--- a/applications/tari_validator_node/src/p2p/rpc/service_impl.rs
+++ b/applications/tari_validator_node/src/p2p/rpc/service_impl.rs
@@ -361,22 +361,17 @@ impl<TStateStore: StateStore + Clone + Send + Sync + 'static> ValidatorNodeRpcSe
         let msg = request.into_message();
         let current_epoch = self.consensus.current_epoch();
 
-        let prev_epoch = current_epoch.saturating_sub(Epoch(1));
-        if prev_epoch.is_zero() {
-            return Err(RpcStatus::not_found("Cannot generate checkpoint for genesis epoch"));
-        }
-
-        if msg.current_epoch != current_epoch {
+        if msg.epoch >= current_epoch.as_u64() {
             // This may occur if one of the nodes has not fully scanned the base layer
             return Err(RpcStatus::bad_request(format!(
-                "Peer requested checkpoint with epoch {} but current epoch is {}",
-                msg.current_epoch, current_epoch
+                "Peer requested checkpoint with epoch {} but the current epoch is {}",
+                msg.epoch, current_epoch
             )));
         }
 
         let checkpoint = self
             .state_store
-            .with_read_tx(|tx| EpochCheckpoint::get(tx, prev_epoch))
+            .with_read_tx(|tx| EpochCheckpoint::get(tx, Epoch(msg.epoch)))
             .optional()
             .map_err(RpcStatus::log_internal_error(LOG_TARGET))?;
 

--- a/bindings/package.json
+++ b/bindings/package.json
@@ -17,6 +17,7 @@
   },
   "scripts": {
     "build-dist": "tsc --project tsconfig.prod.json",
+    "build-dev": "tsc",
     "build": "sh build.sh && tsc"
   },
   "files": [

--- a/dan_layer/consensus/src/hotstuff/on_ready_to_vote_on_local_block.rs
+++ b/dan_layer/consensus/src/hotstuff/on_ready_to_vote_on_local_block.rs
@@ -1679,18 +1679,24 @@ where TConsensusSpec: ConsensusSpec
             target: LOG_TARGET,
             "🌳 COMMIT block {} with {} substate change(s)", block, diff.len()
         );
-        let local_diff = diff.into_filtered(local_committee_info);
-        block.commit_diff(tx, commit_qc_id, local_diff)?;
+        {
+            let _timer = TraceTimer::debug(LOG_TARGET, "commit_block");
+            let local_diff = diff.into_filtered(local_committee_info);
+            block.commit_diff(tx, commit_qc_id, local_diff)?;
+        }
 
-        let finalized_transactions = self
-            .transaction_pool
-            .remove_all(tx, block.all_finalising_transactions_ids())?;
+        let finalized_transactions = {
+            let _timer = TraceTimer::debug(LOG_TARGET, "remove finalized transactions");
+            self.transaction_pool
+                .remove_all(tx, block.all_finalising_transactions_ids())?
+        };
 
         // Whenever we commit a block that will result in an abort for a transaction, we can remove lock conflicts to
         // allow other "blocked" transactions to be proposed.
         TransactionLockConflicts::remove_for_transactions(tx, block.all_aborting_transaction_ids())?;
 
         if !finalized_transactions.is_empty() {
+            let _timer = TraceTimer::debug(LOG_TARGET, "unlock and finalized transactions");
             // Remove locks for finalized transactions
             SubstateRecord::unlock_all(tx, finalized_transactions.iter().map(|t| t.transaction_id()))?;
             TransactionRecord::finalize_all(tx, *block.id(), &finalized_transactions)?;

--- a/dan_layer/consensus/src/hotstuff/pacemaker.rs
+++ b/dan_layer/consensus/src/hotstuff/pacemaker.rs
@@ -170,7 +170,7 @@ impl PaceMaker {
                     leader_timeout.as_mut().reset(self.leader_timeout());
 
                     if leader_failure_suspended {
-                        info!(target: LOG_TARGET, "🧿 Leader timeout while suspended. Current view: {}", self.current_view);
+                        warn!(target: LOG_TARGET, "🧿 Leader timeout while suspended. Current view: {}", self.current_view);
                         leader_failure_triggered_during_suspension = true;
                     } else {
                         info!(target: LOG_TARGET, "⚠️ Leader timeout! Current view: {}, Delta: {:.2?}", self.current_view, self.delta_time());

--- a/dan_layer/p2p/proto/rpc.proto
+++ b/dan_layer/p2p/proto/rpc.proto
@@ -222,7 +222,7 @@ message GetHighQcResponse {
 }
 
 message GetCheckpointRequest {
-  uint64 current_epoch = 1;
+  uint64 epoch = 1;
 }
 
 message GetCheckpointResponse {

--- a/dan_layer/rpc_state_sync/src/state_sync.rs
+++ b/dan_layer/rpc_state_sync/src/state_sync.rs
@@ -89,12 +89,10 @@ where TConsensusSpec: ConsensusSpec<Addr = PeerAddress>
     async fn fetch_epoch_checkpoint(
         &self,
         client: &mut ValidatorNodeRpcClient,
-        current_epoch: Epoch,
+        epoch: Epoch,
     ) -> Result<Option<EpochCheckpoint>, CommsRpcConsensusSyncError> {
         match client
-            .get_checkpoint(GetCheckpointRequest {
-                current_epoch: current_epoch.as_u64(),
-            })
+            .get_checkpoint(GetCheckpointRequest { epoch: epoch.as_u64() })
             .await
         {
             Ok(GetCheckpointResponse {
@@ -452,7 +450,10 @@ where TConsensusSpec: ConsensusSpec<Addr = PeerAddress>
             // fetch checkpoint
             // TODO: NB refactor to fetch the checkpoint once for the shard group - instead of for each shard and each
             // attempt - once it's validated, there is no need to fetch it again
-            let checkpoint = match self.fetch_epoch_checkpoint(&mut client, epoch).await {
+            let prev_epoch = epoch
+                .checked_sub(Epoch(1))
+                .ok_or_else(|| CommsRpcConsensusSyncError::InvalidResponse(anyhow!("Epoch is zero")))?;
+            let checkpoint = match self.fetch_epoch_checkpoint(&mut client, prev_epoch).await {
                 Ok(Some(cp)) => cp,
                 Ok(None) => {
                     // TODO: we should check with f + 1 validators in this case. If a single validator reports
@@ -478,7 +479,7 @@ where TConsensusSpec: ConsensusSpec<Addr = PeerAddress>
             };
 
             info!(target: LOG_TARGET, "🛜 Checkpoint: {checkpoint}");
-            self.validate_checkpoint(&checkpoint, prev_committee, epoch)?;
+            self.validate_checkpoint(&checkpoint, prev_committee, prev_epoch)?;
             self.state_store.with_write_tx(|tx| checkpoint.save(tx))?;
             let mut template_changes = vec![];
 

--- a/dan_layer/state_store_rocksdb/src/reader.rs
+++ b/dan_layer/state_store_rocksdb/src/reader.rs
@@ -544,10 +544,15 @@ impl<'tx, TAddr: NodeAddressable + Serialize + DeserializeOwned + 'tx> StateStor
             });
         }
 
-        let block_ids = self.get_pending_chain_ordered(from_block_id)?;
-
         let cf = self.db().cf(BlockTransactionExecutionModel)?;
         let query = self.db().cf(block_transaction_execution::ByTransactionIdQuery)?;
+
+        // Is the execution is in the queried block
+        if let Some(exec) = cf.get(&(*from_block_id, *transaction_id), OPERATION).optional()? {
+            return Ok(exec);
+        }
+
+        let block_ids = self.get_pending_chain_ordered(from_block_id)?;
 
         // Find any in pending chain?
         for block_id in &block_ids {

--- a/dan_layer/state_store_rocksdb/src/store.rs
+++ b/dan_layer/state_store_rocksdb/src/store.rs
@@ -46,7 +46,6 @@ use crate::{
         foreign_proposal,
         foreign_proposal::ForeignProposalModel,
         foreign_substate_pledge::ForeignSubstatePledgeModel,
-        lock_conflict,
         lock_conflict::LockConflictModel,
         missing_transactions::MissingTransactionModel,
         parked_block::ParkedBlockModel,
@@ -118,7 +117,6 @@ pub fn all_column_families_iter() -> impl Iterator<Item = &'static str> {
         BurntUtxoModel::name(),
         burnt_utxo::ProposedInBlockIndex::name(),
         LockConflictModel::name(),
-        lock_conflict::ByBlockIdQuery::name(),
         EvictedNodeModel::name(),
         ValidatorNodeEpochStatsModel::name(),
     ]
@@ -129,6 +127,7 @@ fn build_default_store_opts() -> rocksdb::Options {
     let mut opts = rocksdb::Options::default();
     opts.set_error_if_exists(false);
     opts.create_if_missing(true);
+    opts.set_periodic_compaction_seconds(60);
     opts.create_missing_column_families(true);
     // TODO: evaluate - might depend on cores?
     opts.set_avoid_unnecessary_blocking_io(true);
@@ -155,6 +154,23 @@ impl<TAddr> RocksDbStateStore<TAddr, TransactionDB> {
             db: Arc::new(db),
             _addr: PhantomData,
         })
+    }
+
+    /// Force compact all column families in the database.
+    /// This is not typically needed but can be useful for experimentation.
+    pub fn compact_all<P: AsRef<Path>>(path: P) -> Result<(), StorageError> {
+        let options = build_default_store_opts();
+        let cf_names = all_column_families_iter();
+        let db = DB::open_cf(&options, path, cf_names).map_err(|e| StorageError::ConnectionError {
+            reason: e.into_string(),
+        })?;
+        for name in all_column_families_iter() {
+            let handle = db.cf_handle(name).ok_or_else(|| StorageError::ConnectionError {
+                reason: format!("Column family {} not found", name),
+            })?;
+            db.compact_range_cf(handle, None::<Vec<u8>>, None::<Vec<u8>>);
+        }
+        Ok(())
     }
 
     pub fn snapshot(&self) -> SnapshotContext<'_, TransactionDB> {

--- a/dan_layer/state_store_rocksdb/src/store.rs
+++ b/dan_layer/state_store_rocksdb/src/store.rs
@@ -127,7 +127,6 @@ fn build_default_store_opts() -> rocksdb::Options {
     let mut opts = rocksdb::Options::default();
     opts.set_error_if_exists(false);
     opts.create_if_missing(true);
-    opts.set_periodic_compaction_seconds(60);
     opts.create_missing_column_families(true);
     // TODO: evaluate - might depend on cores?
     opts.set_avoid_unnecessary_blocking_io(true);

--- a/dan_layer/state_store_rocksdb/src/writer.rs
+++ b/dan_layer/state_store_rocksdb/src/writer.rs
@@ -1400,35 +1400,6 @@ impl<'tx, TAddr: NodeAddressable + 'tx> StateStoreWriteTransaction for RocksDbSt
             debug!(target: LOG_TARGET, "Deleted {num_deleted}/{limit} stale nodes");
         }
 
-        // let cf = self.db().cf(StateTreeModel)?;
-        //
-        // let iter = stale_cf.key_iterator(Ordering::default(), OPERATION);
-        // for result in iter.take(limit) {
-        //     let (shard, key) = result?;
-        //     stale_cf.delete(&(shard, key.clone()), OPERATION)?;
-        //
-        //     let mut queue = VecDeque::new();
-        //     queue.push_back(key);
-        //
-        //     while let Some(node_key) = queue.pop_front() {
-        //         debug!( target: LOG_TARGET, "Deleting stale node {node_key} from shard {shard}", );
-        //         if let Some(node) = cf.get(&(shard, node_key.clone()), OPERATION).optional()? {
-        //             cf.delete(&(shard, node_key.clone()), OPERATION)?;
-        //             match node {
-        //                 Node::Internal(x) => {
-        //                     for (nibble, child) in x.into_children() {
-        //                         let child_key = node_key.gen_child_node_key(child.version, nibble);
-        //                         debug!( target: LOG_TARGET, "Internal node: child: {child_key}");
-        //                         queue.push_back(child_key)
-        //                     }
-        //                 },
-        //                 Node::Leaf(_) => {},
-        //                 Node::Null => {},
-        //             }
-        //         }
-        //     }
-        // }
-
         Ok(())
     }
 

--- a/dan_layer/storage/src/consensus_models/epoch_checkpoint.rs
+++ b/dan_layer/storage/src/consensus_models/epoch_checkpoint.rs
@@ -73,7 +73,7 @@ impl EpochCheckpoint {
         quorum_threshold: usize,
         check_vn: impl Fn(&RistrettoPublicKeyBytes) -> Result<bool, SidechainProofValidationError>,
     ) -> Result<(), EpochCheckpointValidationError> {
-        if self.proof.header().epoch != epoch.as_u64() {
+        if self.epoch() != epoch {
             return Err(EpochCheckpointValidationError::InvalidEpochCheckpoint(anyhow!(
                 "Expected checkpoint epoch {} but proof epoch is {}",
                 self.epoch(),

--- a/scripts/build_webuis.sh
+++ b/scripts/build_webuis.sh
@@ -69,7 +69,7 @@ if [ -z "${skip_bindings}" ]; then
 else
 	echo "Building Bindings (Dist only)..."
 	pnpm install
-  pnpm run build-dist
+  pnpm run build-dev # build with the TS definitions included
 fi
 popd > /dev/null
 
@@ -85,6 +85,7 @@ function build() {
   popd > /dev/null
 }
 
+set +e
 echo "Building Wallet client..."
 build clients/javascript/wallet_daemon_client
 

--- a/utilities/db_inspector/src/webserver/handlers/column_families.rs
+++ b/utilities/db_inspector/src/webserver/handlers/column_families.rs
@@ -1,10 +1,11 @@
 //   Copyright 2025 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use std::sync::Arc;
+use std::{io, path::Path, sync::Arc};
 
-use axum::{extract::Path, Extension, Json};
+use axum::{extract::Path as ExtractPath, Extension, Json};
 use serde::Serialize;
+use tokio::fs;
 
 use crate::{
     config::DatabaseConfig,
@@ -25,6 +26,7 @@ pub async fn list(Extension(context): Extension<Arc<HandlerContext>>) -> Result<
 #[derive(Debug, Clone, Serialize)]
 pub struct ListColumnFamiliesResponse {
     pub cfs: Vec<ColumnFamilyInfo>,
+    pub dir_size: u64,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -34,10 +36,44 @@ pub struct ColumnFamilyInfo {
     pub total_entries_bytes: usize,
 }
 
+async fn dir_size<P: AsRef<Path>>(path: P) -> io::Result<u64> {
+    async fn dir_size(mut dir: fs::ReadDir) -> io::Result<u64> {
+        let mut acc = 0;
+        while let Some(entry) = dir.next_entry().await? {
+            let size = match entry.metadata().await? {
+                data if data.is_dir() => {
+                    let dir = fs::read_dir(entry.path()).await?;
+                    Box::pin(dir_size(dir)).await?
+                },
+                data => data.len(),
+            };
+            acc += size;
+        }
+        Ok(acc)
+    }
+
+    let dir = fs::read_dir(path).await?;
+    dir_size(dir).await
+}
+
 pub async fn list_column_families(
     Extension(context): Extension<Arc<HandlerContext>>,
-    Path(db_name): Path<String>,
+    ExtractPath(db_name): ExtractPath<String>,
 ) -> Result<Json<ListColumnFamiliesResponse>, WebError> {
+    let db_path = context
+        .config()
+        .get_database(&db_name)
+        .map(|db| &db.path)
+        .ok_or_else(|| WebError::bad_request(format!("Database {} not found", db_name)))?;
+    let dir_size = dir_size(db_path).await.map_err(|e| {
+        WebError::internal_server_error(format!(
+            "Error reading dir {} for db {}: {}",
+            db_path.display(),
+            db_name,
+            e
+        ))
+    })?;
+
     let db = context.open_db(&db_name)?;
 
     let cf_info = db.column_family_info()?;
@@ -51,5 +87,6 @@ pub async fn list_column_families(
                 total_entries_bytes: cf.total_entries_bytes,
             })
             .collect(),
+        dir_size,
     }))
 }

--- a/utilities/db_inspector/src/webserver/handlers/mod.rs
+++ b/utilities/db_inspector/src/webserver/handlers/mod.rs
@@ -4,7 +4,7 @@
 pub mod block_diff;
 pub mod blocks;
 pub mod bookkeeping;
-pub mod databases;
+pub mod column_families;
 pub mod state_transitions;
 pub mod tables;
 mod types;

--- a/utilities/db_inspector/src/webserver/server.rs
+++ b/utilities/db_inspector/src/webserver/server.rs
@@ -38,10 +38,10 @@ pub async fn run(context: HandlerContext) -> anyhow::Result<()> {
     let bind_address = context.config().webserver.bind_address;
 
     let mut api = Router::new()
-        .route("/databases", get(handlers::databases::list))
+        .route("/databases", get(handlers::column_families::list))
         .route(
             "/databases/:db_name/column-families",
-            get(handlers::databases::list_column_families),
+            get(handlers::column_families::list_column_families),
         )
         // Special cases
         .route(

--- a/utilities/db_inspector/web_ui/src/routes/ListColumnFamilies.tsx
+++ b/utilities/db_inspector/web_ui/src/routes/ListColumnFamilies.tsx
@@ -17,11 +17,15 @@ export default function ListColumnFamilies() {
     { field: "name", sort: "asc" },
   ]);
 
-  const { data: cfs, isLoading } = useDatabaseCfsList(dbName || "<NOTHING>");
+  const { data, isLoading } = useDatabaseCfsList(dbName || "<NOTHING>");
 
-  if (isLoading || !cfs) {
+  if (isLoading || !data) {
     return <div>Loading...</div>;
   }
+
+  const cfs = data?.cfs;
+  const dirSize = data?.dir_size;
+  const totalBytes = cfs.reduce((acc, cf: any) => acc + cf.total_entries_bytes, 0);
 
   const cols = [
     {
@@ -102,6 +106,16 @@ export default function ListColumnFamilies() {
           }}
           checkboxSelection
         />
+      </Grid>
+      <Grid container spacing={3}>
+        <Grid size={{ xs: 12, md: 12, lg: 12 }}>
+          <Typography variant="h6" style={{ paddingBottom: theme.spacing(2) }}>
+            Total Bytes: {prettyBytes(totalBytes)}
+          </Typography>
+          <Typography variant="h6" style={{ paddingBottom: theme.spacing(2) }}>
+            Directory Size: {prettyBytes(dirSize)}
+          </Typography>
+        </Grid>
       </Grid>
     </>
   );

--- a/utilities/db_inspector/web_ui/src/store/databases.ts
+++ b/utilities/db_inspector/web_ui/src/store/databases.ts
@@ -22,11 +22,19 @@ export const useDatabasesList = () => {
   });
 };
 
+interface ListColumnFamiliesResponse {
+  cfs: {
+    name: string;
+    num_entries: number;
+    total_entries_bytes: number;
+  }[];
+  dir_size: number;
+}
 
 export const useDatabaseCfsList = (dbName: string) => {
-  return useQuery<unknown[], Error>({
+  return useQuery<ListColumnFamiliesResponse, Error>({
     queryKey: ["dbs-cfs", dbName],
-    queryFn: () => client.listColumnFamilies(dbName).then((res) => res.cfs),
+    queryFn: () => client.listColumnFamilies(dbName),
     refetchOnMount: false,
     refetchIntervalInBackground: false,
     refetchOnWindowFocus: false,


### PR DESCRIPTION
Description
---
feat: add VN command to compact the database

Motivation and Context
---
When running a stress test, db file size grew to 1gb with around 250Mb of actual data. After compaction, the db file sizes was less than 200Mb. This is mainly to experiment with compaction, since by default compaction is done every 30 days.

How Has This Been Tested?
---
Manually by running compact for a VN in the swarm

What process can a PR reviewer use to test or verify this change?
---
As above

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a CLI subcommand to compact the validator node database.
  - The database inspector now displays the total directory size for each database.
  - Added a manual compaction feature for RocksDB state stores.

- **Improvements**
  - Enhanced performance tracing during block finalization.
  - Improved type safety and UI display for database column family statistics.
  - Updated CLI and module visibility for clearer public APIs.
  - Changed build scripts to include TypeScript definitions in development builds.
  - Adjusted log levels for better warning visibility during leader timeouts.
  - Simplified validator node startup and error handling with updated CLI subcommand support.
  - Optimized transaction execution lookup in state store for faster access.
  - Refined checkpoint fetching and validation to align with requested epochs.

- **Bug Fixes**
  - Cleaned up obsolete code and improved error handling in various components.

- **Chores**
  - Refactored and renamed modules for clarity in the database inspector.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->