### PR TITLE
feat(engine)!: adds more assertion instructions

### DIFF
--- a/crates/common_types/src/displayable.rs
+++ b/crates/common_types/src/displayable.rs
@@ -158,6 +158,7 @@ impl<T: Display> Displayable for Vec<T> {
         (*self.as_slice()).display()
     }
 }
+
 impl<T: Display> Displayable for VecDeque<T> {
     type Item = VecDeque<T>;
 

--- a/crates/engine/src/runtime/error.rs
+++ b/crates/engine/src/runtime/error.rs
@@ -331,8 +331,8 @@ impl IsNotFoundError for RuntimeError {
 
 #[derive(Debug, thiserror::Error)]
 pub enum AssertError {
-    #[error("The workspace value is not a bucket")]
-    NotABucket,
+    #[error("The workspace value at {key} is not a bucket")]
+    NotABucket { key: WorkspaceOffsetId },
     #[error("Assertion expected bucket to have resource {expected} but has {got}")]
     InvalidResource {
         expected: ResourceAddress,
@@ -346,7 +346,7 @@ pub enum AssertError {
         check: CheckOrd,
         got: Amount,
     },
-    #[error("Assertion failed:expected bucket to contain non-fungible {missing_nft}")]
+    #[error("Assertion failed: expected bucket to contain non-fungible {missing_nft}")]
     BucketContainsNonFungiblesAssertionFail { missing_nft: NonFungibleId },
     #[error("Value is null but expected non-null")]
     ValueIsNull,

--- a/crates/engine/src/runtime/error.rs
+++ b/crates/engine/src/runtime/error.rs
@@ -35,6 +35,7 @@ use tari_engine_types::{
 use tari_ootle_common_types::{displayable::Displayable, optional::IsNotFoundError};
 use tari_ootle_transaction::{
     CheckOrd,
+    NftCheck,
     args::{WorkspaceId, WorkspaceOffsetId},
 };
 use tari_template_lib::{
@@ -346,8 +347,10 @@ pub enum AssertError {
         check: CheckOrd,
         got: Amount,
     },
-    #[error("Assertion failed: expected bucket to contain non-fungible {missing_nft}")]
-    BucketContainsNonFungiblesAssertionFail { missing_nft: NonFungibleId },
+    #[error("Assertion failed: expected bucket to contain {check} {nft}")]
+    BucketContainsNonFungiblesAssertionFail { nft: NonFungibleId, check: NftCheck },
+    #[error("Assertion failed: expected bucket to contain {check} of the non-fungibles but it does not")]
+    BucketContainsNonFungiblesAnyAssertionFail { check: NftCheck },
     #[error("Value is null but expected non-null")]
     ValueIsNull,
 }

--- a/crates/engine/src/runtime/error.rs
+++ b/crates/engine/src/runtime/error.rs
@@ -33,7 +33,10 @@ use tari_engine_types::{
     virtual_substate::VirtualSubstateId,
 };
 use tari_ootle_common_types::{displayable::Displayable, optional::IsNotFoundError};
-use tari_ootle_transaction::args::{WorkspaceId, WorkspaceOffsetId};
+use tari_ootle_transaction::{
+    CheckOrd,
+    args::{WorkspaceId, WorkspaceOffsetId},
+};
 use tari_template_lib::{
     args::{CallAction, VaultFreezeFlag},
     models::{AddressAllocationId, BucketId, ProofId},
@@ -43,6 +46,7 @@ use tari_template_lib::{
         ComponentAddress,
         NonFungibleId,
         ResourceAddress,
+        ResourceType,
         TemplateAddress,
         TransactionReceiptAddress,
         VaultId,
@@ -328,14 +332,24 @@ impl IsNotFoundError for RuntimeError {
 #[derive(Debug, thiserror::Error)]
 pub enum AssertError {
     #[error("The workspace value is not a bucket")]
-    InvalidBucket,
-    #[error("Assert expected bucket to have resource {expected} but has {got}")]
+    NotABucket,
+    #[error("Assertion expected bucket to have resource {expected} but has {got}")]
     InvalidResource {
         expected: ResourceAddress,
         got: ResourceAddress,
     },
-    #[error("Assert expected bucket to have at least {expected} tokens but only has {got}")]
-    InvalidAmount { expected: Amount, got: Amount },
+    #[error("Assertion expected bucket to have resource type {expected} but has {got}")]
+    InvalidResourceType { expected: ResourceType, got: ResourceType },
+    #[error("Assertion failed: expected bucket amount {got} to be {check} {expected}")]
+    BucketAmountAssertionFail {
+        expected: Amount,
+        check: CheckOrd,
+        got: Amount,
+    },
+    #[error("Assertion failed:expected bucket to contain non-fungible {missing_nft}")]
+    BucketContainsNonFungiblesAssertionFail { missing_nft: NonFungibleId },
+    #[error("Value is null but expected non-null")]
+    ValueIsNull,
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/engine/src/runtime/impl.rs
+++ b/crates/engine/src/runtime/impl.rs
@@ -35,7 +35,7 @@ use tari_engine_types::{
     entity_id_provider::EntityIdProvider,
     events::Event,
     hashing::hash_template_code,
-    indexed_value::{IndexedValue, IndexedWellKnownTypes},
+    indexed_value::IndexedValue,
     instruction_result::InstructionResult,
     limits,
     lock::LockFlag,
@@ -50,6 +50,7 @@ use tari_engine_types::{
 use tari_ootle_common_types::{GetVerifier, services::template_provider::TemplateProvider};
 use tari_ootle_transaction::{
     AllocatableAddressType,
+    Assertion,
     ComponentReference,
     ResourceAddressRef,
     args::{InstructionArg, WorkspaceId, WorkspaceOffsetId},
@@ -110,7 +111,6 @@ use tari_template_lib::{
         Metadata,
         NonFungibleAddress,
         OwnerRule,
-        ResourceAddress,
         ResourceInfo,
         ResourceType,
         TemplateAddress,
@@ -132,7 +132,7 @@ use crate::{
         RuntimeError,
         RuntimeInterface,
         engine_args::EngineArgs,
-        error::{ArgumentValidationError, AssertError},
+        error::ArgumentValidationError,
         locking::{LockError, LockedSubstate},
         pay_fee::PayFee,
         scope::PushCallFrame,
@@ -2380,45 +2380,13 @@ where
                     Ok(InvokeResult::unit())
                 })
             },
-            WorkspaceAction::AssertBucketContains => {
-                args.assert_n_args(3)?;
+            WorkspaceAction::Assert => {
+                args.assert_n_args(2)?;
                 let key: WorkspaceOffsetId = args.get(0)?;
-                let resource_address: ResourceAddress = args.get(1)?;
-                let min_amount: Amount = args.get(2)?;
+                let assertion: Assertion = args.get(1)?;
 
-                // get the bucket from the workspace
                 self.tracker.read_with(|state| {
-                    let value = state
-                        .workspace()
-                        .get(key)?
-                        .ok_or_else(|| RuntimeError::ItemNotOnWorkspace {
-                            id: key,
-                            existing_ids: state.workspace().all_ids_iter().collect(),
-                        })?;
-                    let indexed = IndexedWellKnownTypes::from_value(value)?;
-                    let bucket_id = indexed
-                        .bucket_ids()
-                        .first()
-                        .ok_or(RuntimeError::AssertError(AssertError::InvalidBucket))?;
-
-                    let bucket = state.get_bucket(*bucket_id)?;
-
-                    // validate the bucket resource
-                    if *bucket.resource_address() != resource_address {
-                        return Err(RuntimeError::AssertError(AssertError::InvalidResource {
-                            expected: resource_address,
-                            got: *bucket.resource_address(),
-                        }));
-                    }
-
-                    // validate the bucket amount
-                    if bucket.unlocked_amount() < min_amount {
-                        return Err(RuntimeError::AssertError(AssertError::InvalidAmount {
-                            expected: min_amount,
-                            got: bucket.unlocked_amount(),
-                        }));
-                    }
-
+                    state.workspace_assert(key, assertion)?;
                     Ok(InvokeResult::unit())
                 })
             },

--- a/crates/engine/src/runtime/working_state.rs
+++ b/crates/engine/src/runtime/working_state.rs
@@ -1182,10 +1182,8 @@ impl<TStore: StateReader> WorkingState<TStore> {
                 is,
                 amount,
             } => {
-                let indexed = IndexedWellKnownTypes::from_value(value)?;
-                let bucket_id = indexed.bucket_ids().first().ok_or(AssertError::NotABucket)?;
-
-                let bucket = self.get_bucket(*bucket_id)?;
+                let bucket_id = tari_bor::from_value::<BucketId>(value).map_err(|_| AssertError::NotABucket { key })?;
+                let bucket = self.get_bucket(bucket_id)?;
 
                 // validate the bucket resource
                 if *bucket.resource_address() != resource_address {
@@ -1210,10 +1208,8 @@ impl<TStore: StateReader> WorkingState<TStore> {
                 }
             },
             Assertion::BucketContainsNonFungibles { resource_address, nfts } => {
-                let indexed = IndexedWellKnownTypes::from_value(value)?;
-                let bucket_id = indexed.bucket_ids().first().ok_or(AssertError::NotABucket)?;
-
-                let bucket = self.get_bucket(*bucket_id)?;
+                let bucket_id = tari_bor::from_value::<BucketId>(value).map_err(|_| AssertError::NotABucket { key })?;
+                let bucket = self.get_bucket(bucket_id)?;
 
                 // validate the bucket resource
                 if *bucket.resource_address() != resource_address {

--- a/crates/engine/src/runtime/working_state.rs
+++ b/crates/engine/src/runtime/working_state.rs
@@ -37,7 +37,7 @@ use tari_engine_types::{
     virtual_substate::{VirtualSubstate, VirtualSubstateId, VirtualSubstates},
 };
 use tari_ootle_common_types::{Epoch, optional::Optional};
-use tari_ootle_transaction::{Assertion, ResourceAddressRef, args::WorkspaceOffsetId};
+use tari_ootle_transaction::{Assertion, NftCheck, ResourceAddressRef, args::WorkspaceOffsetId};
 use tari_template_lib::{
     args::{MintArg, ResourceDiscriminator, VaultFreezeFlags},
     models::{AddressAllocationId, BucketId, ProofId, ResourceAddressAllocation},
@@ -1207,7 +1207,11 @@ impl<TStore: StateReader> WorkingState<TStore> {
                     return Err(RuntimeError::AssertError(AssertError::ValueIsNull));
                 }
             },
-            Assertion::BucketContainsNonFungibles { resource_address, nfts } => {
+            Assertion::BucketContainsNonFungibles {
+                resource_address,
+                check,
+                nfts,
+            } => {
                 let bucket_id = tari_bor::from_value::<BucketId>(value).map_err(|_| AssertError::NotABucket { key })?;
                 let bucket = self.get_bucket(bucket_id)?;
 
@@ -1228,11 +1232,49 @@ impl<TStore: StateReader> WorkingState<TStore> {
 
                 // validate the bucket contains the specified NFTs
                 for token_id in nfts {
-                    if !bucket.contains_non_fungible_id(&token_id) {
-                        return Err(RuntimeError::AssertError(
-                            AssertError::BucketContainsNonFungiblesAssertionFail { missing_nft: token_id },
-                        ));
+                    let contains = bucket.contains_non_fungible_id(&token_id);
+                    match check {
+                        NftCheck::AnyOf => {
+                            if contains {
+                                return Ok(());
+                            }
+                        },
+                        NftCheck::AllOf => {
+                            if !contains {
+                                return Err(RuntimeError::AssertError(
+                                    AssertError::BucketContainsNonFungiblesAssertionFail { nft: token_id, check },
+                                ));
+                            }
+                        },
+                        NftCheck::NoneOfAll => {
+                            if contains {
+                                return Err(RuntimeError::AssertError(
+                                    AssertError::BucketContainsNonFungiblesAssertionFail { nft: token_id, check },
+                                ));
+                            }
+                        },
+                        NftCheck::NoneOfAny => {
+                            if !contains {
+                                return Ok(());
+                            }
+                        },
                     }
+                }
+
+                match check {
+                    NftCheck::AnyOf => {
+                        // If AnyOf reaches here, we've failed
+                        return Err(RuntimeError::AssertError(
+                            AssertError::BucketContainsNonFungiblesAnyAssertionFail { check },
+                        ));
+                    },
+                    NftCheck::NoneOfAny => {
+                        // If we get here, then for NoneOfAny we succeeded and for NoneOfAny we failed, so we return Err
+                        return Err(RuntimeError::AssertError(
+                            AssertError::BucketContainsNonFungiblesAnyAssertionFail { check },
+                        ));
+                    },
+                    _ => {},
                 }
             },
         }

--- a/crates/engine/src/runtime/working_state.rs
+++ b/crates/engine/src/runtime/working_state.rs
@@ -37,7 +37,7 @@ use tari_engine_types::{
     virtual_substate::{VirtualSubstate, VirtualSubstateId, VirtualSubstates},
 };
 use tari_ootle_common_types::{Epoch, optional::Optional};
-use tari_ootle_transaction::ResourceAddressRef;
+use tari_ootle_transaction::{Assertion, ResourceAddressRef, args::WorkspaceOffsetId};
 use tari_template_lib::{
     args::{MintArg, ResourceDiscriminator, VaultFreezeFlags},
     models::{AddressAllocationId, BucketId, ProofId, ResourceAddressAllocation},
@@ -49,6 +49,7 @@ use tari_template_lib::{
         Hash32,
         NonFungibleAddress,
         ResourceAddress,
+        ResourceType,
         TemplateAddress,
         UtxoAddress,
         ValidatorFeePoolAddress,
@@ -64,6 +65,7 @@ use super::workspace::Workspace;
 use crate::{
     runtime::{
         ActionIdent,
+        AssertError,
         LimitError,
         NativeAction,
         RuntimeError,
@@ -1163,6 +1165,83 @@ impl<TStore: StateReader> WorkingState<TStore> {
 
     pub fn workspace_mut(&mut self) -> &mut Workspace {
         &mut self.workspace
+    }
+
+    pub fn workspace_assert(&self, key: WorkspaceOffsetId, assertion: Assertion) -> Result<(), RuntimeError> {
+        let value = self
+            .workspace()
+            .get(key)?
+            .ok_or_else(|| RuntimeError::ItemNotOnWorkspace {
+                id: key,
+                existing_ids: self.workspace().all_ids_iter().collect(),
+            })?;
+
+        match assertion {
+            Assertion::BucketAmount {
+                resource_address,
+                is,
+                amount,
+            } => {
+                let indexed = IndexedWellKnownTypes::from_value(value)?;
+                let bucket_id = indexed.bucket_ids().first().ok_or(AssertError::NotABucket)?;
+
+                let bucket = self.get_bucket(*bucket_id)?;
+
+                // validate the bucket resource
+                if *bucket.resource_address() != resource_address {
+                    return Err(RuntimeError::AssertError(AssertError::InvalidResource {
+                        expected: resource_address,
+                        got: *bucket.resource_address(),
+                    }));
+                }
+
+                // validate the bucket amount
+                if !is.check(bucket.unlocked_amount(), amount) {
+                    return Err(RuntimeError::AssertError(AssertError::BucketAmountAssertionFail {
+                        expected: amount,
+                        check: is,
+                        got: bucket.unlocked_amount(),
+                    }));
+                }
+            },
+            Assertion::IsNotNull => {
+                if value.is_null() {
+                    return Err(RuntimeError::AssertError(AssertError::ValueIsNull));
+                }
+            },
+            Assertion::BucketContainsNonFungibles { resource_address, nfts } => {
+                let indexed = IndexedWellKnownTypes::from_value(value)?;
+                let bucket_id = indexed.bucket_ids().first().ok_or(AssertError::NotABucket)?;
+
+                let bucket = self.get_bucket(*bucket_id)?;
+
+                // validate the bucket resource
+                if *bucket.resource_address() != resource_address {
+                    return Err(RuntimeError::AssertError(AssertError::InvalidResource {
+                        expected: resource_address,
+                        got: *bucket.resource_address(),
+                    }));
+                }
+
+                if !bucket.resource_type().is_non_fungible() {
+                    return Err(RuntimeError::AssertError(AssertError::InvalidResourceType {
+                        expected: ResourceType::NonFungible,
+                        got: bucket.resource_type(),
+                    }));
+                }
+
+                // validate the bucket contains the specified NFTs
+                for token_id in nfts {
+                    if !bucket.contains_non_fungible_id(&token_id) {
+                        return Err(RuntimeError::AssertError(
+                            AssertError::BucketContainsNonFungiblesAssertionFail { missing_nft: token_id },
+                        ));
+                    }
+                }
+            },
+        }
+
+        Ok(())
     }
 
     pub fn resolve_resource_address_ref(&self, addr_ref: ResourceAddressRef) -> Result<ResourceAddress, RuntimeError> {

--- a/crates/engine/src/runtime/working_state.rs
+++ b/crates/engine/src/runtime/working_state.rs
@@ -1246,14 +1246,14 @@ impl<TStore: StateReader> WorkingState<TStore> {
                                 ));
                             }
                         },
-                        NftCheck::NoneOfAll => {
+                        NftCheck::NoneOf => {
                             if contains {
                                 return Err(RuntimeError::AssertError(
                                     AssertError::BucketContainsNonFungiblesAssertionFail { nft: token_id, check },
                                 ));
                             }
                         },
-                        NftCheck::NoneOfAny => {
+                        NftCheck::NotAllOf => {
                             if !contains {
                                 return Ok(());
                             }
@@ -1262,14 +1262,8 @@ impl<TStore: StateReader> WorkingState<TStore> {
                 }
 
                 match check {
-                    NftCheck::AnyOf => {
+                    NftCheck::AnyOf | NftCheck::NotAllOf => {
                         // If AnyOf reaches here, we've failed
-                        return Err(RuntimeError::AssertError(
-                            AssertError::BucketContainsNonFungiblesAnyAssertionFail { check },
-                        ));
-                    },
-                    NftCheck::NoneOfAny => {
-                        // If we get here, then for NoneOfAny we succeeded and for NoneOfAny we failed, so we return Err
                         return Err(RuntimeError::AssertError(
                             AssertError::BucketContainsNonFungiblesAnyAssertionFail { check },
                         ));

--- a/crates/engine/src/transaction/processor.rs
+++ b/crates/engine/src/transaction/processor.rs
@@ -327,15 +327,10 @@ where
                 runtime.interface_mut().claim_validator_fees(address)?;
                 Ok(InstructionResult::empty())
             },
-            Instruction::AssertBucketContains {
-                key,
-                resource_address,
-                min_amount,
-            } => {
-                runtime.interface_mut().workspace_invoke(
-                    WorkspaceAction::AssertBucketContains,
-                    invoke_args![key, resource_address, min_amount].into(),
-                )?;
+            Instruction::Assert { key, assertion } => {
+                runtime
+                    .interface_mut()
+                    .workspace_invoke(WorkspaceAction::Assert, invoke_args![key, assertion].into())?;
                 Ok(InstructionResult::empty())
             },
             Instruction::TakeFromBucket {

--- a/crates/engine/tests/access_rules.rs
+++ b/crates/engine/tests/access_rules.rs
@@ -435,8 +435,8 @@ mod resource_access_rules {
                 .call_method(user_account, "create_proof_by_non_fungible_ids", args![
                     badge_resource,
                     vec![
-                        NonFungibleId::from_string("withdraw"),
-                        NonFungibleId::from_string("deposit")
+                        NonFungibleId::try_from_string("withdraw").unwrap(),
+                        NonFungibleId::try_from_string("deposit").unwrap()
                     ]
                 ])
                 .put_last_instruction_output_on_workspace("proof")
@@ -776,8 +776,8 @@ mod resource_access_rules {
                     args![
                         badge_resource,
                         vec![
-                            NonFungibleId::from_string("withdraw"),
-                            NonFungibleId::from_string("deposit")
+                            NonFungibleId::try_from_string("withdraw").unwrap(),
+                            NonFungibleId::try_from_string("deposit").unwrap()
                         ]
                     ],
                 )
@@ -818,8 +818,8 @@ mod resource_access_rules {
                     args![
                         badge_resource,
                         vec![
-                            NonFungibleId::from_string("withdraw"),
-                            NonFungibleId::from_string("deposit")
+                            NonFungibleId::try_from_string("withdraw").unwrap(),
+                            NonFungibleId::try_from_string("deposit").unwrap()
                         ]
                     ],
                 )

--- a/crates/engine/tests/asserts.rs
+++ b/crates/engine/tests/asserts.rs
@@ -165,7 +165,12 @@ mod assert_bucket_contains {
             vec![test.account_proof.clone()],
         );
 
-        assert_reject_reason(reason, RuntimeError::AssertError(AssertError::NotABucket));
+        assert_reject_reason(
+            reason,
+            RuntimeError::AssertError(AssertError::NotABucket {
+                key: WorkspaceOffsetId::new(0),
+            }),
+        );
     }
 
     #[test]

--- a/crates/engine/tests/asserts.rs
+++ b/crates/engine/tests/asserts.rs
@@ -5,11 +5,20 @@ use std::vec;
 
 use tari_crypto::ristretto::RistrettoSecretKey;
 use tari_engine::runtime::{AssertError, RuntimeError};
-use tari_ootle_transaction::{Instruction, Transaction, args, args::WorkspaceOffsetId, call_args};
-use tari_template_lib::types::{Amount, ComponentAddress, NonFungibleAddress, ResourceAddress, constants::XTR};
+use tari_ootle_transaction::{Assertion, CheckOrd, Instruction, Transaction, args, args::WorkspaceOffsetId, call_args};
+use tari_template_lib::types::{
+    Amount,
+    ComponentAddress,
+    NonFungibleAddress,
+    NonFungibleId,
+    ResourceAddress,
+    ResourceType,
+    constants::{NFT_FAUCET_COMPONENT_ADDRESS, NFT_FAUCET_RESOURCE_ADDRESS, XTR},
+};
 use tari_template_test_tooling::{TemplateTest, support::assert_error::assert_reject_reason};
 
 const CRATE_PATH: &str = env!("CARGO_MANIFEST_DIR");
+const TEMPLATE_PATH: &str = "tests/templates/tariswap";
 
 const FAUCET_WITHDRAWAL_AMOUNT: u32 = 1000;
 
@@ -23,7 +32,7 @@ struct AssertTest {
 }
 
 fn setup() -> AssertTest {
-    let mut template_test = TemplateTest::new(CRATE_PATH, vec!["tests/templates/tariswap"]);
+    let mut template_test = TemplateTest::new(CRATE_PATH, [TEMPLATE_PATH]);
 
     let faucet_template = template_test.get_template_address("TestFaucet");
 
@@ -62,114 +71,246 @@ fn setup() -> AssertTest {
     }
 }
 
-#[test]
-fn successful_assert() {
-    let mut test: AssertTest = setup();
+mod assert_bucket_contains {
+    use super::*;
 
-    test.template_test.execute_expect_success(
-        Transaction::builder_localnet()
-            .call_method(test.faucet_component, "take_free_coins", args![])
-            .put_last_instruction_output_on_workspace("faucet_bucket")
-            .assert_bucket_contains_at_least("faucet_bucket", test.faucet_resource, FAUCET_WITHDRAWAL_AMOUNT)
-            .call_method(test.account, "deposit", args![Workspace("faucet_bucket")])
-            .build_and_seal(&test.account_key),
-        vec![test.account_proof.clone()],
-    );
+    #[test]
+    fn it_asserts_that_a_bucket_contains() {
+        let mut test: AssertTest = setup();
+
+        test.template_test.execute_expect_success(
+            Transaction::builder_localnet()
+                .call_method(test.faucet_component, "take_free_coins", args![])
+                .put_last_instruction_output_on_workspace("faucet_bucket")
+                .assert_bucket_contains_at_least("faucet_bucket", test.faucet_resource, FAUCET_WITHDRAWAL_AMOUNT)
+                .assert_bucket_contains_exactly("faucet_bucket", test.faucet_resource, FAUCET_WITHDRAWAL_AMOUNT)
+                .assert_bucket_contains_at_most("faucet_bucket", test.faucet_resource, FAUCET_WITHDRAWAL_AMOUNT)
+                .call_method(test.account, "deposit", args![Workspace("faucet_bucket")])
+                .build_and_seal(&test.account_key),
+            vec![test.account_proof.clone()],
+        );
+    }
+
+    #[test]
+    fn it_fails_with_invalid_resource() {
+        let mut test: AssertTest = setup();
+
+        // we are going to assert a different resource than the faucet resource
+        let invalid_resource_address = XTR;
+
+        let reason = test.template_test.execute_expect_failure(
+            Transaction::builder_localnet()
+                .call_method(test.faucet_component, "take_free_coins", args![])
+                .put_last_instruction_output_on_workspace("faucet_bucket")
+                .assert_bucket_contains_at_least("faucet_bucket", invalid_resource_address, FAUCET_WITHDRAWAL_AMOUNT)
+                .call_method(test.account, "deposit", args![Workspace("faucet_bucket")])
+                .build_and_seal(&test.account_key),
+            vec![test.account_proof.clone()],
+        );
+
+        assert_reject_reason(
+            reason,
+            RuntimeError::AssertError(AssertError::InvalidResource {
+                expected: invalid_resource_address,
+                got: test.faucet_resource,
+            }),
+        );
+    }
+
+    #[test]
+    fn it_fails_with_invalid_amount() {
+        let mut test: AssertTest = setup();
+
+        // we are going to assert that the faucet bucket has more tokens that it really has
+        let min_amount = FAUCET_WITHDRAWAL_AMOUNT + 1;
+
+        let reason = test.template_test.execute_expect_failure(
+            Transaction::builder_localnet()
+                .call_method(test.faucet_component, "take_free_coins", args![])
+                .put_last_instruction_output_on_workspace("faucet_bucket")
+                // Passes
+                .assert_bucket_contains_exactly("faucet_bucket", test.faucet_resource, FAUCET_WITHDRAWAL_AMOUNT)
+                // Passes
+                .assert_bucket_contains_at_most("faucet_bucket", test.faucet_resource, min_amount)
+                // Fails
+                .assert_bucket_contains_at_least("faucet_bucket", test.faucet_resource, min_amount)
+                .call_method(test.account, "deposit", args![Workspace("faucet_bucket")])
+                .build_and_seal(&test.account_key),
+            vec![test.account_proof.clone()],
+        );
+
+        assert_reject_reason(
+            reason,
+            RuntimeError::AssertError(AssertError::BucketAmountAssertionFail {
+                expected: min_amount.into(),
+                check: CheckOrd::Gte,
+                got: FAUCET_WITHDRAWAL_AMOUNT.into(),
+            }),
+        );
+    }
+
+    #[test]
+    fn it_fails_with_invalid_bucket() {
+        let mut test: AssertTest = setup();
+
+        let reason = test.template_test.execute_expect_failure(
+            Transaction::builder_localnet()
+                .call_method(test.faucet_component, "take_free_coins", args![])
+                // we are going to assert a workspace value that is NOT a bucket
+                .call_method(test.account, "get_balances", args![])
+                .put_last_instruction_output_on_workspace("invalid_bucket")
+                .assert_bucket_contains_at_least("invalid_bucket", test.faucet_resource, FAUCET_WITHDRAWAL_AMOUNT)
+                .call_method(test.account, "deposit", args![Workspace("invalid_bucket")])
+                .build_and_seal(&test.account_key),
+            vec![test.account_proof.clone()],
+        );
+
+        assert_reject_reason(reason, RuntimeError::AssertError(AssertError::NotABucket));
+    }
+
+    #[test]
+    fn it_fails_with_invalid_workspace_key() {
+        let mut test: AssertTest = setup();
+
+        let reason = test.template_test.execute_expect_failure(
+            Transaction::builder_localnet()
+                .call_method(test.faucet_component, "take_free_coins", args![])
+                .put_last_instruction_output_on_workspace("faucet_bucket")
+                // we are going to assert a key that does not exist in the workspace
+                // assert_bucket_contains would panic if called with a non-existing key
+                .add_instruction(Instruction::Assert {
+                    key: WorkspaceOffsetId::new(999),
+                    assertion: Assertion::BucketAmount {
+                        resource_address: test.faucet_resource,
+                        is: CheckOrd::Gte,
+                        amount: FAUCET_WITHDRAWAL_AMOUNT.into()
+                    }
+                })
+                .call_method(test.account, "deposit", args![Workspace("faucet_bucket")])
+                .build_and_seal(&test.account_key),
+            vec![test.account_proof.clone()],
+        );
+
+        assert_reject_reason(reason, RuntimeError::ItemNotOnWorkspace {
+            id: WorkspaceOffsetId::new(999),
+            existing_ids: vec![0],
+        });
+    }
 }
 
-#[test]
-fn it_fails_with_invalid_resource() {
-    let mut test: AssertTest = setup();
+mod assert_is_not_null {
+    use super::*;
 
-    // we are going to assert a different resource than the faucet resource
-    let invalid_resource_address = XTR;
+    #[test]
+    fn it_fails_with_invalid_workspace_key() {
+        let mut test: AssertTest = setup();
 
-    let reason = test.template_test.execute_expect_failure(
-        Transaction::builder_localnet()
-            .call_method(test.faucet_component, "take_free_coins", args![])
-            .put_last_instruction_output_on_workspace("faucet_bucket")
-            .assert_bucket_contains_at_least("faucet_bucket", invalid_resource_address, FAUCET_WITHDRAWAL_AMOUNT)
-            .call_method(test.account, "deposit", args![Workspace("faucet_bucket")])
-            .build_and_seal(&test.account_key),
-        vec![test.account_proof.clone()],
-    );
+        let reason = test.template_test.execute_expect_failure(
+            Transaction::builder_localnet()
+                // we are going to assert a key that does not exist in the workspace
+                // assert_bucket_contains would panic if called with a non-existing key
+                .add_instruction(Instruction::Assert {
+                    key: WorkspaceOffsetId::new(999),
+                    assertion: Assertion::IsNotNull
+                })
+                .build_and_seal(&test.account_key),
+            vec![],
+        );
 
-    assert_reject_reason(
-        reason,
-        RuntimeError::AssertError(AssertError::InvalidResource {
-            expected: invalid_resource_address,
-            got: test.faucet_resource,
-        }),
-    );
+        // NOT saying that the assertion itself is invalid, but that the key does not exist in the workspace
+        assert_reject_reason(reason, RuntimeError::ItemNotOnWorkspace {
+            id: WorkspaceOffsetId::new(999),
+            existing_ids: vec![],
+        });
+    }
+
+    #[test]
+    fn it_asserts_that_a_workspace_item_is_not_null() {
+        let mut test: AssertTest = setup();
+
+        let reason = test.template_test.execute_expect_failure(
+            Transaction::builder_localnet()
+                .call_method(test.faucet_component, "take_free_coins", args![])
+                .put_last_instruction_output_on_workspace("faucet_bucket")
+                .assert_workspace_item_is_not_null("faucet_bucket")
+                .call_method(test.account, "deposit", args![Workspace("faucet_bucket")])
+                .put_last_instruction_output_on_workspace("should_be_null")
+                .assert_workspace_item_is_not_null("should_be_null")
+                .build_and_seal(&test.account_key),
+            vec![test.account_proof.clone()],
+        );
+
+        assert_reject_reason(reason, AssertError::ValueIsNull);
+    }
 }
 
-#[test]
-fn it_fails_with_invalid_amount() {
-    let mut test: AssertTest = setup();
+mod assert_bucket_contains_non_fungibles {
+    use super::*;
 
-    // we are going to assert that the faucet bucket has more tokens that it really has
-    let min_amount = FAUCET_WITHDRAWAL_AMOUNT + 1;
+    #[test]
+    fn it_checks_for_nfts() {
+        let mut test: AssertTest = setup();
 
-    let reason = test.template_test.execute_expect_failure(
-        Transaction::builder_localnet()
-            .call_method(test.faucet_component, "take_free_coins", args![])
-            .put_last_instruction_output_on_workspace("faucet_bucket")
-            .assert_bucket_contains_at_least("faucet_bucket", test.faucet_resource, min_amount)
-            .call_method(test.account, "deposit", args![Workspace("faucet_bucket")])
-            .build_and_seal(&test.account_key),
-        vec![test.account_proof.clone()],
-    );
+        test.template_test.execute_expect_success(
+            Transaction::builder_localnet()
+                .call_method(NFT_FAUCET_COMPONENT_ADDRESS, "mint", args![5, tari_bor::Value::Null])
+                .put_last_instruction_output_on_workspace("faucet_bucket")
+                .assert_bucket_contains_non_fungibles("faucet_bucket", NFT_FAUCET_RESOURCE_ADDRESS, vec![
+                    NonFungibleId::Uint64(0),
+                    NonFungibleId::Uint64(1),
+                    NonFungibleId::Uint64(2),
+                ])
+                .assert_bucket_contains_non_fungibles("faucet_bucket", NFT_FAUCET_RESOURCE_ADDRESS, vec![
+                    NonFungibleId::Uint64(3),
+                    NonFungibleId::Uint64(4),
+                ])
+                // This essentially asserts that the resource is a particular nft resource
+                .assert_bucket_contains_non_fungibles("faucet_bucket", NFT_FAUCET_RESOURCE_ADDRESS, vec![])
+                .call_method(test.account, "deposit", args![Workspace("faucet_bucket")])
+                .build_and_seal(&test.account_key),
+            vec![test.account_proof.clone()],
+        );
+    }
 
-    assert_reject_reason(
-        reason,
-        RuntimeError::AssertError(AssertError::InvalidAmount {
-            expected: min_amount.into(),
-            got: FAUCET_WITHDRAWAL_AMOUNT.into(),
-        }),
-    );
-}
+    #[test]
+    fn it_fails_if_fungible_resource_provided() {
+        let mut test: AssertTest = setup();
 
-#[test]
-fn it_fails_with_invalid_bucket() {
-    let mut test: AssertTest = setup();
+        // Take some tokens from the faucet to get a bucket with non-fungibles
+        let reason = test.template_test.execute_expect_failure(
+            Transaction::builder_localnet()
+                .call_method(test.faucet_component, "take_free_coins", args![])
+                .put_last_instruction_output_on_workspace("faucet_bucket")
+                .assert_bucket_contains_non_fungibles("faucet_bucket", test.faucet_resource, vec![])
+                .call_method(test.account, "deposit", args![Workspace("faucet_bucket")])
+                .build_and_seal(&test.account_key),
+            vec![test.account_proof.clone()],
+        );
 
-    let reason = test.template_test.execute_expect_failure(
-        Transaction::builder_localnet()
-            .call_method(test.faucet_component, "take_free_coins", args![])
-            // we are going to assert a workspace value that is NOT a bucket
-            .call_method(test.account, "get_balances", args![])
-            .put_last_instruction_output_on_workspace("invalid_bucket")
-            .assert_bucket_contains_at_least("invalid_bucket", test.faucet_resource, FAUCET_WITHDRAWAL_AMOUNT)
-            .call_method(test.account, "deposit", args![Workspace("invalid_bucket")])
-            .build_and_seal(&test.account_key),
-        vec![test.account_proof.clone()],
-    );
+        assert_reject_reason(reason, AssertError::InvalidResourceType {
+            expected: ResourceType::NonFungible,
+            got: ResourceType::Fungible,
+        });
+    }
 
-    assert_reject_reason(reason, RuntimeError::AssertError(AssertError::InvalidBucket));
-}
+    #[test]
+    fn it_fails_if_nft_not_present() {
+        let mut test: AssertTest = setup();
 
-#[test]
-fn it_fails_with_invalid_workspace_key() {
-    let mut test: AssertTest = setup();
+        let reason = test.template_test.execute_expect_failure(
+            Transaction::builder_localnet()
+                .call_method(NFT_FAUCET_COMPONENT_ADDRESS, "mint", args![5, tari_bor::Value::Null])
+                .put_last_instruction_output_on_workspace("faucet_bucket")
+                .assert_bucket_contains_non_fungibles("faucet_bucket", NFT_FAUCET_RESOURCE_ADDRESS, vec![
+                    NonFungibleId::Uint64(5),
+                ])
+                .call_method(test.account, "deposit", args![Workspace("faucet_bucket")])
+                .build_and_seal(&test.account_key),
+            vec![test.account_proof.clone()],
+        );
 
-    let reason = test.template_test.execute_expect_failure(
-        Transaction::builder_localnet()
-            .call_method(test.faucet_component, "take_free_coins", args![])
-            .put_last_instruction_output_on_workspace("faucet_bucket")
-            // we are going to assert a key that does not exist in the workspace
-            // assert_bucket_contains would panic if called with a non-existing key
-            .add_instruction(Instruction::AssertBucketContains {
-                key: WorkspaceOffsetId::new(999),
-                resource_address: test.faucet_resource,
-                min_amount: FAUCET_WITHDRAWAL_AMOUNT.into()
-            })
-            .call_method(test.account, "deposit", args![Workspace("faucet_bucket")])
-            .build_and_seal(&test.account_key),
-        vec![test.account_proof.clone()],
-    );
-
-    assert_reject_reason(reason, RuntimeError::ItemNotOnWorkspace {
-        id: WorkspaceOffsetId::new(999),
-        existing_ids: vec![0],
-    });
+        assert_reject_reason(reason, AssertError::BucketContainsNonFungiblesAssertionFail {
+            missing_nft: NonFungibleId::Uint64(5),
+        });
+    }
 }

--- a/crates/engine/tests/asserts.rs
+++ b/crates/engine/tests/asserts.rs
@@ -250,6 +250,8 @@ mod assert_is_not_null {
 }
 
 mod assert_bucket_contains_non_fungibles {
+    use tari_ootle_transaction::NftCheck;
+
     use super::*;
 
     #[test]
@@ -260,17 +262,29 @@ mod assert_bucket_contains_non_fungibles {
             Transaction::builder_localnet()
                 .call_method(NFT_FAUCET_COMPONENT_ADDRESS, "mint", args![5, tari_bor::Value::Null])
                 .put_last_instruction_output_on_workspace("faucet_bucket")
-                .assert_bucket_contains_non_fungibles("faucet_bucket", NFT_FAUCET_RESOURCE_ADDRESS, vec![
+                .assert_bucket_contains_non_fungibles_all("faucet_bucket", NFT_FAUCET_RESOURCE_ADDRESS, vec![
                     NonFungibleId::Uint64(0),
                     NonFungibleId::Uint64(1),
                     NonFungibleId::Uint64(2),
                 ])
-                .assert_bucket_contains_non_fungibles("faucet_bucket", NFT_FAUCET_RESOURCE_ADDRESS, vec![
+                .assert_bucket_contains_non_fungibles_all("faucet_bucket", NFT_FAUCET_RESOURCE_ADDRESS, vec![
                     NonFungibleId::Uint64(3),
                     NonFungibleId::Uint64(4),
                 ])
                 // This essentially asserts that the resource is a particular nft resource
-                .assert_bucket_contains_non_fungibles("faucet_bucket", NFT_FAUCET_RESOURCE_ADDRESS, vec![])
+                .assert_bucket_contains_non_fungibles_all("faucet_bucket", NFT_FAUCET_RESOURCE_ADDRESS, vec![])
+                .assert_bucket_contains_non_fungibles_any("faucet_bucket", NFT_FAUCET_RESOURCE_ADDRESS, vec![
+                    NonFungibleId::Uint64(3),
+                    NonFungibleId::Uint64(100),
+                ])
+                .assert_bucket_contains_non_fungibles_none_all("faucet_bucket", NFT_FAUCET_RESOURCE_ADDRESS, vec![
+                    NonFungibleId::Uint64(5),
+                    NonFungibleId::Uint64(100),
+                ])
+                .assert_bucket_contains_non_fungibles_none_any("faucet_bucket", NFT_FAUCET_RESOURCE_ADDRESS, vec![
+                    NonFungibleId::Uint64(1),
+                    NonFungibleId::Uint64(100),
+                ])
                 .call_method(test.account, "deposit", args![Workspace("faucet_bucket")])
                 .build_and_seal(&test.account_key),
             vec![test.account_proof.clone()],
@@ -286,7 +300,7 @@ mod assert_bucket_contains_non_fungibles {
             Transaction::builder_localnet()
                 .call_method(test.faucet_component, "take_free_coins", args![])
                 .put_last_instruction_output_on_workspace("faucet_bucket")
-                .assert_bucket_contains_non_fungibles("faucet_bucket", test.faucet_resource, vec![])
+                .assert_bucket_contains_non_fungibles_all("faucet_bucket", test.faucet_resource, vec![])
                 .call_method(test.account, "deposit", args![Workspace("faucet_bucket")])
                 .build_and_seal(&test.account_key),
             vec![test.account_proof.clone()],
@@ -306,7 +320,7 @@ mod assert_bucket_contains_non_fungibles {
             Transaction::builder_localnet()
                 .call_method(NFT_FAUCET_COMPONENT_ADDRESS, "mint", args![5, tari_bor::Value::Null])
                 .put_last_instruction_output_on_workspace("faucet_bucket")
-                .assert_bucket_contains_non_fungibles("faucet_bucket", NFT_FAUCET_RESOURCE_ADDRESS, vec![
+                .assert_bucket_contains_non_fungibles_all("faucet_bucket", NFT_FAUCET_RESOURCE_ADDRESS, vec![
                     NonFungibleId::Uint64(5),
                 ])
                 .call_method(test.account, "deposit", args![Workspace("faucet_bucket")])
@@ -315,7 +329,75 @@ mod assert_bucket_contains_non_fungibles {
         );
 
         assert_reject_reason(reason, AssertError::BucketContainsNonFungiblesAssertionFail {
-            missing_nft: NonFungibleId::Uint64(5),
+            nft: NonFungibleId::Uint64(5),
+            check: NftCheck::AllOf,
+        });
+    }
+
+    #[test]
+    fn it_fails_if_nft_none_present() {
+        let mut test: AssertTest = setup();
+
+        let reason = test.template_test.execute_expect_failure(
+            Transaction::builder_localnet()
+                .call_method(NFT_FAUCET_COMPONENT_ADDRESS, "mint", args![5, tari_bor::Value::Null])
+                .put_last_instruction_output_on_workspace("faucet_bucket")
+                .assert_bucket_contains_non_fungibles_any("faucet_bucket", NFT_FAUCET_RESOURCE_ADDRESS, vec![
+                    NonFungibleId::Uint64(5),
+                    NonFungibleId::Uint64(6),
+                ])
+                .call_method(test.account, "deposit", args![Workspace("faucet_bucket")])
+                .build_and_seal(&test.account_key),
+            vec![test.account_proof.clone()],
+        );
+
+        assert_reject_reason(reason, AssertError::BucketContainsNonFungiblesAnyAssertionFail {
+            check: NftCheck::AnyOf,
+        });
+    }
+
+    #[test]
+    fn it_fails_if_assertion_none_of_all_fails() {
+        let mut test: AssertTest = setup();
+
+        let reason = test.template_test.execute_expect_failure(
+            Transaction::builder_localnet()
+                .call_method(NFT_FAUCET_COMPONENT_ADDRESS, "mint", args![5, tari_bor::Value::Null])
+                .put_last_instruction_output_on_workspace("faucet_bucket")
+                .assert_bucket_contains_non_fungibles_none_all("faucet_bucket", NFT_FAUCET_RESOURCE_ADDRESS, vec![
+                    NonFungibleId::Uint64(0),
+                    NonFungibleId::Uint64(6),
+                ])
+                .call_method(test.account, "deposit", args![Workspace("faucet_bucket")])
+                .build_and_seal(&test.account_key),
+            vec![test.account_proof.clone()],
+        );
+
+        assert_reject_reason(reason, AssertError::BucketContainsNonFungiblesAssertionFail {
+            nft: NonFungibleId::Uint64(0),
+            check: NftCheck::NoneOfAll,
+        });
+    }
+
+    #[test]
+    fn it_fails_if_assertion_none_of_any_fails() {
+        let mut test: AssertTest = setup();
+
+        let reason = test.template_test.execute_expect_failure(
+            Transaction::builder_localnet()
+                .call_method(NFT_FAUCET_COMPONENT_ADDRESS, "mint", args![5, tari_bor::Value::Null])
+                .put_last_instruction_output_on_workspace("faucet_bucket")
+                .assert_bucket_contains_non_fungibles_none_any("faucet_bucket", NFT_FAUCET_RESOURCE_ADDRESS, vec![
+                    NonFungibleId::Uint64(1),
+                    NonFungibleId::Uint64(0),
+                ])
+                .call_method(test.account, "deposit", args![Workspace("faucet_bucket")])
+                .build_and_seal(&test.account_key),
+            vec![test.account_proof.clone()],
+        );
+
+        assert_reject_reason(reason, AssertError::BucketContainsNonFungiblesAnyAssertionFail {
+            check: NftCheck::NoneOfAny,
         });
     }
 }

--- a/crates/engine/tests/asserts.rs
+++ b/crates/engine/tests/asserts.rs
@@ -277,11 +277,11 @@ mod assert_bucket_contains_non_fungibles {
                     NonFungibleId::Uint64(3),
                     NonFungibleId::Uint64(100),
                 ])
-                .assert_bucket_contains_non_fungibles_none_all("faucet_bucket", NFT_FAUCET_RESOURCE_ADDRESS, vec![
+                .assert_bucket_contains_non_fungibles_none_of("faucet_bucket", NFT_FAUCET_RESOURCE_ADDRESS, vec![
                     NonFungibleId::Uint64(5),
                     NonFungibleId::Uint64(100),
                 ])
-                .assert_bucket_contains_non_fungibles_none_any("faucet_bucket", NFT_FAUCET_RESOURCE_ADDRESS, vec![
+                .assert_bucket_contains_non_fungibles_not_any_of("faucet_bucket", NFT_FAUCET_RESOURCE_ADDRESS, vec![
                     NonFungibleId::Uint64(1),
                     NonFungibleId::Uint64(100),
                 ])
@@ -321,6 +321,7 @@ mod assert_bucket_contains_non_fungibles {
                 .call_method(NFT_FAUCET_COMPONENT_ADDRESS, "mint", args![5, tari_bor::Value::Null])
                 .put_last_instruction_output_on_workspace("faucet_bucket")
                 .assert_bucket_contains_non_fungibles_all("faucet_bucket", NFT_FAUCET_RESOURCE_ADDRESS, vec![
+                    NonFungibleId::Uint64(0),
                     NonFungibleId::Uint64(5),
                 ])
                 .call_method(test.account, "deposit", args![Workspace("faucet_bucket")])
@@ -364,7 +365,7 @@ mod assert_bucket_contains_non_fungibles {
             Transaction::builder_localnet()
                 .call_method(NFT_FAUCET_COMPONENT_ADDRESS, "mint", args![5, tari_bor::Value::Null])
                 .put_last_instruction_output_on_workspace("faucet_bucket")
-                .assert_bucket_contains_non_fungibles_none_all("faucet_bucket", NFT_FAUCET_RESOURCE_ADDRESS, vec![
+                .assert_bucket_contains_non_fungibles_none_of("faucet_bucket", NFT_FAUCET_RESOURCE_ADDRESS, vec![
                     NonFungibleId::Uint64(0),
                     NonFungibleId::Uint64(6),
                 ])
@@ -375,7 +376,7 @@ mod assert_bucket_contains_non_fungibles {
 
         assert_reject_reason(reason, AssertError::BucketContainsNonFungiblesAssertionFail {
             nft: NonFungibleId::Uint64(0),
-            check: NftCheck::NoneOfAll,
+            check: NftCheck::NoneOf,
         });
     }
 
@@ -387,7 +388,7 @@ mod assert_bucket_contains_non_fungibles {
             Transaction::builder_localnet()
                 .call_method(NFT_FAUCET_COMPONENT_ADDRESS, "mint", args![5, tari_bor::Value::Null])
                 .put_last_instruction_output_on_workspace("faucet_bucket")
-                .assert_bucket_contains_non_fungibles_none_any("faucet_bucket", NFT_FAUCET_RESOURCE_ADDRESS, vec![
+                .assert_bucket_contains_non_fungibles_not_any_of("faucet_bucket", NFT_FAUCET_RESOURCE_ADDRESS, vec![
                     NonFungibleId::Uint64(1),
                     NonFungibleId::Uint64(0),
                 ])
@@ -397,7 +398,7 @@ mod assert_bucket_contains_non_fungibles {
         );
 
         assert_reject_reason(reason, AssertError::BucketContainsNonFungiblesAnyAssertionFail {
-            check: NftCheck::NoneOfAny,
+            check: NftCheck::NotAllOf,
         });
     }
 }

--- a/crates/engine_types/src/bucket.rs
+++ b/crates/engine_types/src/bucket.rs
@@ -88,6 +88,10 @@ impl Bucket {
         self.resource_container.non_fungible_token_ids()
     }
 
+    pub fn contains_non_fungible_id(&self, id: &NonFungibleId) -> bool {
+        self.resource_container.non_fungible_token_ids().contains(id)
+    }
+
     pub fn take(&mut self, amount: Amount) -> Result<ResourceContainer, ResourceError> {
         self.resource_container.withdraw(amount)
     }

--- a/crates/engine_types/src/substate_serde.rs
+++ b/crates/engine_types/src/substate_serde.rs
@@ -251,7 +251,7 @@ mod tests {
         check(&unclaimed_output_id);
         let non_fungible_id = SubstateId::NonFungible(NonFungibleAddress::new(
             resource_id.as_resource_address().unwrap(),
-            NonFungibleId::from_string("hello"),
+            NonFungibleId::try_from_string("hello").unwrap(),
         ));
         check(&non_fungible_id);
         let transaction_receipt_id =

--- a/crates/template_lib/src/args/types.rs
+++ b/crates/template_lib/src/args/types.rs
@@ -461,15 +461,8 @@ pub enum WorkspaceAction {
     PutLastInstructionOutput,
     Get,
     DropAllProofs,
-    AssertBucketContains,
+    Assert,
     DropAll,
-}
-
-/// A workspace operation argument
-#[derive(Clone, Debug)]
-pub struct WorkspaceInvokeArg {
-    pub action: WorkspaceAction,
-    pub args: Vec<Bytes>,
 }
 
 // -------------------------------- NonFungible -------------------------------- //

--- a/crates/template_lib_types/src/max_string.rs
+++ b/crates/template_lib_types/src/max_string.rs
@@ -8,8 +8,8 @@ use tari_template_abi::rust::{
     prelude::*,
 };
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "borsh", derive(borsh::BorshSerialize))]
+#[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd, Hash)]
+#[cfg_attr(feature = "borsh", derive(borsh::BorshSerialize, borsh::BorshDeserialize))]
 pub struct MaxString<const N: usize> {
     s: Box<str>,
 }
@@ -26,6 +26,16 @@ impl<const N: usize> MaxString<N> {
     pub fn new_checked(s: impl Into<Box<str>>) -> Option<Self> {
         let s = s.into();
         if s.len() <= N { Some(Self { s }) } else { None }
+    }
+
+    /// Creates a new `MaxString` without checking the length.
+    ///
+    /// # Safety
+    /// The caller must ensure that the length of the string does not exceed `N`.
+    pub unsafe fn new_unchecked(s: impl Into<Box<str>>) -> Self {
+        let s = s.into();
+        debug_assert!(s.len() <= N, "string length exceeds maximum of {}: got {}", N, s.len());
+        Self { s }
     }
 
     pub fn into_string(self) -> String {

--- a/crates/template_lib_types/src/substates/non_fungible.rs
+++ b/crates/template_lib_types/src/substates/non_fungible.rs
@@ -11,12 +11,15 @@ use tari_template_abi::{
 
 use super::{BinaryTag, ResourceAddress};
 use crate::{
+    MaxString,
     address_prefixes,
     constants::PUBLIC_IDENTITY_RESOURCE_ADDRESS,
     crypto::RistrettoPublicKeyBytes,
     hex::{fixed_bytes_from_hex, write_hex_fmt},
     serde_helpers,
 };
+
+const NON_FUNGIBLE_ID_STR_MAX_LEN: usize = 64;
 
 /// The unique identification of a non-fungible token inside it's parent resource
 #[derive(Debug, Clone, Ord, PartialOrd, PartialEq, Eq, Serialize, Deserialize, Hash)]
@@ -28,8 +31,7 @@ pub enum NonFungibleId {
         #[serde(with = "serde_helpers::fixed_hex")]
         [u8; 32],
     ),
-    // TODO: limit size
-    String(String),
+    String(#[cfg_attr(feature = "ts", ts(type = "string"))] MaxString<NON_FUNGIBLE_ID_STR_MAX_LEN>),
     Uint32(u32),
     Uint64(#[cfg_attr(feature = "ts", ts(type = "number"))] u64),
 }
@@ -52,14 +54,17 @@ impl NonFungibleId {
         Self::Uint64(id)
     }
 
-    pub fn from_string<T: Into<String>>(id: T) -> Self {
-        Self::String(id.into())
-    }
-
     pub fn try_from_string<T: Into<String>>(id: T) -> Result<Self, ParseNonFungibleIdError> {
         let id = id.into();
         validate_nft_id_str(&id)?;
-        Ok(NonFungibleId::String(id))
+
+        // Avoid long strings in WASM to reduce bin size
+        #[cfg(not(target_arch = "wasm32"))]
+        const EXPECT_MSG: &str = "Invariant violated: String length validated above";
+        #[cfg(target_arch = "wasm32")]
+        const EXPECT_MSG: &str = "NFTSTRLEN";
+
+        Ok(NonFungibleId::String(id.try_into().expect(EXPECT_MSG)))
     }
 
     /// A string in one of the following formats
@@ -136,7 +141,10 @@ impl NonFungibleId {
             )),
             "str" => {
                 validate_nft_id_str(id)?;
-                Ok(NonFungibleId::String(id.to_string()))
+                // SAFETY: length checked
+                Ok(NonFungibleId::String(unsafe {
+                    MaxString::new_unchecked(id.to_string())
+                }))
             },
             "u32" => Ok(NonFungibleId::Uint32(
                 id.parse().map_err(|_| ParseNonFungibleIdError::InvalidUint32)?,
@@ -178,7 +186,7 @@ impl NonFungibleId {
 }
 
 fn validate_nft_id_str(s: &str) -> Result<(), ParseNonFungibleIdError> {
-    if s.is_empty() || s.len() > 64 {
+    if s.is_empty() || s.len() > NON_FUNGIBLE_ID_STR_MAX_LEN {
         return Err(ParseNonFungibleIdError::InvalidStringLength);
     }
     Ok(())
@@ -446,7 +454,7 @@ mod tests {
         fn string_serialization_and_deserialization() {
             let resx_str = "resource_0000000000000000000000000000000000000000000000000000000000000000";
             let resource = ResourceAddress::from_str(resx_str).unwrap();
-            let v = NonFungibleAddress::new(resource, NonFungibleId::String("hello".to_string()));
+            let v = NonFungibleAddress::new(resource, NonFungibleId::try_from_string("hello").unwrap());
             let json = serde_json::to_string_pretty(&v).unwrap();
             assert!(json.contains(resx_str));
 

--- a/crates/transaction/src/builder/mod.rs
+++ b/crates/transaction/src/builder/mod.rs
@@ -21,7 +21,6 @@ use tari_ootle_common_types::{Epoch, SubstateRequirement};
 use tari_template_lib_types::{
     Amount,
     FunctionName,
-    NonFungibleId,
     OwnerRule,
     ResourceAddress,
     TemplateAddress,
@@ -40,6 +39,8 @@ use crate::{
     Instruction,
     IntoSigned,
     MigrateFunction,
+    NftAssertVec,
+    NftCheck,
     ResourceAddressRef,
     Signable,
     Transaction,
@@ -500,10 +501,47 @@ impl<D> TransactionBuilder<D> {
         })
     }
 
-    pub fn assert_bucket_contains_non_fungibles<T: AsRef<str>, N: Into<Box<[NonFungibleId]>>>(
+    pub fn assert_bucket_contains_non_fungibles_all<T: AsRef<str>, N: TryInto<NftAssertVec>>(
         self,
         label: T,
         resource_address: ResourceAddress,
+        nfts: N,
+    ) -> Self {
+        self.assert_bucket_contains_non_fungibles(label, resource_address, NftCheck::AllOf, nfts)
+    }
+
+    pub fn assert_bucket_contains_non_fungibles_any<T: AsRef<str>, N: TryInto<NftAssertVec>>(
+        self,
+        label: T,
+        resource_address: ResourceAddress,
+        nfts: N,
+    ) -> Self {
+        self.assert_bucket_contains_non_fungibles(label, resource_address, NftCheck::AnyOf, nfts)
+    }
+
+    pub fn assert_bucket_contains_non_fungibles_none_all<T: AsRef<str>, N: TryInto<NftAssertVec>>(
+        self,
+        label: T,
+        resource_address: ResourceAddress,
+        nfts: N,
+    ) -> Self {
+        self.assert_bucket_contains_non_fungibles(label, resource_address, NftCheck::NoneOfAll, nfts)
+    }
+
+    pub fn assert_bucket_contains_non_fungibles_none_any<T: AsRef<str>, N: TryInto<NftAssertVec>>(
+        self,
+        label: T,
+        resource_address: ResourceAddress,
+        nfts: N,
+    ) -> Self {
+        self.assert_bucket_contains_non_fungibles(label, resource_address, NftCheck::NoneOfAny, nfts)
+    }
+
+    pub fn assert_bucket_contains_non_fungibles<T: AsRef<str>, N: TryInto<NftAssertVec>>(
+        self,
+        label: T,
+        resource_address: ResourceAddress,
+        check: NftCheck,
         nfts: N,
     ) -> Self {
         let key = self.get_workspace_offset_id_from_named_arg(label.as_ref());
@@ -512,7 +550,10 @@ impl<D> TransactionBuilder<D> {
             key,
             assertion: Assertion::BucketContainsNonFungibles {
                 resource_address,
-                nfts: nfts.into(),
+                check,
+                nfts: nfts.try_into().unwrap_or_else(|_| {
+                    panic!("Oops! The provided non-fungible list contains more items than the limit")
+                }),
             },
         })
     }

--- a/crates/transaction/src/builder/mod.rs
+++ b/crates/transaction/src/builder/mod.rs
@@ -21,6 +21,7 @@ use tari_ootle_common_types::{Epoch, SubstateRequirement};
 use tari_template_lib_types::{
     Amount,
     FunctionName,
+    NonFungibleId,
     OwnerRule,
     ResourceAddress,
     TemplateAddress,
@@ -33,6 +34,8 @@ use tari_template_lib_types::{
 
 use crate::{
     AllocatableAddressType,
+    Assertion,
+    CheckOrd,
     ComponentReference,
     Instruction,
     IntoSigned,
@@ -447,18 +450,79 @@ impl<D> TransactionBuilder<D> {
         })
     }
 
+    pub fn assert_bucket_contains_any<T: AsRef<str>>(self, label: T, resource_address: ResourceAddress) -> Self {
+        self.assert_bucket_amount(label, resource_address, CheckOrd::Gt, Amount::zero())
+    }
+
     pub fn assert_bucket_contains_at_least<T: AsRef<str>, A: Into<Amount>>(
         self,
         label: T,
         resource_address: ResourceAddress,
         min_amount: A,
     ) -> Self {
+        self.assert_bucket_amount(label, resource_address, CheckOrd::Gte, min_amount)
+    }
+
+    pub fn assert_bucket_contains_exactly<T: AsRef<str>, A: Into<Amount>>(
+        self,
+        label: T,
+        resource_address: ResourceAddress,
+        amount: A,
+    ) -> Self {
+        self.assert_bucket_amount(label, resource_address, CheckOrd::Eq, amount)
+    }
+
+    pub fn assert_bucket_contains_at_most<T: AsRef<str>, A: Into<Amount>>(
+        self,
+        label: T,
+        resource_address: ResourceAddress,
+        max_amount: A,
+    ) -> Self {
+        self.assert_bucket_amount(label, resource_address, CheckOrd::Lte, max_amount)
+    }
+
+    pub fn assert_bucket_amount<T: AsRef<str>, A: Into<Amount>>(
+        self,
+        label: T,
+        resource_address: ResourceAddress,
+        is: CheckOrd,
+        amount: A,
+    ) -> Self {
         let key = self.get_workspace_offset_id_from_named_arg(label.as_ref());
 
-        self.add_instruction(Instruction::AssertBucketContains {
+        self.add_instruction(Instruction::Assert {
             key,
-            resource_address,
-            min_amount: min_amount.into(),
+            assertion: Assertion::BucketAmount {
+                resource_address,
+                is,
+                amount: amount.into(),
+            },
+        })
+    }
+
+    pub fn assert_bucket_contains_non_fungibles<T: AsRef<str>, N: Into<Box<[NonFungibleId]>>>(
+        self,
+        label: T,
+        resource_address: ResourceAddress,
+        nfts: N,
+    ) -> Self {
+        let key = self.get_workspace_offset_id_from_named_arg(label.as_ref());
+
+        self.add_instruction(Instruction::Assert {
+            key,
+            assertion: Assertion::BucketContainsNonFungibles {
+                resource_address,
+                nfts: nfts.into(),
+            },
+        })
+    }
+
+    pub fn assert_workspace_item_is_not_null<T: AsRef<str>>(self, label: T) -> Self {
+        let key = self.get_workspace_offset_id_from_named_arg(label.as_ref());
+
+        self.add_instruction(Instruction::Assert {
+            key,
+            assertion: Assertion::IsNotNull,
         })
     }
 
@@ -601,7 +665,12 @@ impl<D> TransactionBuilder<D> {
             Instruction::ClaimValidatorFees { address } => {
                 self.unsigned_transaction.inputs_mut().insert((*address).into());
             },
-            Instruction::AssertBucketContains { resource_address, .. } => {
+            Instruction::Assert {
+                assertion:
+                    Assertion::BucketAmount { resource_address, .. } |
+                    Assertion::BucketContainsNonFungibles { resource_address, .. },
+                ..
+            } => {
                 if *resource_address != XTR {
                     self.unsigned_transaction
                         .inputs_mut()
@@ -611,6 +680,10 @@ impl<D> TransactionBuilder<D> {
             Instruction::UpdateComponentTemplate { component, .. } => {
                 self.add_input_for_component_ref(component);
             },
+            Instruction::Assert {
+                assertion: Assertion::IsNotNull,
+                ..
+            } |
             Instruction::CreateAccount { .. } |
             Instruction::PutLastInstructionOutputOnWorkspace { .. } |
             Instruction::EmitLog { .. } |

--- a/crates/transaction/src/builder/mod.rs
+++ b/crates/transaction/src/builder/mod.rs
@@ -519,22 +519,22 @@ impl<D> TransactionBuilder<D> {
         self.assert_bucket_contains_non_fungibles(label, resource_address, NftCheck::AnyOf, nfts)
     }
 
-    pub fn assert_bucket_contains_non_fungibles_none_all<T: AsRef<str>, N: TryInto<NftAssertVec>>(
+    pub fn assert_bucket_contains_non_fungibles_none_of<T: AsRef<str>, N: TryInto<NftAssertVec>>(
         self,
         label: T,
         resource_address: ResourceAddress,
         nfts: N,
     ) -> Self {
-        self.assert_bucket_contains_non_fungibles(label, resource_address, NftCheck::NoneOfAll, nfts)
+        self.assert_bucket_contains_non_fungibles(label, resource_address, NftCheck::NoneOf, nfts)
     }
 
-    pub fn assert_bucket_contains_non_fungibles_none_any<T: AsRef<str>, N: TryInto<NftAssertVec>>(
+    pub fn assert_bucket_contains_non_fungibles_not_any_of<T: AsRef<str>, N: TryInto<NftAssertVec>>(
         self,
         label: T,
         resource_address: ResourceAddress,
         nfts: N,
     ) -> Self {
-        self.assert_bucket_contains_non_fungibles(label, resource_address, NftCheck::NoneOfAny, nfts)
+        self.assert_bucket_contains_non_fungibles(label, resource_address, NftCheck::NotAllOf, nfts)
     }
 
     pub fn assert_bucket_contains_non_fungibles<T: AsRef<str>, N: TryInto<NftAssertVec>>(

--- a/crates/transaction/src/v1/assertion.rs
+++ b/crates/transaction/src/v1/assertion.rs
@@ -97,8 +97,8 @@ impl Display for CheckOrd {
 pub enum NftCheck {
     AnyOf,
     AllOf,
-    NoneOfAll,
-    NoneOfAny,
+    NoneOf,
+    NotAllOf,
 }
 
 impl Display for NftCheck {
@@ -106,8 +106,8 @@ impl Display for NftCheck {
         let s = match self {
             Self::AnyOf => "any of",
             Self::AllOf => "all of",
-            Self::NoneOfAll => "none of all",
-            Self::NoneOfAny => "none of any",
+            Self::NoneOf => "none of",
+            Self::NotAllOf => "not all of",
         };
         write!(f, "{s}")
     }

--- a/crates/transaction/src/v1/assertion.rs
+++ b/crates/transaction/src/v1/assertion.rs
@@ -32,7 +32,7 @@ impl Display for Assertion {
                 is,
                 amount,
             } => {
-                write!(f, "BucketAtLeast({} {is} {})", resource_address, amount)
+                write!(f, "BucketAmount({} {is} {})", resource_address, amount)
             },
             Self::IsNotNull => write!(f, "IsNotNull"),
             Self::BucketContainsNonFungibles {

--- a/crates/transaction/src/v1/assertion.rs
+++ b/crates/transaction/src/v1/assertion.rs
@@ -4,23 +4,28 @@
 use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
-use tari_template_lib_types::{Amount, NonFungibleId, ResourceAddress};
+use tari_ootle_common_types::displayable::Displayable;
+use tari_template_lib_types::{Amount, MaxVec, NonFungibleId, ResourceAddress};
+
+pub type NftAssertVec = MaxVec<32, NonFungibleId>;
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, borsh::BorshSerialize)]
 #[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export))]
 pub enum Assertion {
-    #[serde(rename = "bkt_amt")]
+    #[serde(rename = "BktAmt")]
     BucketAmount {
         resource_address: ResourceAddress,
         is: CheckOrd,
         amount: Amount,
     },
-    #[serde(rename = "nt_nil")]
+    #[serde(rename = "NtNil")]
     IsNotNull,
-    #[serde(rename = "bkt_ctn_nft")]
+    #[serde(rename = "BktCtnNft")]
     BucketContainsNonFungibles {
         resource_address: ResourceAddress,
-        nfts: Box<[NonFungibleId]>,
+        check: NftCheck,
+        #[cfg_attr(feature = "ts", ts(as = "Vec<NonFungibleId>"))]
+        nfts: NftAssertVec,
     },
 }
 
@@ -37,17 +42,15 @@ impl Display for Assertion {
             Self::IsNotNull => write!(f, "IsNotNull"),
             Self::BucketContainsNonFungibles {
                 resource_address,
+                check,
                 nfts: non_fungible_addresses,
             } => {
                 write!(
                     f,
-                    "BucketContainsNonFungibles({}, [{}])",
+                    "BucketContainsNonFungibles({} {} [{}])",
                     resource_address,
-                    non_fungible_addresses
-                        .iter()
-                        .map(|id| id.to_string())
-                        .collect::<Vec<_>>()
-                        .join(", ")
+                    check,
+                    non_fungible_addresses.display()
                 )
             },
         }
@@ -84,6 +87,27 @@ impl Display for CheckOrd {
             Self::Lt => "<",
             Self::Lte => "<=",
             Self::Eq => "==",
+        };
+        write!(f, "{s}")
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, borsh::BorshSerialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export))]
+pub enum NftCheck {
+    AnyOf,
+    AllOf,
+    NoneOfAll,
+    NoneOfAny,
+}
+
+impl Display for NftCheck {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            Self::AnyOf => "any of",
+            Self::AllOf => "all of",
+            Self::NoneOfAll => "none of all",
+            Self::NoneOfAny => "none of any",
         };
         write!(f, "{s}")
     }

--- a/crates/transaction/src/v1/assertion.rs
+++ b/crates/transaction/src/v1/assertion.rs
@@ -1,0 +1,90 @@
+//   Copyright 2026 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+use std::fmt::Display;
+
+use serde::{Deserialize, Serialize};
+use tari_template_lib_types::{Amount, NonFungibleId, ResourceAddress};
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, borsh::BorshSerialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export))]
+pub enum Assertion {
+    #[serde(rename = "bkt_amt")]
+    BucketAmount {
+        resource_address: ResourceAddress,
+        is: CheckOrd,
+        amount: Amount,
+    },
+    #[serde(rename = "nt_nil")]
+    IsNotNull,
+    #[serde(rename = "bkt_ctn_nft")]
+    BucketContainsNonFungibles {
+        resource_address: ResourceAddress,
+        nfts: Box<[NonFungibleId]>,
+    },
+}
+
+impl Display for Assertion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::BucketAmount {
+                resource_address,
+                is,
+                amount,
+            } => {
+                write!(f, "BucketAtLeast({} {is} {})", resource_address, amount)
+            },
+            Self::IsNotNull => write!(f, "IsNotNull"),
+            Self::BucketContainsNonFungibles {
+                resource_address,
+                nfts: non_fungible_addresses,
+            } => {
+                write!(
+                    f,
+                    "BucketContainsNonFungibles({}, [{}])",
+                    resource_address,
+                    non_fungible_addresses
+                        .iter()
+                        .map(|id| id.to_string())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                )
+            },
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, borsh::BorshSerialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export))]
+pub enum CheckOrd {
+    Gt,
+    Gte,
+    Lt,
+    Lte,
+    Eq,
+}
+
+impl CheckOrd {
+    pub fn check<T: PartialEq<U> + Eq + PartialOrd<U> + Ord, U>(&self, left: T, right: U) -> bool {
+        match self {
+            CheckOrd::Gt => left > right,
+            CheckOrd::Gte => left >= right,
+            CheckOrd::Lt => left < right,
+            CheckOrd::Lte => left <= right,
+            CheckOrd::Eq => left == right,
+        }
+    }
+}
+
+impl Display for CheckOrd {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            Self::Gt => ">",
+            Self::Gte => ">=",
+            Self::Lt => "<",
+            Self::Lte => "<=",
+            Self::Eq => "==",
+        };
+        write!(f, "{s}")
+    }
+}

--- a/crates/transaction/src/v1/instruction.rs
+++ b/crates/transaction/src/v1/instruction.rs
@@ -16,7 +16,6 @@ use tari_template_lib_types::{
     LogLevel,
     MaxString,
     OwnerRule,
-    ResourceAddress,
     TemplateAddress,
     ValidatorFeePoolAddress,
     access_rules::ComponentAccessRules,
@@ -26,6 +25,7 @@ use tari_template_lib_types::{
 
 use crate::{
     AllocatableAddressType,
+    Assertion,
     ComponentReference,
     ResourceAddressRef,
     args::{InstructionArg, WorkspaceId, WorkspaceOffsetId},
@@ -68,10 +68,9 @@ pub enum Instruction {
         address: ValidatorFeePoolAddress,
     },
     DropAllProofsInWorkspace,
-    AssertBucketContains {
+    Assert {
         key: WorkspaceOffsetId,
-        resource_address: ResourceAddress,
-        min_amount: Amount,
+        assertion: Assertion,
     },
     TakeFromBucket {
         input_bucket: WorkspaceOffsetId,
@@ -202,16 +201,8 @@ impl Display for Instruction {
             Self::DropAllProofsInWorkspace => {
                 write!(f, "DropAllProofsInWorkspace")
             },
-            Self::AssertBucketContains {
-                key,
-                resource_address,
-                min_amount,
-            } => {
-                write!(
-                    f,
-                    "AssertBucketContains {{ key: {:?}, resource_address: {}, min_amount: {} }}",
-                    key, resource_address, min_amount
-                )
+            Self::Assert { key, assertion } => {
+                write!(f, "Assert {{ key: {}, assertion: {} }}", key, assertion)
             },
 
             Self::TakeFromBucket {

--- a/crates/transaction/src/v1/mod.rs
+++ b/crates/transaction/src/v1/mod.rs
@@ -1,6 +1,7 @@
 //    Copyright 2024 The Tari Project
 //    SPDX-License-Identifier: BSD-3-Clause
 
+mod assertion;
 mod component_reference;
 mod instruction;
 mod resource_address_ref;
@@ -10,6 +11,7 @@ mod types;
 mod unsealed;
 mod unsigned;
 
+pub use assertion::*;
 pub use component_reference::*;
 pub use instruction::*;
 pub use resource_address_ref::*;

--- a/crates/transaction/src/v1/transaction.rs
+++ b/crates/transaction/src/v1/transaction.rs
@@ -196,7 +196,7 @@ fn calc_instruction_weight(instruction: &Instruction) -> u64 {
         Instruction::ClaimBurn { .. } => CLAIM_FIXED_COST,
         Instruction::ClaimValidatorFees { .. } => 1,
         Instruction::DropAllProofsInWorkspace => 1,
-        Instruction::AssertBucketContains { .. } => 1,
+        Instruction::Assert { .. } => 1,
         Instruction::TakeFromBucket { .. } => 1,
         Instruction::PublishTemplate { binary } => binary.len() as u64 / BINARY_WEIGHT_DIVISOR,
         Instruction::AllocateAddress { .. } => 1,


### PR DESCRIPTION
Description
---
feat(engine)!: adds more assertion instructions

Motivation and Context
---

The assertion instruction we previously had only had a single use. This PR expands that to other useful checks:
- assert if a bucket amount =,<,<=,> a specified value (only >= was implemented previously)
- assert that a workspace item is not null
- assert that a bucket contains any, all, none of any, and none of all of a set of NFTs

How Has This Been Tested?
---
New unit tests



Breaking Changes
---

- [ ] None
- [x] Requires data directory to be deleted
- [ ] Other - Please specify

BREAKING CHANGE: transaciton schema is not backwards compatible