### PR TITLE
fix: transaction builder remove signatures+indexer fixes

### DIFF
--- a/applications/tari_indexer/src/network_client.rs
+++ b/applications/tari_indexer/src/network_client.rs
@@ -3,15 +3,18 @@
 
 use std::{
     collections::{HashMap, HashSet},
-    fmt::Display,
     future::Future,
 };
 
+use indexmap::IndexMap;
 use log::{info, warn};
 use tari_epoch_manager::{EpochManagerError, EpochManagerReader};
-use tari_ootle_common_types::{optional::IsNotFoundError, NodeAddressable, NumPreshards, ShardGroup, SubstateAddress};
+use tari_ootle_common_types::{displayable::Displayable, NodeAddressable, NumPreshards, ShardGroup, SubstateAddress};
 use tari_transaction::{Transaction, TransactionId};
-use tari_validator_node_rpc::client::{ValidatorNodeClientFactory, ValidatorNodeRpcClient};
+use tari_validator_node_rpc::{
+    client::{ValidatorNodeClientFactory, ValidatorNodeRpcClient},
+    ValidatorNodeRpcClientError,
+};
 
 const LOG_TARGET: &str = "tari::indexer::network_client";
 
@@ -27,7 +30,6 @@ where
     TAddr: NodeAddressable + 'static,
     TEpochManager: EpochManagerReader<Addr = TAddr> + 'static,
     TClientFactory: ValidatorNodeClientFactory<TAddr> + 'static,
-    <TClientFactory::Client as ValidatorNodeRpcClient<TAddr>>::Error: IsNotFoundError + 'static,
 {
     pub fn new(epoch_manager: TEpochManager, client_provider: TClientFactory, num_preshards: NumPreshards) -> Self {
         Self {
@@ -88,17 +90,16 @@ where
         Ok(tx_id)
     }
 
-    pub async fn try_single_with_committee<'a, F, T, E, TFut>(
+    pub async fn try_single_with_committee<'a, F, T, TFut>(
         &self,
         substate_address: SubstateAddress,
         callback: F,
     ) -> Result<T, NetworkClientError>
     where
         F: FnMut(TClientFactory::Client) -> TFut,
-        TFut: Future<Output = Result<T, E>> + 'a,
+        TFut: Future<Output = Result<T, ValidatorNodeRpcClientError>> + 'a,
         TClientFactory::Client: 'a,
         T: 'static,
-        E: Display,
     {
         let results = self
             .try_with_committee(std::iter::once(substate_address), callback)
@@ -110,24 +111,23 @@ where
             .expect("Expected exactly one result for single substate address")
             .map_err(|e| NetworkClientError::AllValidatorsFailed {
                 committee_size: 1,
-                last_error: Some(e.to_string()),
+                last_error: Some(e),
             })
     }
 
     /// Fetches the committee members for the given shard and calls the given callback with each member until
     /// the callback returns a `Ok` with results for each shard group. If an Ok is returned, the hashmap is guaranteed
     /// to be the same size as the number of unique shard groups queried.
-    pub async fn try_with_committee<'a, F, T, E, TFut, ISubstateAddr>(
+    pub async fn try_with_committee<'a, F, T, TFut, ISubstateAddr>(
         &self,
         substate_addresses: ISubstateAddr,
         mut callback: F,
-    ) -> Result<HashMap<ShardGroup, Result<T, E>>, NetworkClientError>
+    ) -> Result<IndexMap<ShardGroup, Result<T, ValidatorNodeRpcClientError>>, NetworkClientError>
     where
         F: FnMut(TClientFactory::Client) -> TFut,
-        TFut: Future<Output = Result<T, E>> + 'a,
+        TFut: Future<Output = Result<T, ValidatorNodeRpcClientError>> + 'a,
         TClientFactory::Client: 'a,
         T: 'static,
-        E: Display,
         ISubstateAddr: IntoIterator<Item = SubstateAddress>,
     {
         let epoch = self.epoch_manager.current_epoch().await?;
@@ -161,8 +161,8 @@ where
         }
 
         let mut num_succeeded = 0;
-        let mut results = HashMap::with_capacity(committee_size);
-        let mut last_error = None;
+        let mut results = IndexMap::with_capacity(committee_size);
+        let mut last_error_pos = None;
         for (shard_group, committee) in all_members {
             for member in committee.shuffled() {
                 let client = self.client_provider.create_client(&member.address);
@@ -177,7 +177,7 @@ where
                             target: LOG_TARGET,
                             "Request failed for validator '{}': {}", member, err
                         );
-                        last_error = Some(err.to_string());
+                        last_error_pos = Some(results.len());
                         results.insert(shard_group, Err(err));
                     },
                 }
@@ -185,6 +185,16 @@ where
         }
 
         if num_succeeded == 0 {
+            let mut last_error = None;
+
+            if let Some(pos) = last_error_pos {
+                let (_, last) = results.swap_remove_index(pos).expect("position must exist");
+                // Avoid unwrap_err, because that requires T: Debug
+                match last {
+                    Ok(_) => unreachable!("last_error_pos points to an Err result"),
+                    Err(e) => last_error = Some(e),
+                }
+            }
             return Err(NetworkClientError::AllValidatorsFailed {
                 committee_size,
                 last_error,
@@ -199,10 +209,10 @@ where
 pub enum NetworkClientError {
     #[error("Epoch manager error: {0}")]
     EpochManagerError(#[from] EpochManagerError),
-    #[error("Rpc call failed for all ({committee_size}) validators: {}", .last_error.as_deref().unwrap_or("unknown"))]
+    #[error("Rpc call failed for all ({committee_size}) validators: {}", .last_error.display())]
     AllValidatorsFailed {
         committee_size: usize,
-        last_error: Option<String>,
+        last_error: Option<ValidatorNodeRpcClientError>,
     },
     #[error("No committee at present. Try again later")]
     NoCommitteeMembers,

--- a/applications/tari_indexer/src/rest_api/handlers/transactions.rs
+++ b/applications/tari_indexer/src/rest_api/handlers/transactions.rs
@@ -18,6 +18,7 @@ use tari_indexer_client::types::{
     SubmitTransactionResponse,
 };
 use tari_ootle_common_types::optional::Optional;
+use tari_rpc_framework::RpcStatusCode;
 use tari_transaction::TransactionId;
 use tari_validator_node_rpc::client::TransactionResultStatus;
 use time::{OffsetDateTime, PrimitiveDateTime};
@@ -68,6 +69,23 @@ pub async fn submit_transaction(
         .submit_transaction(transaction)
         .await
         .map_err(|e| match e {
+            TransactionManagerError::NetworkClientError(NetworkClientError::AllValidatorsFailed {
+                last_error: Some(last_err),
+                committee_size,
+            }) => match last_err.status() {
+                Some(status) => match status.as_status_code() {
+                    RpcStatusCode::BadRequest => {
+                        ErrorResponse::bad_request(format!("Bad request: {}", status.details()))
+                    },
+                    RpcStatusCode::NotFound => ErrorResponse::not_found(format!("Not found: {}", status.details())),
+                    _ => ErrorResponse::general_error(format!(
+                        "Rpc error: ({} members) {}",
+                        committee_size,
+                        status.details()
+                    )),
+                },
+                None => ErrorResponse::general_error(format!("Rpc error: ({} members) {}", committee_size, last_err)),
+            },
             TransactionManagerError::NetworkClientError(NetworkClientError::AllValidatorsFailed { .. }) |
             TransactionManagerError::NetworkClientError(NetworkClientError::NoCommitteeMembers) => {
                 ErrorResponse::service_unavailable(format!("All validators failed: {}", e))

--- a/applications/tari_indexer/src/storage_sqlite/reader.rs
+++ b/applications/tari_indexer/src/storage_sqlite/reader.rs
@@ -462,12 +462,19 @@ impl IndexerStoreReadTransaction for SqliteStoreReadTransaction<'_> {
         const OPERATION: &str = "get_transaction_receipt";
         use crate::storage_sqlite::schema::transaction_receipts;
 
+        let receipt_addr_hex = serialize_hex(address.as_object_key());
+
         let receipt_entry = transaction_receipts::table
             .select(transaction_receipts::data)
-            .filter(transaction_receipts::address.eq(address.to_string()))
+            .filter(transaction_receipts::address.eq(receipt_addr_hex))
             .first::<String>(self.connection())
+            .optional()
             .map_err(|e| StorageError::QueryError {
                 reason: format!("{OPERATION}: {}", e),
+            })?
+            .ok_or_else(|| StorageError::NotFound {
+                item: "transaction_receipt",
+                key: address.to_string(),
             })?;
 
         deserialize_json(&receipt_entry)

--- a/applications/tari_indexer/src/transaction_manager/mod.rs
+++ b/applications/tari_indexer/src/transaction_manager/mod.rs
@@ -24,12 +24,7 @@ pub(crate) mod error;
 
 use tari_epoch_manager::EpochManagerReader;
 use tari_indexer_client::types::TransactionEntry;
-use tari_ootle_common_types::{
-    optional::{IsNotFoundError, Optional},
-    NodeAddressable,
-    SubstateRequirementRef,
-    ToSubstateAddress,
-};
+use tari_ootle_common_types::{optional::Optional, NodeAddressable, SubstateRequirementRef, ToSubstateAddress};
 use tari_transaction::{Transaction, TransactionId};
 use tari_validator_node_rpc::client::{
     SubstateResult,
@@ -55,7 +50,6 @@ where
     TAddr: NodeAddressable + 'static,
     TEpochManager: EpochManagerReader<Addr = TAddr> + 'static,
     TClientFactory: ValidatorNodeClientFactory<TAddr> + 'static,
-    <TClientFactory::Client as ValidatorNodeRpcClient<TAddr>>::Error: IsNotFoundError + 'static,
     TStore: IndexerStore,
 {
     pub fn new(network_client: TariNetworkClient<TEpochManager, TClientFactory>, store: TStore) -> Self {
@@ -64,7 +58,7 @@ where
 
     pub async fn submit_transaction(&self, transaction: Transaction) -> Result<TransactionId, TransactionManagerError> {
         if !transaction.verify_all_signatures() {
-            // DEV note: If signatures are invalid here (but they should be valid), this probably indicates an issue
+            // DEV note: If signatures are invalid here, this is probably an issue
             // with the JSON decoding (crates/engine_types/src/argument_parser.rs)
             return Err(TransactionManagerError::InvalidTransaction {
                 transaction_id: transaction.calculate_id(),

--- a/applications/tari_swarm_daemon/src/process_definitions/indexer.rs
+++ b/applications/tari_swarm_daemon/src/process_definitions/indexer.rs
@@ -59,7 +59,8 @@ impl ProcessDefinition for Indexer {
             .arg(format!("-pindexer.web_ui_address={web_ui_listener_address}"))
             .arg(format!("-pindexer.web_ui_public_api_url={api_public_url}"))
             .arg(format!("-pindexer.web_ui_public_graphql_url={graphql_public_url}"))
-            .arg("-pepoch_oracle.base_layer.scanning_interval=1");
+            .arg("-pepoch_oracle.base_layer.scanning_interval=1")
+            .env("API_DEBUG", "1"); // Enable detailed API error messages
 
         // mDNS is not guaranteed to work, so we'll explicitly set the seed peers for the indexer.
         let seed_peers = context.validator_nodes().filter_map(|vn| {

--- a/applications/tari_walletd/src/handlers/accounts.rs
+++ b/applications/tari_walletd/src/handlers/accounts.rs
@@ -29,7 +29,7 @@ use tari_ootle_wallet_sdk::{
 };
 use tari_template_builtin::ACCOUNT_TEMPLATE_ADDRESS;
 use tari_template_lib::{
-    constants::{STEALTH_TARI_RESOURCE_ADDRESS, XTR, XTR_FAUCET_COMPONENT_ADDRESS, XTR_FAUCET_VAULT_ADDRESS},
+    constants::{STEALTH_TARI_RESOURCE_ADDRESS, XTR_FAUCET_COMPONENT_ADDRESS, XTR_FAUCET_VAULT_ADDRESS},
     models::SpendCondition,
     types::{Amount, ResourceType},
 };
@@ -596,7 +596,6 @@ pub async fn handle_create_free_test_coins(
     );
 
     let mut inputs = vec![
-        SubstateRequirement::unversioned(XTR),
         SubstateRequirement::unversioned(XTR_FAUCET_COMPONENT_ADDRESS),
         SubstateRequirement::unversioned(XTR_FAUCET_VAULT_ADDRESS),
     ];
@@ -651,6 +650,7 @@ pub async fn handle_create_free_test_coins(
                 .call_method(*account.component_address(), "pay_fee", args![max_fee])
         })
         .with_inputs(inputs.into_iter().map(|input| input.into_unversioned()))
+        .with_authorized_seal_signer()
         .finish();
 
     let transaction = sdk.signer_api().sign(account_owner_key_id, transaction)?;

--- a/applications/tari_walletd/src/handlers/nfts.rs
+++ b/applications/tari_walletd/src/handlers/nfts.rs
@@ -299,12 +299,12 @@ pub async fn handle_transfer(
         .with_inputs(inputs.into_iter().map(|input| input.into_unversioned()))
         // Seal signer is the fee payer account
         .with_authorized_seal_signer()
-        .map(|builder| {
-            sdk.signer_api()
-                .with_context(&fee_owner_key.public_key().to_byte_type())
-                .sign(account_owner_key_id, builder)
-        })?
         .finish();
+
+    let transaction = sdk
+        .signer_api()
+        .with_context(&fee_owner_key.public_key().to_byte_type())
+        .sign(account_owner_key_id, transaction)?;
 
     let transaction = sdk.signer_api().sign(fee_payer_key_id, transaction)?;
 

--- a/applications/tari_walletd/src/handlers/transaction.rs
+++ b/applications/tari_walletd/src/handlers/transaction.rs
@@ -8,11 +8,10 @@ use axum_jrpc::error::{JsonRpcError, JsonRpcErrorReason};
 use futures::{future, future::Either};
 use log::*;
 use tari_engine_types::ToByteType;
-use tari_ootle_common_types::{optional::Optional, Epoch, Network};
+use tari_ootle_common_types::{optional::Optional, response_status::ResponseErrorStatus, Epoch, Network};
 use tari_ootle_wallet_sdk::{
     apis::{config::ConfigKey, transaction::TransactionApiError},
     models::WalletEvent,
-    network::WalletQueryErrorStatus,
 };
 use tari_ootle_wallet_sdk_services::transaction_service::TransactionServiceError;
 use tari_transaction::{args, Transaction};
@@ -148,19 +147,20 @@ pub async fn handle_submit(
         req.detect_inputs_use_unversioned,
     );
 
-    let mut builder = context
+    let mut transaction = context
         .transaction_builder()
         .with_unsigned_transaction(req.transaction)
-        .with_inputs(detected_inputs);
+        .with_inputs(detected_inputs)
+        .finish();
 
     let main_signer = sdk.key_manager_api().get_public_key(req.seal_signer)?;
     let main_signer_pk = main_signer.public_key.to_byte_type();
     let local_signer = sdk.signer_api().with_context(&main_signer_pk);
     for key in req.other_signers {
-        builder = local_signer.sign(key, builder)?;
+        transaction = local_signer.sign(key, transaction)?;
     }
 
-    let transaction = sdk.signer_api().sign(req.seal_signer, builder.finish())?;
+    let transaction = sdk.signer_api().sign(req.seal_signer, transaction)?;
 
     let tx_id = transaction.calculate_id();
     for lock_id in req.lock_ids {
@@ -186,8 +186,8 @@ pub async fn handle_submit(
                     status,
                     message,
                 }) => match &status {
-                    WalletQueryErrorStatus::TransactionRejected { .. } => transaction_rejected(message),
-                    WalletQueryErrorStatus::NotFound { message } => not_found(message),
+                    ResponseErrorStatus::TransactionRejected { .. } => transaction_rejected(message),
+                    ResponseErrorStatus::NotFound { message } => not_found(message),
                     _ => JsonRpcError::new(
                         JsonRpcErrorReason::ApplicationError(1),
                         format!("Failed to submit transaction: {}", e),
@@ -309,14 +309,14 @@ pub async fn handle_submit_manifest(
     })?;
 
     let signing_key_id = req.signing_key_id.unwrap_or(account_owner_key_id);
-    let key = sdk.key_manager_api().get_key(signing_key_id)?;
 
     let network = context.wallet_sdk().config_api().get::<Network>(ConfigKey::Network)?;
 
     let fee_amount = req.max_fee;
 
-    let builder = Transaction::builder()
+    let transaction = Transaction::builder()
         .for_network(network.as_byte())
+        .with_dry_run(req.dry_run)
         .with_fee_instructions_builder(|builder| {
             if instructions.fee_instructions.is_empty() {
                 builder.call_method(*default_account.component_address(), "pay_fee", args![fee_amount])
@@ -325,29 +325,24 @@ pub async fn handle_submit_manifest(
             }
         })
         .with_instructions(instructions.instructions)
-        .map(|builder| {
-            if signing_key_id == account_owner_key_id {
-                Ok(builder)
-            } else {
-                sdk.signer_api()
-                    .with_context(&key.to_public_key().to_byte_type())
-                    .sign(signing_key_id, builder)
-            }
-        })?;
-    let signatures = builder.signatures().to_vec();
-    let transaction = builder.with_dry_run(req.dry_run).build_unsigned_transaction();
+        .build_unsigned_transaction();
 
     // Detect inputs
     let substates = transaction.to_referenced_substates()?.into_iter().collect::<Vec<_>>();
     let dependencies = sdk.substate_api().locate_dependent_substates(&substates, true).await?;
     let inputs = dependencies.into_iter().map(|input| input.into_unversioned());
 
-    let transaction = transaction
-        .with_inputs(inputs)
-        .authorized_sealed_signer()
-        .with_signatures(signatures);
+    let transaction = transaction.with_inputs(inputs).authorized_sealed_signer();
 
-    let transaction = sdk.signer_api().sign(key.key_id, transaction)?;
+    let transaction = if signing_key_id == account_owner_key_id {
+        transaction.finish()
+    } else {
+        sdk.signer_api()
+            .with_context(default_account.owner_public_key())
+            .sign(signing_key_id, transaction)?
+    };
+
+    let transaction = sdk.signer_api().sign(account_owner_key_id, transaction)?;
 
     if req.dry_run {
         let exec_result = context

--- a/applications/tari_walletd/src/handlers/validator.rs
+++ b/applications/tari_walletd/src/handlers/validator.rs
@@ -179,21 +179,20 @@ pub async fn handle_claim_validator_fees(
         .map(|builder| {
             if let Some(index) = req.claim_key_index {
                 if claim_public_key == *account.address.account_public_key() {
-                    Ok(builder)
+                    Ok(builder.finish())
                 } else {
                     // If the claim key is different from the account secret, we need to sign with both
                     sdk.signer_api()
                         .with_context(account.address.account_public_key())
                         .sign(
                             KeyId::derived(KeyBranch::Account, index),
-                            builder.with_authorized_seal_signer(),
+                            builder.with_authorized_seal_signer().finish(),
                         )
                 }
             } else {
-                Ok(builder)
+                Ok(builder.finish())
             }
-        })?
-        .finish();
+        })?;
 
     let transaction = sdk.signer_api().sign(account_key_id, unsigned_transaction)?;
 

--- a/crates/common_types/src/lib.rs
+++ b/crates/common_types/src/lib.rs
@@ -23,6 +23,7 @@ mod node_height;
 mod num_preshards;
 pub mod optional;
 mod peer_address;
+pub mod response_status;
 pub mod services;
 pub mod shard;
 mod shard_group;

--- a/crates/common_types/src/response_status.rs
+++ b/crates/common_types/src/response_status.rs
@@ -1,0 +1,41 @@
+//   Copyright 2025 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+use std::convert::Infallible;
+
+/// A trait for responses that can provide a [ResponseErrorStatus]
+pub trait TransactionStatusResponseError {
+    fn get_status(&self) -> ResponseErrorStatus;
+    fn get_error_message(&self) -> String;
+}
+
+// This is required for tests (PanicInterface) - in general, if a type is `Infallible` it should never reach the error.
+impl TransactionStatusResponseError for Infallible {
+    fn get_status(&self) -> ResponseErrorStatus {
+        unreachable!("Infallible is not constructible, therefore this is unreachable")
+    }
+
+    fn get_error_message(&self) -> String {
+        unreachable!("Infallible is not constructible, therefore this is unreachable")
+    }
+}
+
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum ResponseErrorStatus {
+    #[error("Not found: {message}")]
+    NotFound { message: String },
+    #[error("Transaction rejected: {message}")]
+    TransactionRejected { message: String },
+    #[error("Internal error: {message}")]
+    InternalError { message: String },
+}
+
+impl TransactionStatusResponseError for ResponseErrorStatus {
+    fn get_status(&self) -> ResponseErrorStatus {
+        self.clone()
+    }
+
+    fn get_error_message(&self) -> String {
+        self.to_string()
+    }
+}

--- a/crates/engine/tests/account.rs
+++ b/crates/engine/tests/account.rs
@@ -200,8 +200,9 @@ fn gasless() {
             .call_method(user_account, "withdraw", args![XTR, Amount(100)])
             .put_last_instruction_output_on_workspace("b")
             .call_method(user2_account, "deposit", args![Workspace("b")])
+            .finish()
             .add_signer(&fee_account_pk.to_byte_type(), &user_account_sk)
-            .build_and_seal(&fee_account_sk),
+            .seal(&fee_account_sk),
         vec![fee_account_proof, user_account_proof],
     );
 

--- a/crates/engine/tests/stealth.rs
+++ b/crates/engine/tests/stealth.rs
@@ -107,8 +107,9 @@ fn basic_transfer() {
     let result = test.execute_expect_success(
         Transaction::builder()
             .stealth_transfer(faucet_resx, transfer.statement)
+            .finish()
             .add_signer(&test.to_public_key_bytes(), &mint.output_masks[0])
-            .build_and_seal(test.secret_key()),
+            .seal(test.secret_key()),
         vec![],
     );
 
@@ -145,8 +146,9 @@ fn programmatic_transfer() {
     let result = test.execute_expect_success(
         Transaction::builder()
             .call_method(faucet, "programmatic_transfer", args![transfer.statement])
+            .finish()
             .add_signer(&test.to_public_key_bytes(), &mint.output_masks[0])
-            .build_and_seal(test.secret_key()),
+            .seal(test.secret_key()),
         vec![],
     );
 
@@ -183,8 +185,9 @@ fn transfer_with_revealed_outputs() {
             .stealth_transfer(faucet_resx, transfer.statement)
             .put_last_instruction_output_on_workspace("bucket")
             .call_method(account, "deposit", args![Workspace("bucket")])
+            .finish()
             .add_signer(&test.to_public_key_bytes(), &mint.output_masks[1])
-            .build_and_seal(test.secret_key()),
+            .seal(test.secret_key()),
         vec![],
     );
 
@@ -238,9 +241,10 @@ fn transfer_revealed_between_accounts() {
             .stealth_transfer_with_input_bucket(faucet_resx, transfer_from_alice_to_bob.statement, "alice_to_bob")
             .put_last_instruction_output_on_workspace("transfer_to_bob")
             .call_method(bob, "deposit", args![Workspace("transfer_to_bob")])
+            .finish()
             .add_signer(&test.to_public_key_bytes(), &mint.output_masks[1])
             .add_signer(&test.to_public_key_bytes(), &mint.output_masks[2])
-            .build_and_seal(&alice_sk),
+            .seal(&alice_sk),
         vec![alice_proof],
     );
 
@@ -282,8 +286,9 @@ fn transfer_invalid_balance_in_statement() {
             .stealth_transfer(faucet_resx, transfer_from_faucet.statement)
             .put_last_instruction_output_on_workspace("bucket")
             .call_method(alice, "deposit", args![Workspace("bucket")])
+            .finish()
             .add_signer(&test.to_public_key_bytes(), &mint.output_masks[0])
-            .build_and_seal(test.secret_key()),
+            .seal(test.secret_key()),
         vec![],
     );
 
@@ -354,8 +359,9 @@ fn transfer_invalid_range_proof_in_statement() {
             .stealth_transfer(faucet_resx, transfer_from_faucet.statement)
             .put_last_instruction_output_on_workspace("bucket")
             .call_method(alice, "deposit", args![Workspace("bucket")])
+            .finish()
             .add_signer(&test.to_public_key_bytes(), &mint.output_masks[0])
-            .build_and_seal(test.secret_key()),
+            .seal(test.secret_key()),
         vec![],
     );
 
@@ -401,8 +407,9 @@ fn many_outputs_in_one_transfer() {
     let result = test.execute_expect_success(
         Transaction::builder()
             .stealth_transfer(faucet_resx, transfer_from_faucet.statement)
+            .finish()
             .add_signer(&test.to_public_key_bytes(), &mint.output_masks[0])
-            .build_and_seal(test.secret_key()),
+            .seal(test.secret_key()),
         vec![],
     );
 
@@ -460,8 +467,9 @@ fn mint_with_view_key() {
     let result = test.execute_expect_success(
         Transaction::builder()
             .stealth_transfer(faucet_resx, withdraw_proof.statement)
+            .finish()
             .add_signer(&test.to_public_key_bytes(), &mint.output_masks[0])
-            .build_and_seal(test.secret_key()),
+            .seal(test.secret_key()),
         vec![],
     );
 
@@ -527,9 +535,10 @@ fn freeze_then_attempt_spend() {
     let reason = test.execute_expect_failure(
         Transaction::builder()
             .stealth_transfer(faucet_resx, transfer.statement.clone())
+            .finish()
             .add_signer(&test.to_public_key_bytes(), &mint.output_masks[0])
             .add_signer(&test.to_public_key_bytes(), &mint.output_masks[1])
-            .build_and_seal(test.secret_key()),
+            .seal(test.secret_key()),
         vec![],
     );
 
@@ -546,9 +555,10 @@ fn freeze_then_attempt_spend() {
     let result = test.execute_expect_success(
         Transaction::builder()
             .stealth_transfer(faucet_resx, transfer.statement)
+            .finish()
             .add_signer(&test.to_public_key_bytes(), &mint.output_masks[0])
             .add_signer(&test.to_public_key_bytes(), &mint.output_masks[1])
-            .build_and_seal(test.secret_key()),
+            .seal(test.secret_key()),
         vec![],
     );
 

--- a/crates/template_test_tooling/src/template_test.rs
+++ b/crates/template_test_tooling/src/template_test.rs
@@ -563,6 +563,7 @@ impl TemplateTest {
         let transaction = Transaction::builder()
             .with_fee_instructions(fee_instructions)
             .with_instructions(instructions)
+            .with_authorized_seal_signer()
             .build_and_seal(&self.secret_key);
 
         self.try_execute(transaction, proofs)

--- a/crates/transaction/src/builder/mod.rs
+++ b/crates/transaction/src/builder/mod.rs
@@ -46,7 +46,6 @@ use crate::{
 #[derive(Debug, Clone, Default)]
 pub struct TransactionBuilder {
     unsigned_transaction: UnsignedTransaction,
-    signatures: Vec<TransactionSignature>,
     workspace_ids: WorkspaceIds,
     fee_instruction_builder: Option<Box<TransactionBuilder>>,
 }
@@ -55,7 +54,6 @@ impl TransactionBuilder {
     pub fn new() -> Self {
         Self {
             unsigned_transaction: UnsignedTransaction::default(),
-            signatures: vec![],
             workspace_ids: WorkspaceIds::new(),
             fee_instruction_builder: Some(Box::new(Self::new_fee_builder())),
         }
@@ -64,7 +62,6 @@ impl TransactionBuilder {
     fn new_fee_builder() -> Self {
         Self {
             unsigned_transaction: UnsignedTransaction::default(),
-            signatures: vec![],
             workspace_ids: WorkspaceIds::new(),
             fee_instruction_builder: None,
         }
@@ -73,7 +70,6 @@ impl TransactionBuilder {
     pub fn with_unsigned_transaction<T: Into<UnsignedTransaction>>(self, unsigned_transaction: T) -> Self {
         Self {
             unsigned_transaction: unsigned_transaction.into(),
-            signatures: vec![],
             workspace_ids: WorkspaceIds::new(),
             fee_instruction_builder: Some(Box::new(Self::new_fee_builder())),
         }
@@ -99,7 +95,6 @@ impl TransactionBuilder {
 
     pub fn with_authorized_seal_signer(mut self) -> Self {
         self.unsigned_transaction = self.unsigned_transaction.authorized_sealed_signer();
-        self.panic_if_signed();
         self
     }
 
@@ -245,6 +240,10 @@ impl TransactionBuilder {
         self.pay_fee_stealth_with_opt_input_bucket(statement, None::<String>)
     }
 
+    fn is_in_fee_builder(&self) -> bool {
+        self.fee_instruction_builder.is_none()
+    }
+
     pub fn pay_fee_using_account<C, A>(self, account: C, amount: A) -> Self
     where
         C: Into<NamedComponentCall>,
@@ -270,10 +269,13 @@ impl TransactionBuilder {
         statement: StealthTransferStatement,
         input_bucket: Option<B>,
     ) -> Self {
-        let revealed_input_bucket = input_bucket.map(|bucket| self.get_workspace_offset_id_from_named_arg(bucket));
-        self.add_instruction(Instruction::PayFee {
-            statement,
-            revealed_input_bucket,
+        self.with_fee_instructions_builder(|builder| {
+            let revealed_input_bucket =
+                input_bucket.map(|bucket| builder.get_workspace_offset_id_from_named_arg(bucket));
+            builder.add_instruction(Instruction::PayFee {
+                statement,
+                revealed_input_bucket,
+            })
         })
     }
 
@@ -344,53 +346,42 @@ impl TransactionBuilder {
 
     pub fn with_fee_instructions<I: IntoIterator<Item = Instruction>>(mut self, instructions: I) -> Self {
         self.unsigned_transaction.fee_instructions_mut().extend(instructions);
-        self.panic_if_signed();
         self
     }
 
     pub fn with_fee_instructions_builder<F: FnOnce(TransactionBuilder) -> TransactionBuilder>(mut self, f: F) -> Self {
-        // TODO: pass in a fee builder type (probably TransactionBuilder<FeeBuilder> which has applicable methods)
+        if self.is_in_fee_builder() {
+            let builder = f(self);
+            return builder;
+        }
         let builder = f(*self.fee_instruction_builder.take().unwrap());
         self.fee_instruction_builder = Some(Box::new(builder));
-        // self.unsigned_transaction
-        //     .fee_instructions_mut()
-        //     .extend(builder.unsigned_transaction.into_instructions());
-        self.panic_if_signed();
         self
     }
 
     pub fn add_fee_instruction(mut self, instruction: Instruction) -> Self {
         self.unsigned_transaction.fee_instructions_mut().push(instruction);
-        self.panic_if_signed();
         self
     }
 
     pub fn add_instruction(mut self, instruction: Instruction) -> Self {
         self.unsigned_transaction.instructions_mut().push(instruction);
-        // Reset the signatures as they are no longer valid
-        self.panic_if_signed();
         self
     }
 
     pub fn with_instructions<I: IntoIterator<Item = Instruction>>(mut self, instructions: I) -> Self {
         self.unsigned_transaction.instructions_mut().extend(instructions);
-        // Reset the signatures as they are no longer valid
-        self.panic_if_signed();
         self
     }
 
     /// Add an input to use in the transaction
     pub fn add_input<I: Into<SubstateRequirement>>(mut self, input_object: I) -> Self {
         self.unsigned_transaction.inputs_mut().insert(input_object.into());
-        // Reset the signatures as they are no longer valid
-        self.panic_if_signed();
         self
     }
 
     pub fn with_inputs<I: IntoIterator<Item = SubstateRequirement>>(mut self, inputs: I) -> Self {
         self.unsigned_transaction = self.unsigned_transaction.with_inputs(inputs);
-        // Reset the signatures as they are no longer valid
-        self.panic_if_signed();
         self
     }
 
@@ -400,15 +391,11 @@ impl TransactionBuilder {
 
     pub fn with_min_epoch(mut self, min_epoch: Option<Epoch>) -> Self {
         self.unsigned_transaction.set_min_epoch(min_epoch);
-        // Reset the signatures as they are no longer valid
-        self.panic_if_signed();
         self
     }
 
     pub fn with_max_epoch(mut self, max_epoch: Option<Epoch>) -> Self {
         self.unsigned_transaction.set_max_epoch(max_epoch);
-        // Reset the signatures as they are no longer valid
-        self.panic_if_signed();
         self
     }
 
@@ -436,36 +423,26 @@ impl TransactionBuilder {
         })
     }
 
-    pub fn build_unsigned_transaction(self) -> UnsignedTransaction {
+    pub fn build_unsigned_transaction(mut self) -> UnsignedTransaction {
+        self.apply_fee_instructions();
         self.unsigned_transaction
     }
 
-    pub fn add_signer(self, sealed_signer: &RistrettoPublicKeyBytes, secret_key: &RistrettoSecretKey) -> Self {
-        let signature = match &self.unsigned_transaction {
-            UnsignedTransaction::V1(tx) => TransactionSignature::sign_v1(secret_key, sealed_signer, tx),
-        };
-        self.add_signature(signature)
+    pub fn add_signer(
+        self,
+        sealed_signer: &RistrettoPublicKeyBytes,
+        secret_key: &RistrettoSecretKey,
+    ) -> UnsealedTransactionV1 {
+        let unsigned = self.build_unsigned_transaction();
+        let signature = TransactionSignature::sign(secret_key, sealed_signer, &unsigned);
+        unsigned.add_signature(signature)
     }
 
-    pub fn add_signature(mut self, signature: TransactionSignature) -> Self {
-        self.signatures.push(signature);
-        self
+    pub fn add_signature(self, signature: TransactionSignature) -> UnsealedTransactionV1 {
+        self.build_unsigned_transaction().add_signature(signature)
     }
 
-    pub fn signatures(&self) -> &[TransactionSignature] {
-        &self.signatures
-    }
-
-    #[track_caller]
-    fn panic_if_signed(&mut self) {
-        // TODO: use the type system to prevent this. Right now, IMO (debatable) it's better to panic than to allow the
-        // builder to potentially produce invalid transactions or unexpected results.
-        if !self.signatures.is_empty() {
-            panic!("Cannot modify a TransactionBuilder after signatures have been added");
-        }
-    }
-
-    pub fn finish(mut self) -> UnsealedTransactionV1 {
+    fn apply_fee_instructions(&mut self) {
         let fee_builder = self
             .fee_instruction_builder
             .take()
@@ -473,22 +450,15 @@ impl TransactionBuilder {
         self.unsigned_transaction
             .fee_instructions_mut()
             .extend(fee_builder.unsigned_transaction.into_instructions());
+    }
 
-        let builder = self.then(|builder| {
-            // This is so that we dont have to add this in a lot of places - TODO: this is an assumption that may not
-            // apply to all transactions
-            if builder.signatures.is_empty() {
-                builder.with_authorized_seal_signer()
-            } else {
-                builder
-            }
-        });
-
-        builder.unsigned_transaction.with_signatures(builder.signatures)
+    pub fn finish(mut self) -> UnsealedTransactionV1 {
+        self.apply_fee_instructions();
+        self.unsigned_transaction.finish()
     }
 
     pub fn build_and_seal(self, secret_key: &RistrettoSecretKey) -> Transaction {
-        self.finish().seal(secret_key)
+        self.with_authorized_seal_signer().finish().seal(secret_key)
     }
 
     fn resolve_call(&self, call: NamedComponentCall) -> ComponentCall {
@@ -553,12 +523,10 @@ impl Signable<&RistrettoPublicKeyBytes> for TransactionBuilder {
 }
 
 impl IntoSigned<&RistrettoPublicKeyBytes> for TransactionBuilder {
-    type SignedOutput = Self;
+    type SignedOutput = UnsealedTransactionV1;
 
     fn into_signed(self, public_key: RistrettoPublicKey, signature: RistrettoSchnorr) -> Self::SignedOutput {
-        self.add_signature(TransactionSignature::new(
-            public_key.to_byte_type(),
-            signature.to_byte_type(),
-        ))
+        self.finish()
+            .add_signature(public_key.to_byte_type(), signature.to_byte_type())
     }
 }

--- a/crates/transaction/src/transaction.rs
+++ b/crates/transaction/src/transaction.rs
@@ -352,8 +352,9 @@ mod tests {
 
         let secret2 = RistrettoSecretKey::random(&mut OsRng);
         let subject = create_transaction()
+            .finish()
             .add_signer(&public_key.to_byte_type(), &secret2)
-            .build_and_seal(&secret);
+            .seal(&secret);
         assert!(subject.verify_all_signatures());
     }
 }

--- a/crates/transaction/src/v1/signature.rs
+++ b/crates/transaction/src/v1/signature.rs
@@ -14,7 +14,13 @@ use tari_engine_types::{ConvertFromByteType, FromByteType, ToByteType};
 use tari_ootle_common_types::{Epoch, SubstateRequirement};
 use tari_template_lib::types::crypto::{RistrettoPublicKeyBytes, SchnorrSignatureBytes};
 
-use crate::{hashing::transaction_hasher_v1, Instruction, UnsealedTransactionV1, UnsignedTransactionV1};
+use crate::{
+    hashing::transaction_hasher_v1,
+    Instruction,
+    UnsealedTransactionV1,
+    UnsignedTransaction,
+    UnsignedTransactionV1,
+};
 
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq, borsh::BorshSerialize)]
 #[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export))]
@@ -81,6 +87,16 @@ pub struct TransactionSignature {
 impl TransactionSignature {
     pub fn new(public_key: RistrettoPublicKeyBytes, signature: SchnorrSignatureBytes) -> Self {
         Self { public_key, signature }
+    }
+
+    pub fn sign(
+        secret_key: &RistrettoSecretKey,
+        seal_signer: &RistrettoPublicKeyBytes,
+        transaction: &UnsignedTransaction,
+    ) -> Self {
+        match transaction {
+            UnsignedTransaction::V1(v1) => Self::sign_v1(secret_key, seal_signer, v1),
+        }
     }
 
     pub fn sign_v1(

--- a/crates/transaction/src/v1/unsealed.rs
+++ b/crates/transaction/src/v1/unsealed.rs
@@ -147,7 +147,12 @@ impl Signable<&RistrettoPublicKeyBytes> for UnsealedTransactionV1 {
 impl IntoSigned for UnsealedTransactionV1 {
     type SignedOutput = Transaction;
 
-    fn into_signed(self, public_key: RistrettoPublicKey, signature: RistrettoSchnorr) -> Self::SignedOutput {
+    fn into_signed(mut self, public_key: RistrettoPublicKey, signature: RistrettoSchnorr) -> Self::SignedOutput {
+        if self.signatures.is_empty() {
+            // Mark that the seal signer is authorized if there are no other signers
+            self.transaction.is_seal_signer_authorized = true;
+        }
+
         self.set_seal_signature(TransactionSealSignature::new(
             public_key.to_byte_type(),
             signature.to_byte_type(),

--- a/crates/validator_node_rpc/src/client.rs
+++ b/crates/validator_node_rpc/src/client.rs
@@ -31,21 +31,19 @@ pub trait ValidatorNodeClientFactory<TAddr: NodeAddressable>: Send + Sync {
 }
 
 pub trait ValidatorNodeRpcClient<TAddr: NodeAddressable>: Send + Sync {
-    type Error: std::error::Error + Send + Sync + 'static;
-
     fn submit_transaction(
         &mut self,
         transaction: Transaction,
-    ) -> impl Future<Output = Result<TransactionId, Self::Error>> + Send;
+    ) -> impl Future<Output = Result<TransactionId, ValidatorNodeRpcClientError>> + Send;
     fn get_finalized_transaction_result(
         &mut self,
         transaction_id: TransactionId,
-    ) -> impl Future<Output = Result<TransactionResultStatus, Self::Error>> + Send;
+    ) -> impl Future<Output = Result<TransactionResultStatus, ValidatorNodeRpcClientError>> + Send;
 
     fn get_substate(
         &mut self,
         substate_req: SubstateRequirementRef<'_>,
-    ) -> impl Future<Output = Result<SubstateResult, Self::Error>> + Send;
+    ) -> impl Future<Output = Result<SubstateResult, ValidatorNodeRpcClientError>> + Send;
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -113,8 +111,6 @@ impl<TAddr: ToPeerId, TMsg: MessageSpec> TariValidatorNodeRpcClient<TAddr, TMsg>
 impl<TAddr: NodeAddressable + ToPeerId, TMsg: MessageSpec> ValidatorNodeRpcClient<TAddr>
     for TariValidatorNodeRpcClient<TAddr, TMsg>
 {
-    type Error = ValidatorNodeRpcClientError;
-
     async fn submit_transaction(
         &mut self,
         transaction: Transaction,
@@ -185,7 +181,10 @@ impl<TAddr: NodeAddressable + ToPeerId, TMsg: MessageSpec> ValidatorNodeRpcClien
         }
     }
 
-    async fn get_substate(&mut self, substate_req: SubstateRequirementRef<'_>) -> Result<SubstateResult, Self::Error> {
+    async fn get_substate(
+        &mut self,
+        substate_req: SubstateRequirementRef<'_>,
+    ) -> Result<SubstateResult, ValidatorNodeRpcClientError> {
         let mut client = self.client_connection().await?;
 
         let request = proto::rpc::GetSubstateRequest {

--- a/crates/validator_node_rpc/src/error.rs
+++ b/crates/validator_node_rpc/src/error.rs
@@ -22,11 +22,21 @@ pub enum ValidatorNodeRpcClientError {
     BorError(#[from] BorError),
 }
 
+impl ValidatorNodeRpcClientError {
+    pub fn status(&self) -> Option<&RpcStatus> {
+        match self {
+            Self::RpcStatusError(status) => Some(status),
+            Self::RpcError(RpcError::RequestFailed(status)) => Some(status),
+            _ => None,
+        }
+    }
+}
+
 impl IsNotFoundError for ValidatorNodeRpcClientError {
     fn is_not_found_error(&self) -> bool {
         match self {
-            ValidatorNodeRpcClientError::RpcStatusError(status) => status.is_not_found(),
-            ValidatorNodeRpcClientError::RpcError(RpcError::RequestFailed(status)) => status.is_not_found(),
+            Self::RpcStatusError(status) => status.is_not_found(),
+            Self::RpcError(RpcError::RequestFailed(status)) => status.is_not_found(),
             _ => false,
         }
     }

--- a/crates/wallet/sdk/src/apis/transaction.rs
+++ b/crates/wallet/sdk/src/apis/transaction.rs
@@ -10,6 +10,7 @@ use tari_engine_types::{
 };
 use tari_ootle_common_types::{
     optional::{IsNotFoundError, Optional},
+    response_status::{ResponseErrorStatus, TransactionStatusResponseError},
     VersionedSubstateIdRef,
 };
 use tari_template_lib::{
@@ -20,7 +21,7 @@ use tari_transaction::{Transaction, TransactionId};
 
 use crate::{
     models::{NewAccountData, TransactionStatus, WalletLockId, WalletTransaction, WalletTransactionUpdate},
-    network::{StatusResponseError, TransactionFinalizedResult, WalletNetworkInterface, WalletQueryErrorStatus},
+    network::{TransactionFinalizedResult, WalletNetworkInterface},
     storage::{WalletStorageError, WalletStore, WalletStoreReader, WalletStoreWriter, WriteableWalletStore},
 };
 
@@ -35,7 +36,7 @@ impl<'a, TStore, TNetworkInterface> TransactionApi<'a, TStore, TNetworkInterface
 where
     TStore: WalletStore,
     TNetworkInterface: WalletNetworkInterface,
-    TNetworkInterface::Error: IsNotFoundError + StatusResponseError,
+    TNetworkInterface::Error: IsNotFoundError + TransactionStatusResponseError,
 {
     pub fn new(store: &'a TStore, network_interface: &'a TNetworkInterface) -> Self {
         Self {
@@ -91,7 +92,7 @@ where
             },
             Err(err) => {
                 return match err.get_status() {
-                    WalletQueryErrorStatus::TransactionRejected { message } => {
+                    ResponseErrorStatus::TransactionRejected { message } => {
                         warn!(target: LOG_TARGET, "Invalid transaction submission: {transaction_id} {message}");
                         self.store.with_write_tx(|tx| {
                             tx.transactions_update(
@@ -343,7 +344,8 @@ where
 
         for (component_addr, substate) in components {
             let component = substate.substate_value().component().unwrap();
-            let indexed = IndexedWellKnownTypes::from_value(component.state())?;
+            let indexed =
+                IndexedWellKnownTypes::from_value(component.state()).map_err(TransactionApiError::IndexedValueError)?;
 
             debug!(target: LOG_TARGET, "Substate {} up", component_addr);
             tx.substates_upsert_root(
@@ -477,13 +479,15 @@ where
                         .non_fungible()
                         .and_then(|s| s.contents())
                         .map(|c| IndexedWellKnownTypes::from_value(c.data()))
-                        .transpose()?;
+                        .transpose()
+                        .map_err(TransactionApiError::IndexedValueError)?;
                     let referenced_mdata = substate
                         .substate_value()
                         .non_fungible()
                         .and_then(|s| s.contents())
                         .map(|c| IndexedWellKnownTypes::from_value(c.mutable_data()))
-                        .transpose()?;
+                        .transpose()
+                        .map_err(TransactionApiError::IndexedValueError)?;
                     tx.substates_upsert_child(
                         &SubstateId::Resource(*resource_address),
                         VersionedSubstateIdRef::new(id, substate.version()),
@@ -523,11 +527,11 @@ pub enum TransactionApiError {
     StoreError(#[from] WalletStorageError),
     #[error("Network interface error: {status} {message}")]
     NetworkInterfaceError {
-        status: WalletQueryErrorStatus,
+        status: ResponseErrorStatus,
         message: String,
     },
     #[error("Failed to extract known type data from value: {0}")]
-    IndexedValueError(#[from] IndexedValueError),
+    IndexedValueError(IndexedValueError),
     #[error("Invalid transaction query response: {details}")]
     InvalidTransactionQueryResponse { details: String },
 }
@@ -538,7 +542,7 @@ impl IsNotFoundError for TransactionApiError {
     }
 }
 
-impl<T: StatusResponseError> From<T> for TransactionApiError {
+impl<T: TransactionStatusResponseError> From<T> for TransactionApiError {
     fn from(value: T) -> Self {
         TransactionApiError::NetworkInterfaceError {
             status: value.get_status(),

--- a/crates/wallet/sdk/src/network.rs
+++ b/crates/wallet/sdk/src/network.rs
@@ -1,7 +1,7 @@
 //   Copyright 2023 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use std::{collections::HashMap, convert::Infallible, future::Future, pin::Pin, time::Duration};
+use std::{collections::HashMap, future::Future, pin::Pin, time::Duration};
 
 use futures::Stream;
 use serde::{Deserialize, Serialize};
@@ -11,7 +11,13 @@ use tari_engine_types::{
     substate::{Substate, SubstateId, SubstateValue},
     Utxo,
 };
-use tari_ootle_common_types::{optional::IsNotFoundError, shard::Shard, Epoch, StateVersion};
+use tari_ootle_common_types::{
+    optional::IsNotFoundError,
+    response_status::TransactionStatusResponseError,
+    shard::Shard,
+    Epoch,
+    StateVersion,
+};
 use tari_template_abi::TemplateDef;
 use tari_template_lib::{
     models::{ResourceAddress, UtxoId},
@@ -27,7 +33,7 @@ use crate::models::UtxoUpdatePayload;
 pub type UtxoUpdateStream<E> = Pin<Box<dyn Stream<Item = Result<UtxoUpdatePayload, E>> + Send + 'static>>;
 
 pub trait WalletNetworkInterface {
-    type Error: IsNotFoundError + StatusResponseError + std::error::Error + Send + Sync + 'static;
+    type Error: IsNotFoundError + TransactionStatusResponseError + std::error::Error + Send + Sync + 'static;
 
     fn query_substate(
         &self,
@@ -76,33 +82,6 @@ pub trait WalletNetworkInterface {
     ) -> impl Future<Output = Result<Vec<(UtxoId, Utxo)>, Self::Error>> + Send;
 
     fn wait_until_ready(&self) -> impl Future<Output = Result<(), Self::Error>> + Send;
-}
-
-/// A trait for responses that can provide a [WalletQueryErrorStatus]
-pub trait StatusResponseError {
-    fn get_status(&self) -> WalletQueryErrorStatus;
-    fn get_error_message(&self) -> String;
-}
-
-// This is required for tests (PanicInterface) - in general, if a type is `Infallible` it should never reach the error.
-impl StatusResponseError for Infallible {
-    fn get_status(&self) -> WalletQueryErrorStatus {
-        unreachable!("Infallible should never be used as an error type in this context")
-    }
-
-    fn get_error_message(&self) -> String {
-        unreachable!("Infallible should never be used as an error type in this context")
-    }
-}
-
-#[derive(Debug, thiserror::Error)]
-pub enum WalletQueryErrorStatus {
-    #[error("Not found: {message}")]
-    NotFound { message: String },
-    #[error("Transaction rejected: {message}")]
-    TransactionRejected { message: String },
-    #[error("Internal error: {message}")]
-    InternalError { message: String },
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/crates/wallet/sdk/tests/support/harness.rs
+++ b/crates/wallet/sdk/tests/support/harness.rs
@@ -12,6 +12,7 @@ use tari_engine_types::{
 };
 use tari_ootle_common_types::{
     optional::{IsNotFoundError, Optional},
+    response_status::{ResponseErrorStatus, TransactionStatusResponseError},
     shard::Shard,
     Epoch,
     Network,
@@ -30,14 +31,7 @@ use tari_ootle_wallet_sdk::{
         WalletLockDropGuard,
         WalletLockId,
     },
-    network::{
-        StatusResponseError,
-        SubstateQueryResult,
-        TransactionQueryResult,
-        UtxoUpdateStream,
-        WalletNetworkInterface,
-        WalletQueryErrorStatus,
-    },
+    network::{SubstateQueryResult, TransactionQueryResult, UtxoUpdateStream, WalletNetworkInterface},
     storage::TagAndPublicNoncePair,
     WalletSdk,
     WalletSdkConfig,
@@ -245,7 +239,7 @@ impl WalletNetworkInterface for PanicNetworkInterface {
 }
 
 #[derive(Debug)]
-pub struct PanicError;
+pub enum PanicError {}
 
 impl std::fmt::Display for PanicError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -255,8 +249,8 @@ impl std::fmt::Display for PanicError {
 
 impl std::error::Error for PanicError {}
 
-impl StatusResponseError for PanicError {
-    fn get_status(&self) -> WalletQueryErrorStatus {
+impl TransactionStatusResponseError for PanicError {
+    fn get_status(&self) -> ResponseErrorStatus {
         panic!("get_status called on PanicError")
     }
 

--- a/crates/wallet/sdk_services/src/account_recovery/service.rs
+++ b/crates/wallet/sdk_services/src/account_recovery/service.rs
@@ -9,13 +9,14 @@ use tari_engine_types::{component::derive_component_address_from_public_key, ToB
 use tari_ootle_common_types::{
     displayable::Displayable,
     optional::{IsNotFoundError, Optional},
+    response_status::TransactionStatusResponseError,
     substate_type::SubstateType,
     Epoch,
 };
 use tari_ootle_wallet_sdk::{
     apis::config::ConfigKey,
     models::{DerivedWalletKey, KeyBranch, KeyId},
-    network::{StatusResponseError, WalletNetworkInterface},
+    network::WalletNetworkInterface,
     WalletSdk,
     WalletSdkSpec,
 };
@@ -37,7 +38,7 @@ pub struct AccountRecoveryService<TSpec: WalletSdkSpec> {
 impl<TSpec> AccountRecoveryService<TSpec>
 where
     TSpec: WalletSdkSpec,
-    <TSpec::NetworkInterface as WalletNetworkInterface>::Error: IsNotFoundError + StatusResponseError,
+    <TSpec::NetworkInterface as WalletNetworkInterface>::Error: IsNotFoundError + TransactionStatusResponseError,
 {
     pub fn new(
         wallet_sdk: WalletSdk<TSpec>,

--- a/crates/wallet/sdk_services/src/indexer_rest_api.rs
+++ b/crates/wallet/sdk_services/src/indexer_rest_api.rs
@@ -30,6 +30,7 @@ use tari_ootle_common_types::{
     array_utils::copy_fixed_checked,
     displayable::Displayable,
     optional::IsNotFoundError,
+    response_status::{ResponseErrorStatus, TransactionStatusResponseError},
     shard::Shard,
     Epoch,
     StateVersion,
@@ -37,13 +38,11 @@ use tari_ootle_common_types::{
 use tari_ootle_wallet_sdk::{
     models::{EndOfShard, StartOfShard, UtxoBurnt, UtxoSpent, UtxoUnspent, UtxoUpdatePayload, WalletUtxoUpdate},
     network::{
-        StatusResponseError,
         SubstateQueryResult,
         TransactionFinalizedResult,
         TransactionQueryResult,
         UtxoUpdateStream,
         WalletNetworkInterface,
-        WalletQueryErrorStatus,
     },
 };
 use tari_template_lib::{
@@ -289,12 +288,12 @@ impl IsNotFoundError for IndexerRestApiNetworkInterfaceError {
     }
 }
 
-impl StatusResponseError for IndexerRestApiNetworkInterfaceError {
-    fn get_status(&self) -> WalletQueryErrorStatus {
+impl TransactionStatusResponseError for IndexerRestApiNetworkInterfaceError {
+    fn get_status(&self) -> ResponseErrorStatus {
         match self {
             IndexerRestApiNetworkInterfaceError::IndexerClientError(err) => {
                 if err.is_not_found_error() {
-                    return WalletQueryErrorStatus::NotFound {
+                    return ResponseErrorStatus::NotFound {
                         message: "The requested resource was not found".to_string(),
                     };
                 }
@@ -302,35 +301,35 @@ impl StatusResponseError for IndexerRestApiNetworkInterfaceError {
                     IndexerRestClientError::RequestFailedWithStatus { code, message }
                         if *code == INVALID_REQUEST_CODE =>
                     {
-                        WalletQueryErrorStatus::TransactionRejected {
+                        ResponseErrorStatus::TransactionRejected {
                             message: message.clone(),
                         }
                     },
                     IndexerRestClientError::RequestFailedWithStatus { code, message } => {
-                        WalletQueryErrorStatus::InternalError {
+                        ResponseErrorStatus::InternalError {
                             message: format!("Indexer request failed with status {code}: {message}"),
                         }
                     },
                     IndexerRestClientError::ErrorResponse { source, details } => {
                         if source.status().map(|s| s.as_u16()) == Some(INVALID_REQUEST_CODE as u16) {
-                            WalletQueryErrorStatus::TransactionRejected {
+                            ResponseErrorStatus::TransactionRejected {
                                 message: format!("Indexer error response: {}. Details: {}", source, details.display()),
                             }
                         } else {
-                            WalletQueryErrorStatus::InternalError {
+                            ResponseErrorStatus::InternalError {
                                 message: format!("Indexer error response: {}", source),
                             }
                         }
                     },
-                    _ => WalletQueryErrorStatus::InternalError {
+                    _ => ResponseErrorStatus::InternalError {
                         message: format!("Indexer client error: {err}"),
                     },
                 }
             },
-            IndexerRestApiNetworkInterfaceError::IndexerParseError(e) => WalletQueryErrorStatus::InternalError {
+            IndexerRestApiNetworkInterfaceError::IndexerParseError(e) => ResponseErrorStatus::InternalError {
                 message: format!("Indexer parse error: {e}"),
             },
-            IndexerRestApiNetworkInterfaceError::StreamDecodeError(e) => WalletQueryErrorStatus::InternalError {
+            IndexerRestApiNetworkInterfaceError::StreamDecodeError(e) => ResponseErrorStatus::InternalError {
                 message: format!("Indexer stream decode error: {e}"),
             },
         }

--- a/crates/wallet/sdk_services/src/transaction_service/service.rs
+++ b/crates/wallet/sdk_services/src/transaction_service/service.rs
@@ -5,7 +5,7 @@ use std::{sync::Arc, time::Duration};
 
 use log::*;
 use tari_engine_types::commit_result::ExecuteResult;
-use tari_ootle_common_types::optional::IsNotFoundError;
+use tari_ootle_common_types::{optional::IsNotFoundError, response_status::TransactionStatusResponseError};
 use tari_ootle_wallet_sdk::{
     models::{
         NewAccountData,
@@ -16,7 +16,7 @@ use tari_ootle_wallet_sdk::{
         WalletEvent,
         WalletLockId,
     },
-    network::{StatusResponseError, WalletNetworkInterface},
+    network::WalletNetworkInterface,
     WalletSdk,
     WalletSdkSpec,
 };
@@ -52,7 +52,7 @@ where
     TSpec::Store: Clone + Send + Sync + 'static,
     TSpec::NetworkInterface: Clone + Send + Sync + 'static,
     TSpec::KeyStore: Clone + Send + Sync + 'static,
-    <TSpec::NetworkInterface as WalletNetworkInterface>::Error: IsNotFoundError + StatusResponseError,
+    <TSpec::NetworkInterface as WalletNetworkInterface>::Error: IsNotFoundError + TransactionStatusResponseError,
 {
     pub fn new(
         notify: Notify<WalletEvent>,

--- a/crates/wallet/sdk_services/src/utxo_scanner/utxo_recovery.rs
+++ b/crates/wallet/sdk_services/src/utxo_scanner/utxo_recovery.rs
@@ -7,6 +7,7 @@ use log::*;
 use tari_engine_types::UtxoOutput;
 use tari_ootle_common_types::{
     optional::{IsNotFoundError, Optional},
+    response_status::TransactionStatusResponseError,
     Network,
 };
 use tari_ootle_wallet_sdk::{
@@ -17,7 +18,7 @@ use tari_ootle_wallet_sdk::{
         UtxoRecoveryStartedEvent,
         WalletEvent,
     },
-    network::{StatusResponseError, WalletNetworkInterface},
+    network::WalletNetworkInterface,
     storage::{ReadableWalletStore, WalletStorageError, WalletStoreReader, WalletStoreWriter, WriteableWalletStore},
     WalletSdk,
     WalletSdkSpec,
@@ -38,7 +39,7 @@ pub struct UtxoRecovery<TSpec: WalletSdkSpec> {
 impl<TSpec> UtxoRecovery<TSpec>
 where
     TSpec: WalletSdkSpec,
-    <TSpec::NetworkInterface as WalletNetworkInterface>::Error: IsNotFoundError + StatusResponseError,
+    <TSpec::NetworkInterface as WalletNetworkInterface>::Error: IsNotFoundError + TransactionStatusResponseError,
 {
     pub fn new(sdk: WalletSdk<TSpec>) -> Self {
         Self {

--- a/utilities/tariswap_test_bench/src/tariswap.rs
+++ b/utilities/tariswap_test_bench/src/tariswap.rs
@@ -147,14 +147,14 @@ impl Runner {
                     .put_last_instruction_output_on_workspace("lp")
                     .call_method(account.component_address, "deposit", args![Workspace("lp")])
                     .with_authorized_seal_signer()
-                    .map(|builder| {
-                        // First sign with the account key to authorize the use of the account component
-                        self.sdk
-                            .signer_api()
-                            .with_context(&primary_account_pk)
-                            .sign(account.owner_key_id.expect("no owner key id"), builder)
-                    })?
                     .finish();
+
+                // First sign with the account key to authorize the use of the account component
+                let transaction = self
+                    .sdk
+                    .signer_api()
+                    .with_context(&primary_account_pk)
+                    .sign(account.owner_key_id.expect("no owner key id"), transaction)?;
 
                 // Then sign with the primary account key to pay the fee
                 let transaction = self.sdk.signer_api().sign(primary_account_key.key_id(), transaction)?;
@@ -274,7 +274,8 @@ impl Runner {
                     ])
                     .put_last_instruction_output_on_workspace("swapped")
                     .call_method(account.component_address, "deposit", args![Workspace("swapped")])
-                    .with_authorized_seal_signer();
+                    .with_authorized_seal_signer()
+                    .finish();
 
                 let transaction = self
                     .sdk
@@ -282,10 +283,7 @@ impl Runner {
                     .with_context(&primary_account_pk)
                     .sign(account.owner_key_id.expect("no owner key id"), transaction)?;
 
-                let transaction = self
-                    .sdk
-                    .signer_api()
-                    .sign(primary_account_key.key_id(), transaction.finish())?;
+                let transaction = self.sdk.signer_api().sign(primary_account_key.key_id(), transaction)?;
 
                 tx_ids.push(self.submit_transaction(transaction).await?);
             }


### PR DESCRIPTION
Description
---
fix: transaction builder remove signatures
fix(indexer): return HTTP bad request error if validators return RPC bad request
fix(indexer): bug in get transaction receipts  always returning internal error

Motivation and Context
---
Previously, it was possible to partially sign a transaction and then make changes to the transaction (invalidating the signature(s)) using the builder. This would result in a panic.

This PR removes the internal signature collection from the builder, and changes the signing functions to return an Unsealed transaction which already has an API for adding futher signatures without allowing changes to the transaction.
Only code that previously used the builder incorrectly (i.e. would panic) will now fail to compile.

How Has This Been Tested?
---
Manually

What process can a PR reviewer use to test or verify this change?
---


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling for transaction submission failures, providing more detailed error information including transaction status and validation committee feedback.

* **Refactor**
  * Standardized error reporting across transaction and network interfaces for consistency and clarity.
  * Restructured transaction signing workflow for better separation of concerns and clearer API semantics.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->