### PR TITLE
docs: updated readme swarm setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ tari_ootle_walletd --network igor -b <yourdesiredconfigfolderpath>
 
 This will start a wallet connected to the Igor Testnet. You can view the public Nodes here:
 
-- Validator Node: http://18.217.22.26:12006
-- Indexer: http://18.217.22.26:12502
+- Validator Node: [http://18.217.22.26:12006]](http://18.217.22.26:12006)
+- Indexer: [http://18.217.22.26:12502](http://18.217.22.26:12502)
 
 Navigate to http://127.0.0.1:5100 to create an account, claim test tokens and start testing features.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ If you're looking for the core Tari base layer code, it's in [this repository](h
 
 ## Accessing the Ootle Testnet
 
-The Tari Ootle Wallet Daemon is available from the release page of the Ootle project: https://github.com/tari-project/tari-ootle/releases
+The Tari Ootle Wallet Daemon is available on the project’s [releases page](https://github.com/tari-project/tari-ootle/releases).
 Unzip the binaries, then run:
 
 ```shell
@@ -58,8 +58,6 @@ cargo run --bin tari_swarm_daemon --release -- -c data/swarm/config.toml start
 ```
 
 > Note: For subsequent runs, you only need to run the third command with the `-k` argument to avoid trying to re-register the Validator Nodes: `cargo run --bin tari_swarm_daemon --release -- -c data/swarm/config.toml start -k`
-
-```
 
 This will get you an instance of the `tari_swarm_daemon`, starting a Minotari base node, a Minotari console wallet, an Ootle validator node, an Ootle wallet and an Indexer.
 Additionally, it will automatically submit the validator node registration and mine blocks until the validator node is active.

--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ cargo run --bin tari_swarm_daemon --release -- -c data/swarm/config.toml init
 cargo run --bin tari_swarm_daemon --release -- -c data/swarm/config.toml start
 ```
 
+> Note: For subsequent runs, you only need to run the third command with the `-k` argument to avoid trying to re-register the Validator Nodes: `cargo run --bin tari_swarm_daemon --release -- -c data/swarm/config.toml start -k`
+
+```
+
 This will get you an instance of the `tari_swarm_daemon`, starting a Minotari base node, a Minotari console wallet, an Ootle validator node, an Ootle wallet and an Indexer.
 Additionally, it will automatically submit the validator node registration and mine blocks until the validator node is active.
 

--- a/README.md
+++ b/README.md
@@ -6,31 +6,67 @@ You can read about the technical specifications of the Ootle in the [RFCs](https
 
 If you're looking for the core Tari base layer code, it's in [this repository](https://github.com/tari-project/tari)
 
-## Tari Validator node
+## Accessing the Ootle Testnet
 
-See the dedicated [README](./applications/tari_validator_node/README.md) for installation and running guides.
+The Tari Ootle Wallet Daemon is available from the release page of the Ootle project: https://github.com/tari-project/tari-ootle/releases
+Unzip the binaries, then run:
 
-## Running and testing a validator
+```shell
+tari_ootle_walletd --network igor -b <yourdesiredconfigfolderpath>
+```
+
+This will start a wallet connected to the Igor Testnet. You can view the public Nodes here:
+
+- Validator Node: http://18.217.22.26:12006
+- Indexer: http://18.217.22.26:12502
+
+Navigate to http://127.0.0.1:5100 to create an account, claim test tokens and start testing features.
+
+## Running the Ootle Locally (Localnet Development Environment)
 
 NOTE: This repo is heavily under development, so these instructions may change without notice.
 
-The easiest way to run a test network is to use `tari_swarm_daemon`.
+The easiest way to test out the Ootle is to use the `tari_swarm_daemon`. This will spin up all necessary MinoTari and Ootle components for a localnet.
+
+Clone both the tari and tari-ootle repositories in the same folder:
+```shell
+mkdir <containerfolder>
+cd <containerfolder>
+git clone https://github.com/tari-project/tari.git
+git clone https://github.com/tari-project/tari-ootle.git ootle
+```
+
+So:
+<Some container folder>
+   | tari
+   | ootle
+
+`cd` into `tari` and change the branch `v4.9.0-pre.1`: 
 
 ```shell
+cd tari
+git fetch origin tag v4.9.0-pre.1
+git checkout v4.9.0-pre.1
+```
+
+Once done, change directory to the `ootle` and run the following from the ootle folder:
+
+```shell
+rustup target add wasm32-unknown-unknown
 cargo run --bin tari_swarm_daemon --release -- -c data/swarm/config.toml init
-# Edit your config. You may need to point it to the path for the tari L1 repo. By default it assumed it's checked out at `../tari`.
 cargo run --bin tari_swarm_daemon --release -- -c data/swarm/config.toml start
 ```
 
-This will start a Minotari base node, a Minotari console wallet, an Ootle validator node, a wallet and an indexer.
-Additionally, it will automatically submit the validator node registration and mine blocks until the validator node is
-active.
+This will get you an instance of the `tari_swarm_daemon`, starting a Minotari base node, a Minotari console wallet, an Ootle validator node, an Ootle wallet and an Indexer.
+Additionally, it will automatically submit the validator node registration and mine blocks until the validator node is active.
 
-Open `http://localhost:8080` where you can administer the running instances, get links to the various web UIs and
-JSON-RPC endpoints, view logs and more.
+Open `http://localhost:8080` where you can administer the running instances, get links to the various web UIs and JSON-RPC endpoints, view logs and more.
 
-NOTE: `tari_swarm_daemon` is specifically for development/debugging and runs a complete local test network. Instructions
-for running a wallet, indexer, or validator node, the feature is still in development.
+NOTE: `tari_swarm_daemon` is specifically for development/debugging and runs a complete local test network. Instructions for running a wallet, indexer, or validator node, the feature is still in development.
+
+## Tari Validator node
+
+See the dedicated [README](./applications/tari_validator_node/README.md) for installation and running guides.
 
 #### Creating a smart contract template
 


### PR DESCRIPTION
Description
---

Updated the README to include more detailed instructions for running the `tari_swarm_daemon` and included instructions for the Igor Testnet/Contractnet

Motivation and Context
---
Correct process for setting up the swarm and critically note the version required for it to work correctly.

How Has This Been Tested?
---
Ran through all instructions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reorganized README into an "Accessing the Ootle Testnet" guide and a separate "Running the Ootle Locally (Localnet Development Environment)" workflow for clearer onboarding.
  * Added step-by-step local setup, daemon startup guidance (including repeat-run options), public node references, and local web UI paths for account creation and token claiming.
  * Moved validator-node details to a dedicated section and clarified which components are started for development/debugging, plus pointers to releases for wallet daemon artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->