### PR TITLE
docs(template-lib): adds example to crate homepage

### DIFF
--- a/crates/template_lib/src/lib.rs
+++ b/crates/template_lib/src/lib.rs
@@ -21,27 +21,113 @@
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 //! This crate provides ergonomic abstractions that allow WASM templates to interact with the Tari Ootle engine.
-//! Most if not all Ootle templates written in rust should depend on this crate.
+//! Almost all Ootle templates written in Rust should depend on this crate.
 //!
-//! In most cases, you will only require the `prelude` which can be included with:
+//! Include the template `prelude` which provides all the necessary imports for writing templates. This includes common
+//! types (e.g. `Component`, `Resource`, `Vault`, `AccessRule` etc.) and macros (e.g. the `template` macro).
 //! ```
 //! use tari_template_lib::prelude::*;
 //! ```
 //!
-//! Typically, a template author will use structs exported from the [models] module, the
-//! [ResourceBuilder](resource::ResourceBuilder) and the [ComponentBuilder](component::ComponentBuilder). This crate
-//! re-exports low-level ABI functions in `tari_template_abi` and the `tari_template_macros` proc macro.
+//! ## Getting started
+//!
+//! Include this crate in your `Cargo.toml`:
+//! ```toml
+//! [dependencies]
+//! tari_template_lib = { version = "*" } # Or specify a specific version
+//! ```
+//!
+//! Apply the `template` macro and define your template struct and its methods.
+//! This macro generates the necessary ABI functions and boilerplate to make your template work with the Ootle engine.
+//!
+//! ```rust
+//! use tari_template_lib::prelude::*;
+//!
+//! // The `template` macro generates and implements the necessary ABI functions, `TemplateDefinition` and other boilerplate that
+//! // hooks up the functions and methods you define to the Ootle execution engine.
+//! // The module name is not important (it is ignored). The `template` macro must be applied to the module that contains your template struct/enum.
+//! #[template]
+//! mod my_template {
+//!    // Bring prelude and anything else into scope.
+//!    use super::*;
+//!
+//!    /// Defines the component state that is stored on-chain. This can be a struct or an enum.
+//!    /// The struct/enum name can be selected arbitrarily, and is exposed in the TemplateDefinition for the template.
+//!    pub struct MyCounter {
+//!       counter: u64,
+//!       /// Vaults contain resources. A vault is a separate substate created within a component, and belongs to that component.
+//!       vault: Vault,
+//!    }
+//!
+//!    impl MyCounter {
+//!     /// A simple constructor.
+//!     /// NOTE: this is a convenience constructor that implicitly creates a component with some defaults. These defaults are restrictive for many use cases
+//!     /// for e.g. all component methods are only callable by the component owner (i.e. the same signer that created the component must sign the transaction
+//!     /// to call any method).
+//!     /// To see how to customise this, see the `custom` constructor below.
+//!      pub fn new() -> Self {
+//!          Self {
+//!             counter: 0,
+//!             // A empty vault that can only hold the native token (XTR). You can also create vaults that hold your own resources (see the `ResourceBuilder`).
+//!             vault: Vault::new_empty(XTR),
+//!          }
+//!      }
+//!
+//!     /// This constructor provides more control over the component configuration.
+//!     ///
+//!     /// ## Arguments
+//!     /// - `address`: An component address allocation. This allows a single transaction to both create and call onto the created component without knowing the component address in advance.
+//!     /// - `access_rules`: Custom method access rules for the component. All methods referenced in the access rules must be defined on the component or the transaction will fail.
+//!     /// - `owner_rule`: Custom owner rule for the component. The owner of a component is able to change access rules and call all methods. Setting `OwnerRule::None` means the component has no owner and all access rules are immutable.
+//!     pub fn custom(address: ComponentAddressAllocation, access_rules: ComponentAccessRules, owner_rule: OwnerRule) -> Component<Self> {
+//!        // Call `new` which initialises the component state. NOTE that this is a completely normal function call. The component
+//!        // is not yet created on-chain.
+//!        let component = Self::new();
+//!
+//!        Component::new(component)
+//!           .with_address_allocation(address)
+//!           .with_access_rules(access_rules)
+//!           .with_owner_rule(owner_rule)
+//!           // Create the component on-chain
+//!           .create()
+//!    }
+//!
+//!   /// Increment the counter by 1. The `CallMethod` instruction is used to invoke this method.
+//!   /// This method is callable as per the access rules defined for the component.
+//!   pub fn increment(&mut self) {
+//!     self.counter += 1;
+//!   }
+//!
+//!    /// A simple associated function that returns a string. The `CallFunction` instruction is used to invoke this function.
+//!    /// Apart from defining constructors, associated functions can provide any shared functionality callable by anyone.
+//!    pub fn some_function(name: String, number: u64) -> String {
+//!       format("Hello {name}, the number is {number}")
+//!    }
+//! }
+//! ```
 //!
 //! ## Template Examples
 //!
-//! - <https://github.com/tari-project/wasm-template>
 //! - <https://github.com/tari-project/wasm-examples>
 //! - <https://github.com/tari-project/tari-ootle/tree/development/crates/engine/tests/templates>
 //!
+//! ## Re-exports
+//!
+//! This crate re-exports common types (`tari_template_lib_types`), low-level ABI functions in `tari_template_abi` and
+//! the `tari_template_macros` proc macro.
+//!
 //! ## no_std
 //!
-//! This crate supports `no_std` environments. To use in `no_std`, disable the `std` feature and enable the `alloc`
-//! feature.
+//! This crate supports `no_std` environments. To use in `no_std`, disable the `std` feature (`default-features =
+//! false`) and enable the `alloc` feature.
+//!
+//! ```toml
+//! [dependencies]
+//! tari_template_lib = { version = "*", default-features = false, features = ["alloc"] }
+//! ```
+//!
+//! You will need to provide a global allocator (e.g. `talc`, `lol_alloc`). This crate provides a panic handler for
+//! `no_std`.
 
 // Support no_std environments
 #![cfg_attr(not(feature = "std"), no_std)]

--- a/crates/template_lib/src/resource/builder/fungible.rs
+++ b/crates/template_lib/src/resource/builder/fungible.rs
@@ -315,7 +315,7 @@ impl FungibleResourceBuilder {
     ///    .add_metadata("CharacterLvl", "99")
     /// .build();
     /// ```
-    pub fn metadata<K: Into<String>, V: Into<String>>(mut self, key: K, value: V) -> Self {
+    pub fn metadata<K: Into<String>, V: Into<String>>(self, key: K, value: V) -> Self {
         self.add_metadata(key, value)
     }
 

--- a/crates/template_lib_types/src/access_rules.rs
+++ b/crates/template_lib_types/src/access_rules.rs
@@ -155,7 +155,7 @@ impl ComponentAccessRules {
     }
 
     /// Add a new access rule for a particular method in the component
-    pub fn method<S: Into<String>>(mut self, name: S, rule: AccessRule) -> Self {
+    pub fn method<S: Into<String>>(self, name: S, rule: AccessRule) -> Self {
         self.add_method_rule(name, rule)
     }
 

--- a/crates/template_lib_types/src/lib.rs
+++ b/crates/template_lib_types/src/lib.rs
@@ -1,6 +1,21 @@
 //   Copyright 2025 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
+//! This crate contains types that are used across the Tari Template ecosystem.
+//!
+//! This includes:
+//! - Substate address types (e.g. `ComponentAddress`, `ResourceAddress`, `NonFungibleAddress` etc.)
+//! - Auth and access rules (e.g. `AccessRule`, `OwnerRule`)
+//! - a 128-bit unsigned `Amount` type and a 192-bit signed `PrecisionAmount` type (if the `precision` feature is
+//!   enabled)
+//! - stealth crypto types and traits (e.g. `EncryptedData`, `StealthTransferStatement` etc.)
+//! - various utility types and traits (e.g. `Metadata`, `Hash`, `MaxBytes`, `MaxString` etc.)
+//!
+//! Include this crate when you need these types but aren't authoring a template (e.g. building a wallet).
+//! For template authors, you typically want to use the `tari_template_lib` crate instead, which re-exports this crate.
+//!
+//! `no_std` is supported by excluding the `std` feature and enabling the `alloc` feature.
+
 // Support no_std environments
 #![cfg_attr(not(feature = "std"), no_std)]
 


### PR DESCRIPTION
Description
---
docs(template-lib): adds example to crate homepage

Motivation and Context
---
Adds a getting started section and an example.
