### PR TITLE
fix(epoch-oracle/configured): catch up to initial epoch from base time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1840,7 +1840,7 @@ dependencies = [
 
 [[package]]
 name = "consensus_tests"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "fern",
  "futures 0.3.31",
@@ -2607,7 +2607,7 @@ dependencies = [
 
 [[package]]
 name = "db_inspector"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "axum 0.8.4",
@@ -3746,7 +3746,7 @@ checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 
 [[package]]
 name = "generate_ristretto_value_lookup"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "clap 3.2.25",
  "human_bytes",
@@ -4993,7 +4993,7 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "integration_tests"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "config",
@@ -5761,7 +5761,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-messaging"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "async-trait",
  "futures-bounded",
@@ -5940,7 +5940,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-substream"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "libp2p",
  "prometheus-client",
@@ -8466,7 +8466,7 @@ dependencies = [
 
 [[package]]
 name = "proto_builder"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "prost-build 0.14.1",
  "sha2",
@@ -10300,7 +10300,7 @@ dependencies = [
 
 [[package]]
 name = "sqlite_message_logger"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "chrono",
  "diesel",
@@ -10341,7 +10341,7 @@ checksum = "e7386b49cb287f6fafbfd3bd604914bccb99fb8d53483f40e1ecfda5d45f3370"
 
 [[package]]
 name = "state_store_tests"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "env_logger 0.11.8",
  "indexmap 2.11.4",
@@ -10730,7 +10730,7 @@ dependencies = [
 
 [[package]]
 name = "tari_base_node_client"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "log",
  "minotari_app_grpc",
@@ -10954,7 +10954,7 @@ dependencies = [
 
 [[package]]
 name = "tari_consensus"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "indexmap 2.11.4",
@@ -10978,7 +10978,7 @@ dependencies = [
 
 [[package]]
 name = "tari_consensus_types"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "borsh",
  "serde",
@@ -11080,7 +11080,7 @@ dependencies = [
 
 [[package]]
 name = "tari_engine"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "blake2",
  "cargo_toml 0.22.3",
@@ -11109,7 +11109,7 @@ dependencies = [
 
 [[package]]
 name = "tari_engine_types"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "base64 0.21.7",
  "bincode 2.0.1",
@@ -11136,7 +11136,7 @@ dependencies = [
 
 [[package]]
 name = "tari_epoch_manager"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "log",
@@ -11158,7 +11158,7 @@ dependencies = [
 
 [[package]]
 name = "tari_epoch_oracles"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "blake2",
@@ -11200,7 +11200,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -11264,7 +11264,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer_client"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "bounded-vec",
@@ -11294,7 +11294,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer_lib"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "log",
  "serde",
@@ -11370,7 +11370,7 @@ dependencies = [
 
 [[package]]
 name = "tari_networking"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11407,7 +11407,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_address"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "bech32",
  "bincode 2.0.1",
@@ -11423,7 +11423,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_app_utilities"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -11462,7 +11462,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_common_types"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "blake2",
  "borsh",
@@ -11490,7 +11490,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_p2p"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "prost 0.14.1",
@@ -11512,7 +11512,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_storage"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "bitflags 2.9.2",
@@ -11537,7 +11537,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_storage_sqlite"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "diesel",
  "diesel_migrations",
@@ -11557,7 +11557,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_cli"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -11586,7 +11586,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_crypto"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "argon2 0.5.3",
  "blake2",
@@ -11610,7 +11610,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_sdk"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "blake2",
@@ -11645,7 +11645,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_sdk_services"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -11670,7 +11670,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_storage_sqlite"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "bigdecimal",
  "diesel",
@@ -11694,7 +11694,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_walletd"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11779,7 +11779,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_framework"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "async-trait",
  "bitflags 2.9.2",
@@ -11803,7 +11803,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_macros"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11812,7 +11812,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_state_sync"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -11832,7 +11832,7 @@ dependencies = [
 
 [[package]]
 name = "tari_scaffolder"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "clap 3.2.25",
@@ -11904,7 +11904,7 @@ dependencies = [
 
 [[package]]
 name = "tari_signaling_server"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "axum 0.8.4",
@@ -11930,7 +11930,7 @@ dependencies = [
 
 [[package]]
 name = "tari_state_store_rocksdb"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -11956,7 +11956,7 @@ dependencies = [
 
 [[package]]
 name = "tari_state_tree"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "indexmap 2.11.4",
  "log",
@@ -11983,7 +11983,7 @@ dependencies = [
 
 [[package]]
 name = "tari_swarm"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "libp2p",
  "libp2p-messaging",
@@ -11993,7 +11993,7 @@ dependencies = [
 
 [[package]]
 name = "tari_swarm_daemon"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12049,7 +12049,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_builtin"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "tari_engine_types",
  "tari_template_lib",
@@ -12101,7 +12101,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_manager"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "bytes 1.10.1",
@@ -12167,7 +12167,7 @@ dependencies = [
 
 [[package]]
 name = "tari_transaction"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "borsh",
  "hex",
@@ -12255,7 +12255,7 @@ dependencies = [
 
 [[package]]
 name = "tari_transaction_manifest"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "proc-macro2",
  "serde_json",
@@ -12289,7 +12289,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "axum 0.8.4",
@@ -12351,7 +12351,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node_cli"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "clap 3.2.25",
@@ -12379,7 +12379,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node_client"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "indexmap 2.11.4",
  "multiaddr 0.18.1",
@@ -12402,7 +12402,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node_rpc"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "prost 0.14.1",
@@ -12424,7 +12424,7 @@ dependencies = [
 
 [[package]]
 name = "tari_wallet_daemon_client"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "reqwest 0.11.27",
  "serde",
@@ -12445,7 +12445,7 @@ dependencies = [
 
 [[package]]
 name = "tari_watcher"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "clap 3.2.25",
@@ -12473,7 +12473,7 @@ dependencies = [
 
 [[package]]
 name = "tariswap_bench"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "clap 4.5.48",
@@ -13132,7 +13132,7 @@ dependencies = [
 
 [[package]]
 name = "transaction_generator"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -13152,7 +13152,7 @@ dependencies = [
 
 [[package]]
 name = "transaction_submitter"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "clap 4.5.48",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 # NOTE: When editing this version, also edit the versions in template_built_in/templates/account and account_nft
 [workspace.package]
-version = "0.14.1"
+version = "0.14.2"
 edition = "2021"
 authors = ["The Tari Development Community"]
 repository = "https://github.com/tari-project/tari-ootle"

--- a/applications/tari_validator_node/src/p2p/rpc/service_impl.rs
+++ b/applications/tari_validator_node/src/p2p/rpc/service_impl.rs
@@ -340,7 +340,7 @@ impl<TStateStore: StateStore + Clone + Send + Sync + 'static> ValidatorNodeRpcSe
             .await
             .map_err(RpcStatus::log_internal_error(LOG_TARGET))?
         {
-            return Err(RpcStatus::general("Node is still scanning the base layer"));
+            return Err(RpcStatus::general("Node is still catching up to the epoch"));
         }
         let current_epoch = self
             .epoch_manager

--- a/crates/epoch_oracles/src/configured/real_time_ticker.rs
+++ b/crates/epoch_oracles/src/configured/real_time_ticker.rs
@@ -73,6 +73,17 @@ impl EpochTicker for RealTimeEpochTicker {
             }));
         }
 
+        if calculated_epoch > self.epoch {
+            let epoch = self.increment_epoch();
+            let epoch_hash = calc_static_epoch_hash(epoch);
+            return Poll::Ready(Some(EpochTickerData {
+                epoch,
+                epoch_hash,
+                // Catching up
+                done_for_now: false,
+            }));
+        }
+
         if let Some(interval_mut) = self.interval.as_mut() {
             loop {
                 ready!(interval_mut.poll_tick(cx));
@@ -123,6 +134,25 @@ mod tests {
                     epoch: Epoch(i),
                     epoch_hash: calc_static_epoch_hash(Epoch(i)),
                     done_for_now: true
+                }))
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn it_catches_up_to_current_epoch() {
+        let base_time = time::OffsetDateTime::now_utc() - time::Duration::seconds(1000);
+        let mut ticker =
+            RealTimeEpochTicker::new(Epoch(500), base_time, Epoch(5)).with_epoch_time_secs(1.try_into().unwrap());
+
+        for i in 5..1002 {
+            let res = timeout(Duration::from_secs(10), poll_fn(|cx| ticker.poll_tick(cx))).await;
+            assert_eq!(
+                res,
+                Ok(Some(EpochTickerData {
+                    epoch: Epoch(i),
+                    epoch_hash: calc_static_epoch_hash(Epoch(i)),
+                    done_for_now: i >= 1000
                 }))
             );
         }


### PR DESCRIPTION
Description
---
fix(epoch-oracle/configured): catch up to initial epoch from base time

Motivation and Context
---
Emit epoch ticks with done_for_now = false until the epoch reaches the current time.

This prevents consensus kicking in prematurely

How Has This Been Tested?
---
New unit test

What process can a PR reviewer use to test or verify this change?
---


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify