### PR TITLE
fix(consensus): implement catchup timeout and rerequest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1677,7 +1677,7 @@ dependencies = [
 
 [[package]]
 name = "consensus_tests"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "fern",
  "futures 0.3.31",
@@ -2536,7 +2536,7 @@ dependencies = [
 
 [[package]]
 name = "db_inspector"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -3638,7 +3638,7 @@ checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 
 [[package]]
 name = "generate_ristretto_value_lookup"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "clap 3.2.25",
  "futures 0.3.31",
@@ -4822,7 +4822,7 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "integration_tests"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "anyhow",
  "config",
@@ -5530,7 +5530,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-messaging"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "async-trait",
  "futures-bounded",
@@ -5709,7 +5709,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-substream"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "libp2p",
  "prometheus-client",
@@ -7263,7 +7263,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "ootle-rs"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -8224,7 +8224,7 @@ dependencies = [
 
 [[package]]
 name = "proto_builder"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "prost-build 0.14.3",
  "sha2",
@@ -10043,7 +10043,7 @@ dependencies = [
 
 [[package]]
 name = "sqlite_message_logger"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "chrono",
  "diesel",
@@ -10443,7 +10443,7 @@ dependencies = [
 
 [[package]]
 name = "tari_base_node_client"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "futures-util",
  "log",
@@ -10667,7 +10667,7 @@ dependencies = [
 
 [[package]]
 name = "tari_consensus"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "anyhow",
  "indexmap 2.13.0",
@@ -10692,7 +10692,7 @@ dependencies = [
 
 [[package]]
 name = "tari_consensus_types"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "borsh",
  "ootle_serde",
@@ -10794,7 +10794,7 @@ dependencies = [
 
 [[package]]
 name = "tari_engine"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "blake2",
  "indexmap 2.13.0",
@@ -10821,7 +10821,7 @@ dependencies = [
 
 [[package]]
 name = "tari_engine_types"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "bincode 2.0.1",
  "blake2",
@@ -10849,7 +10849,7 @@ dependencies = [
 
 [[package]]
 name = "tari_epoch_manager"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "anyhow",
  "log",
@@ -10869,7 +10869,7 @@ dependencies = [
 
 [[package]]
 name = "tari_epoch_oracles"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -10910,7 +10910,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -10982,7 +10982,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer_client"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "anyhow",
  "bounded-vec",
@@ -11015,7 +11015,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer_lib"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "log",
  "prometheus-client",
@@ -11091,7 +11091,7 @@ dependencies = [
 
 [[package]]
 name = "tari_networking"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11127,7 +11127,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_address"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "bech32",
  "bincode 2.0.1",
@@ -11143,7 +11143,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_app_utilities"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -11181,7 +11181,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_common_types"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "blake2",
  "borsh",
@@ -11211,7 +11211,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_p2p"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "anyhow",
  "prost 0.14.3",
@@ -11233,7 +11233,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_storage"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "anyhow",
  "bitflags 2.10.0",
@@ -11260,7 +11260,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_storage_sqlite"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "diesel",
  "diesel_migrations",
@@ -11280,7 +11280,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_transaction"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "bincode 2.0.1",
  "borsh",
@@ -11304,7 +11304,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_cli"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -11333,7 +11333,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_crypto"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "argon2 0.5.3",
  "blake2",
@@ -11362,7 +11362,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_sdk"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "anyhow",
  "digest",
@@ -11399,7 +11399,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_sdk_services"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -11426,7 +11426,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_storage_sqlite"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "bigdecimal",
  "diesel",
@@ -11450,7 +11450,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_walletd"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11536,7 +11536,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_framework"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "async-trait",
  "bitflags 2.10.0",
@@ -11560,7 +11560,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_macros"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11569,7 +11569,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_state_sync"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -11646,7 +11646,7 @@ dependencies = [
 
 [[package]]
 name = "tari_state_store_rocksdb"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -11677,7 +11677,7 @@ dependencies = [
 
 [[package]]
 name = "tari_state_tree"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "indexmap 2.13.0",
  "log",
@@ -11704,7 +11704,7 @@ dependencies = [
 
 [[package]]
 name = "tari_swarm"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "libp2p",
  "libp2p-messaging",
@@ -11715,7 +11715,7 @@ dependencies = [
 
 [[package]]
 name = "tari_swarm_daemon"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11771,7 +11771,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_builtin"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "tari_engine",
  "tari_engine_types",
@@ -11942,7 +11942,7 @@ dependencies = [
 
 [[package]]
 name = "tari_transaction_manifest"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "proc-macro2",
  "serde_json",
@@ -11976,7 +11976,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -12043,7 +12043,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node_client"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "indexmap 2.13.0",
  "multiaddr 0.18.3",
@@ -12066,7 +12066,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node_rpc"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -12089,7 +12089,7 @@ dependencies = [
 
 [[package]]
 name = "tari_wallet_daemon_client"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "ootle_serde",
  "reqwest 0.11.27",
@@ -12111,7 +12111,7 @@ dependencies = [
 
 [[package]]
 name = "tari_watcher"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "anyhow",
  "clap 3.2.25",
@@ -12139,7 +12139,7 @@ dependencies = [
 
 [[package]]
 name = "tariswap_bench"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "anyhow",
  "clap 4.5.54",
@@ -12819,7 +12819,7 @@ dependencies = [
 
 [[package]]
 name = "traffic-sim"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "anyhow",
  "clap 4.5.54",
@@ -12841,7 +12841,7 @@ dependencies = [
 
 [[package]]
 name = "transaction_generator"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -12862,7 +12862,7 @@ dependencies = [
 
 [[package]]
 name = "transaction_submitter"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "anyhow",
  "clap 4.5.54",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.18.0"
+version = "0.18.1"
 edition = "2021"
 authors = ["The Tari Development Community"]
 repository = "https://github.com/tari-project/tari-ootle"

--- a/applications/tari_indexer/src/bootstrap.rs
+++ b/applications/tari_indexer/src/bootstrap.rs
@@ -181,7 +181,7 @@ pub async fn spawn_services(
             num_preshards: consensus_constants.num_preshards,
             base_layer_confirmations: consensus_constants.base_layer_confirmations,
             committee_size: consensus_constants
-                .committee_size
+                .committee_size_per_shard_group
                 .try_into()
                 .context("committee_size must be non-zero")?,
             validator_node_sidechain_id: config.indexer.sidechain_id.as_ref().map(|pk| pk.to_byte_type()),

--- a/applications/tari_validator_node/src/bootstrap.rs
+++ b/applications/tari_validator_node/src/bootstrap.rs
@@ -230,7 +230,7 @@ pub async fn spawn_services(
     let epoch_manager_config = EpochManagerConfig {
         base_layer_confirmations: consensus_constants.base_layer_confirmations,
         committee_size: consensus_constants
-            .committee_size
+            .committee_size_per_shard_group
             .try_into()
             .context("committee size must be non-zero")?,
         validator_node_sidechain_id: config.validator_node.validator_node_sidechain_id.to_byte_type(),

--- a/applications/tari_validator_node/src/consensus/mod.rs
+++ b/applications/tari_validator_node/src/consensus/mod.rs
@@ -82,7 +82,7 @@ pub async fn spawn(
         // NOTE: This value should be greater than the epoch oracle's scanning interval to avoid leader failure by race
         // condition.
         epoch_end_grace_period: Duration::from_secs(10),
-        catch_up_request_timeout: Duration::from_secs(15),
+        catch_up_request_timeout: Duration::from_secs(20),
     };
 
     let hotstuff_worker = HotstuffWorker::<TariConsensusSpec>::new(

--- a/applications/tari_validator_node/src/consensus/mod.rs
+++ b/applications/tari_validator_node/src/consensus/mod.rs
@@ -82,6 +82,7 @@ pub async fn spawn(
         // NOTE: This value should be greater than the epoch oracle's scanning interval to avoid leader failure by race
         // condition.
         epoch_end_grace_period: Duration::from_secs(10),
+        catch_up_request_timeout: Duration::from_secs(15),
     };
 
     let hotstuff_worker = HotstuffWorker::<TariConsensusSpec>::new(

--- a/crates/consensus/src/consensus_constants.rs
+++ b/crates/consensus/src/consensus_constants.rs
@@ -26,19 +26,24 @@ use tari_ootle_common_types::{Network, NumPreshards};
 
 #[derive(Clone, Debug)]
 pub struct ConsensusConstants {
+    /// Number of base layer confirmations required before an L1 block is considered unable to re-org.
     pub base_layer_confirmations: u64,
-    pub committee_size: u32,
-    pub max_base_layer_blocks_ahead: u64,
-    pub max_base_layer_blocks_behind: u64,
+    /// The target size of the committee per shard group.
+    pub committee_size_per_shard_group: u32,
+    /// The number of preshards to break up the shard space.
     pub num_preshards: NumPreshards,
+    /// The maximum block time. The pacemaker will trigger a new view if a block is not received within this time +
+    /// delta.
     pub pacemaker_block_time: Duration,
-    /// The number of missed proposals before a SuspendNode command is sent.
+    /// The number of missed proposals before a node will immediately send a NEWVIEW to the next leader when the node
+    /// who missed the proposals is selected as leader.
     pub missed_proposal_suspend_threshold: u64,
-    /// The number of missed proposals before a EvictNode command is sent.
+    /// The number of missed proposals before a EvictNode command is proposed.
     pub missed_proposal_evict_threshold: u64,
-    /// The number of rounds a node must participate in to be eligible for a ResumeNode command. If a peer is offline,
-    /// gets suspended and comes online, their missed proposal count is decremented for each block that they
-    /// participate (vote) in. Once this reaches zero, the node is considered online and will be reinstated.
+    /// The number of rounds a node must participate before their non-participation is reset. If a peer is offline,
+    /// gets suspended and comes online, their missed proposal count (up to a maximum of
+    /// `missed_proposal_recovery_threshold`) is decremented for each block that they participate (vote) in. Once
+    /// this reaches zero, the node is considered stable and out of suspension.
     pub missed_proposal_recovery_threshold: u64,
     /// The maximum number of commands that a block may contain.
     pub max_number_commands_in_block: usize,
@@ -50,9 +55,7 @@ impl ConsensusConstants {
     pub const fn devnet(committee_size: u32) -> Self {
         Self {
             base_layer_confirmations: 3,
-            committee_size,
-            max_base_layer_blocks_ahead: 5,
-            max_base_layer_blocks_behind: 5,
+            committee_size_per_shard_group: committee_size,
             num_preshards: NumPreshards::current(),
             pacemaker_block_time: Duration::from_secs(10),
             missed_proposal_suspend_threshold: 5,
@@ -65,10 +68,8 @@ impl ConsensusConstants {
 
     pub const fn testnet() -> Self {
         Self {
-            base_layer_confirmations: 3,
-            committee_size: 40,
-            max_base_layer_blocks_ahead: 5,
-            max_base_layer_blocks_behind: 5,
+            base_layer_confirmations: 100,
+            committee_size_per_shard_group: 40,
             num_preshards: NumPreshards::current(),
             pacemaker_block_time: Duration::from_secs(10),
             missed_proposal_suspend_threshold: 5,

--- a/crates/consensus/src/hotstuff/config.rs
+++ b/crates/consensus/src/hotstuff/config.rs
@@ -17,4 +17,5 @@ pub struct HotstuffConfig {
     pub epoch_gc_interval: Duration,
     pub enable_eviction_proposal: bool,
     pub epoch_end_grace_period: Duration,
+    pub catch_up_request_timeout: Duration,
 }

--- a/crates/consensus/src/hotstuff/worker.rs
+++ b/crates/consensus/src/hotstuff/worker.rs
@@ -103,7 +103,7 @@ pub struct HotstuffWorker<TConsensusSpec: ConsensusSpec> {
     on_propose: OnPropose<TConsensusSpec>,
     on_sync_request: OnSyncRequest<TConsensusSpec>,
     on_catch_up_sync: OnCatchUpSync<TConsensusSpec>,
-    worker_state: WorkerState,
+    worker_state: WorkerState<TConsensusSpec::Addr>,
 
     state_store: TConsensusSpec::StateStore,
     leader_strategy: TConsensusSpec::LeaderStrategy,
@@ -340,6 +340,8 @@ impl<TConsensusSpec: ConsensusSpec> HotstuffWorker<TConsensusSpec> {
             .await?
             .fee_claim_public_key;
 
+        // Assume we need to catch up at startup. If we're already at the latest height, validators will not return
+        // blocks.
         self.request_catch_up_sync(&epoch_state).await?;
 
         let mut periodic_tasks = time::interval(Duration::from_secs(10));
@@ -659,16 +661,22 @@ impl<TConsensusSpec: ConsensusSpec> HotstuffWorker<TConsensusSpec> {
     async fn request_catch_up_sync(
         &mut self,
         epoch_state: &EpochState<TConsensusSpec::Addr>,
-    ) -> Result<(), HotStuffError> {
+    ) -> Result<Option<TConsensusSpec::Addr>, HotStuffError> {
+        let current_addr = self.worker_state.catch_up.as_ref().map(|c| c.from.clone());
+        let committee_size = epoch_state.local_committee().len();
         for member in epoch_state.local_committee().shuffled() {
-            if member.address != self.local_validator_addr {
+            // Exclude self and, if there are more than 2 committee members, exclude the current sync peer
+            if member.address != self.local_validator_addr &&
+                (committee_size <= 2 || Some(&member.address) != current_addr.as_ref())
+            {
                 self.on_catch_up_sync
                     .request_sync(epoch_state.epoch(), member.address.clone())
                     .await?;
-                break;
+                return Ok(Some(member.address.clone()));
             }
         }
-        Ok(())
+        // We're the only committee member
+        Ok(None)
     }
 
     async fn on_failure(&mut self, context: &str, err: &HotStuffError) {
@@ -719,18 +727,31 @@ impl<TConsensusSpec: ConsensusSpec> HotstuffWorker<TConsensusSpec> {
         self.on_next_sync_view
             .handle(epoch_state.epoch(), current_height, epoch_state.local_committee())
             .await?;
+
+        self.publish_event(HotstuffEvent::LeaderTimeout { height: current_height });
+
         // If we've gone into 3 leader failures in a row, request a catch up sync
-        if !self.worker_state.is_catching_up() && timeout.is_some_and(|t| t.num_timeouts.is_multiple_of(3)) {
+        if !self.worker_state.is_active_catch_up() && timeout.is_some_and(|t| t.num_timeouts.is_multiple_of(3)) {
             warn!(
                 target: LOG_TARGET,
                 "⚠️ {} Leader timeout count is {}. Requesting catch up sync.",
                 self.local_validator_addr,
                 timeout.as_ref().map(|t| t.num_timeouts).display()
             );
-            self.request_catch_up_sync(epoch_state).await?;
+            let Some(sync_req_from) = self.request_catch_up_sync(epoch_state).await? else {
+                warn!(
+                    target: LOG_TARGET,
+                    "⚠️ {} Cannot request catch up sync as there are no other committee members.",
+                    self.local_validator_addr,
+                );
+                return Ok(());
+            };
+            if let Some(ref mut catch_up) = self.worker_state.catch_up {
+                catch_up.reset_timeout(self.config.catch_up_request_timeout);
+                catch_up.from = sync_req_from;
+            }
         }
 
-        self.publish_event(HotstuffEvent::LeaderTimeout { height: current_height });
         Ok(())
     }
 
@@ -809,6 +830,15 @@ impl<TConsensusSpec: ConsensusSpec> HotstuffWorker<TConsensusSpec> {
         if !propose_now && !propose_epoch_end {
             info!(target: LOG_TARGET, "[on_beat] No transactions to propose. Waiting for a timeout.");
             return Ok(());
+        }
+
+        if propose_epoch_end {
+            info!(
+                target: LOG_TARGET,
+                "[on_beat] Preparing to propose epoch end {}->{}.",
+                epoch_state.epoch,
+                self.next_epoch.as_ref().map(|(e, _)| e).display(),
+            );
         }
 
         self.propose_now(
@@ -917,7 +947,7 @@ impl<TConsensusSpec: ConsensusSpec> HotstuffWorker<TConsensusSpec> {
         propose_epoch_end: bool,
     ) -> Result<(), HotStuffError> {
         // If we're catching up, we don't propose
-        if self.worker_state.is_catching_up() {
+        if self.worker_state.is_active_catch_up() {
             info!(
                 target: LOG_TARGET,
                 "⤵️ [propose_now] {} Currently catching up, will not propose at height ({})",
@@ -948,7 +978,7 @@ impl<TConsensusSpec: ConsensusSpec> HotstuffWorker<TConsensusSpec> {
             .state_store
             .with_read_tx(|tx| HighestSeenBlock::get(tx, epoch_state.epoch()))?;
 
-        // Do we need to fill in gaps with dummy blocks?
+        // If there are timeout "gaps", we need to fill them in with dummy blocks
         let mut dummy_block = None;
         let mut propose_high_tc = None;
         if next_height > highest_block.height + NodeHeight(1) {
@@ -1096,17 +1126,16 @@ impl<TConsensusSpec: ConsensusSpec> HotstuffWorker<TConsensusSpec> {
             Ok(no_vote) => {
                 if let Some(mut catch_up) = self.worker_state.catch_up.take() {
                     if current_height >= catch_up.expected_batch_height {
-                        if catch_up.set_next_batch(current_height) {
+                        if catch_up.set_next_batch(current_height, self.config.catch_up_request_timeout) {
                             info!(
                                 target: LOG_TARGET,
                                 "⏳ Still catching up... current height: {}, expected up to: {}",
                                 current_height,
                                 catch_up.expected_batch_height,
                             );
-                            // TODO: the sender should probably only send one batch, and we request more
-                            // self.on_catch_up_sync
-                            //     .request_sync(epoch_state.epoch(), catch_up.from.clone())
-                            //     .await?;
+                            self.on_catch_up_sync
+                                .request_sync(epoch_state.epoch(), catch_up.from.clone())
+                                .await?;
                             self.worker_state.catch_up = Some(catch_up);
                         } else {
                             info!(
@@ -1185,7 +1214,7 @@ impl<TConsensusSpec: ConsensusSpec> HotstuffWorker<TConsensusSpec> {
             return Err(err);
         }
 
-        if self.worker_state.is_catching_up() {
+        if self.worker_state.is_active_catch_up() {
             warn!(
                 target: LOG_TARGET,
                 "⏳ Already catching up. Ignoring additional catch up."
@@ -1220,11 +1249,12 @@ impl<TConsensusSpec: ConsensusSpec> HotstuffWorker<TConsensusSpec> {
             .request_sync(local_epoch_state.epoch(), vn.address.clone())
             .await?;
 
-        self.worker_state.catch_up = Some(CatchUp {
-            high_qc: remote_height,
-            // we get batches of 100 blocks which can only justify up to view h + 99
-            expected_batch_height: current_height + NodeHeight(99),
-        });
+        self.worker_state.catch_up = Some(CatchUp::new(
+            remote_height,
+            current_height,
+            self.config.catch_up_request_timeout,
+            vn.address,
+        ));
 
         Ok(())
     }
@@ -1302,27 +1332,60 @@ fn log_err<T>(context: &'static str, result: Result<T, HotStuffError>) -> Result
     result
 }
 
-#[derive(Debug, Default)]
-struct WorkerState {
-    pub catch_up: Option<CatchUp>,
+#[derive(Debug)]
+struct WorkerState<TAddr> {
+    /// Keeps track of the active catch up. This can be None even if a catch-up request was sent. The main use of
+    /// this struct is to track timeouts and expected batch heights i.e. we've received a batch of blocks, and we need
+    /// to request more.
+    pub catch_up: Option<CatchUp<TAddr>>,
     pub has_processed_first_block: bool,
 }
 
-impl WorkerState {
-    pub fn is_catching_up(&self) -> bool {
-        self.catch_up.is_some()
+impl<TAddr> WorkerState<TAddr> {
+    pub fn is_active_catch_up(&self) -> bool {
+        self.catch_up.as_ref().is_some_and(|c| !c.has_timed_out())
+    }
+}
+
+impl<TAddr> Default for WorkerState<TAddr> {
+    fn default() -> Self {
+        Self {
+            catch_up: None,
+            has_processed_first_block: false,
+        }
     }
 }
 
 #[derive(Debug)]
-struct CatchUp {
-    pub high_qc: NodeHeight,
+struct CatchUp<TAddr> {
+    pub remote_height: NodeHeight,
     pub expected_batch_height: NodeHeight,
+    pub timeout_at: Instant,
+    pub from: TAddr,
 }
 
-impl CatchUp {
-    pub fn set_next_batch(&mut self, current_height: NodeHeight) -> bool {
-        self.expected_batch_height = (current_height + NodeHeight(99)).min(self.high_qc);
-        self.expected_batch_height < self.high_qc
+impl<TAddr> CatchUp<TAddr> {
+    pub fn new(remote_height: NodeHeight, current_height: NodeHeight, timeout: Duration, from: TAddr) -> Self {
+        Self {
+            remote_height,
+            // we get batches of 100 blocks which can only justify up to view h + 99
+            expected_batch_height: (current_height + NodeHeight(99)).min(remote_height),
+            timeout_at: Instant::now() + timeout,
+            from,
+        }
+    }
+
+    pub fn set_next_batch(&mut self, current_height: NodeHeight, timeout: Duration) -> bool {
+        self.expected_batch_height = (current_height + NodeHeight(99)).min(self.remote_height);
+        self.reset_timeout(timeout);
+        self.expected_batch_height < self.remote_height
+    }
+
+    pub fn reset_timeout(&mut self, timeout: Duration) {
+        self.timeout_at = Instant::now() + timeout;
+    }
+
+    pub fn has_timed_out(&self) -> bool {
+        Instant::now() >= self.timeout_at
     }
 }

--- a/crates/consensus_tests/src/support/harness.rs
+++ b/crates/consensus_tests/src/support/harness.rs
@@ -659,9 +659,7 @@ impl TestBuilder {
                 sidechain_id: None,
                 consensus_constants: ConsensusConstants {
                     base_layer_confirmations: 0,
-                    committee_size: 10,
-                    max_base_layer_blocks_ahead: 5,
-                    max_base_layer_blocks_behind: 5,
+                    committee_size_per_shard_group: 10,
                     num_preshards: TEST_NUM_PRESHARDS,
                     pacemaker_block_time: DEFAULT_PACEMAKER_BLOCK_TIME,
                     missed_proposal_suspend_threshold: 5,

--- a/crates/consensus_tests/src/support/harness.rs
+++ b/crates/consensus_tests/src/support/harness.rs
@@ -674,6 +674,7 @@ impl TestBuilder {
                 epoch_gc_interval: Duration::from_secs(1000),
                 enable_eviction_proposal: true,
                 epoch_end_grace_period: Duration::from_secs(1),
+                catch_up_request_timeout: Duration::from_secs(15),
             },
         }
     }


### PR DESCRIPTION
Description
---
fix(consensus): implement catchup timeout and rerequest

Motivation and Context
---
If block catch-up does not receive blocks, it would never attempt a catch-up again. This PR adds a timeout to catch up, after which blocks can be re-requested again, either after more leader failures or from a higher QC.
