### PR TITLE
fix: add semaphore to prevent foreign proposal ddos

### DIFF
--- a/applications/tari_validator_node/src/consensus/mod.rs
+++ b/applications/tari_validator_node/src/consensus/mod.rs
@@ -85,6 +85,7 @@ pub async fn spawn(
         epoch_gc_interval: Duration::from_secs(60 * 60),
         enable_eviction_proposal: consensus_config.enable_eviction_proposal,
         epoch_end_grace_period: Duration::from_secs(15),
+        max_foreign_proposal_tasks: 100,
     };
 
     let hotstuff_worker = HotstuffWorker::<TariConsensusSpec>::new(

--- a/crates/consensus/src/hotstuff/config.rs
+++ b/crates/consensus/src/hotstuff/config.rs
@@ -17,4 +17,6 @@ pub struct HotstuffConfig {
     pub epoch_gc_interval: Duration,
     pub enable_eviction_proposal: bool,
     pub epoch_end_grace_period: Duration,
+    /// Maximum number of concurrent foreign proposal request tasks
+    pub max_foreign_proposal_tasks: usize,
 }

--- a/crates/consensus/src/hotstuff/on_receive_foreign_proposal.rs
+++ b/crates/consensus/src/hotstuff/on_receive_foreign_proposal.rs
@@ -1,7 +1,7 @@
 //   Copyright 2023 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use std::collections::HashSet;
+use std::{collections::HashSet, sync::Arc};
 
 use anyhow::anyhow;
 use log::*;
@@ -20,11 +20,12 @@ use tari_ootle_storage::{
     StateStore,
     StateStoreReadTransaction,
 };
-use tokio::task;
+use tokio::{sync::Semaphore, task};
 
 use crate::{
     hotstuff::{
         commit_proofs::generate_block_commit_proof,
+        config::HotstuffConfig,
         error::HotStuffError,
         pacemaker_handle::PaceMakerHandle,
         ProposalValidationError,
@@ -48,6 +49,7 @@ pub struct OnReceiveForeignProposalHandler<TConsensusSpec: ConsensusSpec> {
     pacemaker: PaceMakerHandle,
     outbound_messaging: TConsensusSpec::OutboundMessaging,
     recently_requested: HashSet<BlockId>,
+    foreign_proposal_semaphore: Arc<Semaphore>,
 }
 
 impl<TConsensusSpec> OnReceiveForeignProposalHandler<TConsensusSpec>
@@ -58,6 +60,7 @@ where TConsensusSpec: ConsensusSpec
         epoch_manager: TConsensusSpec::EpochManager,
         pacemaker: PaceMakerHandle,
         outbound_messaging: TConsensusSpec::OutboundMessaging,
+        config: &HotstuffConfig,
     ) -> Self {
         Self {
             store,
@@ -65,6 +68,7 @@ where TConsensusSpec: ConsensusSpec
             pacemaker,
             outbound_messaging,
             recently_requested: HashSet::new(),
+            foreign_proposal_semaphore: Arc::new(Semaphore::new(config.max_foreign_proposal_tasks)),
         }
     }
 
@@ -216,10 +220,12 @@ where TConsensusSpec: ConsensusSpec
     ) -> Result<(), HotStuffError> {
         let store = self.store.clone();
         let outbound_messaging = self.outbound_messaging.clone();
+        let semaphore = self.foreign_proposal_semaphore.clone();
 
         // No need for consensus to wait for the task to complete
-        // TODO: bounded spawn to limit the number of concurrent tasks created by possibly malicious requests
+        // Use semaphore to limit the number of concurrent tasks created by possibly malicious requests
         task::spawn(async move {
+            let _permit = semaphore.acquire().await.expect("Semaphore should not be closed");
             let _timer = TraceTimer::debug(LOG_TARGET, "OnReceiveForeignProposalRequest");
             if let Err(err) = Self::handle_requested_task(store, outbound_messaging, from, message).await {
                 error!(target: LOG_TARGET, "Error handling requested foreign proposal: {}", err);

--- a/crates/consensus/src/hotstuff/on_receive_local_proposal.rs
+++ b/crates/consensus/src/hotstuff/on_receive_local_proposal.rs
@@ -114,6 +114,7 @@ impl<TConsensusSpec: ConsensusSpec> OnReceiveLocalProposalHandler<TConsensusSpec
                 epoch_manager,
                 pacemaker,
                 outbound_messaging,
+                &config,
             ),
             on_ready_to_vote_on_local_block: OnReadyToVoteOnLocalBlock::new(
                 local_validator_pk,

--- a/crates/consensus/src/hotstuff/worker.rs
+++ b/crates/consensus/src/hotstuff/worker.rs
@@ -190,6 +190,7 @@ impl<TConsensusSpec: ConsensusSpec> HotstuffWorker<TConsensusSpec> {
                 epoch_manager.clone(),
                 pacemaker.clone_handle(),
                 outbound_messaging.clone(),
+                &config,
             ),
             on_receive_vote: OnReceiveVoteHandler::new(
                 pacemaker.clone_handle(),

--- a/crates/consensus_tests/src/support/harness.rs
+++ b/crates/consensus_tests/src/support/harness.rs
@@ -654,6 +654,7 @@ impl TestBuilder {
                 epoch_gc_interval: Duration::from_secs(1000),
                 enable_eviction_proposal: true,
                 epoch_end_grace_period: Duration::from_secs(1),
+                max_foreign_proposal_tasks: 100,
             },
         }
     }


### PR DESCRIPTION
Attack Vector: A malicious validator can flood the network with ForeignProposalRequest messages, causing the victim node to spawn unlimited async tasks, leading to memory exhaustion and node crash.

Impact: Denial of Service - Complete node failure, potential network partitioning if multiple nodes are targeted.

Severity: CRITICAL

Remediation:

Implement a bounded semaphore or task pool for spawned tasks
Add rate limiting per peer for foreign proposal requests
Consider using tokio::sync::Semaphore to limit concurrent tasks