### PR TITLE
fix(transaction)!: remove cached ID hash from transaction

### DIFF
--- a/applications/tari_dan_wallet_daemon/src/handlers/accounts.rs
+++ b/applications/tari_dan_wallet_daemon/src/handlers/accounts.rs
@@ -375,7 +375,7 @@ pub async fn handle_reveal_funds(
         let transaction = builder.with_inputs(inputs).build_and_seal(&account_key.key);
 
         sdk.confidential_outputs_api()
-            .proofs_set_transaction_hash(proof_id, *transaction.id())?;
+            .proofs_set_transaction_hash(proof_id, transaction.calculate_id())?;
 
         let mut events = notifier.subscribe();
         let tx_id = transaction_service.submit_transaction(transaction, vec![]).await?;
@@ -910,7 +910,7 @@ pub async fn handle_transfer(
 
     // If dry run we can return the result immediately
     if req.dry_run {
-        let transaction_id = *transaction.id();
+        let transaction_id = transaction.calculate_id();
         let execute_result = context
             .transaction_service()
             .submit_dry_run_transaction(transaction, vec![])
@@ -992,7 +992,7 @@ pub async fn handle_confidential_transfer(
             .await?;
 
         if req.dry_run {
-            let transaction_id = *transfer.transaction.id();
+            let transaction_id = transfer.transaction.calculate_id();
             let exec_result = transaction_service
                 .submit_dry_run_transaction(transfer.transaction, transfer.autofill_inputs)
                 .await?;

--- a/applications/tari_dan_wallet_daemon/src/handlers/nfts.rs
+++ b/applications/tari_dan_wallet_daemon/src/handlers/nfts.rs
@@ -425,11 +425,11 @@ pub async fn handle_transfer_nft(
 
     // if dry run, we can return the result immediately
     if req.dry_run {
-        let transaction_id = *transaction.id();
         let execute_result = context
             .transaction_service()
             .submit_dry_run_transaction(transaction, vec![])
             .await?;
+        let transaction_id = execute_result.finalize.transaction_hash.into();
         let finalize = execute_result.finalize;
         return Ok(TransferNftResponse {
             transaction_id,

--- a/applications/tari_dan_wallet_daemon/src/handlers/transaction.rs
+++ b/applications/tari_dan_wallet_daemon/src/handlers/transaction.rs
@@ -151,16 +151,17 @@ pub async fn handle_submit(
         }
     }
 
+    let tx_id = transaction.calculate_id();
     for proof_id in req.proof_ids {
         // update the proofs table with the corresponding transaction hash
         sdk.confidential_outputs_api()
-            .proofs_set_transaction_hash(proof_id, *transaction.id())?;
+            .proofs_set_transaction_hash(proof_id, tx_id)?;
     }
 
     info!(
         target: LOG_TARGET,
         "Submitted transaction with hash {}",
-        transaction.hash()
+        transaction.calculate_id()
     );
 
     let transaction_id = context
@@ -213,13 +214,13 @@ pub async fn handle_submit_dry_run(
     for proof_id in req.proof_ids {
         // update the proofs table with the corresponding transaction hash
         sdk.confidential_outputs_api()
-            .proofs_set_transaction_hash(proof_id, *transaction.id())?;
+            .proofs_set_transaction_hash(proof_id, transaction.calculate_id())?;
     }
 
     info!(
         target: LOG_TARGET,
         "Submitted transaction with hash {}",
-        transaction.hash()
+        transaction.calculate_id()
     );
     let exec_result = context
         .transaction_service()

--- a/applications/tari_dan_wallet_daemon/src/handlers/validator.rs
+++ b/applications/tari_dan_wallet_daemon/src/handlers/validator.rs
@@ -182,7 +182,7 @@ pub async fn handle_claim_validator_fees(
             .submit_dry_run_transaction(transaction, vec![])
             .await?;
         return Ok(ClaimValidatorFeesResponse {
-            transaction_id: *transaction.transaction.id(),
+            transaction_id: transaction.id,
             fee: transaction
                 .finalize
                 .as_ref()

--- a/applications/tari_dan_wallet_daemon/src/services/transaction_service/service.rs
+++ b/applications/tari_dan_wallet_daemon/src/services/transaction_service/service.rs
@@ -124,7 +124,7 @@ where
                 required_substates,
                 reply,
             } => {
-                let transaction_id = *transaction.id();
+                let transaction_id = transaction.calculate_id();
                 let transaction_api = self.wallet_sdk.transaction_api();
                 match transaction_api
                     .submit_dry_run_transaction(transaction, required_substates)
@@ -224,9 +224,9 @@ where
             info!(
                 target: LOG_TARGET,
                 "Resubmitting transaction {}",
-                transaction.transaction.id()
+                transaction.id,
             );
-            let transaction_id = *transaction.transaction.id();
+            let transaction_id = transaction.id;
             transaction_api.submit_transaction(transaction_id).await?;
             notify.notify(TransactionSubmittedEvent {
                 transaction_id,
@@ -254,34 +254,32 @@ where
             pending_transactions.len()
         );
         for transaction in pending_transactions {
+            let tx_id = transaction.id;
             info!(
                 target: LOG_TARGET,
-                "Requesting result for transaction {}",
-                transaction.transaction.id()
+                "Requesting result for transaction {tx_id}",
             );
-            let maybe_finalized_transaction = transaction_api
-                .check_and_store_finalized_transaction(*transaction.transaction.id())
-                .await?;
+            let maybe_finalized_transaction = transaction_api.check_and_store_finalized_transaction(tx_id).await?;
 
             match maybe_finalized_transaction {
                 Some(transaction) => {
                     debug!(
                         target: LOG_TARGET,
                         "Transaction {} has been finalized: {}",
-                        transaction.transaction.id(),
+                        transaction.id,
                         transaction.status,
                     );
                     match transaction.finalize {
                         Some(finalize) => {
                             notify.notify(TransactionFinalizedEvent {
-                                transaction_id: *transaction.transaction.id(),
+                                transaction_id: tx_id,
                                 finalize,
                                 final_fee: transaction.final_fee.unwrap_or_default(),
                                 status: transaction.status,
                             });
                         },
                         None => notify.notify(TransactionInvalidEvent {
-                            transaction_id: *transaction.transaction.id(),
+                            transaction_id: tx_id,
                             status: transaction.status,
                             finalize: transaction.finalize,
                             final_fee: transaction.final_fee,
@@ -291,8 +289,7 @@ where
                 None => {
                     debug!(
                         target: LOG_TARGET,
-                        "Transaction {} is still pending",
-                        transaction.transaction.hash()
+                        "Transaction {tx_id} is still pending",
                     );
                 },
             }

--- a/applications/tari_dan_wallet_daemon/web_ui/src/routes/Transactions/TransactionDetails.tsx
+++ b/applications/tari_dan_wallet_daemon/web_ui/src/routes/Transactions/TransactionDetails.tsx
@@ -21,7 +21,7 @@
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import { useState } from "react";
-import { useLocation } from "react-router-dom";
+import { useParams } from "react-router-dom";
 import { useTransactionDetails } from "../../api/hooks/useTransactions";
 import { Accordion, AccordionDetails, AccordionSummary } from "../../Components/Accordion";
 import { Grid, Table, TableContainer, TableBody, TableRow, TableCell, Button, Fade, Alert } from "@mui/material";
@@ -41,8 +41,6 @@ import Loading from "../../Components/Loading";
 import Error from "../../Components/Error";
 import {
   FinalizeResult,
-  Substate,
-  SubstateId,
   substateIdToString,
   SubstateRequirement,
   TransactionResult,
@@ -52,8 +50,9 @@ import { getRejectReasonFromTransactionResult, rejectReasonToString } from "@tar
 
 export default function TransactionDetails() {
   const [expandedPanels, setExpandedPanels] = useState<string[]>([]);
-  const location = useLocation();
-  const { data, isLoading, isError, error } = useTransactionDetails(location.pathname.split("/")[2]);
+  const params = useParams();
+  const transactionId = params.id!;
+  const { data, isLoading, isError, error } = useTransactionDetails(transactionId);
 
   const handleChange = (panel: string) => (event: React.SyntheticEvent, isExpanded: boolean) => {
     setExpandedPanels((prevExpandedPanels) => {
@@ -101,7 +100,7 @@ export default function TransactionDetails() {
     const handleDownload = () => {
       const json = JSON.stringify(data, null, 2);
       const blob = new Blob([json], { type: "application/json" });
-      const filename = `tx-${data?.transaction?.V1?.id}.json` || "tx-unknown_id.json";
+      const filename = `tx-${transactionId}.json` || "tx-unknown_id.json";
       saveAs(blob, filename);
     };
 
@@ -122,7 +121,6 @@ export default function TransactionDetails() {
       }
     };
 
-    const transaction_id = data.transaction.V1?.id;
     const seal_signature = data.transaction.V1?.seal_signature;
     const transaction_body = data.transaction.V1?.body;
     const transaction = transaction_body?.transaction;
@@ -135,7 +133,7 @@ export default function TransactionDetails() {
               <TableBody>
                 <TableRow>
                   <TableCell>Transaction Hash</TableCell>
-                  <DataTableCell>{transaction_id}</DataTableCell>
+                  <DataTableCell>{transactionId}</DataTableCell>
                 </TableRow>
                 <TableRow>
                   <TableCell>Timestamp</TableCell>
@@ -175,7 +173,7 @@ export default function TransactionDetails() {
                 <TableBody>
                   <TableRow>
                     <TableCell>Transaction Hash</TableCell>
-                    <DataTableCell>{transaction_id}</DataTableCell>
+                    <DataTableCell>{transactionId}</DataTableCell>
                   </TableRow>
                   <TableRow>
                     <TableCell>Timestamp</TableCell>

--- a/applications/tari_dan_wallet_daemon/web_ui/src/routes/Transactions/Transactions.tsx
+++ b/applications/tari_dan_wallet_daemon/web_ui/src/routes/Transactions/Transactions.tsx
@@ -71,12 +71,7 @@ export default function Transactions({ account }: { account: Account }) {
               {data?.transactions
                 ?.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
                 .map((transaction: WalletTransaction) => {
-                  const {
-                    transaction: { V1: tx },
-                    finalize: result,
-                    status,
-                  } = transaction;
-                  const hash = tx.id;
+                  const { transaction: _, finalize: result, status, id: hash } = transaction;
                   return (
                     <TableRow key={hash}>
                       <DataTableCell>

--- a/applications/tari_indexer/src/dry_run/processor.rs
+++ b/applications/tari_indexer/src/dry_run/processor.rs
@@ -92,7 +92,7 @@ where TSubstateCache: SubstateCache + 'static
             return Err(DryRunTransactionProcessorError::NonDryRunTransaction);
         }
 
-        info!(target: LOG_TARGET, "process_transaction: {}", transaction.hash());
+        info!(target: LOG_TARGET, "process_transaction: {}", transaction.calculate_id());
 
         // automatically scan the inputs and add all related involved objects
         // note that this operation does not alter the transaction hash

--- a/applications/tari_indexer/src/json_rpc/handlers.rs
+++ b/applications/tari_indexer/src/json_rpc/handlers.rs
@@ -442,7 +442,7 @@ impl JsonRpcHandlers {
         let request: SubmitTransactionRequest = value.parse_params()?;
 
         if request.is_dry_run {
-            let transaction_id = *request.transaction.id();
+            let transaction_id = request.transaction.calculate_id();
             let exec_result = self
                 .dry_run_transaction_processor
                 .process_transaction(request.transaction, request.required_substates)

--- a/applications/tari_indexer/src/network_client.rs
+++ b/applications/tari_indexer/src/network_client.rs
@@ -42,7 +42,7 @@ where
             return Err(NetworkClientError::NoInputsProvided);
         }
 
-        let tx_id = *transaction.id();
+        let tx_id = transaction.calculate_id();
 
         info!(
             target: LOG_TARGET,

--- a/applications/tari_validator_node/src/consensus/block_transaction_executor.rs
+++ b/applications/tari_validator_node/src/consensus/block_transaction_executor.rs
@@ -77,7 +77,7 @@ where
         current_epoch: Epoch,
         resolved_inputs: &HashMap<SubstateRequirement, Substate>,
     ) -> Result<TransactionExecution, BlockTransactionExecutorError> {
-        let id = *transaction.id();
+        let id = transaction.calculate_id();
 
         info!(target: LOG_TARGET, "Transaction {} executing. {} input(s)", id, resolved_inputs.len());
 

--- a/applications/tari_validator_node/src/json_rpc/handlers.rs
+++ b/applications/tari_validator_node/src/json_rpc/handlers.rs
@@ -188,22 +188,11 @@ impl JsonRpcHandlers {
         debug!(
             target: LOG_TARGET,
             "Transaction {} has {} involved shards",
-            transaction.hash(),
+            transaction.calculate_id(),
             transaction.num_unique_inputs()
         );
 
-        if !transaction.check_id() {
-            return Err(JsonRpcResponse::error(
-                answer_id,
-                JsonRpcError::new(
-                    JsonRpcErrorReason::InvalidParams,
-                    "Transaction ID is invalid".to_string(),
-                    json!(null),
-                ),
-            ));
-        }
-
-        let tx_id = *transaction.id();
+        let tx_id = transaction.calculate_id();
 
         if is_dry_run {
             let result = self

--- a/applications/tari_validator_node/src/p2p/rpc/service_impl.rs
+++ b/applications/tari_validator_node/src/p2p/rpc/service_impl.rs
@@ -102,7 +102,7 @@ impl<TStateStore: StateStore + Clone + Send + Sync + 'static> ValidatorNodeRpcSe
             .try_into()
             .map_err(|e| RpcStatus::bad_request(format!("Malformed transaction: {}", e)))?;
 
-        let transaction_id = *transaction.id();
+        let transaction_id = transaction.calculate_id();
         info!(target: LOG_TARGET, "🌐 Received transaction {transaction_id} from peer");
 
         self.mempool

--- a/applications/tari_validator_node/src/p2p/services/mempool/gossip.rs
+++ b/applications/tari_validator_node/src/p2p/services/mempool/gossip.rs
@@ -160,7 +160,7 @@ impl MempoolGossip<PeerAddress> {
                 })
                 .chain(iter::once(
                     msg.transaction
-                        .id()
+                        .calculate_id()
                         .to_substate_address()
                         .to_shard_group(committee_info.num_preshards(), n),
                 ))

--- a/applications/tari_validator_node/src/p2p/services/mempool/service.rs
+++ b/applications/tari_validator_node/src/p2p/services/mempool/service.rs
@@ -153,7 +153,7 @@ where
     }
 
     async fn handle_new_transaction_from_local(&mut self, transaction: Transaction) -> Result<(), MempoolError> {
-        if self.transaction_exists(transaction.id())? {
+        if self.transaction_exists(&transaction.calculate_id())? {
             return Ok(());
         }
         info!(
@@ -179,17 +179,17 @@ where
         } = result?;
         let DanMessage::NewTransaction(msg) = msg;
         let NewTransactionMessage { transaction } = *msg;
+        let transaction_id = transaction.calculate_id();
 
         if !self.consensus_handle.is_running() {
             info!(
                 target: LOG_TARGET,
-                "🎱 Transaction {} received while not in running state. Ignoring",
-                transaction.id()
+                "🎱 Transaction {transaction_id} received while not in running state. Ignoring",
             );
             return Ok(());
         }
 
-        if self.transaction_exists(transaction.id())? {
+        if self.transaction_exists(&transaction_id)? {
             return Ok(());
         }
         debug!(
@@ -197,7 +197,7 @@ where
             "Received NEW transaction from {}: (size={}) {} {:?}",
             from,
             message_size,
-            transaction.id(),
+            transaction_id,
             transaction
         );
 
@@ -227,25 +227,24 @@ where
     ) -> Result<(), MempoolError> {
         #[cfg(feature = "metrics")]
         self.metrics.on_transaction_received(&transaction);
+        let tx_id = transaction.calculate_id();
 
         if let Err(e) = self.before_execute_validator.validate(&(), &transaction) {
             // Throw the transaction away
             #[cfg(feature = "metrics")]
-            self.metrics.on_transaction_validation_error(transaction.id(), &e);
+            self.metrics.on_transaction_validation_error(&tx_id, &e);
             return Err(e.into());
         }
 
         if transaction.num_unique_inputs() == 0 {
-            warn!(target: LOG_TARGET, "⚠ No involved shards for transaction {}", transaction.id());
+            warn!(target: LOG_TARGET, "⚠ No involved shards for transaction {tx_id}");
             return Err(MempoolError::TransactionValidationError(
-                TransactionValidationError::NoInvolvedShards {
-                    transaction_id: *transaction.id(),
-                },
+                TransactionValidationError::NoInvolvedShards { transaction_id: tx_id },
             ));
         }
 
         let current_epoch = self.consensus_handle.current_view().get_epoch();
-        let tx_substate_address = transaction.id().to_substate_address();
+        let tx_substate_address = tx_id.to_substate_address();
 
         let local_committee_shard = self.epoch_manager.get_local_committee_info(current_epoch).await?;
         let is_input_shard = transaction.is_involved_inputs(&local_committee_shard);
@@ -257,8 +256,8 @@ where
             );
 
         if is_input_shard || is_output_shard {
-            debug!(target: LOG_TARGET, "🎱 New transaction {} in mempool", transaction.id());
-            self.transactions.insert(*transaction.id());
+            debug!(target: LOG_TARGET, "🎱 New transaction {tx_id} in mempool");
+            self.transactions.insert(tx_id);
             self.consensus_handle
                 .notify_new_transaction(transaction.clone(), num_pending)
                 .await
@@ -289,15 +288,14 @@ where
         } else {
             debug!(
                 target: LOG_TARGET,
-                "🙇 Not in committee for transaction {}",
-                transaction.id(),
+                "🙇 Not in committee for transaction {tx_id}",
             );
         }
 
         debug!(
             target: LOG_TARGET,
             "🎱 Propagating transaction {} ({} input(s))",
-            transaction.id(),
+            tx_id,
             transaction.num_unique_inputs(),
         );
         if let Err(e) = self

--- a/applications/tari_validator_node/src/transaction_validators/has_inputs.rs
+++ b/applications/tari_validator_node/src/transaction_validators/has_inputs.rs
@@ -27,7 +27,7 @@ impl Validator<Transaction> for HasInputs {
         if transaction.all_inputs_iter().next().is_none() {
             warn!(target: LOG_TARGET, "HasInputs - FAIL: No input shards");
             return Err(TransactionValidationError::NoInputs {
-                transaction_id: *transaction.id(),
+                transaction_id: transaction.calculate_id(),
             });
         }
 

--- a/bindings/package.json
+++ b/bindings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tari-project/typescript-bindings",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "TypeScript types synchronized to the Tari Ootle Rust codebase",
   "homepage": "https://github.com/tari-project/tari-dan#readme",
   "bugs": {

--- a/bindings/src/types/TransactionV1.ts
+++ b/bindings/src/types/TransactionV1.ts
@@ -4,7 +4,6 @@ import type { UnsealedTransactionV1 } from "./UnsealedTransactionV1";
 import type { VersionedSubstateId } from "./VersionedSubstateId";
 
 export interface TransactionV1 {
-  id: string;
   body: UnsealedTransactionV1;
   seal_signature: TransactionSealSignature;
   filled_inputs: Array<VersionedSubstateId>;

--- a/bindings/src/types/WalletTransaction.ts
+++ b/bindings/src/types/WalletTransaction.ts
@@ -8,6 +8,7 @@ import type { Transaction } from "./Transaction";
 import type { TransactionStatus } from "./TransactionStatus";
 
 export interface WalletTransaction {
+  id: string;
   transaction: Transaction;
   status: TransactionStatus;
   finalize: FinalizeResult | null;

--- a/dan_layer/consensus/src/hotstuff/transaction_manager/manager.rs
+++ b/dan_layer/consensus/src/hotstuff/transaction_manager/manager.rs
@@ -165,10 +165,10 @@ impl<TStateStore: StateStore, TExecutor: BlockTransactionExecutor<TStateStore>>
         }
         if resolved_substates.is_empty() && non_local_inputs.is_empty() {
             // Mempool/missing transaction validations should have not sent the transaction to consensus
-            warn!(target: LOG_TARGET, "⚠️ PREPARE: NEVER HAPPEN transaction {} has no inputs.", transaction.id());
+            warn!(target: LOG_TARGET, "⚠️ PREPARE: NEVER HAPPEN transaction {} has no inputs.", transaction.calculate_id());
             return Err(BlockTransactionExecutorError::InvariantError(format!(
                 "Transaction {} has no inputs",
-                transaction.id()
+                transaction.calculate_id()
             )));
         }
         Ok((resolved_substates, non_local_inputs))
@@ -206,7 +206,7 @@ impl<TStateStore: StateStore, TExecutor: BlockTransactionExecutor<TStateStore>>
     pub fn execute_or_fetch(
         &self,
         store: &mut PendingSubstateStore<TStateStore>,
-        transaction: &Transaction,
+        transaction: &TransactionRecord,
         resolved_inputs: &HashMap<SubstateRequirement, Substate>,
         block: &LeafBlock,
     ) -> Result<TransactionExecution, BlockTransactionExecutorError> {
@@ -225,7 +225,9 @@ impl<TStateStore: StateStore, TExecutor: BlockTransactionExecutor<TStateStore>>
             "👨‍🔧 PREPARE: Executing transaction {}",
             transaction.id(),
         );
-        let execution = self.executor.execute(transaction, block.epoch(), resolved_inputs)?;
+        let execution = self
+            .executor
+            .execute(transaction.transaction(), block.epoch(), resolved_inputs)?;
         Ok(execution)
     }
 
@@ -300,7 +302,7 @@ impl<TStateStore: StateStore, TExecutor: BlockTransactionExecutor<TStateStore>>
         //       Outputs may or may not be local
 
         let local_inputs = store.get_many(local_versions.iter().map(|(req, v)| (req.to_owned(), *v)))?;
-        let execution = self.execute_or_fetch(store, transaction.transaction(), &local_inputs, &block)?;
+        let execution = self.execute_or_fetch(store, transaction, &local_inputs, &block)?;
 
         let is_outputs_local_only = local_committee_info.is_all_local(execution.resulting_outputs());
         if is_outputs_local_only {
@@ -483,7 +485,7 @@ impl<TStateStore: StateStore, TExecutor: BlockTransactionExecutor<TStateStore>>
                 })
             .collect();
 
-        let execution = self.execute_or_fetch(store, transaction.transaction(), &resolved_inputs, &block)?;
+        let execution = self.execute_or_fetch(store, transaction, &resolved_inputs, &block)?;
         info!(
             target: LOG_TARGET,
             "👨‍🔧 PREPARE: Output-Only Executed transaction {} with {} decision",

--- a/dan_layer/consensus_tests/src/consensus.rs
+++ b/dan_layer/consensus_tests/src/consensus.rs
@@ -952,7 +952,7 @@ async fn single_shard_input_conflict() {
 
     let tx1_decision = test
         .get_validator(&TestAddress::new("1"))
-        .get_transaction_execution(tx1.transaction().id())
+        .get_transaction_execution(tx1.id())
         .decision();
     info!("tx1 = {}", tx1.id());
     info!("tx2 = {}", tx2.id());

--- a/dan_layer/consensus_tests/src/support/executions_store.rs
+++ b/dan_layer/consensus_tests/src/support/executions_store.rs
@@ -26,7 +26,10 @@ impl TestExecutionSpecStore {
     }
 
     pub fn insert(&self, spec: ExecuteSpec) -> &Self {
-        self.transactions.write().unwrap().insert(*spec.transaction.id(), spec);
+        self.transactions
+            .write()
+            .unwrap()
+            .insert(spec.transaction.calculate_id(), spec);
         self
     }
 

--- a/dan_layer/consensus_tests/src/support/network.rs
+++ b/dan_layer/consensus_tests/src/support/network.rs
@@ -253,7 +253,7 @@ impl TestNetworkWorker {
                 transaction_store
                     .write()
                     .await
-                    .insert(*tx_record.transaction().id(), tx_record.clone());
+                    .insert(*tx_record.id(), tx_record.clone());
 
                 for (addr, (shard_group, num_committees, tx_new_transaction_to_consensus, _)) in &tx_new_transactions {
                     if dest.is_for(addr, *shard_group, *num_committees) {

--- a/dan_layer/consensus_tests/src/support/transaction.rs
+++ b/dan_layer/consensus_tests/src/support/transaction.rs
@@ -104,9 +104,9 @@ pub fn create_execution_result_for_transaction(
         }
         // We MUST create the transaction receipt
         diff.up(
-            SubstateId::TransactionReceipt(TransactionReceiptAddress::from(*transaction.id())),
+            SubstateId::TransactionReceipt(TransactionReceiptAddress::from(transaction.calculate_id())),
             Substate::new(0, TransactionReceipt {
-                transaction_hash: transaction.id().into_array().into(),
+                transaction_hash: transaction.calculate_id().into_array().into(),
                 events: vec![],
                 logs: vec![],
                 fee_receipt: FeeReceipt {
@@ -126,9 +126,9 @@ pub fn create_execution_result_for_transaction(
         ))
     };
 
-    let result = ExecuteResult {
+    ExecuteResult {
         finalize: FinalizeResult::new(
-            transaction.id().into_array().into(),
+            transaction.calculate_id().into_array().into(),
             vec![],
             vec![],
             result,
@@ -139,9 +139,7 @@ pub fn create_execution_result_for_transaction(
             },
         ),
         execution_time: Duration::from_secs(0),
-    };
-
-    result
+    }
 }
 
 pub fn build_substate_id_for_committee(committee_no: u32, num_committees: u32) -> SubstateId {

--- a/dan_layer/consensus_tests/src/support/transaction_executor.rs
+++ b/dan_layer/consensus_tests/src/support/transaction_executor.rs
@@ -59,7 +59,7 @@ impl<TStateStore: StateStore> BlockTransactionExecutor<TStateStore> for TestBloc
         current_epoch: Epoch,
         resolved_inputs: &HashMap<SubstateRequirement, Substate>,
     ) -> Result<TransactionExecution, BlockTransactionExecutorError> {
-        let id = *transaction.id();
+        let id = transaction.calculate_id();
 
         log::info!("Transaction {} executing. {} input(s)", id, resolved_inputs.len());
 
@@ -76,7 +76,7 @@ impl<TStateStore: StateStore> BlockTransactionExecutor<TStateStore> for TestBloc
         let spec = self
             .store
             .get(&id)
-            .unwrap_or_else(|| panic!("Missing execution spec for transaction {}", transaction.id()));
+            .unwrap_or_else(|| panic!("Missing execution spec for transaction {}", transaction.calculate_id()));
 
         let resolved_inputs = spec
             .input_locks
@@ -106,7 +106,7 @@ impl<TStateStore: StateStore> BlockTransactionExecutor<TStateStore> for TestBloc
                     .map(|input| input.versioned_substate_id().to_next_version()),
             )
             .chain(iter::once(VersionedSubstateId::new(
-                SubstateId::TransactionReceipt(TransactionReceiptAddress::from(*transaction.id())),
+                SubstateId::TransactionReceipt(TransactionReceiptAddress::from(transaction.calculate_id())),
                 0,
             )))
             .map(VersionedSubstateIdLockIntent::output)

--- a/dan_layer/engine/src/transaction/processor.rs
+++ b/dan_layer/engine/src/transaction/processor.rs
@@ -150,8 +150,9 @@ impl<TTemplateProvider: TemplateProvider<Template = LoadedTemplate> + 'static> T
 
     #[allow(clippy::too_many_lines)]
     pub fn execute(self, transaction: Transaction) -> Result<ExecuteResult, TransactionError> {
+        let id = transaction.calculate_id();
         let timer = Instant::now();
-        let entity_id_provider = EntityIdProvider::new(transaction.hash(), 1000);
+        let entity_id_provider = EntityIdProvider::new(id.as_hash(), 1000);
         let Self {
             config,
             template_provider,
@@ -178,7 +179,7 @@ impl<TTemplateProvider: TemplateProvider<Template = LoadedTemplate> + 'static> T
             state_db,
             virtual_substates,
             initial_call_scope,
-            transaction.hash(),
+            id.as_hash(),
             transaction_weight,
         );
 
@@ -205,7 +206,7 @@ impl<TTemplateProvider: TemplateProvider<Template = LoadedTemplate> + 'static> T
         )?;
 
         let runtime = Runtime::new(Arc::new(runtime_interface));
-        let transaction_hash = transaction.hash();
+        let transaction_hash = id.as_hash();
 
         let (fee_instructions, instructions) = transaction.into_instructions();
 

--- a/dan_layer/p2p/src/message.rs
+++ b/dan_layer/p2p/src/message.rs
@@ -21,7 +21,7 @@ impl DanMessage {
 
     pub fn get_message_tag(&self) -> String {
         match self {
-            Self::NewTransaction(msg) => format!("tx_{}", msg.transaction.id()),
+            Self::NewTransaction(msg) => format!("tx_{}", msg.transaction.calculate_id()),
         }
     }
 }
@@ -35,7 +35,7 @@ impl From<NewTransactionMessage> for DanMessage {
 impl Display for DanMessage {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::NewTransaction(msg) => write!(f, "NewTransaction({})", msg.transaction.id()),
+            Self::NewTransaction(msg) => write!(f, "NewTransaction({})", msg.transaction.calculate_id()),
         }
     }
 }

--- a/dan_layer/storage/src/consensus_models/transaction.rs
+++ b/dan_layer/storage/src/consensus_models/transaction.rs
@@ -38,16 +38,20 @@ const LOG_TARGET: &str = "tari::dan::storage::consensus_models::transaction";
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TransactionRecord {
+    pub id: TransactionId,
     pub transaction: Transaction,
 }
 
 impl TransactionRecord {
     pub fn new(transaction: Transaction) -> Self {
-        Self { transaction }
+        Self {
+            id: transaction.calculate_id(),
+            transaction,
+        }
     }
 
     pub fn id(&self) -> &TransactionId {
-        self.transaction.id()
+        &self.id
     }
 
     pub fn transaction(&self) -> &Transaction {
@@ -76,7 +80,7 @@ impl TransactionRecord {
 
     pub fn to_initial_evidence(&self, num_preshards: NumPreshards, num_committees: u32) -> Evidence {
         let inputs = self.transaction.all_inputs_iter();
-        let receipt = self.transaction.id().into_receipt_address();
+        let receipt = self.transaction.calculate_id().into_receipt_address();
         Evidence::from_inputs_and_outputs(num_preshards, num_committees, inputs, [VersionedSubstateId::new(
             receipt, 0,
         )])
@@ -93,7 +97,7 @@ impl TransactionRecord {
         TTx: StateStoreWriteTransaction + Deref,
         TTx::Target: StateStoreReadTransaction,
     {
-        if !Self::exists(&**tx, self.transaction.id())? {
+        if !Self::exists(&**tx, self.id())? {
             self.insert(tx)?;
         }
         Ok(())
@@ -130,7 +134,7 @@ impl TransactionRecord {
         }
         let recs = tx.transactions_get_any(tx_ids.iter())?;
         for rec in &recs {
-            tx_ids.remove(rec.transaction.id());
+            tx_ids.remove(rec.id());
         }
 
         Ok((recs, tx_ids))
@@ -143,11 +147,11 @@ impl TransactionRecord {
         let mut tx_ids = transactions
             .clone()
             .into_iter()
-            .map(|t| (*t.id(), t))
+            .map(|t| (t.calculate_id(), t))
             .collect::<HashMap<_, _>>();
         let mut recs = tx.transactions_get_any(tx_ids.keys())?;
         for rec in &recs {
-            tx_ids.remove(rec.transaction.id());
+            tx_ids.remove(rec.id());
         }
         recs.extend(tx_ids.into_values().map(Self::new));
 

--- a/dan_layer/storage/src/consensus_models/transaction_pool.rs
+++ b/dan_layer/storage/src/consensus_models/transaction_pool.rs
@@ -346,7 +346,7 @@ pub struct TransactionPoolRecord {
 impl TransactionPoolRecord {
     pub fn new_from_transaction(transaction: &Transaction, initial_evidence: Evidence) -> Self {
         Self {
-            transaction_id: *transaction.id(),
+            transaction_id: transaction.calculate_id(),
             evidence: initial_evidence,
             is_global: transaction.is_global(),
             transaction_fee: 0,

--- a/dan_layer/template_test_tooling/src/template_test.rs
+++ b/dan_layer/template_test_tooling/src/template_test.rs
@@ -531,7 +531,7 @@ impl TemplateTest {
             );
         }
 
-        let tx_id = *transaction.id();
+        let tx_id = transaction.calculate_id();
         eprintln!("START Transaction id = \"{}\"", tx_id);
 
         let result = processor.execute(transaction)?;

--- a/dan_layer/transaction/src/builder/mod.rs
+++ b/dan_layer/transaction/src/builder/mod.rs
@@ -121,16 +121,12 @@ impl TransactionBuilder {
         owner_public_key: RistrettoPublicKeyBytes,
         workspace_id: T,
     ) -> Self {
-        let id_str = workspace_id.into();
-        let parsed = parse_workspace_key(id_str).expect("Invalid workspace key format");
-        let workspace_id = self.workspace_ids.get(&parsed.name).unwrap_or_else(|| {
-            panic!("Workspace key '{}' not found", parsed.name);
-        });
+        let workspace_id = self.get_workspace_offset_id_from_named_arg(workspace_id);
         self.add_instruction(Instruction::CreateAccount {
             public_key_address: owner_public_key,
             owner_rule: None,
             access_rules: None,
-            workspace_id: Some(WorkspaceOffsetId::new(workspace_id).with_offset_opt(parsed.offset)),
+            workspace_id: Some(workspace_id),
         })
     }
 
@@ -141,14 +137,7 @@ impl TransactionBuilder {
         access_rules: Option<AccessRules>,
         workspace_id: Option<T>,
     ) -> Self {
-        let workspace_id = workspace_id.map(|id| {
-            let id_str = id.into();
-            let parsed = parse_workspace_key(id_str).expect("Invalid workspace key format");
-            let id = self.workspace_ids.get(&parsed.name).unwrap_or_else(|| {
-                panic!("Workspace key '{}' not found", parsed.name);
-            });
-            WorkspaceOffsetId::new(id).with_offset_opt(parsed.offset)
-        });
+        let workspace_id = workspace_id.map(|id| self.get_workspace_offset_id_from_named_arg(id));
         self.add_instruction(Instruction::CreateAccount {
             public_key_address,
             owner_rule,
@@ -201,12 +190,7 @@ impl TransactionBuilder {
         resource_address: ResourceAddress,
         min_amount: Amount,
     ) -> Self {
-        let parsed = parse_workspace_key(label.as_ref().to_string()).expect("Invalid workspace key format");
-        let id = self
-            .workspace_ids
-            .get(&parsed.name)
-            .unwrap_or_else(|| panic!("Workspace key '{}' not found", label.as_ref()));
-        let key = WorkspaceOffsetId::new(id).with_offset_opt(parsed.offset);
+        let key = self.get_workspace_offset_id_from_named_arg(label.as_ref());
         self.add_instruction(Instruction::AssertBucketContains {
             key,
             resource_address,
@@ -393,5 +377,13 @@ impl TransactionBuilder {
                 },
             })
             .collect()
+    }
+
+    pub fn get_workspace_offset_id_from_named_arg<T: Into<String>>(&self, id: T) -> WorkspaceOffsetId {
+        let parsed = parse_workspace_key(id.into()).expect("Invalid workspace key format");
+        let Some(id) = self.workspace_ids.get(&parsed.name) else {
+            panic!("Workspace key '{}' not found", parsed.name);
+        };
+        WorkspaceOffsetId::new(id).with_offset_opt(parsed.offset)
     }
 }

--- a/dan_layer/transaction/src/transaction.rs
+++ b/dan_layer/transaction/src/transaction.rs
@@ -13,12 +13,13 @@ use tari_dan_common_types::{
     VersionedSubstateId,
 };
 use tari_engine_types::{
+    hashing::{hasher32, EngineHashDomainLabel},
     indexed_value::IndexedValueError,
     instruction::Instruction,
     published_template::PublishedTemplateAddress,
     substate::SubstateId,
 };
-use tari_template_lib::{models::ComponentAddress, types::Hash};
+use tari_template_lib::models::ComponentAddress;
 
 use crate::{
     builder::TransactionBuilder,
@@ -55,16 +56,12 @@ impl Transaction {
         }
     }
 
-    pub fn id(&self) -> &TransactionId {
-        match self {
-            Self::V1(tx) => tx.id(),
-        }
-    }
-
-    pub fn check_id(&self) -> bool {
-        match self {
-            Self::V1(tx) => tx.check_id(),
-        }
+    pub fn calculate_id(&self) -> TransactionId {
+        hasher32(EngineHashDomainLabel::Transaction)
+            .chain(&self)
+            .result()
+            .into_array()
+            .into()
     }
 
     pub fn calculate_transaction_weight(&self) -> TransactionWeight {
@@ -82,12 +79,6 @@ impl Transaction {
     pub fn unsealed_transaction(&self) -> &UnsealedTransactionV1 {
         match self {
             Self::V1(tx) => tx.unsealed_transaction(),
-        }
-    }
-
-    pub fn hash(&self) -> Hash {
-        match self {
-            Self::V1(tx) => tx.hash(),
         }
     }
 

--- a/dan_layer/transaction/src/v1/transaction.rs
+++ b/dan_layer/transaction/src/v1/transaction.rs
@@ -17,18 +17,17 @@ use tari_dan_common_types::{
 };
 use tari_engine_types::{
     confidential::ConfidentialClaim,
-    hashing::{hash_template_code, hasher32, EngineHashDomainLabel},
+    hashing::hash_template_code,
     indexed_value::IndexedValueError,
     instruction::Instruction,
     published_template::PublishedTemplateAddress,
     substate::SubstateId,
 };
-use tari_template_lib::{args::InstructionArg, models::ComponentAddress, types::Hash};
+use tari_template_lib::{args::InstructionArg, models::ComponentAddress};
 
 use crate::{
     v1::signature::TransactionSignature,
     weight::TransactionWeight,
-    TransactionId,
     TransactionSealSignature,
     UnsealedTransactionV1,
 };
@@ -42,8 +41,6 @@ const LOG_TARGET: &str = "tari::dan::transaction::transaction";
     ts(export, export_to = "../../bindings/src/types/")
 )]
 pub struct TransactionV1 {
-    #[cfg_attr(feature = "ts", ts(type = "string"))]
-    id: TransactionId,
     body: UnsealedTransactionV1,
     seal_signature: TransactionSealSignature,
     /// Inputs filled by some authority. These are not part of the transaction hash nor the signature
@@ -52,14 +49,11 @@ pub struct TransactionV1 {
 
 impl TransactionV1 {
     pub fn new(transaction: UnsealedTransactionV1, seal_signature: TransactionSealSignature) -> Self {
-        let mut tx = Self {
-            id: TransactionId::default(),
+        Self {
             body: transaction,
             seal_signature,
             filled_inputs: IndexSet::new(),
-        };
-        tx.id = tx.calculate_hash();
-        tx
+        }
     }
 
     pub const fn schema_version(&self) -> u64 {
@@ -70,30 +64,8 @@ impl TransactionV1 {
         Self { filled_inputs, ..self }
     }
 
-    fn calculate_hash(&self) -> TransactionId {
-        hasher32(EngineHashDomainLabel::Transaction)
-            .chain(&self.seal_signature)
-            .chain(&self.body)
-            .result()
-            .into_array()
-            .into()
-    }
-
     pub fn is_dry_run(&self) -> bool {
         self.body.is_dry_run()
-    }
-
-    pub fn id(&self) -> &TransactionId {
-        &self.id
-    }
-
-    pub fn check_id(&self) -> bool {
-        let id = self.calculate_hash();
-        id == self.id
-    }
-
-    pub fn hash(&self) -> Hash {
-        self.id.into_array().into()
     }
 
     pub fn network(&self) -> u8 {
@@ -238,8 +210,7 @@ impl Display for TransactionV1 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "TransactionV1[{}, Inputs: {}, Fee Instructions: {}, Instructions: {}, Signatures: {}, Filled Inputs: {}]",
-            self.id,
+            "TransactionV1[Inputs: {}, Fee Instructions: {}, Instructions: {}, Signatures: {}, Filled Inputs: {}]",
             self.body.inputs().len(),
             self.body.fee_instructions().len(),
             self.body.instructions().len(),

--- a/dan_layer/wallet/sdk/src/apis/confidential_transfer.rs
+++ b/dan_layer/wallet/sdk/src/apis/confidential_transfer.rs
@@ -521,10 +521,11 @@ where
             .with_inputs(inputs)
             .build_and_seal(&account_secret.key);
 
+        let tx_id = transaction.calculate_id();
         self.outputs_api
-            .proofs_set_transaction_hash(inputs_to_spend.proof_id, *transaction.id())?;
+            .proofs_set_transaction_hash(inputs_to_spend.proof_id, tx_id)?;
         self.outputs_api
-            .proofs_set_transaction_hash(fee_inputs_to_spend.proof_id, *transaction.id())?;
+            .proofs_set_transaction_hash(fee_inputs_to_spend.proof_id, tx_id)?;
 
         Ok(TransferOutput {
             transaction,

--- a/dan_layer/wallet/sdk/src/apis/transaction.rs
+++ b/dan_layer/wallet/sdk/src/apis/transaction.rs
@@ -55,7 +55,7 @@ where
         new_account_info: Option<NewAccountInfo>,
         is_dry_run: bool,
     ) -> Result<TransactionId, TransactionApiError> {
-        let tx_id = *transaction.id();
+        let tx_id = transaction.calculate_id();
         self.store.with_write_tx(|tx| {
             tx.transactions_insert(&transaction, &required_substates, new_account_info.as_ref(), is_dry_run)
         })?;
@@ -101,7 +101,7 @@ where
         self.store
             .with_write_tx(|tx| tx.transactions_insert(&transaction, &required_substates, None, true))?;
 
-        let tx_id = *transaction.id();
+        let tx_id = transaction.calculate_id();
         let result = self
             .network_interface
             .submit_dry_run_transaction(transaction, required_substates)

--- a/dan_layer/wallet/sdk/src/models/wallet_transaction.rs
+++ b/dan_layer/wallet/sdk/src/models/wallet_transaction.rs
@@ -9,7 +9,7 @@ use tari_consensus_types::ProposalCertificate;
 use tari_dan_common_types::SubstateRequirement;
 use tari_engine_types::commit_result::FinalizeResult;
 use tari_template_lib::models::Amount;
-use tari_transaction::Transaction;
+use tari_transaction::{Transaction, TransactionId};
 use time::PrimitiveDateTime;
 
 use crate::models::NewAccountInfo;
@@ -21,6 +21,8 @@ use crate::models::NewAccountInfo;
     ts(export, export_to = "../../bindings/src/types/")
 )]
 pub struct WalletTransaction {
+    #[cfg_attr(feature = "ts", ts(type = "string"))]
+    pub id: TransactionId,
     pub transaction: Transaction,
     pub status: TransactionStatus,
     pub finalize: Option<FinalizeResult>,

--- a/dan_layer/wallet/storage_sqlite/src/models/transaction.rs
+++ b/dan_layer/wallet/storage_sqlite/src/models/transaction.rs
@@ -12,7 +12,10 @@ use tari_dan_wallet_sdk::{
 use tari_transaction::{UnsealedTransactionV1, UnsignedTransactionV1};
 use time::PrimitiveDateTime;
 
-use crate::{schema::transactions, serialization::deserialize_json};
+use crate::{
+    schema::transactions,
+    serialization::{deserialize_hex_try_from, deserialize_json},
+};
 
 const LOG_TARGET: &str = "tari::dan::wallet::storage_sqlite::models::transaction";
 
@@ -50,6 +53,7 @@ impl Transaction {
         let seal_signature = deserialize_json(&self.seal_signature)?;
 
         Ok(WalletTransaction {
+            id: deserialize_hex_try_from(&self.hash)?,
             transaction: tari_transaction::Transaction::new(
                 UnsealedTransactionV1::new(
                     UnsignedTransactionV1 {

--- a/dan_layer/wallet/storage_sqlite/src/writer.rs
+++ b/dan_layer/wallet/storage_sqlite/src/writer.rs
@@ -301,7 +301,7 @@ impl WalletStoreWriter for WriteTransaction<'_> {
 
         diesel::insert_into(transactions::table)
             .values((
-                transactions::hash.eq(transaction.id().to_string()),
+                transactions::hash.eq(transaction.calculate_id().to_string()),
                 transactions::network.eq(i32::from(transaction.network())),
                 transactions::fee_instructions.eq(serialize_json(transaction.fee_instructions())?),
                 transactions::instructions.eq(serialize_json(transaction.instructions())?),

--- a/dan_layer/wallet/storage_sqlite/tests/transaction.rs
+++ b/dan_layer/wallet/storage_sqlite/tests/transaction.rs
@@ -22,12 +22,12 @@ fn get_and_insert_transaction() {
     let transaction = tx.transactions_get(TransactionId::default()).optional().unwrap();
     assert!(transaction.is_none());
     let transaction = build_transaction();
-    let hash = *transaction.id();
+    let hash = transaction.calculate_id();
     tx.transactions_insert(&transaction, &[], None, false).unwrap();
     tx.commit().unwrap();
 
     let mut tx = db.create_read_tx().unwrap();
     let returned = tx.transactions_get(hash).unwrap();
-    assert_eq!(transaction.id(), returned.transaction.id());
+    assert_eq!(transaction.calculate_id(), returned.id);
     assert_eq!(returned.status, TransactionStatus::default());
 }

--- a/integration_tests/tests/cucumber.rs
+++ b/integration_tests/tests/cucumber.rs
@@ -724,19 +724,12 @@ async fn successful_transaction(world: &mut TariWorld) {
         let recent_transactions = recent_transactions_res.transactions;
         // check that all transactions have succeeded
         for tx in &recent_transactions {
-            let get_transaction_req = GetTransactionResultRequest {
-                transaction_id: *tx.id(),
-            };
+            let tx_id = tx.calculate_id();
+            let get_transaction_req = GetTransactionResultRequest { transaction_id: tx_id };
             let get_transaction_res = client
                 .get_transaction_result(get_transaction_req)
                 .await
-                .unwrap_or_else(|_| {
-                    panic!(
-                        "Failed to get transaction with hash {} for vn = {}",
-                        tx.id(),
-                        vn_ps.name
-                    )
-                });
+                .unwrap_or_else(|_| panic!("Failed to get transaction with hash {} for vn = {}", tx_id, vn_ps.name));
             let finalized_tx = get_transaction_res.transaction_execution.result;
             finalized_tx.expect_success();
         }

--- a/utilities/tariswap_test_bench/src/accounts.rs
+++ b/utilities/tariswap_test_bench/src/accounts.rs
@@ -178,7 +178,7 @@ impl Runner {
 
             log::debug!(
                 "Submitted transaction {} to fund {} accounts",
-                transaction.id(),
+                transaction.calculate_id(),
                 accounts.len()
             );
             let result = self.submit_transaction_and_wait(transaction).await?;

--- a/utilities/transaction_generator/src/main.rs
+++ b/utilities/transaction_generator/src/main.rs
@@ -71,7 +71,7 @@ fn main() -> anyhow::Result<()> {
             let receiver = read_transactions(file, 0)?;
 
             while let Ok(transaction) = receiver.recv() {
-                println!("Read transaction: {}", transaction.id());
+                println!("Read transaction: {}", transaction.calculate_id());
             }
         },
     }


### PR DESCRIPTION
Description
---
fix(transaction)!: remove cached ID hash from transaction
minor cleanup in transaction builder
update bindings

Motivation and Context
---
The ID was part of the serialized transaction which is sent over the wire, stored, etc. This PR removes the duplicate ID from the Transaction type. It also updates some wallet API responses to return the ID. The transaction ID is not calculated from the outer type, therefore including the transaction version in the preimage.

How Has This Been Tested?
---
Mnaully, existing test

What process can a PR reviewer use to test or verify this change?
---


Breaking Changes
---

- [ ] None
- [x] Requires data directory to be deleted
- [ ] Other - Please specify