### PR TITLE
chore: v0.17.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1694,7 +1694,7 @@ dependencies = [
 
 [[package]]
 name = "consensus_tests"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "fern",
  "futures 0.3.31",
@@ -2492,7 +2492,7 @@ dependencies = [
 
 [[package]]
 name = "db_inspector"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "axum 0.8.6",
@@ -3638,7 +3638,7 @@ checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 
 [[package]]
 name = "generate_ristretto_value_lookup"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "clap 3.2.25",
  "futures 0.3.31",
@@ -4826,7 +4826,7 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "integration_tests"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "config",
@@ -5552,7 +5552,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-messaging"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "async-trait",
  "futures-bounded",
@@ -5731,7 +5731,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-substream"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "libp2p",
  "prometheus-client",
@@ -8197,7 +8197,7 @@ dependencies = [
 
 [[package]]
 name = "proto_builder"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "prost-build 0.14.1",
  "sha2",
@@ -10042,7 +10042,7 @@ dependencies = [
 
 [[package]]
 name = "sqlite_message_logger"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "chrono",
  "diesel",
@@ -10083,7 +10083,7 @@ checksum = "e7386b49cb287f6fafbfd3bd604914bccb99fb8d53483f40e1ecfda5d45f3370"
 
 [[package]]
 name = "state_store_tests"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "env_logger 0.11.8",
  "indexmap 2.12.0",
@@ -10484,7 +10484,7 @@ dependencies = [
 
 [[package]]
 name = "tari_base_node_client"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "log",
  "minotari_app_grpc",
@@ -10707,7 +10707,7 @@ dependencies = [
 
 [[package]]
 name = "tari_consensus"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "indexmap 2.12.0",
@@ -10731,7 +10731,7 @@ dependencies = [
 
 [[package]]
 name = "tari_consensus_types"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "borsh",
  "serde",
@@ -10832,7 +10832,7 @@ dependencies = [
 
 [[package]]
 name = "tari_engine"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "blake2",
  "cargo_toml 0.22.3",
@@ -10861,7 +10861,7 @@ dependencies = [
 
 [[package]]
 name = "tari_engine_types"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "base64 0.21.7",
  "bincode 2.0.1",
@@ -10888,7 +10888,7 @@ dependencies = [
 
 [[package]]
 name = "tari_epoch_manager"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "log",
@@ -10909,7 +10909,7 @@ dependencies = [
 
 [[package]]
 name = "tari_epoch_oracles"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -10951,7 +10951,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -11023,7 +11023,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer_client"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "bounded-vec",
@@ -11053,7 +11053,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer_lib"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "log",
  "prometheus-client",
@@ -11130,7 +11130,7 @@ dependencies = [
 
 [[package]]
 name = "tari_networking"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11167,7 +11167,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_address"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "bech32",
  "bincode 2.0.1",
@@ -11183,7 +11183,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_app_utilities"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -11220,7 +11220,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_common_types"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "blake2",
  "borsh",
@@ -11248,7 +11248,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_p2p"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "prost 0.14.1",
@@ -11270,7 +11270,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_storage"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "bitflags 2.10.0",
@@ -11295,7 +11295,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_storage_sqlite"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "diesel",
  "diesel_migrations",
@@ -11315,7 +11315,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_cli"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -11344,7 +11344,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_crypto"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "argon2 0.5.3",
  "blake2",
@@ -11369,7 +11369,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_sdk"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -11406,7 +11406,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_sdk_services"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -11431,7 +11431,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_storage_sqlite"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "bigdecimal",
  "diesel",
@@ -11455,7 +11455,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_walletd"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11540,7 +11540,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_framework"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "async-trait",
  "bitflags 2.10.0",
@@ -11564,7 +11564,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_macros"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11573,7 +11573,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_state_sync"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -11650,7 +11650,7 @@ dependencies = [
 
 [[package]]
 name = "tari_state_store_rocksdb"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -11677,7 +11677,7 @@ dependencies = [
 
 [[package]]
 name = "tari_state_tree"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "indexmap 2.12.0",
  "log",
@@ -11704,7 +11704,7 @@ dependencies = [
 
 [[package]]
 name = "tari_swarm"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "libp2p",
  "libp2p-messaging",
@@ -11714,7 +11714,7 @@ dependencies = [
 
 [[package]]
 name = "tari_swarm_daemon"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11769,7 +11769,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_builtin"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "tari_engine_types",
  "tari_template_lib",
@@ -11856,7 +11856,7 @@ dependencies = [
 
 [[package]]
 name = "tari_transaction"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "borsh",
  "hex",
@@ -11955,7 +11955,7 @@ dependencies = [
 
 [[package]]
 name = "tari_transaction_manifest"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "proc-macro2",
  "serde_json",
@@ -11989,7 +11989,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "axum 0.8.6",
@@ -12055,7 +12055,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node_client"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "indexmap 2.12.0",
  "multiaddr 0.18.1",
@@ -12078,7 +12078,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node_rpc"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "prost 0.14.1",
@@ -12100,7 +12100,7 @@ dependencies = [
 
 [[package]]
 name = "tari_wallet_daemon_client"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "reqwest 0.11.27",
  "serde",
@@ -12121,7 +12121,7 @@ dependencies = [
 
 [[package]]
 name = "tari_watcher"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "clap 3.2.25",
@@ -12149,7 +12149,7 @@ dependencies = [
 
 [[package]]
 name = "tariswap_bench"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "clap 4.5.51",
@@ -12828,7 +12828,7 @@ dependencies = [
 
 [[package]]
 name = "traffic-sim"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "clap 4.5.51",
@@ -12850,7 +12850,7 @@ dependencies = [
 
 [[package]]
 name = "transaction_generator"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -12870,7 +12870,7 @@ dependencies = [
 
 [[package]]
 name = "transaction_submitter"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "clap 4.5.51",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 # NOTE: When editing this version, also edit the versions in template_built_in/templates/account and account_nft
 [workspace.package]
-version = "0.16.0"
+version = "0.17.0"
 edition = "2021"
 authors = ["The Tari Development Community"]
 repository = "https://github.com/tari-project/tari-ootle"


### PR DESCRIPTION
This pull request updates the workspace package version in the `Cargo.toml` file from 0.16.0 to 0.17.0. This is a standard version bump and does not introduce any other changes.

- Bumped the workspace package version in `Cargo.toml` from 0.16.0 to 0.17.0 to reflect the next release.