### PR TITLE
fix(indexer): put substate cache in data dir

### DIFF
--- a/applications/tari_app_utilities/config_presets/c_validator_node.toml
+++ b/applications/tari_app_utilities/config_presets/c_validator_node.toml
@@ -9,10 +9,6 @@
 # A path to the file that stores your node identity and secret key (default = "validator_node_id.json")
 #identity_file = "validator_node_id.json"
 
-# A path to the file that stores the tor hidden service private key, if using the tor transport
-# (default = "validator_node_tor_id.json")
-#tor_identity_file = "validator_node_tor_id.json"
-
 # The node's publicly-accessible hostname. This is the host name that is advertised on the network so that
 # peers can find you.
 # _NOTE_: If using the `tor` transport type, public_address will be ignored and an onion address will be

--- a/applications/tari_app_utilities/config_presets/d_indexer.toml
+++ b/applications/tari_app_utilities/config_presets/d_indexer.toml
@@ -9,10 +9,6 @@
 # A path to the file that stores your node identity and secret key (default = "indexer_id.json")
 #identity_file = "indexer_id.json"
 
-# A path to the file that stores the tor hidden service private key, if using the tor transport
-# (default = "indexer_tor_id.json")
-#tor_identity_file = "indexer_tor_id.json"
-
 # The node's publicly-accessible hostname. This is the host name that is advertised on the network so that
 # peers can find you.
 # _NOTE_: If using the `tor` transport type, public_address will be ignored and an onion address will be

--- a/applications/tari_indexer/src/bootstrap.rs
+++ b/applications/tari_indexer/src/bootstrap.rs
@@ -153,7 +153,7 @@ pub async fn spawn_services(
         .spawn(shutdown.clone())?;
 
     // Connect to substate db
-    let store = SqliteIndexerStore::try_create(config.indexer.state_db_path())?;
+    let store = SqliteIndexerStore::try_create(config.state_db_path())?;
     check_store(config, &store)?;
 
     // Epoch event oracle
@@ -211,7 +211,7 @@ pub async fn spawn_services(
     )
     .spawn(shutdown.clone());
 
-    let substate_cache_dir = config.common.base_path.join("substate_cache");
+    let substate_cache_dir = config.to_data_dir().join("substate_cache");
     let substate_cache = SubstateFileCache::new(substate_cache_dir).context("Failed to create substate cache")?;
 
     let substate_scanner = SubstateScanner::new(
@@ -267,12 +267,12 @@ pub struct Services {
 }
 
 fn ensure_directories_exist(config: &ApplicationConfig) -> io::Result<()> {
-    fs::create_dir_all(&config.indexer.data_dir)?;
+    fs::create_dir_all(config.to_data_dir())?;
     Ok(())
 }
 
 fn save_identities(config: &ApplicationConfig, identity: &RistrettoKeypair) -> anyhow::Result<()> {
-    identity_management::save_as_json(&config.indexer.identity_file, identity)
+    identity_management::save_as_json(config.to_identity_file_path(), identity)
         .context("Failed to save indexer identity")?;
 
     Ok(())

--- a/applications/tari_indexer/src/config.rs
+++ b/applications/tari_indexer/src/config.rs
@@ -20,11 +20,7 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::{
-    net::SocketAddr,
-    path::{Path, PathBuf},
-    time::Duration,
-};
+use std::{net::SocketAddr, path::PathBuf, time::Duration};
 
 use config::Config;
 use serde::{Deserialize, Serialize};
@@ -55,15 +51,34 @@ pub struct ApplicationConfig {
 
 impl ApplicationConfig {
     pub fn load_from(cfg: &Config) -> Result<Self, ConfigurationError> {
-        let mut config = Self {
+        let config = Self {
             common: CommonConfig::load_from(cfg)?,
             indexer: IndexerConfig::load_from(cfg)?,
             peer_seeds: PeerSeedsConfig::load_from(cfg)?,
             epoch_oracle: EpochOracleConfig::load_from(cfg)?,
             network: cfg.get("network")?,
         };
-        config.indexer.set_base_path(config.common.base_path());
         Ok(config)
+    }
+
+    pub fn to_identity_file_path(&self) -> PathBuf {
+        if self.indexer.identity_file.is_absolute() {
+            return self.indexer.identity_file.clone();
+        }
+
+        self.common.base_path.join(&self.indexer.identity_file)
+    }
+
+    pub fn to_data_dir(&self) -> PathBuf {
+        if self.indexer.data_dir.is_absolute() {
+            return self.indexer.data_dir.clone();
+        }
+
+        self.common.base_path.join(&self.indexer.data_dir)
+    }
+
+    pub fn state_db_path(&self) -> PathBuf {
+        self.to_data_dir().join("state.db")
     }
 }
 
@@ -74,8 +89,6 @@ pub struct IndexerConfig {
     override_from: Option<String>,
     /// A path to the file that stores your node identity and secret key
     pub identity_file: PathBuf,
-    /// A path to the file that stores the tor hidden service private key, if using the tor transport
-    pub tor_identity_file: PathBuf,
     /// The relative path to store persistent data
     pub data_dir: PathBuf,
     /// The p2p configuration settings
@@ -109,30 +122,11 @@ pub struct IndexerConfig {
     pub event_filters: Vec<EventFilter>,
 }
 
-impl IndexerConfig {
-    pub fn state_db_path(&self) -> PathBuf {
-        self.data_dir.join("state.db")
-    }
-
-    pub fn set_base_path<P: AsRef<Path>>(&mut self, base_path: P) {
-        if !self.identity_file.is_absolute() {
-            self.identity_file = base_path.as_ref().join(&self.identity_file);
-        }
-        if !self.tor_identity_file.is_absolute() {
-            self.tor_identity_file = base_path.as_ref().join(&self.tor_identity_file);
-        }
-        if !self.data_dir.is_absolute() {
-            self.data_dir = base_path.as_ref().join(&self.data_dir);
-        }
-    }
-}
-
 impl Default for IndexerConfig {
     fn default() -> Self {
         Self {
             override_from: None,
             identity_file: PathBuf::from("indexer_id.json"),
-            tor_identity_file: PathBuf::from("indexer_tor_id.json"),
             data_dir: PathBuf::from("data/indexer"),
             p2p: P2pConfig::default(),
             api_listen_address: Some("127.0.0.1:18300".parse().unwrap()),

--- a/applications/tari_indexer/src/lib.rs
+++ b/applications/tari_indexer/src/lib.rs
@@ -77,7 +77,7 @@ const LOG_TARGET: &str = "tari::indexer::app";
 #[allow(clippy::too_many_lines)]
 pub async fn run_indexer(config: ApplicationConfig, mut shutdown_signal: ShutdownSignal) -> anyhow::Result<()> {
     info!(target: LOG_TARGET, "Starting indexer node on network {}", config.network);
-    let keypair = setup_keypair_prompt(&config.indexer.identity_file, true)?;
+    let keypair = setup_keypair_prompt(config.to_identity_file_path(), true)?;
 
     let db_factory = SqliteDbFactory::new(config.indexer.data_dir.clone());
     db_factory

--- a/applications/tari_walletd/src/cli.rs
+++ b/applications/tari_walletd/src/cli.rs
@@ -92,37 +92,37 @@ impl ConfigOverrideProvider for Cli {
         overrides.push(("ootle_wallet_daemon.override_from".to_string(), network.to_string()));
         if let Some(json_rpc_address) = self.json_rpc_address {
             overrides.push((
-                "ootle_wallet_daemon.json_rpc_address".to_string(),
+                format!("{}.ootle_wallet_daemon.json_rpc_address", network),
                 json_rpc_address.to_string(),
             ));
         }
         if let Some(ref json_rpc_url) = self.web_ui_public_json_rpc_url {
             overrides.push((
-                "ootle_wallet_daemon.web_ui_public_json_rpc_url".to_string(),
+                format!("{}.ootle_wallet_daemon.web_ui_public_json_rpc_url", network),
                 json_rpc_url.to_string(),
             ));
         }
         if let Some(ref signaling_server_address) = self.signaling_server_address {
             overrides.push((
-                "ootle_wallet_daemon.signaling_server_address".to_string(),
+                format!("{}.ootle_wallet_daemon.signaling_server_address", network),
                 signaling_server_address.to_string(),
             ));
         }
         if let Some(ref indexer_api_url) = self.indexer_api_url {
             overrides.push((
-                "ootle_wallet_daemon.indexer_api_url".to_string(),
+                format!("{}.ootle_wallet_daemon.indexer_api_url", network),
                 indexer_api_url.to_string(),
             ));
         }
         if let Some(ref file) = self.value_lookup_table_file {
             overrides.push((
-                "ootle_wallet_daemon.value_lookup_table_file".to_string(),
+                format!("{}.ootle_wallet_daemon.value_lookup_table_file", network),
                 file.display().to_string(),
             ));
         }
         if let Some(ref listen_addr) = self.web_ui_listen_addr {
             overrides.push((
-                "ootle_wallet_daemon.web_ui_address".to_string(),
+                format!("{}.ootle_wallet_daemon.web_ui_address", network),
                 listen_addr.to_string(),
             ));
         }

--- a/applications/tari_walletd/src/config.rs
+++ b/applications/tari_walletd/src/config.rs
@@ -43,6 +43,10 @@ impl ApplicationConfig {
         };
         Ok(config)
     }
+
+    pub fn to_data_dir(&self) -> PathBuf {
+        self.common.base_path.join("data")
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/applications/tari_walletd/src/lib.rs
+++ b/applications/tari_walletd/src/lib.rs
@@ -176,7 +176,7 @@ pub async fn run_tari_ootle_walletd(
 }
 
 pub fn init_wallet_store(config: &ApplicationConfig) -> anyhow::Result<SqliteWalletStore> {
-    let store = SqliteWalletStore::try_open(config.common.base_path.join("data/wallet.sqlite"))?;
+    let store = SqliteWalletStore::try_open(config.to_data_dir().join("wallet.sqlite"))?;
     store.run_migrations()?;
     Ok(store)
 }

--- a/applications/tari_walletd/src/main.rs
+++ b/applications/tari_walletd/src/main.rs
@@ -63,10 +63,6 @@ async fn main() -> Result<(), anyhow::Error> {
     if let Some(password) = cli.override_keyring_password.take() {
         config.ootle_wallet_daemon.override_keyring_password = Some(password);
     }
-    if let Some(ref url) = cli.indexer_api_url {
-        // TODO: not sure why the normal load_configuration override doesnt work
-        config.ootle_wallet_daemon.indexer_api_url = url.clone();
-    }
 
     match &cli.command {
         Some(Subcommand::Run) | None => run(cli, config).await?,

--- a/applications/tari_walletd/web_ui/src/routes/AssetVault/Components/AccountDetails.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/AssetVault/Components/AccountDetails.tsx
@@ -115,10 +115,8 @@ function PayRefDialog(props: PayRefDialogProps) {
 
   const handleOnChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const decoded = decodeOotleAddress(address);
-    console.log("Decoded address:", decoded);
     decoded.payRef = event.target.value;
     const addr = encodeOotleAddress(decoded);
-    console.log("Encoded address with payRef:", addr, addr == address);
     setCurrentAddress(addr);
   };
 

--- a/integration_tests/src/indexer.rs
+++ b/integration_tests/src/indexer.rs
@@ -149,7 +149,6 @@ pub async fn spawn_indexer(world: &mut TariWorld, indexer_name: String, base_nod
         config.common.base_path = base_dir.to_path_buf();
         config.indexer.data_dir = base_dir.to_path_buf();
         config.indexer.identity_file = base_dir.join("indexer_id.json");
-        config.indexer.tor_identity_file = base_dir.join("indexer_tor_id.json");
         config.epoch_oracle.base_layer.base_node_grpc_url =
             Some(format!("http://127.0.0.1:{}", base_node_grpc_port).parse().unwrap());
         config.indexer.block_scanning_interval = Duration::from_secs(5);


### PR DESCRIPTION
Description
---
fix(indexer): put substate cache in data dir

Motivation and Context
---
Substate cache was not in the data dir.

How Has This Been Tested?
---

What process can a PR reviewer use to test or verify this change?
---


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved configuration path resolution with helper methods for data directories and identity files
  * Updated wallet daemon configuration overrides to use network-prefixed keys for better multi-network organization

* **Chores**
  * Simplified configuration presets by removing Tor identity file option
  * Removed debug console logging from wallet UI components
  * Removed CLI-driven indexer API URL override from wallet daemon initialization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->