### PR TITLE
fix: fix fee claiming, indexer syncs VN fee pool substates

### DIFF
--- a/applications/tari_indexer/src/network_state_sync/block_scanner.rs
+++ b/applications/tari_indexer/src/network_state_sync/block_scanner.rs
@@ -4,21 +4,16 @@
 use futures::StreamExt;
 use log::*;
 use tari_consensus_types::BlockId;
-use tari_engine_types::substate::SubstateValue;
 use tari_epoch_manager::{service::EpochManagerHandle, EpochManagerReader};
 use tari_ootle_common_types::{committee::Committee, Epoch, PeerAddress, ShardGroup};
 use tari_ootle_p2p::{proto, proto::rpc::SyncBlocksRequest};
-use tari_ootle_storage::{
-    consensus_models::{Block, SubstateUpdateProof},
-    time::{OffsetDateTime, PrimitiveDateTime},
-};
-use tari_template_lib::types::TemplateAddress;
+use tari_ootle_storage::consensus_models::{Block, SubstateUpdateProof};
 use tari_validator_node_rpc::client::{TariValidatorNodeRpcClientFactory, ValidatorNodeClientFactory};
 
 use crate::{
     block_data::BlockData,
     storage_sqlite::{
-        models::{NewScannedBlockId, NewSubstate},
+        models::NewScannedBlockId,
         IndexerStore,
         IndexerStoreReadTransaction,
         IndexerStoreWriteTransaction,
@@ -107,12 +102,19 @@ impl BlockScanner {
 
             count += new_blocks.len();
             for block_data in new_blocks {
-                let timestamp = unix_epoch_to_primitive_date_time(block_data.block.timestamp());
                 // TODO: store blocks
                 // TODO: remove substates (I think). These can be requested lazily and cached (LRU) as needed to allow
                 // TODO: an committed transaction should queue a shard state sync in the affected shards
                 // an upper bound on substates stored in the indexer.
-                self.store_substates_in_db(&block_data.diff, timestamp)?;
+                info!(
+                    target: LOG_TARGET,
+                    "Storing {} substate update(s) for block {} (epoch={}, height={})",
+                    block_data.diff.len(),
+                    block_data.block.id(),
+                    block_data.block.epoch(),
+                    block_data.block.height()
+                );
+                self.store_substates_in_db(&block_data.diff)?;
             }
         }
 
@@ -125,67 +127,30 @@ impl BlockScanner {
             .map_err(|e| e.into())
     }
 
-    fn store_substates_in_db(
-        &self,
-        updates: &[SubstateUpdateProof],
-        timestamp: PrimitiveDateTime,
-    ) -> Result<(), anyhow::Error> {
+    fn store_substates_in_db(&self, updates: &[SubstateUpdateProof]) -> Result<(), anyhow::Error> {
         let mut tx = self.substate_store.create_write_tx()?;
         // store/update up substates if any
         for update in updates {
             match update {
                 SubstateUpdateProof::Create(create) => {
-                    let maybe_substate_value = create.substate.value.value();
-                    if maybe_substate_value.is_none() {
+                    if create.substate.value.value().is_none() {
                         warn!(
                             target: LOG_TARGET,
                             "⚠️ Received UP substate {} without value. This indicates that the substate has been pruned. Some event data is not available.", create.substate.as_versioned_substate_id_ref(),
                         );
                     }
-                    let template_address = maybe_substate_value.and_then(Self::extract_template_address_from_substate);
-                    let module_name = maybe_substate_value.and_then(Self::extract_module_name_from_substate);
-                    let substate_row = NewSubstate {
-                        address: create.substate.substate_id.to_string(),
-                        version: create.substate.version as i32,
-                        data: maybe_substate_value
-                            .map(Self::encode_substate)
-                            .transpose()?
-                            .unwrap_or_default(),
-                        template_address: template_address.map(|s| s.to_string()),
-                        module_name,
-                        timestamp,
-                    };
                     debug!(
                         target: LOG_TARGET,
                         "Saving substate: {:?}",
-                        substate_row
+                        create.substate
                     );
-                    tx.upsert_substate(substate_row)?;
+                    tx.upsert_substate(&create.substate)?;
                 },
                 SubstateUpdateProof::Destroy(_) => {},
             }
         }
         tx.commit()?;
         Ok(())
-    }
-
-    fn extract_template_address_from_substate(substate: &SubstateValue) -> Option<TemplateAddress> {
-        match substate {
-            SubstateValue::Component(c) => Some(c.template_address),
-            _ => None,
-        }
-    }
-
-    fn extract_module_name_from_substate(substate: &SubstateValue) -> Option<String> {
-        match substate {
-            SubstateValue::Component(c) => Some(c.module_name.to_owned()),
-            _ => None,
-        }
-    }
-
-    fn encode_substate(substate: &SubstateValue) -> Result<String, anyhow::Error> {
-        let pretty_json = serde_json::to_string_pretty(&substate)?;
-        Ok(pretty_json)
     }
 
     async fn get_oldest_scanned_epoch(&self) -> Result<Option<Epoch>, anyhow::Error> {
@@ -360,30 +325,4 @@ impl BlockScanner {
 
         Ok(blocks)
     }
-}
-
-fn unix_epoch_to_primitive_date_time(timestamp: u64) -> PrimitiveDateTime {
-    let timestamp = i64::try_from(timestamp).unwrap_or_else(|e| {
-        // TODO: this is very possible because we trust that the timestamp is roughly correct, however
-        // it is purely informational and not enforced in consensus therefore could be any value and
-        // therefore cannot be relied for ordering (use (epoch,height) instead).
-        warn!(
-            target: LOG_TARGET,
-            "Failed to convert block timestamp to PrimitiveDateTime: {}",
-            e
-        );
-        i64::MAX // = August 17, 292278994, 07:12:55.807 UTC
-    });
-    OffsetDateTime::from_unix_timestamp(timestamp)
-        .map(|osdt| PrimitiveDateTime::new(osdt.date(), osdt.time()))
-        .unwrap_or_else(|e| {
-            warn!(
-                target: LOG_TARGET,
-                "Failed to convert block timestamp to OffsetDateTime: {}. Using UNIX_EPOCH",
-                e
-            );
-            // An error cannot be because the timestamp is too small, because we use an u64 and a zero unix
-            // timestamp represents a greater date (1970 AD) than the minimum (9999 BC)
-            PrimitiveDateTime::MAX
-        })
 }

--- a/applications/tari_indexer/src/network_state_sync/worker.rs
+++ b/applications/tari_indexer/src/network_state_sync/worker.rs
@@ -22,7 +22,7 @@ use tari_ootle_common_types::{
 };
 use tari_ootle_p2p::{proto::rpc, TariMessagingSpec};
 use tari_ootle_storage::{
-    consensus_models::{EpochCheckpoint, SubstateUpdateProof, SubstateValueFilterFlags},
+    consensus_models::{EpochCheckpoint, SubstateData, SubstateUpdateProof, SubstateValueFilterFlags},
     StorageError,
 };
 use tari_rpc_framework::__macro_reexports::future::Either;
@@ -282,6 +282,7 @@ impl NetworkWideStateSync {
         let mut update_buf = Vec::new();
         let mut utxos_buf = Vec::new();
         let mut transactions_buf = Vec::new();
+        let mut validator_fee_pools_buf = Vec::new();
 
         let mut has_synced_global_shard = false;
 
@@ -297,6 +298,7 @@ impl NetworkWideStateSync {
                     &mut update_buf,
                     &mut utxos_buf,
                     &mut transactions_buf,
+                    &mut validator_fee_pools_buf,
                     shard_group,
                     &mut session,
                 )
@@ -311,6 +313,7 @@ impl NetworkWideStateSync {
                     &mut update_buf,
                     &mut utxos_buf,
                     &mut transactions_buf,
+                    &mut validator_fee_pools_buf,
                     shard_group,
                     &mut session,
                 )
@@ -328,6 +331,7 @@ impl NetworkWideStateSync {
         update_buf: &mut Vec<(Epoch, SubstateUpdateProof)>,
         utxos_buf: &mut Vec<UtxoUpdateRecord>,
         transactions_buf: &mut Vec<TransactionReceipt>,
+        validator_fee_pools_buf: &mut Vec<SubstateData>,
         shard_group: ShardGroup,
         session: &mut ValidatorRpcSession,
     ) -> Result<(), NetworkStateSyncError> {
@@ -348,6 +352,7 @@ impl NetworkWideStateSync {
                 until_epoch: None,
                 value_filters: (SubstateValueFilterFlags::UTXO |
                     SubstateValueFilterFlags::TEMPLATE |
+                    SubstateValueFilterFlags::VALIDATOR_FEE_POOL |
                     SubstateValueFilterFlags::TRANSACTION_RECEIPT)
                     .bits(),
             })
@@ -389,6 +394,7 @@ impl NetworkWideStateSync {
                     &mut templates_buf,
                     utxos_buf,
                     transactions_buf,
+                    validator_fee_pools_buf,
                 )?;
             }
             if msg.has_more {
@@ -405,6 +411,11 @@ impl NetworkWideStateSync {
                 tx.batch_insert_substate_transitions(shard, state_version, update_buf.drain(..))?;
                 debug!(target: LOG_TARGET, "✅ Committing {} UTXOs for shard {shard} (epoch: {msg_epoch})", utxos_buf.len());
                 tx.batch_insert_utxo_updates(utxos_buf.drain(..))?;
+                // TODO: there are many ways to do this. This is probably not the best way. But this allows wallet to query for validator fee pool values since
+                // block sync does not sync validator fee pools (due to block diffs being removed on block commit).
+                for substate_data in validator_fee_pools_buf.drain(..) {
+                    tx.upsert_substate(&substate_data)?;
+                }
                 // TODO: transaction events and templates
                 debug!(target: LOG_TARGET, "✅ Committing {} transactions for shard {shard} (epoch: {msg_epoch})", transactions_buf.len());
                 self.stats.increase_events(transactions_buf.len());
@@ -453,6 +464,7 @@ fn extend_bufs_from_substate_update(
     templates_buf: &mut Vec<TemplateChange>,
     utxos_buf: &mut Vec<UtxoUpdateRecord>,
     transactions_buf: &mut Vec<TransactionReceipt>,
+    validator_fee_pools_buf: &mut Vec<SubstateData>,
 ) -> Result<(), NetworkStateSyncError> {
     match &update {
         SubstateUpdateProof::Create(create) => match create.substate.value().value() {
@@ -488,6 +500,13 @@ fn extend_bufs_from_substate_update(
                     // This is invalid, but possible given a malfunctioning validator
                     warn!(target: LOG_TARGET, "⚠️ NEVER HAPPEN: Received template substate with invalid address: {}", create.substate.substate_id());
                 }
+            },
+            Some(SubstateValue::ValidatorFeePool(_)) => {
+                validator_fee_pools_buf.push(SubstateData {
+                    substate_id: create.substate.substate_id().clone(),
+                    version: create.substate.version,
+                    value: create.substate.value().clone(),
+                });
             },
             Some(_) => {},
             None => {

--- a/applications/tari_indexer/src/storage_sqlite/migrations/2023-02-16-145719_initial/up.sql
+++ b/applications/tari_indexer/src/storage_sqlite/migrations/2023-02-16-145719_initial/up.sql
@@ -6,8 +6,6 @@ create table substates
     data             text      not NULL,
     template_address text      NULL,
     module_name      text      NULL,
-    -- Block timestamp
-    timestamp        timestamp not NULL,
     updated_at       timestamp not null default current_timestamp,
     created_at       timestamp not null default current_timestamp
 );

--- a/applications/tari_indexer/src/storage_sqlite/models/substate.rs
+++ b/applications/tari_indexer/src/storage_sqlite/models/substate.rs
@@ -43,7 +43,6 @@ pub struct SubstateRecord {
     pub data: String,
     pub template_address: Option<String>,
     pub module_name: Option<String>,
-    pub timestamp: PrimitiveDateTime,
     pub updated_at: PrimitiveDateTime,
     pub created_at: PrimitiveDateTime,
 }
@@ -72,5 +71,4 @@ pub struct NewSubstate {
     pub data: String,
     pub template_address: Option<String>,
     pub module_name: Option<String>,
-    pub timestamp: PrimitiveDateTime,
 }

--- a/applications/tari_indexer/src/storage_sqlite/reader.rs
+++ b/applications/tari_indexer/src/storage_sqlite/reader.rs
@@ -100,7 +100,7 @@ impl IndexerStoreReadTransaction for SqliteStoreReadTransaction<'_> {
                 let substate_id = SubstateId::from_str(&s.address)?;
                 let version = s.version as u32;
                 let template_address = s.template_address.map(|h| deserialize_hex_try_from(&h)).transpose()?;
-                let timestamp = s.timestamp;
+                let timestamp = s.updated_at;
                 Ok(ListSubstateItem {
                     substate_id,
                     module_name: s.module_name,

--- a/applications/tari_indexer/src/storage_sqlite/schema.rs
+++ b/applications/tari_indexer/src/storage_sqlite/schema.rs
@@ -74,7 +74,6 @@ diesel::table! {
         data -> Text,
         template_address -> Nullable<Text>,
         module_name -> Nullable<Text>,
-        timestamp -> Timestamp,
         updated_at -> Timestamp,
         created_at -> Timestamp,
     }

--- a/applications/tari_indexer/src/storage_sqlite/store_factory.rs
+++ b/applications/tari_indexer/src/storage_sqlite/store_factory.rs
@@ -17,7 +17,7 @@ use tari_engine_types::{events::Event, substate::SubstateId, Utxo};
 use tari_indexer_client::types::{ListSubstateItem, NonFungibleSubstate, TransactionEntry};
 use tari_ootle_common_types::{shard::Shard, substate_type::SubstateType, Epoch, ShardGroup, StateVersion};
 use tari_ootle_storage::{
-    consensus_models::{EpochCheckpoint, SubstateUpdateProof},
+    consensus_models::{EpochCheckpoint, SubstateData, SubstateUpdateProof},
     StorageError,
 };
 use tari_ootle_storage_sqlite::{error::SqliteStorageError, SqliteTransaction};
@@ -33,7 +33,7 @@ use tari_transaction::{Transaction, TransactionId};
 
 use crate::{
     storage_sqlite::{
-        models::{EventRecord, KeyValue, NewScannedBlockId, NewSubstate, SubstateRecord, UtxoUpdateRecord},
+        models::{EventRecord, KeyValue, NewScannedBlockId, SubstateRecord, UtxoUpdateRecord},
         reader::SqliteStoreReadTransaction,
         writer::SqliteStoreWriteTransaction,
     },
@@ -209,7 +209,7 @@ pub trait IndexerStoreWriteTransaction {
         &mut self,
         updates: I,
     ) -> Result<(), StorageError>;
-    fn upsert_substate(&mut self, new_substate: NewSubstate) -> Result<(), StorageError>;
+    fn upsert_substate(&mut self, substate: &SubstateData) -> Result<(), StorageError>;
     fn batch_insert_events<I: IntoIterator<Item = Event>>(&mut self, events: I) -> Result<(), StorageError>;
     fn save_scanned_block_id(&mut self, new_scanned_block_id: NewScannedBlockId) -> Result<(), StorageError>;
     fn delete_scanned_epochs_older_than(&mut self, epoch: Epoch) -> Result<(), StorageError>;

--- a/applications/tari_indexer/src/storage_sqlite/writer.rs
+++ b/applications/tari_indexer/src/storage_sqlite/writer.rs
@@ -9,7 +9,7 @@ use serde::Serialize;
 use tari_engine_types::events::Event;
 use tari_ootle_common_types::{shard::Shard, substate_type::SubstateType, Epoch, StateVersion};
 use tari_ootle_storage::{
-    consensus_models::{EpochCheckpoint, SubstateUpdateProof},
+    consensus_models::{EpochCheckpoint, SubstateData, SubstateUpdateProof},
     StorageError,
 };
 use tari_ootle_storage_sqlite::SqliteTransaction;
@@ -170,8 +170,31 @@ impl IndexerStoreWriteTransaction for SqliteStoreWriteTransaction<'_> {
         Ok(())
     }
 
-    fn upsert_substate(&mut self, new_substate: NewSubstate) -> Result<(), StorageError> {
+    fn upsert_substate(&mut self, substate: &SubstateData) -> Result<(), StorageError> {
         use crate::storage_sqlite::schema::substates;
+
+        let template_address = substate
+            .value
+            .value()
+            .and_then(|s| s.component())
+            .map(|c| c.template_address.to_string());
+        let module_name = substate
+            .value
+            .value()
+            .and_then(|s| s.component())
+            .map(|c| c.module_name.clone());
+        let new_substate = NewSubstate {
+            address: substate.substate_id.to_string(),
+            version: substate.version as i32,
+            data: substate
+                .value
+                .value()
+                .map(serialize_json)
+                .transpose()?
+                .unwrap_or_default(),
+            template_address,
+            module_name,
+        };
 
         let address = &new_substate.address;
         let current_substate = substates::table

--- a/applications/tari_indexer/web_ui/package.json
+++ b/applications/tari_indexer/web_ui/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "clean-dist": "rm -rf dist && rm -f tsconfig.tsbuildinfo"
+    "clean-dist": "rm -rf dist/* && rm -f tsconfig.tsbuildinfo"
   },
   "dependencies": {
     "@emotion/react": "^11.14.0",

--- a/applications/tari_swarm_daemon/src/process_definitions/wallet_daemon_create_key.rs
+++ b/applications/tari_swarm_daemon/src/process_definitions/wallet_daemon_create_key.rs
@@ -29,19 +29,7 @@ impl ProcessDefinition for WalletDaemonCreateAccount {
             .arg("-b")
             .arg(context.base_path())
             .arg("--network")
-            .arg(context.network().to_string())
-            .args([
-                "create-account",
-                "--name",
-                "Fees",
-                "--key",
-                "0",
-                "--set-active",
-                "--output",
-                output_path
-                    .to_str()
-                    .context("Non-UTF8 output path in WalletDaemonCreateAccount")?,
-            ]);
+            .arg(context.network().to_string());
 
         if let Some(override_keyring_password) =
             context.get_setting(wallet_daemon::OVERRIDE_KEYRING_PASSWORD_SETTINGS_KEY)
@@ -50,6 +38,19 @@ impl ProcessDefinition for WalletDaemonCreateAccount {
                 .arg("--override-keyring-password")
                 .arg(override_keyring_password);
         }
+
+        command.args([
+            "create-account",
+            "--name",
+            "Validator Fees",
+            "--key",
+            "0",
+            "--set-active",
+            "--output",
+            output_path
+                .to_str()
+                .context("Non-UTF8 output path in WalletDaemonCreateAccount")?,
+        ]);
 
         Ok(command)
     }

--- a/applications/tari_validator_node/src/json_rpc/handlers.rs
+++ b/applications/tari_validator_node/src/json_rpc/handlers.rs
@@ -164,6 +164,7 @@ impl JsonRpcHandlers {
             .get_local_peer_info()
             .await
             .map_err(internal_error(answer_id))?;
+        let fee_claim_public_key = self.config.validator_node.fee_claim_public_key.to_byte_type();
         let response = GetIdentityResponse {
             peer_id: info.peer_id.to_string(),
             public_key: self.keypair.public_key().to_byte_type(),
@@ -171,6 +172,7 @@ impl JsonRpcHandlers {
             supported_protocols: info.protocols.into_iter().map(|p| p.to_string()).collect(),
             protocol_version: info.protocol_version,
             user_agent: info.agent_version,
+            fee_claim_public_key,
         };
 
         Ok(JsonRpcResponse::success(answer_id, response))

--- a/applications/tari_validator_node/src/p2p/rpc/block_sync_task.rs
+++ b/applications/tari_validator_node/src/p2p/rpc/block_sync_task.rs
@@ -182,6 +182,7 @@ impl<TStateStore: StateStore> BlockSyncTask<TStateStore> {
                     .then(|| child.get_substate_updates(tx, self.num_preshards))
                     .transpose()?
                     .unwrap_or_default();
+
                 let transaction_receipts = matches!(
                     substates_selection,
                     proto::rpc::StreamSubstateSelection::TransactionReceiptsOnly

--- a/applications/tari_validator_node/web_ui/package.json
+++ b/applications/tari_validator_node/web_ui/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "clean-dist": "rm -rf dist && rm -f tsconfig.tsbuildinfo"
+    "clean-dist": "rm -rf dist/* && rm -f tsconfig.tsbuildinfo"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/applications/tari_validator_node/web_ui/src/routes/VN/Components/Info.tsx
+++ b/applications/tari_validator_node/web_ui/src/routes/VN/Components/Info.tsx
@@ -35,58 +35,14 @@ import type {
 } from "@tari-project/typescript-bindings";
 
 function Info({
-  epoch,
-  identity,
-  shardKey,
-}: {
+                epoch,
+                identity,
+                shardKey,
+              }: {
   epoch: GetEpochManagerStatsResponse;
   identity: VNGetIdentityResponse;
   shardKey: string | null;
 }) {
-  const [registering, setRegistering] = useState(false);
-  const [registerMessage, setRegisterMessage] = useState("");
-  const [feeClaimPublicKey, setRegisterFeeClaimPublicKey] = useState("");
-
-  const renderShardKey = () => {
-    if (shardKey === null)
-      return (
-        <>
-          {/* <TableRow>
-            <TableCell>Shard key</TableCell>
-            <DataTableCell>
-              <span
-                className={`${registering ? 'disabled-button' : 'button'}`}
-                id="register"
-                onClick={registering ? () => {} : register}
-              >
-                Register
-              </span>
-              {registerMessage ? <span>{registerMessage}</span> : null}
-            </DataTableCell>
-          </TableRow> */}
-          <TableRow>
-            <TableCell>Shard key</TableCell>
-            <DataTableCell>
-              <TextField
-                disabled={registering}
-                name="feeClaimFublicKey"
-                label="Fee Claim Public Key"
-                style={{ flexGrow: 1 }}
-                value={feeClaimPublicKey}
-                onChange={(e) => setRegisterFeeClaimPublicKey(e.target.value)}
-              />
-              {registerMessage ? <span style={{ marginLeft: "20px" }}>{registerMessage}</span> : null}
-            </DataTableCell>
-          </TableRow>
-        </>
-      );
-    return (
-      <TableRow>
-        <TableCell>Shard key</TableCell>
-        <DataTableCell className="key">{shardKey}</DataTableCell>
-      </TableRow>
-    );
-  };
   return (
     <div>
       <TableContainer>
@@ -106,11 +62,14 @@ function Info({
               <TableCell>Listen addresses</TableCell>
               <DataTableCell>{identity.public_addresses?.join("\n")}</DataTableCell>
             </TableRow>
-            <TableRow>
-              <TableCell>Public key</TableCell>
-              <DataTableCell>{identity.public_key}</DataTableCell>
+            <TableRow><TableCell>Public key</TableCell> <DataTableCell>{identity.public_key}</DataTableCell>
             </TableRow>
-            {renderShardKey()}
+            <TableRow><TableCell>Claim key</TableCell> <DataTableCell>{identity.fee_claim_public_key}</DataTableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell>Shard key</TableCell>
+              <DataTableCell className="key">{shardKey}</DataTableCell>
+            </TableRow>
           </TableBody>
         </Table>
       </TableContainer>

--- a/applications/tari_walletd/src/handlers/validator.rs
+++ b/applications/tari_walletd/src/handlers/validator.rs
@@ -9,7 +9,7 @@ use either::Either;
 use log::*;
 use tari_crypto::{keys::PublicKey as _, ristretto::RistrettoPublicKey};
 use tari_engine_types::{substate::SubstateId, ToByteType};
-use tari_ootle_common_types::{derive_fee_pool_address, optional::Optional, SubstateRequirement};
+use tari_ootle_common_types::{derive_fee_pool_address, SubstateAddress, SubstateRequirement};
 use tari_transaction::args;
 use tari_wallet_daemon_client::{
     permissions::JrpcPermission,
@@ -49,41 +49,45 @@ pub async fn handle_get_validator_fees(
         },
         AccountOrKeyIndex::KeyIndex(index) => sdk.key_manager_api().derive_account_key(index)?,
     };
-    let claim_public_key = RistrettoPublicKey::from_secret_key(&claim_key.key);
+    let claim_public_key = RistrettoPublicKey::from_secret_key(&claim_key.key).to_byte_type();
 
     let shards = req
         .shard_group
         .map(|sg| Either::Left(sg.shard_iter()))
         .unwrap_or_else(|| Either::Right(NUM_PRESHARDS.all_shards_iter()));
 
-    let addresses = shards.into_iter().map(|shard| {
-        (
-            shard,
-            derive_fee_pool_address(&claim_public_key.to_byte_type(), NUM_PRESHARDS, shard),
-        )
-    });
+    let ids = shards
+        .into_iter()
+        .map(|shard| derive_fee_pool_address(&claim_public_key, NUM_PRESHARDS, shard))
+        .map(SubstateId::from)
+        .collect::<Vec<_>>();
 
-    let mut fees = HashMap::new();
-
-    // TODO(perf); bulk scan
-    for (shard, address) in addresses {
-        let Some(result) = context
+    let mut fees = HashMap::with_capacity(ids.len());
+    const CHUNK_SIZE: usize = 20;
+    for id_chunk in ids.chunks(CHUNK_SIZE) {
+        let substates = context
             .wallet_sdk()
             .substate_api()
-            .fetch_substate_from_network(&SubstateId::from(address), None)
-            .await
-            .optional()?
-        else {
-            continue;
-        };
+            .get_substates_from_network(id_chunk.to_vec())
+            .await?;
 
-        let Some(amount) = result.substate.as_validator_fee_pool().map(|p| p.amount()) else {
-            warn!(target: LOG_TARGET, "Incorrect substate type found at address {}", address);
-            continue;
-        };
+        info!(target: LOG_TARGET, "🔍️ Found {}/{} fee pool substates for claim key {}", substates.len(), CHUNK_SIZE, claim_public_key);
 
-        if amount > 0 {
-            fees.insert(shard, FeePoolDetails { amount, address });
+        for (substate_id, substate) in substates {
+            let Some(address) = substate_id.as_validator_fee_pool_address() else {
+                warn!(target: LOG_TARGET, "Incorrect substate ID found: {}", substate_id);
+                continue;
+            };
+
+            let Some(amount) = substate.substate_value().as_validator_fee_pool().map(|p| p.amount()) else {
+                warn!(target: LOG_TARGET, "Incorrect substate type found at address {}", substate_id);
+                continue;
+            };
+
+            if amount > 0 {
+                let shard = SubstateAddress::from_substate_id(&substate_id, substate.version()).to_shard(NUM_PRESHARDS);
+                fees.insert(shard, FeePoolDetails { amount, address });
+            }
         }
     }
 

--- a/applications/tari_walletd/web_ui/package.json
+++ b/applications/tari_walletd/web_ui/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "clean-dist": "rm -rf dist && rm -f tsconfig.tsbuildinfo"
+    "clean-dist": "rm -rf dist/* && rm -f tsconfig.tsbuildinfo"
   },
   "dependencies": {
     "@emotion/react": "^11.14.0",

--- a/applications/tari_walletd/web_ui/src/utils/helpers.tsx
+++ b/applications/tari_walletd/web_ui/src/utils/helpers.tsx
@@ -61,6 +61,7 @@ export const renderJson = (json: any) => {
 
   if (typeof json === "string") return <span className="string">"{json}"</span>;
   if (typeof json === "number") return <span className="number">{json}</span>;
+  if (typeof json === "boolean") return <span className="number">{String(json)}</span>;
   return <span className="other">{json || "null"}</span>;
 };
 

--- a/bindings/src/types/validator-node-client/VNGetIdentityResponse.ts
+++ b/bindings/src/types/validator-node-client/VNGetIdentityResponse.ts
@@ -8,4 +8,5 @@ export type VNGetIdentityResponse = {
   supported_protocols: Array<string>;
   protocol_version: string;
   user_agent: string;
+  fee_claim_public_key: RistrettoPublicKeyBytes;
 };

--- a/clients/validator_node_client/src/types.rs
+++ b/clients/validator_node_client/src/types.rs
@@ -65,6 +65,7 @@ pub struct GetIdentityResponse {
     pub supported_protocols: Vec<String>,
     pub protocol_version: String,
     pub user_agent: String,
+    pub fee_claim_public_key: RistrettoPublicKeyBytes,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/engine_types/src/substate.rs
+++ b/crates/engine_types/src/substate.rs
@@ -42,7 +42,7 @@ use tari_template_lib::{
         VaultId,
     },
     prelude::PUBLIC_IDENTITY_RESOURCE_ADDRESS,
-    types::{Hash, ObjectKey},
+    types::{Hash, ObjectKey, TemplateAddress},
 };
 
 use crate::{
@@ -774,6 +774,10 @@ impl SubstateValue {
             SubstateValue::Utxo(utxo) => Some(utxo),
             _ => None,
         }
+    }
+
+    pub fn related_template_address(&self) -> Option<TemplateAddress> {
+        self.as_component().map(|c| c.template_address)
     }
 
     pub fn to_bytes(&self) -> Vec<u8> {

--- a/crates/state_store_rocksdb/src/options.rs
+++ b/crates/state_store_rocksdb/src/options.rs
@@ -12,7 +12,8 @@ pub struct DatabaseOptions {
     pub state_history_length: u64,
     /// The number of epochs back from the current epoch to keep in the database.
     /// This includes blocks, foreign proposals etc.
-    /// The default is 1, which means we keep the previous epoch's data. It is not recommended to set this to 0.
+    /// The default is 1, which means we keep the previous epoch's data until this epoch has passed. It is not
+    /// recommended to set this to 0.
     pub epoch_history_length: Epoch,
 }
 

--- a/crates/storage/src/consensus_models/block.rs
+++ b/crates/storage/src/consensus_models/block.rs
@@ -553,10 +553,6 @@ impl Block {
         Ok(())
     }
 
-    pub fn remove_diff<TTx: StateStoreWriteTransaction>(&self, tx: &mut TTx) -> Result<(), StorageError> {
-        tx.block_diffs_remove(self.id())
-    }
-
     pub fn remove_pending_tree_diff_and_return<TTx: StateStoreWriteTransaction>(
         &self,
         tx: &mut TTx,
@@ -766,6 +762,9 @@ impl Block {
         tx: &TTx,
         num_preshards: NumPreshards,
     ) -> Result<Vec<SubstateUpdateProof>, StorageError> {
+        // The block diff is removed as soon as it is committed, so we need to reconstruct the substate updates from the
+        // committed transactions. TODO: this does not include "implicit" state transitions i.e. validator fee
+        // pools.
         let committed = self
             .commands()
             .iter()

--- a/crates/storage/src/consensus_models/command.rs
+++ b/crates/storage/src/consensus_models/command.rs
@@ -86,7 +86,6 @@ pub enum Command {
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
 enum CommandOrdering<'a> {
     EvictNode,
-    // EvictNode,
     /// Foreign proposals should come first in the block so that they are processed before commands
     ForeignProposal(ShardGroup, &'a BlockId),
     TransactionId(&'a TransactionId),

--- a/crates/wallet/sdk/src/apis/accounts.rs
+++ b/crates/wallet/sdk/src/apis/accounts.rs
@@ -22,7 +22,7 @@ use tari_template_lib::{
 use crate::{
     apis::{
         confidential_transfer::{ConfidentialTransferApiError, ResolvedAccountDetails},
-        key_manager::{KeyManagerApi, KeyManagerApiError},
+        key_manager::{KeyBranch, KeyManagerApi, KeyManagerApiError},
         substate::{SubstatesApi, ValidatorScanResult},
     },
     models::{Account, AccountUpdate, AccountWithAddress, VaultBalance, VaultModel},
@@ -111,6 +111,7 @@ impl<'a, TStore: WalletStore, TNetworkInterface> AccountsApi<'a, TStore, TNetwor
                     return Err(AccountsApiError::AccountNameAlreadyExists { name: name.to_string() });
                 }
             }
+            tx.key_manager_insert_or_ignore(KeyBranch::Account.as_str(), owner_key_index)?;
             tx.accounts_insert(
                 account_name,
                 account_address,

--- a/crates/wallet/sdk/src/apis/substate.rs
+++ b/crates/wallet/sdk/src/apis/substate.rs
@@ -1,13 +1,13 @@
 //   Copyright 2023 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use log::*;
 use tari_engine_types::{
     indexed_value::{IndexedValueError, IndexedWellKnownTypes},
     resource::Resource,
-    substate::{SubstateId, SubstateValue},
+    substate::{Substate, SubstateId, SubstateValue},
     transaction_receipt::TransactionReceiptAddress,
 };
 use tari_ootle_common_types::{
@@ -61,6 +61,16 @@ where
         let mut tx = self.store.create_read_tx()?;
         let substates = tx.substates_get_all(filter_by_type, filter_by_template, limit, offset)?;
         Ok(substates)
+    }
+
+    pub async fn get_substates_from_network(
+        &self,
+        ids: Vec<SubstateId>,
+    ) -> Result<HashMap<SubstateId, Substate>, SubstateApiError> {
+        self.network_interface
+            .get_substates(ids)
+            .await
+            .map_err(|e| SubstateApiError::NetworkInterfaceError(e.into()))
     }
 
     pub fn load_dependent_substates(

--- a/crates/wallet/storage_sqlite/src/writer.rs
+++ b/crates/wallet/storage_sqlite/src/writer.rs
@@ -221,6 +221,9 @@ impl WalletStoreWriter for WriteTransaction<'_> {
         let index = i64::try_from(index)
             .map_err(|_| WalletStorageError::general("key_manager_set_active_index", "index too large"))?;
 
+        // Ensure it exists
+        self.key_manager_insert_or_ignore(branch, index as u64)?;
+
         let active_id = key_manager_states::table
             .select(key_manager_states::id)
             .filter(key_manager_states::branch_seed.eq(branch))


### PR DESCRIPTION
Description
---
fix(swarm): fix create account for fee claiming
fix(wallet): request VN fee pool substates in batches

Motivation and Context
---
The fee claiming setup in swarm was broken
1. the order of the --override-keyring-password flag was incorrect
2. setting the key to active in the walletd cli command would result in an error

Querying each shard for fee pool substates was slow, using the new `get_substates` RPC for batching requests improves performance and greatly reduces requests.

It was also discovered that the indexer does not sync validator fee pools. This was corrected.

How Has This Been Tested?
---
Manually

What process can a PR reviewer use to test or verify this change?
---


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Identity APIs now include a fee-claim public key.

- UI Improvements
  - Validator UI shows Public key and Claim key; shard key is read-only.
  - JSON viewer now renders boolean values explicitly.
  - Default created account renamed to “Validator Fees.”

- Performance
  - Validator fee retrieval is batched for faster, more reliable syncing.

- Bug Fixes
  - Key manager activation now ensures missing entries are created to prevent activation failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->