### PR TITLE
fix(ci): rename packages, only build necessary

### DIFF
--- a/.github/workflows/build_binaries.json
+++ b/.github/workflows/build_binaries.json
@@ -4,6 +4,7 @@
     "runs-on": "ubuntu-22.04",
     "rust": "1.77",
     "target": "x86_64-unknown-linux-gnu",
+    "target_bins": "tari_ootle_walletd, tari_indexer, tari_validator_node, tari_swarm_daemon",
     "cross": false,
     "features": ""
   },
@@ -13,7 +14,7 @@
     "rust": "1.77",
     "target": "aarch64-unknown-linux-gnu",
     "cross": false,
-    "flags": "--workspace --exclude tari_integration_tests",
+    "target_bins": "tari_ootle_walletd, tari_indexer, tari_validator_node, tari_swarm_daemon",
     "build_enabled": true,
     "best_effort": true
   },
@@ -23,7 +24,7 @@
     "rust": "stable",
     "target": "riscv64gc-unknown-linux-gnu",
     "cross": true,
-    "flags": "--workspace --exclude tari_integration_tests",
+    "target_bins": "tari_ootle_walletd, tari_indexer, tari_validator_node, tari_swarm_daemon",
     "build_enabled": true,
     "best_effort": true
   },
@@ -32,6 +33,7 @@
     "runs-on": "macos-13",
     "rust": "1.77",
     "target": "x86_64-apple-darwin",
+    "target_bins": "tari_ootle_walletd, tari_indexer, tari_validator_node, tari_swarm_daemon",
     "cross": false,
     "features": ""
   },
@@ -40,6 +42,7 @@
     "runs-on": "macos-14",
     "rust": "1.77",
     "target": "aarch64-apple-darwin",
+    "target_bins": "tari_ootle_walletd, tari_indexer, tari_validator_node, tari_swarm_daemon",
     "cross": false,
     "features": "",
     "build_enabled": true,
@@ -50,6 +53,7 @@
     "runs-on": "windows-2019",
     "rust": "1.77",
     "target": "x86_64-pc-windows-msvc",
+    "target_bins": "tari_ootle_walletd, tari_indexer, tari_validator_node, tari_swarm_daemon",
     "cross": false,
     "features": ""
   },
@@ -59,7 +63,7 @@
     "rust": "1.77",
     "target": "aarch64-pc-windows-msvc",
     "cross": false,
-    "target_bins": "tari_ootle_wallet_cli, tari_ootle_walletd, tari_indexer, tari_validator_node, tari_signaling_server",
+    "target_bins": "tari_ootle_walletd, tari_indexer, tari_validator_node, tari_swarm_daemon",
     "features": "",
     "build_enabled": true,
     "best_effort": true

--- a/.github/workflows/build_binaries.json
+++ b/.github/workflows/build_binaries.json
@@ -2,19 +2,17 @@
   {
     "name": "linux-x86_64",
     "runs-on": "ubuntu-22.04",
-    "rust": "1.77",
+    "rust": "stable",
     "target": "x86_64-unknown-linux-gnu",
-    "target_bins": "tari_ootle_walletd, tari_indexer, tari_validator_node, tari_swarm_daemon",
     "cross": false,
     "features": ""
   },
   {
     "name": "linux-arm64",
     "runs-on": "ubuntu-22.04-arm",
-    "rust": "1.77",
+    "rust": "stable",
     "target": "aarch64-unknown-linux-gnu",
     "cross": false,
-    "target_bins": "tari_ootle_walletd, tari_indexer, tari_validator_node, tari_swarm_daemon",
     "build_enabled": true,
     "best_effort": true
   },
@@ -24,25 +22,22 @@
     "rust": "stable",
     "target": "riscv64gc-unknown-linux-gnu",
     "cross": true,
-    "target_bins": "tari_ootle_walletd, tari_indexer, tari_validator_node, tari_swarm_daemon",
     "build_enabled": true,
     "best_effort": true
   },
   {
     "name": "macos-x86_64",
     "runs-on": "macos-13",
-    "rust": "1.77",
+    "rust": "stable",
     "target": "x86_64-apple-darwin",
-    "target_bins": "tari_ootle_walletd, tari_indexer, tari_validator_node, tari_swarm_daemon",
     "cross": false,
     "features": ""
   },
   {
     "name": "macos-arm64",
     "runs-on": "macos-14",
-    "rust": "1.77",
+    "rust": "stable",
     "target": "aarch64-apple-darwin",
-    "target_bins": "tari_ootle_walletd, tari_indexer, tari_validator_node, tari_swarm_daemon",
     "cross": false,
     "features": "",
     "build_enabled": true,
@@ -51,19 +46,17 @@
   {
     "name": "windows-x64",
     "runs-on": "windows-2019",
-    "rust": "1.77",
+    "rust": "stable",
     "target": "x86_64-pc-windows-msvc",
-    "target_bins": "tari_ootle_walletd, tari_indexer, tari_validator_node, tari_swarm_daemon",
     "cross": false,
     "features": ""
   },
   {
     "name": "windows-arm64",
     "runs-on": "windows-latest",
-    "rust": "1.77",
+    "rust": "stable",
     "target": "aarch64-pc-windows-msvc",
     "cross": false,
-    "target_bins": "tari_ootle_walletd, tari_indexer, tari_validator_node, tari_swarm_daemon",
     "features": "",
     "build_enabled": true,
     "best_effort": true

--- a/.github/workflows/build_binaries.yml
+++ b/.github/workflows/build_binaries.yml
@@ -21,8 +21,7 @@ env:
   TS_FILENAME: "tari_ootle"
   TS_BUNDLE_ID_BASE: "com.tari.ootle.pkg"
   TS_SIG_FN: "sha256-unsigned.txt"
-  ## Must be a JSon string
-  #  TS_FILES: '["tari_ootle_wallet_cli","tari_ootle_walletd","tari_indexer","tari_validator_node","tari_generate","tari_swarm_daemon"]'
+  ## Must be a JSON string
   TS_FILES: '["tari_ootle_walletd","tari_indexer","tari_validator_node","tari_swarm_daemon"]'
   TS_FEATURES: "default"
   TS_LIBRARIES: ""

--- a/.github/workflows/build_binaries.yml
+++ b/.github/workflows/build_binaries.yml
@@ -18,14 +18,15 @@ name: Build Matrix of Binaries
         default: "development-tag"
 
 env:
-  TS_FILENAME: "tari_network_suite"
-  TS_BUNDLE_ID_BASE: "com.tari.network.pkg"
+  TS_FILENAME: "tari_ootle"
+  TS_BUNDLE_ID_BASE: "com.tari.ootle.pkg"
   TS_SIG_FN: "sha256-unsigned.txt"
   ## Must be a JSon string
-  TS_FILES: '["tari_ootle_wallet_cli","tari_ootle_walletd","tari_indexer","tari_validator_node","tari_generate","tari_swarm_daemon"]'
+  #  TS_FILES: '["tari_ootle_wallet_cli","tari_ootle_walletd","tari_indexer","tari_validator_node","tari_generate","tari_swarm_daemon"]'
+  TS_FILES: '["tari_ootle_walletd","tari_indexer","tari_validator_node","tari_swarm_daemon"]'
   TS_FEATURES: "default"
   TS_LIBRARIES: ""
-  TS_DESCRIPTION: "Tari Suite"
+  TS_DESCRIPTION: "Tari Ootle"
   TS_URL: "https://tari.com"
   # For debug builds
   # TS_BUILD: "debug"


### PR DESCRIPTION
Description
---
tari_network_suite -> tari_ootle
Only include wallet, indexer, vn and swarm in builds 

Motivation and Context
---
Bins like tari_generate and wallet cli are not used or not critical at this stage.
