### PR TITLE
fix(wallet/webui): default private/confidential in send checkbox

### DIFF
--- a/applications/tari_walletd/web_ui/src/routes/AssetVault/Tokens/components/SendMoney.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/AssetVault/Tokens/components/SendMoney.tsx
@@ -55,7 +55,7 @@ export interface SendMoneyDialogProps {
 export function SendMoneyDialog(props: SendMoneyDialogProps) {
   const INITIAL_VALUES: SendMoneyFormState = {
     address: "",
-    outputToConfidential: false,
+    outputToRevealed: false,
     inputSelection: "PreferRevealed",
     amount: "",
     fee: "",
@@ -201,7 +201,7 @@ export function SendMoneyDialog(props: SendMoneyDialogProps) {
         resource_address: props.resource_address || XTR,
         destination_address: transferFormState.address,
         resourceType: props.resource_type,
-        output_to_revealed: !transferFormState.outputToConfidential,
+        output_to_revealed: transferFormState.outputToRevealed,
         input_selection: transferFormState.inputSelection as UtxoInputSelection,
         badge_usage: transferFormState.badge ? { Resource: transferFormState.badge } : ("None" as BadgeUsage),
         output_memo: transferFormState.memo ? { Message: transferFormState.memo } : undefined,
@@ -276,7 +276,7 @@ export function SendMoneyDialog(props: SendMoneyDialogProps) {
         resource_address: props.resource_address!,
         destination_address: transferFormState.address,
         resourceType: props.resource_type,
-        output_to_revealed: !transferFormState.outputToConfidential,
+        output_to_revealed: transferFormState.outputToRevealed,
         input_selection: transferFormState.inputSelection as UtxoInputSelection,
         // TODO: support for other types of BadgeUsage
         badge_usage: transferFormState.badge ? { Resource: transferFormState.badge } : ("None" as BadgeUsage),

--- a/applications/tari_walletd/web_ui/src/routes/AssetVault/Tokens/steps/ConfirmationStep.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/AssetVault/Tokens/steps/ConfirmationStep.tsx
@@ -93,7 +93,7 @@ export default function ConfirmationStep({
             <Typography variant="subtitle2" color="text.secondary">
               Send Confidential Outputs:
             </Typography>
-            <Typography variant="body1">{transferFormState.outputToConfidential ? "Yes" : "No"}</Typography>
+            <Typography variant="body1">{transferFormState.outputToRevealed ? "Yes" : "No"}</Typography>
           </Box>
         )}
 

--- a/applications/tari_walletd/web_ui/src/routes/AssetVault/Tokens/steps/FormStep.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/AssetVault/Tokens/steps/FormStep.tsx
@@ -36,7 +36,7 @@ import { XTR_CURRENCY } from "@utils/constants";
 
 export interface SendMoneyFormState {
   address: string;
-  outputToConfidential: boolean;
+  outputToRevealed: boolean;
   inputSelection: string;
   amount: string;
   fee: string;
@@ -175,15 +175,21 @@ export default function FormStep({
             <FormControlLabel
               control={
                 <CheckBox
-                  name="outputToConfidential"
-                  checked={transferFormState.outputToConfidential}
+                  name="outputToRevealed"
+                  checked={transferFormState.outputToRevealed}
                   onChange={onCheckboxFormValueChange}
                   disabled={disabled}
                 />
               }
-              label="Send Confidential Outputs"
+              label="Send Revealed Funds"
             />
-            {transferFormState.outputToConfidential ? (
+            {transferFormState.outputToRevealed && (
+              <Typography color="warning.main">
+                ⚠️ Warning: Revealed funds are visible on the blockchain and can be viewed by anyone.
+              </Typography>
+            )}
+
+            {transferFormState.outputToRevealed ? null : (
               <TextField
                 name="memo"
                 label="Memo message (optional, max 253 characters)"
@@ -193,7 +199,7 @@ export default function FormStep({
                 style={{ flexGrow: 1 }}
                 disabled={disabled}
               />
-            ) : null}
+            )}
             <InputLabel id="select-input-selection">Input Selection</InputLabel>
             <Select
               name="inputSelection"


### PR DESCRIPTION
Description
---
fix(wallet/webui): default private/confidential in send checkbox

Motivation and Context
---
Now the user will have to check the box to send revealed funds, rather than the other way round.

<img width="802" height="198" alt="image" src="https://github.com/user-attachments/assets/181ca57d-5aaa-47c2-9b17-aa12a6b6ac76" />

How Has This Been Tested?
---

What process can a PR reviewer use to test or verify this change?
---


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced form labels for improved clarity in the send funds interface.
  * Refined memo field visibility based on transfer type selection.
  * Improved form state consistency.

* **New Features**
  * Added warning notification when selecting revealed fund transfers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->