### PR TITLE
fix: allow seed peers to be specified without public key

### DIFF
--- a/applications/tari_app_utilities/src/seed_peer.rs
+++ b/applications/tari_app_utilities/src/seed_peer.rs
@@ -11,22 +11,36 @@ use libp2p_identity as identity;
 use libp2p_identity::PeerId;
 use multiaddr::Multiaddr;
 use tari_crypto::{ristretto::RistrettoPublicKey, tari_utilities::hex::Hex};
+use tari_engine_types::ToByteType;
+use tari_ootle_common_types::displayable::Displayable;
+use tari_template_lib::prelude::RistrettoPublicKeyBytes;
 
-/// Parsed information from a DNS seed record
+/// Parsed information from a peer seed string
 #[derive(Debug, Clone)]
 pub struct SeedPeer {
-    pub public_key: RistrettoPublicKey,
-    pub addresses: Vec<Multiaddr>,
+    public_key: Option<RistrettoPublicKeyBytes>,
+    address: Multiaddr,
 }
 
 impl SeedPeer {
-    pub fn new(public_key: RistrettoPublicKey, addresses: Vec<Multiaddr>) -> Self {
-        Self { public_key, addresses }
+    pub fn public_key(&self) -> Option<&RistrettoPublicKeyBytes> {
+        self.public_key.as_ref()
     }
 
-    pub fn to_peer_id(&self) -> PeerId {
-        let pk = identity::PublicKey::from(identity::sr25519::PublicKey::from(self.public_key.clone()));
-        pk.to_peer_id()
+    pub fn address(&self) -> &Multiaddr {
+        &self.address
+    }
+
+    pub fn into_address(self) -> Multiaddr {
+        self.address
+    }
+
+    pub fn to_peer_id(&self) -> Option<PeerId> {
+        let pk = self.public_key.as_ref()?;
+        let pk = identity::PublicKey::from(
+            identity::sr25519::PublicKey::try_from_bytes(pk.as_bytes()).expect("invariant: valid public key"),
+        );
+        Some(pk.to_peer_id())
     }
 }
 
@@ -34,16 +48,23 @@ impl FromStr for SeedPeer {
     type Err = anyhow::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let mut parts = s.split("::").map(|s| s.trim());
-        let public_key = parts
-            .next()
-            .and_then(|s| RistrettoPublicKey::from_hex(s).ok())
-            .ok_or_else(|| anyhow!("Invalid peer id string"))?;
-        let addresses = parts.map(Multiaddr::from_str).collect::<Result<Vec<_>, _>>()?;
-        if addresses.is_empty() || addresses.iter().any(|a| a.is_empty()) {
-            return Err(anyhow!("Empty or invalid address in seed peer string"));
+        let s = s.trim();
+        if s.starts_with("/") {
+            // This is a Multiaddr, so we assume the public key is not included
+            let address = s.parse().map_err(|err| anyhow!("Invalid address {err}"))?;
+            return Ok(SeedPeer {
+                public_key: None,
+                address,
+            });
         }
-        Ok(SeedPeer { public_key, addresses })
+
+        let (pk, address) = s.split_once("::").ok_or_else(|| anyhow!("Invalid seed peer format"))?;
+        let public_key = RistrettoPublicKey::from_hex(pk).map_err(|err| anyhow!("Invalid public key {err}"))?;
+        let address = address.parse().map_err(|err| anyhow!("Invalid address {err}"))?;
+        Ok(SeedPeer {
+            public_key: Some(public_key.to_byte_type()),
+            address,
+        })
     }
 }
 
@@ -52,12 +73,52 @@ impl Display for SeedPeer {
         write!(
             f,
             "{}::{}",
-            self.public_key,
-            self.addresses
+            self.public_key.display(),
+            self.address
                 .iter()
                 .map(|ma| ma.to_string())
                 .collect::<Vec<_>>()
                 .join("::")
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_parses_with_public_key() {
+        let s = " 0000000000000000000000000000000000000000000000000000000000000000::/ip4/127.0.0.1/tcp/8080";
+
+        let seed_peer = SeedPeer::from_str(s).expect("Failed to parse seed peer");
+        assert_eq!(
+            seed_peer.public_key().unwrap().to_string(),
+            "0000000000000000000000000000000000000000000000000000000000000000"
+        );
+        assert_eq!(seed_peer.address().to_string(), "/ip4/127.0.0.1/tcp/8080");
+
+        assert!(seed_peer.to_peer_id().is_some());
+    }
+
+    #[test]
+    fn it_parses_without_public_key() {
+        let s = "/ip4/127.0.0.1/tcp/8080";
+
+        let seed_peer = SeedPeer::from_str(s).expect("Failed to parse seed peer");
+        assert!(seed_peer.public_key().is_none());
+        assert_eq!(seed_peer.address().to_string(), s);
+    }
+
+    #[test]
+    fn it_parses_ipv6() {
+        let s = "0000000000000000000000000000000000000000000000000000000000000000::/ip6/::1/tcp/8080";
+
+        let seed_peer = SeedPeer::from_str(s).expect("Failed to parse seed peer");
+        assert_eq!(
+            seed_peer.public_key().unwrap().to_string(),
+            "0000000000000000000000000000000000000000000000000000000000000000"
+        );
+        assert_eq!(seed_peer.address().to_string(), "/ip6/::1/tcp/8080");
     }
 }

--- a/applications/tari_indexer/src/bootstrap.rs
+++ b/applications/tari_indexer/src/bootstrap.rs
@@ -93,9 +93,9 @@ pub async fn spawn_services(
         .collect::<anyhow::Result<Vec<SeedPeer>>>()?;
     let seed_peers = seed_peers
         .into_iter()
-        .flat_map(|p| {
+        .map(|p| {
             let peer_id = p.to_peer_id();
-            p.addresses.into_iter().map(move |a| (peer_id, a))
+            (peer_id, p.into_address())
         })
         .collect();
     let (networking, _) = tari_networking::Builder::<TariMessagingSpec>::new(identity)

--- a/applications/tari_indexer/src/cli.rs
+++ b/applications/tari_indexer/src/cli.rs
@@ -89,10 +89,7 @@ impl ConfigOverrideProvider for Cli {
             overrides.push(("p2p.seeds.peer_seeds".to_string(), self.peer_seeds.join(",")));
         }
         if let Some(listener_port) = self.listener_port {
-            overrides.push((
-                "validator_node.p2p.listener_port".to_string(),
-                listener_port.to_string(),
-            ));
+            overrides.push(("indexer.p2p.listener_port".to_string(), listener_port.to_string()));
         }
         if let Some(seconds) = self.scanning_interval {
             overrides.push(("indexer.scanning_interval".to_string(), seconds.to_string()));

--- a/applications/tari_indexer/web_ui/src/routes/VN/Components/Connections.tsx
+++ b/applications/tari_indexer/web_ui/src/routes/VN/Components/Connections.tsx
@@ -102,7 +102,7 @@ function Connections() {
               />
               <TextField
                 name="address"
-                label="CopyAddress"
+                label="Multiaddr"
                 value={formState.address}
                 onChange={onChange}
                 style={{ flexGrow: 1 }}

--- a/applications/tari_swarm_daemon/src/process_definitions/context.rs
+++ b/applications/tari_swarm_daemon/src/process_definitions/context.rs
@@ -14,6 +14,7 @@ use crate::process_manager::{
     MinoTariNodeProcess,
     MinoTariWalletProcess,
     SignalingServerProcess,
+    ValidatorNodeProcess,
 };
 
 pub struct ProcessContext<'a> {
@@ -139,6 +140,10 @@ impl<'a> ProcessContext<'a> {
 
     pub fn minotari_nodes(&self) -> impl Iterator<Item = &MinoTariNodeProcess> {
         self.instances.minotari_nodes()
+    }
+
+    pub fn validator_nodes(&self) -> impl Iterator<Item = &ValidatorNodeProcess> {
+        self.instances.validator_nodes()
     }
 
     pub fn minotari_wallets(&self) -> impl Iterator<Item = &MinoTariWalletProcess> {

--- a/applications/tari_swarm_daemon/src/process_definitions/indexer.rs
+++ b/applications/tari_swarm_daemon/src/process_definitions/indexer.rs
@@ -61,6 +61,16 @@ impl ProcessDefinition for Indexer {
             .arg(format!("-pindexer.web_ui_public_graphql_url={graphql_public_url}"))
             .arg("-pepoch_oracle.base_layer.scanning_interval=1");
 
+        // mDNS is not guaranteed to work, so we'll explicitly set the seed peers for the indexer.
+        let seed_peers = context.validator_nodes().filter_map(|vn| {
+            let port = vn.instance().allocated_ports().get("p2p")?;
+            Some(format!("/ip4/127.0.0.1/tcp/{port}"))
+        });
+
+        for seed in seed_peers {
+            command.arg(format!("--peer-seeds={seed}"));
+        }
+
         Ok(command)
     }
 

--- a/applications/tari_swarm_daemon/src/process_definitions/validator_node.rs
+++ b/applications/tari_swarm_daemon/src/process_definitions/validator_node.rs
@@ -25,6 +25,7 @@ impl ProcessDefinition for ValidatorNode {
         let mut command = Command::new(context.bin());
         let jrpc_port = context.get_free_port("jrpc").await?;
         let web_ui_port = context.get_free_port("web").await?;
+        let p2p_port = context.get_free_port("p2p").await?;
         let listen_ip = context.listen_ip();
 
         let json_rpc_address = format!("{listen_ip}:{jrpc_port}");
@@ -63,6 +64,7 @@ impl ProcessDefinition for ValidatorNode {
             .arg(format!(
                 "-pepoch_oracle.base_layer.base_node_grpc_url={base_node_grpc_url}"
             ))
+            .arg(format!("-pvalidator_node.p2p.listener_port={p2p_port}"))
             .arg(format!("-pvalidator_node.json_rpc_listener_address={json_rpc_address}"))
             .arg(format!("-pvalidator_node.web_ui_listener_address={web_ui_address}"))
             .arg("-pepoch_oracle.base_layer.scanning_interval=1");

--- a/applications/tari_validator_node/src/bootstrap.rs
+++ b/applications/tari_validator_node/src/bootstrap.rs
@@ -152,9 +152,9 @@ pub async fn spawn_services(
         .collect::<anyhow::Result<Vec<_>>>()?;
     let seed_peers = seed_peers
         .into_iter()
-        .flat_map(|p| {
+        .map(|p| {
             let peer_id = p.to_peer_id();
-            p.addresses.into_iter().map(move |a| (peer_id, a))
+            (peer_id, p.into_address())
         })
         .collect();
     #[allow(unused_mut)]

--- a/applications/tari_validator_node/web_ui/src/routes/VN/Components/Connections.tsx
+++ b/applications/tari_validator_node/web_ui/src/routes/VN/Components/Connections.tsx
@@ -101,7 +101,7 @@ function Connections() {
               />
               <TextField
                 name="address"
-                label="CopyAddress"
+                label="Multiaddr"
                 value={formState.address}
                 onChange={onChange}
                 style={{ flexGrow: 1 }}

--- a/networking/core/src/builder.rs
+++ b/networking/core/src/builder.rs
@@ -18,7 +18,7 @@ pub struct Builder<'a, TMsg: MessageSpec> {
     identity: Keypair,
     messaging_mode: MessagingMode<TMsg>,
     config: crate::Config,
-    seed_peers: Vec<(PeerId, Multiaddr)>,
+    seed_peers: Vec<(Option<PeerId>, Multiaddr)>,
     #[cfg(feature = "metrics")]
     registry: Option<&'a mut libp2p::metrics::Registry>,
     #[cfg(not(feature = "metrics"))]
@@ -70,7 +70,7 @@ where
         self
     }
 
-    pub fn with_seed_peers(mut self, seed_peers: Vec<(PeerId, Multiaddr)>) -> Self {
+    pub fn with_seed_peers(mut self, seed_peers: Vec<(Option<PeerId>, Multiaddr)>) -> Self {
         self.seed_peers = seed_peers;
         self
     }
@@ -106,6 +106,7 @@ where
         let local_peer_id = *swarm.local_peer_id();
         let (tx, rx) = mpsc::channel(1);
         let (tx_events, _) = broadcast::channel(100);
+
         #[allow(unused_mut)]
         let mut worker = NetworkingWorker::<TMsg>::new(
             identity,
@@ -114,6 +115,10 @@ where
             messaging_mode,
             swarm,
             config,
+            seed_peers
+                .iter()
+                .filter_map(|(peer_id, addr)| Some(((*peer_id)?, addr.clone())))
+                .collect(),
             seed_peers,
             shutdown_signal,
         );

--- a/networking/core/src/worker.rs
+++ b/networking/core/src/worker.rs
@@ -87,6 +87,7 @@ where
     swarm: TariSwarm<ProstCodec<TMsg::Message>>,
     config: crate::Config,
     relays: RelayState,
+    seed_peers: Vec<(Option<PeerId>, Multiaddr)>,
     is_initial_bootstrap_complete: bool,
     has_sent_announce: bool,
     #[cfg(feature = "metrics")]
@@ -109,6 +110,7 @@ where
         swarm: TariSwarm<ProstCodec<TMsg::Message>>,
         config: crate::Config,
         known_relay_nodes: Vec<(PeerId, Multiaddr)>,
+        seed_peers: Vec<(Option<PeerId>, Multiaddr)>,
         shutdown_signal: ShutdownSignal,
     ) -> Self {
         Self {
@@ -122,6 +124,7 @@ where
             pending_dial_requests: HashMap::new(),
             relays: RelayState::new(known_relay_nodes),
             topic_peers: HashMap::new(),
+            seed_peers,
             swarm,
             config,
             is_initial_bootstrap_complete: false,
@@ -383,6 +386,27 @@ where
                 .add_known_local_public_addresses(self.config.known_local_public_address.clone());
         }
 
+        info!(target: LOG_TARGET, "🥾 Bootstrapping with {} seed peers", self.seed_peers.len());
+        for (peer, addr) in self.seed_peers.drain(..) {
+            let opts = match peer {
+                Some(peer) => DialOpts::peer_id(peer)
+                    .addresses(vec![addr])
+                    .condition(PeerCondition::DisconnectedAndNotDialing)
+                    .extend_addresses_through_behaviour()
+                    .build(),
+                None => DialOpts::unknown_peer_id().address(addr).build(),
+            };
+
+            self.swarm.dial(opts).or_else(|err| {
+                // Peer already has pending dial or established connection - OK
+                if matches!(&err, DialError::DialPeerConditionFalse(_)) {
+                    Ok(())
+                } else {
+                    Err(err)
+                }
+            })?;
+        }
+
         if self.active_connections.len() < self.relays.num_possible_relays() {
             info!(target: LOG_TARGET, "🥾 Bootstrapping with {} known relay peers", self.relays.num_possible_relays());
             for (peer, addrs) in self.relays.possible_relays() {
@@ -402,6 +426,7 @@ where
                         }
                     })?;
             }
+
             self.is_initial_bootstrap_complete = true;
         }
 


### PR DESCRIPTION
Description
---
fix: allow seed peers to be specified without public key
fix(swarm): add validator seed peers to indexer cli args 

Motivation and Context
---
Allow seed peer addresses to be specified without a public key since this is not necessary to connect - if the public key is provided, it is still used to verify the connection (automatically by libp2p). To specify seed peers without a public key, use multiaddr format omitting the `{pk}::` ` e.g. `/ip4/127.0.0.1/tcp/12005`.

If mDNS does not work due to network restrictions the indexer is still able to connect to validator nodes and shard addresses because of the added seed peers.

How Has This Been Tested?
---
Manually with mDNS not working. 

What process can a PR reviewer use to test or verify this change?
---


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify