### PR TITLE
fix(walletd): missing not found errors for AccountMonitorError

### DIFF
--- a/crates/wallet/sdk_services/src/account_monitor/monitor.rs
+++ b/crates/wallet/sdk_services/src/account_monitor/monitor.rs
@@ -305,6 +305,15 @@ pub enum AccountMonitorError {
 
 impl IsNotFoundError for AccountMonitorError {
     fn is_not_found_error(&self) -> bool {
-        matches!(self, Self::Substate(s) if s.is_not_found_error())
+        match self {
+            Self::Transaction(e) => e.is_not_found_error(),
+            Self::Accounts(e) => e.is_not_found_error(),
+            Self::Substate(e) => e.is_not_found_error(),
+            Self::ConfidentialOutputs(e) => e.is_not_found_error(),
+            Self::StealthOutputs(e) => e.is_not_found_error(),
+            Self::NonFungibleTokens(e) => e.is_not_found_error(),
+            Self::Resources(e) => e.is_not_found_error(),
+            Self::DecodeValueFailed(_) | Self::UnexpectedSubstate(_) | Self::ServiceShutdown => false,
+        }
     }
 }

--- a/crates/wallet/sdk_services/src/account_monitor/scanner.rs
+++ b/crates/wallet/sdk_services/src/account_monitor/scanner.rs
@@ -480,6 +480,12 @@ where TSpec: WalletSdkSpec
         for (account_address, value, account_version) in accounts {
             // If we know about this account, mark it as on-chain (if it isn't already)
             if self.mark_account_as_on_chain(&account_address).optional()?.is_none() {
+                debug!(
+                    target: LOG_TARGET,
+                    "🏦 Account {} in transaction {} does not belong to us.",
+                    account_address,
+                    tx_id
+                );
                 continue;
             }
             let mut has_changed = false;


### PR DESCRIPTION
Description
---
fix(walletd): missing not found errors for AccountMonitorError

Motivation and Context
---
Observed errors in the logs when handling transaction events due to an incorrect implementation of `IsNotFoundError` trait 

How Has This Been Tested?
---

What process can a PR reviewer use to test or verify this change?
---


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify