### PR TITLE
feat: expose new methods for wallet connect link

### DIFF
--- a/applications/tari_walletd/web_ui/src/Components/WalletConnectLink/WalletConnectLink.tsx
+++ b/applications/tari_walletd/web_ui/src/Components/WalletConnectLink/WalletConnectLink.tsx
@@ -41,8 +41,10 @@ import { Core } from "@walletconnect/core";
 import { WalletKit } from "@reown/walletkit";
 import {
   accountsCreateFreeTestCoins,
+  accountsGet,
   accountsGetBalances,
   accountsGetDefault,
+  accountsList,
   confidentialViewVaultBalance,
   keysCreate,
   nftList,
@@ -51,6 +53,7 @@ import {
   templatesGet,
   transactionsGetResult,
   transactionsSubmit,
+  walletGetInfo,
 } from "../../utils/json_rpc";
 import useAccountStore from "../../store/accountStore";
 import { buildApprovedNamespaces, getSdkError } from "@walletconnect/utils";
@@ -125,8 +128,12 @@ const ConnectorDialog = () => {
     switch (method) {
       case "tari_getSubstate":
         return substatesGet(params);
+      case "tari_accountsList":
+        return accountsList(params);
       case "tari_getDefaultAccount":
         return accountsGetDefault(params);
+      case "tari_getAccountByAddress":
+        return accountsGet(params);
       case "tari_getAccountBalances":
         return accountsGetBalances(params);
       case "tari_submitTransaction":
@@ -145,6 +152,8 @@ const ConnectorDialog = () => {
         return substatesList(params);
       case "tari_getNftsList":
         return nftList(params);
+      case "tari_getWalletInfo":
+        return walletGetInfo();
       default:
         setError(`Unsupported method ${method}`);
     }

--- a/applications/tari_walletd/web_ui/src/utils/json_rpc.ts
+++ b/applications/tari_walletd/web_ui/src/utils/json_rpc.ts
@@ -90,6 +90,7 @@ import type {
   TransactionWaitResultResponse,
   TransferNftRequest,
   TransferNftResponse,
+  WalletGetInfoResponse,
   WebauthnAlreadyRegisteredResponse,
   WebauthnFinishAuthRequest,
   WebauthnFinishRegisterRequest,
@@ -323,3 +324,6 @@ export const templatesGet = (request: TemplatesGetRequest): Promise<TemplatesGet
 
 export const templatesListAuthored = (request: TemplatesListAuthoredRequest): Promise<TemplatesListAuthoredResponse> =>
   client().then((c) => c.templatesListAuthored(request));
+
+// info
+export const walletGetInfo = (): Promise<WalletGetInfoResponse> => client().then((c) => c.walletGetInfo());


### PR DESCRIPTION
Description
---

Exposes new methods for wallet connect link:
- tari_accountsList
- tari_getAccountByAddress
- tari_getWalletInfo

Motivation and Context
---

Flow editor needs new functionality.
First, it needs to determine the network, that the wallet connection is bound to. It will be returned as part of `tari_getWalletInfo` response.
Second, the editor has to list available accounts and get their details. That is what `tari_accountsList` and `tari_getAccountByAddress` are for.

How Has This Been Tested?
---

Not tested. Will test as soon as this is merged and available via `tari-js` WalletConnect signer.

What process can a PR reviewer use to test or verify this change?
---


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify