### PR TITLE
fix(consensus)!: vote power for validator set

### DIFF
--- a/applications/tari_indexer/src/dry_run/processor.rs
+++ b/applications/tari_indexer/src/dry_run/processor.rs
@@ -146,7 +146,7 @@ impl DryRunTransactionProcessor {
         let mut committee = self.epoch_manager.get_committee_for_substate(epoch, address).await?;
         committee.shuffle();
 
-        let max_failures = committee.max_failures() + 1;
+        let max_failures = committee.max_node_failures() + 1;
 
         let mut nexist_count = 0;
         let mut err_count = 0;

--- a/applications/tari_indexer/src/network_client.rs
+++ b/applications/tari_indexer/src/network_client.rs
@@ -219,8 +219,8 @@ where
         let mut results = HashMap::with_capacity(committee_size);
         let mut last_error = None;
         for (shard_group, committee) in all_members {
-            for member in committee.shuffled().map(|(addr, _)| addr) {
-                let client = self.client_provider.create_client(member);
+            for member in committee.shuffled() {
+                let client = self.client_provider.create_client(&member.address);
                 match callback(client).await {
                     Ok(ret) => {
                         num_succeeded += 1;

--- a/crates/common_types/src/committee.rs
+++ b/crates/common_types/src/committee.rs
@@ -1,14 +1,14 @@
 //   Copyright 2023 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use std::{cmp, ops::RangeInclusive};
+use std::{cmp, fmt::Display, ops::RangeInclusive};
 
 use rand::{rngs::OsRng, seq::SliceRandom};
 use serde::{Deserialize, Serialize};
 use tari_engine_types::substate::SubstateId;
 use tari_template_lib_types::crypto::RistrettoPublicKeyBytes;
 
-use crate::{Epoch, NumPreshards, ShardGroup, SubstateAddress};
+use crate::{Epoch, NumPreshards, ShardGroup, SubstateAddress, VotePower};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Default, Hash)]
 #[cfg_attr(
@@ -17,8 +17,30 @@ use crate::{Epoch, NumPreshards, ShardGroup, SubstateAddress};
     ts(export, export_to = "../../bindings/src/types/")
 )]
 pub struct Committee<TAddr> {
-    #[cfg_attr(feature = "ts", ts(type = "Array<[string, string]>"))]
-    members: Vec<(TAddr, RistrettoPublicKeyBytes)>,
+    members: Vec<CommitteeMember<TAddr>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default, Hash)]
+#[cfg_attr(
+    feature = "ts",
+    derive(ts_rs::TS),
+    ts(export, export_to = "../../bindings/src/types/")
+)]
+pub struct CommitteeMember<TAddr> {
+    pub address: TAddr,
+    #[cfg_attr(feature = "ts", ts(type = "string"))]
+    pub public_key: RistrettoPublicKeyBytes,
+    pub vote_power: VotePower,
+}
+
+impl<TAddr: Display> Display for CommitteeMember<TAddr> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "CommitteeMember(addr={}, pk={}, {})",
+            self.address, self.public_key, self.vote_power
+        )
+    }
 }
 
 impl<TAddr: PartialEq> Committee<TAddr> {
@@ -30,25 +52,40 @@ impl<TAddr: PartialEq> Committee<TAddr> {
         Self::new(Vec::with_capacity(cap))
     }
 
-    pub fn new(members: Vec<(TAddr, RistrettoPublicKeyBytes)>) -> Self {
+    pub fn new(members: Vec<CommitteeMember<TAddr>>) -> Self {
         Self { members }
     }
 
-    pub fn members_mut(&mut self) -> &mut Vec<(TAddr, RistrettoPublicKeyBytes)> {
+    // TODO: remove this - rather create committees from iterators than mutating directly
+    pub fn members_mut(&mut self) -> &mut Vec<CommitteeMember<TAddr>> {
         &mut self.members
     }
 
-    pub fn max_failures(&self) -> usize {
-        let len = self.members.len();
-        if len == 0 {
-            return 0;
+    pub fn max_failures(&self) -> VotePower {
+        let power = self.total_power();
+        if power.is_zero() {
+            return VotePower::of(0);
         }
-        (len - 1) / 3
+        (power - VotePower::of(1)) / VotePower::of(3)
     }
 
-    /// Returns $n - f$ (i.e $2f + 1$) where n is the number of committee members and f is the tolerated failure nodes.
-    pub fn quorum_threshold(&self) -> usize {
-        self.members.len() - self.max_failures()
+    /// Returns $n - f$ (i.e. $2f + 1$) where n is the number of committee members and f is the tolerated failure nodes.
+    pub fn quorum_threshold(&self) -> VotePower {
+        self.total_power() - self.max_failures()
+    }
+
+    pub fn total_power(&self) -> VotePower {
+        self.members
+            .iter()
+            .fold(VotePower::default(), |acc, member| acc + member.vote_power)
+    }
+
+    pub fn max_node_failures(&self) -> usize {
+        // max failures is < 1/3 of the total members
+        if self.is_empty() {
+            return 0;
+        }
+        (self.len() + 1) / 3
     }
 
     pub fn is_empty(&self) -> bool {
@@ -59,17 +96,25 @@ impl<TAddr: PartialEq> Committee<TAddr> {
         self.members.len()
     }
 
-    pub fn contains(&self, member: &TAddr) -> bool {
+    pub fn contains(&self, addr: &TAddr) -> bool {
         // TODO(perf); O(n) lookup
-        self.members.iter().any(|(addr, _)| addr == member)
+        self.members.iter().any(|member| member.address == *addr)
     }
 
     pub fn contains_public_key(&self, public_key: &RistrettoPublicKeyBytes) -> bool {
         // TODO(perf); O(n) lookup
-        self.members.iter().any(|(_, pk)| pk == public_key)
+        self.members.iter().any(|member| *public_key == member.public_key)
     }
 
-    pub fn get(&self, index: usize) -> Option<&(TAddr, RistrettoPublicKeyBytes)> {
+    pub fn get_power_by_public_key(&self, public_key: &RistrettoPublicKeyBytes) -> Option<VotePower> {
+        // TODO(perf); O(n) lookup
+        self.members
+            .iter()
+            .find(|m| m.public_key == *public_key)
+            .map(|m| m.vote_power)
+    }
+
+    pub fn get(&self, index: usize) -> Option<&CommitteeMember<TAddr>> {
         self.members.get(index)
     }
 
@@ -77,16 +122,18 @@ impl<TAddr: PartialEq> Committee<TAddr> {
         self.members.shuffle(&mut OsRng);
     }
 
-    pub fn shuffled(&self) -> impl Iterator<Item = &(TAddr, RistrettoPublicKeyBytes)> + '_ {
+    pub fn shuffled(&self) -> impl Iterator<Item = &CommitteeMember<TAddr>> + '_ {
         self.members.choose_multiple(&mut OsRng, self.len())
     }
 
     pub fn select_n_random(&self, n: usize) -> impl Iterator<Item = &TAddr> + '_ {
-        self.members.choose_multiple(&mut OsRng, n).map(|(addr, _)| addr)
+        self.members
+            .choose_multiple(&mut OsRng, n)
+            .map(|member| &member.address)
     }
 
     pub fn index_of(&self, member: &TAddr) -> Option<usize> {
-        self.members.iter().position(|(addr, _)| addr == member)
+        self.members.iter().position(|m| m.address == *member)
     }
 
     /// Returns the n next members from start_index_inclusive, wrapping around if necessary.
@@ -99,7 +146,7 @@ impl<TAddr: PartialEq> Committee<TAddr> {
         };
         self.members
             .iter()
-            .map(|(addr, _)| addr)
+            .map(|m| &m.address)
             .cycle()
             .skip(start_index_inclusive)
             .take(n)
@@ -116,30 +163,30 @@ impl<TAddr: PartialEq> Committee<TAddr> {
         }
     }
 
-    pub fn iter(&self) -> impl Iterator<Item = &(TAddr, RistrettoPublicKeyBytes)> {
+    pub fn iter(&self) -> impl Iterator<Item = &CommitteeMember<TAddr>> {
         self.members.iter()
     }
 
     pub fn address_iter(&self) -> impl Iterator<Item = &TAddr> + '_ {
-        self.members.iter().map(|(addr, _)| addr)
+        self.members.iter().map(|m| &m.address)
     }
 
     pub fn into_addresses(self) -> impl Iterator<Item = TAddr> {
-        self.members.into_iter().map(|(addr, _)| addr)
+        self.members.into_iter().map(|m| m.address)
     }
 
     pub fn public_keys(&self) -> impl Iterator<Item = &RistrettoPublicKeyBytes> {
-        self.members.iter().map(|(_, pk)| pk)
+        self.members.iter().map(|m| &m.public_key)
     }
 
     pub fn into_public_keys(self) -> impl Iterator<Item = RistrettoPublicKeyBytes> {
-        self.members.into_iter().map(|(_, pk)| pk)
+        self.members.into_iter().map(|m| m.public_key)
     }
 }
 
 impl<TAddr> IntoIterator for Committee<TAddr> {
     type IntoIter = std::vec::IntoIter<Self::Item>;
-    type Item = (TAddr, RistrettoPublicKeyBytes);
+    type Item = CommitteeMember<TAddr>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.members.into_iter()
@@ -147,16 +194,16 @@ impl<TAddr> IntoIterator for Committee<TAddr> {
 }
 
 impl<'a, TAddr> IntoIterator for &'a Committee<TAddr> {
-    type IntoIter = std::slice::Iter<'a, (TAddr, RistrettoPublicKeyBytes)>;
-    type Item = &'a (TAddr, RistrettoPublicKeyBytes);
+    type IntoIter = std::slice::Iter<'a, CommitteeMember<TAddr>>;
+    type Item = &'a CommitteeMember<TAddr>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.members.iter()
     }
 }
 
-impl<TAddr: PartialEq> FromIterator<(TAddr, RistrettoPublicKeyBytes)> for Committee<TAddr> {
-    fn from_iter<T: IntoIterator<Item = (TAddr, RistrettoPublicKeyBytes)>>(iter: T) -> Self {
+impl<TAddr: PartialEq> FromIterator<CommitteeMember<TAddr>> for Committee<TAddr> {
+    fn from_iter<T: IntoIterator<Item = CommitteeMember<TAddr>>>(iter: T) -> Self {
         Self::new(iter.into_iter().collect())
     }
 }
@@ -186,6 +233,7 @@ pub struct CommitteeInfo {
     num_committees: u32,
     shard_group: ShardGroup,
     epoch: Epoch,
+    total_power: VotePower,
 }
 
 impl CommitteeInfo {
@@ -195,6 +243,7 @@ impl CommitteeInfo {
         num_committees: u32,
         shard_group: ShardGroup,
         epoch: Epoch,
+        total_power: VotePower,
     ) -> Self {
         Self {
             num_shards,
@@ -202,6 +251,7 @@ impl CommitteeInfo {
             num_committees,
             shard_group,
             epoch,
+            total_power,
         }
     }
 
@@ -210,22 +260,33 @@ impl CommitteeInfo {
         self.epoch
     }
 
-    /// Returns $n - f$ (i.e $2f + 1$) where n is the number of committee members and f is the tolerated failure nodes.
-    pub fn quorum_threshold(&self) -> u32 {
-        self.num_shard_group_members - self.max_failures()
+    /// Returns $n - f$ (i.e $2f + 1$) where n is the total power of committee members and f is the tolerated failure
+    /// nodes.
+    pub fn quorum_threshold(&self) -> VotePower {
+        self.total_power() - self.max_failures()
     }
 
     /// Returns the maximum number of failures $f$ that can be tolerated by this committee.
-    pub fn max_failures(&self) -> u32 {
-        let len = self.num_shard_group_members;
-        if len == 0 {
-            return 0;
+    pub fn max_failures(&self) -> VotePower {
+        if self.total_power().is_zero() {
+            return VotePower::zero();
         }
-        (len - 1) / 3
+        (self.total_power() - VotePower::of(1)) / VotePower::of(3)
+    }
+
+    /// Returns the total voting power of the committee.
+    pub fn total_power(&self) -> VotePower {
+        self.total_power
     }
 
     pub fn num_shard_group_members(&self) -> u32 {
         self.num_shard_group_members
+    }
+
+    pub fn max_failure_shard_group_members(&self) -> u32 {
+        // max failures is < 1/3 of the total members
+        // NOTE: this is not to be used as a threshold for quorum.
+        (self.num_shard_group_members + 1) / 3
     }
 
     pub fn num_preshards(&self) -> NumPreshards {
@@ -281,7 +342,11 @@ mod tests {
     fn create_committee(size: usize) -> Committee<u32> {
         Committee::new(
             (0..size as u32)
-                .map(|c| (c, RistrettoPublicKeyBytes::default()))
+                .map(|c| CommitteeMember {
+                    address: c,
+                    public_key: RistrettoPublicKeyBytes::default(),
+                    vote_power: VotePower::of(1),
+                })
                 .collect(),
         )
     }

--- a/crates/common_types/src/lib.rs
+++ b/crates/common_types/src/lib.rs
@@ -58,5 +58,7 @@ pub use lock_intent::*;
 mod fee_pool;
 pub use fee_pool::*;
 mod consensus_constants;
-pub mod layer_one_transaction;
 pub use consensus_constants::*;
+pub mod layer_one_transaction;
+mod vote_power;
+pub use vote_power::*;

--- a/crates/common_types/src/vote_power.rs
+++ b/crates/common_types/src/vote_power.rs
@@ -1,0 +1,102 @@
+//    Copyright 2024 The Tari Project
+//    SPDX-License-Identifier: BSD-3-Clause
+
+use std::fmt::Display;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, Default)]
+#[cfg_attr(
+    feature = "ts",
+    derive(ts_rs::TS),
+    ts(export, export_to = "../../bindings/src/types/")
+)]
+pub struct VotePower(u64);
+
+impl VotePower {
+    pub const fn of(value: u64) -> Self {
+        Self(value)
+    }
+
+    pub const fn zero() -> Self {
+        Self(0)
+    }
+
+    pub const fn max() -> Self {
+        Self(u64::MAX)
+    }
+
+    pub const fn value(&self) -> u64 {
+        self.0
+    }
+
+    pub const fn is_zero(&self) -> bool {
+        self.0 == 0
+    }
+
+    pub fn checked_add(self, other: Self) -> Option<Self> {
+        self.0.checked_add(other.0).map(Self)
+    }
+
+    pub fn checked_sub(self, other: Self) -> Option<Self> {
+        self.0.checked_sub(other.0).map(Self)
+    }
+
+    pub fn checked_mul(self, rhs: Self) -> Option<Self> {
+        self.0.checked_mul(rhs.0).map(Self)
+    }
+
+    pub fn checked_div(self, rhs: Self) -> Option<Self> {
+        self.0.checked_div(rhs.0).map(Self)
+    }
+}
+
+impl From<u64> for VotePower {
+    fn from(value: u64) -> Self {
+        Self(value)
+    }
+}
+
+impl Display for VotePower {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "VotePower({})", self.0)
+    }
+}
+
+impl std::ops::Add for VotePower {
+    type Output = Self;
+
+    fn add(self, other: Self) -> Self::Output {
+        Self(self.0 + other.0)
+    }
+}
+
+impl std::ops::Sub for VotePower {
+    type Output = Self;
+
+    fn sub(self, other: Self) -> Self::Output {
+        Self(self.0 - other.0)
+    }
+}
+
+impl std::ops::Mul<Self> for VotePower {
+    type Output = Self;
+
+    fn mul(self, rhs: Self) -> Self::Output {
+        Self(self.0 * rhs.0)
+    }
+}
+
+impl std::ops::Div<Self> for VotePower {
+    type Output = Self;
+
+    fn div(self, rhs: Self) -> Self::Output {
+        Self(self.0 / rhs.0)
+    }
+}
+
+impl std::ops::AddAssign for VotePower {
+    fn add_assign(&mut self, other: Self) {
+        self.0 += other.0;
+    }
+}

--- a/crates/consensus/src/hotstuff/error.rs
+++ b/crates/consensus/src/hotstuff/error.rs
@@ -4,7 +4,7 @@
 use tari_common_types::types::FixedHash;
 use tari_consensus_types::{BlockId, LeafBlock, QcId};
 use tari_epoch_manager::EpochManagerError;
-use tari_ootle_common_types::{Epoch, NodeHeight, ShardGroup, VersionedSubstateIdError};
+use tari_ootle_common_types::{Epoch, NodeHeight, ShardGroup, VersionedSubstateIdError, VotePower};
 use tari_ootle_storage::{
     consensus_models::{BlockError, ForeignProposalCommitProofError, TransactionPoolError},
     StorageError,
@@ -195,8 +195,12 @@ pub enum ProposalValidationError {
         qc: QcId,
         validator: RistrettoPublicKeyBytes,
     },
-    #[error("Quorum was not reached on QC {qc}. {got} out of {required} signatures")]
-    QuorumWasNotReached { qc: QcId, got: usize, required: usize },
+    #[error("Quorum was not reached on QC {qc}. {got} out of {required}")]
+    QuorumWasNotReached {
+        qc: QcId,
+        got: VotePower,
+        required: VotePower,
+    },
     #[error("Invalid network in block {block_id}: expected {expected_network}, given {block_network}")]
     InvalidNetwork {
         expected_network: String,

--- a/crates/consensus/src/hotstuff/on_propose.rs
+++ b/crates/consensus/src/hotstuff/on_propose.rs
@@ -578,7 +578,9 @@ where TConsensusSpec: ConsensusSpec
             .map(|max| {
                 let num_evicted =
                     ValidatorConsensusStats::count_number_evicted_nodes(tx, start_of_chain_block.epoch())?;
-                let max_allowed_to_evict = u64::from(local_committee_info.max_failures())
+                // TODO: technically, we should not evict more than 1/3 of the voting power, not the number of nodes
+                // (but this is currently the same thing)
+                let max_allowed_to_evict = u64::from(local_committee_info.max_failure_shard_group_members())
                     .saturating_sub(num_evicted)
                     .min(max as u64);
                 ValidatorConsensusStats::get_nodes_to_evict(

--- a/crates/consensus/src/hotstuff/on_ready_to_vote_on_local_block.rs
+++ b/crates/consensus/src/hotstuff/on_ready_to_vote_on_local_block.rs
@@ -390,7 +390,9 @@ where TConsensusSpec: ConsensusSpec
                     }
 
                     let num_evicted = ValidatorConsensusStats::count_number_evicted_nodes(tx, block.epoch())?;
-                    let max_allowed_to_evict = u64::from(local_committee_info.quorum_threshold())
+                    // TODO: technically, we should not evict more than 1/3 of the voting power, not the number of nodes
+                    // (but this is currently the same thing)
+                    let max_allowed_to_evict = u64::from(local_committee_info.max_failure_shard_group_members())
                         .saturating_sub(num_evicted)
                         .saturating_sub(proposed_block_change_set.num_evicted_nodes_this_block() as u64);
                     if max_allowed_to_evict == 0 {

--- a/crates/consensus/src/hotstuff/on_receive_foreign_proposal.rs
+++ b/crates/consensus/src/hotstuff/on_receive_foreign_proposal.rs
@@ -166,13 +166,18 @@ where TConsensusSpec: ConsensusSpec
             return Ok(());
         }
 
-        let f = local_committee_info.max_failures() as usize;
         let committee = self
             .epoch_manager
-            .get_committee_by_shard_group(current_epoch, foreign_committee_info.shard_group(), Some(f + 1))
+            .get_committee_by_shard_group(
+                current_epoch,
+                foreign_committee_info.shard_group(),
+                // We only request from one - note that we happen to know that get_committee_by_shard_group shuffles
+                // the committee.
+                Some(1),
+            )
             .await?;
 
-        let Some((selected, _)) = committee.shuffled().next() else {
+        let Some(selected) = committee.iter().next() else {
             warn!(
                 target: LOG_TARGET,
                 "FOREIGN PROPOSAL: No validator selected for the shard group {}",
@@ -190,7 +195,7 @@ where TConsensusSpec: ConsensusSpec
         );
         self.outbound_messaging
             .send(
-                selected.clone(),
+                selected.address.clone(),
                 HotstuffMessage::ForeignProposalRequest(ForeignProposalRequestMessage::ByBlockId {
                     block_id: message.block_id,
                     for_shard_group: local_committee_info.shard_group(),

--- a/crates/consensus/src/hotstuff/on_receive_new_view.rs
+++ b/crates/consensus/src/hotstuff/on_receive_new_view.rs
@@ -138,13 +138,7 @@ where TConsensusSpec: ConsensusSpec
             // HighPc is updated if a quorum is reached in the collector, and will be used if we propose
             if let Err(err) = self
                 .proposal_vote_collector
-                .check_and_collect_vote(
-                    from.clone(),
-                    current_height,
-                    epoch_state.epoch(),
-                    vote,
-                    epoch_state.local_committee_info(),
-                )
+                .check_and_collect_vote(from.clone(), current_height, epoch_state, vote)
                 .await
             {
                 warn!(target: LOG_TARGET, "❌ Error handling vote: {}", err);
@@ -154,22 +148,16 @@ where TConsensusSpec: ConsensusSpec
         // Take note of unique NEWVIEWs so that we can count them
         let Some((timeout_certificate, high_tc)) = self
             .timeout_vote_collector
-            .check_and_collect_vote(
-                from,
-                current_height,
-                epoch_state.epoch(),
-                timeout,
-                epoch_state.local_committee_info(),
-            )
+            .check_and_collect_vote(from, current_height, epoch_state, timeout)
             .await?
         else {
             debug!(target: LOG_TARGET, "🌟 Received NEWVIEW but quorum is not yet reached.");
             return Ok(());
         };
 
-        let threshold = epoch_state.local_committee_info().quorum_threshold() as usize;
+        let threshold = epoch_state.local_committee_info().quorum_threshold();
 
-        info!(target: LOG_TARGET, "🌟✅ NEWVIEW height {} (high_tc: {}) has reached quorum ({}/{})", timeout_height, high_tc, timeout_certificate.signatures().len(), threshold);
+        info!(target: LOG_TARGET, "🌟✅ NEWVIEW height {} (high_tc: {}) has reached quorum ({}/{})", timeout_height, high_tc, timeout_certificate.signatures().len(), threshold.value());
         if timeout_certificate.calculate_id() == *high_tc.id() {
             info!(target: LOG_TARGET, "🕒️ New HIGH TC {}", timeout_certificate);
             // Clear the last sent new view since we have a new certificate

--- a/crates/consensus/src/hotstuff/on_receive_vote.rs
+++ b/crates/consensus/src/hotstuff/on_receive_vote.rs
@@ -52,13 +52,7 @@ where TConsensusSpec: ConsensusSpec
         }
         match self
             .vote_collector
-            .check_and_collect_vote(
-                from,
-                current_height,
-                epoch_state.epoch(),
-                message.vote,
-                epoch_state.local_committee_info(),
-            )
+            .check_and_collect_vote(from, current_height, epoch_state, message.vote)
             .await
         {
             Ok(Some((_, high_qc))) => {

--- a/crates/consensus/src/hotstuff/vote_collector/collector.rs
+++ b/crates/consensus/src/hotstuff/vote_collector/collector.rs
@@ -10,7 +10,7 @@ use std::{
 use log::*;
 use tari_common_types::types::FixedHash;
 use tari_consensus_types::Vote;
-use tari_ootle_common_types::{Epoch, NodeHeight};
+use tari_ootle_common_types::{committee::Committee, Epoch, NodeAddressable, NodeHeight, VotePower};
 use tari_sidechain::QuorumDecision;
 use tokio::sync::RwLock;
 
@@ -28,13 +28,13 @@ impl<V: Vote + Display> VoteCollector<V> {
         }
     }
 
-    pub async fn collect_vote(
+    pub async fn collect_vote<TAddr: NodeAddressable>(
         &self,
         current_epoch: Epoch,
         current_height: NodeHeight,
         sender_hash: FixedHash,
         vote: V,
-        quorum_threshold: usize,
+        committee: &Committee<TAddr>,
     ) -> Option<(Vec<V>, QuorumDecision)> {
         let mut access_mut = self.store.write().await;
         access_mut.clear_votes_before(current_epoch, current_height);
@@ -52,7 +52,8 @@ impl<V: Vote + Display> VoteCollector<V> {
             return None;
         }
 
-        let threshold_decision = access_mut.calculate_threshold_decision(epoch, height, &key, quorum_threshold);
+        let quorum_threshold = committee.quorum_threshold();
+        let threshold_decision = access_mut.calculate_threshold_decision(epoch, height, &key, committee);
 
         let Some(quorum_decision) = threshold_decision.decision else {
             info!(
@@ -60,7 +61,7 @@ impl<V: Vote + Display> VoteCollector<V> {
                 "🔥 Received {} from {} ({} of {}).",
                 vote_display,
                 sender_hash,
-                threshold_decision.count,
+                threshold_decision.total_power,
                 quorum_threshold
             );
             return None;
@@ -68,13 +69,13 @@ impl<V: Vote + Display> VoteCollector<V> {
 
         // We only generate the next qc once when we have a quorum of votes. Any votes received after this
         // are not included in the QC.
-        if threshold_decision.count < quorum_threshold {
+        if threshold_decision.total_power < quorum_threshold {
             info!(
                 target: LOG_TARGET,
                 "🔥 Received {} from {} ({} of {}).",
                 vote_display,
                 sender_hash,
-                threshold_decision.count,
+                threshold_decision.total_power,
                 quorum_threshold
             );
             return None;
@@ -85,7 +86,7 @@ impl<V: Vote + Display> VoteCollector<V> {
             "🔥 Received {} from {} ({} of {}). QUORUM!",
             vote_display,
             sender_hash,
-            threshold_decision.count,
+            threshold_decision.total_power,
             quorum_threshold
         );
 
@@ -165,12 +166,12 @@ impl<V: Vote + Display> VoteStoreInner<V> {
         Some(votes.values())
     }
 
-    pub fn calculate_threshold_decision(
+    pub fn calculate_threshold_decision<TAddr: NodeAddressable>(
         &self,
         epoch: Epoch,
         height: NodeHeight,
         key: &V::Key,
-        quorum_threshold: usize,
+        committee: &Committee<TAddr>,
     ) -> ThresholdDecision {
         let Some(votes_iter) = self.votes_for_key_iter(epoch, height, key) else {
             // Soft invariant protection - technically, this should not happen but the correct ThresholdDecision is
@@ -182,34 +183,36 @@ impl<V: Vote + Display> VoteStoreInner<V> {
             );
 
             return ThresholdDecision {
-                count: 0,
+                total_power: VotePower::zero(),
                 decision: None,
             };
         };
-        let mut count_accept = 0;
-        let mut count_reject = 0;
+        let mut count_accept = VotePower::zero();
+        let mut count_reject = VotePower::zero();
         for vote in votes_iter {
+            let power = committee.get_power_by_public_key(vote.public_key()).unwrap_or_default();
             match vote.decision() {
-                QuorumDecision::Accept => count_accept += 1,
-                QuorumDecision::Reject => count_reject += 1,
+                QuorumDecision::Accept => count_accept += power,
+                QuorumDecision::Reject => count_reject += power,
             }
         }
 
+        let quorum_threshold = committee.quorum_threshold();
         if count_accept >= quorum_threshold {
             return ThresholdDecision {
-                count: count_accept,
+                total_power: count_accept,
                 decision: Some(QuorumDecision::Accept),
             };
         }
         if count_reject >= quorum_threshold {
             return ThresholdDecision {
-                count: count_reject,
+                total_power: count_reject,
                 decision: Some(QuorumDecision::Reject),
             };
         }
 
         ThresholdDecision {
-            count: count_accept + count_reject,
+            total_power: count_accept + count_reject,
             decision: None,
         }
     }
@@ -230,5 +233,5 @@ impl<V: Vote + Display> VoteStoreInner<V> {
 #[derive(Debug, Clone, Copy)]
 pub struct ThresholdDecision {
     pub decision: Option<QuorumDecision>,
-    pub count: usize,
+    pub total_power: VotePower,
 }

--- a/crates/consensus/src/hotstuff/vote_collector/proposal_collector.rs
+++ b/crates/consensus/src/hotstuff/vote_collector/proposal_collector.rs
@@ -4,13 +4,13 @@
 use log::*;
 use tari_common::configuration::Network;
 use tari_consensus_types::{HighPc, ProposalCertificate, ProposalVote, ValidatorSignatureBytes};
-use tari_ootle_common_types::{committee::CommitteeInfo, optional::Optional, Epoch, NodeHeight};
+use tari_ootle_common_types::{optional::Optional, Epoch, NodeHeight};
 use tari_ootle_storage::{consensus_models::Block, StateStore};
 use tari_sidechain::QuorumDecision;
 
 use super::collector::VoteCollector;
 use crate::{
-    hotstuff::{error::HotStuffError, vote_collector::helpers::check_eligibility},
+    hotstuff::{epoch_state::EpochState, error::HotStuffError, vote_collector::helpers::check_eligibility},
     tracing::TraceTimer,
     traits::{CertificateStore, ConsensusSpec, ValidatorSignatureVerifierService},
 };
@@ -53,9 +53,8 @@ where TConsensusSpec: ConsensusSpec
         &self,
         from: TConsensusSpec::Addr,
         current_height: NodeHeight,
-        current_epoch: Epoch,
+        epoch_state: &EpochState<TConsensusSpec::Addr>,
         vote: ProposalVote,
-        local_committee_info: &CommitteeInfo,
     ) -> Result<Option<(ProposalCertificate, HighPc)>, HotStuffError> {
         let _timer = TraceTimer::debug(LOG_TARGET, "check_and_collect_vote");
         debug!(
@@ -63,15 +62,23 @@ where TConsensusSpec: ConsensusSpec
             "Validating vote message from {from}: {vote}"
         );
 
+        let local_committee_info = epoch_state.local_committee_info();
+        let current_epoch = epoch_state.epoch();
+
         let block_id = vote.block_id;
         let sender_vn =
             check_eligibility::<TConsensusSpec, _>(&self.epoch_manager, from, &vote, local_committee_info).await?;
         self.validate_vote(current_epoch, &vote)?;
-        let quorum_threshold = local_committee_info.quorum_threshold() as usize;
         let sender_leaf_hash = sender_vn.get_node_hash(self.network);
         let Some((quorum_votes, quorum_decision)) = self
             .vote_collector
-            .collect_vote(current_epoch, current_height, sender_leaf_hash, vote, quorum_threshold)
+            .collect_vote(
+                current_epoch,
+                current_height,
+                sender_leaf_hash,
+                vote,
+                epoch_state.local_committee(),
+            )
             .await
         else {
             return Ok(None);
@@ -85,11 +92,7 @@ where TConsensusSpec: ConsensusSpec
             );
             return Ok(None);
         };
-        let signatures = quorum_votes
-            .into_iter()
-            .take(quorum_threshold)
-            .map(|vote| vote.signature)
-            .collect();
+        let signatures = quorum_votes.into_iter().map(|vote| vote.signature).collect();
         let new_qc = create_proposal_certificate(signatures, quorum_decision, block);
         let high_qc = self.store.with_write_tx(|tx| new_qc.update_highest(tx))?;
         if new_qc.calculate_id() == *high_qc.id() {

--- a/crates/consensus/src/hotstuff/vote_collector/timeout_collector.rs
+++ b/crates/consensus/src/hotstuff/vote_collector/timeout_collector.rs
@@ -4,12 +4,12 @@
 use log::*;
 use tari_common::configuration::Network;
 use tari_consensus_types::{HighTc, SignedMessage, TimeoutCertificate, TimeoutVote, Vote};
-use tari_ootle_common_types::{committee::CommitteeInfo, Epoch, NodeHeight};
+use tari_ootle_common_types::{Epoch, NodeHeight};
 use tari_ootle_storage::StateStore;
 
 use super::collector::VoteCollector;
 use crate::{
-    hotstuff::{error::HotStuffError, vote_collector::helpers::check_eligibility},
+    hotstuff::{epoch_state::EpochState, error::HotStuffError, vote_collector::helpers::check_eligibility},
     tracing::TraceTimer,
     traits::{CertificateStore, ConsensusSpec, ValidatorSignatureVerifierService},
 };
@@ -48,9 +48,8 @@ where TConsensusSpec: ConsensusSpec
         &self,
         from: TConsensusSpec::Addr,
         current_height: NodeHeight,
-        current_epoch: Epoch,
+        epoch_state: &EpochState<TConsensusSpec::Addr>,
         vote: TimeoutVote,
-        local_committee_info: &CommitteeInfo,
     ) -> Result<Option<(TimeoutCertificate, HighTc)>, HotStuffError> {
         let _timer = TraceTimer::debug(LOG_TARGET, "check_and_collect_vote (TimeoutVote)");
         debug!(
@@ -58,16 +57,23 @@ where TConsensusSpec: ConsensusSpec
             "📬 Validating timeout vote message from {from}: {vote}"
         );
 
+        let current_epoch = epoch_state.epoch();
+        let local_committee_info = epoch_state.local_committee_info();
         let sender_vn =
             check_eligibility::<TConsensusSpec, _>(&self.epoch_manager, from, &vote, local_committee_info).await?;
         self.validate_vote(current_epoch, &vote)?;
-        let quorum_threshold = local_committee_info.quorum_threshold() as usize;
         let sender_leaf_hash = sender_vn.get_node_hash(self.network);
         let height = vote.height;
 
         let Some((quorum_votes, _)) = self
             .vote_collector
-            .collect_vote(current_epoch, current_height, sender_leaf_hash, vote, quorum_threshold)
+            .collect_vote(
+                current_epoch,
+                current_height,
+                sender_leaf_hash,
+                vote,
+                epoch_state.local_committee(),
+            )
             .await
         else {
             return Ok(None);

--- a/crates/consensus/src/hotstuff/worker.rs
+++ b/crates/consensus/src/hotstuff/worker.rs
@@ -444,15 +444,16 @@ impl<TConsensusSpec: ConsensusSpec> HotstuffWorker<TConsensusSpec> {
                     local_committee.shuffle();
                     match local_committee
                         .into_iter()
-                        .find(|(addr, _)| *addr != self.local_validator_addr)
+                        .find(|m| m.address != self.local_validator_addr)
                     {
-                        Some((addr, _)) => {
+                        Some(m) => {
                             warn!(
                                 target: LOG_TARGET,
-                                "⚠️Requesting missing transactions from another validator {addr} because we are (presumably) catching up (local_peer_id = {})",
+                                "⚠️Requesting missing transactions from another validator {} because we are (presumably) catching up (local_peer_id = {})",
+                                m,
                                 self.local_validator_addr,
                             );
-                            request_from_address = addr;
+                            request_from_address = m.address;
                         },
                         None => {
                             warn!(

--- a/crates/consensus/src/traits/leader_strategy.rs
+++ b/crates/consensus/src/traits/leader_strategy.rs
@@ -28,8 +28,8 @@ pub trait LeaderStrategy<TAddr: PartialEq> {
 
     fn is_leader(&self, validator_addr: &TAddr, committee: &Committee<TAddr>, height: NodeHeight) -> bool {
         let position = self.calculate_leader(committee, height);
-        if let Some((addr, _)) = committee.get(position as usize) {
-            addr == validator_addr
+        if let Some(m) = committee.get(position as usize) {
+            m.address == *validator_addr
         } else {
             false
         }
@@ -50,8 +50,8 @@ pub trait LeaderStrategy<TAddr: PartialEq> {
         height: NodeHeight,
     ) -> (&'b TAddr, &'b RistrettoPublicKeyBytes) {
         let index = self.calculate_leader(committee, height);
-        let (addr, pk) = committee.get(index as usize).unwrap();
-        (addr, pk)
+        let m = committee.get(index as usize).unwrap();
+        (&m.address, &m.public_key)
     }
 
     fn get_leader_for_next_height<'b>(

--- a/crates/consensus/src/validations/common.rs
+++ b/crates/consensus/src/validations/common.rs
@@ -14,6 +14,7 @@ use tari_ootle_common_types::{
     NodeHeight,
     NumPreshards,
     ShardGroup,
+    VotePower,
 };
 use tari_ootle_storage::consensus_models::{Block, BlockHeader};
 use tari_sidechain::ProposalCertificateSignatureFields;
@@ -231,17 +232,10 @@ pub fn check_quorum_certificate_signatures<TConsensusSpec: ConsensusSpec>(
         return Ok(());
     }
 
-    if qc.signatures().len() < committee.quorum_threshold() {
-        return Err(ProposalValidationError::QuorumWasNotReached {
-            qc: qc.calculate_id(),
-            got: qc.signatures().len(),
-            required: committee.quorum_threshold(),
-        });
-    }
-
     let mut check_dups = HashSet::with_capacity(qc.signatures().len());
+    let mut total_vote_power = VotePower::zero();
     for signature in qc.signatures() {
-        if !committee.contains_public_key(signature.public_key()) {
+        let Some(power) = committee.get_power_by_public_key(signature.public_key()) else {
             return Err(ProposalValidationError::ValidatorNotInCommittee {
                 validator: signature.public_key().to_string(),
                 details: format!(
@@ -250,7 +244,8 @@ pub fn check_quorum_certificate_signatures<TConsensusSpec: ConsensusSpec>(
                     qc.shard_group(),
                 ),
             });
-        }
+        };
+        total_vote_power += power;
         if !check_dups.insert(signature.public_key()) {
             return Err(ProposalValidationError::QcDuplicateSignature {
                 qc: qc.calculate_id(),
@@ -269,6 +264,14 @@ pub fn check_quorum_certificate_signatures<TConsensusSpec: ConsensusSpec>(
         if !is_valid {
             return Err(ProposalValidationError::QcInvalidSignature { qc: qc.calculate_id() });
         }
+    }
+
+    if total_vote_power < committee.quorum_threshold() {
+        return Err(ProposalValidationError::QuorumWasNotReached {
+            qc: qc.calculate_id(),
+            got: total_vote_power,
+            required: committee.quorum_threshold(),
+        });
     }
 
     Ok(())

--- a/crates/consensus/src/validations/foreign_proposal.rs
+++ b/crates/consensus/src/validations/foreign_proposal.rs
@@ -2,7 +2,7 @@
 //   SPDX-License-Identifier: BSD-3-Clause
 
 use tari_common::configuration::Network;
-use tari_ootle_common_types::committee::Committee;
+use tari_ootle_common_types::{committee::Committee, VotePower};
 use tari_ootle_storage::consensus_models::{CommandsCommitProof, ForeignProposal};
 
 use crate::{
@@ -44,6 +44,10 @@ pub fn check_commit_proof<TConsensusSpec: ConsensusSpec>(
     foreign_committee: &Committee<TConsensusSpec::Addr>,
 ) -> Result<(), ProposalValidationError> {
     let quorum_threshold = foreign_committee.quorum_threshold();
-    proof.validate_committed(quorum_threshold, &|pk| Ok(foreign_committee.contains_public_key(pk)))?;
+    proof.validate_committed(quorum_threshold, &|pk| {
+        Ok(foreign_committee
+            .get_power_by_public_key(pk)
+            .unwrap_or_else(VotePower::zero))
+    })?;
     Ok(())
 }

--- a/crates/consensus_tests/fixtures/committee.json
+++ b/crates/consensus_tests/fixtures/committee.json
@@ -1,36 +1,44 @@
 {
   "members": [
-    [
-      "12D3L7AUza5RLY6xxPYfcKbWPvSoP2iScUyAXBwWwt92WqTYt4gQ",
-      "381fe5f57fb1a780c9c21cf910caba25e2cf5ae1c72691870368b987039c8701"
-    ],
-    [
-      "12D3L7AV61FufHRfY3A5SrxYiwia4Zq4XEEt1hQHTDkytMi52pPZ",
-      "88ddb65b4349ff60e3b9f69c5dcc6a3e6c51e1a4393e97eb1dbfcd40807f7e40"
-    ],
-    [
-      "12D3L7AV2jepJr21tjy2kcfUZUkHD2sqqd8BAg2zrfjm1wt9wvjA",
-      "584b42ac801387ab50e4af50aaea63ff9cf0b4ae8fe199157e811b0eae67cf51"
-    ],
-    [
-      "12D3L7AUz3VVR9YpAyFWDkqrT3oy3C5k2rrcwTiEzDPPo3RVn5WC",
-      "304a1c0f8681f3b133fcf3ed0443932a69a88735358f8b6ab01ea07fde35f275"
-    ],
-    [
-      "12D3L7AVABSfUgLXTzmZhNYbqrnGzcoBQ2ZxoTBf5Rt6nqH7PiUq",
-      "c6e86deb61a147d94fe665363cb5f6fa18c01709169746fe3109edc4f66ec062"
-    ],
-    [
-      "12D3L7AVBDL1yohJxRzq2nE3AEZZ76rg5DSnCtewmKo8g79MNMxy",
-      "d63fc33effb5088b6240f3f1d83a584e32bfcde84b676118979e03eae62d2506"
-    ],
-    [
-      "12D3L7AV4DKJUKxEDcPcmPzruGVTjoQyY5HxPpQHg7mRmWrYADtA",
-      "6e3d251e83d6c256cb9816ef2da17539588eb12077532bd6acb60f1a9270707f"
-    ],
-    [
-      "12D3L7AVDgi1YmAtwFPas7E2N3bhpq1KRyZgBV7B4GXpimaGK1ds",
-      "fafaaf78f615fe666628e421a8b54e4148d6430af28ed6d5e78caab9d004dd3a"
-    ]
+    {
+      "address": "12D3L7AUza5RLY6xxPYfcKbWPvSoP2iScUyAXBwWwt92WqTYt4gQ",
+      "public_key": "381fe5f57fb1a780c9c21cf910caba25e2cf5ae1c72691870368b987039c8701",
+      "vote_power": 1
+    },
+    {
+      "address": "12D3L7AV61FufHRfY3A5SrxYiwia4Zq4XEEt1hQHTDkytMi52pPZ",
+      "public_key": "88ddb65b4349ff60e3b9f69c5dcc6a3e6c51e1a4393e97eb1dbfcd40807f7e40",
+      "vote_power": 1
+    },
+    {
+      "address": "12D3L7AV2jepJr21tjy2kcfUZUkHD2sqqd8BAg2zrfjm1wt9wvjA",
+      "public_key": "584b42ac801387ab50e4af50aaea63ff9cf0b4ae8fe199157e811b0eae67cf51",
+      "vote_power": 1
+    },
+    {
+      "address": "12D3L7AUz3VVR9YpAyFWDkqrT3oy3C5k2rrcwTiEzDPPo3RVn5WC",
+      "public_key": "304a1c0f8681f3b133fcf3ed0443932a69a88735358f8b6ab01ea07fde35f275",
+      "vote_power": 1
+    },
+    {
+      "address": "12D3L7AVABSfUgLXTzmZhNYbqrnGzcoBQ2ZxoTBf5Rt6nqH7PiUq",
+      "public_key": "c6e86deb61a147d94fe665363cb5f6fa18c01709169746fe3109edc4f66ec062",
+      "vote_power": 1
+    },
+    {
+      "address": "12D3L7AVBDL1yohJxRzq2nE3AEZZ76rg5DSnCtewmKo8g79MNMxy",
+      "public_key": "d63fc33effb5088b6240f3f1d83a584e32bfcde84b676118979e03eae62d2506",
+      "vote_power": 1
+    },
+    {
+      "address": "12D3L7AV4DKJUKxEDcPcmPzruGVTjoQyY5HxPpQHg7mRmWrYADtA",
+      "public_key": "6e3d251e83d6c256cb9816ef2da17539588eb12077532bd6acb60f1a9270707f",
+      "vote_power": 1
+    },
+    {
+      "address": "12D3L7AVDgi1YmAtwFPas7E2N3bhpq1KRyZgBV7B4GXpimaGK1ds",
+      "public_key": "fafaaf78f615fe666628e421a8b54e4148d6430af28ed6d5e78caab9d004dd3a",
+      "vote_power": 1
+    }
   ]
 }

--- a/crates/consensus_tests/src/dummy_blocks.rs
+++ b/crates/consensus_tests/src/dummy_blocks.rs
@@ -10,16 +10,16 @@ use tari_consensus::hotstuff::{
 };
 use tari_engine_types::ToByteType;
 use tari_ootle_common_types::{
-    committee::Committee,
+    committee::{Committee, CommitteeMember},
     crypto::create_key_pair_from_seed,
     DerivableFromPublicKey,
     Epoch,
     NodeHeight,
     PeerAddress,
     ShardGroup,
+    VotePower,
 };
 use tari_ootle_storage::consensus_models::Block;
-use tari_template_lib::types::crypto::RistrettoPublicKeyBytes;
 
 use crate::support::{load_json_fixture, RoundRobinLeaderStrategy};
 
@@ -35,7 +35,11 @@ fn dummy_blocks() {
     );
     let committee = (0u8..2)
         .map(|i| create_key_pair_from_seed(i).1)
-        .map(|pk| (PeerAddress::derive_from_public_key(&pk), pk.to_byte_type()))
+        .map(|pk| CommitteeMember {
+            address: PeerAddress::derive_from_public_key(&pk),
+            public_key: pk.to_byte_type(),
+            vote_power: VotePower::of(1),
+        })
         .collect();
 
     let dummy = calculate_dummy_blocks(
@@ -81,8 +85,7 @@ fn last_matches_generated_using_real_data() {
     let candidate = load_json_fixture::<Block>("block_with_dummies.json");
 
     let committee = load_json_fixture::<serde_json::Value>("committee.json");
-    let committee: Vec<(PeerAddress, RistrettoPublicKeyBytes)> =
-        serde_json::from_value(committee["members"].clone()).unwrap();
+    let committee: Vec<CommitteeMember<PeerAddress>> = serde_json::from_value(committee["members"].clone()).unwrap();
     let committee = Committee::new(committee);
 
     let justify = Block::genesis(

--- a/crates/consensus_tests/src/support/epoch_manager.rs
+++ b/crates/consensus_tests/src/support/epoch_manager.rs
@@ -15,6 +15,7 @@ use tari_ootle_common_types::{
     SubstateAddress,
     ToSubstateAddress,
     VersionedSubstateId,
+    VotePower,
 };
 use tari_ootle_storage::{global::models::ValidatorNode, StorageError};
 use tari_template_lib::prelude::RistrettoPublicKeyBytes;
@@ -80,6 +81,7 @@ impl TestEpochManager {
                 start_epoch: our_validator_node.start_epoch,
                 end_epoch: None,
                 fee_claim_public_key: fee_claim_pk,
+                vote_power: our_validator_node.vote_power,
             });
         } else {
             copy.our_validator_node = Some(ValidatorNode {
@@ -89,6 +91,7 @@ impl TestEpochManager {
                 start_epoch: Epoch(0),
                 end_epoch: None,
                 fee_claim_public_key: fee_claim_pk,
+                vote_power: VotePower::of(1),
             });
         }
         copy
@@ -97,24 +100,25 @@ impl TestEpochManager {
     pub async fn add_committees(&self, committees: HashMap<ShardGroup, Committee<TestAddress>>) -> &Self {
         let mut state = self.state_lock().await;
         for (shard_group, committee) in committees {
-            for (address, pk) in committee.iter() {
+            for member in committee.iter() {
                 let substate_id = random_substate_in_shard_group(shard_group, TEST_NUM_PRESHARDS);
                 let substate_id = VersionedSubstateId::new(substate_id, 0);
                 state.validator_nodes.insert(
-                    address.clone(),
+                    member.address.clone(),
                     (
                         ValidatorNode {
-                            address: address.clone(),
-                            public_key: *pk,
+                            address: member.address.clone(),
+                            public_key: member.public_key,
                             shard_key: substate_id.to_substate_address(),
                             start_epoch: Epoch(0),
                             end_epoch: None,
-                            fee_claim_public_key: *pk,
+                            fee_claim_public_key: member.public_key,
+                            vote_power: member.vote_power,
                         },
                         shard_group,
                     ),
                 );
-                state.address_shard.insert(address.clone(), shard_group);
+                state.address_shard.insert(member.address.clone(), shard_group);
             }
 
             state.committees.insert(shard_group, committee);
@@ -186,6 +190,14 @@ impl EpochManagerReader for TestEpochManager {
             .get(&sg)
             .map(|c| c.len())
             .unwrap_or(0);
+        let total_power = self
+            .inner
+            .lock()
+            .await
+            .committees
+            .get(&sg)
+            .map(|c| c.total_power())
+            .unwrap_or_else(VotePower::zero);
 
         Ok(CommitteeInfo::new(
             TEST_NUM_PRESHARDS,
@@ -193,6 +205,7 @@ impl EpochManagerReader for TestEpochManager {
             num_committees,
             sg,
             epoch,
+            total_power,
         ))
     }
 
@@ -224,16 +237,22 @@ impl EpochManagerReader for TestEpochManager {
         let (sg, committee) = state
             .committees
             .iter()
-            .find(|(_, committee)| committee.iter().any(|(addr, _)| addr == address))
+            .find(|(_, committee)| committee.contains(address))
             .unwrap_or_else(|| panic!("Validator {address} not found in any committee"));
         let num_committees = state.committees.len() as u32;
         let num_members = committee.len();
+        let total_power = state
+            .committees
+            .get(sg)
+            .map(|c| c.total_power())
+            .unwrap_or_else(VotePower::zero);
         Ok(CommitteeInfo::new(
             TEST_NUM_PRESHARDS,
             num_members as u32,
             num_committees,
             *sg,
             epoch,
+            total_power,
         ))
     }
 
@@ -285,6 +304,14 @@ impl EpochManagerReader for TestEpochManager {
             .get(&sg)
             .map(|c| c.len())
             .unwrap_or(0);
+        let total_power = self
+            .inner
+            .lock()
+            .await
+            .committees
+            .get(&sg)
+            .map(|c| c.total_power())
+            .unwrap_or_else(VotePower::zero);
 
         Ok(CommitteeInfo::new(
             TEST_NUM_PRESHARDS,
@@ -292,6 +319,7 @@ impl EpochManagerReader for TestEpochManager {
             num_committees,
             sg,
             epoch,
+            total_power,
         ))
     }
 
@@ -314,6 +342,7 @@ impl EpochManagerReader for TestEpochManager {
             start_epoch: vn.start_epoch,
             end_epoch: vn.end_epoch,
             fee_claim_public_key: vn.fee_claim_public_key,
+            vote_power: vn.vote_power,
         })
     }
 

--- a/crates/consensus_tests/src/support/harness.rs
+++ b/crates/consensus_tests/src/support/harness.rs
@@ -21,7 +21,7 @@ use tari_crypto::ristretto::RistrettoPublicKey;
 use tari_engine_types::{substate::SubstateId, ToByteType};
 use tari_epoch_manager::EpochManagerReader;
 use tari_ootle_common_types::{
-    committee::Committee,
+    committee::{Committee, CommitteeMember},
     displayable::Displayable,
     optional::Optional,
     shard::Shard,
@@ -31,6 +31,7 @@ use tari_ootle_common_types::{
     ShardGroup,
     SubstateLockType,
     VersionedSubstateId,
+    VotePower,
 };
 use tari_ootle_storage::{
     consensus_models::{SubstateRecord, TransactionExecution, TransactionRecord},
@@ -685,7 +686,11 @@ impl TestBuilder {
         for addr in addresses {
             let addr = TestAddress::new(addr);
             let (_, pk) = helpers::derive_keypair_from_address(&addr);
-            entry.members_mut().push((addr, pk.to_byte_type()));
+            entry.members_mut().push(CommitteeMember {
+                address: addr,
+                public_key: pk.to_byte_type(),
+                vote_power: VotePower::of(1),
+            });
         }
         self
     }

--- a/crates/epoch_manager/src/service/epoch_manager.rs
+++ b/crates/epoch_manager/src/service/epoch_manager.rs
@@ -33,7 +33,7 @@ use tari_common_types::types::FixedHash;
 use tari_crypto::ristretto::RistrettoPublicKey;
 use tari_engine_types::FromByteType;
 use tari_ootle_common_types::{
-    committee::{Committee, CommitteeInfo},
+    committee::{Committee, CommitteeInfo, CommitteeMember},
     layer_one_transaction::{LayerOnePayloadType, LayerOneTransactionDef},
     optional::Optional,
     DerivableFromPublicKey,
@@ -41,6 +41,7 @@ use tari_ootle_common_types::{
     NodeAddressable,
     ShardGroup,
     SubstateAddress,
+    VotePower,
 };
 use tari_ootle_storage::global::{models::ValidatorNode, DbEpoch, GlobalDb, MetadataKey};
 use tari_ootle_storage_sqlite::global::SqliteGlobalDbAdapter;
@@ -159,8 +160,7 @@ where TSpec: EpochManagerSpec
         validator_public_key: RistrettoPublicKeyBytes,
         claim_public_key: RistrettoPublicKeyBytes,
         shard_key: SubstateAddress,
-        // TODO: use the value of the registration
-        _registration_value: u64,
+        power: VotePower,
     ) -> Result<(), EpochManagerError> {
         info!(target: LOG_TARGET, "Registering validator node for epoch {}", activation_epoch);
 
@@ -177,6 +177,7 @@ where TSpec: EpochManagerSpec
             shard_key,
             activation_epoch,
             claim_public_key,
+            power,
         )?;
 
         if validator_public_key == self.node_public_key {
@@ -335,17 +336,17 @@ where TSpec: EpochManagerSpec
         let committees = self.get_committee_for_shard_group(epoch, shard_group, false, None)?;
 
         let mut res = vec![];
-        for (_, pub_key) in committees {
-            let vn = self.get_validator_node_by_public_key(epoch, &pub_key)?.ok_or_else(|| {
-                EpochManagerError::ValidatorNodeNotRegistered {
-                    address: RistrettoPublicKey::try_from_byte_type(&pub_key)
+        for member in committees {
+            let vn = self
+                .get_validator_node_by_public_key(epoch, &member.public_key)?
+                .ok_or_else(|| EpochManagerError::ValidatorNodeNotRegistered {
+                    address: RistrettoPublicKey::try_from_byte_type(&member.public_key)
                         .ok()
                         .and_then(|pk| TSpec::Addr::try_from_public_key(&pk))
                         .map(|a| a.to_string())
-                        .unwrap_or_else(|| format!("PARSE FAIL for pk bytes {pub_key}")),
+                        .unwrap_or_else(|| format!("PARSE FAIL for pk bytes {}", member.public_key)),
                     epoch,
-                }
-            })?;
+                })?;
             res.push(vn);
         }
         res.sort_by(|a, b| a.shard_key.cmp(&b.shard_key));
@@ -359,7 +360,14 @@ where TSpec: EpochManagerSpec
     ) -> Result<Committee<TSpec::Addr>, EpochManagerError> {
         let result = self.get_committee_vns_from_shard_key(epoch, substate_address)?;
         Ok(Committee::new(
-            result.into_iter().map(|v| (v.address, v.public_key)).collect(),
+            result
+                .into_iter()
+                .map(|v| CommitteeMember {
+                    public_key: v.public_key,
+                    address: v.address,
+                    vote_power: v.vote_power,
+                })
+                .collect(),
         ))
     }
 
@@ -455,6 +463,9 @@ where TSpec: EpochManagerSpec
         let mut tx = self.global_db.create_transaction()?;
         let mut validator_node_db = self.global_db.validator_nodes(&mut tx);
         let num_validators = validator_node_db.count_in_shard_group(epoch, shard_group)?;
+        // NOTE: currently each validator has a vote power of 1, so the total vote power is equal to the number of
+        // validators. This may change in the future if e.g. we introduce staking.
+        let total_vote_power = VotePower::of(num_validators);
         let num_validators = u32::try_from(num_validators).map_err(|_| EpochManagerError::IntegerOverflow {
             func: "get_committee_shard",
         })?;
@@ -464,6 +475,7 @@ where TSpec: EpochManagerSpec
             num_committees,
             shard_group,
             epoch,
+            total_vote_power,
         ))
     }
 

--- a/crates/epoch_manager/src/service/epoch_manager_service.rs
+++ b/crates/epoch_manager/src/service/epoch_manager_service.rs
@@ -23,7 +23,7 @@
 use std::sync::{atomic::AtomicU64, Arc};
 
 use log::*;
-use tari_ootle_common_types::optional::IsNotFoundError;
+use tari_ootle_common_types::{optional::IsNotFoundError, VotePower};
 use tari_ootle_storage::global::GlobalDb;
 use tari_ootle_storage_sqlite::global::SqliteGlobalDbAdapter;
 use tari_shutdown::ShutdownSignal;
@@ -151,7 +151,7 @@ impl<TSpec: EpochManagerSpec> EpochManagerService<TSpec> {
                             claim_public_key,
                             validator_node_public_key,
                             activation_epoch,
-                            minimum_value_promise,
+                            minimum_value_promise: _minimum_value_promise,
                             shard_key,
                         } => {
                             info!(
@@ -166,7 +166,9 @@ impl<TSpec: EpochManagerSpec> EpochManagerService<TSpec> {
                                 validator_node_public_key,
                                 claim_public_key,
                                 shard_key,
-                                minimum_value_promise,
+                                // minimum_value_promise,
+                                // All validators currently get a vote power of 1
+                                VotePower::of(1),
                             )?;
                         },
                         ValidatorNodeChange::Remove { public_key } => {
@@ -300,7 +302,7 @@ impl<TSpec: EpochManagerSpec> EpochManagerService<TSpec> {
                 validator_public_key,
                 claim_public_key,
                 shard_key,
-                value_of_registration,
+                power,
                 reply,
             } => handle(
                 reply,
@@ -309,7 +311,7 @@ impl<TSpec: EpochManagerSpec> EpochManagerService<TSpec> {
                     validator_public_key,
                     claim_public_key,
                     shard_key,
-                    value_of_registration,
+                    power,
                 ),
                 context,
             ),

--- a/crates/epoch_manager/src/service/handle.rs
+++ b/crates/epoch_manager/src/service/handle.rs
@@ -13,6 +13,7 @@ use tari_ootle_common_types::{
     NodeAddressable,
     ShardGroup,
     SubstateAddress,
+    VotePower,
 };
 use tari_ootle_storage::global::models::ValidatorNode;
 use tari_sidechain::EvictionProof;
@@ -79,7 +80,7 @@ impl<TAddr: NodeAddressable> EpochManagerWriter for EpochManagerHandle<TAddr> {
         validator_public_key: RistrettoPublicKeyBytes,
         claim_public_key: RistrettoPublicKeyBytes,
         shard_key: SubstateAddress,
-        value_of_registration: u64,
+        power: VotePower,
     ) -> Result<(), EpochManagerError> {
         let (tx, rx) = oneshot::channel();
         self.tx_request
@@ -87,7 +88,7 @@ impl<TAddr: NodeAddressable> EpochManagerWriter for EpochManagerHandle<TAddr> {
                 activation_epoch,
                 validator_public_key,
                 claim_public_key,
-                value_of_registration,
+                power,
                 shard_key,
                 reply: tx,
             })

--- a/crates/epoch_manager/src/service/types.rs
+++ b/crates/epoch_manager/src/service/types.rs
@@ -9,6 +9,7 @@ use tari_ootle_common_types::{
     Epoch,
     ShardGroup,
     SubstateAddress,
+    VotePower,
 };
 use tari_ootle_storage::global::models::ValidatorNode;
 use tari_sidechain::EvictionProof;
@@ -36,7 +37,7 @@ pub enum EpochManagerRequest<TAddr> {
         activation_epoch: Epoch,
         validator_public_key: RistrettoPublicKeyBytes,
         claim_public_key: RistrettoPublicKeyBytes,
-        value_of_registration: u64,
+        power: VotePower,
         shard_key: SubstateAddress,
         reply: Reply<()>,
     },

--- a/crates/epoch_manager/src/traits.rs
+++ b/crates/epoch_manager/src/traits.rs
@@ -32,6 +32,7 @@ use tari_ootle_common_types::{
     NodeAddressable,
     ShardGroup,
     SubstateAddress,
+    VotePower,
 };
 use tari_ootle_storage::global::models::ValidatorNode;
 use tari_sidechain::EvictionProof;
@@ -56,7 +57,7 @@ pub trait EpochManagerWriter: Send + Sync {
         validator_public_key: RistrettoPublicKeyBytes,
         claim_public_key: RistrettoPublicKeyBytes,
         shard_key: SubstateAddress,
-        value_of_registration: u64,
+        power: VotePower,
     ) -> impl Future<Output = Result<(), EpochManagerError>> + Send;
 
     fn deactivate_validator_node(

--- a/crates/rpc_state_sync/src/state_sync.rs
+++ b/crates/rpc_state_sync/src/state_sync.rs
@@ -22,6 +22,7 @@ use tari_ootle_common_types::{
     PeerAddress,
     ShardGroup,
     VersionedSubstateId,
+    VotePower,
 };
 use tari_ootle_p2p::proto::rpc::{GetCheckpointRequest, GetCheckpointResponse, SyncStateRequest};
 use tari_ootle_storage::{
@@ -400,7 +401,7 @@ where TConsensusSpec: ConsensusSpec<Addr = PeerAddress>
         current_epoch: Epoch,
     ) -> Result<HashMap<ShardGroup, Committee<PeerAddress>>, RpcStateSyncError> {
         // We are behind at least one epoch.
-        // We get the current substate range, and we asks committees from previous epoch in this range to give us
+        // We get the current substate range, and we ask committees from previous epoch in this range to give us
         // data.
         let prev_epoch = current_epoch
             .checked_sub(Epoch(1))
@@ -429,7 +430,9 @@ where TConsensusSpec: ConsensusSpec<Addr = PeerAddress>
     ) -> Result<(), RpcStateSyncError> {
         let quorum_threshold = committee.quorum_threshold();
         checkpoint
-            .validate(epoch, quorum_threshold, |pk| Ok(committee.contains_public_key(pk)))
+            .validate(epoch, quorum_threshold, |pk| {
+                Ok(committee.get_power_by_public_key(pk).unwrap_or_else(VotePower::zero))
+            })
             .map_err(|err| RpcStateSyncError::InvalidResponse(anyhow!("Checkpoint is not valid: {err}",)))?;
 
         info!(
@@ -453,17 +456,17 @@ where TConsensusSpec: ConsensusSpec<Addr = PeerAddress>
         let mut remaining_members = prev_committee.len();
 
         info!(target: LOG_TARGET, "🛜 Syncing state for shard {shard} and epoch {}", epoch.saturating_sub(Epoch(1)));
-        for (addr, _) in prev_committee.shuffled() {
+        for member in prev_committee.shuffled() {
             remaining_members = remaining_members.saturating_sub(1);
-            if our_vn_addr == addr {
+            if *our_vn_addr == member.address {
                 continue;
             }
-            let mut client = match self.establish_rpc_session(addr).await {
+            let mut client = match self.establish_rpc_session(&member.address).await {
                 Ok(c) => c,
                 Err(err) => {
                     warn!(
                         target: LOG_TARGET,
-                        "Failed to establish RPC session with vn {addr}: {err}. Attempting another VN if available"
+                        "Failed to establish RPC session with vn {member}: {err}. Attempting another VN if available"
                     );
                     if remaining_members == 0 {
                         return Err(err);
@@ -497,7 +500,7 @@ where TConsensusSpec: ConsensusSpec<Addr = PeerAddress>
                 Err(err) => {
                     warn!(
                         target: LOG_TARGET,
-                        "⚠️Failed to fetch checkpoint from {addr}: {err}. Attempting another peer if available"
+                        "⚠️Failed to fetch checkpoint from {member}: {err}. Attempting another peer if available"
                     );
                     if remaining_members == 0 {
                         return Err(err);
@@ -522,7 +525,7 @@ where TConsensusSpec: ConsensusSpec<Addr = PeerAddress>
                 Err(err) => {
                     warn!(
                         target: LOG_TARGET,
-                        "⚠️Failed to sync state from {addr}: {err}. Attempting another peer if available"
+                        "⚠️Failed to sync state from {member}: {err}. Attempting another peer if available"
                     );
 
                     if remaining_members == 0 {

--- a/crates/storage/src/consensus_models/commands_commit_proof.rs
+++ b/crates/storage/src/consensus_models/commands_commit_proof.rs
@@ -5,13 +5,14 @@ use anyhow::anyhow;
 use serde::{Deserialize, Serialize};
 use tari_common_types::types::{CompressedPublicKey, FixedHash};
 use tari_crypto::tari_utilities::ByteArray;
+use tari_ootle_common_types::VotePower;
 use tari_sidechain::{CommitProofElement, SidechainBlockCommitProof, SidechainProofValidationError};
 use tari_state_tree::{compute_merkle_root_for_hashes, StateTreeError, TreeHash};
 use tari_template_lib::prelude::RistrettoPublicKeyBytes;
 
 use crate::consensus_models::Command;
 
-pub type CheckVnFunc<'a> = dyn Fn(&RistrettoPublicKeyBytes) -> Result<bool, SidechainProofValidationError> + 'a;
+pub type CheckVnFunc<'a> = dyn Fn(&RistrettoPublicKeyBytes) -> Result<VotePower, SidechainProofValidationError> + 'a;
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 pub enum CommandsCommitProof {
@@ -57,7 +58,7 @@ impl CommandsCommitProof {
 
     pub fn validate_committed(
         &self,
-        quorum_threshold: usize,
+        quorum_threshold: VotePower,
         check_vn: &CheckVnFunc<'_>,
     ) -> Result<(), ForeignProposalCommitProofError> {
         match self {
@@ -83,13 +84,16 @@ impl CommandsCommitProofV1 {
 
     pub fn validate_committed(
         &self,
-        quorum_threshold: usize,
+        quorum_threshold: VotePower,
         check_vn: &CheckVnFunc<'_>,
     ) -> Result<(), ForeignProposalCommitProofError> {
         self.validate_command_merkle_root()?;
         self.commit_proof
-            .validate_committed(quorum_threshold, &|pk: &CompressedPublicKey| {
+            // TODO: Currently 1 Vn = 1 vote power. But this may change in the future. Update the library.
+            .validate_committed(quorum_threshold.value() as usize, &|pk: &CompressedPublicKey| {
+                // TODO: commit proof should validate vote power not just pk existence
                 check_vn(&RistrettoPublicKeyBytes::from_bytes(pk.as_bytes()).expect("already checked"))
+                    .map(|v| !v.is_zero())
             })?;
         Ok(())
     }

--- a/crates/storage/src/consensus_models/epoch_checkpoint.rs
+++ b/crates/storage/src/consensus_models/epoch_checkpoint.rs
@@ -9,7 +9,7 @@ use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 use tari_common_types::types::{CompressedPublicKey, FixedHash};
 use tari_crypto::tari_utilities::ByteArray;
-use tari_ootle_common_types::{shard::Shard, Epoch, ShardGroup};
+use tari_ootle_common_types::{shard::Shard, Epoch, ShardGroup, VotePower};
 use tari_sidechain::{CommandCommitProof, SidechainBlockHeader, SidechainProofValidationError, ToCommand};
 use tari_state_tree::{compute_merkle_root_for_hashes, StateTreeError, TreeHash, SPARSE_MERKLE_PLACEHOLDER_HASH};
 use tari_template_lib::prelude::RistrettoPublicKeyBytes;
@@ -74,8 +74,8 @@ impl EpochCheckpoint {
     pub fn validate(
         &self,
         epoch: Epoch,
-        quorum_threshold: usize,
-        check_vn: impl Fn(&RistrettoPublicKeyBytes) -> Result<bool, SidechainProofValidationError>,
+        quorum_threshold: VotePower,
+        check_vn: impl Fn(&RistrettoPublicKeyBytes) -> Result<VotePower, SidechainProofValidationError>,
     ) -> Result<(), EpochCheckpointValidationError> {
         if self.epoch() != epoch {
             return Err(EpochCheckpointValidationError::InvalidEpochCheckpoint(anyhow!(
@@ -89,12 +89,14 @@ impl EpochCheckpoint {
 
         // Validate the proof
         self.proof
-            .validate_committed(quorum_threshold, &|pk: &CompressedPublicKey| {
+            .validate_committed(quorum_threshold.value() as usize, &|pk: &CompressedPublicKey| {
                 let pk_bytes = RistrettoPublicKeyBytes::from_bytes(pk.as_bytes())
                     // Should not be possible - however, since CompressedPublicKey currently represented using a Vec<u8>
                     // it is possible, in theory, to have a CompressedPublicKey that is any size.
                     .map_err(SidechainProofValidationError::internal_error)?;
-                check_vn(&pk_bytes)
+                // TODO: change this to return and check the actual voting power of the VN. Even if it is always 1 for
+                // now.
+                check_vn(&pk_bytes).map(|power| !power.is_zero())
             })?;
 
         Ok(())

--- a/crates/storage/src/global/backend_adapter.rs
+++ b/crates/storage/src/global/backend_adapter.rs
@@ -30,6 +30,7 @@ use tari_ootle_common_types::{
     NodeAddressable,
     ShardGroup,
     SubstateAddress,
+    VotePower,
 };
 use tari_template_lib::types::{crypto::RistrettoPublicKeyBytes, TemplateAddress};
 
@@ -101,6 +102,7 @@ pub trait GlobalDbAdapter: AtomicDb + Send + Sync + Clone {
         shard_key: SubstateAddress,
         start_epoch: Epoch,
         fee_claim_public_key: RistrettoPublicKeyBytes,
+        power: VotePower,
     ) -> Result<(), Self::Error>;
 
     fn deactivate_validator_node(

--- a/crates/storage/src/global/models/validator_node.rs
+++ b/crates/storage/src/global/models/validator_node.rs
@@ -6,7 +6,14 @@ use std::fmt::Display;
 use serde::{Deserialize, Serialize};
 use tari_common::configuration::Network;
 use tari_common_types::types::FixedHash;
-use tari_ootle_common_types::{displayable::Displayable, vn_node_hash, Epoch, NodeAddressable, SubstateAddress};
+use tari_ootle_common_types::{
+    displayable::Displayable,
+    vn_node_hash,
+    Epoch,
+    NodeAddressable,
+    SubstateAddress,
+    VotePower,
+};
 use tari_template_lib::types::crypto::RistrettoPublicKeyBytes;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -17,6 +24,7 @@ pub struct ValidatorNode<TAddr> {
     pub start_epoch: Epoch,
     pub end_epoch: Option<Epoch>,
     pub fee_claim_public_key: RistrettoPublicKeyBytes,
+    pub vote_power: VotePower,
 }
 
 impl<TAddr: NodeAddressable> ValidatorNode<TAddr> {

--- a/crates/storage/src/global/validator_node_db.rs
+++ b/crates/storage/src/global/validator_node_db.rs
@@ -22,7 +22,7 @@
 
 use std::collections::HashMap;
 
-use tari_ootle_common_types::{committee::Committee, Epoch, ShardGroup, SubstateAddress};
+use tari_ootle_common_types::{committee::Committee, Epoch, ShardGroup, SubstateAddress, VotePower};
 use tari_template_lib::types::crypto::RistrettoPublicKeyBytes;
 
 use crate::global::{models::ValidatorNode, GlobalDbAdapter};
@@ -44,6 +44,7 @@ impl<'a, 'tx, TGlobalDbAdapter: GlobalDbAdapter> ValidatorNodeDb<'a, 'tx, TGloba
         shard_key: SubstateAddress,
         start_epoch: Epoch,
         fee_claim_public_key: RistrettoPublicKeyBytes,
+        power: VotePower,
     ) -> Result<(), TGlobalDbAdapter::Error> {
         self.backend.insert_validator_node(
             self.tx,
@@ -52,6 +53,7 @@ impl<'a, 'tx, TGlobalDbAdapter: GlobalDbAdapter> ValidatorNodeDb<'a, 'tx, TGloba
             shard_key,
             start_epoch,
             fee_claim_public_key,
+            power,
         )
     }
 

--- a/crates/storage_sqlite/migrations/2022-06-20-091532_initial/up.sql
+++ b/crates/storage_sqlite/migrations/2022-06-20-091532_initial/up.sql
@@ -34,7 +34,8 @@ create table validator_nodes
     shard_key            blob                              not null,
     start_epoch          bigint                            not null,
     end_epoch            bigint                            null,
-    fee_claim_public_key blob                              not null
+    fee_claim_public_key blob                              not null,
+    power                bigint                            not null
 );
 
 CREATE TABLE committees

--- a/crates/storage_sqlite/src/global/backend_adapter.rs
+++ b/crates/storage_sqlite/src/global/backend_adapter.rs
@@ -43,12 +43,13 @@ use diesel_migrations::{EmbeddedMigrations, MigrationHarness};
 use log::debug;
 use serde::{de::DeserializeOwned, Serialize};
 use tari_ootle_common_types::{
-    committee::Committee,
+    committee::{Committee, CommitteeMember},
     hashing::ValidatorNodeBalancedMerkleTree,
     Epoch,
     NodeAddressable,
     ShardGroup,
     SubstateAddress,
+    VotePower,
 };
 use tari_ootle_storage::{
     global::{
@@ -145,6 +146,27 @@ impl<TAddr> AtomicDb for SqliteGlobalDbAdapter<TAddr> {
 impl<TAddr: NodeAddressable> GlobalDbAdapter for SqliteGlobalDbAdapter<TAddr> {
     type Addr = TAddr;
 
+    fn get_metadata<T: DeserializeOwned>(
+        &self,
+        tx: &mut Self::DbTransaction<'_>,
+        key: &[u8],
+    ) -> Result<Option<T>, Self::Error> {
+        use crate::global::schema::metadata;
+
+        let row: Option<MetadataModel> =
+            metadata::table
+                .find(key)
+                .first(tx.connection())
+                .optional()
+                .map_err(|source| SqliteStorageError::DieselError {
+                    source,
+                    operation: "get::metadata_key".to_string(),
+                })?;
+
+        let v = row.map(|r| serde_json::from_slice(&r.value)).transpose()?;
+        Ok(v)
+    }
+
     fn set_metadata<T: Serialize>(
         &self,
         tx: &mut Self::DbTransaction<'_>,
@@ -175,25 +197,54 @@ impl<TAddr: NodeAddressable> GlobalDbAdapter for SqliteGlobalDbAdapter<TAddr> {
         Ok(())
     }
 
-    fn get_metadata<T: DeserializeOwned>(
+    fn template_exists(
         &self,
         tx: &mut Self::DbTransaction<'_>,
         key: &[u8],
-    ) -> Result<Option<T>, Self::Error> {
-        use crate::global::schema::metadata;
+        status: Option<TemplateStatus>,
+    ) -> Result<bool, Self::Error> {
+        use crate::global::schema::templates;
 
-        let row: Option<MetadataModel> =
-            metadata::table
-                .find(key)
-                .first(tx.connection())
-                .optional()
-                .map_err(|source| SqliteStorageError::DieselError {
-                    source,
-                    operation: "get::metadata_key".to_string(),
-                })?;
+        let mut query = templates::table
+            .filter(templates::template_address.eq(key))
+            .into_boxed();
+        if let Some(status) = status {
+            query = query.filter(templates::status.eq(status.as_str()));
+        }
 
-        let v = row.map(|r| serde_json::from_slice(&r.value)).transpose()?;
-        Ok(v)
+        let result = query
+            .count()
+            .limit(1)
+            .get_result::<i64>(tx.connection())
+            .map_err(|source| SqliteStorageError::DieselError {
+                source,
+                operation: "exists::metadata".to_string(),
+            })?;
+        Ok(result > 0)
+    }
+
+    fn set_status(
+        &self,
+        tx: &mut Self::DbTransaction<'_>,
+        key: &TemplateAddress,
+        status: TemplateStatus,
+    ) -> Result<(), Self::Error> {
+        use crate::global::schema::templates;
+        let num_affected = diesel::update(templates::table)
+            .filter(templates::template_address.eq(key.as_ref()))
+            .set(templates::status.eq(status.as_str()))
+            .execute(tx.connection())
+            .map_err(|source| SqliteStorageError::DieselError {
+                source,
+                operation: "set_status".to_string(),
+            })?;
+        if num_affected == 0 {
+            return Err(SqliteStorageError::NotFound {
+                item: "template",
+                key: hex::to_hex(key),
+            });
+        }
+        Ok(())
     }
 
     fn get_template(&self, tx: &mut Self::DbTransaction<'_>, key: &[u8]) -> Result<Option<DbTemplate>, Self::Error> {
@@ -357,56 +408,6 @@ impl<TAddr: NodeAddressable> GlobalDbAdapter for SqliteGlobalDbAdapter<TAddr> {
         Ok(())
     }
 
-    fn template_exists(
-        &self,
-        tx: &mut Self::DbTransaction<'_>,
-        key: &[u8],
-        status: Option<TemplateStatus>,
-    ) -> Result<bool, Self::Error> {
-        use crate::global::schema::templates;
-
-        let mut query = templates::table
-            .filter(templates::template_address.eq(key))
-            .into_boxed();
-        if let Some(status) = status {
-            query = query.filter(templates::status.eq(status.as_str()));
-        }
-
-        let result = query
-            .count()
-            .limit(1)
-            .get_result::<i64>(tx.connection())
-            .map_err(|source| SqliteStorageError::DieselError {
-                source,
-                operation: "exists::metadata".to_string(),
-            })?;
-        Ok(result > 0)
-    }
-
-    fn set_status(
-        &self,
-        tx: &mut Self::DbTransaction<'_>,
-        key: &TemplateAddress,
-        status: TemplateStatus,
-    ) -> Result<(), Self::Error> {
-        use crate::global::schema::templates;
-        let num_affected = diesel::update(templates::table)
-            .filter(templates::template_address.eq(key.as_ref()))
-            .set(templates::status.eq(status.as_str()))
-            .execute(tx.connection())
-            .map_err(|source| SqliteStorageError::DieselError {
-                source,
-                operation: "set_status".to_string(),
-            })?;
-        if num_affected == 0 {
-            return Err(SqliteStorageError::NotFound {
-                item: "template",
-                key: hex::to_hex(key),
-            });
-        }
-        Ok(())
-    }
-
     fn insert_validator_node(
         &self,
         tx: &mut Self::DbTransaction<'_>,
@@ -415,6 +416,7 @@ impl<TAddr: NodeAddressable> GlobalDbAdapter for SqliteGlobalDbAdapter<TAddr> {
         shard_key: SubstateAddress,
         start_epoch: Epoch,
         fee_claim_public_key: RistrettoPublicKeyBytes,
+        power: VotePower,
     ) -> Result<(), Self::Error> {
         use crate::global::schema::validator_nodes;
         let addr = serialize_json(&address)?;
@@ -426,6 +428,7 @@ impl<TAddr: NodeAddressable> GlobalDbAdapter for SqliteGlobalDbAdapter<TAddr> {
                 validator_nodes::shard_key.eq(shard_key.as_bytes()),
                 validator_nodes::start_epoch.eq(start_epoch.as_u64() as i64),
                 validator_nodes::fee_claim_public_key.eq(fee_claim_public_key.as_bytes()),
+                validator_nodes::power.eq(power.value() as i64),
             ))
             .execute(tx.connection())
             .map_err(|source| SqliteStorageError::DieselError {
@@ -454,6 +457,50 @@ impl<TAddr: NodeAddressable> GlobalDbAdapter for SqliteGlobalDbAdapter<TAddr> {
             })?;
 
         Ok(())
+    }
+
+    fn get_validator_nodes_within_start_epoch(
+        &self,
+        tx: &mut Self::DbTransaction<'_>,
+        epoch: Epoch,
+    ) -> Result<Vec<ValidatorNode<Self::Addr>>, Self::Error> {
+        use crate::global::schema::validator_nodes;
+
+        let sqlite_vns = validator_nodes::table
+            .filter(validator_nodes::start_epoch.le(epoch.as_u64() as i64))
+            .filter(
+                validator_nodes::end_epoch
+                    .is_null()
+                    .or(validator_nodes::end_epoch.gt(epoch.as_u64() as i64)),
+            )
+            .get_results::<DbValidatorNode>(tx.connection())
+            .map_err(|source| SqliteStorageError::DieselError {
+                source,
+                operation: format!("get::get_validator_nodes_within_epochs({})", epoch),
+            })?;
+
+        distinct_validators_sorted(sqlite_vns)
+    }
+
+    fn get_validator_nodes_within_committee_epoch(
+        &self,
+        tx: &mut Self::DbTransaction<'_>,
+        epoch: Epoch,
+    ) -> Result<Vec<ValidatorNode<Self::Addr>>, Self::Error> {
+        use crate::global::schema::{committees, validator_nodes};
+
+        let sqlite_vns = validator_nodes::table
+            .select(validator_nodes::all_columns)
+            .inner_join(committees::table.on(validator_nodes::id.eq(committees::validator_node_id)))
+            .filter(committees::epoch.eq(epoch.as_u64() as i64))
+            .order_by(validator_nodes::shard_key.asc())
+            .get_results::<DbValidatorNode>(tx.connection())
+            .map_err(|source| SqliteStorageError::DieselError {
+                source,
+                operation: format!("get::get_validator_nodes_within_epochs({})", epoch),
+            })?;
+
+        sqlite_vns.into_iter().map(TryInto::try_into).collect()
     }
 
     fn get_validator_node_by_address(
@@ -542,48 +589,6 @@ impl<TAddr: NodeAddressable> GlobalDbAdapter for SqliteGlobalDbAdapter<TAddr> {
         Ok(count as u64)
     }
 
-    fn validator_nodes_get_committees_for_epoch(
-        &self,
-        tx: &mut Self::DbTransaction<'_>,
-        epoch: Epoch,
-    ) -> Result<HashMap<ShardGroup, Committee<Self::Addr>>, Self::Error> {
-        use crate::global::schema::{committees, validator_nodes};
-
-        let results = committees::table
-            .inner_join(validator_nodes::table.on(committees::validator_node_id.eq(validator_nodes::id)))
-            .select((
-                committees::shard_start,
-                committees::shard_end,
-                validator_nodes::address,
-                validator_nodes::public_key,
-            ))
-            .filter(committees::epoch.eq(epoch.as_u64() as i64))
-            .filter(
-                validator_nodes::end_epoch
-                    .is_null()
-                    .or(validator_nodes::end_epoch.gt(epoch.as_u64() as i64)),
-            )
-            .load::<(i32, i32, String, Vec<u8>)>(tx.connection())
-            .map_err(|source| SqliteStorageError::DieselError {
-                source,
-                operation: "validator_nodes_get_committees".to_string(),
-            })?;
-
-        let mut committees = HashMap::new();
-        for (shard_start, shard_end, address, public_key) in results {
-            let addr = DbValidatorNode::try_parse_address(&address)?;
-            let pk = RistrettoPublicKeyBytes::from_bytes(&public_key)
-                .map_err(|_| SqliteStorageError::MalformedDbData("Invalid public key".to_string()))?;
-            committees
-                .entry(ShardGroup::new(shard_start as u32, shard_end as u32))
-                .or_insert_with(Committee::empty)
-                .members_mut()
-                .push((addr, pk));
-        }
-
-        Ok(committees)
-    }
-
     fn validator_nodes_set_committee_shard(
         &self,
         tx: &mut Self::DbTransaction<'_>,
@@ -655,15 +660,18 @@ impl<TAddr: NodeAddressable> GlobalDbAdapter for SqliteGlobalDbAdapter<TAddr> {
         validators
             .into_iter()
             .map(|vn| {
-                Ok((
-                    DbValidatorNode::try_parse_address(&vn.address)?,
-                    RistrettoPublicKeyBytes::from_bytes(&vn.public_key).map_err(|_| {
-                        SqliteStorageError::MalformedDbData(format!(
-                            "validator_nodes_get_for_shard_group: Invalid public key in validator node record id={}",
-                            vn.id
-                        ))
-                    })?,
-                ))
+                let address = DbValidatorNode::try_parse_address(&vn.address)?;
+                let public_key = RistrettoPublicKeyBytes::from_bytes(&vn.public_key).map_err(|_| {
+                    SqliteStorageError::MalformedDbData(format!(
+                        "validator_nodes_get_for_shard_group: Invalid public key in validator node record id={}",
+                        vn.id
+                    ))
+                })?;
+                Ok(CommitteeMember {
+                    address,
+                    public_key,
+                    vote_power: VotePower::of(vn.power as u64),
+                })
             })
             .collect()
     }
@@ -697,16 +705,17 @@ impl<TAddr: NodeAddressable> GlobalDbAdapter for SqliteGlobalDbAdapter<TAddr> {
                 .entry(committee.as_shard_group())
                 .or_insert_with(|| Committee::empty());
 
-            validators.members_mut().push((
-                DbValidatorNode::try_parse_address(&vn.address)?,
-                RistrettoPublicKeyBytes::from_bytes(&vn.public_key).map_err(|_| {
+            validators.members_mut().push(CommitteeMember {
+                address: DbValidatorNode::try_parse_address(&vn.address)?,
+                public_key: RistrettoPublicKeyBytes::from_bytes(&vn.public_key).map_err(|_| {
                     SqliteStorageError::MalformedDbData(format!(
                         "validator_nodes_get_overlapping_shard_group: Invalid public key in validator node record \
                          id={}",
                         vn.id
                     ))
                 })?,
-            ));
+                vote_power: VotePower::of(vn.power as u64),
+            });
         }
 
         Ok(committees)
@@ -746,48 +755,51 @@ impl<TAddr: NodeAddressable> GlobalDbAdapter for SqliteGlobalDbAdapter<TAddr> {
         Ok(vn)
     }
 
-    fn get_validator_nodes_within_start_epoch(
+    fn validator_nodes_get_committees_for_epoch(
         &self,
         tx: &mut Self::DbTransaction<'_>,
         epoch: Epoch,
-    ) -> Result<Vec<ValidatorNode<Self::Addr>>, Self::Error> {
-        use crate::global::schema::validator_nodes;
+    ) -> Result<HashMap<ShardGroup, Committee<Self::Addr>>, Self::Error> {
+        use crate::global::schema::{committees, validator_nodes};
 
-        let sqlite_vns = validator_nodes::table
-            .filter(validator_nodes::start_epoch.le(epoch.as_u64() as i64))
+        let results = committees::table
+            .inner_join(validator_nodes::table.on(committees::validator_node_id.eq(validator_nodes::id)))
+            .select((
+                committees::shard_start,
+                committees::shard_end,
+                validator_nodes::address,
+                validator_nodes::public_key,
+                validator_nodes::power,
+            ))
+            .filter(committees::epoch.eq(epoch.as_u64() as i64))
             .filter(
                 validator_nodes::end_epoch
                     .is_null()
                     .or(validator_nodes::end_epoch.gt(epoch.as_u64() as i64)),
             )
-            .get_results::<DbValidatorNode>(tx.connection())
+            .load::<(i32, i32, String, Vec<u8>, i64)>(tx.connection())
             .map_err(|source| SqliteStorageError::DieselError {
                 source,
-                operation: format!("get::get_validator_nodes_within_epochs({})", epoch),
+                operation: "validator_nodes_get_committees".to_string(),
             })?;
 
-        distinct_validators_sorted(sqlite_vns)
-    }
+        let mut committees = HashMap::new();
+        for (shard_start, shard_end, address, public_key, power) in results {
+            let addr = DbValidatorNode::try_parse_address(&address)?;
+            let pk = RistrettoPublicKeyBytes::from_bytes(&public_key)
+                .map_err(|_| SqliteStorageError::MalformedDbData("Invalid public key".to_string()))?;
+            committees
+                .entry(ShardGroup::new(shard_start as u32, shard_end as u32))
+                .or_insert_with(Committee::empty)
+                .members_mut()
+                .push(CommitteeMember {
+                    address: addr,
+                    public_key: pk,
+                    vote_power: VotePower::of(power as u64),
+                });
+        }
 
-    fn get_validator_nodes_within_committee_epoch(
-        &self,
-        tx: &mut Self::DbTransaction<'_>,
-        epoch: Epoch,
-    ) -> Result<Vec<ValidatorNode<Self::Addr>>, Self::Error> {
-        use crate::global::schema::{committees, validator_nodes};
-
-        let sqlite_vns = validator_nodes::table
-            .select(validator_nodes::all_columns)
-            .inner_join(committees::table.on(validator_nodes::id.eq(committees::validator_node_id)))
-            .filter(committees::epoch.eq(epoch.as_u64() as i64))
-            .order_by(validator_nodes::shard_key.asc())
-            .get_results::<DbValidatorNode>(tx.connection())
-            .map_err(|source| SqliteStorageError::DieselError {
-                source,
-                operation: format!("get::get_validator_nodes_within_epochs({})", epoch),
-            })?;
-
-        sqlite_vns.into_iter().map(TryInto::try_into).collect()
+        Ok(committees)
     }
 
     fn insert_epoch(&self, tx: &mut Self::DbTransaction<'_>, epoch: DbEpoch) -> Result<(), Self::Error> {

--- a/crates/storage_sqlite/src/global/models/validator_node.rs
+++ b/crates/storage_sqlite/src/global/models/validator_node.rs
@@ -20,7 +20,7 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use tari_ootle_common_types::{Epoch, NodeAddressable, SubstateAddress};
+use tari_ootle_common_types::{Epoch, NodeAddressable, SubstateAddress, VotePower};
 use tari_ootle_storage::global::models::ValidatorNode;
 use tari_template_lib::prelude::RistrettoPublicKeyBytes;
 
@@ -39,6 +39,7 @@ pub struct DbValidatorNode {
     pub start_epoch: i64,
     pub end_epoch: Option<i64>,
     pub fee_claim_public_key: Vec<u8>,
+    pub power: i64,
 }
 impl<TAddr: NodeAddressable> TryFrom<DbValidatorNode> for ValidatorNode<TAddr> {
     type Error = SqliteStorageError;
@@ -60,6 +61,7 @@ impl<TAddr: NodeAddressable> TryFrom<DbValidatorNode> for ValidatorNode<TAddr> {
                     vn.id
                 ))
             })?,
+            vote_power: VotePower::of(vn.power as u64),
         })
     }
 }

--- a/crates/storage_sqlite/src/global/schema.rs
+++ b/crates/storage_sqlite/src/global/schema.rs
@@ -1,13 +1,6 @@
 // @generated automatically by Diesel CLI.
 
 diesel::table! {
-    base_layer_block_info (hash) {
-        hash -> Binary,
-        height -> BigInt,
-    }
-}
-
-diesel::table! {
     bmt_cache (epoch) {
         epoch -> BigInt,
         bmt -> Binary,
@@ -74,13 +67,13 @@ diesel::table! {
         start_epoch -> BigInt,
         end_epoch -> Nullable<BigInt>,
         fee_claim_public_key -> Binary,
+        power -> BigInt,
     }
 }
 
 diesel::joinable!(committees -> validator_nodes (validator_node_id));
 
 diesel::allow_tables_to_appear_in_same_query!(
-    base_layer_block_info,
     bmt_cache,
     committees,
     epochs,

--- a/crates/storage_sqlite/tests/global_db.rs
+++ b/crates/storage_sqlite/tests/global_db.rs
@@ -6,7 +6,7 @@ use rand::rngs::OsRng;
 use tari_common_types::types::FixedHash;
 use tari_crypto::{keys::PublicKey, ristretto::RistrettoPublicKey};
 use tari_engine_types::ToByteType;
-use tari_ootle_common_types::{Epoch, NumPreshards, PeerAddress, ShardGroup, SubstateAddress};
+use tari_ootle_common_types::{Epoch, NumPreshards, PeerAddress, ShardGroup, SubstateAddress, VotePower};
 use tari_ootle_storage::global::{GlobalDb, ValidatorNodeDb};
 use tari_ootle_storage_sqlite::global::SqliteGlobalDbAdapter;
 use tari_utilities::ByteArray;
@@ -53,6 +53,7 @@ fn insert_vn_with_public_key(
             derived_substate_address(&public_key),
             start_epoch,
             public_key.to_byte_type(),
+            VotePower::of(1),
         )
         .unwrap()
 }


### PR DESCRIPTION
Description
---
fix(consensus)!: vote power for validator set

Motivation and Context
---
Currently, a quorum is achieved by counting the number of votes from each validator and asserting that 2f + 1 validators have voted. This PR tracks a voting power value for each validator and determines a quorum threshold by asserting 2/3rds of the voting power has voted. Each validators voting power is currently hard-coded to 1 making the voting equivalent to counting each validator vote equally. However this PR allows some future scheme e.g. PoS where validators may not have equal power.

TODO: Commit proof validations on the L1 do not assign voting power to validators, and therefore cannot validate it. Currently, we simply check that a validator has a non-zero voting power.

How Has This Been Tested?
---
Existing consensus tests

What process can a PR reviewer use to test or verify this change?
---
n/a

Breaking Changes
---

- [ ] None
- [x] Requires data directory to be deleted
- [ ] Other - Please specify

BREAKING CHANGES: validator set database (epoch manager) must be deleted to apply changes