### PR TITLE
fix(state-store): improve iterator performance and mem usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2591,7 +2591,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "db_inspector"
+name = "db-inspector"
 version = "0.19.1"
 dependencies = [
  "anyhow",

--- a/crates/state_store_rocksdb/src/cf_api.rs
+++ b/crates/state_store_rocksdb/src/cf_api.rs
@@ -13,7 +13,7 @@ use tari_ootle_common_types::displayable::Displayable;
 use tari_ootle_storage::Ordering;
 
 use crate::{
-    codecs::{DbCodec, EncodeVec, PrefixCodec, UnitCodec},
+    codecs::{DbCodec, DbDecoder, DbEncoder, EncodeVec, PrefixCodec, UnitCodec},
     error::RocksDbStorageError,
     traits::{Cf, PrefixedCodec, QueryCf, RocksReader, RocksWriter},
 };
@@ -72,18 +72,22 @@ impl<'db, CF: Cf, DB: RocksReader> CfContext<'db, DB, CF> {
         })
     }
 
-    pub fn get(&self, key: &CF::Key, operation: &'static str) -> Result<CF::Value, RocksDbStorageError> {
-        let key = self.encode_key(key);
+    pub fn get_raw_key(&self, key: &[u8], operation: &'static str) -> Result<CF::Value, RocksDbStorageError> {
         let value = self
             .db
-            .get_pinned_cf(self.handle, &key)
+            .get_pinned_cf(self.handle, key)
             .map_err(|e| RocksDbStorageError::RocksDbError { operation, source: e })?;
         let bytes = value.ok_or_else(|| RocksDbStorageError::NotFound {
-            key: Box::new(key),
+            key: Box::new(EncodeVec::from_slice(key)),
             operation,
         })?;
         let value = self.value_codec.decode(&bytes)?;
         Ok(value)
+    }
+
+    pub fn get(&self, key: &CF::Key, operation: &'static str) -> Result<CF::Value, RocksDbStorageError> {
+        let key = self.encode_key(key);
+        self.get_raw_key(key.as_slice(), operation)
     }
 
     pub fn get_raw_pinned(
@@ -101,7 +105,6 @@ impl<'db, CF: Cf, DB: RocksReader> CfContext<'db, DB, CF> {
 
     /// Counts the number of entries in the column family.
     /// WARNING: This operation is O(n) and can be slow for large column families/prefixed tables.
-    /// it also allocates memory for each key/value pair in the column family.
     pub fn count(&self, operation: &'static str) -> Result<usize, RocksDbStorageError> {
         let key_prefix = CF::key_prefix().map(|b| [b]);
         let prefix_bytes = match key_prefix {
@@ -110,10 +113,13 @@ impl<'db, CF: Cf, DB: RocksReader> CfContext<'db, DB, CF> {
         };
         let mut opts = rocksdb::ReadOptions::default();
         opts.set_iterate_range(rocksdb::PrefixRange(prefix_bytes));
-        let iter = self.db.iterator_cf_opt(self.handle, opts, IteratorMode::Start);
+        let iter = self.db.iterator_cf_opt(self.handle, opts, IteratorMode::Start, |x| {
+            x.map_err(|e| RocksDbStorageError::RocksDbError { operation, source: e })
+                .map(|_| ())
+        });
         let mut count = 0;
         for result in iter {
-            let _unused = result.map_err(|e| RocksDbStorageError::RocksDbError { operation, source: e })?;
+            let () = result?;
             count += 1;
         }
         Ok(count)
@@ -121,18 +127,20 @@ impl<'db, CF: Cf, DB: RocksReader> CfContext<'db, DB, CF> {
 
     /// Counts the number of entries with the given prefix in the column family.
     /// WARNING: This operation is O(n) and can be slow for large prefixed tables.
-    /// it also allocates memory for each key/value pair in the column family.
     pub fn count_prefix(&self, prefix: &CF::Key) -> Result<usize, RocksDbStorageError> {
         let prefix = self.encode_key(prefix);
         let mut opts = rocksdb::ReadOptions::default();
         opts.set_iterate_range(rocksdb::PrefixRange(prefix));
-        let iter = self.db.iterator_cf_opt(self.handle, opts, IteratorMode::Start);
-        let mut count = 0;
-        for result in iter {
-            result.map_err(|e| RocksDbStorageError::RocksDbError {
+        let iter = self.db.iterator_cf_opt(self.handle, opts, IteratorMode::Start, |x| {
+            x.map_err(|e| RocksDbStorageError::RocksDbError {
                 operation: "count_prefix",
                 source: e,
-            })?;
+            })
+            .map(|_| ())
+        });
+        let mut count = 0;
+        for result in iter {
+            let () = result?;
             count += 1;
         }
         Ok(count)
@@ -153,15 +161,19 @@ impl<'db, CF: Cf, DB: RocksReader> CfContext<'db, DB, CF> {
     }
 
     /// Returns true if any key exists within the given range, otherwise false.
-    /// WARNING: the bounds must encode the prefix correctly according to the column family's key codec.
+    /// WARNING: the caller must encode the prefix correctly in the range bounds according to the column family's key
+    /// codec.
     pub fn any_exists_within_range(&self, range: impl IterateBounds) -> Result<bool, RocksDbStorageError> {
         let mut opts = rocksdb::ReadOptions::default();
         opts.set_iterate_range(range);
-        let mut iter = self.db.iterator_cf_opt(self.handle, opts, IteratorMode::Start);
-        let next = iter.next().transpose().map_err(|e| RocksDbStorageError::RocksDbError {
-            operation: "any_exists_within_range",
-            source: e,
-        })?;
+        let mut iter = self.db.iterator_cf_opt(self.handle, opts, IteratorMode::Start, |res| {
+            res.map_err(|e| RocksDbStorageError::RocksDbError {
+                operation: "any_exists_within_range",
+                source: e,
+            })
+            .map(|_| ())
+        });
+        let next = iter.next().transpose()?;
         Ok(next.is_some())
     }
 
@@ -211,9 +223,9 @@ impl<'db, CF: Cf, DB: RocksReader> CfContext<'db, DB, CF> {
             None => &[],
         };
         let opts = create_prefixed_read_opts(prefix_bytes, mode);
-        self.db.iterator_cf_opt(self.handle, opts, mode).map(move |res| {
+        self.db.iterator_cf_opt(self.handle, opts, mode, move |res| {
             res.map_err(|e| RocksDbStorageError::RocksDbError { operation, source: e })
-                .and_then(|(k, v)| Ok((self.key_codec.decode(&k)?, self.value_codec.decode(&v)?)))
+                .and_then(|(k, v)| Ok((self.key_codec.decode(k)?, self.value_codec.decode(v)?)))
         })
     }
 
@@ -229,9 +241,9 @@ impl<'db, CF: Cf, DB: RocksReader> CfContext<'db, DB, CF> {
             None => &[],
         };
         let opts = create_prefixed_read_opts(prefix_bytes, mode);
-        self.db.iterator_cf_opt(self.handle, opts, mode).map(move |res| {
+        self.db.iterator_cf_opt(self.handle, opts, mode, move |res| {
             res.map_err(|e| RocksDbStorageError::RocksDbError { operation, source: e })
-                .and_then(|(k, _)| self.key_codec.decode(&k))
+                .and_then(|(k, _)| self.key_codec.decode(k))
         })
     }
 
@@ -247,9 +259,9 @@ impl<'db, CF: Cf, DB: RocksReader> CfContext<'db, DB, CF> {
             None => &[],
         };
         let opts = create_prefixed_read_opts(prefix_bytes, mode);
-        self.db.iterator_cf_opt(self.handle, opts, mode).map(move |res| {
+        self.db.iterator_cf_opt(self.handle, opts, mode, move |res| {
             res.map_err(|e| RocksDbStorageError::RocksDbError { operation, source: e })
-                .and_then(|(_, v)| self.value_codec.decode(&v))
+                .and_then(|(_, v)| self.value_codec.decode(v))
         })
     }
 
@@ -260,12 +272,12 @@ impl<'db, CF: Cf, DB: RocksReader> CfContext<'db, DB, CF> {
     ) -> impl Iterator<Item = Result<(CF::Key, CF::Value), RocksDbStorageError>> + '_ {
         let mode = ordering_to_mode(ordering);
         let opts = range_opts::<CF>(range, mode);
-        self.db.iterator_cf_opt(self.handle, opts, mode).map(move |res| {
+        self.db.iterator_cf_opt(self.handle, opts, mode, move |res| {
             res.map_err(|e| RocksDbStorageError::RocksDbError {
                 operation: "range_iterator_with_codecs",
                 source: e,
             })
-            .and_then(|(k, v)| Ok((self.key_codec.decode(&k)?, self.value_codec.decode(&v)?)))
+            .and_then(|(k, v)| Ok((self.key_codec.decode(k)?, self.value_codec.decode(v)?)))
         })
     }
 
@@ -275,17 +287,19 @@ impl<'db, CF: Cf, DB: RocksReader> CfContext<'db, DB, CF> {
         range: impl IterateBounds,
     ) -> impl Iterator<Item = Result<(K, V), RocksDbStorageError>> + 'db
     where
+        K: 'static,
+        V: 'static,
         KC: DbCodec<K> + Default,
         VC: DbCodec<V> + Default,
     {
         let mode = ordering_to_mode(ordering);
         let opts = range_opts::<CF>(range, mode);
-        self.db.iterator_cf_opt(self.handle, opts, mode).map(move |res| {
+        self.db.iterator_cf_opt(self.handle, opts, mode, |res| {
             res.map_err(|e| RocksDbStorageError::RocksDbError {
                 operation: "range_iterator_with_codecs",
                 source: e,
             })
-            .and_then(|(k, v)| Ok((KC::default().decode(&k)?, VC::default().decode(&v)?)))
+            .and_then(|(k, v)| Ok((KC::default().decode(k)?, VC::default().decode(v)?)))
         })
     }
 
@@ -295,6 +309,7 @@ impl<'db, CF: Cf, DB: RocksReader> CfContext<'db, DB, CF> {
         range: impl IterateBounds,
     ) -> impl Iterator<Item = Result<K, RocksDbStorageError>> + 'db
     where
+        K: 'static,
         C: DbCodec<K> + Default,
     {
         let iter = self.range_iterator_with_codecs::<C, K, UnitCodec, ()>(ordering, range);
@@ -379,8 +394,17 @@ impl<CF: Cf, DB: RocksWriter> CfContext<'_, DB, CF> {
     }
 
     pub fn put(&self, key: &CF::Key, value: &CF::Value, operation: &'static str) -> Result<(), RocksDbStorageError> {
-        let key = self.key_codec.encode(key)?;
         let encoded_value = self.value_codec.encode(value)?;
+        self.put_raw_value(key, &encoded_value, operation)
+    }
+
+    pub fn put_raw_value(
+        &self,
+        key: &CF::Key,
+        encoded_value: &[u8],
+        operation: &'static str,
+    ) -> Result<(), RocksDbStorageError> {
+        let key = self.key_codec.encode(key)?;
 
         self.db
             .put_cf(self.handle, &key, encoded_value)

--- a/crates/state_store_rocksdb/src/codecs/bincode.rs
+++ b/crates/state_store_rocksdb/src/codecs/bincode.rs
@@ -6,7 +6,7 @@ use std::io::{Read, Write};
 use anyhow::anyhow;
 
 use crate::{
-    codecs::{DbCodec, byte_counter::ByteCounter},
+    codecs::{DbDecoder, DbEncoder, byte_counter::ByteCounter},
     error::RocksDbStorageError,
 };
 
@@ -25,53 +25,7 @@ impl<T> Bincode<T> {
     }
 }
 
-impl<T> DbCodec<T> for Bincode<T>
-where T: serde::Serialize + serde::de::DeserializeOwned
-{
-    fn encode_len(&self, value: &T) -> Result<usize, RocksDbStorageError> {
-        let mut counter = ByteCounter::new();
-        bincode::serde::encode_into_std_write(value, &mut counter, BINCODE_CONFIG)
-            .map_err(|e| RocksDbStorageError::EncodeError { source: e.into() })?;
-        Ok(counter.get())
-    }
-
-    fn encode_into<W: Write>(&self, value: &T, writer: &mut W) -> Result<(), RocksDbStorageError> {
-        bincode::serde::encode_into_std_write(value, writer, BINCODE_CONFIG)
-            .map_err(|e| RocksDbStorageError::EncodeError { source: e.into() })?;
-        Ok(())
-    }
-
-    fn decode_reader<R: Read>(&self, reader: &mut R) -> Result<T, RocksDbStorageError> {
-        bincode::serde::decode_from_std_read(reader, BINCODE_CONFIG).map_err(|e| RocksDbStorageError::DecodeError {
-            source: anyhow!(
-                "Bincode deserialization failed for type: {}: {}",
-                std::any::type_name::<T>(),
-                e,
-            ),
-        })
-    }
-}
-
-impl<T> Default for Bincode<T> {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-#[derive(Debug, Clone, Copy)]
-pub struct BincodeRef<T> {
-    _phantom: std::marker::PhantomData<T>,
-}
-
-impl<T> BincodeRef<T> {
-    pub fn new() -> Self {
-        Self {
-            _phantom: std::marker::PhantomData,
-        }
-    }
-}
-
-impl<T> DbCodec<T> for BincodeRef<T>
+impl<T> DbEncoder<T> for Bincode<T>
 where T: serde::Serialize
 {
     fn encode_len(&self, value: &T) -> Result<usize, RocksDbStorageError> {
@@ -86,13 +40,23 @@ where T: serde::Serialize
             .map_err(|e| RocksDbStorageError::EncodeError { source: e.into() })?;
         Ok(())
     }
+}
 
-    fn decode_reader<R: Read>(&self, _reader: &mut R) -> Result<T, RocksDbStorageError> {
-        panic!("BincodeRef::decode_reader() is not supported. You likely need to use the Bincode codec instead.");
+impl<T> DbDecoder<T> for Bincode<T>
+where T: serde::de::DeserializeOwned
+{
+    fn decode_reader<R: Read>(&self, reader: &mut R) -> Result<T, RocksDbStorageError> {
+        bincode::serde::decode_from_std_read(reader, BINCODE_CONFIG).map_err(|e| RocksDbStorageError::DecodeError {
+            source: anyhow!(
+                "Bincode deserialization failed for type: {}: {}",
+                std::any::type_name::<T>(),
+                e,
+            ),
+        })
     }
 }
 
-impl<T> Default for BincodeRef<T> {
+impl<T> Default for Bincode<T> {
     fn default() -> Self {
         Self::new()
     }

--- a/crates/state_store_rocksdb/src/codecs/block_diff.rs
+++ b/crates/state_store_rocksdb/src/codecs/block_diff.rs
@@ -8,7 +8,7 @@ use tari_common_types::types::FixedHash;
 use tari_consensus_types::BlockId;
 
 use crate::{
-    codecs::{DbCodec, SubstateIdCodec},
+    codecs::{DbDecoder, DbEncoder, SubstateIdCodec},
     column_families::block_diff::BlockDiffKey,
     error::RocksDbStorageError,
     utils::read_to_fixed,
@@ -24,7 +24,7 @@ pub struct BlockDiffKeyCodec<T> {
     _phantom: std::marker::PhantomData<T>,
 }
 
-impl DbCodec<BlockDiffKey> for BlockDiffKeyCodec<BlockIdSeqSubstateIdVersion> {
+impl DbEncoder<BlockDiffKey> for BlockDiffKeyCodec<BlockIdSeqSubstateIdVersion> {
     fn encode_len(&self, value: &BlockDiffKey) -> Result<usize, RocksDbStorageError> {
         let len = BlockId::byte_size() + // block_id
             4 + // sequence
@@ -62,7 +62,9 @@ impl DbCodec<BlockDiffKey> for BlockDiffKeyCodec<BlockIdSeqSubstateIdVersion> {
             })?;
         Ok(())
     }
+}
 
+impl DbDecoder<BlockDiffKey> for BlockDiffKeyCodec<BlockIdSeqSubstateIdVersion> {
     fn decode_reader<R: Read>(&self, reader: &mut R) -> Result<BlockDiffKey, RocksDbStorageError> {
         let block_id = FixedHash::new(read_to_fixed(reader).ok_or_else(|| RocksDbStorageError::DecodeError {
             source: anyhow!("BlockIdSubstateIdVersionCodec: Invalid bytes for FixedHash",),
@@ -88,7 +90,7 @@ impl DbCodec<BlockDiffKey> for BlockDiffKeyCodec<BlockIdSeqSubstateIdVersion> {
     }
 }
 
-impl DbCodec<BlockDiffKey> for BlockDiffKeyCodec<SubstateIdBlockIdVersionSeq> {
+impl DbEncoder<BlockDiffKey> for BlockDiffKeyCodec<SubstateIdBlockIdVersionSeq> {
     fn encode_len(&self, value: &BlockDiffKey) -> Result<usize, RocksDbStorageError> {
         let len = self.substate_id_codec.encode_len(&value.substate_id)? + // substate_id
             BlockId::byte_size() + // block_id
@@ -131,7 +133,9 @@ impl DbCodec<BlockDiffKey> for BlockDiffKeyCodec<SubstateIdBlockIdVersionSeq> {
             })?;
         Ok(())
     }
+}
 
+impl DbDecoder<BlockDiffKey> for BlockDiffKeyCodec<SubstateIdBlockIdVersionSeq> {
     fn decode_reader<R: Read>(&self, reader: &mut R) -> Result<BlockDiffKey, RocksDbStorageError> {
         let substate_id = self.substate_id_codec.decode_reader(reader)?;
         let block_id = FixedHash::new(read_to_fixed(reader).ok_or_else(|| RocksDbStorageError::DecodeError {

--- a/crates/state_store_rocksdb/src/codecs/bytes.rs
+++ b/crates/state_store_rocksdb/src/codecs/bytes.rs
@@ -9,7 +9,7 @@ use std::{
 use anyhow::anyhow;
 
 use crate::{
-    codecs::{DbCodec, EncodeVec},
+    codecs::{DbDecoder, DbEncoder, EncodeVec},
     error::RocksDbStorageError,
     utils::read_to_fixed,
 };
@@ -19,12 +19,7 @@ use crate::{
 #[derive(Default)]
 pub struct BytesCodec;
 
-impl<T> DbCodec<T> for BytesCodec
-where
-    T: AsRef<[u8]>,
-    for<'a> T: TryFrom<&'a [u8]>,
-    for<'a> <T as TryFrom<&'a [u8]>>::Error: std::error::Error,
-{
+impl<T: AsRef<[u8]>> DbEncoder<T> for BytesCodec {
     fn encode_len(&self, value: &T) -> Result<usize, RocksDbStorageError> {
         Ok(value.as_ref().len())
     }
@@ -41,7 +36,13 @@ where
     fn encode(&self, value: &T) -> Result<EncodeVec, RocksDbStorageError> {
         Ok(EncodeVec::from_slice(value.as_ref()))
     }
+}
 
+impl<T> DbDecoder<T> for BytesCodec
+where
+    for<'a> T: TryFrom<&'a [u8]>,
+    for<'a> <T as TryFrom<&'a [u8]>>::Error: std::error::Error,
+{
     fn decode_reader<R: Read>(&self, reader: &mut R) -> Result<T, RocksDbStorageError> {
         let mut bytes = Vec::new();
         reader
@@ -63,11 +64,7 @@ pub type BlockIdCodec = FixedBytesCodec<32>;
 #[derive(Debug, Clone, Copy, Default)]
 pub struct FixedBytesCodec<const LEN: usize>;
 
-impl<T, const LEN: usize> DbCodec<T> for FixedBytesCodec<LEN>
-where
-    T: AsRef<[u8]>,
-    T: From<[u8; LEN]>,
-{
+impl<T: AsRef<[u8]>, const LEN: usize> DbEncoder<T> for FixedBytesCodec<LEN> {
     fn encode_len(&self, _value: &T) -> Result<usize, RocksDbStorageError> {
         Ok(LEN)
     }
@@ -83,7 +80,11 @@ where
     fn encode(&self, value: &T) -> Result<EncodeVec, RocksDbStorageError> {
         Ok(EncodeVec::from_slice(value.as_ref()))
     }
+}
 
+impl<T, const LEN: usize> DbDecoder<T> for FixedBytesCodec<LEN>
+where T: From<[u8; LEN]>
+{
     fn decode_reader<R: Read>(&self, reader: &mut R) -> Result<T, RocksDbStorageError> {
         let fixed = read_to_fixed(reader).ok_or_else(|| RocksDbStorageError::DecodeError {
             source: anyhow!("FixedBytesCodec: Expected {} bytes", LEN),

--- a/crates/state_store_rocksdb/src/codecs/column.rs
+++ b/crates/state_store_rocksdb/src/codecs/column.rs
@@ -10,7 +10,7 @@ use std::{
 use anyhow::anyhow;
 
 use crate::{
-    codecs::{DbCodec, EncodeVec},
+    codecs::{DbDecoder, DbEncoder, EncodeVec},
     error::RocksDbStorageError,
     utils::read_to_fixed,
 };
@@ -45,7 +45,7 @@ impl<const COL: u8> Display for ByteColumn<COL> {
 #[derive(Default)]
 pub struct ColumnCodec;
 
-impl<const COL: u32> DbCodec<Column<COL>> for ColumnCodec {
+impl<const COL: u32> DbEncoder<Column<COL>> for ColumnCodec {
     fn encode_len(&self, _value: &Column<COL>) -> Result<usize, RocksDbStorageError> {
         Ok(size_of::<u32>())
     }
@@ -62,7 +62,9 @@ impl<const COL: u32> DbCodec<Column<COL>> for ColumnCodec {
     fn encode(&self, _value: &Column<COL>) -> Result<EncodeVec, RocksDbStorageError> {
         Ok(EncodeVec::new_from_array(COL.to_be_bytes()))
     }
+}
 
+impl<const COL: u32> DbDecoder<Column<COL>> for ColumnCodec {
     fn decode_reader<R: Read>(&self, reader: &mut R) -> Result<Column<COL>, RocksDbStorageError> {
         let arr = read_to_fixed(reader).ok_or_else(|| RocksDbStorageError::DecodeError {
             source: anyhow!("Invalid bytes for ColumnCodec"),
@@ -82,7 +84,7 @@ impl<const COL: u32> DbCodec<Column<COL>> for ColumnCodec {
     }
 }
 
-impl<const COL: u8> DbCodec<ByteColumn<COL>> for ColumnCodec {
+impl<const COL: u8> DbEncoder<ByteColumn<COL>> for ColumnCodec {
     fn encode_len(&self, _value: &ByteColumn<COL>) -> Result<usize, RocksDbStorageError> {
         Ok(1)
     }
@@ -97,7 +99,9 @@ impl<const COL: u8> DbCodec<ByteColumn<COL>> for ColumnCodec {
     fn encode(&self, _value: &ByteColumn<COL>) -> Result<EncodeVec, RocksDbStorageError> {
         Ok(EncodeVec::new_from_array([COL]))
     }
+}
 
+impl<const COL: u8> DbDecoder<ByteColumn<COL>> for ColumnCodec {
     fn decode_reader<R: Read>(&self, reader: &mut R) -> Result<ByteColumn<COL>, RocksDbStorageError> {
         let mut buf = [0u8; 1];
         reader

--- a/crates/state_store_rocksdb/src/codecs/misc.rs
+++ b/crates/state_store_rocksdb/src/codecs/misc.rs
@@ -6,7 +6,7 @@ use std::io::{Read, Write};
 use tari_ootle_common_types::{Epoch, NodeHeight, shard::Shard};
 
 use crate::{
-    codecs::{DbCodec, EncodeVec},
+    codecs::{DbDecoder, DbEncoder, EncodeVec},
     error::RocksDbStorageError,
     utils::read_to_fixed,
 };
@@ -14,7 +14,7 @@ use crate::{
 #[derive(Debug, Clone, Copy, Default)]
 pub struct UnitCodec;
 
-impl DbCodec<()> for UnitCodec {
+impl DbEncoder<()> for UnitCodec {
     fn encode_len(&self, _value: &()) -> Result<usize, RocksDbStorageError> {
         Ok(0)
     }
@@ -26,7 +26,9 @@ impl DbCodec<()> for UnitCodec {
     fn encode(&self, _: &()) -> Result<EncodeVec, RocksDbStorageError> {
         Ok(EncodeVec::empty())
     }
+}
 
+impl DbDecoder<()> for UnitCodec {
     fn decode_reader<R: Read>(&self, _reader: &mut R) -> Result<(), RocksDbStorageError> {
         Ok(())
     }
@@ -35,7 +37,7 @@ impl DbCodec<()> for UnitCodec {
 #[derive(Default)]
 pub struct BoolCodec;
 
-impl DbCodec<bool> for BoolCodec {
+impl DbEncoder<bool> for BoolCodec {
     fn encode_len(&self, _value: &bool) -> Result<usize, RocksDbStorageError> {
         Ok(1)
     }
@@ -52,7 +54,9 @@ impl DbCodec<bool> for BoolCodec {
     fn encode(&self, value: &bool) -> Result<EncodeVec, RocksDbStorageError> {
         Ok(EncodeVec::new_from_array([u8::from(*value)]))
     }
+}
 
+impl DbDecoder<bool> for BoolCodec {
     fn decode_reader<R: Read>(&self, reader: &mut R) -> Result<bool, RocksDbStorageError> {
         let mut buf = [0u8; 1];
         reader
@@ -74,7 +78,7 @@ pub struct NumberCodec<T> {
     _phantom: std::marker::PhantomData<T>,
 }
 
-impl DbCodec<u8> for NumberCodec<u8> {
+impl DbEncoder<u8> for NumberCodec<u8> {
     fn encode_len(&self, _value: &u8) -> Result<usize, RocksDbStorageError> {
         Ok(1)
     }
@@ -91,7 +95,9 @@ impl DbCodec<u8> for NumberCodec<u8> {
     fn encode(&self, value: &u8) -> Result<EncodeVec, RocksDbStorageError> {
         Ok(EncodeVec::new_from_array([*value]))
     }
+}
 
+impl DbDecoder<u8> for NumberCodec<u8> {
     fn decode_reader<R: Read>(&self, reader: &mut R) -> Result<u8, RocksDbStorageError> {
         let mut buf = [0u8; 1];
         reader
@@ -104,7 +110,7 @@ impl DbCodec<u8> for NumberCodec<u8> {
     }
 }
 
-impl DbCodec<u32> for NumberCodec<u32> {
+impl DbEncoder<u32> for NumberCodec<u32> {
     fn encode_len(&self, _value: &u32) -> Result<usize, RocksDbStorageError> {
         Ok(size_of::<u32>())
     }
@@ -121,7 +127,9 @@ impl DbCodec<u32> for NumberCodec<u32> {
     fn encode(&self, value: &u32) -> Result<EncodeVec, RocksDbStorageError> {
         Ok(EncodeVec::new_from_array(value.to_be_bytes()))
     }
+}
 
+impl DbDecoder<u32> for NumberCodec<u32> {
     fn decode_reader<R: Read>(&self, reader: &mut R) -> Result<u32, RocksDbStorageError> {
         let arr = read_to_fixed(reader).ok_or_else(|| RocksDbStorageError::MalformedData {
             operation: "decode u32",
@@ -131,7 +139,7 @@ impl DbCodec<u32> for NumberCodec<u32> {
     }
 }
 
-impl DbCodec<u64> for NumberCodec<u64> {
+impl DbEncoder<u64> for NumberCodec<u64> {
     fn encode_len(&self, _value: &u64) -> Result<usize, RocksDbStorageError> {
         Ok(size_of::<u64>())
     }
@@ -148,7 +156,8 @@ impl DbCodec<u64> for NumberCodec<u64> {
     fn encode(&self, value: &u64) -> Result<EncodeVec, RocksDbStorageError> {
         Ok(EncodeVec::new_from_array(value.to_be_bytes()))
     }
-
+}
+impl DbDecoder<u64> for NumberCodec<u64> {
     fn decode_reader<R: Read>(&self, reader: &mut R) -> Result<u64, RocksDbStorageError> {
         let arr = read_to_fixed(reader).ok_or_else(|| RocksDbStorageError::MalformedData {
             operation: "decode u64",
@@ -158,7 +167,7 @@ impl DbCodec<u64> for NumberCodec<u64> {
     }
 }
 
-impl DbCodec<Epoch> for NumberCodec<Epoch> {
+impl DbEncoder<Epoch> for NumberCodec<Epoch> {
     fn encode_len(&self, _value: &Epoch) -> Result<usize, RocksDbStorageError> {
         Ok(size_of::<Epoch>())
     }
@@ -175,7 +184,9 @@ impl DbCodec<Epoch> for NumberCodec<Epoch> {
     fn encode(&self, epoch: &Epoch) -> Result<EncodeVec, RocksDbStorageError> {
         Ok(EncodeVec::new_from_array(epoch.to_be_bytes()))
     }
+}
 
+impl DbDecoder<Epoch> for NumberCodec<Epoch> {
     fn decode_reader<R: Read>(&self, reader: &mut R) -> Result<Epoch, RocksDbStorageError> {
         let arr = read_to_fixed(reader).ok_or_else(|| RocksDbStorageError::MalformedData {
             operation: "decode Epoch",
@@ -186,7 +197,7 @@ impl DbCodec<Epoch> for NumberCodec<Epoch> {
     }
 }
 
-impl DbCodec<NodeHeight> for NumberCodec<NodeHeight> {
+impl DbEncoder<NodeHeight> for NumberCodec<NodeHeight> {
     fn encode_len(&self, _value: &NodeHeight) -> Result<usize, RocksDbStorageError> {
         Ok(size_of::<NodeHeight>())
     }
@@ -203,7 +214,9 @@ impl DbCodec<NodeHeight> for NumberCodec<NodeHeight> {
     fn encode(&self, value: &NodeHeight) -> Result<EncodeVec, RocksDbStorageError> {
         Ok(EncodeVec::new_from_array(value.as_u64().to_be_bytes()))
     }
+}
 
+impl DbDecoder<NodeHeight> for NumberCodec<NodeHeight> {
     fn decode_reader<R: Read>(&self, reader: &mut R) -> Result<NodeHeight, RocksDbStorageError> {
         let arr = read_to_fixed(reader).ok_or_else(|| RocksDbStorageError::MalformedData {
             operation: "decode NodeHeight",
@@ -214,7 +227,7 @@ impl DbCodec<NodeHeight> for NumberCodec<NodeHeight> {
     }
 }
 
-impl DbCodec<Shard> for NumberCodec<Shard> {
+impl DbEncoder<Shard> for NumberCodec<Shard> {
     fn encode_len(&self, _value: &Shard) -> Result<usize, RocksDbStorageError> {
         Ok(size_of::<Shard>())
     }
@@ -231,7 +244,9 @@ impl DbCodec<Shard> for NumberCodec<Shard> {
     fn encode(&self, shard: &Shard) -> Result<EncodeVec, RocksDbStorageError> {
         Ok(EncodeVec::new_from_array(shard.as_u32().to_be_bytes()))
     }
+}
 
+impl DbDecoder<Shard> for NumberCodec<Shard> {
     fn decode_reader<R: Read>(&self, reader: &mut R) -> Result<Shard, RocksDbStorageError> {
         let arr = read_to_fixed(reader).ok_or_else(|| RocksDbStorageError::MalformedData {
             operation: "decode Shard",

--- a/crates/state_store_rocksdb/src/codecs/mod.rs
+++ b/crates/state_store_rocksdb/src/codecs/mod.rs
@@ -38,7 +38,11 @@ use crate::error::RocksDbStorageError;
 /// When the key is smaller than 100 bytes, it will be stack-allocated. Otherwise, it will be heap-allocated.
 pub type EncodeVec = small_bytes::SmallBytes<100>;
 
-pub trait DbCodec<T> {
+pub trait DbCodec<T>: DbEncoder<T> + DbDecoder<T> {}
+
+impl<T, C> DbCodec<T> for C where C: DbEncoder<T> + DbDecoder<T> {}
+
+pub trait DbEncoder<T> {
     fn encode_len(&self, value: &T) -> Result<usize, RocksDbStorageError>;
     fn encode_into<W: io::Write>(&self, value: &T, writer: &mut W) -> Result<(), RocksDbStorageError>;
     fn encode(&self, value: &T) -> Result<EncodeVec, RocksDbStorageError> {
@@ -54,7 +58,9 @@ pub trait DbCodec<T> {
         self.encode_into(value, &mut buf)?;
         Ok(EncodeVec::from_vec(buf))
     }
+}
 
+pub trait DbDecoder<T> {
     fn decode(&self, bytes: &[u8]) -> Result<T, RocksDbStorageError> {
         let reader = &mut &bytes[..];
         self.decode_reader(reader)
@@ -65,4 +71,3 @@ pub trait DbCodec<T> {
 
 pub type DefaultCodec<T> = Bincode<T>;
 pub type DefaultVersionedCodec<T> = VersionedCodec<DefaultCodec<T>, T>;
-pub type DefaultCodecRef<T> = BincodeRef<T>;

--- a/crates/state_store_rocksdb/src/codecs/prefixed.rs
+++ b/crates/state_store_rocksdb/src/codecs/prefixed.rs
@@ -3,7 +3,10 @@
 
 use std::io;
 
-use crate::{codecs::DbCodec, error::RocksDbStorageError};
+use crate::{
+    codecs::{DbDecoder, DbEncoder},
+    error::RocksDbStorageError,
+};
 
 #[derive(Debug, Clone, Copy, strum_macros::FromRepr)]
 #[repr(u8)]
@@ -75,7 +78,7 @@ pub struct PrefixCodec<P, C> {
     inner: C,
 }
 
-impl<C: DbCodec<T>, P: Prefixed, T> DbCodec<T> for PrefixCodec<P, C> {
+impl<C: DbEncoder<T>, P: Prefixed, T> DbEncoder<T> for PrefixCodec<P, C> {
     fn encode_len(&self, value: &T) -> Result<usize, RocksDbStorageError> {
         self.inner
             .encode_len(value)
@@ -90,7 +93,9 @@ impl<C: DbCodec<T>, P: Prefixed, T> DbCodec<T> for PrefixCodec<P, C> {
         }
         self.inner.encode_into(value, writer)
     }
+}
 
+impl<C: DbDecoder<T>, P: Prefixed, T> DbDecoder<T> for PrefixCodec<P, C> {
     fn decode_reader<R: std::io::Read>(&self, reader: &mut R) -> Result<T, RocksDbStorageError> {
         if let Some(p) = P::prefix() {
             let mut prefix = [0u8; 1];

--- a/crates/state_store_rocksdb/src/codecs/public_key.rs
+++ b/crates/state_store_rocksdb/src/codecs/public_key.rs
@@ -6,7 +6,7 @@ use std::io::{Read, Write};
 use tari_template_lib_types::crypto::RistrettoPublicKeyBytes;
 
 use crate::{
-    codecs::{DbCodec, EncodeVec, FixedBytesCodec},
+    codecs::{DbDecoder, DbEncoder, EncodeVec, FixedBytesCodec},
     error::RocksDbStorageError,
 };
 
@@ -15,7 +15,7 @@ pub struct PublicKeyCodec {
     inner: FixedBytesCodec<{ RistrettoPublicKeyBytes::length() }>,
 }
 
-impl DbCodec<RistrettoPublicKeyBytes> for PublicKeyCodec {
+impl DbEncoder<RistrettoPublicKeyBytes> for PublicKeyCodec {
     fn encode_len(&self, value: &RistrettoPublicKeyBytes) -> Result<usize, RocksDbStorageError> {
         self.inner.encode_len(value)
     }
@@ -31,7 +31,9 @@ impl DbCodec<RistrettoPublicKeyBytes> for PublicKeyCodec {
     fn encode(&self, value: &RistrettoPublicKeyBytes) -> Result<EncodeVec, RocksDbStorageError> {
         self.inner.encode(value)
     }
+}
 
+impl DbDecoder<RistrettoPublicKeyBytes> for PublicKeyCodec {
     fn decode_reader<R: Read>(&self, reader: &mut R) -> Result<RistrettoPublicKeyBytes, RocksDbStorageError> {
         self.inner.decode_reader(reader)
     }

--- a/crates/state_store_rocksdb/src/codecs/shard_group.rs
+++ b/crates/state_store_rocksdb/src/codecs/shard_group.rs
@@ -6,7 +6,7 @@ use std::io::{Read, Write};
 use tari_ootle_common_types::ShardGroup;
 
 use crate::{
-    codecs::{DbCodec, EncodeVec, ShardCodec},
+    codecs::{DbDecoder, DbEncoder, EncodeVec, ShardCodec},
     error::RocksDbStorageError,
 };
 
@@ -15,7 +15,7 @@ pub struct ShardGroupCodec {
     inner: ShardCodec,
 }
 
-impl DbCodec<ShardGroup> for ShardGroupCodec {
+impl DbEncoder<ShardGroup> for ShardGroupCodec {
     fn encode_len(&self, value: &ShardGroup) -> Result<usize, RocksDbStorageError> {
         let start_len = self.inner.encode_len(&value.start())?;
         let end_len = self.inner.encode_len(&value.end())?;
@@ -33,7 +33,9 @@ impl DbCodec<ShardGroup> for ShardGroupCodec {
         let end = self.inner.encode(&value.end())?;
         Ok(EncodeVec::from_slices(&[start.as_slice(), end.as_slice()]))
     }
+}
 
+impl DbDecoder<ShardGroup> for ShardGroupCodec {
     fn decode_reader<R: Read>(&self, reader: &mut R) -> Result<ShardGroup, RocksDbStorageError> {
         let start = self.inner.decode_reader(reader)?;
         let end = self.inner.decode_reader(reader)?;

--- a/crates/state_store_rocksdb/src/codecs/state_tree.rs
+++ b/crates/state_store_rocksdb/src/codecs/state_tree.rs
@@ -7,7 +7,7 @@ use anyhow::anyhow;
 use tari_state_tree::{NibblePath, NodeKey, Version};
 
 use crate::{
-    codecs::DbCodec,
+    codecs::{DbDecoder, DbEncoder},
     error::RocksDbStorageError,
     utils::{read_n_bytes, read_to_fixed},
 };
@@ -50,7 +50,7 @@ impl NodeKeyCodec {
     }
 }
 
-impl DbCodec<NodeKey> for NodeKeyCodec {
+impl DbEncoder<NodeKey> for NodeKeyCodec {
     fn encode_len(&self, value: &NodeKey) -> Result<usize, RocksDbStorageError> {
         self.get_node_key_encoded_len(value)
     }
@@ -58,7 +58,9 @@ impl DbCodec<NodeKey> for NodeKeyCodec {
     fn encode_into<W: io::Write>(&self, value: &NodeKey, writer: &mut W) -> Result<(), RocksDbStorageError> {
         self.encode_node_key_into(value, writer)
     }
+}
 
+impl DbDecoder<NodeKey> for NodeKeyCodec {
     fn decode_reader<R: Read>(&self, reader: &mut R) -> Result<NodeKey, RocksDbStorageError> {
         let buf = read_to_fixed(reader).ok_or_else(|| RocksDbStorageError::DecodeError {
             source: anyhow!("Invalid version bytes"),
@@ -91,17 +93,13 @@ impl DbCodec<NodeKey> for NodeKeyCodec {
     }
 }
 
-impl<'a> DbCodec<&'a NodeKey> for NodeKeyCodec {
+impl<'a> DbEncoder<&'a NodeKey> for NodeKeyCodec {
     fn encode_len(&self, value: &&'a NodeKey) -> Result<usize, RocksDbStorageError> {
         self.get_node_key_encoded_len(value)
     }
 
     fn encode_into<W: io::Write>(&self, value: &&'a NodeKey, writer: &mut W) -> Result<(), RocksDbStorageError> {
         self.encode_node_key_into(value, writer)
-    }
-
-    fn decode_reader<R: Read>(&self, _reader: &mut R) -> Result<&'a NodeKey, RocksDbStorageError> {
-        unreachable!("decode should not be called on NodeKeyCodec with a reference")
     }
 }
 

--- a/crates/state_store_rocksdb/src/codecs/substate_id.rs
+++ b/crates/state_store_rocksdb/src/codecs/substate_id.rs
@@ -8,7 +8,7 @@ use tari_engine_types::substate::SubstateId;
 use tari_ootle_common_types::VersionedSubstateIdRef;
 
 use crate::{
-    codecs::{DbCodec, EncodeVec},
+    codecs::{DbDecoder, DbEncoder, EncodeVec},
     error::RocksDbStorageError,
 };
 
@@ -27,7 +27,7 @@ impl SubstateIdCodec {
     }
 }
 
-impl DbCodec<SubstateId> for SubstateIdCodec {
+impl DbEncoder<SubstateId> for SubstateIdCodec {
     fn encode_len(&self, value: &SubstateId) -> Result<usize, RocksDbStorageError> {
         self.get_substate_id_encoded_len(value)
     }
@@ -35,7 +35,9 @@ impl DbCodec<SubstateId> for SubstateIdCodec {
     fn encode_into<W: Write>(&self, value: &SubstateId, writer: &mut W) -> Result<(), RocksDbStorageError> {
         self.encode_substate_id_into(value, writer)
     }
+}
 
+impl DbDecoder<SubstateId> for SubstateIdCodec {
     fn decode_reader<R: Read>(&self, reader: &mut R) -> Result<SubstateId, RocksDbStorageError> {
         // We use the deserialize_reader here so that no error is returned if there are extra bytes in the buffer
         // in order to use SubstateId as a prefix
@@ -43,7 +45,7 @@ impl DbCodec<SubstateId> for SubstateIdCodec {
     }
 }
 
-impl<'a> DbCodec<&'a SubstateId> for SubstateIdCodec {
+impl<'a> DbEncoder<&'a SubstateId> for SubstateIdCodec {
     fn encode_len(&self, value: &&'a SubstateId) -> Result<usize, RocksDbStorageError> {
         self.get_substate_id_encoded_len(value)
     }
@@ -55,13 +57,9 @@ impl<'a> DbCodec<&'a SubstateId> for SubstateIdCodec {
     fn encode(&self, value: &&'a SubstateId) -> Result<EncodeVec, RocksDbStorageError> {
         SubstateIdCodec.encode(*value)
     }
-
-    fn decode_reader<R: Read>(&self, _reader: &mut R) -> Result<&'a SubstateId, RocksDbStorageError> {
-        unimplemented!("Decoding a reference to a SubstateId is not supported. Use decode_reader for owned values.");
-    }
 }
 
-impl<'a> DbCodec<VersionedSubstateIdRef<'a>> for SubstateIdCodec {
+impl<'a> DbEncoder<VersionedSubstateIdRef<'a>> for SubstateIdCodec {
     fn encode_len(&self, value: &VersionedSubstateIdRef<'a>) -> Result<usize, RocksDbStorageError> {
         self.get_substate_id_encoded_len(value.substate_id())
             .map(|len| len + size_of::<u32>())
@@ -79,10 +77,6 @@ impl<'a> DbCodec<VersionedSubstateIdRef<'a>> for SubstateIdCodec {
                 source: anyhow::anyhow!("VersionedSubstateIdRefCodec: Failed to write version: {}", e),
             })?;
         Ok(())
-    }
-
-    fn decode_reader<R: Read>(&self, _reader: &mut R) -> Result<VersionedSubstateIdRef<'a>, RocksDbStorageError> {
-        unreachable!("Decoding a VersionedSubstateIdRef is not supported. Use decode_reader for owned values.");
     }
 }
 

--- a/crates/state_store_rocksdb/src/codecs/substate_lock.rs
+++ b/crates/state_store_rocksdb/src/codecs/substate_lock.rs
@@ -11,7 +11,7 @@ use tari_ootle_common_types::NodeHeight;
 use tari_ootle_transaction::TransactionId;
 
 use crate::{
-    codecs::{DbCodec, SubstateIdCodec},
+    codecs::{DbDecoder, DbEncoder, SubstateIdCodec},
     column_families::substate_locks::SubstateLockKey,
     error::RocksDbStorageError,
     utils::read_to_fixed,
@@ -61,7 +61,7 @@ impl<T> SubstateLockKeyCodec<T> {
     }
 }
 
-impl DbCodec<SubstateLockKey> for SubstateLockKeyCodec<(TransactionId, SubstateId, BlockId, NodeHeight)> {
+impl DbEncoder<SubstateLockKey> for SubstateLockKeyCodec<(TransactionId, SubstateId, BlockId, NodeHeight)> {
     fn encode_len(&self, value: &SubstateLockKey) -> Result<usize, RocksDbStorageError> {
         self.get_encoded_len(value)
     }
@@ -85,7 +85,9 @@ impl DbCodec<SubstateLockKey> for SubstateLockKeyCodec<(TransactionId, SubstateI
             })?;
         Ok(())
     }
+}
 
+impl DbDecoder<SubstateLockKey> for SubstateLockKeyCodec<(TransactionId, SubstateId, BlockId, NodeHeight)> {
     fn decode_reader<R: Read>(&self, reader: &mut R) -> Result<SubstateLockKey, RocksDbStorageError> {
         let transaction_id = self.decode_transaction_id(reader)?;
         let substate_id = self.decode_substate_id(reader)?;
@@ -100,7 +102,7 @@ impl DbCodec<SubstateLockKey> for SubstateLockKeyCodec<(TransactionId, SubstateI
     }
 }
 
-impl DbCodec<SubstateLockKey> for SubstateLockKeyCodec<(BlockId, SubstateId, TransactionId, NodeHeight)> {
+impl DbEncoder<SubstateLockKey> for SubstateLockKeyCodec<(BlockId, SubstateId, TransactionId, NodeHeight)> {
     fn encode_len(&self, value: &SubstateLockKey) -> Result<usize, RocksDbStorageError> {
         self.get_encoded_len(value)
     }
@@ -124,7 +126,9 @@ impl DbCodec<SubstateLockKey> for SubstateLockKeyCodec<(BlockId, SubstateId, Tra
             })?;
         Ok(())
     }
+}
 
+impl DbDecoder<SubstateLockKey> for SubstateLockKeyCodec<(BlockId, SubstateId, TransactionId, NodeHeight)> {
     fn decode_reader<R: Read>(&self, reader: &mut R) -> Result<SubstateLockKey, RocksDbStorageError> {
         let block_id = self.decode_block_id(reader)?;
         let substate_id = self.decode_substate_id(reader)?;
@@ -140,7 +144,7 @@ impl DbCodec<SubstateLockKey> for SubstateLockKeyCodec<(BlockId, SubstateId, Tra
     }
 }
 
-impl DbCodec<SubstateLockKey> for SubstateLockKeyCodec<(SubstateId, TransactionId, BlockId, NodeHeight)> {
+impl DbEncoder<SubstateLockKey> for SubstateLockKeyCodec<(SubstateId, TransactionId, BlockId, NodeHeight)> {
     fn encode_len(&self, value: &SubstateLockKey) -> Result<usize, RocksDbStorageError> {
         self.get_encoded_len(value)
     }
@@ -168,7 +172,9 @@ impl DbCodec<SubstateLockKey> for SubstateLockKeyCodec<(SubstateId, TransactionI
             })?;
         Ok(())
     }
+}
 
+impl DbDecoder<SubstateLockKey> for SubstateLockKeyCodec<(SubstateId, TransactionId, BlockId, NodeHeight)> {
     fn decode_reader<R: Read>(&self, reader: &mut R) -> Result<SubstateLockKey, RocksDbStorageError> {
         let substate_id = self.decode_substate_id(reader)?;
         let transaction_id = self.decode_transaction_id(reader)?;

--- a/crates/state_store_rocksdb/src/codecs/tuple.rs
+++ b/crates/state_store_rocksdb/src/codecs/tuple.rs
@@ -3,13 +3,16 @@
 
 use std::io::{Read, Write};
 
-use crate::{codecs::DbCodec, error::RocksDbStorageError};
+use crate::{
+    codecs::{DbDecoder, DbEncoder},
+    error::RocksDbStorageError,
+};
 
-impl<A, B, C, CA, CB, CC> DbCodec<(A, B, C)> for (CA, CB, CC)
+impl<A, B, C, CA, CB, CC> DbEncoder<(A, B, C)> for (CA, CB, CC)
 where
-    CA: DbCodec<A>,
-    CB: DbCodec<B>,
-    CC: DbCodec<C>,
+    CA: DbEncoder<A>,
+    CB: DbEncoder<B>,
+    CC: DbEncoder<C>,
 {
     fn encode_len(&self, value: &(A, B, C)) -> Result<usize, RocksDbStorageError> {
         let (ca, cb, cc) = &self;
@@ -26,7 +29,14 @@ where
         cc.encode_into(c, writer)?;
         Ok(())
     }
+}
 
+impl<A, B, C, CA, CB, CC> DbDecoder<(A, B, C)> for (CA, CB, CC)
+where
+    CA: DbDecoder<A>,
+    CB: DbDecoder<B>,
+    CC: DbDecoder<C>,
+{
     fn decode_reader<R: Read>(&self, reader: &mut R) -> Result<(A, B, C), RocksDbStorageError> {
         let (ca, cb, cc) = &self;
         let a = ca.decode_reader(reader)?;
@@ -36,10 +46,10 @@ where
     }
 }
 
-impl<A, B, CA, CB> DbCodec<(A, B)> for (CA, CB)
+impl<A, B, CA, CB> DbEncoder<(A, B)> for (CA, CB)
 where
-    CA: DbCodec<A>,
-    CB: DbCodec<B>,
+    CA: DbEncoder<A>,
+    CB: DbEncoder<B>,
 {
     fn encode_len(&self, value: &(A, B)) -> Result<usize, RocksDbStorageError> {
         let (ca, cb) = &self;
@@ -54,7 +64,13 @@ where
         cb.encode_into(b, writer)?;
         Ok(())
     }
+}
 
+impl<A, B, CA, CB> DbDecoder<(A, B)> for (CA, CB)
+where
+    CA: DbDecoder<A>,
+    CB: DbDecoder<B>,
+{
     fn decode_reader<R: Read>(&self, reader: &mut R) -> Result<(A, B), RocksDbStorageError> {
         let (ca, cb) = &self;
         let a = ca.decode_reader(reader)?;

--- a/crates/state_store_rocksdb/src/codecs/versioned.rs
+++ b/crates/state_store_rocksdb/src/codecs/versioned.rs
@@ -4,7 +4,7 @@
 use std::io::{Read, Write};
 
 use crate::{
-    codecs::{DbCodec, EncodeVec},
+    codecs::{DbDecoder, DbEncoder, EncodeVec},
     error::RocksDbStorageError,
     traits::Versioned,
 };
@@ -14,7 +14,7 @@ pub struct VersionedCodec<C, T> {
     _versioned: std::marker::PhantomData<T>,
 }
 
-impl<C: DbCodec<T>, T: Versioned<Latest = V>, V: Into<T> + Clone> DbCodec<V> for VersionedCodec<C, T> {
+impl<C: DbEncoder<T>, T: Versioned<Latest = V>, V: Into<T> + Clone> DbEncoder<V> for VersionedCodec<C, T> {
     fn encode_len(&self, value: &V) -> Result<usize, RocksDbStorageError> {
         self.codec.encode_len(&value.clone().into())
     }
@@ -27,7 +27,9 @@ impl<C: DbCodec<T>, T: Versioned<Latest = V>, V: Into<T> + Clone> DbCodec<V> for
         let value = value.clone().into();
         self.codec.encode(&value)
     }
+}
 
+impl<C: DbDecoder<T>, T: Versioned<Latest = V>, V: Into<T> + Clone> DbDecoder<V> for VersionedCodec<C, T> {
     fn decode_reader<R: Read>(&self, reader: &mut R) -> Result<V, RocksDbStorageError> {
         let versioned = self.codec.decode_reader(reader)?;
         Ok(versioned.full_upgrade().into_latest())

--- a/crates/state_store_rocksdb/src/column_families/block_diff.rs
+++ b/crates/state_store_rocksdb/src/column_families/block_diff.rs
@@ -12,7 +12,6 @@ use crate::{
         BlockIdCodec,
         BlockIdSeqSubstateIdVersion,
         DefaultCodec,
-        DefaultCodecRef,
         KeyPrefix,
         SubstateIdBlockIdVersionSeq,
         SubstateIdCodec,
@@ -61,30 +60,6 @@ impl Cf for BlockDiffCf {
 
     fn name() -> &'static str {
         BlockCf::name()
-    }
-}
-
-#[derive(Debug, Clone, Serialize)]
-#[serde(transparent)]
-pub struct BlockDiffRef<'a> {
-    pub change: &'a SubstateChange,
-}
-
-/// Allows insertions into the block diffs CF without cloning the substate changes.
-#[derive(Default)]
-pub struct BlockDiffModelRef<'a> {
-    _phantom: std::marker::PhantomData<&'a ()>,
-}
-
-impl<'a> Cf for BlockDiffModelRef<'a> {
-    type Key = <BlockDiffCf as Cf>::Key;
-    type KeyCodec = <BlockDiffCf as Cf>::KeyCodec;
-    type Prefix = <BlockDiffCf as Cf>::Prefix;
-    type Value = BlockDiffRef<'a>;
-    type ValueCodec = DefaultCodecRef<Self::Value>;
-
-    fn name() -> &'static str {
-        BlockDiffCf::name()
     }
 }
 

--- a/crates/state_store_rocksdb/src/column_families/parked_block.rs
+++ b/crates/state_store_rocksdb/src/column_families/parked_block.rs
@@ -25,7 +25,7 @@ use tari_consensus_types::BlockId;
 use tari_ootle_storage::consensus_models::{Block, ForeignProposal};
 
 use crate::{
-    codecs::{BlockIdCodec, DefaultCodec, DefaultCodecRef, KeyPrefix},
+    codecs::{BlockIdCodec, DefaultCodec, KeyPrefix},
     column_families::cf_names,
     prefixed,
     traits::Cf,
@@ -57,21 +57,4 @@ impl Cf for ParkedBlockCf {
 pub struct ParkedBlockDataRef<'a> {
     pub block: &'a Block,
     pub foreign_proposals: &'a [ForeignProposal],
-}
-
-#[derive(Debug, Default)]
-pub struct ParkedBlockModelRef<'a> {
-    _phantom: std::marker::PhantomData<&'a ()>,
-}
-
-impl<'a> Cf for ParkedBlockModelRef<'a> {
-    type Key = BlockId;
-    type KeyCodec = BlockIdCodec;
-    type Prefix = ParkedBlockPrefix;
-    type Value = ParkedBlockDataRef<'a>;
-    type ValueCodec = DefaultCodecRef<Self::Value>;
-
-    fn name() -> &'static str {
-        ParkedBlockCf::name()
-    }
 }

--- a/crates/state_store_rocksdb/src/column_families/state_tree.rs
+++ b/crates/state_store_rocksdb/src/column_families/state_tree.rs
@@ -45,30 +45,6 @@ impl Cf for StateTreeCf {
     }
 }
 
-pub struct StateTreeCfRef<'a> {
-    _phantom: std::marker::PhantomData<&'a ()>,
-}
-
-impl<'a> Cf for StateTreeCfRef<'a> {
-    type Key = (Shard, &'a NodeKey);
-    type KeyCodec = (ShardCodec, NodeKeyCodec);
-    type Prefix = StateTreePrefix;
-    type Value = Node<StateTreePayload>;
-    type ValueCodec = DefaultCodec<Self::Value>;
-
-    fn name() -> &'static str {
-        StateTreeCf::name()
-    }
-}
-
-impl Default for StateTreeCfRef<'_> {
-    fn default() -> Self {
-        Self {
-            _phantom: std::marker::PhantomData,
-        }
-    }
-}
-
 pub struct ByShardStateVersionQuery;
 
 impl QueryCf for ByShardStateVersionQuery {

--- a/crates/state_store_rocksdb/src/column_families/substate_locks.rs
+++ b/crates/state_store_rocksdb/src/column_families/substate_locks.rs
@@ -20,7 +20,7 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::{fmt::Display, marker::PhantomData};
+use std::fmt::Display;
 
 use serde::Serialize;
 use tari_consensus_types::BlockId;
@@ -127,11 +127,11 @@ impl QueryCf for ByBlockIdQuery {
 }
 
 #[derive(Default)]
-pub struct ByBlockIdSubstateIdQuery<'a>(PhantomData<&'a ()>);
+pub struct ByBlockIdSubstateIdQuery;
 
-impl<'a> QueryCf for ByBlockIdSubstateIdQuery<'a> {
+impl QueryCf for ByBlockIdSubstateIdQuery {
     type Cf = BlockIdIndex;
-    type Key = (BlockId, &'a SubstateId);
+    type Key = (BlockId, SubstateId);
     type KeyCodec = (BlockIdCodec, SubstateIdCodec);
 }
 

--- a/crates/state_store_rocksdb/src/dbs/iterator.rs
+++ b/crates/state_store_rocksdb/src/dbs/iterator.rs
@@ -1,0 +1,148 @@
+//   Copyright 2026 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+// Copyright 2020 Tyler Neely
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// TARI MODIFICATIONS:
+// - remove allocated buffers on each iteration, instead passing slices that directly reference the data in RocksDB to a
+//   "mapper" function. This is safe since we restrict the lifetime of the return type of the mapper to 'static, which
+//   forces the caller to return owned data (i.e. no references to the slice). This allows us to avoid unnecessary
+//   allocations and copying of data on each iteration, which can significantly improve performance when iterating over
+//   large datasets.
+
+use rocksdb::{DBAccess, DBRawIteratorWithThreadMode, Direction, IteratorMode};
+
+/// A standard Rust [`Iterator`] over a database or column family.
+///
+/// As an alternative, [`DBRawIteratorWithThreadMode`] is a low level wrapper around
+/// RocksDB's API, which can provide better performance and more features.
+///
+/// ```
+/// use rocksdb::{DB, Direction, IteratorMode, Options};
+///
+/// let tempdir = tempfile::Builder::new()
+///     .prefix("_path_for_rocksdb_storage2")
+///     .tempdir()
+///     .expect("Failed to create temporary path for the _path_for_rocksdb_storage2.");
+/// let path = tempdir.path();
+/// {
+///     let db = DB::open_default(path).unwrap();
+///     let mut iter = db.iterator(IteratorMode::Start); // Always iterates forward
+///     for item in iter {
+///         let (key, value) = item.unwrap();
+///         println!("Saw {:?} {:?}", key, value);
+///     }
+///     iter = db.iterator(IteratorMode::End);  // Always iterates backward
+///     for item in iter {
+///         let (key, value) = item.unwrap();
+///         println!("Saw {:?} {:?}", key, value);
+///     }
+///     iter = db.iterator(IteratorMode::From(b"my key", Direction::Forward)); // From a key in Direction::{forward,reverse}
+///     for item in iter {
+///         let (key, value) = item.unwrap();
+///         println!("Saw {:?} {:?}", key, value);
+///     }
+///
+///     // You can seek with an existing Iterator instance, too
+///     iter = db.iterator(IteratorMode::Start);
+///     iter.set_mode(IteratorMode::From(b"another key", Direction::Reverse));
+///     for item in iter {
+///         let (key, value) = item.unwrap();
+///         println!("Saw {:?} {:?}", key, value);
+///     }
+/// }
+/// let _ = DB::destroy(&Options::default(), path);
+/// ```
+pub struct DbRawKeyValueIterator<'a, D: DBAccess, M> {
+    raw: DBRawIteratorWithThreadMode<'a, D>,
+    map: M,
+    direction: Direction,
+    done: bool,
+}
+
+impl<'a, D: DBAccess, M> DbRawKeyValueIterator<'a, D, M> {
+    pub fn new(raw: DBRawIteratorWithThreadMode<'a, D>, mode: IteratorMode, map: M) -> Self {
+        let mut rv = Self {
+            raw,
+            direction: Direction::Forward, // blown away by set_mode()
+            map,
+            done: false,
+        };
+        rv.set_mode(mode);
+        rv
+    }
+
+    pub fn set_mode(&mut self, mode: IteratorMode) {
+        self.done = false;
+        self.direction = match mode {
+            IteratorMode::Start => {
+                self.raw.seek_to_first();
+                Direction::Forward
+            },
+            IteratorMode::End => {
+                self.raw.seek_to_last();
+                Direction::Reverse
+            },
+            IteratorMode::From(key, Direction::Forward) => {
+                self.raw.seek(key);
+                Direction::Forward
+            },
+            IteratorMode::From(key, Direction::Reverse) => {
+                self.raw.seek_for_prev(key);
+                Direction::Reverse
+            },
+        };
+    }
+}
+
+impl<'db, D, M, R> Iterator for DbRawKeyValueIterator<'db, D, M>
+where
+    D: DBAccess,
+    for<'b> M: FnMut(Result<(&'b [u8], &'b [u8]), rocksdb::Error>) -> R,
+    // This makes the iterator safe forcing the caller to return owned data (i.e. no references to the slice)
+    R: 'static,
+{
+    type Item = R;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // MODIFICATION: we return slices instead of allocating new buffers on each iteration.
+        if self.done {
+            return None;
+        }
+
+        if let Some((key, value)) = self.raw.item() {
+            let ret = (self.map)(Ok((key, value)));
+            // We progress the iterator until the map has been applied since rocksdb makes no guarantee
+            // about the validity of the slices after calling next()/prev().
+            match self.direction {
+                Direction::Forward => self.raw.next(),
+                Direction::Reverse => self.raw.prev(),
+            }
+
+            return Some(ret);
+        }
+
+        self.done = true;
+        self.raw.status().err().map(Err).map(&mut self.map)
+    }
+}
+
+impl<D, M, R> std::iter::FusedIterator for DbRawKeyValueIterator<'_, D, M>
+where
+    D: DBAccess,
+    for<'b> M: FnMut(Result<(&'b [u8], &'b [u8]), rocksdb::Error>) -> R,
+    R: 'static,
+{
+}

--- a/crates/state_store_rocksdb/src/dbs/mod.rs
+++ b/crates/state_store_rocksdb/src/dbs/mod.rs
@@ -1,6 +1,7 @@
 //   Copyright 2025 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
+pub mod iterator;
 pub mod read_only;
 mod snapshot;
 mod transaction;

--- a/crates/state_store_rocksdb/src/dbs/read_only.rs
+++ b/crates/state_store_rocksdb/src/dbs/read_only.rs
@@ -3,7 +3,10 @@
 
 use rocksdb::{AsColumnFamilyRef, DB, DBIteratorWithThreadMode, DBPinnableSlice, Error, IteratorMode, ReadOptions};
 
-use crate::traits::{RocksDatabase, RocksReader};
+use crate::{
+    dbs::iterator::DbRawKeyValueIterator,
+    traits::{RocksDatabase, RocksReader},
+};
 
 pub struct ReadOnlyDb {
     db: DB,
@@ -44,13 +47,18 @@ impl RocksReader for ReadOnlyDb {
         self.db.iterator_cf(cf_handle, mode)
     }
 
-    fn iterator_cf_opt<'a: 'b, 'b>(
+    fn iterator_cf_opt<'a: 'b, 'b, M, R>(
         &'a self,
         cf_handle: &impl AsColumnFamilyRef,
         readopts: ReadOptions,
         mode: IteratorMode,
-    ) -> DBIteratorWithThreadMode<'b, Self::Db> {
-        self.db.iterator_cf_opt(cf_handle, readopts, mode)
+        mapper: M,
+    ) -> DbRawKeyValueIterator<'b, Self::Db, M>
+    where
+        for<'c> M: FnMut(Result<(&'c [u8], &'c [u8]), Error>) -> R,
+    {
+        let raw = self.db.raw_iterator_cf_opt(cf_handle, readopts);
+        DbRawKeyValueIterator::new(raw, mode, mapper)
     }
 
     fn multi_get_cf<'a, 'b: 'a, K, I, W>(&'a self, keys: I) -> Vec<Result<Option<Vec<u8>>, Error>>

--- a/crates/state_store_rocksdb/src/dbs/snapshot.rs
+++ b/crates/state_store_rocksdb/src/dbs/snapshot.rs
@@ -12,7 +12,7 @@ use rocksdb::{
     SnapshotWithThreadMode,
 };
 
-use crate::traits::RocksReader;
+use crate::{dbs::iterator::DbRawKeyValueIterator, traits::RocksReader};
 
 impl<DB: DBAccess> RocksReader for SnapshotWithThreadMode<'_, DB> {
     type Db = DB;
@@ -33,13 +33,26 @@ impl<DB: DBAccess> RocksReader for SnapshotWithThreadMode<'_, DB> {
         self.iterator_cf(cf_handle, mode)
     }
 
-    fn iterator_cf_opt<'a: 'b, 'b>(
+    // fn iterator_cf_opt<'a: 'b, 'b>(
+    //     &'a self,
+    //     cf_handle: &impl AsColumnFamilyRef,
+    //     readopts: ReadOptions,
+    //     mode: IteratorMode,
+    // ) -> DBIteratorWithThreadMode<'b, Self::Db> {
+    //     self.iterator_cf_opt(cf_handle, readopts, mode)
+    // }
+    fn iterator_cf_opt<'a: 'b, 'b, M, R>(
         &'a self,
         cf_handle: &impl AsColumnFamilyRef,
         readopts: ReadOptions,
         mode: IteratorMode,
-    ) -> DBIteratorWithThreadMode<'b, Self::Db> {
-        self.iterator_cf_opt(cf_handle, readopts, mode)
+        mapper: M,
+    ) -> DbRawKeyValueIterator<'b, Self::Db, M>
+    where
+        for<'c> M: FnMut(Result<(&'c [u8], &'c [u8]), Error>) -> R,
+    {
+        let raw = self.raw_iterator_cf_opt(cf_handle, readopts);
+        DbRawKeyValueIterator::new(raw, mode, mapper)
     }
 
     fn multi_get_cf<'a, 'b: 'a, K, I, W>(&'a self, keys: I) -> Vec<Result<Option<Vec<u8>>, Error>>

--- a/crates/state_store_rocksdb/src/dbs/transaction.rs
+++ b/crates/state_store_rocksdb/src/dbs/transaction.rs
@@ -11,7 +11,10 @@ use rocksdb::{
     TransactionDB,
 };
 
-use crate::traits::{RocksDatabase, RocksReader, RocksWriter};
+use crate::{
+    dbs::iterator::DbRawKeyValueIterator,
+    traits::{RocksDatabase, RocksReader, RocksWriter},
+};
 
 impl RocksDatabase for TransactionDB {
     fn cf_handle(&self, name: &str) -> Option<&rocksdb::ColumnFamily> {
@@ -38,18 +41,18 @@ impl RocksReader for Transaction<'_, TransactionDB> {
         self.iterator_cf(cf_handle, mode)
     }
 
-    fn iterator_cf_opt<'a: 'b, 'b>(
+    fn iterator_cf_opt<'a: 'b, 'b, M, R>(
         &'a self,
         cf_handle: &impl AsColumnFamilyRef,
         readopts: ReadOptions,
         mode: IteratorMode,
-    ) -> DBIteratorWithThreadMode<'b, Self::Db> {
-        // TODO: the crate's iterator copies the data into an allocated buffer. We should consider implementing a
-        // zero-copy iterator as long as we can be sure that the slice is not referenced after iter.next().
-        // Currently, we never do zero-copy decoding so unfortunately we pay the allocation costs for nothing.
-        //
-        // related: https://github.com/rust-rocksdb/rust-rocksdb/issues/919
-        self.iterator_cf_opt(cf_handle, readopts, mode)
+        mapper: M,
+    ) -> DbRawKeyValueIterator<'b, Self::Db, M>
+    where
+        for<'c> M: FnMut(Result<(&'c [u8], &'c [u8]), rocksdb::Error>) -> R,
+    {
+        let raw = self.raw_iterator_cf_opt(cf_handle, readopts);
+        DbRawKeyValueIterator::new(raw, mode, mapper)
     }
 
     fn multi_get_cf<'a, 'b: 'a, K, I, W>(&'a self, keys: I) -> Vec<Result<Option<Vec<u8>>, rocksdb::Error>>

--- a/crates/state_store_rocksdb/src/read_only.rs
+++ b/crates/state_store_rocksdb/src/read_only.rs
@@ -3,7 +3,7 @@
 
 use rocksdb::{AsColumnFamilyRef, DBIteratorWithThreadMode, DBPinnableSlice, Error, IteratorMode, ReadOptions};
 
-use crate::traits::RocksReader;
+use crate::{dbs::iterator::DbRawKeyValueIterator, traits::RocksReader};
 
 #[derive(Debug, Clone)]
 pub struct ReadOnly<TX> {
@@ -35,13 +35,17 @@ impl<TX: RocksReader> RocksReader for ReadOnly<TX> {
         self.inner.iterator_cf(cf_handle, mode)
     }
 
-    fn iterator_cf_opt<'a: 'b, 'b>(
+    fn iterator_cf_opt<'a: 'b, 'b, M, R>(
         &'a self,
         cf_handle: &impl AsColumnFamilyRef,
         readopts: ReadOptions,
         mode: IteratorMode,
-    ) -> DBIteratorWithThreadMode<'b, Self::Db> {
-        self.inner.iterator_cf_opt(cf_handle, readopts, mode)
+        mapper: M,
+    ) -> DbRawKeyValueIterator<'b, Self::Db, M>
+    where
+        for<'c> M: FnMut(Result<(&'c [u8], &'c [u8]), Error>) -> R,
+    {
+        self.inner.iterator_cf_opt(cf_handle, readopts, mode, mapper)
     }
 
     fn multi_get_cf<'a, 'b: 'a, K, I, W>(&'a self, keys: I) -> Vec<Result<Option<Vec<u8>>, Error>>

--- a/crates/state_store_rocksdb/src/reader.rs
+++ b/crates/state_store_rocksdb/src/reader.rs
@@ -97,6 +97,7 @@ use tari_template_lib_types::crypto::RistrettoPublicKeyBytes;
 
 use crate::{
     cf_api::DbContext,
+    codecs::DbEncoder,
     column_families::{
         block,
         block::BlockCf,
@@ -136,7 +137,7 @@ use crate::{
         state_transition,
         state_transition::StateTransitionType,
         state_tree,
-        state_tree::StateTreeCfRef,
+        state_tree::StateTreeCf,
         state_tree_shard_versions,
         state_tree_shard_versions::StateTreeShardVersionCf,
         substate,
@@ -152,6 +153,7 @@ use crate::{
     error::RocksDbStorageError,
     read_only::ReadOnly,
     state_tree_iterator::LatestSubstateStateTreeIterator,
+    traits::Cf,
 };
 
 const LOG_TARGET: &str = "tari::ootle::storage::state_store_rocksdb::reader";
@@ -1536,11 +1538,12 @@ impl<'tx, TAddr: NodeAddressable + Serialize + DeserializeOwned + 'tx> StateStor
             return Ok(lock);
         }
 
-        let query = self.db().cf(substate_locks::ByBlockIdSubstateIdQuery::default())?;
+        let query = self.db().cf(substate_locks::ByBlockIdSubstateIdQuery)?;
 
         // TODO: this is on the critical path, improve performance
         for block_id in &pending_chain {
-            let mut iter = query.query_prefix_range_key_iterator(Ordering::default(), &(*block_id, substate_id));
+            let mut iter =
+                query.query_prefix_range_key_iterator(Ordering::default(), &(*block_id, substate_id.clone()));
             if let Some(result) = iter.next() {
                 let key = result?;
                 let lock = cf.get(&key, OPERATION)?;
@@ -1713,8 +1716,11 @@ impl<'tx, TAddr: NodeAddressable + Serialize + DeserializeOwned + 'tx> StateStor
 
     fn state_tree_nodes_get(&self, shard: Shard, key: &NodeKey) -> Result<Node<StateTreePayload>, StorageError> {
         const OPERATION: &str = "state_tree_nodes_get";
-        let cf = self.db().cf(StateTreeCfRef::default())?;
-        let node = cf.get(&(shard, key), OPERATION)?;
+        let cf = self.db().cf(StateTreeCf)?;
+        // We do this to avoid a clone
+        let codec = StateTreeCf::key_codec();
+        let key = codec.encode(&(shard, key))?;
+        let node = cf.get_raw_key(&key, OPERATION)?;
         Ok(node)
     }
 

--- a/crates/state_store_rocksdb/src/traits/column_family.rs
+++ b/crates/state_store_rocksdb/src/traits/column_family.rs
@@ -4,12 +4,12 @@
 use crate::codecs::{DbCodec, PrefixCodec, Prefixed};
 
 pub trait Cf {
-    type Key;
+    type Key: 'static;
 
     type Prefix: Prefixed;
 
     type KeyCodec: Default + DbCodec<Self::Key>;
-    type Value;
+    type Value: 'static;
     type ValueCodec: Default + DbCodec<Self::Value>;
 
     fn name() -> &'static str;
@@ -35,7 +35,8 @@ pub type PrefixedCodec<TCf> = PrefixCodec<<TCf as Cf>::Prefix, <TCf as Cf>::KeyC
 
 pub trait QueryCf {
     type Cf: Cf;
-    type Key;
+    // TODO: ideally we dont restrict to 'static here since that is antithetical to a query
+    type Key: 'static;
 
     type KeyCodec: Default + DbCodec<Self::Key>;
 

--- a/crates/state_store_rocksdb/src/traits/database.rs
+++ b/crates/state_store_rocksdb/src/traits/database.rs
@@ -11,6 +11,8 @@ use rocksdb::{
     ReadOptions,
 };
 
+use crate::dbs::iterator::DbRawKeyValueIterator;
+
 pub trait RocksDatabase {
     fn cf_handle(&self, name: &str) -> Option<&ColumnFamily>;
 }
@@ -28,12 +30,15 @@ pub trait RocksReader {
         mode: IteratorMode,
     ) -> DBIteratorWithThreadMode<'b, Self::Db>;
 
-    fn iterator_cf_opt<'a: 'b, 'b>(
+    fn iterator_cf_opt<'a: 'b, 'b, M, R>(
         &'a self,
         cf_handle: &impl AsColumnFamilyRef,
         readopts: ReadOptions,
         mode: IteratorMode,
-    ) -> DBIteratorWithThreadMode<'b, Self::Db>;
+        mapper: M,
+    ) -> DbRawKeyValueIterator<'b, Self::Db, M>
+    where
+        for<'c> M: FnMut(Result<(&'c [u8], &'c [u8]), Error>) -> R;
 
     fn multi_get_cf<'a, 'b: 'a, K, I, W>(&'a self, keys: I) -> Vec<Result<Option<Vec<u8>>, Error>>
     where

--- a/crates/state_store_rocksdb/src/versioned_types/substate.rs
+++ b/crates/state_store_rocksdb/src/versioned_types/substate.rs
@@ -48,7 +48,7 @@ mod tests {
     use tari_utilities::hex::Hex;
 
     use super::*;
-    use crate::codecs::{DbCodec, DefaultCodec};
+    use crate::codecs::{DbDecoder, DbEncoder, DefaultCodec};
 
     #[test]
     fn encode_decode() {

--- a/crates/state_store_rocksdb/src/writer.rs
+++ b/crates/state_store_rocksdb/src/writer.rs
@@ -93,12 +93,12 @@ use tari_template_lib_types::crypto::RistrettoPublicKeyBytes;
 
 use crate::{
     cf_api::{CfContext, DbContext},
-    codecs::ByteColumn,
+    codecs::{ByteColumn, DbEncoder, DefaultCodec},
     column_families::{
         block,
         block::BlockCf,
         block_diff,
-        block_diff::{BlockDiffCf, BlockDiffKey, BlockDiffModelRef, BlockDiffRef},
+        block_diff::{BlockDiffCf, BlockDiffKey},
         block_transaction_execution,
         block_transaction_execution::BlockTransactionExecutionCf,
         bookkeeping::{
@@ -133,7 +133,7 @@ use crate::{
         lock_conflict::LockConflictCf,
         missing_transactions,
         missing_transactions::MissingTransactionCf,
-        parked_block::{ParkedBlockCf, ParkedBlockDataRef, ParkedBlockModelRef},
+        parked_block::{ParkedBlockCf, ParkedBlockDataRef},
         pending_state_tree_diff,
         pending_state_tree_diff::PendingStateTreeDiffCf,
         state_transition::{
@@ -209,18 +209,21 @@ impl<'a, TAddr: NodeAddressable> RocksDbStateStoreWriteTransaction<'a, TAddr> {
             });
         }
 
-        let cf = self.db().cf(ParkedBlockModelRef::default())?;
+        let cf = self.db().cf(ParkedBlockCf)?;
         // Idempotent
         if cf.exists(block.id(), OPERATION)? {
             return Ok(());
         }
 
+        let codec = DefaultCodec::<ParkedBlockDataRef<'_>>::default();
+        // We need to clone these because the current design does not allow "encode only" CFs/Codecs
+        // which would not have the 'static lifetime requirement on the value
         let parked_block_data = ParkedBlockDataRef {
             block,
             foreign_proposals,
         };
-
-        cf.put(block.id(), &parked_block_data, OPERATION)?;
+        let data = codec.encode(&parked_block_data)?;
+        cf.put_raw_value(block.id(), &data, OPERATION)?;
 
         Ok(())
     }
@@ -376,7 +379,7 @@ impl<'tx, TAddr: NodeAddressable + 'tx> StateStoreWriteTransaction for RocksDbSt
 
     fn block_diffs_insert(&mut self, block_id: &BlockId, changes: &[SubstateChange]) -> Result<(), StorageError> {
         const OPERATION: &str = "block_diffs_insert";
-        let cf = self.db().cf(BlockDiffModelRef::default())?;
+        let cf = self.db().cf(BlockDiffCf)?;
         let index_cf = self.db().cf(block_diff::SubstateIdIndex)?;
 
         assert!(
@@ -392,7 +395,7 @@ impl<'tx, TAddr: NodeAddressable + 'tx> StateStoreWriteTransaction for RocksDbSt
                 version: change.versioned_substate_id().version(),
                 is_up: change.is_up(),
             };
-            cf.put(&key, &BlockDiffRef { change }, OPERATION)?;
+            cf.put(&key, change, OPERATION)?;
             // Note: the key is encoded with substate id first
             index_cf.put(&key, &(), OPERATION)?;
         }

--- a/utilities/db_inspector/Cargo.toml
+++ b/utilities/db_inspector/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "db_inspector"
+name = "db-inspector"
 version.workspace = true
 edition.workspace = true
 authors.workspace = true

--- a/utilities/db_inspector/src/webserver/handlers/tables.rs
+++ b/utilities/db_inspector/src/webserver/handlers/tables.rs
@@ -15,7 +15,7 @@ use serde_json::{json, value::Index};
 use tari_ootle_common_types::displayable::Displayable;
 use tari_ootle_storage::{Ordering, consensus_models::Evidence};
 use tari_state_store_rocksdb::{
-    codecs::{DbCodec, KeyPrefix},
+    codecs::{DbEncoder, KeyPrefix},
     error::RocksDbStorageError,
     traits::Cf,
 };


### PR DESCRIPTION
Description
---
fix(state-store): improve iterator performance and mem usage

Motivation and Context
---
The general-purpose rocksdb iterator [allocates and copies key/value buffers](https://github.com/rust-rocksdb/rust-rocksdb/blob/21e06614d5fbef8bb4c90064310da276f7c3725e/src/db_iterator.rs#L512) from the slice created from the rocksdb FFI call. This is because rocksdb only provides a guarantee on the validity of the slice until next/prev is called, meaning that any references held (e.g. zero-copy deserialization) after each iteration by the consumer may become invalid. This PR creates a new iterator that passes the referenced slices to a "map" function that MUST return `R: 'static`, preventing any inadvertent usage of referenced data, and making the iterator safe.

This suits our current implementation as we do not use zero-copy deser.

How Has This Been Tested?
---
Existing tests, manually (stress test)


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify