### PR TITLE
fix(ui): stealth UXTOs & fee label

### DIFF
--- a/applications/tari_walletd/web_ui/src/components/StyledComponents.ts
+++ b/applications/tari_walletd/web_ui/src/components/StyledComponents.ts
@@ -119,3 +119,9 @@ export const NftCard: React.FC<CardProps> = styled(Card)(() => ({
     transform: "scale(1.02)",
   },
 }));
+
+export const SpacedBox: React.FC<BoxProps> = styled(Box)`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;

--- a/applications/tari_walletd/web_ui/src/components/StyledComponents.ts
+++ b/applications/tari_walletd/web_ui/src/components/StyledComponents.ts
@@ -43,7 +43,7 @@ export const StyledPaper: React.FC<PaperProps> = styled(Paper)(({ theme }) => ({
   border: "1px solid rgba(255,255,255,0.04)",
 }));
 
-export const InnerHeading: React.FC<TypographyProps> = styled(Typography)(({ theme }) => ({
+export const InnerHeading: React.FC<BoxProps> = styled(Box)(({ theme }) => ({
   fontSize: theme.typography.h6.fontSize,
   textTransform: "uppercase",
   borderBottom: `1px solid ${theme.palette.divider}`,

--- a/applications/tari_walletd/web_ui/src/routes/AssetVault/Components/MyAssets.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/AssetVault/Components/MyAssets.tsx
@@ -23,8 +23,8 @@
 import Grid from "@mui/material/Grid";
 import IconButton from "@mui/material/IconButton";
 import { useTheme } from "@mui/material/styles";
-import { InnerHeading, StyledPaper } from "@components/StyledComponents";
-import { refreshAccountsBalances, useAccountsGetDefault } from "@api/hooks/useAccounts";
+import { InnerHeading, SpacedBox, StyledPaper } from "@components/StyledComponents";
+import { refreshAccountsBalances, useAccountsGetBalances, useAccountsGetDefault } from "@api/hooks/useAccounts";
 import useAccountStore from "@store/accountStore";
 import Transactions from "@routes/Transactions/Transactions";
 import AccountDetails from "./AccountDetails";
@@ -36,14 +36,16 @@ import queryClient from "@api/queryClient";
 import PageHeader from "@components/PageHeader";
 import { useEffect } from "react";
 import Loading from "@components/Loading";
-import { Navigate } from "react-router-dom";
+import { Navigate, useNavigate } from "react-router-dom";
+import Button from "@mui/material/Button";
 
 function MyAssets() {
   const theme = useTheme();
+  const navigate = useNavigate();
   const { account, setAccount, setOotleAddress } = useAccountStore();
   const { data: defaultAccount, error, refetch } = useAccountsGetDefault(false);
   const refreshBalances = refreshAccountsBalances();
-
+  const { data: balancesData } = useAccountsGetBalances(substateIdToString(account?.component_address));
   useEffect(() => {
     refetch();
 
@@ -63,7 +65,6 @@ function MyAssets() {
   if (!account) {
     return <Loading />;
   }
-
   const handleRefreshClicked = () => {
     refreshBalances.mutate(substateIdToString(account.component_address));
     queryClient.invalidateQueries({
@@ -73,6 +74,10 @@ function MyAssets() {
       },
     });
   };
+  const resource_address = balancesData?.balances.find((b) => !!b.balance)?.resource_address;
+  const stealUXTOLink = resource_address ? (
+    <Button onClick={() => navigate(`/stealth-utxos/${resource_address}`)}>Looking for your Stealth UXTOs?</Button>
+  ) : null;
 
   return (
     <>
@@ -106,7 +111,12 @@ function MyAssets() {
       </Grid>
       <Grid item xs={12} md={12} lg={12}>
         <StyledPaper>
-          <InnerHeading>Transactions</InnerHeading>
+          <InnerHeading>
+            <SpacedBox>
+              Transactions
+              {stealUXTOLink}
+            </SpacedBox>
+          </InnerHeading>
           <Transactions account={account} />
         </StyledPaper>
       </Grid>

--- a/applications/tari_walletd/web_ui/src/routes/AssetVault/Components/MyAssets.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/AssetVault/Components/MyAssets.tsx
@@ -20,24 +20,24 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import { refreshAccountsBalances, useAccountsGetBalances, useAccountsGetDefault } from "@api/hooks/useAccounts";
 import queryClient from "@api/queryClient";
+import Loading from "@components/Loading";
 import PageHeader from "@components/PageHeader";
+import { InnerHeading, SpacedBox, StyledPaper } from "@components/StyledComponents";
 import { Refresh } from "@mui/icons-material";
+import Button from "@mui/material/Button";
 import Grid from "@mui/material/Grid";
 import IconButton from "@mui/material/IconButton";
 import { useTheme } from "@mui/material/styles";
-import { InnerHeading, SpacedBox, StyledPaper } from "@components/StyledComponents";
-import { refreshAccountsBalances, useAccountsGetBalances, useAccountsGetDefault } from "@api/hooks/useAccounts";
 import Transactions from "@routes/Transactions/Transactions";
 import useAccountStore from "@store/accountStore";
 import { substateIdToString } from "@tari-project/ootle-ts-bindings";
 import { useEffect } from "react";
+import { Navigate, useNavigate } from "react-router-dom";
 import AccountDetails from "./AccountDetails";
 import ActionMenu from "./ActionMenu";
 import Assets from "./Assets";
-import Loading from "@components/Loading";
-import { Navigate, useNavigate } from "react-router-dom";
-import Button from "@mui/material/Button";
 
 function MyAssets() {
   const theme = useTheme();
@@ -74,8 +74,11 @@ function MyAssets() {
       },
     });
   };
-  const resource_address = balancesData?.balances.find((b) => !!b.balance)?.resource_address;
-  const stealUXTOLink = resource_address ? (
+  const resource_address = balancesData?.balances
+    .filter((b) => BigInt(b.balance) > 0n || BigInt(b.confidential_balance) > 0n)
+    .find((b) => b.resource_type === "Stealth")?.resource_address;
+
+  const stealthUXTOLink = resource_address ? (
     <Button onClick={() => navigate(`/stealth-utxos/${resource_address}`)}>Looking for your Stealth UXTOs?</Button>
   ) : null;
 
@@ -114,7 +117,7 @@ function MyAssets() {
           <InnerHeading>
             <SpacedBox>
               Transactions
-              {stealUXTOLink}
+              {stealthUXTOLink}
             </SpacedBox>
           </InnerHeading>
           <Transactions account={account} />

--- a/applications/tari_walletd/web_ui/src/routes/AssetVault/Components/PublishTemplate.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/AssetVault/Components/PublishTemplate.tsx
@@ -210,12 +210,11 @@ function PublishTemplateDialog(props: DialogProps) {
       setValidity({ ...validity, account: true });
     }
   }, [accounts]);
-
   return (
     <Dialog open={props.open} onClose={handleClose}>
       <PopupTitle onClose={handleClose} title="Publish Template" />
       <DialogContent className="dialog-content">
-        <Form onSubmit={onSubmit} className="flex-container-vertical" style={{ paddingTop: theme.spacing(1) }}>
+        <Form onSubmit={onSubmit} className="flex-container-vertical" style={{ paddingTop: theme.spacing(1), gap: 12 }}>
           {accounts && (
             <>
               <InputLabel id="select-account">Account</InputLabel>
@@ -227,6 +226,7 @@ function PublishTemplateDialog(props: DialogProps) {
                 value={formState.account || accounts.find((a: AccountInfo) => a.account.is_default) || ""}
                 onChange={setSelectFormValue}
                 variant="outlined"
+                style={{ marginBottom: theme.spacing(1) }}
               >
                 {accounts.map((account: AccountInfo, i: number) => (
                   <MenuItem key={i} value={substateIdToString(account.account.component_address)}>
@@ -240,9 +240,11 @@ function PublishTemplateDialog(props: DialogProps) {
             className="flex-container"
             style={{
               justifyContent: "flex-start",
+              alignItems: "end",
             }}
           >
             <Button
+              size="small"
               variant="outlined"
               onClick={(e) => {
                 e.preventDefault();
@@ -253,8 +255,9 @@ function PublishTemplateDialog(props: DialogProps) {
               Select WASM
             </Button>
             {formState.file && (
-              <p style={{ color: "blue" }}>
-                {formState.file.name} {formState.binary?.byteLength} bytes
+              <p style={{ color: "#785be0", margin: 0 }}>
+                {formState.file.name}
+                <span style={{ color: "grey" }}> {formState.binary?.byteLength} bytes</span>
               </p>
             )}
             {fpErrors[0] && <p style={{ color: "red" }}>{fpErrors[0].name}</p>}
@@ -263,11 +266,11 @@ function PublishTemplateDialog(props: DialogProps) {
             name="maxFee"
             label="Fee"
             type="number"
-            value={formState.maxFee}
+            value={formState.maxFee || ""}
             placeholder="Enter max fee"
             onChange={setFormValue}
             disabled={disabled}
-            style={{ flexGrow: 1 }}
+            style={{ flexGrow: 1, marginTop: theme.spacing(1) }}
           />
           <Box
             className="flex-container"

--- a/applications/tari_walletd/web_ui/src/routes/AssetVault/Tokens/Tokens.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/AssetVault/Tokens/Tokens.tsx
@@ -27,7 +27,7 @@ import TableContainer from "@mui/material/TableContainer";
 import TableHead from "@mui/material/TableHead";
 import TableRow from "@mui/material/TableRow";
 import IconButton from "@mui/material/IconButton";
-import { Typography, Box, Stack, Icon, Tooltip } from "@mui/material";
+import { Typography, Box, Stack, Tooltip } from "@mui/material";
 import { useState } from "react";
 import FetchStatusCheck from "@components/FetchStatusCheck";
 import { DataTableCell } from "@components/StyledComponents";

--- a/applications/tari_walletd/web_ui/src/services/store/themeStore.ts
+++ b/applications/tari_walletd/web_ui/src/services/store/themeStore.ts
@@ -30,7 +30,7 @@ interface Store {
 
 const matchDark = window.matchMedia("(prefers-color-scheme: dark)")?.matches;
 const initialTheme = matchDark ? "dark" : "light";
-console.debug(initialTheme);
+
 const useThemeStore = create<Store>()(
   persist<Store>(
     (set) => ({

--- a/applications/tari_walletd/web_ui/src/services/store/themeStore.ts
+++ b/applications/tari_walletd/web_ui/src/services/store/themeStore.ts
@@ -28,10 +28,13 @@ interface Store {
   setThemeMode: (mode: "light" | "dark") => void;
 }
 
+const matchDark = window.matchMedia("(prefers-color-scheme: dark)")?.matches;
+const initialTheme = matchDark ? "dark" : "light";
+console.debug(initialTheme);
 const useThemeStore = create<Store>()(
   persist<Store>(
     (set) => ({
-      themeMode: "light",
+      themeMode: initialTheme,
       setThemeMode: (mode) => set({ themeMode: mode }),
     }),
     {


### PR DESCRIPTION
Description
---
- add a little link at transactions to get to the stealth UXTOs (if there's a token with resource address available) 
  - **NB!! -** this only returns the address for the first resource found with a balance, we'd need to check how best to display multiple resources 
- fixed a nesting issue with `InnerHeading`
- set the initial theme based on user dark mode preference

Motivation and Context
---
- users (it's me, i'm users) may assume that they'd see _all_ txs including stealth UXTOs in the main Transactions list, and not notice the little wallet icon initially 
- `Fee` input label was janked after the estimation came in:

<img width="1196" height="726" alt="optimised_26-02_11-12_1855" src="https://github.com/user-attachments/assets/5452f1c4-c816-459a-a124-8b1bdaad0d04" />


How Has This Been Tested?
---

- locally:

**stealth UXTO link:**

https://github.com/user-attachments/assets/12904bff-b3fc-4c72-95af-a8ef4b434450

**fee label:**

https://github.com/user-attachments/assets/ec889d4b-c959-45cd-8ce5-11d6c0c0fa3c


What process can a PR reviewer use to test or verify this change?
---

- have a token with balance (send or recieve to your address)
- see link come up 

- try publish a template
- see fixed label 

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify