### PR TITLE
fix(ootle-rs): include the reject reason when only fee tx is committed

### DIFF
--- a/crates/wallet/ootle-rs/src/provider/tx_watcher.rs
+++ b/crates/wallet/ootle-rs/src/provider/tx_watcher.rs
@@ -267,7 +267,62 @@ impl PendingTransaction {
 
     pub async fn watch(&self) -> Result<TransactionOutcome, PendingTransactionError> {
         match self.register(self.default_timeout).await?.await {
-            Ok(outcome) => Ok(outcome.into()),
+            Ok(FinalizeOutcome::Commit) => Ok(TransactionOutcome::Commit),
+            Ok(FinalizeOutcome::FeeIntentCommit) => {
+                // The transaction was accepted but the main transaction was not committed. This can occur when the
+                // transaction was rejected after the fee intent was committed, or if the transaction is still pending
+                // but the fee intent was committed. In either case, we need to query the transaction result to
+                // determine the actual outcome.
+                tracing::warn!(
+                    "Transaction fee intent committed but main transaction not committed for tx_id: {}. Querying \
+                     transaction result to determine actual outcome.",
+                    self.tx_id
+                );
+                match self.try_get_transaction_result().await {
+                    Ok(Some(IndexerTransactionFinalizedResult::Pending)) => {
+                        // Indexer bug?
+                        Err(PendingTransactionError::IndexerClientError(
+                            IndexerRestClientError::InvalidResponse {
+                                message: format!(
+                                    "Transaction {} is still pending after fee intent commit. This may indicate an \
+                                     indexer issue.",
+                                    self.tx_id
+                                ),
+                            },
+                        ))
+                    },
+                    Ok(Some(IndexerTransactionFinalizedResult::Finalized {
+                        execution_result,
+                        abort_details,
+                        ..
+                    })) => {
+                        if let Some(result) = execution_result {
+                            return match result.finalize.result {
+                                TransactionResult::Accept(_) => Ok(TransactionOutcome::Commit),
+                                TransactionResult::AcceptFeeRejectRest(_, reason) => {
+                                    Ok(TransactionOutcome::OnlyFeeCommit(reason))
+                                },
+                                TransactionResult::Reject(reason) => Ok(TransactionOutcome::Reject(reason)),
+                            };
+                        }
+
+                        // Any commit case would have been handled above, so this is a rejection
+                        let reason = abort_details.unwrap_or_else(|| "Unknown".to_string());
+                        Err(PendingTransactionError::TransactionRejected {
+                            tx_id: self.tx_id,
+                            reason,
+                        })
+                    },
+                    Ok(None) => {
+                        tracing::error!("Transaction result not found after fee reject: {}", self.tx_id);
+                        Err(PendingTransactionError::Timeout { tx_id: self.tx_id })
+                    },
+                    Err(e) => {
+                        tracing::error!("Failed to get transaction result after fee reject: {}", e);
+                        Err(PendingTransactionError::Timeout { tx_id: self.tx_id })
+                    },
+                }
+            },
             Err(PendingTransactionError::Timeout { .. }) => {
                 tracing::warn!("Transaction watch timed out, attempting direct query: {}", self.tx_id);
                 match self.try_get_transaction_result().await {
@@ -283,7 +338,9 @@ impl PendingTransaction {
                         if let Some(result) = execution_result {
                             return match result.finalize.result {
                                 TransactionResult::Accept(_) => Ok(TransactionOutcome::Commit),
-                                TransactionResult::AcceptFeeRejectRest(_, _) => Ok(TransactionOutcome::OnlyFeeCommit),
+                                TransactionResult::AcceptFeeRejectRest(_, reason) => {
+                                    Ok(TransactionOutcome::OnlyFeeCommit(reason))
+                                },
                                 TransactionResult::Reject(reason) => Ok(TransactionOutcome::Reject(reason)),
                             };
                         }

--- a/crates/wallet/ootle-rs/src/types/transaction/outcome.rs
+++ b/crates/wallet/ootle-rs/src/types/transaction/outcome.rs
@@ -3,37 +3,35 @@
 
 use std::fmt;
 
-use tari_ootle_common_types::engine_types::{commit_result::RejectReason, transaction_receipt::FinalizeOutcome};
+use tari_ootle_common_types::engine_types::commit_result::RejectReason;
 
 #[derive(Debug, Clone)]
 pub enum TransactionOutcome {
     /// The transaction was fully committed.
     Commit,
     /// Only the fee intent was committed. The main transaction was not committed.
-    OnlyFeeCommit,
+    OnlyFeeCommit(RejectReason),
     /// Transaction was rejected with the given reason. NOTE: calling get_receipt on the transaction will fail.
     Reject(RejectReason),
 }
 
 impl TransactionOutcome {
     pub fn is_commit(&self) -> bool {
-        matches!(self, TransactionOutcome::Commit | TransactionOutcome::OnlyFeeCommit)
+        matches!(self, TransactionOutcome::Commit)
     }
 
     pub fn is_only_fee_commit(&self) -> bool {
-        matches!(self, TransactionOutcome::OnlyFeeCommit)
+        matches!(self, TransactionOutcome::OnlyFeeCommit(_))
     }
 
     pub fn is_reject(&self) -> bool {
         matches!(self, TransactionOutcome::Reject(_))
     }
-}
 
-impl From<FinalizeOutcome> for TransactionOutcome {
-    fn from(value: FinalizeOutcome) -> Self {
-        match value {
-            FinalizeOutcome::Commit => Self::Commit,
-            FinalizeOutcome::FeeIntentCommit => Self::OnlyFeeCommit,
+    pub fn reject_reason(&self) -> Option<&RejectReason> {
+        match self {
+            TransactionOutcome::OnlyFeeCommit(reason) | TransactionOutcome::Reject(reason) => Some(reason),
+            _ => None,
         }
     }
 }
@@ -42,8 +40,8 @@ impl fmt::Display for TransactionOutcome {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             TransactionOutcome::Commit => write!(f, "Commit"),
-            TransactionOutcome::OnlyFeeCommit => write!(f, "OnlyFeeCommit"),
-            TransactionOutcome::Reject(reason) => write!(f, "Reject({})", reason),
+            TransactionOutcome::OnlyFeeCommit(reason) => write!(f, "OnlyFeeCommit({reason})"),
+            TransactionOutcome::Reject(reason) => write!(f, "Reject({reason})"),
         }
     }
 }


### PR DESCRIPTION
Description
---
fix(ootle-rs): include the reject reason when only fee tx is committed

Motivation and Context
---
This makes it easy to see why a tx failed.