### PR TITLE
fix(epoch_oracle): integer underflow error in configured oracle

### DIFF
--- a/CHECKLISTS.md
+++ b/CHECKLISTS.md
@@ -13,7 +13,7 @@
 
 ## Release checklist
 
-- [ ] Ensure development branch is up to date
+- [ ] Ensure the version bump PR is merged and the main branch is up to date
 - [ ] Create the tag for the release
     - Use `git tag -s vX.Y.Z -m "vX.Y.Z"`. This ensures the tag is signed.
 - [ ] Push the tag to the remote repository

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1840,7 +1840,7 @@ dependencies = [
 
 [[package]]
 name = "consensus_tests"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "fern",
  "futures 0.3.31",
@@ -2607,7 +2607,7 @@ dependencies = [
 
 [[package]]
 name = "db_inspector"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "axum 0.8.4",
@@ -3746,7 +3746,7 @@ checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 
 [[package]]
 name = "generate_ristretto_value_lookup"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "clap 3.2.25",
  "human_bytes",
@@ -4993,7 +4993,7 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "integration_tests"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "config",
@@ -5761,7 +5761,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-messaging"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "futures-bounded",
@@ -5940,7 +5940,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-substream"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "libp2p",
  "prometheus-client",
@@ -8466,7 +8466,7 @@ dependencies = [
 
 [[package]]
 name = "proto_builder"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "prost-build 0.14.1",
  "sha2",
@@ -10300,7 +10300,7 @@ dependencies = [
 
 [[package]]
 name = "sqlite_message_logger"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "chrono",
  "diesel",
@@ -10341,7 +10341,7 @@ checksum = "e7386b49cb287f6fafbfd3bd604914bccb99fb8d53483f40e1ecfda5d45f3370"
 
 [[package]]
 name = "state_store_tests"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "env_logger 0.11.8",
  "indexmap 2.11.4",
@@ -10730,7 +10730,7 @@ dependencies = [
 
 [[package]]
 name = "tari_base_node_client"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "log",
  "minotari_app_grpc",
@@ -10954,7 +10954,7 @@ dependencies = [
 
 [[package]]
 name = "tari_consensus"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "indexmap 2.11.4",
@@ -10978,7 +10978,7 @@ dependencies = [
 
 [[package]]
 name = "tari_consensus_types"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "borsh",
  "serde",
@@ -11080,7 +11080,7 @@ dependencies = [
 
 [[package]]
 name = "tari_engine"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "blake2",
  "cargo_toml 0.22.3",
@@ -11109,7 +11109,7 @@ dependencies = [
 
 [[package]]
 name = "tari_engine_types"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "base64 0.21.7",
  "bincode 2.0.1",
@@ -11136,7 +11136,7 @@ dependencies = [
 
 [[package]]
 name = "tari_epoch_manager"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "log",
@@ -11158,7 +11158,7 @@ dependencies = [
 
 [[package]]
 name = "tari_epoch_oracles"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -11199,7 +11199,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -11263,7 +11263,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer_client"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "bounded-vec",
@@ -11293,7 +11293,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer_lib"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "log",
  "serde",
@@ -11369,7 +11369,7 @@ dependencies = [
 
 [[package]]
 name = "tari_networking"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11406,7 +11406,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_address"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "bech32",
  "bincode 2.0.1",
@@ -11422,7 +11422,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_app_utilities"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -11461,7 +11461,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_common_types"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "blake2",
  "borsh",
@@ -11489,7 +11489,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_p2p"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "prost 0.14.1",
@@ -11511,7 +11511,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_storage"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "bitflags 2.9.2",
@@ -11536,7 +11536,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_storage_sqlite"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "diesel",
  "diesel_migrations",
@@ -11556,7 +11556,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_cli"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -11585,7 +11585,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_crypto"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "argon2 0.5.3",
  "blake2",
@@ -11609,7 +11609,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_sdk"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -11643,7 +11643,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_sdk_services"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -11668,7 +11668,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_storage_sqlite"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "bigdecimal",
  "diesel",
@@ -11692,7 +11692,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_walletd"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11777,7 +11777,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_framework"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "bitflags 2.9.2",
@@ -11801,7 +11801,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_macros"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11810,7 +11810,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_state_sync"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -11830,7 +11830,7 @@ dependencies = [
 
 [[package]]
 name = "tari_scaffolder"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "clap 3.2.25",
@@ -11902,7 +11902,7 @@ dependencies = [
 
 [[package]]
 name = "tari_signaling_server"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "axum 0.8.4",
@@ -11928,7 +11928,7 @@ dependencies = [
 
 [[package]]
 name = "tari_state_store_rocksdb"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -11954,7 +11954,7 @@ dependencies = [
 
 [[package]]
 name = "tari_state_tree"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "indexmap 2.11.4",
  "log",
@@ -11981,7 +11981,7 @@ dependencies = [
 
 [[package]]
 name = "tari_swarm"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "libp2p",
  "libp2p-messaging",
@@ -11991,7 +11991,7 @@ dependencies = [
 
 [[package]]
 name = "tari_swarm_daemon"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12047,7 +12047,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_builtin"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "tari_engine_types",
  "tari_template_lib",
@@ -12099,7 +12099,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_manager"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "bytes 1.10.1",
@@ -12165,7 +12165,7 @@ dependencies = [
 
 [[package]]
 name = "tari_transaction"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "borsh",
  "hex",
@@ -12253,7 +12253,7 @@ dependencies = [
 
 [[package]]
 name = "tari_transaction_manifest"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "proc-macro2",
  "syn 2.0.103",
@@ -12286,7 +12286,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "axum 0.8.4",
@@ -12348,7 +12348,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node_cli"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "clap 3.2.25",
@@ -12376,7 +12376,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node_client"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "indexmap 2.11.4",
  "multiaddr 0.18.1",
@@ -12399,7 +12399,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node_rpc"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "prost 0.14.1",
@@ -12421,7 +12421,7 @@ dependencies = [
 
 [[package]]
 name = "tari_wallet_daemon_client"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "reqwest 0.11.27",
  "serde",
@@ -12442,7 +12442,7 @@ dependencies = [
 
 [[package]]
 name = "tari_watcher"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "clap 3.2.25",
@@ -12470,7 +12470,7 @@ dependencies = [
 
 [[package]]
 name = "tariswap_bench"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "clap 4.5.48",
@@ -13129,7 +13129,7 @@ dependencies = [
 
 [[package]]
 name = "transaction_generator"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -13149,7 +13149,7 @@ dependencies = [
 
 [[package]]
 name = "transaction_submitter"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "clap 4.5.48",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 # NOTE: When editing this version, also edit the versions in template_built_in/templates/account and account_nft
 [workspace.package]
-version = "0.11.2"
+version = "0.12.0"
 edition = "2021"
 authors = ["The Tari Development Community"]
 repository = "https://github.com/tari-project/tari-ootle"

--- a/applications/tari_validator_node/src/node.rs
+++ b/applications/tari_validator_node/src/node.rs
@@ -66,6 +66,11 @@ impl ValidatorNode {
             tokio::select! {
                 _ = tokio::signal::ctrl_c() => {
                     info!(target: LOG_TARGET, "💤 Received SIGINT");
+                    // Second SIGINT forces shutdown
+                    if shutdown.is_triggered() {
+                        warn!(target: LOG_TARGET, "💤 Shutdown NOW");
+                        break;
+                    }
                     shutdown.trigger();
                 },
 

--- a/crates/epoch_oracles/src/configured/oracle.rs
+++ b/crates/epoch_oracles/src/configured/oracle.rs
@@ -95,6 +95,16 @@ impl<TStore: EpochOracleStore + Send, TTicker: EpochTicker> ConfiguredEpochOracl
     fn prepare_next_epoch(&mut self, epoch_ticker_data: EpochTickerData) -> anyhow::Result<()> {
         let next_epoch = epoch_ticker_data.epoch;
         let epoch_hash = epoch_ticker_data.epoch_hash;
+        if next_epoch.is_zero() {
+            // If at epoch 0, just emit the epoch changed and done for now events
+            self.pending_events.push_back(EpochEvent::EpochChanged {
+                epoch: next_epoch,
+                epoch_hash,
+            });
+
+            return Ok(());
+        }
+
         let done_for_now = epoch_ticker_data.done_for_now;
         let prev_epoch = next_epoch - Epoch(1);
         self.store


### PR DESCRIPTION
Description
---
fix(epoch_oracle): integer underflow error in configured oracle
version v0.20.0
A second ctrl_c force shutsdown the validator node

Motivation and Context
---
Fixes possible integer underflow in the configured oracle.
```
thread 'tokio-runtime-worker' panicked at crates/common_types/src/epoch.rs:89:1:
attempt to subtract with overflow
```
How Has This Been Tested?
---
Manually


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Immediate shutdown on a second Ctrl-C during validator node startup.
  * Improved initial epoch handling to emit an epoch change and skip unnecessary processing.

* Documentation
  * Updated release checklist to require merging the version bump PR and confirming the main branch is up to date.

* Chores
  * Bumped workspace version to 0.12.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->