### PR TITLE
feat: swarm is able to start only wallets

### DIFF
--- a/applications/tari_swarm_daemon/src/process_definitions/wallet_daemon.rs
+++ b/applications/tari_swarm_daemon/src/process_definitions/wallet_daemon.rs
@@ -11,6 +11,7 @@ use crate::process_definitions::{ProcessContext, ProcessDefinition};
 
 pub const WALLET_DAEMON_AUTH_SETTINGS_KEY: &str = "wallet_daemon_auth";
 pub const WALLET_DAEMON_SEED_WORDS_SETTINGS_KEY: &str = "wallet_daemon_seed_words";
+pub const WALLET_DAEMON_INDEXER_URL_SETTINGS_KEY: &str = "indexer_url";
 pub const OVERRIDE_KEYRING_PASSWORD_SETTINGS_KEY: &str = "override_keyring_password";
 const ARGS_SETTINGS_KEY: &str = "args";
 const WALLET_DAEMON_AUTH_DEFAULT: &str = "none";
@@ -36,18 +37,24 @@ impl ProcessDefinition for WalletDaemon {
         let json_rpc_address = format!("{listen_ip}:{jrpc_port}");
         let web_ui_address = format!("{listen_ip}:{web_ui_port}");
 
-        let indexer = context
-            .indexers()
-            .next()
-            .ok_or_else(|| anyhow!("Indexer should be started before wallet daemon"))?;
-        let indexer_url = format!(
-            "http://127.0.0.1:{}",
-            indexer
-                .instance()
-                .allocated_ports()
-                .get("api")
-                .ok_or_else(|| anyhow!("Indexer api port not found"))?
-        );
+        let indexer_url = context
+            .get_setting(WALLET_DAEMON_INDEXER_URL_SETTINGS_KEY)
+            .map(|s| s.to_string())
+            .map(anyhow::Ok)
+            .unwrap_or_else(|| {
+                let indexer = context
+                    .indexers()
+                    .next()
+                    .ok_or_else(|| anyhow!("Indexer should be started before wallet daemon"))?;
+                Ok(format!(
+                    "http://127.0.0.1:{}",
+                    indexer
+                        .instance()
+                        .allocated_ports()
+                        .get("api")
+                        .ok_or_else(|| anyhow!("Indexer api port not found"))?
+                ))
+            })?;
 
         let auth = context
             .get_setting(WALLET_DAEMON_AUTH_SETTINGS_KEY)

--- a/applications/tari_swarm_daemon/src/process_manager/manager.rs
+++ b/applications/tari_swarm_daemon/src/process_manager/manager.rs
@@ -136,8 +136,22 @@ impl ProcessManager {
 
     async fn register_nodes_and_templates_as_required(
         &mut self,
-        layer_one_transaction_service: &mut LayerOneTransactionService,
+        layer_one_transaction_service: Option<&mut LayerOneTransactionService>,
     ) -> anyhow::Result<()> {
+        if self.skip_registration {
+            return Ok(());
+        }
+
+        let layer_one_transaction_service = match layer_one_transaction_service {
+            Some(service) => service,
+            None => {
+                return Err(anyhow!(
+                    "No MinotariConsoleWallet available. Please start a wallet before registering validator nodes and \
+                     templates or use --skip-registration flag to skip this.",
+                ))
+            },
+        };
+
         // Add the watchers
         for vn in self.instance_manager.validator_nodes() {
             let l1_tx_path = vn.layer_one_transaction_path();
@@ -145,9 +159,6 @@ impl ProcessManager {
             layer_one_transaction_service.add_watch(l1_tx_path);
         }
 
-        if self.skip_registration {
-            return Ok(());
-        }
         let mut templates_to_register = vec![];
         if !self.disable_template_auto_register {
             let registered_templates = self.registered_templates().await?;
@@ -349,8 +360,6 @@ impl ProcessManager {
             }
         }
 
-        let mut layer_one_transaction_service = self.create_layer_one_transaction_service().await?;
-
         if self.enable_manual_connect {
             {
                 info!("Connecting all validator nodes manually");
@@ -367,8 +376,10 @@ impl ProcessManager {
             }
         }
 
+        let mut layer_one_transaction_service = self.create_layer_one_transaction_service().await?;
+
         {
-            let fut = pin!(self.register_nodes_and_templates_as_required(&mut layer_one_transaction_service));
+            let fut = pin!(self.register_nodes_and_templates_as_required(layer_one_transaction_service.as_mut()));
             match shutdown_signal.clone().select(fut).await {
                 Either::Left(_) => {
                     info!("Shutting down process manager");
@@ -388,13 +399,13 @@ impl ProcessManager {
         loop {
             tokio::select! {
                 Some(req) = self.rx_request.recv() => {
-                    if let Err(err) = self.handle_request(req, &mut layer_one_transaction_service).await {
+                    if let Err(err) = self.handle_request(req, layer_one_transaction_service.as_mut()).await {
                         log::error!("Error handling request: {:?}", err);
                     }
                 },
 
                 _ = interval.tick() => {
-                    if let Err(err) = self.on_tick(&mut layer_one_transaction_service).await {
+                    if let Err(err) = self.on_tick(layer_one_transaction_service.as_mut()).await {
                         log::error!("(on_tick) Error: {:?}", err);
                     }
                 },
@@ -409,8 +420,16 @@ impl ProcessManager {
         Ok(())
     }
 
-    async fn on_tick(&mut self, layer_one_transaction_service: &mut LayerOneTransactionService) -> anyhow::Result<()> {
+    async fn on_tick(
+        &mut self,
+        layer_one_transaction_service: Option<&mut LayerOneTransactionService>,
+    ) -> anyhow::Result<()> {
         self.clear_terminated_instances()?;
+
+        let Some(layer_one_transaction_service) = layer_one_transaction_service else {
+            debug!("🫙 No MinotariConsoleWallet available. Skipping layer one transaction processing");
+            return Ok(());
+        };
 
         // Check for layer one transactions
         let processed = layer_one_transaction_service.process_any().await?;
@@ -428,22 +447,22 @@ impl ProcessManager {
         Ok(())
     }
 
-    async fn create_layer_one_transaction_service(&self) -> anyhow::Result<LayerOneTransactionService> {
-        let wallet = self
-            .instance_manager
-            .minotari_wallets()
-            .next()
-            .ok_or_else(|| anyhow!("No MinoTariConsoleWallet instances found"))?;
+    async fn create_layer_one_transaction_service(&self) -> anyhow::Result<Option<LayerOneTransactionService>> {
+        let wallet = self.instance_manager.minotari_wallets().next();
+        let Some(wallet) = wallet else {
+            return Ok(None);
+        };
+
         let client = wallet.connect_client().await?;
         let service = LayerOneTransactionService::init(client)?;
-        Ok(service)
+        Ok(Some(service))
     }
 
     #[allow(clippy::too_many_lines)]
     async fn handle_request(
         &mut self,
         req: ProcessManagerRequest,
-        layer_one_transaction_service: &mut LayerOneTransactionService,
+        layer_one_transaction_service: Option<&mut LayerOneTransactionService>,
     ) -> anyhow::Result<()> {
         use ProcessManagerRequest::*;
         match req {
@@ -542,6 +561,18 @@ impl ProcessManager {
                 }
             },
             RegisterValidatorNode { instance_id, reply } => {
+                let Some(layer_one_transaction_service) = layer_one_transaction_service else {
+                    if reply
+                        .send(Err(anyhow!(
+                            "No MinotariConsoleWallet available. Please start a wallet before registering validator \
+                             nodes",
+                        )))
+                        .is_err()
+                    {
+                        log::warn!("Request cancelled before response could be sent")
+                    }
+                    return Ok(());
+                };
                 let result = self
                     .register_validator_node(instance_id, layer_one_transaction_service)
                     .await;

--- a/utilities/traffic-sim/src/config.rs
+++ b/utilities/traffic-sim/src/config.rs
@@ -1,0 +1,16 @@
+//   Copyright 2025 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+use reqwest::Url;
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub struct Config {
+    pub exchange_wallet_url: String,
+    pub wallets: Vec<WalletConfig>,
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub struct WalletConfig {
+    pub name: String,
+    pub url: Url,
+}

--- a/utilities/traffic-sim/src/main.rs
+++ b/utilities/traffic-sim/src/main.rs
@@ -2,6 +2,7 @@
 //   SPDX-License-Identifier: BSD-3-Clause
 
 mod coin;
+mod config;
 mod sim;
 
 use std::path::{Path, PathBuf};
@@ -12,27 +13,18 @@ use log::LevelFilter;
 use tari_ootle_common_types::engine_types::published_template::PublishedTemplateAddress;
 use tari_template_lib::models::{ResourceAddress, UtxoId};
 
-use crate::sim::TrafficSim;
+use crate::{
+    coin::Coin,
+    config::{Config, WalletConfig},
+    sim::TrafficSim,
+};
 
 #[derive(Parser)]
 #[command(name = "traffic-sim")]
 #[command(about = "A CLI tool for simulating traffic between wallets in a swarm")]
 struct Cli {
-    #[arg(
-        long,
-        default_value = "http://localhost:8080/json_rpc",
-        help = "URL of the swarm API"
-    )]
-    swarm_url: String,
-
-    #[arg(
-        short = 'x',
-        long,
-        default_value = "http://localhost:9000/json_rpc",
-        help = "URL of the exchange wallet API"
-    )]
-    exchange_wallet_url: String,
-
+    #[arg(short = 'c', long, default_value = "./config.json", help = "URL of the swarm API")]
+    config: PathBuf,
     #[command(subcommand)]
     command: Commands,
 }
@@ -92,8 +84,28 @@ enum Commands {
         #[arg(long, alias = "csv", help = "Path to output CSV file with results")]
         csv_output: Option<PathBuf>,
     },
+    #[command(alias = "swarm-config")]
+    GenerateConfigFromSwarm {
+        #[arg(
+            long,
+            default_value = "http://localhost:8080/json_rpc",
+            help = "URL of the swarm API"
+        )]
+        swarm_url: String,
+
+        #[arg(
+            short = 'x',
+            long,
+            default_value = "http://localhost:9000/json_rpc",
+            help = "URL of the exchange wallet API"
+        )]
+        exchange_wallet_url: String,
+        #[arg(short = 'o', long, help = "Output path for the generated config file")]
+        output: PathBuf,
+    },
 }
 
+#[allow(clippy::too_many_lines)]
 #[tokio::main]
 async fn main() -> Result<()> {
     env_logger::builder().filter_level(LevelFilter::Info).init();
@@ -109,9 +121,10 @@ async fn main() -> Result<()> {
             if min_value >= max_value {
                 return Err(anyhow::anyhow!("min-value must be less than max-value"));
             }
-            let coin = coin_file.as_ref().map(read_coin_file).transpose()?;
+            let config = read_json_file::<Config, _>(cli.config)?;
+            let coin = coin_file.as_ref().map(read_json_file::<Coin, _>).transpose()?;
 
-            let mut sim = TrafficSim::new(cli.swarm_url, cli.exchange_wallet_url);
+            let mut sim = TrafficSim::new(config);
             let resource_address = coin
                 .as_ref()
                 .map(|c| c.resource_address)
@@ -125,19 +138,23 @@ async fn main() -> Result<()> {
             template_address,
             coin_file,
         } => {
-            let mut sim = TrafficSim::new(cli.swarm_url, cli.exchange_wallet_url);
+            let config = read_json_file::<Config, _>(cli.config)?;
+            let mut sim = TrafficSim::new(config);
             sim.setup_stablecoin(template_address, coin_file).await?;
         },
         Commands::Setup { coin_file } => {
-            let coin = read_coin_file(coin_file)?;
-            let mut sim = TrafficSim::new(cli.swarm_url, cli.exchange_wallet_url);
+            let config = read_json_file::<Config, _>(cli.config)?;
+            let coin = read_json_file::<Coin, _>(coin_file)?;
+
+            let mut sim = TrafficSim::new(config);
             sim.connect_to_wallets().await?;
             sim.setup_accounts().await?;
             sim.setup_wallet_funds(coin.component_address, coin.resource_address, coin.admin_badge)
                 .await?;
         },
         Commands::ListWallets => {
-            let mut sim = TrafficSim::new(cli.swarm_url, cli.exchange_wallet_url);
+            let config = read_json_file::<Config, _>(cli.config)?;
+            let mut sim = TrafficSim::new(config);
             sim.connect_to_wallets().await?;
             if sim.wallets().is_empty() {
                 println!("No wallets found in swarm");
@@ -157,7 +174,8 @@ async fn main() -> Result<()> {
             specific_id,
             csv_output,
         } => {
-            let mut sim = TrafficSim::new(cli.swarm_url, cli.exchange_wallet_url);
+            let config = read_json_file::<Config, _>(cli.config)?;
+            let mut sim = TrafficSim::new(config);
             sim.decrypt_utxos(
                 min_value,
                 max_value,
@@ -174,13 +192,34 @@ async fn main() -> Result<()> {
             )
             .await?;
         },
+        Commands::GenerateConfigFromSwarm {
+            swarm_url,
+            exchange_wallet_url,
+            output,
+        } => {
+            let wallets = TrafficSim::get_wallets_from_swarm(&swarm_url).await?;
+            let config = Config {
+                exchange_wallet_url,
+                wallets: wallets
+                    .iter()
+                    .map(|w| WalletConfig {
+                        name: w.name.clone(),
+                        url: w.client.endpoint().clone(),
+                    })
+                    .collect(),
+            };
+
+            let file = std::fs::File::create(&output).context("Failed to create config file")?;
+            serde_json::to_writer_pretty(file, &config).context("Failed to write config file")?;
+            println!("Config file written to {}", output.display());
+        },
     }
 
     Ok(())
 }
 
-fn read_coin_file<P: AsRef<Path>>(path: P) -> Result<coin::Coin> {
-    let file = std::fs::File::open(path).context("Failed to open coin file")?;
-    let coin = serde_json::from_reader(file).context("Failed to parse coin file")?;
-    Ok(coin)
+fn read_json_file<T: serde::de::DeserializeOwned, P: AsRef<Path>>(path: P) -> Result<T> {
+    let file = std::fs::File::open(path).context("Failed to open JSON file")?;
+    let data = serde_json::from_reader(file).context("Failed to parse json file")?;
+    Ok(data)
 }

--- a/utilities/traffic-sim/src/sim.rs
+++ b/utilities/traffic-sim/src/sim.rs
@@ -50,7 +50,7 @@ use tari_wallet_daemon_client::{
 };
 use tokio::time::sleep;
 
-use crate::coin::Coin;
+use crate::{coin::Coin, config::Config};
 
 pub struct Wallet {
     pub name: String,
@@ -85,17 +85,15 @@ impl Wallet {
 }
 
 pub struct TrafficSim {
-    swarm_url: String,
-    exchange_wallet_url: String,
+    config: Config,
     wallets: Vec<Wallet>,
     accounts: Vec<AccountWithAddress>,
 }
 
 impl TrafficSim {
-    pub fn new(swarm_url: String, exchange_wallet_url: String) -> Self {
+    pub fn new(config: Config) -> Self {
         Self {
-            swarm_url,
-            exchange_wallet_url,
+            config,
             wallets: Vec::new(),
             accounts: Vec::new(),
         }
@@ -106,7 +104,7 @@ impl TrafficSim {
     }
 
     pub async fn connect_exchange_wallet(&self) -> anyhow::Result<Wallet> {
-        Wallet::connect("Exchange".to_string(), &self.exchange_wallet_url).await
+        Wallet::connect("Exchange".to_string(), &self.config.exchange_wallet_url).await
     }
 
     pub async fn connect_indexer_client(
@@ -123,6 +121,14 @@ impl TrafficSim {
     }
 
     pub async fn connect_to_wallets(&mut self) -> anyhow::Result<()> {
+        for wallet in &self.config.wallets {
+            let wallet = Wallet::connect(wallet.name.clone(), wallet.url.as_str()).await?;
+            self.wallets.push(wallet);
+        }
+        Ok(())
+    }
+
+    pub async fn get_wallets_from_swarm(swarm_url: &str) -> anyhow::Result<Vec<Wallet>> {
         #[derive(Debug, Clone, serde::Deserialize)]
         pub struct InstanceInfo {
             #[allow(dead_code)]
@@ -144,7 +150,7 @@ impl TrafficSim {
         }
 
         let response = Client::new()
-            .post(&self.swarm_url)
+            .post(swarm_url)
             .json(&json!({
                 "jsonrpc": "2.0",
                 "method": "list_instances",
@@ -169,12 +175,13 @@ impl TrafficSim {
             Some((instance.name, format!("http://localhost:{}/json_rpc", rpc_port)))
         });
 
+        let mut wallets = vec![];
         for (name, addr) in addrs {
             let wallet = Wallet::connect(name, &addr).await?;
-            self.wallets.push(wallet);
+            wallets.push(wallet);
         }
 
-        Ok(())
+        Ok(wallets)
     }
 
     pub async fn send_random_transaction(
@@ -523,7 +530,6 @@ impl TrafficSim {
         min_value: u64,
         max_value: u64,
     ) -> anyhow::Result<()> {
-        log::info!("Fetching wallets from swarm at: {}", self.swarm_url);
         self.connect_to_wallets().await?;
         self.setup_accounts().await?;
 


### PR DESCRIPTION
Description
---
feat: swarm is able to start only wallets
feat: add swarm setting to configure wallets indexer_url

Motivation and Context
---
Swarm previously required at least one console wallet to work. THis PR removes this requirement, so that we can start many L2 wallets only for spam testing.

How Has This Been Tested?
---
Manually

What process can a PR reviewer use to test or verify this change?
---


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Traffic-sim now uses configuration files instead of direct CLI parameters for setup
  * Added `GenerateConfigFromSwarm` command to automatically generate configuration files from swarm data
  * Wallet daemon indexer URL is now configurable via settings with automatic discovery fallback

* **Changes**
  * Process manager updated to support optional wallet service handling with improved error management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->