### PR TITLE
docs: updated prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,34 @@ You can read about the technical specifications of the Ootle in the [RFCs](https
 
 If you're looking for the core Tari base layer code, it's in [this repository](https://github.com/tari-project/tari)
 
+## Prerequisites
+
+You will require the following in order to successfully build the Ootle and/or run the Ootle locally via the Localnet environment:
+
+- **Rust**: Install Rust via [rustup](https://rustup.rs), and add a WASM target:
+
+```bash
+rustup target add wasm32-unknown-unknown
+```
+
+- **Node.js & npm**: Node.js is required for building the React UI components. The easiest way to manage this follow the instructions at [node.js](https://nodejs.org/en/download) for your desired operating system and package/version managers. 
+
+- **Linux-only steps**: Ensure you have the following dependencies installed: 
+
+```bash
+sudo apt-get update
+sudo apt-get install -y \
+  build-essential \
+  openssl \
+  libssl-dev \
+  pkg-config \
+  libsqlite3-dev \
+  git \
+  cmake \
+  protobuf-compiler \
+  libprotobuf-dev
+```
+
 ## Accessing the Ootle Testnet
 
 The Tari Ootle Wallet Daemon is available on the project’s [releases page](https://github.com/tari-project/tari-ootle/releases).
@@ -26,10 +54,7 @@ Navigate to http://127.0.0.1:5100 to create an account, claim test tokens and st
 
 NOTE: This repo is heavily under development, so these instructions may change without notice.
 
-### Prerequisites
-Make sure you have the following installed:
-
-* pnpm
+Confirm you have installed all the prerequisites listed in the **Prerequisites** section (Rust, Node.js, npm, linux dependencies)
 
 ### Running 
 The easiest way to test out the Ootle is to use the `tari_swarm_daemon`. This will spin up all necessary MinoTari and Ootle components for a localnet.
@@ -121,7 +146,4 @@ For other environments, the "manual" process is as follows:
    - Depending on the network configuration, this may take **tens to hundreds of blocks** before the burn is picked up.
 
 7. **Claim the burn**.  
-   Use the Ootle wallet web UI or the `tari_ootle_wallet_cli` tool to claim the burn using the burn proof via the **"Claim Burn"** dialog.  
-
-
-
+   Use the Ootle wallet web UI or the `tari_ootle_wallet_cli` tool to claim the burn using the burn proof via the **"Claim Burn"** dialog.

--- a/README.md
+++ b/README.md
@@ -11,18 +11,18 @@ If you're looking for the core Tari base layer code, it's in [this repository](h
 You will require the following tools and dependencies to successfully build the Ootle and/or run the Ootle locally via the Localnet environment:
 
 - **C/C++ compiler**
-   - Linux: `gcc` or `clang`
-   - macOS: `clang` (via Xcode CLI tools)
-   - Windows: `MSVC` (via Visual Studio Build Tools)
+  - Linux: `gcc` or `clang`
+  - macOS: `clang` (via Xcode CLI tools)
+  - Windows: `MSVC` (via Visual Studio Build Tools)
 - **Build tools**
-   - `make`, `cmake`, or equivalent
-   - `pkg-config` (Linux/macOS)
+  - `make`, `cmake`, or equivalent
+  - `pkg-config` (Linux/macOS)
 - **Libraries**
-   - OpenSSL development libraries (`libssl-dev`)
-   - SQLite development libraries (`libsqlite3-dev`)
-   - Protobuf compiler (`protoc`) and headers (`libprotobuf-dev`)
+  - OpenSSL development libraries (`libssl-dev`)
+  - SQLite development libraries (`libsqlite3-dev`)
+  - Protobuf compiler (`protoc`) and headers (`libprotobuf-dev`)
 - **Other**
-   - `git`
+  - `git`
 
 - **Rust (>=1.74)**: Install Rust via [rustup](https://rustup.rs), and add a WASM target:
 

--- a/README.md
+++ b/README.md
@@ -8,32 +8,30 @@ If you're looking for the core Tari base layer code, it's in [this repository](h
 
 ## Prerequisites
 
-You will require the following in order to successfully build the Ootle and/or run the Ootle locally via the Localnet environment:
+You will require the following tools and dependencies to successfully build the Ootle and/or run the Ootle locally via the Localnet environment:
 
-- **Rust**: Install Rust via [rustup](https://rustup.rs), and add a WASM target:
+- **C/C++ compiler**
+   - Linux: `gcc` or `clang`
+   - macOS: `clang` (via Xcode CLI tools)
+   - Windows: `MSVC` (via Visual Studio Build Tools)
+- **Build tools**
+   - `make`, `cmake`, or equivalent
+   - `pkg-config` (Linux/macOS)
+- **Libraries**
+   - OpenSSL development libraries (`libssl-dev`)
+   - SQLite development libraries (`libsqlite3-dev`)
+   - Protobuf compiler (`protoc`) and headers (`libprotobuf-dev`)
+- **Other**
+   - `git`
+
+- **Rust (>=1.74)**: Install Rust via [rustup](https://rustup.rs), and add a WASM target:
 
 ```bash
 rustup target add wasm32-unknown-unknown
 ```
 
-- **Node.js & npm**: Node.js is required for building the React UI components. The easiest way to manage this follow the instructions at [node.js](https://nodejs.org/en/download) for your desired operating system and package/version managers. 
-
-- **Linux-only steps**: Ensure you have the following dependencies installed: 
-
-```bash
-sudo apt-get update
-sudo apt-get install -y \
-  build-essential \
-  openssl \
-  libssl-dev \
-  pkg-config \
-  libsqlite3-dev \
-  git \
-  cmake \
-  protobuf-compiler \
-  libprotobuf-dev
-```
-
+- **Node.js (>=20.x) & npm**: Node.js is required for building the React UI components. Follow the instructions at [node.js](https://nodejs.org/en/download) for your desired operating system and package/version managers. We recommend installing Node.js via [`nvm`](https://github.com/nvm-sh/nvm) to easily manage versions across projects.
+ 
 ## Accessing the Ootle Testnet
 
 The Tari Ootle Wallet Daemon is available on the project’s [releases page](https://github.com/tari-project/tari-ootle/releases).

--- a/README.md
+++ b/README.md
@@ -24,9 +24,12 @@ You will require the following tools and dependencies to successfully build the 
 - **Other**
   - `git`
 
-- **Rust (>=1.74)**: Install Rust via [rustup](https://rustup.rs), and add a WASM target:
+- **Rust (=1.88)**: Install Rust using [rustup](https://rustup.rs), and add a WASM target:
 
 ```bash
+# Install the rust version in rust-toolchain.toml
+rustup install
+# Add wasm target
 rustup target add wasm32-unknown-unknown
 ```
 


### PR DESCRIPTION
Description
---

Expanded on @stringhandler's addition of pnpm (https://github.com/tari-project/tari-ootle/commit/11744a7951be9627879d5ebbe9b69fa4dd43be37) and added a prerequisites section to ensure people have the necessary dependencies installed before proceeding. Should ideally match up with https://github.com/tari-project/tari-ootle/pull/1553

Motivation and Context
---

Clarifying prerequisites to minimise failed steps following other instructions.

How Has This Been Tested?
---

Currently has not be tested in a clean environment.

Breaking Changes
---
- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive Prerequisites section listing OS-specific C/C++ toolchains, build tools, libraries, Git, Rust (wasm target) and Node.js/npm.
  * Added an unzip-and-run step for accessing the testnet, including how to start the Ootle wallet daemon.
  * Added clone instructions for running locally (clone both repositories into the same folder) and consolidated Localnet prerequisites.
  * Fixed formatting around the Claim Burn step.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->