### PR TITLE
fix(engine): reduce memory for WASM calls + ensure threads disable

### DIFF
--- a/applications/tari_walletd/src/handlers/accounts.rs
+++ b/applications/tari_walletd/src/handlers/accounts.rs
@@ -749,7 +749,7 @@ pub async fn handle_transfer(
         .await
         .optional()?;
 
-    let mut builder = context.transaction_builder().create_account(req.destination_public_key);
+    let builder = context.transaction_builder().create_account(req.destination_public_key);
 
     if let Some(ValidatorScanResult { id: address, substate }) = existing_dest_account {
         inputs.insert(address.into());

--- a/crates/engine/src/wasm/environment.rs
+++ b/crates/engine/src/wasm/environment.rs
@@ -22,8 +22,7 @@
 
 use std::{
     fmt::{Debug, Formatter},
-    ops::Range,
-    sync::{Arc, Mutex},
+    sync::{Arc, Mutex, MutexGuard},
 };
 
 use tari_template_abi::{TemplateDef, ABI_TEMPLATE_DEF_GLOBAL_NAME};
@@ -65,7 +64,7 @@ impl<T: Send + 'static> WasmEnv<T> {
     }
 
     pub(super) fn set_last_panic(&self, message: String) {
-        *self.last_panic.lock().unwrap() = Some(message);
+        *self.last_panic_mut() = Some(message);
     }
 
     pub(super) fn alloc<S: AsStoreMut>(&self, store: &mut S, len: u32) -> Result<WasmPtr<u8>, WasmExecutionError> {
@@ -77,16 +76,24 @@ impl<T: Send + 'static> WasmEnv<T> {
         Ok(ptr)
     }
 
+    fn last_panic_mut(&self) -> MutexGuard<'_, Option<String>> {
+        self.last_panic.lock().expect("last_panic poisoned")
+    }
+
     pub(super) fn take_last_panic_message(&self) -> Option<String> {
-        self.last_panic.lock().unwrap().take()
+        self.last_panic_mut().take()
+    }
+
+    fn last_engine_error_mut(&self) -> MutexGuard<'_, Option<RuntimeError>> {
+        self.last_engine_error.lock().expect("last_engine_error poisoned")
     }
 
     pub(super) fn set_last_engine_error(&self, error: RuntimeError) {
-        *self.last_engine_error.lock().unwrap() = Some(error);
+        *self.last_engine_error_mut() = Some(error);
     }
 
     pub(super) fn take_last_engine_error(&self) -> Option<RuntimeError> {
-        self.last_engine_error.lock().unwrap().take()
+        self.last_engine_error_mut().take()
     }
 
     pub(super) fn load_abi<S: AsStoreMut>(
@@ -102,9 +109,12 @@ impl<T: Send + 'static> WasmEnv<T> {
             .ok_or(WasmExecutionError::ExportError(ExportError::IncompatibleType))? as u32;
 
         // Load ABI from memory
-        let data = self.read_memory_with_embedded_len(store, ptr)?;
-        let decoded = tari_bor::decode(&data).map_err(WasmExecutionError::AbiDecodeError)?;
-        Ok(decoded)
+        // SAFETY: WasmEnv is not used concurrently
+        unsafe {
+            self.with_memory_with_embedded_len(store, ptr, |data| {
+                tari_bor::decode(data).map_err(WasmExecutionError::AbiDecodeError)
+            })?
+        }
     }
 
     pub(super) fn memory_writer<'a, S: AsStoreMut>(
@@ -116,45 +126,89 @@ impl<T: Send + 'static> WasmEnv<T> {
         Ok(MemWriter::new(ptr, view))
     }
 
-    pub(super) fn read_memory_with_embedded_len<S: AsStoreRef>(
-        &self,
-        store: &mut S,
-        offset: u32,
-    ) -> Result<Vec<u8>, WasmExecutionError> {
-        let memory = self.get_memory()?;
-        let view = memory.view(store);
-        let mut buf = [0u8; 4];
-        view.read(u64::from(offset), &mut buf)?;
-
-        let len = u32::from_le_bytes(buf);
-        let start = offset + 4;
-        let data = copy_range_to_vec(&view, start..start + len)?;
-
-        Ok(data)
-    }
-
-    pub(super) fn read_from_memory<S: AsStoreRef>(
+    /// Retrieves a slice of memory at the given pointer and length, and calls the provided callback with that slice.
+    /// Returns an error if the pointer and length are out of memory bounds.
+    ///
+    /// # Safety
+    /// This function provides direct access to the memory slice. The caller must ensure that the memory is not
+    /// modified while the slice is in use.
+    /// It is undefined behaviour to modify the memory contents in any way including by calling a wasm
+    /// function that writes to the memory or by resizing the memory.
+    pub(super) unsafe fn with_memory_slice<S: AsStoreRef, F: FnMut(&[u8]) -> R, R>(
         &self,
         store: &mut S,
         ptr: WasmPtr<u8>,
         len: u32,
-    ) -> Result<Vec<u8>, WasmExecutionError> {
+        mut callback: F,
+    ) -> Result<R, WasmExecutionError> {
         let memory = self.get_memory()?;
         let view = memory.view(store);
-        let mem_size = view.data_size();
-        let ptr_plus_len = ptr
-            .offset()
-            .checked_add(len)
-            .ok_or(WasmExecutionError::MaxMemorySizeExceeded)?;
-        if u64::from(ptr.offset()) >= mem_size || u64::from(ptr_plus_len) >= mem_size {
-            return Err(WasmExecutionError::MemoryPointerOutOfRange {
-                size: mem_size,
+
+        let slice = view.data_unchecked();
+
+        let start = ptr.offset() as usize;
+        let end = start
+            .checked_add(len as usize)
+            .ok_or(WasmExecutionError::MemoryPointerOutOfRange {
+                size: slice.len() as u64,
                 pointer: u64::from(ptr.offset()),
                 len: u64::from(len),
-            });
-        }
-        let data = copy_range_to_vec(&view, ptr.offset()..ptr_plus_len)?;
-        Ok(data)
+            })?;
+
+        let slice = slice
+            .get(start..end)
+            .ok_or(WasmExecutionError::MemoryPointerOutOfRange {
+                size: slice.len() as u64,
+                pointer: u64::from(ptr.offset()),
+                len: u64::from(len),
+            })?;
+
+        Ok(callback(slice))
+    }
+
+    /// Reads the 4-byte length prefix at the given offset and calls the provided callback with the payload slice
+    /// (`offset + 4..offset + 4 + len`) i.e. excluding the length prefix. Returns an error if the length prefix or
+    /// payload is out of memory bounds.
+    ///
+    /// # Safety
+    /// This function provides direct access to the memory slice. The caller must ensure that the memory is not
+    /// modified while the slice is in use.
+    /// It is undefined behaviour to modify the memory contents in any way including by calling a wasm
+    /// function that writes to the memory or by resizing the memory.
+    pub(super) unsafe fn with_memory_with_embedded_len<S: AsStoreRef, F: FnMut(&[u8]) -> R, R>(
+        &self,
+        store: &mut S,
+        offset: u32,
+        mut callback: F,
+    ) -> Result<R, WasmExecutionError> {
+        let memory = self.get_memory()?;
+        let view = memory.view(store);
+        let len = read_len_from_memory(&view, offset)?;
+        let start = offset
+            .checked_add(4)
+            .ok_or(WasmExecutionError::MemoryPointerOutOfRange {
+                size: view.data_size(),
+                pointer: u64::from(offset),
+                len: 4,
+            })?;
+        let end = start
+            .checked_add(len)
+            .ok_or(WasmExecutionError::MemoryPointerOutOfRange {
+                size: view.data_size(),
+                pointer: u64::from(start),
+                len: u64::from(len),
+            })?;
+
+        let slice = view.data_unchecked();
+        let slice = slice
+            .get(start as usize..end as usize)
+            .ok_or(WasmExecutionError::MemoryPointerOutOfRange {
+                size: slice.len() as u64,
+                pointer: u64::from(start),
+                len: u64::from(len),
+            })?;
+
+        Ok(callback(slice))
     }
 
     pub(super) fn memory_size<S: AsStoreRef>(&self, store: &mut S) -> Result<usize, WasmExecutionError> {
@@ -201,7 +255,7 @@ impl<T: Debug> Debug for WasmEnv<T> {
         f.debug_struct("WasmEnv")
             .field("memory", &"LazyInit<Memory>")
             .field("tari_alloc", &" LazyInit<NativeFunc<(i32), (i32)>")
-            .field("State", &self.state)
+            .field("state", &self.state)
             .finish()
     }
 }
@@ -227,20 +281,8 @@ impl AllocPtr {
     }
 }
 
-/// Copies a range of the memory and returns it as a vector of bytes
-/// This is a u32 version of MemoryView::copy_range_to_vec
-fn copy_range_to_vec(view: &MemoryView, range: Range<u32>) -> Result<Vec<u8>, MemoryAccessError> {
-    let mut new_memory = Vec::new();
-    let mut offset = range.start;
-    let size = u32::try_from(view.data_size()).map_err(|_| MemoryAccessError::Overflow)?;
-    let end = range.end.min(size);
-    let mut chunk = [0u8; 40960];
-    while offset < end {
-        let remaining = end - offset;
-        let sublen = remaining.min(chunk.len() as u32) as usize;
-        view.read(u64::from(offset), chunk.get_mut(..sublen).expect("length checked"))?;
-        new_memory.extend_from_slice(chunk.get(..sublen).expect("length checked"));
-        offset += sublen as u32;
-    }
-    Ok(new_memory)
+fn read_len_from_memory(view: &MemoryView, offset: u32) -> Result<u32, MemoryAccessError> {
+    let mut buf = [0u8; 4];
+    view.read(u64::from(offset), &mut buf)?;
+    Ok(u32::from_le_bytes(buf))
 }

--- a/crates/engine/src/wasm/module.rs
+++ b/crates/engine/src/wasm/module.rs
@@ -26,7 +26,7 @@ use tari_engine_types::limits;
 use tari_template_abi::{FunctionDef, TemplateDef, Type, ABI_TEMPLATE_DEF_GLOBAL_NAME};
 use wasmer::{
     imports,
-    sys::{BaseTunables, CompilerConfig, Cranelift, CraneliftOptLevel, NativeEngineExt, Target},
+    sys::{BaseTunables, CompilerConfig, Cranelift, CraneliftOptLevel, EngineBuilder, Target},
     AsStoreMut,
     Engine,
     ExportError,
@@ -117,10 +117,24 @@ impl WasmModule {
             .canonicalize_nans(true);
         // TODO: Configure metering limit
         compiler.push_middleware(Arc::new(metering::middleware(100_000_000)));
-        let mut engine = Engine::from(compiler);
-        engine.set_tunables(tunables);
 
-        engine
+        let mut features = wasmer::sys::Features::default();
+        features
+            // Explicitly disable threads and multi value, the remaining defaults are repeated here for clarity
+            .threads(false)
+            .bulk_memory(true)
+            .multi_value(false)
+            .reference_types(true)
+            .simd(true)
+            .tail_call(false)
+            .memory64(false)
+            .multi_memory(false)
+            .exceptions(false)
+            .module_linking(false);
+
+        let mut engine = EngineBuilder::new(compiler).set_features(Some(features)).engine();
+        engine.set_tunables(tunables);
+        Engine::from(engine)
     }
 }
 

--- a/crates/engine/src/wasm/process.rs
+++ b/crates/engine/src/wasm/process.rs
@@ -151,75 +151,86 @@ impl WasmProcess {
             return WasmPtr::null();
         }
 
-        let (env_mut, mut store) = env.data_and_store_mut();
-        let arg = match env_mut.read_from_memory(&mut store, arg_ptr, arg_len) {
-            Ok(arg) => arg,
-            Err(err) => {
-                log::error!(target: LOG_TARGET, "Failed to read from memory: {}", err);
-                return WasmPtr::null();
-            },
-        };
+        let (env_mut, store) = env.data_and_store_mut();
 
         log::debug!(target: LOG_TARGET, "Engine call: {:?}", op);
 
         let result = match op {
-            EngineOp::EmitLog => Self::handle(store, env_mut, arg, |env, arg: EmitLogArg| {
+            EngineOp::EmitLog => Self::handle(store, env_mut, arg_ptr, arg_len, |env, arg: EmitLogArg| {
                 env.interface().emit_log(arg.level, arg.message)
             }),
-            EngineOp::ComponentInvoke => Self::handle(store, env_mut, arg, |env, arg: ComponentInvokeArg| {
-                env.interface()
-                    .component_invoke(arg.component_ref, arg.action, arg.args.into())
-            }),
-            EngineOp::ResourceInvoke => Self::handle(store, env_mut, arg, |env, arg: ResourceInvokeArg| {
-                env.interface()
-                    .resource_invoke(arg.resource_ref, arg.action, arg.args.into())
-            }),
-            EngineOp::VaultInvoke => Self::handle(store, env_mut, arg, |env, arg: VaultInvokeArg| {
+            EngineOp::ComponentInvoke => {
+                Self::handle(store, env_mut, arg_ptr, arg_len, |env, arg: ComponentInvokeArg| {
+                    env.interface()
+                        .component_invoke(arg.component_ref, arg.action, arg.args.into())
+                })
+            },
+            EngineOp::ResourceInvoke => {
+                Self::handle(store, env_mut, arg_ptr, arg_len, |env, arg: ResourceInvokeArg| {
+                    env.interface()
+                        .resource_invoke(arg.resource_ref, arg.action, arg.args.into())
+                })
+            },
+            EngineOp::VaultInvoke => Self::handle(store, env_mut, arg_ptr, arg_len, |env, arg: VaultInvokeArg| {
                 env.interface().vault_invoke(arg.vault_ref, arg.action, arg.args.into())
             }),
-            EngineOp::BucketInvoke => Self::handle(store, env_mut, arg, |env, arg: BucketInvokeArg| {
+            EngineOp::BucketInvoke => Self::handle(store, env_mut, arg_ptr, arg_len, |env, arg: BucketInvokeArg| {
                 env.interface()
                     .bucket_invoke(arg.bucket_ref, arg.action, arg.args.into())
             }),
-            EngineOp::NonFungibleInvoke => Self::handle(store, env_mut, arg, |env, arg: NonFungibleInvokeArg| {
-                env.interface()
-                    .non_fungible_invoke(arg.address, arg.action, arg.args.into())
-            }),
-            EngineOp::GenerateUniqueId => {
-                Self::handle(store, env_mut, arg, |env, _arg: ()| env.interface().generate_uuid())
-            },
-            EngineOp::ConsensusInvoke => Self::handle(store, env_mut, arg, |env, arg: ConsensusInvokeArg| {
-                env.interface().consensus_invoke(arg.action)
-            }),
-            EngineOp::CallerContextInvoke => Self::handle(store, env_mut, arg, |env, arg: CallerContextInvokeArg| {
-                env.interface().caller_context_invoke(arg.action, arg.args.into())
-            }),
-            EngineOp::AddressAllocationInvoke => {
-                Self::handle(store, env_mut, arg, |env, arg: AddressAllocationInvokeArg| {
-                    env.interface().allocate_address_invoke(arg)
+            EngineOp::NonFungibleInvoke => {
+                Self::handle(store, env_mut, arg_ptr, arg_len, |env, arg: NonFungibleInvokeArg| {
+                    env.interface()
+                        .non_fungible_invoke(arg.address, arg.action, arg.args.into())
                 })
             },
-            EngineOp::GenerateRandomInvoke => Self::handle(store, env_mut, arg, |env, arg: GenerateRandomInvokeArg| {
-                env.interface().generate_random_invoke(arg.action)
+            EngineOp::GenerateUniqueId => Self::handle(store, env_mut, arg_ptr, arg_len, |env, _arg: ()| {
+                env.interface().generate_uuid()
             }),
-            EngineOp::EmitEvent => Self::handle(store, env_mut, arg, |env, arg: EmitEventArg| {
+            EngineOp::ConsensusInvoke => {
+                Self::handle(store, env_mut, arg_ptr, arg_len, |env, arg: ConsensusInvokeArg| {
+                    env.interface().consensus_invoke(arg.action)
+                })
+            },
+            EngineOp::CallerContextInvoke => {
+                Self::handle(store, env_mut, arg_ptr, arg_len, |env, arg: CallerContextInvokeArg| {
+                    env.interface().caller_context_invoke(arg.action, arg.args.into())
+                })
+            },
+            EngineOp::AddressAllocationInvoke => Self::handle(
+                store,
+                env_mut,
+                arg_ptr,
+                arg_len,
+                |env, arg: AddressAllocationInvokeArg| env.interface().allocate_address_invoke(arg),
+            ),
+            EngineOp::GenerateRandomInvoke => {
+                Self::handle(store, env_mut, arg_ptr, arg_len, |env, arg: GenerateRandomInvokeArg| {
+                    env.interface().generate_random_invoke(arg.action)
+                })
+            },
+            EngineOp::EmitEvent => Self::handle(store, env_mut, arg_ptr, arg_len, |env, arg: EmitEventArg| {
                 env.interface().emit_event(arg.topic, arg.payload)
             }),
-            EngineOp::CallInvoke => Self::handle(store, env_mut, arg, |env, arg: CallInvokeArg| {
+            EngineOp::CallInvoke => Self::handle(store, env_mut, arg_ptr, arg_len, |env, arg: CallInvokeArg| {
                 env.interface().call_invoke(arg.action, arg.args.into())
             }),
-            EngineOp::ProofInvoke => Self::handle(store, env_mut, arg, |env, arg: ProofInvokeArg| {
+            EngineOp::ProofInvoke => Self::handle(store, env_mut, arg_ptr, arg_len, |env, arg: ProofInvokeArg| {
                 log::debug!(target: LOG_TARGET, "proof action = {:?}", arg.action);
                 env.interface().proof_invoke(arg.proof_ref, arg.action, arg.args.into())
             }),
-            EngineOp::BuiltinTemplateInvoke => {
-                Self::handle(store, env_mut, arg, |env, arg: BuiltinTemplateInvokeArg| {
-                    env.interface().builtin_template_invoke(arg.action)
+            EngineOp::BuiltinTemplateInvoke => Self::handle(
+                store,
+                env_mut,
+                arg_ptr,
+                arg_len,
+                |env, arg: BuiltinTemplateInvokeArg| env.interface().builtin_template_invoke(arg.action),
+            ),
+            EngineOp::SignatureInvoke => {
+                Self::handle(store, env_mut, arg_ptr, arg_len, |env, arg: SignatureInvokeArg| {
+                    env.interface().signature_invoke(arg.action, arg.args.into())
                 })
             },
-            EngineOp::SignatureInvoke => Self::handle(store, env_mut, arg, |env, arg: SignatureInvokeArg| {
-                env.interface().signature_invoke(arg.action, arg.args.into())
-            }),
         };
 
         result.unwrap_or_else(|err| {
@@ -243,7 +254,8 @@ impl WasmProcess {
     pub fn handle<T, U, E>(
         mut store: StoreMut,
         env_mut: &mut WasmEnv<Runtime>,
-        args: Vec<u8>,
+        arg_ptr: WasmPtr<u8>,
+        arg_len: u32,
         f: fn(&mut Runtime, T) -> Result<U, E>,
     ) -> Result<WasmPtr<u8>, WasmExecutionError>
     where
@@ -251,13 +263,19 @@ impl WasmProcess {
         U: Serialize,
         WasmExecutionError: From<E>,
     {
-        let decoded = decode_exact(&args).map_err(|e| {
-            eprintln!("Failed to decode args: {}", e);
-            WasmExecutionError::EngineArgDecodeFailed(e)
-        })?;
+        // SAFETY: WasmProcess is not used concurrently and templates are not able to spawn threads
+        let decoded = unsafe {
+            env_mut.with_memory_slice(&mut store, arg_ptr, arg_len, |arg| {
+                decode_exact(arg).map_err(|e| {
+                    log::error!(target: LOG_TARGET, "Failed to decode args for engine call: {}", e);
+                    WasmExecutionError::EngineArgDecodeFailed(e)
+                })
+            })
+        }??;
         let resp = f(env_mut.state_mut(), decoded)?;
         let len = encoded_len(&resp)?;
         let ptr = env_mut.alloc(&mut store, len as u32)?;
+        // Encode response directly into the WASM memory. The WASM code is responsible for freeing it.
         let mut writer = env_mut.memory_writer(&mut store, ptr)?;
         encode_with_len_to_writer(&mut writer, &resp)?;
         Ok(ptr)
@@ -346,10 +364,13 @@ impl Invokable<Store> for WasmProcess {
         };
 
         // Read response from memory
-        let raw = self.env.read_memory_with_embedded_len(store, ptr.offset())?;
+        // SAFETY: WasmProcess is not used concurrently
+        let value = unsafe {
+            self.env
+                .with_memory_with_embedded_len(store, ptr.offset(), IndexedValue::from_raw)??
+        };
 
-        let value = IndexedValue::from_raw(&raw)?;
-
+        self.env.state().interface().validate_return_value(&value)?;
         self.env
             .state()
             .interface()
@@ -366,13 +387,13 @@ fn debug_handler<T: Send + 'static>(mut env: FunctionEnvMut<WasmEnv<T>>, arg_ptr
     const WASM_DEBUG_LOG_TARGET: &str = "tari::ootle::wasm";
     let (state, mut store) = env.data_and_store_mut();
 
-    match state.read_from_memory(&mut store, arg_ptr, arg_len) {
-        Ok(arg) => {
-            eprintln!("DEBUG: {}", String::from_utf8_lossy(&arg));
-        },
-        Err(err) => {
+    // SAFETY: WasmProcess is not used concurrently
+    unsafe {
+        if let Err(err) = state.with_memory_slice(&mut store, arg_ptr, arg_len, |msg| {
+            eprintln!("DEBUG: {}", String::from_utf8_lossy(msg));
+        }) {
             log::error!(target: WASM_DEBUG_LOG_TARGET, "Failed to read from memory: {}", err);
-        },
+        }
     }
 }
 
@@ -386,23 +407,25 @@ fn on_panic_handler<T: Send + 'static>(
     const WASM_DEBUG_LOG_TARGET: &str = "tari::ootle::wasm";
     let (state, mut store) = env.data_and_store_mut();
 
-    match state.read_from_memory(&mut store, msg_ptr, msg_len as u32) {
-        Ok(msg) => {
-            let msg = String::from_utf8_lossy(&msg);
-            log::error!(target: WASM_DEBUG_LOG_TARGET, "📣 PANIC: ({}:{}) {}", line, col, msg);
-            state.set_last_panic(msg.to_string());
-        },
-        Err(err) => {
-            log::error!(
-                target: WASM_DEBUG_LOG_TARGET,
-                "📣 PANIC: WASM template panicked but did not provide a valid memory pointer to on_panic \
-                 callback: {}",
-                err
-            );
-            state.set_last_panic(format!(
-                "WASM panicked but did not provide a valid message pointer to on_panic callback: {}",
-                err
-            ));
-        },
+    // SAFETY: There is no way to call this function concurrently
+    unsafe {
+        state
+            .with_memory_slice(&mut store, msg_ptr, msg_len as u32, |msg| {
+                let msg = String::from_utf8_lossy(msg);
+                log::error!(target: WASM_DEBUG_LOG_TARGET, "📣 PANIC: ({}:{}) {}", line, col, msg);
+                state.set_last_panic(msg.to_string());
+            })
+            .unwrap_or_else(|err| {
+                log::error!(
+                    target: WASM_DEBUG_LOG_TARGET,
+                    "📣 PANIC: WASM template panicked but did not provide a valid memory pointer to on_panic \
+                     callback: {}",
+                    err
+                );
+                state.set_last_panic(format!(
+                    "WASM panicked but did not provide a valid message pointer to on_panic callback: {}",
+                    err
+                ));
+            });
     }
 }

--- a/crates/engine/tests/no_concurrency.rs
+++ b/crates/engine/tests/no_concurrency.rs
@@ -1,0 +1,41 @@
+//   Copyright 2025 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+use tari_template_test_tooling::{support::assert_error::assert_reject_reason, TemplateTest};
+use tari_transaction::{args, Transaction};
+
+const TEMPLATE_NAME: &str = "NoConcurrency";
+const TEMPLATE_PATHS: &[&str] = &["no_concurrency"];
+const CRATE_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/templates");
+
+#[test]
+fn it_panics_if_template_attempts_to_spawn_a_thread() {
+    let mut test = TemplateTest::new(CRATE_PATH, TEMPLATE_PATHS);
+
+    let reason = test.execute_expect_failure(
+        Transaction::builder_localnet()
+            .call_function(
+                test.get_template_address(TEMPLATE_NAME),
+                "try_to_spawn_a_thread_static",
+                args![],
+            )
+            .finish()
+            .seal(test.secret_key()),
+        vec![],
+    );
+
+    // Source of the error message:
+    // https://github.com/rust-lang/rust/blob/3fda0e426ca17b0baa0d6e765a0d23f487350573/library/std/src/sys/thread/unsupported.rs#L20
+    // This means that the thread spawn was not even attempted from WASM.
+
+    // We have explicitly disabled threads in the engine and not included wasmer-wasix which would provide threads
+    // support. Currently, thread support is not included in the lastest wasi_preview2 spec, but wasmer have attempted
+    // to support it with wasmer-wasix as a stop-gap extension to the wasi API.
+    //
+    // WASI is not a new WASM instruction set, and the way thread spawning would require a host function to spawn the
+    // thread. Therefore, this test doesn't really make sense. If a user successfully compiles a
+    // template with "thread support" and attempts to run it in the engine, the instantiation would fail due to missing
+    // host functions. Importantly, we validate that the binary does not require invalid imports before
+    // accepting the template on chain.
+    assert_reject_reason(&reason, "operation not supported on this platform");
+}

--- a/crates/engine/tests/templates/no_concurrency/Cargo.toml
+++ b/crates/engine/tests/templates/no_concurrency/Cargo.toml
@@ -1,0 +1,14 @@
+[workspace]
+[package]
+name = "no_concurrency"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+tari_template_lib = { path = "../../../../template_lib" }
+
+
+[lib]
+crate-type = ["cdylib", "lib"]

--- a/crates/engine/tests/templates/no_concurrency/src/lib.rs
+++ b/crates/engine/tests/templates/no_concurrency/src/lib.rs
@@ -1,0 +1,24 @@
+//   Copyright 2025 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+use tari_template_lib::prelude::*;
+
+#[template]
+mod template {
+    use super::*;
+
+    pub struct NoConcurrency {}
+
+    impl NoConcurrency {
+        pub fn try_to_spawn_a_thread_static() {
+            std::thread::spawn(|| {
+                // Try an engine call for fun, hopefully we cant get here
+                CallerContext::transaction_signer_public_key();
+                std::thread::sleep(std::time::Duration::from_millis(100));
+                unreachable!("Should not be able to spawn threads");
+            })
+            .join()
+            .unwrap();
+        }
+    }
+}

--- a/crates/engine/tests/test.rs
+++ b/crates/engine/tests/test.rs
@@ -49,7 +49,6 @@ use tari_utilities::hex::to_hex;
 use wasmer::ExportError;
 
 const CRATE_PATH: &str = env!("CARGO_MANIFEST_DIR");
-
 #[test]
 fn test_hello_world() {
     let mut template_test = TemplateTest::new(CRATE_PATH, vec!["tests/templates/hello_world"]);

--- a/crates/template_abi/src/types.rs
+++ b/crates/template_abi/src/types.rs
@@ -56,7 +56,7 @@ impl TemplateDef {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export))]
 pub struct TemplateDefV1 {
     pub template_name: String,


### PR DESCRIPTION
Description
---
fix(engine): reduce memory for WASM calls 
fix(engine): explicitly disable threads

Motivation and Context
---
Instead of allocating each call argument and return value on the host heap and en/decoding, we read directly from
the WASM memory view. This is unsafe only if the memory is mutated during encoding. Since we only execute on a single thread the safety invariant is maintained.

Explicitly disabled threads on the cranelift compiler (although the docs said this was [already disabled by default](https://github.com/wasmerio/wasmer/blob/048fb90efb4ba01ad184bc3eac0a9f3f4ab4c2c0/lib/types/src/features.rs#L111), [it is not](https://github.com/wasmerio/wasmer/blob/048fb90efb4ba01ad184bc3eac0a9f3f4ab4c2c0/lib/types/src/features.rs#L47))

NOTE: that the added test does NOT actually test "WASM cant spawn threads". What is happening is `std::thread::spawn` panics when called, causing the transaction to fail. WASM does not natively have a "spawn threads" instruction, rather specs like WASI aim to add future support (maybe). Threads _could_ be spawned by the runtime by exposing this functionality as a function import to the WASM, but since we dont do this, multithreaded host calls are not possible.

How Has This Been Tested?
---
Engine tests, manual stress test

```
  Success rate: 100.00%
  Transactions submitted: 10000
  Transactions committed: 10000
  Transactions errored: 0
  Up substates: 40000
  Down substates: 10000
  Total execution time: 12.24s (slowest: 87.63ms, fastest: 572.37µs)
  Avg execution time: 1ms 
```

What process can a PR reviewer use to test or verify this change?
---


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify