### PR TITLE
fix(template_macro): allow enum components

### DIFF
--- a/crates/engine/tests/templates/state/src/lib.rs
+++ b/crates/engine/tests/templates/state/src/lib.rs
@@ -26,27 +26,31 @@ use tari_template_lib::prelude::*;
 mod state_template {
     use super::*;
 
-    pub struct State {
-        value: u32,
+    #[derive(Default)]
+    pub enum State {
+        #[default]
+        Zero,
+        One,
+        Other(u32),
     }
 
     impl State {
         pub fn new() -> Component<Self> {
-            Component::new(Self { value: 0 })
+            Component::new(Self::default())
                 .with_access_rules(AccessRules::new().default(rule!(allow_all)))
                 .create()
         }
 
         pub fn create_multiple(n: u32) {
             (0..n).for_each(|i| {
-                Component::new(Self { value: i })
+                Component::new(Self::from(i))
                     .with_access_rules(AccessRules::new().default(rule!(allow_all)))
                     .create();
             });
         }
 
         pub fn restricted() -> Component<Self> {
-            Component::new(Self { value: 0 })
+            Component::new(Self::default())
                 .with_access_rules(
                     AccessRules::new()
                         .add_method_rule("get", rule!(allow_all))
@@ -56,12 +60,26 @@ mod state_template {
         }
 
         pub fn set(&mut self, value: u32) {
-            debug!("Changing value from {} to {}", self.value, value);
-            self.value = value;
+            debug!("Changing value from {:?} to {}", self, value);
+            *self = value.into();
         }
 
         pub fn get(&self) -> u32 {
-            self.value
+            match self {
+                State::Zero => 0,
+                State::One => 1,
+                State::Other(value) => *value,
+            }
+        }
+    }
+
+    impl From<u32> for State {
+        fn from(value: u32) -> Self {
+            match value {
+                0 => State::Zero,
+                1 => State::One,
+                _ => State::Other(value),
+            }
         }
     }
 }

--- a/crates/template_macros/src/template/ast.rs
+++ b/crates/template_macros/src/template/ast.rs
@@ -77,6 +77,14 @@ impl Parse for TemplateAst {
                         template_name = Some(item.ident.clone());
                     }
                 },
+                Item::Enum(ref mut item) => {
+                    item.attrs
+                        .push(syn::parse_quote!(#[derive(Debug, serde::Serialize, serde::Deserialize)]));
+                    item.attrs.push(syn::parse_quote!(#[serde(crate = "self::serde")]));
+                    if template_name.is_none() {
+                        template_name = Some(item.ident.clone());
+                    }
+                },
                 // TODO: check name matches template name
                 Item::Impl(_) => {
                     has_impl = true;


### PR DESCRIPTION
Description
---
fix(template_macro): allow enum components

Motivation and Context
---
Allows components to be enums. This could be useful for various purposes e.g. state machines etc

How Has This Been Tested?
---
Modified state template

What process can a PR reviewer use to test or verify this change?
---
Implement a component as an enum

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify