### PR TITLE
chore: downgrade keyring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2696,16 +2696,11 @@ version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42a16374481d92aed73ae45b1f120207d8e71d24fb89f357fadbd8f946fd84b"
 dependencies = [
- "aes",
- "block-padding",
- "cbc",
  "dbus",
  "futures-util",
- "hkdf",
  "num",
  "once_cell",
  "rand 0.8.5",
- "sha2",
 ]
 
 [[package]]
@@ -5345,15 +5340,17 @@ dependencies = [
 
 [[package]]
 name = "keyring"
-version = "4.0.0-rc.1"
+version = "3.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb06f73ca0ea1cbd3858e54404585e33dccb860cb4fc8a66ad5e75a5736f3f19"
+checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
 dependencies = [
  "byteorder",
  "dbus-secret-service",
  "log",
+ "security-framework 2.11.1",
  "security-framework 3.2.0",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
+ "zeroize",
 ]
 
 [[package]]
@@ -14384,6 +14381,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.2",
 ]
 
 [[package]]

--- a/crates/wallet/sdk/Cargo.toml
+++ b/crates/wallet/sdk/Cargo.toml
@@ -31,7 +31,7 @@ time = { workspace = true, features = ["serde", "serde-human-readable"] }
 thiserror = { workspace = true }
 ts-rs = { workspace = true, optional = true }
 webauthn-rs = { workspace = true }
-keyring = { version = "4.0.0-rc.1", features = ["apple-native", "windows-native", "secret-service"] }
+keyring = { version = "3.6.3", features = ["apple-native", "windows-native", "sync-secret-service"] }
 passwords = "3.1.16"
 zeroize = { workspace = true }
 


### PR DESCRIPTION
Description
---

Downgrades `keyring` library from yanked `4.0.0-rc.1` to `3.6.3`

Motivation and Context
---

I need to add `tari_wallet_daemon_client` as an external dependency to Tari Universe.
But since `keyring` version `4.0.0-rc.1` is yanked, it is no longer possible.

ALL `4.*` versions are yanked, so we need to downgrade.

<img width="1024" height="741" alt="Screenshot 2025-07-28 at 13 23 33" src="https://github.com/user-attachments/assets/2f661c15-3fdd-4a67-814c-645fa65bd1c4" />


How Has This Been Tested?
---

What process can a PR reviewer use to test or verify this change?
---


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify