### PR TITLE
fix(wallet/webui): honour resource divisibility in UI

### DIFF
--- a/applications/tari_walletd/web_ui/src/routes/AssetVault/NFTs/components/NftParts.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/AssetVault/NFTs/components/NftParts.tsx
@@ -29,13 +29,12 @@ import { NftCard as Card, DataTableCell } from "@components/StyledComponents";
 import { convertCborValue } from "@utils/cbor";
 import { shortenSubstateId, displayNftId } from "@utils/helpers";
 import SendNft from "./SendNft";
-
+import { Fragment } from "react/jsx-runtime";
 
 function NftCard({ nft }: { nft: NonFungibleToken }) {
   const mutableData = convertCborValue(nft.mutable_data);
-  const data = convertCborValue(nft.data);
+  const data = convertCborValue(nft.data) as Record<string, any> | undefined;
   const imageUrl = mutableData?.image_url;
-  const originalOwner = data?.original_owner;
 
   return (
     <Grid item xs={12} sm={6} md={4} lg={3}>
@@ -59,19 +58,15 @@ function NftCard({ nft }: { nft: NonFungibleToken }) {
             <Typography variant="h6" component="h2" fontWeight="bold" noWrap>
               {displayNftId(nft.nft_id)}
             </Typography>
-            <Chip
-              icon={
-                nft.is_burnt ? (
-                  <CancelRoundedIcon style={{ height: 16, width: 16 }} />
-                ) : (
-                  <CheckCircleRoundedIcon style={{ height: 16, width: 16 }} />
-                )
-              }
-              label={nft.is_burnt ? "Burnt" : "Active"}
-              color={nft.is_burnt ? "error" : "success"}
-              size="small"
-              variant="outlined"
-            />
+            {nft.is_burnt && (
+              <Chip
+                icon={<CancelRoundedIcon style={{ height: 16, width: 16 }} />}
+                label={"Burnt"}
+                color={"error"}
+                size="small"
+                variant="outlined"
+              />
+            )}
           </Box>
 
           <Divider />
@@ -81,15 +76,30 @@ function NftCard({ nft }: { nft: NonFungibleToken }) {
           </Typography>
 
           <Divider />
-          <Typography variant="subtitle2">Original Owner:</Typography>
-          <Typography variant="body2" color="text.secondary" gutterBottom>
-            <CopyAddress address={originalOwner || ""} />
-          </Typography>
+          {data ? <NftData data={data} /> : null}
 
           <SendNft nftId={nft.nft_id} resourceAddress={nft.resource_address} />
         </CardContent>
       </Card>
     </Grid>
+  );
+}
+
+function NftData({ data }: { data: Record<string, any> }) {
+  return (
+    <>
+      {Object.keys(data).map((key, i) => {
+        const value = data[key];
+        return (
+          <Fragment key={i}>
+            <Typography variant="subtitle2">{key}</Typography>
+            <Typography variant="body2" color="text.secondary" gutterBottom>
+              <CopyAddress address={String(value)} />
+            </Typography>
+          </Fragment>
+        );
+      })}
+    </>
   );
 }
 

--- a/applications/tari_walletd/web_ui/src/routes/AssetVault/Tokens/Tokens.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/AssetVault/Tokens/Tokens.tsx
@@ -150,17 +150,19 @@ function Tokens({ account }: { account: Account }) {
 
   return (
     <>
-      <SendMoneyDialog
-        open={resourceToSend !== null}
-        handleClose={() => setResourceToSend(null)}
-        onSendComplete={() => setResourceToSend(null)}
-        resource_address={resourceToSend?.address}
-        resource_type={resourceToSend?.resource_type!}
-        token_symbol={
-          balancesData?.balances.find((b: BalanceEntry) => b.resource_address === resourceToSend?.address)
-            ?.token_symbol || ""
-        }
-      />
+      {resourceToSend == null ? null : (
+        <SendMoneyDialog
+          open={true}
+          handleClose={() => setResourceToSend(null)}
+          onSendComplete={() => setResourceToSend(null)}
+          resource_address={resourceToSend?.address}
+          resource_type={resourceToSend?.resource_type!}
+          token_symbol={
+            balancesData?.balances.find((b: BalanceEntry) => b.resource_address === resourceToSend?.address)
+              ?.token_symbol || ""
+          }
+        />
+      )}
       <FetchStatusCheck
         isError={balancesIsError as boolean}
         errorMessage={(balancesError as { message?: string })?.message || "Error fetching data"}
@@ -202,37 +204,34 @@ function Tokens({ account }: { account: Account }) {
                   </TableRow>
                 </TableHead>
                 <TableBody>
-                  {balancesData?.balances.map(
-                    (
-                      {
-                        resource_address,
-                        balance,
-                        resource_type,
-                        confidential_balance,
-                        token_symbol,
-                        vault_address,
-                        divisibility,
-                      }: BalanceEntry,
-                      i: number,
-                    ) => (
-                      <BalanceRow
-                        key={i}
-                        token_symbol={token_symbol || ""}
-                        resource_address={resource_address}
-                        resource_type={resource_type}
-                        balance={balance}
-                        confidential_balance={confidential_balance}
-                        vault_address={vault_address ?? undefined} // convert null to undefined
-                        divisibility={divisibility}
-                        onSendClicked={
-                          handleSendResourceClicked as (
-                            resource_address: ResourceAddress,
-                            resource_type: ResourceType,
-                          ) => void
-                        }
-                      />
-                    ),
-                  )}
+                  {balancesData?.balances
+                    .filter((b) => BigInt(b.balance) > 0n || BigInt(b.confidential_balance) > 0n)
+                    .map(
+                      (
+                        {
+                          resource_address,
+                          balance,
+                          resource_type,
+                          confidential_balance,
+                          token_symbol,
+                          vault_address,
+                          divisibility,
+                        }: BalanceEntry,
+                        i: number,
+                      ) => (
+                        <BalanceRow
+                          key={i}
+                          token_symbol={token_symbol || ""}
+                          resource_address={resource_address}
+                          resource_type={resource_type}
+                          balance={balance}
+                          confidential_balance={confidential_balance}
+                          vault_address={vault_address ?? undefined} // convert null to undefined
+                          divisibility={divisibility}
+                          onSendClicked={handleSendResourceClicked}
+                        />
+                      ),
+                    )}
                 </TableBody>
               </Table>
             </TableContainer>

--- a/applications/tari_walletd/web_ui/src/routes/AssetVault/Tokens/components/SendMoney.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/AssetVault/Tokens/components/SendMoney.tsx
@@ -80,9 +80,12 @@ export function SendMoneyDialog(props: SendMoneyDialogProps) {
     .map((b: BalanceEntry) => b.resource_address) as string[];
 
   // Find the available balance for the resource we're trying to send
-  const balanceEntry = data?.balances?.find(
-    (b: BalanceEntry) => b.resource_address === (props.resource_address || XTR),
-  );
+  const balanceEntry = data?.balances?.find((b: BalanceEntry) => b.resource_address === props.resource_address);
+
+  if (!balanceEntry) {
+    console.warn("No balance entry found for resource", props.resource_address);
+    return null;
+  }
 
   // Function to calculate available balance based on input selection
   const calculateAvailableBalance = () => {
@@ -114,17 +117,6 @@ export function SendMoneyDialog(props: SendMoneyDialogProps) {
   };
 
   const availableBalance = calculateAvailableBalance();
-
-  const transfer = {
-    account: substateIdToString(account.component_address),
-    amount: Math.floor((parseFloat(transferFormState.amount) || 0) * Math.pow(10, balanceEntry?.divisibility || 6)),
-    resource_address: props.resource_address!,
-    destination_address: transferFormState.address,
-    resourceType: props.resource_type,
-    output_to_revealed: !transferFormState.outputToConfidential,
-    input_selection: transferFormState.inputSelection as ConfidentialTransferInputSelection,
-    badge: transferFormState.badge,
-  };
 
   function setFormValue(e: React.ChangeEvent<HTMLInputElement>) {
     const { name, value } = e.target;
@@ -179,14 +171,19 @@ export function SendMoneyDialog(props: SendMoneyDialogProps) {
     if (!account || isEstimatingFee || !transferFormState.address.trim() || !transferFormState.amount) {
       return;
     }
+    if (!balanceEntry) {
+      console.warn("No balance entry found for resource", props.resource_address);
+      return;
+    }
 
     setIsEstimatingFee(true);
 
     try {
+      let amount = Math.floor((parseFloat(transferFormState.amount) || 0) * Math.pow(10, balanceEntry.divisibility));
       // Create transfer object with current form state
       const currentTransfer = {
         account: substateIdToString(account.component_address),
-        amount: Math.floor((parseFloat(transferFormState.amount) || 0) * Math.pow(10, balanceEntry?.divisibility || 6)),
+        amount,
         resource_address: props.resource_address || XTR,
         destination_address: transferFormState.address,
         resourceType: props.resource_type,
@@ -246,6 +243,18 @@ export function SendMoneyDialog(props: SendMoneyDialogProps) {
     setActiveStep(2);
 
     try {
+      let amount = Math.floor((parseFloat(transferFormState.amount) || 0) * Math.pow(10, balanceEntry.divisibility));
+      const transfer = {
+        account: substateIdToString(account.component_address),
+        amount,
+        resource_address: props.resource_address!,
+        destination_address: transferFormState.address,
+        resourceType: props.resource_type,
+        output_to_revealed: !transferFormState.outputToConfidential,
+        input_selection: transferFormState.inputSelection as ConfidentialTransferInputSelection,
+        badge: transferFormState.badge,
+      };
+
       await sendIt?.({
         ...transfer,
         dry_run: false,
@@ -299,7 +308,7 @@ export function SendMoneyDialog(props: SendMoneyDialogProps) {
             isEstimatingFee={isEstimatingFee}
             availableBalance={availableBalance}
             token_symbol={props.token_symbol}
-            divisibility={balanceEntry?.divisibility || 6}
+            divisibility={balanceEntry.divisibility}
             onSubmit={handleFormSubmit}
             onCancel={handleClose}
             onFormValueChange={setFormValue}

--- a/applications/tari_walletd/web_ui/src/routes/AssetVault/Tokens/steps/FormStep.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/AssetVault/Tokens/steps/FormStep.tsx
@@ -104,9 +104,8 @@ export default function FormStep({
     }
 
     // Otherwise, show formatted value
-    const hasDecimals = amount.includes(".") && amount.split(".")[1].length > 0;
     return num.toLocaleString("en-US", {
-      minimumFractionDigits: hasDecimals ? 0 : 2,
+      minimumFractionDigits: 0,
       maximumFractionDigits: divisibility,
     });
   };
@@ -205,13 +204,13 @@ export default function FormStep({
           error={hasInsufficientFunds}
           helperText={
             hasInsufficientFunds
-              ? `Insufficient funds. Available balance: ${formatDisplayCurrency(availableBalance || 0)}`
+              ? `Insufficient funds. Available balance: ${formatDisplayCurrency(availableBalance || 0, divisibility, token_symbol)}`
               : availableBalance !== undefined
-                ? `Available balance: ${formatDisplayCurrency(availableBalance)}`
+                ? `Available balance: ${formatDisplayCurrency(availableBalance, divisibility, token_symbol)}`
                 : undefined
           }
           InputProps={{
-            placeholder: "0.0",
+            placeholder: "0" + (divisibility > 0 ? "." + "0".repeat(divisibility) : ""),
             endAdornment: token_symbol ? <InputAdornment position="end">{token_symbol}</InputAdornment> : undefined,
           }}
         />

--- a/applications/tari_walletd/web_ui/src/routes/StealthUtxoList/StealthUtxoList.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/StealthUtxoList/StealthUtxoList.tsx
@@ -109,7 +109,9 @@ function StealthUtxoList({ account }: { account: Account }) {
                         {shortenString(utxo.address.id)}
                         <CopyToClipboard copy={utxo.address.id} />
                       </DataTableCell>
-                      <DataTableCell>{bigintToDecimalString(utxo.value, 6)} {currencySymbol}</DataTableCell>
+                      <DataTableCell>
+                        {bigintToDecimalString(utxo.value, 6)} {currencySymbol}
+                      </DataTableCell>
                       <DataTableCell>
                         <StatusChip status={utxo.status} />
                       </DataTableCell>

--- a/applications/tari_walletd/web_ui/src/utils/helpers.tsx
+++ b/applications/tari_walletd/web_ui/src/utils/helpers.tsx
@@ -277,16 +277,18 @@ export const formatCurrency = (amount: number | bigint): string => {
   }
 };
 
-// Helper function for formatting amounts that are already in display units (XTR)
-export const formatDisplayCurrency = (amount: number): string => {
-  const currencySymbol = useCurrencyStore.getState().currencySymbol;
-
+// Helper function for formatting currency amounts
+export const formatDisplayCurrency = (
+  amount: number,
+  divisibility: number,
+  currencySymbol: string | undefined,
+): string => {
   if (isNaN(amount)) {
     return `0 ${currencySymbol}`;
   }
   return `${amount.toLocaleString("en-US", {
     minimumFractionDigits: 0,
-    maximumFractionDigits: CURRENCY.DECIMALS,
+    maximumFractionDigits: divisibility,
   })} ${currencySymbol}`;
 };
 

--- a/crates/wallet/storage_sqlite/src/reader.rs
+++ b/crates/wallet/storage_sqlite/src/reader.rs
@@ -952,6 +952,7 @@ impl WalletStoreReader for ReadTransaction<'_> {
         }
 
         let rows = query
+            .order_by(stealth_outputs::id.desc())
             .get_results::<(models::StealthOutput, String)>(self.connection())
             .map_err(|e| WalletStorageError::general(OPERATION, e))?;
 


### PR DESCRIPTION
Description
---
fix(wallet/webui): honour resource divisibility in UI
Display NFT metadata (originalOwner is only metadata that was added for the testnet faucet NFT)
Remove "Active" chip from NFTs (could be confusing)

Motivation and Context
---
Use correct divisibility and token symbol when formatting currency

How Has This Been Tested?
---

What process can a PR reviewer use to test or verify this change?
---


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Display NFT data as key/value details within NFT cards and rows.

* Improvements
  * Token list hides assets with zero balance.
  * Amount formatting and placeholders now respect each token’s divisibility.
  * Balance and “Insufficient funds” messages include token symbol and precise formatting.
  * Send dialog only appears when initiating a send.

* Bug Fixes
  * Burn status is shown only for burnt NFTs.
  * Prevents send/fee actions when no balance is available for the selected token, avoiding inconsistent transfers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->