### PR TITLE
fix(template-lib): expose prelude for all arch targets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11865,7 +11865,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_lib"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "borsh",
  "serde",

--- a/crates/template_lib/Cargo.toml
+++ b/crates/template_lib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_template_lib"
 description = "Tari template library provides abstrations that interface with the Tari validator engine"
-version = "0.19.0"
+version = "0.19.1"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/template_lib/src/lib.rs
+++ b/crates/template_lib/src/lib.rs
@@ -175,7 +175,6 @@ mod engine;
 pub use engine::engine;
 
 pub mod panic_hook;
-#[cfg(target_arch = "wasm32")]
 pub mod prelude;
 // Re-export for macro
 pub use tari_bor::to_value;


### PR DESCRIPTION
Description
---
fix(template-lib): expose prelude for all arch targets

Motivation and Context
---
Tests in the same crate fail to compile if prelude is not present.
