### PR TITLE
chore(ci): expose tari_ootle_walletd binary for download

### DIFF
--- a/.github/workflows/build_binaries.yml
+++ b/.github/workflows/build_binaries.yml
@@ -23,8 +23,11 @@ env:
   TS_SIG_FN: "sha256-unsigned.txt"
   ## Must be a JSON string
   TS_FILES: '["tari_ootle_walletd","tari_indexer","tari_validator_node","tari_swarm_daemon"]'
+  ## Binaries exposed as standalone downloads
+  TS_FILES_STANDALONE: '["tari_ootle_walletd"]'
   TS_FEATURES: "default"
   TS_LIBRARIES: ""
+  TS_EXT: "" # or ".exe" for Windows builds
   TS_DESCRIPTION: "Tari Ootle"
   TS_URL: "https://tari.com"
   # For debug builds
@@ -690,6 +693,26 @@ jobs:
         with:
           name: ${{ env.TS_FILENAME }}_archive-${{ matrix.builds.name }}
           path: "${{ github.workspace }}${{ env.TS_DIST }}/${{ env.BINFILE }}.zip*"
+
+      - name: Prep Standalone tari_ootle_walletd binary for upload
+        shell: bash
+        run: |
+          set -xo pipefail
+          cp -v "${{ github.workspace }}${{ env.TS_DIST }}/tari_ootle_walletd${{ env.TS_EXT }}" \
+            "${{ github.workspace }}${{ env.TS_DIST }}/tari_ootle_walletd-${{ env.TARI_VERSION }}-${{ env.VSHA_SHORT }}-${{ matrix.builds.name }}${{ env.TS_EXT }}"
+          echo "Compute files shasum"
+          ${SHARUN} "${{ github.workspace }}${{ env.TS_DIST }}/tari_ootle_walletd-${{ env.TARI_VERSION }}-${{ env.VSHA_SHORT }}-${{ matrix.builds.name }}${{ env.TS_EXT }}" \
+            >> "${{ github.workspace }}${{ env.TS_DIST }}/tari_ootle_walletd-${{ env.TARI_VERSION }}-${{ env.VSHA_SHORT }}-${{ matrix.builds.name }}${{ env.TS_EXT }}.sha256"
+          echo "Show the shasum"
+          cat "${{ github.workspace }}${{ env.TS_DIST }}/tari_ootle_walletd-${{ env.TARI_VERSION }}-${{ env.VSHA_SHORT }}-${{ matrix.builds.name }}${{ env.TS_EXT }}.sha256"
+          echo "Checksum verification archive is "
+          ${SHARUN} --check "${{ github.workspace }}${{ env.TS_DIST }}/tari_ootle_walletd-${{ env.TARI_VERSION }}-${{ env.VSHA_SHORT }}-${{ matrix.builds.name }}${{ env.TS_EXT }}.sha256"
+
+      - name: Artifact upload for Standalone tari_ootle_walletd binary
+        uses: actions/upload-artifact@v6
+        with:
+          name: tari_ootle_walletd-${{ env.TARI_VERSION }}-${{ env.VSHA_SHORT }}-${{ matrix.builds.name }}
+          path: "${{ github.workspace }}${{ env.TS_DIST }}/tari_ootle_walletd-${{ env.TARI_VERSION }}-${{ env.VSHA_SHORT }}-${{ matrix.builds.name }}${{ env.TS_EXT }}*"
 
   macOS-universal-assemble:
     name: macOS universal assemble


### PR DESCRIPTION
Description
expose tari_ootle_walletd binary for download

Motivation and Context
reduce user confusion on what to use in the archive of tools
