### PR TITLE
fix(consensus): fix endless leader failure cycle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1692,7 +1692,7 @@ dependencies = [
 
 [[package]]
 name = "consensus_tests"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "fern",
  "futures 0.3.31",
@@ -2643,7 +2643,7 @@ dependencies = [
 
 [[package]]
 name = "db-inspector"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -3769,7 +3769,7 @@ checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 
 [[package]]
 name = "generate_ristretto_value_lookup"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "clap 3.2.25",
  "futures 0.3.31",
@@ -4875,7 +4875,7 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "integration_tests"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "anyhow",
  "config",
@@ -5591,7 +5591,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-messaging"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "async-trait",
  "futures-bounded",
@@ -5770,7 +5770,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-substream"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "libp2p",
  "prometheus-client",
@@ -8335,7 +8335,7 @@ dependencies = [
 
 [[package]]
 name = "proto_builder"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "prost-build 0.14.3",
  "sha2 0.10.9",
@@ -10125,7 +10125,7 @@ dependencies = [
 
 [[package]]
 name = "sqlite_message_logger"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "chrono",
  "diesel",
@@ -10514,7 +10514,7 @@ dependencies = [
 
 [[package]]
 name = "tari_base_node_client"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "futures-util",
  "log",
@@ -10739,7 +10739,7 @@ dependencies = [
 
 [[package]]
 name = "tari_consensus"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "anyhow",
  "indexmap 2.13.0",
@@ -10764,7 +10764,7 @@ dependencies = [
 
 [[package]]
 name = "tari_consensus_types"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "borsh",
  "ootle_serde",
@@ -10866,7 +10866,7 @@ dependencies = [
 
 [[package]]
 name = "tari_engine"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "blake2",
  "criterion",
@@ -10893,7 +10893,7 @@ dependencies = [
 
 [[package]]
 name = "tari_engine_types"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "bincode 2.0.1",
  "blake2",
@@ -10920,7 +10920,7 @@ dependencies = [
 
 [[package]]
 name = "tari_epoch_manager"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "anyhow",
  "log",
@@ -10940,7 +10940,7 @@ dependencies = [
 
 [[package]]
 name = "tari_epoch_oracles"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "anyhow",
  "blake2",
@@ -10993,7 +10993,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -11063,7 +11063,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer_client"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "anyhow",
  "bounded-vec",
@@ -11093,7 +11093,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer_lib"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "log",
  "prometheus-client",
@@ -11169,7 +11169,7 @@ dependencies = [
 
 [[package]]
 name = "tari_networking"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11221,7 +11221,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_app_utilities"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -11260,7 +11260,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_common_types"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "blake2",
  "borsh",
@@ -11286,7 +11286,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_p2p"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "anyhow",
  "libp2p-identity",
@@ -11310,7 +11310,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_storage"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "anyhow",
  "bitflags 2.10.0",
@@ -11337,7 +11337,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_storage_sqlite"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "diesel",
  "diesel_migrations",
@@ -11358,7 +11358,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_transaction"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "bincode 2.0.1",
  "borsh",
@@ -11382,7 +11382,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_cli"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -11504,7 +11504,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_storage_sqlite"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "bigdecimal",
  "diesel",
@@ -11528,7 +11528,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_walletd"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11615,7 +11615,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_framework"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "async-trait",
  "bitflags 2.10.0",
@@ -11639,7 +11639,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_macros"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11648,7 +11648,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_state_sync"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -11725,7 +11725,7 @@ dependencies = [
 
 [[package]]
 name = "tari_state_store_rocksdb"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -11756,7 +11756,7 @@ dependencies = [
 
 [[package]]
 name = "tari_state_tree"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "indexmap 2.13.0",
  "log",
@@ -11782,7 +11782,7 @@ dependencies = [
 
 [[package]]
 name = "tari_swarm"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "libp2p",
  "libp2p-messaging",
@@ -11793,7 +11793,7 @@ dependencies = [
 
 [[package]]
 name = "tari_swarm_daemon"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11849,7 +11849,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_builtin"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "ootle_byte_type",
  "tari_crypto",
@@ -11904,7 +11904,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_test_tooling"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "anyhow",
  "cargo_toml 0.22.3",
@@ -12020,7 +12020,7 @@ dependencies = [
 
 [[package]]
 name = "tari_transaction_manifest"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "proc-macro2",
  "serde_json",
@@ -12054,7 +12054,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -12120,7 +12120,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node_client"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "indexmap 2.13.0",
  "multiaddr 0.18.3",
@@ -12144,7 +12144,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node_rpc"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -12167,7 +12167,7 @@ dependencies = [
 
 [[package]]
 name = "tari_wallet_daemon_client"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "hex",
  "ootle_serde",
@@ -12191,7 +12191,7 @@ dependencies = [
 
 [[package]]
 name = "tari_watcher"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "anyhow",
  "clap 3.2.25",
@@ -12219,7 +12219,7 @@ dependencies = [
 
 [[package]]
 name = "tariswap_bench"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "anyhow",
  "clap 4.5.54",
@@ -12899,7 +12899,7 @@ dependencies = [
 
 [[package]]
 name = "traffic-sim"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "anyhow",
  "clap 4.5.54",
@@ -12921,7 +12921,7 @@ dependencies = [
 
 [[package]]
 name = "transaction_generator"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -12942,7 +12942,7 @@ dependencies = [
 
 [[package]]
 name = "transaction_submitter"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "anyhow",
  "clap 4.5.54",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.25.2"
+version = "0.25.3"
 edition = "2024"
 authors = ["The Tari Development Community"]
 repository = "https://github.com/tari-project/tari-ootle"

--- a/applications/tari_ootle_app_utilities/Cargo.toml
+++ b/applications/tari_ootle_app_utilities/Cargo.toml
@@ -29,7 +29,7 @@ ootle_byte_type = { workspace = true, features = ["crypto"] }
 anyhow = { workspace = true }
 blake2 = { workspace = true }
 bincode = { workspace = true, features = ["serde"] }
-clap = { workspace = true }
+clap = { workspace = true, features = ["derive", "env"] }
 libp2p-identity = { workspace = true }
 log = { workspace = true, features = ["std"] }
 multiaddr = { workspace = true }

--- a/crates/consensus/src/hotstuff/on_catch_up_sync.rs
+++ b/crates/consensus/src/hotstuff/on_catch_up_sync.rs
@@ -43,8 +43,8 @@ impl<TConsensusSpec: ConsensusSpec> OnCatchUpSync<TConsensusSpec> {
         };
 
         // Reset leader timeout to previous height since we're behind and need to process catch up blocks. This is the
-        // only case where the view is non-monotonic. TODO: is this correct/necessary?
-        // self.pacemaker.reset_view(epoch, block_height, block_height).await?;
+        // only case where the view is non-monotonic.
+        self.pacemaker.reset_view(epoch, block_height, block_height).await?;
 
         info!(
             target: LOG_TARGET,

--- a/crates/consensus/src/hotstuff/on_receive_local_proposal.rs
+++ b/crates/consensus/src/hotstuff/on_receive_local_proposal.rs
@@ -8,7 +8,6 @@ use ootle_byte_type::ToByteType;
 use tari_consensus_types::{
     Decision,
     HighPc,
-    HighestSeenBlock,
     LastSentVote,
     PcId,
     ProposalCertificate,
@@ -870,17 +869,12 @@ impl<TConsensusSpec: ConsensusSpec> OnReceiveLocalProposalHandler<TConsensusSpec
         if candidate_block.timeout_certificate().is_some() {
             let num_dummies = candidate_block.height().as_u64() - justify_block.height().as_u64() - 1;
             info!(target: LOG_TARGET, "🔨 Creating {} dummy block(s) for block {}", num_dummies, candidate_block);
-            // On a leader failure we want to include the highest valid block we've seen. We have already asserted above
-            // that we know the block in the proposal certificate (or else we kick into catch-up sync). Assuming that PC
-            // was included in the highest-seen block (that, for whatever reason, did not get justified) we
-            // can assume that this highest-seen block used to create dummy blocks is the same as the
-            // proposer.
-            let highest_seen_block = HighestSeenBlock::get(tx, candidate_block.epoch())?;
-            let highest_seen_block = Block::get(tx, highest_seen_block.block_id())?;
-
+            // On a leader failure we use the justify block (QC-certified block) as the starting point for dummy
+            // blocks. This is deterministic across all honest nodes since the QC is included in the candidate
+            // block and all nodes have the justified block stored.
             let dummy_blocks = calculate_dummy_blocks_from_justify(
                 &candidate_block,
-                &highest_seen_block,
+                &justify_block,
                 &self.leader_strategy,
                 local_committee,
             );
@@ -890,7 +884,7 @@ impl<TConsensusSpec: ConsensusSpec> OnReceiveLocalProposalHandler<TConsensusSpec
                 if candidate_block.parent() != last_dummy.id() {
                     warn!(target: LOG_TARGET, "❌ Bad proposal, unable to find dummy blocks (last dummy: {}) for candidate block {}", last_dummy, candidate_block);
                     return Err(ProposalValidationError::CandidateBlockDoesNotExtendJustify {
-                        justify_block_height: highest_seen_block.height(),
+                        justify_block_height: justify_block.height(),
                         candidate_block_height: candidate_block.height(),
                     }
                     .into());

--- a/crates/consensus/src/hotstuff/worker.rs
+++ b/crates/consensus/src/hotstuff/worker.rs
@@ -974,15 +974,15 @@ impl<TConsensusSpec: ConsensusSpec> HotstuffWorker<TConsensusSpec> {
         let mut dummy_block = None;
         let mut propose_high_tc = None;
         if next_height > highest_block.height + NodeHeight(1) {
-            let (high_qc, high_tc, parent) = self.state_store.with_read_tx(|tx| {
+            let (high_qc, high_tc, justify_block) = self.state_store.with_read_tx(|tx| {
                 let high_qc = HighPc::get(tx, epoch_state.epoch())?;
                 let high_qc = ProposalCertificate::get(tx, high_qc.epoch(), high_qc.id())?;
                 let high_tc = HighTc::get(tx, epoch_state.epoch()).optional()?;
                 let high_tc = high_tc
                     .map(|tc| TimeoutCertificate::get(tx, tc.epoch(), tc.id()))
                     .transpose()?;
-                let block = Block::get(tx, highest_block.block_id())?;
-                Ok::<_, HotStuffError>((high_qc, high_tc, block))
+                let justify_block = Block::get(tx, &high_qc.calculate_block_id())?;
+                Ok::<_, HotStuffError>((high_qc, high_tc, justify_block))
             })?;
 
             propose_high_tc = high_tc;
@@ -993,19 +993,19 @@ impl<TConsensusSpec: ConsensusSpec> HotstuffWorker<TConsensusSpec> {
             );
 
             if let Some(dummy) = calculate_last_dummy_block(
-                highest_block.height,
+                justify_block.height(),
                 next_height,
                 self.config.network,
                 epoch_state.epoch(),
-                parent.shard_group(),
-                *parent.id(),
+                justify_block.shard_group(),
+                *justify_block.id(),
                 &high_qc,
-                *parent.state_merkle_root(),
+                *justify_block.state_merkle_root(),
                 &self.leader_strategy,
                 epoch_state.local_committee(),
-                parent.timestamp(),
-                *parent.header().accumulated_data(),
-                *parent.epoch_hash(),
+                justify_block.timestamp(),
+                *justify_block.header().accumulated_data(),
+                *justify_block.epoch_hash(),
             ) {
                 dummy_block = Some(dummy);
             }


### PR DESCRIPTION
Description
---
fix(consensus): fix endless leader failure catch up cycle
Bump version 0.25.3

Motivation and Context
---

Two related bugs caused an endless leader failure catch up cycle

Fix: Catch-Up Sync Deadlock  

 When a node falls behind (e.g., misses blocks during leader failures), catch-up sync sends the missing blocks as regular Proposal messages. However, the inbound message filter (msg_relative_view in on_inbound_message.rs:250) discards these blocks as "Past" because their QC heights are below the node's current view height. The node
 advanced its view via leader timeouts (NEXTSYNCVIEW) without actually storing those blocks. This creates an unrecoverable deadlock: the node requests catch-up, receives the blocks it needs, discards them, and repeats forever.

 Root Cause

 The node's view height (tracked by the pacemaker CurrentView) can advance beyond its stored block height (HighPC) via leader timeouts. The catch-up blocks have QC heights corresponding to the stored chain, which is below the view height, so they're classified as "Past" and dropped.

## Problem

When consecutive leader failures occur (e.g. timeouts at heights 81, 82, 83 after a certified block at height 80), the next leader proposes a block at height 84 with **dummy blocks** to fill the gap. Every validator must independently reconstruct the exact same dummy block chain to verify the proposal.

Both the proposer (`worker.rs`) and validators (`on_receive_local_proposal.rs`) were using `HighestSeenBlock` as the starting point for dummy block generation. `HighestSeenBlock` is **node-local** state — different nodes can have seen different unjustified blocks, making the generated dummy block IDs non-deterministic across the network.

**Observed**: Most validators had `HighestSeenBlock` at height 82 (`96b8fe61...`), one node had it at height 80 (`cb55ad84...`), and the proposer had yet another value. Every validator rejected the proposed block.

## Solution

Use the **justify block** (the block certified by the QC / HighPC) as the starting point instead. The justify block is the only block guaranteed to be identical across all honest nodes, since its identity is determined by the QC which is included in the candidate block and verified by all validators.

How Has This Been Tested?
---
Existing tests and manually



Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify