### PR TITLE
fix(consensus)!: re-request foreign proposals after timeout + other fixes

### DIFF
--- a/applications/tari_indexer/src/network_client.rs
+++ b/applications/tari_indexer/src/network_client.rs
@@ -150,7 +150,7 @@ where
 
             let committee = self
                 .epoch_manager
-                .get_committee_by_shard_group(epoch, shard_group, Some(100))
+                .get_committee_by_shard_group(epoch, shard_group, Some(100), true)
                 .await?;
             all_members.insert(shard_group, committee);
         }

--- a/applications/tari_indexer/src/network_state_sync/committee_client.rs
+++ b/applications/tari_indexer/src/network_state_sync/committee_client.rs
@@ -2,6 +2,7 @@
 //   SPDX-License-Identifier: BSD-3-Clause
 
 use std::{
+    collections::HashSet,
     fmt::Display,
     future::Future,
     ops::{Deref, DerefMut},
@@ -21,7 +22,7 @@ pub struct ValidatorCommitteeRpcPool {
     shard_group: ShardGroup,
     pool: RpcMultiPool<TariMessagingSpec>,
     epoch_manager: EpochManagerHandle<PeerAddress>,
-    past_failed_nodes: Vec<PeerAddress>,
+    past_failed_nodes: HashSet<PeerAddress>,
 }
 
 impl ValidatorCommitteeRpcPool {
@@ -34,7 +35,7 @@ impl ValidatorCommitteeRpcPool {
             shard_group,
             pool: RpcMultiPool::new(networking),
             epoch_manager,
-            past_failed_nodes: vec![],
+            past_failed_nodes: HashSet::new(),
         }
     }
 
@@ -69,7 +70,7 @@ impl ValidatorCommitteeRpcPool {
                         "Failed to create new session for validator '{}': {}", member, err
                     );
                     last_error = Some(err);
-                    self.past_failed_nodes.push(member.address);
+                    self.past_failed_nodes.insert(member.address);
                 },
             }
         }
@@ -102,7 +103,7 @@ impl ValidatorCommitteeRpcPool {
     {
         let epoch = self.epoch_manager.get_current_epoch();
         let mut last_error = None;
-        let mut attempted = vec![];
+        let mut attempted = HashSet::new();
         loop {
             let Some(vn) = self
                 .epoch_manager
@@ -126,8 +127,8 @@ impl ValidatorCommitteeRpcPool {
                         "Failed to create session for validator '{}': {}", vn, err
                     );
                     last_error = Some(err.to_string());
-                    attempted.push(vn.address);
-                    self.past_failed_nodes.push(vn.address);
+                    attempted.insert(vn.address);
+                    self.past_failed_nodes.insert(vn.address);
                     continue; // Skip this member and try the next one
                 },
             };
@@ -145,7 +146,7 @@ impl ValidatorCommitteeRpcPool {
                 },
             }
 
-            attempted.push(vn.address);
+            attempted.insert(vn.address);
         }
 
         Err(ValidatorCommitteeClientError::AllValidatorsFailed {

--- a/applications/tari_indexer/src/network_state_sync/worker.rs
+++ b/applications/tari_indexer/src/network_state_sync/worker.rs
@@ -232,7 +232,7 @@ impl NetworkWideStateSync {
 
             let committee = self
                 .epoch_manager
-                .get_committee_by_shard_group(prev_epoch, shard_group, None)
+                .get_committee_by_shard_group(prev_epoch, shard_group, None, false)
                 .await?;
 
             // TODO: continue on failure

--- a/applications/tari_validator_node/src/json_rpc/handlers.rs
+++ b/applications/tari_validator_node/src/json_rpc/handlers.rs
@@ -323,7 +323,7 @@ impl JsonRpcHandlers {
         }
         let tx_pool = self
             .state_store
-            .with_read_tx(|tx| tx.transaction_pool_get_all())
+            .with_read_tx(|tx| tx.transaction_pool_get_all(1000))
             .map_err(internal_error(answer_id.clone()))?;
         let res = json!({ "tx_pool": tx_pool });
         Ok(JsonRpcResponse::success(answer_id, res))

--- a/crates/consensus/src/bounded_spawn.rs
+++ b/crates/consensus/src/bounded_spawn.rs
@@ -1,0 +1,173 @@
+//   Copyright 2023 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+use std::{future::Future, sync::Arc};
+
+use tokio::{
+    sync::{OwnedSemaphorePermit, Semaphore},
+    task::JoinHandle,
+};
+
+/// Error emitted from [`try_spawn`](self::BoundedSpawn::try_spawn) when there are no tasks available
+#[derive(Debug)]
+pub struct TrySpawnError;
+
+/// A task executor bounded by a semaphore.
+///
+/// Use the asynchronous spawn method to spawn a task. If a given number of tasks are already spawned and have not
+/// completed, the spawn function will block (asynchronously) until a previously spawned task completes.
+pub struct BoundedSpawn {
+    // inner: runtime::Handle,
+    semaphore: Arc<Semaphore>,
+}
+
+impl BoundedSpawn {
+    pub fn new(num_permits: usize) -> Self {
+        Self {
+            semaphore: Arc::new(Semaphore::new(num_permits)),
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn allow_maximum() -> Self {
+        Self::new(Self::max_theoretical_tasks())
+    }
+
+    #[allow(dead_code)]
+    pub const fn max_theoretical_tasks() -> usize {
+        // Maximum from here: https://github.com/tokio-rs/tokio/blob/ce9eabfdd12a14efb74f5e6d507f2acbe7a814c9/tokio/src/sync/batch_semaphore.rs#L101
+        // NOTE: usize::MAX >> 3 does not work. The reason is not clear, however 1152921504606846975 tasks seems
+        // sufficient
+        usize::MAX >> 4
+    }
+
+    #[allow(dead_code)]
+    pub fn can_spawn(&self) -> bool {
+        self.num_available() > 0
+    }
+
+    /// Returns the remaining number of tasks that can be spawned on this executor without waiting.
+    #[allow(dead_code)]
+    pub fn num_available(&self) -> usize {
+        self.semaphore.available_permits()
+    }
+
+    pub fn try_spawn<F>(&self, future: F) -> Result<JoinHandle<F::Output>, TrySpawnError>
+    where
+        F: Future + Send + 'static,
+        F::Output: Send + 'static,
+    {
+        let permit = self.semaphore.clone().try_acquire_owned().map_err(|_| TrySpawnError)?;
+        let handle = self.do_spawn(permit, future);
+        Ok(handle)
+    }
+
+    /// Spawn a future onto the Tokio runtime asynchronously blocking if there are too many
+    /// spawned tasks.
+    ///
+    /// This spawns the given future onto the runtime's executor, usually a
+    /// thread pool. The thread pool is then responsible for polling the future
+    /// until it completes.
+    ///
+    /// If the number of pending tasks exceeds the num_permits value given to `BoundedExecutor::new`
+    /// the future returned from spawn will block until a permit is released.
+    ///
+    /// See [module level][mod] documentation for more details.
+    ///
+    /// [mod]: index.html
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tokio::runtime::Handle;
+    /// use tari_comms::bounded_executor::BoundedExecutor;
+    ///
+    /// # fn dox() {
+    /// // Create the runtime
+    /// let executor = BoundedExecutor::new(1);
+    ///
+    /// // Spawn a future onto the runtime
+    /// // NOTE: BoundedExecutor::spawn is an async function and therefore, must be polled/awaited for the task to be spawned
+    /// let task1 = executor.spawn(async {
+    ///     println!("now running on a worker thread");
+    /// });
+    /// // This will spawn after task1
+    /// let task2 = executor.spawn(async {
+    ///     println!("will always run after the first task");
+    /// });
+    ///
+    /// Handle::current().block_on(task1);
+    /// Handle::current().block_on(task2);
+    /// # }
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// This function panics if the spawn fails. Failure occurs if the executor
+    /// is currently at capacity and is unable to spawn a new future.
+    #[allow(dead_code)]
+    pub async fn spawn<F>(&self, future: F) -> JoinHandle<F::Output>
+    where
+        F: Future + Send + 'static,
+        F::Output: Send + 'static,
+    {
+        // SAFETY: acquire_owned only fails if the semaphore is closed (i.e self.semaphore.close() is called) - this
+        // never happens in this implementation
+        let permit = self.semaphore.clone().acquire_owned().await.expect("semaphore closed");
+        self.do_spawn(permit, future)
+    }
+
+    fn do_spawn<F>(&self, permit: OwnedSemaphorePermit, future: F) -> JoinHandle<F::Output>
+    where
+        F: Future + Send + 'static,
+        F::Output: Send + 'static,
+    {
+        tokio::spawn(async move {
+            // Task is finished, release the permit
+            let ret = future.await;
+            drop(permit);
+            ret
+        })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::{
+        sync::{
+            atomic::{AtomicBool, Ordering},
+            Arc,
+        },
+        time::Duration,
+    };
+
+    use tokio::time::sleep;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn spawn() {
+        let flag = Arc::new(AtomicBool::new(false));
+        let flag_cloned = flag.clone();
+        let executor = BoundedSpawn::new(1);
+
+        // Spawn 1
+        let task1_fut = executor
+            .spawn(async move {
+                sleep(Duration::from_millis(1)).await;
+                flag_cloned.store(true, Ordering::SeqCst);
+            })
+            .await;
+
+        // Spawn 2
+        let task2_fut = executor
+            .spawn(async move {
+                // This will panic if this task is spawned before task1 completes (e.g if num_permitted > 1)
+                assert!(flag.load(Ordering::SeqCst));
+            })
+            .await;
+
+        task2_fut.await.unwrap();
+        task1_fut.await.unwrap();
+    }
+}

--- a/crates/consensus/src/hotstuff/block_change_set.rs
+++ b/crates/consensus/src/hotstuff/block_change_set.rs
@@ -256,7 +256,7 @@ impl ProposedBlockChangeSet {
     }
 
     pub fn apply_transaction_update(&self, tx_rec_mut: &mut TransactionPoolRecord) {
-        if let Some(update) = self.transaction_changes.get(tx_rec_mut.transaction_id()) {
+        if let Some(update) = self.transaction_changes.get(tx_rec_mut.id()) {
             update.apply_update(tx_rec_mut);
         }
     }
@@ -402,10 +402,7 @@ impl ProposedBlockChangeSet {
         &mut self,
         transaction: TransactionPoolRecord,
     ) -> Result<&mut Self, TransactionPoolError> {
-        let change_mut = self
-            .transaction_changes
-            .entry(*transaction.transaction_id())
-            .or_default();
+        let change_mut = self.transaction_changes.entry(*transaction.id()).or_default();
 
         debug!(
             target: LOG_TARGET,
@@ -417,7 +414,7 @@ impl ProposedBlockChangeSet {
         debug!(
             target: LOG_TARGET,
             "📝 next transaction update ({} {} {} is_ready_now={}, {:#}) in block {}",
-            next_update.transaction().transaction_id(),
+            next_update.transaction().id(),
             next_update.transaction().current_stage(),
             next_update.decision(),
             next_update.is_ready_now(),
@@ -461,14 +458,14 @@ impl ProposedBlockChangeSet {
             debug!(
                 target: LOG_TARGET,
                 "📝 Sequencing new transaction {} {} {} is_ready_now={}",
-                pool_rec.transaction_id(),
+                pool_rec.id(),
                 pool_rec.current_stage(),
                 pool_rec.current_local_decision(),
                 pool_rec.is_ready()
             );
             // TODO: TransactionPool abstraction is not great, so calling the store method directly
             tx.transaction_pool_insert_new(
-                *pool_rec.transaction_id(),
+                *pool_rec.id(),
                 pool_rec.current_local_decision(),
                 pool_rec.evidence(),
                 pool_rec.is_ready(),
@@ -554,7 +551,7 @@ impl ProposedBlockChangeSet {
         }
 
         for transaction in &self.new_transactions_to_sequence {
-            debug!(target: LOG_TARGET, "[drop] Sequence new transaction: {}", transaction.transaction_id());
+            debug!(target: LOG_TARGET, "[drop] Sequence new transaction: {}", transaction.id());
         }
 
         for (transaction_id, change) in &self.transaction_changes {
@@ -652,7 +649,7 @@ mod tests {
     fn check_max_mem_usage() {
         let sz = size_of::<ProposedBlockChangeSet>();
         eprintln!("ProposedBlockChangeSet: {}", sz);
-        const TARGET_MAX_MEM_USAGE: usize = 13_240_000;
+        const TARGET_MAX_MEM_USAGE: usize = 13_336_000;
         let mem_block_diff = size_of::<SubstateChange>() * MEM_MAX_BLOCK_DIFF_CHANGES;
         eprintln!("mem_block_diff: {}KiB", mem_block_diff / 1024);
         let mem_state_tree_diffs =

--- a/crates/consensus/src/hotstuff/foreign_proposal_processor.rs
+++ b/crates/consensus/src/hotstuff/foreign_proposal_processor.rs
@@ -118,7 +118,7 @@ pub fn process_foreign_block<TStore: StateStore>(
                         target: LOG_TARGET,
                         "⚠️ Foreign LocalPrepare proposal ({}) received LOCAL_PREPARE for transaction {} but current transaction stage is {}. Ignoring.",
                         proposal,
-                        tx_rec.transaction_id(),
+                        tx_rec.id(),
                         tx_rec.current_stage()
                     );
                     continue;
@@ -131,20 +131,18 @@ pub fn process_foreign_block<TStore: StateStore>(
                         info!(
                             target: LOG_TARGET,
                             "⚠️ Foreign committee ABORT transaction {}. Update overall decision to ABORT. Local stage: {}, Leaf: {}",
-                            tx_rec.transaction_id(), tx_rec.current_stage(), local_leaf
+                            tx_rec.id(), tx_rec.current_stage(), local_leaf
                         );
 
                         // Add an abort execution since we previously decided to commit
-                        let exec = TransactionExecution::abort(
-                            tx_rec.transaction_id(),
-                            RejectReason::ForeignShardGroupDecidedToAbort {
+                        let exec =
+                            TransactionExecution::abort(tx_rec.id(), RejectReason::ForeignShardGroupDecidedToAbort {
                                 start_shard: foreign_shard_group.start().as_u32(),
                                 end_shard: foreign_shard_group.end().as_u32(),
                                 abort_reason,
-                            },
-                        );
+                            });
                         tx_rec.set_local_decision(exec.decision());
-                        proposed_block_change_set.add_transaction_execution(*tx_rec.transaction_id(), exec)?;
+                        proposed_block_change_set.add_transaction_execution(*tx_rec.id(), exec)?;
                     }
                 }
 
@@ -195,7 +193,7 @@ pub fn process_foreign_block<TStore: StateStore>(
                     if let Some(conflicting_transaction_id) =
                         LockedSubstateValue::get_transaction_id_that_conflicts_with_write_locks(
                             substate_store.read_transaction(),
-                            tx_rec.transaction_id(),
+                            tx_rec.id(),
                             inputs,
                         )?
                     {
@@ -241,22 +239,20 @@ pub fn process_foreign_block<TStore: StateStore>(
                                 target: LOG_TARGET,
                                 "⚠️ Foreign proposal {} received for transaction {} but a conflicting transaction ({}) has already been prepared by this node. Abort.",
                                 proposal,
-                                tx_rec.transaction_id(),
+                                tx_rec.id(),
                                 conflicting_transaction_id
                             );
 
                             // Add an abort execution since we previously decided to commit
-                            let exec = TransactionExecution::abort(
-                                tx_rec.transaction_id(),
-                                RejectReason::ForeignPledgeInputConflict,
-                            );
+                            let exec =
+                                TransactionExecution::abort(tx_rec.id(), RejectReason::ForeignPledgeInputConflict);
                             tx_rec.set_local_decision(exec.decision());
-                            proposed_block_change_set.add_transaction_execution(*tx_rec.transaction_id(), exec)?;
+                            proposed_block_change_set.add_transaction_execution(*tx_rec.id(), exec)?;
                         } else {
                             info!(
                                 target: LOG_TARGET,
                                 "Transaction {} conflicts with {} but does not conflict with any foreign pledges. No need to abort.",
-                                tx_rec.transaction_id(),
+                                tx_rec.id(),
                                 conflicting_transaction_id
                             );
                         }
@@ -287,7 +283,7 @@ pub fn process_foreign_block<TStore: StateStore>(
                     info!(
                         target: LOG_TARGET,
                         "🧩 FOREIGN PROPOSAL {foreign_shard_group}: (Initial sequence from LocalPrepare) Transaction is ready for Prepare({}, {}) Local Stage: {}",
-                        tx_rec.transaction_id(),
+                        tx_rec.id(),
                         tx_rec.current_decision(),
                         tx_rec.current_stage()
                     );
@@ -305,7 +301,7 @@ pub fn process_foreign_block<TStore: StateStore>(
                         info!(
                             target: LOG_TARGET,
                             "🧩 FOREIGN PROPOSAL {foreign_shard_group}: (Initial sequence from LocalPrepare) Transaction is ready for Prepare({}, {}) Local Stage: {}",
-                            tx_rec.transaction_id(),
+                            tx_rec.id(),
                             tx_rec.current_decision(),
                             tx_rec.current_stage()
                         );
@@ -315,7 +311,7 @@ pub fn process_foreign_block<TStore: StateStore>(
                         info!(
                             target: LOG_TARGET,
                             "🧩 FOREIGN PROPOSAL {foreign_shard_group}: (Initial sequence from LocalPrepare) Transaction is NOT ready for Prepare({}, {}) Local Stage: {}",
-                            tx_rec.transaction_id(),
+                            tx_rec.id(),
                             tx_rec.current_decision(),
                             tx_rec.current_stage()
                         );
@@ -334,7 +330,7 @@ pub fn process_foreign_block<TStore: StateStore>(
                     info!(
                         target: LOG_TARGET,
                         "🧩 FOREIGN PROPOSAL {foreign_shard_group}: Transaction is ready for propose AllPrepared({}, {}) Local Stage: {}",
-                        tx_rec.transaction_id(),
+                        tx_rec.id(),
                         tx_rec.current_decision(),
                         tx_rec.current_stage()
                     );
@@ -345,7 +341,7 @@ pub fn process_foreign_block<TStore: StateStore>(
                         target: LOG_TARGET,
                         "🧩 FOREIGN PROPOSAL {foreign_shard_group}: Transaction is NOT ready for AllPrepared({}, {}) Local Stage: {}, \
                         All Justified: {}. Waiting for local proposal and/or additional foreign proposals for all other shard groups.",
-                        tx_rec.transaction_id(),
+                        tx_rec.id(),
                         tx_rec.current_decision(),
                         tx_rec.current_stage(),
                         tx_rec.evidence().all_input_shard_groups_prepared(local_shard_group)
@@ -394,7 +390,7 @@ pub fn process_foreign_block<TStore: StateStore>(
                         target: LOG_TARGET,
                         "⚠️ Foreign proposal {} received LOCAL_ACCEPT for transaction {} but current transaction stage is {}. Ignoring.",
                         proposal,
-                        tx_rec.transaction_id(),
+                        tx_rec.id(),
                         tx_rec.current_stage(),
                     );
                     continue;
@@ -407,19 +403,17 @@ pub fn process_foreign_block<TStore: StateStore>(
                         info!(
                             target: LOG_TARGET,
                             "⚠️ Foreign {foreign_shard_group} ABORT {}. Update overall decision to ABORT. Local stage: {}, Leaf: {}",
-                            tx_rec.transaction_id(), tx_rec.current_stage(), local_leaf
+                            tx_rec.id(), tx_rec.current_stage(), local_leaf
                         );
                         // Add an abort execution since we previously decided to commit
-                        let exec = TransactionExecution::abort(
-                            tx_rec.transaction_id(),
-                            RejectReason::ForeignShardGroupDecidedToAbort {
+                        let exec =
+                            TransactionExecution::abort(tx_rec.id(), RejectReason::ForeignShardGroupDecidedToAbort {
                                 start_shard: foreign_shard_group.start().as_u32(),
                                 end_shard: foreign_shard_group.end().as_u32(),
                                 abort_reason,
-                            },
-                        );
+                            });
                         tx_rec.set_local_decision(exec.decision());
-                        proposed_block_change_set.add_transaction_execution(*tx_rec.transaction_id(), exec)?;
+                        proposed_block_change_set.add_transaction_execution(*tx_rec.id(), exec)?;
                     }
                 }
 
@@ -476,7 +470,7 @@ pub fn process_foreign_block<TStore: StateStore>(
                         info!(
                             target: LOG_TARGET,
                             "🧩 FOREIGN PROPOSAL {foreign_shard_group}: (Initial sequence from LocalAccept) Transaction is ready for Prepare({}, {}) Local Stage: {}",
-                            tx_rec.transaction_id(),
+                            tx_rec.id(),
                             tx_rec.current_decision(),
                             tx_rec.current_stage()
                         );
@@ -487,7 +481,7 @@ pub fn process_foreign_block<TStore: StateStore>(
                         info!(
                             target: LOG_TARGET,
                             "🧩 FOREIGN PROPOSAL {foreign_shard_group}: (Initial sequence from LocalAccept) Transaction is NOT ready for Prepare({}, {}) Local Stage: {}",
-                            tx_rec.transaction_id(),
+                            tx_rec.id(),
                             tx_rec.current_decision(),
                             tx_rec.current_stage()
                         );
@@ -503,7 +497,7 @@ pub fn process_foreign_block<TStore: StateStore>(
                     info!(
                         target: LOG_TARGET,
                         "🧩 FOREIGN PROPOSAL {foreign_shard_group}: Transaction is ready for propose ALL_PREPARED({}, {}) Local Stage: {}",
-                        tx_rec.transaction_id(),
+                        tx_rec.id(),
                         tx_rec.current_decision(),
                         tx_rec.current_stage()
                     );
@@ -517,7 +511,7 @@ pub fn process_foreign_block<TStore: StateStore>(
                     info!(
                         target: LOG_TARGET,
                         "🧩 FOREIGN PROPOSAL {foreign_shard_group}: Transaction is ready for propose ALL_ACCEPT({}, {}) Local Stage: {}",
-                        tx_rec.transaction_id(),
+                        tx_rec.id(),
                         tx_rec.current_decision(),
                         tx_rec.current_stage()
                     );
@@ -527,7 +521,7 @@ pub fn process_foreign_block<TStore: StateStore>(
                     info!(
                         target: LOG_TARGET,
                         "🧩 FOREIGN PROPOSAL {foreign_shard_group}: Transaction is NOT ready for AllAccept({}, {}) Local Stage: {}, All Justified: {}. Waiting for local or foreign proposal.",
-                        tx_rec.transaction_id(),
+                        tx_rec.id(),
                         tx_rec.current_decision(),
                         tx_rec.current_stage(),
                         tx_rec.evidence().all_shard_groups_accepted()
@@ -620,11 +614,7 @@ fn add_pledges(
                 }
             })?;
             let output_pledges = foreign_sg_evidence.output_pledge_iter().collect();
-            proposed_block_change_set.add_foreign_pledges(
-                transaction.transaction_id(),
-                foreign_shard_group,
-                output_pledges,
-            );
+            proposed_block_change_set.add_foreign_pledges(transaction.id(), foreign_shard_group, output_pledges);
 
             let Some(pledges) = block_pledge.get_all_pledges_for_evidence(foreign_sg_evidence) else {
                 if transaction.evidence().is_committee_output_only(foreign_shard_group) {
@@ -674,7 +664,7 @@ fn add_pledges(
                 pledges.display()
             );
 
-            proposed_block_change_set.add_foreign_pledges(transaction.transaction_id(), foreign_shard_group, pledges);
+            proposed_block_change_set.add_foreign_pledges(transaction.id(), foreign_shard_group, pledges);
         },
         Decision::Abort(reason) => {
             debug!(target: LOG_TARGET, "Transaction {} was ABORTED by foreign node ({}). No pledges expected.", atom.id, reason);
@@ -696,7 +686,7 @@ fn has_all_foreign_input_pledges<TTx: StateStoreReadTransaction>(
         .filter(|(sg, _)| local_committee_info.shard_group() != **sg)
         .flat_map(|(_, ev)| ev.inputs());
 
-    let current_pledges = proposed_block_change_set.get_foreign_pledges(tx_rec.transaction_id());
+    let current_pledges = proposed_block_change_set.get_foreign_pledges(tx_rec.id());
 
     for (id, data) in foreign_inputs {
         let Some(data) = data else {
@@ -713,7 +703,7 @@ fn has_all_foreign_input_pledges<TTx: StateStoreReadTransaction>(
         }
 
         if tx.foreign_substate_pledges_exists_for_transaction_and_address(
-            tx_rec.transaction_id(),
+            tx_rec.id(),
             SubstateAddress::from_substate_id(id, data.version),
         )? {
             continue;
@@ -721,7 +711,7 @@ fn has_all_foreign_input_pledges<TTx: StateStoreReadTransaction>(
         debug!(
             target: LOG_TARGET,
             "Transaction {} is missing a pledge for input {}",
-            tx_rec.transaction_id(),
+            tx_rec.id(),
             id
         );
         return Ok(false);

--- a/crates/consensus/src/hotstuff/on_inbound_message.rs
+++ b/crates/consensus/src/hotstuff/on_inbound_message.rs
@@ -334,37 +334,8 @@ fn msg_relative_view(
             // Foreign proposals are always applicable
             MessageRelativeView::Current
         },
-        HotstuffMessage::ForeignProposalNotification(msg) => {
-            if msg.epoch < current_epoch {
-                return MessageRelativeView::Past {
-                    epoch: msg.epoch,
-                    height: NodeHeight::zero(),
-                };
-            }
-            if msg.epoch > current_epoch {
-                return MessageRelativeView::Future {
-                    epoch: msg.epoch,
-                    height: NodeHeight::zero(),
-                };
-            }
-            MessageRelativeView::Current
-        },
-        HotstuffMessage::ForeignProposalRequest(msg) => {
-            if msg.epoch() < current_epoch {
-                return MessageRelativeView::Past {
-                    epoch: msg.epoch(),
-                    height: NodeHeight::zero(),
-                };
-            }
-            if msg.epoch() > current_epoch {
-                return MessageRelativeView::Future {
-                    epoch: msg.epoch(),
-                    // Foreign height is not locally relevant, we can process it when we reach the epoch
-                    height: NodeHeight::zero(),
-                };
-            }
-            MessageRelativeView::Current
-        },
+        HotstuffMessage::ForeignProposalNotification(_) => MessageRelativeView::Current,
+        HotstuffMessage::ForeignProposalRequest(_) => MessageRelativeView::Current,
         HotstuffMessage::MissingTransactionsRequest(msg) => {
             if msg.epoch < current_epoch {
                 return MessageRelativeView::Past {

--- a/crates/consensus/src/hotstuff/on_propose.rs
+++ b/crates/consensus/src/hotstuff/on_propose.rs
@@ -228,7 +228,7 @@ where TConsensusSpec: ConsensusSpec
         } else {
             let committee = self
                 .epoch_manager
-                .get_committee_by_shard_group(epoch, local_committee_info.shard_group(), None)
+                .get_committee_by_shard_group(epoch, local_committee_info.shard_group(), None, false)
                 .await?;
 
             info!(
@@ -317,8 +317,9 @@ where TConsensusSpec: ConsensusSpec
         let start_of_chain_block = highest_seen_block;
         let parent_block = dummy_block.unwrap_or_else(|| highest_seen_block.as_leaf());
         let highest_seen_block = Block::get(tx, highest_seen_block.block_id())?;
+        let is_end_of_epoch_in_chain = highest_seen_block.is_epoch_end_proposed_in_chain(tx)?;
 
-        let should_not_propose_commands = can_propose_epoch_end || {
+        let should_not_propose_commands = is_end_of_epoch_in_chain || can_propose_epoch_end || {
             // TODO: prevent proposers from proposing transactions after an epoch end command is in the justified
             // pending chain, regardless of whether we see the end of epoch or not (race condition).
             // If the last justified/parent block is an epoch end block, we dont propose commands since the block will
@@ -329,21 +330,24 @@ where TConsensusSpec: ConsensusSpec
         let mut total_leader_fee = 0u64;
         let mut accumulated_data = *highest_seen_block.header().accumulated_data();
 
-        let batch = if should_not_propose_commands {
-            ProposalBatch::default()
-        } else {
-            self.fetch_next_proposal_batch(tx, local_committee_info, start_of_chain_block)?
-        };
-
         let mut substate_store = PendingSubstateStore::new(
             tx,
             start_of_chain_block.as_leaf(),
             self.config.consensus_constants.num_preshards,
         );
 
-        debug!(target: LOG_TARGET, "🌿 PROPOSE: {} (justify: {}) {batch}", highest_seen_block.height(), justify_block.height());
         let mut executed_transactions = HashMap::new();
-        let mut commands = if can_propose_epoch_end {
+
+        let batch = if should_not_propose_commands {
+            ProposalBatch::default()
+        } else {
+            self.fetch_next_proposal_batch(tx, local_committee_info, start_of_chain_block)?
+        };
+        debug!(target: LOG_TARGET, "🌿 PROPOSE: {} (justify: {}) {batch}", highest_seen_block.height(), justify_block.height());
+
+        let mut commands = if is_end_of_epoch_in_chain {
+            BTreeSet::from_iter([])
+        } else if can_propose_epoch_end {
             BTreeSet::from_iter([Command::EndEpoch])
         } else {
             BTreeSet::from_iter(
@@ -597,7 +601,7 @@ where TConsensusSpec: ConsensusSpec
         info!(
             target: LOG_TARGET,
             "👨‍🔧 PROPOSE: PREPARE transaction {}",
-            pool_tx.transaction_id(),
+            pool_tx.id(),
         );
 
         let prepared = self
@@ -609,13 +613,10 @@ where TConsensusSpec: ConsensusSpec
             warn!(
                 target: LOG_TARGET,
                 "⚠️ Transaction {} has lock conflicts, but no hard conflicts. Skipping proposing this transaction...",
-                pool_tx.transaction_id(),
+                pool_tx.id(),
             );
 
-            lock_conflicts.add(
-                *pool_tx.transaction_id(),
-                prepared.into_lock_status().into_lock_conflicts(),
-            );
+            lock_conflicts.add(*pool_tx.id(), prepared.into_lock_status().into_lock_conflicts());
             return Ok(None);
         }
 
@@ -633,7 +634,7 @@ where TConsensusSpec: ConsensusSpec
                     info!(
                         target: LOG_TARGET,
                         "🏠️ Transaction {} is local only, proposing LocalOnly",
-                        pool_tx.transaction_id(),
+                        pool_tx.id(),
                     );
 
                     if pool_tx.current_decision().is_commit() {
@@ -648,7 +649,7 @@ where TConsensusSpec: ConsensusSpec
                             HotStuffError::InvariantError(format!(
                                 "prepare_transaction: Transaction {} has COMMIT decision but execution failed when \
                                  proposing",
-                                pool_tx.transaction_id(),
+                                pool_tx.id(),
                             ))
                         })?;
 
@@ -656,7 +657,7 @@ where TConsensusSpec: ConsensusSpec
                             error!(
                                 target: LOG_TARGET,
                                 "🔒 Failed to write to temporary state store for transaction {} for LocalOnly: {}. Skipping proposing this transaction...",
-                                pool_tx.transaction_id(),
+                                pool_tx.id(),
                                 err,
                             );
                             // Only error if it is not related to lock errors
@@ -665,7 +666,7 @@ where TConsensusSpec: ConsensusSpec
                         }
                     }
 
-                    executed_transactions.insert(*pool_tx.transaction_id(), execution);
+                    executed_transactions.insert(*pool_tx.id(), execution);
 
                     let atom = pool_tx.get_current_transaction_atom();
                     Ok(Some(Command::LocalOnly(atom)))
@@ -674,7 +675,7 @@ where TConsensusSpec: ConsensusSpec
                     info!(
                         target: LOG_TARGET,
                         "⚠️ Transaction is LOCAL-ONLY EARLY ABORT, proposing LocalOnly({}, ABORT)",
-                        pool_tx.transaction_id()
+                        pool_tx.id()
                     );
                     pool_tx
                         .set_local_decision(execution.decision())
@@ -685,7 +686,7 @@ where TConsensusSpec: ConsensusSpec
                             local_committee_info.num_committees(),
                         ));
 
-                    executed_transactions.insert(*pool_tx.transaction_id(), execution);
+                    executed_transactions.insert(*pool_tx.id(), execution);
                     let atom = pool_tx.get_current_transaction_atom();
                     Ok(Some(Command::LocalOnly(atom)))
                 },
@@ -726,7 +727,7 @@ where TConsensusSpec: ConsensusSpec
                             }
                         }
 
-                        executed_transactions.insert(*pool_tx.transaction_id(), *execution);
+                        executed_transactions.insert(*pool_tx.id(), *execution);
                     },
                     EvidenceOrExecution::Evidence { evidence, .. } => {
                         // CASE: All local inputs were resolved. We need to continue with consensus to get the
@@ -741,7 +742,7 @@ where TConsensusSpec: ConsensusSpec
                 info!(
                     target: LOG_TARGET,
                     "🌍 Transaction involves foreign shard groups, proposing Prepare({}, {})",
-                    pool_tx.transaction_id(),
+                    pool_tx.id(),
                     pool_tx.current_decision(),
                 );
 
@@ -758,7 +759,7 @@ where TConsensusSpec: ConsensusSpec
                     debug!(
                         target: LOG_TARGET,
                         "ℹ️ Transaction {} is output-only for {}, proposing LocalAccept",
-                        pool_tx.transaction_id(),
+                        pool_tx.id(),
                         local_committee_info.shard_group()
                     );
                     let atom = pool_tx.get_current_transaction_atom();
@@ -793,26 +794,24 @@ where TConsensusSpec: ConsensusSpec
             .resulting_outputs()
             .iter()
             .filter(|o| local_committee_info.includes_substate_id(o.substate_id()));
-        let lock_status = substate_store.try_lock_all(*tx_rec.transaction_id(), local_outputs, false)?;
+        let lock_status = substate_store.try_lock_all(*tx_rec.id(), local_outputs, false)?;
         if let Some(err) = lock_status.failures().first() {
             warn!(
                 target: LOG_TARGET,
                 "⚠️ Failed to lock outputs for transaction {}: {}",
-                tx_rec.transaction_id(),
+                tx_rec.id(),
                 err,
             );
             // If the transaction does not lock, we propose to abort it
-            let execution = TransactionExecution::abort(
-                tx_rec.transaction_id(),
-                RejectReason::FailedToLockOutputs(err.to_string()),
-            );
+            let execution =
+                TransactionExecution::abort(tx_rec.id(), RejectReason::FailedToLockOutputs(err.to_string()));
             tx_rec.update_from_execution(
                 local_committee_info.num_preshards(),
                 local_committee_info.num_committees(),
                 &execution,
             );
 
-            executed_transactions.insert(*tx_rec.transaction_id(), execution);
+            executed_transactions.insert(*tx_rec.id(), execution);
             return Ok(Some(Command::LocalAccept(tx_rec.get_current_transaction_atom())));
         }
 
@@ -821,7 +820,7 @@ where TConsensusSpec: ConsensusSpec
             local_committee_info.num_committees(),
             &execution,
         );
-        executed_transactions.insert(*tx_rec.transaction_id(), execution);
+        executed_transactions.insert(*tx_rec.id(), execution);
         // If we locally decided to ABORT, we are still saying that we think all prepared and, after execution decide to
         // ABORT. When we enter the acceptance phase, we will propose SomeAccept for this case.
         let atom = self.get_transaction_atom_with_leader_fee(&tx_rec)?;
@@ -846,13 +845,13 @@ where TConsensusSpec: ConsensusSpec
             .ok_or_else(|| {
                 HotStuffError::InvariantError(format!(
                     "accept_transaction: Transaction {} has COMMIT decision but execution is missing",
-                    tx_rec.transaction_id(),
+                    tx_rec.id(),
                 ))
             })?;
         let diff = execution.result().finalize.any_accept().ok_or_else(|| {
             HotStuffError::InvariantError(format!(
                 "local_accept_transaction: Transaction {} has COMMIT decision but execution failed when proposing",
-                tx_rec.transaction_id(),
+                tx_rec.id(),
             ))
         })?;
         let filtered_diff = filter_diff_for_committee(local_committee_info, diff);
@@ -860,7 +859,7 @@ where TConsensusSpec: ConsensusSpec
             error!(
                 target: LOG_TARGET,
                 "🔒 Failed to write to temporary state store for transaction {} for Accept: {}. Skipping proposing this transaction...",
-                tx_rec.transaction_id(),
+                tx_rec.id(),
                 err,
             );
             // Only error if it is not related to lock errors
@@ -881,7 +880,7 @@ where TConsensusSpec: ConsensusSpec
             let involved = NonZeroU64::new(num_involved_shard_groups as u64).ok_or_else(|| {
                 HotStuffError::InvariantError(format!(
                     "PROPOSE: Transaction {} involves zero shard groups",
-                    tx_rec.transaction_id(),
+                    tx_rec.id(),
                 ))
             })?;
             let leader_fee = tx_rec.calculate_leader_fee(involved, self.config.consensus_constants.fee_exhaust_divisor);

--- a/crates/consensus/src/hotstuff/on_ready_to_vote_on_local_block.rs
+++ b/crates/consensus/src/hotstuff/on_ready_to_vote_on_local_block.rs
@@ -511,7 +511,7 @@ where TConsensusSpec: ConsensusSpec
             warn!(
                 target: LOG_TARGET,
                 "❌ Stage disagreement for tx {} in block {}. Leader proposed LocalOnly, local stage is {}",
-                pool_tx.transaction_id(),
+                pool_tx.id(),
                 block,
                 pool_tx.current_stage(),
             );
@@ -542,7 +542,7 @@ where TConsensusSpec: ConsensusSpec
                         info!(
                             target: LOG_TARGET,
                             "👨‍🔧 LocalOnly: Prepare for transaction {} ({}) in block {}",
-                            pool_tx.transaction_id(),
+                            pool_tx.id(),
                             pool_tx.current_decision(),
                             block,
                         );
@@ -553,7 +553,7 @@ where TConsensusSpec: ConsensusSpec
                             warn!(
                                 target: LOG_TARGET,
                                 "❌ Prepare decision disagreement for tx {} in block {}. Leader proposed {}, we decided {}",
-                                pool_tx.transaction_id(),
+                                pool_tx.id(),
                                 block,
                                 atom.decision,
                                 pool_tx.current_decision()
@@ -610,14 +610,14 @@ where TConsensusSpec: ConsensusSpec
                             *total_exhaust_burn += u128::from(calculated_leader_fee.exhaust_burn());
                         }
 
-                        proposed_block_change_set.add_transaction_execution(*pool_tx.transaction_id(), execution)?;
+                        proposed_block_change_set.add_transaction_execution(*pool_tx.id(), execution)?;
                     },
                     LocalPreparedTransaction::EarlyAbort { execution, .. } => {
                         if atom.decision.is_commit() {
                             warn!(
                                 target: LOG_TARGET,
                                 "❌ Failed to lock inputs/outputs for transaction {} but leader proposed COMMIT. Not voting for block {}",
-                                pool_tx.transaction_id(),
+                                pool_tx.id(),
                                 block,
                             );
                             return Ok(Some(NoVoteReason::DecisionDisagreement {
@@ -632,7 +632,7 @@ where TConsensusSpec: ConsensusSpec
                             target: LOG_TARGET,
                             "⚠️ Proposer chose to ABORT and we chose to ABORT due to lock conflict for transaction {} in block {}",
                             block,
-                            pool_tx.transaction_id(),
+                            pool_tx.id(),
                         );
                         pool_tx
                             .set_local_decision(execution.decision())
@@ -641,7 +641,7 @@ where TConsensusSpec: ConsensusSpec
                                 local_committee_info.num_preshards(),
                                 local_committee_info.num_committees(),
                             ));
-                        proposed_block_change_set.add_transaction_execution(*pool_tx.transaction_id(), execution)?;
+                        proposed_block_change_set.add_transaction_execution(*pool_tx.id(), execution)?;
                     },
                 }
             },
@@ -676,7 +676,7 @@ where TConsensusSpec: ConsensusSpec
         info!(
             target: LOG_TARGET,
             "👨‍🔧 PREPARE: Transaction {} in block {}",
-            tx_rec.transaction_id(),
+            tx_rec.id(),
             block,
         );
 
@@ -684,7 +684,7 @@ where TConsensusSpec: ConsensusSpec
             warn!(
                 target: LOG_TARGET,
                 "❌ Stage disagreement for tx {} in block {}. Leader proposed Prepare, local stage is {}",
-                tx_rec.transaction_id(),
+                tx_rec.id(),
                 block,
                 tx_rec.current_stage(),
             );
@@ -695,13 +695,13 @@ where TConsensusSpec: ConsensusSpec
         }
 
         // Foreign block could have already resulted in an ABORT execution
-        let maybe_execution = proposed_block_change_set.take_transaction_execution(tx_rec.transaction_id());
+        let maybe_execution = proposed_block_change_set.take_transaction_execution(tx_rec.id());
         let prepared = if maybe_execution.as_ref().is_some_and(|e| e.decision().is_abort()) {
             let execution = maybe_execution.expect("is_some_and");
             info!(
                 target: LOG_TARGET,
                 "👨‍🔧 PREPARE: Transaction {} in block {} is already ABORTED by foreign block",
-                tx_rec.transaction_id(),
+                tx_rec.id(),
                 execution.block_id()
             );
             PreparedTransaction::new_multishard_executed(execution.into_transaction_execution(), LockStatus::new())
@@ -753,7 +753,7 @@ where TConsensusSpec: ConsensusSpec
                         debug!(
                             target: LOG_TARGET,
                             "👨‍🔧 PREPARE: Transaction {} in block {} is executed",
-                            tx_rec.transaction_id(),
+                            tx_rec.id(),
                             block,
                         );
                         // CASE: All inputs are local and outputs are foreign (i.e. the transaction is
@@ -778,13 +778,13 @@ where TConsensusSpec: ConsensusSpec
                                 tx_rec.set_leader_fee(leader_fee);
                             }
                         }
-                        proposed_block_change_set.add_transaction_execution(*tx_rec.transaction_id(), *execution)?;
+                        proposed_block_change_set.add_transaction_execution(*tx_rec.id(), *execution)?;
                     },
                     EvidenceOrExecution::Evidence { evidence } => {
                         debug!(
                             target: LOG_TARGET,
                             "👨‍🔧 PREPARE: Transaction {} in block {} is not executed. Using partial evidence.",
-                            tx_rec.transaction_id(),
+                            tx_rec.id(),
                             block,
                         );
                         // CASE: All local inputs were resolved. We need to continue with consensus to get the
@@ -828,7 +828,7 @@ where TConsensusSpec: ConsensusSpec
                 "{} ❌ LocalPrepare Stage disagreement in block {} for transaction {}. Leader proposed LocalPrepare, but local stage is {}",
                 self.local_validator_pk,
                 block,
-                tx_rec.transaction_id(),
+                tx_rec.id(),
                 tx_rec.current_stage()
             );
             return Ok(Some(NoVoteReason::StageDisagreement {
@@ -852,7 +852,7 @@ where TConsensusSpec: ConsensusSpec
             warn!(
                 target: LOG_TARGET,
                 "❌ LocalPrepared transaction fee disagreement tx {} in block {}. Leader proposed {}, we calculated {}",
-                tx_rec.transaction_id(),
+                tx_rec.id(),
                 block,
                 atom.transaction_fee,
                 tx_rec.transaction_fee()
@@ -866,7 +866,7 @@ where TConsensusSpec: ConsensusSpec
             warn!(
                 target: LOG_TARGET,
                 "❌ LocalPrepared evidence disagreement tx {} in block {}. Leader proposed {}, local {}",
-                tx_rec.transaction_id(),
+                tx_rec.id(),
                 block,
                 atom.evidence,
                 tx_rec.evidence()
@@ -906,7 +906,8 @@ where TConsensusSpec: ConsensusSpec
         };
 
         if tx_rec.current_stage().is_new() {
-            // CASE: This was supposedly sequenced because we are aborting or because we are an output-only shardgroup
+            // CASE: This was sequenced immediately as LocalAccept, which can only mean either we are aborting or we are
+            // an output-only Shard Group
             if let Some(reason) = self.initial_prepare_multishard(
                 &mut tx_rec,
                 block,
@@ -925,11 +926,11 @@ where TConsensusSpec: ConsensusSpec
                 warn!(
                     target: LOG_TARGET,
                     "❌ LocalAccept: transaction {} in block {} is not output-only",
-                    tx_rec.transaction_id(),
+                    tx_rec.id(),
                     block,
                 );
                 return Ok(Some(NoVoteReason::OutputOnlyDisagreement {
-                    transaction_id: *tx_rec.transaction_id(),
+                    transaction_id: *tx_rec.id(),
                     shard_group: local_committee_info.shard_group(),
                     command: "LocalAccept",
                     stage: tx_rec.current_stage(),
@@ -942,7 +943,7 @@ where TConsensusSpec: ConsensusSpec
                 warn!(
                     target: LOG_TARGET,
                     "❌ LocalAccept: transaction {} in block {} is not in COMMITTED LocalPrepared stage (committed stage: {}, current stage: {})",
-                    tx_rec.transaction_id(),
+                    tx_rec.id(),
                     block,
                     tx_rec.committed_stage(),
                     tx_rec.current_stage(),
@@ -958,12 +959,12 @@ where TConsensusSpec: ConsensusSpec
                 warn!(
                     target: LOG_TARGET,
                     "❌ NO VOTE AllPrepare: transaction {} in block {} has not received all foreign input pledges",
-                    tx_rec.transaction_id(),
+                    tx_rec.id(),
                     block,
                 );
                 return Ok(Some(NoVoteReason::NotAllForeignInputPledges));
             }
-            let transaction_id = *tx_rec.transaction_id();
+            let transaction_id = *tx_rec.id();
             let execution = self.execute_transaction(tx, block.as_leaf(), block.epoch(), transaction)?;
             let execution = execution.into_transaction_execution();
 
@@ -982,7 +983,7 @@ where TConsensusSpec: ConsensusSpec
                     .resulting_outputs()
                     .iter()
                     .filter(|o| local_committee_info.includes_substate_id(o.substate_id()));
-                let lock_status = substate_store.try_lock_all(*tx_rec.transaction_id(), local_outputs, false)?;
+                let lock_status = substate_store.try_lock_all(*tx_rec.id(), local_outputs, false)?;
                 if let Some(err) = lock_status.failures().first() {
                     if atom.decision.is_commit() {
                         // If we disagree with any local decision we abstain from voting
@@ -990,7 +991,7 @@ where TConsensusSpec: ConsensusSpec
                             target: LOG_TARGET,
                             "❌ NO VOTE LocalAccept: Lock failure: {} but leader decided COMMIT for tx {} in block {}. Leader proposed COMMIT, we decided ABORT",
                             err,
-                            tx_rec.transaction_id(),
+                            tx_rec.id(),
                             block,
                         );
                         return Ok(Some(NoVoteReason::DecisionDisagreement {
@@ -1002,7 +1003,7 @@ where TConsensusSpec: ConsensusSpec
                     info!(
                         target: LOG_TARGET,
                         "⚠️ Failed to lock outputs for transaction {} in block {}. Error: {}",
-                        tx_rec.transaction_id(),
+                        tx_rec.id(),
                         block,
                         err
                     );
@@ -1019,7 +1020,7 @@ where TConsensusSpec: ConsensusSpec
                         .set_next_stage_and_readiness(TransactionPoolStage::LocalAccepted, block.shard_group())?;
 
                     proposed_block_change_set
-                        .add_transaction_execution(*tx_rec.transaction_id(), execution)?
+                        .add_transaction_execution(*tx_rec.id(), execution)?
                         .set_next_transaction_update(tx_rec)?;
 
                     return Ok(None);
@@ -1029,11 +1030,11 @@ where TConsensusSpec: ConsensusSpec
             info!(
                 target: LOG_TARGET,
                 "👨‍🔧 LocalAccept: Executed transaction {} in block {} with decision {}",
-                tx_rec.transaction_id(),
+                tx_rec.id(),
                 block,
                 execution.decision()
             );
-            proposed_block_change_set.add_transaction_execution(*tx_rec.transaction_id(), execution)?;
+            proposed_block_change_set.add_transaction_execution(*tx_rec.id(), execution)?;
         } else {
             // Abort - nothing to do here
         }
@@ -1042,7 +1043,7 @@ where TConsensusSpec: ConsensusSpec
             warn!(
                 target: LOG_TARGET,
                 "❌ NO VOTE LocalAccept: transaction fee disagreement tx {} in block {}. Leader proposed {}, we calculated {}",
-                tx_rec.transaction_id(),
+                tx_rec.id(),
                 block,
                 atom.transaction_fee,
                 tx_rec.transaction_fee()
@@ -1099,7 +1100,7 @@ where TConsensusSpec: ConsensusSpec
             warn!(
                 target: LOG_TARGET,
                 "❌ NO VOTE: Evidence mismatch for LocalAccept transaction {} in block {}. Leader proposed evidence {}, but we calculated {}",
-                tx_rec.transaction_id(),
+                tx_rec.id(),
                 block,
                 atom.evidence,
                 tx_rec.evidence()
@@ -1157,7 +1158,7 @@ where TConsensusSpec: ConsensusSpec
                 target: LOG_TARGET,
                 "❌ NO VOTE: AllAccept Stage disagreement in block {} for transaction {}. Leader proposed AllAccept, but local stage is {}",
                 block,
-                tx_rec.transaction_id(),
+                tx_rec.id(),
                 tx_rec.current_stage()
             );
             return Ok(Some(NoVoteReason::StageDisagreement {
@@ -1170,7 +1171,7 @@ where TConsensusSpec: ConsensusSpec
             warn!(
                 target: LOG_TARGET,
                 "❌ NO VOTE: AllAccept decision disagreement for transaction {} in block {}. Leader proposed COMMIT, we decided ABORT",
-                tx_rec.transaction_id(),
+                tx_rec.id(),
                 block,
             );
             return Ok(Some(NoVoteReason::DecisionDisagreement {
@@ -1183,7 +1184,7 @@ where TConsensusSpec: ConsensusSpec
             warn!(
                 target: LOG_TARGET,
                 "❌ NO VOTE: AllAccept transaction fee disagreement tx {} in block {}. Leader proposed {}, we calculated {}",
-                tx_rec.transaction_id(),
+                tx_rec.id(),
                 block,
                 atom.transaction_fee,
                 tx_rec.transaction_fee()
@@ -1205,7 +1206,7 @@ where TConsensusSpec: ConsensusSpec
             HotStuffError::InvariantError(format!(
                 "evaluate_all_accept_command: Transaction {} has COMMIT decision and is at LocalAccepted stage but \
                  leader fee is missing",
-                tx_rec.transaction_id()
+                tx_rec.id()
             ))
         })?;
 
@@ -1236,7 +1237,7 @@ where TConsensusSpec: ConsensusSpec
             warn!(
                 target: LOG_TARGET,
                 "❌ NO VOTE: AllAccept disagreement for transaction {} in block {}. Leader proposed that all foreign pledges have been received but locally this is not the case",
-                tx_rec.transaction_id(),
+                tx_rec.id(),
                 block,
             );
             return Ok(Some(NoVoteReason::NotAllForeignInputPledges));
@@ -1257,7 +1258,7 @@ where TConsensusSpec: ConsensusSpec
             warn!(
                 target: LOG_TARGET,
                 "❌ NO VOTE: AllAccept disagreement for transaction {} in block {}. Leader proposed evidence {}, but we calculated {}",
-                tx_rec.transaction_id(),
+                tx_rec.id(),
                 block,
                 atom.evidence,
                 tx_rec.evidence()
@@ -1267,19 +1268,19 @@ where TConsensusSpec: ConsensusSpec
             }));
         }
 
-        let execution = BlockTransactionExecution::get_pending_for_block(tx, tx_rec.transaction_id(), &block.as_leaf())
+        let execution = BlockTransactionExecution::get_pending_for_block(tx, tx_rec.id(), &block.as_leaf())
             .optional()?
             .ok_or_else(|| {
                 HotStuffError::InvariantError(format!(
                     "evaluate_all_accept_command: Transaction {} has COMMIT decision but execution is missing",
-                    tx_rec.transaction_id()
+                    tx_rec.id()
                 ))
             })?;
 
         let diff = execution.result().finalize.any_accept().ok_or_else(|| {
             HotStuffError::InvariantError(format!(
                 "evaluate_local_accept_command: Transaction {} has COMMIT decision but execution failed when proposing",
-                tx_rec.transaction_id(),
+                tx_rec.id(),
             ))
         })?;
 
@@ -1332,7 +1333,7 @@ where TConsensusSpec: ConsensusSpec
                 "{} ❌ Stage disagreement in block {} for transaction {}. Leader proposed SomeAccept, but local stage is {}",
                 self.local_validator_pk,
                 block,
-                tx_rec.transaction_id(),
+                tx_rec.id(),
                 tx_rec.current_stage()
             );
             return Ok(Some(NoVoteReason::StageDisagreement {
@@ -1347,7 +1348,7 @@ where TConsensusSpec: ConsensusSpec
             warn!(
                 target: LOG_TARGET,
                 "❌ SomeAccept decision disagreement for transaction {} in block {}. Leader proposed ABORT, we decided COMMIT",
-                tx_rec.transaction_id(),
+                tx_rec.id(),
                 block,
             );
             return Ok(Some(NoVoteReason::DecisionDisagreement {
@@ -1360,7 +1361,7 @@ where TConsensusSpec: ConsensusSpec
             warn!(
                 target: LOG_TARGET,
                 "❌ SomeAccept transaction fee disagreement tx {} in block {}. Leader proposed {}, we calculated {}",
-                tx_rec.transaction_id(),
+                tx_rec.id(),
                 block,
                 atom.transaction_fee,
                 tx_rec.transaction_fee()
@@ -1585,7 +1586,7 @@ where TConsensusSpec: ConsensusSpec
             let _timer = TraceTimer::debug(LOG_TARGET, "unlock and finalized transactions")
                 .with_iterations(finalized_transactions.len());
             // Remove locks for finalized transactions
-            SubstateRecord::unlock_all(tx, finalized_transactions.iter().map(|t| t.transaction_id()))?;
+            SubstateRecord::unlock_all(tx, finalized_transactions.iter().map(|t| t.id()))?;
             TransactionRecord::finalize_all(tx, &finalized_transactions)?;
 
             debug!(

--- a/crates/consensus/src/hotstuff/on_receive_foreign_proposal.rs
+++ b/crates/consensus/src/hotstuff/on_receive_foreign_proposal.rs
@@ -1,13 +1,16 @@
 //   Copyright 2023 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use std::collections::HashSet;
+use std::{
+    collections::{hash_map::Entry, HashMap, HashSet},
+    time::{Duration, Instant},
+};
 
 use anyhow::anyhow;
 use log::*;
 use tari_consensus_types::{BlockId, ProposalCertificate};
 use tari_epoch_manager::EpochManagerReader;
-use tari_ootle_common_types::{committee::CommitteeInfo, optional::Optional, Epoch, ShardGroup};
+use tari_ootle_common_types::{committee::CommitteeInfo, optional::Optional, Epoch, NodeAddressable, ShardGroup};
 use tari_ootle_storage::{
     consensus_models::{
         Block,
@@ -20,9 +23,9 @@ use tari_ootle_storage::{
     StateStore,
     StateStoreReadTransaction,
 };
-use tokio::task;
 
 use crate::{
+    bounded_spawn::BoundedSpawn,
     hotstuff::{
         commit_proofs::generate_block_commit_proof,
         error::HotStuffError,
@@ -41,13 +44,13 @@ use crate::{
 
 const LOG_TARGET: &str = "tari::ootle::consensus::hotstuff::on_receive_foreign_proposal";
 
-#[derive(Clone)]
 pub struct OnReceiveForeignProposalHandler<TConsensusSpec: ConsensusSpec> {
     store: TConsensusSpec::StateStore,
     epoch_manager: TConsensusSpec::EpochManager,
     pacemaker: PaceMakerHandle,
     outbound_messaging: TConsensusSpec::OutboundMessaging,
-    recently_requested: HashSet<BlockId>,
+    pending_requests: PendingRequests<TConsensusSpec::Addr>,
+    bounded_spawner: BoundedSpawn,
 }
 
 impl<TConsensusSpec> OnReceiveForeignProposalHandler<TConsensusSpec>
@@ -64,7 +67,8 @@ where TConsensusSpec: ConsensusSpec
             epoch_manager,
             pacemaker,
             outbound_messaging,
-            recently_requested: HashSet::new(),
+            pending_requests: PendingRequests::new(),
+            bounded_spawner: BoundedSpawn::new(20),
         }
     }
 
@@ -84,7 +88,7 @@ where TConsensusSpec: ConsensusSpec
                 "FOREIGN PROPOSAL: Already received proposal for block {}",
                 block_id
             );
-            self.remove_recently_requested(&block_id);
+            self.pending_requests.remove(&block_id);
             return Ok(());
         }
 
@@ -102,20 +106,11 @@ where TConsensusSpec: ConsensusSpec
             Ok::<_, HotStuffError>(())
         })?;
 
-        // TODO: keep track of requested proposals and if there are any non-responses after a certain time, request from
-        // another node
-        self.remove_recently_requested(&block_id);
+        self.pending_requests.remove(&block_id);
 
         // Foreign proposals to propose
         self.pacemaker.beat();
         Ok(())
-    }
-
-    fn remove_recently_requested(&mut self, block_id: &BlockId) {
-        self.recently_requested.remove(block_id);
-        if self.recently_requested.capacity() - self.recently_requested.len() > 1000 {
-            self.recently_requested.shrink_to_fit();
-        }
     }
 
     pub async fn handle_notification_received(
@@ -131,7 +126,7 @@ where TConsensusSpec: ConsensusSpec
             from,
             message.block_id,
         );
-        if self.recently_requested.contains(&message.block_id) {
+        if self.pending_requests.contains(&message.block_id) {
             info!(
                 target: LOG_TARGET,
                 "🌐 FOREIGN PROPOSAL: Already requested block {}. Ignoring.",
@@ -171,9 +166,10 @@ where TConsensusSpec: ConsensusSpec
             .get_committee_by_shard_group(
                 current_epoch,
                 foreign_committee_info.shard_group(),
-                // We only request from one - note that we happen to know that get_committee_by_shard_group shuffles
-                // the committee.
+                // We only request from one
                 Some(1),
+                // Shuffle to select a random peer
+                true,
             )
             .await?;
 
@@ -204,7 +200,8 @@ where TConsensusSpec: ConsensusSpec
             )
             .await?;
 
-        self.recently_requested.insert(message.block_id);
+        self.pending_requests
+            .insert(selected.address.clone(), message.block_id, foreign_committee_info);
 
         Ok(())
     }
@@ -217,14 +214,26 @@ where TConsensusSpec: ConsensusSpec
         let store = self.store.clone();
         let outbound_messaging = self.outbound_messaging.clone();
 
-        // No need for consensus to wait for the task to complete
-        // TODO: bounded spawn to limit the number of concurrent tasks created by possibly malicious requests
-        task::spawn(async move {
-            let _timer = TraceTimer::debug(LOG_TARGET, "OnReceiveForeignProposalRequest");
-            if let Err(err) = Self::handle_requested_task(store, outbound_messaging, from, message).await {
-                error!(target: LOG_TARGET, "Error handling requested foreign proposal: {}", err);
-            }
-        });
+        // Spawn: Dont block consensus when processing requests.
+        if self
+            .bounded_spawner
+            .try_spawn({
+                let from = from.clone();
+                async move {
+                    let _timer = TraceTimer::debug(LOG_TARGET, "OnReceiveForeignProposalRequest");
+                    if let Err(err) = Self::handle_requested_task(store, outbound_messaging, from, message).await {
+                        error!(target: LOG_TARGET, "Error handling requested foreign proposal: {}", err);
+                    }
+                }
+            })
+            .is_err()
+        {
+            warn!(
+                target: LOG_TARGET,
+                "⚠️ FOREIGN PROPOSAL: too many concurrent foreign proposal requests, dropping request from {}",
+                from
+            );
+        }
 
         Ok(())
     }
@@ -286,12 +295,89 @@ where TConsensusSpec: ConsensusSpec
                     .send(from, HotstuffMessage::ForeignProposal(proposal.into()))
                     .await?;
             },
-            ForeignProposalRequestMessage::ByTransactionId { .. } => {
-                error!(
+        }
+
+        Ok(())
+    }
+
+    pub async fn handle_timed_out_requests(
+        &mut self,
+        local_committee_info: &CommitteeInfo,
+    ) -> Result<(), HotStuffError> {
+        const TIMEOUT: Duration = Duration::from_secs(30);
+        let timed_out = self
+            .pending_requests
+            .drain_timed_out(TIMEOUT)
+            .take(10)
+            .collect::<Vec<_>>();
+        if !timed_out.is_empty() {
+            info!(
+                target: LOG_TARGET,
+                "🌐 FOREIGN PROPOSAL: {} request(s) timed out",
+                timed_out.len(),
+            );
+        }
+        for (block_id, requests) in timed_out {
+            info!(
+                target: LOG_TARGET,
+                "🌐 FOREIGN PROPOSAL: Request for block {} timed out (previously sent to {} unique peers). Retrying...",
+                block_id,
+                requests.num_unique_peers()
+            );
+
+            if self
+                .store
+                .with_read_tx(|tx| ForeignProposalRecord::record_exists(tx, &block_id))?
+            {
+                // This is expected behaviour, we may receive the same foreign proposal notification multiple times
+                debug!(
                     target: LOG_TARGET,
-                    "TODO FOREIGN PROPOSAL: Request by transaction id is not supported. Ignoring."
+                    "FOREIGN PROPOSAL: Already received proposal for block {}",
+                    block_id,
                 );
-            },
+                return Ok(());
+            }
+
+            if requests.num_unique_peers() >= local_committee_info.num_shard_group_members() as usize {
+                warn!(
+                    target: LOG_TARGET,
+                    "🌐 FOREIGN PROPOSAL: All validators in shard group {} have been requested for block {}. \
+                     Aborting further requests.",
+                    requests.shard_group(),
+                    block_id,
+                );
+                // If a FP is never received + proposed by any local member, the transaction will TIMEOUT and ABORT
+                return Ok(());
+            }
+
+            let shard_group = requests.shard_group();
+            let epoch = requests.epoch();
+
+            let selected = self
+                .epoch_manager
+                .get_random_committee_member(requests.epoch(), Some(requests.shard_group()), requests.peers)
+                .await?;
+
+            info!(
+                target: LOG_TARGET,
+                "🌐 REQUEST foreign proposal {} for block {} from {}",
+                shard_group,
+                block_id,
+                selected,
+            );
+            self.outbound_messaging
+                .send(
+                    selected.address.clone(),
+                    HotstuffMessage::ForeignProposalRequest(ForeignProposalRequestMessage::ByBlockId {
+                        block_id,
+                        for_shard_group: local_committee_info.shard_group(),
+                        epoch,
+                    }),
+                )
+                .await?;
+
+            self.pending_requests
+                .insert(selected.address.clone(), block_id, requests.committee_info)
         }
 
         Ok(())
@@ -333,11 +419,12 @@ where TConsensusSpec: ConsensusSpec
     ) -> Result<(), ProposalValidationError> {
         // TODO: validations specific to the foreign proposal. General block validations (signature etc) are already
         //       performed in on_message_validate. These should be in the validator helper module.
+        let epoch = local_committee_info.epoch();
+        // Allow one epoch behind as Prepare/Accept rounds may have been conducted in the previous/subsequent epoch
+        // before/after epoch end
+        let epoch_range = epoch.saturating_sub(Epoch(1))..=epoch + Epoch(1);
 
-        if proposal.epoch() != local_committee_info.epoch() &&
-            // Allow one epoch behind as Prepare/Accept rounds may have been conducted in the previous epoch before epoch end
-            proposal.epoch() != local_committee_info.epoch() - Epoch(1)
-        {
+        if !epoch_range.contains(&proposal.epoch()) {
             warn!(
                 target: LOG_TARGET,
                 "⚠️ FOREIGN PROPOSAL: Invalid proposal epoch: {}. Current epoch: {}",
@@ -499,4 +586,74 @@ fn generate_transaction_commands_commit_proof_for_shard_group<TTx: StateStoreRea
     let proof = generate_block_commit_proof(tx, commit_qc, committed_block)?;
     let command_commit_proof = CommandsCommitProof::new_latest(applicable_commands.collect(), proof);
     Ok(command_commit_proof)
+}
+
+struct PendingRequests<TAddr> {
+    pending: HashMap<BlockId, ForeignRequests<TAddr>>,
+}
+
+impl<TAddr: NodeAddressable> PendingRequests<TAddr> {
+    pub(self) fn new() -> Self {
+        Self {
+            pending: HashMap::new(),
+        }
+    }
+
+    pub(self) fn contains(&self, block_id: &BlockId) -> bool {
+        self.pending.contains_key(block_id)
+    }
+
+    pub(self) fn insert(&mut self, address: TAddr, block_id: BlockId, committee_info: CommitteeInfo) {
+        match self.pending.entry(block_id) {
+            Entry::Occupied(occupied) => {
+                let entry = occupied.into_mut();
+                entry.peers.insert(address);
+                entry.at = Instant::now();
+            },
+            Entry::Vacant(vacant) => {
+                let mut peers = HashSet::new();
+                peers.insert(address);
+                vacant.insert(ForeignRequests {
+                    peers,
+                    committee_info,
+                    at: Instant::now(),
+                });
+            },
+        }
+    }
+
+    pub(self) fn remove(&mut self, block_id: &BlockId) -> Option<ForeignRequests<TAddr>> {
+        let item = self.pending.remove(block_id);
+        if self.pending.capacity() >= 1000 {
+            self.pending.shrink_to_fit();
+        }
+        item
+    }
+
+    pub(self) fn drain_timed_out(
+        &mut self,
+        timeout: Duration,
+    ) -> impl Iterator<Item = (BlockId, ForeignRequests<TAddr>)> + '_ {
+        self.pending.extract_if(move |_, reqs| reqs.at.elapsed() >= timeout)
+    }
+}
+
+struct ForeignRequests<TAddr> {
+    pub peers: HashSet<TAddr>,
+    pub committee_info: CommitteeInfo,
+    pub at: Instant,
+}
+
+impl<TAddr> ForeignRequests<TAddr> {
+    pub fn epoch(&self) -> Epoch {
+        self.committee_info.epoch()
+    }
+
+    pub fn shard_group(&self) -> ShardGroup {
+        self.committee_info.shard_group()
+    }
+
+    pub fn num_unique_peers(&self) -> usize {
+        self.peers.len()
+    }
 }

--- a/crates/consensus/src/hotstuff/substate_store/pending_store.rs
+++ b/crates/consensus/src/hotstuff/substate_store/pending_store.rs
@@ -510,9 +510,10 @@ impl<'store, 'tx, TStore: StateStore + 'store + 'tx> PendingSubstateStore<'store
                 if has_local_only_rules && requested_lock_type.is_write() {
                     warn!(
                         target: LOG_TARGET,
-                        "⚠️ Lock conflict(1): [{}] Read lock(local_only={}) is present. Requested lock is {}(local_only={})",
+                        "⚠️ Lock conflict(1): [{}] Read lock(local_only={}) is present in {}. Requested lock is {}(local_only={})",
                         versioned_substate_id,
                         existing.is_local_only(),
+                        existing.transaction_id(),
                         requested_lock_type,
                         is_local_only
                     );
@@ -531,9 +532,10 @@ impl<'store, 'tx, TStore: StateStore + 'store + 'tx> PendingSubstateStore<'store
                 if !has_local_only_rules && !same_transaction && !requested_lock_type.is_read() {
                     warn!(
                         target: LOG_TARGET,
-                        "⚠️ Lock conflict(2): [{}] Read lock(local_only={}) is present. Requested lock is {}(local_only={})",
+                        "⚠️ Lock conflict(2): [{}] Read lock(local_only={}) is present in {}. Requested lock is {}(local_only={})",
                         versioned_substate_id,
                         existing.is_local_only(),
+                        existing.transaction_id(),
                         requested_lock_type,
                         is_local_only
                     );
@@ -552,9 +554,10 @@ impl<'store, 'tx, TStore: StateStore + 'store + 'tx> PendingSubstateStore<'store
                 if !has_local_only_rules && same_transaction && !requested_lock_type.is_output() {
                     warn!(
                         target: LOG_TARGET,
-                        "⚠️ Lock conflict(3): [{}] Read lock(local_only={}) is present. Requested lock is {}(local_only={})",
+                        "⚠️ Lock conflict(3): [{}] Read lock(local_only={}) is present in {}. Requested lock is {}(local_only={})",
                         versioned_substate_id,
                         existing.is_local_only(),
+                        existing.transaction_id(),
                         requested_lock_type,
                         is_local_only
                     );
@@ -609,9 +612,10 @@ impl<'store, 'tx, TStore: StateStore + 'store + 'tx> PendingSubstateStore<'store
                 if !requested_lock_type.is_output() {
                     warn!(
                         target: LOG_TARGET,
-                        "⚠️ Lock conflict: [{}] Write lock(local_only={}) is present. Requested lock is {}(local_only={})",
+                        "⚠️ Lock conflict: [{}] Write lock(local_only={}) is present in {}. Requested lock is {}(local_only={})",
                         versioned_substate_id,
                         existing.is_local_only(),
+                        existing.transaction_id(),
                         requested_lock_type,
                         is_local_only
                     );
@@ -642,10 +646,11 @@ impl<'store, 'tx, TStore: StateStore + 'store + 'tx> PendingSubstateStore<'store
                 if !has_local_only_rules {
                     warn!(
                         target: LOG_TARGET,
-                        "⚠️ Lock conflict: [{}, {}] Output lock(local_only={}) is present. Requested lock is {}(local_only={})",
+                        "⚠️ Lock conflict: [{}, {}] Output lock(local_only={}) is present in {}. Requested lock is {}(local_only={})",
                         transaction_id,
                         versioned_substate_id,
                         existing.is_local_only(),
+                        existing.transaction_id(),
                         requested_lock_type,
                         is_local_only
                     );
@@ -664,10 +669,11 @@ impl<'store, 'tx, TStore: StateStore + 'store + 'tx> PendingSubstateStore<'store
                 if requested_lock_type.is_output() {
                     warn!(
                         target: LOG_TARGET,
-                        "⚠️ Lock conflict: [{}, {}] Output lock(local_only={}) is present. Requested lock is Output(local_only={})",
+                        "⚠️ Lock conflict: [{}, {}] Output lock(local_only={}) is present in {}. Requested lock is Output(local_only={})",
                         transaction_id,
                         versioned_substate_id,
                         existing.is_local_only(),
+                        existing.transaction_id(),
                         is_local_only
                     );
                     return Err(LockFailedError::LockConflict {

--- a/crates/consensus/src/hotstuff/worker.rs
+++ b/crates/consensus/src/hotstuff/worker.rs
@@ -4,7 +4,7 @@
 use std::{
     fmt::{Debug, Formatter},
     iter,
-    time::Instant,
+    time::{Duration, Instant},
 };
 
 use log::*;
@@ -26,6 +26,7 @@ use tari_ootle_storage::{
     consensus_models::{
         Block,
         BookkeepingModel,
+        EpochCheckpoint,
         ForeignProposalRecord,
         NoVoteReason,
         TransactionPool,
@@ -36,7 +37,10 @@ use tari_ootle_storage::{
 use tari_shutdown::ShutdownSignal;
 use tari_template_lib_types::crypto::RistrettoPublicKeyBytes;
 use tari_transaction::{Transaction, TransactionId};
-use tokio::sync::{broadcast, mpsc};
+use tokio::{
+    sync::{broadcast, mpsc},
+    time,
+};
 
 use super::{
     calculate_last_dummy_block,
@@ -247,9 +251,31 @@ impl<TConsensusSpec: ConsensusSpec> HotstuffWorker<TConsensusSpec> {
         &self.pacemaker
     }
 
+    async fn get_starting_epoch(&self) -> Result<(Epoch, FixedHash), HotStuffError> {
+        // NOTE: we assume the latest checkpoint has been synced already
+        let checkpoint = self
+            .state_store
+            .with_read_tx(|tx| EpochCheckpoint::get_last_checkpoint(tx))
+            .optional()?;
+
+        let last_finalised_epoch = checkpoint.map(|ch| ch.epoch());
+
+        let current_epoch = {
+            // Typically, the current epoch = last finalised epoch + 1. Unless, the epoch was not finalised yet at
+            // startup.
+            match last_finalised_epoch {
+                Some(epoch) => epoch + Epoch(1),
+                None => self.epoch_manager.current_epoch().await?,
+            }
+        };
+
+        let epoch_hash = self.epoch_manager.get_epoch_hash(current_epoch).await?;
+
+        Ok((current_epoch, epoch_hash))
+    }
+
     pub async fn start(&mut self) -> Result<(), HotStuffError> {
-        let current_epoch = self.epoch_manager.current_epoch().await?;
-        let current_epoch_hash = self.epoch_manager.get_current_epoch_hash().await?;
+        let (current_epoch, current_epoch_hash) = self.get_starting_epoch().await?;
         let local_committee_info = self.epoch_manager.get_local_committee_info(current_epoch).await?;
 
         self.create_genesis_block_if_required(current_epoch, current_epoch_hash, local_committee_info.shard_group())?;
@@ -315,6 +341,9 @@ impl<TConsensusSpec: ConsensusSpec> HotstuffWorker<TConsensusSpec> {
             .fee_claim_public_key;
 
         self.request_catch_up_sync(&epoch_state).await?;
+
+        let mut periodic_tasks = time::interval(Duration::from_secs(10));
+        periodic_tasks.set_missed_tick_behavior(time::MissedTickBehavior::Delay);
 
         loop {
             let current_height = self.pacemaker.current_view().get_height();
@@ -393,6 +422,13 @@ impl<TConsensusSpec: ConsensusSpec> HotstuffWorker<TConsensusSpec> {
                     if let Err(e) = self.on_leader_timeout(&epoch_state, current_height, Some(timeout)).await {
                         self.on_failure("on_leader_timeout", &e).await;
                         return Err(e);
+                    }
+                },
+
+                _ = periodic_tasks.tick() => {
+                    if let Err(e) = self.on_task_tick(&epoch_state).await {
+                        self.hooks.on_error(&e);
+                        error!(target: LOG_TARGET, "🚨Error during periodic task: {}", e);
                     }
                 },
 
@@ -681,6 +717,15 @@ impl<TConsensusSpec: ConsensusSpec> HotstuffWorker<TConsensusSpec> {
         }
 
         self.publish_event(HotstuffEvent::LeaderTimeout { height: current_height });
+        Ok(())
+    }
+
+    async fn on_task_tick(&mut self, epoch_state: &EpochState<TConsensusSpec::Addr>) -> Result<(), HotStuffError> {
+        // Re-request foreign proposals that have had no response after a timeout
+        self.on_receive_foreign_proposal
+            .handle_timed_out_requests(epoch_state.local_committee_info())
+            .await?;
+
         Ok(())
     }
 
@@ -1146,7 +1191,7 @@ impl<TConsensusSpec: ConsensusSpec> HotstuffWorker<TConsensusSpec> {
                     .get_random_committee_member(
                         local_epoch_state.epoch(),
                         Some(local_epoch_state.local_committee_info.shard_group()),
-                        vec![self.local_validator_addr.clone()],
+                        [self.local_validator_addr.clone()].into_iter().collect(),
                     )
                     .await?
             },

--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -1,6 +1,7 @@
 //   Copyright 2023 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
+mod bounded_spawn;
 pub mod consensus_constants;
 pub mod hotstuff;
 pub mod messages;

--- a/crates/consensus/src/messages/foreign_proposal.rs
+++ b/crates/consensus/src/messages/foreign_proposal.rs
@@ -7,7 +7,6 @@ use serde::Serialize;
 use tari_consensus_types::BlockId;
 use tari_ootle_common_types::{Epoch, ShardGroup};
 use tari_ootle_storage::consensus_models::{ForeignParkedProposal, ForeignProposal, ForeignProposalRecord};
-use tari_transaction::TransactionId;
 
 #[derive(Debug, Clone, Serialize)]
 pub struct ForeignProposalMessage {
@@ -61,7 +60,7 @@ impl Display for ForeignProposalNotificationMessage {
         write!(
             f,
             "ForeignProposalNotificationMessage({}, {})",
-            self.epoch, self.block_id
+            self.epoch, self.block_id,
         )
     }
 }
@@ -76,20 +75,12 @@ pub enum ForeignProposalRequestMessage {
         for_shard_group: ShardGroup,
         epoch: Epoch,
     },
-    /// Request a foreign proposal for a specific transaction ID. This is used as a "bump" when a transaction is
-    /// reached LocalPrepared but the foreign proposal has not yet been received after some time.
-    ByTransactionId {
-        transaction_id: TransactionId,
-        for_shard_group: ShardGroup,
-        epoch: Epoch,
-    },
 }
 
 impl ForeignProposalRequestMessage {
     pub fn epoch(&self) -> Epoch {
         match self {
             Self::ByBlockId { epoch, .. } => *epoch,
-            Self::ByTransactionId { epoch, .. } => *epoch,
         }
     }
 }
@@ -106,17 +97,6 @@ impl Display for ForeignProposalRequestMessage {
                     f,
                     "ForeignProposalRequestMessage(ByBlockId, {}, {}, {})",
                     epoch, for_shard_group, block_id
-                )
-            },
-            Self::ByTransactionId {
-                transaction_id,
-                for_shard_group,
-                epoch,
-            } => {
-                write!(
-                    f,
-                    "ForeignProposalRequestMessage(ByTransactionId, {}, {}, {})",
-                    epoch, for_shard_group, transaction_id
                 )
             },
         }

--- a/crates/consensus_tests/src/support/epoch_manager.rs
+++ b/crates/consensus_tests/src/support/epoch_manager.rs
@@ -1,7 +1,11 @@
 //   Copyright 2023 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use std::{collections::HashMap, sync::Arc, time::Instant};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+    time::Instant,
+};
 
 use rand::seq::IteratorRandom;
 use tari_common_types::types::FixedHash;
@@ -218,6 +222,14 @@ impl EpochManagerReader for TestEpochManager {
         Ok(self.inner.lock().await.last_epoch_hash)
     }
 
+    async fn get_epoch_hash(&self, epoch: Epoch) -> Result<FixedHash, EpochManagerError> {
+        let lock = self.inner.lock().await;
+        if epoch != lock.current_epoch {
+            panic!("TestEpochManager does not support fetching historical epoch hashes");
+        }
+        Ok(lock.last_epoch_hash)
+    }
+
     async fn get_num_committees(&self, _epoch: Epoch) -> Result<u32, EpochManagerError> {
         Ok(self.inner.lock().await.committees.len() as u32)
     }
@@ -262,11 +274,15 @@ impl EpochManagerReader for TestEpochManager {
         _epoch: Epoch,
         shard_group: ShardGroup,
         limit: Option<usize>,
+        shuffled: bool,
     ) -> Result<Committee<Self::Addr>, EpochManagerError> {
         let state = self.state_lock().await;
         let Some(mut committee) = state.committees.get(&shard_group).cloned() else {
             panic!("Committee not found for shard group {}", shard_group);
         };
+        if shuffled {
+            committee.shuffle();
+        }
 
         if let Some(limit) = limit {
             committee.members_mut().truncate(limit);
@@ -365,7 +381,7 @@ impl EpochManagerReader for TestEpochManager {
         &self,
         _epoch: Epoch,
         shard_group: Option<ShardGroup>,
-        excluding: Vec<Self::Addr>,
+        excluding: HashSet<Self::Addr>,
     ) -> Result<ValidatorNode<Self::Addr>, EpochManagerError> {
         let state = self.state_lock().await;
         let vn = match shard_group {

--- a/crates/consensus_tests/src/support/harness.rs
+++ b/crates/consensus_tests/src/support/harness.rs
@@ -283,7 +283,10 @@ impl Test {
 
     pub fn dump_pool_info(&self) {
         for v in self.validators.values().sorted_unstable_by_key(|a| &a.address) {
-            let pool = v.state_store.with_read_tx(|tx| tx.transaction_pool_get_all()).unwrap();
+            let pool = v
+                .state_store
+                .with_read_tx(|tx| tx.transaction_pool_get_all(1000))
+                .unwrap();
             println!("Validator {}", v.address);
             let mut table = Table::new();
             table
@@ -302,7 +305,7 @@ impl Test {
                     v.address,
                     tx.current_stage(),
                     tx.pending_stage().display(),
-                    tx.transaction_id(),
+                    tx.id(),
                     tx.current_decision(),
                     tx.is_ready(),
                     format!(

--- a/crates/consensus_tests/src/support/messaging_impls.rs
+++ b/crates/consensus_tests/src/support/messaging_impls.rs
@@ -88,7 +88,7 @@ impl OutboundMessaging for TestOutboundMessaging {
             .map_err(|e| OutboundMessagingError::UpstreamError(e.into()))?;
         let peers = self
             .epoch_manager
-            .get_committee_by_shard_group(epoch, shard_group, None)
+            .get_committee_by_shard_group(epoch, shard_group, None, false)
             .await
             .map_err(|e| OutboundMessagingError::UpstreamError(e.into()))?
             .into_addresses();

--- a/crates/consensus_types/src/ids/block_id.rs
+++ b/crates/consensus_types/src/ids/block_id.rs
@@ -6,6 +6,7 @@ use tari_ootle_common_types::hashing;
 
 crate::create_hash_type!(
     /// The ID of a block in the Tari consensus protocol.
+    #[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export, type = "string"))]
     BlockId
 );
 

--- a/crates/epoch_manager/src/service/epoch_manager.rs
+++ b/crates/epoch_manager/src/service/epoch_manager.rs
@@ -22,7 +22,7 @@
 
 use std::{
     cmp,
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     num::NonZeroU32,
     sync::{atomic, atomic::AtomicU64, Arc},
 };
@@ -42,7 +42,7 @@ use tari_ootle_common_types::{
     SubstateAddress,
     VotePower,
 };
-use tari_ootle_storage::global::{models::ValidatorNode, BlockHeaderModel, DbEpoch, GlobalDb, MetadataKey};
+use tari_ootle_storage::global::{models::ValidatorNode, BlockHeaderModel, GlobalDb, MetadataKey};
 use tari_ootle_storage_sqlite::global::SqliteGlobalDbAdapter;
 use tari_sidechain::EvictionProof;
 use tari_template_lib_types::crypto::RistrettoPublicKeyBytes;
@@ -203,16 +203,9 @@ where TSpec: EpochManagerSpec
     }
 
     pub fn insert_current_epoch(&mut self, epoch: Epoch, epoch_hash: FixedHash) -> Result<(), EpochManagerError> {
-        let epoch_height = epoch.0;
-        let db_epoch = DbEpoch {
-            epoch: epoch_height,
-            // TODO: remove validator node mr from epoch db
-            validator_node_mr: FixedHash::default().as_slice().to_vec(),
-        };
-
         let mut tx = self.global_db.create_transaction()?;
 
-        self.global_db.epochs(&mut tx).insert_epoch(db_epoch)?;
+        self.global_db.epochs(&mut tx).insert_epoch(epoch, epoch_hash)?;
         let mut metadata = self.global_db.metadata(&mut tx);
         metadata.set_metadata(MetadataKey::EpochManagerCurrentEpoch.as_key_bytes(), &epoch)?;
         metadata.set_metadata(MetadataKey::EpochManagerLastEpochHash.as_key_bytes(), &epoch_hash)?;
@@ -231,8 +224,18 @@ where TSpec: EpochManagerSpec
         self.current_epoch.store(epoch.as_u64(), atomic::Ordering::SeqCst);
     }
 
-    pub fn current_epoch_hash(&self) -> FixedHash {
-        self.current_epoch_hash
+    pub fn get_epoch_hash(&self, epoch: Epoch) -> Result<FixedHash, EpochManagerError> {
+        if epoch == self.current_epoch() {
+            return Ok(self.current_epoch_hash);
+        }
+
+        let mut tx = self.global_db.create_transaction()?;
+        let data = self
+            .global_db
+            .epochs(&mut tx)
+            .get_epoch_data(epoch)?
+            .ok_or(EpochManagerError::NoEpochFound(epoch))?;
+        Ok(data.epoch_hash)
     }
 
     pub fn get_validator_node_by_public_key(
@@ -475,7 +478,7 @@ where TSpec: EpochManagerSpec
         &self,
         epoch: Epoch,
         shard_group: Option<ShardGroup>,
-        excluding: Vec<TSpec::Addr>,
+        excluding: HashSet<TSpec::Addr>,
     ) -> Result<ValidatorNode<TSpec::Addr>, EpochManagerError> {
         let mut tx = self.global_db.create_transaction()?;
         let mut validator_node_db = self.global_db.validator_nodes(&mut tx);

--- a/crates/epoch_manager/src/service/epoch_manager_service.rs
+++ b/crates/epoch_manager/src/service/epoch_manager_service.rs
@@ -318,8 +318,8 @@ impl<TSpec: EpochManagerSpec> EpochManagerService<TSpec> {
         let context = &format!("{:?}", req);
         match req {
             EpochManagerRequest::CurrentEpoch { reply } => handle(reply, Ok(self.inner.current_epoch()), context),
-            EpochManagerRequest::CurrentEpochHash { reply } => {
-                handle(reply, Ok(self.inner.current_epoch_hash()), context)
+            EpochManagerRequest::GetEpochHash { epoch, reply } => {
+                handle(reply, self.inner.get_epoch_hash(epoch), context)
             },
             EpochManagerRequest::GetValidatorNodeByPublicKey {
                 epoch,
@@ -419,12 +419,13 @@ impl<TSpec: EpochManagerSpec> EpochManagerService<TSpec> {
             EpochManagerRequest::GetCommitteeForShardGroup {
                 epoch,
                 shard_group,
+                shuffled,
                 limit,
                 reply,
             } => handle(
                 reply,
                 self.inner
-                    .get_committee_for_shard_group(epoch, shard_group, true, limit),
+                    .get_committee_for_shard_group(epoch, shard_group, shuffled, limit),
                 context,
             ),
             EpochManagerRequest::GetCommitteesOverlappingShardGroup {

--- a/crates/epoch_manager/src/service/handle.rs
+++ b/crates/epoch_manager/src/service/handle.rs
@@ -2,7 +2,7 @@
 //   SPDX-License-Identifier: BSD-3-Clause
 
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     sync::{atomic::AtomicU64, Arc},
 };
 
@@ -289,9 +289,20 @@ impl<TAddr: NodeAddressable> EpochManagerReader for EpochManagerHandle<TAddr> {
     }
 
     async fn get_current_epoch_hash(&self) -> Result<FixedHash, EpochManagerError> {
+        let epoch = self.get_current_epoch();
         let (tx, rx) = oneshot::channel();
         self.tx_request
-            .send(EpochManagerRequest::CurrentEpochHash { reply: tx })
+            .send(EpochManagerRequest::GetEpochHash { epoch, reply: tx })
+            .await
+            .map_err(|_| EpochManagerError::SendError)?;
+
+        rx.await.map_err(|_| EpochManagerError::ReceiveError)?
+    }
+
+    async fn get_epoch_hash(&self, epoch: Epoch) -> Result<FixedHash, EpochManagerError> {
+        let (tx, rx) = oneshot::channel();
+        self.tx_request
+            .send(EpochManagerRequest::GetEpochHash { epoch, reply: tx })
             .await
             .map_err(|_| EpochManagerError::SendError)?;
 
@@ -313,12 +324,14 @@ impl<TAddr: NodeAddressable> EpochManagerReader for EpochManagerHandle<TAddr> {
         epoch: Epoch,
         shard_group: ShardGroup,
         limit: Option<usize>,
+        shuffled: bool,
     ) -> Result<Committee<Self::Addr>, EpochManagerError> {
         let (tx, rx) = oneshot::channel();
         self.tx_request
             .send(EpochManagerRequest::GetCommitteeForShardGroup {
                 epoch,
                 shard_group,
+                shuffled,
                 limit,
                 reply: tx,
             })
@@ -362,7 +375,7 @@ impl<TAddr: NodeAddressable> EpochManagerReader for EpochManagerHandle<TAddr> {
         &self,
         epoch: Epoch,
         shard_group: Option<ShardGroup>,
-        excluding: Vec<TAddr>,
+        excluding: HashSet<TAddr>,
     ) -> Result<ValidatorNode<TAddr>, EpochManagerError> {
         let (tx, rx) = oneshot::channel();
         self.tx_request

--- a/crates/epoch_manager/src/service/types.rs
+++ b/crates/epoch_manager/src/service/types.rs
@@ -1,7 +1,7 @@
 //   Copyright 2023 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use tari_common_types::types::FixedHash;
 use tari_ootle_common_types::{
@@ -25,7 +25,8 @@ pub enum EpochManagerRequest<TAddr> {
     CurrentEpoch {
         reply: Reply<Epoch>,
     },
-    CurrentEpochHash {
+    GetEpochHash {
+        epoch: Epoch,
         reply: Reply<FixedHash>,
     },
     GetValidatorNodeByPublicKey {
@@ -95,6 +96,7 @@ pub enum EpochManagerRequest<TAddr> {
     GetCommitteeForShardGroup {
         epoch: Epoch,
         shard_group: ShardGroup,
+        shuffled: bool,
         limit: Option<usize>,
         reply: Reply<Committee<TAddr>>,
     },
@@ -113,7 +115,7 @@ pub enum EpochManagerRequest<TAddr> {
     GetRandomCommitteeMemberFromShardGroup {
         epoch: Epoch,
         shard_group: Option<ShardGroup>,
-        excluding: Vec<TAddr>,
+        excluding: HashSet<TAddr>,
         reply: Reply<ValidatorNode<TAddr>>,
     },
     GetNetworkDescription {

--- a/crates/epoch_manager/src/traits.rs
+++ b/crates/epoch_manager/src/traits.rs
@@ -20,7 +20,10 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::{collections::HashMap, future::Future};
+use std::{
+    collections::{HashMap, HashSet},
+    future::Future,
+};
 
 use tari_common_types::types::FixedHash;
 use tari_ootle_common_types::{
@@ -131,6 +134,7 @@ pub trait EpochManagerReader: Send + Sync {
 
     fn current_epoch(&self) -> impl Future<Output = Result<Epoch, EpochManagerError>> + Send;
     fn get_current_epoch_hash(&self) -> impl Future<Output = Result<FixedHash, EpochManagerError>> + Send;
+    fn get_epoch_hash(&self, epoch: Epoch) -> impl Future<Output = Result<FixedHash, EpochManagerError>> + Send;
 
     fn get_num_committees(&self, epoch: Epoch) -> impl Future<Output = Result<u32, EpochManagerError>> + Send;
 
@@ -139,6 +143,7 @@ pub trait EpochManagerReader: Send + Sync {
         epoch: Epoch,
         shards: ShardGroup,
         limit: Option<usize>,
+        shuffled: bool,
     ) -> impl Future<Output = Result<Committee<Self::Addr>, EpochManagerError>> + Send;
     fn get_committees_overlapping_shard_group(
         &self,
@@ -222,7 +227,7 @@ pub trait EpochManagerReader: Send + Sync {
         &self,
         epoch: Epoch,
         shard_group: Option<ShardGroup>,
-        excluding: Vec<Self::Addr>,
+        excluding: HashSet<Self::Addr>,
     ) -> impl Future<Output = Result<ValidatorNode<Self::Addr>, EpochManagerError>> + Send;
 }
 

--- a/crates/p2p/proto/consensus.proto
+++ b/crates/p2p/proto/consensus.proto
@@ -51,18 +51,11 @@ message ForeignProposalNotification {
 message ForeignProposalRequest {
   oneof request {
     ForeignProposalRequestByBlockId by_block_id = 1;
-    ForeignProposalRequestByTransactionId by_transaction_id = 2;
   }
 }
 
 message ForeignProposalRequestByBlockId {
   bytes block_id = 1;
-  uint32 for_shard_group = 2;
-  uint64 epoch = 3;
-}
-
-message ForeignProposalRequestByTransactionId {
-  bytes transaction_id = 1;
   uint32 for_shard_group = 2;
   uint64 epoch = 3;
 }

--- a/crates/p2p/src/conversions/consensus.rs
+++ b/crates/p2p/src/conversions/consensus.rs
@@ -309,19 +309,6 @@ impl From<&ForeignProposalRequestMessage> for proto::consensus::ForeignProposalR
                     },
                 )),
             },
-            ForeignProposalRequestMessage::ByTransactionId {
-                transaction_id,
-                for_shard_group,
-                epoch,
-            } => Self {
-                request: Some(proto::consensus::foreign_proposal_request::Request::ByTransactionId(
-                    proto::consensus::ForeignProposalRequestByTransactionId {
-                        transaction_id: transaction_id.as_bytes().to_vec(),
-                        for_shard_group: for_shard_group.encode_as_u32(),
-                        epoch: epoch.as_u64(),
-                    },
-                )),
-            },
         }
     }
 }
@@ -338,14 +325,6 @@ impl TryFrom<proto::consensus::ForeignProposalRequest> for ForeignProposalReques
                     for_shard_group: ShardGroup::decode_from_u32(by_block_id.for_shard_group)
                         .ok_or_else(|| anyhow!("Invalid ShardGroup"))?,
                     epoch: Epoch(by_block_id.epoch),
-                }
-            },
-            proto::consensus::foreign_proposal_request::Request::ByTransactionId(by_transaction_id) => {
-                ForeignProposalRequestMessage::ByTransactionId {
-                    transaction_id: TransactionId::try_from(by_transaction_id.transaction_id)?,
-                    for_shard_group: ShardGroup::decode_from_u32(by_transaction_id.for_shard_group)
-                        .ok_or_else(|| anyhow!("Invalid ShardGroup"))?,
-                    epoch: Epoch(by_transaction_id.epoch),
                 }
             },
         })

--- a/crates/rpc_state_sync/src/state_sync.rs
+++ b/crates/rpc_state_sync/src/state_sync.rs
@@ -454,7 +454,7 @@ where TConsensusSpec: ConsensusSpec<Addr = PeerAddress>
                     // first epoch is not 0 but the first epoch where validators become active).
                     warn!(
                         target: LOG_TARGET,
-                        "❓No checkpoint for epoch {epoch}. This may mean that this is the first epoch in the network"
+                        "❓️ No checkpoint for epoch {prev_epoch}. This may mean that this is the first epoch in the network or the epoch has not yet been finalized.",
                     );
                     return Ok(None);
                 },

--- a/crates/state_store_rocksdb/src/cf_api.rs
+++ b/crates/state_store_rocksdb/src/cf_api.rs
@@ -147,6 +147,8 @@ impl<CF: Cf, DB: RocksReader> CfContext<'_, DB, CF> {
         self.any_exists_within_range(rocksdb::PrefixRange(self.encode_key(prefix)))
     }
 
+    /// Returns true if any key exists within the given range, otherwise false.
+    /// WARNING: the bounds must encode the prefix correctly according to the column family's key codec.
     pub fn any_exists_within_range(&self, range: impl IterateBounds) -> Result<bool, RocksDbStorageError> {
         let mut opts = rocksdb::ReadOptions::default();
         opts.set_iterate_range(range);

--- a/crates/state_store_rocksdb/src/reader.rs
+++ b/crates/state_store_rocksdb/src/reader.rs
@@ -481,6 +481,19 @@ impl<'tx, TAddr: NodeAddressable + Serialize + DeserializeOwned + 'tx> StateStor
         Ok(high_tc)
     }
 
+    fn is_block_in_end_of_epoch_chain(&self, block_id: &BlockId) -> Result<bool, StorageError> {
+        const OPERATION: &str = "is_block_in_end_of_epoch_chain";
+        let block_cf = self.db().cf(BlockCf)?;
+        let chain = self.get_pending_chain_ordered(block_id)?;
+        for block in chain {
+            let block = block_cf.get(&block, OPERATION)?;
+            if block.is_epoch_end() {
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+
     fn foreign_proposals_get_any<'a, I: IntoIterator<Item = &'a BlockId>>(
         &self,
         block_ids: I,
@@ -1177,7 +1190,7 @@ impl<'tx, TAddr: NodeAddressable + Serialize + DeserializeOwned + 'tx> StateStor
         for block_id in pending_chain {
             let mut iter = query.prefix_range_value_iterator(Ordering::default(), &(block_id, *transaction_id));
             if let Some(update) = iter.next().transpose()? {
-                trace!(
+                debug!(
                     target: LOG_TARGET,
                     "{OPERATION}: found update {} for block {}: {:#} -> {:#}",
                     update.transaction_id, block_id,
@@ -1200,7 +1213,7 @@ impl<'tx, TAddr: NodeAddressable + Serialize + DeserializeOwned + 'tx> StateStor
         Ok(exists)
     }
 
-    fn transaction_pool_get_all(&self) -> Result<Vec<TransactionPoolRecord>, StorageError> {
+    fn transaction_pool_get_all(&self, limit: usize) -> Result<Vec<TransactionPoolRecord>, StorageError> {
         // TODO: Only used in tests
         const OPERATION: &str = "transaction_pool_get_all";
         let cf = self.db().cf(TransactionPoolCf)?;
@@ -1219,13 +1232,16 @@ impl<'tx, TAddr: NodeAddressable + Serialize + DeserializeOwned + 'tx> StateStor
 
         let n = cf.count(OPERATION)?;
         let iter = cf.value_iterator(Ordering::Ascending, OPERATION);
-        let mut transactions = Vec::with_capacity(n);
+        let mut transactions = Vec::with_capacity(n.min(limit));
         for result in iter {
             let mut tx = result?;
-            if let Some(update) = updates.remove(tx.transaction_id()) {
+            if let Some(update) = updates.remove(tx.id()) {
                 update.merge_into(&mut tx);
             }
             transactions.push(tx);
+            if transactions.len() == limit {
+                break;
+            }
         }
         Ok(transactions)
     }
@@ -1269,14 +1285,14 @@ impl<'tx, TAddr: NodeAddressable + Serialize + DeserializeOwned + 'tx> StateStor
 
         for result in iter {
             let mut tx = result?;
-            if lock_conflicted.contains(tx.transaction_id()) {
+            if lock_conflicted.contains(tx.id()) {
                 continue;
             }
 
-            if lock_conflicts_cf.exists_prefix(tx.transaction_id())? {
+            if lock_conflicts_cf.exists_prefix(tx.id())? {
                 continue;
             }
-            if let Some(update) = updates.remove(tx.transaction_id()) {
+            if let Some(update) = updates.remove(tx.id()) {
                 update.merge_into(&mut tx);
             }
             if tx.is_ready() {
@@ -1321,10 +1337,10 @@ impl<'tx, TAddr: NodeAddressable + Serialize + DeserializeOwned + 'tx> StateStor
 
         for result in iter {
             let tx_id = result?;
-            // It's possible that the transaction has been removed from the pool in another thread 😱 - observed in
-            // consensus_tests
             if must_query {
                 let Some(tx_pool_rec) = cf.get(&tx_id, OPERATION).optional()? else {
+                    // It's possible that the transaction has been removed from the pool in another thread 😱 - observed
+                    // in consensus_tests
                     continue;
                 };
 
@@ -1340,14 +1356,15 @@ impl<'tx, TAddr: NodeAddressable + Serialize + DeserializeOwned + 'tx> StateStor
                     }
                 }
 
-                if skip_lock_conflicted {
-                    let iter = lock_conflict_query.query_prefix_range_iterator(Ordering::default(), &tx_id);
-                    for result in iter {
-                        let (_, value) = result?;
-                        if !value.is_local_only {
-                            continue;
-                        }
-                    }
+                if skip_lock_conflicted && lock_conflict_query.exists_prefix(&tx_id)? {
+                    continue;
+                    // let iter = lock_conflict_query.query_prefix_range_iterator(Ordering::default(), &tx_id);
+                    // for result in iter {
+                    //     let (_, value) = result?;
+                    //     if !value.is_local_only {
+                    //         continue;
+                    //     }
+                    // }
                 }
             }
 
@@ -1776,6 +1793,17 @@ impl<'tx, TAddr: NodeAddressable + Serialize + DeserializeOwned + 'tx> StateStor
         const OPERATION: &str = "epoch_checkpoint_get_by_shard_group";
         let cf = self.db().cf(EpochCheckpointCf)?;
         let checkpoint = cf.get(&(epoch, shard_group), OPERATION)?;
+        Ok(checkpoint)
+    }
+
+    fn epoch_checkpoint_get_last(&self) -> Result<EpochCheckpoint, StorageError> {
+        const OPERATION: &str = "epoch_checkpoint_get_last";
+        let cf = self.db().cf(EpochCheckpointCf)?;
+        let mut iter = cf.iterator(Ordering::Descending, OPERATION);
+        let (_, checkpoint) = iter.next().ok_or_else(|| StorageError::NotFound {
+            item: "EpochCheckpoint",
+            key: "last".to_string(),
+        })??;
         Ok(checkpoint)
     }
 

--- a/crates/state_store_rocksdb/src/writer.rs
+++ b/crates/state_store_rocksdb/src/writer.rs
@@ -81,6 +81,7 @@ use tari_ootle_storage::{
         ValidatorConsensusStats,
         ValidatorStatsUpdate,
     },
+    time,
     Ordering,
     StateStoreReadTransaction,
     StateStoreWriteTransaction,
@@ -670,10 +671,10 @@ impl<'tx, TAddr: NodeAddressable + 'tx> StateStoreWriteTransaction for RocksDbSt
         // Add transactions to finalized CF
         let data = FinalizedTransactionLinkData { finalized_at: now() };
         for transaction in iter {
-            finalized_cf.put(transaction.transaction_id(), &data, OPERATION)?;
+            finalized_cf.put(transaction.id(), &data, OPERATION)?;
 
             // Delete from block index which is used for querying pending executions
-            let iter = exec_query.query_prefix_range_key_iterator(Ordering::default(), transaction.transaction_id());
+            let iter = exec_query.query_prefix_range_key_iterator(Ordering::default(), transaction.id());
             for result in iter {
                 let (tx_id, block_id, height) = result?;
                 exec_index_cf.delete(&(block_id, tx_id, height), OPERATION)?;
@@ -824,6 +825,8 @@ impl<'tx, TAddr: NodeAddressable + 'tx> StateStoreWriteTransaction for RocksDbSt
             None,
             None,
             is_ready,
+            time::OffsetDateTime::now_utc(),
+            None,
         );
 
         self.db()
@@ -874,6 +877,7 @@ impl<'tx, TAddr: NodeAddressable + 'tx> StateStoreWriteTransaction for RocksDbSt
 
         tx_pool_value.set_is_ready(update.is_ready_now());
         tx_pool_value.set_pending_stage(Some(update.stage()));
+        tx_pool_value.set_last_updated(*block.block_id(), time::OffsetDateTime::now_utc());
         cf.put(update.transaction_id(), &tx_pool_value, OPERATION)?;
 
         Ok(())
@@ -888,7 +892,7 @@ impl<'tx, TAddr: NodeAddressable + 'tx> StateStoreWriteTransaction for RocksDbSt
         let cf = self.db().cf(TransactionPoolCf)?;
         let pool_recs = cf.multi_get(transaction_ids, OPERATION)?;
         for tx in &pool_recs {
-            cf.delete(tx.transaction_id(), OPERATION)?;
+            cf.delete(tx.id(), OPERATION)?;
         }
 
         Ok(pool_recs)

--- a/crates/state_store_tests/src/transactions.rs
+++ b/crates/state_store_tests/src/transactions.rs
@@ -92,22 +92,10 @@ mod confirm_all_transitions {
         tx.transaction_pool_insert_new(atom3.id, atom3.decision, &Evidence::empty(), true, false)
             .unwrap();
         let block_id = *block1.id();
-        let transactions = tx.transaction_pool_get_all().unwrap();
-        let mut tx_1 = transactions
-            .iter()
-            .find(|tx| *tx.transaction_id() == atom1.id)
-            .unwrap()
-            .clone();
-        let mut tx_2 = transactions
-            .iter()
-            .find(|tx| *tx.transaction_id() == atom2.id)
-            .unwrap()
-            .clone();
-        let mut tx_3 = transactions
-            .iter()
-            .find(|tx| *tx.transaction_id() == atom3.id)
-            .unwrap()
-            .clone();
+        let transactions = tx.transaction_pool_get_all(1000).unwrap();
+        let mut tx_1 = transactions.iter().find(|tx| *tx.id() == atom1.id).unwrap().clone();
+        let mut tx_2 = transactions.iter().find(|tx| *tx.id() == atom2.id).unwrap().clone();
+        let mut tx_3 = transactions.iter().find(|tx| *tx.id() == atom3.id).unwrap().clone();
 
         assert!(tx.transaction_pool_exists(&atom1.id).unwrap());
         assert!(tx.transaction_pool_exists(&atom2.id).unwrap());
@@ -326,7 +314,7 @@ mod transaction_execution_operations {
         // transactions_finalize_all
         tx.transaction_pool_insert_new(*tx1.id(), Decision::Commit, &Evidence::empty(), true, false)
             .unwrap();
-        let transactions = tx.transaction_pool_get_all().unwrap();
+        let transactions = tx.transaction_pool_get_all(1000).unwrap();
         assert_eq!(transactions.len(), 1);
         tx.transactions_finalize_all(transactions.iter()).unwrap();
 

--- a/crates/storage/src/consensus_models/block.rs
+++ b/crates/storage/src/consensus_models/block.rs
@@ -901,6 +901,13 @@ impl Block {
         Ok(false)
     }
 
+    pub fn is_epoch_end_proposed_in_chain<TTx: StateStoreReadTransaction>(
+        &self,
+        tx: &TTx,
+    ) -> Result<bool, StorageError> {
+        tx.is_block_in_end_of_epoch_chain(self.id())
+    }
+
     pub fn get_block_pledge<TTx: StateStoreReadTransaction>(
         &self,
         tx: &TTx,

--- a/crates/storage/src/consensus_models/epoch_checkpoint.rs
+++ b/crates/storage/src/consensus_models/epoch_checkpoint.rs
@@ -178,6 +178,10 @@ impl EpochCheckpoint {
         tx.epoch_checkpoint_get_all_from_epoch(from_epoch, limit)
     }
 
+    pub fn get_last_checkpoint<TTx: StateStoreReadTransaction>(tx: &TTx) -> Result<Self, StorageError> {
+        tx.epoch_checkpoint_get_last()
+    }
+
     pub fn get_by_shard_group<TTx: StateStoreReadTransaction>(
         tx: &TTx,
         epoch: Epoch,

--- a/crates/storage/src/consensus_models/evidence.rs
+++ b/crates/storage/src/consensus_models/evidence.rs
@@ -199,6 +199,12 @@ impl Evidence {
         self.evidence.get(&shard_group).is_none_or(|e| e.inputs().is_empty())
     }
 
+    pub fn output_only_shard_groups_iter(&self) -> impl Iterator<Item = ShardGroup> + '_ {
+        self.evidence
+            .iter()
+            .filter_map(|(sg, e)| if e.inputs().is_empty() { Some(*sg) } else { None })
+    }
+
     pub fn is_committee_input_only(&self, shard_group: ShardGroup) -> bool {
         self.evidence.get(&shard_group).is_none_or(|e| e.outputs().is_empty())
     }

--- a/crates/storage/src/consensus_models/transaction_pool.rs
+++ b/crates/storage/src/consensus_models/transaction_pool.rs
@@ -7,6 +7,7 @@ use std::{
     marker::PhantomData,
     num::NonZeroU64,
     str::FromStr,
+    time::Duration,
 };
 
 use log::*;
@@ -91,6 +92,15 @@ impl<TStateStore: StateStore> TransactionPool<TStateStore> {
             )?;
         }
         Ok(())
+    }
+
+    pub fn get_all(
+        &self,
+        tx: &TStateStore::ReadTransaction<'_>,
+        limit: usize,
+    ) -> Result<Vec<TransactionPoolRecord>, TransactionPoolError> {
+        let recs = tx.transaction_pool_get_all(limit)?;
+        Ok(recs)
     }
 
     pub fn get_batch_for_next_block(
@@ -333,6 +343,9 @@ pub struct TransactionPoolRecord {
     local_decision: Option<Decision>,
     remote_decision: Option<Decision>,
     is_ready: bool,
+    #[cfg_attr(feature = "ts", ts(type = "string"))]
+    last_updated: time::OffsetDateTime,
+    last_updated_in_block: Option<BlockId>,
 }
 
 impl TransactionPoolRecord {
@@ -349,6 +362,8 @@ impl TransactionPoolRecord {
             local_decision: None,
             remote_decision: None,
             is_ready: false,
+            last_updated: time::OffsetDateTime::now_utc(),
+            last_updated_in_block: None,
         }
     }
 
@@ -364,6 +379,8 @@ impl TransactionPoolRecord {
         local_decision: Option<Decision>,
         remote_decision: Option<Decision>,
         is_ready: bool,
+        last_updated: time::OffsetDateTime,
+        last_updated_in_block: Option<BlockId>,
     ) -> Self {
         Self {
             transaction_id: id,
@@ -377,6 +394,8 @@ impl TransactionPoolRecord {
             local_decision,
             remote_decision,
             is_ready,
+            last_updated,
+            last_updated_in_block,
         }
     }
 
@@ -425,7 +444,7 @@ impl TransactionPoolRecord {
         self.remote_decision
     }
 
-    pub fn transaction_id(&self) -> &TransactionId {
+    pub fn id(&self) -> &TransactionId {
         &self.transaction_id
     }
 
@@ -472,7 +491,7 @@ impl TransactionPoolRecord {
     }
 
     pub fn to_receipt_id(&self) -> TransactionReceiptAddress {
-        (*self.transaction_id()).into()
+        (*self.id()).into()
     }
 
     pub fn get_current_transaction_atom(&self) -> TransactionAtom {
@@ -557,6 +576,12 @@ impl TransactionPoolRecord {
         self
     }
 
+    pub fn set_last_updated(&mut self, in_block: BlockId, timestamp: time::OffsetDateTime) -> &mut Self {
+        self.last_updated_in_block = Some(in_block);
+        self.last_updated = timestamp;
+        self
+    }
+
     pub fn set_stage(&mut self, stage: TransactionPoolStage) -> &mut Self {
         self.stage = stage;
         self
@@ -597,7 +622,7 @@ impl TransactionPoolRecord {
         info!(
             target: LOG_TARGET,
             "📝 Setting next update for transaction {} to {}->{},is_ready={}->{},{}->{}",
-            self.transaction_id(),
+            self.id(),
             self.current_stage(),
             next_stage,
             self.is_ready,
@@ -619,6 +644,17 @@ impl TransactionPoolRecord {
     pub fn set_evidence(&mut self, evidence: Evidence) -> &mut Self {
         self.evidence = evidence;
         self
+    }
+
+    pub fn since_last_updated(&self) -> Duration {
+        let d = time::OffsetDateTime::now_utc() - self.last_updated;
+        // If d is negative (perhaps only possible with a mal-timed clock adjustment), we treat this like a saturating
+        // sub (zero duration)
+        d.try_into().unwrap_or_default()
+    }
+
+    pub fn last_updated_in_block(&self) -> Option<&BlockId> {
+        self.last_updated_in_block.as_ref()
     }
 
     /// Merges the given evidence into the existing evidence of the transaction pool record.
@@ -675,7 +711,7 @@ impl TransactionPoolRecord {
         I: IntoIterator<Item = &'a TransactionId>,
     {
         let recs = tx.transaction_pool_remove_all(transaction_ids)?;
-        let iter = recs.iter().map(|rec| rec.transaction_id());
+        let iter = recs.iter().map(|rec| rec.id());
         // Clear any related foreign pledges
         tx.foreign_substate_pledges_remove_many(iter.clone())?;
         // Clear any related lock_conflicts
@@ -696,7 +732,7 @@ impl TransactionPoolRecord {
         &self,
         tx: &TTx,
     ) -> Result<TransactionRecord, TransactionPoolError> {
-        let transaction = TransactionRecord::get(tx, self.transaction_id())?;
+        let transaction = TransactionRecord::get(tx, self.id())?;
         Ok(transaction)
     }
 
@@ -705,7 +741,7 @@ impl TransactionPoolRecord {
         tx: &TTx,
         from_block: &LeafBlock,
     ) -> Result<BlockTransactionExecution, TransactionPoolError> {
-        let exec = BlockTransactionExecution::get_pending_for_block(tx, self.transaction_id(), from_block)?;
+        let exec = BlockTransactionExecution::get_pending_for_block(tx, self.id(), from_block)?;
         Ok(exec)
     }
 
@@ -767,20 +803,20 @@ impl TransactionPoolRecord {
                 debug!(
                     target: LOG_TARGET,
                     "Transaction {} is missing a version for substate_id {}",
-                    self.transaction_id(),
+                    self.id(),
                     substate_id,
                 );
                 return Ok(false);
             };
             let address = SubstateAddress::from_substate_id(substate_id, version);
             // TODO(perf): O(n) queries
-            if tx.foreign_substate_pledges_exists_for_transaction_and_address(self.transaction_id(), address)? {
+            if tx.foreign_substate_pledges_exists_for_transaction_and_address(self.id(), address)? {
                 continue;
             }
 
             if log_enabled!(Level::Debug) {
                 // Load them for debugging purposes
-                let pledges = tx.foreign_substate_pledges_get_all_by_transaction_id(self.transaction_id())?;
+                let pledges = tx.foreign_substate_pledges_get_all_by_transaction_id(self.id())?;
                 let remote_shard_group = address.to_shard_group(
                     local_committee_info.num_preshards(),
                     local_committee_info.num_committees(),
@@ -794,7 +830,7 @@ impl TransactionPoolRecord {
                     target: LOG_TARGET,
                     "{} Transaction {} is missing a foreign {} pledge for {}:{} from {} ({} pledge(s) found)",
                     local_committee_info.shard_group(),
-                    self.transaction_id(),
+                    self.id(),
                     lock_type,
                     substate_id,
                     version,
@@ -869,6 +905,8 @@ mod tests {
                 local_decision: None,
                 remote_decision: None,
                 is_ready: false,
+                last_updated: time::OffsetDateTime::now_utc(),
+                last_updated_in_block: None,
             }
         }
 

--- a/crates/storage/src/consensus_models/transaction_pool_status_update.rs
+++ b/crates/storage/src/consensus_models/transaction_pool_status_update.rs
@@ -26,7 +26,7 @@ impl TransactionPoolStatusUpdate {
     }
 
     pub fn transaction_id(&self) -> &TransactionId {
-        self.transaction.transaction_id()
+        self.transaction.id()
     }
 
     pub fn stage(&self) -> TransactionPoolStage {

--- a/crates/storage/src/global/backend_adapter.rs
+++ b/crates/storage/src/global/backend_adapter.rs
@@ -20,7 +20,7 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use serde::{de::DeserializeOwned, Serialize};
 use tari_common_types::types::FixedHash;
@@ -35,7 +35,7 @@ use tari_ootle_common_types::{
 };
 use tari_template_lib::types::{crypto::RistrettoPublicKeyBytes, TemplateAddress};
 
-use super::{BlockHeaderModel, DbEpoch, TemplateStatus};
+use super::{BlockHeaderModel, EpochData, TemplateStatus};
 use crate::{
     atomic::AtomicDb,
     global::{
@@ -175,7 +175,7 @@ pub trait GlobalDbAdapter: AtomicDb + Send + Sync + Clone {
         tx: &mut Self::DbTransaction<'_>,
         epoch: Epoch,
         shard_group: Option<ShardGroup>,
-        excluding: Vec<Self::Addr>,
+        excluding: HashSet<Self::Addr>,
     ) -> Result<ValidatorNode<Self::Addr>, Self::Error>;
 
     fn validator_nodes_get_committees_for_epoch(
@@ -184,8 +184,13 @@ pub trait GlobalDbAdapter: AtomicDb + Send + Sync + Clone {
         epoch: Epoch,
     ) -> Result<HashMap<ShardGroup, Committee<Self::Addr>>, Self::Error>;
 
-    fn insert_epoch(&self, tx: &mut Self::DbTransaction<'_>, epoch: DbEpoch) -> Result<(), Self::Error>;
-    fn get_epoch(&self, tx: &mut Self::DbTransaction<'_>, epoch: u64) -> Result<Option<DbEpoch>, Self::Error>;
+    fn insert_epoch(
+        &self,
+        tx: &mut Self::DbTransaction<'_>,
+        epoch: Epoch,
+        epoch_hash: FixedHash,
+    ) -> Result<(), Self::Error>;
+    fn get_epoch(&self, tx: &mut Self::DbTransaction<'_>, epoch: Epoch) -> Result<Option<EpochData>, Self::Error>;
 
     fn insert_bmt(
         &self,
@@ -214,7 +219,12 @@ pub trait GlobalDbAdapter: AtomicDb + Send + Sync + Clone {
     fn get_block_header_by_hash(
         &self,
         tx: &mut Self::DbTransaction<'_>,
-        epoch: Epoch,
+        max_epoch: Epoch,
         block_hash: &FixedHash,
+    ) -> Result<BlockHeaderModel, Self::Error>;
+    fn get_first_block_header_by_epoch(
+        &self,
+        tx: &mut Self::DbTransaction<'_>,
+        epoch: Epoch,
     ) -> Result<BlockHeaderModel, Self::Error>;
 }

--- a/crates/storage/src/global/block_header.rs
+++ b/crates/storage/src/global/block_header.rs
@@ -42,6 +42,13 @@ impl<'a, 'tx, TGlobalDbAdapter: GlobalDbAdapter> BlockHeaderDb<'a, 'tx, TGlobalD
     pub fn get_by_hash(&mut self, epoch: Epoch, hash: &FixedHash) -> Result<BlockHeaderModel, TGlobalDbAdapter::Error> {
         self.backend.get_block_header_by_hash(self.tx, epoch, hash)
     }
+
+    pub fn get_first_block_header_in_epoch(
+        &mut self,
+        epoch: Epoch,
+    ) -> Result<BlockHeaderModel, TGlobalDbAdapter::Error> {
+        self.backend.get_first_block_header_by_epoch(self.tx, epoch)
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/crates/storage/src/global/epoch_db.rs
+++ b/crates/storage/src/global/epoch_db.rs
@@ -20,6 +20,9 @@
 //   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //   USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+use tari_common_types::types::FixedHash;
+use tari_ootle_common_types::Epoch;
+
 use crate::global::GlobalDbAdapter;
 
 pub struct EpochDb<'a, 'tx, TGlobalDbAdapter: GlobalDbAdapter> {
@@ -32,17 +35,17 @@ impl<'a, 'tx, TGlobalDbAdapter: GlobalDbAdapter> EpochDb<'a, 'tx, TGlobalDbAdapt
         Self { backend, tx }
     }
 
-    pub fn insert_epoch(&mut self, db_epoch: DbEpoch) -> Result<(), TGlobalDbAdapter::Error> {
-        self.backend.insert_epoch(self.tx, db_epoch)
+    pub fn insert_epoch(&mut self, epoch: Epoch, epoch_hash: FixedHash) -> Result<(), TGlobalDbAdapter::Error> {
+        self.backend.insert_epoch(self.tx, epoch, epoch_hash)
     }
 
-    pub fn get_epoch_data(&mut self, epoch: u64) -> Result<Option<DbEpoch>, TGlobalDbAdapter::Error> {
+    pub fn get_epoch_data(&mut self, epoch: Epoch) -> Result<Option<EpochData>, TGlobalDbAdapter::Error> {
         self.backend.get_epoch(self.tx, epoch)
     }
 }
 
 #[derive(Debug, Clone)]
-pub struct DbEpoch {
+pub struct EpochData {
     pub epoch: u64,
-    pub validator_node_mr: Vec<u8>,
+    pub epoch_hash: FixedHash,
 }

--- a/crates/storage/src/global/mod.rs
+++ b/crates/storage/src/global/mod.rs
@@ -35,7 +35,7 @@ mod validator_node_db;
 pub use validator_node_db::ValidatorNodeDb;
 
 mod epoch_db;
-pub use epoch_db::{DbEpoch, EpochDb};
+pub use epoch_db::{EpochData, EpochDb};
 
 mod base_layer_db;
 pub use base_layer_db::*;

--- a/crates/storage/src/global/validator_node_db.rs
+++ b/crates/storage/src/global/validator_node_db.rs
@@ -20,7 +20,7 @@
 //   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //   USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use tari_ootle_common_types::{committee::Committee, Epoch, ShardGroup, SubstateAddress, VotePower};
 use tari_template_lib::types::crypto::RistrettoPublicKeyBytes;
@@ -139,7 +139,7 @@ impl<'a, 'tx, TGlobalDbAdapter: GlobalDbAdapter> ValidatorNodeDb<'a, 'tx, TGloba
         &mut self,
         epoch: Epoch,
         shard_group: Option<ShardGroup>,
-        excluding: Vec<TGlobalDbAdapter::Addr>,
+        excluding: HashSet<TGlobalDbAdapter::Addr>,
     ) -> Result<ValidatorNode<TGlobalDbAdapter::Addr>, TGlobalDbAdapter::Error> {
         self.backend
             .validator_nodes_get_random_committee_member_from_shard_group(self.tx, epoch, shard_group, excluding)

--- a/crates/storage/src/state_store/mod.rs
+++ b/crates/storage/src/state_store/mod.rs
@@ -124,6 +124,7 @@ pub trait StateStoreReadTransaction: Sized {
     fn last_sent_new_view_get(&self, epoch: Epoch) -> Result<LastSentNewView, StorageError>;
     fn high_pc_get(&self, epoch: Epoch) -> Result<HighPc, StorageError>;
     fn high_tc_get(&self, epoch: Epoch) -> Result<HighTc, StorageError>;
+    fn is_block_in_end_of_epoch_chain(&self, block_id: &BlockId) -> Result<bool, StorageError>;
     fn foreign_proposals_get_any<'a, I: IntoIterator<Item = &'a BlockId>>(
         &self,
         block_ids: I,
@@ -222,7 +223,7 @@ pub trait StateStoreReadTransaction: Sized {
         transaction_id: &TransactionId,
     ) -> Result<TransactionPoolRecord, StorageError>;
     fn transaction_pool_exists(&self, transaction_id: &TransactionId) -> Result<bool, StorageError>;
-    fn transaction_pool_get_all(&self) -> Result<Vec<TransactionPoolRecord>, StorageError>;
+    fn transaction_pool_get_all(&self, limit: usize) -> Result<Vec<TransactionPoolRecord>, StorageError>;
     fn transaction_pool_get_many_ready(
         &self,
         max_txs: usize,
@@ -308,6 +309,8 @@ pub trait StateStoreReadTransaction: Sized {
         epoch: Epoch,
         shard_group: ShardGroup,
     ) -> Result<EpochCheckpoint, StorageError>;
+
+    fn epoch_checkpoint_get_last(&self) -> Result<EpochCheckpoint, StorageError>;
 
     // -------------------------------- Foreign Substate Pledges -------------------------------- //
     fn foreign_substate_pledges_exists_for_transaction_and_address<T: ToSubstateAddress>(

--- a/crates/storage_sqlite/migrations/2022-06-20-091532_initial/up.sql
+++ b/crates/storage_sqlite/migrations/2022-06-20-091532_initial/up.sql
@@ -82,8 +82,8 @@ create unique index templates_template_address_index on templates (template_addr
 
 create table epochs
 (
-    epoch             bigint primary key not null,
-    validator_node_mr blob               not null
+    epoch      bigint primary key not null,
+    epoch_hash blob               not null
 );
 
 create table bmt_cache

--- a/crates/storage_sqlite/src/global/backend_adapter.rs
+++ b/crates/storage_sqlite/src/global/backend_adapter.rs
@@ -56,10 +56,10 @@ use tari_ootle_storage::{
     global::{
         models::ValidatorNode,
         BlockHeaderModel,
-        DbEpoch,
         DbLayer1Transaction,
         DbTemplate,
         DbTemplateUpdate,
+        EpochData,
         GlobalDbAdapter,
         TemplateStatus,
     },
@@ -72,7 +72,7 @@ use super::{models, models::DbValidatorNode};
 use crate::{
     error::SqliteStorageError,
     global::{
-        models::{DbCommittee, MetadataModel, NewEpoch, NewTemplateModel, TemplateModel, TemplateUpdateModel},
+        models::{DbCommittee, MetadataModel, NewTemplateModel, TemplateModel, TemplateUpdateModel},
         serialization::serialize_json,
     },
     SqliteTransaction,
@@ -728,7 +728,7 @@ impl<TAddr: NodeAddressable> GlobalDbAdapter for SqliteGlobalDbAdapter<TAddr> {
         tx: &mut Self::DbTransaction<'_>,
         epoch: Epoch,
         shard_group: Option<ShardGroup>,
-        excluding: Vec<Self::Addr>,
+        excluding: HashSet<Self::Addr>,
     ) -> Result<ValidatorNode<Self::Addr>, Self::Error> {
         use crate::global::schema::{committees, validator_nodes};
 
@@ -815,13 +815,19 @@ impl<TAddr: NodeAddressable> GlobalDbAdapter for SqliteGlobalDbAdapter<TAddr> {
         Ok(committees)
     }
 
-    fn insert_epoch(&self, tx: &mut Self::DbTransaction<'_>, epoch: DbEpoch) -> Result<(), Self::Error> {
+    fn insert_epoch(
+        &self,
+        tx: &mut Self::DbTransaction<'_>,
+        epoch: Epoch,
+        epoch_hash: FixedHash,
+    ) -> Result<(), Self::Error> {
         use crate::global::schema::epochs;
 
-        let sqlite_epoch: NewEpoch = epoch.into();
-
         diesel::insert_into(epochs::table)
-            .values(&sqlite_epoch)
+            .values((
+                epochs::epoch.eq(epoch.as_u64() as i64),
+                epochs::epoch_hash.eq(epoch_hash.as_slice()),
+            ))
             .execute(tx.connection())
             .map_err(|source| SqliteStorageError::DieselError {
                 source,
@@ -831,11 +837,11 @@ impl<TAddr: NodeAddressable> GlobalDbAdapter for SqliteGlobalDbAdapter<TAddr> {
         Ok(())
     }
 
-    fn get_epoch(&self, tx: &mut Self::DbTransaction<'_>, epoch: u64) -> Result<Option<DbEpoch>, Self::Error> {
+    fn get_epoch(&self, tx: &mut Self::DbTransaction<'_>, epoch: Epoch) -> Result<Option<EpochData>, Self::Error> {
         use crate::global::schema::epochs::dsl;
 
-        let query_res: Option<models::Epoch> = dsl::epochs
-            .find(epoch as i64)
+        let query_res: Option<models::DbEpochData> = dsl::epochs
+            .find(epoch.as_u64() as i64)
             .first(tx.connection())
             .optional()
             .map_err(|source| SqliteStorageError::DieselError {
@@ -843,10 +849,7 @@ impl<TAddr: NodeAddressable> GlobalDbAdapter for SqliteGlobalDbAdapter<TAddr> {
                 operation: "get::epoch",
             })?;
 
-        match query_res {
-            Some(e) => Ok(Some(e.into())),
-            None => Ok(None),
-        }
+        query_res.map(EpochData::try_from).transpose()
     }
 
     fn insert_bmt(
@@ -941,18 +944,37 @@ impl<TAddr: NodeAddressable> GlobalDbAdapter for SqliteGlobalDbAdapter<TAddr> {
     fn get_block_header_by_hash(
         &self,
         tx: &mut Self::DbTransaction<'_>,
-        epoch: Epoch,
+        max_epoch: Epoch,
         block_hash: &FixedHash,
     ) -> Result<BlockHeaderModel, Self::Error> {
         use crate::global::schema::block_headers;
 
         let header = block_headers::table
             .filter(block_headers::block_hash.eq(block_hash.as_bytes()))
-            .filter(block_headers::epoch.le(epoch.as_u64() as i64))
+            .filter(block_headers::epoch.le(max_epoch.as_u64() as i64))
             .first::<models::BlockHeaderModel>(tx.connection())
             .map_err(|source| SqliteStorageError::DieselError {
                 source,
                 operation: "get::block_header_by_hash",
+            })?;
+
+        header.try_into()
+    }
+
+    fn get_first_block_header_by_epoch(
+        &self,
+        tx: &mut Self::DbTransaction<'_>,
+        epoch: Epoch,
+    ) -> Result<BlockHeaderModel, Self::Error> {
+        use crate::global::schema::block_headers;
+
+        let header = block_headers::table
+            .filter(block_headers::epoch.eq(epoch.as_u64() as i64))
+            .order_by(block_headers::height.asc())
+            .first::<models::BlockHeaderModel>(tx.connection())
+            .map_err(|source| SqliteStorageError::DieselError {
+                source,
+                operation: "get::first_block_header_by_epoch",
             })?;
 
         header.try_into()

--- a/crates/storage_sqlite/src/global/models/epoch.rs
+++ b/crates/storage_sqlite/src/global/models/epoch.rs
@@ -20,37 +20,28 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use tari_ootle_storage::global::DbEpoch;
+use tari_ootle_storage::global::EpochData;
 
-use crate::global::schema::*;
+use crate::error::SqliteStorageError;
 
 #[derive(Queryable)]
-pub struct Epoch {
-    pub epoch: i64,
-    pub validator_node_mr: Vec<u8>,
-}
-
-impl From<Epoch> for DbEpoch {
-    fn from(e: Epoch) -> Self {
-        Self {
-            epoch: e.epoch as u64,
-            validator_node_mr: e.validator_node_mr,
-        }
-    }
-}
-
-#[derive(Insertable)]
 #[diesel(table_name = epochs)]
-pub struct NewEpoch {
+pub struct DbEpochData {
     pub epoch: i64,
-    pub validator_node_mr: Vec<u8>,
+    pub epoch_hash: Vec<u8>,
 }
 
-impl From<DbEpoch> for NewEpoch {
-    fn from(e: DbEpoch) -> Self {
-        Self {
-            epoch: e.epoch as i64,
-            validator_node_mr: e.validator_node_mr,
-        }
+impl TryFrom<DbEpochData> for EpochData {
+    type Error = SqliteStorageError;
+
+    fn try_from(e: DbEpochData) -> Result<Self, Self::Error> {
+        Ok(Self {
+            epoch: e.epoch as u64,
+            epoch_hash: e.epoch_hash.try_into().map_err(|e| SqliteStorageError::DecodingError {
+                operation: "TryFrom<DbEpochData> for EpochData",
+                item: "Epoch",
+                details: format!("epoch_hash incorrect length: {e}"),
+            })?,
+        })
     }
 }

--- a/crates/storage_sqlite/src/global/schema.rs
+++ b/crates/storage_sqlite/src/global/schema.rs
@@ -32,7 +32,7 @@ diesel::table! {
 diesel::table! {
     epochs (epoch) {
         epoch -> BigInt,
-        validator_node_mr -> Binary,
+        epoch_hash -> Binary,
     }
 }
 

--- a/utilities/db_inspector/src/webserver/handlers/mod.rs
+++ b/utilities/db_inspector/src/webserver/handlers/mod.rs
@@ -20,10 +20,5 @@ pub async fn not_found() -> Result<impl axum::response::IntoResponse, WebError> 
 
 pub fn slugify_type_name<T>(_cf: T) -> String {
     let type_name = std::any::type_name::<T>();
-    type_name
-        .rsplit("::")
-        .take(2)
-        .map(|s| s.to_lowercase())
-        .collect::<Vec<_>>()
-        .join("_")
+    type_name.rsplit("::").take(2).collect::<Vec<_>>().join("--")
 }

--- a/utilities/db_inspector/web_ui/src/routes/InspectCf.tsx
+++ b/utilities/db_inspector/web_ui/src/routes/InspectCf.tsx
@@ -92,8 +92,7 @@ export default function InspectCf() {
     setError(null);
     setIsLoading(true);
 
-    const desc = cfName == "blockcf_block";
-    const query = { limit: pagination.pageSize, page: pagination.page, query: pagination.query || "", desc };
+    const query = { limit: pagination.pageSize, page: pagination.page, query: pagination.query || "", desc: true };
     client.listCfItems(dbName!, cfName!, query as Params).then((res) => {
       setData(res);
     }).catch((err) => {


### PR DESCRIPTION
Description
---
consensus: fix bug that can cause a missed checkpoint after VN restart
consensus: re-request foreign proposals if not received within timeout
consensus: fix bug sometimes caused "stuck" transactions when changing epochs (multishard case)
consensus: fix potential DoS vector (unbounded spawn for foreign proposal requests)

Motivation and Context
---
Transactions may get stuck indefinitely if a required foreign proposal is not received by at least one non-faulty node, 
this PR improves robustness by timing out if a requested foreign proposal is not received within a timeout.

How Has This Been Tested?
---
Manually

What process can a PR reviewer use to test or verify this change?
---


Breaking Changes
---

- [ ] None
- [x] Requires data directory to be deleted
- [ ] Other - Please specify