### PR TITLE
fix(consensus)!: single byte entity ID + fixes

### DIFF
--- a/crates/consensus/src/hotstuff/block_change_set.rs
+++ b/crates/consensus/src/hotstuff/block_change_set.rs
@@ -393,8 +393,7 @@ impl ProposedBlockChangeSet {
         transaction: &Transaction,
         initial_evidence: Evidence,
     ) -> TransactionPoolRecord {
-        let mut rec = TransactionPoolRecord::new_from_transaction(transaction, initial_evidence);
-        rec.set_ready(true);
+        let rec = TransactionPoolRecord::new_from_transaction(transaction, initial_evidence);
         self.new_transactions_to_sequence.push(rec.clone());
         rec
     }

--- a/crates/consensus/src/hotstuff/on_propose.rs
+++ b/crates/consensus/src/hotstuff/on_propose.rs
@@ -255,6 +255,7 @@ where TConsensusSpec: ConsensusSpec
         start_of_chain_id: &LeafBlock,
         pool_tx: TransactionPoolRecord,
         local_committee_info: &CommitteeInfo,
+        change_set: &ProposedBlockChangeSet,
         substate_store: &mut PendingSubstateStore<TConsensusSpec::StateStore>,
         executed_transactions: &mut HashMap<TransactionId, TransactionExecution>,
         lock_conflicts: &mut TransactionLockConflicts,
@@ -264,6 +265,7 @@ where TConsensusSpec: ConsensusSpec
                 start_of_chain_id,
                 pool_tx,
                 local_committee_info,
+                change_set,
                 substate_store,
                 executed_transactions,
                 lock_conflicts,
@@ -273,6 +275,7 @@ where TConsensusSpec: ConsensusSpec
             TransactionPoolStage::LocalPrepared => self.local_accept_transaction(
                 start_of_chain_id,
                 local_committee_info,
+                change_set,
                 pool_tx,
                 substate_store,
                 executed_transactions,
@@ -419,6 +422,7 @@ where TConsensusSpec: ConsensusSpec
                 &start_of_chain_block.as_leaf(),
                 transaction,
                 local_committee_info,
+                &change_set,
                 &mut substate_store,
                 &mut executed_transactions,
                 &mut lock_conflicts,
@@ -594,6 +598,7 @@ where TConsensusSpec: ConsensusSpec
         parent_block: &LeafBlock,
         mut pool_tx: TransactionPoolRecord,
         local_committee_info: &CommitteeInfo,
+        change_set: &ProposedBlockChangeSet,
         substate_store: &mut PendingSubstateStore<TConsensusSpec::StateStore>,
         executed_transactions: &mut HashMap<TransactionId, TransactionExecution>,
         lock_conflicts: &mut TransactionLockConflicts,
@@ -606,7 +611,13 @@ where TConsensusSpec: ConsensusSpec
 
         let prepared = self
             .transaction_manager
-            .prepare(substate_store, local_committee_info, &pool_tx, *parent_block)
+            .prepare(
+                substate_store,
+                local_committee_info,
+                &pool_tx,
+                *parent_block,
+                change_set,
+            )
             .map_err(|e| HotStuffError::TransactionExecutorError(e.to_string()))?;
 
         if prepared.lock_status().is_any_failed() && !prepared.lock_status().is_hard_conflict() {
@@ -776,6 +787,7 @@ where TConsensusSpec: ConsensusSpec
         &self,
         parent_block: &LeafBlock,
         local_committee_info: &CommitteeInfo,
+        change_set: &ProposedBlockChangeSet,
         mut tx_rec: TransactionPoolRecord,
         substate_store: &mut PendingSubstateStore<TConsensusSpec::StateStore>,
         executed_transactions: &mut HashMap<TransactionId, TransactionExecution>,
@@ -787,7 +799,7 @@ where TConsensusSpec: ConsensusSpec
 
         let tx = substate_store.read_transaction();
         let transaction = tx_rec.get_transaction(tx)?;
-        let execution = self.execute_transaction(tx, parent_block, transaction)?;
+        let execution = self.execute_transaction(tx, parent_block, transaction, change_set)?;
 
         // Try to lock all local outputs
         let local_outputs = execution
@@ -894,6 +906,7 @@ where TConsensusSpec: ConsensusSpec
         tx: &<TConsensusSpec::StateStore as StateStore>::ReadTransaction<'_>,
         parent_block: &LeafBlock,
         transaction: TransactionRecord,
+        change_set: &ProposedBlockChangeSet,
     ) -> Result<TransactionExecution, HotStuffError> {
         // Should have been executed already if all inputs are local
         if let Some(execution) =
@@ -907,7 +920,11 @@ where TConsensusSpec: ConsensusSpec
             return Ok(execution.into_transaction_execution());
         }
 
-        let pledged = PledgedTransaction::load_pledges(tx, transaction)?;
+        let mut pledged = PledgedTransaction::load_pledges(tx, transaction)?;
+        let transaction_id = *pledged.id();
+        pledged
+            .foreign_pledges
+            .extend(change_set.get_foreign_pledges(&transaction_id).cloned());
 
         info!(
             target: LOG_TARGET,

--- a/crates/consensus/src/hotstuff/on_ready_to_vote_on_local_block.rs
+++ b/crates/consensus/src/hotstuff/on_ready_to_vote_on_local_block.rs
@@ -524,7 +524,13 @@ where TConsensusSpec: ConsensusSpec
         // TODO(perf): proposer shouldn't have to do this twice, esp. executing the transaction and locking
         let prepared = self
             .transaction_manager
-            .prepare(substate_store, local_committee_info, &pool_tx, block.as_leaf())
+            .prepare(
+                substate_store,
+                local_committee_info,
+                &pool_tx,
+                block.as_leaf(),
+                proposed_block_change_set,
+            )
             .map_err(|e| HotStuffError::TransactionExecutorError(e.to_string()))?;
 
         match prepared {
@@ -707,7 +713,13 @@ where TConsensusSpec: ConsensusSpec
             PreparedTransaction::new_multishard_executed(execution.into_transaction_execution(), LockStatus::new())
         } else {
             self.transaction_manager
-                .prepare(substate_store, local_committee_info, tx_rec, block.as_leaf())
+                .prepare(
+                    substate_store,
+                    local_committee_info,
+                    tx_rec,
+                    block.as_leaf(),
+                    proposed_block_change_set,
+                )
                 .map_err(|e| HotStuffError::TransactionExecutorError(e.to_string()))?
         };
 
@@ -965,7 +977,13 @@ where TConsensusSpec: ConsensusSpec
                 return Ok(Some(NoVoteReason::NotAllForeignInputPledges));
             }
             let transaction_id = *tx_rec.id();
-            let execution = self.execute_transaction(tx, block.as_leaf(), block.epoch(), transaction)?;
+            let execution = self.execute_transaction(
+                tx,
+                block.as_leaf(),
+                block.epoch(),
+                transaction,
+                proposed_block_change_set,
+            )?;
             let execution = execution.into_transaction_execution();
 
             // TODO: can we modify input locks at this point? For multi-shard input transactions, we locked all inputs
@@ -1450,6 +1468,7 @@ where TConsensusSpec: ConsensusSpec
         block: LeafBlock,
         current_epoch: Epoch,
         transaction: TransactionRecord,
+        change_set: &ProposedBlockChangeSet,
     ) -> Result<BlockTransactionExecution, HotStuffError> {
         info!(
             target: LOG_TARGET,
@@ -1464,9 +1483,12 @@ where TConsensusSpec: ConsensusSpec
             return Ok(execution);
         }
 
-        let pledged = PledgedTransaction::load_pledges(tx, transaction)?;
-
+        let mut pledged = PledgedTransaction::load_pledges(tx, transaction)?;
         let transaction_id = *pledged.id();
+        pledged
+            .foreign_pledges
+            .extend(change_set.get_foreign_pledges(&transaction_id).cloned());
+
         let executed = self
             .transaction_manager
             .execute(current_epoch, pledged)

--- a/crates/consensus/src/hotstuff/transaction_manager/manager.rs
+++ b/crates/consensus/src/hotstuff/transaction_manager/manager.rs
@@ -34,7 +34,10 @@ use tari_transaction::{Transaction, TransactionId};
 
 use super::{PledgedTransaction, PreparedTransaction};
 use crate::{
-    hotstuff::substate_store::{LockStatus, PendingSubstateStore, SubstateStoreError},
+    hotstuff::{
+        block_change_set::ProposedBlockChangeSet,
+        substate_store::{LockStatus, PendingSubstateStore, SubstateStoreError},
+    },
     tracing::TraceTimer,
     traits::{BlockTransactionExecutor, BlockTransactionExecutorError},
 };
@@ -63,6 +66,7 @@ impl<TStateStore: StateStore, TExecutor: BlockTransactionExecutor<TStateStore>>
         local_committee_info: &CommitteeInfo,
         pool_tx: &TransactionPoolRecord,
         block: LeafBlock,
+        change_set: &ProposedBlockChangeSet,
     ) -> Result<PreparedTransaction, BlockTransactionExecutorError> {
         let _timer = TraceTimer::info(LOG_TARGET, "prepare");
         let transaction = pool_tx.get_transaction(store.read_transaction())?;
@@ -104,6 +108,7 @@ impl<TStateStore: StateStore, TExecutor: BlockTransactionExecutor<TStateStore>>
                     &transaction,
                     non_local_inputs,
                     block,
+                    change_set,
                 ),
             ResolvedTransactionInputs::OnlyTombstones => {
                 self.prepare_local_input_transaction(store, local_committee_info, &transaction, IndexMap::new(), block)
@@ -503,12 +508,12 @@ impl<TStateStore: StateStore, TExecutor: BlockTransactionExecutor<TStateStore>>
         store: &mut PendingSubstateStore<TStateStore>,
         local_committee_info: &CommitteeInfo,
         transaction: &TransactionRecord,
-        // TODO: check if we have all pledges before executing
-        _non_local_inputs: IndexSet<SubstateRequirementRef<'_>>,
+        non_local_inputs: IndexSet<SubstateRequirementRef<'_>>,
         block: LeafBlock,
+        change_set: &ProposedBlockChangeSet,
     ) -> Result<PreparedTransaction, BlockTransactionExecutorError> {
         let transaction_id = *transaction.id();
-        // We're output-only
+        // We're output-only, so only need to gather foreign pledges
         let foreign_pledges = transaction.get_foreign_pledges(store.read_transaction())?;
 
         info!(
@@ -518,19 +523,37 @@ impl<TStateStore: StateStore, TExecutor: BlockTransactionExecutor<TStateStore>>
             foreign_pledges.len()
         );
 
+        let proposed_foreign_pledges = change_set.get_foreign_pledges(&transaction_id);
         let resolved_inputs = foreign_pledges
             .into_iter()
+            // NOTE: that duplicate pledges (which should not happen) will be NOT overwritten by the proposed ones due to HashMap from_iter behaviour
+            .chain(proposed_foreign_pledges.cloned())
             // Exclude any output pledges
             .filter_map(|pledge| pledge.into_input())
             .map(|(id, substate)|
                 {
                     let version = id.version();
                     (
+                        // SubstateRequirement
                         id.into(),
                         Substate::new(version, substate),
                     )
                 })
-            .collect();
+            .collect::<HashMap<_, _>>();
+
+        // Check that we have all the required foreign input pledges
+        if let Some(req) = non_local_inputs
+            .iter()
+            .find(|req| !resolved_inputs.contains_key(req.substate_id()))
+        {
+            error!(target: LOG_TARGET, "⚠️ PREPARE: Missing {req} foreign input pledge for transaction {}", transaction_id);
+            // NOTE: crashes consensus. The foreign proposal should have already been verified to include all input
+            // pledges.
+            return Err(BlockTransactionExecutorError::InvariantError(format!(
+                "Missing foreign input pledge for transaction {}: {}",
+                transaction_id, req
+            )));
+        }
 
         let execution = self.execute_or_fetch(store, transaction, &resolved_inputs, &block)?;
         info!(

--- a/crates/engine_types/src/substate.rs
+++ b/crates/engine_types/src/substate.rs
@@ -212,6 +212,8 @@ impl SubstateId {
                     .trailing_bytes()
                     .into();
 
+                // This makes each NFT live on the same shard as the resource (for possible improved efficiency)
+                // TODO: Review whether this is a good idea, as it leads to shard hotspots.
                 ObjectKey::new(addr.resource_address().as_entity_id(), key)
             },
             SubstateId::ClaimedOutputTombstone(addr) => *addr.as_object_key(),

--- a/crates/state_store_tests/src/helpers.rs
+++ b/crates/state_store_tests/src/helpers.rs
@@ -198,17 +198,21 @@ pub fn substate_id_tx_seed(transaction_id: TransactionId, seed: u32) -> Substate
     buf[..].copy_from_slice(&transaction_id.as_hash().as_slice()[..EntityId::LENGTH]);
     let entity_id = EntityId::from_array(buf);
     let mut buf = [0u8; ComponentKey::LENGTH];
-    buf[..size_of::<u32>()].copy_from_slice(&seed.to_be_bytes());
+    buf[..].copy_from_slice(&transaction_id.as_hash().as_slice()[..ComponentKey::LENGTH]);
+    let len = buf.len();
+    buf[len - size_of::<u32>()..].copy_from_slice(&seed.to_be_bytes());
     let component_key = ComponentKey::new(buf);
     SubstateId::Component(ComponentAddress::new(ObjectKey::new(entity_id, component_key)))
 }
 
 pub fn substate_id_seed(seed: u32) -> SubstateId {
     let mut buf = [0u8; EntityId::LENGTH];
-    buf[..size_of::<u32>()].copy_from_slice(&seed.to_be_bytes());
+    let end = size_of::<u32>().min(EntityId::LENGTH);
+    buf[..end].copy_from_slice(&seed.to_be_bytes()[..end]);
     let entity_id = EntityId::from_array(buf);
     let mut buf = [0u8; ComponentKey::LENGTH];
-    buf[..size_of::<u32>()].copy_from_slice(&seed.to_be_bytes());
+    let end = size_of::<u32>().min(ComponentKey::LENGTH);
+    buf[..end].copy_from_slice(&seed.to_be_bytes()[..end]);
     let component_key = ComponentKey::new(buf);
     SubstateId::Component(ComponentAddress::new(ObjectKey::new(entity_id, component_key)))
 }

--- a/crates/storage/src/consensus_models/block_pledges.rs
+++ b/crates/storage/src/consensus_models/block_pledges.rs
@@ -16,9 +16,10 @@ use tari_ootle_common_types::{
 };
 
 use crate::consensus_models::ShardGroupEvidence;
-pub type SubstatePledges = Vec<SubstatePledge>;
 
 const LOG_TARGET: &str = "tari::ootle::storage::consensus_models::block_pledges";
+
+pub type SubstatePledges = Vec<SubstatePledge>;
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct BlockPledge {
@@ -44,8 +45,8 @@ impl BlockPledge {
         self.pledges.contains_key(id)
     }
 
-    pub fn get_all_pledges_for_evidence(&self, evidence: &ShardGroupEvidence) -> Option<Vec<SubstatePledge>> {
-        let mut pledges = Vec::with_capacity(evidence.inputs().len());
+    pub fn get_all_pledges_for_evidence(&self, evidence: &ShardGroupEvidence) -> Option<SubstatePledges> {
+        let mut pledges = SubstatePledges::with_capacity(evidence.inputs().len());
         for (substate_id, ev) in evidence.all_pledged_inputs_iter() {
             // If any are missing return None
             let substate = self.pledges.get(substate_id)?;
@@ -220,7 +221,7 @@ impl SubstatePledge {
     }
 }
 
-/// These are to detect and prevent duplicates in pledging.
+/// Used to detect and prevent duplicate pledges without making SubstateValue implement Hash/PartialEq/Eq
 impl Hash for SubstatePledge {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.substate_id().hash(state);
@@ -231,6 +232,7 @@ impl Hash for SubstatePledge {
 
 impl PartialEq for SubstatePledge {
     fn eq(&self, other: &Self) -> bool {
+        // NB: important that PartialEq and Hash are consistent
         self.as_substate_lock_type() == other.as_substate_lock_type() &&
             self.versioned_substate_id() == other.versioned_substate_id()
     }
@@ -306,5 +308,64 @@ mod tests {
 
         evidence.insert(id3.substate_id().clone(), id3.version(), SubstateLockType::Write);
         assert!(!pledge.has_all_input_substate_values_for(&evidence));
+    }
+
+    #[test]
+    fn partial_eq_and_hash_are_consistent() {
+        let substate_value1 = substate_value(1);
+        let id1 = create_substate_id(1);
+
+        let pledge1 = SubstatePledge::Input {
+            substate_id: id1.clone(),
+            is_write: true,
+            substate: Box::new(substate_value1.clone()),
+        };
+
+        let pledge2 = SubstatePledge::Input {
+            substate_id: id1.clone(),
+            is_write: true,
+            substate: Box::new(substate_value1.clone()),
+        };
+
+        let pledge3 = SubstatePledge::Input {
+            substate_id: id1,
+            is_write: false,
+            substate: Box::new(substate_value1),
+        };
+
+        use std::{
+            collections::hash_map::DefaultHasher,
+            hash::{Hash, Hasher},
+        };
+
+        let mut hasher1 = DefaultHasher::new();
+        pledge1.hash(&mut hasher1);
+        let hash1 = hasher1.finish();
+
+        let mut hasher2 = DefaultHasher::new();
+        pledge2.hash(&mut hasher2);
+        let hash2 = hasher2.finish();
+
+        let mut hasher3 = DefaultHasher::new();
+        pledge3.hash(&mut hasher3);
+        let hash3 = hasher3.finish();
+
+        if pledge1 == pledge2 {
+            assert_eq!(hash1, hash2);
+        } else {
+            assert_ne!(hash1, hash2);
+        }
+
+        if pledge1 == pledge3 {
+            assert_eq!(hash1, hash3);
+        } else {
+            assert_ne!(hash1, hash3);
+        }
+
+        if pledge2 == pledge3 {
+            assert_eq!(hash2, hash3);
+        } else {
+            assert_ne!(hash2, hash3);
+        }
     }
 }

--- a/crates/template_lib_types/src/entity_id.rs
+++ b/crates/template_lib_types/src/entity_id.rs
@@ -20,7 +20,10 @@ pub struct EntityId(
 );
 
 impl EntityId {
-    pub const LENGTH: usize = 20;
+    /// The length in bytes of an EntityId
+    /// This is only 1 byte because a single byte is a sufficient prefix to "bind" a substate to a particular shard
+    /// given that max NumPreshards is 256.
+    pub const LENGTH: usize = 1;
 
     pub const fn new(bytes: [u8; Self::LENGTH]) -> Self {
         Self(bytes)
@@ -117,7 +120,9 @@ pub struct ComponentKey(
 );
 
 impl ComponentKey {
-    pub const LENGTH: usize = 12;
+    /// The length in bytes of a ComponentKey
+    /// This is 31 bytes so that when combined with the 1 byte EntityId it forms a 32 byte ObjectKey
+    pub const LENGTH: usize = 31;
 
     pub const fn new(bytes: [u8; Self::LENGTH]) -> Self {
         Self(bytes)


### PR DESCRIPTION
Description
---
fix(consensus)!: single byte entity ID 
fix(consensus): remove naive set_ready(true) call, which can cause transactions to be sequenced before all foreign proposals are received
fix(consensus): include foreign pledges added in the current block changeset when executing. This fixes missing input errors when a foreign proposal and associated transaction proposal are included in the same block. This also checks for missing pledges before executing, to clearly differentiate between a missing input in a transaction and missing foreign pledge.

Motivation and Context
---
A single byte prefix is sufficient to "bind" substates to a particular shard (given NumPreshards::max() == 256).
Previously we used 20 bytes, which therefore reduced the entropy bytes of the substate to 32-20=12 bytes.
This change massively reduces (making it vanishingly small) the chances of collisions within a particular shard.

How Has This Been Tested?
---
Manaully, existing tests

What process can a PR reviewer use to test or verify this change?
---


Breaking Changes
---

- [ ] None
- [x] Requires data directory to be deleted
- [ ] Other - Please specify