### PR TITLE
fix(engine): generic state reader

### DIFF
--- a/applications/tari_indexer/src/dry_run/processor.rs
+++ b/applications/tari_indexer/src/dry_run/processor.rs
@@ -86,7 +86,7 @@ impl DryRunTransactionProcessor {
         let found_substates = self.fetch_input_substates(&transaction).await?;
         let package = self.construct_template_package(&transaction, &found_substates).await?;
 
-        let virtual_substates = self.get_virtual_substates(&transaction, epoch).await?;
+        let virtual_substates = self.get_virtual_substates(&transaction, epoch);
 
         let mut state_store = new_memory_store();
         state_store.set_many(found_substates)?;
@@ -141,18 +141,10 @@ impl DryRunTransactionProcessor {
         Ok(susbtates)
     }
 
-    async fn get_virtual_substates(
-        &self,
-        _transaction: &Transaction,
-        epoch: Epoch,
-    ) -> Result<VirtualSubstates, DryRunTransactionProcessorError> {
-        let mut virtual_substates = VirtualSubstates::new();
-
-        virtual_substates.insert(
+    fn get_virtual_substates(&self, _transaction: &Transaction, epoch: Epoch) -> VirtualSubstates {
+        VirtualSubstates::from_iter([(
             VirtualSubstateId::CurrentEpoch,
             VirtualSubstate::CurrentEpoch(epoch.as_u64()),
-        );
-
-        Ok(virtual_substates)
+        )])
     }
 }

--- a/applications/tari_ootle_app_utilities/src/transaction_executor.rs
+++ b/applications/tari_ootle_app_utilities/src/transaction_executor.rs
@@ -7,7 +7,7 @@ use tari_engine::{
     executables::Executable,
     fees::{FeeModule, FeeTable},
     runtime::{AuthParams, RuntimeModule},
-    state_store::{memory::ReadOnlyMemoryStateStore, StateStoreError},
+    state_store::{StateReader, StateStoreError},
     template::LoadedTemplate,
     traits::ClaimProofVerifier,
     transaction::{ModulesCollection, TransactionError, TransactionProcessor},
@@ -25,13 +25,13 @@ use tari_template_lib::prelude::NonFungibleAddress;
 
 const _LOG_TARGET: &str = "tari::ootle::transaction_executor";
 
-pub trait TransactionExecutor {
+pub trait TransactionExecutor<TStore> {
     type Error: std::error::Error + Send + Sync + 'static;
 
     fn execute(
         &self,
         transaction: &Transaction,
-        state_store: ReadOnlyMemoryStateStore,
+        state_store: TStore,
         virtual_substates: VirtualSubstates,
     ) -> Result<ExecutionOutput, Self::Error>;
 }
@@ -83,19 +83,19 @@ impl ExecutionOutput {
 }
 
 #[derive(Clone)]
-pub struct TariTransactionProcessor<TTemplateProvider> {
+pub struct TariTransactionProcessor<TStore, TTemplateProvider> {
     template_provider: Arc<TTemplateProvider>,
-    modules: ModulesCollection,
+    modules: ModulesCollection<TStore>,
     claim_burn_proof_verifier: Arc<dyn ClaimProofVerifier + Send + Sync + 'static>,
 }
 
-impl<TTemplateProvider> TariTransactionProcessor<TTemplateProvider> {
+impl<TStore: StateReader + 'static, TTemplateProvider> TariTransactionProcessor<TStore, TTemplateProvider> {
     pub fn new(
         template_provider: TTemplateProvider,
         fee_table: FeeTable,
         claim_burn_proof_verifier: Arc<dyn ClaimProofVerifier + Send + Sync + 'static>,
     ) -> Self {
-        let modules = vec![Box::new(FeeModule::new(0, fee_table)) as Box<dyn RuntimeModule>];
+        let modules = vec![Box::new(FeeModule::new(0, fee_table)) as Box<dyn RuntimeModule<TStore>>];
         Self {
             template_provider: Arc::new(template_provider),
             modules: Arc::from(modules),
@@ -104,7 +104,8 @@ impl<TTemplateProvider> TariTransactionProcessor<TTemplateProvider> {
     }
 }
 
-impl<TTemplateProvider> TransactionExecutor for TariTransactionProcessor<TTemplateProvider>
+impl<TStore: StateReader + Clone + 'static, TTemplateProvider> TransactionExecutor<TStore>
+    for TariTransactionProcessor<TStore, TTemplateProvider>
 where TTemplateProvider: TemplateProvider<Template = LoadedTemplate>
 {
     type Error = TransactionProcessorError;
@@ -112,7 +113,7 @@ where TTemplateProvider: TemplateProvider<Template = LoadedTemplate>
     fn execute(
         &self,
         transaction: &Transaction,
-        state_store: ReadOnlyMemoryStateStore,
+        state_store: TStore,
         virtual_substates: VirtualSubstates,
     ) -> Result<ExecutionOutput, Self::Error> {
         // Include signature public key badges for all transaction signers in the initial auth scope

--- a/applications/tari_validator_node/src/consensus/block_transaction_executor.rs
+++ b/applications/tari_validator_node/src/consensus/block_transaction_executor.rs
@@ -5,7 +5,11 @@ use std::{collections::HashMap, sync::Arc};
 
 use log::info;
 use tari_consensus::traits::{BlockTransactionExecutor, BlockTransactionExecutorError};
-use tari_engine::state_store::{memory::MemoryStateStore, new_memory_store, StateWriter};
+use tari_engine::state_store::{
+    memory::{MemoryStateStore, ReadOnlyMemoryStateStore},
+    new_memory_store,
+    StateWriter,
+};
 use tari_engine_types::{
     substate::Substate,
     virtual_substate::{VirtualSubstate, VirtualSubstateId, VirtualSubstates},
@@ -28,7 +32,9 @@ pub struct TarBlockTransactionExecutor<TExecutor, TValidator> {
     validator: Arc<TValidator>,
 }
 
-impl<TExecutor: TransactionExecutor, TValidator> TarBlockTransactionExecutor<TExecutor, TValidator> {
+impl<TExecutor: TransactionExecutor<ReadOnlyMemoryStateStore>, TValidator>
+    TarBlockTransactionExecutor<TExecutor, TValidator>
+{
     pub fn new(executor: TExecutor, validator: TValidator) -> Self {
         Self {
             executor,
@@ -54,7 +60,7 @@ impl<TExecutor, TStateStore, TValidator> BlockTransactionExecutor<TStateStore>
     for TarBlockTransactionExecutor<TExecutor, TValidator>
 where
     TStateStore: StateStore,
-    TExecutor: TransactionExecutor,
+    TExecutor: TransactionExecutor<ReadOnlyMemoryStateStore>,
     for<'a> TValidator: Validator<Transaction, Context = ValidationContext, Error = TransactionValidationError>,
 {
     fn validate(
@@ -83,11 +89,10 @@ where
         let mut state_db = new_memory_store();
         Self::add_substates_to_memory_db(resolved_inputs, &mut state_db)?;
 
-        let mut virtual_substates = VirtualSubstates::new();
-        virtual_substates.insert(
+        let virtual_substates = VirtualSubstates::from_iter([(
             VirtualSubstateId::CurrentEpoch,
             VirtualSubstate::CurrentEpoch(current_epoch.as_u64()),
-        );
+        )]);
 
         // Execute the transaction and get the result
         let exec_output = self

--- a/applications/tari_validator_node/src/consensus/mod.rs
+++ b/applications/tari_validator_node/src/consensus/mod.rs
@@ -8,7 +8,6 @@ use tari_consensus::{
     traits::ConsensusSpec,
 };
 use tari_epoch_manager::service::EpochManagerHandle;
-use tari_ootle_app_utilities::transaction_executor::TariTransactionProcessor;
 use tari_ootle_common_types::{Network, PeerAddress};
 use tari_ootle_storage::consensus_models::TransactionPool;
 use tari_ootle_transaction::Transaction;
@@ -44,9 +43,8 @@ use tari_template_lib::prelude::RistrettoPublicKeyBytes;
 
 use crate::{
     config::ConsensusConfig,
-    consensus::spec::ValidatorNodeStateStore,
+    consensus::spec::{ValidatorNodeStateStore, ValidatorTransactionProcessor},
     p2p::NopLogger,
-    state_store_template_provider::StateStoreTemplateProvider,
 };
 
 pub type ConsensusTransactionValidator = BoxedValidator<ValidationContext, Transaction, TransactionValidationError>;
@@ -64,10 +62,7 @@ pub async fn spawn(
     client_factory: TariValidatorNodeRpcClientFactory,
     hooks: <TariConsensusSpec as ConsensusSpec>::Hooks,
     shutdown_signal: ShutdownSignal,
-    transaction_executor: TarBlockTransactionExecutor<
-        TariTransactionProcessor<StateStoreTemplateProvider<ValidatorNodeStateStore>>,
-        ConsensusTransactionValidator,
-    >,
+    transaction_executor: TarBlockTransactionExecutor<ValidatorTransactionProcessor, ConsensusTransactionValidator>,
     tx_hotstuff_events: broadcast::Sender<HotstuffEvent>,
     consensus_constants: ConsensusConstants,
 ) -> (JoinHandle<Result<(), anyhow::Error>>, ConsensusHandle) {

--- a/applications/tari_validator_node/src/consensus/spec.rs
+++ b/applications/tari_validator_node/src/consensus/spec.rs
@@ -4,6 +4,7 @@
 #[cfg(not(feature = "metrics"))]
 use tari_consensus::traits::hooks::NoopHooks;
 use tari_consensus::traits::ConsensusSpec;
+use tari_engine::state_store::memory::ReadOnlyMemoryStateStore;
 use tari_epoch_manager::service::EpochManagerHandle;
 use tari_ootle_app_utilities::transaction_executor::TariTransactionProcessor;
 use tari_ootle_common_types::PeerAddress;
@@ -26,7 +27,8 @@ use crate::{
 };
 
 pub type ValidatorNodeStateStore = tari_state_store_rocksdb::RocksDbStateStore<PeerAddress>;
-pub type ValidatorTransactionProcessor = TariTransactionProcessor<StateStoreTemplateProvider<ValidatorNodeStateStore>>;
+pub type ValidatorTransactionProcessor =
+    TariTransactionProcessor<ReadOnlyMemoryStateStore, StateStoreTemplateProvider<ValidatorNodeStateStore>>;
 #[derive(Clone)]
 pub struct TariConsensusSpec;
 

--- a/crates/consensus_tests/src/support/transaction_executor.rs
+++ b/crates/consensus_tests/src/support/transaction_executor.rs
@@ -9,10 +9,7 @@ use std::{
 
 use tari_consensus::traits::{BlockTransactionExecutor, BlockTransactionExecutorError};
 use tari_engine::state_store::{memory::MemoryStateStore, new_memory_store, StateWriter};
-use tari_engine_types::{
-    substate::{Substate, SubstateId},
-    virtual_substate::{VirtualSubstate, VirtualSubstateId, VirtualSubstates},
-};
+use tari_engine_types::substate::{Substate, SubstateId};
 use tari_ootle_common_types::{
     displayable::Displayable,
     Epoch,
@@ -97,12 +94,6 @@ impl<TStateStore: StateStore> BlockTransactionExecutor<TStateStore> for TestBloc
         // Create a memory db with all the input substates, needed for the transaction execution
         let mut state_db = new_memory_store();
         Self::add_substates_to_memory_db(resolved_inputs, &mut state_db)?;
-
-        let mut virtual_substates = VirtualSubstates::new();
-        virtual_substates.insert(
-            VirtualSubstateId::CurrentEpoch,
-            VirtualSubstate::CurrentEpoch(current_epoch.as_u64()),
-        );
 
         let spec = self.store.get(&id).unwrap_or_else(|| {
             panic!(

--- a/crates/engine/src/fees/fee_module.rs
+++ b/crates/engine/src/fees/fee_module.rs
@@ -5,7 +5,10 @@ use tari_bor::{encode_into_writer, ByteCounter};
 use tari_engine_types::fees::FeeSource;
 
 use super::FeeTable;
-use crate::runtime::{RuntimeEvent, RuntimeModule, RuntimeModuleError, StateTracker};
+use crate::{
+    runtime::{RuntimeEvent, RuntimeModule, RuntimeModuleError, StateTracker},
+    state_store::StateReader,
+};
 
 pub struct FeeModule {
     initial_cost: u64,
@@ -21,8 +24,8 @@ impl FeeModule {
     }
 }
 
-impl RuntimeModule for FeeModule {
-    fn on_initialize(&self, track: &mut StateTracker) -> Result<(), RuntimeModuleError> {
+impl<TStore: StateReader> RuntimeModule<TStore> for FeeModule {
+    fn on_initialize(&self, track: &mut StateTracker<TStore>) -> Result<(), RuntimeModuleError> {
         track.add_fee_charge(FeeSource::Initial, self.initial_cost);
         let transaction_weight = track.get_transaction_weight();
         let transaction_weight_cost = transaction_weight.as_u64() * self.fee_table.per_transaction_weight_cost();
@@ -31,12 +34,16 @@ impl RuntimeModule for FeeModule {
         Ok(())
     }
 
-    fn on_runtime_call(&self, track: &mut StateTracker, _call: &'static str) -> Result<(), RuntimeModuleError> {
+    fn on_runtime_call(&self, track: &mut StateTracker<TStore>, _call: &'static str) -> Result<(), RuntimeModuleError> {
         track.add_fee_charge(FeeSource::RuntimeCall, self.fee_table.per_module_call_cost());
         Ok(())
     }
 
-    fn on_template_loaded(&self, track: &mut StateTracker, bytes_loaded: usize) -> Result<(), RuntimeModuleError> {
+    fn on_template_loaded(
+        &self,
+        track: &mut StateTracker<TStore>,
+        bytes_loaded: usize,
+    ) -> Result<(), RuntimeModuleError> {
         const TEMPLATE_BYTES_LOADED_COST_DIVISOR: u64 = 3000; // 3 KB = 1 cost unit
         let template_load_cost_unit =
             u64::try_from(bytes_loaded).unwrap_or(u64::MAX) / TEMPLATE_BYTES_LOADED_COST_DIVISOR;
@@ -51,7 +58,7 @@ impl RuntimeModule for FeeModule {
         Ok(())
     }
 
-    fn on_before_finalize(&self, track: &mut StateTracker) -> Result<(), RuntimeModuleError> {
+    fn on_before_finalize(&self, track: &mut StateTracker<TStore>) -> Result<(), RuntimeModuleError> {
         let total_storage = track.with_substates_to_persist(|changes| {
             let mut counter = ByteCounter::new();
             for substate in changes.values() {
@@ -83,7 +90,11 @@ impl RuntimeModule for FeeModule {
         Ok(())
     }
 
-    fn on_runtime_event(&self, track: &mut StateTracker, call: &RuntimeEvent) -> Result<(), RuntimeModuleError> {
+    fn on_runtime_event(
+        &self,
+        track: &mut StateTracker<TStore>,
+        call: &RuntimeEvent,
+    ) -> Result<(), RuntimeModuleError> {
         match call {
             RuntimeEvent::SignatureVerified => {
                 track.add_fee_charge(

--- a/crates/engine/src/runtime/impl.rs
+++ b/crates/engine/src/runtime/impl.rs
@@ -142,6 +142,7 @@ use crate::{
         RuntimeError,
         RuntimeInterface,
     },
+    state_store::StateReader,
     template::LoadedTemplate,
     traits::ClaimProofVerifier,
     transaction::{ModulesCollection, TransactionProcessor},
@@ -149,25 +150,27 @@ use crate::{
 
 const LOG_TARGET: &str = "tari::ootle::engine::runtime::impl";
 
-pub struct RuntimeInterfaceImpl<TTemplateProvider> {
-    tracker: StateTracker,
+pub struct RuntimeInterfaceImpl<TStore, TTemplateProvider> {
+    tracker: StateTracker<TStore>,
     template_provider: Arc<TTemplateProvider>,
     entity_id_provider: EntityIdProvider,
     seal_signer_public_key: RistrettoPublicKeyBytes,
-    modules: ModulesCollection,
+    modules: ModulesCollection<TStore>,
     claim_burn_proof_verifier: Arc<dyn ClaimProofVerifier + Send + Sync + 'static>,
     /// A pointer to the runtime that is set after initialization to allow for cross-template calls.
     /// This is using an atomic pointer simply to make RuntimeInterfaceImpl Send + Sync to satisfy wasmer trait bounds.
     runtime_pointer: Option<AtomicPtr<Box<dyn RuntimeInterface>>>,
 }
 
-impl<TTemplateProvider: TemplateProvider<Template = LoadedTemplate>> RuntimeInterfaceImpl<TTemplateProvider> {
+impl<TStore: StateReader + Clone + 'static, TTemplateProvider: TemplateProvider<Template = LoadedTemplate>>
+    RuntimeInterfaceImpl<TStore, TTemplateProvider>
+{
     pub fn initialize(
-        tracker: StateTracker,
+        tracker: StateTracker<TStore>,
         template_provider: Arc<TTemplateProvider>,
         signer_public_key: RistrettoPublicKeyBytes,
         entity_id_provider: EntityIdProvider,
-        modules: ModulesCollection,
+        modules: ModulesCollection<TStore>,
         claim_burn_proof_verifier: Arc<dyn ClaimProofVerifier + Send + Sync + 'static>,
     ) -> Result<Self, RuntimeError> {
         let mut runtime = Self {
@@ -256,7 +259,7 @@ impl<TTemplateProvider: TemplateProvider<Template = LoadedTemplate>> RuntimeInte
         action: &str,
         substate_id: T,
         payload: Metadata,
-        state_mut: &mut WorkingState,
+        state_mut: &mut WorkingState<TStore>,
     ) -> Result<(), RuntimeError> {
         let (&template_address, _) = state_mut.current_template()?;
         let event = Event::std(Some(substate_id.into()), template_address, object_name, action, payload);
@@ -340,7 +343,7 @@ impl<TTemplateProvider: TemplateProvider<Template = LoadedTemplate>> RuntimeInte
     ) -> Result<InstructionResult, RuntimeError> {
         let mut call_runtime = self.get_call_runtime();
 
-        TransactionProcessor::call_method(
+        TransactionProcessor::<TStore, _>::call_method(
             &*self.template_provider,
             &mut call_runtime,
             component_address.into(),
@@ -362,7 +365,7 @@ impl<TTemplateProvider: TemplateProvider<Template = LoadedTemplate>> RuntimeInte
     ) -> Result<InstructionResult, RuntimeError> {
         let mut call_runtime = self.get_call_runtime();
 
-        TransactionProcessor::call_function(
+        TransactionProcessor::<TStore, _>::call_function(
             &*self.template_provider,
             &mut call_runtime,
             template_address,
@@ -436,8 +439,10 @@ impl<TTemplateProvider: TemplateProvider<Template = LoadedTemplate>> RuntimeInte
     }
 }
 
-impl<TTemplateProvider: TemplateProvider<Template = LoadedTemplate>> RuntimeInterface
-    for RuntimeInterfaceImpl<TTemplateProvider>
+impl<TStore, TTemplateProvider> RuntimeInterface for RuntimeInterfaceImpl<TStore, TTemplateProvider>
+where
+    TStore: StateReader + Clone + 'static,
+    TTemplateProvider: TemplateProvider<Template = LoadedTemplate>,
 {
     fn next_entity_id(&self) -> Result<EntityId, RuntimeError> {
         let id = self.entity_id_provider.next_entity_id()?;

--- a/crates/engine/src/runtime/mod.rs
+++ b/crates/engine/src/runtime/mod.rs
@@ -105,7 +105,7 @@ pub use tracker::StateTracker;
 
 use crate::runtime::{locking::LockedSubstate, scope::PushCallFrame};
 
-pub trait RuntimeInterface: Send + Sync {
+pub trait RuntimeInterface {
     fn next_entity_id(&self) -> Result<EntityId, RuntimeError>;
     fn emit_event(&mut self, topic: String, payload: Metadata) -> Result<(), RuntimeError>;
 

--- a/crates/engine/src/runtime/module.rs
+++ b/crates/engine/src/runtime/module.rs
@@ -3,24 +3,36 @@
 
 use crate::runtime::StateTracker;
 
-pub trait RuntimeModule: Send + Sync {
-    fn on_initialize(&self, _track: &mut StateTracker) -> Result<(), RuntimeModuleError> {
+pub trait RuntimeModule<TStore>: Send + Sync {
+    fn on_initialize(&self, _track: &mut StateTracker<TStore>) -> Result<(), RuntimeModuleError> {
         Ok(())
     }
 
-    fn on_runtime_call(&self, _track: &mut StateTracker, _call: &'static str) -> Result<(), RuntimeModuleError> {
+    fn on_runtime_call(
+        &self,
+        _track: &mut StateTracker<TStore>,
+        _call: &'static str,
+    ) -> Result<(), RuntimeModuleError> {
         Ok(())
     }
 
-    fn on_template_loaded(&self, _track: &mut StateTracker, _bytes_loaded: usize) -> Result<(), RuntimeModuleError> {
+    fn on_template_loaded(
+        &self,
+        _track: &mut StateTracker<TStore>,
+        _bytes_loaded: usize,
+    ) -> Result<(), RuntimeModuleError> {
         Ok(())
     }
 
-    fn on_before_finalize(&self, _track: &mut StateTracker) -> Result<(), RuntimeModuleError> {
+    fn on_before_finalize(&self, _track: &mut StateTracker<TStore>) -> Result<(), RuntimeModuleError> {
         Ok(())
     }
 
-    fn on_runtime_event(&self, _track: &mut StateTracker, _call: &RuntimeEvent) -> Result<(), RuntimeModuleError> {
+    fn on_runtime_event(
+        &self,
+        _track: &mut StateTracker<TStore>,
+        _call: &RuntimeEvent,
+    ) -> Result<(), RuntimeModuleError> {
         Ok(())
     }
 }

--- a/crates/engine/src/runtime/state_store.rs
+++ b/crates/engine/src/runtime/state_store.rs
@@ -19,11 +19,11 @@ use crate::{
         locking::{LockError, LockedSubstates},
         RuntimeError,
     },
-    state_store::{memory::ReadOnlyMemoryStateStore, StateReader},
+    state_store::StateReader,
 };
 
 #[derive(Debug, Clone)]
-pub struct WorkingStateStore {
+pub struct WorkingStateStore<TStore> {
     // This must be ordered deterministically since we use this to create the substate diff
     /// New and mutates substates are placed into this map.
     new_substates: IndexMap<SubstateId, SubstateValue>,
@@ -35,11 +35,11 @@ pub struct WorkingStateStore {
 
     downed_utxos: IndexSet<UtxoAddress>,
     /// The underlying state store that is used to load substates that are not in the working state maps.
-    state_store: ReadOnlyMemoryStateStore,
+    state_store: TStore,
 }
 
-impl WorkingStateStore {
-    pub fn new(state_store: ReadOnlyMemoryStateStore) -> Self {
+impl<TStore: StateReader> WorkingStateStore<TStore> {
+    pub fn new(state_store: TStore) -> Self {
         Self {
             new_substates: IndexMap::new(),
             loaded_substates: HashMap::new(),
@@ -82,19 +82,19 @@ impl WorkingStateStore {
     ) -> Result<Option<R>, RuntimeError> {
         let lock = self.locked_substates.get(lock_id, LockFlag::Write)?;
         if let Some(mut substate) = self.loaded_substates.remove(lock.substate_id()) {
-            match callback(lock.substate_id(), substate.substate_value_mut())? {
+            return match callback(lock.substate_id(), substate.substate_value_mut())? {
                 Some(ret) => {
                     self.new_substates
                         .insert(lock.substate_id().clone(), substate.into_substate_value());
-                    return Ok(Some(ret));
+                    Ok(Some(ret))
                 },
                 None => {
                     // It is undefined (i.e. a bug) to mutate the state and return None from the callback.
                     // We do not explicitly assert this however for performance reasons.
                     self.loaded_substates.insert(lock.substate_id().clone(), substate);
-                    return Ok(None);
+                    Ok(None)
                 },
-            }
+            };
         }
 
         let substate_mut =
@@ -210,10 +210,6 @@ impl WorkingStateStore {
             .iter()
             .filter(|(address, _)| address.is_vault())
             .map(|(addr, vault)| (addr.as_vault_id().unwrap(), vault.as_vault().unwrap()))
-    }
-
-    pub(super) fn state_store(&self) -> &ReadOnlyMemoryStateStore {
-        &self.state_store
     }
 
     /// Loads and caches the component address. No lock is required for this operation.

--- a/crates/engine/src/runtime/tracker.rs
+++ b/crates/engine/src/runtime/tracker.rs
@@ -51,28 +51,33 @@ use crate::{
         workspace::Workspace,
         RuntimeError,
     },
-    state_store::memory::ReadOnlyMemoryStateStore,
+    state_store::StateReader,
 };
 
 const LOG_TARGET: &str = "tari::ootle::engine::runtime::state_tracker";
 
 #[derive(Debug)]
-pub struct StateTracker {
-    working_state: WorkingState,
-    fee_checkpoint: Option<WorkingState>,
+pub struct StateTracker<TStore> {
+    working_state: Option<WorkingState<TStore>>,
+    fee_checkpoint: Option<WorkingState<TStore>>,
     transaction_weight: TransactionWeight,
 }
 
-impl StateTracker {
+impl<TStore: StateReader> StateTracker<TStore> {
     pub fn new(
-        state_store: ReadOnlyMemoryStateStore,
+        state_store: TStore,
         virtual_substates: VirtualSubstates,
         initial_call_scope: CallScope,
         transaction_hash: Hash,
         transaction_weight: TransactionWeight,
     ) -> Self {
         Self {
-            working_state: WorkingState::new(state_store, virtual_substates, initial_call_scope, transaction_hash),
+            working_state: Some(WorkingState::new(
+                state_store,
+                virtual_substates,
+                initial_call_scope,
+                transaction_hash,
+            )),
             fee_checkpoint: None,
             transaction_weight,
         }
@@ -314,17 +319,7 @@ impl StateTracker {
         Ok(finalized)
     }
 
-    pub fn fee_checkpoint(&mut self) -> Result<(), RuntimeError> {
-        let state = self.read_with(|state| {
-            // Check that the checkpoint is in a valid state
-            state.validate_finalized().map(|_| state.clone())
-        })?;
-
-        self.fee_checkpoint = Some(state.clone());
-        Ok(())
-    }
-
-    fn take_fee_checkpoint(&mut self) -> Option<WorkingState> {
+    fn take_fee_checkpoint(&mut self) -> Option<WorkingState<TStore>> {
         let mut fee_cp = self.fee_checkpoint.take()?;
         // Preserve fee state across resets so that we can charge for fees incurred during execution before the
         // failure
@@ -334,8 +329,8 @@ impl StateTracker {
         Some(fee_cp)
     }
 
-    fn take_working_state(&mut self) -> WorkingState {
-        self.write_with(|current_state| current_state.take_state())
+    fn take_working_state(&mut self) -> WorkingState<TStore> {
+        self.working_state.take().expect("Working state has been taken")
     }
 
     pub fn with_substates_to_persist<F: FnMut(&IndexMap<SubstateId, SubstateValue>) -> R, R>(&mut self, mut f: F) -> R {
@@ -358,15 +353,27 @@ impl StateTracker {
         self.read_with(|state| state.fee_state().total_charges())
     }
 
-    pub(super) fn read_with<R, F: FnOnce(&WorkingState) -> R>(&self, f: F) -> R {
-        f(&self.working_state)
+    pub(super) fn read_with<R, F: FnOnce(&WorkingState<TStore>) -> R>(&self, f: F) -> R {
+        f(self.working_state.as_ref().expect("Working state has been taken"))
     }
 
-    pub(super) fn write_with<R, F: FnOnce(&mut WorkingState) -> R>(&mut self, f: F) -> R {
-        f(&mut self.working_state)
+    pub(super) fn write_with<R, F: FnOnce(&mut WorkingState<TStore>) -> R>(&mut self, f: F) -> R {
+        f(self.working_state.as_mut().expect("Working state has been taken"))
     }
 
     pub(super) fn is_fee_intent_checkpointed(&self) -> bool {
         self.fee_checkpoint.is_some()
+    }
+}
+
+impl<TStore: StateReader + Clone> StateTracker<TStore> {
+    pub fn fee_checkpoint(&mut self) -> Result<(), RuntimeError> {
+        let state = self.read_with(|state| {
+            // Check that the checkpoint is in a valid state
+            state.validate_finalized().map(|_| state.clone())
+        })?;
+
+        self.fee_checkpoint = Some(state);
+        Ok(())
     }
 }

--- a/crates/engine/src/runtime/tracker_auth.rs
+++ b/crates/engine/src/runtime/tracker_auth.rs
@@ -15,14 +15,17 @@ use tari_template_lib::{
     types::NonFungibleAddress,
 };
 
-use crate::runtime::{working_state::WorkingState, ActionIdent, AuthorizationScope, RuntimeError};
+use crate::{
+    runtime::{working_state::WorkingState, ActionIdent, AuthorizationScope, RuntimeError},
+    state_store::StateReader,
+};
 
-pub struct Authorization<'a> {
-    state: &'a WorkingState,
+pub struct Authorization<'a, TStore> {
+    state: &'a WorkingState<TStore>,
 }
 
-impl<'a> Authorization<'a> {
-    pub(super) fn new(state: &'a WorkingState) -> Self {
+impl<'a, TStore: StateReader> Authorization<'a, TStore> {
+    pub(super) fn new(state: &'a WorkingState<TStore>) -> Self {
         Self { state }
     }
 
@@ -106,8 +109,8 @@ impl<'a> Authorization<'a> {
     }
 }
 
-fn check_ownership(
-    state: &WorkingState,
+fn check_ownership<TStore: StateReader>(
+    state: &WorkingState<TStore>,
     scope: &AuthorizationScope,
     ownership: Ownership<'_>,
 ) -> Result<bool, RuntimeError> {
@@ -136,8 +139,8 @@ fn check_ownership(
     }
 }
 
-fn check_access_rule(
-    state: &WorkingState,
+fn check_access_rule<TStore: StateReader>(
+    state: &WorkingState<TStore>,
     scope: &AuthorizationScope,
     rule: &AccessRule,
 ) -> Result<bool, RuntimeError> {
@@ -148,8 +151,8 @@ fn check_access_rule(
     }
 }
 
-fn check_restricted_access_rule(
-    state: &WorkingState,
+fn check_restricted_access_rule<TStore: StateReader>(
+    state: &WorkingState<TStore>,
     scope: &AuthorizationScope,
     rule: &RestrictedAccessRule,
 ) -> Result<bool, RuntimeError> {
@@ -174,8 +177,8 @@ fn check_restricted_access_rule(
     }
 }
 
-fn check_require_rule(
-    state: &WorkingState,
+fn check_require_rule<TStore: StateReader>(
+    state: &WorkingState<TStore>,
     scope: &AuthorizationScope,
     rule: &RequireRule,
 ) -> Result<bool, RuntimeError> {
@@ -215,8 +218,8 @@ fn check_require_rule(
     }
 }
 
-fn check_requirement(
-    state: &WorkingState,
+fn check_requirement<TStore: StateReader>(
+    state: &WorkingState<TStore>,
     scope: &AuthorizationScope,
     requirement: &RuleRequirement,
 ) -> Result<bool, RuntimeError> {

--- a/crates/engine/src/runtime/working_state.rs
+++ b/crates/engine/src/runtime/working_state.rs
@@ -75,13 +75,13 @@ use crate::{
         RuntimeError,
         TransactionCommitError,
     },
-    state_store::memory::ReadOnlyMemoryStateStore,
+    state_store::StateReader,
 };
 
 const LOG_TARGET: &str = "dan::engine::runtime::working_state";
 
 #[derive(Debug, Clone)]
-pub(super) struct WorkingState {
+pub(super) struct WorkingState<TStore> {
     transaction_hash: Hash,
     events: Vec<Event>,
     logs: Vec<LogEntry>,
@@ -92,7 +92,7 @@ pub(super) struct WorkingState {
     proofs: HashMap<ProofId, Proof>,
     object_ids: ObjectIds,
 
-    store: WorkingStateStore,
+    store: WorkingStateStore<TStore>,
 
     virtual_substates: VirtualSubstates,
     validator_fee_withdrawals: Vec<ValidatorFeeWithdrawal>,
@@ -105,9 +105,9 @@ pub(super) struct WorkingState {
     fee_state: FeeState,
 }
 
-impl WorkingState {
+impl<TStore: StateReader> WorkingState<TStore> {
     pub fn new(
-        state_store: ReadOnlyMemoryStateStore,
+        state_store: TStore,
         virtual_substates: VirtualSubstates,
         initial_call_scope: CallScope,
         transaction_hash: Hash,
@@ -987,7 +987,7 @@ impl WorkingState {
         Ok(())
     }
 
-    pub fn authorization(&self) -> Authorization<'_> {
+    pub fn authorization(&self) -> Authorization<'_, TStore> {
         Authorization::new(self)
     }
 
@@ -1154,16 +1154,6 @@ impl WorkingState {
 
     pub fn base_call_scope(&self) -> &CallScope {
         &self.initial_call_scope
-    }
-
-    pub fn take_state(&mut self) -> Self {
-        let new_state = WorkingState::new(
-            self.store.state_store().clone(),
-            VirtualSubstates::new(),
-            CallScope::new(),
-            self.transaction_hash,
-        );
-        mem::replace(self, new_state)
     }
 
     pub fn workspace(&self) -> &Workspace {
@@ -1463,7 +1453,7 @@ impl WorkingState {
         Ok(substate_diff)
     }
 
-    pub fn store(&self) -> &WorkingStateStore {
+    pub fn store(&self) -> &WorkingStateStore<TStore> {
         &self.store
     }
 

--- a/crates/engine/src/transaction/processor.rs
+++ b/crates/engine/src/transaction/processor.rs
@@ -77,7 +77,7 @@ use crate::{
         RuntimeModule,
         StateTracker,
     },
-    state_store::memory::ReadOnlyMemoryStateStore,
+    state_store::StateReader,
     template::LoadedTemplate,
     traits::{ClaimProofVerifier, Invokable},
     transaction::{error::TransactionErrorKind, TransactionError},
@@ -88,24 +88,28 @@ const LOG_TARGET: &str = "tari::ootle::engine::instruction_processor";
 const ACCOUNT_CONSTRUCTOR_FUNCTION: &str = "create";
 const ACCOUNT_DEPOSIT_METHOD: &str = "deposit";
 
-pub type ModulesCollection = Arc<[Box<dyn RuntimeModule>]>;
+pub type ModulesCollection<TStore> = Arc<[Box<dyn RuntimeModule<TStore>>]>;
 
-pub struct TransactionProcessor<TTemplateProvider> {
+pub struct TransactionProcessor<TStore, TTemplateProvider> {
     template_provider: Arc<TTemplateProvider>,
-    state_db: ReadOnlyMemoryStateStore,
+    state_db: TStore,
     auth_params: AuthParams,
     virtual_substates: VirtualSubstates,
-    modules: ModulesCollection,
+    modules: ModulesCollection<TStore>,
     claim_burn_proof_verifier: Arc<dyn ClaimProofVerifier + Send + Sync + 'static>,
 }
 
-impl<TTemplateProvider: TemplateProvider<Template = LoadedTemplate>> TransactionProcessor<TTemplateProvider> {
+impl<TStore, TTemplateProvider> TransactionProcessor<TStore, TTemplateProvider>
+where
+    TStore: StateReader + Clone + 'static,
+    TTemplateProvider: TemplateProvider<Template = LoadedTemplate>,
+{
     pub fn new(
         template_provider: Arc<TTemplateProvider>,
-        state_db: ReadOnlyMemoryStateStore,
+        state_db: TStore,
         auth_params: AuthParams,
         virtual_substates: VirtualSubstates,
-        modules: ModulesCollection,
+        modules: ModulesCollection<TStore>,
         claim_burn_proof_verifier: Arc<dyn ClaimProofVerifier + Send + Sync + 'static>,
     ) -> Self {
         Self {

--- a/crates/engine_types/src/virtual_substate.rs
+++ b/crates/engine_types/src/virtual_substate.rs
@@ -4,7 +4,8 @@
 use std::{
     collections::HashMap,
     fmt::{Display, Formatter},
-    ops::{Deref, DerefMut},
+    ops::Deref,
+    sync::Arc,
 };
 
 use serde::{Deserialize, Serialize};
@@ -27,16 +28,12 @@ pub enum VirtualSubstate {
     CurrentEpoch(u64),
 }
 
-// Developer note: this struct has two non-functional purposes:
-// 1. so that we do not have to type out the HashMap type in many places, and
-// 2. so that the clippy::mutable_key_type annotation is not needed in many places
-
-/// Virtual substate collection
+/// Read-only Virtual substate collection. THis collection is cheap to clone.
 #[derive(Debug, Clone, Default)]
-pub struct VirtualSubstates(HashMap<VirtualSubstateId, VirtualSubstate>);
+pub struct VirtualSubstates(Arc<HashMap<VirtualSubstateId, VirtualSubstate>>);
 
 impl VirtualSubstates {
-    pub fn new() -> Self {
+    pub fn empty() -> Self {
         Self::default()
     }
 
@@ -45,10 +42,6 @@ impl VirtualSubstates {
             Some(VirtualSubstate::CurrentEpoch(epoch)) => Some(*epoch),
             _ => None,
         }
-    }
-
-    pub fn with_capacity(capacity: usize) -> Self {
-        Self(HashMap::with_capacity(capacity))
     }
 }
 
@@ -60,23 +53,14 @@ impl Deref for VirtualSubstates {
     }
 }
 
-impl DerefMut for VirtualSubstates {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-
-impl IntoIterator for VirtualSubstates {
-    type IntoIter = <HashMap<VirtualSubstateId, VirtualSubstate> as IntoIterator>::IntoIter;
-    type Item = <HashMap<VirtualSubstateId, VirtualSubstate> as IntoIterator>::Item;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.0.into_iter()
-    }
-}
-
 impl FromIterator<(VirtualSubstateId, VirtualSubstate)> for VirtualSubstates {
     fn from_iter<T: IntoIterator<Item = (VirtualSubstateId, VirtualSubstate)>>(iter: T) -> Self {
-        Self(iter.into_iter().collect())
+        Self(Arc::new(iter.into_iter().collect()))
+    }
+}
+
+impl From<HashMap<VirtualSubstateId, VirtualSubstate>> for VirtualSubstates {
+    fn from(map: HashMap<VirtualSubstateId, VirtualSubstate>) -> Self {
+        Self(Arc::new(map))
     }
 }

--- a/crates/template_test_tooling/src/template_test.rs
+++ b/crates/template_test_tooling/src/template_test.rs
@@ -23,7 +23,10 @@ use tari_engine::{
     executables::Executable,
     fees::{FeeModule, FeeTable},
     runtime::{AuthParams, RuntimeModule},
-    state_store::{memory::MemoryStateStore, StateWriter},
+    state_store::{
+        memory::{MemoryStateStore, ReadOnlyMemoryStateStore},
+        StateWriter,
+    },
     template::LoadedTemplate,
     transaction::{TransactionError, TransactionProcessor},
     wasm::LoadedWasmTemplate,
@@ -32,7 +35,7 @@ use tari_engine_types::{
     commit_result::{ExecuteResult, RejectReason},
     indexed_value::IndexedWellKnownTypes,
     substate::{SubstateDiff, SubstateId},
-    virtual_substate::{VirtualSubstate, VirtualSubstateId, VirtualSubstates},
+    virtual_substate::{VirtualSubstate, VirtualSubstateId},
 };
 use tari_ootle_common_types::{crypto::create_key_pair_from_seed, substate_type::SubstateType, SubstateRequirement};
 use tari_ootle_transaction::{
@@ -88,7 +91,7 @@ pub struct TemplateTest {
     state_store: MemoryStateStore,
     enable_fees: bool,
     fee_table: FeeTable,
-    virtual_substates: VirtualSubstates,
+    virtual_substates: HashMap<VirtualSubstateId, VirtualSubstate>,
     key_seed: u8,
     auto_add_proofs_from_signers: bool,
 }
@@ -181,8 +184,8 @@ impl TemplateTest {
             }
         }
 
-        let mut virtual_substates = VirtualSubstates::new();
-        virtual_substates.insert(VirtualSubstateId::CurrentEpoch, VirtualSubstate::CurrentEpoch(0));
+        let virtual_substates =
+            HashMap::from_iter([(VirtualSubstateId::CurrentEpoch, VirtualSubstate::CurrentEpoch(0))]);
 
         Self {
             package: Arc::new(package),
@@ -575,7 +578,7 @@ impl TemplateTest {
         transaction: Transaction,
         mut proofs: Vec<NonFungibleAddress>,
     ) -> Result<ExecuteResult, TransactionError> {
-        let mut modules: Vec<Box<dyn RuntimeModule>> = Vec::with_capacity(2);
+        let mut modules: Vec<Box<dyn RuntimeModule<ReadOnlyMemoryStateStore>>> = Vec::with_capacity(2);
 
         modules.push(Box::new(self.track_calls.clone()));
 
@@ -599,7 +602,7 @@ impl TemplateTest {
             self.package.clone(),
             self.state_store.clone().into_read_only(),
             auth_params,
-            self.virtual_substates.clone(),
+            self.virtual_substates.clone().into(),
             Arc::from(modules.into_boxed_slice()),
             Arc::new(AlwaysPassesProofVerifier),
         );
@@ -752,8 +755,7 @@ impl TemplateTest {
             &manifest,
             variables.into_iter().map(|(a, b)| (a.to_string(), b)).collect(),
             Default::default(),
-        )
-        .unwrap();
+        )?;
         self.execute_and_commit(instructions.instructions, proofs)
     }
 

--- a/crates/template_test_tooling/src/track_calls.rs
+++ b/crates/template_test_tooling/src/track_calls.rs
@@ -26,8 +26,12 @@ impl TrackCallsModule {
     }
 }
 
-impl RuntimeModule for TrackCallsModule {
-    fn on_runtime_call(&self, _tracker: &mut StateTracker, call: &'static str) -> Result<(), RuntimeModuleError> {
+impl<TStore> RuntimeModule<TStore> for TrackCallsModule {
+    fn on_runtime_call(
+        &self,
+        _tracker: &mut StateTracker<TStore>,
+        call: &'static str,
+    ) -> Result<(), RuntimeModuleError> {
         self.calls.write().unwrap().push(call);
         Ok(())
     }


### PR DESCRIPTION
Description
---
fix(engine): generic state reader

Motivation and Context
---
In future, we could pass in other StateReader implementations that could be used to determine which states were accessed during execution to determine required transaction inputs. 

How Has This Been Tested?
---
Existing tests

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify