### PR TITLE
fix: clippy error + move type conversion for JSON to JRPC handler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12170,7 +12170,6 @@ dependencies = [
  "tari_shutdown",
  "tari_template_builtin",
  "tari_template_lib",
- "tari_validator_node_client",
  "tari_validator_node_rpc",
  "thiserror 1.0.69",
  "tokio",

--- a/applications/tari_validator_node/src/json_rpc/handlers.rs
+++ b/applications/tari_validator_node/src/json_rpc/handlers.rs
@@ -71,6 +71,7 @@ use tari_validator_node_client::types::{
     AddPeerResponse,
     ConnectionDirection,
     DryRunTransactionFinalizeResult,
+    FunctionDef,
     GetAllVnsRequest,
     GetAllVnsResponse,
     GetBlockRequest,
@@ -108,6 +109,7 @@ use tari_validator_node_client::types::{
     SubmitTransactionRequest,
     SubmitTransactionResponse,
     SubstateStatus,
+    TemplateAbi,
     TemplateMetadata,
 };
 
@@ -507,11 +509,26 @@ impl JsonRpcHandlers {
             .await
             .map_err(internal_error(answer_id))?;
 
-        let abi = self
+        let loaded = self
             .template_manager
             .load_template_abi(req.template_address)
             .await
             .map_err(internal_error(answer_id))?;
+        let abi = TemplateAbi {
+            template_name: loaded.template_def().template_name().to_string(),
+            functions: loaded
+                .template_def()
+                .functions()
+                .iter()
+                .map(|f| FunctionDef {
+                    name: f.name.clone(),
+                    arguments: f.arguments.to_vec(),
+                    output: f.output.to_string(),
+                    is_mut: f.is_mut,
+                })
+                .collect(),
+            version: loaded.template_def().tari_version().to_string(),
+        };
 
         Ok(JsonRpcResponse::success(answer_id, GetTemplateResponse {
             registration_metadata: TemplateMetadata {

--- a/crates/template_manager/Cargo.toml
+++ b/crates/template_manager/Cargo.toml
@@ -20,7 +20,6 @@ tari_rpc_framework = { workspace = true }
 tari_shutdown = { workspace = true }
 tari_template_builtin = { workspace = true }
 tari_template_lib = { workspace = true }
-tari_validator_node_client = { workspace = true }
 tari_validator_node_rpc = { workspace = true }
 
 anyhow = { workspace = true }

--- a/crates/template_manager/src/implementation/service.rs
+++ b/crates/template_manager/src/implementation/service.rs
@@ -21,7 +21,7 @@
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use log::*;
-use tari_engine::wasm::WasmModule;
+use tari_engine::{template::LoadedTemplate, wasm::WasmModule};
 use tari_engine_types::calculate_template_binary_hash;
 use tari_epoch_manager::EpochManagerReader;
 use tari_ootle_common_types::{services::template_provider::TemplateProvider, Epoch, NodeAddressable, ToPeerId};
@@ -29,7 +29,6 @@ use tari_ootle_p2p::proto::rpc::TemplateType;
 use tari_ootle_storage::global::{DbTemplateType, DbTemplateUpdate, TemplateStatus};
 use tari_shutdown::ShutdownSignal;
 use tari_template_lib::types::{crypto::RistrettoPublicKeyBytes, Hash, TemplateAddress};
-use tari_validator_node_client::types::{FunctionDef, TemplateAbi};
 use tari_validator_node_rpc::client::TariValidatorNodeRpcClientFactory;
 use tokio::{
     sync::{mpsc, oneshot},
@@ -252,26 +251,12 @@ where
         }
     }
 
-    fn handle_load_template_abi(&mut self, address: TemplateAddress) -> Result<TemplateAbi, TemplateManagerError> {
+    fn handle_load_template_abi(&mut self, address: TemplateAddress) -> Result<LoadedTemplate, TemplateManagerError> {
         let loaded = self
             .manager
             .get_template_module(&address)?
             .ok_or(TemplateManagerError::TemplateNotFound { address })?;
-        Ok(TemplateAbi {
-            template_name: loaded.template_def().template_name().to_string(),
-            functions: loaded
-                .template_def()
-                .functions()
-                .iter()
-                .map(|f| FunctionDef {
-                    name: f.name.clone(),
-                    arguments: f.arguments.iter().cloned().collect(),
-                    output: f.output.to_string(),
-                    is_mut: f.is_mut,
-                })
-                .collect(),
-            version: loaded.template_def().tari_version().to_string(),
-        })
+        Ok(loaded)
     }
 
     fn handle_completed_download(&mut self, download: DownloadResult) -> Result<(), TemplateManagerError> {

--- a/crates/template_manager/src/interface/handle.rs
+++ b/crates/template_manager/src/interface/handle.rs
@@ -22,11 +22,11 @@
 
 use reqwest::Url;
 use tari_common_types::types::FixedHash;
+use tari_engine::template::LoadedTemplate;
 use tari_epoch_manager::traits::TemplateDownloader;
 use tari_ootle_common_types::Epoch;
 use tari_ootle_storage::global::TemplateStatus;
 use tari_template_lib::types::{crypto::RistrettoPublicKeyBytes, TemplateAddress};
-use tari_validator_node_client::types::TemplateAbi;
 use tokio::sync::{mpsc, oneshot};
 
 use super::{
@@ -59,7 +59,7 @@ impl TemplateManagerHandle {
         rx.await.map_err(|_| TemplateManagerError::ChannelClosed)?
     }
 
-    pub async fn load_template_abi(&self, address: TemplateAddress) -> Result<TemplateAbi, TemplateManagerError> {
+    pub async fn load_template_abi(&self, address: TemplateAddress) -> Result<LoadedTemplate, TemplateManagerError> {
         let (tx, rx) = oneshot::channel();
         self.request_tx
             .send(TemplateManagerRequest::LoadTemplateAbi { address, reply: tx })

--- a/crates/template_manager/src/interface/types.rs
+++ b/crates/template_manager/src/interface/types.rs
@@ -22,6 +22,7 @@
 
 use reqwest::Url;
 use tari_common_types::types::FixedHash;
+use tari_engine::template::LoadedTemplate;
 use tari_engine_types::published_template::PublishedTemplateAddress;
 use tari_ootle_common_types::Epoch;
 use tari_ootle_storage::{
@@ -29,7 +30,6 @@ use tari_ootle_storage::{
     StorageError,
 };
 use tari_template_lib::{prelude::RistrettoPublicKeyBytes, types::TemplateAddress};
-use tari_validator_node_client::types::TemplateAbi;
 use tokio::{sync::oneshot, task::JoinHandle};
 
 use super::TemplateManagerError;
@@ -161,7 +161,7 @@ pub enum TemplateManagerRequest {
     },
     LoadTemplateAbi {
         address: TemplateAddress,
-        reply: Reply<TemplateAbi>,
+        reply: Reply<LoadedTemplate>,
     },
     TemplateExists {
         address: TemplateAddress,


### PR DESCRIPTION
Description
---
fix: clippy error + move type conversion for JSON to JRPC handler

Motivation and Context
---
Minor clippy error, move code that converts an internal type to an API type out of the template manager into the JRPC handler

How Has This Been Tested?
---

What process can a PR reviewer use to test or verify this change?
---


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - JSON-RPC get_template now returns richer template details: template name, version, and a list of functions with arguments, outputs, and mutability.

- Refactor
  - Template loading now forwards the full loaded template object instead of a pared-down ABI.
  - Public API changed: template-loading calls now return the full loaded template; clients should update integrations to handle the new response shape.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->