### PR TITLE
fix(consensus): more explicit vote equivocation detection

### DIFF
--- a/crates/consensus/src/hotstuff/on_inbound_message.rs
+++ b/crates/consensus/src/hotstuff/on_inbound_message.rs
@@ -112,12 +112,15 @@ impl<TConsensusSpec: ConsensusSpec> MessageBuffer<TConsensusSpec> {
         while let Some(result) = self.inbound_messaging.next_message().await {
             let (from, msg) = result?;
 
-            // If we receive an FP that is greater than our current epoch, we buffer it. The height is not relevant.
-            if let HotstuffMessage::ForeignProposal(ref m) = msg {
-                if m.proposal.epoch() > current_epoch {
-                    self.push_to_buffer(m.proposal.epoch(), NodeHeight::zero(), from, msg);
-                    continue;
-                }
+            if msg.epoch() > current_epoch + Epoch(1) {
+                warn!(
+                    target: LOG_TARGET,
+                    "🗑️ Discard non-applicable message {} for epoch {}. Current epoch is {}",
+                    msg,
+                    msg.epoch(),
+                    current_epoch
+                );
+                continue;
             }
 
             match msg_relative_view(&msg, current_epoch, current_height, has_processed_first_block) {
@@ -160,7 +163,33 @@ impl<TConsensusSpec: ConsensusSpec> MessageBuffer<TConsensusSpec> {
     }
 
     fn push_to_buffer(&mut self, epoch: Epoch, height: NodeHeight, from: TConsensusSpec::Addr, msg: HotstuffMessage) {
-        self.buffer.entry((epoch, height)).or_default().push_back((from, msg));
+        const MAX_BUFFERED_MESSAGES_PER_VIEW: usize = 1000;
+        const MAX_BUFFERED_VIEWS: usize = 100_000;
+        if self.buffer.len() >= MAX_BUFFERED_VIEWS {
+            warn!(
+                target: LOG_TARGET,
+                "🗑️ Discarding message {} for view {}/{} as buffer view limit of {} reached",
+                msg,
+                epoch,
+                height,
+                MAX_BUFFERED_VIEWS
+            );
+            return;
+        }
+
+        let messages_mut = self.buffer.entry((epoch, height)).or_default();
+        if messages_mut.len() > MAX_BUFFERED_MESSAGES_PER_VIEW {
+            warn!(
+                target: LOG_TARGET,
+                "🗑️ Discarding message {} for view {}/{} as buffer limit of {} reached",
+                msg,
+                epoch,
+                height,
+                MAX_BUFFERED_MESSAGES_PER_VIEW
+            );
+            return;
+        }
+        messages_mut.push_back((from, msg));
     }
 }
 
@@ -338,6 +367,7 @@ fn msg_relative_view(
             if msg.epoch() > current_epoch {
                 return MessageRelativeView::Future {
                     epoch: msg.epoch(),
+                    // Foreign height is not locally relevant, we can process it when we reach the epoch
                     height: NodeHeight::zero(),
                 };
             }

--- a/crates/consensus/src/hotstuff/vote_collector/collector.rs
+++ b/crates/consensus/src/hotstuff/vote_collector/collector.rs
@@ -35,24 +35,15 @@ impl<V: Vote + Display> VoteCollector<V> {
         sender_hash: FixedHash,
         vote: V,
         committee: &Committee<TAddr>,
-    ) -> Option<(Vec<V>, QuorumDecision)> {
+    ) -> Result<Option<(Vec<V>, QuorumDecision)>, VoteEquivocationDetected<V>> {
         let mut access_mut = self.store.write().await;
         access_mut.clear_votes_before(current_epoch, current_height);
         let epoch = vote.epoch();
         let height = vote.height();
-        let key = vote.key();
         let vote_display = vote.to_string();
-        if !access_mut.save_vote(sender_hash, vote) {
-            debug!(
-                target: LOG_TARGET,
-                "❓️ Received duplicate vote for {}. This could be malicious because a validator should only vote once for the same block.",
-                vote_display,
-            );
-            // We already have a vote for this block from this sender
-            return None;
-        }
+        access_mut.save_vote(sender_hash, vote)?;
 
-        let threshold_decision = access_mut.calculate_threshold_decision(epoch, height, &key, committee);
+        let threshold_decision = access_mut.calculate_threshold_decision(epoch, height, committee);
 
         let quorum_threshold = committee.quorum_threshold();
         let Some(quorum_decision) = threshold_decision.decision else {
@@ -64,7 +55,7 @@ impl<V: Vote + Display> VoteCollector<V> {
                 threshold_decision.total_power,
                 quorum_threshold
             );
-            return None;
+            return Ok(None);
         };
 
         // We only generate the next qc once when we have a quorum of votes. Any votes received after this
@@ -78,7 +69,7 @@ impl<V: Vote + Display> VoteCollector<V> {
                 threshold_decision.total_power,
                 quorum_threshold
             );
-            return None;
+            return Ok(None);
         }
 
         debug!(
@@ -90,9 +81,9 @@ impl<V: Vote + Display> VoteCollector<V> {
             quorum_threshold
         );
 
-        let votes = access_mut.take_votes_with_decision_for_key(epoch, height, &key, quorum_decision)?;
+        let votes = access_mut.take_votes_with_decision(epoch, height, quorum_decision);
 
-        Some((votes, quorum_decision))
+        Ok(votes.map(|v| (v, quorum_decision)))
     }
 }
 
@@ -103,12 +94,11 @@ type SenderVotesCollection<V> = HashMap<FixedHash, V>;
 struct VoteStoreInner<V: Vote> {
     /// Maps (Epoch,Height) -> map (key -> map (sender leaf hash -> vote))
     /// The key is some type that uniquely keys the vote e.g BlockId or (Epoch,Height)
-    store: BTreeMap<(Epoch, NodeHeight), HashMap<V::Key, SenderVotesCollection<V>>>,
+    store: BTreeMap<(Epoch, NodeHeight), SenderVotesCollection<V>>,
 }
 
 impl<V: Vote + Display> VoteStoreInner<V> {
     const VOTE_BYTE_SIZE: usize = size_of::<V>() + size_of::<FixedHash>();
-    const VOTE_KEY_SIZE: usize = size_of::<V::Key>();
 
     pub fn new() -> Self {
         Self { store: BTreeMap::new() }
@@ -119,14 +109,12 @@ impl<V: Vote + Display> VoteStoreInner<V> {
         self.log_buffer_size();
     }
 
-    /// Save a vote to the store. Returns false if a previous vote for the block by the sender was already present,
-    /// otherwise true. Even if the vote is different, it is not considered a duplicate/invalid and does not
-    /// overwrite the previous vote.
-    pub fn save_vote(&mut self, sender_hash: FixedHash, vote: V) -> bool {
+    /// Save a vote to the store. Returns VoteEquivocationDetected if a previous vote for the block by the sender was
+    /// already present.
+    pub fn save_vote(&mut self, sender_hash: FixedHash, vote: V) -> Result<(), VoteEquivocationDetected<V>> {
         let epoch_height = (vote.epoch(), vote.height());
         let view_votes_mut = self.store.entry(epoch_height).or_default();
-        let votes_mut = view_votes_mut.entry(vote.key()).or_default();
-        if votes_mut.contains_key(&sender_hash) {
+        if let Some(prev_vote) = view_votes_mut.remove(&sender_hash) {
             warn!(
                 target: LOG_TARGET,
                 "❓️ Received duplicate vote for {} from {} (sender hash). This could be malicious because a validator should only vote once for the same block.",
@@ -134,35 +122,34 @@ impl<V: Vote + Display> VoteStoreInner<V> {
                 sender_hash
             );
             // We already have a vote for this block from this sender
-            return false;
+            return Err(VoteEquivocationDetected {
+                epoch: vote.epoch(),
+                height: vote.height(),
+                sender_hash,
+                previous_vote: prev_vote,
+                new_vote: vote,
+            });
         }
 
-        votes_mut.insert(sender_hash, vote);
-        true
+        view_votes_mut.insert(sender_hash, vote);
+        Ok(())
     }
 
-    pub fn take_votes_with_decision_for_key(
+    pub fn take_votes_with_decision(
         &mut self,
         epoch: Epoch,
         height: NodeHeight,
-        key: &V::Key,
         decision: QuorumDecision,
     ) -> Option<Vec<V>> {
         let epoch_height = (epoch, height);
-        let mut keyed_votes = self.store.remove(&epoch_height)?;
-        // Discard any other votes for this epoch/height that are not for the key
-        let votes = keyed_votes.remove(key)?;
-        if keyed_votes.is_empty() {
-            // Remove the empty map
-            self.store.remove(&epoch_height);
-        }
+        // Take all votes, discarding any other votes for this epoch/height that do not match the decision
+        let votes = self.store.remove(&epoch_height)?;
         Some(votes.into_values().filter(|vote| vote.decision() == decision).collect())
     }
 
-    fn votes_for_key_iter(&self, epoch: Epoch, height: NodeHeight, key: &V::Key) -> Option<impl Iterator<Item = &V>> {
+    fn votes_for_key_iter(&self, epoch: Epoch, height: NodeHeight) -> Option<impl Iterator<Item = &V>> {
         let epoch_height = (epoch, height);
-        let epoch_height_votes = self.store.get(&epoch_height)?;
-        let votes = epoch_height_votes.get(key)?;
+        let votes = self.store.get(&epoch_height)?;
         Some(votes.values())
     }
 
@@ -170,10 +157,9 @@ impl<V: Vote + Display> VoteStoreInner<V> {
         &self,
         epoch: Epoch,
         height: NodeHeight,
-        key: &V::Key,
         committee: &Committee<TAddr>,
     ) -> ThresholdDecision {
-        let Some(votes_iter) = self.votes_for_key_iter(epoch, height, key) else {
+        let Some(votes_iter) = self.votes_for_key_iter(epoch, height) else {
             // Soft invariant protection - technically, this should not happen but the correct ThresholdDecision is
             // returned regardless i.e. 0 votes
             error!(
@@ -220,10 +206,10 @@ impl<V: Vote + Display> VoteStoreInner<V> {
     fn log_buffer_size(&self) {
         debug!(
             target: LOG_TARGET,
-            "Vote store size: used: {:.2?}KiB ({} entries)",
+            "Vote store size: used: >{:.2?}KiB ({} entries)",
             self.store.values() .map(|v|
-                v.len() * Self::VOTE_KEY_SIZE +
-                v.values().map(|v| v.len()).sum::<usize>() * Self::VOTE_BYTE_SIZE
+                v.len() * FixedHash::byte_size() +
+                v.len() * Self::VOTE_BYTE_SIZE
             ).sum::<usize>() as f32 / 1024f32,
             self.store.len(),
         );
@@ -234,6 +220,16 @@ impl<V: Vote + Display> VoteStoreInner<V> {
 pub struct ThresholdDecision {
     pub decision: Option<QuorumDecision>,
     pub total_power: VotePower,
+}
+
+#[derive(Debug, Clone, thiserror::Error)]
+#[error("Vote equivocation detected at epoch {epoch}, height {height} from sender hash {sender_hash}")]
+pub struct VoteEquivocationDetected<V: Vote> {
+    pub epoch: Epoch,
+    pub height: NodeHeight,
+    pub sender_hash: FixedHash,
+    pub previous_vote: V,
+    pub new_vote: V,
 }
 
 #[cfg(test)]
@@ -250,7 +246,6 @@ mod tests {
     struct TestVote {
         epoch: Epoch,
         height: NodeHeight,
-        key: u32,
     }
 
     impl Display for TestVote {
@@ -276,18 +271,12 @@ mod tests {
     }
 
     impl Vote for TestVote {
-        type Key = u32;
-
         fn epoch(&self) -> Epoch {
             self.epoch
         }
 
         fn height(&self) -> NodeHeight {
             self.height
-        }
-
-        fn key(&self) -> Self::Key {
-            self.key
         }
 
         fn decision(&self) -> QuorumDecision {
@@ -301,10 +290,10 @@ mod tests {
         let vote = TestVote {
             epoch: Epoch(1),
             height: NodeHeight(1),
-            key: 42,
         };
-        let result = store.save_vote(FixedHash::zero(), vote.clone());
-        assert!(result, "Expected to save a new vote successfully");
+        store
+            .save_vote(FixedHash::zero(), vote.clone())
+            .expect("Expected to save a new vote successfully");
     }
 
     #[test]
@@ -313,13 +302,12 @@ mod tests {
         let vote = TestVote {
             epoch: Epoch(1),
             height: NodeHeight(1),
-            key: 42,
         };
-        let result = store.save_vote(FixedHash::zero(), vote.clone());
-        assert!(result, "Expected to save a new vote successfully");
+        store
+            .save_vote(FixedHash::zero(), vote.clone())
+            .expect("Expected to save a new vote successfully");
 
         // Try to save the same vote again
-        let result_duplicate = store.save_vote(FixedHash::zero(), vote);
-        assert!(!result_duplicate, "Expected duplicate vote to be rejected");
+        store.save_vote(FixedHash::zero(), vote).unwrap_err();
     }
 }

--- a/crates/consensus/src/hotstuff/vote_collector/collector.rs
+++ b/crates/consensus/src/hotstuff/vote_collector/collector.rs
@@ -12,6 +12,7 @@ use tari_common_types::types::FixedHash;
 use tari_consensus_types::Vote;
 use tari_ootle_common_types::{committee::Committee, Epoch, NodeAddressable, NodeHeight, VotePower};
 use tari_sidechain::QuorumDecision;
+use tari_template_lib_types::crypto::RistrettoPublicKeyBytes;
 use tokio::sync::RwLock;
 
 const LOG_TARGET: &str = "tari::ootle::consensus::hotstuff::vote_collector";
@@ -41,7 +42,7 @@ impl<V: Vote + Display> VoteCollector<V> {
         let epoch = vote.epoch();
         let height = vote.height();
         let vote_display = vote.to_string();
-        access_mut.save_vote(sender_hash, vote)?;
+        access_mut.save_vote(vote)?;
 
         let threshold_decision = access_mut.calculate_threshold_decision(epoch, height, committee);
 
@@ -88,7 +89,7 @@ impl<V: Vote + Display> VoteCollector<V> {
 }
 
 /// Collection of votes indexed by sender leaf hash
-type SenderVotesCollection<V> = HashMap<FixedHash, V>;
+type SenderVotesCollection<V> = HashMap<RistrettoPublicKeyBytes, V>;
 
 #[derive(Debug, Default)]
 struct VoteStoreInner<V: Vote> {
@@ -98,7 +99,7 @@ struct VoteStoreInner<V: Vote> {
 }
 
 impl<V: Vote + Display> VoteStoreInner<V> {
-    const VOTE_BYTE_SIZE: usize = size_of::<V>() + size_of::<FixedHash>();
+    const VOTE_BYTE_SIZE: usize = size_of::<V>() + size_of::<RistrettoPublicKeyBytes>();
 
     pub fn new() -> Self {
         Self { store: BTreeMap::new() }
@@ -111,27 +112,37 @@ impl<V: Vote + Display> VoteStoreInner<V> {
 
     /// Save a vote to the store. Returns VoteEquivocationDetected if a previous vote for the block by the sender was
     /// already present.
-    pub fn save_vote(&mut self, sender_hash: FixedHash, vote: V) -> Result<(), VoteEquivocationDetected<V>> {
+    pub fn save_vote(&mut self, vote: V) -> Result<(), VoteEquivocationDetected<V>> {
         let epoch_height = (vote.epoch(), vote.height());
         let view_votes_mut = self.store.entry(epoch_height).or_default();
-        if let Some(prev_vote) = view_votes_mut.remove(&sender_hash) {
+        if let Some(prev_vote) = view_votes_mut.get(vote.public_key()) {
+            let is_same_vote = prev_vote.signature() == vote.signature();
+            if is_same_vote {
+                debug!(
+                    target: LOG_TARGET,
+                    "ℹ️  Received identical duplicate vote {}. Ignoring.",
+                    vote,
+                );
+                return Ok(());
+            }
+
             warn!(
                 target: LOG_TARGET,
-                "❓️ Received duplicate vote for {} from {} (sender hash). This could be malicious because a validator should only vote once for the same block.",
+                "❓️ Received duplicate vote for {}. This could be malicious because a validator should only vote once for the same block.",
                 vote,
-                sender_hash
             );
+            let prev_vote = view_votes_mut.remove(vote.public_key()).expect("Vote is present");
             // We already have a vote for this block from this sender
             return Err(VoteEquivocationDetected {
                 epoch: vote.epoch(),
                 height: vote.height(),
-                sender_hash,
+                public_key: *vote.public_key(),
                 previous_vote: prev_vote,
                 new_vote: vote,
             });
         }
 
-        view_votes_mut.insert(sender_hash, vote);
+        view_votes_mut.insert(*vote.public_key(), vote);
         Ok(())
     }
 
@@ -207,10 +218,9 @@ impl<V: Vote + Display> VoteStoreInner<V> {
         debug!(
             target: LOG_TARGET,
             "Vote store size: used: >{:.2?}KiB ({} entries)",
-            self.store.values() .map(|v|
-                v.len() * FixedHash::byte_size() +
-                v.len() * Self::VOTE_BYTE_SIZE
-            ).sum::<usize>() as f32 / 1024f32,
+            self.store.values()
+                .map(|v| v.len() * Self::VOTE_BYTE_SIZE)
+                .sum::<usize>() as f32 / 1024f32,
             self.store.len(),
         );
     }
@@ -223,11 +233,11 @@ pub struct ThresholdDecision {
 }
 
 #[derive(Debug, Clone, thiserror::Error)]
-#[error("Vote equivocation detected at epoch {epoch}, height {height} from sender hash {sender_hash}")]
+#[error("Vote equivocation detected at epoch {epoch}, height {height} from {public_key}")]
 pub struct VoteEquivocationDetected<V: Vote> {
     pub epoch: Epoch,
     pub height: NodeHeight,
-    pub sender_hash: FixedHash,
+    pub public_key: RistrettoPublicKeyBytes,
     pub previous_vote: V,
     pub new_vote: V,
 }
@@ -235,7 +245,7 @@ pub struct VoteEquivocationDetected<V: Vote> {
 #[cfg(test)]
 mod tests {
     use tari_consensus_types::{SignedMessage, ToSignatureMessage};
-    use tari_template_lib_types::crypto::{RistrettoPublicKeyBytes, SchnorrSignatureBytes};
+    use tari_template_lib_types::crypto::{RistrettoPublicKeyBytes, Scalar32Bytes, SchnorrSignatureBytes};
 
     use super::*;
 
@@ -246,6 +256,8 @@ mod tests {
     struct TestVote {
         epoch: Epoch,
         height: NodeHeight,
+        sig: SchnorrSignatureBytes,
+        public_key: RistrettoPublicKeyBytes,
     }
 
     impl Display for TestVote {
@@ -262,11 +274,11 @@ mod tests {
 
     impl SignedMessage for TestVote {
         fn signature(&self) -> &SchnorrSignatureBytes {
-            &ZERO_SIG
+            &self.sig
         }
 
         fn public_key(&self) -> &RistrettoPublicKeyBytes {
-            &ZERO_PUBKEY
+            &self.public_key
         }
     }
 
@@ -290,9 +302,11 @@ mod tests {
         let vote = TestVote {
             epoch: Epoch(1),
             height: NodeHeight(1),
+            sig: ZERO_SIG,
+            public_key: ZERO_PUBKEY,
         };
         store
-            .save_vote(FixedHash::zero(), vote.clone())
+            .save_vote(vote.clone())
             .expect("Expected to save a new vote successfully");
     }
 
@@ -302,12 +316,24 @@ mod tests {
         let vote = TestVote {
             epoch: Epoch(1),
             height: NodeHeight(1),
+            sig: ZERO_SIG,
+            public_key: ZERO_PUBKEY,
         };
         store
-            .save_vote(FixedHash::zero(), vote.clone())
+            .save_vote(vote.clone())
             .expect("Expected to save a new vote successfully");
 
-        // Try to save the same vote again
-        store.save_vote(FixedHash::zero(), vote).unwrap_err();
+        // Try to save the same vote again - exact same vote is OK
+        store.save_vote(vote).unwrap();
+
+        let vote = TestVote {
+            epoch: Epoch(1),
+            height: NodeHeight(1),
+            public_key: ZERO_PUBKEY,
+            sig: SchnorrSignatureBytes::new([1u8; 32].into(), Scalar32Bytes::zero()),
+        };
+
+        // Try to save the a different vote from the same public key and epoch/height - should error
+        store.save_vote(vote).unwrap_err();
     }
 }

--- a/crates/consensus/src/hotstuff/vote_collector/proposal_collector.rs
+++ b/crates/consensus/src/hotstuff/vote_collector/proposal_collector.rs
@@ -75,7 +75,7 @@ where TConsensusSpec: ConsensusSpec
             block_id
         );
         let sender_leaf_hash = sender_vn.get_node_hash(self.network);
-        let Some((quorum_votes, quorum_decision)) = self
+        let result = self
             .vote_collector
             .collect_vote(
                 current_epoch,
@@ -84,29 +84,43 @@ where TConsensusSpec: ConsensusSpec
                 vote,
                 epoch_state.local_committee(),
             )
-            .await
-        else {
-            return Ok(None);
-        };
+            .await;
 
-        let Some(block) = self.store.with_read_tx(|tx| Block::get(tx, &block_id).optional())? else {
-            warn!(
-                target: LOG_TARGET,
-                "❓️ Received vote for unknown block {}. Possible race condition where a quorum of votes arrived before the block.",
-                block_id
-            );
-            return Ok(None);
-        };
-        let signatures = quorum_votes.into_iter().map(|vote| vote.signature).collect();
-        let new_qc = create_proposal_certificate(signatures, quorum_decision, block);
-        let high_qc = self.store.with_write_tx(|tx| new_qc.update_highest(tx))?;
-        if new_qc.calculate_id() == *high_qc.id() {
-            info!(target: LOG_TARGET, "🔥 New HIGH {}", new_qc);
-        } else {
-            info!(target: LOG_TARGET, "❓️ New QC from votes {} but it is not the high qc {}", new_qc, high_qc);
+        match result {
+            Ok(Some((quorum_votes, quorum_decision))) => {
+                let Some(block) = self.store.with_read_tx(|tx| Block::get(tx, &block_id).optional())? else {
+                    warn!(
+                        target: LOG_TARGET,
+                        "❓️ Received vote for unknown block {}. Possible race condition where a quorum of votes arrived before the block.",
+                        block_id
+                    );
+                    return Ok(None);
+                };
+                let signatures = quorum_votes.into_iter().map(|vote| vote.signature).collect();
+                let new_qc = create_proposal_certificate(signatures, quorum_decision, block);
+                let high_qc = self.store.with_write_tx(|tx| new_qc.update_highest(tx))?;
+                if new_qc.calculate_id() == *high_qc.id() {
+                    info!(target: LOG_TARGET, "🔥 New HIGH {}", new_qc);
+                } else {
+                    warn!(target: LOG_TARGET, "❓️ New QC from votes {} but it is not the high qc {}", new_qc, high_qc);
+                }
+
+                Ok(Some((new_qc, high_qc)))
+            },
+            Ok(None) => {
+                debug!(
+                    target: LOG_TARGET,
+                    "🟡 No quorum reached yet for ProposalVote at height {}",
+                    current_height
+                );
+                Ok(None)
+            },
+            Err(err) => {
+                warn!(target: LOG_TARGET, "❌ {}", err);
+                // TODO: store equivocation evidence and punish
+                Ok(None)
+            },
         }
-
-        Ok(Some((new_qc, high_qc)))
     }
 
     fn validate_vote(&self, current_epoch: Epoch, vote: &ProposalVote) -> Result<(), HotStuffError> {

--- a/crates/consensus/src/hotstuff/vote_collector/timeout_collector.rs
+++ b/crates/consensus/src/hotstuff/vote_collector/timeout_collector.rs
@@ -64,7 +64,7 @@ where TConsensusSpec: ConsensusSpec
         let sender_leaf_hash = sender_vn.get_node_hash(self.network);
         let height = vote.height;
 
-        let Some((quorum_votes, _)) = self
+        let result = self
             .vote_collector
             .collect_vote(
                 current_epoch,
@@ -73,22 +73,31 @@ where TConsensusSpec: ConsensusSpec
                 vote,
                 epoch_state.local_committee(),
             )
-            .await
-        else {
-            debug!(target: LOG_TARGET, "🟡 No quorum reached yet for TimeoutVote at height {}", height);
-            return Ok(None);
-        };
+            .await;
 
-        let signatures = quorum_votes.into_iter().map(|vote| vote.signature).collect();
-        let new_tc = TimeoutCertificate::new(current_epoch, height, signatures);
-        let high_tc = self.store.with_write_tx(|tx| new_tc.update_highest(tx))?;
-        if new_tc.calculate_id() == *high_tc.id() {
-            info!(target: LOG_TARGET, "🕒️ New HIGH {}", new_tc);
-        } else {
-            info!(target: LOG_TARGET, "❓️ New TC from votes {} but it is not the highest TC {}", new_tc, high_tc);
+        match result {
+            Ok(Some((quorum_votes, _))) => {
+                let signatures = quorum_votes.into_iter().map(|vote| vote.signature).collect();
+                let new_tc = TimeoutCertificate::new(current_epoch, height, signatures);
+                let high_tc = self.store.with_write_tx(|tx| new_tc.update_highest(tx))?;
+                if new_tc.calculate_id() == *high_tc.id() {
+                    info!(target: LOG_TARGET, "🕒️ New HIGH {}", new_tc);
+                } else {
+                    info!(target: LOG_TARGET, "❓️ New TC from votes {} but it is not the highest TC {}", new_tc, high_tc);
+                }
+
+                Ok(Some((new_tc, high_tc)))
+            },
+            Ok(None) => {
+                debug!(target: LOG_TARGET, "🟡 No quorum reached yet for TimeoutVote at height {}", height);
+                Ok(None)
+            },
+            Err(err) => {
+                warn!(target: LOG_TARGET, "❌ {}", err);
+                // TODO: track equivocation and penalize nodes
+                Ok(None)
+            },
         }
-
-        Ok(Some((new_tc, high_tc)))
     }
 
     fn validate_vote(&self, current_epoch: Epoch, vote: &TimeoutVote) -> Result<(), HotStuffError> {

--- a/crates/consensus_types/src/certificates/proposal_vote.rs
+++ b/crates/consensus_types/src/certificates/proposal_vote.rs
@@ -24,12 +24,6 @@ pub struct ProposalVote {
 }
 
 impl Vote for ProposalVote {
-    type Key = BlockId;
-
-    fn key(&self) -> Self::Key {
-        self.block_id
-    }
-
     fn epoch(&self) -> Epoch {
         self.epoch
     }

--- a/crates/consensus_types/src/certificates/timeout_vote.rs
+++ b/crates/consensus_types/src/certificates/timeout_vote.rs
@@ -26,12 +26,6 @@ impl TimeoutVote {
 }
 
 impl Vote for TimeoutVote {
-    type Key = (Epoch, NodeHeight);
-
-    fn key(&self) -> Self::Key {
-        (self.epoch, self.height)
-    }
-
     fn epoch(&self) -> Epoch {
         self.epoch
     }

--- a/crates/consensus_types/src/traits.rs
+++ b/crates/consensus_types/src/traits.rs
@@ -1,8 +1,6 @@
 //   Copyright 2025 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use std::hash::Hash;
-
 use tari_common_types::types::FixedHash;
 use tari_ootle_common_types::{Epoch, NodeHeight};
 use tari_sidechain::QuorumDecision;
@@ -18,10 +16,6 @@ pub trait SignedMessage: ToSignatureMessage {
 }
 
 pub trait Vote: SignedMessage {
-    type Key: Hash + Eq + 'static;
-
-    fn key(&self) -> Self::Key;
-
     fn epoch(&self) -> Epoch;
     fn height(&self) -> NodeHeight;
     fn decision(&self) -> QuorumDecision;


### PR DESCRIPTION
Description
---
fix(consensus): more explicit vote equivocation detection
fix: message buffer upper bound size

Motivation and Context
---
Equivocation was previously ignored with an debug log message that mentioned that quorum is not reached.
This PR adds an explicit warning and error struct that will allow us to store and punish this behaviour in future.
Since there is currently no slashing mechanism that has been decided, we only log and ignore for now. 

How Has This Been Tested?
---
Existing tests updated


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify