### PR TITLE
fix(bor)!: fix bincode encoding for cbor value

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1670,7 +1670,7 @@ dependencies = [
 
 [[package]]
 name = "consensus_tests"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "fern",
  "futures 0.3.31",
@@ -2610,7 +2610,7 @@ dependencies = [
 
 [[package]]
 name = "db-inspector"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -3730,7 +3730,7 @@ checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 
 [[package]]
 name = "generate_ristretto_value_lookup"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "clap 3.2.25",
  "futures 0.3.31",
@@ -4917,7 +4917,7 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "integration_tests"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "config",
@@ -5633,7 +5633,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-messaging"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "async-trait",
  "futures-bounded",
@@ -5812,7 +5812,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-substream"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "libp2p",
  "prometheus-client",
@@ -7378,7 +7378,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "ootle-rs"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -8377,7 +8377,7 @@ dependencies = [
 
 [[package]]
 name = "proto_builder"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "prost-build 0.14.3",
  "sha2 0.10.9",
@@ -10186,7 +10186,7 @@ dependencies = [
 
 [[package]]
 name = "sqlite_message_logger"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "chrono",
  "diesel",
@@ -10576,7 +10576,7 @@ checksum = "b1dd07eb858a2067e2f3c7155d54e929265c264e6f37efe3ee7a8d1b5a1dd0ba"
 
 [[package]]
 name = "tari-ledger-client"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "hex",
  "ledger-transport",
@@ -10602,7 +10602,7 @@ dependencies = [
 
 [[package]]
 name = "tari_base_node_client"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "futures-util",
  "log",
@@ -10623,8 +10623,9 @@ dependencies = [
 
 [[package]]
 name = "tari_bor"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
+ "bincode 2.0.1",
  "borsh",
  "ciborium",
  "ciborium-io",
@@ -10826,7 +10827,7 @@ dependencies = [
 
 [[package]]
 name = "tari_consensus"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "indexmap 2.13.0",
@@ -10851,7 +10852,7 @@ dependencies = [
 
 [[package]]
 name = "tari_consensus_types"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "borsh",
  "ootle_serde",
@@ -10953,7 +10954,7 @@ dependencies = [
 
 [[package]]
 name = "tari_engine"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "blake2",
  "criterion",
@@ -10981,7 +10982,7 @@ dependencies = [
 
 [[package]]
 name = "tari_engine_types"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "bincode 2.0.1",
  "blake2",
@@ -11008,7 +11009,7 @@ dependencies = [
 
 [[package]]
 name = "tari_epoch_manager"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "log",
@@ -11028,7 +11029,7 @@ dependencies = [
 
 [[package]]
 name = "tari_epoch_oracles"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -11081,7 +11082,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -11153,7 +11154,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer_client"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "bounded-vec",
@@ -11186,7 +11187,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer_lib"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "log",
  "prometheus-client",
@@ -11262,7 +11263,7 @@ dependencies = [
 
 [[package]]
 name = "tari_networking"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11298,7 +11299,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_address"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "bech32",
  "bincode 2.0.1",
@@ -11314,7 +11315,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_app_utilities"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -11353,7 +11354,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_common_types"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "blake2",
  "borsh",
@@ -11382,7 +11383,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_p2p"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "libp2p-identity",
@@ -11406,7 +11407,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_storage"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "bitflags 2.10.0",
@@ -11433,7 +11434,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_storage_sqlite"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "diesel",
  "diesel_migrations",
@@ -11454,7 +11455,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_transaction"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "bincode 2.0.1",
  "borsh",
@@ -11478,7 +11479,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_cli"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -11507,7 +11508,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_crypto"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "argon2 0.5.3",
  "blake2",
@@ -11536,7 +11537,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_sdk"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "digest 0.10.7",
@@ -11573,7 +11574,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_sdk_services"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -11600,7 +11601,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_storage_sqlite"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "bigdecimal",
  "diesel",
@@ -11624,7 +11625,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_walletd"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11710,7 +11711,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_framework"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "async-trait",
  "bitflags 2.10.0",
@@ -11734,7 +11735,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_macros"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11743,7 +11744,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_state_sync"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -11820,7 +11821,7 @@ dependencies = [
 
 [[package]]
 name = "tari_state_store_rocksdb"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -11851,7 +11852,7 @@ dependencies = [
 
 [[package]]
 name = "tari_state_tree"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "indexmap 2.13.0",
  "log",
@@ -11877,7 +11878,7 @@ dependencies = [
 
 [[package]]
 name = "tari_swarm"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "libp2p",
  "libp2p-messaging",
@@ -11888,7 +11889,7 @@ dependencies = [
 
 [[package]]
 name = "tari_swarm_daemon"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11944,7 +11945,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_builtin"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "tari_engine",
  "tari_engine_types",
@@ -12113,7 +12114,7 @@ dependencies = [
 
 [[package]]
 name = "tari_transaction_manifest"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "proc-macro2",
  "serde_json",
@@ -12147,7 +12148,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -12214,7 +12215,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node_client"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "indexmap 2.13.0",
  "multiaddr 0.18.3",
@@ -12238,7 +12239,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node_rpc"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -12261,7 +12262,7 @@ dependencies = [
 
 [[package]]
 name = "tari_wallet_daemon_client"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "ootle_serde",
  "reqwest 0.11.27",
@@ -12283,7 +12284,7 @@ dependencies = [
 
 [[package]]
 name = "tari_watcher"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "clap 3.2.25",
@@ -12311,7 +12312,7 @@ dependencies = [
 
 [[package]]
 name = "tariswap_bench"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "clap 4.5.54",
@@ -13001,7 +13002,7 @@ dependencies = [
 
 [[package]]
 name = "traffic-sim"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "clap 4.5.54",
@@ -13023,7 +13024,7 @@ dependencies = [
 
 [[package]]
 name = "transaction_generator"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -13044,7 +13045,7 @@ dependencies = [
 
 [[package]]
 name = "transaction_submitter"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "clap 4.5.54",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.20.1"
+version = "0.21.0"
 edition = "2024"
 authors = ["The Tari Development Community"]
 repository = "https://github.com/tari-project/tari-ootle"
@@ -117,7 +117,7 @@ tari_template_lib = { version = "0.19", path = "crates/template_lib" }
 tari_template_lib_types = { version = "0.19", path = "crates/template_lib_types", default-features = false }
 tari_template_abi = { version = "0.15", path = "crates/template_abi", default-features = false }
 tari_template_macros = { version = "0.15", path = "crates/template_macros" }
-tari_bor = { version = "0.12", path = "crates/tari_bor", default-features = false }
+tari_bor = { version = "0.13", path = "crates/tari_bor", default-features = false }
 
 ootle_byte_type = { path = "crates/ootle_byte_type", version = "0.2" }
 ootle_serde = { path = "crates/ootle_serde", version = "0.1" }

--- a/applications/tari_walletd/src/handlers/accounts.rs
+++ b/applications/tari_walletd/src/handlers/accounts.rs
@@ -495,10 +495,8 @@ pub async fn handle_claim_burn(
     let account_owner_public_key = account_owner.to_public_key();
     let view_only = sdk.key_manager_api().get_key(account.view_only_key_id())?;
     let view_only_public_key = view_only.to_public_key();
-    let memo = Memo::new_message("Claimed burned XTR from L1").expect("valid memo");
-    // NOTE: the confidential encryption format and the bullet proofs currently do not support amounts larger than
-    // u64::MAX. Apart from it being insane/basically impossible to have that much XTR in a single UTXO, the L1 emission
-    // will reach this much in many thousands of years.
+    let memo = Memo::new_message("Burnt funds claimed from L1").expect("valid memo");
+
     let encrypted_data = sdk.stealth_crypto_api().encrypt_value_and_mask(
         final_amount,
         &mask.key,

--- a/crates/engine_types/Cargo.toml
+++ b/crates/engine_types/Cargo.toml
@@ -8,7 +8,7 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-tari_bor = { workspace = true, features = ["std", "json_encoding"] }
+tari_bor = { workspace = true, features = ["std", "cbor_value_encoding_fix"] }
 tari_crypto = { workspace = true, features = ["borsh"] }
 tari_hashing = { workspace = true }
 tari_template_abi = { workspace = true, features = ["std"] }

--- a/crates/ootle_serde/Cargo.toml
+++ b/crates/ootle_serde/Cargo.toml
@@ -8,7 +8,7 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-tari_bor = { workspace = true, optional = true, features = ["std", "json_encoding"] }
+tari_bor = { workspace = true, optional = true, features = ["std", "cbor_value_encoding_fix"] }
 
 serde = { workspace = true }
 base64 = { workspace = true, optional = true }

--- a/crates/ootle_serde/src/cbor_value.rs
+++ b/crates/ootle_serde/src/cbor_value.rs
@@ -2,46 +2,25 @@
 //   SPDX-License-Identifier: BSD-3-Clause
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use tari_bor::json_encoding::{CborValueJsonSerializeWrapper, CiboruimValueDeserializeFixWrapper};
+use tari_bor::cbor_value_encoding_fix::{CborValueDeserializeFixWrapper, CborValueSerializeFixWrapper};
 
 pub fn serialize<S: Serializer>(v: &tari_bor::Value, s: S) -> Result<S::Ok, S::Error> {
-    if s.is_human_readable() {
-        // This uses a wrapper type to serialize the CBOR value to a JSON-compatible format
-        // We cannot use this wrapper for non-human-readable formats because then the resulting CBOR would be would not
-        // be valid CBOR binary data
-        CborValueJsonSerializeWrapper(v).serialize(s)
+    if cfg!(feature = "bincode-compat") || s.is_human_readable() {
+        // This uses a wrapper type to serialize the CBOR value to a JSON and bincode-compatible format
+        // We cannot use this wrapper for cbor encoding itself (non-human readable) because then the result
+        // would be would not be valid CBOR binary data.
+        CborValueSerializeFixWrapper(v).serialize(s)
     } else {
-        #[cfg(feature = "bincode-compat")]
-        {
-            // This is to support bincode since the default ciborium serde implementation uses deserialize_any instead
-            // // of serializing the cbor::Value enum directly
-            // - unfortunately, when using CBOR, Value::Bytes will be used instead of the actual CBOR representation.
-            // NOTE: this increases fees (see FeeModule::on_before_finalize)
-            // Other solutions include:
-            // - switching to cbor4ii, implementing to_value and from_value and a serializer that supports
-            //   deserialize_any
-            // - storing a Vec<u8> and incurring the extra encode/decode steps (what this does)
-            let vec = tari_bor::encode(v).map_err(serde::ser::Error::custom)?;
-            s.serialize_bytes(&vec)
-        }
-        #[cfg(not(feature = "bincode-compat"))]
         v.serialize(s)
     }
 }
 
 pub fn deserialize<'de, D>(d: D) -> Result<tari_bor::Value, D::Error>
 where D: Deserializer<'de> {
-    if d.is_human_readable() {
-        let wrapper = CiboruimValueDeserializeFixWrapper::deserialize(d)?;
+    if cfg!(feature = "bincode-compat") || d.is_human_readable() {
+        let wrapper = CborValueDeserializeFixWrapper::deserialize(d)?;
         Ok(wrapper.0)
     } else {
-        #[cfg(feature = "bincode-compat")]
-        {
-            use crate::visitor::BytesVisitor;
-            let bytes = d.deserialize_byte_buf(BytesVisitor::new())?;
-            tari_bor::decode_exact(bytes.as_ref()).map_err(serde::de::Error::custom)
-        }
-        #[cfg(not(feature = "bincode-compat"))]
         tari_bor::Value::deserialize(d)
     }
 }
@@ -92,6 +71,25 @@ mod tests {
             })
             .unwrap(),
         };
+
+        // These assertions only work with bincode-compat disabled
+        // The check that the resulting Value is the CBOR of the Test struct, not the
+        // Value enum itself encoded as CBOR
+        #[cfg(not(feature = "bincode-compat"))]
+        {
+            use tari_bor::Tagged;
+            let value = tari_bor::to_value(&test).unwrap();
+            let (k, v) = value.as_map().expect("expected map").get(0).expect("expected value");
+            assert_eq!(k.as_text().expect("expected string"), "value");
+
+            let (k, v) = v.as_map().expect("expected map").get(1).expect("expected message");
+            assert_eq!(k.as_text().expect("expected string"), "message");
+            let (t, v) = v.as_tag().expect("expected resource tag");
+            assert_eq!(t, ResourceAddress::TAG);
+            v.as_bytes().expect("expected bytes");
+            let t = tari_bor::from_value::<Test>(&value).unwrap();
+            assert_eq!(test, t);
+        }
 
         let bytes = tari_bor::encode(&test).unwrap();
         let t = tari_bor::decode_exact::<Test>(&bytes).unwrap();

--- a/crates/tari_bor/Cargo.toml
+++ b/crates/tari_bor/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_bor"
 description = "The binary object representation (BOR) crate provides a binary encoding for template/engine data types"
-version = "0.12.0"
+version = "0.13.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true
@@ -16,11 +16,12 @@ borsh = { workspace = true, optional = true, default-features = false }
 
 [dev-dependencies]
 serde_json = { workspace = true }
+bincode = { workspace = true, features = ["serde"] }
 
 [features]
 default = ["std"]
 borsh = ["dep:borsh"]
 std = ["serde/std", "ciborium/std", "ciborium-io/std", "borsh?/std"]
 alloc = ["serde/alloc", "ciborium-io/alloc"]
-json_encoding = []
+cbor_value_encoding_fix = []
 ts = ["dep:ts-rs"]

--- a/crates/tari_bor/src/cbor_value_encoding_fix.rs
+++ b/crates/tari_bor/src/cbor_value_encoding_fix.rs
@@ -11,27 +11,27 @@ use core::{fmt, fmt::Formatter, marker::PhantomData};
 use ciborium::{Value, value::Integer};
 use serde::{de::VariantAccess, ser::SerializeTupleVariant};
 
-pub struct CborValueJsonSerializeWrapper<'a>(pub &'a Value);
+pub struct CborValueSerializeFixWrapper<'a>(pub &'a Value);
 
-impl serde::Serialize for CborValueJsonSerializeWrapper<'_> {
+impl serde::Serialize for CborValueSerializeFixWrapper<'_> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where S: serde::Serializer {
         match &self.0 {
-            Value::Integer(__field0) => {
-                let value = i128::from(*__field0);
-                serializer.serialize_newtype_variant("Value", 1u32, "Integer", &value)
+            Value::Integer(field0) => {
+                let value = i128::from(*field0);
+                serializer.serialize_newtype_variant("Value", 0u32, "Integer", &value)
             },
-            Value::Bytes(__field0) => {
-                serde::Serializer::serialize_newtype_variant(serializer, "Value", 1u32, "Bytes", __field0)
+            Value::Bytes(field0) => {
+                serde::Serializer::serialize_newtype_variant(serializer, "Value", 1u32, "Bytes", field0)
             },
-            Value::Float(__field0) => {
-                serde::Serializer::serialize_newtype_variant(serializer, "Value", 2u32, "Float", __field0)
+            Value::Float(field0) => {
+                serde::Serializer::serialize_newtype_variant(serializer, "Value", 2u32, "Float", field0)
             },
-            Value::Text(__field0) => {
-                serde::Serializer::serialize_newtype_variant(serializer, "Value", 3u32, "Text", __field0)
+            Value::Text(field0) => {
+                serde::Serializer::serialize_newtype_variant(serializer, "Value", 3u32, "Text", field0)
             },
-            Value::Bool(__field0) => {
-                serde::Serializer::serialize_newtype_variant(serializer, "Value", 4u32, "Bool", __field0)
+            Value::Bool(field0) => {
+                serde::Serializer::serialize_newtype_variant(serializer, "Value", 4u32, "Bool", field0)
             },
             Value::Null => serde::Serializer::serialize_unit_variant(serializer, "Value", 5u32, "Null"),
             Value::Tag(tag, value) => {
@@ -53,15 +53,15 @@ impl serde::Serialize for CborValueJsonSerializeWrapper<'_> {
     }
 }
 
-pub struct CiboruimValueDeserializeFixWrapper(pub Value);
+pub struct CborValueDeserializeFixWrapper(pub Value);
 
-impl CiboruimValueDeserializeFixWrapper {
+impl CborValueDeserializeFixWrapper {
     pub fn into_inner(self) -> Value {
         self.0
     }
 }
 
-impl<'de> serde::Deserialize<'de> for CiboruimValueDeserializeFixWrapper {
+impl<'de> serde::Deserialize<'de> for CborValueDeserializeFixWrapper {
     #[allow(clippy::too_many_lines)]
     fn deserialize<__D>(__deserializer: __D) -> Result<Self, __D::Error>
     where __D: serde::Deserializer<'de> {
@@ -150,11 +150,11 @@ impl<'de> serde::Deserialize<'de> for CiboruimValueDeserializeFixWrapper {
         }
         #[doc(hidden)]
         struct __Visitor<'de> {
-            marker: PhantomData<CiboruimValueDeserializeFixWrapper>,
+            marker: PhantomData<CborValueDeserializeFixWrapper>,
             lifetime: PhantomData<&'de ()>,
         }
         impl<'de> serde::de::Visitor<'de> for __Visitor<'de> {
-            type Value = CiboruimValueDeserializeFixWrapper;
+            type Value = CborValueDeserializeFixWrapper;
 
             fn expecting(&self, __formatter: &mut Formatter) -> fmt::Result {
                 Formatter::write_str(__formatter, "enum Value")
@@ -163,40 +163,40 @@ impl<'de> serde::Deserialize<'de> for CiboruimValueDeserializeFixWrapper {
             fn visit_enum<__A>(self, __data: __A) -> Result<Self::Value, __A::Error>
             where __A: serde::de::EnumAccess<'de> {
                 match serde::de::EnumAccess::variant(__data)? {
-                    (__Field::Integer, __variant) => {
-                        let a = __variant.newtype_variant::<i128>()?;
-                        Ok(CiboruimValueDeserializeFixWrapper(Value::Integer(
-                            Integer::try_from(a).map_err(serde::de::Error::custom)?,
+                    (__Field::Integer, variant) => {
+                        let int = variant.newtype_variant::<i128>()?;
+                        Ok(CborValueDeserializeFixWrapper(Value::Integer(
+                            Integer::try_from(int).map_err(serde::de::Error::custom)?,
                         )))
                     },
-                    (__Field::Bytes, __variant) => __variant
+                    (__Field::Bytes, variant) => variant
                         .newtype_variant()
                         .map(Value::Bytes)
-                        .map(CiboruimValueDeserializeFixWrapper),
-                    (__Field::Float, __variant) => __variant
+                        .map(CborValueDeserializeFixWrapper),
+                    (__Field::Float, variant) => variant
                         .newtype_variant()
                         .map(Value::Float)
-                        .map(CiboruimValueDeserializeFixWrapper),
-                    (__Field::Text, __variant) => __variant
+                        .map(CborValueDeserializeFixWrapper),
+                    (__Field::Text, variant) => variant
                         .newtype_variant()
                         .map(Value::Text)
-                        .map(CiboruimValueDeserializeFixWrapper),
-                    (__Field::Bool, __variant) => __variant
+                        .map(CborValueDeserializeFixWrapper),
+                    (__Field::Bool, variant) => variant
                         .newtype_variant()
                         .map(Value::Bool)
-                        .map(CiboruimValueDeserializeFixWrapper),
-                    (__Field::Null, __variant) => {
-                        __variant.unit_variant()?;
-                        Ok(CiboruimValueDeserializeFixWrapper(Value::Null))
+                        .map(CborValueDeserializeFixWrapper),
+                    (__Field::Null, variant) => {
+                        variant.unit_variant()?;
+                        Ok(CborValueDeserializeFixWrapper(Value::Null))
                     },
-                    (__Field::Tag, __variant) => {
+                    (__Field::Tag, variant) => {
                         #[doc(hidden)]
                         struct __Visitor<'de> {
-                            marker: PhantomData<CiboruimValueDeserializeFixWrapper>,
+                            marker: PhantomData<CborValueDeserializeFixWrapper>,
                             lifetime: PhantomData<&'de ()>,
                         }
                         impl<'de> serde::de::Visitor<'de> for __Visitor<'de> {
-                            type Value = CiboruimValueDeserializeFixWrapper;
+                            type Value = CborValueDeserializeFixWrapper;
 
                             fn expecting(&self, __formatter: &mut Formatter) -> fmt::Result {
                                 Formatter::write_str(__formatter, "tuple variant Value::Tag")
@@ -214,36 +214,36 @@ impl<'de> serde::Deserialize<'de> for CiboruimValueDeserializeFixWrapper {
                                         ));
                                     },
                                 };
-                                let wrapped = serde::de::SeqAccess::next_element::<CiboruimValueDeserializeFixWrapper>(
-                                    &mut __seq,
-                                )?
-                                .ok_or_else(|| {
-                                    serde::de::Error::invalid_length(
-                                        1usize,
-                                        &"tuple variant Value::Tag with 2 elements",
-                                    )
-                                })?;
-                                Ok(CiboruimValueDeserializeFixWrapper(Value::Tag(
+                                let wrapped =
+                                    serde::de::SeqAccess::next_element::<CborValueDeserializeFixWrapper>(&mut __seq)?
+                                        .ok_or_else(|| {
+                                        serde::de::Error::invalid_length(
+                                            1usize,
+                                            &"tuple variant Value::Tag with 2 elements",
+                                        )
+                                    })?;
+                                Ok(CborValueDeserializeFixWrapper(Value::Tag(
                                     __field0,
                                     Box::new(wrapped.0),
                                 )))
                             }
                         }
-                        VariantAccess::tuple_variant(__variant, 2usize, __Visitor {
+                        VariantAccess::tuple_variant(variant, 2usize, __Visitor {
                             marker: PhantomData,
                             lifetime: PhantomData,
                         })
                     },
                     (__Field::Array, __variant) => {
-                        let values = __variant.newtype_variant::<Vec<CiboruimValueDeserializeFixWrapper>>()?;
-                        Ok(CiboruimValueDeserializeFixWrapper(Value::Array(
+                        let values = __variant.newtype_variant::<Vec<CborValueDeserializeFixWrapper>>()?;
+                        Ok(CborValueDeserializeFixWrapper(Value::Array(
                             values.into_iter().map(|v| v.0).collect(),
                         )))
                     },
                     (__Field::Map, __variant) => {
                         let values = __variant
-                            .newtype_variant::<Vec<(CiboruimValueDeserializeFixWrapper, CiboruimValueDeserializeFixWrapper)>>()?;
-                        Ok(CiboruimValueDeserializeFixWrapper(Value::Map(
+                            .newtype_variant::<Vec<(CborValueDeserializeFixWrapper, CborValueDeserializeFixWrapper)>>(
+                            )?;
+                        Ok(CborValueDeserializeFixWrapper(Value::Map(
                             values.into_iter().map(|(k, v)| (k.0, v.0)).collect(),
                         )))
                     },
@@ -267,10 +267,9 @@ mod tests {
 
     use super::*;
 
-    #[test]
-    fn decode_encode() {
+    fn sample() -> Value {
         let bytes = [1u8; 32];
-        let sample = cbor!({
+        cbor!({
             "code" => 415,
             "message" => null,
             "continue" => false,
@@ -279,12 +278,31 @@ mod tests {
             "array" => [{()=>1}, {123=>2}, {cbor!({"A"=>1}).unwrap()=>3}],
             "extra" => { "numbers" => [8.2341e+4, 0.251425] },
         })
-        .unwrap();
-        let s1 = serde_json::to_string(&CborValueJsonSerializeWrapper(&sample)).unwrap();
-        let decoded = serde_json::from_str::<CiboruimValueDeserializeFixWrapper>(&s1).unwrap();
+        .unwrap()
+    }
+
+    #[test]
+    fn decode_encode() {
+        let sample = sample();
+        let s1 = serde_json::to_string(&CborValueSerializeFixWrapper(&sample)).unwrap();
+        let decoded = serde_json::from_str::<CborValueDeserializeFixWrapper>(&s1).unwrap();
         // Decoded value matches original
         assert_eq!(sample, decoded.0);
-        let s2 = serde_json::to_string(&CborValueJsonSerializeWrapper(&decoded.0)).unwrap();
+        let s2 = serde_json::to_string(&CborValueSerializeFixWrapper(&decoded.0)).unwrap();
+        // Re-encode to string, which should be identical to the previously encoded JSON string
+        assert_eq!(s1, s2);
+    }
+
+    #[test]
+    fn decode_encode_bincode() {
+        const BINCODE_STD: bincode::config::Configuration = bincode::config::standard();
+        let sample = sample();
+        let s1 = bincode::serde::encode_to_vec(CborValueSerializeFixWrapper(&sample), BINCODE_STD).unwrap();
+        let (decoded, _) =
+            bincode::serde::decode_from_slice::<CborValueDeserializeFixWrapper, _>(&s1, BINCODE_STD).unwrap();
+        // Decoded value matches original
+        assert_eq!(sample, decoded.0);
+        let s2 = bincode::serde::encode_to_vec(CborValueSerializeFixWrapper(&decoded.0), BINCODE_STD).unwrap();
         // Re-encode to string, which should be identical to the previously encoded JSON string
         assert_eq!(s1, s2);
     }

--- a/crates/tari_bor/src/lib.rs
+++ b/crates/tari_bor/src/lib.rs
@@ -16,9 +16,9 @@ mod tag;
 pub use tag::*;
 
 mod byte_counter;
+#[cfg(all(feature = "std", feature = "cbor_value_encoding_fix"))]
+pub mod cbor_value_encoding_fix;
 mod error;
-#[cfg(all(feature = "std", feature = "json_encoding"))]
-pub mod json_encoding;
 mod walker;
 
 pub use ciborium::{cbor, value::Value};

--- a/crates/template_lib_types/src/substates/resource.rs
+++ b/crates/template_lib_types/src/substates/resource.rs
@@ -20,7 +20,7 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use tari_bor::BorTag;
+use tari_bor::{BorTag, Tagged};
 use tari_template_abi::rust::{
     fmt,
     fmt::{Display, Formatter},
@@ -101,6 +101,10 @@ impl AsRef<[u8]> for ResourceAddress {
 }
 
 newtype_struct_serde_impl!(ResourceAddress, BorTag<ObjectKey, TAG>);
+
+impl Tagged for ResourceAddress {
+    const TAG: u64 = TAG;
+}
 
 #[cfg(test)]
 mod tests {

--- a/crates/wallet/storage_sqlite/Cargo.toml
+++ b/crates/wallet/storage_sqlite/Cargo.toml
@@ -8,7 +8,7 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-tari_bor = { workspace = true, features = ["json_encoding"] }
+tari_bor = { workspace = true, features = ["cbor_value_encoding_fix"] }
 tari_ootle_common_types = { workspace = true }
 tari_ootle_wallet_sdk = { workspace = true }
 tari_engine_types = { workspace = true }

--- a/crates/wallet/storage_sqlite/src/models/non_fungible_tokens.rs
+++ b/crates/wallet/storage_sqlite/src/models/non_fungible_tokens.rs
@@ -3,7 +3,7 @@
 
 use std::str::FromStr;
 
-use tari_bor::json_encoding::CiboruimValueDeserializeFixWrapper;
+use tari_bor::cbor_value_encoding_fix::CborValueDeserializeFixWrapper;
 use tari_ootle_wallet_sdk::storage::WalletStorageError;
 use tari_template_lib_types::{NonFungibleId, ResourceAddress, VaultId};
 use time::PrimitiveDateTime;
@@ -29,14 +29,14 @@ impl NonFungibleToken {
         self,
         vault_id: VaultId,
     ) -> Result<tari_ootle_wallet_sdk::models::NonFungibleToken, WalletStorageError> {
-        let data: CiboruimValueDeserializeFixWrapper =
+        let data: CborValueDeserializeFixWrapper =
             serde_json::from_str(&self.data).map_err(|e| WalletStorageError::DecodingError {
                 operation: "try_from",
                 item: "non_fungible_tokens.data",
                 details: e.to_string(),
             })?;
 
-        let mutable_data: CiboruimValueDeserializeFixWrapper =
+        let mutable_data: CborValueDeserializeFixWrapper =
             serde_json::from_str(&self.mutable_data).map_err(|e| WalletStorageError::DecodingError {
                 operation: "try_from",
                 item: "non_fungible_tokens.data",

--- a/crates/wallet/storage_sqlite/src/writer.rs
+++ b/crates/wallet/storage_sqlite/src/writer.rs
@@ -21,7 +21,7 @@ use diesel::{
 };
 use log::*;
 use serde::Serialize;
-use tari_bor::json_encoding::CborValueJsonSerializeWrapper;
+use tari_bor::cbor_value_encoding_fix::CborValueSerializeFixWrapper;
 use tari_engine_types::{
     resource::Resource,
     substate::{SubstateDiff, SubstateId},
@@ -1494,7 +1494,7 @@ impl WalletStoreWriter for WriteTransaction<'_> {
     fn non_fungible_token_upsert(&mut self, non_fungible_token: &NonFungibleToken) -> Result<(), WalletStorageError> {
         use crate::schema::{non_fungible_tokens, vaults};
 
-        let data = serde_json::to_string(&CborValueJsonSerializeWrapper(&non_fungible_token.data)).map_err(|e| {
+        let data = serde_json::to_string(&CborValueSerializeFixWrapper(&non_fungible_token.data)).map_err(|e| {
             WalletStorageError::DecodingError {
                 operation: "non_fungible_token_upsert",
                 item: "non_fungible_tokens.data",
@@ -1502,7 +1502,7 @@ impl WalletStoreWriter for WriteTransaction<'_> {
             }
         })?;
 
-        let mutable_data = serde_json::to_string(&CborValueJsonSerializeWrapper(&non_fungible_token.mutable_data))
+        let mutable_data = serde_json::to_string(&CborValueSerializeFixWrapper(&non_fungible_token.mutable_data))
             .map_err(|e| WalletStorageError::DecodingError {
                 operation: "non_fungible_token_upsert",
                 item: "non_fungible_tokens.mutable_data",


### PR DESCRIPTION
Description
---
fix(bor)!: fix bincode encoding for cbor value
workspace version 0.21.0

Motivation and Context
---
Found a bug in the non-human-readable encoding for wrapped CBOR values. This caused a bincode error when used.
Added failing tests for this case. The previous bincode encoding scheme utilised a hack which required extra allocations to allow this to work previously. This PR removes this hack and enables the fix wrapper for bincode (used in the state db).

How Has This Been Tested?
---
Manually, existing tests


Breaking Changes
---

- [ ] None
- [x] Requires data directory to be deleted
- [ ] Other - Please specify

BREAKING CHANGE: the fixed de/encoding is not backward compatible with the previous hacky encoding