### PR TITLE
Batch fetch substates api

### DIFF
--- a/applications/tari_indexer/openrpc.json
+++ b/applications/tari_indexer/openrpc.json
@@ -9,7 +9,7 @@
     },
     "servers": [
         {
-            "url": "http://localhost:183000"
+            "url": "http://localhost:18300"
         }
     ],
     "methods": [

--- a/applications/tari_indexer/openrpc.json
+++ b/applications/tari_indexer/openrpc.json
@@ -1,352 +1,431 @@
 {
-  "openrpc": "1.0.0-rc1",
-  "info": {
-    "version": "1.0.0",
-    "title": "Tari Indexer",
-    "license": {
-      "name": "MIT"
-    }
-  },
-  "servers": [
-    {
-      "url": "http://localhost:183000"
-    }
-  ],
-  "methods": [
-    {
-      "name": "get_connections",
-      "summary": "",
-      "tags": [],
-      "params": [],
-      "result": {
-        "name": "epoch_stats",
-        "description": "",
-        "schema": {}
-      },
-      "errors": [],
-      "examples": [
+    "openrpc": "1.0.0-rc1",
+    "info": {
+        "version": "1.0.0",
+        "title": "Tari Indexer",
+        "license": {
+            "name": "MIT"
+        }
+    },
+    "servers": [
         {
-          "name": "default",
-          "description": "",
-          "params": [],
-          "result": {
-            "name": "example1",
-            "value": {
-              "connections": [
+            "url": "http://localhost:183000"
+        }
+    ],
+    "methods": [
+        {
+            "name": "get_connections",
+            "summary": "",
+            "tags": [],
+            "params": [],
+            "result": {
+                "name": "epoch_stats",
+                "description": "",
+                "schema": {}
+            },
+            "errors": [],
+            "examples": [
                 {
-                  "address": "/onion3/zqydnqgtapphitwdxr4sfg5kuvv7kbs5ye54yjy2mybi7f7qxd5jeiyd:18141",
-                  "age": 9946,
-                  "direction": false,
-                  "node_id": [
-                    208,
-                    146,
-                    146,
-                    229,
-                    165,
-                    144,
-                    10,
-                    41,
-                    56,
-                    35,
-                    69,
-                    224,
-                    120
-                  ],
-                  "public_key": "b4a0b93ccd3a50ab8f7fb766cc9fea59e574283d69a53fe60d6aa842f42ecd38"
-                }
-              ]
-            }
-          }
-        }
-      ]
-    },
-    {
-      "name": "get_identity",
-      "summary": "",
-      "tags": [],
-      "params": [],
-      "result": {
-        "name": "epoch_stats",
-        "description": "",
-        "schema": {}
-      },
-      "errors": [],
-      "examples": [
-        {
-          "name": "default",
-          "description": "",
-          "params": [],
-          "result": {
-            "name": "example1",
-            "value": {
-              "node_id": "9c8d9ee038b16a424a30b4fad8",
-              "public_address": "/onion3/5m3262svmddswg5q7apa5eciwxwgip5jghzv4xc2jknrh26bysfzwsyd:18141",
-              "public_key": "7a149364bb8beb7f0cc6a100350391b4debd7dbaf7880bab421f024feca02b1f"
-            }
-          }
-        }
-      ]
-    },
-    {
-      "name": "get_addresses",
-      "summary": "",
-      "tags": [],
-      "params": [],
-      "result": {
-        "name": "epoch_stats",
-        "description": "",
-        "schema": {}
-      },
-      "errors": [],
-      "examples": [
-        {
-          "name": "default",
-          "description": "",
-          "params": [],
-          "result": {
-            "name": "example1",
-            "value": [
-              [
-                "component_e4773b971b876238475c904927435d625d892132e7d7b80c3cc81698fcc4a2dd",
-                0
-              ],
-              [
-                "component_7c45d28ffa167b10d2fa700ce29343de692b97422a65485d0a00e8e7578d692e",
-                0
-              ],
-              [
-                "component_3bca9b603e196b60f261aad0db85e7b55d52c46d687cdbb54194b706423fb1aa",
-                0
-              ]
-            ]
-          }
-        }
-      ]
-    },
-    {
-      "name": "get_substate",
-      "summary": "",
-      "tags": [],
-      "params": [],
-      "result": {
-        "name": "epoch_stats",
-        "description": "",
-        "schema": {}
-      },
-      "errors": [],
-      "examples": [
-        {
-          "name": "default",
-          "description": "",
-          "params": [],
-          "result": {
-            "name": "example1",
-            "value": {
-              "substate": {
-                "Component": {
-                  "access_rules": {
-                    "default": {
-                      "Restricted": {
-                        "Require": {
-                          "id": {
-                            "U256": [
-                              242,
-                              92,
-                              64,
-                              223,
-                              207,
-                              57,
-                              225,
-                              163,
-                              175,
-                              11,
-                              109,
-                              189,
-                              230,
-                              209,
-                              24,
-                              78,
-                              225,
-                              250,
-                              171,
-                              247,
-                              14,
-                              102,
-                              246,
-                              15,
-                              193,
-                              145,
-                              233,
-                              156,
-                              24,
-                              197,
-                              147,
-                              116
+                    "name": "default",
+                    "description": "",
+                    "params": [],
+                    "result": {
+                        "name": "example1",
+                        "value": {
+                            "connections": [
+                                {
+                                    "address": "/onion3/zqydnqgtapphitwdxr4sfg5kuvv7kbs5ye54yjy2mybi7f7qxd5jeiyd:18141",
+                                    "age": 9946,
+                                    "direction": false,
+                                    "node_id": [
+                                        208,
+                                        146,
+                                        146,
+                                        229,
+                                        165,
+                                        144,
+                                        10,
+                                        41,
+                                        56,
+                                        35,
+                                        69,
+                                        224,
+                                        120
+                                    ],
+                                    "public_key": "b4a0b93ccd3a50ab8f7fb766cc9fea59e574283d69a53fe60d6aa842f42ecd38"
+                                }
                             ]
-                          },
-                          "resource_address": [
-                            1,
-                            0,
-                            0,
-                            0,
-                            0,
-                            0,
-                            0,
-                            0,
-                            0,
-                            0,
-                            0,
-                            0,
-                            0,
-                            0,
-                            0,
-                            0,
-                            0,
-                            0,
-                            0,
-                            0,
-                            0,
-                            0,
-                            0,
-                            0,
-                            0,
-                            0,
-                            0,
-                            0,
-                            0,
-                            0,
-                            0,
-                            0
-                          ]
                         }
-                      }
-                    },
-                    "method_access": {
-                      "balance": "AllowAll",
-                      "deposit": "AllowAll",
-                      "deposit_all": "AllowAll",
-                      "get_balances": "AllowAll",
-                      "get_non_fungible_ids": "AllowAll"
-                    },
-                    "native_method_access": {}
-                  },
-                  "module_name": "Account",
-                  "state": {
-                    "state": [
-                      0,
-                      0,
-                      0,
-                      0
-                    ]
-                  },
-                  "template_address": [
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0
-                  ]
-                }
-              }
-            }
-          }
-        }
-      ]
-    },
-    {
-      "name": "get_substates",
-      "summary": "Fetch multiple substates in a single request",
-      "tags": [],
-      "params": [
-        {
-          "name": "requests",
-          "required": true,
-          "schema": {
-            "$ref": "#/components/schemas/GetSubstatesRequest"
-          }
-        }
-      ],
-      "result": {
-        "name": "get_substates_response",
-        "description": "Batch substate fetch response",
-        "schema": {
-          "$ref": "#/components/schemas/GetSubstatesResponse"
-        }
-      },
-      "errors": [],
-      "examples": [
-        {
-          "name": "default",
-          "description": "",
-          "params": [
-            {
-              "name": "requests",
-              "value": {
-                "requests": [
-                  {
-                    "address": [
-                      "component_e4773b971b876238475c904927435d625d892132e7d7b80c3cc81698fcc4a2dd",
-                      0
-                    ]
-                  },
-                  {
-                    "address": [
-                      "component_7c45d28ffa167b10d2fa700ce29343de692b97422a65485d0a00e8e7578d692e",
-                      0
-                    ]
-                  }
-                ]
-              }
-            }
-          ],
-          "result": {
-            "name": "example1",
-            "value": {
-              "items": [
-                {
-                  "address": [
-                    "component_e4773b971b876238475c904927435d625d892132e7d7b80c3cc81698fcc4a2dd",
-                    0
-                  ],
-                  "substate": {
-                    "Component": {
-                      "module_name": "Account",
-                      "state": {
-                        "state": [
-                          0,
-                          0,
-                          0,
-                          0
-                        ]
-                      }
                     }
-                  },
-                  "version": 0
+                }
+            ]
+        },
+        {
+            "name": "get_identity",
+            "summary": "",
+            "tags": [],
+            "params": [],
+            "result": {
+                "name": "epoch_stats",
+                "description": "",
+                "schema": {}
+            },
+            "errors": [],
+            "examples": [
+                {
+                    "name": "default",
+                    "description": "",
+                    "params": [],
+                    "result": {
+                        "name": "example1",
+                        "value": {
+                            "node_id": "9c8d9ee038b16a424a30b4fad8",
+                            "public_address": "/onion3/5m3262svmddswg5q7apa5eciwxwgip5jghzv4xc2jknrh26bysfzwsyd:18141",
+                            "public_key": "7a149364bb8beb7f0cc6a100350391b4debd7dbaf7880bab421f024feca02b1f"
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "name": "get_addresses",
+            "summary": "",
+            "tags": [],
+            "params": [],
+            "result": {
+                "name": "epoch_stats",
+                "description": "",
+                "schema": {}
+            },
+            "errors": [],
+            "examples": [
+                {
+                    "name": "default",
+                    "description": "",
+                    "params": [],
+                    "result": {
+                        "name": "example1",
+                        "value": [
+                            [
+                                "component_e4773b971b876238475c904927435d625d892132e7d7b80c3cc81698fcc4a2dd",
+                                0
+                            ],
+                            [
+                                "component_7c45d28ffa167b10d2fa700ce29343de692b97422a65485d0a00e8e7578d692e",
+                                0
+                            ],
+                            [
+                                "component_3bca9b603e196b60f261aad0db85e7b55d52c46d687cdbb54194b706423fb1aa",
+                                0
+                            ]
+                        ]
+                    }
+                }
+            ]
+        },
+        {
+            "name": "get_substate",
+            "summary": "",
+            "tags": [],
+            "params": [],
+            "result": {
+                "name": "epoch_stats",
+                "description": "",
+                "schema": {}
+            },
+            "errors": [],
+            "examples": [
+                {
+                    "name": "default",
+                    "description": "",
+                    "params": [],
+                    "result": {
+                        "name": "example1",
+                        "value": {
+                            "substate": {
+                                "Component": {
+                                    "access_rules": {
+                                        "default": {
+                                            "Restricted": {
+                                                "Require": {
+                                                    "id": {
+                                                        "U256": [
+                                                            242,
+                                                            92,
+                                                            64,
+                                                            223,
+                                                            207,
+                                                            57,
+                                                            225,
+                                                            163,
+                                                            175,
+                                                            11,
+                                                            109,
+                                                            189,
+                                                            230,
+                                                            209,
+                                                            24,
+                                                            78,
+                                                            225,
+                                                            250,
+                                                            171,
+                                                            247,
+                                                            14,
+                                                            102,
+                                                            246,
+                                                            15,
+                                                            193,
+                                                            145,
+                                                            233,
+                                                            156,
+                                                            24,
+                                                            197,
+                                                            147,
+                                                            116
+                                                        ]
+                                                    },
+                                                    "resource_address": [
+                                                        1,
+                                                        0,
+                                                        0,
+                                                        0,
+                                                        0,
+                                                        0,
+                                                        0,
+                                                        0,
+                                                        0,
+                                                        0,
+                                                        0,
+                                                        0,
+                                                        0,
+                                                        0,
+                                                        0,
+                                                        0,
+                                                        0,
+                                                        0,
+                                                        0,
+                                                        0,
+                                                        0,
+                                                        0,
+                                                        0,
+                                                        0,
+                                                        0,
+                                                        0,
+                                                        0,
+                                                        0,
+                                                        0,
+                                                        0,
+                                                        0,
+                                                        0
+                                                    ]
+                                                }
+                                            }
+                                        },
+                                        "method_access": {
+                                            "balance": "AllowAll",
+                                            "deposit": "AllowAll",
+                                            "deposit_all": "AllowAll",
+                                            "get_balances": "AllowAll",
+                                            "get_non_fungible_ids": "AllowAll"
+                                        },
+                                        "native_method_access": {}
+                                    },
+                                    "module_name": "Account",
+                                    "state": {
+                                        "state": [
+                                            0,
+                                            0,
+                                            0,
+                                            0
+                                        ]
+                                    },
+                                    "template_address": [
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "name": "get_substates",
+            "summary": "Fetch multiple substates in a single request",
+            "tags": [],
+            "params": [
+                {
+                    "name": "requests",
+                    "required": true,
+                    "schema": {
+                        "$ref": "#/components/schemas/GetSubstatesRequest"
+                    }
+                }
+            ],
+            "result": {
+                "name": "get_substates_response",
+                "description": "Batch substate fetch response",
+                "schema": {
+                    "$ref": "#/components/schemas/GetSubstatesResponse"
+                }
+            },
+            "errors": [],
+            "examples": [
+                {
+                    "name": "default",
+                    "description": "",
+                    "params": [
+                        {
+                            "name": "requests",
+                            "value": {
+                                "requests": [
+                                    {
+                                        "address": [
+                                            "component_e4773b971b876238475c904927435d625d892132e7d7b80c3cc81698fcc4a2dd",
+                                            0
+                                        ]
+                                    },
+                                    {
+                                        "address": [
+                                            "component_7c45d28ffa167b10d2fa700ce29343de692b97422a65485d0a00e8e7578d692e",
+                                            0
+                                        ]
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "result": {
+                        "name": "example1",
+                        "value": {
+                            "responses": [
+                                {
+                                    "address": [
+                                        "component_e4773b971b876238475c904927435d625d892132e7d7b80c3cc81698fcc4a2dd",
+                                        0
+                                    ],
+                                    "substate": {
+                                        "Component": {
+                                            "module_name": "Account",
+                                            "state": {
+                                                "state": [
+                                                    0,
+                                                    0,
+                                                    0,
+                                                    0
+                                                ]
+                                            }
+                                        }
+                                    },
+                                    "version": 0
+                                }
+                            ]
+                        }
+                    }
+                }
+            ]
+        }
+    ],
+    "components": {
+        "schemas": {
+            "GetSubstateRequest": {
+                "type": "object",
+                "properties": {
+                    "address": {
+                        "type": "array",
+                        "items": {}
+                    }
                 },
+                "required": [
+                    "address"
+                ]
+            },
+            "GetSubstateResponse": {
+                "type": "object",
+                "properties": {
+                    "address": {
+                        "type": "array",
+                        "items": {}
+                    },
+                    "substate": {
+                        "type": "object"
+                    },
+                    "version": {
+                        "type": "integer"
+                    }
+                },
+                "required": [
+                    "address",
+                    "substate",
+                    "version"
+                ]
+            },
+            "GetSubstatesRequest": {
+                "type": "object",
+                "properties": {
+                    "requests": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/GetSubstateRequest"
+                        }
+                    }
+                },
+                "required": [
+                    "requests"
+                ]
+            },
+            "GetSubstatesResponse": {
+                "type": "object",
+                "properties": {
+                    "responses": {
+                        "type": "array",
+                        "items": {
+                            "anyOf": [
+                                {
+                                    "$ref": "#/components/schemas/GetSubstateResponse"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "required": [
+                    "responses"
+                ]
+            }
+        }
+    }
+}

--- a/applications/tari_indexer/openrpc.json
+++ b/applications/tari_indexer/openrpc.json
@@ -279,320 +279,102 @@
           }
         }
       ]
-    },
+    }
+    ,
     {
       "name": "get_substates",
-      "summary": "",
+      "summary": "Fetch multiple substates in a single call",
       "tags": [],
-      "params": [],
-      "result": {
-        "name": "epoch_stats",
-        "description": "",
-        "schema": {}
-      },
-      "errors": [],
-      "examples": [
+      "params": [
         {
-          "name": "default",
-          "description": "",
-          "params": [],
-          "result": {
-            "name": "example1",
-            "value": {
-              "substate": {
-                "Component": {
-                  "access_rules": {
-                    "default": {
-                      "Restricted": {
-                        "Require": {
-                          "id": {
-                            "U256": [
-                              242,
-                              92,
-                              64,
-                              223,
-                              207,
-                              57,
-                              225,
-                              163,
-                              175,
-                              11,
-                              109,
-                              189,
-                              230,
-                              209,
-                              24,
-                              78,
-                              225,
-                              250,
-                              171,
-                              247,
-                              14,
-                              102,
-                              246,
-                              15,
-                              193,
-                              145,
-                              233,
-                              156,
-                              24,
-                              197,
-                              147,
-                              116
-                            ]
-                          },
-                          "resource_address": [
-                            1,
-                            0,
-                            0,
-                            0,
-                            0,
-                            0,
-                            0,
-                            0,
-                            0,
-                            0,
-                            0,
-                            0,
-                            0,
-                            0,
-                            0,
-                            0,
-                            0,
-                            0,
-                            0,
-                            0,
-                            0,
-                            0,
-                            0,
-                            0,
-                            0,
-                            0,
-                            0,
-                            0,
-                            0,
-                            0,
-                            0,
-                            0
-                          ]
-                        }
-                      }
-                    },
-                    "method_access": {
-                      "balance": "AllowAll",
-                      "deposit": "AllowAll",
-                      "deposit_all": "AllowAll",
-                      "get_balances": "AllowAll",
-                      "get_non_fungible_ids": "AllowAll"
-                    },
-                    "native_method_access": {}
-                  },
-                  "module_name": "Account",
-                  "state": {
-                    "state": [
-                      0,
-                      0,
-                      0,
-                      0
-                    ]
-                  },
-                  "template_address": [
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0
-                  ]
-                }
-              }
+          "name": "requests",
+          "description": "Array of substate requests",
+          "required": true,
+          "schema": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "address": { "type": "string" },
+                "version": { "type": ["integer", "null"] },
+                "local_search_only": { "type": ["boolean", "null"] }
+              },
+              "required": ["address"]
             }
           }
         }
-      ]
-    },
+      ],
+      "result": {
+        "name": "responses",
+        "description": "Responses for each request, aligned by index",
+        "schema": {
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "address": { "type": "string" },
+                  "version": { "type": "integer" },
+                  "substate": { "type": "object" }
+                },
+                "required": ["address", "version", "substate"]
+              },
+              { "type": "null" }
+            ]
+          }
+        }
+      },
+      "errors": [],
+      "examples": []
+    }
+    ,
     {
       "name": "fetch_substates",
-      "summary": "",
+      "summary": "Alias of get_substates",
       "tags": [],
-      "params": [],
-      "result": {
-        "name": "epoch_stats",
-        "description": "",
-        "schema": {}
-      },
-      "errors": [],
-      "examples": [
+      "params": [
         {
-          "name": "default",
-          "description": "",
-          "params": [],
-          "result": {
-            "name": "example1",
-            "value": {
-              "substate": {
-                "Component": {
-                  "access_rules": {
-                    "default": {
-                      "Restricted": {
-                        "Require": {
-                          "id": {
-                            "U256": [
-                              242,
-                              92,
-                              64,
-                              223,
-                              207,
-                              57,
-                              225,
-                              163,
-                              175,
-                              11,
-                              109,
-                              189,
-                              230,
-                              209,
-                              24,
-                              78,
-                              225,
-                              250,
-                              171,
-                              247,
-                              14,
-                              102,
-                              246,
-                              15,
-                              193,
-                              145,
-                              233,
-                              156,
-                              24,
-                              197,
-                              147,
-                              116
-                            ]
-                          },
-                          "resource_address": [
-                            1,
-                            0,
-                            0,
-                            0,
-                            0,
-                            0,
-                            0,
-                            0,
-                            0,
-                            0,
-                            0,
-                            0,
-                            0,
-                            0,
-                            0,
-                            0,
-                            0,
-                            0,
-                            0,
-                            0,
-                            0,
-                            0,
-                            0,
-                            0,
-                            0,
-                            0,
-                            0,
-                            0,
-                            0,
-                            0,
-                            0,
-                            0
-                          ]
-                        }
-                      }
-                    },
-                    "method_access": {
-                      "balance": "AllowAll",
-                      "deposit": "AllowAll",
-                      "deposit_all": "AllowAll",
-                      "get_balances": "AllowAll",
-                      "get_non_fungible_ids": "AllowAll"
-                    },
-                    "native_method_access": {}
-                  },
-                  "module_name": "Account",
-                  "state": {
-                    "state": [
-                      0,
-                      0,
-                      0,
-                      0
-                    ]
-                  },
-                  "template_address": [
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0
-                  ]
-                }
-              }
+          "name": "requests",
+          "description": "Array of substate requests",
+          "required": true,
+          "schema": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "address": { "type": "string" },
+                "version": { "type": ["integer", "null"] },
+                "local_search_only": { "type": ["boolean", "null"] }
+              },
+              "required": ["address"]
             }
           }
         }
-      ]
+      ],
+      "result": {
+        "name": "responses",
+        "description": "Responses for each request, aligned by index",
+        "schema": {
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "address": { "type": "string" },
+                  "version": { "type": "integer" },
+                  "substate": { "type": "object" }
+                },
+                "required": ["address", "version", "substate"]
+              },
+              { "type": "null" }
+            ]
+          }
+        }
+      },
+      "errors": [],
+      "examples": []
     }
   ],
   "components": {

--- a/applications/tari_indexer/openrpc.json
+++ b/applications/tari_indexer/openrpc.json
@@ -279,106 +279,74 @@
           }
         }
       ]
-    }
-    ,
+    },
     {
       "name": "get_substates",
-      "summary": "Fetch multiple substates in a single call",
+      "summary": "Fetch multiple substates in a single request",
       "tags": [],
       "params": [
         {
           "name": "requests",
-          "description": "Array of substate requests",
           "required": true,
           "schema": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "address": { "type": "string" },
-                "version": { "type": ["integer", "null"] },
-                "local_search_only": { "type": ["boolean", "null"] }
-              },
-              "required": ["address"]
-            }
+            "$ref": "#/components/schemas/GetSubstatesRequest"
           }
         }
       ],
       "result": {
-        "name": "responses",
-        "description": "Responses for each request, aligned by index",
+        "name": "get_substates_response",
+        "description": "Batch substate fetch response",
         "schema": {
-          "type": "array",
-          "items": {
-            "anyOf": [
-              {
-                "type": "object",
-                "properties": {
-                  "address": { "type": "string" },
-                  "version": { "type": "integer" },
-                  "substate": { "type": "object" }
-                },
-                "required": ["address", "version", "substate"]
-              },
-              { "type": "null" }
-            ]
-          }
+          "$ref": "#/components/schemas/GetSubstatesResponse"
         }
       },
       "errors": [],
-      "examples": []
-    }
-    ,
-    {
-      "name": "fetch_substates",
-      "summary": "Alias of get_substates",
-      "tags": [],
-      "params": [
+      "examples": [
         {
-          "name": "requests",
-          "description": "Array of substate requests",
-          "required": true,
-          "schema": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "address": { "type": "string" },
-                "version": { "type": ["integer", "null"] },
-                "local_search_only": { "type": ["boolean", "null"] }
-              },
-              "required": ["address"]
+          "name": "default",
+          "description": "",
+          "params": [
+            {
+              "name": "requests",
+              "value": {
+                "requests": [
+                  {
+                    "address": [
+                      "component_e4773b971b876238475c904927435d625d892132e7d7b80c3cc81698fcc4a2dd",
+                      0
+                    ]
+                  },
+                  {
+                    "address": [
+                      "component_7c45d28ffa167b10d2fa700ce29343de692b97422a65485d0a00e8e7578d692e",
+                      0
+                    ]
+                  }
+                ]
+              }
             }
-          }
-        }
-      ],
-      "result": {
-        "name": "responses",
-        "description": "Responses for each request, aligned by index",
-        "schema": {
-          "type": "array",
-          "items": {
-            "anyOf": [
-              {
-                "type": "object",
-                "properties": {
-                  "address": { "type": "string" },
-                  "version": { "type": "integer" },
-                  "substate": { "type": "object" }
+          ],
+          "result": {
+            "name": "example1",
+            "value": {
+              "items": [
+                {
+                  "address": [
+                    "component_e4773b971b876238475c904927435d625d892132e7d7b80c3cc81698fcc4a2dd",
+                    0
+                  ],
+                  "substate": {
+                    "Component": {
+                      "module_name": "Account",
+                      "state": {
+                        "state": [
+                          0,
+                          0,
+                          0,
+                          0
+                        ]
+                      }
+                    }
+                  },
+                  "version": 0
                 },
-                "required": ["address", "version", "substate"]
-              },
-              { "type": "null" }
-            ]
-          }
-        }
-      },
-      "errors": [],
-      "examples": []
-    }
-  ],
-  "components": {
-    "contentDescriptors": {},
-    "schemas": {}
-  }
-}

--- a/applications/tari_indexer/openrpc.json
+++ b/applications/tari_indexer/openrpc.json
@@ -355,6 +355,82 @@
                     }
                 }
             ]
+        },
+        {
+            "name": "fetch_substates",
+            "summary": "Fetch multiple substates in a single request",
+            "tags": [],
+            "params": [
+                {
+                    "name": "requests",
+                    "required": true,
+                    "schema": {
+                        "$ref": "#/components/schemas/GetSubstatesRequest"
+                    }
+                }
+            ],
+            "result": {
+                "name": "fetch_substates_response",
+                "description": "Batch substate fetch response",
+                "schema": {
+                    "$ref": "#/components/schemas/GetSubstatesResponse"
+                }
+            },
+            "errors": [],
+            "examples": [
+                {
+                    "name": "default",
+                    "description": "",
+                    "params": [
+                        {
+                            "name": "requests",
+                            "value": {
+                                "requests": [
+                                    {
+                                        "address": [
+                                            "component_e4773b971b876238475c904927435d625d892132e7d7b80c3cc81698fcc4a2dd",
+                                            0
+                                        ]
+                                    },
+                                    {
+                                        "address": [
+                                            "component_7c45d28ffa167b10d2fa700ce29343de692b97422a65485d0a00e8e7578d692e",
+                                            0
+                                        ]
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "result": {
+                        "name": "example1",
+                        "value": {
+                            "responses": [
+                                {
+                                    "address": [
+                                        "component_e4773b971b876238475c904927435d625d892132e7d7b80c3cc81698fcc4a2dd",
+                                        0
+                                    ],
+                                    "substate": {
+                                        "Component": {
+                                            "module_name": "Account",
+                                            "state": {
+                                                "state": [
+                                                    0,
+                                                    0,
+                                                    0,
+                                                    0
+                                                ]
+                                            }
+                                        }
+                                    },
+                                    "version": 0
+                                }
+                            ]
+                        }
+                    }
+                }
+            ]
         }
     ],
     "components": {

--- a/applications/tari_indexer/openrpc.json
+++ b/applications/tari_indexer/openrpc.json
@@ -279,6 +279,320 @@
           }
         }
       ]
+    },
+    {
+      "name": "get_substates",
+      "summary": "",
+      "tags": [],
+      "params": [],
+      "result": {
+        "name": "epoch_stats",
+        "description": "",
+        "schema": {}
+      },
+      "errors": [],
+      "examples": [
+        {
+          "name": "default",
+          "description": "",
+          "params": [],
+          "result": {
+            "name": "example1",
+            "value": {
+              "substate": {
+                "Component": {
+                  "access_rules": {
+                    "default": {
+                      "Restricted": {
+                        "Require": {
+                          "id": {
+                            "U256": [
+                              242,
+                              92,
+                              64,
+                              223,
+                              207,
+                              57,
+                              225,
+                              163,
+                              175,
+                              11,
+                              109,
+                              189,
+                              230,
+                              209,
+                              24,
+                              78,
+                              225,
+                              250,
+                              171,
+                              247,
+                              14,
+                              102,
+                              246,
+                              15,
+                              193,
+                              145,
+                              233,
+                              156,
+                              24,
+                              197,
+                              147,
+                              116
+                            ]
+                          },
+                          "resource_address": [
+                            1,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0
+                          ]
+                        }
+                      }
+                    },
+                    "method_access": {
+                      "balance": "AllowAll",
+                      "deposit": "AllowAll",
+                      "deposit_all": "AllowAll",
+                      "get_balances": "AllowAll",
+                      "get_non_fungible_ids": "AllowAll"
+                    },
+                    "native_method_access": {}
+                  },
+                  "module_name": "Account",
+                  "state": {
+                    "state": [
+                      0,
+                      0,
+                      0,
+                      0
+                    ]
+                  },
+                  "template_address": [
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0
+                  ]
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "fetch_substates",
+      "summary": "",
+      "tags": [],
+      "params": [],
+      "result": {
+        "name": "epoch_stats",
+        "description": "",
+        "schema": {}
+      },
+      "errors": [],
+      "examples": [
+        {
+          "name": "default",
+          "description": "",
+          "params": [],
+          "result": {
+            "name": "example1",
+            "value": {
+              "substate": {
+                "Component": {
+                  "access_rules": {
+                    "default": {
+                      "Restricted": {
+                        "Require": {
+                          "id": {
+                            "U256": [
+                              242,
+                              92,
+                              64,
+                              223,
+                              207,
+                              57,
+                              225,
+                              163,
+                              175,
+                              11,
+                              109,
+                              189,
+                              230,
+                              209,
+                              24,
+                              78,
+                              225,
+                              250,
+                              171,
+                              247,
+                              14,
+                              102,
+                              246,
+                              15,
+                              193,
+                              145,
+                              233,
+                              156,
+                              24,
+                              197,
+                              147,
+                              116
+                            ]
+                          },
+                          "resource_address": [
+                            1,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0
+                          ]
+                        }
+                      }
+                    },
+                    "method_access": {
+                      "balance": "AllowAll",
+                      "deposit": "AllowAll",
+                      "deposit_all": "AllowAll",
+                      "get_balances": "AllowAll",
+                      "get_non_fungible_ids": "AllowAll"
+                    },
+                    "native_method_access": {}
+                  },
+                  "module_name": "Account",
+                  "state": {
+                    "state": [
+                      0,
+                      0,
+                      0,
+                      0
+                    ]
+                  },
+                  "template_address": [
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0
+                  ]
+                }
+              }
+            }
+          }
+        }
+      ]
     }
   ],
   "components": {

--- a/applications/tari_indexer/src/json_rpc/server.rs
+++ b/applications/tari_indexer/src/json_rpc/server.rs
@@ -72,6 +72,7 @@ async fn handler(Extension(handlers): Extension<Arc<JsonRpcHandlers>>, value: Js
         "list_substates" => handlers.list_substates(value).await,
         "get_substate" => handlers.get_substate(value).await,
         "get_substates" => handlers.get_substates(value).await,
+        "fetch_substates" => handlers.get_substates(value).await,
         "inspect_substate" => handlers.inspect_substate(value).await,
         "get_connections" => handlers.get_connections(value).await,
         "get_non_fungibles" => handlers.get_non_fungibles(value).await,

--- a/applications/tari_indexer/src/json_rpc/server.rs
+++ b/applications/tari_indexer/src/json_rpc/server.rs
@@ -71,6 +71,7 @@ async fn handler(Extension(handlers): Extension<Arc<JsonRpcHandlers>>, value: Js
         "get_comms_stats" => handlers.get_comms_stats(value).await,
         "list_substates" => handlers.list_substates(value).await,
         "get_substate" => handlers.get_substate(value).await,
+        "get_substates" => handlers.get_substates(value).await,
         "inspect_substate" => handlers.inspect_substate(value).await,
         "get_connections" => handlers.get_connections(value).await,
         "get_non_fungibles" => handlers.get_non_fungibles(value).await,

--- a/clients/tari_indexer_client/src/json_rpc_client.rs
+++ b/clients/tari_indexer_client/src/json_rpc_client.rs
@@ -35,6 +35,8 @@ use crate::{
         GetNonFungiblesResponse,
         GetSubstateRequest,
         GetSubstateResponse,
+        GetSubstatesRequest,
+        GetSubstatesResponse,
         GetTemplateDefinitionRequest,
         GetTemplateDefinitionResponse,
         GetTransactionResultRequest,
@@ -84,6 +86,13 @@ impl IndexerJsonRpcClient {
 
     pub async fn get_substate(&mut self, req: GetSubstateRequest) -> Result<GetSubstateResponse, IndexerClientError> {
         self.send_request("get_substate", req).await
+    }
+
+    pub async fn get_substates(
+        &mut self,
+        req: GetSubstatesRequest,
+    ) -> Result<GetSubstatesResponse, IndexerClientError> {
+        self.send_request("get_substates", req).await
     }
 
     pub async fn list_substates(

--- a/clients/tari_indexer_client/src/json_rpc_client.rs
+++ b/clients/tari_indexer_client/src/json_rpc_client.rs
@@ -95,6 +95,13 @@ impl IndexerJsonRpcClient {
         self.send_request("get_substates", req).await
     }
 
+    pub async fn fetch_substates(
+        &mut self,
+        req: GetSubstatesRequest,
+    ) -> Result<GetSubstatesResponse, IndexerClientError> {
+        self.send_request("fetch_substates", req).await
+    }
+
     pub async fn list_substates(
         &mut self,
         req: ListSubstatesRequest,

--- a/clients/tari_indexer_client/src/types.rs
+++ b/clients/tari_indexer_client/src/types.rs
@@ -25,7 +25,7 @@ use tari_transaction::{Transaction, TransactionId};
     ts(
        export,
        export_to = "../../bindings/src/types/tari-indexer-client/",
-       rename = "IndexerGetSubstatesRequest"
+       rename = "IndexerListSubstatesRequest"
    )
 )]
 pub struct ListSubstatesRequest {
@@ -50,11 +50,6 @@ pub struct ListSubstatesResponse {
     feature = "ts",
     derive(ts_rs::TS),
     ts(export, export_to = "../../bindings/src/types/tari-indexer-client/")
-    ts(
-        export,
-        export_to = "../../bindings/src/types/tari-indexer-client/",
-        rename = "IndexerGetSubstatesResponse"
-    )
 )]
 pub struct ListSubstateItem {
     pub substate_id: SubstateId,
@@ -102,7 +97,11 @@ pub struct GetSubstateResponse {
 #[cfg_attr(
     feature = "ts",
     derive(ts_rs::TS),
-    ts(export, export_to = "../../bindings/src/types/tari-indexer-client/")
+    ts(
+       export,
+       export_to = "../../bindings/src/types/tari-indexer-client/",
+       rename = "IndexerGetSubstatesRequest"
+    )
 )]
 pub struct GetSubstatesRequest {
     pub requests: Vec<GetSubstateRequest>,
@@ -112,7 +111,11 @@ pub struct GetSubstatesRequest {
 #[cfg_attr(
     feature = "ts",
     derive(ts_rs::TS),
-    ts(export, export_to = "../../bindings/src/types/tari-indexer-client/")
+    ts(
+        export,
+        export_to = "../../bindings/src/types/tari-indexer-client/",
+        rename = "IndexerGetSubstatesResponse"
+    )
 )]
 pub struct GetSubstatesResponse {
     pub responses: Vec<Option<GetSubstateResponse>>,

--- a/clients/tari_indexer_client/src/types.rs
+++ b/clients/tari_indexer_client/src/types.rs
@@ -95,6 +95,26 @@ pub struct GetSubstateResponse {
     derive(ts_rs::TS),
     ts(export, export_to = "../../bindings/src/types/tari-indexer-client/")
 )]
+pub struct GetSubstatesRequest {
+    pub requests: Vec<GetSubstateRequest>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(
+    feature = "ts",
+    derive(ts_rs::TS),
+    ts(export, export_to = "../../bindings/src/types/tari-indexer-client/")
+)]
+pub struct GetSubstatesResponse {
+    pub responses: Vec<Option<GetSubstateResponse>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(
+    feature = "ts",
+    derive(ts_rs::TS),
+    ts(export, export_to = "../../bindings/src/types/tari-indexer-client/")
+)]
 pub struct InspectSubstateRequest {
     #[cfg_attr(feature = "ts", ts(type = "string"))]
     pub address: SubstateId,

--- a/clients/tari_indexer_client/src/types.rs
+++ b/clients/tari_indexer_client/src/types.rs
@@ -22,7 +22,11 @@ use tari_transaction::{Transaction, TransactionId};
 #[cfg_attr(
     feature = "ts",
     derive(ts_rs::TS),
-    ts(export, export_to = "../../bindings/src/types/tari-indexer-client/")
+    ts(
+       export,
+       export_to = "../../bindings/src/types/tari-indexer-client/",
+       rename = "IndexerGetSubstatesRequest"
+   )
 )]
 pub struct ListSubstatesRequest {
     pub filter_by_template: Option<TemplateAddress>,
@@ -46,6 +50,11 @@ pub struct ListSubstatesResponse {
     feature = "ts",
     derive(ts_rs::TS),
     ts(export, export_to = "../../bindings/src/types/tari-indexer-client/")
+    ts(
+        export,
+        export_to = "../../bindings/src/types/tari-indexer-client/",
+        rename = "IndexerGetSubstatesResponse"
+    )
 )]
 pub struct ListSubstateItem {
     pub substate_id: SubstateId,


### PR DESCRIPTION
Description
This PR introduces a new batch API endpoint for fetching substates in the indexer and enhances the "Recent Transactions" list in the Indexer Web UI.

Motivation and Context
The new get_substates JSON-RPC API allows clients, such as wallets, to efficiently retrieve multiple substates in a single batched request, reducing the need for numerous individual calls and improving network efficiency.

The improvements to the Indexer Web UI's "Recent Transactions" list aim to provide a more comprehensive and user-friendly overview of transaction details, including their status and total fees, aligning with the user experience of the Ootle wallet. The created_at timestamp is also retained for better transaction tracking.

How Has This Been Tested?
The changes were validated by compiling the Rust tari_indexer and tari_indexer_client crates and building the tari_indexer/web_ui to ensure correct rendering of UI components and integration of new data.

What process can a PR reviewer use to test or verify this change?
Verify Batch Substate API (get_substates) and Verify Indexer Web UI Transaction List Improvements

Breaking Changes
[x]

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added batch substate retrieval via a new get_substates JSON‑RPC method to fetch multiple substates in one request.
  * Added fetch_substates as an alias for compatibility with existing integrations.
  * Client SDK exposes get_substates/fetch_substates helpers and new batch request/response types.

* **Documentation**
  * Public API docs (OpenRPC) updated with the new batch endpoint, request/response schemas, and examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->