### PR TITLE
chore(ci): minor updates, readme and mac intel runner

### DIFF
--- a/.github/workflows/build_binaries.json
+++ b/.github/workflows/build_binaries.json
@@ -27,7 +27,7 @@
   },
   {
     "name": "macos-x86_64",
-    "runs-on": "macos-13",
+    "runs-on": "macos-15-intel",
     "rust": "stable",
     "target": "x86_64-apple-darwin",
     "cross": false,

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ tari_ootle_walletd --network igor -b <yourdesiredconfigfolderpath>
 
 This will start a wallet connected to the Igor Testnet. You can view the public Nodes here:
 
-- Validator Node: [http://18.217.22.26:12006]](http://18.217.22.26:12006)
+- Validator Node: [http://18.217.22.26:12006](http://18.217.22.26:12006)
 - Indexer: [http://18.217.22.26:12502](http://18.217.22.26:12502)
 
 Navigate to http://127.0.0.1:5100 to create an account, claim test tokens and start testing features.


### PR DESCRIPTION
Description
Fix markdown in ReadMe
Bump github mac intel runner

Motivation and Context
Remove some warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Corrected a malformed Markdown link for the Validator Node in the README so the link renders and directs properly.
- Chores
  - Updated CI to build macOS x86_64 binaries on a newer macOS 15 Intel runner, improving alignment with current infrastructure and maintaining build reliability. No user-facing behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->