### PR TITLE
chore: update libp2p RUSTSEC-2026-0002

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2448,7 +2448,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -3032,7 +3032,6 @@ checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand_core 0.6.4",
  "serde",
  "sha2",
  "subtle",
@@ -3190,7 +3189,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3840,8 +3839,6 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "allocator-api2",
- "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -3862,11 +3859,11 @@ dependencies = [
 
 [[package]]
 name = "hashlink"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
- "hashbrown 0.14.5",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -4794,7 +4791,7 @@ dependencies = [
  "minotari_node",
  "minotari_node_grpc_client",
  "minotari_wallet",
- "multiaddr 0.18.1",
+ "multiaddr 0.18.3",
  "notify",
  "rand 0.8.5",
  "regex",
@@ -4903,7 +4900,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5257,8 +5254,8 @@ checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libp2p"
-version = "0.56.0"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=75053056e55752945626169845ed302e3b1158d5#75053056e55752945626169845ed302e3b1158d5"
+version = "0.56.1"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=95b732e9bebe192808693b6017c0cd6be5e5fcde#95b732e9bebe192808693b6017c0cd6be5e5fcde"
 dependencies = [
  "bytes 1.10.1",
  "either",
@@ -5277,7 +5274,6 @@ dependencies = [
  "libp2p-mdns",
  "libp2p-metrics",
  "libp2p-noise",
- "libp2p-peer-store",
  "libp2p-ping",
  "libp2p-quic",
  "libp2p-relay",
@@ -5286,7 +5282,7 @@ dependencies = [
  "libp2p-tcp",
  "libp2p-upnp",
  "libp2p-yamux",
- "multiaddr 0.18.1",
+ "multiaddr 0.18.3",
  "pin-project 1.1.10",
  "rw-stream-sink",
  "thiserror 2.0.17",
@@ -5294,8 +5290,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-allow-block-list"
-version = "0.5.0"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=75053056e55752945626169845ed302e3b1158d5#75053056e55752945626169845ed302e3b1158d5"
+version = "0.6.0"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=95b732e9bebe192808693b6017c0cd6be5e5fcde#95b732e9bebe192808693b6017c0cd6be5e5fcde"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -5304,8 +5300,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-autonat"
-version = "0.14.1"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=75053056e55752945626169845ed302e3b1158d5#75053056e55752945626169845ed302e3b1158d5"
+version = "0.15.0"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=95b732e9bebe192808693b6017c0cd6be5e5fcde#95b732e9bebe192808693b6017c0cd6be5e5fcde"
 dependencies = [
  "async-trait",
  "asynchronous-codec",
@@ -5318,7 +5314,7 @@ dependencies = [
  "libp2p-request-response",
  "libp2p-swarm",
  "quick-protobuf",
- "quick-protobuf-codec 0.3.1 (git+https://github.com/tari-project/rust-libp2p.git?rev=75053056e55752945626169845ed302e3b1158d5)",
+ "quick-protobuf-codec 0.3.1 (git+https://github.com/tari-project/rust-libp2p.git?rev=95b732e9bebe192808693b6017c0cd6be5e5fcde)",
  "rand 0.8.5",
  "rand_core 0.6.4",
  "thiserror 2.0.17",
@@ -5328,8 +5324,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-connection-limits"
-version = "0.5.1"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=75053056e55752945626169845ed302e3b1158d5#75053056e55752945626169845ed302e3b1158d5"
+version = "0.6.0"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=95b732e9bebe192808693b6017c0cd6be5e5fcde#95b732e9bebe192808693b6017c0cd6be5e5fcde"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -5338,15 +5334,15 @@ dependencies = [
 
 [[package]]
 name = "libp2p-core"
-version = "0.43.1"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=75053056e55752945626169845ed302e3b1158d5#75053056e55752945626169845ed302e3b1158d5"
+version = "0.43.2"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=95b732e9bebe192808693b6017c0cd6be5e5fcde#95b732e9bebe192808693b6017c0cd6be5e5fcde"
 dependencies = [
  "either",
  "fnv",
  "futures 0.3.31",
  "futures-timer",
  "libp2p-identity",
- "multiaddr 0.18.1",
+ "multiaddr 0.18.3",
  "multihash 0.19.3",
  "multistream-select",
  "parking_lot",
@@ -5362,20 +5358,20 @@ dependencies = [
 
 [[package]]
 name = "libp2p-dcutr"
-version = "0.13.0"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=75053056e55752945626169845ed302e3b1158d5#75053056e55752945626169845ed302e3b1158d5"
+version = "0.14.0"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=95b732e9bebe192808693b6017c0cd6be5e5fcde#95b732e9bebe192808693b6017c0cd6be5e5fcde"
 dependencies = [
  "asynchronous-codec",
  "either",
  "futures 0.3.31",
  "futures-bounded",
  "futures-timer",
+ "hashlink 0.10.0",
  "libp2p-core",
  "libp2p-identity",
  "libp2p-swarm",
- "lru",
  "quick-protobuf",
- "quick-protobuf-codec 0.3.1 (git+https://github.com/tari-project/rust-libp2p.git?rev=75053056e55752945626169845ed302e3b1158d5)",
+ "quick-protobuf-codec 0.3.1 (git+https://github.com/tari-project/rust-libp2p.git?rev=95b732e9bebe192808693b6017c0cd6be5e5fcde)",
  "thiserror 2.0.17",
  "tracing",
  "web-time",
@@ -5384,7 +5380,7 @@ dependencies = [
 [[package]]
 name = "libp2p-dns"
 version = "0.44.0"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=75053056e55752945626169845ed302e3b1158d5#75053056e55752945626169845ed302e3b1158d5"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=95b732e9bebe192808693b6017c0cd6be5e5fcde#95b732e9bebe192808693b6017c0cd6be5e5fcde"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -5398,8 +5394,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-gossipsub"
-version = "0.49.0"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=75053056e55752945626169845ed302e3b1158d5#75053056e55752945626169845ed302e3b1158d5"
+version = "0.50.0"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=95b732e9bebe192808693b6017c0cd6be5e5fcde#95b732e9bebe192808693b6017c0cd6be5e5fcde"
 dependencies = [
  "async-channel",
  "asynchronous-codec",
@@ -5411,13 +5407,14 @@ dependencies = [
  "futures 0.3.31",
  "futures-timer",
  "getrandom 0.2.16",
- "hashlink 0.9.1",
+ "hashlink 0.10.0",
  "hex_fmt",
  "libp2p-core",
  "libp2p-identity",
  "libp2p-swarm",
+ "prometheus-client",
  "quick-protobuf",
- "quick-protobuf-codec 0.3.1 (git+https://github.com/tari-project/rust-libp2p.git?rev=75053056e55752945626169845ed302e3b1158d5)",
+ "quick-protobuf-codec 0.3.1 (git+https://github.com/tari-project/rust-libp2p.git?rev=95b732e9bebe192808693b6017c0cd6be5e5fcde)",
  "rand 0.8.5",
  "regex",
  "sha2",
@@ -5428,7 +5425,7 @@ dependencies = [
 [[package]]
 name = "libp2p-identify"
 version = "0.47.0"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=75053056e55752945626169845ed302e3b1158d5#75053056e55752945626169845ed302e3b1158d5"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=95b732e9bebe192808693b6017c0cd6be5e5fcde#95b732e9bebe192808693b6017c0cd6be5e5fcde"
 dependencies = [
  "asynchronous-codec",
  "either",
@@ -5439,7 +5436,7 @@ dependencies = [
  "libp2p-identity",
  "libp2p-swarm",
  "quick-protobuf",
- "quick-protobuf-codec 0.3.1 (git+https://github.com/tari-project/rust-libp2p.git?rev=75053056e55752945626169845ed302e3b1158d5)",
+ "quick-protobuf-codec 0.3.1 (git+https://github.com/tari-project/rust-libp2p.git?rev=95b732e9bebe192808693b6017c0cd6be5e5fcde)",
  "smallvec 1.15.1",
  "thiserror 2.0.17",
  "tracing",
@@ -5447,8 +5444,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-identity"
-version = "0.2.11"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=75053056e55752945626169845ed302e3b1158d5#75053056e55752945626169845ed302e3b1158d5"
+version = "0.2.13"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=95b732e9bebe192808693b6017c0cd6be5e5fcde#95b732e9bebe192808693b6017c0cd6be5e5fcde"
 dependencies = [
  "bs58 0.5.1",
  "ed25519-dalek",
@@ -5467,7 +5464,7 @@ dependencies = [
 [[package]]
 name = "libp2p-mdns"
 version = "0.48.0"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=75053056e55752945626169845ed302e3b1158d5#75053056e55752945626169845ed302e3b1158d5"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=95b732e9bebe192808693b6017c0cd6be5e5fcde#95b732e9bebe192808693b6017c0cd6be5e5fcde"
 dependencies = [
  "futures 0.3.31",
  "hickory-proto 0.25.2",
@@ -5477,7 +5474,7 @@ dependencies = [
  "libp2p-swarm",
  "rand 0.8.5",
  "smallvec 1.15.1",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "tokio",
  "tracing",
 ]
@@ -5497,8 +5494,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-metrics"
-version = "0.17.0"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=75053056e55752945626169845ed302e3b1158d5#75053056e55752945626169845ed302e3b1158d5"
+version = "0.17.1"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=95b732e9bebe192808693b6017c0cd6be5e5fcde#95b732e9bebe192808693b6017c0cd6be5e5fcde"
 dependencies = [
  "futures 0.3.31",
  "libp2p-core",
@@ -5517,14 +5514,14 @@ dependencies = [
 [[package]]
 name = "libp2p-noise"
 version = "0.46.1"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=75053056e55752945626169845ed302e3b1158d5#75053056e55752945626169845ed302e3b1158d5"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=95b732e9bebe192808693b6017c0cd6be5e5fcde#95b732e9bebe192808693b6017c0cd6be5e5fcde"
 dependencies = [
  "asynchronous-codec",
  "bytes 1.10.1",
  "futures 0.3.31",
  "libp2p-core",
  "libp2p-identity",
- "multiaddr 0.18.1",
+ "multiaddr 0.18.3",
  "multihash 0.19.3",
  "quick-protobuf",
  "rand 0.8.5",
@@ -5539,11 +5536,11 @@ dependencies = [
 [[package]]
 name = "libp2p-peer-store"
 version = "0.1.0"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=75053056e55752945626169845ed302e3b1158d5#75053056e55752945626169845ed302e3b1158d5"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=95b732e9bebe192808693b6017c0cd6be5e5fcde#95b732e9bebe192808693b6017c0cd6be5e5fcde"
 dependencies = [
+ "hashlink 0.10.0",
  "libp2p-core",
  "libp2p-swarm",
- "lru",
 ]
 
 [[package]]
@@ -5566,8 +5563,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-ping"
-version = "0.46.0"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=75053056e55752945626169845ed302e3b1158d5#75053056e55752945626169845ed302e3b1158d5"
+version = "0.47.0"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=95b732e9bebe192808693b6017c0cd6be5e5fcde#95b732e9bebe192808693b6017c0cd6be5e5fcde"
 dependencies = [
  "futures 0.3.31",
  "futures-timer",
@@ -5582,7 +5579,7 @@ dependencies = [
 [[package]]
 name = "libp2p-quic"
 version = "0.13.0"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=75053056e55752945626169845ed302e3b1158d5#75053056e55752945626169845ed302e3b1158d5"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=95b732e9bebe192808693b6017c0cd6be5e5fcde#95b732e9bebe192808693b6017c0cd6be5e5fcde"
 dependencies = [
  "futures 0.3.31",
  "futures-timer",
@@ -5594,7 +5591,7 @@ dependencies = [
  "rand 0.8.5",
  "ring",
  "rustls 0.23.35",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -5602,8 +5599,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-relay"
-version = "0.20.0"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=75053056e55752945626169845ed302e3b1158d5#75053056e55752945626169845ed302e3b1158d5"
+version = "0.21.1"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=95b732e9bebe192808693b6017c0cd6be5e5fcde#95b732e9bebe192808693b6017c0cd6be5e5fcde"
 dependencies = [
  "asynchronous-codec",
  "bytes 1.10.1",
@@ -5615,7 +5612,7 @@ dependencies = [
  "libp2p-identity",
  "libp2p-swarm",
  "quick-protobuf",
- "quick-protobuf-codec 0.3.1 (git+https://github.com/tari-project/rust-libp2p.git?rev=75053056e55752945626169845ed302e3b1158d5)",
+ "quick-protobuf-codec 0.3.1 (git+https://github.com/tari-project/rust-libp2p.git?rev=95b732e9bebe192808693b6017c0cd6be5e5fcde)",
  "rand 0.8.5",
  "static_assertions",
  "thiserror 2.0.17",
@@ -5625,8 +5622,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-rendezvous"
-version = "0.16.1"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=75053056e55752945626169845ed302e3b1158d5#75053056e55752945626169845ed302e3b1158d5"
+version = "0.17.0"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=95b732e9bebe192808693b6017c0cd6be5e5fcde#95b732e9bebe192808693b6017c0cd6be5e5fcde"
 dependencies = [
  "async-trait",
  "asynchronous-codec",
@@ -5638,7 +5635,7 @@ dependencies = [
  "libp2p-request-response",
  "libp2p-swarm",
  "quick-protobuf",
- "quick-protobuf-codec 0.3.1 (git+https://github.com/tari-project/rust-libp2p.git?rev=75053056e55752945626169845ed302e3b1158d5)",
+ "quick-protobuf-codec 0.3.1 (git+https://github.com/tari-project/rust-libp2p.git?rev=95b732e9bebe192808693b6017c0cd6be5e5fcde)",
  "rand 0.8.5",
  "thiserror 2.0.17",
  "tracing",
@@ -5647,8 +5644,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-request-response"
-version = "0.28.1"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=75053056e55752945626169845ed302e3b1158d5#75053056e55752945626169845ed302e3b1158d5"
+version = "0.29.0"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=95b732e9bebe192808693b6017c0cd6be5e5fcde#95b732e9bebe192808693b6017c0cd6be5e5fcde"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -5674,16 +5671,16 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm"
 version = "0.47.0"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=75053056e55752945626169845ed302e3b1158d5#75053056e55752945626169845ed302e3b1158d5"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=95b732e9bebe192808693b6017c0cd6be5e5fcde#95b732e9bebe192808693b6017c0cd6be5e5fcde"
 dependencies = [
  "either",
  "fnv",
  "futures 0.3.31",
  "futures-timer",
+ "hashlink 0.10.0",
  "libp2p-core",
  "libp2p-identity",
  "libp2p-swarm-derive",
- "lru",
  "multistream-select",
  "rand 0.8.5",
  "smallvec 1.15.1",
@@ -5695,7 +5692,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm-derive"
 version = "0.35.1"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=75053056e55752945626169845ed302e3b1158d5#75053056e55752945626169845ed302e3b1158d5"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=95b732e9bebe192808693b6017c0cd6be5e5fcde#95b732e9bebe192808693b6017c0cd6be5e5fcde"
 dependencies = [
  "heck 0.5.0",
  "quote",
@@ -5704,15 +5701,15 @@ dependencies = [
 
 [[package]]
 name = "libp2p-tcp"
-version = "0.43.0"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=75053056e55752945626169845ed302e3b1158d5#75053056e55752945626169845ed302e3b1158d5"
+version = "0.44.1"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=95b732e9bebe192808693b6017c0cd6be5e5fcde#95b732e9bebe192808693b6017c0cd6be5e5fcde"
 dependencies = [
  "futures 0.3.31",
  "futures-timer",
  "if-watch",
  "libc",
  "libp2p-core",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "tokio",
  "tracing",
 ]
@@ -5720,7 +5717,7 @@ dependencies = [
 [[package]]
 name = "libp2p-tls"
 version = "0.6.2"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=75053056e55752945626169845ed302e3b1158d5#75053056e55752945626169845ed302e3b1158d5"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=95b732e9bebe192808693b6017c0cd6be5e5fcde#95b732e9bebe192808693b6017c0cd6be5e5fcde"
 dependencies = [
  "futures 0.3.31",
  "futures-rustls",
@@ -5737,8 +5734,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-upnp"
-version = "0.4.1"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=75053056e55752945626169845ed302e3b1158d5#75053056e55752945626169845ed302e3b1158d5"
+version = "0.6.0"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=95b732e9bebe192808693b6017c0cd6be5e5fcde#95b732e9bebe192808693b6017c0cd6be5e5fcde"
 dependencies = [
  "futures 0.3.31",
  "futures-timer",
@@ -5752,7 +5749,7 @@ dependencies = [
 [[package]]
 name = "libp2p-yamux"
 version = "0.47.0"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=75053056e55752945626169845ed302e3b1158d5#75053056e55752945626169845ed302e3b1158d5"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=95b732e9bebe192808693b6017c0cd6be5e5fcde#95b732e9bebe192808693b6017c0cd6be5e5fcde"
 dependencies = [
  "either",
  "futures 0.3.31",
@@ -5999,15 +5996,6 @@ dependencies = [
  "flate2",
  "regex",
  "thiserror 1.0.69",
-]
-
-[[package]]
-name = "lru"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
-dependencies = [
- "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -6664,11 +6652,12 @@ dependencies = [
 
 [[package]]
 name = "multiaddr"
-version = "0.18.1"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=75053056e55752945626169845ed302e3b1158d5#75053056e55752945626169845ed302e3b1158d5"
+version = "0.18.3"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=95b732e9bebe192808693b6017c0cd6be5e5fcde#95b732e9bebe192808693b6017c0cd6be5e5fcde"
 dependencies = [
  "arrayref",
  "byteorder",
+ "bytes 1.10.1",
  "data-encoding",
  "libp2p-identity",
  "multibase",
@@ -6676,7 +6665,7 @@ dependencies = [
  "percent-encoding",
  "serde",
  "static_assertions",
- "unsigned-varint 0.7.2",
+ "unsigned-varint 0.8.0",
  "url",
 ]
 
@@ -6742,7 +6731,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 [[package]]
 name = "multistream-select"
 version = "0.13.0"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=75053056e55752945626169845ed302e3b1158d5#75053056e55752945626169845ed302e3b1158d5"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=95b732e9bebe192808693b6017c0cd6be5e5fcde#95b732e9bebe192808693b6017c0cd6be5e5fcde"
 dependencies = [
  "bytes 1.10.1",
  "futures 0.3.31",
@@ -6994,7 +6983,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7129,7 +7118,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
 dependencies = [
- "proc-macro-crate 3.4.0",
+ "proc-macro-crate 1.1.3",
  "proc-macro2",
  "quote",
  "syn 2.0.110",
@@ -7585,7 +7574,7 @@ dependencies = [
  "aes-gcm",
  "aes-kw",
  "argon2 0.5.3",
- "base64 0.22.1",
+ "base64 0.21.7",
  "bitfield",
  "block-padding",
  "blowfish",
@@ -7926,9 +7915,9 @@ dependencies = [
 
 [[package]]
 name = "prometheus-client"
-version = "0.23.1"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf41c1a7c32ed72abe5082fb19505b969095c12da9f5732a4bc9878757fd087c"
+checksum = "e4500adecd7af8e0e9f4dbce15cfee07ce913fbf6ad605cc468b83f2d531ee94"
 dependencies = [
  "dtoa",
  "itoa",
@@ -7938,9 +7927,9 @@ dependencies = [
 
 [[package]]
 name = "prometheus-client-derive-encode"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
+checksum = "9adf1691c04c0a5ff46ff8f262b58beb07b0dbb61f96f9f54f6cbd82106ed87f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8231,7 +8220,7 @@ dependencies = [
 [[package]]
 name = "quick-protobuf-codec"
 version = "0.3.1"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=75053056e55752945626169845ed302e3b1158d5#75053056e55752945626169845ed302e3b1158d5"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=95b732e9bebe192808693b6017c0cd6be5e5fcde#95b732e9bebe192808693b6017c0cd6be5e5fcde"
 dependencies = [
  "asynchronous-codec",
  "bytes 1.10.1",
@@ -8302,7 +8291,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.1",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8991,7 +8980,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9154,7 +9143,7 @@ dependencies = [
 [[package]]
 name = "rw-stream-sink"
 version = "0.4.0"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=75053056e55752945626169845ed302e3b1158d5#75053056e55752945626169845ed302e3b1158d5"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=95b732e9bebe192808693b6017c0cd6be5e5fcde#95b732e9bebe192808693b6017c0cd6be5e5fcde"
 dependencies = [
  "futures 0.3.31",
  "pin-project 1.1.10",
@@ -10882,7 +10871,7 @@ dependencies = [
  "bytes 1.10.1",
  "futures 0.3.31",
  "log",
- "multiaddr 0.18.1",
+ "multiaddr 0.18.3",
  "prost 0.14.1",
  "reqwest 0.11.27",
  "serde",
@@ -11043,7 +11032,7 @@ dependencies = [
  "config",
  "libp2p-identity",
  "log",
- "multiaddr 0.18.1",
+ "multiaddr 0.18.3",
  "rand 0.8.5",
  "serde",
  "serde_json5",
@@ -11172,7 +11161,7 @@ dependencies = [
  "base64 0.22.1",
  "clap 3.2.25",
  "log",
- "multiaddr 0.18.1",
+ "multiaddr 0.18.3",
  "reqwest 0.11.27",
  "serde_json",
  "tari_bor",
@@ -11563,6 +11552,7 @@ version = "0.17.0"
 dependencies = [
  "libp2p",
  "libp2p-messaging",
+ "libp2p-peer-store",
  "libp2p-substream",
  "thiserror 2.0.17",
 ]
@@ -11914,7 +11904,7 @@ name = "tari_validator_node_client"
 version = "0.17.0"
 dependencies = [
  "indexmap 2.12.0",
- "multiaddr 0.18.1",
+ "multiaddr 0.18.3",
  "reqwest 0.11.27",
  "serde",
  "serde_json",
@@ -12035,7 +12025,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -13798,7 +13788,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,8 +184,9 @@ indexmap = "2.11.4"
 indoc = "1.0.6"
 lazy_static = "1.4.0"
 # Use Tari's libp2p fork that adds support for Schnorr-Ristretto
-libp2p-identity = { git = "https://github.com/tari-project/rust-libp2p.git", rev = "75053056e55752945626169845ed302e3b1158d5" }
-libp2p = { git = "https://github.com/tari-project/rust-libp2p.git", rev = "75053056e55752945626169845ed302e3b1158d5", version = "0.56.0", default-features = false }
+libp2p-identity = { git = "https://github.com/tari-project/rust-libp2p.git", rev = "95b732e9bebe192808693b6017c0cd6be5e5fcde" }
+libp2p = { git = "https://github.com/tari-project/rust-libp2p.git", rev = "95b732e9bebe192808693b6017c0cd6be5e5fcde", version = "0.56.0", default-features = false }
+libp2p-peer-store = { git = "https://github.com/tari-project/rust-libp2p.git", rev = "95b732e9bebe192808693b6017c0cd6be5e5fcde", version = "0.1.0", default-features = false }
 #libp2p = "0.53.1"
 #libp2p-identity = "0.2.8"
 libsqlite3-sys = "0.30.1"
@@ -193,14 +194,14 @@ log = "0.4.20"
 log4rs = "1.3"
 mime_guess = "2.0.4"
 mini-moka = "0.10.0"
-multiaddr = { git = "https://github.com/tari-project/rust-libp2p.git", rev = "75053056e55752945626169845ed302e3b1158d5" }
+multiaddr = { git = "https://github.com/tari-project/rust-libp2p.git", rev = "95b732e9bebe192808693b6017c0cd6be5e5fcde" }
 #multiaddr = "0.18"
 newtype-ops = "0.1.4"
 num-integer = { version = "0.1.46", default-features = false }
 once_cell = "1.18.0"
 pin-project = "1.1"
 proc-macro2 = "1.0"
-prometheus-client = { version = "0.23", default-features = false }
+prometheus-client = { version = "0.24", default-features = false }
 prost = "0.14"
 prost-build = "0.14"
 prost-types = "0.14"

--- a/applications/tari_indexer/src/rest_api/handlers/transactions.rs
+++ b/applications/tari_indexer/src/rest_api/handlers/transactions.rs
@@ -55,26 +55,30 @@ pub async fn submit_transaction(
         .submit_transaction(transaction)
         .await
         .map_err(|e| match e {
-            TransactionManagerError::NetworkClientError(NetworkClientError::AllValidatorsFailed {
-                last_error: Some(last_err),
-                committee_size,
-            }) => match last_err.status() {
-                Some(status) => match status.as_status_code() {
-                    RpcStatusCode::BadRequest => {
-                        ErrorResponse::bad_request(format!("Bad request: {}", status.details()))
+            TransactionManagerError::NetworkClientError(net_err) => match *net_err {
+                NetworkClientError::AllValidatorsFailed {
+                    last_error: Some(last_err),
+                    committee_size,
+                } => match last_err.status() {
+                    Some(status) => match status.as_status_code() {
+                        RpcStatusCode::BadRequest => {
+                            ErrorResponse::bad_request(format!("Bad request: {}", status.details()))
+                        },
+                        RpcStatusCode::NotFound => ErrorResponse::not_found(format!("Not found: {}", status.details())),
+                        _ => ErrorResponse::general_error(format!(
+                            "Rpc error: ({} members) {}",
+                            committee_size,
+                            status.details()
+                        )),
                     },
-                    RpcStatusCode::NotFound => ErrorResponse::not_found(format!("Not found: {}", status.details())),
-                    _ => ErrorResponse::general_error(format!(
-                        "Rpc error: ({} members) {}",
-                        committee_size,
-                        status.details()
-                    )),
+                    None => {
+                        ErrorResponse::general_error(format!("Rpc error: ({} members) {}", committee_size, last_err))
+                    },
                 },
-                None => ErrorResponse::general_error(format!("Rpc error: ({} members) {}", committee_size, last_err)),
-            },
-            TransactionManagerError::NetworkClientError(NetworkClientError::AllValidatorsFailed { .. }) |
-            TransactionManagerError::NetworkClientError(NetworkClientError::NoCommitteeMembers) => {
-                ErrorResponse::service_unavailable(format!("All validators failed: {}", e))
+                e @ NetworkClientError::AllValidatorsFailed { .. } | e @ NetworkClientError::NoCommitteeMembers => {
+                    ErrorResponse::service_unavailable(format!("All validators failed: {}", e))
+                },
+                e => ErrorResponse::anyhow(e),
             },
             TransactionManagerError::InvalidTransaction {
                 transaction_id,

--- a/applications/tari_indexer/src/transaction_manager/error.rs
+++ b/applications/tari_indexer/src/transaction_manager/error.rs
@@ -16,7 +16,7 @@ pub enum TransactionManagerError {
         details: String,
     },
     #[error(transparent)]
-    NetworkClientError(#[from] NetworkClientError),
+    NetworkClientError(Box<NetworkClientError>),
     #[error("{entity} not found: {key}")]
     NotFound { entity: &'static str, key: String },
     #[error(transparent)]
@@ -30,5 +30,11 @@ pub enum TransactionManagerError {
 impl IsNotFoundError for TransactionManagerError {
     fn is_not_found_error(&self) -> bool {
         matches!(self, Self::NotFound { .. })
+    }
+}
+
+impl From<NetworkClientError> for TransactionManagerError {
+    fn from(err: NetworkClientError) -> Self {
+        Self::NetworkClientError(Box::new(err))
     }
 }

--- a/crates/validator_node_rpc/src/error.rs
+++ b/crates/validator_node_rpc/src/error.rs
@@ -3,13 +3,11 @@
 
 use tari_bor::BorError;
 use tari_networking::NetworkingError;
-use tari_ootle_common_types::{optional::IsNotFoundError, PeerAddress};
+use tari_ootle_common_types::optional::IsNotFoundError;
 use tari_rpc_framework::{RpcError, RpcStatus};
 
 #[derive(Debug, thiserror::Error)]
 pub enum ValidatorNodeRpcClientError {
-    #[error("Protocol violations for peer {peer}: {details}")]
-    ProtocolViolation { peer: PeerAddress, details: String },
     #[error("NetworkingError: {0}")]
     NetworkingError(#[from] NetworkingError),
     #[error("RpcError: {0}")]

--- a/networking/swarm/Cargo.toml
+++ b/networking/swarm/Cargo.toml
@@ -10,8 +10,9 @@ license.workspace = true
 metrics = ["libp2p/metrics", "libp2p-substream/metrics", "libp2p-messaging/metrics"]
 
 [dependencies]
-libp2p = { workspace = true, features = ["tokio", "noise", "macros", "ping", "tcp", "identify", "yamux", "relay", "quic", "dcutr", "gossipsub", "mdns", "autonat", "rendezvous", "peer-store"] }
+libp2p = { workspace = true, features = ["tokio", "noise", "macros", "ping", "tcp", "identify", "yamux", "relay", "quic", "dcutr", "gossipsub", "mdns", "autonat", "rendezvous"] }
 libp2p-messaging = { workspace = true, features = ["prost"] }
 libp2p-substream = { workspace = true }
+libp2p-peer-store = { workspace = true }
 
 thiserror = { workspace = true }

--- a/networking/swarm/src/behaviour.rs
+++ b/networking/swarm/src/behaviour.rs
@@ -16,8 +16,6 @@ use libp2p::{
     identity::Keypair,
     mdns,
     noise,
-    peer_store,
-    peer_store::memory_store::MemoryStore,
     ping,
     relay,
     rendezvous,
@@ -29,6 +27,8 @@ use libp2p::{
     SwarmBuilder,
 };
 use libp2p_messaging as messaging;
+use libp2p_peer_store as peer_store;
+use libp2p_peer_store::memory_store::MemoryStore;
 use libp2p_substream as substream;
 
 use crate::{


### PR DESCRIPTION
Description
---
chore: update libp2p

Motivation and Context
---
Fixes https://github.com/tari-project/tari-ootle/issues/1713

How Has This Been Tested?
---
Manually, existing tests 

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify