### PR TITLE
feat: health check endpoints for vn and indexer

### DIFF
--- a/applications/tari_indexer/src/rest_api/handlers/misc.rs
+++ b/applications/tari_indexer/src/rest_api/handlers/misc.rs
@@ -1,7 +1,12 @@
 //   Copyright 2025 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use axum::{response::Response, Extension, Json};
+use axum::{
+    response::{IntoResponse, Response},
+    Extension,
+    Json,
+};
+use serde_json::json;
 use tari_epoch_manager::EpochManagerReader;
 use tari_epoch_oracles::store::StoreKey;
 use tari_indexer_client::{
@@ -81,4 +86,47 @@ pub async fn get_epoch_manager_stats(
         current_block_hash: current_epoch_hash,
     };
     Ok(Json(response))
+}
+
+#[utoipa::path(get, path = "/health", description = "Health check")]
+pub async fn health(Extension(context): Extension<HandlerContext>) -> impl IntoResponse {
+    let current_epoch = context.epoch_manager().get_current_epoch();
+    let epoch_manager_ok = !context.epoch_manager().is_closed();
+    let network_ok = !context.networking().is_closed();
+    let db_ok = context
+        .global_db()
+        .with_read_tx(|tx| tx.execute_sql("SELECT 1"))
+        .is_ok();
+    let status = if epoch_manager_ok && network_ok && db_ok {
+        "ok"
+    } else {
+        "error"
+    };
+
+    let is_ok = epoch_manager_ok && network_ok && db_ok;
+
+    let body = json!({
+        "status": status,
+        "current_epoch": current_epoch.as_u64(),
+        "epoch_manager_ok": epoch_manager_ok,
+        "network_ok": network_ok,
+        "db_ok": db_ok,
+    });
+
+    if is_ok {
+        (axum::http::StatusCode::OK, Json(body)).into_response()
+    } else {
+        (axum::http::StatusCode::SERVICE_UNAVAILABLE, Json(body)).into_response()
+    }
+}
+
+#[utoipa::path(get, path = "/ready", description = "Indexer readiness check")]
+pub async fn ready(Extension(context): Extension<HandlerContext>) -> HandlerResult<Json<serde_json::Value>> {
+    match context.epoch_manager().is_initial_scanning_complete().await {
+        Ok(true) => Ok(Json(json!({}))),
+        Ok(false) => Err(ErrorResponse::service_unavailable(
+            "Indexer is still scanning".to_string(),
+        )),
+        Err(e) => Err(ErrorResponse::anyhow(e)),
+    }
 }

--- a/applications/tari_indexer/src/rest_api/server.rs
+++ b/applications/tari_indexer/src/rest_api/server.rs
@@ -60,6 +60,8 @@ impl Server {
         let context = HandlerContext::from_services(services);
 
         let router = Router::new()
+            .route("/health", get(handlers::misc::health))
+            .route("/ready", get(handlers::misc::ready))
             .route("/identity", get(handlers::misc::get_identity))
             .route("/wait-until-ready", get(handlers::misc::wait_until_ready))
             .route("/epoch-manager/stats", get(handlers::misc::get_epoch_manager_stats))

--- a/applications/tari_validator_node/src/json_rpc/handlers.rs
+++ b/applications/tari_validator_node/src/json_rpc/handlers.rs
@@ -31,6 +31,7 @@ use log::*;
 use serde_json::{self as json, json};
 use tari_base_node_client::types::BaseLayerValidatorNode;
 use tari_common_types::types::CompressedPublicKey;
+use tari_consensus::hotstuff::ConsensusCurrentState;
 use tari_consensus_types::{Decision, LeafBlock};
 use tari_crypto::{ristretto::RistrettoPublicKey, tari_utilities::ByteArray};
 use tari_engine_types::{ConvertFromByteType, ToByteType};
@@ -153,6 +154,14 @@ impl JsonRpcHandlers {
 
     pub fn sidechain_id(&self) -> Option<&RistrettoPublicKey> {
         self.config.validator_node.validator_node_sidechain_id.as_ref()
+    }
+
+    pub fn networking_is_active(&self) -> bool {
+        !self.networking.is_closed()
+    }
+
+    pub fn consensus_status(&self) -> ConsensusCurrentState {
+        self.consensus.get_current_state()
     }
 }
 

--- a/applications/tari_validator_node/src/json_rpc/server.rs
+++ b/applications/tari_validator_node/src/json_rpc/server.rs
@@ -22,9 +22,17 @@
 
 use std::{future::IntoFuture, net::SocketAddr, sync::Arc};
 
-use axum::{extract::Extension, routing::post, Router};
+use axum::{
+    extract::Extension,
+    response::IntoResponse,
+    routing::{get, post},
+    Json,
+    Router,
+};
 use axum_jrpc::{error::JsonRpcErrorReason, JrpcResult, JsonRpcAnswer, JsonRpcExtractor};
 use log::*;
+use serde_json::json;
+use tari_consensus::hotstuff::ConsensusCurrentState;
 use tari_ootle_app_utilities::tcp::try_bind_with_fallback;
 use tower_http::cors::CorsLayer;
 
@@ -39,7 +47,8 @@ pub async fn spawn_json_rpc(
 ) -> Result<SocketAddr, anyhow::Error> {
     let router = Router::new()
         .route("/", post(handler))
-        .route("/json_rpc", post(handler));
+        .route("/json_rpc", post(handler))
+        .route("/health", get(health_check));
     #[cfg(feature = "metrics")]
     let router = router.route(
         "/_metrics",
@@ -114,4 +123,29 @@ async fn handler(Extension(handlers): Extension<Arc<JsonRpcHandlers>>, value: Js
         }
     }
     result
+}
+
+async fn health_check(Extension(handlers): Extension<Arc<JsonRpcHandlers>>) -> impl IntoResponse {
+    let is_net_ok = handlers.networking_is_active();
+    let status = handlers.consensus_status();
+    let is_ok = is_net_ok &&
+        matches!(
+            status,
+            ConsensusCurrentState::Idle |
+                ConsensusCurrentState::Running |
+                ConsensusCurrentState::Syncing |
+                ConsensusCurrentState::CheckSync
+        );
+
+    let body = json!({
+        "status": if is_ok { "ok" } else { "error" },
+        "networking_ok": is_net_ok,
+        "consensus_status": status,
+    });
+
+    if is_ok {
+        (axum::http::StatusCode::OK, Json(body)).into_response()
+    } else {
+        (axum::http::StatusCode::SERVICE_UNAVAILABLE, Json(body)).into_response()
+    }
 }

--- a/crates/epoch_manager/src/service/handle.rs
+++ b/crates/epoch_manager/src/service/handle.rs
@@ -72,6 +72,10 @@ impl<TAddr: NodeAddressable> EpochManagerHandle<TAddr> {
         Epoch(self.current_epoch.load(std::sync::atomic::Ordering::SeqCst))
     }
 
+    pub fn is_closed(&self) -> bool {
+        self.tx_request.is_closed()
+    }
+
     pub async fn get_network_description(&self) -> Result<NetworkDescription, EpochManagerError> {
         let (tx, rx) = oneshot::channel();
         self.tx_request

--- a/networking/core/src/handle.rs
+++ b/networking/core/src/handle.rs
@@ -184,6 +184,10 @@ impl<TMsg: MessageSpec> NetworkingHandle<TMsg> {
         }
     }
 
+    pub fn is_closed(&self) -> bool {
+        self.tx_request.is_closed()
+    }
+
     pub fn subscribe_events(&self) -> broadcast::Receiver<NetworkingEvent> {
         self.tx_events
             .upgrade()


### PR DESCRIPTION
Description
---
feat: health check endpoints for vn and indexer


Motivation and Context
---
`GET /health` for validator and indexer 
`GET /ready` for indexer (returns 503 SERVICE UNAVAILABLE if not ready)

How Has This Been Tested?
---
Manually

What process can a PR reviewer use to test or verify this change?
---


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added health check endpoints for both indexer and validator node services, providing real-time visibility into system health including networking, consensus state, and database connectivity.
  * Added readiness endpoint for the indexer to confirm initial data scanning completion and system readiness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->