### PR TITLE
fix: make it explicit that fungible resource has no privacy features

### DIFF
--- a/applications/tari_indexer/src/rest_api/server.rs
+++ b/applications/tari_indexer/src/rest_api/server.rs
@@ -65,28 +65,34 @@ impl Server {
                 "/network/connections",
                 get(handlers::network::get_connections).post(handlers::network::add_connection),
             )
-            .route("/substates/{substate_id}", get(handlers::substates::get_substate))
-            .route(
-                "/substates",
-                get(handlers::substates::list_substates).post(handlers::substates::fetch_substates),
+            .nest("/substates", Router::new()
+                .route("/fetch", post(handlers::substates::fetch_substates))
+                .route("/{substate_id}", get(handlers::substates::get_substate))
+                .route("/", get(handlers::substates::list_substates))
             )
-            .route("/transactions", post(handlers::transactions::submit_transaction))
-            .route(
-                "/transactions/recent",
-                get(handlers::transactions::list_recent_transactions),
+            .nest("/transactions", Router::new()
+                .route("/", post(handlers::transactions::submit_transaction))
+                .route(
+                    "/recent",
+                    get(handlers::transactions::list_recent_transactions),
+                )
+                .route(
+                    "/{transaction_id}/result",
+                    get(handlers::transactions::get_transaction_result),
+                )
             )
-            .route(
-                "/transactions/{transaction_id}/result",
-                get(handlers::transactions::get_transaction_result),
+            .nest("/templates", Router::new()
+                .route(
+                    "/{template_address}",
+                    get(handlers::templates::get_template_definition),
+                )
+                .route("/", get(handlers::templates::list_templates))
             )
-            .route(
-                "/templates/{template_address}",
-                get(handlers::templates::get_template_definition),
-            )
-            .route("/templates", get(handlers::templates::list_templates))
             .route("/non-fungibles", get(handlers::nfts::get_non_fungibles)) // Placeholder for future non-fungible endpoints
-            .route("/utxos/fetch", post(handlers::utxos::fetch_utxos))
-            .route("/utxos/stream", post(handlers::utxos::stream_utxo_updates))
+            .nest("/utxos", Router::new()
+                .route("/fetch", post(handlers::utxos::fetch_utxos))
+                .route("/stream", post(handlers::utxos::stream_utxo_updates))
+            )
             .layer(CorsLayer::permissive())
             .layer(RequestBodyLimitLayer::new(REQUEST_BODY_LIMIT))
             .merge(SwaggerUi::new("/swagger-ui").url("/openapi.json", ApiDoc::openapi()))

--- a/crates/engine/tests/templates/access_rules/src/lib.rs
+++ b/crates/engine/tests/templates/access_rules/src/lib.rs
@@ -36,7 +36,7 @@ mod access_rules_template {
             resource_rules: ResourceAccessRules,
             recall_rule: AccessRule,
         ) -> Component<AccessRulesTest> {
-            let tokens = ResourceBuilder::fungible()
+            let tokens = ResourceBuilder::public_fungible()
                 .with_owner_rule(owner_rule.clone())
                 .with_access_rules(resource_rules)
                 .initial_supply(1000);
@@ -59,7 +59,7 @@ mod access_rules_template {
         pub fn default_rules() -> Component<AccessRulesTest> {
             let badges = create_badge_resource(rule!(deny_all));
 
-            let tokens = ResourceBuilder::fungible().initial_supply(1000);
+            let tokens = ResourceBuilder::public_fungible().initial_supply(1000);
 
             Component::create(Self {
                 value: 0,
@@ -75,7 +75,7 @@ mod access_rules_template {
 
             let address_alloc = CallerContext::allocate_component_address(None);
 
-            let tokens = ResourceBuilder::fungible()
+            let tokens = ResourceBuilder::public_fungible()
                 .with_authorization_hook(address_alloc.get_address(), hook)
                 .initial_supply(1000);
 
@@ -98,7 +98,7 @@ mod access_rules_template {
             let id = address_alloc.id();
             info!("Allocated address: {id}");
 
-            let tokens = ResourceBuilder::fungible()
+            let tokens = ResourceBuilder::public_fungible()
                 .with_authorization_hook(
                     address_alloc.get_address(),
                     "malicious_auth_hook_set_state_on_another_component",
@@ -121,7 +121,7 @@ mod access_rules_template {
             let badges = create_badge_resource(rule!(allow_all));
 
             let badge_resource = badges.resource_address();
-            let tokens = ResourceBuilder::fungible()
+            let tokens = ResourceBuilder::public_fungible()
                 .mintable(rule!(non_fungible(NonFungibleAddress::new(
                     badge_resource,
                     NonFungibleId::from_string("mint")
@@ -155,7 +155,7 @@ mod access_rules_template {
             let badges = create_badge_resource(rule!(allow_all));
 
             let badge_resource = badges.resource_address();
-            let tokens = ResourceBuilder::fungible()
+            let tokens = ResourceBuilder::public_fungible()
                 .mintable(rule!(resource(badge_resource)))
                 .burnable(rule!(resource(badge_resource)))
                 .withdrawable(rule!(resource(badge_resource)))
@@ -177,7 +177,7 @@ mod access_rules_template {
             let badges = create_badge_resource(rule!(allow_all));
 
             let allocation = CallerContext::allocate_component_address(None);
-            let tokens = ResourceBuilder::fungible()
+            let tokens = ResourceBuilder::public_fungible()
                 .mintable(rule!(component(allocation.get_address())))
                 // Only access rules apply, this just makes the test simpler because we do not need to change the transaction signer
                 .with_owner_rule(OwnerRule::None)

--- a/crates/engine/tests/templates/burn/src/lib.rs
+++ b/crates/engine/tests/templates/burn/src/lib.rs
@@ -17,7 +17,7 @@ mod template {
 
     impl Burn {
         pub fn new(confidential_supply: ConfidentialOutputStatement) -> Component<Self> {
-            let fungible = ResourceBuilder::fungible()
+            let fungible = ResourceBuilder::public_fungible()
                 .burnable(rule!(allow_all))
                 .initial_supply(1_000_000);
 

--- a/crates/engine/tests/templates/fungible/src/lib.rs
+++ b/crates/engine/tests/templates/fungible/src/lib.rs
@@ -38,7 +38,7 @@ mod template {
         }
 
         pub fn with_address_and_supply(alloc: ComponentAddressAllocation, supply: Amount) -> Component<Self> {
-            let fungible = ResourceBuilder::fungible()
+            let fungible = ResourceBuilder::public_fungible()
                 .mintable(rule!(allow_all))
                 .initial_supply(supply);
             let confidential = ResourceBuilder::confidential()

--- a/crates/engine/tests/templates/recall/src/lib.rs
+++ b/crates/engine/tests/templates/recall/src/lib.rs
@@ -25,7 +25,7 @@ mod template {
             ResourceAddress,
             ResourceAddress,
         ) {
-            let fungible = ResourceBuilder::fungible()
+            let fungible = ResourceBuilder::public_fungible()
                 .recallable(rule!(allow_all))
                 .initial_supply(1_000_000);
 

--- a/crates/engine/tests/templates/resource/src/lib.rs
+++ b/crates/engine/tests/templates/resource/src/lib.rs
@@ -34,7 +34,7 @@ mod template {
 
     impl ResourceTest {
         pub fn new() -> Component<Self> {
-            let fungible = ResourceBuilder::fungible().initial_supply(1000);
+            let fungible = ResourceBuilder::public_fungible().initial_supply(1000);
             let non_fungible = ResourceBuilder::non_fungible()
                 .initial_supply([NonFungibleId::from_u64(1), NonFungibleId::from_u64(2)]);
             let confidential = ResourceBuilder::confidential()

--- a/crates/engine/tests/templates/tariswap/src/lib.rs
+++ b/crates/engine/tests/templates/tariswap/src/lib.rs
@@ -54,7 +54,7 @@ mod tariswap {
 
             // create the lp resource
             // TODO: add lp resource minting/burning security, only this component should be allowed
-            let lp_resource = ResourceBuilder::fungible().with_token_symbol("LP").build();
+            let lp_resource = ResourceBuilder::public_fungible().with_token_symbol("LP").build();
 
             Component::new(Self {
                 pools,

--- a/crates/template_lib/src/resource/builder/fungible.rs
+++ b/crates/template_lib/src/resource/builder/fungible.rs
@@ -21,7 +21,7 @@ use crate::{
 ///
 /// # Usage
 ///
-/// You typically start by creating a new builder via [`ResourceBuilder::fungible()`],
+/// You typically start by creating a new builder via [`ResourceBuilder::public_fungible()`],
 /// then chain configuration methods like `.with_owner_rule()`, `.mintable()`, or
 /// `.with_token_symbol()`, and finally call `.build()` or `.initial_supply()` to create
 /// the resource.
@@ -32,7 +32,7 @@ use crate::{
 /// ```ignore
 /// use tari_template_lib::resource::builder::ResourceBuilder;
 ///
-/// let resource_address = ResourceBuilder::fungible()
+/// let resource_address = ResourceBuilder::public_fungible()
 ///     .with_token_symbol("TARI")
 ///     .with_divisibility(9)
 ///     .mintable(rule!(allow_all))
@@ -44,7 +44,7 @@ use crate::{
 /// use tari_template_lib::resource::builder::ResourceBuilder;
 /// use tari_template_lib::types::Amount;
 ///
-/// let bucket = ResourceBuilder::fungible()
+/// let bucket = ResourceBuilder::public_fungible()
 ///     .with_token_symbol("YOUR_TOKEN")
 ///     .initial_supply(Amount::from(1_000_000));
 /// ```
@@ -80,7 +80,7 @@ impl FungibleResourceBuilder {
     ///
     /// ```ignore
     /// use tari_template_lib::prelude::*;
-    /// let resource = ResourceBuilder::fungible()
+    /// let resource = ResourceBuilder::public_fungible()
     ///    .with_owner_rule(rule!(allow_all))
     ///   .then(|builder| {
     ///     if some_condition {
@@ -133,7 +133,7 @@ impl FungibleResourceBuilder {
     /// ```rust, ignore
     /// use tari_template_lib::auth::AccessRule;
     /// use tari_template_lib::resource::builder::ResourceBuilder;
-    /// ResourceBuilder::fungible()
+    /// ResourceBuilder::public_fungible()
     ///     .mintable(rule!(allow_all))
     ///     .build();
     /// ```
@@ -152,7 +152,7 @@ impl FungibleResourceBuilder {
     /// ```rust, ignore
     /// use tari_template_lib::auth::AccessRule;
     /// use tari_template_lib::resource::builder::ResourceBuilder;
-    /// ResourceBuilder::fungible()
+    /// ResourceBuilder::public_fungible()
     ///     .burnable(rule!(allow_all))
     ///     .build();
     /// ```
@@ -174,7 +174,7 @@ impl FungibleResourceBuilder {
     /// ```rust, ignore
     /// use tari_template_lib::auth::AccessRule;
     /// use tari_template_lib::resource::builder::ResourceBuilder;
-    /// ResourceBuilder::fungible()
+    /// ResourceBuilder::public_fungible()
     ///    .recallable(rule!(allow_all))
     ///   .build();
     /// ```
@@ -200,7 +200,7 @@ impl FungibleResourceBuilder {
     /// ```rust, ignore
     /// use tari_template_lib::auth::AccessRule;
     /// use tari_template_lib::resource::builder::ResourceBuilder;
-    /// ResourceBuilder::fungible()
+    /// ResourceBuilder::public_fungible()
     ///     .withdrawable(AccessRule::DenyAll)
     ///     .build();
     /// ```
@@ -220,7 +220,7 @@ impl FungibleResourceBuilder {
     /// ```rust, ignore
     /// use tari_template_lib::auth::AccessRule;
     /// use tari_template_lib::resource::builder::ResourceBuilder;
-    /// ResourceBuilder::fungible()
+    /// ResourceBuilder::public_fungible()
     ///    .depositable(rule!(allow_all))
     ///     .build();
     /// ```
@@ -241,7 +241,7 @@ impl FungibleResourceBuilder {
     /// ```rust, ignore
     /// use tari_template_lib::auth::AccessRule;
     /// use tari_template_lib::resource::builder::ResourceBuilder;
-    /// ResourceBuilder::fungible()
+    /// ResourceBuilder::public_fungible()
     ///     .update_access_rules(AccessRule::require_owner())
     ///     .build();
     /// ```
@@ -255,7 +255,7 @@ impl FungibleResourceBuilder {
     /// # Examples
     /// ```rust, ignore
     ///  use tari_template_lib::resource::builder::ResourceBuilder;
-    /// ResourceBuilder::fungible()
+    /// ResourceBuilder::public_fungible()
     ///     .with_token_symbol("MY_TOKEN")
     ///     .build();
     /// ```
@@ -275,7 +275,7 @@ impl FungibleResourceBuilder {
     /// # Examples
     /// ```rust, ignore
     /// use tari_template_lib::resource::builder::ResourceBuilder;
-    /// ResourceBuilder::fungible()
+    /// ResourceBuilder::public_fungible()
     ///    .add_metadata("CharacterName", "Tari")
     ///    .add_metadata("CharacterType", "Mascot")
     ///    .add_metadata("CharacterLvl", "99")
@@ -298,7 +298,7 @@ impl FungibleResourceBuilder {
     ///     ("Type", "NFT"),
     ///     ("Creator", "Tari Project"),
     /// ]);
-    /// let address = ResourceBuilder::fungible()
+    /// let address = ResourceBuilder::public_fungible()
     ///     .with_metadata(metadata)
     ///     .build();
     /// ```
@@ -315,7 +315,7 @@ impl FungibleResourceBuilder {
     /// # Examples
     /// ```rust, ignore
     /// use tari_template_lib::resource::builder::ResourceBuilder;
-    /// ResourceBuilder::fungible()
+    /// ResourceBuilder::public_fungible()
     ///     .with_image_url("https://example.com/my_token_image.png".to_string())
     ///     .build();
     /// ```
@@ -335,7 +335,7 @@ impl FungibleResourceBuilder {
     /// # Examples
     /// ```rust, ignore
     /// use tari_template_lib::resource::builder::ResourceBuilder;
-    /// ResourceBuilder::fungible()
+    /// ResourceBuilder::public_fungible()
     ///     .with_divisibility(9)
     ///     .build();
     /// ```
@@ -358,7 +358,7 @@ impl FungibleResourceBuilder {
     /// Building a resource with a hook from within a component
     /// ```ignore
     /// use tari_template_lib::{caller_context::CallerContext, prelude::ResourceBuilder};
-    /// ResourceBuilder::fungible()
+    /// ResourceBuilder::public_fungible()
     ///     .with_authorization_hook(CallerContext::current_component_address(), "my_hook")
     ///     .build();
     /// ```
@@ -368,7 +368,7 @@ impl FungibleResourceBuilder {
     /// ```ignore
     /// use tari_template_lib::{caller_context::CallerContext, prelude::ResourceBuilder};
     /// let alloc = CallerContext::allocate_component_address();
-    /// ResourceBuilder::fungible()
+    /// ResourceBuilder::public_fungible()
     ///     .with_authorization_hook(*alloc.address(), "my_hook")
     ///     .build();
     /// ```
@@ -385,7 +385,7 @@ impl FungibleResourceBuilder {
     /// # Examples
     /// ```rust, ignore
     /// use tari_template_lib::resource::builder::ResourceBuilder;
-    /// ResourceBuilder::fungible()
+    /// ResourceBuilder::public_fungible()
     ///     .disable_total_supply_tracking()
     ///     .build();
     /// ```
@@ -409,7 +409,7 @@ impl FungibleResourceBuilder {
     /// ```rust, ignore
     /// use tari_template_lib::resource::builder::ResourceBuilder;
     /// use tari_template_lib::types::Amount;
-    /// let bucket = ResourceBuilder::fungible()
+    /// let bucket = ResourceBuilder::public_fungible()
     ///     .with_token_symbol("YOUR_TOKEN")
     ///     .initial_supply(Amount::from(1_000_000));
     /// ```

--- a/crates/template_lib/src/resource/builder/mod.rs
+++ b/crates/template_lib/src/resource/builder/mod.rs
@@ -51,7 +51,7 @@ impl ResourceBuilder {
     ///
     /// WARNING: this resource is not confidential. Balances in vaults will be visible to anyone with access to the
     /// ledger.
-    pub fn fungible() -> FungibleResourceBuilder {
+    pub fn public_fungible() -> FungibleResourceBuilder {
         FungibleResourceBuilder::new()
     }
 

--- a/crates/template_test_tooling/templates/faucet/src/lib.rs
+++ b/crates/template_test_tooling/templates/faucet/src/lib.rs
@@ -36,7 +36,7 @@ mod faucet_template {
         }
 
         pub fn mint_with_symbol(initial_supply: Amount, symbol: String) -> Component<Self> {
-            let coins = ResourceBuilder::fungible()
+            let coins = ResourceBuilder::public_fungible()
                 .with_token_symbol(symbol)
                 .initial_supply(initial_supply);
 

--- a/utilities/tariswap_test_bench/templates/faucet/src/lib.rs
+++ b/utilities/tariswap_test_bench/templates/faucet/src/lib.rs
@@ -32,7 +32,7 @@ mod template {
 
     impl TestFaucet {
         pub fn mint(initial_supply: Amount) -> Component<Self> {
-            let coins = ResourceBuilder::fungible()
+            let coins = ResourceBuilder::public_fungible()
                 .with_token_symbol("FAUCET")
                 .initial_supply(initial_supply);
 

--- a/utilities/tariswap_test_bench/templates/tariswap/src/lib.rs
+++ b/utilities/tariswap_test_bench/templates/tariswap/src/lib.rs
@@ -55,7 +55,7 @@ mod tariswap {
 
             // create the lp resource
             // TODO: add lp resource minting/burning security, only this component should be allowed
-            let lp_resource = ResourceBuilder::fungible().with_token_symbol("LP").build();
+            let lp_resource = ResourceBuilder::public_fungible().with_token_symbol("LP").build();
 
             Component::new(Self {
                 pools,


### PR DESCRIPTION
Description
---
fix: make it explicit that fungible resource has no privacy features
fix: indexer route ordering incorrect for `substates/fetch`

Motivation and Context
---
Renamed to `ResourceBuilder::public_fungible()`

How Has This Been Tested?
---
Existing tests, manually

What process can a PR reviewer use to test or verify this change?
---


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized REST API into nested routes for clearer paths:
    - /substates (list, fetch, get by ID)
    - /transactions (submit, recent, result by ID)
    - /templates (list, get by address)
    - /utxos (fetch, stream updates)
  * Preserved existing middleware behavior (CORS, body limits, Swagger UI).

* **Documentation**
  * Updated guides and examples to use the “public fungible” resource constructor.

* **Tests**
  * Updated templates and test tooling to align with the “public fungible” resource constructor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->