### PR TITLE
fix!: real time epoch ticker, indexer fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1840,7 +1840,7 @@ dependencies = [
 
 [[package]]
 name = "consensus_tests"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "fern",
  "futures 0.3.31",
@@ -2607,7 +2607,7 @@ dependencies = [
 
 [[package]]
 name = "db_inspector"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "axum 0.8.4",
@@ -3746,7 +3746,7 @@ checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 
 [[package]]
 name = "generate_ristretto_value_lookup"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "clap 3.2.25",
  "human_bytes",
@@ -4993,7 +4993,7 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "integration_tests"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "config",
@@ -5761,7 +5761,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-messaging"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "async-trait",
  "futures-bounded",
@@ -5940,7 +5940,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-substream"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "libp2p",
  "prometheus-client",
@@ -8466,7 +8466,7 @@ dependencies = [
 
 [[package]]
 name = "proto_builder"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "prost-build 0.14.1",
  "sha2",
@@ -10300,7 +10300,7 @@ dependencies = [
 
 [[package]]
 name = "sqlite_message_logger"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "chrono",
  "diesel",
@@ -10341,7 +10341,7 @@ checksum = "e7386b49cb287f6fafbfd3bd604914bccb99fb8d53483f40e1ecfda5d45f3370"
 
 [[package]]
 name = "state_store_tests"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "env_logger 0.11.8",
  "indexmap 2.11.4",
@@ -10730,7 +10730,7 @@ dependencies = [
 
 [[package]]
 name = "tari_base_node_client"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "log",
  "minotari_app_grpc",
@@ -10954,7 +10954,7 @@ dependencies = [
 
 [[package]]
 name = "tari_consensus"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "indexmap 2.11.4",
@@ -10978,7 +10978,7 @@ dependencies = [
 
 [[package]]
 name = "tari_consensus_types"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "borsh",
  "serde",
@@ -11080,7 +11080,7 @@ dependencies = [
 
 [[package]]
 name = "tari_engine"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "blake2",
  "cargo_toml 0.22.3",
@@ -11109,7 +11109,7 @@ dependencies = [
 
 [[package]]
 name = "tari_engine_types"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "base64 0.21.7",
  "bincode 2.0.1",
@@ -11136,7 +11136,7 @@ dependencies = [
 
 [[package]]
 name = "tari_epoch_manager"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "log",
@@ -11158,7 +11158,7 @@ dependencies = [
 
 [[package]]
 name = "tari_epoch_oracles"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -11177,6 +11177,7 @@ dependencies = [
  "tari_transaction_components",
  "tari_utilities",
  "thiserror 2.0.17",
+ "time",
  "tokio",
  "url",
 ]
@@ -11199,7 +11200,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -11263,7 +11264,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer_client"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "bounded-vec",
@@ -11293,7 +11294,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer_lib"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "log",
  "serde",
@@ -11369,7 +11370,7 @@ dependencies = [
 
 [[package]]
 name = "tari_networking"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11406,7 +11407,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_address"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "bech32",
  "bincode 2.0.1",
@@ -11422,7 +11423,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_app_utilities"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -11461,7 +11462,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_common_types"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "blake2",
  "borsh",
@@ -11489,7 +11490,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_p2p"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "prost 0.14.1",
@@ -11511,7 +11512,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_storage"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "bitflags 2.9.2",
@@ -11536,7 +11537,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_storage_sqlite"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "diesel",
  "diesel_migrations",
@@ -11556,7 +11557,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_cli"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -11585,7 +11586,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_crypto"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "argon2 0.5.3",
  "blake2",
@@ -11609,7 +11610,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_sdk"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -11644,7 +11645,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_sdk_services"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -11669,7 +11670,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_storage_sqlite"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "bigdecimal",
  "diesel",
@@ -11693,7 +11694,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_walletd"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11778,7 +11779,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_framework"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "async-trait",
  "bitflags 2.9.2",
@@ -11802,7 +11803,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_macros"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11811,7 +11812,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_state_sync"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -11831,7 +11832,7 @@ dependencies = [
 
 [[package]]
 name = "tari_scaffolder"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "clap 3.2.25",
@@ -11903,7 +11904,7 @@ dependencies = [
 
 [[package]]
 name = "tari_signaling_server"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "axum 0.8.4",
@@ -11929,7 +11930,7 @@ dependencies = [
 
 [[package]]
 name = "tari_state_store_rocksdb"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -11955,7 +11956,7 @@ dependencies = [
 
 [[package]]
 name = "tari_state_tree"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "indexmap 2.11.4",
  "log",
@@ -11982,7 +11983,7 @@ dependencies = [
 
 [[package]]
 name = "tari_swarm"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "libp2p",
  "libp2p-messaging",
@@ -11992,7 +11993,7 @@ dependencies = [
 
 [[package]]
 name = "tari_swarm_daemon"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12048,7 +12049,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_builtin"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "tari_engine_types",
  "tari_template_lib",
@@ -12100,7 +12101,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_manager"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "bytes 1.10.1",
@@ -12166,7 +12167,7 @@ dependencies = [
 
 [[package]]
 name = "tari_transaction"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "borsh",
  "hex",
@@ -12254,7 +12255,7 @@ dependencies = [
 
 [[package]]
 name = "tari_transaction_manifest"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "proc-macro2",
  "serde_json",
@@ -12288,7 +12289,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "axum 0.8.4",
@@ -12350,7 +12351,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node_cli"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "clap 3.2.25",
@@ -12378,7 +12379,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node_client"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "indexmap 2.11.4",
  "multiaddr 0.18.1",
@@ -12401,7 +12402,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node_rpc"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "prost 0.14.1",
@@ -12423,7 +12424,7 @@ dependencies = [
 
 [[package]]
 name = "tari_wallet_daemon_client"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "reqwest 0.11.27",
  "serde",
@@ -12444,7 +12445,7 @@ dependencies = [
 
 [[package]]
 name = "tari_watcher"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "clap 3.2.25",
@@ -12472,7 +12473,7 @@ dependencies = [
 
 [[package]]
 name = "tariswap_bench"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "clap 4.5.48",
@@ -13131,7 +13132,7 @@ dependencies = [
 
 [[package]]
 name = "transaction_generator"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -13151,7 +13152,7 @@ dependencies = [
 
 [[package]]
 name = "transaction_submitter"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "clap 4.5.48",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 # NOTE: When editing this version, also edit the versions in template_built_in/templates/account and account_nft
 [workspace.package]
-version = "0.14.0"
+version = "0.14.1"
 edition = "2021"
 authors = ["The Tari Development Community"]
 repository = "https://github.com/tari-project/tari-ootle"

--- a/applications/tari_indexer/src/bootstrap.rs
+++ b/applications/tari_indexer/src/bootstrap.rs
@@ -27,10 +27,7 @@ use libp2p::identity;
 use log::warn;
 use minotari_app_utilities::identity_management;
 use tari_base_node_client::grpc::GrpcBaseNodeClient;
-use tari_common::{
-    configuration::bootstrap::{grpc_default_port, ApplicationType},
-    exit_codes::{ExitCode, ExitError},
-};
+use tari_common::configuration::bootstrap::{grpc_default_port, ApplicationType};
 use tari_consensus::consensus_constants::ConsensusConstants;
 use tari_crypto::tari_utilities::ByteArray;
 use tari_engine::transaction::TransactionProcessorConfig;
@@ -38,7 +35,7 @@ use tari_engine_types::ToByteType;
 use tari_epoch_manager::service::{EpochManagerConfig, EpochManagerHandle};
 use tari_epoch_oracles::{
     base_layer::BaseLayerOracle,
-    configured::{ConfiguredEpochOracle, IntervalEpochTicker},
+    configured::{ConfiguredEpochOracle, RealTimeEpochTicker},
     hybrid::{watch_ticker, HybridEpochOracle},
     store::EpochOracleStore,
     EpochOracle,
@@ -91,12 +88,8 @@ pub async fn spawn_services(
     ensure_directories_exist(config)?;
 
     // Initialize networking
-    let identity = identity::Keypair::sr25519_from_bytes(keypair.secret_key().as_bytes().to_vec()).map_err(|e| {
-        ExitError::new(
-            ExitCode::ConfigError,
-            format!("Failed to create libp2p identity from secret bytes: {}", e),
-        )
-    })?;
+    let identity = identity::Keypair::sr25519_from_bytes(keypair.secret_key().as_bytes().to_vec())
+        .context("Failed to create libp2p identity from secret bytes")?;
     let seed_peers = config
         .peer_seeds
         .peer_seeds
@@ -219,8 +212,7 @@ pub async fn spawn_services(
     .spawn(shutdown.clone());
 
     let substate_cache_dir = config.common.base_path.join("substate_cache");
-    let substate_cache = SubstateFileCache::new(substate_cache_dir)
-        .map_err(|e| ExitError::new(ExitCode::ConfigError, format!("Substate cache error: {}", e)))?;
+    let substate_cache = SubstateFileCache::new(substate_cache_dir).context("Failed to create substate cache")?;
 
     let substate_scanner = SubstateScanner::new(
         epoch_manager.clone(),
@@ -279,14 +271,14 @@ fn ensure_directories_exist(config: &ApplicationConfig) -> io::Result<()> {
     Ok(())
 }
 
-fn save_identities(config: &ApplicationConfig, identity: &RistrettoKeypair) -> Result<(), ExitError> {
+fn save_identities(config: &ApplicationConfig, identity: &RistrettoKeypair) -> anyhow::Result<()> {
     identity_management::save_as_json(&config.indexer.identity_file, identity)
-        .map_err(|e| ExitError::new(ExitCode::ConfigError, format!("Failed to save node identity: {}", e)))?;
+        .context("Failed to save indexer identity")?;
 
     Ok(())
 }
 
-async fn create_base_layer_client(config: &ApplicationConfig) -> Result<GrpcBaseNodeClient, ExitError> {
+async fn create_base_layer_client(config: &ApplicationConfig) -> anyhow::Result<GrpcBaseNodeClient> {
     let url = config
         .epoch_oracle
         .base_layer
@@ -303,14 +295,14 @@ async fn create_base_layer_client(config: &ApplicationConfig) -> Result<GrpcBase
         });
     GrpcBaseNodeClient::connect(url)
         .await
-        .map_err(|err| ExitError::new(ExitCode::ConfigError, format!("Could not connect to base node {}", err)))
+        .context("Failed to create gRPC base node client")
 }
 
 async fn create_epoch_oracle<TStore: EpochOracleStore + Clone + Send + 'static>(
     config: &ApplicationConfig,
     store: TStore,
     consensus_constants: &ConsensusConstants,
-) -> Result<EpochOracle<TStore>, ExitError> {
+) -> anyhow::Result<EpochOracle<TStore>> {
     match config.epoch_oracle.oracle_type {
         EpochOracleType::BaseLayer => {
             let oracle = create_base_layer_epoch_oracle(config, store, consensus_constants).await?;
@@ -331,7 +323,7 @@ async fn create_base_layer_epoch_oracle<TStore: EpochOracleStore + 'static>(
     config: &ApplicationConfig,
     store: TStore,
     consensus_constants: &ConsensusConstants,
-) -> Result<BaseLayerOracle<TStore>, ExitError> {
+) -> anyhow::Result<BaseLayerOracle<TStore>> {
     let mut base_node_client = create_base_layer_client(config).await?;
     verify_correct_network(&mut base_node_client, config.network).await?;
     Ok(BaseLayerOracle::new(
@@ -353,16 +345,17 @@ async fn create_base_layer_epoch_oracle<TStore: EpochOracleStore + 'static>(
 async fn create_configured_epoch_oracle<TStore: EpochOracleStore + Send>(
     config: &ApplicationConfig,
     store: TStore,
-) -> Result<ConfiguredEpochOracle<TStore, IntervalEpochTicker>, ExitError> {
+) -> anyhow::Result<ConfiguredEpochOracle<TStore, RealTimeEpochTicker>> {
     let oracle_config = config.epoch_oracle.configured.load().await?;
-    Ok(ConfiguredEpochOracle::new(oracle_config, store))
+    let oracle = ConfiguredEpochOracle::create(oracle_config, store)?;
+    Ok(oracle)
 }
 
 async fn create_hybrid_epoch_oracle<TStore: EpochOracleStore + Clone + Send + 'static>(
     config: &ApplicationConfig,
     store: TStore,
     consensus_constants: &ConsensusConstants,
-) -> Result<HybridEpochOracle<TStore>, ExitError> {
+) -> anyhow::Result<HybridEpochOracle<TStore>> {
     let base_layer_oracle = create_base_layer_epoch_oracle(config, store.clone(), consensus_constants).await?;
     let oracle_config = config.epoch_oracle.configured.load().await?;
     let (ticker, trigger) = watch_ticker();

--- a/applications/tari_indexer/src/cli.rs
+++ b/applications/tari_indexer/src/cli.rs
@@ -24,9 +24,15 @@ use std::{net::SocketAddr, path::PathBuf};
 
 use clap::Parser;
 use minotari_app_utilities::common_cli_args::CommonCliArgs;
-use tari_common::configuration::{ConfigOverrideProvider, Network as L1Network};
+use tari_common::{
+    configuration::{ConfigOverrideProvider, Network as L1Network},
+    SubConfigPath,
+};
 use tari_engine_types::substate::SubstateId;
-use tari_ootle_app_utilities::{configuration::convert_l1_network_to_network, p2p_config::ReachabilityMode};
+use tari_ootle_app_utilities::{
+    configuration::convert_l1_network_to_network,
+    p2p_config::{PeerSeedsConfig, ReachabilityMode},
+};
 use tari_ootle_common_types::Network;
 use url::Url;
 
@@ -91,7 +97,14 @@ impl ConfigOverrideProvider for Cli {
         }
 
         if !self.peer_seeds.is_empty() {
-            overrides.push(("p2p.seeds.peer_seeds".to_string(), self.peer_seeds.join(",")));
+            overrides.push((
+                format!("{}.peer_seeds", PeerSeedsConfig::main_key_prefix()),
+                self.peer_seeds.join(","),
+            ));
+            overrides.push((
+                format!("{}.{}.peer_seeds", network, PeerSeedsConfig::main_key_prefix()),
+                self.peer_seeds.join(","),
+            ));
         }
         if let Some(listener_port) = self.listener_port {
             overrides.push(("indexer.p2p.listener_port".to_string(), listener_port.to_string()));

--- a/applications/tari_indexer/src/lib.rs
+++ b/applications/tari_indexer/src/lib.rs
@@ -75,7 +75,7 @@ use crate::{
 const LOG_TARGET: &str = "tari::indexer::app";
 
 #[allow(clippy::too_many_lines)]
-pub async fn run_indexer(config: ApplicationConfig, mut shutdown_signal: ShutdownSignal) -> Result<(), ExitError> {
+pub async fn run_indexer(config: ApplicationConfig, mut shutdown_signal: ShutdownSignal) -> anyhow::Result<()> {
     info!(target: LOG_TARGET, "Starting indexer node on network {}", config.network);
     let keypair = setup_keypair_prompt(&config.indexer.identity_file, true)?;
 

--- a/applications/tari_indexer/src/main.rs
+++ b/applications/tari_indexer/src/main.rs
@@ -23,10 +23,7 @@
 use std::{fs, panic, process};
 
 use log::*;
-use tari_common::{
-    exit_codes::{ExitCode, ExitError},
-    initialize_logging,
-};
+use tari_common::initialize_logging;
 use tari_indexer::{cli::Cli, config::ApplicationConfig, run_indexer};
 use tari_ootle_app_utilities::configuration::load_configuration;
 use tari_shutdown::Shutdown;
@@ -44,24 +41,16 @@ async fn main() {
     }));
 
     if let Err(err) = main_inner().await {
-        let exit_code = err.exit_code;
-        eprintln!("{:?}", err);
-        error!(
-            target: LOG_TARGET,
-            "Exiting with code ({}) {:?}: {}",
-            exit_code as i32,
-            exit_code,
-            err.details.unwrap_or_default()
-        );
-        process::exit(exit_code as i32);
+        eprintln!("CRASH: {:?}", err);
+        error!(target: LOG_TARGET, "CRASH: {:?}", err);
+        process::exit(1);
     }
 }
 
-async fn main_inner() -> Result<(), ExitError> {
+async fn main_inner() -> anyhow::Result<()> {
     let cli = Cli::init();
     let config_path = cli.common.config_path();
-    let cfg = load_configuration(config_path, true, &cli, cli.network_override())
-        .map_err(|e| ExitError::new(ExitCode::ConfigError, e))?;
+    let cfg = load_configuration(config_path, true, &cli, cli.network_override())?;
     let config = ApplicationConfig::load_from(&cfg)?;
     // Remove the file if it was left behind by a previous run
     let _file = fs::remove_file(config.common.base_path.join("pid"));

--- a/applications/tari_indexer/src/network_state_sync/committee_client.rs
+++ b/applications/tari_indexer/src/network_state_sync/committee_client.rs
@@ -57,7 +57,7 @@ impl ValidatorCommitteeRpcPool {
                 Err(err) => {
                     warn!(
                         target: LOG_TARGET,
-                        "Failed to create session for validator '{}': {}", member, err
+                        "Failed to create new session for validator '{}': {}", member, err
                     );
                     last_error = Some(err);
                     self.past_failed_nodes.push(member.address);

--- a/applications/tari_indexer/src/rest_api/error.rs
+++ b/applications/tari_indexer/src/rest_api/error.rs
@@ -1,7 +1,7 @@
 //   Copyright 2025 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use std::borrow::Cow;
+use std::{borrow::Cow, env};
 
 use axum::{http::StatusCode, response::IntoResponse, Json};
 use log::*;
@@ -51,11 +51,20 @@ impl ErrorResponse {
     pub fn internal_error(msg: impl Into<Box<str>>) -> Self {
         let msg = msg.into();
         error!(target: LOG_TARGET, "Internal server error: {}", msg);
-        let msg = if cfg!(debug_assertions) || option_env!("API_DEBUG").is_some_and(|v| v != "0") {
+        let msg = if cfg!(debug_assertions) || env::var("API_DEBUG").ok().is_some_and(|v| v != "0") {
             msg
         } else {
             "Internal server error".into()
         };
+        Self {
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+            error: msg,
+        }
+    }
+
+    pub fn general_error(msg: impl Into<Box<str>>) -> Self {
+        let msg = msg.into();
+        error!(target: LOG_TARGET, "General error: {}", msg);
         Self {
             status: StatusCode::INTERNAL_SERVER_ERROR,
             error: msg,

--- a/applications/tari_indexer/src/rest_api/handlers/network.rs
+++ b/applications/tari_indexer/src/rest_api/handlers/network.rs
@@ -116,10 +116,12 @@ pub async fn add_connection(
                 .build(),
         )
         .await
-        .map_err(ErrorResponse::anyhow)?;
+        .map_err(|err| ErrorResponse::general_error(err.to_string()))?;
 
     if wait_for_dial {
-        dial_wait.await.map_err(ErrorResponse::anyhow)?;
+        dial_wait
+            .await
+            .map_err(|err| ErrorResponse::general_error(format!("Failed to dial peer {}: {}", peer_id, err)))?;
     }
 
     Ok(Json(AddPeerResponse {}))

--- a/applications/tari_validator_node/src/bootstrap.rs
+++ b/applications/tari_validator_node/src/bootstrap.rs
@@ -44,7 +44,7 @@ use tari_epoch_manager::{
 };
 use tari_epoch_oracles::{
     base_layer::BaseLayerOracle,
-    configured::{ConfiguredEpochOracle, IntervalEpochTicker},
+    configured::{ConfiguredEpochOracle, RealTimeEpochTicker},
     hybrid::{watch_ticker, HybridEpochOracle},
     store::EpochOracleStore,
     EpochOracle,
@@ -526,7 +526,7 @@ async fn create_epoch_oracle<TStore: EpochOracleStore + Send + Clone + 'static>(
     config: &ApplicationConfig,
     store: TStore,
     consensus_constants: &ConsensusConstants,
-) -> Result<EpochOracle<TStore>, ExitError> {
+) -> anyhow::Result<EpochOracle<TStore>> {
     match config.epoch_oracle.oracle_type {
         EpochOracleType::BaseLayer => {
             let oracle = create_base_layer_epoch_oracle(config, store, consensus_constants).await?;
@@ -547,7 +547,7 @@ async fn create_base_layer_epoch_oracle<TStore: EpochOracleStore + 'static>(
     config: &ApplicationConfig,
     store: TStore,
     consensus_constants: &ConsensusConstants,
-) -> Result<BaseLayerOracle<TStore>, ExitError> {
+) -> anyhow::Result<BaseLayerOracle<TStore>> {
     let mut base_node_client = create_base_layer_client(config.network, &config.epoch_oracle.base_layer).await?;
     verify_correct_network(&mut base_node_client, config.network).await?;
     Ok(BaseLayerOracle::new(
@@ -577,16 +577,17 @@ async fn create_base_layer_epoch_oracle<TStore: EpochOracleStore + 'static>(
 async fn create_configured_epoch_oracle<TStore: EpochOracleStore + Send>(
     config: &ApplicationConfig,
     store: TStore,
-) -> Result<ConfiguredEpochOracle<TStore, IntervalEpochTicker>, ExitError> {
+) -> anyhow::Result<ConfiguredEpochOracle<TStore, RealTimeEpochTicker>> {
     let oracle_config = config.epoch_oracle.configured.load().await?;
-    Ok(ConfiguredEpochOracle::new(oracle_config, store))
+    let oracle = ConfiguredEpochOracle::create(oracle_config, store)?;
+    Ok(oracle)
 }
 
 async fn create_hybrid_epoch_oracle<TStore: EpochOracleStore + Clone + Send + 'static>(
     config: &ApplicationConfig,
     store: TStore,
     consensus_constants: &ConsensusConstants,
-) -> Result<HybridEpochOracle<TStore>, ExitError> {
+) -> anyhow::Result<HybridEpochOracle<TStore>> {
     let base_layer_oracle = create_base_layer_epoch_oracle(config, store.clone(), consensus_constants).await?;
     let oracle_config = config.epoch_oracle.configured.load().await?;
     let (ticker, trigger) = watch_ticker();

--- a/crates/epoch_oracles/Cargo.toml
+++ b/crates/epoch_oracles/Cargo.toml
@@ -26,6 +26,7 @@ log = { workspace = true }
 tokio = { workspace = true, features = ["time"] }
 thiserror = { workspace = true }
 serde = { workspace = true }
+time = { workspace = true, features = ["serde", "serde-human-readable"] }
 url = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/crates/epoch_oracles/src/configured/config.rs
+++ b/crates/epoch_oracles/src/configured/config.rs
@@ -15,6 +15,8 @@ pub struct Config {
     #[serde(with = "serde_with::duration::optional_seconds")]
     pub epoch_time: Option<Duration>,
     pub initial_epoch: Epoch,
+    #[serde(with = "time::serde::iso8601")]
+    pub base_time: time::OffsetDateTime,
     #[serde(default)]
     pub validators: Vec<Validator>,
 }
@@ -24,6 +26,7 @@ impl Default for Config {
         Self {
             epoch_time: None,
             initial_epoch: Epoch(0),
+            base_time: time::OffsetDateTime::now_utc(),
             validators: vec![],
         }
     }

--- a/crates/epoch_oracles/src/configured/mod.rs
+++ b/crates/epoch_oracles/src/configured/mod.rs
@@ -4,7 +4,9 @@
 mod config;
 mod epoch_ticker;
 mod oracle;
+mod real_time_ticker;
 
 pub use config::*;
 pub use epoch_ticker::*;
 pub use oracle::*;
+pub use real_time_ticker::*;

--- a/crates/epoch_oracles/src/configured/oracle.rs
+++ b/crates/epoch_oracles/src/configured/oracle.rs
@@ -7,17 +7,14 @@ use std::{
     task::{Context, Poll},
 };
 
+use anyhow::Context as _;
 use log::*;
 use tari_epoch_manager::epoch_event_oracle::{EpochEvent, EpochEventOracle, ValidatorNodeChange};
 use tari_ootle_common_types::{displayable::Displayable, Epoch};
 
 use super::config::Config;
 use crate::{
-    configured::{
-        epoch_ticker::{EpochTicker, IntervalEpochTicker},
-        EpochTickerData,
-        Validator,
-    },
+    configured::{epoch_ticker::EpochTicker, real_time_ticker::RealTimeEpochTicker, EpochTickerData, Validator},
     store::{EpochOracleStore, StoreKey},
 };
 
@@ -32,14 +29,19 @@ pub struct ConfiguredEpochOracle<TStore, TTicker> {
     is_initialized: bool,
     is_done: bool,
 }
-impl<TStore: EpochOracleStore + Send> ConfiguredEpochOracle<TStore, IntervalEpochTicker> {
-    pub fn new(config: Config, store: TStore) -> Self {
+impl<TStore: EpochOracleStore + Send> ConfiguredEpochOracle<TStore, RealTimeEpochTicker> {
+    pub fn create(config: Config, store: TStore) -> anyhow::Result<Self> {
         let epoch = store
-            .get(StoreKey::ConfiguredCurrentEpoch.as_key_bytes())
-            .expect("Failed to get current epoch from store")
+            .get(StoreKey::ConfiguredCurrentEpoch.as_key_bytes())?
             .unwrap_or_else(Epoch::zero);
-        let ticker = IntervalEpochTicker::new(config.epoch_time, config.initial_epoch, epoch);
-        Self {
+        let mut ticker = RealTimeEpochTicker::new(config.initial_epoch, config.base_time, epoch);
+        if let Some(epoch_time) = config.epoch_time {
+            ticker = ticker.with_epoch_time_secs(epoch_time.as_secs().try_into().context("Epoch time cannot be zero")?);
+        } else {
+            ticker = ticker.disable_ticks();
+        }
+
+        Ok(Self {
             config,
             store,
             ticker,
@@ -47,7 +49,7 @@ impl<TStore: EpochOracleStore + Send> ConfiguredEpochOracle<TStore, IntervalEpoc
             queued_validators: HashMap::new(),
             is_initialized: false,
             is_done: false,
-        }
+        })
     }
 }
 

--- a/crates/epoch_oracles/src/configured/real_time_ticker.rs
+++ b/crates/epoch_oracles/src/configured/real_time_ticker.rs
@@ -1,0 +1,130 @@
+//   Copyright 2025 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+use std::{
+    num::NonZeroU64,
+    task::{ready, Context, Poll},
+    time::Duration,
+};
+
+use tari_common_types::types::FixedHash;
+use tari_ootle_common_types::Epoch;
+
+use crate::configured::{EpochTicker, EpochTickerData};
+
+#[derive(Debug)]
+pub struct RealTimeEpochTicker {
+    base_time: time::OffsetDateTime,
+    epoch_time_secs: NonZeroU64,
+    initial_epoch: Epoch,
+    interval: Option<tokio::time::Interval>,
+    epoch: Epoch,
+}
+
+impl RealTimeEpochTicker {
+    pub fn new(initial_epoch: Epoch, base_time: time::OffsetDateTime, start_epoch: Epoch) -> Self {
+        Self {
+            interval: Some({
+                let mut interval = tokio::time::interval(Duration::from_secs(1));
+                interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Burst);
+                interval
+            }),
+            epoch_time_secs: NonZeroU64::new(120).expect("Non zero"),
+            initial_epoch,
+            base_time,
+            epoch: start_epoch,
+        }
+    }
+
+    pub fn disable_ticks(mut self) -> Self {
+        self.interval = None;
+        self
+    }
+
+    pub fn with_epoch_time_secs(mut self, epoch_time_secs: NonZeroU64) -> Self {
+        self.epoch_time_secs = epoch_time_secs;
+        self
+    }
+
+    fn calc_current_epoch(&self) -> Epoch {
+        let now = time::OffsetDateTime::now_utc();
+        let elapsed_secs = (now - self.base_time).whole_seconds().max(0) as u64 / self.epoch_time_secs.get();
+        Epoch(elapsed_secs)
+    }
+
+    fn increment_epoch(&mut self) -> Epoch {
+        let epoch = self.epoch;
+        self.epoch += Epoch(1);
+        epoch
+    }
+}
+
+impl EpochTicker for RealTimeEpochTicker {
+    fn poll_tick(&mut self, cx: &mut Context) -> Poll<Option<EpochTickerData>> {
+        let calculated_epoch = self.calc_current_epoch();
+
+        if calculated_epoch < self.initial_epoch {
+            let epoch = self.increment_epoch();
+            let epoch_hash = calc_static_epoch_hash(epoch);
+            return Poll::Ready(Some(EpochTickerData {
+                epoch,
+                epoch_hash,
+                done_for_now: false,
+            }));
+        }
+
+        if let Some(interval_mut) = self.interval.as_mut() {
+            loop {
+                ready!(interval_mut.poll_tick(cx));
+
+                if self.epoch.is_zero() || self.epoch <= calculated_epoch {
+                    let epoch = self.increment_epoch();
+                    let epoch_hash = calc_static_epoch_hash(epoch);
+                    return Poll::Ready(Some(EpochTickerData {
+                        epoch,
+                        epoch_hash,
+                        done_for_now: true,
+                    }));
+                }
+            }
+        }
+        // Ticks have been disabled, never return any new epochs
+        assert!(self.interval.is_none(), "If interval is Some, we should not reach here");
+        Poll::Pending
+    }
+}
+fn calc_static_epoch_hash(epoch: Epoch) -> FixedHash {
+    const U64_SIZE: usize = size_of::<u64>();
+    const HASH_SIZE: usize = FixedHash::byte_size();
+    let mut epoch_hash = [0u8; HASH_SIZE];
+    epoch_hash[HASH_SIZE - U64_SIZE..].copy_from_slice(&epoch.to_be_bytes());
+    epoch_hash.into()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{future::poll_fn, time::Duration};
+
+    use tokio::time::timeout;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn it_ticks_according_to_relative_time() {
+        let base_time = time::OffsetDateTime::now_utc();
+        let mut ticker =
+            RealTimeEpochTicker::new(Epoch(0), base_time, Epoch(0)).with_epoch_time_secs(1.try_into().unwrap());
+
+        for i in 0..5 {
+            let res = timeout(Duration::from_secs(10), poll_fn(|cx| ticker.poll_tick(cx))).await;
+            assert_eq!(
+                res,
+                Ok(Some(EpochTickerData {
+                    epoch: Epoch(i),
+                    epoch_hash: calc_static_epoch_hash(Epoch(i)),
+                    done_for_now: true
+                }))
+            );
+        }
+    }
+}

--- a/crates/epoch_oracles/src/lib.rs
+++ b/crates/epoch_oracles/src/lib.rs
@@ -3,7 +3,7 @@
 
 use tari_epoch_manager::epoch_event_oracle::{EpochEvent, EpochEventOracle};
 
-use crate::{configured::IntervalEpochTicker, store::EpochOracleStore};
+use crate::{configured::RealTimeEpochTicker, store::EpochOracleStore};
 
 #[cfg(feature = "base_layer")]
 pub mod base_layer;
@@ -15,7 +15,7 @@ pub mod store;
 pub enum EpochOracle<TStore> {
     #[cfg(feature = "base_layer")]
     BaseLayer(base_layer::BaseLayerOracle<TStore>),
-    Configured(configured::ConfiguredEpochOracle<TStore, IntervalEpochTicker>),
+    Configured(configured::ConfiguredEpochOracle<TStore, RealTimeEpochTicker>),
     #[cfg(feature = "base_layer")]
     Hybrid(hybrid::HybridEpochOracle<TStore>),
 }

--- a/crates/storage_sqlite/migrations/2022-06-20-091532_initial/up.sql
+++ b/crates/storage_sqlite/migrations/2022-06-20-091532_initial/up.sql
@@ -38,6 +38,8 @@ create table validator_nodes
     power                bigint                            not null
 );
 
+CREATE INDEX validator_nodes_address_index ON validator_nodes (address);
+
 CREATE TABLE committees
 (
     id                INTEGER PRIMARY KEY autoincrement NOT NULL,

--- a/crates/storage_sqlite/src/global/backend_adapter.rs
+++ b/crates/storage_sqlite/src/global/backend_adapter.rs
@@ -736,7 +736,13 @@ impl<TAddr: NodeAddressable> GlobalDbAdapter for SqliteGlobalDbAdapter<TAddr> {
             .inner_join(committees::table.on(validator_nodes::id.eq(committees::validator_node_id)))
             .select(validator_nodes::all_columns)
             .filter(committees::epoch.eq(epoch.as_u64() as i64))
-            .filter(validator_nodes::address.ne_all(excluding.into_iter().map(|a| a.to_string())))
+            .filter(
+                validator_nodes::address.ne_all(
+                    excluding
+                        .iter()
+                        .map(|a| serialize_json(a).expect("serialize address to json")),
+                ),
+            )
             .order_by(sql_random())
             .into_boxed();
 
@@ -748,9 +754,14 @@ impl<TAddr: NodeAddressable> GlobalDbAdapter for SqliteGlobalDbAdapter<TAddr> {
 
         let vn = query
             .first::<DbValidatorNode>(tx.connection())
+            .optional()
             .map_err(|source| SqliteStorageError::DieselError {
                 source,
                 operation: "get::validator_node",
+            })?
+            .ok_or(SqliteStorageError::NotFound {
+                item: "validator_node",
+                key: "random selection in validator_nodes_get_random_committee_member_from_shard_group".to_string(),
             })?;
 
         let vn = vn.try_into()?;

--- a/integration_tests/src/indexer.rs
+++ b/integration_tests/src/indexer.rs
@@ -24,10 +24,7 @@ use std::{path::PathBuf, time::Duration};
 
 use multiaddr::multiaddr;
 use reqwest::Url;
-use tari_common::{
-    configuration::{CommonConfig, StringList},
-    exit_codes::ExitError,
-};
+use tari_common::configuration::{CommonConfig, StringList};
 use tari_indexer::{
     config::{ApplicationConfig, IndexerConfig},
     run_indexer,
@@ -58,7 +55,7 @@ pub struct IndexerProcess {
     pub graphql_port: u16,
     pub base_node_grpc_port: u16,
     pub web_ui_port: u16,
-    pub handle: task::JoinHandle<Result<(), ExitError>>,
+    pub handle: task::JoinHandle<anyhow::Result<()>>,
     pub temp_dir_path: String,
     pub shutdown: Shutdown,
     pub db_path: PathBuf,

--- a/networking/core/src/config.rs
+++ b/networking/core/src/config.rs
@@ -29,7 +29,7 @@ impl Default for Config {
             ],
             reachability_mode: ReachabilityMode::default(),
             announce: false,
-            check_connections_interval: Duration::from_secs(2 * 60 * 60),
+            check_connections_interval: Duration::from_secs(2 * 60),
             known_local_public_address: vec![],
             rendezvous_namespace: "tari".to_string(),
             rendezvous_peer_limit: Some(1000),

--- a/networking/core/src/worker.rs
+++ b/networking/core/src/worker.rs
@@ -406,11 +406,18 @@ where
             info!(target: LOG_TARGET, "🥾 BOOTSTRAP: dialing {} seed peers", self.seed_peers.len());
             for (peer, addr) in self.seed_peers.drain(..) {
                 let opts = match peer {
-                    Some(peer) => DialOpts::peer_id(peer)
-                        .addresses(vec![addr])
-                        .condition(PeerCondition::DisconnectedAndNotDialing)
-                        .extend_addresses_through_behaviour()
-                        .build(),
+                    Some(peer) => {
+                        self.swarm
+                            .behaviour_mut()
+                            .peer_store
+                            .store_mut()
+                            .add_address(&peer, &addr);
+                        DialOpts::peer_id(peer)
+                            .addresses(vec![addr])
+                            .condition(PeerCondition::DisconnectedAndNotDialing)
+                            .extend_addresses_through_behaviour()
+                            .build()
+                    },
                     None => DialOpts::unknown_peer_id().address(addr).build(),
                 };
 
@@ -428,6 +435,13 @@ where
         if self.active_connections.len() < self.relays.num_possible_relays() {
             info!(target: LOG_TARGET, "🥾 BOOTSTRAP: dialing {} known relay peers", self.relays.num_possible_relays());
             for (peer, addrs) in self.relays.possible_relays() {
+                for addr in addrs {
+                    self.swarm
+                        .behaviour_mut()
+                        .peer_store
+                        .store_mut()
+                        .add_address(peer, addr);
+                }
                 self.swarm
                     .dial(
                         DialOpts::peer_id(*peer)


### PR DESCRIPTION
Description
---
fix!: real time epoch ticker, indexer fixes
fix: seed peers cli override
fix: exclusion query when fetching random validator member

Motivation and Context
---
Use an epoch ticker "synchronised" by the local clock. This allows multiple validators to be used when using the configured epoch oracle, without starting them at the same time.

How Has This Been Tested?
---
Manually, new unit test

What process can a PR reviewer use to test or verify this change?
---


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped version to 0.14.1.

* **Performance**
  * Added DB index for faster validator node address lookups.
  * Reduced network connection check interval to 2 minutes for more responsive monitoring.

* **Improvements**
  * Enhanced epoch oracle with real-time timing and initialization options.
  * More consistent, unified error reporting across the indexer and validator node.
  * Improved peer address caching during network bootstrap.
  * API error responses include a general-error helper and better debug control.
  * CLI: peer seed overrides now support namespaced keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->