### PR TITLE
fix(manifest): add support for metadata, cbor, pubkey calls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12257,6 +12257,7 @@ name = "tari_transaction_manifest"
 version = "0.13.1"
 dependencies = [
  "proc-macro2",
+ "serde_json",
  "syn 2.0.103",
  "tari_bor",
  "tari_engine_types",

--- a/applications/tari_walletd/web_ui/src/routes/AssetVault/Tokens/components/SendMoney.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/AssetVault/Tokens/components/SendMoney.tsx
@@ -203,8 +203,14 @@ export function SendMoneyDialog(props: SendMoneyDialogProps) {
       const resp = await transactionsWaitResult({ transaction_id: result.transaction_id, timeout_secs: null });
       const transactionResult = resp.result?.result;
 
-      if (!transactionResult || !("Accept" in transactionResult)) {
+      if (!transactionResult) {
         throw new Error("Fee estimation failed");
+      }
+      if ("Rejected" in transactionResult) {
+        throw new Error(`Transaction rejected: ${transactionResult.Rejected}`);
+      }
+      if ("AcceptFeeRejectRest" in transactionResult) {
+        throw new Error(`Transaction rejected: ${transactionResult.AcceptFeeRejectRest[1]}`);
       }
 
       let fee = resp.final_fee;

--- a/crates/template_lib/src/models/metadata.rs
+++ b/crates/template_lib/src/models/metadata.rs
@@ -64,14 +64,11 @@ impl FromStr for Metadata {
     type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if !s.contains('=') {
-            return Err("Invalid metadata string, missing '='".to_string());
-        }
         let pairs = s.split(',').map(|pair| {
-            let mut split = pair.split('=');
-            let key = split.next().ok_or_else(|| "Missing key".to_string())?;
-            let value = split.next().ok_or_else(|| "Missing value".to_string())?;
-            Ok::<(String, String), String>((key.to_string(), value.to_string()))
+            let (key, value) = pair
+                .split_once('=')
+                .ok_or_else(|| "Invalid key=value pair".to_string())?;
+            Ok::<_, String>((key.trim().to_string(), value.trim().to_string()))
         });
         let mut map = BTreeMap::new();
         for pair in pairs {

--- a/crates/template_lib/src/models/utxo.rs
+++ b/crates/template_lib/src/models/utxo.rs
@@ -9,7 +9,7 @@ use tari_template_abi::rust::{
 };
 use tari_template_lib_types::{
     crypto::PedersenCommitmentBytes,
-    from_hex,
+    from_hex_to_array,
     hex::write_hex_fmt,
     serde_helpers,
     KeyParseError,
@@ -88,7 +88,7 @@ impl UtxoId {
     }
 
     pub fn from_hex(hex: &str) -> Result<Self, KeyParseError> {
-        from_hex(hex).map(Self::from_array)
+        from_hex_to_array(hex).map(Self::from_array)
     }
 
     pub fn into_commitment_bytes(self) -> PedersenCommitmentBytes {

--- a/crates/template_lib_types/src/entity_id.rs
+++ b/crates/template_lib_types/src/entity_id.rs
@@ -39,7 +39,7 @@ impl EntityId {
     }
 
     pub fn from_hex(s: &str) -> Result<Self, KeyParseError> {
-        from_hex(s).map(Self::from_array)
+        from_hex_to_array(s).map(Self::from_array)
     }
 
     pub fn write_hex_fmt<W: fmt::Write>(&self, writer: &mut W) -> fmt::Result {
@@ -163,7 +163,7 @@ impl ObjectKey {
     }
 
     pub fn from_hex(s: &str) -> Result<Self, KeyParseError> {
-        from_hex(s).map(Self::from_array)
+        from_hex_to_array(s).map(Self::from_array)
     }
 
     pub fn write_hex_fmt<W: fmt::Write>(&self, writer: &mut W) -> fmt::Result {
@@ -261,7 +261,7 @@ impl Display for KeyParseError {
     }
 }
 
-pub fn from_hex<const N: usize>(s: &str) -> Result<[u8; N], KeyParseError> {
+pub fn from_hex_to_array<const N: usize>(s: &str) -> Result<[u8; N], KeyParseError> {
     if s.len() != N * 2 {
         return Err(KeyParseError);
     }

--- a/crates/transaction/src/args.rs
+++ b/crates/transaction/src/args.rs
@@ -87,7 +87,7 @@ impl InstructionArg {
     }
 
     pub fn from_type<T: Serialize>(val: &T) -> Result<Self, tari_bor::BorError> {
-        Ok(Self::Literal(encode(val)?.into()))
+        Ok(Self::raw_literal_bytes(encode(val)?))
     }
 
     pub fn workspace(id: WorkspaceId, offset: Option<usize>) -> Self {

--- a/crates/transaction/src/transaction_id.rs
+++ b/crates/transaction/src/transaction_id.rs
@@ -10,7 +10,7 @@ use borsh::BorshSerialize;
 use serde::{Deserialize, Serialize};
 use tari_engine_types::{serde_with, transaction_receipt::TransactionReceiptAddress};
 use tari_ootle_common_types::{SubstateAddress, ToSubstateAddress};
-use tari_template_lib::types::{from_hex, hex::write_hex_fmt, Hash, KeyParseError};
+use tari_template_lib::types::{from_hex_to_array, hex::write_hex_fmt, Hash, KeyParseError};
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize, Serialize, Default, BorshSerialize)]
 #[serde(transparent)]
@@ -39,7 +39,7 @@ impl TransactionId {
     }
 
     pub fn from_hex(hex: &str) -> Result<Self, KeyParseError> {
-        let bytes = from_hex(hex)?;
+        let bytes = from_hex_to_array(hex)?;
         Ok(Self(bytes))
     }
 

--- a/crates/transaction_manifest/Cargo.toml
+++ b/crates/transaction_manifest/Cargo.toml
@@ -17,3 +17,4 @@ tari_bor = { workspace = true, default-features = true }
 proc-macro2 = { workspace = true }
 syn = { workspace = true, features = ["full", "extra-traits"] }
 thiserror = { workspace = true }
+serde_json = { workspace = true }

--- a/crates/transaction_manifest/src/generator.rs
+++ b/crates/transaction_manifest/src/generator.rs
@@ -4,9 +4,8 @@
 use std::collections::HashMap;
 
 use proc_macro2::Ident;
-use syn::Lit;
 use tari_engine_types::substate::SubstateId;
-use tari_template_lib::{models::NonFungibleId, types::TemplateAddress};
+use tari_template_lib::types::TemplateAddress;
 use tari_transaction::{
     args::{InstructionArg, WorkspaceId, WorkspaceOffsetId},
     call_arg,
@@ -16,7 +15,8 @@ use tari_transaction::{
 use crate::{
     ast::ManifestAst,
     error::ManifestError,
-    parser::{InvokeIntent, ManifestIntent, ManifestLiteral, SpecialLiteral},
+    parser::{InvokeIntent, ManifestIntent, ManifestLiteral, OrVar, SpecialLiteral},
+    value::lit_to_arg,
     ManifestInstructions,
     ManifestValue,
 };
@@ -142,6 +142,7 @@ impl ManifestInstructionGenerator {
                 level: log.level,
                 message: log.message,
             }]),
+            ManifestIntent::DropAllProofs => Ok(vec![Instruction::DropAllProofsInWorkspace]),
         }
     }
 
@@ -156,46 +157,30 @@ impl ManifestInstructionGenerator {
         args.into_iter()
             .map(|arg| match arg {
                 ManifestLiteral::Lit(lit) => lit_to_arg(&lit),
-                ManifestLiteral::Workspace(ident) => {
-                    // Is it a global?
-                    self.globals
-                        .get(&ident.to_string())
-                        .or_else(|| self.global_aliases.get(&ident.to_string()))
-                        .map(|v| match v {
-                            ManifestValue::SubstateId(addr) => match addr {
-                                SubstateId::Component(addr) => Ok(call_arg!(*addr)),
-                                SubstateId::Resource(addr) => Ok(call_arg!(*addr)),
-                                // TODO: should tx receipt addresses be allowed to be referenced?
-                                SubstateId::TransactionReceipt(addr) => Ok(call_arg!(*addr)),
-                                SubstateId::Vault(addr) => Ok(call_arg!(*addr)),
-                                SubstateId::NonFungible(addr) => Ok(call_arg!(addr)),
-                                SubstateId::ClaimedOutputTombstone(addr) => Ok(call_arg!(*addr)),
-                                SubstateId::Template(addr) => Ok(call_arg!(*addr)),
-                                SubstateId::ValidatorFeePool(addr) => Ok(call_arg!(*addr)),
-                                SubstateId::Utxo(addr) => Ok(call_arg!(*addr)),
-                            },
-                            ManifestValue::Literal(lit) => lit_to_arg(lit),
-                            ManifestValue::NonFungibleId(id) => Ok(call_arg!(id.clone())),
-                            ManifestValue::Value(blob) => Ok(InstructionArg::literal(blob.clone()).unwrap()),
-                        })
-                        .or_else(|| {
-                            // Or is it a variable on the worktop?
-                            self.workspace_ids
-                                .get(&ident.to_string())
-                                // TODO: support offsets
-                                .map(|id| Ok(InstructionArg::Workspace(WorkspaceOffsetId::new(*id))))
-                        })
-                        .ok_or_else(|| {
-                            // Or undefined
-                            ManifestError::UndefinedVariable {
-                                name: ident.to_string(),
-                            }
-                        })?
-                },
+                ManifestLiteral::Workspace(ident) => self.get_ident(&ident.to_string()),
                 ManifestLiteral::Special(SpecialLiteral::Amount(amount)) => Ok(call_arg!(amount)),
-                ManifestLiteral::Special(SpecialLiteral::NonFungibleId(lit)) => {
-                    let id = lit_to_nonfungible_id(&lit)?;
-                    Ok(call_arg!(id))
+                ManifestLiteral::Special(SpecialLiteral::NonFungibleId(id)) => Ok(call_arg!(id)),
+                ManifestLiteral::Special(SpecialLiteral::Cbor(value)) => {
+                    Ok(InstructionArg::literal(value).expect("CBOR literal serialization should not fail"))
+                },
+                ManifestLiteral::Special(SpecialLiteral::Metadata(metadata)) => Ok(call_arg!(metadata)),
+                ManifestLiteral::Special(SpecialLiteral::SubstateId(id_or_var)) => match id_or_var {
+                    OrVar::Var(ident) => self.get_ident(&ident.to_string()),
+                    OrVar::Value(id) => Ok(call_arg!(id)),
+                },
+                ManifestLiteral::Special(SpecialLiteral::Address(var_or_id)) => match var_or_id {
+                    OrVar::Var(ident) => self.get_ident(&ident.to_string()),
+                    OrVar::Value(id) => match id {
+                        SubstateId::Component(addr) => Ok(call_arg!(addr)),
+                        SubstateId::Resource(addr) => Ok(call_arg!(addr)),
+                        SubstateId::Vault(addr) => Ok(call_arg!(addr)),
+                        SubstateId::ClaimedOutputTombstone(addr) => Ok(call_arg!(addr)),
+                        SubstateId::NonFungible(addr) => Ok(call_arg!(addr)),
+                        SubstateId::TransactionReceipt(addr) => Ok(call_arg!(addr)),
+                        SubstateId::Template(addr) => Ok(call_arg!(addr)),
+                        SubstateId::ValidatorFeePool(addr) => Ok(call_arg!(addr)),
+                        SubstateId::Utxo(addr) => Ok(call_arg!(addr)),
+                    },
                 },
             })
             .collect()
@@ -219,81 +204,22 @@ impl ManifestInstructionGenerator {
             .get(name)
             .ok_or_else(|| ManifestError::UndefinedGlobal { name: name.to_string() })
     }
-}
 
-fn lit_to_arg(lit: &Lit) -> Result<InstructionArg, ManifestError> {
-    match lit {
-        Lit::Str(s) => Ok(call_arg!(s.value())),
-        Lit::Int(i) => match i.suffix() {
-            "u8" => Ok(call_arg!(i.base10_parse::<u8>()?)),
-            "u16" => Ok(call_arg!(i.base10_parse::<u16>()?)),
-            "u32" => Ok(call_arg!(i.base10_parse::<u32>()?)),
-            "u64" => Ok(call_arg!(i.base10_parse::<u64>()?)),
-            "u128" => Ok(call_arg!(i.base10_parse::<u128>()?)),
-            "i8" => Ok(call_arg!(i.base10_parse::<i8>()?)),
-            "i16" => Ok(call_arg!(i.base10_parse::<i16>()?)),
-            "i32" => Ok(call_arg!(i.base10_parse::<i32>()?)),
-            "i64" => Ok(call_arg!(i.base10_parse::<i64>()?)),
-            "" | "i128" => Ok(call_arg!(i.base10_parse::<i128>()?)),
-            _ => Err(ManifestError::UnsupportedExpr(format!(
-                r#"Unsupported integer suffix "{}""#,
-                i.suffix()
-            ))),
-        },
-        Lit::Bool(b) => Ok(call_arg!(b.value())),
-        Lit::ByteStr(v) => Ok(call_arg!(v.value())),
-        Lit::Byte(v) => Ok(call_arg!(v.value())),
-        Lit::Char(v) => Ok(call_arg!(v.value().to_string())),
-        Lit::Float(v) => Err(ManifestError::UnsupportedExpr(format!(
-            "Float literals not supported ({})",
-            v
-        ))),
-        Lit::Verbatim(v) => Err(ManifestError::UnsupportedExpr(format!(
-            "Raw token literals not supported ({})",
-            v
-        ))),
-        _ => Err(ManifestError::UnsupportedExpr(format!(
-            "Unsupported literal type ({:?})",
-            lit
-        ))),
-    }
-}
-
-fn lit_to_nonfungible_id(lit: &Lit) -> Result<NonFungibleId, ManifestError> {
-    match lit {
-        Lit::Str(s) => Ok(NonFungibleId::try_from_string(s.value()).map_err(|e| {
-            ManifestError::UnsupportedExpr(format!(
-                "Invalid non-fungible ID string literal ({:?}) ({})",
-                e,
-                s.value()
-            ))
-        })?),
-        Lit::ByteStr(v) => {
-            let bytes = v.value();
-            if bytes.len() != 32 {
-                return Err(ManifestError::UnsupportedExpr(
-                    "Non-fungible ID byte string literal length must be less than 32 bytes".to_string(),
-                ));
-            }
-
-            let mut id = [0u8; 32];
-            id.copy_from_slice(&bytes);
-            Ok(NonFungibleId::from_u256(id))
-        },
-        Lit::Int(v) => match v.suffix() {
-            "u8" | "u16" | "u32" => Ok(NonFungibleId::from_u32(v.base10_parse()?)),
-            "u64" => Ok(NonFungibleId::from_u64(v.base10_parse()?)),
-            "" => Err(ManifestError::UnsupportedExpr(
-                "Non-fungible ID integer literal must have a type suffix specified (1u32, 2u64 etc)".to_string(),
-            )),
-            _ => Err(ManifestError::UnsupportedExpr(format!(
-                "Invalid non-fungible ID integer literal suffix ({})",
-                v.suffix()
-            ))),
-        },
-        _ => Err(ManifestError::UnsupportedExpr(format!(
-            "Unsupported non-fungible ID literal ({:?})",
-            lit
-        ))),
+    fn get_ident(&self, name: &str) -> Result<InstructionArg, ManifestError> {
+        self.globals
+            .get(name)
+            .or_else(|| self.global_aliases.get(name))
+            .map(|v| v.to_arg())
+            .or_else(|| {
+                // Or is it a variable on the worktop?
+                self.workspace_ids
+                    .get(name)
+                    // TODO: support offsets
+                    .map(|id| Ok(InstructionArg::Workspace(WorkspaceOffsetId::new(*id))))
+            })
+            .ok_or_else(|| {
+                // Or undefined
+                ManifestError::UndefinedVariable { name: name.to_string() }
+            })?
     }
 }

--- a/crates/transaction_manifest/src/parser.rs
+++ b/crates/transaction_manifest/src/parser.rs
@@ -28,11 +28,16 @@ use syn::{
     Stmt,
     UseTree,
 };
+use tari_engine_types::{json_cbor::convert_json_to_cbor, substate::SubstateId};
 use tari_template_builtin::ACCOUNT_TEMPLATE_ADDRESS;
 use tari_template_lib::{
     args::LogLevel,
-    types::{Amount, TemplateAddress},
+    constants::XTR,
+    models::{Metadata, NonFungibleId},
+    types::{hex::bytes_from_hex, Amount, TemplateAddress},
 };
+
+use crate::error::ManifestError;
 
 #[derive(Debug, Clone)]
 pub enum ManifestIntent {
@@ -40,6 +45,7 @@ pub enum ManifestIntent {
     InvokeComponent(InvokeIntent),
     AssignInput(AssignInputStmt),
     Log(LogIntent),
+    DropAllProofs,
 }
 
 #[derive(Debug, Clone)]
@@ -79,7 +85,17 @@ pub enum ManifestLiteral {
 #[derive(Debug, Clone)]
 pub enum SpecialLiteral {
     Amount(Amount),
-    NonFungibleId(Lit),
+    NonFungibleId(NonFungibleId),
+    Cbor(tari_bor::Value),
+    Metadata(Metadata),
+    SubstateId(OrVar<SubstateId>),
+    Address(OrVar<SubstateId>),
+}
+
+#[derive(Debug, Clone)]
+pub enum OrVar<T> {
+    Var(Ident),
+    Value(T),
 }
 
 pub struct ManifestParser;
@@ -177,11 +193,22 @@ impl ManifestParser {
             Stmt::Local(local) => self.handle_local(local),
             // component.function_name(arg1, arg2);
             Stmt::Expr(expr, _) => self.handle_semi_expr(expr),
+            Stmt::Macro(mac) => self.handle_macro_stmt(mac),
             _ => Err(syn::Error::new_spanned(
                 stmt.clone(),
                 format!("Invalid statement {:?}", stmt),
             )),
         }
+    }
+
+    fn handle_macro_stmt(&self, mac: syn::StmtMacro) -> Result<ManifestIntent, syn::Error> {
+        let Macro { path, tokens, .. } = mac.mac;
+
+        let Some(mac_ident) = path.segments.first() else {
+            return Err(syn::Error::new_spanned(path, "macro path must have a single segment"));
+        };
+
+        macro_call(&mac_ident.ident, tokens)
     }
 
     fn handle_local(&self, local: Local) -> Result<ManifestIntent, syn::Error> {
@@ -356,6 +383,7 @@ fn macro_call(mac: &Ident, tokens: TokenStream) -> Result<ManifestIntent, syn::E
             level: LogLevel::Error,
             message: parse2::<LitStr>(tokens)?.value(),
         })),
+        "drop_all_proofs" => Ok(ManifestIntent::DropAllProofs),
         _ => Err(syn::Error::new_spanned(mac, "Invalid macro name")),
     }
 }
@@ -365,12 +393,18 @@ fn build_arguments(args: Punctuated<Expr, Comma>) -> Result<Vec<ManifestLiteral>
         .map(|arg| match arg {
             Expr::Lit(lit) => Ok(ManifestLiteral::Lit(lit.lit)),
 
-            Expr::Path(expr_path) => {
-                if let Some(seg) = expr_path.path.segments.first() {
-                    Ok(ManifestLiteral::Workspace(seg.ident.clone()))
+            Expr::Path(ExprPath { path, .. }) => {
+                if let Some(seg) = path.segments.first() {
+                    if seg.ident == "XTR" {
+                        Ok(ManifestLiteral::Special(SpecialLiteral::Address(OrVar::Value(
+                            XTR.into(),
+                        ))))
+                    } else {
+                        Ok(ManifestLiteral::Workspace(seg.ident.clone()))
+                    }
                 } else {
                     Err(syn::Error::new_spanned(
-                        expr_path,
+                        path,
                         "Invalid path, only single segment paths are supported",
                     ))
                 }
@@ -394,6 +428,21 @@ fn build_arguments(args: Punctuated<Expr, Comma>) -> Result<Vec<ManifestLiteral>
                     ))
                 }
             },
+            Expr::Macro(ExprMacro { mac, .. }) => match mac.path.get_ident() {
+                Some(name) if name == "cbor" => {
+                    let cbor_value: serde_json::Value = serde_json::from_str(&mac.tokens.to_string()).map_err(|e| {
+                        syn::Error::new_spanned(&mac.tokens, format!("Failed to parse CBOR JSON value: {}", e))
+                    })?;
+                    let cbor = convert_json_to_cbor(cbor_value).map_err(|e| {
+                        syn::Error::new_spanned(&mac.tokens, format!("Failed to convert JSON to CBOR value: {}", e))
+                    })?;
+                    Ok(ManifestLiteral::Special(SpecialLiteral::Cbor(cbor)))
+                },
+                _ => Err(syn::Error::new_spanned(
+                    mac,
+                    "Invalid argument, only literals and variables are supported",
+                )),
+            },
             _ => Err(syn::Error::new_spanned(
                 arg,
                 "Invalid argument, only literals and variables are supported",
@@ -402,37 +451,147 @@ fn build_arguments(args: Punctuated<Expr, Comma>) -> Result<Vec<ManifestLiteral>
         .collect()
 }
 
+#[allow(clippy::too_many_lines)]
 fn handle_special_literals(name: &Ident, args: Punctuated<Expr, Comma>) -> Result<ManifestLiteral, syn::Error> {
-    if name == "Amount" {
-        let amt = args
-            .first()
-            .ok_or_else(|| syn::Error::new_spanned(name, "Invalid function call"))?;
-        match amt {
-            Expr::Lit(ExprLit { lit: Lit::Int(lit), .. }) => {
-                Ok(ManifestLiteral::Special(SpecialLiteral::Amount(lit.base10_parse()?)))
-            },
-            _ => Err(syn::Error::new_spanned(
-                amt,
-                "Invalid argument, only literals and variables are supported",
-            )),
-        }
-    } else if name == "NonFungibleId" {
-        let arg = args
-            .first()
-            .ok_or_else(|| syn::Error::new_spanned(name, "Invalid function call"))?;
-        if let Expr::Lit(ExprLit { lit, .. }) = arg {
-            Ok(ManifestLiteral::Special(SpecialLiteral::NonFungibleId(lit.clone())))
-        } else {
-            Err(syn::Error::new_spanned(
-                arg,
-                "Invalid argument, only literals and variables are supported",
-            ))
-        }
-    } else {
-        Err(syn::Error::new_spanned(
+    let name_str = name.to_string();
+    match name_str.as_str() {
+        "Amount" => {
+            let amt = args
+                .first()
+                .ok_or_else(|| syn::Error::new_spanned(name, "Invalid function call"))?;
+            match amt {
+                Expr::Lit(ExprLit { lit: Lit::Int(lit), .. }) => {
+                    Ok(ManifestLiteral::Special(SpecialLiteral::Amount(lit.base10_parse()?)))
+                },
+                _ => Err(syn::Error::new_spanned(
+                    amt,
+                    "Invalid argument, only literals and variables are supported",
+                )),
+            }
+        },
+        "SubstateId" | "Address" => {
+            let arg = args
+                .first()
+                .ok_or_else(|| syn::Error::new_spanned(name, "Invalid function call"))?;
+            match arg {
+                Expr::Lit(ExprLit {
+                    lit: Lit::Str(lit_str), ..
+                }) => {
+                    let id = lit_str.value().parse().map_err(|e| {
+                        syn::Error::new_spanned(lit_str, format!("Failed to parse Bytes from hex string: {}", e))
+                    })?;
+                    if name_str == "Address" {
+                        Ok(ManifestLiteral::Special(SpecialLiteral::Address(OrVar::Value(id))))
+                    } else {
+                        Ok(ManifestLiteral::Special(SpecialLiteral::SubstateId(OrVar::Value(id))))
+                    }
+                },
+                // TODO: more general support for this
+                Expr::Path(ExprPath { path, .. }) => {
+                    if let Some(seg) = path.segments.first() {
+                        if name_str == "Address" {
+                            Ok(ManifestLiteral::Special(SpecialLiteral::Address(OrVar::Var(
+                                seg.ident.clone(),
+                            ))))
+                        } else {
+                            Ok(ManifestLiteral::Special(SpecialLiteral::SubstateId(OrVar::Var(
+                                seg.ident.clone(),
+                            ))))
+                        }
+                    } else {
+                        Err(syn::Error::new_spanned(
+                            path,
+                            "Invalid path, only single segment paths are supported",
+                        ))
+                    }
+                },
+                _ => Err(syn::Error::new_spanned(
+                    arg,
+                    "Invalid argument, only string literals are supported for Substate",
+                )),
+            }
+        },
+        "NonFungibleId" => {
+            let arg = args
+                .first()
+                .ok_or_else(|| syn::Error::new_spanned(name, "Invalid function call"))?;
+            if let Expr::Lit(ExprLit { lit, .. }) = arg {
+                let id = lit_to_nonfungible_id(lit)
+                    .map_err(|e| syn::Error::new_spanned(lit, format!("Failed to parse NonFungibleId: {}", e)))?;
+                Ok(ManifestLiteral::Special(SpecialLiteral::NonFungibleId(id)))
+            } else {
+                Err(syn::Error::new_spanned(
+                    arg,
+                    "Invalid argument, only literals and variables are supported",
+                ))
+            }
+        },
+        "Metadata" => {
+            let arg = args
+                .first()
+                .ok_or_else(|| syn::Error::new_spanned(name, "Invalid function call"))?;
+            if let Expr::Lit(ExprLit {
+                lit: Lit::Str(lit_str), ..
+            }) = arg
+            {
+                let metadata: Metadata = lit_str.value().parse().map_err(|e| {
+                    syn::Error::new_spanned(lit_str, format!("Failed to parse Metadata JSON value: {}", e))
+                })?;
+                Ok(ManifestLiteral::Special(SpecialLiteral::Metadata(metadata)))
+            } else {
+                Err(syn::Error::new_spanned(
+                    arg,
+                    "Invalid argument, only string literals are supported for Metadata",
+                ))
+            }
+        },
+        "HexBytes" | "PublicKey" => {
+            let arg = args
+                .first()
+                .ok_or_else(|| syn::Error::new_spanned(name, "Invalid function call"))?;
+            if let Expr::Lit(ExprLit {
+                lit: Lit::Str(lit_str), ..
+            }) = arg
+            {
+                let bytes = bytes_from_hex(&lit_str.value()).map_err(|e| {
+                    syn::Error::new_spanned(lit_str, format!("Failed to parse Bytes from hex string: {}", e))
+                })?;
+                Ok(ManifestLiteral::Special(SpecialLiteral::Cbor(tari_bor::Value::Bytes(
+                    bytes,
+                ))))
+            } else {
+                Err(syn::Error::new_spanned(
+                    arg,
+                    "Invalid argument, only string literals are supported for Bytes",
+                ))
+            }
+        },
+        "Cbor" => {
+            let expr = args
+                .first()
+                .ok_or_else(|| syn::Error::new_spanned(name, "Invalid function call"))?;
+            match expr {
+                Expr::Lit(ExprLit { lit: Lit::Str(lit), .. }) => {
+                    let cbor_value: serde_json::Value = serde_json::from_str(&lit.value())
+                        .map_err(|e| syn::Error::new_spanned(lit, format!("Failed to parse CBOR JSON value: {}", e)))?;
+                    let cbor = convert_json_to_cbor(cbor_value).map_err(|e| {
+                        syn::Error::new_spanned(lit, format!("Failed to convert JSON to CBOR value: {}", e))
+                    })?;
+                    Ok(ManifestLiteral::Special(SpecialLiteral::Cbor(cbor)))
+                },
+                _ => Err(syn::Error::new_spanned(
+                    expr,
+                    "Invalid argument, only string literals are supported",
+                )),
+            }
+        },
+        s => Err(syn::Error::new_spanned(
             name,
-            "Invalid function call, only Amount is supported",
-        ))
+            format!(
+                "Invalid function call '{s}', only Amount, SubstateId, Address, NonFungibleId, Metadata, HexBytes, \
+                 Cbor and PublicKey are supported"
+            ),
+        )),
     }
 }
 
@@ -451,5 +610,44 @@ fn extract_single_var_name(expr: &Expr) -> Result<Ident, syn::Error> {
             expr.clone(),
             format!("Invalid method call {:?}", expr),
         )),
+    }
+}
+
+fn lit_to_nonfungible_id(lit: &Lit) -> Result<NonFungibleId, ManifestError> {
+    match lit {
+        Lit::Str(s) => Ok(NonFungibleId::try_from_string(s.value()).map_err(|e| {
+            ManifestError::UnsupportedExpr(format!(
+                "Invalid non-fungible ID string literal ({:?}) ({})",
+                e,
+                s.value()
+            ))
+        })?),
+        Lit::ByteStr(v) => {
+            let bytes = v.value();
+            if bytes.len() != 32 {
+                return Err(ManifestError::UnsupportedExpr(
+                    "Non-fungible ID byte string literal length must be less than 32 bytes".to_string(),
+                ));
+            }
+
+            let mut id = [0u8; 32];
+            id.copy_from_slice(&bytes);
+            Ok(NonFungibleId::from_u256(id))
+        },
+        Lit::Int(v) => match v.suffix() {
+            "u8" | "u16" | "u32" => Ok(NonFungibleId::from_u32(v.base10_parse()?)),
+            "u64" => Ok(NonFungibleId::from_u64(v.base10_parse()?)),
+            "" => Err(ManifestError::UnsupportedExpr(
+                "Non-fungible ID integer literal must have a type suffix specified (1u32, 2u64 etc)".to_string(),
+            )),
+            _ => Err(ManifestError::UnsupportedExpr(format!(
+                "Invalid non-fungible ID integer literal suffix ({})",
+                v.suffix()
+            ))),
+        },
+        _ => Err(ManifestError::UnsupportedExpr(format!(
+            "Unsupported non-fungible ID literal ({:?})",
+            lit
+        ))),
     }
 }

--- a/crates/transaction_manifest/src/value.rs
+++ b/crates/transaction_manifest/src/value.rs
@@ -7,6 +7,9 @@ use syn::{parse2, Lit};
 use tari_bor::{BorError, Serialize};
 use tari_engine_types::substate::SubstateId;
 use tari_template_lib::{models::NonFungibleId, to_value};
+use tari_transaction::{args::InstructionArg, call_arg};
+
+use crate::error::ManifestError;
 
 #[derive(Debug, Clone)]
 pub enum ManifestValue {
@@ -27,11 +30,69 @@ impl ManifestValue {
             _ => None,
         }
     }
+
+    pub fn to_arg(&self) -> Result<InstructionArg, ManifestError> {
+        match self {
+            ManifestValue::SubstateId(addr) => match addr {
+                SubstateId::Component(addr) => Ok(call_arg!(*addr)),
+                SubstateId::Resource(addr) => Ok(call_arg!(*addr)),
+                // TODO: should tx receipt addresses be allowed to be referenced?
+                SubstateId::TransactionReceipt(addr) => Ok(call_arg!(*addr)),
+                SubstateId::Vault(addr) => Ok(call_arg!(*addr)),
+                SubstateId::NonFungible(addr) => Ok(call_arg!(addr)),
+                SubstateId::ClaimedOutputTombstone(addr) => Ok(call_arg!(*addr)),
+                SubstateId::Template(addr) => Ok(call_arg!(*addr)),
+                SubstateId::ValidatorFeePool(addr) => Ok(call_arg!(*addr)),
+                SubstateId::Utxo(addr) => Ok(call_arg!(*addr)),
+            },
+            ManifestValue::Literal(lit) => lit_to_arg(lit),
+            ManifestValue::NonFungibleId(id) => Ok(call_arg!(id.clone())),
+            ManifestValue::Value(blob) => Ok(InstructionArg::literal(blob.clone()).unwrap()),
+        }
+    }
 }
 
 impl<T: Into<SubstateId>> From<T> for ManifestValue {
     fn from(addr: T) -> Self {
         ManifestValue::SubstateId(addr.into())
+    }
+}
+
+pub fn lit_to_arg(lit: &Lit) -> Result<InstructionArg, ManifestError> {
+    match lit {
+        Lit::Str(s) => Ok(call_arg!(s.value())),
+        Lit::Int(i) => match i.suffix() {
+            "u8" => Ok(call_arg!(i.base10_parse::<u8>()?)),
+            "u16" => Ok(call_arg!(i.base10_parse::<u16>()?)),
+            "u32" => Ok(call_arg!(i.base10_parse::<u32>()?)),
+            "u64" => Ok(call_arg!(i.base10_parse::<u64>()?)),
+            "u128" => Ok(call_arg!(i.base10_parse::<u128>()?)),
+            "i8" => Ok(call_arg!(i.base10_parse::<i8>()?)),
+            "i16" => Ok(call_arg!(i.base10_parse::<i16>()?)),
+            "i32" => Ok(call_arg!(i.base10_parse::<i32>()?)),
+            "i64" => Ok(call_arg!(i.base10_parse::<i64>()?)),
+            "" | "i128" => Ok(call_arg!(i.base10_parse::<i128>()?)),
+            _ => Err(ManifestError::UnsupportedExpr(format!(
+                r#"Unsupported integer suffix "{}""#,
+                i.suffix()
+            ))),
+        },
+        Lit::Bool(b) => Ok(call_arg!(b.value())),
+        Lit::ByteStr(v) => Ok(call_arg!(v.value())),
+        Lit::Byte(v) => Ok(call_arg!(v.value())),
+        Lit::Char(v) => Ok(call_arg!(v.value().to_string())),
+        Lit::Float(v) => Err(ManifestError::UnsupportedExpr(format!(
+            "Float literals not supported ({})",
+            v
+        ))),
+        Lit::Verbatim(v) => Err(ManifestError::UnsupportedExpr(format!(
+            "Raw token literals not supported ({})",
+            v
+        ))),
+        _ => Err(ManifestError::UnsupportedExpr(format!(
+            "Unsupported literal type ({:?})",
+            lit
+        ))),
     }
 }
 

--- a/crates/transaction_manifest/tests/examples/picture_seller.rs
+++ b/crates/transaction_manifest/tests/examples/picture_seller.rs
@@ -20,9 +20,11 @@ fn main() {
     // initialize a user account with some faucet funds
     let funds = faucet.take_free_coins(1_000);
     account.deposit(funds);
-
-    // TODO: XTR builtin
-    let XTR = var!["xtr_resource"];
+    account.set_public_key(
+        PublicKey("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"),
+        Address("component_0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"),
+        cbor!({"some": {"data": [1, 2, 3]}}),
+    );
 
     // buy a picture
     let bucket = account.withdraw(XTR, 1_000);

--- a/crates/transaction_manifest/tests/parser.rs
+++ b/crates/transaction_manifest/tests/parser.rs
@@ -20,11 +20,14 @@
 //   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //   USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::{collections::HashMap, fs};
+use std::{collections::HashMap, fs, str::FromStr};
 
+use tari_bor::cbor;
 use tari_engine_types::substate::SubstateId;
 use tari_template_lib::{
-    models::{ComponentAddress, ResourceAddress},
+    constants::XTR,
+    models::ComponentAddress,
+    prelude::RistrettoPublicKeyBytes,
     types::{ObjectKey, TemplateAddress},
 };
 use tari_transaction::{call_args, Instruction};
@@ -37,7 +40,6 @@ fn manifest_smoke_test() {
     let account_component = ComponentAddress::new([0u8; ObjectKey::LENGTH].into());
     let picture_seller_component = ComponentAddress::new([1u8; ObjectKey::LENGTH].into());
     let test_faucet_component = ComponentAddress::new([2u8; ObjectKey::LENGTH].into());
-    let xtr_resource = ResourceAddress::from([3u8; ObjectKey::LENGTH]);
     let picture_seller_template =
         TemplateAddress::from_hex("c2b621869ec2929d3b9503ea41054f01b468ce99e50254b58e460f608ae377f7").unwrap();
 
@@ -51,7 +53,6 @@ fn manifest_smoke_test() {
             "test_faucet".to_string(),
             SubstateId::Component(test_faucet_component).into(),
         ),
-        ("xtr_resource".to_string(), SubstateId::Resource(xtr_resource).into()),
     ]);
     let ManifestInstructions {
         instructions,
@@ -78,8 +79,21 @@ fn manifest_smoke_test() {
         },
         Instruction::CallMethod {
             call: account_component.into(),
+            method: "set_public_key".to_string(),
+            args: call_args![
+                RistrettoPublicKeyBytes::from_hex("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")
+                    .unwrap(),
+                ComponentAddress::from_str(
+                    "component_0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+                )
+                .unwrap(),
+                cbor!({"some" => {"data" => [1, 2, 3]}}).unwrap()
+            ],
+        },
+        Instruction::CallMethod {
+            call: account_component.into(),
             method: "withdraw".to_string(),
-            args: call_args![xtr_resource, 1_000],
+            args: call_args![XTR, 1_000],
         },
         Instruction::PutLastInstructionOutputOnWorkspace { key: 2 },
         Instruction::CallMethod {


### PR DESCRIPTION
Description
---
fix(manifest): add support for metadata, cbor, pubkey calls

Motivation and Context
---
Needed to call arbitrary templates from the wallet.

Syntax:
```rust
let ret = my_component.my_method(
  Address("component_xxxx"), 
  XTR, 
  PublicKey("deafbeaf..."), 
  Metadata("a=b,c=d"), 
  cbor!({"hello": {"json-style":"objects"}})
);
```

How Has This Been Tested?
---
Manually, updated existing test

What process can a PR reviewer use to test or verify this change?
---


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added DropAllProofs operation to transaction manifests
  * Added CBOR and Metadata literal support
  * Added SubstateId and Address literal forms and expanded manifest literal handling

* **Bug Fixes**
  * More granular fee-estimation error reporting and validation
  * More robust key=value parsing with whitespace trimming and clearer errors

* **Chores**
  * Added serde_json as a workspace dependency
<!-- end of auto-generated comment: release notes by coderabbit.ai -->