### PR TITLE
fix: add an error case for dropped subscriber

### DIFF
--- a/applications/tari_validator_node/src/consensus/handle.rs
+++ b/applications/tari_validator_node/src/consensus/handle.rs
@@ -50,8 +50,8 @@ impl ConsensusHandle {
         &self.current_view
     }
 
-    pub fn subscribe_to_hotstuff_events(&mut self) -> broadcast::Receiver<HotstuffEvent> {
-        self.events_subscription.subscribe()
+    pub fn subscribe_to_hotstuff_events(&mut self) -> Result<broadcast::Receiver<HotstuffEvent>, anyhow::Error> {
+        Ok(self.events_subscription.try_subscribe()?)
     }
 
     pub fn get_current_state(&self) -> ConsensusCurrentState {

--- a/applications/tari_validator_node/src/event_subscription.rs
+++ b/applications/tari_validator_node/src/event_subscription.rs
@@ -22,6 +22,12 @@
 
 use tokio::sync::broadcast;
 
+#[derive(Debug, thiserror::Error)]
+pub enum EventSubscriptionError {
+    #[error("The sender has been dropped")]
+    SenderDropped,
+}
+
 /// Wraps a broadcast sender, allowing a subscription (Receiver) to be obtained but removing the ability to send an
 /// event.
 ///
@@ -35,9 +41,9 @@ impl<T> EventSubscription<T> {
         Self(sender)
     }
 
-    pub fn subscribe(&self) -> broadcast::Receiver<T> {
-        let sender = self.0.upgrade().unwrap_or_else(|| broadcast::Sender::new(1));
-        sender.subscribe()
+    pub fn try_subscribe(&self) -> Result<broadcast::Receiver<T>, EventSubscriptionError> {
+        let sender = self.0.upgrade().ok_or(EventSubscriptionError::SenderDropped)?;
+        Ok(sender.subscribe())
     }
 }
 

--- a/applications/tari_validator_node/src/event_subscription.rs
+++ b/applications/tari_validator_node/src/event_subscription.rs
@@ -24,7 +24,7 @@ use tokio::sync::broadcast;
 
 #[derive(Debug, thiserror::Error)]
 pub enum EventSubscriptionError {
-    #[error("The sender has been dropped")]
+    #[error("All event senders have dropped on initialzation. This indicates a bug in the node.")]
     SenderDropped,
 }
 

--- a/applications/tari_validator_node/src/node.rs
+++ b/applications/tari_validator_node/src/node.rs
@@ -44,7 +44,7 @@ impl ValidatorNode {
     }
 
     pub async fn start(mut self, mut shutdown: Shutdown) -> Result<(), anyhow::Error> {
-        let mut hotstuff_events = self.services.consensus_handle.subscribe_to_hotstuff_events();
+        let mut hotstuff_events = self.services.consensus_handle.subscribe_to_hotstuff_events()?;
         let mut epoch_manager_events = self.services.epoch_manager.subscribe();
 
         // if let Err(err) = self.dial_local_shard_peers().await {

--- a/applications/tari_validator_node/src/p2p/services/mempool/service.rs
+++ b/applications/tari_validator_node/src/p2p/services/mempool/service.rs
@@ -92,7 +92,7 @@ where
     }
 
     pub async fn run(mut self) -> anyhow::Result<()> {
-        let mut consensus_events = self.consensus_handle.subscribe_to_hotstuff_events();
+        let mut consensus_events = self.consensus_handle.subscribe_to_hotstuff_events()?;
 
         loop {
             tokio::select! {


### PR DESCRIPTION
The previous implementation, if all senders had dropped (should never happen), the function would create a subscription that would never emit new items. Although this is completely fine in this case, this may be surprising in future and potentially lead to bugs. 

This PR instead chooses to "crash" the node on initialisation. The error message indicates to developers that there is a bug.
