### PR TITLE
fix(template_lib)!: remove unused vault/bucket functions + docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11793,16 +11793,17 @@ dependencies = [
 name = "tari_template_builtin"
 version = "0.10.3"
 dependencies = [
+ "serde",
+ "tari_bor",
  "tari_engine_types",
  "tari_template_lib",
- "tari_template_lib_types",
  "tari_template_test_tooling",
  "tari_transaction",
 ]
 
 [[package]]
 name = "tari_template_lib"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "borsh",
  "newtype-ops",

--- a/applications/tari_walletd/src/handlers/confidential.rs
+++ b/applications/tari_walletd/src/handlers/confidential.rs
@@ -107,7 +107,6 @@ pub async fn handle_create_transfer_proof(
             anyhow::anyhow!("Indexer returned a non-resource substate when scanning for a resource address")
         })?
         .to_view_key_public_key()
-        .transpose()
         .map_err(|_| {
             JsonRpcError::new(
                 JsonRpcErrorReason::InvalidRequest,

--- a/crates/engine/src/runtime/engine_args.rs
+++ b/crates/engine/src/runtime/engine_args.rs
@@ -19,6 +19,13 @@ impl EngineArgs {
     }
 
     pub fn get<T: DeserializeOwned>(&self, index: usize) -> Result<T, RuntimeError> {
+        self.get_opt(index)?.ok_or_else(|| RuntimeError::InvalidArgument {
+            argument: type_name::<T>(),
+            reason: "Argument not provided".to_string(),
+        })
+    }
+
+    pub fn get_opt<T: DeserializeOwned>(&self, index: usize) -> Result<Option<T>, RuntimeError> {
         self.args
             .get(index)
             .map(|arg| decode_exact(arg))
@@ -26,10 +33,6 @@ impl EngineArgs {
             .map_err(|e| RuntimeError::InvalidArgument {
                 argument: type_name::<T>(),
                 reason: format!("Argument failed to decode. Err: {:?}", e),
-            })?
-            .ok_or_else(|| RuntimeError::InvalidArgument {
-                argument: type_name::<T>(),
-                reason: "Argument not provided".to_string(),
             })
     }
 

--- a/crates/engine/src/runtime/impl.rs
+++ b/crates/engine/src/runtime/impl.rs
@@ -1337,7 +1337,6 @@ impl<TTemplateProvider: TemplateProvider<Template = LoadedTemplate>> RuntimeInte
                     let maybe_view_key =
                         resource
                             .to_view_key_public_key()
-                            .transpose()
                             .map_err(|e| RuntimeError::InvariantError {
                                 function: "VaultAction::Withdraw",
                                 details: format!(
@@ -1496,7 +1495,6 @@ impl<TTemplateProvider: TemplateProvider<Template = LoadedTemplate>> RuntimeInte
                     let maybe_view_key =
                         resource
                             .to_view_key_public_key()
-                            .transpose()
                             .map_err(|e| RuntimeError::InvariantError {
                                 function: "VaultAction::ConfidentialReveal",
                                 details: format!(
@@ -1507,7 +1505,7 @@ impl<TTemplateProvider: TemplateProvider<Template = LoadedTemplate>> RuntimeInte
                             })?;
 
                     let vault_mut = state.get_vault_mut(&vault_lock)?;
-                    let resource_container = vault_mut.reveal_confidential(arg.proof, maybe_view_key.as_ref())?;
+                    let resource_container = vault_mut.withdraw_confidential(arg.proof, maybe_view_key.as_ref())?;
                     let bucket_id = state.id_provider()?.new_bucket_id();
                     state.new_bucket(bucket_id, resource_container)?;
 
@@ -1552,18 +1550,12 @@ impl<TTemplateProvider: TemplateProvider<Template = LoadedTemplate>> RuntimeInte
                         resource.as_ownership(),
                         resource.access_rules(),
                     )?;
-                    let view_key =
-                        resource
-                            .to_view_key_public_key()
-                            .transpose()
-                            .map_err(|e| RuntimeError::InvariantError {
-                                function: "VaultAction::PayFee",
-                                details: format!(
-                                    "Resource {} has a malformed view key: {}",
-                                    resource_lock.address(),
-                                    e
-                                ),
-                            })?;
+                    let view_key = resource
+                        .to_view_key_public_key()
+                        .map_err(|e| RuntimeError::InvariantError {
+                            function: "VaultAction::PayFee",
+                            details: format!("Resource {} has a malformed view key: {}", resource_lock.address(), e),
+                        })?;
 
                     let vault_mut = state.get_vault_mut(&vault_lock)?;
 
@@ -1573,7 +1565,7 @@ impl<TTemplateProvider: TemplateProvider<Template = LoadedTemplate>> RuntimeInte
                         container.deposit(withdrawn)?;
                     }
                     if let Some(proof) = arg.proof {
-                        let revealed = vault_mut.reveal_confidential(proof, view_key.as_ref())?;
+                        let revealed = vault_mut.withdraw_confidential(proof, view_key.as_ref())?;
                         container.deposit(revealed)?;
                     }
                     if container.amount().is_zero() {
@@ -1820,18 +1812,12 @@ impl<TTemplateProvider: TemplateProvider<Template = LoadedTemplate>> RuntimeInte
                     let bucket = state.get_bucket(bucket_id)?;
                     let resource_lock = state.read_lock_substate(&(*bucket.resource_address()).into())?;
                     let resource = state.get_resource(&resource_lock)?;
-                    let view_key =
-                        resource
-                            .to_view_key_public_key()
-                            .transpose()
-                            .map_err(|e| RuntimeError::InvariantError {
-                                function: "BucketAction::TakeConfidential",
-                                details: format!(
-                                    "Resource {} has a malformed view key: {}",
-                                    resource_lock.address(),
-                                    e
-                                ),
-                            })?;
+                    let view_key = resource
+                        .to_view_key_public_key()
+                        .map_err(|e| RuntimeError::InvariantError {
+                            function: "BucketAction::TakeConfidential",
+                            details: format!("Resource {} has a malformed view key: {}", resource_lock.address(), e),
+                        })?;
                     let bucket_mut = state.get_bucket_mut(bucket_id)?;
                     let resource = bucket_mut.take_confidential(proof, view_key.as_ref())?;
                     let bucket_id = state.id_provider()?.new_bucket_id();
@@ -1851,36 +1837,6 @@ impl<TTemplateProvider: TemplateProvider<Template = LoadedTemplate>> RuntimeInte
                     let other_bucket = state.take_bucket(other_bucket_id)?;
                     let bucket = state.get_bucket_mut(bucket_id)?;
                     bucket.join(other_bucket)?;
-                    Ok(InvokeResult::encode(&bucket_id)?)
-                })
-            },
-            BucketAction::RevealConfidential => {
-                let bucket_id = bucket_ref.bucket_id().ok_or_else(|| RuntimeError::InvalidArgument {
-                    argument: "bucket_ref",
-                    reason: "RevealConfidential bucket action requires a bucket id".to_string(),
-                })?;
-                let proof = args.assert_one_arg()?;
-                self.tracker.write_with(|state| {
-                    let bucket = state.get_bucket(bucket_id)?;
-                    let resource_lock = state.read_lock_substate(&(*bucket.resource_address()).into())?;
-                    let resource = state.get_resource(&resource_lock)?;
-                    let view_key =
-                        resource
-                            .to_view_key_public_key()
-                            .transpose()
-                            .map_err(|e| RuntimeError::InvariantError {
-                                function: "BucketAction::RevealConfidential",
-                                details: format!(
-                                    "Resource {} has a malformed view key: {}",
-                                    resource_lock.address(),
-                                    e
-                                ),
-                            })?;
-                    let bucket = state.get_bucket_mut(bucket_id)?;
-                    let resource = bucket.reveal_confidential(proof, view_key.as_ref())?;
-                    let bucket_id = state.id_provider()?.new_bucket_id();
-                    state.new_bucket(bucket_id, resource)?;
-                    state.unlock_substate(resource_lock)?;
                     Ok(InvokeResult::encode(&bucket_id)?)
                 })
             },

--- a/crates/engine/src/runtime/working_state.rs
+++ b/crates/engine/src/runtime/working_state.rs
@@ -548,12 +548,12 @@ impl WorkingState {
                     target: LOG_TARGET,
                     "Minting confidential tokens on resource: {}", resource_address
                 );
-                let maybe_view_key = resource.to_view_key_public_key().transpose().map_err(|e| {
-                    RuntimeError::InvariantError {
+                let maybe_view_key = resource
+                    .to_view_key_public_key()
+                    .map_err(|e| RuntimeError::InvariantError {
                         function: "MintArg::Confidential",
                         details: format!("Resource contained a malformed view key: {e}. This should never happen!",),
-                    }
-                })?;
+                    })?;
                 ResourceContainer::mint_confidential(resource_address, *proof, maybe_view_key.as_ref())?
             },
         };

--- a/crates/engine/tests/confidential.rs
+++ b/crates/engine/tests/confidential.rs
@@ -12,6 +12,7 @@ use tari_engine_types::{
     substate::SubstateId,
 };
 use tari_ootle_common_types::substate_type::SubstateType;
+use tari_template_builtin::account::Account;
 use tari_template_lib::{
     call_args,
     models::{Amount, ComponentAddress},
@@ -163,7 +164,7 @@ fn transfer_confidential_amounts_between_accounts() {
         let coins1 = account1.withdraw_confidential(faucet_resx, withdraw_proof);
 
         let split_proof = var!["split_proof"];
-        let coins2 = ConfidentialUtilities::split(coins1, split_proof);
+        let coins2 = ConfidentialUtilities::take_from_bucket(coins1, split_proof);
 
         account1.deposit(coins1);
         account2.deposit(coins2);
@@ -216,11 +217,11 @@ fn transfer_confidential_fails_with_invalid_balance() {
 #[test]
 fn reveal_confidential_and_transfer() {
     let (confidential_proof, faucet_mask, _change) = generate_confidential_proof(Amount(100_000), None);
-    let (mut template_test, faucet, faucet_resx) = setup(confidential_proof, None);
+    let (mut test, faucet, faucet_resx) = setup(confidential_proof, None);
 
     // Create an account
-    let (account1, owner1, _k) = template_test.create_funded_account();
-    let (account2, owner2, _k) = template_test.create_funded_account();
+    let (account1, owner1, _k) = test.create_funded_account();
+    let (account2, owner2, _k) = test.create_funded_account();
 
     // Create proof for transfer
 
@@ -230,6 +231,7 @@ fn reveal_confidential_and_transfer() {
     // Then reveal the rest
     let reveal_bucket_proof = generate_withdraw_proof(&reveal_proof.output_mask, Amount(0), None, Amount(10));
 
+    let faucet_resx = faucet_resx.as_resource_address().unwrap();
     // Transfer faucet funds into account 1
     let vars = [
         ("faucet", faucet.into()),
@@ -243,7 +245,7 @@ fn reveal_confidential_and_transfer() {
             ManifestValue::new_value(&reveal_bucket_proof.proof).unwrap(),
         ),
     ];
-    let result = template_test
+    let _result = test
         .execute_and_commit_manifest(
             r#"
         let faucet = var!["faucet"];
@@ -259,10 +261,10 @@ fn reveal_confidential_and_transfer() {
         account1.deposit(coins);
 
         // Reveal 90 tokens and 10 confidentially and deposit both funds into account 2
-        let revealed_funds = account1.reveal_confidential(resource, reveal_proof);
-        let revealed_rest_funds = ConfidentialUtilities::reveal(revealed_funds, reveal_bucket_proof);
-        account2.deposit(revealed_funds);
-        account2.deposit(revealed_rest_funds);
+        let revealed_funds = account1.withdraw_confidential(resource, reveal_proof);
+        let revealed_rest_funds = ConfidentialUtilities::take_from_bucket(revealed_funds, reveal_bucket_proof);
+        let joined = ConfidentialUtilities::join_buckets(revealed_funds, revealed_rest_funds);
+        account2.deposit(joined);
 
         // Account2 can withdraw revealed funds by amount
         let small_amt = account2.withdraw(resource, Amount(10));
@@ -276,14 +278,17 @@ fn reveal_confidential_and_transfer() {
         )
         .unwrap();
 
-    assert_eq!(
-        result.finalize.execution_results[12].decode::<Amount>().unwrap(),
-        Amount(10)
-    );
-    assert_eq!(
-        result.finalize.execution_results[13].decode::<Amount>().unwrap(),
-        Amount(90)
-    );
+    let acc1 = test.read_only_state_store().get_component(account1).unwrap();
+    let acc1 = Account::from_value(acc1.state()).unwrap();
+    let vault1 = acc1.get_vault_by_resource(&faucet_resx).unwrap();
+    let vault1 = test.read_only_state_store().get_vault(&vault1).unwrap();
+    assert_eq!(vault1.balance(), Amount(10));
+
+    let acc2 = test.read_only_state_store().get_component(account2).unwrap();
+    let acc2 = Account::from_value(acc2.state()).unwrap();
+    let vault2 = acc2.get_vault_by_resource(&faucet_resx).unwrap();
+    let vault2 = test.read_only_state_store().get_vault(&vault2).unwrap();
+    assert_eq!(vault2.balance(), Amount(90));
 }
 
 #[test]
@@ -327,7 +332,7 @@ fn attempt_to_reveal_with_unbalanced_proof() {
         account1.deposit(coins);
 
         // Reveal 100 tokens and deposit revealed funds into account 2
-        let revealed_funds = account1.reveal_confidential(resource, reveal_proof);
+        let revealed_funds = account1.withdraw_confidential(resource, reveal_proof);
         account2.deposit(revealed_funds);
 
         account1.balance(resource);

--- a/crates/engine/tests/templates/confidential/faucet/src/lib.rs
+++ b/crates/engine/tests/templates/confidential/faucet/src/lib.rs
@@ -91,8 +91,9 @@ mod faucet_template {
         }
 
         /// Utility function for tests
-        pub fn split_coins(bucket: Bucket, proof: ConfidentialWithdrawProof) -> (Bucket, Bucket) {
-            bucket.split_confidential(proof)
+        pub fn split_coins(mut bucket: Bucket, proof: ConfidentialWithdrawProof) -> (Bucket, Bucket) {
+            let new_bucket = bucket.take_confidential(proof);
+            (new_bucket, bucket)
         }
 
         pub fn vault_balance(&self) -> Amount {

--- a/crates/engine/tests/templates/confidential/utilities/src/lib.rs
+++ b/crates/engine/tests/templates/confidential/utilities/src/lib.rs
@@ -29,16 +29,14 @@ mod faucet_template {
     pub struct ConfidentialUtilities;
 
     impl ConfidentialUtilities {
-        /// Split a bucket into two buckets, one containing the output commitment and one containing the change
-        /// commitment
-        pub fn split(mut bucket: Bucket, proof: ConfidentialWithdrawProof) -> Bucket {
+        /// Withdraws from a bucket and returns a new bucket containing the withdrawn funds.
+        pub fn take_from_bucket(mut bucket: Bucket, proof: ConfidentialWithdrawProof) -> Bucket {
             bucket.take_confidential(proof)
         }
 
-        /// Split a bucket into two buckets, one containing the output commitment and one containing the change
-        /// commitment
-        pub fn reveal(mut bucket: Bucket, proof: ConfidentialWithdrawProof) -> Bucket {
-            bucket.reveal_confidential(proof)
+        /// Joins two buckets into one, returning a new bucket containing the combined value of the same resource..
+        pub fn join_buckets(mut bucket1: Bucket, bucket2: Bucket) -> Bucket {
+            bucket1.join(bucket2)
         }
     }
 }

--- a/crates/engine/tests/templates/nft/basic_nft/src/lib.rs
+++ b/crates/engine/tests/templates/nft/basic_nft/src/lib.rs
@@ -123,7 +123,7 @@ mod sparkle_nft_template {
                 bucket.resource_address() == self.address,
                 "Cannot burn bucket not from this collection"
             );
-            debug!("Burning bucket {} containing {}", bucket.id(), bucket.amount());
+            debug!("Burning bucket {} containing {}", bucket, bucket.amount());
             // This is all that's required, typically the template would not need to include a burn function because a
             // native instruction can be used instead
             bucket.burn();

--- a/crates/engine/tests/templates/resource/src/lib.rs
+++ b/crates/engine/tests/templates/resource/src/lib.rs
@@ -68,12 +68,8 @@ mod template {
 
         pub fn confidential_join(&self, output: ConfidentialOutputStatement) {
             let commitments = ResourceManager::get(self.confidential.resource_address()).mint_confidential(output);
-            let b1 = self
-                .confidential
-                .withdraw_confidential(ConfidentialWithdrawProof::revealed_withdraw(10));
-            let b2 = self
-                .confidential
-                .withdraw_confidential(ConfidentialWithdrawProof::revealed_withdraw(900));
+            let b1 = self.confidential.withdraw(10);
+            let b2 = self.confidential.withdraw(900);
             let joined = b1.join(b2);
             let joined = joined.join(commitments);
             assert_eq!(joined.amount(), 910);

--- a/crates/engine_types/src/bucket.rs
+++ b/crates/engine_types/src/bucket.rs
@@ -96,14 +96,6 @@ impl Bucket {
         self.resource_container.deposit(other.resource_container)
     }
 
-    pub fn reveal_confidential(
-        &mut self,
-        proof: ConfidentialWithdrawProof,
-        view_key: Option<&RistrettoPublicKey>,
-    ) -> Result<ResourceContainer, ResourceError> {
-        self.resource_container.reveal_confidential(proof, view_key)
-    }
-
     pub fn lock_all(&mut self) -> Result<LockedResource, ResourceError> {
         let locked_resource = self.resource_container.lock_all()?;
         Ok(LockedResource::new(

--- a/crates/engine_types/src/resource.rs
+++ b/crates/engine_types/src/resource.rs
@@ -97,9 +97,11 @@ impl Resource {
         self.view_key.as_ref()
     }
 
-    pub fn to_view_key_public_key(&self) -> Option<Result<RistrettoPublicKey, ByteArrayError>> {
-        let view_key = self.view_key.as_ref()?;
-        Some(RistrettoPublicKey::try_from_byte_type(view_key))
+    pub fn to_view_key_public_key(&self) -> Result<Option<RistrettoPublicKey>, ByteArrayError> {
+        match self.view_key.as_ref() {
+            Some(view_key) => RistrettoPublicKey::try_from_byte_type(view_key).map(Some),
+            None => Ok(None),
+        }
     }
 
     pub fn auth_hook(&self) -> Option<&AuthHook> {

--- a/crates/engine_types/src/resource_container.rs
+++ b/crates/engine_types/src/resource_container.rs
@@ -505,14 +505,6 @@ impl ResourceContainer {
         }
     }
 
-    pub fn reveal_confidential(
-        &mut self,
-        proof: ConfidentialWithdrawProof,
-        view_key: Option<&RistrettoPublicKey>,
-    ) -> Result<ResourceContainer, ResourceError> {
-        self.withdraw_confidential(proof, view_key)
-    }
-
     /// Returns all confidential commitments. If the resource is not confidential, None is returned.
     pub fn get_confidential_commitments(&self) -> Option<&BTreeMap<PedersenCommitmentBytes, ConfidentialOutput>> {
         match self {

--- a/crates/engine_types/src/vault.rs
+++ b/crates/engine_types/src/vault.rs
@@ -119,14 +119,6 @@ impl Vault {
         self.resource_container.non_fungible_token_ids()
     }
 
-    pub fn reveal_confidential(
-        &mut self,
-        proof: ConfidentialWithdrawProof,
-        view_key: Option<&RistrettoPublicKey>,
-    ) -> Result<ResourceContainer, ResourceError> {
-        self.resource_container.reveal_confidential(proof, view_key)
-    }
-
     pub fn resource_container_mut(&mut self) -> &mut ResourceContainer {
         &mut self.resource_container
     }

--- a/crates/template_builtin/Cargo.toml
+++ b/crates/template_builtin/Cargo.toml
@@ -7,7 +7,10 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-tari_template_lib_types = { workspace = true }
+tari_template_lib = { workspace = true }
+tari_bor = { workspace = true }
+
+serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 tari_template_test_tooling = { workspace = true }

--- a/crates/template_builtin/src/account.rs
+++ b/crates/template_builtin/src/account.rs
@@ -1,0 +1,29 @@
+//    Copyright 2025 The Tari Project
+//    SPDX-License-Identifier: BSD-3-Clause
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+use tari_bor::from_value;
+use tari_template_lib::models::{ResourceAddress, Vault, VaultId};
+
+/// Represents an account containing multiple vaults, each identified by a resource address.
+/// This contains the same state as the `Account` built-in template.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Account {
+    vaults: BTreeMap<ResourceAddress, Vault>,
+}
+
+impl Account {
+    pub fn from_value(value: &tari_bor::Value) -> Result<Self, tari_bor::BorError> {
+        from_value(value)
+    }
+
+    pub fn vaults(&self) -> &BTreeMap<ResourceAddress, Vault> {
+        &self.vaults
+    }
+
+    pub fn get_vault_by_resource(&self, resource_address: &ResourceAddress) -> Option<VaultId> {
+        self.vaults.get(resource_address).map(|vault| vault.vault_id())
+    }
+}

--- a/crates/template_builtin/src/lib.rs
+++ b/crates/template_builtin/src/lib.rs
@@ -20,7 +20,9 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use tari_template_lib_types::TemplateAddress;
+pub mod account;
+
+use tari_template_lib::types::TemplateAddress;
 
 pub const ACCOUNT_TEMPLATE_ADDRESS: TemplateAddress = TemplateAddress::from_array([0; 32]);
 pub const NFT_FAUCET_TEMPLATE_ADDRESS: TemplateAddress = TemplateAddress::from_array([

--- a/crates/template_builtin/templates/account/src/lib.rs
+++ b/crates/template_builtin/templates/account/src/lib.rs
@@ -174,21 +174,17 @@ mod account_template {
             self.vaults.iter().map(|(k, v)| (*k, v.balance())).collect()
         }
 
-        pub fn reveal_confidential(&mut self, resource: ResourceAddress, proof: ConfidentialWithdrawProof) -> Bucket {
-            emit_event("reveal_confidential", [
-                ("num_inputs", proof.inputs.len().to_string()),
-                ("resource", resource.to_string()),
-            ]);
-            let v = self.get_vault_mut(resource);
-            v.reveal_confidential(proof)
-        }
-
+        /// Withdraws funds using the ConfidentialWithdrawProof, and immediately deposits the withdraw back into the
+        /// vault. It will panic if the proof is invalid or the resource type contained in the vault is not
+        /// confidential. This is useful for converting confidential tokens into revealed tokens and vice versa.
         pub fn join_confidential(&mut self, resource: ResourceAddress, proof: ConfidentialWithdrawProof) {
             emit_event("join_confidential", [
                 ("num_inputs", proof.inputs.len().to_string()),
                 ("resource", resource.to_string()),
             ]);
-            self.get_vault_mut(resource).join_confidential(proof);
+            let vault_mut = self.get_vault_mut(resource);
+            let bucket = vault_mut.withdraw_confidential(proof);
+            vault_mut.deposit(bucket);
         }
 
         // Fee methods. These are used to pay fees and satisfy a "duck-typed" interface.

--- a/crates/template_lib/Cargo.toml
+++ b/crates/template_lib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_template_lib"
 description = "Tari template library provides abstrations that interface with the Tari validator engine"
-version = "0.10.0"
+version = "0.11.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/template_lib/src/args/types.rs
+++ b/crates/template_lib/src/args/types.rs
@@ -452,7 +452,6 @@ pub enum BucketAction {
     Take,
     TakeConfidential,
     Join,
-    RevealConfidential,
     Burn,
     CreateProof,
     GetNonFungibleIds,

--- a/crates/template_lib/src/lib.rs
+++ b/crates/template_lib/src/lib.rs
@@ -20,13 +20,27 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-//! This crate contains an interface for WASM templates to interact with the state of the Tari Network, as well as
-//! some utilities for executing functions that may be slow in the WASM environment.
+//! This crate provides ergonomic abstractions that allow WASM templates to interact with the Tari Ootle engine.
+//! Most if not all Ootle templates written in rust should depend on this crate.
 //!
 //! In most cases, you will only require the `prelude` which can be included with:
 //! ```
 //! use tari_template_lib::prelude::*;
 //! ```
+//!
+//! Typically, a template author will use structs exported from the [models] module, the
+//! [ResourceBuilder](resource::ResourceBuilder) and the [ComponentBuilder](component::ComponentBuilder). This crate
+//! re-exports low-level ABI functions in `tari_template_abi` and the `tari_template_macros` proc macro.
+//!
+//! ## Template Examples
+//!
+//! - <https://github.com/tari-project/wasm-template>
+//! - <https://github.com/tari-project/wasm-examples>
+//! - <https://github.com/tari-project/tari-ootle/tree/development/crates/engine/tests/templates>
+//!
+//! ## no_std
+//!
+//! no_std can be enabled using the `no_std` feature flag.
 
 pub mod auth;
 

--- a/crates/template_lib/src/models/address_allocation.rs
+++ b/crates/template_lib/src/models/address_allocation.rs
@@ -9,23 +9,29 @@ use crate::{
     models::{BinaryTag, ComponentAddress, ResourceAddress},
 };
 
+/// Represents an allocation of an address for a component or resource.
 pub type AddressAllocationId = u32;
 
 const COMPONENT_TAG: u64 = BinaryTag::AllocatedComponentAddress.as_u64();
 
+/// Represents an allocation of an address for a component.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq)]
 #[serde(transparent)]
 pub struct ComponentAddressAllocation(BorTag<AddressAllocationId, COMPONENT_TAG>);
 
 impl ComponentAddressAllocation {
+    /// Creates a new `ComponentAddressAllocation` with the given ID.
+    /// For internal use.
     pub fn new(id: AddressAllocationId) -> Self {
         Self(BorTag::new(id))
     }
 
+    /// Returns the ID of the address allocation.
     pub fn id(&self) -> AddressAllocationId {
         self.0.into_inner()
     }
 
+    /// Retrieves the allocated address for the component.
     pub fn get_address(&self) -> ComponentAddress {
         let resp: InvokeResult = call_engine(
             EngineOp::AddressAllocationInvoke,
@@ -39,19 +45,24 @@ impl ComponentAddressAllocation {
 
 const RESOURCE_TAG: u64 = BinaryTag::AllocatedResourceAddress.as_u64();
 
+/// Represents an allocation of an address for a resource.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq)]
 #[serde(transparent)]
 pub struct ResourceAddressAllocation(BorTag<AddressAllocationId, RESOURCE_TAG>);
 
 impl ResourceAddressAllocation {
+    /// Creates a new `ResourceAddressAllocation` with the given ID.
+    /// For internal use.
     pub fn new(id: AddressAllocationId) -> Self {
         Self(BorTag::new(id))
     }
 
+    /// Returns the ID of the address allocation.
     pub fn id(&self) -> AddressAllocationId {
         self.0.into_inner()
     }
 
+    /// Retrieves the allocated address for the resource.
     pub fn get_address(&self) -> ResourceAddress {
         let resp: InvokeResult = call_engine(
             EngineOp::AddressAllocationInvoke,

--- a/crates/template_lib/src/models/amount.rs
+++ b/crates/template_lib/src/models/amount.rs
@@ -30,7 +30,7 @@ use tari_template_abi::rust::{
     num::TryFromIntError,
 };
 
-/// Represents an integer quantity of any fungible or non-fungible resource
+/// Represents an signed integer quantity
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, Default)]
 #[cfg_attr(feature = "borsh", derive(borsh::BorshSerialize))]
 #[serde(transparent)]
@@ -44,55 +44,68 @@ pub struct Amount(#[cfg_attr(feature = "ts", ts(type = "number"))] pub i64);
 impl Amount {
     pub const MAX: Amount = Amount(i64::MAX);
 
+    /// Creates a new `Amount` from an `i64` value.
     pub const fn new(amount: i64) -> Self {
         Amount(amount)
     }
 
+    /// Creates a new `Amount` with a value of zero.
     pub const fn zero() -> Self {
         Amount(0)
     }
 
+    /// Returns true if the amount is zero.
     pub fn is_zero(&self) -> bool {
         self.0 == 0
     }
 
+    /// Returns true if the amount is positive (greater than or equal to zero).
     pub fn is_positive(&self) -> bool {
         self.0 >= 0
     }
 
+    /// Returns true if the amount is negative (less than zero).
     pub fn is_negative(&self) -> bool {
         !self.is_positive()
     }
 
+    /// Returns the value of the amount as an `i64`.
     pub fn value(&self) -> i64 {
         self.0
     }
 
+    /// Returns the value of the amount as a `u64` if it is non-negative, otherwise returns `None`.
     pub fn checked_add(&self, other: Self) -> Option<Self> {
         self.0.checked_add(other.0).map(Amount)
     }
 
+    /// Returns the sum of two amounts, saturating at `i64::MAX` if the result exceeds it.
     pub fn saturating_add(&self, other: Self) -> Self {
         Amount(self.0.saturating_add(other.0))
     }
 
+    /// Returns the difference of two amounts, saturating at `0` if the result is negative.
     pub fn checked_sub(&self, other: Self) -> Option<Self> {
         self.0.checked_sub(other.0).map(Amount)
     }
 
+    /// Returns the difference of two amounts, saturating at `0` if the result is negative.
     pub fn saturating_sub(&self, other: Self) -> Self {
         Amount(self.0.saturating_sub(other.0))
     }
 
-    pub fn saturating_sub_positive(&self, other: Self) -> Self {
+    /// Returns the difference of two amounts, returning `None` if the result is negative.
+    pub fn saturating_sub_positive(&self, other: Self) -> Option<Self> {
         let amount = Amount(self.0 - other.0);
         if amount.is_negative() {
-            Amount(0)
+            None
         } else {
-            amount
+            Some(amount)
         }
     }
 
+    /// Returns the difference of two amounts, returning `None` if the result is negative or if either amount is
+    /// negative.
     pub fn checked_sub_positive(&self, other: Self) -> Option<Self> {
         if self.is_negative() || other.is_negative() {
             return None;
@@ -104,18 +117,22 @@ impl Amount {
         Some(Amount(self.0 - other.0))
     }
 
+    /// Returns the product of two amounts, returning `None` if the result overflows.
     pub fn checked_mul(&self, other: &Self) -> Option<Self> {
         self.0.checked_mul(other.0).map(Amount)
     }
 
+    /// Returns the product of two amounts, saturating at `i64::MAX` if the result exceeds it.
     pub fn saturating_mul(&self, other: &Self) -> Self {
         Amount(self.0.saturating_mul(other.0))
     }
 
+    /// Returns the quotient of two amounts, returning `None` if the divisor is zero or if the result overflows.
     pub fn checked_div(&self, other: &Self) -> Option<Self> {
         self.0.checked_div(other.0).map(Amount)
     }
 
+    /// Returns the quotient of two amounts, saturating at `i64::MAX` if the result exceeds it.
     pub fn saturating_div(&self, other: &Self) -> Self {
         Amount(self.0.saturating_div(other.0))
     }

--- a/crates/template_lib/src/models/bucket.rs
+++ b/crates/template_lib/src/models/bucket.rs
@@ -227,3 +227,9 @@ impl Bucket {
         Self { id }
     }
 }
+
+impl fmt::Display for Bucket {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Bucket({})", self.id.0.inner())
+    }
+}

--- a/crates/template_lib/src/models/bucket.rs
+++ b/crates/template_lib/src/models/bucket.rs
@@ -35,7 +35,7 @@ use crate::{
 
 const TAG: u64 = BinaryTag::BucketId.as_u64();
 
-/// A bucket's unique identification during the transaction execution
+/// A bucket identifier. This identifier is assigned at runtime.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Ord, PartialOrd, Hash)]
 #[cfg_attr(feature = "ts", derive(TS), ts(export, export_to = "../../bindings/src/types/"))]
 pub struct BucketId(#[cfg_attr(feature = "ts", ts(type = "number"))] BorTag<u32, TAG>);
@@ -52,8 +52,8 @@ impl fmt::Display for BucketId {
     }
 }
 
-/// A temporary container of resources. Buckets only live during a transaction execution and must be empty at the end of
-/// the transaction.
+/// A temporary container of resources. Buckets exist during a transaction execution. All buckets must be
+/// consumed (deposited into a vault, burned etc) before the end of the transaction or the entire transaction will fail.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct Bucket {
@@ -61,15 +61,12 @@ pub struct Bucket {
 }
 
 impl Bucket {
-    pub const fn from_id(id: BucketId) -> Self {
-        Self { id }
-    }
-
-    pub fn id(&self) -> BucketId {
+    /// Returns the BucketId of this bucket
+    pub(crate) fn id(&self) -> BucketId {
         self.id
     }
 
-    /// Returns the resource address of the tokens that this bucket holds
+    /// Returns the resource address of the tokens held in this bucket
     pub fn resource_address(&self) -> ResourceAddress {
         let resp: InvokeResult = call_engine(EngineOp::BucketInvoke, &BucketInvokeArg {
             bucket_ref: BucketRef::Ref(self.id),
@@ -81,7 +78,7 @@ impl Bucket {
             .expect("Bucket GetResourceAddress returned invalid resource address")
     }
 
-    /// Returns the the type of resource that this bucket holds
+    /// Returns the type of resource held in this bucket
     pub fn resource_type(&self) -> ResourceType {
         let resp: InvokeResult = call_engine(EngineOp::BucketInvoke, &BucketInvokeArg {
             bucket_ref: BucketRef::Ref(self.id),
@@ -95,6 +92,12 @@ impl Bucket {
 
     /// Withdraws `amount` tokens from the bucket into a new bucket.
     /// It will panic if there are not enough tokens in the bucket
+    ///
+    /// * for fungible resources, the `amount` is the number of tokens to withdraw
+    /// * for non-fungible resources, the `amount` is the number of _non-specific_ non-fungible tokens to withdraw.
+    ///   Prefer take_non_fungible if you want to withdraw specific non-fungible tokens.
+    /// * for confidential resources, the `amount` is the number of revealed tokens to withdraw. Use `take_confidential`
+    ///   to withdraw confidential tokens with a proof.
     pub fn take(&mut self, amount: Amount) -> Self {
         assert!(!amount.is_zero() && amount.is_positive());
         let resp: InvokeResult = call_engine(EngineOp::BucketInvoke, &BucketInvokeArg {
@@ -106,8 +109,9 @@ impl Bucket {
         resp.decode().expect("Bucket Take returned invalid bucket")
     }
 
-    /// Withdraws an amount (specified in the `proof`) of confidential tokens from the bucket into a new bucket.
-    /// It will panic if the proof is invalid or there are not enough tokens in the bucket
+    /// Takes (withdraws) confidential resources from the bucket into a new bucket.
+    /// It will panic if the withdraw fails for any reason, including if the proof withdraws from unknown inputs,
+    /// withdraws more funds than are available or is otherwise invalid.
     pub fn take_confidential(&mut self, proof: ConfidentialWithdrawProof) -> Self {
         let resp: InvokeResult = call_engine(EngineOp::BucketInvoke, &BucketInvokeArg {
             bucket_ref: BucketRef::Ref(self.id),
@@ -119,7 +123,7 @@ impl Bucket {
     }
 
     /// Destroy all the tokens that this bucket holds.
-    /// It will panic if the caller does not have the appropriate permissions
+    /// It will panic if the caller does not have the appropriate permission to burn the resource.
     pub fn burn(&self) {
         let resp: InvokeResult = call_engine(EngineOp::BucketInvoke, &BucketInvokeArg {
             bucket_ref: BucketRef::Ref(self.id),
@@ -130,23 +134,8 @@ impl Bucket {
         resp.decode().expect("Bucket Burn returned invalid result")
     }
 
-    /// Split the current bucket, returning two new buckets, one with `amount` tokens and the other with the rest.
-    /// It will panic if there are not enough tokens in the bucket
-    pub fn split(mut self, amount: Amount) -> (Self, Self) {
-        let new_bucket = self.take(amount);
-        (new_bucket, self)
-    }
-
-    /// Split the current bucket, returning two new buckets, one with an amount (specified in the `proof`) of
-    /// confidential tokens and the other with the rest. It will panic if the proof is invalid or there are not
-    /// enough tokens in the bucket
-    pub fn split_confidential(mut self, proof: ConfidentialWithdrawProof) -> (Self, Self) {
-        let new_bucket = self.take_confidential(proof);
-        (new_bucket, self)
-    }
-
-    /// Joins the bucket with another of the same resource type, returning a new joined bucket with the value of both.
-    /// Will panic if the other bucket is not of the same resource type.
+    /// Joins the bucket with another of the same resource, returning a new joined bucket with the value of both.
+    /// Will panic if the other bucket does not contain the same resource.
     pub fn join(self, other: Bucket) -> Self {
         let resp: InvokeResult = call_engine(EngineOp::BucketInvoke, &BucketInvokeArg {
             bucket_ref: BucketRef::Ref(self.id),
@@ -157,7 +146,9 @@ impl Bucket {
         resp.decode().expect("Bucket join returned invalid result")
     }
 
-    /// Returns how many tokens this bucket holds
+    /// Returns the amount of tokens held in this bucket.
+    ///
+    /// Note that if the resource is confidential, only the revealed amount is returned.
     pub fn amount(&self) -> Amount {
         let resp: InvokeResult = call_engine(EngineOp::BucketInvoke, &BucketInvokeArg {
             bucket_ref: BucketRef::Ref(self.id),
@@ -168,20 +159,8 @@ impl Bucket {
         resp.decode().expect("Bucket GetAmount returned invalid amount")
     }
 
-    /// Returns a new bucket with revealed funds, specified by the `proof`.
-    /// The amount of tokens will not change, only how many of those tokens will be known by everyone
-    pub fn reveal_confidential(&mut self, proof: ConfidentialWithdrawProof) -> Bucket {
-        let resp: InvokeResult = call_engine(EngineOp::BucketInvoke, &BucketInvokeArg {
-            bucket_ref: BucketRef::Ref(self.id),
-            action: BucketAction::RevealConfidential,
-            args: invoke_args![proof],
-        });
-
-        resp.decode()
-            .expect("Bucket RevealConfidential returned invalid result")
-    }
-
-    /// Create a proof of token balances in the bucket, used mainly for cross-template calls
+    /// Create a proof of ownership for all tokens in the bucket, used mainly for cross-template calls.
+    /// Note that until the proof is dropped, the contained tokens are locked and cannot be used/deposited.
     pub fn create_proof(&self) -> Proof {
         let resp: InvokeResult = call_engine(EngineOp::BucketInvoke, &BucketInvokeArg {
             bucket_ref: BucketRef::Ref(self.id),
@@ -193,6 +172,7 @@ impl Bucket {
     }
 
     /// Returns the IDs of all the non-fungibles in this bucket
+    /// If the resource is not a non-fungible resource, an empty vector is returned.
     pub fn get_non_fungible_ids(&self) -> Vec<NonFungibleId> {
         let resp: InvokeResult = call_engine(EngineOp::BucketInvoke, &BucketInvokeArg {
             bucket_ref: BucketRef::Ref(self.id),
@@ -204,7 +184,8 @@ impl Bucket {
             .expect("get_non_fungible_ids returned invalid non fungible ids")
     }
 
-    /// Returns all the non-fungibles in this bucket
+    /// Returns all the non-fungibles in this bucket.
+    /// If the resource is not a non-fungible resource, an empty vector is returned.
     pub fn get_non_fungibles(&self) -> Vec<NonFungible> {
         let resp: InvokeResult = call_engine(EngineOp::BucketInvoke, &BucketInvokeArg {
             bucket_ref: BucketRef::Ref(self.id),
@@ -215,6 +196,8 @@ impl Bucket {
         resp.decode().expect("get_non_fungibles returned invalid non fungibles")
     }
 
+    /// Returns the number of confidential commitments in this bucket.
+    /// Note that this is not indicative of the number of tokens in the bucket, as these are blinded.
     pub fn count_confidential_commitments(&self) -> u32 {
         let resp: InvokeResult = call_engine(EngineOp::BucketInvoke, &BucketInvokeArg {
             bucket_ref: BucketRef::Ref(self.id),
@@ -226,11 +209,21 @@ impl Bucket {
             .expect("count_confidential_commitments returned invalid u32")
     }
 
+    /// Asserts that the bucket does not contain any confidential commitments.
+    /// This is useful to ensure that a bucket is not holding any confidential commitments before performing
+    /// an operation e.g. depositing it into a vault that expects only revealed funds.
     pub fn assert_contains_no_confidential_funds(&self) {
         let count = self.count_confidential_commitments();
         assert_eq!(
             count, 0,
             "Expected bucket to have no confidential commitments, but found {count}",
         );
+    }
+
+    /// Creates a new bucket from a bucket ID. This is used internally. Performing any operations on this bucket will
+    /// fail if the bucket is not in scope or does not exist. Rather use methods like `Vault::withdraw` to obtain a
+    /// bucket.
+    pub const fn from_id(id: BucketId) -> Self {
+        Self { id }
     }
 }

--- a/crates/template_lib/src/models/component.rs
+++ b/crates/template_lib/src/models/component.rs
@@ -32,7 +32,7 @@ use crate::{models::BinaryTag, newtype_struct_serde_impl};
 
 const TAG: u64 = BinaryTag::ComponentAddress.as_u64();
 
-/// A component's unique identification in the Tari network
+/// A component's unique global identifier.
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(
     feature = "ts",
@@ -42,27 +42,33 @@ const TAG: u64 = BinaryTag::ComponentAddress.as_u64();
 pub struct ComponentAddress(#[cfg_attr(feature = "ts", ts(type = "string"))] BorTag<ObjectKey, TAG>);
 
 impl ComponentAddress {
+    /// Creates a new `ComponentAddress` from an `ObjectKey`. For internal use only.
     pub const fn new(substate_key: ObjectKey) -> Self {
         Self(BorTag::new(substate_key))
     }
 
+    /// Returns the underlying `ObjectKey` of this `ComponentAddress`.
     pub fn as_object_key(&self) -> &ObjectKey {
         &self.0
     }
 
+    /// Returns the underlying byte slice.
     pub fn as_bytes(&self) -> &[u8] {
         self.0.as_ref()
     }
 
+    /// Creates a new `ComponentAddress` from a hex string.
     pub fn from_hex(hex: &str) -> Result<Self, KeyParseError> {
         let key = ObjectKey::from_hex(hex)?;
         Ok(Self::new(key))
     }
 
+    /// Creates a new `ComponentAddress` from a byte array.
     pub fn from_array(arr: [u8; ObjectKey::LENGTH]) -> Self {
         Self::new(ObjectKey::from_array(arr))
     }
 
+    /// Returns the `EntityId` associated with this component address.
     pub fn entity_id(&self) -> EntityId {
         self.0.inner().as_entity_id()
     }

--- a/crates/template_lib/src/models/confidential_proof.rs
+++ b/crates/template_lib/src/models/confidential_proof.rs
@@ -142,7 +142,16 @@ pub struct ViewableBalanceProofChallengeFields<'a> {
     pub r_prime: &'a RistrettoPublicKeyBytes,
 }
 
-/// A zero-knowledge proof that a transfer of confidential resources is valid
+/// A confidential proof that defines a confidential and/or revealed withdrawal, e.g. from a vault containing
+/// confidential resources. This proof contains:
+/// - Inputs: The confidential inputs that are being withdrawn identified by their Pedersen commitments.
+/// - Input revealed amount: The amount of revealed funds to withdraw.
+/// - Output proof: The confidential output statement that contains the output and change statements, range proof, and
+///   revealed amounts.
+/// - Balance proof: The balance proof signature that proves knowledge of the excess. inputs - output - change = (0)
+///   where (0) is the excess. Knowledge of the excess is not possible unless the inputs and outputs balance.
+///
+/// Withdrawals can be revealed only, confidential only, or a mix of both.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[cfg_attr(
     feature = "ts",
@@ -162,10 +171,12 @@ pub struct ConfidentialWithdrawProof {
 }
 
 impl ConfidentialWithdrawProof {
-    /// Creates a withdrawal proof for revealed funds of a specific amount
+    /// Creates a valid withdrawal proof for revealed funds of a specific amount.
     pub fn revealed_withdraw<T: Into<Amount>>(amount: T) -> Self {
         // There are no confidential inputs or outputs (this amounts to the same thing as a Fungible resource transfer)
-        // So signature s = 0 + e.x where x is a 0 excess, is valid.
+        // So signature s = 0 + e.x where x is a 0 excess, is technically valid. Note that signature verification
+        // explicitly disallows the zero key. However, we explicitly check for this case in the
+        // `is_revealed_only` method and consider the signature valid.
         let balance_proof = BalanceProofSignature::zero();
 
         let amount = amount.into();
@@ -177,6 +188,7 @@ impl ConfidentialWithdrawProof {
         }
     }
 
+    /// Creates a withdrawal proof for a confidential transfer that transfers revealed funds to confidential outputs.
     pub fn revealed_to_confidential<T: Into<Amount>>(
         input_revealed_amount: T,
         output_proof: ConfidentialOutputStatement,

--- a/crates/template_lib/src/models/layer_one_commitment.rs
+++ b/crates/template_lib/src/models/layer_one_commitment.rs
@@ -14,8 +14,9 @@ use crate::models::BinaryTag;
 
 const TAG: u64 = BinaryTag::UnclaimedConfidentialOutputAddress.as_u64();
 
-/// The unique identification of a unclaimed confidential output in the Tari network.
-/// Used when a user wants to claim burned funds from the Minotari network into the Tari network
+/// The global identifier of a unclaimed confidential output in the Tari network.
+/// This substate is created when a L1 UTXO is detected as burnt, and consumed when a user submits a valid claim burn
+/// transaction.
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[cfg_attr(
     feature = "ts",

--- a/crates/template_lib/src/models/proof.rs
+++ b/crates/template_lib/src/models/proof.rs
@@ -179,7 +179,8 @@ impl Drop for ProofAccess {
     }
 }
 
-/// A convenience wrapper for managing proofs in templates
+/// A RAII type that holds a reference to a proof that is authorized for use.
+/// Once this is dropped the proof goes out of scope and can no longer be used.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProofAuth {
     pub id: ProofId,

--- a/crates/template_lib/src/models/resource.rs
+++ b/crates/template_lib/src/models/resource.rs
@@ -33,7 +33,7 @@ use crate::{newtype_struct_serde_impl, prelude::CONFIDENTIAL_TARI_RESOURCE_ADDRE
 
 const TAG: u64 = BinaryTag::ResourceAddress.as_u64();
 
-/// The unique identification of a resource in the Tari network
+/// The globally-unique identifier of a resource.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(
     feature = "ts",

--- a/crates/template_lib/src/models/vault.rs
+++ b/crates/template_lib/src/models/vault.rs
@@ -37,7 +37,6 @@ use tari_template_lib_types::{EntityId, KeyParseError, ObjectKey};
 use super::{BinaryTag, NonFungible, Proof, ProofAuth};
 use crate::{
     args::{
-        ConfidentialRevealArg,
         InvokeResult,
         PayFeeArg,
         VaultAction,
@@ -171,7 +170,9 @@ impl Display for VaultRef {
     }
 }
 
-/// A permanent container of resources. Vaults live after the end of a transaction.
+/// References a secure container of a single resource and provides an abstraction for vault operations.
+/// A vault can hold fungible tokens, non-fungible tokens, or confidential tokens.
+/// A vault is identified by a globally-unique `VaultId`.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct Vault {
@@ -179,14 +180,14 @@ pub struct Vault {
 }
 
 impl Vault {
-    /// Returns a new vault with an empty balance
+    /// Creates a new empty vault for the provided resource address.
     pub fn new_empty(resource_address: ResourceAddress) -> Self {
         let resp: InvokeResult = call_engine(EngineOp::VaultInvoke, &VaultInvokeArg {
             vault_ref: VaultRef::Vault {
                 address: resource_address,
             },
             action: VaultAction::Create,
-            args: call_args![],
+            args: invoke_args![],
         });
 
         Self {
@@ -194,8 +195,18 @@ impl Vault {
         }
     }
 
-    /// Returns a new vault that will contain all the tokens from the provided bucket.
-    /// The bucket will be empty after the call
+    /// Returns a new vault that contains all the tokens from the provided bucket.
+    /// The bucket is consumed and cannot be used after this call.
+    ///
+    /// # Panics
+    /// if the the bucket contains a different resource than the vault
+    ///
+    /// # Example
+    /// ```rust,ignore
+    /// use tari_template_lib::models::{Bucket, Vault};
+    /// let bucket = self.get_a_bucket();
+    /// let vault = Vault::from_bucket(bucket);
+    /// ```
     pub fn from_bucket(bucket: Bucket) -> Self {
         let resource_address = bucket.resource_address();
         let vault = Self::new_empty(resource_address);
@@ -204,8 +215,10 @@ impl Vault {
     }
 
     /// Deposit all the tokens from the provided bucket into the vault.
-    /// The bucket will be empty after the call.
-    /// It will panic if the tokens in the bucket are from a different resource than the ones in the vault
+    /// The bucket is consumed and cannot be used after this call.
+    ///
+    /// # Panics
+    /// If the the bucket contains a different resource than the vault
     pub fn deposit(&self, bucket: Bucket) {
         let result: InvokeResult = call_engine(EngineOp::VaultInvoke, &VaultInvokeArg {
             vault_ref: self.vault_ref(),
@@ -216,7 +229,12 @@ impl Vault {
         result.decode::<()>().expect("deposit failed");
     }
 
-    /// Withdraw an `amount` of tokens from the vault into a new bucket.
+    /// Withdraw an `amount` of tokens from the vault and creates a new bucket to contain them.
+    ///
+    /// * For fungible resources, withdraw `amount` tokens.
+    /// * For non-fungible resources, withdraw a `amount` non-fungible tokens in an unspecified order. Typically,
+    ///   `withdraw_non_fungible` is more useful for non-fungible resources.
+    /// * For confidential resources, this call panics and the transaction fails.
     pub fn withdraw<T: Into<Amount>>(&self, amount: T) -> Bucket {
         let resp: InvokeResult = call_engine(EngineOp::VaultInvoke, &VaultInvokeArg {
             vault_ref: self.vault_ref(),
@@ -247,8 +265,18 @@ impl Vault {
         resp.decode().expect("failed to decode Bucket")
     }
 
-    /// Withdraws an amount (specified in the `proof`) of confidential tokens from the vault into a new bucket.
-    /// It will panic if the proof is invalid or there are not enough tokens in the vault
+    /// Withdraws confidential resources from the vault into a new bucket.
+    /// It will panic if the withdraw fails for any reason, including if the proof withdraws from unknown inputs,
+    /// withdraws more funds than are available or is otherwise invalid.
+    ///
+    /// # Example
+    /// ```rust,ignore
+    /// use tari_template_lib::models::{Vault, ConfidentialWithdrawProof};
+    /// let vault = self.my_vault;
+    /// let proof = // .. wallet generates a ConfidentialWithdrawProof
+    /// let bucket = vault.withdraw_confidential(proof);
+    /// /// // The bucket now contains the withdrawn confidential funds
+    /// ```
     pub fn withdraw_confidential(&self, proof: ConfidentialWithdrawProof) -> Bucket {
         let resp: InvokeResult = call_engine(EngineOp::VaultInvoke, &VaultInvokeArg {
             vault_ref: self.vault_ref(),
@@ -265,7 +293,12 @@ impl Vault {
         self.withdraw(self.balance())
     }
 
-    /// Returns how many tokens this vault holds
+    /// Returns how many tokens this vault holds.
+    ///
+    /// * For fungible resources, returns the total amount of tokens.
+    /// * For non-fungible resources, returns the total number of non-fungible tokens.
+    /// * For confidential resources, returns the total amount of revealed tokens. Confidential tokens are not included
+    ///   in this amount as these are blinded.
     pub fn balance(&self) -> Amount {
         let resp: InvokeResult = call_engine(EngineOp::VaultInvoke, &VaultInvokeArg {
             vault_ref: self.vault_ref(),
@@ -276,7 +309,7 @@ impl Vault {
         resp.decode().expect("failed to decode Amount")
     }
 
-    /// Returns how many tokens this vault holds
+    /// Returns how many tokens are locked (unspendable) in this vault.
     pub fn locked_balance(&self) -> Amount {
         let resp: InvokeResult = call_engine(EngineOp::VaultInvoke, &VaultInvokeArg {
             vault_ref: self.vault_ref(),
@@ -287,7 +320,8 @@ impl Vault {
         resp.decode().expect("failed to decode Amount")
     }
 
-    /// Returns how many commitments (related to confidential balances) this vault holds
+    /// Returns how many confidential outputs this vault holds.
+    /// This is not indicative of the value of the confidential tokens (these are blinded).
     pub fn commitment_count(&self) -> u32 {
         let resp: InvokeResult = call_engine(EngineOp::VaultInvoke, &VaultInvokeArg {
             vault_ref: self.vault_ref(),
@@ -298,7 +332,7 @@ impl Vault {
         resp.decode().expect("failed to decode commitment count")
     }
 
-    /// Returns the IDs of all the non-fungible this vault
+    /// Returns the IDs of all the non-fungibles contained in this vault.
     pub fn get_non_fungible_ids(&self) -> Vec<NonFungibleId> {
         let resp: InvokeResult = call_engine(EngineOp::VaultInvoke, &VaultInvokeArg {
             vault_ref: self.vault_ref(),
@@ -310,7 +344,7 @@ impl Vault {
             .expect("get_non_fungible_ids returned invalid non fungible ids")
     }
 
-    /// Returns all the non-fungibles in this vault
+    /// Returns all the non-fungibles in this vault including their metadata.
     pub fn get_non_fungibles(&self) -> Vec<NonFungible> {
         let resp: InvokeResult = call_engine(EngineOp::VaultInvoke, &VaultInvokeArg {
             vault_ref: self.vault_ref(),
@@ -333,25 +367,13 @@ impl Vault {
             .expect("GetResourceAddress returned invalid resource address")
     }
 
-    /// Returns the the type of resource that this vault holds
+    /// Returns the the type of resource that this vault holds.
     pub fn resource_type(&self) -> ResourceType {
         ResourceManager::get(self.resource_address()).resource_type()
     }
 
-    /// Returns a new bucket with revealed funds, specified by the `proof`.
-    /// The amount of tokens will not change, only how many of those tokens will be known by everyone
-    pub fn reveal_confidential(&self, proof: ConfidentialWithdrawProof) -> Bucket {
-        let resp: InvokeResult = call_engine(EngineOp::VaultInvoke, &VaultInvokeArg {
-            vault_ref: self.vault_ref(),
-            action: VaultAction::ConfidentialReveal,
-            args: invoke_args![ConfidentialRevealArg { proof }],
-        });
-
-        Bucket::from_id(resp.decode().expect("reveal_confidential returned invalid bucket"))
-    }
-
     /// Pay a transaction fee with the funds present in the vault.
-    /// Note that the vault must hold native Tari tokens to perform this operation
+    /// Note that the vault must hold native Tari tokens to perform this operation.
     pub fn pay_fee(&self, amount: Amount) {
         let _resp: InvokeResult = call_engine(EngineOp::VaultInvoke, &VaultInvokeArg {
             vault_ref: self.vault_ref(),
@@ -362,6 +384,7 @@ impl Vault {
 
     /// Pay a transaction fee with the confidential funds present in the vault.
     /// Note that the vault must hold native Tari tokens to perform this operation
+    /// The withdraw proof must result in a non-zero amount of revealed funds.
     pub fn pay_fee_confidential(&self, proof: ConfidentialWithdrawProof) {
         let _resp: InvokeResult = call_engine(EngineOp::VaultInvoke, &VaultInvokeArg {
             vault_ref: self.vault_ref(),
@@ -373,23 +396,32 @@ impl Vault {
         });
     }
 
-    /// Deposit an amount (specified in the `proof`) of confidential tokens into the vault.
-    /// It will panic if the proof is invalid or the resource of the proof is not the same as the one in the vault
-    pub fn join_confidential(&self, proof: ConfidentialWithdrawProof) {
-        let bucket = self.withdraw_confidential(proof);
-        self.deposit(bucket);
-    }
-
-    /// Create a new proof that allows the holder to access the tokens in the vault with future instructions.
-    /// The tokens will be locked during the lifespan of the transaction until the proof is destroyed.
+    /// Creates a new [ProofAuth] that references a proof that proves ownership of all the vault's tokens.
+    ///
+    /// # Example
+    /// ```rust,ignore
+    /// use tari_template_lib::models::Vault;
+    /// let vault = self.my_vault;
+    /// let _auth = vault.authorize(); // RAII pattern
+    /// perform_some_action_that_requires_authorization();
+    /// // _auth is dropped here, and the proof is goes out of scope
+    /// /// ```
     pub fn authorize(&self) -> ProofAuth {
         let proof = self.create_proof();
         ProofAuth { id: proof.id() }
     }
 
-    /// Create a new proof that allows the holder to access the tokens in the vault with future instructions.
-    /// It will execute the provided function after the proof is generated.
-    /// The tokens will be locked during the lifespan of the transaction until the proof is destroyed
+    /// Uses all the tokens in the vault to authorize some actions within the provided function.
+    /// All tokens will be locked during the lifespan of the transaction until the proof is destroyed after the function
+    /// returns.
+    ///
+    /// # Example
+    /// ```rust,ignore
+    /// use tari_template_lib::models::Vault;
+    /// let vault = self.my_vault;
+    /// vault.authorize_with(|| {
+    ///     perform_some_action_that_requires_authorization();
+    /// });
     pub fn authorize_with<F: FnOnce() -> R, R>(&self, f: F) -> R {
         let _auth = self.authorize();
         f()
@@ -409,8 +441,8 @@ impl Vault {
     }
 
     /// Returns a new proof that demonstrates ownership of a specific amount of tokens.
-    /// The tokens will be locked during the lifespan of the transaction until the proof is destroyed.
-    /// Used mostly for cross-component calls
+    /// The tokens will be locked during the lifespan of the proof i.e until proof.drop() is called.
+    /// Used primarily to authorize cross-component calls.
     pub fn create_proof_by_amount(&self, amount: Amount) -> Proof {
         let resp: InvokeResult = call_engine(EngineOp::VaultInvoke, &VaultInvokeArg {
             vault_ref: self.vault_ref(),
@@ -422,8 +454,8 @@ impl Vault {
     }
 
     /// Returns a new proof that demonstrates ownership of a specific set of non-fungibles.
-    /// The tokens will be locked during the lifespan of the transaction until the proof is destroyed.
-    /// Used mostly for cross-component calls
+    /// The tokens will be locked during the lifespan of the proof i.e until proof.drop() is called.
+    /// Used primarily to authorize cross-component calls using "badges".
     pub fn create_proof_by_non_fungible_ids(&self, ids: BTreeSet<NonFungibleId>) -> Proof {
         let resp: InvokeResult = call_engine(EngineOp::VaultInvoke, &VaultInvokeArg {
             vault_ref: self.vault_ref(),
@@ -434,6 +466,7 @@ impl Vault {
         resp.decode().expect("CreateProofByNonFungibles failed")
     }
 
+    /// Returns the VaultId of this vault.
     pub fn vault_id(&self) -> VaultId {
         self.vault_id
     }
@@ -442,6 +475,9 @@ impl Vault {
         VaultRef::Ref(self.vault_id)
     }
 
+    /// Creates a vault from the provided `VaultId`. Unless the transaction is authorized to use this vault, performing
+    /// any operations on the resulting vault will fail. This is used in unit tests to test various "unusual" scenarios
+    /// and should not be used in production templates.
     pub fn for_test(vault_id: VaultId) -> Self {
         Self { vault_id }
     }

--- a/crates/template_lib/src/resource/builder/confidential.rs
+++ b/crates/template_lib/src/resource/builder/confidential.rs
@@ -11,7 +11,7 @@ use crate::{
     types::crypto::RistrettoPublicKeyBytes,
 };
 
-/// Utility for building confidential resources inside templates
+/// Implements the builder pattern for Confidential resources.
 pub struct ConfidentialResourceBuilder {
     metadata: Metadata,
     access_rules: ResourceAccessRules,

--- a/crates/template_lib/src/resource/manager.rs
+++ b/crates/template_lib/src/resource/manager.rs
@@ -56,7 +56,14 @@ use crate::{
     types::crypto::{PedersenCommitmentBytes, RistrettoPublicKeyBytes},
 };
 
-/// Utility for managing resources inside templates
+/// Provides an interface for various resource operations e.g. Minting, recalling, creating, etc.
+///
+/// # Example
+/// ```rust,ignore
+/// use tari_template_lib::resource::manager::ResourceManager;
+/// let resource_manager = ResourceManager::get(my_resource_address);
+/// resource_manager.mint_fungible(Amount(1000));
+/// ```
 #[derive(Debug)]
 pub struct ResourceManager {
     resource_address: Option<ResourceAddress>,
@@ -105,7 +112,7 @@ impl ResourceManager {
     /// * `access_rules` - Rules that will govern access to the resource
     /// * `metadata` - Collection of information used to describe the resource
     /// * `mint_arg` - Specification of the initial tokens that will be minted on resource creation
-    pub fn create(
+    pub(crate) fn create(
         &self,
         resource_type: ResourceType,
         owner_rule: OwnerRule,

--- a/crates/wallet/sdk/src/apis/confidential_transfer.rs
+++ b/crates/wallet/sdk/src/apis/confidential_transfer.rs
@@ -192,13 +192,14 @@ where
                     self.outputs_api
                         .lock_outputs_until_partial_amount(&src_vault.address, spend_amount, proof_id)?;
 
-                let revealed_to_spend =
-                    spend_amount.saturating_sub_positive(amount_locked.try_into().map_err(|_| {
+                let revealed_to_spend = spend_amount
+                    .saturating_sub_positive(amount_locked.try_into().map_err(|_| {
                         ConfidentialTransferApiError::InvalidParameter {
                             param: "transfer_param",
                             reason: "Attempt to spend more than Amount::MAX".to_string(),
                         }
-                    })?);
+                    })?)
+                    .unwrap_or_else(Amount::zero);
 
                 if src_vault.revealed_balance < revealed_to_spend {
                     return Err(ConfidentialTransferApiError::InsufficientFunds);


### PR DESCRIPTION
Description
---
fix(template_lib)!: remove unused vault/bucket functions 
docs: update template lib docs

Motivation and Context
---
Several vault and bucket functions were aliasing withdraw and served no purpose. To avoid having to maintain them, they were removed.

The reveal vault operation was redundant since it is equivalent to a confidential withdraw. This operation was removed.

Updated documentation for the tari_template_lib module, vaults, buckets, resource builder and component builder.

How Has This Been Tested?
---
Rustdoc and existing tests

What process can a PR reviewer use to test or verify this change?
---
cargo doc --open

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify