### PR TITLE
fix(wallet)!: add memo to output info

### DIFF
--- a/crates/wallet/sdk/src/models/stealth_output.rs
+++ b/crates/wallet/sdk/src/models/stealth_output.rs
@@ -55,6 +55,7 @@ pub struct StealthOutputInfo {
     pub public_nonce: RistrettoPublicKeyBytes,
     pub encrypted_data: EncryptedData,
     pub value: u64,
+    pub memo: Option<Memo>,
     pub is_on_chain: bool,
 }
 

--- a/crates/wallet/storage_sqlite/src/models/stealth_output.rs
+++ b/crates/wallet/storage_sqlite/src/models/stealth_output.rs
@@ -131,6 +131,7 @@ impl TryFrom<StealthOutput> for StealthOutputInfo {
                 details: "Corrupt db: invalid hex representation".to_string(),
             })?,
             value: value.value as u64,
+            memo: value.memo_json.as_ref().map(deserialize_json).transpose()?,
             is_on_chain: value.is_on_chain,
         })
     }


### PR DESCRIPTION
Description
---
fix(wallet)!: add memo to output info

Motivation and Context
---
Memo was missing from output info

How Has This Been Tested?
---

What process can a PR reviewer use to test or verify this change?
---


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for storing and retrieving memos associated with stealth outputs in the wallet, enabling users to attach and retrieve descriptive information with their transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->