### PR TITLE
chore: bump bindings version to 1.16.0

### DIFF
--- a/bindings/package.json
+++ b/bindings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tari-project/typescript-bindings",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "description": "TypeScript types synchronized to the Tari Ootle Rust codebase",
   "homepage": "https://github.com/tari-project/tari-ootle#readme",
   "bugs": {


### PR DESCRIPTION
Description
---
chore: bump bindings version to 1.16.0 to create a new bindings release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Bumped @tari-project/typescript-bindings package version from 1.15.0 to 1.16.0.
  - No functional or API changes; existing behavior remains unchanged.
  - No modifications to public exports or configuration.
  - Ensures version alignment for distribution and release management.
  - Low-risk maintenance update with no impact on user workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->