### PR TITLE
fix: test verifying no_std works

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12014,7 +12014,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_lib"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "borsh",
  "serde",

--- a/crates/engine/tests/no_std.rs
+++ b/crates/engine/tests/no_std.rs
@@ -1,0 +1,39 @@
+//   Copyright 2025 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+use tari_engine_types::indexed_value::IndexedValue;
+use tari_template_lib::models::ComponentAddress;
+use tari_template_test_tooling::TemplateTest;
+use tari_transaction::{args, Transaction};
+
+#[test]
+fn it_compiles_when_using_no_std() {
+    let mut test = TemplateTest::new(["tests/templates/no_std"]);
+
+    let access_rules_template = test.get_template_address("NoStdCounter");
+
+    let result = test.execute_expect_success(
+        Transaction::builder()
+            .allocate_component_address("no_std_counter")
+            .call_function(access_rules_template, "with_address", args![Workspace(
+                "no_std_counter"
+            )])
+            .call_method("no_std_counter", "increment", args![])
+            .build_and_seal(test.secret_key()),
+        // Because we deny_all on deposits, we need to supply the owner proof to be able to deposit the initial
+        // tokens into the new vaults
+        vec![test.owner_proof()],
+    );
+
+    let component_address: ComponentAddress = result.finalize.execution_results[1].decode().unwrap();
+
+    let component = test.read_only_state_store().get_component(component_address).unwrap();
+
+    let value: u128 = IndexedValue::from_value(component.into_state())
+        .unwrap()
+        .get_value("$.value")
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(value, 1);
+}

--- a/crates/engine/tests/templates/no_std/Cargo.toml
+++ b/crates/engine/tests/templates/no_std/Cargo.toml
@@ -1,0 +1,13 @@
+[workspace]
+[package]
+name = "state"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+tari_template_lib = { path = "../../../../template_lib", default-features = false, features = ["macro"] }
+
+[lib]
+crate-type = ["cdylib", "lib"]

--- a/crates/engine/tests/templates/no_std/src/lib.rs
+++ b/crates/engine/tests/templates/no_std/src/lib.rs
@@ -1,0 +1,44 @@
+//   Copyright 2025 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+#![no_std]
+
+use tari_template_lib::{
+    prelude::*,
+    template_dependencies::rust::{format, vec::Vec},
+};
+
+#[template]
+mod template {
+    use super::*;
+
+    #[derive(Default)]
+    pub struct NoStdCounter {
+        value: u128,
+    }
+
+    impl NoStdCounter {
+        pub fn new() -> Component<Self> {
+            Component::new(Self::default())
+                .with_access_rules(AccessRules::new().default(rule!(allow_all)))
+                .create()
+        }
+
+        pub fn with_address(address: ComponentAddressAllocation) -> Component<Self> {
+            Component::new(Self::default())
+                .with_access_rules(AccessRules::new().default(rule!(allow_all)))
+                .with_address_allocation(address)
+                .create()
+        }
+
+        pub fn increment(&mut self) {
+            debug!("Incrementing counter (current:{})", self.value);
+            self.value += 1;
+        }
+
+        pub fn reset_to(&mut self, value: u128) {
+            debug!("Changing value from {:?} to {}", self.value, value);
+            self.value = value;
+        }
+    }
+}

--- a/crates/engine/tests/templates/no_std/src/lib.rs
+++ b/crates/engine/tests/templates/no_std/src/lib.rs
@@ -3,10 +3,7 @@
 
 #![no_std]
 
-use tari_template_lib::{
-    prelude::*,
-    template_dependencies::rust::{format, vec::Vec},
-};
+use tari_template_lib::prelude::*;
 
 #[template]
 mod template {

--- a/crates/template_lib/Cargo.toml
+++ b/crates/template_lib/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "tari_template_lib"
 description = "Tari template library provides abstrations that interface with the Tari validator engine"
-version = "0.12.1"
+version = "0.12.2"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true
 license.workspace = true
 
 [dependencies]
-tari_template_abi = { workspace = true }
-tari_template_lib_types = { workspace = true }
+tari_template_abi = { workspace = true, default-features = false }
+tari_template_lib_types = { workspace = true, default-features = false }
 tari_template_macros = { workspace = true, optional = true }
 tari_bor = { workspace = true, default-features = false }
 
@@ -23,6 +23,7 @@ serde_json = { workspace = true }
 [features]
 default = ["macro", "std"]
 macro = ["tari_template_macros"]
-std = ["serde/std", "tari_bor/std"]
+std = ["serde/std", "tari_bor/std", "tari_template_abi/std", "tari_template_lib_types/std"]
+alloc = ["serde/alloc", "tari_bor/alloc", "tari_template_abi/alloc"]
 ts = ["ts-rs"]
 borsh = ["dep:borsh", "tari_template_lib_types/borsh"]

--- a/crates/template_lib/src/macros.rs
+++ b/crates/template_lib/src/macros.rs
@@ -12,7 +12,7 @@ macro_rules! debug {
         $crate::macros::call_debug($fmt)
     };
     ($fmt:expr, $($args:tt)*) => {
-        $crate::macros::call_debug(format!($fmt, $($args)*))
+        $crate::macros::call_debug($crate::template_dependencies::rust::format!($fmt, $($args)*))
     };
 }
 
@@ -20,10 +20,10 @@ macro_rules! debug {
 #[macro_export]
 macro_rules! log {
     ($lvl:expr, $fmt:expr) => {
-        $crate::engine().emit_log($lvl, format!($fmt))
+        $crate::engine().emit_log($lvl, $crate::template_dependencies::rust::format!($fmt))
     };
     ($lvl:expr, $fmt:expr, $($args:tt)*) => {
-        $crate::engine().emit_log($lvl, format!($fmt, $($args)*))
+        $crate::engine().emit_log($lvl, $crate::template_dependencies::rust::format!($fmt, $($args)*))
     };
 }
 

--- a/crates/template_macros/src/template/dispatcher.rs
+++ b/crates/template_macros/src/template/dispatcher.rs
@@ -51,11 +51,11 @@ pub fn generate_dispatcher(ast: &TemplateAst) -> Result<TokenStream> {
                 panic!("call_info is null");
             }
 
-            let call_data = unsafe { Vec::from_raw_parts(call_info, call_info_len as usize, call_info_len as usize) };
+            let call_data = unsafe { rust::vec::Vec::from_raw_parts(call_info, call_info_len as usize, call_info_len as usize) };
             let call_info: CallInfo = decode_exact(&call_data).expect("Failed to decode CallArgs");
 
             init_context(&call_info);
-            engine().emit_log(LogLevel::Debug, format!("Call {}", call_info.func_name));
+            engine().emit_log(LogLevel::Debug, rust::format!("Call {}", call_info.func_name));
 
             let result;
             match call_info.func_name.as_str() {


### PR DESCRIPTION
Description
---
test: test verifying no_std works
fix: exclude feature std in abi and types libs unless std is used in template_lib

Motivation and Context
---

no_std counter example drops about 200kb (very roughly, conditions apply etc)

How Has This Been Tested?
---
New test

What process can a PR reviewer use to test or verify this change?
---


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify