### PR TITLE
fix: substates not available after some time

### DIFF
--- a/applications/tari_indexer/src/dry_run/error.rs
+++ b/applications/tari_indexer/src/dry_run/error.rs
@@ -41,7 +41,7 @@ pub enum DryRunTransactionProcessorError {
     PayloadProcessor(#[from] TransactionProcessorError),
     #[error(
         "All validators for epoch {epoch} substate {substate_requirement} failed to return substate. does_not_exist: \
-         {nexist_count}/{max_failures}, substate_down: {err_count}/{max_failures} (committee_size: {committee_size})"
+         {nexist_count}/{max_failures}, errored: {err_count}/{max_failures} (committee_size: {committee_size})"
     )]
     AllValidatorsFailedToReturnSubstate {
         substate_requirement: SubstateRequirement,

--- a/applications/tari_validator_node/src/p2p/rpc/service_impl.rs
+++ b/applications/tari_validator_node/src/p2p/rpc/service_impl.rs
@@ -173,6 +173,9 @@ impl<TStateStore: StateStore + Clone + Send + Sync + 'static> ValidatorNodeRpcSe
 
         let created_qc = substate
             .get_created_proposal_certificate(&tx)
+            // TODO: We may not have this... We dont sync PCs. Hmm...
+            // This does not actually prove this substate was committed anyhow.
+            .optional()
             .map_err(RpcStatus::log_internal_error(LOG_TARGET))?;
 
         let resp = if substate.is_destroyed() {
@@ -183,7 +186,7 @@ impl<TStateStore: StateStore + Clone + Send + Sync + 'static> ValidatorNodeRpcSe
                 status: SubstateStatus::Down as i32,
                 address: substate.substate_id().to_bytes(),
                 version: substate.version(),
-                quorum_certificates: Some(created_qc)
+                quorum_certificates: created_qc
                     .into_iter()
                     .chain(destroyed_qc)
                     .map(|qc| (&qc).into())
@@ -199,7 +202,7 @@ impl<TStateStore: StateStore + Clone + Send + Sync + 'static> ValidatorNodeRpcSe
                     .substate_value()
                     .map(|v| v.to_bytes())
                     .ok_or_else(|| RpcStatus::general("NEVER HAPPEN: UP substate has no value"))?,
-                quorum_certificates: vec![(&created_qc).into()],
+                quorum_certificates: created_qc.iter().map(Into::into).collect(),
             }
         };
 


### PR DESCRIPTION
Description
---
fix: substates not available after some time

Motivation and Context
---
After some time substate would become unavailable. This is due to the proposal certificates (PC) not being available (either due to sync or epoch cleanup).

For now, we simply omit the PC in this case since:
1. they don't actually prove commit
2. clients do not currently validate them 

How Has This Been Tested?
---
Manually

What process can a PR reviewer use to test or verify this change?
---


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify