### PR TITLE
feat: implement rendezvous protocol, remove peer sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -945,6 +945,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bimap"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5427,9 +5433,11 @@ dependencies = [
  "libp2p-mdns",
  "libp2p-metrics",
  "libp2p-noise",
+ "libp2p-peer-store",
  "libp2p-ping",
  "libp2p-quic",
  "libp2p-relay",
+ "libp2p-rendezvous",
  "libp2p-swarm",
  "libp2p-tcp",
  "libp2p-upnp",
@@ -5686,6 +5694,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libp2p-peer-store"
+version = "0.1.0"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=d3222727e9a79eb32bfe324247ce1ccc1445fb14#d3222727e9a79eb32bfe324247ce1ccc1445fb14"
+dependencies = [
+ "libp2p-core",
+ "libp2p-swarm",
+ "lru",
+]
+
+[[package]]
 name = "libp2p-peersync"
 version = "0.1.0"
 dependencies = [
@@ -5757,6 +5775,28 @@ dependencies = [
  "quick-protobuf-codec 0.3.1 (git+https://github.com/tari-project/rust-libp2p.git?rev=d3222727e9a79eb32bfe324247ce1ccc1445fb14)",
  "rand 0.8.5",
  "static_assertions",
+ "thiserror 2.0.12",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "libp2p-rendezvous"
+version = "0.16.1"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=d3222727e9a79eb32bfe324247ce1ccc1445fb14#d3222727e9a79eb32bfe324247ce1ccc1445fb14"
+dependencies = [
+ "async-trait",
+ "asynchronous-codec",
+ "bimap",
+ "futures 0.3.31",
+ "futures-timer",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-request-response",
+ "libp2p-swarm",
+ "quick-protobuf",
+ "quick-protobuf-codec 0.3.1 (git+https://github.com/tari-project/rust-libp2p.git?rev=d3222727e9a79eb32bfe324247ce1ccc1445fb14)",
+ "rand 0.8.5",
  "thiserror 2.0.12",
  "tracing",
  "web-time",
@@ -11499,7 +11539,6 @@ version = "0.9.2"
 dependencies = [
  "libp2p",
  "libp2p-messaging",
- "libp2p-peersync",
  "libp2p-substream",
  "thiserror 1.0.69",
 ]
@@ -11518,6 +11557,7 @@ dependencies = [
  "futures 0.3.31",
  "humantime 2.2.0",
  "include_dir",
+ "indexmap 2.9.0",
  "json5",
  "lockfile",
  "log",

--- a/applications/tari_app_utilities/src/p2p_config.rs
+++ b/applications/tari_app_utilities/src/p2p_config.rs
@@ -11,6 +11,7 @@ use tari_common::{configuration::StringList, SubConfigPath};
 #[serde(deny_unknown_fields)]
 pub struct P2pConfig {
     pub enable_mdns: bool,
+    pub enable_rendezvous: bool,
     pub listener_port: u16,
     pub reachability_mode: ReachabilityMode,
 }
@@ -19,6 +20,7 @@ impl Default for P2pConfig {
     fn default() -> Self {
         Self {
             enable_mdns: true,
+            enable_rendezvous: false,
             listener_port: 0,
             reachability_mode: ReachabilityMode::default(),
         }
@@ -67,11 +69,13 @@ impl Display for ReachabilityMode {
 #[serde(deny_unknown_fields)]
 pub struct PeerSeedsConfig {
     pub override_from: Option<String>,
-    /// Custom specified peer seed nodes
+    /// Peer seed nodes
     pub peer_seeds: StringList,
     /// DNS seeds hosts. The DNS TXT records are queried from these hosts and the resulting peers added to the comms
     /// peer list.
     pub dns_seeds: StringList,
+    /// Specify a rendezvous server used for peer discovery.
+    pub rendezvous_server: Option<String>,
     // TODO
     // #[serde(
     //     deserialize_with = "deserialize_string_or_struct",

--- a/applications/tari_indexer/src/bootstrap.rs
+++ b/applications/tari_indexer/src/bootstrap.rs
@@ -24,6 +24,7 @@ use std::{fs, io, str::FromStr};
 
 use anyhow::Context;
 use libp2p::identity;
+use log::warn;
 use minotari_app_utilities::identity_management;
 use tari_base_node_client::grpc::GrpcBaseNodeClient;
 use tari_common::{
@@ -66,7 +67,7 @@ use crate::{
     Noop,
 };
 
-const _LOG_TARGET: &str = "tari_indexer::bootstrap";
+const LOG_TARGET: &str = "tari_indexer::bootstrap";
 
 #[allow(clippy::too_many_lines)]
 pub async fn spawn_services(
@@ -101,7 +102,15 @@ pub async fn spawn_services(
     let (networking, _) = tari_networking::Builder::<TariMessagingSpec>::new(identity)
         .with_messaging_mode(MessagingMode::Disabled)
         .with_config(tari_networking::Config {
-            listener_port: config.indexer.p2p.listener_port,
+            // TODO: configurable
+            listeners: vec![
+                format!("/ip4/0.0.0.0/tcp/{}", config.indexer.p2p.listener_port)
+                    .parse()
+                    .expect("Failed to parse listener address"),
+                format!("/ip4/0.0.0.0/udp/{}/quic-v1", config.indexer.p2p.listener_port)
+                    .parse()
+                    .expect("Failed to parse listener address"),
+            ],
             swarm: SwarmConfig {
                 protocol_version: format!("/tari/{}/0.0.1", config.network).parse().unwrap(),
                 user_agent: "/tari/indexer/0.0.1".to_string(),
@@ -109,13 +118,34 @@ pub async fn spawn_services(
                 enable_relay: true,
                 relay_circuit_limits: RelayCircuitLimits::high(),
                 relay_reservation_limits: RelayReservationLimits::high(),
+                rendezvous_server_enabled: config.indexer.p2p.enable_rendezvous,
                 ..Default::default()
             },
             reachability_mode: config.indexer.p2p.reachability_mode.into(),
             announce: false,
+            rendezvous_namespace: format!(
+                "tari-{}",
+                config.network.to_string().to_lowercase()
+            ),
             ..Default::default()
         })
         .with_seed_peers(seed_peers)
+        .then(|builder| {
+            match config.peer_seeds.rendezvous_server.as_ref() {
+                Some(server) => {
+                    let server = SeedPeer::from_str(server)
+                        .expect("Failed to parse rendezvous server seed peer");
+                    if let Some(peer_id) = server.to_peer_id() {
+                        let addr = server.address().clone();
+                        builder.with_rendezvous_server(peer_id, addr)
+                    } else{
+                        warn!(target: LOG_TARGET, "Rendezvous server peer ID is not set, skipping rendezvous server configuration");
+                        builder
+                    }
+                },
+                None => builder,
+            }
+        })
         .spawn(shutdown.clone())?;
 
     // Connect to substate db

--- a/applications/tari_swarm_daemon/Cargo.toml
+++ b/applications/tari_swarm_daemon/Cargo.toml
@@ -36,6 +36,7 @@ humantime = { workspace = true }
 include_dir = { workspace = true }
 json5 = { workspace = true }
 lockfile = "0.4.0"
+indexmap = { workspace = true }
 slug = "0.1.6"
 log = { workspace = true }
 mime_guess = { workspace = true }

--- a/applications/tari_swarm_daemon/src/config.rs
+++ b/applications/tari_swarm_daemon/src/config.rs
@@ -20,6 +20,7 @@ use crate::cli::{Cli, Commands};
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(deny_unknown_fields)]
+#[allow(clippy::struct_excessive_bools)]
 pub struct Config {
     pub base_dir: PathBuf,
     pub start_port: u16,
@@ -33,6 +34,8 @@ pub struct Config {
     pub skip_registration: bool,
     #[serde(default = "default_as_true")]
     pub auto_register_previous_templates: bool,
+    #[serde(default, skip_serializing_if = "Clone::clone")]
+    pub enable_manual_validator_connect: bool,
     pub public_ip: Option<IpAddr>,
     #[serde(default)]
     pub log_to_file: bool,

--- a/applications/tari_swarm_daemon/src/main.rs
+++ b/applications/tari_swarm_daemon/src/main.rs
@@ -204,6 +204,7 @@ fn get_base_config(cli: &Cli) -> anyhow::Result<Config> {
             executables,
         },
         auto_register_previous_templates: true,
+        enable_manual_validator_connect: false,
         public_ip: None,
         log_to_file: false,
     })

--- a/applications/tari_swarm_daemon/src/process_manager/instances/manager.rs
+++ b/applications/tari_swarm_daemon/src/process_manager/instances/manager.rs
@@ -11,6 +11,7 @@ use std::{
 };
 
 use anyhow::{anyhow, Context};
+use indexmap::IndexMap;
 use log::info;
 use slug::slugify;
 use tari_common::configuration::Network;
@@ -43,13 +44,13 @@ pub struct InstanceManager {
     config: Vec<InstanceConfig>,
     global_settings: HashMap<String, String>,
     network: Network,
-    minotari_nodes: HashMap<InstanceId, MinoTariNodeProcess>,
-    minotari_wallets: HashMap<InstanceId, MinoTariWalletProcess>,
-    minotari_miners: HashMap<InstanceId, MinoTariMinerProcess>,
-    validator_nodes: HashMap<InstanceId, ValidatorNodeProcess>,
-    indexers: HashMap<InstanceId, IndexerProcess>,
-    wallet_daemons: HashMap<InstanceId, WalletDaemonProcess>,
-    signaling_servers: HashMap<InstanceId, SignalingServerProcess>,
+    minotari_nodes: IndexMap<InstanceId, MinoTariNodeProcess>,
+    minotari_wallets: IndexMap<InstanceId, MinoTariWalletProcess>,
+    minotari_miners: IndexMap<InstanceId, MinoTariMinerProcess>,
+    validator_nodes: IndexMap<InstanceId, ValidatorNodeProcess>,
+    indexers: IndexMap<InstanceId, IndexerProcess>,
+    wallet_daemons: IndexMap<InstanceId, WalletDaemonProcess>,
+    signaling_servers: IndexMap<InstanceId, SignalingServerProcess>,
     port_allocator: PortAllocator,
     instance_id: InstanceId,
 }
@@ -67,13 +68,13 @@ impl InstanceManager {
             config,
             network,
             global_settings,
-            minotari_nodes: HashMap::new(),
-            minotari_wallets: HashMap::new(),
-            minotari_miners: HashMap::new(),
-            validator_nodes: HashMap::new(),
-            indexers: HashMap::new(),
-            wallet_daemons: HashMap::new(),
-            signaling_servers: HashMap::new(),
+            minotari_nodes: IndexMap::new(),
+            minotari_wallets: IndexMap::new(),
+            minotari_miners: IndexMap::new(),
+            validator_nodes: IndexMap::new(),
+            indexers: IndexMap::new(),
+            wallet_daemons: IndexMap::new(),
+            signaling_servers: IndexMap::new(),
             port_allocator: PortAllocator::new(start_port),
             instance_id: 0,
         }
@@ -263,34 +264,34 @@ impl InstanceManager {
         match instance_type {
             InstanceType::MinoTariNode => {
                 self.minotari_nodes
-                    .insert(instance_id, MinoTariNodeProcess::new(instance));
+                    .insert_sorted(instance_id, MinoTariNodeProcess::new(instance));
             },
             InstanceType::MinoTariConsoleWallet => {
                 self.minotari_wallets
-                    .insert(instance_id, MinoTariWalletProcess::new(instance));
+                    .insert_sorted(instance_id, MinoTariWalletProcess::new(instance));
             },
             InstanceType::MinoTariMiner => {
                 self.minotari_miners
-                    .insert(instance_id, MinoTariMinerProcess::new(instance));
+                    .insert_sorted(instance_id, MinoTariMinerProcess::new(instance));
             },
             InstanceType::TariValidatorNode => {
                 self.validator_nodes
-                    .insert(instance_id, ValidatorNodeProcess::new(instance));
+                    .insert_sorted(instance_id, ValidatorNodeProcess::new(instance));
             },
             InstanceType::TariIndexer => {
-                self.indexers.insert(instance_id, IndexerProcess::new(instance));
+                self.indexers.insert_sorted(instance_id, IndexerProcess::new(instance));
             },
             InstanceType::TariSignalingServer => {
                 self.signaling_servers
-                    .insert(instance_id, SignalingServerProcess::new(instance));
+                    .insert_sorted(instance_id, SignalingServerProcess::new(instance));
             },
             InstanceType::TariWalletDaemon => {
                 self.wallet_daemons
-                    .insert(instance_id, WalletDaemonProcess::new(instance));
+                    .insert_sorted(instance_id, WalletDaemonProcess::new(instance));
             },
             InstanceType::TariWalletDaemonCreateKey => {
                 self.wallet_daemons
-                    .insert(instance_id, WalletDaemonProcess::new(instance));
+                    .insert_sorted(instance_id, WalletDaemonProcess::new(instance));
             },
         }
 
@@ -418,28 +419,28 @@ impl InstanceManager {
 
         match instance.instance_type() {
             InstanceType::MinoTariNode => {
-                self.minotari_nodes.remove(&id);
+                self.minotari_nodes.shift_remove(&id);
             },
             InstanceType::MinoTariConsoleWallet => {
-                self.minotari_wallets.remove(&id);
+                self.minotari_wallets.shift_remove(&id);
             },
             InstanceType::MinoTariMiner => {
-                self.minotari_miners.remove(&id);
+                self.minotari_miners.shift_remove(&id);
             },
             InstanceType::TariValidatorNode => {
-                self.validator_nodes.remove(&id);
+                self.validator_nodes.shift_remove(&id);
             },
             InstanceType::TariIndexer => {
-                self.indexers.remove(&id);
+                self.indexers.shift_remove(&id);
             },
             InstanceType::TariSignalingServer => {
-                self.signaling_servers.remove(&id);
+                self.signaling_servers.shift_remove(&id);
             },
             InstanceType::TariWalletDaemon => {
-                self.wallet_daemons.remove(&id);
+                self.wallet_daemons.shift_remove(&id);
             },
             InstanceType::TariWalletDaemonCreateKey => {
-                self.wallet_daemons.remove(&id);
+                self.wallet_daemons.shift_remove(&id);
             },
         }
 

--- a/applications/tari_swarm_daemon/src/process_manager/manager.rs
+++ b/applications/tari_swarm_daemon/src/process_manager/manager.rs
@@ -19,7 +19,7 @@ use tari_engine::wasm::WasmModule;
 use tari_engine_types::calculate_template_binary_hash;
 use tari_shutdown::ShutdownSignal;
 use tari_template_lib_types::TemplateAddress;
-use tari_validator_node_client::types::GetTemplatesRequest;
+use tari_validator_node_client::types::{AddPeerRequest, GetTemplatesRequest};
 use tokio::{sync::mpsc, time, time::sleep};
 use url::Url;
 
@@ -43,6 +43,7 @@ pub struct ProcessManager {
     shutdown_signal: ShutdownSignal,
     skip_registration: bool,
     disable_template_auto_register: bool,
+    enable_manual_connect: bool,
     base_dir: PathBuf,
     web_server_port: u16,
 }
@@ -71,6 +72,7 @@ impl ProcessManager {
             rx_request,
             shutdown_signal,
             disable_template_auto_register: !config.auto_register_previous_templates,
+            enable_manual_connect: config.enable_manual_validator_connect,
             base_dir: config.base_dir.clone(),
             web_server_port: match config.webserver.bind_address {
                 SocketAddr::V4(addr) => addr.port(),
@@ -89,6 +91,41 @@ impl ProcessManager {
         sleep(Duration::from_secs(self.instance_manager.num_instances() as u64)).await;
         self.check_instances_running()?;
 
+        Ok(())
+    }
+
+    async fn connect_all_validators(&mut self) -> anyhow::Result<()> {
+        info!("Connecting all nodes");
+        let mut clients = vec![];
+        let mut ids = vec![];
+        for vn in self.instance_manager.validator_nodes_mut() {
+            match vn.connect_client() {
+                Ok(mut client) => {
+                    info!("🟢 Validator node {} connected", vn.instance().name());
+                    let id = client.get_identity().await?;
+                    clients.push(client);
+                    ids.push(id);
+                },
+                Err(err) => {
+                    log::error!("Failed to connect to validator node {}: {}", vn.instance().name(), err);
+                },
+            }
+        }
+
+        for (i, client) in clients.iter_mut().enumerate() {
+            for (j, id) in ids.iter().enumerate() {
+                if i == j {
+                    continue; // Skip self
+                }
+                client
+                    .add_peer(AddPeerRequest {
+                        public_key: id.public_key,
+                        addresses: id.public_addresses.clone(),
+                        wait_for_dial: false,
+                    })
+                    .await?;
+            }
+        }
         Ok(())
     }
 
@@ -308,6 +345,22 @@ impl ProcessManager {
         }
 
         let mut layer_one_transaction_service = self.create_layer_one_transaction_service().await?;
+
+        if self.enable_manual_connect {
+            {
+                info!("Connecting all validator nodes manually");
+                let fut = pin!(self.connect_all_validators());
+                match shutdown_signal.clone().select(fut).await {
+                    Either::Left(_) => {
+                        info!("Shutting down process manager during validator connection");
+                        return Ok(());
+                    },
+                    Either::Right((result, _)) => {
+                        result?;
+                    },
+                }
+            }
+        }
 
         {
             let fut = pin!(self.register_nodes_and_templates_as_required(&mut layer_one_transaction_service));

--- a/applications/tari_validator_node/src/bootstrap.rs
+++ b/applications/tari_validator_node/src/bootstrap.rs
@@ -164,7 +164,15 @@ pub async fn spawn_services(
             tx_gossip_messages_by_topic,
         })
         .with_config(tari_networking::Config {
-            listener_port: config.validator_node.p2p.listener_port,
+            // TODO: configurable
+            listeners: vec![
+                format!("/ip4/0.0.0.0/tcp/{}", config.validator_node.p2p.listener_port)
+                    .parse()
+                    .expect("Failed to parse listener address"),
+                format!("/ip4/0.0.0.0/udp/{}/quic-v1", config.validator_node.p2p.listener_port)
+                    .parse()
+                    .expect("Failed to parse listener address"),
+            ],
             swarm: SwarmConfig {
                 protocol_version: format!("/tari/{}/0.0.1", config.network).parse().unwrap(),
                 user_agent: "/tari/validator/0.0.1".to_string(),
@@ -173,13 +181,34 @@ pub async fn spawn_services(
                 // TODO: allow node operator to configure
                 relay_circuit_limits: RelayCircuitLimits::high(),
                 relay_reservation_limits: RelayReservationLimits::high(),
+                rendezvous_server_enabled: config.validator_node.p2p.enable_rendezvous,
                 ..Default::default()
             },
             reachability_mode: config.validator_node.p2p.reachability_mode.into(),
             announce: true,
+            rendezvous_namespace: format!(
+                "tari-{}",
+                config.network.to_string().to_lowercase()
+            ),
             ..Default::default()
         })
-        .with_seed_peers(seed_peers);
+        .with_seed_peers(seed_peers)
+        .then(|builder| {
+            match config.peer_seeds.rendezvous_server.as_ref() {
+                Some(server) => {
+                    let server = SeedPeer::from_str(server)
+                        .expect("Failed to parse rendezvous server seed peer");
+                    if let Some(peer_id) = server.to_peer_id() {
+                        let addr = server.address().clone();
+                        builder.with_rendezvous_server(peer_id, addr)
+                    } else{
+                        warn!(target: LOG_TARGET, "Rendezvous server peer ID is not set, skipping rendezvous server configuration");
+                        builder
+                    }
+                },
+                None => builder,
+            }
+        });
 
     #[cfg(feature = "metrics")]
     {

--- a/networking/core/src/builder.rs
+++ b/networking/core/src/builder.rs
@@ -19,6 +19,7 @@ pub struct Builder<'a, TMsg: MessageSpec> {
     messaging_mode: MessagingMode<TMsg>,
     config: crate::Config,
     seed_peers: Vec<(Option<PeerId>, Multiaddr)>,
+    rendezvous_server: Option<(PeerId, Multiaddr)>,
     #[cfg(feature = "metrics")]
     registry: Option<&'a mut libp2p::metrics::Registry>,
     #[cfg(not(feature = "metrics"))]
@@ -39,6 +40,7 @@ where
             messaging_mode: MessagingMode::Disabled,
             config: crate::Config::default(),
             seed_peers: Vec::new(),
+            rendezvous_server: None,
             #[cfg(feature = "metrics")]
             registry: None,
             #[cfg(not(feature = "metrics"))]
@@ -52,11 +54,16 @@ where
             messaging_mode: mode,
             config: self.config,
             seed_peers: self.seed_peers,
+            rendezvous_server: self.rendezvous_server,
             #[cfg(feature = "metrics")]
             registry: self.registry,
             #[cfg(not(feature = "metrics"))]
             _marker: std::marker::PhantomData,
         }
+    }
+
+    pub fn then(self, f: impl FnOnce(Self) -> Self) -> Self {
+        f(self)
     }
 
     pub fn with_config(mut self, config: crate::Config) -> Self {
@@ -75,6 +82,14 @@ where
         self
     }
 
+    pub fn with_rendezvous_server(mut self, peer_id: PeerId, addr: Multiaddr) -> Self {
+        if !is_supported_multiaddr(&addr) {
+            panic!("Unsupported rendezvous server multi-address: {}", addr);
+        }
+        self.rendezvous_server = Some((peer_id, addr));
+        self
+    }
+
     pub fn spawn(
         self,
         shutdown_signal: ShutdownSignal,
@@ -84,6 +99,7 @@ where
             messaging_mode,
             mut config,
             seed_peers,
+            rendezvous_server,
             #[cfg(feature = "metrics")]
             registry,
             #[cfg(not(feature = "metrics"))]
@@ -120,6 +136,7 @@ where
                 .filter_map(|(peer_id, addr)| Some(((*peer_id)?, addr.clone())))
                 .collect(),
             seed_peers,
+            rendezvous_server,
             shutdown_signal,
         );
         #[cfg(feature = "metrics")]

--- a/networking/core/src/config.rs
+++ b/networking/core/src/config.rs
@@ -8,22 +8,31 @@ use libp2p::Multiaddr;
 #[derive(Debug, Clone)]
 pub struct Config {
     pub swarm: tari_swarm::Config,
-    pub listener_port: u16,
+    pub listeners: Vec<Multiaddr>,
     pub reachability_mode: ReachabilityMode,
     pub announce: bool,
     pub check_connections_interval: Duration,
     pub known_local_public_address: Vec<Multiaddr>,
+    /// The namespace used for rendezvous service registration.
+    /// This MUST be less than 255 characters.
+    pub rendezvous_namespace: String,
+    pub rendezvous_peer_limit: Option<u64>,
 }
 
 impl Default for Config {
     fn default() -> Self {
         Self {
             swarm: tari_swarm::Config::default(),
-            listener_port: 0,
+            listeners: vec![
+                "/ip4/0.0.0.0/tcp/0".parse().expect("Invalid multiaddr"),
+                "/ip4/0.0.0.0/udp/0/quic-v1".parse().expect("Invalid multiaddr"),
+            ],
             reachability_mode: ReachabilityMode::default(),
             announce: false,
             check_connections_interval: Duration::from_secs(2 * 60 * 60),
             known_local_public_address: vec![],
+            rendezvous_namespace: "tari".to_string(),
+            rendezvous_peer_limit: Some(1000),
         }
     }
 }

--- a/networking/core/src/error.rs
+++ b/networking/core/src/error.rs
@@ -51,8 +51,8 @@ pub enum NetworkingError {
     RpcError(#[from] RpcError),
     #[error("Transport error: {0}")]
     TransportError(#[from] TransportError<io::Error>),
-    #[error("Peer sync error: {0}")]
-    PeerSyncError(#[from] tari_swarm::peersync::Error),
+    #[error("Rendezvous client register error: {0}")]
+    RendezvousRegisterError(#[from] tari_swarm::rendezvous::client::RegisterError),
     #[error("Messaging is disabled")]
     MessagingDisabled,
 }

--- a/networking/core/src/handle.rs
+++ b/networking/core/src/handle.rs
@@ -49,56 +49,58 @@ use crate::{
 
 const LOG_TARGET: &str = "tari::networking::handle";
 
+pub type Reply<T> = oneshot::Sender<Result<T, NetworkingError>>;
+
 pub enum NetworkingRequest<TMsg: MessageSpec> {
     DialPeer {
         dial_opts: DialOpts,
-        reply_tx: oneshot::Sender<Result<Waiter<()>, NetworkingError>>,
+        reply_tx: Reply<Waiter<()>>,
     },
     GetConnectedPeers {
-        reply_tx: oneshot::Sender<Result<Vec<PeerId>, NetworkingError>>,
+        reply_tx: Reply<Vec<PeerId>>,
     },
     SendMessage {
         peer: PeerId,
         message: TMsg::Message,
-        reply_tx: oneshot::Sender<Result<(), NetworkingError>>,
+        reply_tx: Reply<()>,
     },
     SendMulticast {
         destination: MulticastDestination,
         message: TMsg::Message,
-        reply_tx: oneshot::Sender<Result<usize, NetworkingError>>,
+        reply_tx: Reply<usize>,
     },
     PublishGossip {
         topic: IdentTopic,
         message: Vec<u8>,
-        reply_tx: oneshot::Sender<Result<(), NetworkingError>>,
+        reply_tx: Reply<()>,
     },
     SubscribeTopic {
         topic: IdentTopic,
         explicit_topic_peers: Vec<PeerId>,
-        reply_tx: oneshot::Sender<Result<(), NetworkingError>>,
+        reply_tx: Reply<()>,
     },
     UnsubscribeTopic {
         topic: IdentTopic,
-        reply_tx: oneshot::Sender<Result<(), NetworkingError>>,
+        reply_tx: Reply<()>,
     },
     IsSubscribedTopic {
         topic: IdentTopic,
-        reply_tx: oneshot::Sender<Result<bool, NetworkingError>>,
+        reply_tx: Reply<bool>,
     },
     OpenSubstream {
         peer_id: PeerId,
         protocol_id: StreamProtocol,
-        reply_tx: oneshot::Sender<Result<NegotiatedSubstream<Substream>, NetworkingError>>,
+        reply_tx: Reply<NegotiatedSubstream<Substream>>,
     },
     AddProtocolNotifier {
         protocols: HashSet<StreamProtocol>,
         tx_notifier: mpsc::UnboundedSender<ProtocolNotification<Substream>>,
     },
     GetActiveConnections {
-        reply_tx: oneshot::Sender<Result<Vec<Connection>, NetworkingError>>,
+        reply_tx: Reply<Vec<Connection>>,
     },
     GetLocalPeerInfo {
-        reply_tx: oneshot::Sender<Result<PeerInfo, NetworkingError>>,
+        reply_tx: Reply<PeerInfo>,
     },
     SetWantPeers(HashSet<PeerId>),
 }

--- a/networking/core/src/lib.rs
+++ b/networking/core/src/lib.rs
@@ -26,6 +26,7 @@ mod message_mode;
 mod notify;
 mod peer;
 mod relay_state;
+mod rendezvous_state;
 
 pub use builder::Builder;
 pub use config::*;

--- a/networking/core/src/rendezvous_state.rs
+++ b/networking/core/src/rendezvous_state.rs
@@ -1,0 +1,56 @@
+//    Copyright 2025 The Tari Project
+//    SPDX-License-Identifier: BSD-3-Clause
+
+use libp2p::Multiaddr;
+use tari_swarm::rendezvous::Cookie;
+
+use crate::PeerId;
+
+pub struct RendezvousState {
+    rendezvous_server: Option<(PeerId, RvPeerState)>,
+}
+
+#[derive(Debug, Clone)]
+pub struct RvPeerState {
+    address: Multiaddr,
+    cookie: Option<Cookie>,
+}
+
+impl RendezvousState {
+    pub fn new(server: Option<(PeerId, Multiaddr)>) -> Self {
+        Self {
+            rendezvous_server: server.map(|(peer_id, addr)| {
+                (peer_id, RvPeerState {
+                    address: addr,
+                    cookie: None,
+                })
+            }),
+        }
+    }
+
+    pub fn set_cookie(&mut self, cookie: Cookie) -> bool {
+        match self.rendezvous_server.as_mut() {
+            Some((_, state_mut)) => {
+                state_mut.cookie = Some(cookie);
+                true
+            },
+            None => false,
+        }
+    }
+
+    pub fn get_peer_and_cookie(&self) -> Option<(PeerId, Option<Cookie>)> {
+        self.rendezvous_server
+            .as_ref()
+            .map(|(peer_id, state)| (*peer_id, state.cookie.clone()))
+    }
+
+    pub fn get_peer_and_address(&self) -> Option<(PeerId, Multiaddr)> {
+        self.peer_and_address().map(|(peer_id, addr)| (*peer_id, addr.clone()))
+    }
+
+    pub fn peer_and_address(&self) -> Option<(&PeerId, &Multiaddr)> {
+        self.rendezvous_server
+            .as_ref()
+            .map(|(peer_id, state)| (peer_id, &state.address))
+    }
+}

--- a/networking/core/src/worker.rs
+++ b/networking/core/src/worker.rs
@@ -15,7 +15,7 @@ use libp2p::{
     dcutr,
     futures::StreamExt,
     gossipsub,
-    gossipsub::{IdentTopic, MessageId, PublishError, TopicHash},
+    gossipsub::{MessageId, PublishError, TopicHash},
     identify,
     identity,
     mdns,
@@ -39,7 +39,9 @@ use tari_swarm::{
     is_supported_multiaddr,
     messaging,
     messaging::{prost, prost::ProstCodec},
-    peersync,
+    protocol_ids,
+    rendezvous,
+    rendezvous::Namespace,
     substream,
     substream::{NegotiatedSubstream, ProtocolNotification, StreamId},
     TariNodeBehaviourEvent,
@@ -57,16 +59,18 @@ use crate::{
     handle::NetworkingRequest,
     notify::Notifiers,
     relay_state::RelayState,
+    rendezvous_state::RendezvousState,
     MessageSpec,
     MessagingMode,
     NetworkingError,
+    ReachabilityMode,
 };
 
 const LOG_TARGET: &str = "tari::ootle::networking::service::worker";
 
 type ReplyTx<T> = oneshot::Sender<Result<T, NetworkingError>>;
 
-const PEER_ANNOUNCE_TOPIC: &str = "peer-announce";
+// const PEER_ANNOUNCE_TOPIC: &str = "peer-announce";
 
 pub struct NetworkingWorker<TMsg>
 where
@@ -86,10 +90,10 @@ where
     topic_peers: HashMap<TopicHash, Vec<PeerId>>,
     swarm: TariSwarm<ProstCodec<TMsg::Message>>,
     config: crate::Config,
+    rendezvous_state: RendezvousState,
     relays: RelayState,
     seed_peers: Vec<(Option<PeerId>, Multiaddr)>,
     is_initial_bootstrap_complete: bool,
-    has_sent_announce: bool,
     #[cfg(feature = "metrics")]
     metrics: Option<tari_swarm::metrics::Metrics>,
     shutdown_signal: ShutdownSignal,
@@ -111,6 +115,7 @@ where
         config: crate::Config,
         known_relay_nodes: Vec<(PeerId, Multiaddr)>,
         seed_peers: Vec<(Option<PeerId>, Multiaddr)>,
+        rendezvous_server: Option<(PeerId, Multiaddr)>,
         shutdown_signal: ShutdownSignal,
     ) -> Self {
         Self {
@@ -124,11 +129,11 @@ where
             pending_dial_requests: HashMap::new(),
             relays: RelayState::new(known_relay_nodes),
             topic_peers: HashMap::new(),
+            rendezvous_state: RendezvousState::new(rendezvous_server),
             seed_peers,
             swarm,
             config,
             is_initial_bootstrap_complete: false,
-            has_sent_announce: false,
             #[cfg(feature = "metrics")]
             metrics: None,
             shutdown_signal,
@@ -151,17 +156,18 @@ where
 
     pub async fn run(mut self) -> anyhow::Result<()> {
         info!(target: LOG_TARGET, "🌐 Starting networking service {:?}", self.config);
-        // Listen on all interfaces TODO: Configure
-        self.swarm.listen_on(
-            format!("/ip4/0.0.0.0/tcp/{}", self.config.listener_port)
-                .parse()
-                .unwrap(),
-        )?;
-        self.swarm.listen_on(
-            format!("/ip4/0.0.0.0/udp/{}/quic-v1", self.config.listener_port)
-                .parse()
-                .unwrap(),
-        )?;
+        if self.config.listeners.is_empty() {
+            self.config.reachability_mode = ReachabilityMode::Private;
+            info!(target: LOG_TARGET, "No listeners configured, this node will not accept incoming connections");
+        }
+        // Setup listeners
+        for listener in &self.config.listeners {
+            if !is_supported_multiaddr(listener) {
+                warn!(target: LOG_TARGET, "Unsupported listener multiaddr {}", listener);
+                continue;
+            }
+            self.swarm.listen_on(listener.clone())?;
+        }
 
         if self.config.reachability_mode.is_private() {
             self.attempt_relay_reservation();
@@ -169,10 +175,10 @@ where
 
         let mut check_connections_interval = time::interval(self.config.check_connections_interval);
 
-        self.swarm
-            .behaviour_mut()
-            .gossipsub
-            .subscribe(&IdentTopic::new(PEER_ANNOUNCE_TOPIC))?;
+        // self.swarm
+        //     .behaviour_mut()
+        //     .gossipsub
+        //     .subscribe(&IdentTopic::new(PEER_ANNOUNCE_TOPIC))?;
 
         loop {
             tokio::select! {
@@ -370,8 +376,7 @@ where
                 let _ignore = reply_tx.send(Ok(peer));
             },
             NetworkingRequest::SetWantPeers(peers) => {
-                info!(target: LOG_TARGET, "🧭 Setting want peers to {:?}", peers);
-                self.swarm.behaviour_mut().peer_sync.want_peers(peers).await?;
+                info!(target: LOG_TARGET, "🧭 (CURRENTLY NO-OP) Setting want peers to {:?} ", peers);
             },
         }
 
@@ -380,40 +385,54 @@ where
 
     async fn bootstrap(&mut self) -> Result<(), NetworkingError> {
         if !self.is_initial_bootstrap_complete {
-            self.swarm
-                .behaviour_mut()
-                .peer_sync
-                .add_known_local_public_addresses(self.config.known_local_public_address.clone());
-        }
-
-        info!(target: LOG_TARGET, "🥾 Bootstrapping with {} seed peers", self.seed_peers.len());
-        for (peer, addr) in self.seed_peers.drain(..) {
-            let opts = match peer {
-                Some(peer) => DialOpts::peer_id(peer)
-                    .addresses(vec![addr])
+            if let Some((peer_id, addr)) = self.rendezvous_state.get_peer_and_address() {
+                info!(target: LOG_TARGET, "🥾BOOTSTRAP: dialing rendezvous peer {peer_id} at address {addr}");
+                let opts = DialOpts::peer_id(peer_id)
+                    .addresses(vec![addr.clone()])
                     .condition(PeerCondition::DisconnectedAndNotDialing)
                     .extend_addresses_through_behaviour()
-                    .build(),
-                None => DialOpts::unknown_peer_id().address(addr).build(),
-            };
+                    .build();
 
-            self.swarm.dial(opts).or_else(|err| {
-                // Peer already has pending dial or established connection - OK
-                if matches!(&err, DialError::DialPeerConditionFalse(_)) {
-                    Ok(())
-                } else {
-                    Err(err)
-                }
-            })?;
+                self.swarm.dial(opts).or_else(|err| {
+                    // Peer already has pending dial or established connection - OK
+                    if matches!(&err, DialError::DialPeerConditionFalse(_)) {
+                        Ok(())
+                    } else {
+                        Err(err)
+                    }
+                })?;
+            }
+
+            info!(target: LOG_TARGET, "🥾 BOOTSTRAP: dialing {} seed peers", self.seed_peers.len());
+            for (peer, addr) in self.seed_peers.drain(..) {
+                let opts = match peer {
+                    Some(peer) => DialOpts::peer_id(peer)
+                        .addresses(vec![addr])
+                        .condition(PeerCondition::DisconnectedAndNotDialing)
+                        .extend_addresses_through_behaviour()
+                        .build(),
+                    None => DialOpts::unknown_peer_id().address(addr).build(),
+                };
+
+                self.swarm.dial(opts).or_else(|err| {
+                    // Peer already has pending dial or established connection - OK
+                    if matches!(&err, DialError::DialPeerConditionFalse(_)) {
+                        Ok(())
+                    } else {
+                        Err(err)
+                    }
+                })?;
+            }
         }
 
         if self.active_connections.len() < self.relays.num_possible_relays() {
-            info!(target: LOG_TARGET, "🥾 Bootstrapping with {} known relay peers", self.relays.num_possible_relays());
+            info!(target: LOG_TARGET, "🥾 BOOTSTRAP: dialing {} known relay peers", self.relays.num_possible_relays());
             for (peer, addrs) in self.relays.possible_relays() {
                 self.swarm
                     .dial(
                         DialOpts::peer_id(*peer)
                             .addresses(addrs.iter().cloned().collect())
+                            .condition(PeerCondition::DisconnectedAndNotDialing)
                             .extend_addresses_through_behaviour()
                             .build(),
                     )
@@ -498,11 +517,15 @@ where
                 }
 
                 if matches!(error, DialError::NoAddresses) {
-                    self.swarm
-                        .behaviour_mut()
-                        .peer_sync
-                        .add_want_peers(Some(peer_id))
-                        .await?;
+                    if let Some((peer_id, cookie)) = self.rendezvous_state.get_peer_and_cookie() {
+                        let ns = self.get_rendezvous_namespace();
+                        self.swarm.behaviour_mut().rendezvous_client.discover(
+                            Some(ns),
+                            cookie,
+                            self.config.rendezvous_peer_limit,
+                            peer_id,
+                        );
+                    }
                 }
             },
             SwarmEvent::ExternalAddrConfirmed { address } => {
@@ -641,23 +664,28 @@ where
             Autonat(event) => {
                 self.on_autonat_event(event)?;
             },
-            PeerSync(peersync::Event::LocalPeerRecordUpdated) => {
-                if self.config.announce && !self.has_sent_announce {
-                    let record = self.swarm.behaviour().peer_sync.local_peer_record();
-                    info!(target: LOG_TARGET, "📣 Sending local peer announce with {} address(es)", record.addresses().len());
-                    let proto_rec = record.encode_to_proto()?;
-                    self.swarm
-                        .behaviour_mut()
-                        .gossipsub
-                        .publish(IdentTopic::new(PEER_ANNOUNCE_TOPIC), proto_rec)?;
-                    self.has_sent_announce = true;
-                }
+            RendezvousServer(event) => {
+                info!(target: LOG_TARGET, "ℹ️ RendezvousServer event: {:?}", event);
             },
-            PeerSync(peersync::Event::PeerBatchReceived { new_peers, from_peer }) => {
-                info!(target: LOG_TARGET, "🧑‍🧑‍🧒‍🧒 Peer batch received: from_peer={}, new_peers={}", from_peer, new_peers);
+            RendezvousClient(rendezvous::client::Event::Discovered {
+                rendezvous_node,
+                registrations,
+                cookie,
+            }) => {
+                info!(
+                    target: LOG_TARGET,
+                    "🌐 RendezvousClient {} discovered {} node(s) on namespace {}",
+                    rendezvous_node,
+                    registrations.len(),
+                    cookie.namespace().map(|s| format!("'{s}'")).unwrap_or_else(|| "''".to_string()),
+                );
+                self.rendezvous_state.set_cookie(cookie);
             },
-            PeerSync(event) => {
-                info!(target: LOG_TARGET, "ℹ️ PeerSync event: {:?}", event);
+            RendezvousClient(event) => {
+                info!(target: LOG_TARGET, "ℹ️ RendezvousClient event: {:?}", event);
+            },
+            PeerStore(event) => {
+                info!(target: LOG_TARGET, "🧑‍🧑‍🧒‍🧒 PeerStore event: {:?}", event);
             },
         }
 
@@ -671,64 +699,18 @@ where
         source: PeerId,
         message: gossipsub::Message,
     ) -> Result<(), NetworkingError> {
-        if message.topic == IdentTopic::new(PEER_ANNOUNCE_TOPIC).into() {
-            info!(target: LOG_TARGET, "📢 Peer announce message: ({bytes} bytes) from {source:?}", bytes = message.data.len(), source = message.source);
-            let rec = peersync::SignedPeerRecord::decode_from_proto(message.data.as_slice())?;
-            if let Some(addr) = rec.addresses.iter().find(|a| !is_supported_multiaddr(a)) {
-                warn!(target: LOG_TARGET, "📢 Discarding peer announce message with unsupported address {addr}");
-                return Ok(());
-            }
-            let behaviour_mut = self.swarm.behaviour_mut();
-            match behaviour_mut.peer_sync.validate_and_add_peer_record(rec).await {
-                Ok(_) => {
-                    info!(target: LOG_TARGET, "📢 Peer announce message added to peer store");
-                    if !behaviour_mut.gossipsub.report_message_validation_result(
-                        &message_id,
-                        &propagation_source,
-                        gossipsub::MessageAcceptance::Accept,
-                    ) {
-                        warn!(target: LOG_TARGET, "Unable to report_message_validation_result accept for topic {}, {} bytes because message was not in cache", message.topic, message.data.len());
-                    }
-                },
-                // Invalid message
-                Err(err @ peersync::Error::InvalidMessage { .. }) |
-                Err(err @ peersync::Error::DecodeMultiaddr { .. }) |
-                Err(err @ peersync::Error::InvalidSignedPeer { .. }) => {
-                    if !behaviour_mut.gossipsub.report_message_validation_result(
-                        &message_id,
-                        &propagation_source,
-                        gossipsub::MessageAcceptance::Reject,
-                    ) {
-                        warn!(target: LOG_TARGET, "Unable to report_message_validation_result reject for topic {}, {} bytes because message was not in cache", message.topic, message.data.len());
-                    }
-                    return Err(err.into());
-                },
-                // Some other internal error
-                Err(err) => {
-                    warn!(target: LOG_TARGET, "📢 Peer announce message failed to add to peer store: {}", err);
-                    if !behaviour_mut.gossipsub.report_message_validation_result(
-                        &message_id,
-                        &propagation_source,
-                        gossipsub::MessageAcceptance::Accept,
-                    ) {
-                        warn!(target: LOG_TARGET, "Unable to report_message_validation_result accept for topic {}, {} bytes because message was not in cache", message.topic, message.data.len());
-                    }
-                },
-            }
-        } else {
-            // We accept all messages as we cannot validate them in this service.
-            // We could allow users to report back the validation result e.g. if a proposal is valid, however a naive
-            // implementation would likely incur a substantial cost for many messages.
-            if !self.swarm.behaviour_mut().gossipsub.report_message_validation_result(
-                &message_id,
-                &propagation_source,
-                gossipsub::MessageAcceptance::Accept,
-            ) {
-                warn!(target: LOG_TARGET, "Unable to report_message_validation_result accept for topic {}, {} bytes because message was not in cache", message.topic, message.data.len());
-            }
-            if let Err(e) = self.messaging_mode.send_gossip_message(source, message) {
-                warn!(target: LOG_TARGET, "📢 Gossipsub message failed to be handled: {}", e);
-            }
+        // We accept all messages as we cannot validate them in this service.
+        // We could allow users to report back the validation result e.g. if a proposal is valid, however a naive
+        // implementation would likely incur a substantial cost for many messages.
+        if !self.swarm.behaviour_mut().gossipsub.report_message_validation_result(
+            &message_id,
+            &propagation_source,
+            gossipsub::MessageAcceptance::Accept,
+        ) {
+            warn!(target: LOG_TARGET, "Unable to report_message_validation_result accept for topic {}, {} bytes because message was not in cache", message.topic, message.data.len());
+        }
+        if let Err(e) = self.messaging_mode.send_gossip_message(source, message) {
+            warn!(target: LOG_TARGET, "📢 Gossipsub message failed to be handled: {}", e);
         }
         Ok(())
     }
@@ -747,7 +729,12 @@ where
                 for (peer, addr) in peers_and_addrs {
                     debug!(target: LOG_TARGET, "📡 mDNS discovered peer {} at {}", peer, addr);
                     self.swarm
-                        .dial(DialOpts::peer_id(peer).addresses(vec![addr]).build())
+                        .dial(
+                            DialOpts::peer_id(peer)
+                                .addresses(vec![addr])
+                                .extend_addresses_through_behaviour()
+                                .build(),
+                        )
                         .or_else(|err| {
                             // Peer already has pending dial or established connection - OK
                             if matches!(&err, DialError::DialPeerConditionFalse(_)) {
@@ -771,14 +758,6 @@ where
         use autonat::Event::*;
         match event {
             StatusChanged { old, new } => {
-                if let Some(public_address) = self.swarm.behaviour().autonat.public_address().cloned() {
-                    info!(target: LOG_TARGET, "🌍️ Autonat: Our public address is {public_address}");
-                    self.swarm
-                        .behaviour_mut()
-                        .peer_sync
-                        .add_known_local_public_addresses(vec![public_address]);
-                }
-
                 // If we are/were "Private", let's establish a relay reservation with a known relay
                 if (self.config.reachability_mode.is_private() ||
                     new == NatStatus::Private ||
@@ -806,6 +785,7 @@ where
                 DialOpts::peer_id(relay.peer_id)
                     .addresses(relay.addresses.clone())
                     .condition(PeerCondition::NotDialing)
+                    .extend_addresses_through_behaviour()
                     .build(),
             ) {
                 if is_dial_error_caused_by_remote(&err) {
@@ -887,9 +867,27 @@ where
             return Ok(());
         }
 
+        if self
+            .rendezvous_state
+            .peer_and_address()
+            .is_some_and(|(p, _)| *p == peer_id)
+        {
+            info!(target: LOG_TARGET, "Connected to rendezvous server {}. Registering", peer_id);
+            let ns = self.get_rendezvous_namespace();
+            if let Err(err) = self
+                .swarm
+                .behaviour_mut()
+                .rendezvous_client
+                // Default Ttl of 10 hours
+                .register(ns, peer_id, Some(10 * 60 * 20))
+            {
+                warn!(target: LOG_TARGET, "Failed to register with rendezvous server {}: {}", peer_id, err);
+            }
+        }
+
         self.update_connected_peers(&peer_id, &info);
 
-        let is_relay = info.protocols.contains(&relay::HOP_PROTOCOL_NAME);
+        let is_relay = info.protocols.contains(&protocol_ids::RELAY_HOP_PROTOCOL);
 
         let is_connected_through_relay = self
             .active_connections
@@ -976,11 +974,6 @@ where
 
         match self.swarm.listen_on(circuit_addr.clone()) {
             Ok(id) => {
-                let local_peer_id = *self.swarm.local_peer_id();
-                self.swarm
-                    .behaviour_mut()
-                    .peer_sync
-                    .add_known_local_public_addresses(vec![circuit_addr.with(Protocol::P2p(local_peer_id))]);
                 info!(target: LOG_TARGET, "🌍️ Peer {peer_id} is a relay. Listening (id={id:?}) for circuit connections");
                 let Some(relay_mut) = self.relays.selected_relay_mut() else {
                     // unreachable
@@ -1046,6 +1039,11 @@ where
         if let Ok(num) = self.tx_events.send(event) {
             debug!(target: LOG_TARGET, "📢 Published networking event to {num} subscribers");
         }
+    }
+
+    fn get_rendezvous_namespace(&self) -> Namespace {
+        // Panic: namespace MUST be less than 255 characters
+        Namespace::new(self.config.rendezvous_namespace.clone()).expect("configuration error")
     }
 }
 

--- a/networking/swarm/Cargo.toml
+++ b/networking/swarm/Cargo.toml
@@ -7,12 +7,11 @@ repository.workspace = true
 license.workspace = true
 
 [features]
-metrics = ["libp2p/metrics", "libp2p-substream/metrics", "libp2p-messaging/metrics", "libp2p-peersync/metrics"]
+metrics = ["libp2p/metrics", "libp2p-substream/metrics", "libp2p-messaging/metrics"]
 
 [dependencies]
-libp2p = { workspace = true, features = ["tokio", "noise", "macros", "ping", "tcp", "identify", "yamux", "relay", "quic", "dcutr", "gossipsub", "mdns", "autonat"] }
+libp2p = { workspace = true, features = ["tokio", "noise", "macros", "ping", "tcp", "identify", "yamux", "relay", "quic", "dcutr", "gossipsub", "mdns", "autonat", "rendezvous", "peer-store"] }
 libp2p-messaging = { workspace = true, features = ["prost"] }
 libp2p-substream = { workspace = true }
-libp2p-peersync = { workspace = true }
 
 thiserror = { workspace = true }

--- a/networking/swarm/src/behaviour.rs
+++ b/networking/swarm/src/behaviour.rs
@@ -16,8 +16,11 @@ use libp2p::{
     identity::Keypair,
     mdns,
     noise,
+    peer_store,
+    peer_store::memory_store::MemoryStore,
     ping,
     relay,
+    rendezvous,
     swarm::{behaviour::toggle::Toggle, NetworkBehaviour},
     tcp,
     yamux,
@@ -26,14 +29,14 @@ use libp2p::{
     SwarmBuilder,
 };
 use libp2p_messaging as messaging;
-use libp2p_peersync as peer_sync;
-use libp2p_peersync::store::MemoryPeerStore;
 use libp2p_substream as substream;
 
 use crate::{
     config::{Config, RelayCircuitLimits, RelayReservationLimits},
     error::TariSwarmError,
 };
+
+pub type PeerData = ();
 
 #[derive(NetworkBehaviour)]
 pub struct TariNodeBehaviour<TCodec>
@@ -49,7 +52,9 @@ where TCodec: messaging::Codec + Send + Clone + 'static
 
     pub identify: identify::Behaviour,
     pub mdns: Toggle<mdns::tokio::Behaviour>,
-    pub peer_sync: peer_sync::Behaviour<MemoryPeerStore>,
+    pub rendezvous_server: Toggle<rendezvous::server::Behaviour>,
+    pub rendezvous_client: rendezvous::client::Behaviour,
+    pub peer_store: peer_store::Behaviour<MemoryStore<PeerData>>,
 
     pub substream: substream::Behaviour,
     pub messaging: Toggle<messaging::Behaviour<TCodec>>,
@@ -149,9 +154,18 @@ where
             // autonat
             let autonat = autonat::Behaviour::new(local_peer_id, autonat::Config::default());
 
-            // Peer sync
-            let peer_sync =
-                peer_sync::Behaviour::new(keypair.clone(), MemoryPeerStore::new(), peer_sync::Config::default());
+            // Rendezvous server
+            let rendezvous_server = if config.rendezvous_server_enabled {
+                Some(rendezvous::server::Behaviour::new(rendezvous::server::Config::default()))
+            } else {
+                None
+            };
+
+            // Rendezvous client
+            let rendezvous_client = rendezvous::client::Behaviour::new(keypair.clone());
+
+            // Peer store
+            let peer_store = peer_store::Behaviour::new(MemoryStore::new(peer_store::memory_store::Config::default()));
 
             Ok(TariNodeBehaviour {
                 ping,
@@ -165,7 +179,9 @@ where
                 messaging: Toggle::from(messaging),
                 connection_limits,
                 mdns: Toggle::from(maybe_mdns),
-                peer_sync,
+                peer_store,
+                rendezvous_server: Toggle::from(rendezvous_server),
+                rendezvous_client,
             })
         })
         .map_err(|e| TariSwarmError::BehaviourError(e.to_string()))?

--- a/networking/swarm/src/config.rs
+++ b/networking/swarm/src/config.rs
@@ -8,6 +8,7 @@ use libp2p::ping;
 use crate::protocol_version::ProtocolVersion;
 
 #[derive(Debug, Clone)]
+#[allow(clippy::struct_excessive_bools)]
 pub struct Config {
     pub protocol_version: ProtocolVersion,
     pub user_agent: String,
@@ -22,6 +23,7 @@ pub struct Config {
     pub relay_reservation_limits: RelayReservationLimits,
     pub identify_interval: Duration,
     pub gossip_sub_max_message_size: usize,
+    pub rendezvous_server_enabled: bool,
 }
 
 impl Default for Config {
@@ -42,6 +44,7 @@ impl Default for Config {
             identify_interval: Duration::from_secs(5 * 60),
             // 128KiB, 2 times the libp2p default
             gossip_sub_max_message_size: 124 * 1024,
+            rendezvous_server_enabled: false,
         }
     }
 }

--- a/networking/swarm/src/lib.rs
+++ b/networking/swarm/src/lib.rs
@@ -8,6 +8,7 @@ mod protocol_version;
 
 #[cfg(feature = "metrics")]
 pub mod metrics;
+pub mod protocol_ids;
 
 pub use behaviour::*;
 pub use config::Config;
@@ -16,7 +17,6 @@ pub use protocol_version::*;
 
 pub type TariSwarm<TMsg> = libp2p::Swarm<TariNodeBehaviour<TMsg>>;
 
-pub use libp2p::{identity, swarm};
+pub use libp2p::{identity, rendezvous, swarm};
 pub use libp2p_messaging as messaging;
-pub use libp2p_peersync as peersync;
 pub use libp2p_substream as substream;

--- a/networking/swarm/src/metrics.rs
+++ b/networking/swarm/src/metrics.rs
@@ -29,13 +29,15 @@ impl<TCodec: libp2p_messaging::Codec + Send + Clone + 'static> Recorder<TariNode
             TariNodeBehaviourEvent::Identify(identify_event) => self.libp2p_metrics.record(identify_event),
             TariNodeBehaviourEvent::RelayClient(_) => {}, // Metrics not implemented for RelayClient
             TariNodeBehaviourEvent::Relay(relay_event) => self.libp2p_metrics.record(relay_event),
+            TariNodeBehaviourEvent::RendezvousServer(_) => {}, // Metrics not implemented
+            TariNodeBehaviourEvent::RendezvousClient(_) => {}, // Metrics not implemented
+            TariNodeBehaviourEvent::PeerStore(_) => {},        // No metrics for PeerStore events
             TariNodeBehaviourEvent::Gossipsub(gossipsub_event) => self.libp2p_metrics.record(gossipsub_event),
             TariNodeBehaviourEvent::Messaging(messaging_event) => self.extended_metrics.record(messaging_event),
             TariNodeBehaviourEvent::Substream(substream_event) => self.extended_metrics.record(substream_event),
             TariNodeBehaviourEvent::ConnectionLimits(_) => {}, // No events for connection limits
             TariNodeBehaviourEvent::Mdns(_) => {},             // No metrics for mDNS events
             TariNodeBehaviourEvent::Autonat(_) => {},          // No metrics for Autonat events
-            TariNodeBehaviourEvent::PeerSync(peer_sync_event) => self.extended_metrics.record(peer_sync_event),
         }
     }
 }
@@ -43,7 +45,6 @@ impl<TCodec: libp2p_messaging::Codec + Send + Clone + 'static> Recorder<TariNode
 pub struct ExtendedMetrics {
     substream: libp2p_substream::metrics::Metrics,
     messaging: libp2p_messaging::metrics::Metrics,
-    peer_sync: libp2p_peersync::metrics::Metrics,
 }
 
 impl ExtendedMetrics {
@@ -52,7 +53,6 @@ impl ExtendedMetrics {
         Self {
             substream: libp2p_substream::metrics::Metrics::new(registry),
             messaging: libp2p_messaging::metrics::Metrics::new(registry),
-            peer_sync: libp2p_peersync::metrics::Metrics::new(registry),
         }
     }
 }
@@ -66,11 +66,5 @@ impl Recorder<libp2p_substream::Event> for ExtendedMetrics {
 impl<TMsg> Recorder<libp2p_messaging::Event<TMsg>> for ExtendedMetrics {
     fn record(&self, event: &libp2p_messaging::Event<TMsg>) {
         self.messaging.record(event);
-    }
-}
-
-impl Recorder<libp2p_peersync::Event> for ExtendedMetrics {
-    fn record(&self, event: &libp2p_peersync::Event) {
-        self.peer_sync.record(event);
     }
 }

--- a/networking/swarm/src/protocol_ids.rs
+++ b/networking/swarm/src/protocol_ids.rs
@@ -1,0 +1,4 @@
+//    Copyright 2025 The Tari Project
+//    SPDX-License-Identifier: BSD-3-Clause
+
+pub use libp2p::relay::HOP_PROTOCOL_NAME as RELAY_HOP_PROTOCOL;


### PR DESCRIPTION
Description
---
feat: implement rendezvous protocol, remove peer sync
feat(swarm): optionally connect validator nodes "manually"
fix: removes peer anounce broadcast
feat: adds the new peer store behaviour from libp2p

Motivation and Context
---
Basic implementation of rendezvous discovery with configuration of a rendezvous server.

If mDNS does not work (as it does on my current network/machine) then swarm nodes cannot connect. To account for this, I added an option to the swarm config where you may enable "manual" connection of validator nodes i.e. getting all peer ids and addresses using JSON-RPC and manually adding peers to each validator. Testing rendezvous in swarm is tricky as the rendezvous server needs to be set at startup, before we know the peer id and addresses of other peers. There would be ways to achieve this, but it's easier to manually connect. 

How Has This Been Tested?
---
Swarm changes tested manually. Testing of rendezvous implementation would be better on a test network, so I plan to do that.
 
What process can a PR reviewer use to test or verify this change?
---
N/A

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify