### PR TITLE
fix(consensus): return votes to collector if no rx block

### DIFF
--- a/crates/consensus/src/hotstuff/vote_collector/collector.rs
+++ b/crates/consensus/src/hotstuff/vote_collector/collector.rs
@@ -86,6 +86,19 @@ impl<V: Vote + Display> VoteCollector<V> {
 
         Ok(votes.map(|v| (v, quorum_decision)))
     }
+
+    pub async fn return_votes(&self, votes: Vec<V>) {
+        let mut access_mut = self.store.write().await;
+        for vote in votes {
+            if let Err(err) = access_mut.save_vote(vote) {
+                // To panic or not to panic? That is the question...
+                error!(
+                    target: LOG_TARGET,
+                    "❌: BUG DETECTED: EQUIVOCATION on returned votes should not be possible: {}", err,
+                );
+            }
+        }
+    }
 }
 
 /// Collection of votes indexed by sender leaf hash

--- a/crates/consensus/src/hotstuff/vote_collector/proposal_collector.rs
+++ b/crates/consensus/src/hotstuff/vote_collector/proposal_collector.rs
@@ -91,9 +91,12 @@ where TConsensusSpec: ConsensusSpec
                 let Some(block) = self.store.with_read_tx(|tx| Block::get(tx, &block_id).optional())? else {
                     warn!(
                         target: LOG_TARGET,
-                        "❓️ Received vote for unknown block {}. Possible race condition where a quorum of votes arrived before the block.",
+                        "❓️ Received QUORUM on unknown block {}. Possible race condition where a quorum of votes arrived before the block.",
                         block_id
                     );
+                    // The vote will be re-processed when the block arrives and WE vote on it, so there is no special
+                    // handling needed
+                    self.vote_collector.return_votes(quorum_votes).await;
                     return Ok(None);
                 };
                 let signatures = quorum_votes.into_iter().map(|vote| vote.signature).collect();

--- a/networking/core/src/worker.rs
+++ b/networking/core/src/worker.rs
@@ -790,7 +790,7 @@ where
                 info!(target: LOG_TARGET, "🌍️ Autonat status changed from {:?} to {:?}", old, new);
             },
             _ => {
-                info!(target: LOG_TARGET, "🌍️ Autonat event: {:?}", event);
+                debug!(target: LOG_TARGET, "🌍️ Autonat event: {:?}", event);
             },
         }
 

--- a/utilities/tariswap_test_bench/src/tariswap.rs
+++ b/utilities/tariswap_test_bench/src/tariswap.rs
@@ -215,6 +215,7 @@ impl Runner {
         amount_b_for_a: Amount,
         faucet: &Faucet,
     ) -> anyhow::Result<()> {
+        const SWAP_FEE: u64 = 1500;
         let primary_account_key = self
             .sdk
             .key_manager_api()
@@ -252,7 +253,7 @@ impl Runner {
                         SubstateRequirement::unversioned(tariswap.lp_resource_address),
                     ])
                     .with_inputs(tariswap.vaults.values().map(|v| SubstateRequirement::unversioned(*v)))
-                    .pay_fee_from_component(account.component_address, 1100)
+                    .pay_fee_from_component(account.component_address, SWAP_FEE)
                     .call_method(tariswap.component_address, "get_pool_balance", args![XTR])
                     .call_method(tariswap.component_address, "get_pool_balance", args![
                         faucet.resource_address,
@@ -323,7 +324,7 @@ impl Runner {
                         SubstateRequirement::unversioned(tariswap.lp_resource_address),
                     ])
                     .with_inputs(tariswap.vaults.values().map(|v| SubstateRequirement::unversioned(*v)))
-                    .pay_fee_from_component(account.component_address, 1100)
+                    .pay_fee_from_component(account.component_address, SWAP_FEE)
                     .call_method(tariswap.component_address, "get_pool_balance", args![XTR])
                     .call_method(tariswap.component_address, "get_pool_balance", args![
                         faucet.resource_address


### PR DESCRIPTION
Description
---
fix(consensus): return votes to collector if no rx block

Motivation and Context
---
On quorum, the collector removes the votes and returns them. The vote handler then attempts to load the block, and if it is not found, returns and discards the quorum of votes, leading to a leader failure. This PR fixes this by returning the votes to the colllector in this case. We assume that when the blockis received, the handler will receive the node's own vote and trigger a new high QC, so there is no additional handling of this case required.

How Has This Been Tested?
---
Manually, as it's quite tricky to test. Observed in logs: quorum -> unknown block -> received node's vote -> new HIGH QC -> no leader failure



Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify