### PR TITLE
feat: adds hybrid epoch oracle

### DIFF
--- a/applications/tari_dan_app_utilities/src/epoch_oracle_config.rs
+++ b/applications/tari_dan_app_utilities/src/epoch_oracle_config.rs
@@ -32,6 +32,7 @@ pub enum EpochOracleType {
     #[default]
     BaseLayer,
     Configured,
+    Hybrid,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/applications/tari_indexer/src/bootstrap.rs
+++ b/applications/tari_indexer/src/bootstrap.rs
@@ -45,7 +45,13 @@ use tari_dan_storage::global::GlobalDb;
 use tari_dan_storage_sqlite::global::SqliteGlobalDbAdapter;
 use tari_engine_types::ToByteType;
 use tari_epoch_manager::service::{EpochManagerConfig, EpochManagerHandle};
-use tari_epoch_oracles::{base_layer::BaseLayerOracle, configured::ConfiguredEpochOracle, EpochOracle};
+use tari_epoch_oracles::{
+    base_layer::BaseLayerOracle,
+    configured::ConfiguredEpochOracle,
+    hybrid::HybridEpochOracle,
+    store::EpochOracleStore,
+    EpochOracle,
+};
 use tari_networking::{MessagingMode, NetworkingHandle, RelayCircuitLimits, RelayReservationLimits, SwarmConfig};
 use tari_shutdown::ShutdownSignal;
 use tari_template_lib::prelude::RistrettoPublicKeyBytes;
@@ -118,29 +124,7 @@ pub async fn spawn_services(
     let substate_store = SqliteSubstateStore::try_create(config.indexer.state_db_path())?;
 
     // Epoch event oracle
-    let epoch_event_oracle = match config.epoch_oracle.oracle_type {
-        EpochOracleType::BaseLayer => {
-            let mut base_node_client = create_base_layer_client(config).await?;
-            verify_correct_network(&mut base_node_client, config.network).await?;
-            EpochOracle::BaseLayer(BaseLayerOracle::new(
-                global_db.clone(),
-                base_node_client,
-                consensus_constants.base_layer_confirmations,
-                config.epoch_oracle.base_layer.scanning_interval,
-                config.indexer.sidechain_id.as_ref().map(|p| p.to_byte_type()),
-                config
-                    .indexer
-                    .burnt_utxo_sidechain_id
-                    .as_ref()
-                    .map(|p| p.to_byte_type()),
-                config.indexer.sidechain_id.as_ref().map(|p| p.to_byte_type()),
-            ))
-        },
-        EpochOracleType::Configured => EpochOracle::Configured(ConfiguredEpochOracle::new(
-            config.epoch_oracle.configured.load().await?,
-            global_db.clone(),
-        )),
-    };
+    let epoch_event_oracle = create_epoch_oracle(config, global_db.clone(), &consensus_constants).await?;
 
     let (template_queue_sender, template_queue_receiver) = TemplateDownloadQueue::create();
 
@@ -235,4 +219,59 @@ async fn create_base_layer_client(config: &ApplicationConfig) -> Result<GrpcBase
     GrpcBaseNodeClient::connect(url)
         .await
         .map_err(|err| ExitError::new(ExitCode::ConfigError, format!("Could not connect to base node {}", err)))
+}
+
+async fn create_epoch_oracle<TStore: EpochOracleStore + Clone + Send + 'static>(
+    config: &ApplicationConfig,
+    store: TStore,
+    consensus_constants: &ConsensusConstants,
+) -> Result<EpochOracle<TStore>, ExitError> {
+    match config.epoch_oracle.oracle_type {
+        EpochOracleType::BaseLayer => {
+            let oracle = create_base_layer_epoch_oracle(config, store, consensus_constants).await?;
+            Ok(EpochOracle::BaseLayer(oracle))
+        },
+        EpochOracleType::Configured => {
+            let oracle = create_configured_epoch_oracle(config, store).await?;
+            Ok(EpochOracle::Configured(oracle))
+        },
+        EpochOracleType::Hybrid => {
+            let base_layer_oracle = create_base_layer_epoch_oracle(config, store.clone(), consensus_constants).await?;
+            let configured_oracle = create_configured_epoch_oracle(config, store).await?;
+            Ok(EpochOracle::Hybrid(HybridEpochOracle::new(
+                configured_oracle,
+                base_layer_oracle,
+            )))
+        },
+    }
+}
+
+async fn create_base_layer_epoch_oracle<TStore: EpochOracleStore + 'static>(
+    config: &ApplicationConfig,
+    store: TStore,
+    consensus_constants: &ConsensusConstants,
+) -> Result<BaseLayerOracle<TStore>, ExitError> {
+    let mut base_node_client = create_base_layer_client(config).await?;
+    verify_correct_network(&mut base_node_client, config.network).await?;
+    Ok(BaseLayerOracle::new(
+        store,
+        base_node_client,
+        consensus_constants.base_layer_confirmations,
+        config.epoch_oracle.base_layer.scanning_interval,
+        config.indexer.sidechain_id.as_ref().map(|p| p.to_byte_type()),
+        config
+            .indexer
+            .burnt_utxo_sidechain_id
+            .as_ref()
+            .map(|p| p.to_byte_type()),
+        config.indexer.sidechain_id.as_ref().map(|p| p.to_byte_type()),
+    ))
+}
+
+async fn create_configured_epoch_oracle<TStore: EpochOracleStore + Send>(
+    config: &ApplicationConfig,
+    store: TStore,
+) -> Result<ConfiguredEpochOracle<TStore>, ExitError> {
+    let oracle_config = config.epoch_oracle.configured.load().await?;
+    Ok(ConfiguredEpochOracle::new(oracle_config, store))
 }

--- a/applications/tari_validator_node/src/bootstrap.rs
+++ b/applications/tari_validator_node/src/bootstrap.rs
@@ -59,7 +59,13 @@ use tari_epoch_manager::{
     service::{EpochManagerConfig, EpochManagerHandle},
     EpochManagerReader,
 };
-use tari_epoch_oracles::{base_layer::BaseLayerOracle, configured::ConfiguredEpochOracle, EpochOracle};
+use tari_epoch_oracles::{
+    base_layer::BaseLayerOracle,
+    configured::ConfiguredEpochOracle,
+    hybrid::HybridEpochOracle,
+    store::EpochOracleStore,
+    EpochOracle,
+};
 use tari_indexer_lib::substate_scanner::SubstateScanner;
 use tari_networking::{MessagingMode, NetworkingHandle, RelayCircuitLimits, RelayReservationLimits, SwarmConfig};
 use tari_rpc_framework::RpcServer;
@@ -206,38 +212,7 @@ pub async fn spawn_services(
     };
 
     // Epoch event scanner
-    let epoch_event_oracle = match config.epoch_oracle.oracle_type {
-        EpochOracleType::BaseLayer => {
-            let mut base_node_client =
-                create_base_layer_client(config.network, &config.epoch_oracle.base_layer).await?;
-            verify_correct_network(&mut base_node_client, config.network).await?;
-            EpochOracle::BaseLayer(BaseLayerOracle::new(
-                global_db.clone(),
-                base_node_client,
-                consensus_constants.base_layer_confirmations,
-                config.epoch_oracle.base_layer.scanning_interval,
-                config
-                    .validator_node
-                    .validator_node_sidechain_id
-                    .as_ref()
-                    .map(|pk| pk.to_byte_type()),
-                config
-                    .validator_node
-                    .burnt_utxo_sidechain_id
-                    .as_ref()
-                    .map(|pk| pk.to_byte_type()),
-                config
-                    .validator_node
-                    .template_sidechain_id
-                    .as_ref()
-                    .map(|pk| pk.to_byte_type()),
-            ))
-        },
-        EpochOracleType::Configured => EpochOracle::Configured(ConfiguredEpochOracle::new(
-            config.epoch_oracle.configured.load().await?,
-            global_db.clone(),
-        )),
-    };
+    let epoch_event_oracle = create_epoch_oracle(&config, global_db.clone(), &consensus_constants).await?;
 
     let (template_queue_sender, template_queue_receiver) = TemplateDownloadQueue::create();
 
@@ -540,4 +515,67 @@ async fn create_base_layer_client(
         })?;
 
     Ok(base_node_client)
+}
+
+async fn create_epoch_oracle<TStore: EpochOracleStore + Send + Clone + 'static>(
+    config: &ApplicationConfig,
+    store: TStore,
+    consensus_constants: &ConsensusConstants,
+) -> Result<EpochOracle<TStore>, ExitError> {
+    match config.epoch_oracle.oracle_type {
+        EpochOracleType::BaseLayer => {
+            let oracle = create_base_layer_epoch_oracle(config, store, consensus_constants).await?;
+            Ok(EpochOracle::BaseLayer(oracle))
+        },
+        EpochOracleType::Configured => {
+            let oracle = create_configured_epoch_oracle(config, store).await?;
+            Ok(EpochOracle::Configured(oracle))
+        },
+        EpochOracleType::Hybrid => {
+            let base_layer_oracle = create_base_layer_epoch_oracle(config, store.clone(), consensus_constants).await?;
+            let configured_oracle = create_configured_epoch_oracle(config, store).await?;
+            Ok(EpochOracle::Hybrid(HybridEpochOracle::new(
+                configured_oracle,
+                base_layer_oracle,
+            )))
+        },
+    }
+}
+
+async fn create_base_layer_epoch_oracle<TStore: EpochOracleStore + 'static>(
+    config: &ApplicationConfig,
+    store: TStore,
+    consensus_constants: &ConsensusConstants,
+) -> Result<BaseLayerOracle<TStore>, ExitError> {
+    let mut base_node_client = create_base_layer_client(config.network, &config.epoch_oracle.base_layer).await?;
+    verify_correct_network(&mut base_node_client, config.network).await?;
+    Ok(BaseLayerOracle::new(
+        store,
+        base_node_client,
+        consensus_constants.base_layer_confirmations,
+        config.epoch_oracle.base_layer.scanning_interval,
+        config
+            .validator_node
+            .validator_node_sidechain_id
+            .as_ref()
+            .map(|p| p.to_byte_type()),
+        config
+            .validator_node
+            .burnt_utxo_sidechain_id
+            .as_ref()
+            .map(|p| p.to_byte_type()),
+        config
+            .validator_node
+            .template_sidechain_id
+            .as_ref()
+            .map(|p| p.to_byte_type()),
+    ))
+}
+
+async fn create_configured_epoch_oracle<TStore: EpochOracleStore + Send>(
+    config: &ApplicationConfig,
+    store: TStore,
+) -> Result<ConfiguredEpochOracle<TStore>, ExitError> {
+    let oracle_config = config.epoch_oracle.configured.load().await?;
+    Ok(ConfiguredEpochOracle::new(oracle_config, store))
 }

--- a/dan_layer/epoch_oracles/src/base_layer/mod.rs
+++ b/dan_layer/epoch_oracles/src/base_layer/mod.rs
@@ -104,7 +104,7 @@ impl<TStore: EpochOracleStore + 'static> BaseLayerOracle<TStore> {
 }
 
 impl<TStore: EpochOracleStore> BaseLayerOracleInner<TStore> {
-    pub fn load_initial_state(&mut self) -> Result<(), BaseLayerOracleError> {
+    fn load_initial_state(&mut self) -> Result<(), BaseLayerOracleError> {
         self.last_scanned_tip = self
             .store
             .get(StoreKey::BaseLayerLastScannedTip.as_key_bytes())

--- a/dan_layer/epoch_oracles/src/hybrid/mod.rs
+++ b/dan_layer/epoch_oracles/src/hybrid/mod.rs
@@ -1,0 +1,5 @@
+//   Copyright 2025 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+mod oracle;
+pub use oracle::*;

--- a/dan_layer/epoch_oracles/src/hybrid/oracle.rs
+++ b/dan_layer/epoch_oracles/src/hybrid/oracle.rs
@@ -1,0 +1,74 @@
+//   Copyright 2025 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+use log::*;
+use tari_epoch_manager::epoch_event_oracle::{EpochEvent, EpochEventOracle};
+
+use crate::{base_layer::BaseLayerOracle, configured::ConfiguredEpochOracle, store::EpochOracleStore};
+
+const LOG_TARGET: &str = "tari::dan::epoch_oracles::hybrid";
+
+pub struct HybridEpochOracle<TStore> {
+    configured: ConfiguredEpochOracle<TStore>,
+    base_layer: BaseLayerOracle<TStore>,
+}
+
+impl<TStore: EpochOracleStore + Send + 'static> HybridEpochOracle<TStore> {
+    pub fn new(configured: ConfiguredEpochOracle<TStore>, base_layer: BaseLayerOracle<TStore>) -> Self {
+        Self { configured, base_layer }
+    }
+
+    fn should_emit_configured(&self, event: &EpochEvent) -> bool {
+        match event {
+            EpochEvent::Error(_) |
+            // Let the configured oracle handle validator nodes
+            EpochEvent::ActiveValidatorNodeSetChanged { .. } |
+            EpochEvent::NewValidatorRegistered { .. } |
+            EpochEvent::NewValidatorNodeExit { .. } |
+            EpochEvent::NewCodeTemplateDownload { .. } |
+            EpochEvent::NewEvictionProof { .. } => true,
+            // These events are handled by the base layer oracle
+            EpochEvent::NewConfidentialOutput { .. } |
+            EpochEvent::EpochChanged { .. } |
+            EpochEvent::DoneForNow { .. } => false,
+        }
+    }
+
+    fn should_emit_base_layer(&self, event: &EpochEvent) -> bool {
+        match event {
+            EpochEvent::Error(_) |
+            // Let the base layer oracle handle epoch timing and UTXO events
+            EpochEvent::NewConfidentialOutput { .. } |
+            EpochEvent::EpochChanged { .. } |
+            EpochEvent::NewCodeTemplateDownload { .. } |
+            EpochEvent::DoneForNow { .. } => true,
+            EpochEvent::ActiveValidatorNodeSetChanged { .. } |
+            EpochEvent::NewValidatorRegistered { .. } |
+            EpochEvent::NewValidatorNodeExit { .. } |
+            EpochEvent::NewEvictionProof { .. } => false,
+        }
+    }
+}
+
+impl<TStore: EpochOracleStore + Send + 'static> EpochEventOracle for HybridEpochOracle<TStore> {
+    async fn next_epoch_event(&mut self) -> Option<EpochEvent> {
+        loop {
+            tokio::select! {
+                event = self.configured.next_epoch_event() => {
+                    let event = event?;
+                    debug!(target: LOG_TARGET, "📝 Configured epoch event: {}", event);
+                    if self.should_emit_configured(&event) {
+                        return Some(event);
+                    }
+                },
+                event = self.base_layer.next_epoch_event() => {
+                    let event = event?;
+                    debug!(target: LOG_TARGET, "⛓️ Base layer epoch event: {}", event);
+                    if self.should_emit_base_layer(&event) {
+                        return Some(event);
+                    }
+                },
+            }
+        }
+    }
+}

--- a/dan_layer/epoch_oracles/src/lib.rs
+++ b/dan_layer/epoch_oracles/src/lib.rs
@@ -8,12 +8,16 @@ use crate::store::EpochOracleStore;
 #[cfg(feature = "base_layer")]
 pub mod base_layer;
 pub mod configured;
+#[cfg(feature = "base_layer")]
+pub mod hybrid;
 pub mod store;
 
 pub enum EpochOracle<TStore> {
     #[cfg(feature = "base_layer")]
     BaseLayer(base_layer::BaseLayerOracle<TStore>),
     Configured(configured::ConfiguredEpochOracle<TStore>),
+    #[cfg(feature = "base_layer")]
+    Hybrid(hybrid::HybridEpochOracle<TStore>),
 }
 
 impl<TStore: EpochOracleStore + Send + 'static> EpochEventOracle for EpochOracle<TStore> {
@@ -22,6 +26,8 @@ impl<TStore: EpochOracleStore + Send + 'static> EpochEventOracle for EpochOracle
             #[cfg(feature = "base_layer")]
             EpochOracle::BaseLayer(base_layer) => base_layer.next_epoch_event().await,
             EpochOracle::Configured(configured) => configured.next_epoch_event().await,
+            #[cfg(feature = "base_layer")]
+            EpochOracle::Hybrid(hybrid) => hybrid.next_epoch_event().await,
         }
     }
 }

--- a/utilities/db_inspector/src/webserver/handlers/tables.rs
+++ b/utilities/db_inspector/src/webserver/handlers/tables.rs
@@ -59,12 +59,21 @@ where
                 let skip = req.page.unwrap_or(0) * page_size;
 
                 let mut total_bytes = 0usize;
+                let mut largest_row_size = 0usize;
+                let mut smallest_row_size = usize::MAX;
                 for result in iter.skip(skip).take(page_size) {
                     let (key, value) = result?;
                     let bytes = cf
                         .get_raw_pinned(&key, OPERATION)
                         .map_err(|e| anyhow!("Failed to get_raw_pinned: {}", e))?;
-                    total_bytes += bytes.map(|b| b.len()).unwrap_or(0);
+                    let size = bytes.map(|b| b.len()).unwrap_or(0);
+                    total_bytes += size;
+                    if size > largest_row_size {
+                        largest_row_size = size;
+                    }
+                    if size < smallest_row_size {
+                        smallest_row_size = size;
+                    }
 
                     let mut value =
                         serde_json::to_value(value).map_err(|e| anyhow!("Failed to serialize value: {}", e))?;
@@ -81,8 +90,11 @@ where
                     table.add_row(value);
                 }
                 let total = cf.count(OPERATION)?;
-                table.set_total_entries(total);
-                table.set_total_bytes(total_bytes);
+                table
+                    .set_total_entries(total)
+                    .set_total_bytes(total_bytes)
+                    .set_largest_row_size(largest_row_size)
+                    .set_smallest_row_size(smallest_row_size);
 
                 Ok::<_, WebError>(Json(table))
             }

--- a/utilities/db_inspector/src/webserver/handlers/types.rs
+++ b/utilities/db_inspector/src/webserver/handlers/types.rs
@@ -36,6 +36,8 @@ pub struct TableResponse {
     rows: Vec<json::Value>,
     total_entries: Option<usize>,
     total_bytes: usize,
+    largest_row_size: usize,
+    smallest_row_size: usize,
 }
 
 impl TableResponse {
@@ -45,6 +47,8 @@ impl TableResponse {
             rows: vec![],
             total_entries: None,
             total_bytes: 0,
+            largest_row_size: 0,
+            smallest_row_size: 0,
         }
     }
 
@@ -54,6 +58,8 @@ impl TableResponse {
             rows: vec![],
             total_entries: None,
             total_bytes: 0,
+            largest_row_size: 0,
+            smallest_row_size: usize::MAX,
         }
     }
 
@@ -74,6 +80,16 @@ impl TableResponse {
 
     pub fn set_total_bytes(&mut self, count: usize) -> &mut Self {
         self.total_bytes = count;
+        self
+    }
+
+    pub fn set_largest_row_size(&mut self, size: usize) -> &mut Self {
+        self.largest_row_size = size;
+        self
+    }
+
+    pub fn set_smallest_row_size(&mut self, size: usize) -> &mut Self {
+        self.smallest_row_size = size;
         self
     }
 }

--- a/utilities/db_inspector/web_ui/src/routes/InspectCf.tsx
+++ b/utilities/db_inspector/web_ui/src/routes/InspectCf.tsx
@@ -24,6 +24,8 @@ interface ColumnFamilyData {
   rows: Row[];
   total_entries: number;
   total_bytes: number;
+  largest_row_size: number;
+  smallest_row_size: number;
 }
 
 interface PaginationModel extends GridPaginationModel {
@@ -197,6 +199,24 @@ export default function InspectCf() {
             <Typography variant="h6">
               Total value
               bytes: {prettyBytes(data.total_bytes)} (avg: {prettyBytes(data.total_bytes / data.rows.length)})
+            </Typography>
+          </Grid>
+        </Grid>
+      ) : null}
+      {data?.rows.length && data?.largest_row_size ? (
+        <Grid container spacing={12}>
+          <Grid size={12}>
+            <Typography variant="h6">
+              Largest row size: {prettyBytes(data.largest_row_size)}
+            </Typography>
+          </Grid>
+        </Grid>
+      ) : null}
+      {data?.rows.length && data?.smallest_row_size ? (
+        <Grid container spacing={12}>
+          <Grid size={12}>
+            <Typography variant="h6">
+              Smallest row size: {prettyBytes(data.smallest_row_size)}
             </Typography>
           </Grid>
         </Grid>


### PR DESCRIPTION
Description
---
Adds a hybrid epoch oracle that scans the base layer for epoch timing, and UTXOs but allows validators to be configured.

Motivation and Context
---

Closes #1429

How Has This Been Tested?
---
Not explicitly tested yet, hybrid composes two tested epoch oracles together.

What process can a PR reviewer use to test or verify this change?
---
Set the oracle to hybrid

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify