### PR TITLE
feat(engine): charge for loading templates

### DIFF
--- a/applications/tari_app_utilities/src/fee_tables.rs
+++ b/applications/tari_app_utilities/src/fee_tables.rs
@@ -11,6 +11,7 @@ const TESTNET_FEE_TABLE: FeeTable = FeeTable {
     per_event_cost: 1,
     per_log_cost: 1,
     per_signature_verification_cost: 10,
+    per_template_load_cost_unit: 1,
 };
 
 // TODO: finalize these values
@@ -21,6 +22,7 @@ const MAINNET_FEE_TABLE: FeeTable = FeeTable {
     per_event_cost: 1,
     per_log_cost: 1,
     per_signature_verification_cost: 10,
+    per_template_load_cost_unit: 1,
 };
 
 pub const fn get_fee_table_by_network(network: Network) -> &'static FeeTable {

--- a/bindings/src/types/FeeSource.ts
+++ b/bindings/src/types/FeeSource.ts
@@ -7,4 +7,5 @@ export type FeeSource =
   | "Events"
   | "Logs"
   | "TransactionWeight"
-  | "SignatureVerification";
+  | "SignatureVerification"
+  | "TemplateLoad";

--- a/crates/engine/src/fees/fee_module.rs
+++ b/crates/engine/src/fees/fee_module.rs
@@ -36,6 +36,21 @@ impl RuntimeModule for FeeModule {
         Ok(())
     }
 
+    fn on_template_loaded(&self, track: &StateTracker, bytes_loaded: usize) -> Result<(), RuntimeModuleError> {
+        const TEMPLATE_BYTES_LOADED_COST_DIVISOR: u64 = 3000; // 3 KB = 1 cost unit
+        let template_load_cost_unit =
+            u64::try_from(bytes_loaded).unwrap_or(u64::MAX) / TEMPLATE_BYTES_LOADED_COST_DIVISOR;
+
+        let fee_charge = template_load_cost_unit
+            .checked_mul(self.fee_table.per_template_load_cost_unit())
+            .ok_or_else(|| {
+                RuntimeModuleError::Overflow("Overflow calculating template load weight cost".to_string())
+            })?;
+
+        track.add_fee_charge(FeeSource::TemplateLoad, fee_charge);
+        Ok(())
+    }
+
     fn on_before_finalize(&self, track: &StateTracker) -> Result<(), RuntimeModuleError> {
         let total_storage = track.with_substates_to_persist(|changes| {
             let mut counter = ByteCounter::new();

--- a/crates/engine/src/fees/fee_table.rs
+++ b/crates/engine/src/fees/fee_table.rs
@@ -9,6 +9,7 @@ pub struct FeeTable {
     pub per_event_cost: u64,
     pub per_log_cost: u64,
     pub per_signature_verification_cost: u64,
+    pub per_template_load_cost_unit: u64,
 }
 
 impl FeeTable {
@@ -20,6 +21,7 @@ impl FeeTable {
             per_event_cost: 0,
             per_log_cost: 0,
             per_signature_verification_cost: 0,
+            per_template_load_cost_unit: 0,
         }
     }
 
@@ -45,5 +47,9 @@ impl FeeTable {
 
     pub fn per_signature_verification_cost(&self) -> u64 {
         self.per_signature_verification_cost
+    }
+
+    pub fn per_template_load_cost_unit(&self) -> u64 {
+        self.per_template_load_cost_unit
     }
 }

--- a/crates/engine/src/runtime/impl.rs
+++ b/crates/engine/src/runtime/impl.rs
@@ -49,7 +49,7 @@ use tari_engine_types::{
 };
 use tari_ootle_common_types::{services::template_provider::TemplateProvider, GetVerifier};
 use tari_template_abi::{TemplateDef, Type};
-use tari_template_builtin::{ACCOUNT_TEMPLATE_ADDRESS, NFT_FAUCET_TEMPLATE_ADDRESS};
+use tari_template_builtin::{is_builtin_template_address, ACCOUNT_TEMPLATE_ADDRESS, NFT_FAUCET_TEMPLATE_ADDRESS};
 use tari_template_lib::{
     args::{
         AddressAllocationInvokeArg,
@@ -2844,6 +2844,22 @@ impl<TTemplateProvider: TemplateProvider<Template = LoadedTemplate>> RuntimeInte
             state_mut.pay_fee(container, None)?;
             Ok(())
         })
+    }
+
+    fn track_template_loaded(
+        &self,
+        template_address: &TemplateAddress,
+        bytes_loaded: usize,
+    ) -> Result<(), RuntimeError> {
+        // Built-in templates are zero-cost
+        if is_builtin_template_address(template_address) {
+            return Ok(());
+        }
+
+        for module in &self.modules {
+            module.on_template_loaded(&self.tracker, bytes_loaded)?;
+        }
+        Ok(())
     }
 }
 

--- a/crates/engine/src/runtime/mod.rs
+++ b/crates/engine/src/runtime/mod.rs
@@ -89,7 +89,7 @@ use tari_template_lib::{
     },
     invoke_args,
     models::{BucketId, ComponentAddress, Metadata, NonFungibleAddress, StealthTransferStatement, VaultRef},
-    types::{engine_args::SignatureAction, EntityId},
+    types::{engine_args::SignatureAction, EntityId, TemplateAddress},
 };
 use tari_transaction::{
     args::{InstructionArg, WorkspaceId, WorkspaceOffsetId},
@@ -212,6 +212,12 @@ pub trait RuntimeInterface: Send + Sync {
         &self,
         statement: StealthTransferStatement,
         revealed_funds_bucket: Option<BucketId>,
+    ) -> Result<(), RuntimeError>;
+
+    fn track_template_loaded(
+        &self,
+        template_address: &TemplateAddress,
+        bytes_loaded: usize,
     ) -> Result<(), RuntimeError>;
 }
 

--- a/crates/engine/src/runtime/module.rs
+++ b/crates/engine/src/runtime/module.rs
@@ -12,6 +12,10 @@ pub trait RuntimeModule: Send + Sync {
         Ok(())
     }
 
+    fn on_template_loaded(&self, _track: &StateTracker, _bytes_loaded: usize) -> Result<(), RuntimeModuleError> {
+        Ok(())
+    }
+
     fn on_before_finalize(&self, _track: &StateTracker) -> Result<(), RuntimeModuleError> {
         Ok(())
     }

--- a/crates/engine/src/transaction/processor.rs
+++ b/crates/engine/src/transaction/processor.rs
@@ -545,9 +545,13 @@ impl<TTemplateProvider: TemplateProvider<Template = LoadedTemplate>> Transaction
                 address: *template_address,
                 details: e.to_string(),
             })?
-            .ok_or(TransactionError::TemplateNotFound {
+            .ok_or_else(|| TransactionError::TemplateNotFound {
                 address: *template_address,
             })?;
+
+        runtime
+            .interface()
+            .track_template_loaded(template_address, template.code_size())?;
 
         let function_def = template.template_def().get_function(function).cloned().ok_or_else(|| {
             TransactionError::FunctionNotFound {
@@ -596,6 +600,10 @@ impl<TTemplateProvider: TemplateProvider<Template = LoadedTemplate>> Transaction
             .ok_or(TransactionError::TemplateNotFound {
                 address: template_address,
             })?;
+
+        runtime
+            .interface()
+            .track_template_loaded(&template_address, template.code_size())?;
 
         let function_def = template.template_def().get_function(method).cloned().ok_or_else(|| {
             TransactionError::FunctionNotFound {

--- a/crates/engine/tests/fees.rs
+++ b/crates/engine/tests/fees.rs
@@ -243,7 +243,7 @@ fn fail_pay_less_fees_than_fee_transaction() {
                         .call_method(
                             account,
                             "pay_fee".to_string(),
-                            args![100],
+                            args![127],
                         )
 
                 })
@@ -267,7 +267,7 @@ fn fail_pay_less_fees_than_fee_transaction() {
     let (_, s) = diff.up_iter().find(|(id, _)| id.is_vault()).expect("Account not found");
     assert_eq!(
         s.substate_value().as_vault().unwrap().balance(),
-        orig_balance - Amount::from(100)
+        orig_balance - Amount::from(127)
     );
 
     // Fee was not deducted

--- a/crates/engine_types/src/fees.rs
+++ b/crates/engine_types/src/fees.rs
@@ -70,6 +70,7 @@ pub enum FeeSource {
     Logs,
     TransactionWeight,
     SignatureVerification,
+    TemplateLoad,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, borsh::BorshSerialize)]

--- a/crates/template_builtin/src/lib.rs
+++ b/crates/template_builtin/src/lib.rs
@@ -72,3 +72,7 @@ pub const fn all_builtin_templates() -> &'static [(TemplateAddress, &'static [u8
         // ),
     ]
 }
+
+pub fn is_builtin_template_address(addr: &TemplateAddress) -> bool {
+    *addr == ACCOUNT_TEMPLATE_ADDRESS || *addr == NFT_FAUCET_TEMPLATE_ADDRESS || *addr == XTR_FAUCET_TEMPLATE_ADDRESS
+}

--- a/crates/template_test_tooling/src/template_test.rs
+++ b/crates/template_test_tooling/src/template_test.rs
@@ -175,6 +175,7 @@ impl TemplateTest {
                 per_event_cost: 1,
                 per_log_cost: 1,
                 per_signature_verification_cost: 1,
+                per_template_load_cost_unit: 1,
             },
             key_seed: 1,
             auto_add_proofs_from_signers: true,


### PR DESCRIPTION
Description
---
feat(engine): charge for loading templates

Motivation and Context
---
Provide fees to validators for loading non-builtin templates and incentivises authors to minimise template binary size.

Fee table includes a charge per template load cost unit where each cost unit is worth 3000 bytes.

How Has This Been Tested?
---
Manually

What process can a PR reviewer use to test or verify this change?
---


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Templates now incur a size-based load fee with configurable per-template cost rates for testnet and mainnet; built‑in templates are exempt.
  * Introduced a new fee category for template loads and runtime hooks that record and charge template loading.

* **Tests**
  * Updated fee-related test expectations to reflect the revised template-load fee calculations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->