### PR TITLE
fix(consensus)!: properly account for forks for substate locks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -982,7 +982,7 @@ dependencies = [
  "bitflags 2.9.0",
  "cexpr",
  "clang-sys",
- "itertools 0.11.0",
+ "itertools 0.12.1",
  "lazy_static",
  "lazycell",
  "proc-macro2",
@@ -3201,6 +3201,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3224,6 +3234,19 @@ dependencies = [
  "log",
  "regex",
  "termcolor",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
 ]
 
 [[package]]
@@ -5019,6 +5042,30 @@ dependencies = [
  "serde",
  "serde_json",
  "uuid 0.8.2",
+]
+
+[[package]]
+name = "jiff"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a194df1107f33c79f4f93d02c80798520551949d59dfad22b6157048a88cca93"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c6e1db7ed32c6c71b759497fae34bf7933636f75a251b9e736555da426f6442"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -7819,6 +7866,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
 
 [[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8068,7 +8124,7 @@ checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes 1.10.1",
  "heck 0.5.0",
- "itertools 0.11.0",
+ "itertools 0.12.1",
  "log",
  "multimap 0.10.0",
  "once_cell",
@@ -8088,7 +8144,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck 0.5.0",
- "itertools 0.11.0",
+ "itertools 0.14.0",
  "log",
  "multimap 0.10.0",
  "once_cell",
@@ -8134,7 +8190,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.100",
@@ -8147,7 +8203,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.100",
@@ -9842,7 +9898,9 @@ checksum = "e7386b49cb287f6fafbfd3bd604914bccb99fb8d53483f40e1ecfda5d45f3370"
 name = "state_store_tests"
 version = "0.9.2"
 dependencies = [
+ "env_logger 0.11.8",
  "indexmap 2.9.0",
+ "log",
  "rand 0.8.5",
  "tari_bor",
  "tari_common_types",

--- a/applications/tari_swarm_daemon/src/main.rs
+++ b/applications/tari_swarm_daemon/src/main.rs
@@ -1,9 +1,14 @@
 //   Copyright 2024 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use std::{collections::HashMap, future::Future, pin::Pin};
+use std::{
+    collections::HashMap,
+    future::Future,
+    pin::{pin, Pin},
+};
 
 use anyhow::{anyhow, Context};
+use futures::future::{select, Either};
 use tari_common::configuration::Network;
 use tari_shutdown::Shutdown;
 use tokio::fs;
@@ -231,24 +236,38 @@ async fn start(cli: &Cli) -> anyhow::Result<()> {
     tokio::select! {
         _ = signal => {
             log::info!("Terminating all instances...");
+            terminate_all_instances(&pm_handle).await?;
             shutdown.trigger();
-            let num_instances = pm_handle.stop_all().await?;
-            log::info!("Terminated {num_instances} instances");
         },
         result = webserver => {
             log::info!("Terminating all instances...");
-            let num_instances = pm_handle.stop_all().await?;
-            log::info!("Terminated {num_instances} instances");
+            terminate_all_instances(&pm_handle).await?;
             result?.context("web server crashed")?;
             log::info!("Webserver exited");
         },
         result = task_handle => {
+            // We cannot call terminate_all_instances since the process manager has crashed
+            shutdown.trigger();
             result?.context("process manager crashed")?;
             log::info!("Process manager exited");
         }
     }
 
     Ok(())
+}
+
+async fn terminate_all_instances(pm_handle: &process_manager::ProcessManagerHandle) -> anyhow::Result<()> {
+    let exit_sig = exit_signal().context("exit_signal")?;
+    let stop_all = pm_handle.stop_all();
+    match select(exit_sig, pin!(stop_all)).await {
+        // If the exit signal was received first (second ctrl+c), we exit immediately
+        Either::Left(_) => Err(anyhow!("Received interrupt while stopping instances")),
+        Either::Right((r, _)) => {
+            let num_instances = r?;
+            log::info!("Terminated {num_instances} instances");
+            Ok(())
+        },
+    }
 }
 
 async fn create_paths(config: &Config) -> anyhow::Result<()> {

--- a/dan_layer/consensus/src/hotstuff/block_change_set.rs
+++ b/dan_layer/consensus/src/hotstuff/block_change_set.rs
@@ -314,6 +314,17 @@ impl ProposedBlockChangeSet {
             .and_then(|change| change.execution.take())
     }
 
+    pub fn take_all_transaction_executions(
+        &mut self,
+    ) -> impl Iterator<Item = (TransactionId, TransactionExecution)> + '_ {
+        self.transaction_changes.drain(..).filter_map(|(tx_id, mut change)| {
+            change
+                .execution
+                .take()
+                .map(|execution| (tx_id, execution.into_transaction_execution()))
+        })
+    }
+
     pub fn add_transaction_execution(
         &mut self,
         transaction_id: TransactionId,
@@ -444,7 +455,7 @@ impl ProposedBlockChangeSet {
         }
 
         // Save locks
-        SubstateRecord::lock_all(tx, &self.block.block_id, &self.substate_locks)?;
+        SubstateRecord::lock_all(tx, &self.block, &self.substate_locks)?;
 
         // Sequence new transactions
         for pool_rec in &self.new_transactions_to_sequence {

--- a/dan_layer/consensus/src/hotstuff/foreign_proposal_processor.rs
+++ b/dan_layer/consensus/src/hotstuff/foreign_proposal_processor.rs
@@ -18,7 +18,7 @@ use tari_dan_storage::{
         BlockPledge,
         Command,
         Evidence,
-        ForeignProposalRecord,
+        ForeignProposal,
         LockedSubstateValue,
         TransactionAtom,
         TransactionExecution,
@@ -49,21 +49,28 @@ const LOG_TARGET: &str = "tari::dan::consensus::hotstuff::foreign_proposal_proce
 pub fn process_foreign_block<TStore: StateStore>(
     tx: &TStore::ReadTransaction<'_>,
     local_leaf: &LeafBlock,
-    foreign_proposal: &ForeignProposalRecord,
+    proposal: &ForeignProposal,
     local_committee_info: &CommitteeInfo,
     substate_store: &mut PendingSubstateStore<TStore>,
     proposed_block_change_set: &mut ProposedBlockChangeSet,
 ) -> Result<(), HotStuffError> {
     let _timer = TraceTimer::info(LOG_TARGET, "process_foreign_block");
 
-    let foreign_shard_group = foreign_proposal.proposal().shard_group_unchecked();
+    let foreign_shard_group = proposal.shard_group_unchecked();
     info!(
         target: LOG_TARGET,
         "🧩 Processing FOREIGN PROPOSAL {}",
-        foreign_proposal,
+        proposal,
     );
+    // Used for logging purposes
+    let foreign_block_id = proposal.calculate_block_id();
+    let foreign_proposal_as_leaf = LeafBlock {
+        block_id: foreign_block_id,
+        height: proposal.height(),
+        epoch: proposal.epoch(),
+        shard_group: foreign_shard_group,
+    };
 
-    let proposal = foreign_proposal.proposal();
     let block_pledge = proposal.block_pledge();
     let mut command_count = 0usize;
 
@@ -78,7 +85,7 @@ pub fn process_foreign_block<TStore: StateStore>(
                     warn!(
                         target: LOG_TARGET,
                         "🧩 FOREIGN PROPOSAL {foreign_shard_group}: Command: LocalPrepare({}, {}), block: {} not relevant to local committee",
-                        atom.id, atom.decision, foreign_proposal.block_id(),
+                        atom.id, atom.decision, foreign_block_id,
                     );
                     continue;
                 }
@@ -86,7 +93,7 @@ pub fn process_foreign_block<TStore: StateStore>(
                 debug!(
                     target: LOG_TARGET,
                     "🧩 FOREIGN PROPOSAL {foreign_shard_group}: Command: LocalPrepare({}, {}), block: {}",
-                    atom.id,atom.decision, foreign_proposal.block_id(),
+                    atom.id,atom.decision, foreign_block_id,
                 );
 
                 let Some(mut tx_rec) = get_or_sequence_transaction(
@@ -95,7 +102,7 @@ pub fn process_foreign_block<TStore: StateStore>(
                     local_committee_info.num_committees(),
                     &atom.id,
                     local_leaf,
-                    foreign_proposal.block_id(),
+                    &foreign_block_id,
                     proposed_block_change_set,
                 )?
                 else {
@@ -111,7 +118,7 @@ pub fn process_foreign_block<TStore: StateStore>(
                     warn!(
                         target: LOG_TARGET,
                         "⚠️ Foreign LocalPrepare proposal ({}) received LOCAL_PREPARE for transaction {} but current transaction stage is {}. Ignoring.",
-                        foreign_proposal,
+                        proposal,
                         tx_rec.transaction_id(),
                         tx_rec.current_stage()
                     );
@@ -145,7 +152,7 @@ pub fn process_foreign_block<TStore: StateStore>(
                 // Update the transaction record with any new information provided by this foreign block
                 let Some(foreign_evidence) = atom.evidence.get(&foreign_shard_group) else {
                     return Err(ProposalValidationError::ForeignInvalidPledge {
-                        block: foreign_proposal.as_leaf(),
+                        block: foreign_proposal_as_leaf,
                         transaction_id: atom.id,
                         shard_group: foreign_shard_group,
                         details: "Foreign proposal did not contain evidence for its own shard group".to_string(),
@@ -160,8 +167,7 @@ pub fn process_foreign_block<TStore: StateStore>(
                         HotStuffError::InvariantError(format!(
                             "Foreign proposal {} does not contain a justify QC for shard group {} - this should have \
                              been rejected by validations",
-                            foreign_proposal.block_id(),
-                            foreign_shard_group
+                            foreign_block_id, foreign_shard_group
                         ))
                     })?;
 
@@ -235,7 +241,7 @@ pub fn process_foreign_block<TStore: StateStore>(
                             warn!(
                                 target: LOG_TARGET,
                                 "⚠️ Foreign proposal {} received for transaction {} but a conflicting transaction ({}) has already been prepared by this node. Abort.",
-                                foreign_proposal,
+                                proposal,
                                 tx_rec.transaction_id(),
                                 conflicting_transaction_id
                             );
@@ -260,7 +266,7 @@ pub fn process_foreign_block<TStore: StateStore>(
 
                 add_pledges(
                     &tx_rec,
-                    foreign_proposal.as_leaf(),
+                    foreign_proposal_as_leaf,
                     atom,
                     block_pledge,
                     foreign_shard_group,
@@ -355,7 +361,7 @@ pub fn process_foreign_block<TStore: StateStore>(
                     warn!(
                         target: LOG_TARGET,
                         "🧩❓️ FOREIGN PROPOSAL {foreign_shard_group}: Command: LocalAccept({}, {}), block: {} not relevant to local committee",
-                        atom.id, atom.decision, foreign_proposal.block_id(),
+                        atom.id, atom.decision, foreign_block_id,
                     );
                     continue;
                 }
@@ -363,7 +369,7 @@ pub fn process_foreign_block<TStore: StateStore>(
                 debug!(
                     target: LOG_TARGET,
                     "🧩 FOREIGN PROPOSAL {foreign_shard_group}: Command: LocalAccept({}, {}), block: {}",
-                    atom.id, atom.decision, foreign_proposal.block_id(),
+                    atom.id, atom.decision, foreign_block_id,
                 );
 
                 let Some(mut tx_rec) = get_or_sequence_transaction(
@@ -372,7 +378,7 @@ pub fn process_foreign_block<TStore: StateStore>(
                     local_committee_info.num_committees(),
                     &atom.id,
                     local_leaf,
-                    foreign_proposal.block_id(),
+                    &foreign_block_id,
                     proposed_block_change_set,
                 )?
                 else {
@@ -388,7 +394,7 @@ pub fn process_foreign_block<TStore: StateStore>(
                     warn!(
                         target: LOG_TARGET,
                         "⚠️ Foreign proposal {} received LOCAL_ACCEPT for transaction {} but current transaction stage is {}. Ignoring.",
-                        foreign_proposal,
+                        proposal,
                         tx_rec.transaction_id(),
                         tx_rec.current_stage(),
                     );
@@ -421,7 +427,7 @@ pub fn process_foreign_block<TStore: StateStore>(
                 // Update the transaction record with any new information provided by this foreign block
                 let Some(foreign_evidence) = atom.evidence.get(&foreign_shard_group) else {
                     return Err(ProposalValidationError::ForeignInvalidPledge {
-                        block: foreign_proposal.as_leaf(),
+                        block: foreign_proposal_as_leaf,
                         transaction_id: atom.id,
                         shard_group: foreign_shard_group,
                         details: "Foreign proposal did not contain evidence for its own shard group".to_string(),
@@ -435,8 +441,7 @@ pub fn process_foreign_block<TStore: StateStore>(
                         HotStuffError::InvariantError(format!(
                             "Foreign proposal {} does not contain a justify QC for shard group {} - this should have \
                              already been validated",
-                            foreign_proposal.block_id(),
-                            foreign_shard_group
+                            foreign_block_id, foreign_shard_group
                         ))
                     })?;
 
@@ -449,7 +454,7 @@ pub fn process_foreign_block<TStore: StateStore>(
 
                 add_pledges(
                     &tx_rec,
-                    foreign_proposal.as_leaf(),
+                    foreign_proposal_as_leaf,
                     atom,
                     block_pledge,
                     foreign_shard_group,
@@ -537,7 +542,7 @@ pub fn process_foreign_block<TStore: StateStore>(
                 warn!(
                     target: LOG_TARGET,
                     "❓️ NEVER HAPPEN: Foreign proposal received {} contains an EndEpoch command. This is invalid behaviour but continuing anyway.",
-                    foreign_proposal
+                    proposal
                 );
                 continue;
             },
@@ -559,13 +564,13 @@ pub fn process_foreign_block<TStore: StateStore>(
         target: LOG_TARGET,
         "🧩 FOREIGN PROPOSAL: Processed {} commands from foreign block {}",
         command_count,
-        foreign_proposal
+        proposal
     );
     if command_count == 0 {
         warn!(
             target: LOG_TARGET,
             "⚠️ FOREIGN PROPOSAL: No commands were applicable for foreign block {}. Ignoring.",
-            foreign_proposal
+            proposal
         );
     }
 

--- a/dan_layer/consensus/src/hotstuff/on_inbound_message.rs
+++ b/dan_layer/consensus/src/hotstuff/on_inbound_message.rs
@@ -181,7 +181,7 @@ fn msg_relative_view(msg: &HotstuffMessage, current_epoch: Epoch, current_height
                 // Special case, the justify height and the current height are zero
                 ((current_height.is_zero() && justify_height.is_zero()) ||
                     // The proposal (supposedly) justifies the next view change
-                    justify_height == next_height ||
+                    justify_height >= next_height ||
                     // The proposal is for the current view (catch up)
                     block_height == next_height ||
                     // or, the timeout certificate height is higher than the current height

--- a/dan_layer/consensus/src/hotstuff/on_propose.rs
+++ b/dan_layer/consensus/src/hotstuff/on_propose.rs
@@ -65,6 +65,7 @@ use crate::{
         epoch_state::EpochState,
         error::HotStuffError,
         filter_diff_for_committee,
+        foreign_proposal_processor::process_foreign_block,
         process_newly_justified_block,
         substate_store::PendingSubstateStore,
         transaction_manager::{
@@ -325,16 +326,6 @@ where TConsensusSpec: ConsensusSpec
         let justify_block = Block::get(tx, &high_qc_certificate.calculate_block_id())?;
         let start_of_chain_block = highest_seen_block;
         let parent_block = dummy_block.unwrap_or_else(|| highest_seen_block.as_leaf());
-        // // The parent block will only ever not exist if it is a dummy block
-        // let parent_exists = Block::record_exists(tx, parent_block.block_id())?;
-        // let start_of_chain_block = if parent_exists {
-        //     // Parent exists - we can include its state in the MR calc, foreign propose etc.
-        //     parent_block
-        // } else {
-        //     // Parent does not exist which means we have dummy blocks between the parent and the justified block so
-        // we     // can exclude them from the query. There are a few queries that will fail if we used a
-        // non-existent block.     justify_block.as_leaf_block()
-        // };
 
         let should_not_propose_commands = can_propose_epoch_end || {
             // TODO: prevent proposers from proposing transactions after an epoch end command is in the justified
@@ -355,7 +346,7 @@ where TConsensusSpec: ConsensusSpec
 
         let mut substate_store = PendingSubstateStore::new(
             tx,
-            *start_of_chain_block.block_id(),
+            start_of_chain_block.as_leaf(),
             self.config.consensus_constants.num_preshards,
         );
 
@@ -392,30 +383,28 @@ where TConsensusSpec: ConsensusSpec
             // evidence. And that should determine if they are ready. However this is difficult because we
             // get the batch from the database which isnt aware of which foreign proposals we're going to
             // propose. This is why the system currently never proposes foreign proposals affecting a
-            // transaction in the same block for LocalPrepare/LocalAccept and can result in evidence in the
-            // atom having missing Prepare/Accept QCs (which are added on subsequent proposals).
-            // let locked_block = LockedBlock::get(tx, epoch)?;
-            // let num_proposals = batch.foreign_proposals.len();
-            // let foreign_proposals = mem::replace(&mut batch.foreign_proposals, Vec::with_capacity(num_proposals));
-            // for fp in foreign_proposals {
-            //     if let Err(err) = process_foreign_block(
-            //         tx,
-            //         &high_qc_certificate.as_leaf_block(),
-            //         &locked_block,
-            //         &fp,
-            //         local_committee_info,
-            //         &mut change_set,
-            //     ) {
-            //         warn!(
-            //             target: LOG_TARGET,
-            //             "Failed to process foreign proposal: {}. Skipping this proposal...",
-            //             err
-            //         );
-            //         // TODO: mark as invalid
-            //         continue;
-            //     }
-            //     batch.foreign_proposals.push(fp);
-            // }
+            // transaction in the same block for LocalPrepare/LocalAccept.
+            for fp in &batch.foreign_proposals {
+                if let Err(err) = process_foreign_block(
+                    tx,
+                    &high_qc_certificate.as_leaf_block(),
+                    fp,
+                    local_committee_info,
+                    &mut substate_store,
+                    &mut change_set,
+                ) {
+                    warn!(
+                        target: LOG_TARGET,
+                        "Failed to process foreign proposal: {}. Not proposing...",
+                        err
+                    );
+                    // TODO: should mark as invalid?
+                    continue;
+                }
+            }
+
+            // Add all (ABORT) executions that may have resulted from foreign proposals
+            executed_transactions.extend(change_set.take_all_transaction_executions());
 
             if !justify_block.has_justify_qc() {
                 // TODO: we dont need to process transactions here that are not in the batch

--- a/dan_layer/consensus/src/hotstuff/on_ready_to_vote_on_local_block.rs
+++ b/dan_layer/consensus/src/hotstuff/on_ready_to_vote_on_local_block.rs
@@ -283,7 +283,7 @@ where TConsensusSpec: ConsensusSpec
         // Store used for transactions that have inputs without specific versions.
         // It lives through the entire block so multiple transactions can be sequenced together in the same block
         let mut substate_store =
-            PendingSubstateStore::new(tx, *block.parent(), self.config.consensus_constants.num_preshards);
+            PendingSubstateStore::new(tx, block.as_leaf(), self.config.consensus_constants.num_preshards);
         let mut total_leader_fee = 0;
 
         for cmd in block.commands() {
@@ -1447,7 +1447,7 @@ where TConsensusSpec: ConsensusSpec
         if let Err(err) = process_foreign_block(
             tx,
             &local_block.as_leaf(),
-            &fp,
+            fp.proposal(),
             local_committee_info,
             substate_store,
             proposed_block_change_set,

--- a/dan_layer/consensus/src/hotstuff/on_receive_new_view.rs
+++ b/dan_layer/consensus/src/hotstuff/on_receive_new_view.rs
@@ -66,15 +66,20 @@ where TConsensusSpec: ConsensusSpec
         let _timer = TraceTimer::debug(LOG_TARGET, "OnReceiveNewView");
 
         let NewViewMessage {
-            high_pc: high_qc,
+            high_pc,
             last_vote,
             timeout,
         } = message;
         let timeout_height = timeout.height;
         info!(
             target: LOG_TARGET,
-            "🌟 NEWVIEW from {from} with timeout height {timeout_height} with qc {high_qc}",
+            "🌟 NEWVIEW from {from} with timeout height {timeout_height} with qc {high_pc}",
         );
+        if high_pc.epoch() != epoch_state.epoch() {
+            warn!(target: LOG_TARGET, "❌ NEWVIEW from {from} with epoch {} but current epoch is {}", high_pc.epoch(), epoch_state.epoch());
+            return Ok(());
+        }
+
         if timeout_height < current_height {
             warn!(target: LOG_TARGET, "❌ Ignoring NEWVIEW for {timeout_height} less than the current {current_height}.");
             return Ok(());
@@ -83,16 +88,16 @@ where TConsensusSpec: ConsensusSpec
         let is_qc_valid = self.store.with_read_tx(|tx| {
             let local_high_qc = HighPc::get(tx, epoch_state.epoch())?;
             // Only accept a higher QC than the local one
-            if local_high_qc.block_height > high_qc.height() {
+            if local_high_qc.block_height > high_pc.height() {
                 return Ok(false);
             }
 
-            if let Err(err) = self.validate_qc(&high_qc, epoch_state, self.proposal_vote_collector.signing_service()) {
+            if let Err(err) = self.validate_qc(&high_pc, epoch_state, self.proposal_vote_collector.signing_service()) {
                 warn!(target: LOG_TARGET, "❌ NEWVIEW: Invalid QC: {}", err);
                 return Ok(false);
             }
 
-            if !Block::record_exists(tx, &high_qc.calculate_block_id())? {
+            if !Block::record_exists(tx, &high_pc.calculate_block_id())? {
                 // Sync if we do not have the block for this valid QC
                 let local_height = LeafBlock::get(tx, epoch_state.epoch())
                     .optional()?
@@ -100,7 +105,7 @@ where TConsensusSpec: ConsensusSpec
                     .unwrap_or_default();
                 return Err(HotStuffError::FallenBehind {
                     local_height,
-                    qc_height: high_qc.height(),
+                    qc_height: high_pc.height(),
                 });
             }
 

--- a/dan_layer/consensus/src/hotstuff/substate_store/pending_store.rs
+++ b/dan_layer/consensus/src/hotstuff/substate_store/pending_store.rs
@@ -5,7 +5,7 @@ use std::{borrow::Cow, collections::HashMap, fmt::Display};
 
 use indexmap::IndexMap;
 use log::*;
-use tari_consensus_types::BlockId;
+use tari_consensus_types::LeafBlock;
 use tari_dan_common_types::{
     displayable::Displayable,
     optional::Optional,
@@ -44,12 +44,12 @@ pub struct PendingSubstateStore<'store, 'tx, TStore: StateStore + 'store + 'tx> 
     /// Append only list of changes ordered oldest to newest
     diff: Vec<SubstateChange>,
     new_locks: IndexMap<SubstateId, Vec<SubstateLock>>,
-    parent_block: BlockId,
+    parent_block: LeafBlock,
     num_preshards: NumPreshards,
 }
 
 impl<'a, 'tx, TStore: StateStore + 'a> PendingSubstateStore<'a, 'tx, TStore> {
-    pub fn new(store: &'a TStore::ReadTransaction<'tx>, parent_block: BlockId, num_preshards: NumPreshards) -> Self {
+    pub fn new(store: &'a TStore::ReadTransaction<'tx>, parent_block: LeafBlock, num_preshards: NumPreshards) -> Self {
         Self {
             store,
             pending: HashMap::new(),
@@ -67,7 +67,8 @@ impl<'a, 'tx, TStore: StateStore + 'a> PendingSubstateStore<'a, 'tx, TStore> {
 
     fn get_latest_change_from_store(&self, id: &SubstateId) -> Result<SubstateChange, SubstateStoreError> {
         if let Some(change) =
-            BlockDiff::get_last_change_for_substate(self.read_transaction(), &self.parent_block, id).optional()?
+            BlockDiff::get_last_change_for_substate(self.read_transaction(), self.parent_block.block_id(), id)
+                .optional()?
         {
             return Ok(change);
         }
@@ -198,7 +199,8 @@ impl<'store, 'tx, TStore: StateStore + 'store + 'tx> ReadableSubstateStore
         }
 
         if let Some(change) =
-            BlockDiff::get_for_versioned_substate(self.read_transaction(), &self.parent_block, id).optional()?
+            BlockDiff::get_for_versioned_substate(self.read_transaction(), self.parent_block.block_id(), id)
+                .optional()?
         {
             return change
                 .into_up()
@@ -312,7 +314,8 @@ impl<'store, 'tx, TStore: StateStore + 'store + 'tx> PendingSubstateStore<'store
         }
 
         if let Some(change) =
-            BlockDiff::get_last_change_for_substate(self.read_transaction(), &self.parent_block, id).optional()?
+            BlockDiff::get_last_change_for_substate(self.read_transaction(), self.parent_block.block_id(), id)
+                .optional()?
         {
             let version = change.versioned_substate_id().version();
             return Ok(LatestSubstateVersion {
@@ -438,7 +441,7 @@ impl<'store, 'tx, TStore: StateStore + 'store + 'tx> PendingSubstateStore<'store
         is_local_only: bool,
     ) -> Result<(), SubstateStoreError> {
         let requested_lock_type = requested_lock.lock_type();
-        info!(
+        debug!(
             target: LOG_TARGET,
             "🔒️ Requested substate lock: {}",
             requested_lock
@@ -446,7 +449,8 @@ impl<'store, 'tx, TStore: StateStore + 'store + 'tx> PendingSubstateStore<'store
 
         let versioned_substate_id = requested_lock.to_versioned_substate_id_ref();
 
-        let Some(existing) = self.get_latest_lock_by_id(versioned_substate_id.substate_id())? else {
+        let Some(existing) = self.get_latest_lock_by_id(&self.parent_block, versioned_substate_id.substate_id())?
+        else {
             if requested_lock_type.is_output() {
                 self.lock_assert_not_exist(versioned_substate_id)?;
             } else {
@@ -696,14 +700,18 @@ impl<'store, 'tx, TStore: StateStore + 'store + 'tx> PendingSubstateStore<'store
         self.diff.push(change)
     }
 
-    pub fn get_latest_lock_by_id(&self, id: &SubstateId) -> Result<Option<Cow<'_, SubstateLock>>, SubstateStoreError> {
+    pub fn get_latest_lock_by_id(
+        &self,
+        block: &LeafBlock,
+        id: &SubstateId,
+    ) -> Result<Option<Cow<'_, SubstateLock>>, SubstateStoreError> {
         if let Some(lock) = self.new_locks.get(id).and_then(|locks| locks.last()) {
             return Ok(Some(Cow::Borrowed(lock)));
         }
 
         let maybe_lock = self
             .read_transaction()
-            .substate_locks_get_latest_for_substate(id)
+            .substate_locks_get_latest_for_substate(block, id)
             .optional()?;
         Ok(maybe_lock.map(Cow::Owned))
     }
@@ -740,7 +748,8 @@ impl<'store, 'tx, TStore: StateStore + 'store + 'tx> PendingSubstateStore<'store
         );
 
         if let Some(change) =
-            BlockDiff::get_for_versioned_substate(self.read_transaction(), &self.parent_block, id).optional()?
+            BlockDiff::get_for_versioned_substate(self.read_transaction(), self.parent_block.block_id(), id)
+                .optional()?
         {
             if change.is_up() {
                 return Ok(());
@@ -780,7 +789,8 @@ impl<'store, 'tx, TStore: StateStore + 'store + 'tx> PendingSubstateStore<'store
         }
 
         if let Some(change) =
-            BlockDiff::get_for_versioned_substate(self.read_transaction(), &self.parent_block, id).optional()?
+            BlockDiff::get_for_versioned_substate(self.read_transaction(), self.parent_block.block_id(), id)
+                .optional()?
         {
             if change.is_up() {
                 return Err(SubstateStoreError::ExpectedSubstateDown { id: id.to_owned() });
@@ -811,7 +821,8 @@ impl<'store, 'tx, TStore: StateStore + 'store + 'tx> PendingSubstateStore<'store
         }
 
         if let Some(change) =
-            BlockDiff::get_for_versioned_substate(self.read_transaction(), &self.parent_block, id).optional()?
+            BlockDiff::get_for_versioned_substate(self.read_transaction(), self.parent_block.block_id(), id)
+                .optional()?
         {
             if change.is_up() {
                 return Err(SubstateStoreError::LockFailed(LockFailedError::SubstateIsUp {

--- a/dan_layer/consensus/src/hotstuff/worker.rs
+++ b/dan_layer/consensus/src/hotstuff/worker.rs
@@ -730,7 +730,7 @@ impl<TConsensusSpec: ConsensusSpec> HotstuffWorker<TConsensusSpec> {
             }
         }
 
-        self.propose_now(epoch_state, next_height, *local_claim_public_key)
+        self.propose_now(epoch_state, next_height, false, *local_claim_public_key)
             .await?;
 
         Ok(())
@@ -799,8 +799,13 @@ impl<TConsensusSpec: ConsensusSpec> HotstuffWorker<TConsensusSpec> {
                 .len(),
         );
 
-        self.propose_now(epoch_state, next_height_to_propose, *local_claim_public_key)
-            .await?;
+        self.propose_now(
+            epoch_state,
+            next_height_to_propose,
+            forced_height.is_some(),
+            *local_claim_public_key,
+        )
+        .await?;
 
         Ok(())
     }
@@ -809,6 +814,7 @@ impl<TConsensusSpec: ConsensusSpec> HotstuffWorker<TConsensusSpec> {
         &mut self,
         epoch_state: &EpochState<TConsensusSpec::Addr>,
         next_height: NodeHeight,
+        is_timeout: bool,
         local_claim_public_key: RistrettoPublicKeyBytes,
     ) -> Result<(), HotStuffError> {
         // We use the highest seen block - specifically to handle the case where a block is proposed and locally
@@ -854,6 +860,16 @@ impl<TConsensusSpec: ConsensusSpec> HotstuffWorker<TConsensusSpec> {
             ) {
                 dummy_block = Some(dummy);
             }
+        } else if is_timeout {
+            // If this is a timeout (without dummies because the highest block is the parent), we need to propose with
+            // the highest timeout certificate
+            let high_tc = self.state_store.with_read_tx(|tx| {
+                let high_tc = HighTc::get(tx, epoch_state.epoch())?;
+                TimeoutCertificate::get(tx, high_tc.epoch(), high_tc.id())
+            })?;
+            propose_high_tc = Some(high_tc);
+        } else {
+            // Nothing to do
         }
 
         // TODO: suggest adding self.epoch_manager.did_epoch_change_recently() and only propose when that is not the

--- a/dan_layer/consensus_tests/src/consensus.rs
+++ b/dan_layer/consensus_tests/src/consensus.rs
@@ -1245,11 +1245,11 @@ async fn multishard_unversioned_input_conflict() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn multishard_unversioned_input_conflict_delay_prepare() {
-    // CASE: Tx1 and Tx2 use id1 as an input, Comm1 sequences Tx1 and simultaneously Comm2 sequences Tx2.
-    // Since the id2 and id3 substates are uncommon to the transactions and live in Comm2, Comm2 and lock both
-    // transactions. Comm1 will not have yet pledged a value for id1 to Tx1. This allows Comm1 to delay sequencing Tx1
-    // (due to a soft lock conflict) until Tx2 is finalized. The output of Tx2 will be pledged to Tx1.
-    // This is a natural consequence (i.e. no special code) of the local substate locks.
+    // CASE: Tx1 and Tx2 use id1 as an input, Committee0 sequences Tx1 and simultaneously Committee1 sequences Tx2.
+    // Since the id2 and id3 substates are uncommon to the transactions and live in Committee1, Committee1 can lock both
+    // transactions. Committee0 will not have yet pledged the value for id1 to Tx1. This allows Committee0 to delay
+    // sequencing Tx1 (due to a soft lock conflict) until Tx2 is finalized. The output of Tx2 will be pledged to
+    // Tx1. This is a natural consequence (i.e. no special code) of the local substate locks.
     setup_logger();
     let mut test = Test::builder()
         .add_committee(0, vec!["1", "2"])

--- a/dan_layer/consensus_tests/src/leader_failure.rs
+++ b/dan_layer/consensus_tests/src/leader_failure.rs
@@ -291,7 +291,6 @@ async fn multi_shard_node_goes_down() {
     // proof still validates with dummy blocks included
     setup_logger();
     let mut test = Test::builder()
-        .with_rocks_path("/tmp/test{}")
         // Allow enough time for leader failures
         .with_test_timeout(Duration::from_secs(60))
         .modify_consensus_constants(|config_mut| {

--- a/dan_layer/consensus_tests/src/substate_store.rs
+++ b/dan_layer/consensus_tests/src/substate_store.rs
@@ -6,8 +6,17 @@ use tari_consensus::{
     hotstuff::substate_store::{LockFailedError, PendingSubstateStore, SubstateStoreError},
     traits::{CertificateStore, ReadableSubstateStore, WriteableSubstateStore},
 };
-use tari_consensus_types::{BlockId, QcId};
-use tari_dan_common_types::{shard::Shard, NumPreshards, PeerAddress, SubstateLockType, VersionedSubstateId};
+use tari_consensus_types::{BlockId, LeafBlock, QcId};
+use tari_dan_common_types::{
+    shard::Shard,
+    Epoch,
+    NodeHeight,
+    NumPreshards,
+    PeerAddress,
+    ShardGroup,
+    SubstateLockType,
+    VersionedSubstateId,
+};
 use tari_dan_storage::{
     consensus_models::{Block, RequireLockIntentRef, SubstateChange, SubstateRecord},
     StateStore,
@@ -235,7 +244,16 @@ fn create_store() -> (TestStore, TempDir) {
 fn create_pending_store<'a, 'tx, TStore: StateStore>(
     tx: &'a TStore::ReadTransaction<'tx>,
 ) -> PendingSubstateStore<'a, 'tx, TStore> {
-    PendingSubstateStore::new(tx, BlockId::zero(), TEST_NUM_PRESHARDS)
+    PendingSubstateStore::new(
+        tx,
+        LeafBlock {
+            block_id: BlockId::zero(),
+            height: NodeHeight::zero(),
+            epoch: Epoch::zero(),
+            shard_group: ShardGroup::all_shards(TEST_NUM_PRESHARDS),
+        },
+        TEST_NUM_PRESHARDS,
+    )
 }
 
 fn new_substate_id(seed: u8) -> SubstateId {

--- a/dan_layer/state_store_rocksdb/src/cf_api.rs
+++ b/dan_layer/state_store_rocksdb/src/cf_api.rs
@@ -8,7 +8,7 @@ use std::{
     ops::Range,
 };
 
-use rocksdb::{ColumnFamily, IterateBounds, IteratorMode, Transaction, TransactionDB};
+use rocksdb::{ColumnFamily, IterateBounds, IteratorMode, TransactionDB};
 use tari_dan_common_types::displayable::Displayable;
 use tari_dan_storage::Ordering;
 
@@ -18,20 +18,17 @@ use crate::{
     traits::{Cf, QueryCf, RocksReader, RocksWriter},
 };
 
-pub struct DbContext<'db> {
+pub struct DbContext<'db, TX> {
     db: &'db TransactionDB,
-    tx: &'db Transaction<'db, TransactionDB>,
+    tx: &'db TX,
 }
 
-impl<'db> DbContext<'db> {
-    pub(crate) fn new(db: &'db TransactionDB, tx: &'db Transaction<'db, TransactionDB>) -> Self {
+impl<'db, TX> DbContext<'db, TX> {
+    pub(crate) fn new(db: &'db TransactionDB, tx: &'db TX) -> Self {
         Self { db, tx }
     }
 
-    pub fn cf<CF: Cf>(
-        &self,
-        _cf: CF,
-    ) -> Result<CfContext<'db, Transaction<'db, TransactionDB>, CF>, RocksDbStorageError> {
+    pub fn cf<CF: Cf>(&self, _cf: CF) -> Result<CfContext<'db, TX, CF>, RocksDbStorageError> {
         let handle = self
             .db
             .cf_handle(CF::name())

--- a/dan_layer/state_store_rocksdb/src/codecs/bytes.rs
+++ b/dan_layer/state_store_rocksdb/src/codecs/bytes.rs
@@ -4,8 +4,6 @@
 use std::any::type_name;
 
 use anyhow::anyhow;
-use tari_common_types::types::FixedHash;
-use tari_consensus_types::BlockId;
 
 use crate::{
     codecs::{DbCodec, EncodeVec},
@@ -36,6 +34,7 @@ where
 }
 pub type FixedBytesCodec32 = FixedBytesCodec<32>;
 pub type TransactionIdCodec = FixedBytesCodec<32>;
+pub type BlockIdCodec = FixedBytesCodec<32>;
 
 #[derive(Debug, Clone, Copy, Default)]
 pub struct FixedBytesCodec<const LEN: usize>;
@@ -55,21 +54,5 @@ where
         })?;
         let ret = T::from(fixed);
         Ok(ret)
-    }
-}
-
-#[derive(Debug, Clone, Copy, Default)]
-pub struct BlockIdCodec;
-
-impl DbCodec<BlockId> for BlockIdCodec {
-    fn encode(&self, value: &BlockId) -> Result<EncodeVec, RocksDbStorageError> {
-        Ok(EncodeVec::new_from_array(value.into_array()))
-    }
-
-    fn decode(&self, mut bytes: &[u8]) -> Result<BlockId, RocksDbStorageError> {
-        let hash = read_to_fixed(&mut bytes).ok_or_else(|| RocksDbStorageError::DecodeError {
-            source: anyhow!("BlockIdCodec: failed to decode too few bytes"),
-        })?;
-        Ok(BlockId::new(FixedHash::new(hash)))
     }
 }

--- a/dan_layer/state_store_rocksdb/src/codecs/substate_lock.rs
+++ b/dan_layer/state_store_rocksdb/src/codecs/substate_lock.rs
@@ -4,6 +4,7 @@
 use anyhow::anyhow;
 use tari_common_types::types::FixedHash;
 use tari_consensus_types::BlockId;
+use tari_dan_common_types::NodeHeight;
 use tari_engine_types::substate::SubstateId;
 use tari_transaction::TransactionId;
 
@@ -38,17 +39,29 @@ impl<T> SubstateLockKeyCodec<T> {
         let substate_id = self.substate_id_codec.decode_reader(reader)?;
         Ok(substate_id)
     }
+
+    fn decode_block_height(&self, reader: &mut &[u8]) -> Result<NodeHeight, RocksDbStorageError> {
+        let height = read_to_fixed(reader).ok_or_else(|| RocksDbStorageError::DecodeError {
+            source: anyhow!(
+                "SubstateLockKeyCodec: Invalid bytes len={} for NodeHeight",
+                reader.len()
+            ),
+        })?;
+        Ok(NodeHeight(u64::from_be_bytes(height)))
+    }
 }
 
-impl DbCodec<SubstateLockKey> for SubstateLockKeyCodec<(TransactionId, SubstateId, BlockId)> {
+impl DbCodec<SubstateLockKey> for SubstateLockKeyCodec<(TransactionId, SubstateId, BlockId, NodeHeight)> {
     fn encode(&self, value: &SubstateLockKey) -> Result<EncodeVec, RocksDbStorageError> {
         let tx_id_bytes = value.transaction_id.as_bytes();
         let block_id_bytes = value.block_id.as_bytes();
         let substate_id_bytes = self.substate_id_codec.encode(&value.substate_id)?;
+        let block_height_bytes = value.block_height.as_u64().to_be_bytes();
         Ok(EncodeVec::from_slices(&[
             tx_id_bytes,
             &substate_id_bytes,
             block_id_bytes,
+            &block_height_bytes,
         ]))
     }
 
@@ -57,23 +70,27 @@ impl DbCodec<SubstateLockKey> for SubstateLockKeyCodec<(TransactionId, SubstateI
         let transaction_id = self.decode_transaction_id(reader)?;
         let substate_id = self.decode_substate_id(reader)?;
         let block_id = self.decode_block_id(reader)?;
+        let block_height = self.decode_block_height(reader)?;
         Ok(SubstateLockKey {
             block_id,
             substate_id,
             transaction_id,
+            block_height,
         })
     }
 }
 
-impl DbCodec<SubstateLockKey> for SubstateLockKeyCodec<(BlockId, SubstateId, TransactionId)> {
+impl DbCodec<SubstateLockKey> for SubstateLockKeyCodec<(BlockId, SubstateId, TransactionId, NodeHeight)> {
     fn encode(&self, value: &SubstateLockKey) -> Result<EncodeVec, RocksDbStorageError> {
         let tx_id_bytes = value.transaction_id.as_bytes();
         let block_id_bytes = value.block_id.as_bytes();
         let substate_id_bytes = self.substate_id_codec.encode(&value.substate_id)?;
+        let block_height_bytes = value.block_height.as_u64().to_be_bytes();
         Ok(EncodeVec::from_slices(&[
             block_id_bytes,
             &substate_id_bytes,
             tx_id_bytes,
+            &block_height_bytes,
         ]))
     }
 
@@ -82,24 +99,28 @@ impl DbCodec<SubstateLockKey> for SubstateLockKeyCodec<(BlockId, SubstateId, Tra
         let block_id = self.decode_block_id(reader)?;
         let substate_id = self.decode_substate_id(reader)?;
         let transaction_id = self.decode_transaction_id(reader)?;
+        let block_height = self.decode_block_height(reader)?;
 
         Ok(SubstateLockKey {
             block_id,
             substate_id,
             transaction_id,
+            block_height,
         })
     }
 }
 
-impl DbCodec<SubstateLockKey> for SubstateLockKeyCodec<(SubstateId, TransactionId, BlockId)> {
+impl DbCodec<SubstateLockKey> for SubstateLockKeyCodec<(SubstateId, TransactionId, BlockId, NodeHeight)> {
     fn encode(&self, value: &SubstateLockKey) -> Result<EncodeVec, RocksDbStorageError> {
         let tx_id_bytes = value.transaction_id.as_bytes();
         let block_id_bytes = value.block_id.as_bytes();
         let substate_id_bytes = self.substate_id_codec.encode(&value.substate_id)?;
+        let block_height_bytes = value.block_height.as_u64().to_be_bytes();
         Ok(EncodeVec::from_slices(&[
             &substate_id_bytes,
             tx_id_bytes,
             block_id_bytes,
+            &block_height_bytes,
         ]))
     }
 
@@ -108,11 +129,13 @@ impl DbCodec<SubstateLockKey> for SubstateLockKeyCodec<(SubstateId, TransactionI
         let substate_id = self.decode_substate_id(reader)?;
         let transaction_id = self.decode_transaction_id(reader)?;
         let block_id = self.decode_block_id(reader)?;
+        let block_height = self.decode_block_height(reader)?;
 
         Ok(SubstateLockKey {
             block_id,
             substate_id,
             transaction_id,
+            block_height,
         })
     }
 }

--- a/dan_layer/state_store_rocksdb/src/column_families/substate_locks.rs
+++ b/dan_layer/state_store_rocksdb/src/column_families/substate_locks.rs
@@ -20,11 +20,11 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::fmt::Display;
+use std::{fmt::Display, marker::PhantomData};
 
 use serde::Serialize;
 use tari_consensus_types::BlockId;
-use tari_dan_common_types::SubstateLockType;
+use tari_dan_common_types::{NodeHeight, SubstateLockType};
 use tari_dan_storage::consensus_models::SubstateLock;
 use tari_engine_types::substate::SubstateId;
 use tari_transaction::TransactionId;
@@ -37,6 +37,7 @@ use crate::{
 #[derive(Debug, PartialEq, Eq, Serialize)]
 pub struct SubstateLockKey {
     pub block_id: BlockId,
+    pub block_height: NodeHeight,
     pub substate_id: SubstateId,
     pub transaction_id: TransactionId,
 }
@@ -45,8 +46,8 @@ impl Display for SubstateLockKey {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "SubstateLockKey {{ block_id: {}, substate_id: {}, transaction_id: {} }}",
-            self.block_id, self.substate_id, self.transaction_id
+            "SubstateLockKey {{ block: {}/{}, substate_id: {}, transaction_id: {} }}",
+            self.block_height, self.block_id, self.substate_id, self.transaction_id
         )
     }
 }
@@ -55,7 +56,7 @@ pub struct SubstateLockModel;
 
 impl Cf for SubstateLockModel {
     type Key = SubstateLockKey;
-    type KeyCodec = SubstateLockKeyCodec<(TransactionId, SubstateId, BlockId)>;
+    type KeyCodec = SubstateLockKeyCodec<(TransactionId, SubstateId, BlockId, NodeHeight)>;
     type Value = SubstateLock;
     type ValueCodec = DefaultCodec<Self::Value>;
 
@@ -70,7 +71,7 @@ impl Cf for HeadIndex {
     type Key = SubstateId;
     type KeyCodec = SubstateIdCodec;
     type Value = SubstateLockKey;
-    type ValueCodec = SubstateLockKeyCodec<(TransactionId, SubstateId, BlockId)>;
+    type ValueCodec = SubstateLockKeyCodec<(TransactionId, SubstateId, BlockId, NodeHeight)>;
 
     fn name() -> &'static str {
         "locks_head_idx"
@@ -89,7 +90,7 @@ pub struct BlockIdIndex;
 
 impl Cf for BlockIdIndex {
     type Key = SubstateLockKey;
-    type KeyCodec = SubstateLockKeyCodec<(BlockId, SubstateId, TransactionId)>;
+    type KeyCodec = SubstateLockKeyCodec<(BlockId, SubstateId, TransactionId, NodeHeight)>;
     type Value = ();
     type ValueCodec = UnitCodec;
 
@@ -106,11 +107,20 @@ impl QueryCf for ByBlockIdQuery {
     type KeyCodec = BlockIdCodec;
 }
 
+#[derive(Default)]
+pub struct ByBlockIdSubstateIdQuery<'a>(PhantomData<&'a ()>);
+
+impl<'a> QueryCf for ByBlockIdSubstateIdQuery<'a> {
+    type Cf = BlockIdIndex;
+    type Key = (BlockId, &'a SubstateId);
+    type KeyCodec = (BlockIdCodec, SubstateIdCodec);
+}
+
 pub struct SubstateIdIndex;
 
 impl Cf for SubstateIdIndex {
     type Key = SubstateLockKey;
-    type KeyCodec = SubstateLockKeyCodec<(SubstateId, TransactionId, BlockId)>;
+    type KeyCodec = SubstateLockKeyCodec<(SubstateId, TransactionId, BlockId, NodeHeight)>;
     type Value = SubstateLockType;
     type ValueCodec = DefaultCodec<Self::Value>;
 

--- a/dan_layer/state_store_rocksdb/src/lib.rs
+++ b/dan_layer/state_store_rocksdb/src/lib.rs
@@ -34,10 +34,11 @@ pub use store::*;
 
 mod dbs;
 mod info;
-pub mod read_only;
+pub mod read_only_ctx;
 pub mod snapshot;
 
 mod options;
 pub use options::*;
+mod read_only;
 #[cfg(test)]
 mod tests;

--- a/dan_layer/state_store_rocksdb/src/read_only.rs
+++ b/dan_layer/state_store_rocksdb/src/read_only.rs
@@ -1,27 +1,55 @@
 //   Copyright 2025 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use std::any::type_name;
+use rocksdb::{AsColumnFamilyRef, DBIteratorWithThreadMode, DBPinnableSlice, Error, IteratorMode, ReadOptions};
 
-use crate::{cf_api::CfContext, dbs::read_only::ReadOnlyDb, error::RocksDbStorageError, traits::Cf};
+use crate::traits::RocksReader;
 
-pub struct ReadOnlyContext<'db> {
-    db: &'db ReadOnlyDb,
+#[derive(Debug, Clone)]
+pub struct ReadOnly<TX> {
+    pub(crate) inner: TX,
 }
 
-impl<'db> ReadOnlyContext<'db> {
-    pub(crate) fn new(db: &'db ReadOnlyDb) -> Self {
-        Self { db }
+impl<TX> ReadOnly<TX> {
+    pub fn new(inner: TX) -> Self {
+        Self { inner }
+    }
+}
+
+impl<TX: RocksReader> RocksReader for ReadOnly<TX> {
+    type Db = TX::Db;
+
+    fn get_pinned_cf<K: AsRef<[u8]>>(
+        &self,
+        cf: &impl AsColumnFamilyRef,
+        key: K,
+    ) -> Result<Option<DBPinnableSlice>, Error> {
+        self.inner.get_pinned_cf(cf, key)
     }
 
-    pub fn cf<CF: Cf>(&'db self, _cf: CF) -> Result<CfContext<'db, ReadOnlyDb, CF>, RocksDbStorageError> {
-        let handle = self
-            .db
-            .cf_handle(CF::name())
-            .ok_or_else(|| RocksDbStorageError::ColumnFamilyNotFound {
-                operation: "create CF context",
-                cf: format!("CF={}, cf_name={}", type_name::<CF>(), CF::name()),
-            })?;
-        CfContext::create(self.db, handle)
+    fn iterator_cf<'a: 'b, 'b>(
+        &'a self,
+        cf_handle: &impl AsColumnFamilyRef,
+        mode: IteratorMode,
+    ) -> DBIteratorWithThreadMode<'b, Self::Db> {
+        self.inner.iterator_cf(cf_handle, mode)
+    }
+
+    fn iterator_cf_opt<'a: 'b, 'b>(
+        &'a self,
+        cf_handle: &impl AsColumnFamilyRef,
+        readopts: ReadOptions,
+        mode: IteratorMode,
+    ) -> DBIteratorWithThreadMode<'b, Self::Db> {
+        self.inner.iterator_cf_opt(cf_handle, readopts, mode)
+    }
+
+    fn multi_get_cf<'a, 'b: 'a, K, I, W>(&'a self, keys: I) -> Vec<Result<Option<Vec<u8>>, Error>>
+    where
+        K: AsRef<[u8]>,
+        I: IntoIterator<Item = (&'b W, K)>,
+        W: 'b + AsColumnFamilyRef,
+    {
+        self.inner.multi_get_cf(keys)
     }
 }

--- a/dan_layer/state_store_rocksdb/src/read_only_ctx.rs
+++ b/dan_layer/state_store_rocksdb/src/read_only_ctx.rs
@@ -1,0 +1,27 @@
+//   Copyright 2025 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+use std::any::type_name;
+
+use crate::{cf_api::CfContext, dbs::read_only::ReadOnlyDb, error::RocksDbStorageError, traits::Cf};
+
+pub struct ReadOnlyContext<'db> {
+    db: &'db ReadOnlyDb,
+}
+
+impl<'db> ReadOnlyContext<'db> {
+    pub(crate) fn new(db: &'db ReadOnlyDb) -> Self {
+        Self { db }
+    }
+
+    pub fn cf<CF: Cf>(&'db self, _cf: CF) -> Result<CfContext<'db, ReadOnlyDb, CF>, RocksDbStorageError> {
+        let handle = self
+            .db
+            .cf_handle(CF::name())
+            .ok_or_else(|| RocksDbStorageError::ColumnFamilyNotFound {
+                operation: "create CF context",
+                cf: format!("CF={}, cf_name={}", type_name::<CF>(), CF::name()),
+            })?;
+        CfContext::create(self.db, handle)
+    }
+}

--- a/dan_layer/state_store_rocksdb/src/reader.rs
+++ b/dan_layer/state_store_rocksdb/src/reader.rs
@@ -151,18 +151,21 @@ use crate::{
         validator_node_epoch_stats::ValidatorNodeEpochStatsCf,
     },
     error::RocksDbStorageError,
+    read_only::ReadOnly,
 };
 
 const LOG_TARGET: &str = "tari::dan::storage::state_store_rocksdb::reader";
 
+pub(crate) type ReadOnlyTransaction<'a> = ReadOnly<Transaction<'a, TransactionDB>>;
+
 pub struct RocksDbStateStoreReadTransaction<'a, TAddr> {
-    tx: Transaction<'a, TransactionDB>,
+    tx: ReadOnlyTransaction<'a>,
     db: &'a TransactionDB,
     _addr: PhantomData<TAddr>,
 }
 
 impl<'a, TAddr> RocksDbStateStoreReadTransaction<'a, TAddr> {
-    pub(crate) fn new(db: &'a TransactionDB, tx: Transaction<'a, TransactionDB>) -> Self {
+    pub(crate) fn new(db: &'a TransactionDB, tx: ReadOnlyTransaction<'a>) -> Self {
         Self {
             tx,
             db,
@@ -170,28 +173,16 @@ impl<'a, TAddr> RocksDbStateStoreReadTransaction<'a, TAddr> {
         }
     }
 
-    pub fn db(&self) -> DbContext<'_> {
+    pub fn db(&self) -> DbContext<'_, ReadOnlyTransaction<'_>> {
         DbContext::new(self.db, &self.tx)
     }
 
     pub(crate) fn rocksdb_transaction(&self) -> &Transaction<'a, TransactionDB> {
-        &self.tx
+        &self.tx.inner
     }
 
-    pub(crate) fn commit(self) -> Result<(), RocksDbStorageError> {
-        self.tx.commit().map_err(|source| RocksDbStorageError::RocksDbError {
-            source,
-            operation: "commit",
-        })?;
-        Ok(())
-    }
-
-    pub(crate) fn rollback(self) -> Result<(), RocksDbStorageError> {
-        self.tx.rollback().map_err(|source| RocksDbStorageError::RocksDbError {
-            source,
-            operation: "commit",
-        })?;
-        Ok(())
+    pub(crate) fn into_rocksdb_transaction(self) -> Transaction<'a, TransactionDB> {
+        self.tx.inner
     }
 }
 
@@ -246,7 +237,7 @@ impl<'a, TAddr: NodeAddressable + Serialize + DeserializeOwned + 'a> RocksDbStat
             "{OPERATION}: end block {end_block} is in pending chain",
         );
 
-        let commit_block = self.get_commit_block_id()?;
+        let commit_block = self.get_commit_block()?;
 
         while let Some(parent_id) = chain_cf.get(&block_id, OPERATION).optional()? {
             trace!(
@@ -355,7 +346,7 @@ impl<'a, TAddr: NodeAddressable + Serialize + DeserializeOwned + 'a> RocksDbStat
         Ok(blocks)
     }
 
-    pub fn get_commit_block_id(&self) -> Result<CommitBlock, RocksDbStorageError> {
+    pub fn get_commit_block(&self) -> Result<CommitBlock, RocksDbStorageError> {
         let cf = self.db().cf(CommitBlockCf)?;
         let value = cf.get_by_default_key("get_commit_block")?;
         Ok(value)
@@ -782,7 +773,7 @@ impl<'tx, TAddr: NodeAddressable + Serialize + DeserializeOwned + 'tx> StateStor
         Ok(exists)
     }
 
-    fn blocks_is_ancestor(&self, descendant: &BlockId, ancestor: &BlockId) -> Result<bool, StorageError> {
+    fn blocks_is_pending_ancestor(&self, descendant: &BlockId, ancestor: &BlockId) -> Result<bool, StorageError> {
         const OPERATION: &str = "blocks_is_ancestor";
         // Defensive checks, technically not needed as this will return false if the blocks do not exist.
         // We could remove them to save some reads on the blocks CF.
@@ -798,12 +789,9 @@ impl<'tx, TAddr: NodeAddressable + Serialize + DeserializeOwned + 'tx> StateStor
             });
         }
 
-        // TODO: This only works for non-committed/pending blocks - we only use this for the safenode predicate where
+        // NOTE: This only works for non-committed/pending blocks - we only use this for the safenode predicate where
         // the ancestor block is the locked block and so is in the pending chain. Therefore, the pending chain
-        // index is sufficient. This differs from the Sqlite implementation which provides the correct result
-        // for any block. Changing the trait method name and SQLite impl to reflect that this only returns the
-        // result for pending blocks would be a good idea.
-
+        // index is sufficient.
         let chain_cf = self.db().cf(chain::PendingChainIndex)?;
 
         let mut block_id = *descendant;
@@ -1211,7 +1199,7 @@ impl<'tx, TAddr: NodeAddressable + Serialize + DeserializeOwned + 'tx> StateStor
         const OPERATION: &str = "transaction_pool_get_all";
         let cf = self.db().cf(TransactionPoolCf)?;
 
-        let commit_block = self.get_commit_block_id()?;
+        let commit_block = self.get_commit_block()?;
         let pending_chain = self.get_pending_chain_ordered(&commit_block.block_id)?;
         let query = self.db().cf(transaction_pool_state_update::ByBlockIdQuery)?;
         let mut updates = HashMap::new();
@@ -1463,6 +1451,12 @@ impl<'tx, TAddr: NodeAddressable + Serialize + DeserializeOwned + 'tx> StateStor
         Ok(locked_substates)
     }
 
+    /// Returns the transaction ID of any write lock found for any of the given substates, or None if there are no write
+    /// locks.
+    ///
+    /// # Used for:
+    /// Foreign proposal conflict resolution, to check if there is a conflicting write lock in a foreign proposal by
+    /// another locally proposed transaction.
     fn substate_locks_has_any_write_locks_for_substates<'a, I: IntoIterator<Item = &'a SubstateId>>(
         &self,
         exclude_transaction_id: Option<&TransactionId>,
@@ -1483,10 +1477,8 @@ impl<'tx, TAddr: NodeAddressable + Serialize + DeserializeOwned + 'tx> StateStor
                 if !lock_type.is_write() {
                     continue;
                 }
-                if let Some(exclude_transaction_id) = exclude_transaction_id {
-                    if key.transaction_id == *exclude_transaction_id {
-                        continue;
-                    }
+                if exclude_transaction_id.is_some_and(|ex| *ex == key.transaction_id) {
+                    continue;
                 }
 
                 return Ok(Some(key.transaction_id));
@@ -1496,12 +1488,58 @@ impl<'tx, TAddr: NodeAddressable + Serialize + DeserializeOwned + 'tx> StateStor
         Ok(None)
     }
 
-    fn substate_locks_get_latest_for_substate(&self, substate_id: &SubstateId) -> Result<SubstateLock, StorageError> {
+    /// Returns the latest substate lock for a given substate ID, searching through the pending chain and committed
+    /// chain.
+    ///
+    /// # Used for:
+    /// Local proposal conflict resolution, to check if a substate is locked by another transaction.
+    fn substate_locks_get_latest_for_substate(
+        &self,
+        leaf_block: &LeafBlock,
+        substate_id: &SubstateId,
+    ) -> Result<SubstateLock, StorageError> {
         const OPERATION: &str = "substate_locks_get_latest_for_substate";
-
         let cf = self.db().cf(SubstateLockModel)?;
-        let index = self.db().cf(substate_locks::HeadIndex)?;
-        let key = index.get(substate_id, OPERATION)?;
+
+        let pending_chain = self.get_pending_chain_ordered(leaf_block.block_id())?;
+
+        // Check if the substate lock is in the head index (typical case optimisation)
+        let head_idx = self.db().cf(substate_locks::HeadIndex)?;
+        if let Some(head) = head_idx.get(substate_id, OPERATION).optional()? {
+            if pending_chain.contains(&head.block_id) {
+                let lock = cf.get(&head, OPERATION)?;
+                return Ok(lock);
+            }
+        }
+
+        let query = self.db().cf(substate_locks::ByBlockIdSubstateIdQuery::default())?;
+
+        // TODO: this is on the critical path, improve performance
+        for block_id in &pending_chain {
+            let mut iter = query.query_prefix_range_key_iterator(Ordering::default(), &(*block_id, substate_id));
+            if let Some(result) = iter.next() {
+                let key = result?;
+                let lock = cf.get(&key, OPERATION)?;
+                return Ok(lock);
+            }
+        }
+
+        // In the committed chain?
+        let commit_block = self.get_commit_block()?;
+        let query = self.db().cf(substate_locks::BySubstateIdQuery)?;
+        let mut iter = query.query_prefix_range_key_iterator(Ordering::default(), substate_id);
+        let key = iter
+            .find_map(|r| match r {
+                Ok(key) if key.block_height <= commit_block.height => Some(Ok(key)),
+                Ok(_) => None,
+                Err(err) => Some(Err(err)),
+            })
+            .transpose()?
+            .ok_or_else(|| StorageError::NotFound {
+                item: "SubstateLock",
+                key: format!("for substate {substate_id} in block {leaf_block}"),
+            })?;
+
         let lock = cf.get(&key, OPERATION)?;
         Ok(lock)
     }

--- a/dan_layer/state_store_rocksdb/src/store.rs
+++ b/dan_layer/state_store_rocksdb/src/store.rs
@@ -70,7 +70,8 @@ use crate::{
     error::RocksDbStorageError,
     info::ColumnFamilyInfo,
     options::DatabaseOptions,
-    read_only::ReadOnlyContext,
+    read_only::ReadOnly,
+    read_only_ctx::ReadOnlyContext,
     reader::RocksDbStateStoreReadTransaction,
     snapshot::SnapshotContext,
     traits::{Cf, RocksDatabase, RocksReader},
@@ -291,7 +292,7 @@ impl<TAddr: NodeAddressable + Serialize + DeserializeOwned> StateStore for Rocks
         // are incorrect, they can be simply be defaulted.
         opts.set_max_write_batch_size(1);
         write_opts.disable_wal(true);
-        let tx = self.db.transaction_opt(&write_opts, &opts);
+        let tx = ReadOnly::new(self.db.transaction_opt(&write_opts, &opts));
         Ok(RocksDbStateStoreReadTransaction::new(&self.db, tx))
     }
 

--- a/dan_layer/state_store_rocksdb/src/tests.rs
+++ b/dan_layer/state_store_rocksdb/src/tests.rs
@@ -32,7 +32,10 @@ pub fn create_rocksdb(cf_names: impl IntoIterator<Item = &'static str>) -> (Tran
     (db, temp_dir)
 }
 
-pub fn ctx<'a>(db: &'a TransactionDB<SingleThreaded>, tx: &'a Transaction<TransactionDB>) -> DbContext<'a> {
+pub fn ctx<'a>(
+    db: &'a TransactionDB<SingleThreaded>,
+    tx: &'a Transaction<TransactionDB>,
+) -> DbContext<'a, Transaction<'a, TransactionDB<SingleThreaded>>> {
     DbContext::new(db, tx)
 }
 

--- a/dan_layer/state_store_rocksdb/src/writer.rs
+++ b/dan_layer/state_store_rocksdb/src/writer.rs
@@ -153,12 +153,16 @@ use crate::{
         transaction_pool_state_update::{TransactionPoolStateUpdateCf, TransactionPoolStateUpdateData},
         validator_node_epoch_stats::ValidatorNodeEpochStatsCf,
     },
+    error::RocksDbStorageError,
     options::DatabaseOptions,
+    read_only::ReadOnly,
     reader::RocksDbStateStoreReadTransaction,
     utils::now,
 };
 
 const LOG_TARGET: &str = "tari::dan::storage::state_store_rocksdb::writer";
+
+type DbWriteContext<'a> = DbContext<'a, Transaction<'a, TransactionDB>>;
 
 pub struct RocksDbStateStoreWriteTransaction<'a, TAddr> {
     /// None indicates if the transaction has been explicitly committed/rolled back
@@ -171,12 +175,13 @@ impl<'a, TAddr: NodeAddressable> RocksDbStateStoreWriteTransaction<'a, TAddr> {
     pub(crate) fn new(db: &'a TransactionDB, tx: Transaction<'a, TransactionDB>, options: &'a DatabaseOptions) -> Self {
         Self {
             db,
-            transaction: Some(RocksDbStateStoreReadTransaction::new(db, tx)),
+            // We have access to the inner transaction so we can use it to read/write
+            transaction: Some(RocksDbStateStoreReadTransaction::new(db, ReadOnly::new(tx))),
             options,
         }
     }
 
-    fn db(&self) -> DbContext<'_> {
+    pub fn db(&self) -> DbWriteContext<'_> {
         DbContext::new(self.db, self.tx())
     }
 
@@ -233,7 +238,14 @@ impl<'tx, TAddr: NodeAddressable + 'tx> StateStoreWriteTransaction for RocksDbSt
 
     fn commit(&mut self) -> Result<(), StorageError> {
         // Take so that we mark this transaction as complete in the drop impl
-        self.transaction.take().expect("commit: already committed").commit()?;
+        let tx = self.transaction.take().expect("commit: already committed");
+
+        tx.into_rocksdb_transaction()
+            .commit()
+            .map_err(|source| RocksDbStorageError::RocksDbError {
+                source,
+                operation: "commit",
+            })?;
         Ok(())
     }
 
@@ -242,7 +254,12 @@ impl<'tx, TAddr: NodeAddressable + 'tx> StateStoreWriteTransaction for RocksDbSt
         self.transaction
             .take()
             .expect("rollback: already committed")
-            .rollback()?;
+            .into_rocksdb_transaction()
+            .rollback()
+            .map_err(|source| RocksDbStorageError::RocksDbError {
+                source,
+                operation: "commit",
+            })?;
         Ok(())
     }
 
@@ -1071,7 +1088,7 @@ impl<'tx, TAddr: NodeAddressable + 'tx> StateStoreWriteTransaction for RocksDbSt
 
     fn substate_locks_insert_all<'a, I: IntoIterator<Item = (&'a SubstateId, &'a Vec<SubstateLock>)>>(
         &mut self,
-        block_id: &BlockId,
+        block: &LeafBlock,
         locks: I,
     ) -> Result<(), StorageError> {
         const OPERATION: &str = "substate_locks_insert_all";
@@ -1083,9 +1100,9 @@ impl<'tx, TAddr: NodeAddressable + 'tx> StateStoreWriteTransaction for RocksDbSt
         for (substate_id, locks) in locks {
             let mut last_key = None;
             for lock in locks {
-                // TODO: reference the substate id
                 let key = SubstateLockKey {
-                    block_id: *block_id,
+                    block_id: *block.block_id(),
+                    block_height: block.height(),
                     substate_id: substate_id.clone(),
                     transaction_id: *lock.transaction_id(),
                 };
@@ -1130,11 +1147,10 @@ impl<'tx, TAddr: NodeAddressable + 'tx> StateStoreWriteTransaction for RocksDbSt
                 index_cf.delete(&key, OPERATION)?;
                 substate_index_cf.delete(&key, OPERATION)?;
                 // TODO: this could leave the head index in an inconsistent state - I suspect we should implement locks
-                // in-memory instead of in persistence perhaps only persisting the entire lock state when consensus
-                // shuts down - that is to say, not fixing this now :)
-                for result in head_index_cf.value_iterator(Ordering::default(), OPERATION) {
-                    let head_key = result?;
-                    if head_key == key {
+                // in-memory instead of in persistence perhaps (or not) persisting the entire lock state asynchronously
+                // as blocks are processed (to account for node restarts)
+                if let Some(head_key) = head_index_cf.get(&key.substate_id, OPERATION).optional()? {
+                    if head_key.transaction_id == key.transaction_id {
                         head_index_cf.delete(&key.substate_id, OPERATION)?;
                     }
                 }
@@ -1150,6 +1166,7 @@ impl<'tx, TAddr: NodeAddressable + 'tx> StateStoreWriteTransaction for RocksDbSt
         let cf = self.db().cf(SubstateLockModel)?;
         let index_cf = self.db().cf(substate_locks::BlockIdIndex)?;
         let substate_index_cf = self.db().cf(substate_locks::SubstateIdIndex)?;
+        let head_index_cf = self.db().cf(substate_locks::HeadIndex)?;
         let query_cf = self.db().cf(substate_locks::ByBlockIdQuery)?;
         let iter = query_cf.query_prefix_range_key_iterator(Ordering::Ascending, block_id);
         for result in iter {
@@ -1157,6 +1174,11 @@ impl<'tx, TAddr: NodeAddressable + 'tx> StateStoreWriteTransaction for RocksDbSt
             cf.delete(&key, OPERATION)?;
             index_cf.delete(&key, OPERATION)?;
             substate_index_cf.delete(&key, OPERATION)?;
+            if let Some(head_key) = head_index_cf.get(&key.substate_id, OPERATION).optional()? {
+                if head_key.block_id == key.block_id {
+                    head_index_cf.delete(&key.substate_id, OPERATION)?;
+                }
+            }
         }
 
         Ok(())
@@ -1783,13 +1805,23 @@ impl<'a, TAddr> Deref for RocksDbStateStoreWriteTransaction<'a, TAddr> {
 
 impl<TAddr> Drop for RocksDbStateStoreWriteTransaction<'_, TAddr> {
     fn drop(&mut self) {
-        if let Some(tx) = self.transaction.take() {
+        if self.transaction.is_some() {
             warn!(
                 target: LOG_TARGET,
                 "State store write transaction was not committed/rolled back. Rolling back"
             );
-
-            if let Err(err) = tx.rollback() {
+            // Take so that we mark this transaction as complete in the drop impl
+            if let Err(err) = self
+                .transaction
+                .take()
+                .expect("rollback: already committed")
+                .into_rocksdb_transaction()
+                .rollback()
+                .map_err(|source| RocksDbStorageError::RocksDbError {
+                    source,
+                    operation: "commit",
+                })
+            {
                 error!(
                     target: LOG_TARGET,
                     "Failed to rollback state store write transaction: {}", err
@@ -1848,7 +1880,7 @@ mod cleanup {
         certificates::{proposal::ProposalCertificateCf, timeout::TimeoutCertificateCf},
     };
 
-    pub fn foreign_proposals_for_epoch(db: &DbContext<'_>, up_to_epoch: Epoch) -> Result<(), StorageError> {
+    pub fn foreign_proposals_for_epoch(db: &DbWriteContext<'_>, up_to_epoch: Epoch) -> Result<(), StorageError> {
         const OPERATION: &str = "cleanup::foreign_proposals_for_epoch";
         let up_to_epoch = up_to_epoch + Epoch(1); // Make it inclusive
         let cf = db.cf(foreign_proposal::ByEpochQuery)?;
@@ -1877,7 +1909,7 @@ mod cleanup {
         Ok(())
     }
 
-    pub fn cleanup_blocks_for_epoch(db: &DbContext<'_>, up_to_epoch: Epoch) -> Result<(), StorageError> {
+    pub fn cleanup_blocks_for_epoch(db: &DbWriteContext<'_>, up_to_epoch: Epoch) -> Result<(), StorageError> {
         const OPERATION: &str = "cleanup::cleanup_blocks_for_epoch";
         let up_to_epoch = up_to_epoch + Epoch(1); // Make it inclusive
         let cf = db.cf(BlockCf)?;
@@ -1907,7 +1939,7 @@ mod cleanup {
         Ok(())
     }
 
-    pub fn cleanup_qcs_for_epoch(db: &DbContext<'_>, up_to_epoch: Epoch) -> Result<(), StorageError> {
+    pub fn cleanup_qcs_for_epoch(db: &DbWriteContext<'_>, up_to_epoch: Epoch) -> Result<(), StorageError> {
         const OPERATION: &str = "cleanup::cleanup_qcs_for_epoch";
         let up_to_epoch = up_to_epoch + Epoch(1); // Make it inclusive
         let cf = db.cf(ProposalCertificateCf)?;

--- a/dan_layer/state_store_tests/Cargo.toml
+++ b/dan_layer/state_store_tests/Cargo.toml
@@ -25,3 +25,5 @@ tari_consensus_types = { workspace = true }
 indexmap = { workspace = true }
 rand = { workspace = true }
 tempfile = { workspace = true }
+log = { workspace = true }
+env_logger = { version = "0.11.8" }

--- a/dan_layer/state_store_tests/src/blocks.rs
+++ b/dan_layer/state_store_tests/src/blocks.rs
@@ -159,15 +159,15 @@ mod block_parent_operations {
         assert_eq!(res.calculate_id(), *block2.id());
 
         // blocks_is_ancestor
-        let res = tx.blocks_is_ancestor(block2.id(), block1.id()).unwrap();
+        let res = tx.blocks_is_pending_ancestor(block2.id(), block1.id()).unwrap();
         assert!(res);
-        let res = tx.blocks_is_ancestor(block2.id(), zero_block.id()).unwrap();
+        let res = tx.blocks_is_pending_ancestor(block2.id(), zero_block.id()).unwrap();
         assert!(res);
-        let res = tx.blocks_is_ancestor(block1.id(), zero_block.id()).unwrap();
+        let res = tx.blocks_is_pending_ancestor(block1.id(), zero_block.id()).unwrap();
         assert!(res);
-        let res = tx.blocks_is_ancestor(block1.id(), block2.id()).unwrap();
+        let res = tx.blocks_is_pending_ancestor(block1.id(), block2.id()).unwrap();
         assert!(!res);
-        let res = tx.blocks_is_ancestor(block2.id(), block2.id()).unwrap();
+        let res = tx.blocks_is_pending_ancestor(block2.id(), block2.id()).unwrap();
         assert!(!res);
 
         // blocks_get_ids_by_parent

--- a/dan_layer/state_store_tests/src/helpers.rs
+++ b/dan_layer/state_store_tests/src/helpers.rs
@@ -149,6 +149,16 @@ pub fn build_substate_value(entity_id: Option<EntityId>) -> SubstateValue {
     })
 }
 
+pub fn substate_id_tx_seed(transaction_id: TransactionId, seed: u32) -> SubstateId {
+    let mut buf = [0u8; EntityId::LENGTH];
+    buf[..].copy_from_slice(&transaction_id.as_hash().as_slice()[..EntityId::LENGTH]);
+    let entity_id = EntityId::from_array(buf);
+    let mut buf = [0u8; ComponentKey::LENGTH];
+    buf[..size_of::<u32>()].copy_from_slice(&seed.to_be_bytes());
+    let component_key = ComponentKey::new(buf);
+    SubstateId::Component(ComponentAddress::new(ObjectKey::new(entity_id, component_key)))
+}
+
 pub fn substate_id_seed(seed: u32) -> SubstateId {
     let mut buf = [0u8; EntityId::LENGTH];
     buf[..size_of::<u32>()].copy_from_slice(&seed.to_be_bytes());

--- a/dan_layer/state_store_tests/src/substate_locks.rs
+++ b/dan_layer/state_store_tests/src/substate_locks.rs
@@ -19,27 +19,34 @@ use crate::helpers::{
     create_chain,
     create_random_substate_id,
     create_rocksdb,
-    substate_id_seed,
+    substate_id_tx_seed,
     transaction_id_from_seed,
 };
 
 #[test]
 fn rocksdb() {
+    env_logger::builder().filter_level(log::LevelFilter::Debug).init();
     let (db, _tmp) = create_rocksdb();
     run_test(db);
 }
 
 fn run_test(db: impl StateStore) {
     let mut tx = db.create_write_tx().unwrap();
-    let s1 = create_random_substate_id();
-    // tx.substate_locks_get_locked_substates_for_transaction()
-    let s = tx.substate_locks_get_latest_for_substate(&s1).optional().unwrap();
-    assert!(s.is_none());
 
     let chain = create_chain(10);
     commit_chain(&mut tx, &chain);
-    let b8 = *chain[8].id();
-    let b9 = *chain[9].id();
+    let b7 = chain[7].as_leaf();
+    let b8 = chain[8].as_leaf();
+    let b9 = chain[9].as_leaf();
+
+    log::debug!("b7: {}, b8: {}, b9: {}", b7, b8, b9);
+
+    let s1 = create_random_substate_id();
+    let s = tx
+        .substate_locks_get_latest_for_substate(&chain[0].as_leaf(), &s1)
+        .optional()
+        .unwrap();
+    assert!(s.is_none());
 
     let tx_1 = transaction_id_from_seed(1);
     let tx_1_locks = gen_locks(tx_1, 5).collect::<IndexMap<_, _>>();
@@ -84,7 +91,7 @@ fn run_test(db: impl StateStore) {
     }
 
     for (id, locks) in &all_locks {
-        let s = tx.substate_locks_get_latest_for_substate(id).unwrap();
+        let s = tx.substate_locks_get_latest_for_substate(&b9, id).unwrap();
         let l = locks.last().unwrap();
         assert_eq!(s.lock_type(), l.lock_type());
         assert_eq!(s.version(), l.version());
@@ -94,12 +101,16 @@ fn run_test(db: impl StateStore) {
             .unwrap();
         assert_eq!(locked_by_tx.len(), *tx_id_counts.get(l.transaction_id()).unwrap());
     }
+    for id in locks_for_b9.keys() {
+        let s = tx.substate_locks_get_latest_for_substate(&b8, id).optional().unwrap();
+        assert!(s.is_none());
+    }
 
     tx.substate_locks_remove_many_for_transactions(Some(&tx_1)).unwrap();
     let locked_by_tx = tx.substate_locks_get_locked_substates_for_transaction(&tx_1).unwrap();
     assert_eq!(locked_by_tx.len(), 0);
 
-    tx.substate_locks_remove_any_by_block_id(&b9).unwrap();
+    tx.substate_locks_remove_any_by_block_id(b9.block_id()).unwrap();
     let locked_by_tx = tx.substate_locks_get_locked_substates_for_transaction(&tx_3).unwrap();
     assert_eq!(locked_by_tx.len(), 0);
     let locked_by_tx = tx.substate_locks_get_locked_substates_for_transaction(&tx_4).unwrap();
@@ -110,7 +121,7 @@ fn run_test(db: impl StateStore) {
 
 fn gen_locks(transaction_id: TransactionId, num: usize) -> impl Iterator<Item = (SubstateId, SubstateLock)> {
     (0..num as u64).map(move |i| {
-        let id = substate_id_seed(i as u32);
+        let id = substate_id_tx_seed(transaction_id, i as u32);
         let lock = SubstateLock::new(transaction_id, i as u32, SubstateLockType::Write, false);
         (id, lock)
     })

--- a/dan_layer/storage/src/consensus_models/block.rs
+++ b/dan_layer/storage/src/consensus_models/block.rs
@@ -648,7 +648,20 @@ impl Block {
         tx.blocks_set_qcs(self.id(), None, Some(qc_id))
     }
 
-    pub fn extends<TTx: StateStoreReadTransaction>(&self, tx: &TTx, ancestor: &BlockId) -> Result<bool, StorageError> {
+    /// Checks if this block extends the given ancestor block.
+    ///
+    /// ## Behaviour
+    /// 1. if self.id == ancestor.id, then this returns false
+    /// 2. if self.parent == ancestor.id, then this returns true
+    /// 3. this only checks for uncommitted (pending) blocks and will return false if the block is committed (unless the
+    ///    two blocks happen to be direct descendants i.e. point 2).
+    /// 4. if self.parent does not exist, then false is returned.
+    /// 5. if ancestor does not exist, an error is returned.
+    pub fn extends_pending<TTx: StateStoreReadTransaction>(
+        &self,
+        tx: &TTx,
+        ancestor: &BlockId,
+    ) -> Result<bool, StorageError> {
         if self.id() == ancestor {
             return Ok(false);
         }
@@ -660,7 +673,7 @@ impl Block {
             return Ok(false);
         }
 
-        tx.blocks_is_ancestor(self.parent(), ancestor)
+        tx.blocks_is_pending_ancestor(self.parent(), ancestor)
     }
 
     pub fn get_parent<TTx: StateStoreReadTransaction>(&self, tx: &TTx) -> Result<Block, StorageError> {
@@ -839,7 +852,7 @@ impl Block {
         }
 
         // Safety rule
-        if self.extends(tx, locked.block_id())? {
+        if self.extends_pending(tx, locked.block_id())? {
             return Ok(true);
         }
 

--- a/dan_layer/storage/src/consensus_models/substate.rs
+++ b/dan_layer/storage/src/consensus_models/substate.rs
@@ -5,7 +5,7 @@ use std::{collections::HashSet, fmt, fmt::Display};
 
 use serde::{Deserialize, Serialize};
 use tari_common_types::types::FixedHash;
-use tari_consensus_types::{BlockId, ProposalCertificate, QcId};
+use tari_consensus_types::{BlockId, LeafBlock, ProposalCertificate, QcId};
 use tari_dan_common_types::{
     displayable::Displayable,
     shard::Shard,
@@ -153,10 +153,10 @@ impl SubstateRecord {
         I: IntoIterator<Item = (&'a SubstateId, &'a Vec<SubstateLock>)>,
     >(
         tx: &mut TTx,
-        block_id: &BlockId,
+        block: &LeafBlock,
         locks: I,
     ) -> Result<(), StorageError> {
-        tx.substate_locks_insert_all(block_id, locks)
+        tx.substate_locks_insert_all(block, locks)
     }
 
     pub fn unlock_all<'a, TTx: StateStoreWriteTransaction, I: Iterator<Item = &'a TransactionId>>(

--- a/dan_layer/storage/src/consensus_models/substate_lock.rs
+++ b/dan_layer/storage/src/consensus_models/substate_lock.rs
@@ -53,11 +53,11 @@ impl SubstateLock {
     }
 
     pub fn is_input(&self) -> bool {
-        self.lock_type.is_input()
+        self.lock_type().is_input()
     }
 
     pub fn is_output(&self) -> bool {
-        self.lock_type.is_output()
+        self.lock_type().is_output()
     }
 }
 
@@ -90,12 +90,12 @@ impl LockedSubstateValue {
 
     pub fn satisfies_requirements<'a, T: Into<SubstateRequirementRef<'a>>>(&self, requirement: T) -> bool {
         let requirement = requirement.into();
-        requirement.version().is_none_or(|v| v == self.lock.version) && *requirement.substate_id() == self.substate_id
+        requirement.version().is_none_or(|v| v == self.lock.version()) && *requirement.substate_id() == self.substate_id
     }
 
     pub fn satisfies_lock_intent<T: LockIntent>(&self, lock_intent: T) -> bool {
-        lock_intent.version_to_lock() == self.lock.version &&
-            self.lock.lock_type.allows(lock_intent.lock_type()) &&
+        lock_intent.version_to_lock() == self.lock.version() &&
+            self.lock.lock_type().allows(lock_intent.lock_type()) &&
             *lock_intent.substate_id() == self.substate_id
     }
 

--- a/dan_layer/storage/src/consensus_models/transaction_pool_status_update.rs
+++ b/dan_layer/storage/src/consensus_models/transaction_pool_status_update.rs
@@ -64,6 +64,10 @@ impl TransactionPoolStatusUpdate {
     pub fn apply(&self, tx_rec_mut: &mut TransactionPoolRecord) {
         tx_rec_mut.set_evidence(self.evidence().clone());
         tx_rec_mut.set_ready(self.is_ready_now());
+        tx_rec_mut.set_local_decision(self.transaction().current_decision());
+        if let Some(decision) = self.transaction().remote_decision() {
+            tx_rec_mut.set_remote_decision(decision);
+        }
     }
 }
 

--- a/dan_layer/storage/src/state_store/mod.rs
+++ b/dan_layer/storage/src/state_store/mod.rs
@@ -169,7 +169,7 @@ pub trait StateStoreReadTransaction: Sized {
         limit: usize,
     ) -> Result<Vec<Block>, StorageError>;
     fn blocks_exists(&self, block_id: &BlockId) -> Result<bool, StorageError>;
-    fn blocks_is_ancestor(&self, descendant: &BlockId, ancestor: &BlockId) -> Result<bool, StorageError>;
+    fn blocks_is_pending_ancestor(&self, descendant: &BlockId, ancestor: &BlockId) -> Result<bool, StorageError>;
     fn blocks_get_committed_by_parent(&self, parent: &BlockId) -> Result<Block, StorageError>;
     fn blocks_get_pending_ids_by_parent(&self, parent: &BlockId) -> Result<Vec<BlockId>, StorageError>;
 
@@ -264,7 +264,11 @@ pub trait StateStoreReadTransaction: Sized {
         substate_ids: I,
     ) -> Result<Option<TransactionId>, StorageError>;
 
-    fn substate_locks_get_latest_for_substate(&self, substate_id: &SubstateId) -> Result<SubstateLock, StorageError>;
+    fn substate_locks_get_latest_for_substate(
+        &self,
+        leaf_block: &LeafBlock,
+        substate_id: &SubstateId,
+    ) -> Result<SubstateLock, StorageError>;
 
     fn pending_state_tree_diffs_get_all_up_to_commit_block(
         &self,
@@ -463,7 +467,7 @@ pub trait StateStoreWriteTransaction {
     //---------------------------------- Substates --------------------------------------------//
     fn substate_locks_insert_all<'a, I: IntoIterator<Item = (&'a SubstateId, &'a Vec<SubstateLock>)>>(
         &mut self,
-        block_id: &BlockId,
+        block: &LeafBlock,
         locks: I,
     ) -> Result<(), StorageError>;
 

--- a/utilities/db_inspector/src/webserver/handlers/bookkeeping.rs
+++ b/utilities/db_inspector/src/webserver/handlers/bookkeeping.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use axum::{extract::Path, Extension, Json};
 use serde_json::json;
 use tari_dan_common_types::optional::Optional;
-use tari_state_store_rocksdb::{codecs::ByteColumn, column_families, read_only::ReadOnlyContext, traits::Cf};
+use tari_state_store_rocksdb::{codecs::ByteColumn, column_families, read_only_ctx::ReadOnlyContext, traits::Cf};
 
 use crate::webserver::{
     context::HandlerContext,


### PR DESCRIPTION
Description
---
fix(consensus)!: properly account for forks for substate locks
fix(swarm); possible lockup when using ctrl+c
fix(storage/rocksdb): read only type in read transaction (compile error if using RocksWriter methods on db context)
fix(consensus): process foreign proposals during propose

Motivation and Context
---

`substate_locks_get_latest_for_substate` call did not account for forks

How Has This Been Tested?
---
Existing tests (this case not explicitly tested)

Breaking Changes
---

- [ ] None
- [x] Requires data directory to be deleted
- [ ] Other - Please specify