### PR TITLE
fix(walletd/webui): hide alpha/developer features

### DIFF
--- a/applications/tari_walletd/build.rs
+++ b/applications/tari_walletd/build.rs
@@ -27,15 +27,15 @@ const NPM_COMMANDS: &[(&str, &[&str], EnvVars)] = &[
     ("../../bindings", &["install"], &[]),
     ("../../bindings", &["run", "build-dev"], &[]),
     ("../../clients/javascript/wallet_daemon_client", &["install"], &[]),
-    ("../../clients/javascript/wallet_daemon_client", &["run", "build"], {
+    ("../../clients/javascript/wallet_daemon_client", &["run", "build"], &[]),
+    ("./web_ui", &["clean-dist"], &[]),
+    ("./web_ui", &["install"], &[]),
+    ("./web_ui", &["run", "build"], {
         match option_env!("TARI_WALLET_ALPHA_FEATURES") {
             Some(feat) => &[("VITE_ALPHA_FEATURES", feat)],
             _ => &[],
         }
     }),
-    ("./web_ui", &["clean-dist"], &[]),
-    ("./web_ui", &["install"], &[]),
-    ("./web_ui", &["run", "build"], &[]),
 ];
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/applications/tari_walletd/build.rs
+++ b/applications/tari_walletd/build.rs
@@ -22,14 +22,20 @@
 
 use std::{env, fs, process::Command};
 
-const NPM_COMMANDS: &[(&str, &[&str])] = &[
-    ("../../bindings", &["install"]),
-    ("../../bindings", &["run", "build-dev"]),
-    ("../../clients/javascript/wallet_daemon_client", &["install"]),
-    ("../../clients/javascript/wallet_daemon_client", &["run", "build"]),
-    ("./web_ui", &["clean-dist"]),
-    ("./web_ui", &["install"]),
-    ("./web_ui", &["run", "build"]),
+type EnvVars = &'static [(&'static str, &'static str)];
+const NPM_COMMANDS: &[(&str, &[&str], EnvVars)] = &[
+    ("../../bindings", &["install"], &[]),
+    ("../../bindings", &["run", "build-dev"], &[]),
+    ("../../clients/javascript/wallet_daemon_client", &["install"], &[]),
+    ("../../clients/javascript/wallet_daemon_client", &["run", "build"], {
+        match option_env!("TARI_WALLET_ALPHA_FEATURES") {
+            Some(feat) => &[("VITE_ALPHA_FEATURES", feat)],
+            _ => &[],
+        }
+    }),
+    ("./web_ui", &["clean-dist"], &[]),
+    ("./web_ui", &["install"], &[]),
+    ("./web_ui", &["run", "build"], &[]),
 ];
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -57,8 +63,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     #[cfg(not(windows))]
     const NPM: &str = "pnpm";
 
-    for (target, args) in NPM_COMMANDS {
-        match Command::new(NPM).args(*args).current_dir(target).output() {
+    for (target, args, envs) in NPM_COMMANDS {
+        match Command::new(NPM)
+            .args(*args)
+            .envs(envs.iter().copied())
+            .current_dir(target)
+            .output()
+        {
             Ok(output) if !output.status.success() => {
                 println!(
                     "cargo:warning='pnpm {}' in {} exited with non-zero status code",

--- a/applications/tari_walletd/web_ui/.env.example
+++ b/applications/tari_walletd/web_ui/.env.example
@@ -2,3 +2,7 @@ VITE_DAEMON_JRPC_ADDRESS=http://localhost:9000
 
 # If not set, the wallet daemon will not support walletconnect
 #VITE_WALLET_CONNECT_PROJECT_ID=
+# WebAuthn relying party ID. If not set, WebAuthn will use window.location.hostname
+#VITE_DAEMON_WEBAUTHN_RP_ID=
+# Show tools that are not yet/ever meant for production use
+#VITE_ALPHA_FEATURES=manifest,flowEditor

--- a/applications/tari_walletd/web_ui/src/components/MenuItems.tsx
+++ b/applications/tari_walletd/web_ui/src/components/MenuItems.tsx
@@ -42,6 +42,8 @@ import { LuLayoutTemplate } from "react-icons/lu";
 
 function MainListItems() {
   const theme = useTheme();
+  // Compile time environment variable to show/hide dev tools
+  const features = (import.meta.env.VITE_ALPHA_FEATURES || "").split(",");
 
   const iconStyle = {
     height: 22,
@@ -61,48 +63,13 @@ function MainListItems() {
       activeIcon: <IoHome style={activeIconStyle} />,
       link: "/",
     },
-    // {
-    //   title: 'Accounts',
-    //   icon: <IoBarChartOutline style={iconStyle} />,
-    //   activeIcon: <IoBarChart style={activeIconStyle} />,
-    //   link: '/accounts',
-    // },
-    // {
-    //   title: 'Keys',
-    //   icon: <IoKeyOutline style={iconStyle} />,
-    //   activeIcon: <IoKey style={activeIconStyle} />,
-    //   link: 'keys',
-    // },
-    // {
-    //   title: 'Transactions',
-    //   icon: <IoWalletOutline style={iconStyle} />,
-    //   activeIcon: <IoWallet style={activeIconStyle} />,
-    //   link: 'transactions',
-    // },
-    // {
-    //   title: 'Access Tokens',
-    //   icon: <IoTicketOutline style={iconStyle} />,
-    //   activeIcon: <IoTicket style={activeIconStyle} />,
-    //   link: 'access-tokens',
-    // },
     {
       title: "Templates",
       icon: <LuLayoutTemplate style={iconStyle} />,
       activeIcon: <LuLayoutTemplate style={activeIconStyle} />,
       link: "templates",
     },
-    {
-      title: "Manifest",
-      icon: <IoTerminalOutline style={iconStyle} />,
-      activeIcon: <IoTerminal style={activeIconStyle} />,
-      link: "manifest",
-    },
-    {
-      title: "Flow Editor",
-      icon: <IoGitMerge style={iconStyle} />,
-      activeIcon: <IoGitMerge style={activeIconStyle} />,
-      link: "flow-editor",
-    },
+
     {
       title: "Settings",
       icon: <IoSettingsOutline style={iconStyle} />,
@@ -110,6 +77,23 @@ function MainListItems() {
       link: "settings",
     },
   ];
+
+  if (features.includes("manifest")) {
+    mainItems.push({
+      title: "Manifest",
+      icon: <IoTerminalOutline style={iconStyle} />,
+      activeIcon: <IoTerminal style={activeIconStyle} />,
+      link: "manifest",
+    });
+  }
+  if (features.includes("flowEditor")) {
+    mainItems.push({
+      title: "Flow Editor",
+      icon: <IoGitMerge style={iconStyle} />,
+      activeIcon: <IoGitMerge style={activeIconStyle} />,
+      link: "flow-editor",
+    });
+  }
 
   return (
     <Box


### PR DESCRIPTION
Description
---
fix(walletd/webui): hide alpha/developer features

Motivation and Context
---
Hides the alpha features like manifest and flow editor by default

To unhide them, compile the wallet with `TARI_WALLET_ALPHA_FEATURES=manifest,flowEditor` 
or add a `.env` to `applications/walletd/web_ui` containing `VITE_ALPHA_FEATURES=manifest,flowEditor`

How Has This Been Tested?
---
Manually

What process can a PR reviewer use to test or verify this change?
---
As above

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify