### PR TITLE
test(engine): adds more testcases that attempt to steal funds from vaults

### DIFF
--- a/dan_layer/engine/src/transaction/processor.rs
+++ b/dan_layer/engine/src/transaction/processor.rs
@@ -140,6 +140,7 @@ impl<TTemplateProvider: TemplateProvider<Template = LoadedTemplate> + 'static> T
         }
     }
 
+    #[allow(clippy::too_many_lines)]
     pub fn execute(self, transaction: Transaction) -> Result<ExecuteResult, TransactionError> {
         let timer = Instant::now();
         let entity_id_provider = EntityIdProvider::new(transaction.hash(), 1000);
@@ -156,6 +157,11 @@ impl<TTemplateProvider: TemplateProvider<Template = LoadedTemplate> + 'static> T
         let mut initial_call_scope = CallScope::new();
         initial_call_scope.set_auth_scope(initial_auth_scope);
         for input in transaction.all_inputs_iter() {
+            log::error!(
+                target: LOG_TARGET,
+                "Adding substate to initial call scope: {}",
+                input.substate_id
+            );
             initial_call_scope.add_substate_to_owned(input.substate_id.clone());
         }
 

--- a/dan_layer/engine/src/wasm/compile.rs
+++ b/dan_layer/engine/src/wasm/compile.rs
@@ -21,6 +21,7 @@
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use std::{
+    ffi::OsStr,
     fs,
     fs::File,
     io,
@@ -69,24 +70,32 @@ crate-type = ["cdylib", "lib"]
 
     compile_template(temp_dir.path(), features)
 }
-
-pub fn compile_template_with_custom_target_dir<P: AsRef<Path>>(
-    package_dir: P,
-    features: &[&str],
-    target_dir: P,
-) -> io::Result<WasmModule> {
-    compile_template_internal(package_dir, features, Some(target_dir))
+pub fn compile_template<P>(package_dir: P, features: &[&str]) -> io::Result<WasmModule>
+where P: AsRef<Path> {
+    compile_template_internal(package_dir, features, None::<(String, String)>)
 }
 
-pub fn compile_template<P: AsRef<Path>>(package_dir: P, features: &[&str]) -> io::Result<WasmModule> {
-    compile_template_internal(package_dir, features, None)
-}
-
-fn compile_template_internal<P: AsRef<Path>>(
+pub fn compile_template_with_envs<P, TEnvs, K, V>(
     package_dir: P,
     features: &[&str],
-    target_dir: Option<P>,
-) -> io::Result<WasmModule> {
+    envs: TEnvs,
+) -> io::Result<WasmModule>
+where
+    P: AsRef<Path>,
+
+    TEnvs: IntoIterator<Item = (K, V)>,
+    K: AsRef<OsStr>,
+    V: AsRef<OsStr>,
+{
+    compile_template_internal(package_dir, features, envs)
+}
+fn compile_template_internal<P, TEnvs, K, V>(package_dir: P, features: &[&str], envs: TEnvs) -> io::Result<WasmModule>
+where
+    P: AsRef<Path>,
+    TEnvs: IntoIterator<Item = (K, V)>,
+    K: AsRef<OsStr>,
+    V: AsRef<OsStr>,
+{
     if !package_dir.as_ref().exists() {
         return Err(io::Error::new(
             ErrorKind::NotFound,
@@ -106,6 +115,7 @@ fn compile_template_internal<P: AsRef<Path>>(
 
     let output = Command::new("cargo")
         .current_dir(package_dir.as_ref())
+        .envs(envs)
         .args(args)
         .output()?;
     if !output.status.success() {
@@ -140,20 +150,14 @@ fn compile_template_internal<P: AsRef<Path>>(
     };
 
     // path of the wasm executable
-    let mut path = match target_dir {
-        Some(target_dir) => target_dir.as_ref().to_path_buf(),
-        None => {
-            let mut path = package_dir.as_ref().to_path_buf();
-            path.push("target");
-            path
-        },
-    };
-    path.push("wasm32-unknown-unknown");
-    path.push("release");
-    path.push(wasm_name);
-    path.set_extension("wasm");
+    let path = package_dir
+        .as_ref()
+        .join("target")
+        .join("wasm32-unknown-unknown")
+        .join("release")
+        .join(wasm_name)
+        .with_extension("wasm");
 
-    // return
     let code = fs::read(path)?;
     Ok(WasmModule::from_code(code))
 }

--- a/dan_layer/engine/tests/shenanigans.rs
+++ b/dan_layer/engine/tests/shenanigans.rs
@@ -1,7 +1,7 @@
 //   Copyright 2023 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use tari_dan_engine::runtime::RuntimeError;
+use tari_dan_engine::runtime::{ActionIdent, NativeAction, RuntimeError};
 use tari_engine_types::{indexed_value::IndexedWellKnownTypes, resource_container::ResourceError};
 use tari_template_lib::{
     args,
@@ -312,5 +312,118 @@ fn it_disallows_minting_different_resource_type() {
         operate: "mint",
         expected: ResourceType::NonFungible,
         given: ResourceType::Fungible,
+    });
+}
+
+#[test]
+fn it_does_not_bring_non_owned_vault_id_into_scope() {
+    let mut test = TemplateTest::new(["tests/templates/shenanigans"]);
+    let template_addr = test.get_template_address("Shenanigans");
+    let (account, _, _) = test.create_funded_account();
+    let vault_id = {
+        let store = test.read_only_state_store();
+        let component = store.get_component(account).unwrap();
+        let values = IndexedWellKnownTypes::from_value(component.state()).unwrap();
+        values.vault_ids()[0]
+    };
+
+    let reason = test.execute_expect_failure(
+        Transaction::builder()
+            .call_function(template_addr, "with_stolen_vault", args![vault_id])
+            .put_last_instruction_output_on_workspace("bucket")
+            .call_method(account, "deposit", args![Workspace("bucket")])
+            .add_input(vault_id)
+            .build_and_seal(test.get_test_secret_key()),
+        vec![],
+    );
+
+    assert_reject_reason(reason, RuntimeError::SubstateOutOfScope { id: vault_id.into() });
+}
+
+#[test]
+fn it_disallows_withdraws_from_vaults_outside_of_component_context() {
+    let mut test = TemplateTest::new(["tests/templates/shenanigans"]);
+    let (account, _, _) = test.create_funded_account();
+    let vault_id = {
+        let store = test.read_only_state_store();
+        let component = store.get_component(account).unwrap();
+        let values = IndexedWellKnownTypes::from_value(component.state()).unwrap();
+        values.vault_ids()[0]
+    };
+
+    let template_addr = test.compile_new_template("Shenanigans", "tests/templates/shenanigans", &[], [(
+        "VAULT_ID",
+        vault_id.to_string(),
+    )]);
+
+    let reason = test.execute_expect_failure(
+        Transaction::builder()
+            .call_function(template_addr, "take_from_hardcoded_vault", args![])
+            .put_last_instruction_output_on_workspace("bucket")
+            .call_method(account, "deposit", args![Workspace("bucket")])
+            .add_input(vault_id)
+            .build_and_seal(test.get_test_secret_key()),
+        vec![],
+    );
+
+    assert_reject_reason(reason, RuntimeError::NotInComponentContext {
+        action: ActionIdent::Native(NativeAction::Vault(VaultAction::Withdraw)),
+    });
+
+    let reason = test.execute_expect_failure(
+        Transaction::builder()
+            .call_function(template_addr, "take_from_vault_and_return_bucket", args![vault_id,])
+            .put_last_instruction_output_on_workspace("bucket")
+            .call_method(account, "deposit", args![Workspace("bucket")])
+            .add_input(vault_id)
+            .build_and_seal(test.get_test_secret_key()),
+        vec![],
+    );
+
+    assert_reject_reason(reason, RuntimeError::NotInComponentContext {
+        action: ActionIdent::Native(NativeAction::Vault(VaultAction::Withdraw)),
+    });
+}
+
+#[test]
+fn it_disallows_withdraws_from_vaults_outside_of_owning_component() {
+    let mut test = TemplateTest::new(["tests/templates/shenanigans"]);
+    let (account, _, _) = test.create_funded_account();
+    let vault_id = {
+        let store = test.read_only_state_store();
+        let component = store.get_component(account).unwrap();
+        let values = IndexedWellKnownTypes::from_value(component.state()).unwrap();
+        values.vault_ids()[0]
+    };
+
+    let template_addr = test.compile_new_template("Shenanigans", "tests/templates/shenanigans", &[], [(
+        "VAULT_ID",
+        vault_id.to_string(),
+    )]);
+
+    let result = test.execute_expect_success(
+        Transaction::builder()
+            .call_function(template_addr, "new", args![])
+            .build_and_seal(test.get_test_secret_key()),
+        vec![],
+    );
+
+    let component = result.finalize.execution_results[0]
+        .decode::<ComponentAddress>()
+        .unwrap();
+
+    let reason = test.execute_expect_failure(
+        Transaction::builder()
+            .call_method(component, "take_from_hardcoded_vault_in_component_context", args![])
+            .put_last_instruction_output_on_workspace("bucket")
+            .call_method(account, "deposit", args![Workspace("bucket")])
+            .add_input(vault_id)
+            .build_and_seal(test.get_test_secret_key()),
+        vec![test.get_test_proof()],
+    );
+
+    assert_reject_reason(reason, RuntimeError::SubstateNotOwned {
+        id: vault_id.into(),
+        requested_owner: Box::new(component.into()),
     });
 }

--- a/dan_layer/engine/tests/templates/shenanigans/src/lib.rs
+++ b/dan_layer/engine/tests/templates/shenanigans/src/lib.rs
@@ -13,7 +13,7 @@ mod template {
         component_address: Option<ComponentAddress>,
         vault: Option<Vault>,
         vault_copy: Option<Vault>,
-        vault_ref: Option<tari_template_lib::models::VaultId>,
+        vault_ref: Option<VaultId>,
     }
 
     impl Shenanigans {
@@ -38,31 +38,31 @@ mod template {
             }
         }
 
-        pub fn ref_stolen_vault(vault_id: tari_template_lib::models::VaultId) -> Self {
+        pub fn ref_stolen_vault(vault_id: VaultId) -> Self {
             Self {
-                vault_ref: Some(vault_id),
+                vault_ref: Some(vault_id.into()),
                 ..Default::default()
             }
         }
 
-        pub fn with_stolen_vault(vault_id: tari_template_lib::models::VaultId) -> Component<Self> {
-            let mut stolen = Vault::for_test(vault_id);
+        pub fn with_stolen_vault(vault_id: VaultId) -> Component<Self> {
+            let stolen = Vault::for_test(vault_id.into());
             Component::new(Self {
                 vault: Some(stolen),
                 ..Default::default()
             })
-                .with_access_rules(AccessRules::allow_all())
-                .with_owner_rule(OwnerRule::ByAccessRule(rule!(allow_all)))
-                .create()
+            .with_access_rules(AccessRules::allow_all())
+            .with_owner_rule(OwnerRule::ByAccessRule(rule!(allow_all)))
+            .create()
         }
 
         pub fn attempt_to_steal_funds_using_cross_template_call(
-            vault_id: tari_template_lib::models::VaultId,
+            vault_id: VaultId,
             dest_component: ComponentAddress,
             amount: Option<Amount>,
         ) {
             debug!("Attempting to steal funds from vault {}", vault_id);
-            let mut vault = Vault::for_test(vault_id);
+            let mut vault = Vault::for_test(vault_id.into());
             let stolen = if let Some(amt) = amount {
                 vault.withdraw(amt)
             } else {
@@ -96,7 +96,7 @@ mod template {
                 resource_address: Some(resx),
                 ..Default::default()
             })
-                .create();
+            .create();
 
             Self::default()
         }
@@ -107,7 +107,7 @@ mod template {
                 resource_address: Some(resx),
                 ..Default::default()
             })
-                .create();
+            .create();
 
             Self {
                 component_address: Some(*component.address()),
@@ -142,10 +142,27 @@ mod template {
             let _auth = stolen_proof.authorize();
         }
 
-        pub fn take_from_a_vault(&mut self, vault_id: tari_template_lib::models::VaultId, amount: Amount) {
-            let mut vault = Vault::for_test(vault_id);
+        pub fn take_from_a_vault(&mut self, vault_id: VaultId, amount: Amount) {
+            let mut vault = Vault::for_test(vault_id.into());
             let stolen = vault.withdraw(amount);
             self.vault.as_mut().unwrap().deposit(stolen);
+        }
+
+        pub fn take_from_vault_and_return_bucket(vault_id: VaultId) -> Bucket {
+            let mut stolen = Vault::for_test(vault_id.into());
+            stolen.withdraw_all()
+        }
+
+        pub fn take_from_hardcoded_vault() -> Bucket {
+            let vault_id = option_env!["VAULT_ID"].expect("VAULT_ID must be set at compile time");
+            let mut stolen = Vault::for_test(vault_id.parse().unwrap());
+            stolen.withdraw_all()
+        }
+
+        pub fn take_from_hardcoded_vault_in_component_context(&self) -> Bucket {
+            let vault_id = option_env!["VAULT_ID"].expect("VAULT_ID must be set at compile time");
+            let mut stolen = Vault::for_test(vault_id.parse().unwrap());
+            stolen.withdraw_all()
         }
 
         pub fn empty_state_on_component(&self, address: tari_template_lib::models::ComponentAddress) {

--- a/dan_layer/template_test_tooling/src/package_builder.rs
+++ b/dan_layer/template_test_tooling/src/package_builder.rs
@@ -3,6 +3,7 @@
 
 use std::{
     collections::HashMap,
+    ffi::OsStr,
     path::Path,
     sync::{Arc, Mutex},
 };
@@ -11,10 +12,7 @@ use tari_dan_common_types::services::template_provider::TemplateProvider;
 use tari_dan_engine::{
     abi::TemplateDef,
     template::{LoadedTemplate, TemplateLoaderError, TemplateModuleLoader},
-    wasm::{
-        compile::{compile_template, compile_template_with_custom_target_dir},
-        WasmModule,
-    },
+    wasm::{compile::compile_template_with_envs, WasmModule},
 };
 use tari_engine_types::hashing::hash_template_code;
 use tari_template_builtin::get_template_builtin;
@@ -65,24 +63,35 @@ impl PackageBuilder {
         }
     }
 
-    pub fn add_template<P: AsRef<Path>>(&mut self, path: P, target_dir: Option<P>) -> &mut Self {
-        self.add_template_with_features(path, &[], target_dir)
+    pub fn add_template<P>(&mut self, path: P) -> &mut Self
+    where P: AsRef<Path> {
+        self.add_template_opts(path, &[], None::<(String, String)>);
+        self
     }
 
-    pub fn add_template_with_features<P: AsRef<Path>>(
-        &mut self,
-        path: P,
-        features: &[&str],
-        target_dir: Option<P>,
-    ) -> &mut Self {
-        let wasm = match target_dir {
-            None => compile_template(path, features).unwrap(),
-            Some(target_dir) => compile_template_with_custom_target_dir(path, features, target_dir).unwrap(),
-        };
+    pub fn add_template_with_envs<P, TEnvs, K, V>(&mut self, path: P, envs: TEnvs) -> &mut Self
+    where
+        P: AsRef<Path>,
+        TEnvs: IntoIterator<Item = (K, V)>,
+        K: AsRef<OsStr>,
+        V: AsRef<OsStr>,
+    {
+        self.add_template_opts(path, &[], envs);
+        self
+    }
+
+    pub fn add_template_opts<P, TEnvs, K, V>(&mut self, path: P, features: &[&str], envs: TEnvs) -> TemplateAddress
+    where
+        P: AsRef<Path>,
+        TEnvs: IntoIterator<Item = (K, V)>,
+        K: AsRef<OsStr>,
+        V: AsRef<OsStr>,
+    {
+        let wasm = compile_template_with_envs(path, features, envs).unwrap();
         let template_addr = hash_template_code(wasm.code());
         let wasm = wasm.load_template().unwrap();
         self.add_loaded_template(template_addr, wasm);
-        self
+        template_addr
     }
 
     pub fn add_loaded_template(&mut self, address: TemplateAddress, template: LoadedTemplate) -> &mut Self {

--- a/dan_layer/template_test_tooling/src/template_test.rs
+++ b/dan_layer/template_test_tooling/src/template_test.rs
@@ -3,6 +3,7 @@
 
 use std::{
     collections::{HashMap, HashSet},
+    ffi::OsStr,
     path::Path,
     sync::Arc,
     time::Instant,
@@ -56,7 +57,7 @@ pub fn test_faucet_component() -> ComponentAddress {
 }
 
 pub struct TemplateTest {
-    package: Arc<Package>,
+    package: Package,
     track_calls: TrackCallsModule,
     secret_key: RistrettoSecretKey,
     public_key: RistrettoPublicKey,
@@ -71,20 +72,30 @@ pub struct TemplateTest {
 
 impl TemplateTest {
     pub fn new<I: IntoIterator<Item = P>, P: Clone + AsRef<Path>>(template_paths: I) -> Self {
-        Self::new_internal(template_paths, None)
+        Self::new_internal(template_paths, None::<(String, String)>)
     }
 
-    pub fn new_with_shared_target_dir<I: IntoIterator<Item = P>, P: Clone + AsRef<Path>>(
-        template_paths: I,
-        target_dir: P,
-    ) -> Self {
-        Self::new_internal(template_paths, Some(target_dir))
+    pub fn new_with_compile_envs<I, P, TEnvs, K, V>(template_paths: I, envs: TEnvs) -> Self
+    where
+        I: IntoIterator<Item = P>,
+        P: Clone + AsRef<Path>,
+        TEnvs: IntoIterator<Item = (K, V)>,
+        TEnvs::IntoIter: Clone,
+        K: AsRef<OsStr>,
+        V: AsRef<OsStr>,
+    {
+        Self::new_internal(template_paths, envs)
     }
 
-    fn new_internal<I: IntoIterator<Item = P>, P: Clone + AsRef<Path>>(
-        template_paths: I,
-        target_dir: Option<P>,
-    ) -> Self {
+    fn new_internal<I, P, TEnvs, K, V>(template_paths: I, envs: TEnvs) -> Self
+    where
+        I: IntoIterator<Item = P>,
+        P: Clone + AsRef<Path>,
+        TEnvs: IntoIterator<Item = (K, V)>,
+        TEnvs::IntoIter: Clone,
+        K: AsRef<OsStr>,
+        V: AsRef<OsStr>,
+    {
         let mut builder = Package::builder();
 
         // Add builtin templates
@@ -92,11 +103,12 @@ impl TemplateTest {
         builder.add_builtin_template(&ACCOUNT_NFT_TEMPLATE_ADDRESS);
 
         // Add the faucet template for fungible tokens
-        builder.add_template(concat!(env!("CARGO_MANIFEST_DIR"), "/templates/faucet"), None);
+        builder.add_template(concat!(env!("CARGO_MANIFEST_DIR"), "/templates/faucet"));
 
         // Add all of the templates specified in the argument
+        let envs_iter = envs.into_iter();
         for path in template_paths {
-            builder.add_template(path, target_dir.clone());
+            builder.add_template_with_envs(path, envs_iter.clone());
         }
 
         let package = builder.build();
@@ -127,7 +139,7 @@ impl TemplateTest {
         virtual_substates.insert(VirtualSubstateId::CurrentEpoch, VirtualSubstate::CurrentEpoch(0));
 
         Self {
-            package: Arc::new(package),
+            package,
             track_calls: TrackCallsModule::new(),
             public_key,
             secret_key,
@@ -194,6 +206,32 @@ impl TemplateTest {
                 }),
             )
             .unwrap();
+    }
+
+    pub fn compile_new_template<T, P, TEnvs, K, V>(
+        &mut self,
+        name: T,
+        path: P,
+        features: &[&str],
+        envs: TEnvs,
+    ) -> TemplateAddress
+    where
+        T: Into<String>,
+        P: AsRef<Path>,
+        TEnvs: IntoIterator<Item = (K, V)>,
+        TEnvs::IntoIter: Clone,
+        K: AsRef<OsStr>,
+        V: AsRef<OsStr>,
+    {
+        let mut builder = Package::builder();
+        for (addr, template) in self.package.templates() {
+            builder.add_loaded_template(addr, template);
+        }
+        let template_addr = builder.add_template_opts(path, features, envs);
+        self.package = builder.build();
+        self.name_to_template.insert(name.into(), template_addr);
+
+        template_addr
     }
 
     pub fn enable_fees(&mut self) -> &mut Self {
@@ -492,7 +530,7 @@ impl TemplateTest {
             TransactionProcessorConfig::builder()
                 .with_network(Network::LocalNet)
                 .build(),
-            self.package.clone(),
+            Arc::new(self.package.clone()),
             self.state_store.clone().into_read_only(),
             auth_params,
             self.virtual_substates.clone(),


### PR DESCRIPTION
Description
---
test(engine): test attempts to steal vault funds using hardcoded vault id
test(engine): test denying args that contain a vault id

Motivation and Context
---
This PR checks for attempts to steal vault funds by hard-coding a vault ID and attempting to withdraw.

Closes #1424 - it was found that this issue has already been solved but not explicitly tested for, this PR includes these tests

EDIT: recalling funds/badges from a vault is a legitimate use case for passing vault IDS as args. This PR was edited to remove the check to deny vault ids as args which involves removing the "deny passing vault id" error and changing the failure assertions to "Vault not owned" error variants. I realised that denying Vault IDs explicitly improved error UX a little but did not actually add any additional security since it is always possible to construct a vault ID from data in an undetectable way. Therefore, it is a false sense of security, and the only checks that matter are within the engine scoping.

How Has This Been Tested?
---
New unit tests

What process can a PR reviewer use to test or verify this change?
---
Attempt to steal vault funds by writing a template that withdraws from a vault (any vault other than a vault created from the template itself)

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for compiling templates with custom environment variables, enabling greater flexibility during template builds.
  - Introduced methods for dynamically compiling and adding new templates with specific features and environment variables during tests.

- **Bug Fixes**
  - Improved runtime checks and error reporting for vault access, ensuring vaults cannot be accessed or withdrawn from outside their owning component context.

- **Tests**
  - Added new tests to verify vault access controls, including checks against unauthorized vault ID usage and withdrawals.

- **Refactor**
  - Simplified and unified template addition and compilation interfaces in test tooling, removing support for custom target directories in favor of environment variable configuration.
  - Streamlined internal handling of packages and template compilation in test utilities for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->