### PR TITLE
feat(vn): add feature to enable tokio console

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1851,12 +1851,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "console-api"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8030735ecb0d128428b64cd379809817e620a40e5001c54465b99ec5feec2857"
+dependencies = [
+ "futures-core",
+ "prost 0.13.5",
+ "prost-types 0.13.5",
+ "tonic 0.12.3",
+ "tracing-core",
+]
+
+[[package]]
 name = "console-subscriber"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4cf42660ac07fcebed809cfe561dd8730bcd35b075215e6479c516bcd0d11cb"
 dependencies = [
- "console-api",
+ "console-api 0.5.0",
  "crossbeam-channel",
  "crossbeam-utils",
  "futures 0.3.31",
@@ -1869,6 +1882,32 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tonic 0.9.2",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "console-subscriber"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6539aa9c6a4cd31f4b1c040f860a1eac9aa80e7df6b05d506a6e7179936d6a01"
+dependencies = [
+ "console-api 0.8.1",
+ "crossbeam-channel",
+ "crossbeam-utils",
+ "futures-task",
+ "hdrhistogram",
+ "humantime 2.2.0",
+ "hyper-util",
+ "prost 0.13.5",
+ "prost-types 0.13.5",
+ "serde",
+ "serde_json",
+ "thread_local",
+ "tokio",
+ "tokio-stream",
+ "tonic 0.12.3",
  "tracing",
  "tracing-core",
  "tracing-subscriber",
@@ -6420,7 +6459,7 @@ dependencies = [
  "chrono",
  "clap 3.2.25",
  "config",
- "console-subscriber",
+ "console-subscriber 0.1.10",
  "crossterm 0.28.1",
  "dialoguer 0.10.4",
  "digest",
@@ -6511,7 +6550,7 @@ dependencies = [
  "chrono",
  "clap 3.2.25",
  "config",
- "console-subscriber",
+ "console-subscriber 0.1.10",
  "crossterm 0.28.1",
  "derive_more 0.99.19",
  "either",
@@ -11723,6 +11762,7 @@ dependencies = [
  "axum-jrpc",
  "clap 3.2.25",
  "config",
+ "console-subscriber 0.4.1",
  "either",
  "futures 0.3.31",
  "include_dir",

--- a/applications/tari_swarm_daemon/src/config.rs
+++ b/applications/tari_swarm_daemon/src/config.rs
@@ -124,6 +124,8 @@ pub struct InstanceConfig {
     pub num_instances: u32,
     #[serde(alias = "extra_args")]
     pub settings: HashMap<String, String>,
+    #[serde(default)]
+    pub envs: Vec<(String, String)>,
 }
 
 impl InstanceConfig {
@@ -135,6 +137,7 @@ impl InstanceConfig {
             instance_type,
             num_instances: 1,
             settings: HashMap::new(),
+            envs: Vec::new(),
         }
     }
 
@@ -230,7 +233,6 @@ pub struct ExecutableConfig {
     pub instance_type: InstanceType,
     pub execuable_path: Option<PathBuf>,
     pub compile: Option<CompileConfig>,
-    pub env: Vec<(String, String)>,
 }
 
 impl ExecutableConfig {
@@ -248,6 +250,8 @@ pub struct CompileConfig {
     pub target_dir: Option<PathBuf>,
     #[serde(default)]
     pub features: Vec<String>,
+    #[serde(default)]
+    pub envs: Vec<(String, String)>,
 }
 
 impl CompileConfig {

--- a/applications/tari_swarm_daemon/src/main.rs
+++ b/applications/tari_swarm_daemon/src/main.rs
@@ -84,8 +84,8 @@ fn get_base_config(cli: &Cli) -> anyhow::Result<Config> {
                 // Default is "{working_dir}/target/release"
                 target_dir: None,
                 features: vec![],
+                envs: vec![],
             }),
-            env: vec![],
         },
         ExecutableConfig {
             instance_type: InstanceType::MinoTariConsoleWallet,
@@ -95,8 +95,8 @@ fn get_base_config(cli: &Cli) -> anyhow::Result<Config> {
                 package_name: "minotari_console_wallet".to_string(),
                 target_dir: None,
                 features: vec![],
+                envs: vec![],
             }),
-            env: vec![],
         },
         ExecutableConfig {
             instance_type: InstanceType::MinoTariMiner,
@@ -106,8 +106,8 @@ fn get_base_config(cli: &Cli) -> anyhow::Result<Config> {
                 package_name: "minotari_miner".to_string(),
                 target_dir: None,
                 features: vec![],
+                envs: vec![],
             }),
-            env: vec![],
         },
         ExecutableConfig {
             instance_type: InstanceType::TariValidatorNode,
@@ -117,8 +117,8 @@ fn get_base_config(cli: &Cli) -> anyhow::Result<Config> {
                 package_name: "tari_validator_node".to_string(),
                 target_dir: None,
                 features: vec!["web_ui".to_string()],
+                envs: vec![],
             }),
-            env: vec![],
         },
         ExecutableConfig {
             instance_type: InstanceType::TariIndexer,
@@ -128,8 +128,8 @@ fn get_base_config(cli: &Cli) -> anyhow::Result<Config> {
                 package_name: "tari_indexer".to_string(),
                 target_dir: None,
                 features: vec!["web_ui".to_string()],
+                envs: vec![],
             }),
-            env: vec![],
         },
         // ExecutableConfig {
         //     instance_type: InstanceType::TariSignalingServer,
@@ -149,8 +149,8 @@ fn get_base_config(cli: &Cli) -> anyhow::Result<Config> {
                 package_name: "tari_dan_wallet_daemon".to_string(),
                 target_dir: None,
                 features: vec!["web_ui".to_string()],
+                envs: vec![],
             }),
-            env: vec![],
         },
     ];
     let instances = vec![

--- a/applications/tari_swarm_daemon/src/process_definitions/validator_node.rs
+++ b/applications/tari_swarm_daemon/src/process_definitions/validator_node.rs
@@ -67,6 +67,10 @@ impl ProcessDefinition for ValidatorNode {
             .arg(format!("-pvalidator_node.web_ui_listener_address={web_ui_address}"))
             .arg("-pepoch_oracle.base_layer.scanning_interval=1");
 
+        if let Some(console_port) = context.get_setting("tokio_console_port") {
+            command.arg(format!("--tokio-console-port={console_port}"));
+        }
+
         Ok(command)
     }
 

--- a/applications/tari_swarm_daemon/src/process_manager/executables/executable.rs
+++ b/applications/tari_swarm_daemon/src/process_manager/executables/executable.rs
@@ -8,5 +8,4 @@ use crate::config::InstanceType;
 pub struct Executable {
     pub instance_type: InstanceType,
     pub path: PathBuf,
-    pub env: Vec<(String, String)>,
 }

--- a/applications/tari_swarm_daemon/src/process_manager/executables/manager.rs
+++ b/applications/tari_swarm_daemon/src/process_manager/executables/manager.rs
@@ -45,7 +45,6 @@ impl ExecutableManager {
                 self.prepared.push(Executable {
                     instance_type: exec.instance_type,
                     path: exec_path,
-                    env: exec.env.clone(),
                 });
                 continue;
             }
@@ -62,7 +61,12 @@ impl ExecutableManager {
                 exec.instance_type,
                 compile.working_dir().display()
             );
-            let mut child = cargo_build(compile.working_dir(), &compile.package_name, &compile.features)?;
+            let mut child = cargo_build(
+                compile.working_dir(),
+                &compile.package_name,
+                &compile.features,
+                &compile.envs,
+            )?;
             tasks.push(async move {
                 let status = child.wait().await?;
                 Ok::<_, anyhow::Error>((status, exec))
@@ -87,7 +91,6 @@ impl ExecutableManager {
             self.prepared.push(Executable {
                 instance_type: exec.instance_type,
                 path: bin_path,
-                env: exec.env.clone(),
             })
         }
 
@@ -119,7 +122,7 @@ impl ExecutableManager {
                 .context("working_dir does not exist")?;
             let package = &compile.package_name;
 
-            let mut child = cargo_build(&working_dir, package, &compile.features)?;
+            let mut child = cargo_build(&working_dir, package, &compile.features, &compile.envs)?;
             let status = child.wait().await?;
 
             if !status.success() {
@@ -139,7 +142,6 @@ impl ExecutableManager {
                     path: bin_path.canonicalize().with_context(|| {
                         anyhow!("The compiled binary at path '{}' does not exist.", bin_path.display())
                     })?,
-                    env: exec.env.clone(),
                 });
                 self.prepared.last().unwrap()
             };
@@ -160,7 +162,18 @@ impl ExecutableManager {
     }
 }
 
-fn cargo_build<P: AsRef<Path>>(working_dir: P, package: &str, features: &[String]) -> io::Result<Child> {
+fn cargo_build<'env, P, TENVS, K, V>(
+    working_dir: P,
+    package: &str,
+    features: &[String],
+    envs: TENVS,
+) -> io::Result<Child>
+where
+    P: AsRef<Path>,
+    TENVS: IntoIterator<Item = &'env (K, V)>,
+    K: AsRef<str> + 'env,
+    V: AsRef<str> + 'env,
+{
     let mut cmd = Command::new("cargo");
     cmd.args(["build", "--release", "--bin", package]);
     for feature in features {
@@ -170,6 +183,7 @@ fn cargo_build<P: AsRef<Path>>(working_dir: P, package: &str, features: &[String
     cmd
         // Ensure host environment vars are available
         .envs(env::vars())
+        .envs(envs.into_iter().map(|(k, v)| (k.as_ref(), v.as_ref())))
         .current_dir(working_dir)
         .kill_on_drop(true)
         .spawn()

--- a/applications/tari_swarm_daemon/src/process_manager/handle.rs
+++ b/applications/tari_swarm_daemon/src/process_manager/handle.rs
@@ -21,7 +21,7 @@ pub enum ProcessManagerRequest {
     CreateInstance {
         name: String,
         instance_type: InstanceType,
-        args: HashMap<String, String>,
+        settings: HashMap<String, String>,
         reply: Reply<InstanceId>,
     },
     ListInstances {
@@ -197,14 +197,14 @@ impl ProcessManagerHandle {
         &self,
         name: String,
         instance_type: InstanceType,
-        args: A,
+        settings: A,
     ) -> anyhow::Result<InstanceId> {
         let (tx_reply, rx_reply) = oneshot::channel();
         self.tx_request
             .send(ProcessManagerRequest::CreateInstance {
                 name,
                 instance_type,
-                args: args.into(),
+                settings: settings.into(),
                 reply: tx_reply,
             })
             .await?;

--- a/applications/tari_swarm_daemon/src/process_manager/instances/instance.rs
+++ b/applications/tari_swarm_daemon/src/process_manager/instances/instance.rs
@@ -17,6 +17,7 @@ pub struct Instance {
     allocated_ports: AllocatedPorts,
     base_path: PathBuf,
     settings: HashMap<String, String>,
+    envs: Vec<(String, String)>,
     exit_status: Option<ExitStatus>,
 }
 
@@ -28,6 +29,7 @@ impl Instance {
         child: Child,
         allocated_ports: AllocatedPorts,
         base_path: PathBuf,
+        envs: Vec<(String, String)>,
         settings: HashMap<String, String>,
     ) -> Self {
         Self {
@@ -37,6 +39,7 @@ impl Instance {
             child,
             allocated_ports,
             base_path,
+            envs,
             settings,
             exit_status: None,
         }
@@ -68,6 +71,10 @@ impl Instance {
 
     pub fn base_path(&self) -> &PathBuf {
         &self.base_path
+    }
+
+    pub fn envs(&self) -> &[(String, String)] {
+        &self.envs
     }
 
     pub fn settings(&self) -> &HashMap<String, String> {

--- a/applications/tari_swarm_daemon/src/process_manager/instances/manager.rs
+++ b/applications/tari_swarm_daemon/src/process_manager/instances/manager.rs
@@ -97,6 +97,7 @@ impl InstanceManager {
                     instance.instance_type,
                     instance.instance_name(i),
                     instance.base_path_override().cloned(),
+                    instance.envs.clone(),
                     settings.clone(),
                 )
                 .await?;
@@ -111,6 +112,7 @@ impl InstanceManager {
         instance_type: InstanceType,
         instance_name: String,
         base_path_override: Option<PathBuf>,
+        envs: Vec<(String, String)>,
         settings: HashMap<String, String>,
     ) -> anyhow::Result<InstanceId> {
         let instance_id = self.next_instance_id();
@@ -120,6 +122,7 @@ impl InstanceManager {
             instance_type,
             instance_name,
             base_path_override,
+            envs,
             settings,
             None,
         )
@@ -134,6 +137,7 @@ impl InstanceManager {
         instance_type: InstanceType,
         instance_name: String,
         base_path_override: Option<PathBuf>,
+        instance_envs: Vec<(String, String)>,
         mut instance_settings: HashMap<String, String>,
         ports: Option<AllocatedPorts>,
     ) -> anyhow::Result<InstanceId> {
@@ -191,7 +195,7 @@ impl InstanceManager {
         let context = ProcessContext::new(
             instance_id,
             &executable.path,
-            &executable.env,
+            &instance_envs,
             base_path.clone(),
             processes_path,
             self.network,
@@ -238,6 +242,7 @@ impl InstanceManager {
             // This saves us from having to join the network string to the path all over the place, since everything we
             // want is under {base_dir}/{network}
             base_path.join(self.network.to_string()),
+            instance_envs,
             instance_settings,
         );
 
@@ -356,6 +361,7 @@ impl InstanceManager {
         let instance_name = instance.name().to_string();
         let settings = instance.settings().clone();
         let ports = instance.allocated_ports().clone();
+        let envs = instance.envs().to_vec();
 
         // This will just overwrite the previous instance
         self.fork(
@@ -364,6 +370,7 @@ impl InstanceManager {
             instance_type,
             instance_name,
             None,
+            envs,
             settings,
             Some(ports),
         )

--- a/applications/tari_swarm_daemon/src/process_manager/manager.rs
+++ b/applications/tari_swarm_daemon/src/process_manager/manager.rs
@@ -392,10 +392,10 @@ impl ProcessManager {
             CreateInstance {
                 name,
                 instance_type,
-                args,
+                settings,
                 reply,
             } => {
-                if self.instance_manager.instances().any(|i| i.name() == name) {
+                let Some(instance) = self.instance_manager.instances().find(|i| i.name() == name) else {
                     if reply
                         .send(Err(anyhow!(
                             "Instance with name '{name}' already exists. Please choose a different name",
@@ -405,7 +405,9 @@ impl ProcessManager {
                         log::warn!("Request cancelled before response could be sent")
                     }
                     return Ok(());
-                }
+                };
+
+                let envs = instance.envs().to_vec();
 
                 let executable = self.executable_manager.get_executable(instance_type).ok_or_else(|| {
                     anyhow!(
@@ -414,7 +416,7 @@ impl ProcessManager {
                 })?;
                 let result = self
                     .instance_manager
-                    .fork_new(executable, instance_type, name, None, args)
+                    .fork_new(executable, instance_type, name, None, envs, settings)
                     .await;
 
                 if reply.send(result).is_err() {
@@ -675,10 +677,17 @@ impl ProcessManager {
                 anyhow!("No executable configuration for 'MinoTariMiner'. Please add this to the configuration")
             })?;
 
-        let args = HashMap::from([("max_blocks".to_string(), blocks.to_string())]);
+        let settings = HashMap::from([("max_blocks".to_string(), blocks.to_string())]);
         let id = self
             .instance_manager
-            .fork_new(executable, InstanceType::MinoTariMiner, "miner".to_string(), None, args)
+            .fork_new(
+                executable,
+                InstanceType::MinoTariMiner,
+                "miner".to_string(),
+                None,
+                vec![],
+                settings,
+            )
             .await?;
 
         let status = self.instance_manager.wait(id).await?;

--- a/applications/tari_validator_node/Cargo.toml
+++ b/applications/tari_validator_node/Cargo.toml
@@ -10,6 +10,8 @@ license.workspace = true
 [features]
 default = ["metrics", "web_ui"]
 metrics = ["prometheus"]
+# Note: must be compiled with RUSTFLAGS='--cfg rust_unstable' to use
+tokio_debug = ["console-subscriber"]
 web_ui = []
 
 [dependencies]
@@ -76,6 +78,8 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["default", "macros", "time", "sync", "rt-multi-thread", "fs", "signal"] }
 tower-http = { workspace = true, features = ["default", "cors"] }
+
+console-subscriber = { version = "0.4.1", optional = true }
 
 [build-dependencies]
 tari_common = { workspace = true, features = ["build"] }

--- a/applications/tari_validator_node/src/cli.rs
+++ b/applications/tari_validator_node/src/cli.rs
@@ -61,6 +61,8 @@ pub struct Cli {
     /// FOR DEBUGGING PURPOSES ONLY
     #[clap(long, short = 'd')]
     pub debug_templates: Vec<String>,
+    #[clap(long, env = "TARI_VN_TOKIO_CONSOLE_PORT")]
+    pub tokio_console_port: Option<u16>,
     #[clap(subcommand)]
     pub command: Option<Subcommand>,
 }

--- a/applications/tari_validator_node/src/main.rs
+++ b/applications/tari_validator_node/src/main.rs
@@ -35,11 +35,11 @@ use crate::cli::Cli;
 
 const LOG_TARGET: &str = "tari::validator_node::app";
 
+#[cfg(feature = "tokio_debug")]
+const DEBUG_PORT: u16 = console_subscriber::Server::DEFAULT_PORT;
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    // Uncomment to enable tokio tracing via tokio-console
-    // console_subscriber::init();
-
     // Setup a panic hook which prints the default rust panic message but also exits the process. This makes a panic in
     // any thread "crash" the system instead of silently continuing.
     let default_hook = panic::take_hook();
@@ -49,6 +49,15 @@ async fn main() -> anyhow::Result<()> {
     }));
 
     let cli = Cli::parse();
+    // enable tokio tracing via tokio-console
+    #[cfg(feature = "tokio_debug")]
+    console_subscriber::Builder::default()
+        .server_addr((
+            std::net::Ipv4Addr::LOCALHOST,
+            cli.tokio_console_port.unwrap_or(DEBUG_PORT),
+        ))
+        .init();
+
     let config_path = cli.common.config_path();
     let cfg = load_configuration(config_path, true, &cli, cli.common.network)?;
     let config = ApplicationConfig::load_from(&cfg)?;


### PR DESCRIPTION
Description
---
feat(vn): add feature to enable tokio console
feat(vn): allow tokio console port to be configured by cli arg
fix(swarm): allow compile-time envs to be set
fix(swarm): move runtime envs to instance settings

Motivation and Context
---

Allows us to use tokio console. NOTE: multiple instances are not yet supported in swarm since each instance would need a different port (currently panics if single port is used with > 1 instance). Validators could be started with individual ports manually, and configured to connect to the swarm.

How Has This Been Tested?
---
Manaully, with TariValidatorNode num_instances = 1 

What process can a PR reviewer use to test or verify this change?
---
As above

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify