### PR TITLE
feat: ledger client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -269,7 +269,7 @@ dependencies = [
  "nom 7.1.3",
  "num-traits",
  "rusticata-macros",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
 ]
 
@@ -360,7 +360,7 @@ dependencies = [
  "serde_urlencoded",
  "static_assertions_next",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -394,7 +394,7 @@ dependencies = [
  "quote",
  "strum 0.27.2",
  "syn 2.0.114",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -706,7 +706,7 @@ dependencies = [
  "mime",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -897,7 +897,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1041,7 +1041,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09dc0086e469182132244e9b8d313a0742e1132da43a08c24b9dd3c18e0faf3a"
 dependencies = [
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3945,7 +3945,7 @@ dependencies = [
  "pest_derive",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4139,7 +4139,7 @@ dependencies = [
  "rand 0.9.2",
  "ring",
  "socket2 0.5.10",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tinyvec",
  "tokio",
  "tracing",
@@ -4167,7 +4167,7 @@ dependencies = [
  "ring",
  "rustls 0.23.36",
  "rustls-platform-verifier",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tinyvec",
  "tokio",
  "tokio-rustls 0.26.4",
@@ -4191,7 +4191,7 @@ dependencies = [
  "rand 0.9.2",
  "resolv-conf",
  "smallvec 1.15.1",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -4213,7 +4213,7 @@ dependencies = [
  "resolv-conf",
  "rustls 0.23.36",
  "smallvec 1.15.1",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-rustls 0.26.4",
  "tracing",
@@ -4360,7 +4360,7 @@ dependencies = [
  "similar",
  "stringmetrics",
  "tabwriter",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "url",
@@ -5437,7 +5437,7 @@ dependencies = [
  "multiaddr 0.18.3",
  "pin-project 1.1.10",
  "rw-stream-sink",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5469,7 +5469,7 @@ dependencies = [
  "quick-protobuf-codec 0.3.1 (git+https://github.com/tari-project/rust-libp2p.git?rev=6929685c9818d30a3bacdcf842951b8e890e3f01)",
  "rand 0.8.5",
  "rand_core 0.6.4",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
  "web-time",
 ]
@@ -5502,7 +5502,7 @@ dependencies = [
  "quick-protobuf",
  "rand 0.8.5",
  "rw-stream-sink",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
  "unsigned-varint 0.8.0",
  "web-time",
@@ -5524,7 +5524,7 @@ dependencies = [
  "libp2p-swarm",
  "quick-protobuf",
  "quick-protobuf-codec 0.3.1 (git+https://github.com/tari-project/rust-libp2p.git?rev=6929685c9818d30a3bacdcf842951b8e890e3f01)",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
  "web-time",
 ]
@@ -5590,7 +5590,7 @@ dependencies = [
  "quick-protobuf",
  "quick-protobuf-codec 0.3.1 (git+https://github.com/tari-project/rust-libp2p.git?rev=6929685c9818d30a3bacdcf842951b8e890e3f01)",
  "smallvec 1.15.1",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -5608,7 +5608,7 @@ dependencies = [
  "serde",
  "sha2 0.10.9",
  "tari_crypto",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
  "zeroize",
 ]
@@ -5679,7 +5679,7 @@ dependencies = [
  "rand 0.8.5",
  "snow",
  "static_assertions",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
  "x25519-dalek",
  "zeroize",
@@ -5709,7 +5709,7 @@ dependencies = [
  "prometheus-client",
  "quick-protobuf",
  "quick-protobuf-codec 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -5744,7 +5744,7 @@ dependencies = [
  "ring",
  "rustls 0.23.36",
  "socket2 0.6.1",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -5767,7 +5767,7 @@ dependencies = [
  "quick-protobuf-codec 0.3.1 (git+https://github.com/tari-project/rust-libp2p.git?rev=6929685c9818d30a3bacdcf842951b8e890e3f01)",
  "rand 0.8.5",
  "static_assertions",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
  "web-time",
 ]
@@ -5789,7 +5789,7 @@ dependencies = [
  "quick-protobuf",
  "quick-protobuf-codec 0.3.1 (git+https://github.com/tari-project/rust-libp2p.git?rev=6929685c9818d30a3bacdcf842951b8e890e3f01)",
  "rand 0.8.5",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
  "web-time",
 ]
@@ -5879,7 +5879,7 @@ dependencies = [
  "ring",
  "rustls 0.23.36",
  "rustls-webpki 0.103.8",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "x509-parser 0.17.0",
  "yasna",
 ]
@@ -5906,7 +5906,7 @@ dependencies = [
  "either",
  "futures 0.3.31",
  "libp2p-core",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
  "yamux 0.12.1",
  "yamux 0.13.8",
@@ -6066,7 +6066,7 @@ checksum = "0a60bf300a990b2d1ebdde4228e873e8e4da40d834adbf5265f3da1457ede652"
 dependencies = [
  "libc",
  "neli",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "windows-sys 0.61.2",
 ]
 
@@ -6122,7 +6122,7 @@ dependencies = [
  "serde-value",
  "serde_json",
  "serde_yaml",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "thread-id",
  "typemap-ors",
  "unicode-segmentation",
@@ -6178,7 +6178,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb4bdc8b0ce69932332cf76d24af69c3a155242af95c226b2ab6c2e371ed1149"
 dependencies = [
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "zerocopy",
  "zerocopy-derive",
 ]
@@ -6418,7 +6418,7 @@ dependencies = [
  "tari_sidechain",
  "tari_transaction_components",
  "tari_utilities",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tonic 0.13.1",
  "tonic-build",
@@ -6443,7 +6443,7 @@ dependencies = [
  "tari_features",
  "tari_p2p",
  "tari_utilities",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tonic 0.13.1",
 ]
@@ -6494,7 +6494,7 @@ dependencies = [
  "tari_transaction_components",
  "tari_transaction_key_manager",
  "tari_utilities",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tonic 0.13.1",
  "tui",
@@ -6531,7 +6531,7 @@ dependencies = [
  "tari_crypto",
  "tari_script",
  "tari_utilities",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -6579,7 +6579,7 @@ dependencies = [
  "tari_storage",
  "tari_transaction_components",
  "tari_utilities",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tonic 0.13.1",
  "tower-http",
@@ -6662,7 +6662,7 @@ dependencies = [
  "tari_transaction_key_manager",
  "tari_utilities",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tower 0.4.13",
  "url",
@@ -6678,7 +6678,7 @@ dependencies = [
  "minotari_app_grpc",
  "tari_common",
  "tari_common_types",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tonic 0.13.1",
 ]
 
@@ -7004,7 +7004,7 @@ dependencies = [
  "log",
  "netlink-packet-core",
  "netlink-sys",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -7399,7 +7399,7 @@ dependencies = [
  "tari_ootle_wallet_crypto",
  "tari_template_builtin",
  "tari_template_lib_types",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -8192,7 +8192,7 @@ dependencies = [
  "memchr",
  "parking_lot",
  "protobuf",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -8480,7 +8480,7 @@ dependencies = [
  "asynchronous-codec",
  "bytes 1.11.1",
  "quick-protobuf",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "unsigned-varint 0.8.0",
 ]
 
@@ -8508,7 +8508,7 @@ dependencies = [
  "rustc-hash 2.1.1",
  "rustls 0.23.36",
  "socket2 0.6.1",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -8529,7 +8529,7 @@ dependencies = [
  "rustls 0.23.36",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -9999,7 +9999,7 @@ checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
 dependencies = [
  "num-bigint",
  "num-traits",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
 ]
 
@@ -10180,7 +10180,7 @@ dependencies = [
  "cc",
  "hashbrown 0.16.1",
  "js-sys",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "wasm-bindgen",
 ]
 
@@ -10575,6 +10575,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1dd07eb858a2067e2f3c7155d54e929265c264e6f37efe3ee7a8d1b5a1dd0ba"
 
 [[package]]
+name = "tari-ledger-client"
+version = "0.20.1"
+dependencies = [
+ "hex",
+ "ledger-transport",
+ "ledger-transport-hid",
+ "minotari_ledger_wallet_common",
+ "reqwest 0.11.27",
+ "serde",
+ "tari_crypto",
+ "tari_template_lib_types",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
 name = "tari-tiny-keccak"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10599,7 +10615,7 @@ dependencies = [
  "tari_template_lib",
  "tari_transaction_components",
  "tari_utilities",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tonic 0.13.1",
  "ts-rs",
  "url",
@@ -10660,7 +10676,7 @@ dependencies = [
  "structopt",
  "tari_features",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "toml 0.5.11",
 ]
 
@@ -10677,7 +10693,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tari_utilities",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
 ]
 
@@ -10712,7 +10728,7 @@ dependencies = [
  "tari_hashing 5.3.0-pre.0",
  "tari_max_size",
  "tari_utilities",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "utoipa",
  "zeroize",
 ]
@@ -10754,7 +10770,7 @@ dependencies = [
  "tari_shutdown",
  "tari_storage",
  "tari_utilities",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tokio-util 0.6.10",
@@ -10792,7 +10808,7 @@ dependencies = [
  "tari_crypto",
  "tari_shutdown",
  "tari_utilities",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tower 0.4.13",
  "zeroize",
@@ -10829,7 +10845,7 @@ dependencies = [
  "tari_sidechain",
  "tari_state_tree",
  "tari_template_lib_types",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
 ]
 
@@ -10906,7 +10922,7 @@ dependencies = [
  "tari_test_utils",
  "tari_transaction_components",
  "tari_utilities",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "url",
@@ -10958,7 +10974,7 @@ dependencies = [
  "tari_template_test_tooling",
  "tari_transaction_manifest",
  "tari_utilities",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "wasmer",
  "wasmer-middlewares",
 ]
@@ -10986,7 +11002,7 @@ dependencies = [
  "tari_hashing 5.1.0",
  "tari_template_abi",
  "tari_template_lib",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "ts-rs",
 ]
 
@@ -11006,7 +11022,7 @@ dependencies = [
  "tari_shutdown",
  "tari_sidechain",
  "tari_template_lib_types",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
 ]
 
@@ -11030,7 +11046,7 @@ dependencies = [
  "tari_ootle_storage_sqlite",
  "tari_template_lib",
  "tari_transaction_components",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
  "tokio",
 ]
@@ -11121,7 +11137,7 @@ dependencies = [
  "tari_template_builtin",
  "tari_template_lib_types",
  "tari_validator_node_rpc",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
  "tokio",
  "tokio-stream",
@@ -11162,7 +11178,7 @@ dependencies = [
  "tari_ootle_wallet_sdk",
  "tari_template_abi",
  "tari_template_lib_types",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "ts-rs",
  "utoipa",
@@ -11179,7 +11195,7 @@ dependencies = [
  "tari_epoch_manager",
  "tari_ootle_common_types",
  "tari_validator_node_rpc",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -11193,7 +11209,7 @@ dependencies = [
  "serde",
  "tari_crypto",
  "tari_hashing 5.3.0-pre.0",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -11218,7 +11234,7 @@ dependencies = [
  "borsh",
  "serde",
  "tari_utilities",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -11228,7 +11244,7 @@ source = "git+https://github.com/tari-project/tari.git?tag=v5.3.0-pre.0#32df87fa
 dependencies = [
  "once_cell",
  "prometheus",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -11241,7 +11257,7 @@ dependencies = [
  "serde",
  "tari_crypto",
  "tari_utilities",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -11257,7 +11273,7 @@ dependencies = [
  "tari_rpc_framework",
  "tari_shutdown",
  "tari_swarm",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
 ]
 
@@ -11277,7 +11293,7 @@ dependencies = [
  "tari_hashing 5.3.0-pre.0",
  "tari_transaction_components",
  "tari_utilities",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -11292,7 +11308,7 @@ dependencies = [
  "tari_crypto",
  "tari_ootle_common_types",
  "tari_template_lib_types",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "ts-rs",
 ]
 
@@ -11329,7 +11345,7 @@ dependencies = [
  "tari_ootle_transaction",
  "tari_template_lib",
  "tari_transaction_components",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "toml 0.9.11+spec-1.1.0",
  "url",
@@ -11360,7 +11376,7 @@ dependencies = [
  "tari_mmr",
  "tari_template_lib",
  "tari_template_lib_types",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "ts-rs",
 ]
 
@@ -11410,7 +11426,7 @@ dependencies = [
  "tari_state_tree",
  "tari_template_lib",
  "tari_template_lib_types",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
  "ts-rs",
 ]
@@ -11433,7 +11449,7 @@ dependencies = [
  "tari_ootle_storage",
  "tari_template_lib",
  "tari_utilities",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -11456,7 +11472,7 @@ dependencies = [
  "tari_hashing 5.3.0-pre.0",
  "tari_ootle_common_types",
  "tari_template_lib",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "ts-rs",
 ]
 
@@ -11482,7 +11498,7 @@ dependencies = [
  "tari_transaction_manifest",
  "tari_utilities",
  "tari_wallet_daemon_client",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
  "tokio",
  "url",
@@ -11513,7 +11529,7 @@ dependencies = [
  "tari_ootle_common_types",
  "tari_template_lib_types",
  "tari_utilities",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "ts-rs",
  "zeroize",
 ]
@@ -11547,7 +11563,7 @@ dependencies = [
  "tari_template_lib",
  "tari_transaction_components",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
  "tokio",
  "ts-rs",
@@ -11576,7 +11592,7 @@ dependencies = [
  "tari_template_abi",
  "tari_template_builtin",
  "tari_template_lib_types",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
  "tokio",
  "url",
@@ -11653,7 +11669,7 @@ dependencies = [
  "tari_utilities",
  "tari_wallet_daemon_client",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tower-http",
  "url",
@@ -11686,7 +11702,7 @@ dependencies = [
  "tari_service_framework",
  "tari_shutdown",
  "tari_utilities",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tower 0.4.13",
@@ -11709,7 +11725,7 @@ dependencies = [
  "proto_builder",
  "tari_metrics",
  "tari_shutdown",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-util 0.7.18",
  "tower 0.5.2",
@@ -11741,7 +11757,7 @@ dependencies = [
  "tari_rpc_framework",
  "tari_state_tree",
  "tari_validator_node_rpc",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -11759,7 +11775,7 @@ dependencies = [
  "tari_crypto",
  "tari_max_size",
  "tari_utilities",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -11772,7 +11788,7 @@ dependencies = [
  "futures 0.3.31",
  "log",
  "tari_shutdown",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tower-service",
 ]
@@ -11799,7 +11815,7 @@ dependencies = [
  "tari_hashing 5.3.0-pre.0",
  "tari_jellyfish",
  "tari_utilities",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -11830,7 +11846,7 @@ dependencies = [
  "tari_template_lib_types",
  "tari_utilities",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -11844,7 +11860,7 @@ dependencies = [
  "tari_jellyfish",
  "tari_ootle_common_types",
  "tari_template_lib_types",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -11856,7 +11872,7 @@ dependencies = [
  "lmdb-zero",
  "log",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -11867,7 +11883,7 @@ dependencies = [
  "libp2p-messaging",
  "libp2p-peer-store",
  "libp2p-substream",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -11907,7 +11923,7 @@ dependencies = [
  "tari_transaction_components",
  "tari_validator_node_client",
  "tari_wallet_daemon_client",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "toml 0.9.11+spec-1.1.0",
  "tonic 0.13.1",
@@ -11999,7 +12015,7 @@ dependencies = [
  "tari_template_builtin",
  "tari_template_lib",
  "tari_transaction_manifest",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -12055,7 +12071,7 @@ dependencies = [
  "tari_script",
  "tari_sidechain",
  "tari_utilities",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "utoipa",
  "uuid",
@@ -12090,7 +12106,7 @@ dependencies = [
  "tari_service_framework",
  "tari_transaction_components",
  "tari_utilities",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "zeroize",
 ]
@@ -12107,7 +12123,7 @@ dependencies = [
  "tari_ootle_transaction",
  "tari_template_builtin",
  "tari_template_lib",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -12189,7 +12205,7 @@ dependencies = [
  "tari_transaction_components",
  "tari_validator_node_client",
  "tari_validator_node_rpc",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
  "tokio",
  "tower-http",
@@ -12216,7 +12232,7 @@ dependencies = [
  "tari_sidechain",
  "tari_template_abi",
  "tari_template_lib_types",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "ts-rs",
 ]
 
@@ -12239,7 +12255,7 @@ dependencies = [
  "tari_ootle_transaction",
  "tari_rpc_framework",
  "tari_rpc_macros",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
 ]
 
@@ -12258,7 +12274,7 @@ dependencies = [
  "tari_ootle_wallet_sdk",
  "tari_template_abi",
  "tari_template_lib",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
  "ts-rs",
  "webauthn-rs-proto",
@@ -12379,11 +12395,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.17",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -12399,9 +12415,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12928,7 +12944,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "786d480bce6247ab75f005b14ae1624ad978d3029d9113f0a22fa1ac773faeaf"
 dependencies = [
  "crossbeam-channel",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
  "tracing-subscriber",
 ]
@@ -13059,7 +13075,7 @@ checksum = "4994acea2522cd2b3b85c1d9529a55991e3ad5e25cdcd3de9d505972c4379424"
 dependencies = [
  "chrono",
  "indexmap 2.13.0",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "ts-rs-macros",
 ]
 
@@ -13101,7 +13117,7 @@ dependencies = [
  "log",
  "rand 0.9.2",
  "sha1 0.10.6",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "utf-8",
 ]
 
@@ -13593,7 +13609,7 @@ dependencies = [
  "shared-buffer",
  "tar",
  "target-lexicon",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
  "wasm-bindgen",
  "wasmer-compiler",
@@ -13632,7 +13648,7 @@ dependencies = [
  "smallvec 1.15.1",
  "target-lexicon",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "wasmer-types",
  "wasmer-vm",
  "wasmparser",
@@ -13701,7 +13717,7 @@ dependencies = [
  "rkyv",
  "sha2 0.11.0-rc.5",
  "target-lexicon",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -13729,7 +13745,7 @@ dependencies = [
  "region",
  "rustversion",
  "scopeguard",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "wasmer-types",
  "windows-sys 0.61.2",
 ]
@@ -14653,7 +14669,7 @@ dependencies = [
  "nom 7.1.3",
  "oid-registry 0.8.1",
  "rusticata-macros",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ members = [
     "crates/wallet/sdk",
     "crates/wallet/sdk_services",
     "crates/wallet/storage_sqlite",
+    "crates/wallet/tari-ledger-client",
     "crates/ootle_address",
     "crates/ootle_serde",
     "crates/ootle_byte_type",
@@ -145,6 +146,9 @@ tari_p2p = { git = "https://github.com/tari-project/tari.git", tag = "v5.3.0-pre
 
 tari_crypto = "0.22.0"
 tari_utilities = "0.8.0"
+
+## Ledger
+minotari_ledger_wallet_common = { git = "https://github.com/tari-project/tari.git", tag = "v5.3.0-pre.0" }
 
 # networking crates
 proto_builder = { path = "networking/proto_builder" }

--- a/crates/wallet/tari-ledger-client/Cargo.toml
+++ b/crates/wallet/tari-ledger-client/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "tari-ledger-client"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
+
+[dependencies]
+minotari_ledger_wallet_common = { workspace = true }
+tari_template_lib_types = { workspace = true }
+
+ledger-transport = "0.11.0"
+ledger-transport-hid = { version = "0.11.0", optional = true }
+thiserror = { workspace = true }
+tari_crypto = { workspace = true }
+
+# Speculos transport
+reqwest = { workspace = true, features = ["json"], optional = true }
+serde = { workspace = true, optional = true }
+hex = { workspace = true, optional = true }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+
+[features]
+speculos-transport = ["serde", "reqwest", "hex"]
+hid-transport = ["dep:ledger-transport-hid"]

--- a/crates/wallet/tari-ledger-client/src/client.rs
+++ b/crates/wallet/tari-ledger-client/src/client.rs
@@ -1,0 +1,440 @@
+//   Copyright 2026 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+use ledger_transport::{APDUCommand, APDUErrorCode, Exchange};
+use minotari_ledger_wallet_common::common_types::{AppSW, Instruction, LedgerKeyBranch};
+use tari_crypto::{
+    ristretto::{CompressedRistrettoComAndPubSig, RistrettoPublicKey, RistrettoSecretKey},
+    tari_utilities::ByteArray,
+};
+use tari_template_lib_types::crypto::{PedersenCommitmentBytes, RistrettoPublicKeyBytes, SchnorrSignatureBytes};
+
+use crate::{decode::DecodeAnswer, error::LedgerClientError};
+
+pub type LedgerClientResult<T, E> = Result<T, LedgerClientError<E>>;
+
+const CLA: u8 = 0x80;
+
+pub struct LedgerClient<T> {
+    inner: T,
+}
+
+impl<T: Exchange> LedgerClient<T> {
+    pub fn new(inner: T) -> Self {
+        Self { inner }
+    }
+
+    pub async fn get_app_version(&self) -> LedgerClientResult<String, T::Error> {
+        let command = APDUCommand {
+            cla: CLA,
+            ins: Instruction::GetVersion as u8,
+            p1: 0,
+            p2: 0,
+            data: Vec::<u8>::new(),
+        };
+        let answer = self.inner.exchange(&command).await?;
+        apdu_err(answer.error_code())?;
+        answer.decode()
+    }
+
+    pub async fn get_app_name(&self) -> LedgerClientResult<String, T::Error> {
+        let command = APDUCommand {
+            cla: CLA,
+            ins: Instruction::GetAppName as u8,
+            p1: 0,
+            p2: 0,
+            data: Vec::<u8>::new(),
+        };
+        let answer = self.inner.exchange(&command).await?;
+        apdu_err(answer.error_code())?;
+        answer.decode()
+    }
+
+    pub async fn get_public_spend_key(&self, account: u64) -> LedgerClientResult<RistrettoPublicKeyBytes, T::Error> {
+        let acc_bytes = account.to_le_bytes();
+
+        let command = APDUCommand {
+            cla: CLA,
+            ins: Instruction::GetPublicSpendKey as u8,
+            p1: 0,
+            p2: 0,
+            data: acc_bytes.as_slice(),
+        };
+        let answer = self.inner.exchange(&command).await?;
+        apdu_err(answer.error_code())?;
+        answer.decode()
+    }
+
+    pub async fn get_public_key(
+        &self,
+        account: u64,
+        index: u64,
+        branch: LedgerKeyBranch,
+    ) -> LedgerClientResult<RistrettoPublicKeyBytes, T::Error> {
+        let data = [
+            account.to_le_bytes().as_slice(),
+            index.to_le_bytes().as_slice(),
+            cst_u8_u64_le_bytes(branch.as_byte()).as_slice(),
+        ]
+        .concat();
+
+        let command = APDUCommand {
+            cla: CLA,
+            ins: Instruction::GetPublicKey as u8,
+            p1: 0,
+            p2: 0,
+            data,
+        };
+        let answer = self.inner.exchange(&command).await?;
+        apdu_err(answer.error_code())?;
+
+        answer.decode()
+    }
+
+    pub async fn get_script_signature_managed(
+        &self,
+        account: u64,
+        network_byte: u8,
+        version: u8,
+        branch: &LedgerKeyBranch,
+        index: u64,
+        value: &RistrettoSecretKey,
+        commitment_private_key: &RistrettoSecretKey,
+        commitment: &PedersenCommitmentBytes,
+        message: [u8; 32],
+    ) -> LedgerClientResult<CompressedRistrettoComAndPubSig, T::Error> {
+        let data = [
+            account.to_le_bytes().as_slice(),
+            cst_u8_u64_le_bytes(network_byte).as_slice(),
+            cst_u8_u64_le_bytes(version).as_slice(),
+            value.as_bytes(),
+            commitment_private_key.as_bytes(),
+            commitment.as_bytes(),
+            message.as_slice(),
+            cst_u8_u64_le_bytes(branch.as_byte()).as_slice(),
+            index.to_le_bytes().as_slice(),
+        ]
+        .concat();
+
+        let command = APDUCommand {
+            cla: CLA,
+            ins: Instruction::GetScriptSignatureManaged as u8,
+            p1: 0,
+            p2: 0,
+            data,
+        };
+        let answer = self.inner.exchange(&command).await?;
+        apdu_err(answer.error_code())?;
+        answer.decode()
+    }
+
+    pub async fn get_script_signature_derived(
+        &self,
+        account: u64,
+        network_byte: u8,
+        version: u8,
+        branch_key: &RistrettoSecretKey,
+        value: &RistrettoSecretKey,
+        commitment_private_key: &RistrettoSecretKey,
+        commitment: &PedersenCommitmentBytes,
+        message: [u8; 32],
+    ) -> LedgerClientResult<CompressedRistrettoComAndPubSig, T::Error> {
+        let data = [
+            account.to_le_bytes().as_slice(),
+            cst_u8_u64_le_bytes(network_byte).as_slice(),
+            cst_u8_u64_le_bytes(version).as_slice(),
+            value.as_bytes(),
+            commitment_private_key.as_bytes(),
+            commitment.as_bytes(),
+            message.as_slice(),
+            branch_key.as_bytes(),
+        ]
+        .concat();
+
+        let command = APDUCommand {
+            cla: CLA,
+            ins: Instruction::GetScriptSignatureDerived as u8,
+            p1: 0,
+            p2: 0,
+            data,
+        };
+        let answer = self.inner.exchange(&command).await?;
+        apdu_err(answer.error_code())?;
+        answer.decode()
+    }
+
+    pub async fn get_script_offset(
+        &self,
+        account: u64,
+        partial_script_offset: &RistrettoSecretKey,
+        derived_script_keys: &[RistrettoSecretKey],
+        script_key_indexes: &[(LedgerKeyBranch, u64)],
+        derived_sender_offsets: &[RistrettoSecretKey],
+        sender_offset_indexes: &[(LedgerKeyBranch, u64)],
+    ) -> LedgerClientResult<RistrettoSecretKey, T::Error> {
+        let num_commands = 1 +
+            1 +
+            sender_offset_indexes.len() +
+            script_key_indexes.len() +
+            derived_sender_offsets.len() +
+            derived_script_keys.len();
+        let mut data = Vec::with_capacity(num_commands);
+
+        // Requires execution of multiple commands due to APDU data size limits, so we prepare each command's the data
+        // as follows:
+
+        // 1. Set lengths
+        data.push(
+            [
+                account.to_le_bytes().as_slice(),
+                cst_usize_u64_le_bytes(sender_offset_indexes.len()).as_slice(),
+                cst_usize_u64_le_bytes(script_key_indexes.len()).as_slice(),
+                cst_usize_u64_le_bytes(derived_sender_offsets.len()).as_slice(),
+                cst_usize_u64_le_bytes(derived_script_keys.len()).as_slice(),
+            ]
+            .concat(),
+        );
+
+        // 2. Partial script offset
+        data.push(partial_script_offset.as_bytes().to_vec());
+
+        // Sender offsets
+        for (branch, index) in sender_offset_indexes {
+            data.push(
+                [
+                    cst_u8_u64_le_bytes(branch.as_byte()).as_slice(),
+                    index.to_le_bytes().as_slice(),
+                ]
+                .concat(),
+            );
+        }
+
+        // Script keys
+        for (branch, index) in script_key_indexes {
+            data.push(
+                [
+                    cst_u8_u64_le_bytes(branch.as_byte()).as_slice(),
+                    index.to_le_bytes().as_slice(),
+                ]
+                .concat(),
+            );
+        }
+
+        // Derived sender offsets
+        for key in derived_sender_offsets {
+            data.push(key.as_bytes().to_vec());
+        }
+
+        // Derived script keys
+        for key in derived_script_keys {
+            data.push(key.as_bytes().to_vec());
+        }
+
+        // Send the commands sequentially, each command updates internal state on the device until we send p2 = 0 on the
+        // last command, which triggers the device to return the final result
+        for (i, datum) in data.iter().enumerate() {
+            let more = i + 1 != data.len();
+            let command = APDUCommand {
+                cla: CLA,
+                ins: Instruction::GetScriptOffset as u8,
+                p1: i as u8,
+                p2: u8::from(more),
+                data: datum.as_slice(),
+            };
+            let answer = self.inner.exchange(&command).await?;
+            apdu_err(answer.error_code())?;
+            if !more {
+                return answer.decode();
+            }
+        }
+
+        unreachable!(
+            "Data vector is guaranteed to have at least one element, so loop will always return before reaching this \
+             point"
+        );
+    }
+
+    pub async fn get_secret_view_key(&self, account: u64) -> LedgerClientResult<RistrettoPublicKeyBytes, T::Error> {
+        let acc_bytes = account.to_le_bytes();
+        let command = APDUCommand {
+            cla: CLA,
+            ins: Instruction::GetViewKey as u8,
+            p1: 0,
+            p2: 0,
+            data: acc_bytes.as_slice(),
+        };
+        let answer = self.inner.exchange(&command).await?;
+        apdu_err(answer.error_code())?;
+
+        answer.decode()
+    }
+
+    pub async fn get_dh_shared_secret(
+        &self,
+        account: u64,
+        index: u64,
+        branch: LedgerKeyBranch,
+        public_key: &RistrettoPublicKeyBytes,
+    ) -> LedgerClientResult<RistrettoPublicKey, T::Error> {
+        let data = [
+            account.to_le_bytes().as_slice(),
+            index.to_le_bytes().as_slice(),
+            cst_u8_u64_le_bytes(branch.as_byte()).as_slice(),
+            public_key.as_slice(),
+        ]
+        .concat();
+
+        let command = APDUCommand {
+            cla: CLA,
+            ins: Instruction::GetDHSharedSecret as u8,
+            p1: 0,
+            p2: 0,
+            data,
+        };
+        let answer = self.inner.exchange(&command).await?;
+        apdu_err(answer.error_code())?;
+
+        answer.decode()
+    }
+
+    pub async fn get_raw_schnorr_signature(
+        &self,
+        account: u64,
+        private_key_index: u64,
+        private_key_branch: LedgerKeyBranch,
+        nonce_index: u64,
+        nonce_branch: LedgerKeyBranch,
+        challenge: &[u8; 64],
+    ) -> LedgerClientResult<SchnorrSignatureBytes, T::Error> {
+        let data = [
+            account.to_le_bytes().as_slice(),
+            private_key_index.to_le_bytes().as_slice(),
+            cst_u8_u64_le_bytes(private_key_branch.as_byte()).as_slice(),
+            nonce_index.to_le_bytes().as_slice(),
+            cst_u8_u64_le_bytes(nonce_branch.as_byte()).as_slice(),
+            challenge.as_slice(),
+        ]
+        .concat();
+
+        let command = APDUCommand {
+            cla: CLA,
+            ins: Instruction::GetRawSchnorrSignature as u8,
+            p1: 0,
+            p2: 0,
+            data,
+        };
+        let answer = self.inner.exchange(&command).await?;
+        apdu_err(answer.error_code())?;
+
+        answer.decode()
+    }
+
+    pub async fn get_script_schnorr_signature(
+        &self,
+        account: u64,
+        private_key_index: u64,
+        private_key_branch: LedgerKeyBranch,
+        nonce: &[u8],
+    ) -> LedgerClientResult<SchnorrSignatureBytes, T::Error> {
+        let data = [
+            account.to_le_bytes().as_slice(),
+            private_key_index.to_le_bytes().as_slice(),
+            cst_u8_u64_le_bytes(private_key_branch.as_byte()).as_slice(),
+            nonce,
+        ]
+        .concat();
+
+        let command = APDUCommand {
+            cla: CLA,
+            ins: Instruction::GetScriptSchnorrSignature as u8,
+            p1: 0,
+            p2: 0,
+            data,
+        };
+        let answer = self.inner.exchange(&command).await?;
+        apdu_err(answer.error_code())?;
+
+        answer.decode()
+    }
+}
+
+const fn cst_u8_u64_le_bytes(value: u8) -> [u8; 8] {
+    [value, 0, 0, 0, 0, 0, 0, 0]
+}
+
+const fn cst_usize_u64_le_bytes(value: usize) -> [u8; 8] {
+    let value = value as u64;
+    value.to_le_bytes()
+}
+
+fn apdu_err<E>(code: Result<APDUErrorCode, u16>) -> LedgerClientResult<(), E> {
+    match code {
+        Ok(APDUErrorCode::NoError) => Ok(()),
+        Ok(code) => Err(LedgerClientError::APDUError { code }),
+        Err(code) => AppSW::try_from(code)
+            .map_err(|_| LedgerClientError::APDUOtherCodeError { code })
+            .and_then(|app_sw| Err(LedgerClientError::AppError { code: app_sw })),
+    }
+}
+
+#[cfg(all(test, feature = "speculos-transport"))]
+mod tests {
+    use super::*;
+    use crate::speculos_transport::SpeculosTransport;
+
+    #[tokio::test]
+    #[ignore = "Requires Speculos to be running with the minotari_ledger_wallet app."]
+    async fn test_commands() {
+        let transport = SpeculosTransport::new();
+        let client = LedgerClient::new(transport);
+
+        let version = client.get_app_version().await.unwrap();
+        assert_eq!(version, "5.3.0-pre.0");
+
+        let app_name = client.get_app_name().await.unwrap();
+        assert_eq!(app_name, "minotari_ledger_wallet");
+
+        let public_spend_key = client.get_public_spend_key(0).await.unwrap();
+        assert_eq!(public_spend_key.len(), 32);
+
+        let public_key = client.get_public_key(0, 0, LedgerKeyBranch::Spend).await.unwrap();
+        assert_eq!(public_key.len(), 32);
+
+        let view_key = client.get_secret_view_key(0).await.unwrap();
+        assert_eq!(view_key.len(), 32);
+
+        let _valid_dh_shared_secret = client
+            .get_dh_shared_secret(0, 0, LedgerKeyBranch::Spend, &public_key)
+            .await
+            .unwrap();
+
+        let script_offset = client
+            .get_script_offset(
+                0,
+                &RistrettoSecretKey::from(1),
+                &[RistrettoSecretKey::from(2)],
+                &[(LedgerKeyBranch::Spend, 0)],
+                &[RistrettoSecretKey::from(3)],
+                &[(LedgerKeyBranch::Spend, 0)],
+            )
+            .await
+            .unwrap();
+        assert_eq!(script_offset.as_bytes().len(), 32);
+
+        let challenge = [0u8; 64];
+        let raw_schnorr_signature = client
+            .get_raw_schnorr_signature(0, 0, LedgerKeyBranch::Spend, 0, LedgerKeyBranch::Spend, &challenge)
+            .await
+            .unwrap();
+        assert_eq!(raw_schnorr_signature.public_nonce().len(), 32);
+        assert_eq!(raw_schnorr_signature.signature().len(), 32);
+
+        let nonce = [0u8; 32];
+        let script_schnorr_signature = client
+            .get_script_schnorr_signature(0, 0, LedgerKeyBranch::Spend, &nonce)
+            .await
+            .unwrap();
+        assert_eq!(script_schnorr_signature.public_nonce().len(), 32);
+        assert_eq!(script_schnorr_signature.signature().len(), 32);
+    }
+}

--- a/crates/wallet/tari-ledger-client/src/decode.rs
+++ b/crates/wallet/tari-ledger-client/src/decode.rs
@@ -1,0 +1,129 @@
+//   Copyright 2026 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+use std::ops::Deref;
+
+use ledger_transport::APDUAnswer;
+use tari_crypto::{
+    compressed_key::CompressedKey,
+    ristretto::{
+        CompressedRistrettoComAndPubSig,
+        RistrettoPublicKey,
+        RistrettoSecretKey,
+        pedersen::CompressedPedersenCommitment,
+    },
+    tari_utilities::ByteArray,
+};
+use tari_template_lib_types::crypto::{RistrettoPublicKeyBytes, Scalar32Bytes, SchnorrSignatureBytes};
+
+use crate::LedgerClientError;
+
+pub trait DecodeAnswer<Out> {
+    fn decode<E>(&self) -> Result<Out, LedgerClientError<E>>
+    where Self: Sized;
+}
+
+impl<B: Deref<Target = [u8]>> DecodeAnswer<RistrettoPublicKeyBytes> for APDUAnswer<B> {
+    fn decode<E>(&self) -> Result<RistrettoPublicKeyBytes, LedgerClientError<E>>
+    where Self: Sized {
+        // Ignore the version byte (TODO: validate the version?)
+        let bytes = self.data().get(1..).ok_or_else(|| LedgerClientError::InvalidResponse {
+            details: "response too short".to_string(),
+        })?;
+        RistrettoPublicKeyBytes::try_from(bytes)
+            .map_err(|e| LedgerClientError::InvalidResponse { details: e.to_string() })
+    }
+}
+
+impl<B: Deref<Target = [u8]>> DecodeAnswer<String> for APDUAnswer<B> {
+    fn decode<E>(&self) -> Result<String, LedgerClientError<E>>
+    where Self: Sized {
+        let bytes = self.data();
+        str::from_utf8(bytes)
+            .map(|s| s.to_string())
+            .map_err(|e| LedgerClientError::InvalidResponse { details: e.to_string() })
+    }
+}
+
+impl<B: Deref<Target = [u8]>> DecodeAnswer<CompressedRistrettoComAndPubSig> for APDUAnswer<B> {
+    fn decode<E>(&self) -> Result<CompressedRistrettoComAndPubSig, LedgerClientError<E>>
+    where Self: Sized {
+        let data = self.data();
+        if data.len() < 161 {
+            return Err(LedgerClientError::InvalidResponse {
+                details: format!("response has invalid length: expected 161, got {}", data.len()),
+            });
+        }
+
+        let public_nonce =
+            CompressedPedersenCommitment::from_canonical_bytes(data.get(1..33).expect("Length already checked"))
+                .map_err(|e| LedgerClientError::InvalidResponse { details: e.to_string() })?;
+        let pub_key = CompressedKey::<RistrettoPublicKey>::from_canonical_bytes(
+            data.get(33..65).expect("Length already checked"),
+        )
+        .map_err(|e| LedgerClientError::InvalidResponse { details: e.to_string() })?;
+        let u_a = RistrettoSecretKey::from_canonical_bytes(data.get(65..97).expect("Length already checked"))
+            .map_err(|e| LedgerClientError::InvalidResponse { details: e.to_string() })?;
+        let u_x = RistrettoSecretKey::from_canonical_bytes(data.get(97..129).expect("Length already checked"))
+            .map_err(|e| LedgerClientError::InvalidResponse { details: e.to_string() })?;
+        let u_y = RistrettoSecretKey::from_canonical_bytes(data.get(129..161).expect("Length already checked"))
+            .map_err(|e| LedgerClientError::InvalidResponse { details: e.to_string() })?;
+
+        Ok(CompressedRistrettoComAndPubSig::new(
+            public_nonce,
+            pub_key,
+            u_a,
+            u_x,
+            u_y,
+        ))
+    }
+}
+
+impl<B: Deref<Target = [u8]>> DecodeAnswer<RistrettoSecretKey> for APDUAnswer<B> {
+    fn decode<E>(&self) -> Result<RistrettoSecretKey, LedgerClientError<E>>
+    where Self: Sized {
+        let data = self.data();
+        if data.len() < 33 {
+            return Err(LedgerClientError::InvalidResponse {
+                details: format!("response has invalid length: expected 33, got {}", data.len()),
+            });
+        }
+
+        RistrettoSecretKey::from_canonical_bytes(data.get(1..33).expect("Length already checked"))
+            .map_err(|e| LedgerClientError::InvalidResponse { details: e.to_string() })
+    }
+}
+
+impl<B: Deref<Target = [u8]>> DecodeAnswer<SchnorrSignatureBytes> for APDUAnswer<B> {
+    fn decode<E>(&self) -> Result<SchnorrSignatureBytes, LedgerClientError<E>>
+    where Self: Sized {
+        let data = self.data();
+        if data.len() < 65 {
+            return Err(LedgerClientError::InvalidResponse {
+                details: format!("response has invalid length: expected 65, got {}", data.len()),
+            });
+        }
+
+        let public_nonce = RistrettoPublicKeyBytes::from_bytes(data.get(1..33).expect("Length already checked"))
+            .expect("Length already checked");
+        let sig = Scalar32Bytes::from_bytes(data.get(33..65).expect("Length already checked"))
+            .expect("Length already checked");
+
+        Ok(SchnorrSignatureBytes::new(public_nonce, sig))
+    }
+}
+
+impl<B: Deref<Target = [u8]>> DecodeAnswer<RistrettoPublicKey> for APDUAnswer<B> {
+    fn decode<E>(&self) -> Result<RistrettoPublicKey, LedgerClientError<E>>
+    where Self: Sized {
+        let data = self.data();
+        if data.len() < 33 {
+            return Err(LedgerClientError::InvalidResponse {
+                details: format!("response has invalid length: expected 33, got {}", data.len()),
+            });
+        }
+
+        RistrettoPublicKey::from_canonical_bytes(data.get(1..33).expect("Length already checked"))
+            .map_err(|e| LedgerClientError::InvalidResponse { details: e.to_string() })
+    }
+}

--- a/crates/wallet/tari-ledger-client/src/error.rs
+++ b/crates/wallet/tari-ledger-client/src/error.rs
@@ -1,0 +1,19 @@
+//   Copyright 2026 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+use ledger_transport::APDUErrorCode;
+use minotari_ledger_wallet_common::common_types::AppSW;
+
+#[derive(Debug, thiserror::Error)]
+pub enum LedgerClientError<E> {
+    #[error("Ledger transport error: {0}")]
+    Transport(#[from] E),
+    #[error("Invalid response from ledger: {details}")]
+    InvalidResponse { details: String },
+    #[error("Ledger returned APDU error code: {code}")]
+    APDUError { code: APDUErrorCode },
+    #[error("Ledger returned unknown APDU error code: {code}")]
+    APDUOtherCodeError { code: u16 },
+    #[error("Ledger returned application error code: {code:?}")]
+    AppError { code: AppSW },
+}

--- a/crates/wallet/tari-ledger-client/src/hid.rs
+++ b/crates/wallet/tari-ledger-client/src/hid.rs
@@ -1,0 +1,9 @@
+//   Copyright 2026 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+use ledger_transport_hid::TransportNativeHID;
+
+use crate::LedgerClient;
+
+/// Native HID ledger client
+pub type LedgerHidClient = LedgerClient<TransportNativeHID>;

--- a/crates/wallet/tari-ledger-client/src/lib.rs
+++ b/crates/wallet/tari-ledger-client/src/lib.rs
@@ -1,0 +1,16 @@
+//   Copyright 2026 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+mod client;
+mod error;
+#[cfg(feature = "hid-transport")]
+mod hid;
+
+pub use client::*;
+pub use error::*;
+#[cfg(feature = "hid-transport")]
+pub use hid::*;
+
+mod decode;
+#[cfg(feature = "speculos-transport")]
+pub mod speculos_transport;

--- a/crates/wallet/tari-ledger-client/src/speculos_transport.rs
+++ b/crates/wallet/tari-ledger-client/src/speculos_transport.rs
@@ -1,0 +1,53 @@
+//   Copyright 2026 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+use std::ops::Deref;
+
+use ledger_transport::{APDUAnswer, APDUCommand, Exchange, async_trait};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Default)]
+pub struct SpeculosTransport {
+    inner: reqwest::Client,
+    url: String,
+}
+
+impl SpeculosTransport {
+    pub fn new() -> Self {
+        Self {
+            inner: reqwest::Client::new(),
+            url: "http://localhost:5000/apdu".to_string(),
+        }
+    }
+
+    pub fn with_url(mut self, url: String) -> Self {
+        self.url = url;
+        self
+    }
+}
+
+#[async_trait]
+impl Exchange for SpeculosTransport {
+    type AnswerType = Vec<u8>;
+    type Error = reqwest::Error;
+
+    async fn exchange<I>(&self, command: &APDUCommand<I>) -> Result<APDUAnswer<Self::AnswerType>, Self::Error>
+    where I: Deref<Target = [u8]> + Send + Sync {
+        let data = hex::encode(command.serialize());
+        let response = self.inner.post(&self.url).json(&Request { data }).send().await?;
+
+        let answer = response.json::<Answer>().await?;
+        let data = hex::decode(answer.data).unwrap();
+        Ok(APDUAnswer::from_answer(data).expect("answer should be valid"))
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct Request {
+    data: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct Answer {
+    data: String,
+}


### PR DESCRIPTION
Description
---
feat: ledger client

Motivation and Context
---

Ledger client that communicates with the minotari ledger app. The client is decoupled from a particular transport. Two transports are available behind feature flags, namely `native hid` and `speculos` (for testing)

Next up: will attempt to use this to create a ledger backend for ootle-rs. This may require extending the minotari app to include stealth key creation, or an ootle-specific app. 

How Has This Been Tested?
---
Unit test that runs all commands against the minotari app deployed on speculos. Unfortunately, these are not run on CI because of the probable complexity in deploying Speculos on CI


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify