### PR TITLE
fix(walletd): jwt panic after upgrade + default indexer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5139,11 +5139,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
 dependencies = [
  "base64 0.22.1",
+ "ed25519-dalek",
  "getrandom 0.2.17",
+ "hmac",
  "js-sys",
+ "p256",
+ "p384",
  "pem",
+ "rand 0.8.5",
+ "rsa",
  "serde",
  "serde_json",
+ "sha2",
  "signature 2.2.0",
  "simple_asn1",
 ]

--- a/applications/tari_ootle_app_utilities/config_presets/e_wallet_daemon.toml
+++ b/applications/tari_ootle_app_utilities/config_presets/e_wallet_daemon.toml
@@ -14,9 +14,6 @@
 [localnet.ootle_wallet_daemon]
 # Indexer API url (default: http://127.0.0.1:18200)
 # indexer_api_url = "http://127.0.0.1:18200"
-[esme.ootle_wallet_daemon]
+[esmeralda.ootle_wallet_daemon]
 # Indexer API url for Esme.
-indexer_api_url = "http://217.182.93.147:50124"
-[igor.ootle_wallet_daemon]
-# Indexer API url for Igor.
-indexer_api_url = "http://217.182.93.147:50124"
+indexer_api_url = "http://217.182.93.35:50124/"

--- a/applications/tari_walletd/Cargo.toml
+++ b/applications/tari_walletd/Cargo.toml
@@ -41,7 +41,7 @@ humantime-serde = { workspace = true }
 futures = { workspace = true }
 include_dir = { workspace = true, optional = true }
 indexmap = { workspace = true }
-jsonwebtoken = { workspace = true }
+jsonwebtoken = { workspace = true, features = ["rust_crypto"] }
 libsqlite3-sys = { workspace = true, features = ["bundled"] }
 log = { workspace = true }
 log4rs = { workspace = true, features = [

--- a/crates/engine/tests/templates/buggy/src/lib.rs
+++ b/crates/engine/tests/templates/buggy/src/lib.rs
@@ -50,11 +50,11 @@ pub static _ABI_TEMPLATE_DEF: [u8; 53] = [
 ];
 
 #[unsafe(no_mangle)]
-pub extern "C" fn Buggy_main(_call_info: *mut u8, _call_info_len: usize) -> *mut u8 {
+pub unsafe extern "C" fn Buggy_main(_call_info: *mut u8, _call_info_len: usize) -> *mut u8 {
     ptr::null_mut()
 }
 
-extern "C" {
+unsafe extern "C" {
     pub fn tari_engine(op: i32, input_ptr: *const u8, input_len: usize) -> *mut u8;
     pub fn debug(input_ptr: *const u8, input_len: usize);
     pub fn on_panic(msg_ptr: *const u8, msg_len: u32, line: u32, column: u32);


### PR DESCRIPTION
Description
---
fix(walletd): jwt panic after upgrade + default indexer

Motivation and Context
---
Fixed panic on startup after JWT upgrade
ref https://github.com/tari-project/tari-ootle/pull/1746

Correctly set the default esme indexer url
