### PR TITLE
fix(db-inspector): improve state tree table

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2505,6 +2505,7 @@ dependencies = [
  "mime_guess",
  "serde",
  "serde_json",
+ "tari_jellyfish",
  "tari_ootle_common_types",
  "tari_ootle_storage",
  "tari_state_store_rocksdb",

--- a/crates/state_store_rocksdb/src/cf_api.rs
+++ b/crates/state_store_rocksdb/src/cf_api.rs
@@ -100,6 +100,8 @@ impl<CF: Cf, DB: RocksReader> CfContext<'_, DB, CF> {
         Ok(value)
     }
 
+    /// Counts the number of entries in the column family.
+    /// WARNING: This operation is O(n) and can be slow for large column families/prefixed tables.
     pub fn count(&self, operation: &'static str) -> Result<usize, RocksDbStorageError> {
         let key_prefix = CF::key_prefix().map(|b| [b]);
         let prefix_bytes = match key_prefix {

--- a/utilities/db_inspector/Cargo.toml
+++ b/utilities/db_inspector/Cargo.toml
@@ -10,6 +10,7 @@ license.workspace = true
 tari_ootle_storage = { workspace = true }
 tari_state_store_rocksdb = { workspace = true }
 tari_ootle_common_types = { workspace = true }
+tari_jellyfish = { workspace = true }
 
 anyhow = { workspace = true }
 axum = { workspace = true }

--- a/utilities/db_inspector/src/webserver/handlers/mod.rs
+++ b/utilities/db_inspector/src/webserver/handlers/mod.rs
@@ -9,6 +9,7 @@ pub mod column_families;
 pub mod databases;
 pub mod foreign_substate_pledges;
 pub mod state_transitions;
+pub mod state_tree;
 pub mod tables;
 mod types;
 

--- a/utilities/db_inspector/src/webserver/handlers/state_tree.rs
+++ b/utilities/db_inspector/src/webserver/handlers/state_tree.rs
@@ -1,0 +1,101 @@
+//   Copyright 2025 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+use std::sync::Arc;
+
+use axum::{
+    extract::{Path, Query},
+    Extension,
+    Json,
+};
+use serde_json::json;
+use tari_ootle_storage::Ordering;
+use tari_state_store_rocksdb::{column_families::state_tree::StateTreeCf, error::RocksDbStorageError, traits::Cf};
+
+use crate::webserver::{
+    context::HandlerContext,
+    error::WebError,
+    handlers::types::{decode_hex_prefix, Column, TableRequest, TableResponse},
+};
+
+pub async fn list(
+    Extension(context): Extension<Arc<HandlerContext>>,
+    Path(db_name): Path<String>,
+    Query(req): Query<TableRequest>,
+) -> Result<Json<TableResponse>, WebError> {
+    const OPERATION: &str = "list_state_tree";
+    let db = context.open_db(&db_name)?;
+    let mut table = TableResponse::new([
+        Column::new("shard", "Shard"),
+        Column::new("key", "Key"),
+        Column::new("type", "Type"),
+        Column::new("leaf_count", "Leaf Count"),
+        Column::new("substate_addr", "Substate Address"),
+        Column::new("version", "Version"),
+    ]);
+    let tx = db.read_only_context();
+
+    let cf = tx.cf(StateTreeCf)?;
+
+    let ordering = if req.desc {
+        Ordering::Descending
+    } else {
+        Ordering::Ascending
+    };
+    type Key = <StateTreeCf as Cf>::Key;
+    type Value = <StateTreeCf as Cf>::Value;
+    let iter: Box<dyn Iterator<Item = Result<(Key, Value), RocksDbStorageError>>> =
+        if let Some(prefix_hex) = req.query.as_ref() {
+            let key_prefix = decode_hex_prefix::<StateTreeCf>(prefix_hex)?;
+            Box::new(cf.prefix_range_iterator_raw_key(ordering, key_prefix))
+        } else {
+            Box::new(cf.iterator(ordering, OPERATION))
+        };
+
+    let row_limit = req.limit.unwrap_or(1_000);
+    let row_skip = req.page.unwrap_or(0).saturating_mul(row_limit);
+    for result in iter.skip(row_skip).take(row_limit) {
+        let ((shard, node_key), node) = result?;
+        let encoded_key = cf.encode_key(&(shard, node_key.clone()));
+        let key_hex = hex::encode(&encoded_key);
+        match node {
+            tari_jellyfish::Node::Internal(node) => {
+                table.add_row(json!({
+                    "id": key_hex,
+                    "shard": shard,
+                    "key": node_key.to_string(),
+                    "type": "Internal",
+                    "leaf_count": node.leaf_count(),
+                    "substate_addr": "",
+                    "version": node_key.version(),
+                }));
+            },
+            tari_jellyfish::Node::Leaf(node) => {
+                table.add_row(json!({
+                    "id": key_hex,
+                    "shard": shard,
+                    "key": node_key.to_string(),
+                    "type": "Leaf",
+                    "leaf_count": 0,
+                    "substate_addr": node.payload(),
+                    "version": node.version(),
+                }));
+            },
+            tari_jellyfish::Node::Null => {
+                table.add_row(json!({
+                    "id": key_hex,
+                    "shard": shard,
+                    "key": node_key.to_string(),
+                    "type": "Null",
+                    "leaf_count": 0,
+                    "substate_addr": "",
+                    "version": node_key.version(),
+                }));
+            },
+        }
+    }
+    let count = cf.count(OPERATION)?;
+    table.set_total_entries(count);
+
+    Ok(Json(table))
+}

--- a/utilities/db_inspector/src/webserver/server.rs
+++ b/utilities/db_inspector/src/webserver/server.rs
@@ -65,6 +65,10 @@ pub async fn run(context: HandlerContext) -> anyhow::Result<()> {
             get(handlers::bookkeeping::list),
         )
         .route(
+            &format!("/databases/{{db_name}}/column-families/{}", slugify_type_name(column_families::state_tree::StateTreeCf)),
+            get(handlers::state_tree::list),
+        )
+        .route(
             &format!("/databases/{{db_name}}/column-families/{}", slugify_type_name(column_families::foreign_substate_pledge::ForeignSubstatePledgeCf)),
             get(handlers::foreign_substate_pledges::list),
         );
@@ -104,7 +108,7 @@ pub async fn run(context: HandlerContext) -> anyhow::Result<()> {
         // column_families::state_transition::StateTransitionModel,
         // column_families::foreign_substate_pledge::ForeignSubstatePledgeModel,
         column_families::pending_state_tree_diff::PendingStateTreeDiffCf,
-        column_families::state_tree::StateTreeCf,
+        // column_families::state_tree::StateTreeCf,
         column_families::state_tree::StateTreeStaleNodesCf,
         column_families::state_tree_shard_versions::StateTreeShardVersionCf,
         column_families::epoch_checkpoint::EpochCheckpointCf,


### PR DESCRIPTION
This pull request adds support for inspecting the state tree column family in the database inspector webserver. The main addition is a new handler and API route that allows users to list and view nodes in the state tree, including their type, shard, key, leaf count, substate address, and version. The changes also update dependencies to support this new functionality.

**State tree inspection feature:**

* Added `state_tree.rs` handler to provide an API endpoint for listing state tree nodes, including handling pagination, filtering by key prefix, and formatting node details for the response.
* Registered the new route in the webserver so users can access state tree data through the `/databases/{db_name}/column-families/state_tree` endpoint.
* Enabled the `state_tree` module in the handlers mod to expose the new functionality.

**Dependency updates:**

* Added `tari_jellyfish` as a workspace dependency in `Cargo.toml` to support state tree node decoding and processing.

**Codebase organization:**

* Commented out the direct use of `StateTreeCf` in the list of column families to avoid duplicate registration, since it's now handled by the new route.