### PR TITLE
fix(epochoracle): remove base layer only function from oracle trait

### DIFF
--- a/applications/tari_indexer/src/bootstrap.rs
+++ b/applications/tari_indexer/src/bootstrap.rs
@@ -33,7 +33,12 @@ use tari_crypto::tari_utilities::ByteArray;
 use tari_engine_types::ToByteType;
 use tari_epoch_manager::service::{EpochManagerConfig, EpochManagerHandle};
 use tari_epoch_oracles::{
-    base_layer::{BaseLayerEpochOracleConfig, BaseLayerEpochOracleFeatures, BaseLayerOracle},
+    base_layer::{
+        BaseLayerBlockHeaderStore,
+        BaseLayerEpochOracleConfig,
+        BaseLayerEpochOracleFeatures,
+        BaseLayerOracle,
+    },
     configured::{ConfiguredEpochOracle, RealTimeEpochTicker},
     hybrid::{watch_ticker, HybridEpochOracle},
     store::EpochOracleStore,
@@ -304,7 +309,7 @@ async fn create_base_layer_client(config: &ApplicationConfig) -> anyhow::Result<
         .context("Failed to create gRPC base node client")
 }
 
-async fn create_epoch_oracle<TStore: EpochOracleStore + Clone + Send + 'static>(
+async fn create_epoch_oracle<TStore: EpochOracleStore + BaseLayerBlockHeaderStore + Clone + Send + 'static>(
     config: &ApplicationConfig,
     store: TStore,
     consensus_constants: &ConsensusConstants,
@@ -325,7 +330,7 @@ async fn create_epoch_oracle<TStore: EpochOracleStore + Clone + Send + 'static>(
     }
 }
 
-async fn create_base_layer_epoch_oracle<TStore: EpochOracleStore + 'static>(
+async fn create_base_layer_epoch_oracle<TStore: EpochOracleStore + BaseLayerBlockHeaderStore + 'static>(
     config: &ApplicationConfig,
     store: TStore,
     consensus_constants: &ConsensusConstants,
@@ -358,7 +363,7 @@ async fn create_configured_epoch_oracle<TStore: EpochOracleStore + Send>(
     Ok(oracle)
 }
 
-async fn create_hybrid_epoch_oracle<TStore: EpochOracleStore + Clone + Send + 'static>(
+async fn create_hybrid_epoch_oracle<TStore: EpochOracleStore + BaseLayerBlockHeaderStore + Clone + Send + 'static>(
     config: &ApplicationConfig,
     store: TStore,
     consensus_constants: &ConsensusConstants,

--- a/applications/tari_validator_node/src/bootstrap.rs
+++ b/applications/tari_validator_node/src/bootstrap.rs
@@ -42,7 +42,12 @@ use tari_epoch_manager::{
     EpochManagerReader,
 };
 use tari_epoch_oracles::{
-    base_layer::{BaseLayerEpochOracleConfig, BaseLayerEpochOracleFeatures, BaseLayerOracle},
+    base_layer::{
+        BaseLayerBlockHeaderStore,
+        BaseLayerEpochOracleConfig,
+        BaseLayerEpochOracleFeatures,
+        BaseLayerOracle,
+    },
     configured::{ConfiguredEpochOracle, RealTimeEpochTicker},
     hybrid::{watch_ticker, HybridEpochOracle},
     store::EpochOracleStore,
@@ -491,7 +496,7 @@ async fn create_base_layer_client(
     Ok(base_node_client)
 }
 
-async fn create_epoch_oracle<TStore: EpochOracleStore + Send + Clone + 'static>(
+async fn create_epoch_oracle<TStore: EpochOracleStore + BaseLayerBlockHeaderStore + Send + Clone + 'static>(
     config: &ApplicationConfig,
     store: TStore,
     consensus_constants: &ConsensusConstants,
@@ -516,7 +521,7 @@ async fn create_epoch_oracle<TStore: EpochOracleStore + Send + Clone + 'static>(
     }
 }
 
-async fn create_base_layer_epoch_oracle<TStore: EpochOracleStore + 'static>(
+async fn create_base_layer_epoch_oracle<TStore: EpochOracleStore + BaseLayerBlockHeaderStore + 'static>(
     config: &ApplicationConfig,
     store: TStore,
     consensus_constants: &ConsensusConstants,
@@ -551,7 +556,7 @@ async fn create_configured_epoch_oracle<TStore: EpochOracleStore + Send>(
     Ok(oracle)
 }
 
-async fn create_hybrid_epoch_oracle<TStore: EpochOracleStore + Clone + Send + 'static>(
+async fn create_hybrid_epoch_oracle<TStore: EpochOracleStore + BaseLayerBlockHeaderStore + Clone + Send + 'static>(
     config: &ApplicationConfig,
     store: TStore,
     consensus_constants: &ConsensusConstants,

--- a/crates/common_types/src/substate_address.rs
+++ b/crates/common_types/src/substate_address.rs
@@ -125,12 +125,6 @@ impl SubstateAddress {
             .expect("SubstateAddress: object_key_bytes must return valid ObjectKey bytes")
     }
 
-    pub fn to_version(&self) -> u32 {
-        let mut buf = [0u8; size_of::<u32>()];
-        buf.copy_from_slice(&self.0[ObjectKey::LENGTH..]);
-        u32::from_be_bytes(buf)
-    }
-
     pub fn to_u256(&self) -> U256 {
         let mut buf = [0u8; ObjectKey::LENGTH];
         buf.copy_from_slice(&self.0[..ObjectKey::LENGTH]);
@@ -154,41 +148,6 @@ impl SubstateAddress {
             .min(num_shards);
 
         Shard::from(shard_number)
-
-        // // 2^15-1 shards with 40 vns per shard = 1,310,680 validators. This limit exists to prevent next_power_of_two
-        // // from panicking.
-        // let num_shards = num_shards.min(MAX_NUM_SHARDS);
-        //
-        // // Round down to the next power of two.
-        // let next_shards_pow_two = num_shards.next_power_of_two();
-        // let half_shard_size = U256::MAX >> next_shards_pow_two.trailing_zeros();
-        // let mut next_pow_2_shard =
-        //     u32::try_from(addr_u256 / half_shard_size).expect("to_shard: num_shards is a u32, so this cannot fail");
-        //
-        // // On boundary
-        // if addr_u256 % half_shard_size == 0 {
-        //     next_pow_2_shard = next_pow_2_shard.saturating_sub(1);
-        // }
-        //
-        // // Half the next power of two i.e. num_shards rounded down to previous power of two
-        // let num_shards_pow_two = next_shards_pow_two >> 1;
-        // // The "extra" half shards in the space
-        // let num_half_shards = num_shards % num_shards_pow_two;
-        //
-        // // Shard that we would be in if num_shards was a power of two
-        // let shard = next_pow_2_shard / 2;
-        //
-        // // If the shard is higher than all half shards,
-        // let shard = if shard >= num_half_shards {
-        //     // then add those half shards in
-        //     shard + num_half_shards
-        // } else {
-        //     // otherwise, we use the shard number we'd be in if num_shards was the next power of two
-        //     next_pow_2_shard
-        // };
-        //
-        // // u256::MAX address needs to be clamped to the last shard index
-        // cmp::min(shard, num_shards - 1).into()
     }
 
     pub fn to_shard_group(&self, num_shards: NumPreshards, num_committees: u32) -> ShardGroup {
@@ -356,63 +315,6 @@ mod tests {
         let range = Shard::from(8).to_substate_address_range(NumPreshards::P8);
         assert_range(range, address_at(7, 8)..=address_at(8, 8));
     }
-
-    // #[test]
-    // fn shard_range() {
-    //     let range = SubstateAddress::zero().to_address_range(2);
-    //     assert_range(range, SubstateAddress::zero()..address_at(1, 2));
-    //     let range = SubstateAddress::max().to_address_range(2);
-    //     assert_range(range, address_at(1, 2)..=SubstateAddress::max());
-    //
-    //     // num_shards is a power of two
-    //     let power_of_twos =
-    //         iter::successors(Some(MAX_NUM_SHARDS.next_power_of_two() >> 1), |&x| Some(x >> 1)).take(15 - 2);
-    //     for power_of_two in power_of_twos {
-    //         for i in 0..power_of_two {
-    //             let range = address_at(i, power_of_two).to_address_range(power_of_two);
-    //             if i == 0 {
-    //                 assert_range(range, SubstateAddress::zero()..address_at(1, power_of_two));
-    //             } else if i >= power_of_two - 1 {
-    //                 assert_range(range, address_at(i, power_of_two)..=SubstateAddress::max());
-    //             } else {
-    //                 assert_range(range, address_at(i, power_of_two)..address_at(i + 1, power_of_two));
-    //             }
-    //         }
-    //     }
-    //
-    //     // Half shards
-    //     let range = address_at(0, 8).to_address_range(6);
-    //     assert_range(range, SubstateAddress::zero()..address_at(1, 8));
-    //     let range = address_at(1, 8).to_address_range(6);
-    //     assert_range(range, address_at(1, 8)..address_at(2, 8));
-    //     let range = address_at(2, 8).to_address_range(6);
-    //     assert_range(range, address_at(2, 8)..address_at(3, 8));
-    //     let range = address_at(3, 8).to_address_range(6);
-    //     assert_range(range, address_at(3, 8)..address_at(4, 8));
-    //     // Whole shards
-    //     let range = address_at(4, 8).to_address_range(6);
-    //     assert_range(range, address_at(4, 8)..address_at(6, 8));
-    //     let range = address_at(5, 8).to_address_range(6);
-    //     assert_range(range, address_at(4, 8)..address_at(6, 8));
-    //     let range = address_at(6, 8).to_address_range(6);
-    //     assert_range(range, address_at(6, 8)..=SubstateAddress::max());
-    //     let range = address_at(7, 8).to_address_range(6);
-    //     assert_range(range, address_at(6, 8)..=SubstateAddress::max());
-    //     let range = address_at(8, 8).to_address_range(6);
-    //     assert_range(range, address_at(6, 8)..=SubstateAddress::max());
-    //
-    //     let range = plus_one(address_at(1, 4)).to_address_range(20);
-    //     // The half shards will split at intervals of END_SHARD_MAX / 32
-    //     assert_range(range, address_at(8, 32)..address_at(10, 32));
-    //
-    //     let range = plus_one(divide_floor(SubstateAddress::max(), 2)).to_address_range(10);
-    //     assert_range(range, address_at(8, 16)..address_at(10, 16));
-    //
-    //     let range = address_at(42, 256).to_address_range(256);
-    //     assert_range(range, address_at(42, 256)..address_at(43, 256));
-    //     let range = address_at(128, 256).to_address_range(256);
-    //     assert_range(range, address_at(128, 256)..address_at(129, 256));
-    // }
 
     #[test]
     fn to_shard() {

--- a/crates/epoch_oracles/src/base_layer/header_store.rs
+++ b/crates/epoch_oracles/src/base_layer/header_store.rs
@@ -1,0 +1,36 @@
+//   Copyright 2026 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+use tari_common_types::types::FixedHash;
+use tari_node_components::blocks::BlockHeader;
+use tari_ootle_common_types::{Epoch, NodeAddressable};
+use tari_ootle_storage::global::{BlockHeaderModel, GlobalDb};
+use tari_ootle_storage_sqlite::global::SqliteGlobalDbAdapter;
+
+pub trait BaseLayerBlockHeaderStore {
+    fn add_block_headers<I: IntoIterator<Item = (Epoch, FixedHash, BlockHeader)>>(
+        &self,
+        headers: I,
+    ) -> anyhow::Result<()>;
+}
+
+impl<TAddr: NodeAddressable> BaseLayerBlockHeaderStore for GlobalDb<SqliteGlobalDbAdapter<TAddr>> {
+    fn add_block_headers<I: IntoIterator<Item = (Epoch, FixedHash, BlockHeader)>>(
+        &self,
+        headers: I,
+    ) -> anyhow::Result<()> {
+        let mut tx = self.create_transaction()?;
+        let mut header_db = self.block_headers(&mut tx);
+        for (epoch, block_hash, header) in headers {
+            header_db.insert(BlockHeaderModel {
+                epoch,
+                height: header.height,
+                block_hash,
+                kernel_merkle_root: header.kernel_mr,
+                validator_node_merkle_root: header.validator_node_mr,
+            })?;
+        }
+        tx.commit()?;
+        Ok(())
+    }
+}

--- a/crates/epoch_oracles/src/base_layer/mod.rs
+++ b/crates/epoch_oracles/src/base_layer/mod.rs
@@ -3,7 +3,9 @@
 
 mod config;
 mod header_hasher;
+mod header_store;
 mod oracle;
 
 pub use config::*;
+pub use header_store::*;
 pub use oracle::*;

--- a/crates/epoch_oracles/src/base_layer/oracle.rs
+++ b/crates/epoch_oracles/src/base_layer/oracle.rs
@@ -25,7 +25,12 @@ use tari_template_lib::types::crypto::RistrettoPublicKeyBytes;
 use tokio::time;
 
 use crate::{
-    base_layer::{header_hasher::hash_header, BaseLayerEpochOracleConfig, BaseLayerEpochOracleFeatures},
+    base_layer::{
+        header_hasher::hash_header,
+        BaseLayerBlockHeaderStore,
+        BaseLayerEpochOracleConfig,
+        BaseLayerEpochOracleFeatures,
+    },
     store::{EpochOracleStore, StoreKey},
 };
 
@@ -63,7 +68,7 @@ struct BaseLayerOracleInner<TStore> {
     network: Network,
 }
 
-impl<TStore: EpochOracleStore + 'static> BaseLayerOracle<TStore> {
+impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore + 'static> BaseLayerOracle<TStore> {
     pub fn new(
         store: TStore,
         base_node_client: GrpcBaseNodeClient,
@@ -99,7 +104,7 @@ impl<TStore: EpochOracleStore + 'static> BaseLayerOracle<TStore> {
     }
 }
 
-impl<TStore: EpochOracleStore> BaseLayerOracleInner<TStore> {
+impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore> BaseLayerOracleInner<TStore> {
     fn load_initial_state(&mut self) -> Result<(), BaseLayerOracleError> {
         self.last_scanned_tip = self
             .store
@@ -435,7 +440,7 @@ impl<TStore: EpochOracleStore> BaseLayerOracleInner<TStore> {
     }
 }
 
-impl<TStore: EpochOracleStore + Send + 'static> BaseLayerOracle<TStore> {
+impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore + Send + 'static> BaseLayerOracle<TStore> {
     fn poll_next_event(&mut self, cx: &mut Context) -> Poll<Option<EpochEvent>> {
         if self.is_done {
             return Poll::Ready(None);
@@ -518,7 +523,9 @@ impl<TStore: EpochOracleStore + Send + 'static> BaseLayerOracle<TStore> {
     }
 }
 
-impl<TStore: EpochOracleStore + Send + 'static> EpochEventOracle for BaseLayerOracle<TStore> {
+impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore + Send + 'static> EpochEventOracle
+    for BaseLayerOracle<TStore>
+{
     /// Returns a Future that returns the next event, completing a round of scanning if necessary.
     /// This Future is cancel-safe. Returns None if a shutdown is triggered.
     async fn next_epoch_event(&mut self) -> Option<EpochEvent> {

--- a/crates/epoch_oracles/src/hybrid/oracle.rs
+++ b/crates/epoch_oracles/src/hybrid/oracle.rs
@@ -6,7 +6,7 @@ use tari_epoch_manager::epoch_event_oracle::{EpochEvent, EpochEventOracle};
 use tokio::sync::watch;
 
 use crate::{
-    base_layer::BaseLayerOracle,
+    base_layer::{BaseLayerBlockHeaderStore, BaseLayerOracle},
     configured::{ConfiguredEpochOracle, EpochTickerData},
     hybrid::watch_ticker::WatchEpochTicker,
     store::EpochOracleStore,
@@ -21,7 +21,7 @@ pub struct HybridEpochOracle<TStore> {
     has_initial_sync_completed: bool,
 }
 
-impl<TStore: EpochOracleStore + Send + 'static> HybridEpochOracle<TStore> {
+impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore + Send + 'static> HybridEpochOracle<TStore> {
     pub fn new(
         configured: ConfiguredEpochOracle<TStore, WatchEpochTicker>,
         base_layer: BaseLayerOracle<TStore>,
@@ -36,7 +36,9 @@ impl<TStore: EpochOracleStore + Send + 'static> HybridEpochOracle<TStore> {
     }
 }
 
-impl<TStore: EpochOracleStore + Send + 'static> EpochEventOracle for HybridEpochOracle<TStore> {
+impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore + Send + 'static> EpochEventOracle
+    for HybridEpochOracle<TStore>
+{
     async fn next_epoch_event(&mut self) -> Option<EpochEvent> {
         loop {
             tokio::select! {

--- a/crates/epoch_oracles/src/lib.rs
+++ b/crates/epoch_oracles/src/lib.rs
@@ -20,14 +20,28 @@ pub enum EpochOracle<TStore> {
     Hybrid(hybrid::HybridEpochOracle<TStore>),
 }
 
-impl<TStore: EpochOracleStore + Send + 'static> EpochEventOracle for EpochOracle<TStore> {
+#[cfg(feature = "base_layer")]
+impl<TStore> EpochEventOracle for EpochOracle<TStore>
+where
+    TStore: EpochOracleStore + Send + 'static,
+    TStore: base_layer::BaseLayerBlockHeaderStore,
+{
     async fn next_epoch_event(&mut self) -> Option<EpochEvent> {
         match self {
-            #[cfg(feature = "base_layer")]
             EpochOracle::BaseLayer(base_layer) => base_layer.next_epoch_event().await,
             EpochOracle::Configured(configured) => configured.next_epoch_event().await,
-            #[cfg(feature = "base_layer")]
             EpochOracle::Hybrid(hybrid) => hybrid.next_epoch_event().await,
+        }
+    }
+}
+
+#[cfg(not(feature = "base_layer"))]
+impl<TStore> EpochEventOracle for EpochOracle<TStore>
+where TStore: EpochOracleStore + Send + 'static
+{
+    async fn next_epoch_event(&mut self) -> Option<EpochEvent> {
+        match self {
+            EpochOracle::Configured(configured) => configured.next_epoch_event().await,
         }
     }
 }

--- a/crates/epoch_oracles/src/store.rs
+++ b/crates/epoch_oracles/src/store.rs
@@ -2,19 +2,13 @@
 //   SPDX-License-Identifier: BSD-3-Clause
 
 use serde::{de::DeserializeOwned, Serialize};
-use tari_common_types::types::FixedHash;
-use tari_node_components::blocks::BlockHeader;
-use tari_ootle_common_types::{Epoch, NodeAddressable};
-use tari_ootle_storage::global::{BlockHeaderModel, GlobalDb};
+use tari_ootle_common_types::NodeAddressable;
+use tari_ootle_storage::global::GlobalDb;
 use tari_ootle_storage_sqlite::global::SqliteGlobalDbAdapter;
 
 pub trait EpochOracleStore {
     fn get<T: DeserializeOwned>(&self, key: &[u8]) -> anyhow::Result<Option<T>>;
     fn set<T: Serialize>(&self, key: &[u8], value: &T) -> anyhow::Result<()>;
-    fn add_block_headers<I: IntoIterator<Item = (Epoch, FixedHash, BlockHeader)>>(
-        &self,
-        headers: I,
-    ) -> anyhow::Result<()>;
 }
 
 pub enum StoreKey {
@@ -49,25 +43,6 @@ impl<TAddr: NodeAddressable> EpochOracleStore for GlobalDb<SqliteGlobalDbAdapter
     fn set<T: Serialize>(&self, key: &[u8], value: &T) -> anyhow::Result<()> {
         let mut tx = self.create_transaction()?;
         self.metadata(&mut tx).set_metadata(key, value)?;
-        tx.commit()?;
-        Ok(())
-    }
-
-    fn add_block_headers<I: IntoIterator<Item = (Epoch, FixedHash, BlockHeader)>>(
-        &self,
-        headers: I,
-    ) -> anyhow::Result<()> {
-        let mut tx = self.create_transaction()?;
-        let mut header_db = self.block_headers(&mut tx);
-        for (epoch, block_hash, header) in headers {
-            header_db.insert(BlockHeaderModel {
-                epoch,
-                height: header.height,
-                block_hash,
-                kernel_merkle_root: header.kernel_mr,
-                validator_node_merkle_root: header.validator_node_mr,
-            })?;
-        }
         tx.commit()?;
         Ok(())
     }

--- a/crates/storage/src/consensus_models/block_pledges.rs
+++ b/crates/storage/src/consensus_models/block_pledges.rs
@@ -274,7 +274,7 @@ mod tests {
             owner_key: None,
             owner_rule: Default::default(),
             access_rules: ComponentAccessRules::allow_all(),
-            entity_id: EntityId::from_array([seed; 20]),
+            entity_id: EntityId::from_array([seed; EntityId::LENGTH]),
             body: ComponentBody::empty(),
         })
     }


### PR DESCRIPTION
Description
---
fix(epochoracle): remove base layer only function from oracle trait

Motivation and Context
---
If the base layer feature is disabled, the public epoch trait would still need to include base layer dependencies. This caused a compilation error when running consensus tests that do not use the base layer oracle. By [separating the traits](https://www.wikiwand.com/en/articles/Interface_segregation_principle) we avoid this problem and improve decoupling.
