### PR TITLE
fix(state_sync)!: sync state version

### DIFF
--- a/applications/tari_validator_node/src/p2p/rpc/service_impl.rs
+++ b/applications/tari_validator_node/src/p2p/rpc/service_impl.rs
@@ -54,7 +54,7 @@ use tari_rpc_framework::{Request, Response, RpcStatus, Streaming};
 use tari_template_lib::types::{HashParseError, TemplateAddress};
 use tari_template_manager::interface::TemplateManagerHandle;
 use tari_transaction::{Transaction, TransactionId};
-use tari_validator_node_rpc::rpc_service::ValidatorNodeRpcService;
+use tari_validator_node_rpc::{rpc_service::ValidatorNodeRpcService, STATE_SYNC_MAX_BATCH_SIZE};
 use tokio::{sync::mpsc, task};
 
 use crate::p2p::{
@@ -393,6 +393,7 @@ impl<TStateStore: StateStore + Clone + Send + Sync + 'static> ValidatorNodeRpcSe
                 sender,
                 last_state_transition_for_chain,
                 end_epoch,
+                STATE_SYNC_MAX_BATCH_SIZE,
             )
             .run(),
         );

--- a/applications/tari_validator_node/src/p2p/rpc/state_sync_task.rs
+++ b/applications/tari_validator_node/src/p2p/rpc/state_sync_task.rs
@@ -14,8 +14,6 @@ use tokio::sync::mpsc;
 
 const LOG_TARGET: &str = "tari::ootle::rpc::sync_task";
 
-const BATCH_SIZE: usize = 100;
-
 type UpdateBuffer = Vec<StateTransition>;
 
 pub struct StateSyncTask<TStateStore: StateStore> {
@@ -23,6 +21,7 @@ pub struct StateSyncTask<TStateStore: StateStore> {
     sender: mpsc::Sender<Result<SyncStateResponse, RpcStatus>>,
     start_state_transition_id: StateTransitionId,
     current_epoch: Epoch,
+    batch_size: usize,
 }
 
 impl<TStateStore: StateStore> StateSyncTask<TStateStore> {
@@ -31,17 +30,19 @@ impl<TStateStore: StateStore> StateSyncTask<TStateStore> {
         sender: mpsc::Sender<Result<SyncStateResponse, RpcStatus>>,
         start_state_transition_id: StateTransitionId,
         current_epoch: Epoch,
+        batch_size: usize,
     ) -> Self {
         Self {
             store,
             sender,
             start_state_transition_id,
             current_epoch,
+            batch_size,
         }
     }
 
     pub async fn run(mut self) -> Result<(), ()> {
-        let mut buffer = Vec::with_capacity(BATCH_SIZE);
+        let mut buffer = Vec::with_capacity(self.batch_size);
         let mut current_state_transition_id = self.start_state_transition_id;
         let mut counter = 0usize;
         loop {
@@ -93,7 +94,7 @@ impl<TStateStore: StateStore> StateSyncTask<TStateStore> {
     ) -> Result<Option<StateTransitionId>, StorageError> {
         self.store.with_read_tx(|tx| {
             let state_transitions =
-                StateTransition::get_n_after(tx, BATCH_SIZE, current_state_transition_id, self.current_epoch)
+                StateTransition::get_n_after(tx, self.batch_size, current_state_transition_id, self.current_epoch)
                     .optional()?
                     .unwrap_or_default();
 

--- a/crates/p2p/proto/rpc.proto
+++ b/crates/p2p/proto/rpc.proto
@@ -89,29 +89,6 @@ message GetPeersResponse {
   repeated tari.ootle.network.PeerIdentityClaim claims = 2;
 }
 
-message VnStateSyncRequest {
-  tari.ootle.common.SubstateAddress start_address = 1;
-  tari.ootle.common.SubstateAddress end_address = 2;
-  repeated tari.ootle.common.SubstateAddress inventory = 3;
-}
-
-message VnStateSyncResponse {
-  bytes address = 1;
-  uint32 version = 2;
-  bytes substate = 3;
-
-  uint64 created_epoch = 4;
-  uint64 created_height = 5;
-  bytes created_block = 6;
-  bytes created_transaction = 7;
-  bytes created_justify = 8;
-
-  tari.ootle.common.Epoch destroyed_epoch = 9;
-  bytes destroyed_block = 10;
-  bytes destroyed_transaction = 11;
-  bytes destroyed_justify = 12;
-}
-
 message GetSubstateRequest {
   tari.ootle.transaction.SubstateRequirement substate_requirement = 1;
 }
@@ -244,6 +221,7 @@ message SyncStateResponse {
 message StateTransition {
   StateTransitionId id = 1;
   SubstateUpdate update = 2;
+  uint64 state_version = 3;
 }
 
 message StateTransitionId {

--- a/crates/p2p/src/conversions/rpc.rs
+++ b/crates/p2p/src/conversions/rpc.rs
@@ -167,7 +167,11 @@ impl TryFrom<proto::rpc::StateTransition> for StateTransition {
             .update
             .ok_or_else(|| anyhow::anyhow!("Missing state transition update"))?;
         let update = SubstateUpdate::try_from(update)?;
-        Ok(Self { id, update })
+        Ok(Self {
+            id,
+            state_version: value.state_version,
+            update,
+        })
     }
 }
 
@@ -176,6 +180,7 @@ impl From<StateTransition> for proto::rpc::StateTransition {
         Self {
             id: Some(value.id.into()),
             update: Some(value.update.into()),
+            state_version: value.state_version,
         }
     }
 }

--- a/crates/rpc_state_sync/src/state_sync.rs
+++ b/crates/rpc_state_sync/src/state_sync.rs
@@ -1,7 +1,10 @@
 //   Copyright 2023 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use std::{cmp, collections::HashMap, time::Instant};
+use std::{
+    collections::{BTreeMap, HashMap},
+    time::Instant,
+};
 
 use anyhow::anyhow;
 use futures::StreamExt;
@@ -55,11 +58,11 @@ use tari_template_manager::interface::{TemplateChange, TemplateManagerHandle};
 use tari_validator_node_rpc::{
     client::{TariValidatorNodeRpcClientFactory, ValidatorNodeClientFactory},
     rpc_service::ValidatorNodeRpcClient,
+    STATE_SYNC_MAX_BATCH_SIZE,
 };
 
 use crate::{error::RpcStateSyncError, stats::StateSyncStats};
 
-const BATCH_SIZE: usize = 100;
 const LOG_TARGET: &str = "tari::ootle::comms_rpc_state_sync";
 
 pub struct RpcStateSyncClientProtocol<TConsensusSpec: ConsensusSpec> {
@@ -158,22 +161,19 @@ where TConsensusSpec: ConsensusSpec<Addr = PeerAddress>
             .optional()?
             .unwrap_or_else(|| StateTransitionId::initial(shard));
 
-        let persisted_version = self
+        let mut maybe_persisted_state_version = self
             .state_store
             .with_read_tx(|tx| tx.state_tree_versions_get_latest(shard))?;
 
         if current_epoch == last_state_transition_id.epoch() {
             info!(target: LOG_TARGET, "🛜Already up to date. No need to sync.");
-            return Ok(persisted_version);
+            return Ok(maybe_persisted_state_version);
         }
-
-        let mut maybe_current_version = persisted_version;
-        let current_version = maybe_current_version.unwrap_or(0);
 
         info!(
             target: LOG_TARGET,
             "🛜Syncing from v{} to state transition {last_state_transition_id}",
-            current_version
+            maybe_persisted_state_version.unwrap_or(0)
         );
 
         self.stats.total_requests += 1;
@@ -193,7 +193,7 @@ where TConsensusSpec: ConsensusSpec<Addr = PeerAddress>
             let msg = match result {
                 Ok(msg) => msg,
                 Err(err) if err.is_not_found() => {
-                    return Ok(maybe_current_version);
+                    return Ok(maybe_persisted_state_version);
                 },
                 Err(err) => {
                     return Err(err.into());
@@ -205,123 +205,137 @@ where TConsensusSpec: ConsensusSpec<Addr = PeerAddress>
                     "Received empty state transition batch."
                 )));
             }
+            if msg.transitions.len() > STATE_SYNC_MAX_BATCH_SIZE {
+                return Err(RpcStateSyncError::InvalidResponse(anyhow!(
+                    "Received too many state transitions in a batch: {}. Expected at most {}.",
+                    msg.transitions.len(),
+                    STATE_SYNC_MAX_BATCH_SIZE
+                )));
+            }
 
             self.stats.total_transitions += msg.transitions.len() as u64;
 
-            tree_changes.reserve_exact(cmp::min(msg.transitions.len(), BATCH_SIZE));
+            // Batch the response into a state_version -> Vec<StateTransition> map
+            let mut transitions =
+                msg.transitions
+                    .into_iter()
+                    .try_fold(BTreeMap::<_, Vec<_>>::new(), |mut acc, transition| {
+                        let transition =
+                            StateTransition::try_from(transition).map_err(RpcStateSyncError::InvalidResponse)?;
+                        acc.entry(transition.state_version).or_default().push(transition);
+                        Ok::<_, RpcStateSyncError>(acc)
+                    })?;
 
-            self.state_store.with_write_tx(|tx| {
-                info!(
-                    target: LOG_TARGET,
-                    "🛜 Next state updates batch of size {} from v{}",
-                    msg.transitions.len(),
-                    current_version
-                );
+            loop {
+                let Some((state_version, transitions_for_state_version)) = transitions.pop_first() else {
+                    info!(target: LOG_TARGET, "🛜 No more state transitions to process for shard {shard}");
+                    break;
+                };
 
-                let mut store = ShardScopedTreeStoreWriter::new(tx, shard);
+                tree_changes.reserve_exact(transitions_for_state_version.len());
 
-                for transition in msg.transitions {
-                    let transition =
-                        StateTransition::try_from(transition).map_err(RpcStateSyncError::InvalidResponse)?;
-                    if transition.id.shard() != shard {
-                        return Err(RpcStateSyncError::InvalidResponse(anyhow!(
-                            "Received state transition for shard {} which is not the expected shard {}.",
-                            transition.id.shard(),
-                            shard
-                        )));
-                    }
+                self.state_store.with_write_tx(|tx| {
+                    info!(
+                        target: LOG_TARGET,
+                        "🛜 Next state updates batch of size {} from v{}",
+                        transitions_for_state_version.len(),
+                        state_version
+                    );
 
-                    if transition.id.epoch().is_zero() {
-                        return Err(RpcStateSyncError::InvalidResponse(anyhow!(
-                            "Received state transition with epoch 0."
-                        )));
-                    }
+                    let mut store = ShardScopedTreeStoreWriter::new(tx, shard);
 
-                    if transition.id.epoch() >= current_epoch {
-                        return Err(RpcStateSyncError::InvalidResponse(anyhow!(
-                            "Received state transition for epoch {} which is at or ahead of our current epoch {}.",
-                            transition.id.epoch(),
-                            current_epoch
-                        )));
-                    }
-
-                    let change = match &transition.update {
-                        SubstateUpdate::Create(create) => {
-                            let id = create.substate.as_versioned_substate_id_ref();
-                            if let Some(template_address) = create.substate.substate_id.as_template() {
-                                match create
-                                    .substate
-                                    .value
-                                    .value() {
-                                    Some(value) => {
-                                        let template = value.as_template()
-                                            .ok_or_else(|| RpcStateSyncError::InvalidResponse(
-                                                anyhow!("Validator returned a template address {} but substate value was not a template", id.substate_id())
-                                            ))?;
-
-                                        info!(target: LOG_TARGET, "🛜 Add template {id}");
-                                        template_changes_mut.push(TemplateChange::Add {
-                                            template_address,
-                                            author_public_key: template.author,
-                                            binary_hash: template.binary_hash.into_array().into(),
-                                            epoch: transition.id.epoch(),
-                                        });
-                                    }
-                                    None => {
-                                        // TODO: currently you cannot DOWN a template. If we were to allow deprecations, it would likely be marking the template as deprecated rather than DOWNing it, and not permitting any template (non-component) calls to the template.
-                                        // We could still handle this case by requesting the template by address and verifying the template address hash i.e. peers send author and binary.
-                                        warn!(target: LOG_TARGET, "❗️ NEVER HAPPEN: Validator sent us a template {} that has no value, indicating it will be DOWNed later. We are not able to sync it", id);
-                                    }
-                                };
-                            }
-
-                            SubstateTreeChange::Up {
-                                id: id.to_owned(),
-                                value_hash: create.substate.to_value_hash(),
-                            }
+                    for transition in transitions_for_state_version {
+                        if transition.id.shard() != shard {
+                            return Err(RpcStateSyncError::InvalidResponse(anyhow!(
+                                "Received state transition for shard {} which is not the expected shard {}.",
+                                transition.id.shard(),
+                                shard
+                            )));
                         }
-                        SubstateUpdate::Destroy(destroy) => {
-                            if let Some(template_address) = destroy.substate_id.as_template() {
-                                info!(target: LOG_TARGET, "🛜 Deprecate template {}", template_address);
-                                template_changes_mut.push(TemplateChange::Deprecate { template_address });
-                            }
 
-                            SubstateTreeChange::Down {
-                                id: destroy.to_versioned_substate_id()
-                            }
+                        if transition.id.epoch().is_zero() {
+                            return Err(RpcStateSyncError::InvalidResponse(anyhow!(
+                                "Received state transition with epoch 0."
+                            )));
                         }
-                    };
 
+                        if transition.id.epoch() >= current_epoch {
+                            return Err(RpcStateSyncError::InvalidResponse(anyhow!(
+                                "Received state transition for epoch {} which is at or ahead of our current epoch {}.",
+                                transition.id.epoch(),
+                                current_epoch
+                            )));
+                        }
 
+                        let change = match &transition.update {
+                            SubstateUpdate::Create(create) => {
+                                let id = create.substate.as_versioned_substate_id_ref();
+                                if let Some(template_address) = create.substate.substate_id.as_template() {
+                                    match create
+                                        .substate
+                                        .value
+                                        .value() {
+                                        Some(value) => {
+                                            let template = value.as_template()
+                                                .ok_or_else(|| RpcStateSyncError::InvalidResponse(
+                                                    anyhow!("Validator returned a template address {} but substate value was not a template", id.substate_id())
+                                                ))?;
 
-                    info!(target: LOG_TARGET, "🛜 Applying state update (v{}) {}", current_version, transition);
-                    self.commit_update(store.transaction(), checkpoint, checkpoint_block_id, transition)?;
+                                            info!(target: LOG_TARGET, "🛜 Add template {id}");
+                                            template_changes_mut.push(TemplateChange::Add {
+                                                template_address,
+                                                author_public_key: template.author,
+                                                binary_hash: template.binary_hash.into_array().into(),
+                                                epoch: transition.id.epoch(),
+                                            });
+                                        }
+                                        None => {
+                                            // TODO: currently you cannot DOWN a template. If we were to allow deprecations, it would likely be marking the template as deprecated rather than DOWNing it, and not permitting any template (non-component) calls to the template.
+                                            // We could still handle this case by requesting the template by address and verifying the template address hash i.e. peers send author and binary.
+                                            warn!(target: LOG_TARGET, "❗️ NEVER HAPPEN: Validator sent us a template {} that has no value, indicating it will be DOWNed later. We are not able to sync it", id);
+                                        }
+                                    };
+                                }
 
-                    tree_changes.push(change);
-                    if tree_changes.len() == BATCH_SIZE {
+                                SubstateTreeChange::Up {
+                                    id: id.to_owned(),
+                                    value_hash: create.substate.to_value_hash(),
+                                }
+                            }
+                            SubstateUpdate::Destroy(destroy) => {
+                                if let Some(template_address) = destroy.substate_id.as_template() {
+                                    info!(target: LOG_TARGET, "🛜 Deprecate template {}", template_address);
+                                    template_changes_mut.push(TemplateChange::Deprecate { template_address });
+                                }
+
+                                SubstateTreeChange::Down {
+                                    id: destroy.to_versioned_substate_id()
+                                }
+                            }
+                        };
+
+                        info!(target: LOG_TARGET, "🛜 Applying state update (v{}) {}", state_version, transition);
+                        self.commit_update(store.transaction(), checkpoint, checkpoint_block_id, transition)?;
+
+                        tree_changes.push(change);
+                    }
+
+                    info!(target: LOG_TARGET, "🛜 {} state update(s) for v{}", tree_changes.len(), state_version);
+
+                    if !tree_changes.is_empty() {
                         let mut state_tree = SpreadPrefixStateTree::new(&mut store);
-                        let next_version = current_version + 1;
-                        info!(target: LOG_TARGET, "🛜 Committing {} state tree changes v{} to v{}", tree_changes.len(), current_version, next_version);
-                        state_tree.batch_put_substate_changes(maybe_current_version, next_version, tree_changes.drain(..))?;
-                        maybe_current_version = Some(next_version);
-                        store.set_version(next_version)?;
+                        info!(target: LOG_TARGET, "🛜 Committing {} state tree changes batch v{}", tree_changes.len(), state_version);
+                        state_tree.batch_put_substate_changes(maybe_persisted_state_version, state_version, tree_changes.drain(..))?;
+                        maybe_persisted_state_version = Some(state_version);
+                        store.set_version(state_version)?;
                     }
-                }
 
-                if !tree_changes.is_empty() {
-                    let mut state_tree = SpreadPrefixStateTree::new(&mut store);
-                    let next_version = current_version + 1;
-                    info!(target: LOG_TARGET, "🛜 Committing final {} state tree changes v{} to v{}", tree_changes.len(), current_version, next_version);
-                    state_tree.batch_put_substate_changes(maybe_current_version, next_version, tree_changes.drain(..))?;
-                    maybe_current_version = Some(next_version);
-                    store.set_version(next_version)?;
-                }
-
-                Ok::<_, RpcStateSyncError>(())
-            })?;
+                    Ok::<_, RpcStateSyncError>(())
+                })?;
+            }
         }
 
-        let local_state_root = self.calculate_state_root_for_shard(shard, maybe_current_version)?;
+        let local_state_root = self.calculate_state_root_for_shard(shard, maybe_persisted_state_version)?;
         if local_state_root != checkpoint_state_root {
             error!(
                 target: LOG_TARGET,
@@ -337,9 +351,9 @@ where TConsensusSpec: ConsensusSpec<Addr = PeerAddress>
             });
         }
 
-        info!(target: LOG_TARGET, "🛜 Synced state for {shard} to v{} with root {local_state_root}", maybe_current_version.unwrap_or(0));
+        info!(target: LOG_TARGET, "🛜 Synced state for {shard} to v{} with root {local_state_root}", maybe_persisted_state_version.unwrap_or(0));
 
-        Ok(maybe_current_version)
+        Ok(maybe_persisted_state_version)
     }
 
     fn calculate_state_root_for_shard(

--- a/crates/state_store_rocksdb/src/column_families/state_transition.rs
+++ b/crates/state_store_rocksdb/src/column_families/state_transition.rs
@@ -23,6 +23,7 @@
 use serde::{Deserialize, Serialize};
 use tari_ootle_common_types::{shard::Shard, SubstateAddress};
 use tari_ootle_storage::consensus_models::StateTransitionId;
+use tari_state_tree::Version;
 
 use crate::{
     codecs::{DefaultCodec, EpochCodec, NumberCodec, ShardCodec, StateTransitionIdCodec},
@@ -33,6 +34,7 @@ use crate::{
 pub struct StateTransitionModelData {
     pub substate_address: SubstateAddress,
     pub transition: StateTransitionType,
+    pub state_version: Version,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]

--- a/crates/state_store_rocksdb/src/reader.rs
+++ b/crates/state_store_rocksdb/src/reader.rs
@@ -1646,7 +1646,11 @@ impl<'tx, TAddr: NodeAddressable + Serialize + DeserializeOwned + 'tx> StateStor
                 }),
             };
 
-            transitions.push(StateTransition { id: key, update });
+            transitions.push(StateTransition {
+                id: key,
+                state_version: value.state_version,
+                update,
+            });
             if transitions.len() == n {
                 break;
             }

--- a/crates/state_store_rocksdb/src/writer.rs
+++ b/crates/state_store_rocksdb/src/writer.rs
@@ -1216,6 +1216,12 @@ impl<'tx, TAddr: NodeAddressable + 'tx> StateStoreWriteTransaction for RocksDbSt
             OPERATION,
         )?;
 
+        let shard_state_version = db
+            .cf(StateTreeShardVersionCf)?
+            .get(&substate.created_by_shard, OPERATION)
+            .optional()?
+            .unwrap_or_default();
+
         let seq_index = db.cf(state_transition::ShardSeqIndex)?;
         let seq = seq_index.get(&substate.created_by_shard, OPERATION).optional()?;
         let next_seq = seq.map(|s| s + 1).unwrap_or(1);
@@ -1223,6 +1229,7 @@ impl<'tx, TAddr: NodeAddressable + 'tx> StateStoreWriteTransaction for RocksDbSt
         let id = StateTransitionId::new(substate.created_at_epoch, substate.created_by_shard, next_seq);
         let transition = StateTransitionModelData {
             substate_address: address,
+            state_version: shard_state_version,
             transition: StateTransitionType::Up,
         };
 
@@ -1269,8 +1276,16 @@ impl<'tx, TAddr: NodeAddressable + 'tx> StateStoreWriteTransaction for RocksDbSt
         let next_seq = seq.map(|s| s + 1).unwrap_or(1);
 
         let transitions_cf = db.cf(StateTransitionCf)?;
+
+        let shard_state_version = db
+            .cf(StateTreeShardVersionCf)?
+            .get(&shard, OPERATION)
+            .optional()?
+            .unwrap_or_default();
+
         let data = StateTransitionModelData {
             substate_address: address,
+            state_version: shard_state_version,
             transition: StateTransitionType::Down,
         };
         let id = StateTransitionId::new(epoch, shard, next_seq);

--- a/crates/storage/src/consensus_models/state_transition.rs
+++ b/crates/storage/src/consensus_models/state_transition.rs
@@ -9,13 +9,14 @@ use std::{
 
 use serde::{Deserialize, Serialize};
 use tari_ootle_common_types::{shard::Shard, Epoch};
-use tari_state_tree::SubstateTreeChange;
+use tari_state_tree::{SubstateTreeChange, Version};
 
 use crate::{consensus_models::SubstateUpdate, StateStoreReadTransaction, StorageError};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StateTransition {
     pub id: StateTransitionId,
+    pub state_version: Version,
     pub update: SubstateUpdate,
 }
 

--- a/crates/validator_node_rpc/src/lib.rs
+++ b/crates/validator_node_rpc/src/lib.rs
@@ -24,3 +24,5 @@ pub mod client;
 mod error;
 pub mod rpc_service;
 pub use error::ValidatorNodeRpcClientError;
+
+pub const STATE_SYNC_MAX_BATCH_SIZE: usize = 100;


### PR DESCRIPTION
Description
---
fix(state_sync)!: sync state version

Motivation and Context
---
The shard state version is now synchronised across validators. However, this invariant is not enforced by consensus.
A future PR (or the change to the JMT #1472) may enforce this in future.

This is the first part that enables clients to periodically sync state changes using a (shard, state_version) tuple.

How Has This Been Tested?
---
Manually by deleting a validator node's data and restarting it, observing sync logs and checking the database against the sync node

What process can a PR reviewer use to test or verify this change?
---
Sync should work as before

Breaking Changes
---

- [ ] None
- [x] Requires data directory to be deleted
- [ ] Other - Please specify

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - State transitions now include a version, enabling more robust syncing and auditing.
  - State sync processes per-version batches with a defined maximum batch size, improving performance and stability.

- Refactor
  - Streamlined state-sync flow with clearer progress and completion logging.

- Chores
  - RPC protocol updated; legacy state-sync messages removed. Ensure peers are upgraded for compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->