### PR TITLE
docs(engine): document rules! macro

### DIFF
--- a/dan_layer/template_builtin/templates/account/src/lib.rs
+++ b/dan_layer/template_builtin/templates/account/src/lib.rs
@@ -45,9 +45,11 @@ mod account_template {
                 .to_public_key()
                 .unwrap_or_else(|| panic!("public_key_token is not a valid public key: {}", public_key_token));
 
+            // The owner of this account is either provided explicitly or defaults to the provided public key.
             let owner_rule = owner_rule.unwrap_or(OwnerRule::ByPublicKey(public_key));
 
             let access_rules = access_rules.unwrap_or(
+                // By default, allow deposits from anyone
                 AccessRules::new()
                     .add_method_rule("balance", rule!(allow_all))
                     .add_method_rule("get_balances", rule!(allow_all))
@@ -55,7 +57,7 @@ mod account_template {
                     .add_method_rule("deposit_all", rule!(allow_all))
                     .add_method_rule("get_non_fungible_ids", rule!(allow_all))
                     // By default, only the owner of the token will be able to withdraw funds from the account
-                    .default(rule!(non_fungible(public_key_token))),
+                    .default(rule!(deny_all)),
             );
 
             // add the funds from the (optional) bucket

--- a/dan_layer/template_lib/src/auth/access_rules.rs
+++ b/dan_layer/template_lib/src/auth/access_rules.rs
@@ -15,8 +15,11 @@ use crate::models::{ComponentAddress, NonFungibleAddress, ResourceAddress};
     ts(export, export_to = "../../bindings/src/types/")
 )]
 pub enum AccessRule {
+    /// AccessRule always passes
     AllowAll,
+    /// AccessRule always fails
     DenyAll,
+    /// AccessRule that requires a specific condition to be met
     Restricted(RestrictedAccessRule),
 }
 
@@ -50,8 +53,11 @@ impl AccessRule {
     ts(export, export_to = "../../bindings/src/types/")
 )]
 pub enum RestrictedAccessRule {
+    /// Requires a specific condition to be met
     Require(RequireRule),
+    /// Requires any of the specified conditions to be met (logical OR)
     AnyOf(Vec<RestrictedAccessRule>),
+    /// Requires all of the specified conditions to be met (logical AND)
     AllOf(Vec<RestrictedAccessRule>),
 }
 
@@ -107,7 +113,7 @@ impl From<TemplateAddress> for RuleRequirement {
     }
 }
 
-/// An enum that represents the possible ways to require access to components or resources
+/// A rule requiring specific condition(s) to be met
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[cfg_attr(
     feature = "ts",
@@ -115,8 +121,11 @@ impl From<TemplateAddress> for RuleRequirement {
     ts(export, export_to = "../../bindings/src/types/")
 )]
 pub enum RequireRule {
+    /// Requires a specific condition to be met
     Require(RuleRequirement),
+    /// Requires any of the specified conditions to be met (logical OR)
     AnyOf(Vec<RuleRequirement>),
+    /// Requires all of the specified conditions to be met (logical AND)
     AllOf(Vec<RuleRequirement>),
 }
 
@@ -309,6 +318,43 @@ impl Default for ResourceAccessRules {
     }
 }
 
+/// A macro to build access rules for components and resources.
+///
+/// It allows for defining rules such as `allow_all`, `deny_all`, and more complex rules using `any_of` and `all_of`
+/// constructs.
+///
+/// # Examples:
+///
+/// ```rust
+/// use tari_template_lib::rule;
+/// // Allow all access
+/// let allow_all_rule = rule!(allow_all);
+/// // Deny all access
+/// let deny_all_rule = rule!(deny_all);
+/// // Restricted access to a specific resource
+/// let resource_address = tari_template_lib::models::ResourceAddress::new(
+///     tari_template_lib::types::ObjectKey::default(),
+/// );
+/// let resource_rule = rule!(resource(resource_address));
+/// // Restricted access to a component
+/// let component_address = tari_template_lib::models::ComponentAddress::new(
+///     tari_template_lib::types::ObjectKey::default(),
+/// );
+/// let component_rule = rule!(component(component_address));
+/// // Restricted access to a template
+/// let template_address = tari_template_lib::types::TemplateAddress::default();
+/// let template_rule = rule!(template(template_address));
+/// // Restricted access to a non-fungible token
+/// let non_fungible_address = tari_template_lib::models::NonFungibleAddress::from_public_key(
+///     tari_template_lib::types::crypto::RistrettoPublicKeyBytes::default(),
+/// );
+/// let non_fungible_rule = rule!(non_fungible(non_fungible_address));
+/// // Complex rules using `any_of` and `all_of`
+/// let complex_rule = rule!(any_of(
+///     component(component_address),
+///     resource(resource_address)
+/// ));
+/// ```
 #[macro_export]
 macro_rules! rule {
     (allow_all) => {

--- a/dan_layer/template_lib/src/auth/owner_rule.rs
+++ b/dan_layer/template_lib/src/auth/owner_rule.rs
@@ -21,10 +21,14 @@ pub struct Ownership<'a> {
     ts(export, export_to = "../../bindings/src/types/")
 )]
 pub enum OwnerRule {
+    /// The owner is the signer of the transaction that created the value
     #[default]
     OwnedBySigner,
+    /// There is no owner, only access rules apply
     None,
+    /// The owner is anyone who satisfies an access rule
     ByAccessRule(AccessRule),
+    /// The owner is a specific public key
     ByPublicKey(#[cfg_attr(feature = "ts", ts(type = "Array<number>"))] RistrettoPublicKeyBytes),
 }
 

--- a/dan_layer/template_lib/src/component/instance.rs
+++ b/dan_layer/template_lib/src/component/instance.rs
@@ -43,7 +43,7 @@ impl<T> ComponentBuilder<T> {
     /// Component::new(..)
     /// .with_address_allocation(allocation)
     /// ```
-    /// Calling this followed by `with_address_allocation` will cause the transaction to fail
+    /// Calling this followed by `with_address_allocation` will cause execution to fail
     pub fn with_public_key_address(mut self, public_key: RistrettoPublicKeyBytes) -> Self {
         self.address_allocation = Some(CallerContext::allocate_component_address(Some(public_key)));
         self

--- a/dan_layer/template_lib/src/context.rs
+++ b/dan_layer/template_lib/src/context.rs
@@ -47,7 +47,7 @@ fn with_context<R, F: FnOnce(&mut Option<SystemContext>) -> R>(_f: F) -> R {
     panic!("System context is not available on non-WASM targets");
 }
 
-/// TODO: YAGNI currently, it may come into play for cross-template requests
+/// TODO: YAGNI currently
 #[derive(Debug, Serialize, Deserialize)]
 pub struct AbiContext {}
 

--- a/dan_layer/template_lib/src/engine.rs
+++ b/dan_layer/template_lib/src/engine.rs
@@ -36,7 +36,6 @@ use crate::{
 
 /// Returns the corresponding `TariEngine` of the current template execution
 pub fn engine() -> TariEngine {
-    // TODO: I expect some thread local state to be included here
     TariEngine::new(get_context())
 }
 


### PR DESCRIPTION
Description
---
docs(engine): document rules! macro
fix(builtin/account): unnesessary to assign public key token to default access rules 

Motivation and Context
---
rules! macro needed some docs and examples.

The default for access rules can be deny (i.e. owner rule is all that applies)
