### PR TITLE
fix(epoch-oracles): finish implementation of hybrid epoch oracle

### DIFF
--- a/applications/tari_dan_app_utilities/config_presets/a_common.toml
+++ b/applications/tari_dan_app_utilities/config_presets/a_common.toml
@@ -34,25 +34,3 @@ check_interval = 300
 [metrics]
 # server_bind_address = "127.0.0.1:5577"
 # push_endpoint = http://localhost:9091/metrics/job/base-node
-[epoch_oracle]
-oracle = "BaseLayer"
-# Or
-#oracle = "Configured"
-[epoch_oracle.base_layer]
-# The Minotari base node's GRPC url. (default = "http://127.0.0.1:<port>" the <port> value is based on network)
-#base_node_grpc_url = "http://127.0.0.1:18142"
-
-# How often do we want to scan the base layer for changes in seconds. (default = 10)
-#scanning_interval = 10
-
-[epoch_oracle.configured]
-# Absolute or relative (to current working dir) path to the oracle config file.
-# Example toml:
-#  epoch_time = 720 # 12 minutes
-#  initial_epoch = 1
-#  [[[epoch_oracle.configured.validators]]
-#  public_key = "7056240dedac879422d9d319704eddd699b1b5b4ab82a2b49324a1dae591dd78"
-#  claim_key = "7056240dedac879422d9d319704eddd699b1b5b4ab82a2b49324a1dae591dd78"
-#  registration_epoch = 5
-#  shard_group = { start = 1, end_inclusive = 256 }
-#config_file = "/path/to/oracle/config.toml"

--- a/applications/tari_dan_app_utilities/config_presets/f_epoch_oracle.toml
+++ b/applications/tari_dan_app_utilities/config_presets/f_epoch_oracle.toml
@@ -1,0 +1,38 @@
+########################################################################################################################
+#                                                                                                                      #
+#                                    Epoch Oracle Configuration Options                                                #
+#                                                                                                                      #
+########################################################################################################################
+
+[epoch_oracle]
+# The oracle type can be either "BaseLayer", "Configured" or "Hybrid".
+# "BaseLayer" oracle uses the Tari base node to determine the epoch and scans layer 2 UTXOs.
+# "Configured" oracle uses a pre-defined configuration file to determine the epoch and validators.
+# "Hybrid" oracle combines both the base layer and configured oracles. i.e. base layer determines the epoch, burnt UTXOs
+# and the configured oracle provides the validators.
+
+#oracle = "BaseLayer"
+
+[epoch_oracle.base_layer]
+# The Tari base node's GRPC URL. If none is specified, http://localhost:{port} will be used where {port} is the network-specific default.
+#base_node_grpc_url = "http://localhost:18142"
+
+# Interval between base layer scans in seconds. Default is 5 seconds.
+#scanning_interval = 5
+
+[epoch_oracle.configured]
+
+# The configured epoch oracle's toml or json configuration file path.
+# E.g
+#{
+# "epoch_time: 120,
+# "initial_epoch": 3,
+#  "validators": [{
+#    "public_key": "04efea68c9bff8f9c25fe89310abf91955e33344f4b77bb0d31ea80a80128e67",
+#    "claim_key": "04efea68c9bff8f9c25fe89310abf91955e33344f4b77bb0d31ea80a80128e67",
+#    "shard_group": {"start": 1,"end_inclusive": 256},
+#    "registration_epoch": 5
+#  }]
+#}
+#config_file = "epoch_oracle_config.toml"
+

--- a/applications/tari_dan_app_utilities/src/configuration.rs
+++ b/applications/tari_dan_app_utilities/src/configuration.rs
@@ -96,13 +96,14 @@ pub fn load_configuration_with_overrides<P: AsRef<Path>, TOverride: ConfigOverri
 
 /// Returns the default configuration file template in parts from the embedded presets. If use_mining_config is true,
 /// the base node configuration that enables mining is returned, otherwise the non-mining configuration is returned.
-pub fn get_default_config() -> [&'static str; 5] {
+pub fn get_default_config() -> [&'static str; 6] {
     [
         include_str!("../config_presets/a_common.toml"),
         include_str!("../config_presets/b_peer_seeds.toml"),
         include_str!("../config_presets/c_validator_node.toml"),
         include_str!("../config_presets/d_indexer.toml"),
         include_str!("../config_presets/e_dan_wallet_daemon.toml"),
+        include_str!("../config_presets/f_epoch_oracle.toml"),
     ]
 }
 

--- a/applications/tari_dan_app_utilities/src/epoch_oracle_config.rs
+++ b/applications/tari_dan_app_utilities/src/epoch_oracle_config.rs
@@ -39,7 +39,7 @@ pub enum EpochOracleType {
 pub struct BaseLayerOracleConfig {
     /// The Tari base node's GRPC URL. If none is specified, http://localhost:{port} will be used where {port} is the network-specific default.
     pub base_node_grpc_url: Option<Url>,
-    /// Interval between base layer scans
+    /// Interval between base layer scans in seconds.
     #[serde(with = "serde_with::duration::seconds")]
     pub scanning_interval: Duration,
 }
@@ -48,7 +48,7 @@ impl Default for BaseLayerOracleConfig {
     fn default() -> Self {
         Self {
             base_node_grpc_url: None,
-            scanning_interval: Duration::from_secs(10),
+            scanning_interval: Duration::from_secs(5),
         }
     }
 }

--- a/applications/tari_dan_app_utilities/src/keypair.rs
+++ b/applications/tari_dan_app_utilities/src/keypair.rs
@@ -152,7 +152,7 @@ fn load_keypair<P: AsRef<Path>>(path: P) -> Result<RistrettoKeypair, IdentityErr
 ///
 /// ## Returns
 /// Result containing the node identity, string will indicate reason on error
-fn create_new_keypair<P: AsRef<Path>>(path: P) -> Result<RistrettoKeypair, IdentityError> {
+pub fn create_new_keypair<P: AsRef<Path>>(path: P) -> Result<RistrettoKeypair, IdentityError> {
     let node_identity = RistrettoKeypair::random(&mut OsRng);
     save_as_json(&path, &node_identity)?;
     Ok(node_identity)

--- a/applications/tari_dan_wallet_daemon/src/http_ui/server.rs
+++ b/applications/tari_dan_wallet_daemon/src/http_ui/server.rs
@@ -29,7 +29,7 @@ use axum::{
     Router,
 };
 use include_dir::{include_dir, Dir};
-use log::{error, info};
+use log::*;
 use reqwest::{header, StatusCode};
 use url::Url;
 
@@ -43,7 +43,7 @@ pub async fn run_http_ui_server(address: SocketAddr, json_rpc_address: Url) -> R
 
     info!(target: LOG_TARGET, "🕸️ Web UI started at http://{}", address);
     let server = axum::Server::try_bind(&address).or_else(|_| {
-        error!(
+        warn!(
             target: LOG_TARGET,
             "🕸️ Failed to bind on preferred address {}. Trying OS-assigned", address
         );

--- a/applications/tari_dan_wallet_daemon/web_ui/src/routes/AssetVault/Components/PublishTemplate.tsx
+++ b/applications/tari_dan_wallet_daemon/web_ui/src/routes/AssetVault/Components/PublishTemplate.tsx
@@ -84,11 +84,7 @@ function PublishTemplateDialog(props: DialogProps) {
   };
   const [disabled, setDisabled] = useState(false);
   const [formState, setFormState] = useState<FormState>(INITIAL_VALUES);
-  const [validity, setValidity] = useState<object>({
-    file: false,
-    account: false,
-    maxFee: true,
-  });
+
   const [allValid, setAllValid] = useState(false);
 
   const { account, setPopup } = useAccountStore();
@@ -97,6 +93,11 @@ function PublishTemplateDialog(props: DialogProps) {
 
   let { data: accountsResp } = useAccountsList(0, 1000);
   let accounts = accountsResp?.accounts;
+  const [validity, setValidity] = useState<object>({
+    file: false,
+    account: Boolean(accounts?.length),
+    maxFee: true,
+  });
 
   const { mutateAsync: publishTemplate } = usePublishTemplate();
 

--- a/applications/tari_indexer/src/bootstrap.rs
+++ b/applications/tari_indexer/src/bootstrap.rs
@@ -47,8 +47,8 @@ use tari_engine_types::ToByteType;
 use tari_epoch_manager::service::{EpochManagerConfig, EpochManagerHandle};
 use tari_epoch_oracles::{
     base_layer::BaseLayerOracle,
-    configured::ConfiguredEpochOracle,
-    hybrid::HybridEpochOracle,
+    configured::{ConfiguredEpochOracle, IntervalEpochTicker},
+    hybrid::{watch_ticker, HybridEpochOracle},
     store::EpochOracleStore,
     EpochOracle,
 };
@@ -236,12 +236,8 @@ async fn create_epoch_oracle<TStore: EpochOracleStore + Clone + Send + 'static>(
             Ok(EpochOracle::Configured(oracle))
         },
         EpochOracleType::Hybrid => {
-            let base_layer_oracle = create_base_layer_epoch_oracle(config, store.clone(), consensus_constants).await?;
-            let configured_oracle = create_configured_epoch_oracle(config, store).await?;
-            Ok(EpochOracle::Hybrid(HybridEpochOracle::new(
-                configured_oracle,
-                base_layer_oracle,
-            )))
+            let oracle = create_hybrid_epoch_oracle(config, store, consensus_constants).await?;
+            Ok(EpochOracle::Hybrid(oracle))
         },
     }
 }
@@ -271,7 +267,19 @@ async fn create_base_layer_epoch_oracle<TStore: EpochOracleStore + 'static>(
 async fn create_configured_epoch_oracle<TStore: EpochOracleStore + Send>(
     config: &ApplicationConfig,
     store: TStore,
-) -> Result<ConfiguredEpochOracle<TStore>, ExitError> {
+) -> Result<ConfiguredEpochOracle<TStore, IntervalEpochTicker>, ExitError> {
     let oracle_config = config.epoch_oracle.configured.load().await?;
     Ok(ConfiguredEpochOracle::new(oracle_config, store))
+}
+
+async fn create_hybrid_epoch_oracle<TStore: EpochOracleStore + Clone + Send + 'static>(
+    config: &ApplicationConfig,
+    store: TStore,
+    consensus_constants: &ConsensusConstants,
+) -> Result<HybridEpochOracle<TStore>, ExitError> {
+    let base_layer_oracle = create_base_layer_epoch_oracle(config, store.clone(), consensus_constants).await?;
+    let oracle_config = config.epoch_oracle.configured.load().await?;
+    let (ticker, trigger) = watch_ticker();
+    let configured_oracle = ConfiguredEpochOracle::with_custom_ticker(oracle_config, store, ticker);
+    Ok(HybridEpochOracle::new(configured_oracle, base_layer_oracle, trigger))
 }

--- a/applications/tari_indexer/src/cli.rs
+++ b/applications/tari_indexer/src/cli.rs
@@ -20,13 +20,14 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::net::SocketAddr;
+use std::{net::SocketAddr, path::PathBuf};
 
 use clap::Parser;
 use minotari_app_utilities::common_cli_args::CommonCliArgs;
 use tari_common::configuration::{ConfigOverrideProvider, Network};
 use tari_dan_app_utilities::p2p_config::ReachabilityMode;
 use tari_engine_types::substate::SubstateId;
+use url::Url;
 
 #[derive(Parser, Debug)]
 #[clap(author, version, about, long_about = None)]
@@ -44,7 +45,10 @@ pub struct Cli {
     /// Bind address for JSON-rpc server
     #[clap(long, short = 'r', alias = "rpc-address")]
     pub json_rpc_address: Option<SocketAddr>,
-
+    #[clap(long, alias = "node-grpc", short = 'g', env = "TARI_INDEXER_MINOTARI_NODE_GRPC_URL")]
+    pub epoch_oracle_minotari_node_grpc_url: Option<Url>,
+    #[clap(long, alias = "oracle-config")]
+    pub epoch_oracle_config: Option<PathBuf>,
     // Networking
     #[clap(long, short = 's')]
     pub peer_seeds: Vec<String>,
@@ -107,6 +111,21 @@ impl ConfigOverrideProvider for Cli {
         }
         if self.disable_mdns {
             overrides.push(("indexer.p2p.enable_mdns".to_string(), "false".to_string()));
+        }
+        if let Some(url) = self.epoch_oracle_minotari_node_grpc_url.as_ref() {
+            overrides.push((
+                "epoch_oracle.base_layer.base_node_grpc_url".to_string(),
+                url.to_string(),
+            ));
+        }
+        if let Some(ref config_path) = self.epoch_oracle_config {
+            overrides.push((
+                "epoch_oracle.configured.config_file".to_string(),
+                config_path
+                    .to_str()
+                    .expect("epoch_oracle_config must be a UTF-8 string")
+                    .to_string(),
+            ));
         }
         overrides
     }

--- a/applications/tari_indexer/src/graphql/server.rs
+++ b/applications/tari_indexer/src/graphql/server.rs
@@ -66,7 +66,7 @@ pub async fn run_graphql(
 
     let server = axum::Server::try_bind(&preferred_address)
         .or_else(|_| {
-            error!(
+            warn!(
                 target: LOG_TARGET,
                 "🌐 Failed to bind on preferred address {}. Trying OS-assigned", preferred_address
             );

--- a/applications/tari_indexer/src/http_ui/server.rs
+++ b/applications/tari_indexer/src/http_ui/server.rs
@@ -29,7 +29,7 @@ use axum::{
     Router,
 };
 use include_dir::{include_dir, Dir};
-use log::{error, info};
+use log::*;
 use url::Url;
 
 const LOG_TARGET: &str = "tari::indexer::web_ui::server";
@@ -51,7 +51,7 @@ pub async fn run_http_ui_server(
 
     info!(target: LOG_TARGET, "🕸️ Web UI started at http://{}", address);
     let server = axum::Server::try_bind(&address).or_else(|_| {
-        error!(
+        warn!(
             target: LOG_TARGET,
             "🕸️ Failed to bind on preferred address {}. Trying OS-assigned", address
         );

--- a/applications/tari_indexer/src/json_rpc/handlers.rs
+++ b/applications/tari_indexer/src/json_rpc/handlers.rs
@@ -31,21 +31,20 @@ use axum_jrpc::{
 use libp2p::swarm::dial_opts::{DialOpts, PeerCondition};
 use log::{error, info, warn};
 use serde_json::{self as json, json, Value};
-use tari_common_types::types::FixedHash;
 use tari_consensus_types::Decision;
 use tari_crypto::{ristretto::RistrettoPublicKey, tari_utilities::hex::to_hex};
 use tari_dan_app_utilities::{keypair::RistrettoKeypair, substate_file_cache::SubstateFileCache};
-use tari_dan_common_types::{optional::Optional, public_key_to_peer_id, Epoch, PeerAddress, SubstateRequirement};
+use tari_dan_common_types::{optional::Optional, public_key_to_peer_id, PeerAddress, SubstateRequirement};
 use tari_dan_engine::{template::TemplateModuleLoader, wasm::WasmModule};
 use tari_dan_p2p::TariMessagingSpec;
 use tari_dan_storage::{
     global::GlobalDb,
     time::{PrimitiveDateTime, UtcDateTime},
 };
-use tari_dan_storage_sqlite::{error::SqliteStorageError, global::SqliteGlobalDbAdapter};
+use tari_dan_storage_sqlite::global::SqliteGlobalDbAdapter;
 use tari_engine_types::{FromByteType, ToByteType};
 use tari_epoch_manager::{service::EpochManagerHandle, EpochManagerReader};
-use tari_epoch_oracles::{configured::calc_static_epoch_hash, store::StoreKey};
+use tari_epoch_oracles::store::StoreKey;
 use tari_indexer_client::types::{
     self,
     AddPeerRequest,
@@ -512,38 +511,20 @@ impl JsonRpcHandlers {
 
     pub async fn get_epoch_manager_stats(&self, value: JsonRpcExtractor) -> JrpcResult {
         let answer_id = value.get_answer_id();
-        let current_epoch = self.epoch_manager.current_epoch().await.map_err(|e| {
-            JsonRpcResponse::error(
-                answer_id,
-                JsonRpcError::new(
-                    JsonRpcErrorReason::InternalError,
-                    format!("Could not get current epoch: {}", e),
-                    json::Value::Null,
-                ),
-            )
-        })?;
-        let (current_block_hash, current_block_height) = self
+        let current_epoch = self.epoch_manager.get_current_epoch();
+        let current_epoch_hash = self
+            .epoch_manager
+            .get_current_epoch_hash()
+            .await
+            .map_err(internal_error(answer_id))?;
+
+        let current_block_height = self
             .global_db
             .create_transaction()
             .and_then(|mut tx| {
-                // This pokes into the internals of the oracles a bit. And can give incorrect results if we switch
-                // between them.
-                let current_epoch = self
-                    .global_db
+                self.global_db
                     .metadata(&mut tx)
-                    .get_metadata::<Epoch>(StoreKey::StaticCurrentEpoch.as_key_bytes())?;
-                let block_hash = self
-                    .global_db
-                    .metadata(&mut tx)
-                    .get_metadata::<FixedHash>(StoreKey::BaseLayerLastScannedBlockHash.as_key_bytes())?
-                    .or_else(|| current_epoch.map(calc_static_epoch_hash));
-                let block_height = self
-                    .global_db
-                    .metadata(&mut tx)
-                    .get_metadata::<u64>(StoreKey::BaseLayerLastScannedBlockHeight.as_key_bytes())?
-                    // Just use the epoch here
-                    .or(current_epoch.map(|e| e.as_u64()));
-                Ok::<_, SqliteStorageError>((block_hash.unwrap_or_default(), block_height.unwrap_or_default()))
+                    .get_metadata::<u64>(StoreKey::BaseLayerLastScannedBlockHeight.as_key_bytes())
             })
             .map_err(|e| {
                 JsonRpcResponse::error(
@@ -558,8 +539,8 @@ impl JsonRpcHandlers {
 
         let response = GetEpochManagerStatsResponse {
             current_epoch,
-            current_block_height,
-            current_block_hash,
+            current_block_height: current_block_height.unwrap_or(0),
+            current_block_hash: current_epoch_hash,
         };
         Ok(JsonRpcResponse::success(answer_id, response))
     }

--- a/applications/tari_indexer/src/json_rpc/server.rs
+++ b/applications/tari_indexer/src/json_rpc/server.rs
@@ -47,7 +47,7 @@ pub fn spawn_json_rpc(preferred_address: SocketAddr, handlers: JsonRpcHandlers) 
         .layer(CorsLayer::permissive());
 
     let server = axum::Server::try_bind(&preferred_address).or_else(|_| {
-        error!(
+        warn!(
             target: LOG_TARGET,
             "🌐 Failed to bind on preferred address {}. Trying OS-assigned", preferred_address
         );

--- a/applications/tari_swarm_daemon/src/webserver/server.rs
+++ b/applications/tari_swarm_daemon/src/webserver/server.rs
@@ -65,7 +65,7 @@ pub async fn run(context: HandlerContext) -> anyhow::Result<()> {
         .layer(CorsLayer::permissive());
 
     let server = axum::Server::try_bind(&bind_address).or_else(|_| {
-        error!(
+        warn!(
             target: LOG_TARGET,
             "🕸️ Failed to bind on preferred address {}. Trying OS-assigned", bind_address
         );

--- a/applications/tari_validator_node/src/bootstrap.rs
+++ b/applications/tari_validator_node/src/bootstrap.rs
@@ -61,8 +61,8 @@ use tari_epoch_manager::{
 };
 use tari_epoch_oracles::{
     base_layer::BaseLayerOracle,
-    configured::ConfiguredEpochOracle,
-    hybrid::HybridEpochOracle,
+    configured::{ConfiguredEpochOracle, IntervalEpochTicker},
+    hybrid::{watch_ticker, HybridEpochOracle},
     store::EpochOracleStore,
     EpochOracle,
 };
@@ -532,12 +532,8 @@ async fn create_epoch_oracle<TStore: EpochOracleStore + Send + Clone + 'static>(
             Ok(EpochOracle::Configured(oracle))
         },
         EpochOracleType::Hybrid => {
-            let base_layer_oracle = create_base_layer_epoch_oracle(config, store.clone(), consensus_constants).await?;
-            let configured_oracle = create_configured_epoch_oracle(config, store).await?;
-            Ok(EpochOracle::Hybrid(HybridEpochOracle::new(
-                configured_oracle,
-                base_layer_oracle,
-            )))
+            let oracle = create_hybrid_epoch_oracle(config, store, consensus_constants).await?;
+            Ok(EpochOracle::Hybrid(oracle))
         },
     }
 }
@@ -575,7 +571,19 @@ async fn create_base_layer_epoch_oracle<TStore: EpochOracleStore + 'static>(
 async fn create_configured_epoch_oracle<TStore: EpochOracleStore + Send>(
     config: &ApplicationConfig,
     store: TStore,
-) -> Result<ConfiguredEpochOracle<TStore>, ExitError> {
+) -> Result<ConfiguredEpochOracle<TStore, IntervalEpochTicker>, ExitError> {
     let oracle_config = config.epoch_oracle.configured.load().await?;
     Ok(ConfiguredEpochOracle::new(oracle_config, store))
+}
+
+async fn create_hybrid_epoch_oracle<TStore: EpochOracleStore + Clone + Send + 'static>(
+    config: &ApplicationConfig,
+    store: TStore,
+    consensus_constants: &ConsensusConstants,
+) -> Result<HybridEpochOracle<TStore>, ExitError> {
+    let base_layer_oracle = create_base_layer_epoch_oracle(config, store.clone(), consensus_constants).await?;
+    let oracle_config = config.epoch_oracle.configured.load().await?;
+    let (ticker, trigger) = watch_ticker();
+    let configured_oracle = ConfiguredEpochOracle::with_custom_ticker(oracle_config, store, ticker);
+    Ok(HybridEpochOracle::new(configured_oracle, base_layer_oracle, trigger))
 }

--- a/applications/tari_validator_node/src/cli.rs
+++ b/applications/tari_validator_node/src/cli.rs
@@ -20,7 +20,7 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::net::SocketAddr;
+use std::{net::SocketAddr, path::PathBuf};
 
 use clap::Parser;
 use minotari_app_utilities::common_cli_args::CommonCliArgs;
@@ -45,7 +45,9 @@ pub struct Cli {
     #[clap(long, env = "TARI_VN_JSON_RPC_PUBLIC_URL")]
     pub json_rpc_public_url: Option<String>,
     #[clap(long, alias = "node-grpc", short = 'g', env = "TARI_VN_MINOTARI_NODE_GRPC_URL")]
-    pub minotari_node_grpc_url: Option<Url>,
+    pub epoch_oracle_minotari_node_grpc_url: Option<Url>,
+    #[clap(long, alias = "oracle-config")]
+    pub epoch_oracle_config: Option<PathBuf>,
     #[clap(long, short = 's')]
     pub peer_seeds: Vec<String>,
     #[clap(long)]
@@ -106,10 +108,19 @@ impl ConfigOverrideProvider for Cli {
         if self.disable_mdns {
             overrides.push(("validator_node.p2p.enable_mdns".to_string(), "false".to_string()));
         }
-        if let Some(url) = self.minotari_node_grpc_url.as_ref() {
+        if let Some(url) = self.epoch_oracle_minotari_node_grpc_url.as_ref() {
             overrides.push((
                 "epoch_oracle.base_layer.base_node_grpc_url".to_string(),
                 url.to_string(),
+            ));
+        }
+        if let Some(ref config_path) = self.epoch_oracle_config {
+            overrides.push((
+                "epoch_oracle.configured.config_file".to_string(),
+                config_path
+                    .to_str()
+                    .expect("epoch_oracle_config must be a UTF-8 string")
+                    .to_string(),
             ));
         }
         overrides
@@ -122,4 +133,6 @@ pub enum Subcommand {
     Start,
     /// Compact the database and exit
     CompactDb,
+    /// Generate an identity keypair if one does not exist and exit
+    GenerateIdentity,
 }

--- a/applications/tari_validator_node/src/dan_node.rs
+++ b/applications/tari_validator_node/src/dan_node.rs
@@ -54,6 +54,15 @@ impl DanNode {
         // let mut sigterm = signal(SignalKind::terminate())?;
 
         loop {
+            let metrics = tokio::runtime::Handle::current().metrics();
+            info!(
+                target: LOG_TARGET,
+                "Tokio runtime metrics: num_alive_tasks={}, num_workers={}, global_queue_depth={}",
+                metrics.num_alive_tasks(),
+                metrics.num_workers(),
+                metrics.global_queue_depth(),
+            );
+
             tokio::select! {
                 _ = tokio::signal::ctrl_c() => {
                     info!(target: LOG_TARGET, "💤 Received SIGINT");

--- a/applications/tari_validator_node/src/http_ui/server.rs
+++ b/applications/tari_validator_node/src/http_ui/server.rs
@@ -29,7 +29,7 @@ use axum::{
     Router,
 };
 use include_dir::{include_dir, Dir};
-use log::{error, info};
+use log::*;
 use reqwest::{header, header::HeaderValue, StatusCode};
 
 const LOG_TARGET: &str = "tari::validator_node::web_ui::server";
@@ -42,7 +42,7 @@ pub async fn run_http_ui_server(address: SocketAddr, json_rpc_address: String) -
 
     info!(target: LOG_TARGET, "🕸️ Web UI started at http://{}", address);
     let server = axum::Server::try_bind(&address).or_else(|_| {
-        error!(
+        warn!(
             target: LOG_TARGET,
             "🕸️ Failed to bind on preferred address {}. Trying OS-assigned", address
         );

--- a/applications/tari_validator_node/src/json_rpc/handlers.rs
+++ b/applications/tari_validator_node/src/json_rpc/handlers.rs
@@ -30,7 +30,7 @@ use libp2p::swarm::dial_opts::{DialOpts, PeerCondition};
 use log::*;
 use serde_json::{self as json, json};
 use tari_base_node_client::types::BaseLayerValidatorNode;
-use tari_common_types::types::{CompressedPublicKey, FixedHash};
+use tari_common_types::types::CompressedPublicKey;
 use tari_consensus_types::{Decision, LeafBlock};
 use tari_core::transactions::transaction_components::ValidatorNodeSignature;
 use tari_crypto::{ristretto::RistrettoPublicKey, tari_utilities::ByteArray};
@@ -57,10 +57,10 @@ use tari_dan_storage::{
     StateStoreReadTransaction,
     StorageError,
 };
-use tari_dan_storage_sqlite::{error::SqliteStorageError, global::SqliteGlobalDbAdapter};
+use tari_dan_storage_sqlite::global::SqliteGlobalDbAdapter;
 use tari_engine_types::{FromByteType, ToByteType};
 use tari_epoch_manager::{service::EpochManagerHandle, traits::LayerOneTransactionSubmitter, EpochManagerReader};
-use tari_epoch_oracles::{configured::calc_static_epoch_hash, store::StoreKey};
+use tari_epoch_oracles::store::StoreKey;
 use tari_networking::{is_supported_multiaddr, NetworkingHandle, NetworkingService};
 use tari_sidechain::QuorumDecision;
 use tari_template_lib::prelude::{RistrettoPublicKeyBytes, Scalar32Bytes, SchnorrSignatureBytes};
@@ -562,29 +562,19 @@ impl JsonRpcHandlers {
             .await
             .map_err(internal_error(answer_id))?;
         let current_epoch = self.epoch_manager.get_current_epoch();
+        let current_epoch_hash = self
+            .epoch_manager
+            .get_current_epoch_hash()
+            .await
+            .map_err(internal_error(answer_id))?;
 
-        let (current_block_hash, current_block_height) = self
+        let current_block_height = self
             .global_db
             .create_transaction()
             .and_then(|mut tx| {
-                // This pokes into the internals of the oracles a bit. And can give incorrect results if we switch
-                // between them.
-                let current_epoch = self
-                    .global_db
+                self.global_db
                     .metadata(&mut tx)
-                    .get_metadata::<Epoch>(StoreKey::StaticCurrentEpoch.as_key_bytes())?;
-                let block_hash = self
-                    .global_db
-                    .metadata(&mut tx)
-                    .get_metadata::<FixedHash>(StoreKey::BaseLayerLastScannedBlockHash.as_key_bytes())?
-                    .or_else(|| current_epoch.map(calc_static_epoch_hash));
-                let block_height = self
-                    .global_db
-                    .metadata(&mut tx)
-                    .get_metadata::<u64>(StoreKey::BaseLayerLastScannedBlockHeight.as_key_bytes())?
-                    // Just use the epoch here
-                    .or(current_epoch.map(|e| e.as_u64()));
-                Ok::<_, SqliteStorageError>((block_hash.unwrap_or_default(), block_height.unwrap_or_default()))
+                    .get_metadata::<u64>(StoreKey::BaseLayerLastScannedBlockHeight.as_key_bytes())
             })
             .map_err(|e| {
                 JsonRpcResponse::error(
@@ -642,8 +632,8 @@ impl JsonRpcHandlers {
             .map_err(internal_error(answer_id))?;
         let response = GetEpochManagerStatsResponse {
             current_epoch,
-            current_block_height,
-            current_block_hash,
+            current_block_height: current_block_height.unwrap_or(0),
+            current_block_hash: current_epoch_hash,
             is_initial_scanning_complete,
             is_valid: committee_info.is_some(),
             start_epoch: local_vn_start_epoch,

--- a/applications/tari_validator_node/src/json_rpc/server.rs
+++ b/applications/tari_validator_node/src/json_rpc/server.rs
@@ -46,7 +46,7 @@ pub fn spawn_json_rpc(
         .layer(CorsLayer::permissive());
 
     let server = axum::Server::try_bind(&preferred_address).or_else(|_| {
-        error!(
+        warn!(
             target: LOG_TARGET,
             "🌐 Failed to bind on preferred address {}. Trying OS-assigned", preferred_address
         );

--- a/applications/tari_validator_node/src/lib.rs
+++ b/applications/tari_validator_node/src/lib.rs
@@ -46,7 +46,7 @@ use serde::{Deserialize, Serialize};
 use tari_common::exit_codes::{ExitCode, ExitError};
 use tari_consensus::consensus_constants::ConsensusConstants;
 use tari_dan_app_utilities::{
-    keypair::setup_keypair_prompt,
+    keypair::RistrettoKeypair,
     template_download_queue::TemplateDownloadQueue,
     utxo_store::StateUtxoStore,
 };
@@ -90,12 +90,12 @@ pub struct ShardKey {
     substate_address: Option<SubstateAddress>,
 }
 
-pub async fn run_validator_node(config: ApplicationConfig, shutdown: Shutdown) -> Result<(), anyhow::Error> {
+pub async fn run_validator_node(
+    keypair: RistrettoKeypair,
+    config: ApplicationConfig,
+    shutdown: Shutdown,
+) -> Result<(), anyhow::Error> {
     info!(target: LOG_TARGET, "Starting validator node on network {}", config.network);
-    let keypair = setup_keypair_prompt(
-        &config.validator_node.identity_file,
-        !config.validator_node.dont_create_id,
-    )?;
 
     let db_factory = SqliteDbFactory::new(config.validator_node.data_dir.clone());
     db_factory

--- a/applications/tari_validator_node/src/main.rs
+++ b/applications/tari_validator_node/src/main.rs
@@ -27,7 +27,7 @@ use std::{fs, panic, process};
 use clap::Parser;
 use log::*;
 use tari_common::initialize_logging;
-use tari_dan_app_utilities::configuration::load_configuration;
+use tari_dan_app_utilities::{configuration::load_configuration, keypair::setup_keypair_prompt};
 use tari_shutdown::Shutdown;
 use tari_validator_node::{run_validator_node, ApplicationConfig};
 
@@ -79,10 +79,36 @@ async fn main() -> anyhow::Result<()> {
         },
         Some(cli::Subcommand::Start) | None => {
             let shutdown = Shutdown::new();
-            run_validator_node(config, shutdown).await?;
+            let keypair = setup_keypair_prompt(
+                &config.validator_node.identity_file,
+                !config.validator_node.dont_create_id,
+            )?;
+
+            run_validator_node(keypair, config, shutdown).await?;
             info!(target: LOG_TARGET, "Validator node shutdown successfully");
         },
+        Some(cli::Subcommand::GenerateIdentity) => {
+            let keypair = setup_keypair_prompt(
+                &config.validator_node.identity_file,
+                !config.validator_node.dont_create_id,
+            )?;
+
+            info!(
+                target: LOG_TARGET,
+                "Generated identity with public key: {}",
+                keypair.public_key()
+            );
+        },
     }
+
+    let metrics = tokio::runtime::Handle::current().metrics();
+    info!(
+        target: LOG_TARGET,
+        "Tokio runtime metrics: num_alive_tasks={}, num_workers={}, global_queue_depth={}",
+        metrics.num_alive_tasks(),
+        metrics.num_workers(),
+        metrics.global_queue_depth(),
+    );
 
     Ok(())
 }

--- a/dan_layer/common_types/src/epoch.rs
+++ b/dan_layer/common_types/src/epoch.rs
@@ -28,7 +28,7 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "ts")]
 use ts_rs::TS;
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize, Serialize, BorshSerialize)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize, Serialize, BorshSerialize)]
 #[cfg_attr(feature = "ts", derive(TS), ts(export, export_to = "../../bindings/src/types/"))]
 pub struct Epoch(#[cfg_attr(feature = "ts", ts(type = "number"))] pub u64);
 

--- a/dan_layer/consensus/src/hotstuff/error.rs
+++ b/dan_layer/consensus/src/hotstuff/error.rs
@@ -87,9 +87,11 @@ pub enum HotStuffError {
     InvariantError(String),
     #[error("Sync error: {0}")]
     SyncError(anyhow::Error),
-    #[error("Fallen behind: local_height={local_height}, qc_height={qc_height}")]
+    #[error("Fallen behind: local={local_epoch}/{local_height}, qc={qc_epoch}/{qc_height}")]
     FallenBehind {
+        local_epoch: Epoch,
         local_height: NodeHeight,
+        qc_epoch: Epoch,
         qc_height: NodeHeight,
     },
     #[error("Transaction executor error: {0}")]

--- a/dan_layer/consensus/src/hotstuff/on_catch_up_sync.rs
+++ b/dan_layer/consensus/src/hotstuff/on_catch_up_sync.rs
@@ -39,7 +39,7 @@ impl<TConsensusSpec: ConsensusSpec> OnCatchUpSync<TConsensusSpec> {
         let block_height = if high_qc.epoch() == epoch {
             high_qc.block_height()
         } else {
-            NodeHeight::zero()
+            NodeHeight(1)
         };
 
         // Reset leader timeout to previous height since we're behind and need to process catch up blocks. This is the

--- a/dan_layer/consensus/src/hotstuff/on_catch_up_sync_request.rs
+++ b/dan_layer/consensus/src/hotstuff/on_catch_up_sync_request.rs
@@ -3,7 +3,7 @@
 
 use log::*;
 use tari_consensus_types::{LastProposed, LastSentVote, LeafBlock};
-use tari_dan_common_types::{optional::Optional, Epoch};
+use tari_dan_common_types::{optional::Optional, Epoch, NodeHeight};
 use tari_dan_storage::{
     consensus_models::{Block, BookkeepingModel},
     StateStore,
@@ -98,7 +98,7 @@ impl<TConsensusSpec: ConsensusSpec> OnSyncRequest<TConsensusSpec> {
                 let blocks = Block::get_all_blocks_between(
                     tx,
                     msg.epoch,
-                    msg.block_height,
+                    msg.block_height.max(NodeHeight(1)),
                     leaf_block.height(),
                     false,
                     1000,

--- a/dan_layer/consensus/src/hotstuff/on_receive_new_view.rs
+++ b/dan_layer/consensus/src/hotstuff/on_receive_new_view.rs
@@ -7,6 +7,7 @@ use tari_dan_common_types::{optional::Optional, NodeHeight};
 use tari_dan_storage::{
     consensus_models::{Block, BookkeepingModel},
     StateStore,
+    StateStoreWriteTransaction,
 };
 
 use super::vote_collector::{ProposalVoteCollector, TimeoutVoteCollector};
@@ -104,7 +105,9 @@ where TConsensusSpec: ConsensusSpec
                     .map(|leaf| leaf.height())
                     .unwrap_or_default();
                 return Err(HotStuffError::FallenBehind {
+                    local_epoch: epoch_state.epoch(),
                     local_height,
+                    qc_epoch: high_pc.epoch(),
                     qc_height: high_pc.height(),
                 });
             }
@@ -169,6 +172,8 @@ where TConsensusSpec: ConsensusSpec
         info!(target: LOG_TARGET, "🌟✅ NEWVIEW height {} (high_tc: {}) has reached quorum ({}/{})", timeout_height, high_tc, timeout_certificate.signatures().len(), threshold);
         if timeout_certificate.calculate_id() == *high_tc.id() {
             info!(target: LOG_TARGET, "🕒️ New HIGH TC {}", timeout_certificate);
+            // Clear the last sent new view since we have a new certificate
+            self.store.with_write_tx(|tx| tx.last_sent_new_view_clear())?;
             self.pacemaker.force_beat(high_tc.height());
         } else {
             info!(target: LOG_TARGET, "❓️ New TC from votes {} but it is not the highest TC {}", timeout_certificate, high_tc);

--- a/dan_layer/consensus/src/hotstuff/vote_collector/collector.rs
+++ b/dan_layer/consensus/src/hotstuff/vote_collector/collector.rs
@@ -43,6 +43,11 @@ impl<V: Vote + Display> VoteCollector<V> {
         let key = vote.key();
         let vote_display = vote.to_string();
         if !access_mut.save_vote(sender_hash, vote) {
+            debug!(
+                target: LOG_TARGET,
+                "❓️ Received duplicate vote for {}. This could be malicious because a validator should only vote once for the same block.",
+                vote_display,
+            );
             // We already have a vote for this block from this sender
             return None;
         }

--- a/dan_layer/consensus/src/hotstuff/worker.rs
+++ b/dan_layer/consensus/src/hotstuff/worker.rs
@@ -423,9 +423,7 @@ impl<TConsensusSpec: ConsensusSpec> HotstuffWorker<TConsensusSpec> {
                     .dispatch_hotstuff_message(epoch_state, current_height, from, msg)
                     .await
                 {
-                    self.on_failure("on_unvalidated_message -> dispatch_hotstuff_message", &e)
-                        .await;
-                    return Err(e);
+                    return self.handle_hotstuff_error(epoch_state, None, e).await;
                 }
                 Ok(())
             },
@@ -473,21 +471,12 @@ impl<TConsensusSpec: ConsensusSpec> HotstuffWorker<TConsensusSpec> {
             },
             MessageValidationResult::Discard => Ok(()),
             // In these cases, we want to propagate the error back to the state machine, to allow sync
-            MessageValidationResult::Invalid {
-                err: err @ HotStuffError::FallenBehind { .. },
-                ..
-            } |
-            MessageValidationResult::Invalid {
-                err: err @ HotStuffError::ProposalValidationError(ProposalValidationError::FutureEpoch { .. }),
-                ..
-            } => {
-                self.hooks.on_error(&err);
-                Err(err)
-            },
-            MessageValidationResult::Invalid { err, from, message } => {
-                self.hooks.on_error(&err);
-                error!(target: LOG_TARGET, "🚨 Invalid message from {from}: {err} - {message}");
-                Ok(())
+            MessageValidationResult::Invalid { err, message, from } => {
+                if let HotStuffError::ProposalValidationError(_) = err {
+                    error!(target: LOG_TARGET, "🚨 Invalid message from {from}: {err} - {message}");
+                }
+
+                self.handle_hotstuff_error(epoch_state, None, err).await
             },
         }
     }
@@ -974,22 +963,75 @@ impl<TConsensusSpec: ConsensusSpec> HotstuffWorker<TConsensusSpec> {
                 // We decided NOVOTE, so we immediately send a NEWVIEW
                 self.on_leader_timeout(epoch_state, current_height).await
             },
-            Err(err @ HotStuffError::ProposalValidationError(ProposalValidationError::JustifyBlockNotFound { .. })) => {
-                let vn = self
-                    .epoch_manager
-                    .get_validator_node_by_public_key(epoch_state.epoch(), proposed_by)
-                    .await?;
+            Err(err) => self.handle_hotstuff_error(epoch_state, Some(proposed_by), err).await,
+        }
+    }
+
+    async fn handle_hotstuff_error(
+        &mut self,
+        local_epoch_state: &EpochState<TConsensusSpec::Addr>,
+        catch_up_from: Option<RistrettoPublicKeyBytes>,
+        err: HotStuffError,
+    ) -> Result<(), HotStuffError> {
+        self.hooks.on_error(&err);
+        let (remote_epoch, remote_height) = match &err {
+            HotStuffError::FallenBehind {
+                qc_epoch, qc_height, ..
+            } => (*qc_epoch, *qc_height),
+            HotStuffError::ProposalValidationError(ProposalValidationError::JustifyBlockNotFound {
+                justify_block,
+                ..
+            }) => (justify_block.epoch(), justify_block.height()),
+            HotStuffError::ProposalValidationError(err) => {
                 warn!(
                     target: LOG_TARGET,
-                    "⚠️This node has fallen behind due to a missing justified block: {err}"
+                    "⚠️ Proposal validation error: {err}."
                 );
-                self.on_catch_up_sync
-                    .request_sync(epoch_state.epoch(), vn.address)
-                    .await?;
-                Ok(())
+                // Failed validations should  not crash consensus
+                return Ok(());
             },
-            Err(err) => Err(err),
+            _ => {
+                // Other errors can pass though
+                return Err(err);
+            },
+        };
+
+        if remote_epoch > local_epoch_state.epoch() {
+            // We are in a future epoch, so we cannot justify this block
+            warn!(
+                target: LOG_TARGET,
+                "❌ Justify block {remote_epoch}/{remote_height} is in a future epoch > current epoch {}. State sync required.",
+                local_epoch_state.epoch()
+            );
+            // Sync
+            return Err(err);
         }
+        // Otherwise, catch up
+        let vn = match catch_up_from {
+            Some(pk) => {
+                self.epoch_manager
+                    .get_validator_node_by_public_key(local_epoch_state.epoch(), pk)
+                    .await?
+            },
+            None => {
+                self.epoch_manager
+                    .get_random_committee_member(
+                        local_epoch_state.epoch(),
+                        Some(local_epoch_state.local_committee_info.shard_group()),
+                        vec![self.local_validator_addr.clone()],
+                    )
+                    .await?
+            },
+        };
+
+        warn!(
+            target: LOG_TARGET,
+            "⚠️This node has fallen behind due to a missing justified block: {err}. Catching up"
+        );
+        self.on_catch_up_sync
+            .request_sync(local_epoch_state.epoch(), vn.address)
+            .await?;
+        Ok(())
     }
 
     fn create_genesis_block_if_required(

--- a/dan_layer/consensus/src/traits/certificate.rs
+++ b/dan_layer/consensus/src/traits/certificate.rs
@@ -62,6 +62,10 @@ impl CertificateStore for ProposalCertificate {
     {
         match HighPc::get(&**tx, self.epoch()).optional()? {
             Some(high_pc) if high_pc.block_height() >= self.height() => {
+                // EDGE CASE: If we receive a new high PC, clear the last sent new view. This is because we could have
+                // sent many unsuccessful NEWVIEWs (likely we're offline) and the chain progressed
+                // without us. But then if we need to send NEWVIEWs again, it will be aligned with the network view.
+                tx.last_sent_new_view_clear()?;
                 info!(
                     target: LOG_TARGET,
                     "🔥 HIGH_PC ({}, previous high PC: {} {}) - not new",

--- a/dan_layer/epoch_manager/src/epoch_event_oracle/event.rs
+++ b/dan_layer/epoch_manager/src/epoch_event_oracle/event.rs
@@ -48,6 +48,7 @@ pub enum EpochEvent {
     },
     DoneForNow {
         epoch: Epoch,
+        epoch_hash: FixedHash,
     },
 }
 
@@ -123,7 +124,9 @@ impl Display for EpochEvent {
             EpochEvent::EpochChanged { epoch, epoch_hash } => {
                 write!(f, "EpochChanged {{ epoch: {}, epoch_hash: {} }}", epoch, epoch_hash)
             },
-            EpochEvent::DoneForNow { epoch } => write!(f, "DoneForNow {{ epoch: {} }}", epoch),
+            EpochEvent::DoneForNow { epoch, epoch_hash } => {
+                write!(f, "DoneForNow {{ epoch: {}, hash: {} }}", epoch, epoch_hash)
+            },
         }
     }
 }

--- a/dan_layer/epoch_manager/src/service/epoch_manager_service.rs
+++ b/dan_layer/epoch_manager/src/service/epoch_manager_service.rs
@@ -232,7 +232,7 @@ impl<TSpec: EpochManagerSpec> EpochManagerService<TSpec> {
             EpochEvent::NewConfidentialOutput { epoch, substate } => {
                 self.utxo_store.add_unclaimed_utxo(epoch, substate)?;
             },
-            EpochEvent::DoneForNow { epoch } => {
+            EpochEvent::DoneForNow { epoch, .. } => {
                 debug!(target: LOG_TARGET, "Epoch event scanner done for now at {epoch}. Current epoch: {}", self.inner.current_epoch());
                 self.inner.on_scanning_complete().await?;
             },

--- a/dan_layer/epoch_oracles/Cargo.toml
+++ b/dan_layer/epoch_oracles/Cargo.toml
@@ -25,6 +25,10 @@ thiserror = { workspace = true }
 serde = { workspace = true }
 url = { workspace = true, optional = true }
 
+[dev-dependencies]
+tokio = { workspace = true, features = ["time", "macros"] }
+
+
 [features]
 base_layer = [
     "tari_base_node_client",

--- a/dan_layer/epoch_oracles/src/base_layer/mod.rs
+++ b/dan_layer/epoch_oracles/src/base_layer/mod.rs
@@ -168,7 +168,10 @@ impl<TStore: EpochOracleStore> BaseLayerOracleInner<TStore> {
                     let epoch = constants.height_to_epoch(lagged_height);
                     // If no progress has been made since restarting, we still need to tell the epoch manager that
                     // scanning is done
-                    self.pending_events.push_back(EpochEvent::DoneForNow { epoch });
+                    self.pending_events.push_back(EpochEvent::DoneForNow {
+                        epoch,
+                        epoch_hash: self.last_epoch_hash.unwrap_or_else(FixedHash::zero),
+                    });
                 }
             },
         }
@@ -554,7 +557,10 @@ impl<TStore: EpochOracleStore> BaseLayerOracleInner<TStore> {
         } else {
             let constants = self.base_node_client.get_consensus_constants(lagged_height).await?;
             let epoch = constants.height_to_epoch(lagged_height);
-            self.pending_events.push_back(EpochEvent::DoneForNow { epoch });
+            self.pending_events.push_back(EpochEvent::DoneForNow {
+                epoch,
+                epoch_hash: current_hash.unwrap_or_else(FixedHash::zero),
+            });
         }
 
         Ok(())

--- a/dan_layer/epoch_oracles/src/configured/epoch_ticker.rs
+++ b/dan_layer/epoch_oracles/src/configured/epoch_ticker.rs
@@ -1,0 +1,106 @@
+//   Copyright 2025 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+use std::task::{ready, Context, Poll};
+
+use tari_common_types::types::FixedHash;
+use tari_dan_common_types::Epoch;
+
+pub trait EpochTicker {
+    fn poll_tick(&mut self, cx: &mut Context) -> Poll<Option<EpochTickerData>>;
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct EpochTickerData {
+    pub epoch: Epoch,
+    pub epoch_hash: FixedHash,
+    pub done_for_now: bool,
+}
+
+#[derive(Debug)]
+pub struct IntervalEpochTicker {
+    interval: Option<tokio::time::Interval>,
+    initial_epoch: Epoch,
+    epoch: Epoch,
+}
+
+impl IntervalEpochTicker {
+    pub fn new(interval: Option<tokio::time::Duration>, initial_epoch: Epoch, current_epoch: Epoch) -> Self {
+        Self {
+            interval: interval.map(|d| {
+                let mut interval = tokio::time::interval(d);
+                interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Burst);
+                interval
+            }),
+            initial_epoch,
+            epoch: current_epoch,
+        }
+    }
+
+    fn increment_epoch(&mut self) -> Epoch {
+        let epoch = self.epoch;
+        self.epoch += Epoch(1);
+        epoch
+    }
+}
+
+impl EpochTicker for IntervalEpochTicker {
+    fn poll_tick(&mut self, cx: &mut Context) -> Poll<Option<EpochTickerData>> {
+        // Tick quickly initially
+        if self.epoch < self.initial_epoch {
+            let epoch = self.increment_epoch();
+            let epoch_hash = calc_static_epoch_hash(epoch);
+            return Poll::Ready(Some(EpochTickerData {
+                epoch,
+                epoch_hash,
+                done_for_now: false,
+            }));
+        }
+
+        if let Some(interval_mut) = self.interval.as_mut() {
+            ready!(interval_mut.poll_tick(cx));
+            let epoch = self.increment_epoch();
+            let epoch_hash = calc_static_epoch_hash(epoch);
+            return Poll::Ready(Some(EpochTickerData {
+                epoch,
+                epoch_hash,
+                done_for_now: true,
+            }));
+        }
+        Poll::Pending
+    }
+}
+
+fn calc_static_epoch_hash(epoch: Epoch) -> FixedHash {
+    const U64_SIZE: usize = size_of::<u64>();
+    const HASH_SIZE: usize = FixedHash::byte_size();
+    let mut epoch_hash = [0u8; HASH_SIZE];
+    epoch_hash[HASH_SIZE - U64_SIZE..].copy_from_slice(&epoch.to_be_bytes());
+    epoch_hash.into()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{future::poll_fn, time::Duration};
+
+    use tokio::time::timeout;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn it_ticks_according_to_interval() {
+        let mut ticker = IntervalEpochTicker::new(Some(Duration::from_millis(10)), Epoch(0), Epoch(0));
+
+        for i in 0..5 {
+            let res = timeout(Duration::from_secs(1), poll_fn(|cx| ticker.poll_tick(cx))).await;
+            assert_eq!(
+                res,
+                Ok(Some(EpochTickerData {
+                    epoch: Epoch(i),
+                    epoch_hash: calc_static_epoch_hash(Epoch(i)),
+                    done_for_now: true
+                }))
+            );
+        }
+    }
+}

--- a/dan_layer/epoch_oracles/src/configured/mod.rs
+++ b/dan_layer/epoch_oracles/src/configured/mod.rs
@@ -2,7 +2,9 @@
 //   SPDX-License-Identifier: BSD-3-Clause
 
 mod config;
+mod epoch_ticker;
 mod oracle;
 
 pub use config::*;
+pub use epoch_ticker::*;
 pub use oracle::*;

--- a/dan_layer/epoch_oracles/src/configured/oracle.rs
+++ b/dan_layer/epoch_oracles/src/configured/oracle.rs
@@ -3,44 +3,63 @@
 
 use std::{
     collections::{HashMap, VecDeque},
-    future::{poll_fn, Future},
-    pin::Pin,
+    future::poll_fn,
     task::{Context, Poll},
 };
 
 use log::*;
-use tari_common_types::types::FixedHash;
 use tari_dan_common_types::{displayable::Displayable, Epoch};
 use tari_epoch_manager::epoch_event_oracle::{EpochEvent, EpochEventOracle, ValidatorNodeChange};
-use tokio::{time, time::Sleep};
 
 use super::config::Config;
 use crate::{
-    configured::Validator,
+    configured::{
+        epoch_ticker::{EpochTicker, IntervalEpochTicker},
+        EpochTickerData,
+        Validator,
+    },
     store::{EpochOracleStore, StoreKey},
 };
 
 const LOG_TARGET: &str = "tari::dan::epoch_oracles::configured";
 
-pub struct ConfiguredEpochOracle<TStore> {
+pub struct ConfiguredEpochOracle<TStore, TTicker> {
     config: Config,
     pending_events: VecDeque<EpochEvent>,
     store: TStore,
-    sleep: Option<Pin<Box<Sleep>>>,
+    ticker: TTicker,
     queued_validators: HashMap<Epoch, Vec<Validator>>,
     is_initialized: bool,
     is_done: bool,
 }
-
-impl<TStore: EpochOracleStore + Send> ConfiguredEpochOracle<TStore> {
+impl<TStore: EpochOracleStore + Send> ConfiguredEpochOracle<TStore, IntervalEpochTicker> {
     pub fn new(config: Config, store: TStore) -> Self {
+        let epoch = store
+            .get(StoreKey::ConfiguredCurrentEpoch.as_key_bytes())
+            .expect("Failed to get current epoch from store")
+            .unwrap_or_else(Epoch::zero);
+        let ticker = IntervalEpochTicker::new(config.epoch_time, config.initial_epoch, epoch);
         Self {
             config,
             store,
-            is_initialized: false,
+            ticker,
             pending_events: VecDeque::new(),
             queued_validators: HashMap::new(),
-            sleep: None,
+            is_initialized: false,
+            is_done: false,
+        }
+    }
+}
+
+impl<TStore: EpochOracleStore + Send, TTicker: EpochTicker> ConfiguredEpochOracle<TStore, TTicker> {
+    pub fn with_custom_ticker(config: Config, store: TStore, ticker: TTicker) -> Self {
+        Self {
+            config,
+            store,
+            ticker,
+            pending_events: VecDeque::new(),
+            queued_validators: HashMap::new(),
+            is_initialized: false,
             is_done: false,
         }
     }
@@ -48,7 +67,7 @@ impl<TStore: EpochOracleStore + Send> ConfiguredEpochOracle<TStore> {
     fn initialize(&mut self) -> anyhow::Result<()> {
         let epoch = self
             .store
-            .get(StoreKey::StaticCurrentEpoch.as_key_bytes())?
+            .get(StoreKey::ConfiguredCurrentEpoch.as_key_bytes())?
             .unwrap_or_else(Epoch::zero);
 
         for vn in &self.config.validators {
@@ -70,69 +89,28 @@ impl<TStore: EpochOracleStore + Send> ConfiguredEpochOracle<TStore> {
             self.queued_validators.values().map(|vns| vns.len()).sum::<usize>(),
         );
 
-        let is_initialized = self
-            .store
-            .get::<bool>(StoreKey::StaticIsInitialized.as_key_bytes())?
-            .unwrap_or(false);
-        if is_initialized {
-            return Ok(());
-        }
-
-        let size = self.config.initial_epoch.as_u64() as usize + self.config.validators.len() + 1;
-        self.pending_events.reserve(size);
-        for epoch in 0..=self.config.initial_epoch.as_u64() {
-            let epoch = Epoch::from(epoch);
-            let registered_vns = self.config.validators.iter().filter(|v| v.registration_epoch == epoch);
-
-            self.pending_events
-                .extend(registered_vns.map(|vn| EpochEvent::NewValidatorRegistered {
-                    epoch,
-                    claim_public_key: vn.claim_key,
-                    validator_node_public_key: vn.public_key,
-                }));
-
-            let next_epoch = epoch + Epoch(1);
-            if let Some(vns) = self.queued_validators.remove(&next_epoch) {
-                self.pending_events
-                    .push_back(EpochEvent::ActiveValidatorNodeSetChanged {
-                        epoch,
-                        node_changes: vns
-                            .into_iter()
-                            .map(|vn| ValidatorNodeChange::Add {
-                                claim_public_key: vn.claim_key,
-                                validator_node_public_key: vn.public_key,
-                                activation_epoch: epoch,
-                                minimum_value_promise: 0,
-                                shard_key: vn.calculate_shard_key(),
-                            })
-                            .collect(),
-                    });
-            }
-
-            self.pending_events.push_back(EpochEvent::EpochChanged {
-                epoch,
-                epoch_hash: calc_static_epoch_hash(epoch),
-            });
-        }
-
-        self.store.set(StoreKey::StaticIsInitialized.as_key_bytes(), &true)?;
-        self.store
-            .set(StoreKey::StaticCurrentEpoch.as_key_bytes(), &self.config.initial_epoch)?;
         Ok(())
     }
 
-    fn prepare_next_epoch(&mut self) -> anyhow::Result<()> {
-        let epoch = self
-            .store
-            .get(StoreKey::StaticCurrentEpoch.as_key_bytes())?
-            .unwrap_or_else(Epoch::zero);
-        let next_epoch = epoch + Epoch(1);
+    fn prepare_next_epoch(&mut self, epoch_ticker_data: EpochTickerData) -> anyhow::Result<()> {
+        let next_epoch = epoch_ticker_data.epoch;
+        let epoch_hash = epoch_ticker_data.epoch_hash;
+        let done_for_now = epoch_ticker_data.done_for_now;
+        let prev_epoch = next_epoch - Epoch(1);
         self.store
-            .set(StoreKey::StaticCurrentEpoch.as_key_bytes(), &next_epoch)?;
-        let epoch_hash = calc_static_epoch_hash(next_epoch);
+            .set(StoreKey::ConfiguredCurrentEpoch.as_key_bytes(), &next_epoch)?;
 
+        debug!(
+            target: LOG_TARGET,
+            "☘️ Preparing next epoch {next_epoch}",
+        );
         let next_next_epoch = next_epoch + Epoch(1);
         if let Some(vns) = self.queued_validators.get(&next_next_epoch) {
+            debug!(
+                target: LOG_TARGET,
+                "☘️ {} VNS registered for epoch {next_next_epoch}",
+                vns.len()
+            );
             // Emit these one epoch before a VN becomes active
             self.pending_events
                 .extend(vns.iter().map(|vn| EpochEvent::NewValidatorRegistered {
@@ -143,9 +121,14 @@ impl<TStore: EpochOracleStore + Send> ConfiguredEpochOracle<TStore> {
         }
 
         if let Some(vns) = self.queued_validators.remove(&next_epoch) {
+            debug!(
+                target: LOG_TARGET,
+                "☘️ {} VNS activated for epoch {next_epoch}",
+                vns.len()
+            );
             self.pending_events
                 .push_back(EpochEvent::ActiveValidatorNodeSetChanged {
-                    epoch,
+                    epoch: prev_epoch,
                     node_changes: vns
                         .into_iter()
                         .map(|vn| ValidatorNodeChange::Add {
@@ -163,8 +146,13 @@ impl<TStore: EpochOracleStore + Send> ConfiguredEpochOracle<TStore> {
             epoch: next_epoch,
             epoch_hash,
         });
-        self.pending_events
-            .push_back(EpochEvent::DoneForNow { epoch: next_epoch });
+
+        if done_for_now {
+            self.pending_events.push_back(EpochEvent::DoneForNow {
+                epoch: next_epoch,
+                epoch_hash,
+            });
+        }
 
         Ok(())
     }
@@ -179,11 +167,6 @@ impl<TStore: EpochOracleStore + Send> ConfiguredEpochOracle<TStore> {
                 self.is_done = true;
                 return Poll::Ready(Some(EpochEvent::error(err)));
             }
-
-            // Oracle always notifies the caller when initial scanning has completed.
-            self.pending_events.push_back(EpochEvent::DoneForNow {
-                epoch: self.config.initial_epoch,
-            });
             self.is_initialized = true;
         }
 
@@ -192,36 +175,32 @@ impl<TStore: EpochOracleStore + Send> ConfiguredEpochOracle<TStore> {
                 return Poll::Ready(Some(event));
             }
 
-            if let Some(epoch_time) = self.config.epoch_time {
-                if self.sleep.is_none() {
-                    self.sleep = Some(Box::pin(time::sleep(epoch_time)));
-                }
-            }
-
-            if let Some(sleep) = self.sleep.as_mut() {
-                if sleep.as_mut().poll(cx).is_pending() {
-                    return Poll::Pending;
-                }
-                if let Err(err) = self.prepare_next_epoch() {
+            match self.ticker.poll_tick(cx) {
+                Poll::Ready(Some(data)) => {
+                    info!(target: LOG_TARGET, "⏰ Ticker ticked for epoch {}, done_for_now = {}", data.epoch, data.done_for_now);
+                    if let Err(err) = self.prepare_next_epoch(data) {
+                        self.is_done = true;
+                        return Poll::Ready(Some(EpochEvent::error(err)));
+                    }
+                },
+                Poll::Ready(None) => {
+                    debug!(target: LOG_TARGET, "Ticker returned None");
                     self.is_done = true;
-                    return Poll::Ready(Some(EpochEvent::error(err)));
-                }
+                    return Poll::Ready(None);
+                },
+                Poll::Pending => {
+                    // Still waiting for the next tick
+                    return Poll::Pending;
+                },
             }
-            self.sleep = None;
         }
     }
 }
 
-impl<TStore: EpochOracleStore + Send> EpochEventOracle for ConfiguredEpochOracle<TStore> {
+impl<TStore: EpochOracleStore + Send, TTicker: EpochTicker + Send> EpochEventOracle
+    for ConfiguredEpochOracle<TStore, TTicker>
+{
     async fn next_epoch_event(&mut self) -> Option<EpochEvent> {
         poll_fn(|cx| self.poll(cx)).await
     }
-}
-
-pub fn calc_static_epoch_hash(epoch: Epoch) -> FixedHash {
-    const U64_SIZE: usize = size_of::<u64>();
-    const HASH_SIZE: usize = FixedHash::byte_size();
-    let mut epoch_hash = [0u8; HASH_SIZE];
-    epoch_hash[HASH_SIZE - U64_SIZE..].copy_from_slice(&epoch.to_be_bytes());
-    epoch_hash.into()
 }

--- a/dan_layer/epoch_oracles/src/hybrid/mod.rs
+++ b/dan_layer/epoch_oracles/src/hybrid/mod.rs
@@ -2,4 +2,7 @@
 //   SPDX-License-Identifier: BSD-3-Clause
 
 mod oracle;
+mod watch_ticker;
+
 pub use oracle::*;
+pub use watch_ticker::*;

--- a/dan_layer/epoch_oracles/src/hybrid/oracle.rs
+++ b/dan_layer/epoch_oracles/src/hybrid/oracle.rs
@@ -3,19 +3,36 @@
 
 use log::*;
 use tari_epoch_manager::epoch_event_oracle::{EpochEvent, EpochEventOracle};
+use tokio::sync::watch;
 
-use crate::{base_layer::BaseLayerOracle, configured::ConfiguredEpochOracle, store::EpochOracleStore};
+use crate::{
+    base_layer::BaseLayerOracle,
+    configured::{ConfiguredEpochOracle, EpochTickerData},
+    hybrid::watch_ticker::WatchEpochTicker,
+    store::EpochOracleStore,
+};
 
 const LOG_TARGET: &str = "tari::dan::epoch_oracles::hybrid";
 
 pub struct HybridEpochOracle<TStore> {
-    configured: ConfiguredEpochOracle<TStore>,
+    configured: ConfiguredEpochOracle<TStore, WatchEpochTicker>,
     base_layer: BaseLayerOracle<TStore>,
+    trigger: watch::Sender<EpochTickerData>,
+    has_initial_sync_completed: bool,
 }
 
 impl<TStore: EpochOracleStore + Send + 'static> HybridEpochOracle<TStore> {
-    pub fn new(configured: ConfiguredEpochOracle<TStore>, base_layer: BaseLayerOracle<TStore>) -> Self {
-        Self { configured, base_layer }
+    pub fn new(
+        configured: ConfiguredEpochOracle<TStore, WatchEpochTicker>,
+        base_layer: BaseLayerOracle<TStore>,
+        trigger: watch::Sender<EpochTickerData>,
+    ) -> Self {
+        Self {
+            configured,
+            base_layer,
+            trigger,
+            has_initial_sync_completed: false,
+        }
     }
 
     fn should_emit_configured(&self, event: &EpochEvent) -> bool {
@@ -26,11 +43,11 @@ impl<TStore: EpochOracleStore + Send + 'static> HybridEpochOracle<TStore> {
             EpochEvent::NewValidatorRegistered { .. } |
             EpochEvent::NewValidatorNodeExit { .. } |
             EpochEvent::NewCodeTemplateDownload { .. } |
-            EpochEvent::NewEvictionProof { .. } => true,
-            // These events are handled by the base layer oracle
-            EpochEvent::NewConfidentialOutput { .. } |
             EpochEvent::EpochChanged { .. } |
-            EpochEvent::DoneForNow { .. } => false,
+            EpochEvent::NewEvictionProof { .. } |
+            EpochEvent::DoneForNow { .. } => true,
+            // These events are handled by the base layer oracle
+            EpochEvent::NewConfidentialOutput { .. }  => false
         }
     }
 
@@ -39,9 +56,9 @@ impl<TStore: EpochOracleStore + Send + 'static> HybridEpochOracle<TStore> {
             EpochEvent::Error(_) |
             // Let the base layer oracle handle epoch timing and UTXO events
             EpochEvent::NewConfidentialOutput { .. } |
+            EpochEvent::NewCodeTemplateDownload { .. } => true,
+            EpochEvent::DoneForNow { .. }  |
             EpochEvent::EpochChanged { .. } |
-            EpochEvent::NewCodeTemplateDownload { .. } |
-            EpochEvent::DoneForNow { .. } => true,
             EpochEvent::ActiveValidatorNodeSetChanged { .. } |
             EpochEvent::NewValidatorRegistered { .. } |
             EpochEvent::NewValidatorNodeExit { .. } |
@@ -54,6 +71,8 @@ impl<TStore: EpochOracleStore + Send + 'static> EpochEventOracle for HybridEpoch
     async fn next_epoch_event(&mut self) -> Option<EpochEvent> {
         loop {
             tokio::select! {
+                biased;
+
                 event = self.configured.next_epoch_event() => {
                     let event = event?;
                     debug!(target: LOG_TARGET, "📝 Configured epoch event: {}", event);
@@ -64,6 +83,28 @@ impl<TStore: EpochOracleStore + Send + 'static> EpochEventOracle for HybridEpoch
                 event = self.base_layer.next_epoch_event() => {
                     let event = event?;
                     debug!(target: LOG_TARGET, "⛓️ Base layer epoch event: {}", event);
+                    match event {
+                        // Trigger the watch sender for epoch changes
+                        EpochEvent::EpochChanged { epoch, epoch_hash } => {
+                            let _ignore = self.trigger.send(EpochTickerData {
+                                epoch,
+                                epoch_hash,
+                                done_for_now: self.has_initial_sync_completed,
+                            });
+                        },
+                        EpochEvent::DoneForNow {epoch, epoch_hash} => {
+                            if !self.has_initial_sync_completed {
+                                let _ignore = self.trigger.send(EpochTickerData{
+                                    epoch,
+                                    epoch_hash,
+                                    done_for_now: true,
+                                });
+                                self.has_initial_sync_completed = true;
+                            }
+                        },
+                        // Ignore other events that are not epoch changes
+                        _ => {},
+                    }
                     if self.should_emit_base_layer(&event) {
                         return Some(event);
                     }

--- a/dan_layer/epoch_oracles/src/hybrid/watch_ticker.rs
+++ b/dan_layer/epoch_oracles/src/hybrid/watch_ticker.rs
@@ -1,0 +1,110 @@
+//   Copyright 2025 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use tokio::sync::watch;
+
+use crate::configured::{EpochTicker, EpochTickerData};
+
+pub fn watch_ticker() -> (WatchEpochTicker, watch::Sender<EpochTickerData>) {
+    let (tx, mut rx) = watch::channel(EpochTickerData::default());
+    // Dont want the dummy epoch 0 data
+    rx.mark_unchanged();
+    (WatchEpochTicker::new(rx), tx)
+}
+
+type TickerFuture = Pin<Box<dyn Future<Output = Option<watch::Receiver<EpochTickerData>>> + Send>>;
+
+pub struct WatchEpochTicker {
+    watch: Option<watch::Receiver<EpochTickerData>>,
+    ticker_fut: Option<TickerFuture>,
+}
+
+impl WatchEpochTicker {
+    pub fn new(watch: watch::Receiver<EpochTickerData>) -> Self {
+        Self {
+            watch: Some(watch),
+            ticker_fut: None,
+        }
+    }
+}
+
+impl EpochTicker for WatchEpochTicker {
+    fn poll_tick(&mut self, cx: &mut Context) -> Poll<Option<EpochTickerData>> {
+        if self.watch.is_none() && self.ticker_fut.is_none() {
+            // Polling after completion
+            return Poll::Pending;
+        }
+
+        loop {
+            if self.ticker_fut.is_none() {
+                // Create a future that will resolve when the watch changes
+                // NOTE that you cannot clone the watch receiver, because only the cloned watch will be marked as seen.
+                let mut watch = self.watch.take().expect("watch receiver is None");
+                self.ticker_fut = Some(Box::pin(async move {
+                    if watch.changed().await.is_ok() {
+                        Some(watch)
+                    } else {
+                        None
+                    }
+                }));
+            }
+            if let Some(fut) = self.ticker_fut.as_mut() {
+                // Poll the future to see if it has resolved
+                match fut.as_mut().poll(cx) {
+                    Poll::Ready(Some(mut watch)) => {
+                        // Read the latest value from the watch receiver and mark it as seen
+                        let epoch_data = watch.borrow_and_update().clone();
+                        self.ticker_fut = None; // Reset the future after polling
+                        self.watch = Some(watch);
+                        return Poll::Ready(Some(epoch_data));
+                    },
+                    Poll::Ready(None) => {
+                        // The watch receiver has been dropped, so we can stop polling
+                        self.ticker_fut = None;
+                        return Poll::Ready(None);
+                    },
+                    Poll::Pending => {
+                        // The future is still pending, so we can return Pending
+                        return Poll::Pending;
+                    },
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::future::poll_fn;
+
+    use tari_common_types::types::FixedHash;
+    use tari_dan_common_types::Epoch;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn it_picks_up_ticks() {
+        let (mut ticker, sender) = watch_ticker();
+        // Send a new tick
+        let data = EpochTickerData {
+            epoch: Epoch(1),
+            epoch_hash: FixedHash::default(),
+            done_for_now: false,
+        };
+        sender.send(data.clone()).unwrap();
+        let res = poll_fn(|cx| ticker.poll_tick(cx)).await;
+        assert_eq!(res, Some(data));
+
+        drop(sender);
+
+        // Poll again after the sender is dropped
+        let res = poll_fn(|cx| ticker.poll_tick(cx)).await;
+        assert_eq!(res, None, "Expected None after sender is dropped");
+    }
+}

--- a/dan_layer/epoch_oracles/src/lib.rs
+++ b/dan_layer/epoch_oracles/src/lib.rs
@@ -3,7 +3,7 @@
 
 use tari_epoch_manager::epoch_event_oracle::{EpochEvent, EpochEventOracle};
 
-use crate::store::EpochOracleStore;
+use crate::{configured::IntervalEpochTicker, store::EpochOracleStore};
 
 #[cfg(feature = "base_layer")]
 pub mod base_layer;
@@ -15,7 +15,7 @@ pub mod store;
 pub enum EpochOracle<TStore> {
     #[cfg(feature = "base_layer")]
     BaseLayer(base_layer::BaseLayerOracle<TStore>),
-    Configured(configured::ConfiguredEpochOracle<TStore>),
+    Configured(configured::ConfiguredEpochOracle<TStore, IntervalEpochTicker>),
     #[cfg(feature = "base_layer")]
     Hybrid(hybrid::HybridEpochOracle<TStore>),
 }

--- a/dan_layer/epoch_oracles/src/store.rs
+++ b/dan_layer/epoch_oracles/src/store.rs
@@ -17,8 +17,8 @@ pub enum StoreKey {
     BaseLayerLastScannedBlockHash,
     BaseLayerLastEpochHash,
     BaseLayerNextBlockHash,
-    StaticIsInitialized,
-    StaticCurrentEpoch,
+    ConfiguredIsInitialized,
+    ConfiguredCurrentEpoch,
 }
 
 impl StoreKey {
@@ -29,8 +29,8 @@ impl StoreKey {
             Self::BaseLayerLastScannedBlockHeight => b"base_layer.last_scanned_block_height",
             Self::BaseLayerLastEpochHash => b"base_layer.last_epoch_hash",
             Self::BaseLayerNextBlockHash => b"base_layer.next_block_hash",
-            Self::StaticIsInitialized => b"configured_oracle.is_initialized",
-            Self::StaticCurrentEpoch => b"configured_oracle.current_epoch",
+            Self::ConfiguredIsInitialized => b"configured_oracle.is_initialized",
+            Self::ConfiguredCurrentEpoch => b"configured_oracle.current_epoch",
         }
     }
 }

--- a/dan_layer/state_store_rocksdb/src/writer.rs
+++ b/dan_layer/state_store_rocksdb/src/writer.rs
@@ -482,6 +482,13 @@ impl<'tx, TAddr: NodeAddressable + 'tx> StateStoreWriteTransaction for RocksDbSt
         Ok(())
     }
 
+    fn last_sent_new_view_clear(&mut self) -> Result<(), StorageError> {
+        self.db()
+            .cf(LastSentNewViewCf)?
+            .delete(&ByteColumn, "last_sent_new_view_clear")?;
+        Ok(())
+    }
+
     fn locked_block_set(&mut self, locked_block: &LockedBlock) -> Result<(), StorageError> {
         self.db()
             .cf(LockedBlockCf)?

--- a/dan_layer/storage/src/state_store/mod.rs
+++ b/dan_layer/storage/src/state_store/mod.rs
@@ -379,6 +379,8 @@ pub trait StateStoreWriteTransaction {
     fn leaf_block_set(&mut self, leaf_node: &LeafBlock) -> Result<(), StorageError>;
     fn highest_seen_block_set(&mut self, last_seen_block: &HighestSeenBlock) -> Result<(), StorageError>;
     fn last_sent_new_view_set(&mut self, last_sent_new_view: &LastSentNewView) -> Result<(), StorageError>;
+    /// Clears the last sent new view record for the current epoch. If there is no record, it is a no-op.
+    fn last_sent_new_view_clear(&mut self) -> Result<(), StorageError>;
     fn locked_block_set(&mut self, locked_block: &LockedBlock) -> Result<(), StorageError>;
     fn high_pc_set(&mut self, high_pc: &HighPc) -> Result<(), StorageError>;
     fn high_tc_set(&mut self, high_tc: &HighTc) -> Result<(), StorageError>;

--- a/integration_tests/src/validator_node.rs
+++ b/integration_tests/src/validator_node.rs
@@ -29,7 +29,11 @@ use std::{
 use reqwest::Url;
 use tari_common::configuration::{CommonConfig, StringList};
 use tari_crypto::ristretto::RistrettoPublicKey;
-use tari_dan_app_utilities::{epoch_oracle_config::EpochOracleConfig, p2p_config::PeerSeedsConfig};
+use tari_dan_app_utilities::{
+    epoch_oracle_config::EpochOracleConfig,
+    keypair::create_new_keypair,
+    p2p_config::PeerSeedsConfig,
+};
 use tari_dan_common_types::layer_one_transaction::{LayerOneTransactionDef, ValidatorRegistrationParams};
 use tari_engine_types::FromByteType;
 use tari_p2p::Network;
@@ -171,7 +175,8 @@ pub async fn spawn_validator_node(
 
             // Add all other VNs as peer seeds
             config.peer_seeds.peer_seeds = StringList::from(peer_seeds);
-            run_validator_node(config, shutdown).await
+            let keypair = create_new_keypair(&config.validator_node.identity_file).expect("Could not create keypair");
+            run_validator_node(keypair, config, shutdown).await
         }
     });
 

--- a/utilities/db_inspector/src/webserver/server.rs
+++ b/utilities/db_inspector/src/webserver/server.rs
@@ -124,7 +124,7 @@ pub async fn run(context: HandlerContext) -> anyhow::Result<()> {
         .layer(Extension(Arc::new(context)));
 
     let server = axum::Server::try_bind(&bind_address).or_else(|_| {
-        error!(
+        warn!(
             target: LOG_TARGET,
             "🕸️ Failed to bind on preferred address {}. Trying OS-assigned", bind_address
         );


### PR DESCRIPTION
Description
---
fix(epoch-oracles): implement ticker for configured oracle that ticks based on base layer scanning
fix(consensus): handle some edge cases for detecting the need for catchup/sync
chore: add separate epoch oracle config preset

Motivation and Context
---
This allows for hybrid epoch oracle, that takes epoch timing from the base layer but allows validators to be configured to be registered at a specific base layer epoch without a base layer UTXO

This could be useful for testnets that do not require/permit arbitrary validators to be registered.

How Has This Been Tested?
---
Manually by configuring hybrid oracle and two validator nodes 

What process can a PR reviewer use to test or verify this change?
---
As Above

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify