### PR TITLE
fix(network/rpc): remove connection close handling in RPC

### DIFF
--- a/networking/rpc_framework/src/client/mod.rs
+++ b/networking/rpc_framework/src/client/mod.rs
@@ -752,8 +752,7 @@ where TSubstream: AsyncRead + AsyncWrite + Unpin + Send
             match Self::convert_to_result(resp) {
                 Ok(Ok(resp)) => {
                     let is_finished = resp.is_finished();
-                    // The consumer may drop the receiver before all responses are received.
-                    // We handle this by sending a 'FIN' message to the server.
+                    // If the consumer drops the receiver, we can stop sending responses.
                     if response_tx.is_closed() {
                         // We have timed out on the response but since we've closed, we just exit
                         break;

--- a/networking/rpc_framework/src/client/mod.rs
+++ b/networking/rpc_framework/src/client/mod.rs
@@ -132,7 +132,7 @@ impl RpcClient {
     pub async fn request_response<T, R, M>(&mut self, request: T, method: M) -> Result<R, RpcError>
     where
         T: prost::Message,
-        R: prost::Message + Default + std::fmt::Debug,
+        R: prost::Message + Default + fmt::Debug,
         M: Into<RpcMethod>,
     {
         let req_bytes = request.encode_to_vec();
@@ -695,7 +695,8 @@ where TSubstream: AsyncRead + AsyncWrite + Unpin + Send
             let resp_result = match resp_result {
                 Some(r) => r,
                 None => {
-                    self.premature_close(request_id, method).await?;
+                    // The consumer has dropped the receiver before all responses are received.
+                    // Closing
                     break;
                 },
             };
@@ -723,12 +724,13 @@ where TSubstream: AsyncRead + AsyncWrite + Unpin + Send
                 Err(RpcError::ReplyTimeout) => {
                     debug!(
                         target: LOG_TARGET,
-                        "Request {} (method={}) timed out", request_id, method,
+                        "Request {} (method={}) timed out (resp_closed={})", request_id, method, response_tx.is_closed()
                     );
                     #[cfg(feature = "metrics")]
                     metrics::client_timeouts(&self.peer_id, &self.protocol_id).inc();
                     if response_tx.is_closed() {
-                        self.premature_close(request_id, method).await?;
+                        // The consumer has dropped the receiver before all responses are received.
+                        // We have timed out on the response but since we've closed, we just exit
                     } else {
                         let _result = response_tx.send(Err(RpcStatus::timed_out("Response timed out"))).await;
                     }
@@ -753,7 +755,7 @@ where TSubstream: AsyncRead + AsyncWrite + Unpin + Send
                     // The consumer may drop the receiver before all responses are received.
                     // We handle this by sending a 'FIN' message to the server.
                     if response_tx.is_closed() {
-                        self.premature_close(request_id, method).await?;
+                        // We have timed out on the response but since we've closed, we just exit
                         break;
                     } else {
                         let _result = response_tx.send(Ok(resp)).await;
@@ -784,29 +786,6 @@ where TSubstream: AsyncRead + AsyncWrite + Unpin + Send
             }
         }
 
-        Ok(())
-    }
-
-    async fn premature_close(&mut self, request_id: u16, method: u32) -> Result<(), RpcError> {
-        warn!(
-            target: LOG_TARGET,
-            "(peer={}) Response receiver was dropped before the response/stream could complete for protocol {}, \
-             interrupting the stream. ",
-            self.peer_id,
-            self.protocol_name()
-        );
-        let req = proto::RpcRequest {
-            request_id: u32::from(request_id),
-            method,
-            flags: RpcMessageFlags::FIN.bits().into(),
-            deadline: self.config.deadline.map(|d| d.as_secs()).unwrap_or(0),
-            ..Default::default()
-        };
-
-        // If we cannot set FIN quickly, just exit
-        if let Ok(res) = time::timeout(Duration::from_secs(2), self.send_request(req)).await {
-            res?;
-        }
         Ok(())
     }
 

--- a/networking/rpc_framework/src/server/mod.rs
+++ b/networking/rpc_framework/src/server/mod.rs
@@ -43,14 +43,12 @@ use std::{
     future::Future,
     io,
     io::ErrorKind,
-    pin::Pin,
     sync::Arc,
-    task::Poll,
     time::{Duration, Instant},
 };
 
 use bytes::Bytes;
-use futures::{future, stream::FuturesUnordered, SinkExt, Stream, StreamExt};
+use futures::{stream::FuturesUnordered, SinkExt, StreamExt};
 use libp2p::{PeerId, StreamProtocol};
 use libp2p_substream::{ProtocolEvent, ProtocolNotification};
 use log::*;
@@ -726,47 +724,29 @@ where TSvc: Service<Request<Bytes>, Response = Response<Body>, Error = RpcStatus
                 self.logging_context_string.clone(),
                 request_id,
                 "message read",
-                stream.next(),
+                time::timeout(deadline, stream.next()),
             );
-            let timeout = time::sleep(deadline);
 
-            tokio::select! {
-                // Check if the client interrupted the outgoing stream
-                Err(err) = self.check_interruptions() => {
-                    match err {
-                        err @ RpcServerError::ClientInterruptedStream => {
-                            debug!(target: LOG_TARGET, "Stream was interrupted by client: {}", err);
-                            break;
-                        },
-                        err => {
-                            error!(target: LOG_TARGET, "Stream was interrupted: {}", err);
-                            return Err(err);
-                        },
-                    }
+            let result = next_item.await;
+            match result {
+                Ok(Some(msg)) => {
+                    #[cfg(feature = "metrics")]
+                    metrics::outbound_response_bytes(&self.peer_id, &self.protocol).observe(msg.len() as f64);
+                    debug!(
+                        target: LOG_TARGET,
+                        "({}) Sending body len = {}",
+                        self.logging_context_string,
+                        msg.len()
+                    );
+
+                    self.framed.send(msg).await?;
                 },
-                msg = next_item => {
-                     match msg {
-                         Some(msg) => {
-                            #[cfg(feature = "metrics")]
-                            metrics::outbound_response_bytes(&self.peer_id, &self.protocol).observe(msg.len() as f64);
-                            debug!(
-                                target: LOG_TARGET,
-                                "({}) Sending body len = {}",
-                                self.logging_context_string,
-                                msg.len()
-                            );
-
-                            self.framed.send(msg).await?;
-                        },
-                        None => {
-                            debug!(target: LOG_TARGET, "{} Request complete", self.logging_context_string,);
-                            break;
-                        },
-                    }
+                Ok(None) => {
+                    debug!(target: LOG_TARGET, "{} Request complete", self.logging_context_string,);
+                    break;
                 },
-
-                _ = timeout => {
-                     debug!(
+                Err(_) => {
+                    debug!(
                         target: LOG_TARGET,
                         "({}) Failed to return result within client deadline ({:.0?})",
                         self.logging_context_string,
@@ -781,64 +761,10 @@ where TSvc: Service<Request<Bytes>, Response = Response<Body>, Error = RpcStatus
                     )
                     .inc();
                     break;
-                }
-            } // end select!
+                },
+            }
         } // end loop
         Ok(())
-    }
-
-    async fn check_interruptions(&mut self) -> Result<(), RpcServerError> {
-        let check = future::poll_fn(|cx| match Pin::new(&mut self.framed).poll_next(cx) {
-            Poll::Ready(Some(Ok(mut msg))) => {
-                let decoded_msg = match proto::RpcRequest::decode(&mut msg) {
-                    Ok(msg) => msg,
-                    Err(err) => {
-                        error!(target: LOG_TARGET, "Client send MALFORMED response: {}", err);
-                        return Poll::Ready(Some(RpcServerError::UnexpectedIncomingMessageMalformed));
-                    },
-                };
-                let u8_bits = match u8::try_from(decoded_msg.flags) {
-                    Ok(bits) => bits,
-                    Err(err) => {
-                        error!(target: LOG_TARGET, "Client send MALFORMED flags: {}", err);
-                        return Poll::Ready(Some(RpcServerError::ProtocolError(format!(
-                            "invalid message flag: must be less than {}",
-                            u8::MAX
-                        ))));
-                    },
-                };
-
-                let msg_flags = match RpcMessageFlags::from_bits(u8_bits) {
-                    Some(flags) => flags,
-                    None => {
-                        error!(target: LOG_TARGET, "Client send MALFORMED flags: {}", u8_bits);
-                        return Poll::Ready(Some(RpcServerError::ProtocolError(format!(
-                            "invalid message flag, does not match any flags ({})",
-                            u8_bits
-                        ))));
-                    },
-                };
-                if msg_flags.is_fin() {
-                    Poll::Ready(Some(RpcServerError::ClientInterruptedStream))
-                } else {
-                    Poll::Ready(Some(RpcServerError::UnexpectedIncomingMessage(format!(
-                        "flags={:?}, method={}, req_id={}",
-                        decoded_msg.flags(),
-                        decoded_msg.method,
-                        decoded_msg.request_id
-                    ))))
-                }
-            },
-            Poll::Ready(Some(Err(err))) if err.kind() == io::ErrorKind::WouldBlock => Poll::Ready(None),
-            Poll::Ready(Some(Err(err))) => Poll::Ready(Some(RpcServerError::from(err))),
-            Poll::Ready(None) => Poll::Ready(Some(RpcServerError::StreamClosedByRemote)),
-            Poll::Pending => Poll::Ready(None),
-        })
-        .await;
-        match check {
-            Some(err) => Err(err),
-            None => Ok(()),
-        }
     }
 }
 


### PR DESCRIPTION
Description
---
fix(network/rpc): remove connection close handling in RPC

Motivation and Context
---
RPC was designed to deal with substreams which fail to detect when a connection is dropped while streaming. libp2p handles this in their substreams, meaning that this extra logic is unnecessary. This logic also could lead to request messages being dropped instead of queued up when a substream is reused in a pool.

How Has This Been Tested?
---
Manually


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify