### PR TITLE
fix: use npm instead of pnpm

### DIFF
--- a/applications/tari_indexer/build.rs
+++ b/applications/tari_indexer/build.rs
@@ -42,9 +42,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         return Ok(());
     }
     #[cfg(windows)]
-    const NPM: &str = "pnpm.cmd";
+    const NPM: &str = "npm.cmd";
     #[cfg(not(windows))]
-    const NPM: &str = "pnpm";
+    const NPM: &str = "npm";
 
     if let Err(error) = Command::new(NPM).arg("install").current_dir("./web_ui").status() {
         println!("cargo:warning='npm install' error : {:?}", error);

--- a/applications/tari_validator_node/build.rs
+++ b/applications/tari_validator_node/build.rs
@@ -45,9 +45,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     #[cfg(windows)]
-    const NPM: &str = "pnpm.cmd";
+    const NPM: &str = "npm.cmd";
     #[cfg(not(windows))]
-    const NPM: &str = "pnpm";
+    const NPM: &str = "npm";
 
     if let Err(error) = Command::new(NPM).arg("install").current_dir("./web_ui").status() {
         println!("cargo:warning='{NPM} install' error : {:?}", error);

--- a/applications/tari_walletd/build.rs
+++ b/applications/tari_walletd/build.rs
@@ -53,15 +53,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     #[cfg(windows)]
-    const NPM: &str = "pnpm.cmd";
+    const NPM: &str = "npm.cmd";
     #[cfg(not(windows))]
-    const NPM: &str = "pnpm";
+    const NPM: &str = "npm";
 
     for (target, args) in NPM_COMMANDS {
         match Command::new(NPM).args(*args).current_dir(target).output() {
             Ok(output) if !output.status.success() => {
                 println!(
-                    "cargo:warning='pnpm {}' in {} exited with non-zero status code",
+                    "cargo:warning='npm {}' in {} exited with non-zero status code",
                     args.iter().map(|s| s.to_string()).collect::<Vec<_>>().join(" "),
                     target
                 );

--- a/utilities/db_inspector/build.rs
+++ b/utilities/db_inspector/build.rs
@@ -21,10 +21,10 @@ fn main() {
 }
 fn run() -> Result<(), Box<dyn std::error::Error>> {
     #[cfg(target_os = "windows")]
-    const BIN: &str = "pnpm.cmd";
+    const BIN: &str = "npm.cmd";
     #[cfg(not(target_os = "windows"))]
-    const BIN: &str = "pnpm";
-    run_command(BIN, &["install", "--frozen-lockfile"])?;
+    const BIN: &str = "npm";
+    run_command(BIN, &["ci"])?;
     run_command(BIN, &["run", "build"])?;
 
     Ok(())

--- a/utilities/db_inspector/web_ui/package-lock.json
+++ b/utilities/db_inspector/web_ui/package-lock.json
@@ -1,0 +1,902 @@
+{
+  "name": "db-inspector",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "db-inspector",
+      "version": "0.0.0",
+      "dependencies": {
+        "@emotion/react": "^11.14.0",
+        "@emotion/styled": "^11.14.0",
+        "@mui/icons-material": "^5.11.11",
+        "@mui/material": "^7.0.2",
+        "@mui/x-data-grid": "^7.28.3",
+        "@tanstack/react-query": "^4.36.1",
+        "pretty-bytes": "^6.1.1",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
+        "react-icons": "^5.5.0",
+        "react-router-dom": "^6.9.0",
+        "zustand": "^4.5.6",
+        "zustand-persist": "^0.4.0"
+      },
+      "devDependencies": {
+        "@eslint/js": "^9.21.0",
+        "@types/react": "^19.0.10",
+        "@types/react-dom": "^19.0.4",
+        "@vitejs/plugin-react": "^4.3.4",
+        "eslint": "^9.21.0",
+        "eslint-plugin-react-hooks": "^5.1.0",
+        "eslint-plugin-react-refresh": "^0.4.19",
+        "globals": "^16.3.0",
+        "typescript": "~5.7.2",
+        "typescript-eslint": "^8.24.1",
+        "vite": "^6.2.7"
+      }
+    },
+    "../../../node_modules/.pnpm/@emotion+react@11.14.0_@types+react@19.1.0_react@19.1.0/node_modules/@emotion/react": {
+      "version": "11.14.0",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "@emotion/babel-plugin": "^11.13.5",
+        "@emotion/cache": "^11.14.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.2.0",
+        "@emotion/utils": "^1.4.2",
+        "@emotion/weak-memoize": "^0.4.0",
+        "hoist-non-react-statics": "^3.3.1"
+      },
+      "devDependencies": {
+        "@definitelytyped/dtslint": "0.0.112",
+        "@emotion/css": "11.13.5",
+        "@emotion/css-prettifier": "1.2.0",
+        "@emotion/server": "11.11.0",
+        "@emotion/styled": "11.14.0",
+        "@types/hoist-non-react-statics": "^3.3.5",
+        "html-tag-names": "^1.1.2",
+        "react": "16.14.0",
+        "svg-tag-names": "^1.1.1",
+        "typescript": "^5.4.5"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "../../../node_modules/.pnpm/@emotion+styled@11.14.0_@emotion+react@11.14.0_@types+react@19.1.0_react@19.1.0__@types+react@19.1.0_react@19.1.0/node_modules/@emotion/styled": {
+      "version": "11.14.0",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "@emotion/babel-plugin": "^11.13.5",
+        "@emotion/is-prop-valid": "^1.3.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.2.0",
+        "@emotion/utils": "^1.4.2"
+      },
+      "devDependencies": {
+        "@definitelytyped/dtslint": "0.0.112",
+        "@emotion/react": "11.14.0",
+        "react": "16.14.0",
+        "typescript": "^5.4.5"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.0.0-rc.0",
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "../../../node_modules/.pnpm/@eslint+js@9.24.0/node_modules/@eslint/js": {
+      "version": "9.24.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "../../../node_modules/.pnpm/@mui+icons-material@5.17.1_@mui+material@7.0.2_@emotion+react@11.14.0_@types+react@19.1_c182f000e2343d7f7216b66e0f16895b/node_modules/@mui/icons-material": {
+      "version": "5.17.1",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.9"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@mui/material": "^5.0.0",
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "../../../node_modules/.pnpm/@mui+material@7.0.2_@emotion+react@11.14.0_@types+react@19.1.0_react@19.1.0__@emotion+s_ed0efe7b00b408d6e5b1f79b0f3daaaf/node_modules/@mui/material": {
+      "version": "7.0.2",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.0",
+        "@mui/core-downloads-tracker": "^7.0.2",
+        "@mui/system": "^7.0.2",
+        "@mui/types": "^7.4.1",
+        "@mui/utils": "^7.0.2",
+        "@popperjs/core": "^2.11.8",
+        "@types/react-transition-group": "^4.4.12",
+        "clsx": "^2.1.1",
+        "csstype": "^3.1.3",
+        "prop-types": "^15.8.1",
+        "react-is": "^19.1.0",
+        "react-transition-group": "^4.4.5"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.5.0",
+        "@emotion/styled": "^11.3.0",
+        "@mui/material-pigment-css": "^7.0.2",
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        },
+        "@mui/material-pigment-css": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "../../../node_modules/.pnpm/@mui+x-data-grid@7.28.3_@emotion+react@11.14.0_@types+react@19.1.0_react@19.1.0__@emoti_95bb8323414a6e37dd939001b2a7564f/node_modules/@mui/x-data-grid": {
+      "version": "7.28.3",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.25.7",
+        "@mui/utils": "^5.16.6 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta",
+        "@mui/x-internals": "7.28.0",
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1",
+        "reselect": "^5.1.1",
+        "use-sync-external-store": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.9.0",
+        "@emotion/styled": "^11.8.1",
+        "@mui/material": "^5.15.14 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta",
+        "@mui/system": "^5.15.14 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        }
+      }
+    },
+    "../../../node_modules/.pnpm/@tanstack+react-query@4.36.1_react-dom@19.1.0_react@19.1.0__react@19.1.0/node_modules/@tanstack/react-query": {
+      "version": "4.36.1",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "4.36.1",
+        "use-sync-external-store": "^1.2.0"
+      },
+      "devDependencies": {
+        "@types/jscodeshift": "^0.11.3",
+        "@types/react": "^18.0.14",
+        "@types/react-dom": "^18.0.5",
+        "@types/use-sync-external-store": "^0.0.3",
+        "jscodeshift": "^0.13.1",
+        "react": "^18.2.0",
+        "react-17": "npm:react@^17.0.2",
+        "react-dom": "^18.2.0",
+        "react-dom-17": "npm:react-dom@^17.0.2",
+        "react-error-boundary": "^3.1.4"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-native": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
+    "../../../node_modules/.pnpm/@types+react-dom@19.1.2_@types+react@19.1.0/node_modules/@types/react-dom": {
+      "version": "19.1.2",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.0.0"
+      }
+    },
+    "../../../node_modules/.pnpm/@types+react@19.1.0/node_modules/@types/react": {
+      "version": "19.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.0.2"
+      }
+    },
+    "../../../node_modules/.pnpm/@vitejs+plugin-react@4.3.4_vite@6.3.5_@types+node@22.14.0_jiti@2.4.2_lightningcss@1.30.1_/node_modules/@vitejs/plugin-react": {
+      "version": "4.3.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.26.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.25.9",
+        "@babel/plugin-transform-react-jsx-source": "^7.25.9",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.14.2"
+      },
+      "devDependencies": {
+        "unbuild": "^2.0.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0"
+      }
+    },
+    "../../../node_modules/.pnpm/eslint-plugin-react-hooks@5.2.0_eslint@9.24.0_jiti@2.4.2_/node_modules/eslint-plugin-react-hooks": {
+      "version": "5.2.0",
+      "dev": true,
+      "license": "MIT",
+      "devDependencies": {
+        "@babel/eslint-parser": "^7.11.4",
+        "@babel/preset-typescript": "^7.26.0",
+        "@tsconfig/strictest": "^2.0.5",
+        "@types/eslint": "^8.56.12",
+        "@types/estree": "^1.0.6",
+        "@types/estree-jsx": "^1.0.5",
+        "@types/node": "^20.2.5",
+        "@typescript-eslint/parser-v2": "npm:@typescript-eslint/parser@^2.26.0",
+        "@typescript-eslint/parser-v3": "npm:@typescript-eslint/parser@^3.10.0",
+        "@typescript-eslint/parser-v4": "npm:@typescript-eslint/parser@^4.1.0",
+        "@typescript-eslint/parser-v5": "npm:@typescript-eslint/parser@^5.62.0",
+        "babel-eslint": "^10.0.3",
+        "eslint-v7": "npm:eslint@^7.7.0",
+        "eslint-v9": "npm:eslint@^9.0.0",
+        "jest": "^29.5.0",
+        "typescript": "^5.4.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
+      }
+    },
+    "../../../node_modules/.pnpm/eslint-plugin-react-refresh@0.4.19_eslint@9.24.0_jiti@2.4.2_/node_modules/eslint-plugin-react-refresh": {
+      "version": "0.4.19",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "eslint": ">=8.40"
+      }
+    },
+    "../../../node_modules/.pnpm/eslint@9.24.0_jiti@2.4.2/node_modules/eslint": {
+      "version": "9.24.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.20.0",
+        "@eslint/config-helpers": "^0.2.0",
+        "@eslint/core": "^0.12.0",
+        "@eslint/eslintrc": "^3.3.1",
+        "@eslint/js": "9.24.0",
+        "@eslint/plugin-kit": "^0.2.7",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "@types/json-schema": "^7.0.15",
+        "ajv": "^6.12.4",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.3.0",
+        "eslint-visitor-keys": "^4.2.0",
+        "espree": "^10.3.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "devDependencies": {
+        "@arethetypeswrong/cli": "^0.17.0",
+        "@babel/core": "^7.4.3",
+        "@babel/preset-env": "^7.4.3",
+        "@cypress/webpack-preprocessor": "^6.0.2",
+        "@eslint/json": "^0.11.0",
+        "@trunkio/launcher": "^1.3.0",
+        "@types/node": "^22.13.14",
+        "@typescript-eslint/parser": "^8.4.0",
+        "babel-loader": "^8.0.5",
+        "c8": "^7.12.0",
+        "chai": "^4.0.1",
+        "cheerio": "^0.22.0",
+        "common-tags": "^1.8.0",
+        "core-js": "^3.1.3",
+        "cypress": "^14.1.0",
+        "ejs": "^3.0.2",
+        "eslint": "file:.",
+        "eslint-config-eslint": "file:packages/eslint-config-eslint",
+        "eslint-plugin-eslint-plugin": "^6.0.0",
+        "eslint-plugin-expect-type": "^0.6.0",
+        "eslint-plugin-yml": "^1.14.0",
+        "eslint-release": "^3.3.0",
+        "eslint-rule-composer": "^0.3.0",
+        "eslump": "^3.0.0",
+        "esprima": "^4.0.1",
+        "fast-glob": "^3.2.11",
+        "fs-teardown": "^0.1.3",
+        "glob": "^10.0.0",
+        "globals": "^15.0.0",
+        "got": "^11.8.3",
+        "gray-matter": "^4.0.3",
+        "jiti": "^2.1.0",
+        "knip": "^5.32.0",
+        "lint-staged": "^11.0.0",
+        "load-perf": "^0.2.0",
+        "markdown-it": "^12.2.0",
+        "markdown-it-container": "^3.0.0",
+        "marked": "^4.0.8",
+        "metascraper": "^5.25.7",
+        "metascraper-description": "^5.25.7",
+        "metascraper-image": "^5.29.3",
+        "metascraper-logo": "^5.25.7",
+        "metascraper-logo-favicon": "^5.25.7",
+        "metascraper-title": "^5.25.7",
+        "mocha": "^10.7.3",
+        "node-polyfill-webpack-plugin": "^1.0.3",
+        "npm-license": "^0.3.3",
+        "pirates": "^4.0.5",
+        "progress": "^2.0.3",
+        "proxyquire": "^2.0.1",
+        "recast": "^0.23.0",
+        "regenerator-runtime": "^0.14.0",
+        "semver": "^7.5.3",
+        "shelljs": "^0.9.0",
+        "sinon": "^11.0.0",
+        "typescript": "^5.3.3",
+        "webpack": "^5.23.0",
+        "webpack-cli": "^4.5.0",
+        "yorkie": "^2.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "../../../node_modules/.pnpm/pretty-bytes@6.1.1/node_modules/pretty-bytes": {
+      "version": "6.1.1",
+      "license": "MIT",
+      "devDependencies": {
+        "ava": "^4.0.1",
+        "tsd": "^0.19.1",
+        "xo": "^0.54.0"
+      },
+      "engines": {
+        "node": "^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "../../../node_modules/.pnpm/react-dom@19.1.0_react@19.1.0/node_modules/react-dom": {
+      "version": "19.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.26.0"
+      },
+      "peerDependencies": {
+        "react": "^19.1.0"
+      }
+    },
+    "../../../node_modules/.pnpm/react-icons@5.5.0_react@19.1.0/node_modules/react-icons": {
+      "version": "5.5.0",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "../../../node_modules/.pnpm/react-router-dom@6.30.0_react-dom@19.1.0_react@19.1.0__react@19.1.0/node_modules/react-router-dom": {
+      "version": "6.30.0",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0",
+        "react-router": "6.30.0"
+      },
+      "devDependencies": {
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "../../../node_modules/.pnpm/react@19.1.0/node_modules/react": {
+      "version": "19.1.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "../../../node_modules/.pnpm/typescript-eslint@8.29.1_eslint@9.24.0_jiti@2.4.2__typescript@5.7.3/node_modules/typescript-eslint": {
+      "version": "8.29.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.29.1",
+        "@typescript-eslint/parser": "8.29.1",
+        "@typescript-eslint/utils": "8.29.1"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.8",
+        "downlevel-dts": "*",
+        "prettier": "^3.2.5",
+        "rimraf": "*",
+        "typescript": "*",
+        "vitest": "^3.0.8"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "../../../node_modules/.pnpm/typescript@5.7.3/node_modules/typescript": {
+      "version": "5.7.3",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "devDependencies": {
+        "@dprint/formatter": "^0.4.1",
+        "@dprint/typescript": "0.93.0",
+        "@esfx/canceltoken": "^1.0.0",
+        "@eslint/js": "^9.11.1",
+        "@octokit/rest": "^21.0.2",
+        "@types/chai": "^4.3.20",
+        "@types/diff": "^5.2.2",
+        "@types/minimist": "^1.2.5",
+        "@types/mocha": "^10.0.8",
+        "@types/ms": "^0.7.34",
+        "@types/node": "latest",
+        "@types/source-map-support": "^0.5.10",
+        "@types/which": "^3.0.4",
+        "@typescript-eslint/rule-tester": "^8.8.0",
+        "@typescript-eslint/type-utils": "^8.8.0",
+        "@typescript-eslint/utils": "^8.8.0",
+        "azure-devops-node-api": "^14.1.0",
+        "c8": "^10.1.2",
+        "chai": "^4.5.0",
+        "chalk": "^4.1.2",
+        "chokidar": "^3.6.0",
+        "diff": "^5.2.0",
+        "dprint": "^0.47.2",
+        "esbuild": "^0.24.0",
+        "eslint": "^9.11.1",
+        "eslint-formatter-autolinkable-stylish": "^1.4.0",
+        "eslint-plugin-regexp": "^2.6.0",
+        "fast-xml-parser": "^4.5.0",
+        "glob": "^10.4.5",
+        "globals": "^15.9.0",
+        "hereby": "^1.10.0",
+        "jsonc-parser": "^3.3.1",
+        "knip": "^5.30.6",
+        "minimist": "^1.2.8",
+        "mocha": "^10.7.3",
+        "mocha-fivemat-progress-reporter": "^0.1.0",
+        "monocart-coverage-reports": "^2.11.0",
+        "ms": "^2.1.3",
+        "playwright": "^1.47.2",
+        "source-map-support": "^0.5.21",
+        "tslib": "^2.7.0",
+        "typescript": "^5.6.2",
+        "typescript-eslint": "^8.8.0",
+        "which": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "../../../node_modules/.pnpm/vite@6.3.5_@types+node@22.14.0_jiti@2.4.2_lightningcss@1.30.1/node_modules/vite": {
+      "version": "6.3.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "devDependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@babel/parser": "^7.27.0",
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "@polka/compression": "^1.0.0-next.25",
+        "@rollup/plugin-alias": "^5.1.1",
+        "@rollup/plugin-commonjs": "^28.0.3",
+        "@rollup/plugin-dynamic-import-vars": "2.1.4",
+        "@rollup/plugin-json": "^6.1.0",
+        "@rollup/plugin-node-resolve": "16.0.1",
+        "@rollup/pluginutils": "^5.1.4",
+        "@types/escape-html": "^1.0.4",
+        "@types/pnpapi": "^0.0.5",
+        "artichokie": "^0.3.1",
+        "cac": "^6.7.14",
+        "chokidar": "^3.6.0",
+        "connect": "^3.7.0",
+        "convert-source-map": "^2.0.0",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.4.0",
+        "dep-types": "link:./src/types",
+        "dotenv": "^16.5.0",
+        "dotenv-expand": "^12.0.2",
+        "es-module-lexer": "^1.6.0",
+        "escape-html": "^1.0.3",
+        "estree-walker": "^3.0.3",
+        "etag": "^1.8.1",
+        "http-proxy": "^1.18.1",
+        "launch-editor-middleware": "^2.10.0",
+        "lightningcss": "^1.29.3",
+        "magic-string": "^0.30.17",
+        "mlly": "^1.7.4",
+        "mrmime": "^2.0.1",
+        "nanoid": "^5.1.5",
+        "open": "^10.1.1",
+        "parse5": "^7.2.1",
+        "pathe": "^2.0.3",
+        "periscopic": "^4.0.2",
+        "picocolors": "^1.1.1",
+        "postcss-import": "^16.1.0",
+        "postcss-load-config": "^6.0.1",
+        "postcss-modules": "^6.0.1",
+        "resolve.exports": "^2.0.3",
+        "rollup-plugin-dts": "^6.2.1",
+        "rollup-plugin-esbuild": "^6.2.1",
+        "rollup-plugin-license": "^3.6.0",
+        "sass": "^1.86.3",
+        "sass-embedded": "^1.86.3",
+        "sirv": "^3.0.1",
+        "source-map-support": "^0.5.21",
+        "strip-literal": "^3.0.0",
+        "terser": "^5.39.0",
+        "tsconfck": "^3.1.5",
+        "tslib": "^2.8.1",
+        "types": "link:./types",
+        "ufo": "^1.6.1",
+        "ws": "^8.18.1"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "../../../node_modules/.pnpm/zustand-persist@0.4.0_react@19.1.0_zustand@4.5.6_@types+react@19.1.0_react@19.1.0_/node_modules/zustand-persist": {
+      "version": "0.4.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@babel/core": "^7.11.6",
+        "@babel/preset-env": "^7.11.5",
+        "@babel/preset-react": "^7.10.4",
+        "@babel/preset-typescript": "^7.10.4",
+        "@rollup/plugin-typescript": "^5.0.2",
+        "@testing-library/jest-dom": "^5.11.4",
+        "@testing-library/react": "^11.0.2",
+        "@types/jest": "^26.0.13",
+        "@types/node": "^12.0.0",
+        "@types/react": "17.0.0",
+        "@types/react-dom": "17.0.0",
+        "@typescript-eslint/eslint-plugin": "2.x",
+        "@typescript-eslint/parser": "2.x",
+        "babel-eslint": "10.x",
+        "babel-jest": "26.6.0",
+        "babel-loader": "^8.1.0",
+        "babel-plugin-named-asset-import": "^0.3.6",
+        "cspell": "^4.1.0",
+        "eslint": "7.11.0",
+        "eslint-config-react-app": "^5.2.1",
+        "eslint-plugin-flowtype": "4.x",
+        "eslint-plugin-import": "2.x",
+        "eslint-plugin-jsx-a11y": "6.x",
+        "eslint-plugin-react": "7.x",
+        "eslint-plugin-react-hooks": "2.x",
+        "husky": "^4.2.5",
+        "jest": "26.6.0",
+        "jest-environment-jsdom-sixteen": "^1.0.3",
+        "lint-staged": ">=10",
+        "prettier": "^2.1.1",
+        "rimraf": "^3.0.2",
+        "rollup": "^2.26.9",
+        "storage-memory": "^0.0.2",
+        "tslib": "^2.0.1",
+        "typescript": "^4.0.2",
+        "webpack": "4.44.2",
+        "zustand": "^3.6.3"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "zustand": ">=3.6.3"
+      }
+    },
+    "../../../node_modules/.pnpm/zustand@4.5.6_@types+react@19.1.0_react@19.1.0/node_modules/zustand": {
+      "version": "4.5.6",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@emotion/react": {
+      "resolved": "../../../node_modules/.pnpm/@emotion+react@11.14.0_@types+react@19.1.0_react@19.1.0/node_modules/@emotion/react",
+      "link": true
+    },
+    "node_modules/@emotion/styled": {
+      "resolved": "../../../node_modules/.pnpm/@emotion+styled@11.14.0_@emotion+react@11.14.0_@types+react@19.1.0_react@19.1.0__@types+react@19.1.0_react@19.1.0/node_modules/@emotion/styled",
+      "link": true
+    },
+    "node_modules/@eslint/js": {
+      "resolved": "../../../node_modules/.pnpm/@eslint+js@9.24.0/node_modules/@eslint/js",
+      "link": true
+    },
+    "node_modules/@mui/icons-material": {
+      "resolved": "../../../node_modules/.pnpm/@mui+icons-material@5.17.1_@mui+material@7.0.2_@emotion+react@11.14.0_@types+react@19.1_c182f000e2343d7f7216b66e0f16895b/node_modules/@mui/icons-material",
+      "link": true
+    },
+    "node_modules/@mui/material": {
+      "resolved": "../../../node_modules/.pnpm/@mui+material@7.0.2_@emotion+react@11.14.0_@types+react@19.1.0_react@19.1.0__@emotion+s_ed0efe7b00b408d6e5b1f79b0f3daaaf/node_modules/@mui/material",
+      "link": true
+    },
+    "node_modules/@mui/x-data-grid": {
+      "resolved": "../../../node_modules/.pnpm/@mui+x-data-grid@7.28.3_@emotion+react@11.14.0_@types+react@19.1.0_react@19.1.0__@emoti_95bb8323414a6e37dd939001b2a7564f/node_modules/@mui/x-data-grid",
+      "link": true
+    },
+    "node_modules/@tanstack/react-query": {
+      "resolved": "../../../node_modules/.pnpm/@tanstack+react-query@4.36.1_react-dom@19.1.0_react@19.1.0__react@19.1.0/node_modules/@tanstack/react-query",
+      "link": true
+    },
+    "node_modules/@types/react": {
+      "resolved": "../../../node_modules/.pnpm/@types+react@19.1.0/node_modules/@types/react",
+      "link": true
+    },
+    "node_modules/@types/react-dom": {
+      "resolved": "../../../node_modules/.pnpm/@types+react-dom@19.1.2_@types+react@19.1.0/node_modules/@types/react-dom",
+      "link": true
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "resolved": "../../../node_modules/.pnpm/@vitejs+plugin-react@4.3.4_vite@6.3.5_@types+node@22.14.0_jiti@2.4.2_lightningcss@1.30.1_/node_modules/@vitejs/plugin-react",
+      "link": true
+    },
+    "node_modules/eslint": {
+      "resolved": "../../../node_modules/.pnpm/eslint@9.24.0_jiti@2.4.2/node_modules/eslint",
+      "link": true
+    },
+    "node_modules/eslint-plugin-react-hooks": {
+      "resolved": "../../../node_modules/.pnpm/eslint-plugin-react-hooks@5.2.0_eslint@9.24.0_jiti@2.4.2_/node_modules/eslint-plugin-react-hooks",
+      "link": true
+    },
+    "node_modules/eslint-plugin-react-refresh": {
+      "resolved": "../../../node_modules/.pnpm/eslint-plugin-react-refresh@0.4.19_eslint@9.24.0_jiti@2.4.2_/node_modules/eslint-plugin-react-refresh",
+      "link": true
+    },
+    "node_modules/globals": {
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-16.3.0.tgz",
+      "integrity": "sha512-bqWEnJ1Nt3neqx2q5SFfGS8r/ahumIakg3HcwtNlrVlwXIeNumWn/c7Pn/wKzGhf6SaW6H6uWXLqC30STCMchQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pretty-bytes": {
+      "resolved": "../../../node_modules/.pnpm/pretty-bytes@6.1.1/node_modules/pretty-bytes",
+      "link": true
+    },
+    "node_modules/react": {
+      "resolved": "../../../node_modules/.pnpm/react@19.1.0/node_modules/react",
+      "link": true
+    },
+    "node_modules/react-dom": {
+      "resolved": "../../../node_modules/.pnpm/react-dom@19.1.0_react@19.1.0/node_modules/react-dom",
+      "link": true
+    },
+    "node_modules/react-icons": {
+      "resolved": "../../../node_modules/.pnpm/react-icons@5.5.0_react@19.1.0/node_modules/react-icons",
+      "link": true
+    },
+    "node_modules/react-router-dom": {
+      "resolved": "../../../node_modules/.pnpm/react-router-dom@6.30.0_react-dom@19.1.0_react@19.1.0__react@19.1.0/node_modules/react-router-dom",
+      "link": true
+    },
+    "node_modules/typescript": {
+      "resolved": "../../../node_modules/.pnpm/typescript@5.7.3/node_modules/typescript",
+      "link": true
+    },
+    "node_modules/typescript-eslint": {
+      "resolved": "../../../node_modules/.pnpm/typescript-eslint@8.29.1_eslint@9.24.0_jiti@2.4.2__typescript@5.7.3/node_modules/typescript-eslint",
+      "link": true
+    },
+    "node_modules/vite": {
+      "resolved": "../../../node_modules/.pnpm/vite@6.3.5_@types+node@22.14.0_jiti@2.4.2_lightningcss@1.30.1/node_modules/vite",
+      "link": true
+    },
+    "node_modules/zustand": {
+      "resolved": "../../../node_modules/.pnpm/zustand@4.5.6_@types+react@19.1.0_react@19.1.0/node_modules/zustand",
+      "link": true
+    },
+    "node_modules/zustand-persist": {
+      "resolved": "../../../node_modules/.pnpm/zustand-persist@0.4.0_react@19.1.0_zustand@4.5.6_@types+react@19.1.0_react@19.1.0_/node_modules/zustand-persist",
+      "link": true
+    }
+  }
+}

--- a/utilities/db_inspector/web_ui/package.json
+++ b/utilities/db_inspector/web_ui/package.json
@@ -32,7 +32,7 @@
     "eslint": "^9.21.0",
     "eslint-plugin-react-hooks": "^5.1.0",
     "eslint-plugin-react-refresh": "^0.4.19",
-    "globals": "^15.15.0",
+    "globals": "^16.3.0",
     "typescript": "~5.7.2",
     "typescript-eslint": "^8.24.1",
     "vite": "^6.2.7"


### PR DESCRIPTION
Description
---

Switch back to npm

Motivation and Context
---
We didnt really need pnpm, it generally is much more reliable, but shouldnt be necessary to build the web uis.

How Has This Been Tested?
---

What process can a PR reviewer use to test or verify this change?
---


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Standardized web UI build tooling to use npm instead of pnpm across multiple components and platforms.
  - Install and build steps remain functionally the same; one component now uses npm ci for reproducible installs.
  - Bumped devDependency "globals" in the DB inspector web UI.
  - No runtime, API, or CLI changes; end users should not notice functional differences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->