### PR TITLE
feat(swarm): allows overriding start port per instance type

### DIFF
--- a/applications/tari_app_utilities/config_presets/e_wallet_daemon.toml
+++ b/applications/tari_app_utilities/config_presets/e_wallet_daemon.toml
@@ -16,4 +16,4 @@
 # indexer_json_rpc_url = "http://127.0.0.1:18200/json_rpc"
 [igor.ootle_wallet_daemon]
 # Indexer JSON-RPC url for Igor.
-indexer_json_rpc_url = "http://18.217.22.26:12008/json_rpc"
+indexer_json_rpc_url = "http://18.217.22.26:12500/json_rpc"

--- a/applications/tari_swarm_daemon/src/config.rs
+++ b/applications/tari_swarm_daemon/src/config.rs
@@ -129,6 +129,9 @@ pub struct InstanceConfig {
     pub settings: HashMap<String, String>,
     #[serde(default)]
     pub envs: Vec<(String, String)>,
+    /// Override the initial port-allocation port for this instance.
+    #[serde(default, rename = "start_port")]
+    pub start_port_override: Option<u16>,
 }
 
 impl InstanceConfig {
@@ -140,6 +143,7 @@ impl InstanceConfig {
             instance_type,
             num_instances: 1,
             settings: HashMap::new(),
+            start_port_override: None,
             envs: Vec::new(),
         }
     }
@@ -183,7 +187,7 @@ impl InstanceConfig {
     }
 }
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, serde::Serialize, serde::Deserialize)]
 pub enum InstanceType {
     MinoTariNode,
     MinoTariConsoleWallet,

--- a/applications/tari_swarm_daemon/src/process_manager/instances/manager.rs
+++ b/applications/tari_swarm_daemon/src/process_manager/instances/manager.rs
@@ -65,6 +65,7 @@ impl InstanceManager {
     ) -> Self {
         Self {
             base_path,
+            port_allocator: PortAllocator::new(start_port, &config),
             config,
             network,
             global_settings,
@@ -75,7 +76,6 @@ impl InstanceManager {
             indexers: IndexMap::new(),
             wallet_daemons: IndexMap::new(),
             signaling_servers: IndexMap::new(),
-            port_allocator: PortAllocator::new(start_port),
             instance_id: 0,
         }
     }
@@ -158,7 +158,7 @@ impl InstanceManager {
             listen_ip
         );
 
-        let mut allocated_ports = ports.unwrap_or_else(|| self.port_allocator.create());
+        let mut allocated_ports = ports.unwrap_or_else(|| self.port_allocator.create(instance_type));
 
         let processes_path = self.base_path.join("processes");
         let base_path = match base_path_override {

--- a/applications/tari_swarm_daemon/src/process_manager/port_allocator.rs
+++ b/applications/tari_swarm_daemon/src/process_manager/port_allocator.rs
@@ -1,38 +1,52 @@
 //   Copyright 2024 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use std::{collections::HashMap, net::SocketAddr};
+use std::{
+    collections::HashMap,
+    net::SocketAddr,
+    sync::{atomic, atomic::AtomicU16, Arc},
+};
 
 use tokio::net::TcpListener;
 
-use crate::process_manager::InstanceId;
+use crate::{
+    config::{InstanceConfig, InstanceType},
+    process_manager::InstanceId,
+};
 
 pub struct PortAllocator {
     instances: HashMap<InstanceId, AllocatedPorts>,
-    current_port: u16,
+    start_port_overrides: HashMap<InstanceType, Arc<AtomicU16>>,
+    current_port: Arc<AtomicU16>,
 }
 
 impl PortAllocator {
-    pub fn new(start_port: u16) -> Self {
+    pub fn new(start_port: u16, instance_config: &[InstanceConfig]) -> Self {
         Self {
             instances: HashMap::new(),
-            current_port: start_port,
+            start_port_overrides: instance_config
+                .iter()
+                .filter_map(|c| {
+                    c.start_port_override
+                        .map(|p| (c.instance_type, Arc::new(AtomicU16::new(p))))
+                })
+                .collect(),
+            current_port: Arc::new(AtomicU16::new(start_port)),
         }
     }
 
-    // pub fn get_ports(&self, instance_id: InstanceId) -> Option<&AllocatedPorts> {
-    //     self.instances.get(&instance_id)
-    // }
-
-    pub fn create(&mut self) -> AllocatedPorts {
+    pub fn create(&mut self, instance_type: InstanceType) -> AllocatedPorts {
         AllocatedPorts {
             ports: HashMap::new(),
-            current_port: self.current_port,
+            current_port: self
+                .start_port_overrides
+                .get(&instance_type)
+                .cloned()
+                .unwrap_or_else(|| self.current_port.clone()),
         }
     }
 
     pub fn register(&mut self, instance_id: InstanceId, ports: AllocatedPorts) {
-        self.current_port = ports.current_port;
         self.instances.insert(instance_id, ports);
     }
 
@@ -43,7 +57,7 @@ impl PortAllocator {
 
 #[derive(Debug, Clone)]
 pub struct AllocatedPorts {
-    current_port: u16,
+    current_port: Arc<AtomicU16>,
     ports: HashMap<&'static str, u16>,
 }
 
@@ -60,13 +74,16 @@ impl AllocatedPorts {
         self.ports
     }
 
+    fn next_port(&self) -> u16 {
+        self.current_port.fetch_add(1, atomic::Ordering::SeqCst)
+    }
+
     pub async fn get_or_next_port(&mut self, name: &'static str) -> u16 {
         if let Some(port) = self.ports.get(name) {
             return *port;
         }
         loop {
-            let port = self.current_port;
-            self.current_port += 1;
+            let port = self.next_port();
             if check_local_port(port).await {
                 log::debug!("Port {port} is free for {name}");
                 self.ports.insert(name, port);


### PR DESCRIPTION
Description
---
feat(swarm): allows overriding start port per instance type
update default indexer url for igor network

Motivation and Context
---
This is useful when we need to set a consistent port for a particular instance type, e.g indexer, regardless of how many other instances e.g validators nodes we have in a network. 

How Has This Been Tested?
---
Running a swarm with a start port override configured

What process can a PR reviewer use to test or verify this change?
---
As above

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify