### PR TITLE
chore(walletd): wallet/send dialog UI cleanups

### DIFF
--- a/applications/tari_walletd/web_ui/package.json
+++ b/applications/tari_walletd/web_ui/package.json
@@ -34,7 +34,7 @@
     "react-dom": "^19.2.4",
     "react-icons": "^5.5.0",
     "react-qr-code": "^2.0.18",
-    "react-router-dom": "^7.13.1",
+    "react-router": "^7.13.1",
     "use-file-picker": "^2.1.4",
     "use-react-router-breadcrumbs": "^4.0.1",
     "zustand": "catalog:",

--- a/applications/tari_walletd/web_ui/src/App.tsx
+++ b/applications/tari_walletd/web_ui/src/App.tsx
@@ -41,7 +41,7 @@ import useAuthStore from "@store/authStore";
 import Layout from "@theme/LayoutMain";
 import { getClientInstance, isValidJwt } from "@utils/json_rpc";
 import { useEffect, useState } from "react";
-import { Route, Routes } from "react-router-dom";
+import { Route, Routes } from "react-router";
 import { ErrorNotificationProvider } from "./contexts/ErrorNotificationContext";
 
 export const breadcrumbRoutes = [

--- a/applications/tari_walletd/web_ui/src/components/Breadcrumbs.tsx
+++ b/applications/tari_walletd/web_ui/src/components/Breadcrumbs.tsx
@@ -22,7 +22,7 @@
 
 import { Breadcrumbs, Link } from "@mui/material";
 import React from "react";
-import { Link as RouterLink } from "react-router-dom";
+import { Link as RouterLink } from "react-router";
 import useBreadcrumbs from "use-react-router-breadcrumbs";
 
 interface BreadcrumbsItem {

--- a/applications/tari_walletd/web_ui/src/components/CopyAddress.tsx
+++ b/applications/tari_walletd/web_ui/src/components/CopyAddress.tsx
@@ -21,6 +21,7 @@
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import CopyToClipboard from "@components/CopyToClipboard";
+import { Stack } from "@mui/material";
 import { shortenString } from "@tari-project/ootle-ts-bindings";
 import { isSubstateIdString, shortenSubstateId, substateIdToString } from "@utils/helpers";
 
@@ -35,9 +36,9 @@ export default function CopyAddress({ address, display }: Props) {
   const displayStr = display && (typeof display === "object" ? shortenSubstateId(display) : display);
 
   return (
-    <>
+    <Stack direction="row" gap={1} style={{ width: "max-content" }}>
       <span title={addressString}>{displayStr || shortAddress}</span>
       <CopyToClipboard copy={addressString} />
-    </>
+    </Stack>
   );
 }

--- a/applications/tari_walletd/web_ui/src/components/CopyAddress.tsx
+++ b/applications/tari_walletd/web_ui/src/components/CopyAddress.tsx
@@ -22,6 +22,7 @@
 
 import CopyToClipboard from "@components/CopyToClipboard";
 import { Stack } from "@mui/material";
+import Typography from "@mui/material/Typography";
 import { shortenString } from "@tari-project/ootle-ts-bindings";
 import { isSubstateIdString, shortenSubstateId, substateIdToString } from "@utils/helpers";
 
@@ -36,8 +37,10 @@ export default function CopyAddress({ address, display }: Props) {
   const displayStr = display && (typeof display === "object" ? shortenSubstateId(display) : display);
 
   return (
-    <Stack direction="row" gap={1} style={{ width: "max-content" }}>
-      <span title={addressString}>{displayStr || shortAddress}</span>
+    <Stack direction="row" gap={1} style={{ width: "max-content" }} alignItems="center">
+      <Typography variant="span" title={addressString}>
+        {displayStr || shortAddress}
+      </Typography>
       <CopyToClipboard copy={addressString} />
     </Stack>
   );

--- a/applications/tari_walletd/web_ui/src/components/CopyAddress.tsx
+++ b/applications/tari_walletd/web_ui/src/components/CopyAddress.tsx
@@ -37,7 +37,7 @@ export default function CopyAddress({ address, display }: Props) {
   const displayStr = display && (typeof display === "object" ? shortenSubstateId(display) : display);
 
   return (
-    <Stack direction="row" gap={1} style={{ width: "max-content" }} alignItems="center">
+    <Stack direction="row" gap={0.3} style={{ width: "max-content" }} alignItems="center">
       <Typography variant="span" title={addressString}>
         {displayStr || shortAddress}
       </Typography>

--- a/applications/tari_walletd/web_ui/src/components/CopyToClipboard.tsx
+++ b/applications/tari_walletd/web_ui/src/components/CopyToClipboard.tsx
@@ -32,7 +32,7 @@ interface CopyProps {
   iconHeight?: string;
 }
 
-const CopyToClipboard = ({ copy, title, iconWidth = "16px", iconHeight = "16px" }: CopyProps) => {
+const CopyToClipboard = ({ copy, title, iconWidth = "14px", iconHeight = "14px" }: CopyProps) => {
   const [tooltip, setTooltip] = useState<string | null>(null);
   const handleClick = async (copyThis: string) => {
     try {

--- a/applications/tari_walletd/web_ui/src/components/CopyToClipboard.tsx
+++ b/applications/tari_walletd/web_ui/src/components/CopyToClipboard.tsx
@@ -27,13 +27,12 @@ import { useState } from "react";
 
 interface CopyProps {
   copy: string;
-  floatright?: boolean;
   title?: string;
   iconWidth?: string;
   iconHeight?: string;
 }
 
-const CopyToClipboard = ({ copy, floatright, title, iconWidth = "16px", iconHeight = "16px" }: CopyProps) => {
+const CopyToClipboard = ({ copy, title, iconWidth = "16px", iconHeight = "16px" }: CopyProps) => {
   const [tooltip, setTooltip] = useState<string | null>(null);
   const handleClick = async (copyThis: string) => {
     try {
@@ -49,28 +48,17 @@ const CopyToClipboard = ({ copy, floatright, title, iconWidth = "16px", iconHeig
   };
 
   return (
-    <>
-      <IconButton
-        onClick={() => handleClick(copy)}
-        size="small"
-        aria-label="copy to clipboard"
-        style={
-          floatright
-            ? { float: "right", marginLeft: "10px", marginRight: "10px" }
-            : { marginLeft: "10px", marginRight: "10px" }
-        }
-      >
-        <Tooltip title={tooltip ? tooltip : title || copy} arrow>
-          <ContentCopyIcon
-            color="primary"
-            style={{
-              width: iconWidth,
-              height: iconHeight,
-            }}
-          />
-        </Tooltip>
-      </IconButton>
-    </>
+    <IconButton onClick={() => handleClick(copy)} size="small" aria-label="copy to clipboard">
+      <Tooltip title={tooltip ? tooltip : title || copy} arrow>
+        <ContentCopyIcon
+          color="primary"
+          style={{
+            width: iconWidth,
+            height: iconHeight,
+          }}
+        />
+      </Tooltip>
+    </IconButton>
   );
 };
 

--- a/applications/tari_walletd/web_ui/src/components/MenuItems.tsx
+++ b/applications/tari_walletd/web_ui/src/components/MenuItems.tsx
@@ -30,7 +30,7 @@ import { useTheme } from "@mui/material/styles";
 import Tooltip from "@mui/material/Tooltip";
 import { IoHome, IoHomeOutline, IoSettings, IoSettingsOutline, IoTerminal, IoTerminalOutline } from "react-icons/io5";
 import { LuLayoutTemplate } from "react-icons/lu";
-import { NavLink } from "react-router-dom";
+import { NavLink } from "react-router";
 
 function MainListItems() {
   const theme = useTheme();

--- a/applications/tari_walletd/web_ui/src/components/StyledComponents.ts
+++ b/applications/tari_walletd/web_ui/src/components/StyledComponents.ts
@@ -55,7 +55,6 @@ export const InnerHeading: React.FC<BoxProps> = styled(Box)(({ theme }) => ({
 export const DataTableCell: React.FC<TableCellProps> = styled(TableCell)(({ theme }) => ({
   fontFamily: "'Courier New', Courier, monospace",
   fontSize: "14px",
-  width: "fit-content",
 }));
 
 export const CodeBlock: React.FC<BoxProps> = styled(Box)(({ theme }) => ({

--- a/applications/tari_walletd/web_ui/src/components/StyledComponents.ts
+++ b/applications/tari_walletd/web_ui/src/components/StyledComponents.ts
@@ -55,6 +55,7 @@ export const InnerHeading: React.FC<BoxProps> = styled(Box)(({ theme }) => ({
 export const DataTableCell: React.FC<TableCellProps> = styled(TableCell)(({ theme }) => ({
   fontFamily: "'Courier New', Courier, monospace",
   fontSize: "14px",
+  width: "fit-content",
 }));
 
 export const CodeBlock: React.FC<BoxProps> = styled(Box)(({ theme }) => ({
@@ -119,9 +120,3 @@ export const NftCard: React.FC<CardProps> = styled(Card)(() => ({
     transform: "scale(1.02)",
   },
 }));
-
-export const SpacedBox: React.FC<BoxProps> = styled(Box)`
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-`;

--- a/applications/tari_walletd/web_ui/src/components/StyledComponents.ts
+++ b/applications/tari_walletd/web_ui/src/components/StyledComponents.ts
@@ -52,10 +52,18 @@ export const InnerHeading: React.FC<BoxProps> = styled(Box)(({ theme }) => ({
   letterSpacing: "1.5px",
 }));
 
-export const DataTableCell: React.FC<TableCellProps> = styled(TableCell)(({ theme }) => ({
+export const DataTableCell: React.FC<TableCellProps> = styled(TableCell)(() => ({
   fontFamily: "'Courier New', Courier, monospace",
   fontSize: "14px",
 }));
+
+export const FluidTableCell: React.FC<TableCellProps> = styled(TableCell)`
+  font-size: 14px;
+  font-family: "Courier New", Courier, monospace;
+  vertical-align: bottom;
+  padding: min(10vw, 14px);
+  white-space: nowrap;
+`;
 
 export const CodeBlock: React.FC<BoxProps> = styled(Box)(({ theme }) => ({
   backgroundColor: theme.palette.accent.background,

--- a/applications/tari_walletd/web_ui/src/components/TransactionsStatusChip.tsx
+++ b/applications/tari_walletd/web_ui/src/components/TransactionsStatusChip.tsx
@@ -22,6 +22,7 @@
 
 import { Avatar, Chip } from "@mui/material";
 import { useTheme } from "@mui/material/styles";
+import useMediaQuery from "@mui/material/useMediaQuery";
 import type { TransactionStatus } from "@tari-project/ootle-ts-bindings";
 import { ReactNode } from "react";
 import { IoCheckmarkOutline, IoCloseOutline, IoDiamondOutline, IoHourglassOutline, IoReload } from "react-icons/io5";
@@ -43,6 +44,7 @@ const colorList: Record<string, string> = {
 
 export default function TransactionsStatusChip({ status, showTitle = true }: StatusChipProps) {
   const theme = useTheme();
+  const isSm = useMediaQuery(theme.breakpoints.down("sm"));
 
   const iconList: Record<string, ReactNode> = {
     Accepted: <IoCheckmarkOutline style={{ height: 14, width: 14 }} color={theme.palette.background.paper} />,
@@ -64,22 +66,19 @@ export default function TransactionsStatusChip({ status, showTitle = true }: Sta
 
   if (status === "OnlyFeeAccepted") {
     const leftColor = colorList["Accepted"];
-    const rightColor = colorList["Rejected"];
     background = `linear-gradient(to right, ${leftColor} 50%, ${colorList["Rejected"]} 50%)`;
   }
 
   if (!showTitle) {
-    let leftColor = colorList["Accepted"];
-    let rightColor = colorList["Rejected"];
-
-    return <Avatar sx={{ bgcolor: bgColor, height: 22, width: 22 }}>{iconList[status]}</Avatar>;
+    return <Avatar style={{ background: bgColor, height: 22, width: 22 }}>{iconList[status]}</Avatar>;
   } else {
     return (
       <Chip
-        avatar={<Avatar sx={{ bgcolor: bgColor, background: background }}>{iconList[status]}</Avatar>}
+        avatar={<Avatar style={{ background: background || bgColor }}>{iconList[status]}</Avatar>}
         label={status}
         style={{ color: colorList[status], borderColor: colorList[status] }}
         variant="outlined"
+        size={isSm ? "small" : "medium"}
       />
     );
   }

--- a/applications/tari_walletd/web_ui/src/components/WalletConnectLink/WalletConnectLink.tsx
+++ b/applications/tari_walletd/web_ui/src/components/WalletConnectLink/WalletConnectLink.tsx
@@ -36,6 +36,7 @@ import IconButton from "@mui/material/IconButton";
 import { useTheme } from "@mui/material/styles";
 import TextField from "@mui/material/TextField";
 import Typography from "@mui/material/Typography";
+import useMediaQuery from "@mui/material/useMediaQuery";
 import { WalletKit } from "@reown/walletkit";
 import useAccountStore from "@store/accountStore";
 import {
@@ -72,6 +73,7 @@ const ConnectorDialog = () => {
   const linkRef = useRef<HTMLInputElement>(null);
   const accountStore = useAccountStore();
   const theme = useTheme();
+  const isMd = useMediaQuery(theme.breakpoints.up("sm"));
   const [_chosenOptionalPermissions, setChosenOptionalPermissions] = useState<boolean[]>([]);
 
   const [web3wallet, setWeb3wallet] = useState<any | undefined>();
@@ -388,7 +390,7 @@ const ConnectorDialog = () => {
   } else {
     return (
       <>
-        <Button variant="contained" color="primary" onClick={handleOpen} size="large">
+        <Button variant="contained" color="primary" onClick={handleOpen} size={isMd ? "large" : "small"}>
           Connect with WalletConnect
         </Button>
         <Dialog open={isOpen} onClose={handleClose}>

--- a/applications/tari_walletd/web_ui/src/components/auth/web_authn/components/Login.tsx
+++ b/applications/tari_walletd/web_ui/src/components/auth/web_authn/components/Login.tsx
@@ -12,7 +12,7 @@ import { WebauthnFinishAuthRequest } from "@tari-project/ootle-ts-bindings";
 import { getClientInstance, webauthnStartAuth } from "@utils/json_rpc";
 import { Buffer } from "buffer";
 import { FormEvent, useState } from "react";
-import { Form } from "react-router-dom";
+import { Form } from "react-router";
 
 export const getCredential = async (challenge: any, allowCredentials: any) => {
   const publicKeyCredentialRequestOptions: PublicKeyCredentialRequestOptions = {

--- a/applications/tari_walletd/web_ui/src/components/auth/web_authn/components/Registration.tsx
+++ b/applications/tari_walletd/web_ui/src/components/auth/web_authn/components/Registration.tsx
@@ -12,7 +12,7 @@ import Typography from "@mui/material/Typography";
 import { getClientInstance, webauthnFinishRegistration, webauthnStartRegistration } from "@utils/json_rpc";
 import { Buffer } from "buffer";
 import { FormEvent, useState } from "react";
-import { Form } from "react-router-dom";
+import { Form } from "react-router";
 
 const WEBAUTHN_RP_ID = import.meta.env.VITE_DAEMON_WEBAUTHN_RP_ID || window.location.hostname;
 

--- a/applications/tari_walletd/web_ui/src/main.tsx
+++ b/applications/tari_walletd/web_ui/src/main.tsx
@@ -28,7 +28,7 @@ import { QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import "@theme/theme.css";
 import ReactDOM from "react-dom/client";
-import { createBrowserRouter, RouterProvider } from "react-router-dom";
+import { createBrowserRouter, RouterProvider } from "react-router";
 
 const router = createBrowserRouter([
   {

--- a/applications/tari_walletd/web_ui/src/routes/AccountDetails/AccountDetails.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/AccountDetails/AccountDetails.tsx
@@ -43,7 +43,7 @@ import { formatCurrency, handleChangePage, handleChangeRowsPerPage } from "@util
 import { accountsAssociateStealthResource } from "@utils/json_rpc";
 import { useState } from "react";
 import { IoAdd } from "react-icons/io5";
-import { Form, useParams } from "react-router-dom";
+import { Form, useParams } from "react-router";
 import { useAccountsGet, useAccountsGetBalances } from "../../services/api/hooks/useAccounts";
 
 function BalanceRow(props: BalanceEntry) {

--- a/applications/tari_walletd/web_ui/src/routes/AssetVault/Components/AccountDetails.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/AssetVault/Components/AccountDetails.tsx
@@ -30,6 +30,7 @@ import {
   DialogContent,
   DialogContentText,
   DialogTitle,
+  Stack,
   TextField,
   Tooltip,
 } from "@mui/material";
@@ -88,12 +89,14 @@ function AccountDetails() {
               <CopyAddress address={substateIdToString(account.component_address)} />
             </DataTableCell>
             <DataTableCell>
-              <CopyAddress address={address} />
-              <Tooltip title="PayRef address">
-                <IconButton size="small" onClick={(_e) => setPayRefDialogOpen(true)} color="primary">
-                  <IoPaperPlaneOutline />
-                </IconButton>
-              </Tooltip>
+              <Stack direction="row" gap={1}>
+                <CopyAddress address={address} />
+                <Tooltip title="PayRef address">
+                  <IconButton size="small" onClick={(_e) => setPayRefDialogOpen(true)} color="primary">
+                    <IoPaperPlaneOutline />
+                  </IconButton>
+                </Tooltip>
+              </Stack>
             </DataTableCell>
           </TableRow>
         </TableBody>

--- a/applications/tari_walletd/web_ui/src/routes/AssetVault/Components/AddAccount.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/AssetVault/Components/AddAccount.tsx
@@ -33,7 +33,7 @@ import TextField from "@mui/material/TextField";
 import useAccountStore from "@store/accountStore";
 import type { AccountsCreateResponse } from "@tari-project/ootle-ts-bindings";
 import { FormEvent, useState } from "react";
-import { Form } from "react-router-dom";
+import { Form } from "react-router";
 
 function AddAccount({ open, setOpen }: { open: boolean; setOpen: React.Dispatch<React.SetStateAction<boolean>> }) {
   const [accountFormState, setAccountFormState] = useState({

--- a/applications/tari_walletd/web_ui/src/routes/AssetVault/Components/Assets.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/AssetVault/Components/Assets.tsx
@@ -50,7 +50,7 @@ function TabPanel(props: TabPanelProps) {
       {...other}
     >
       {value === index && (
-        <Box>
+        <Box style={{ paddingTop: 16 }}>
           <Typography component="div">{children}</Typography>
         </Box>
       )}

--- a/applications/tari_walletd/web_ui/src/routes/AssetVault/Components/Assets.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/AssetVault/Components/Assets.tsx
@@ -22,7 +22,10 @@
 
 import { ApiError } from "@api/helpers/types";
 import { useNFTsList } from "@api/hooks/useNfts";
-import { Box, Tab, Tabs, Typography } from "@mui/material";
+import Box from "@mui/material/Box";
+import Tab from "@mui/material/Tab";
+import Tabs from "@mui/material/Tabs";
+import Typography from "@mui/material/Typography";
 import NFTList from "@routes/AssetVault/NFTs/NFTList";
 import Tokens from "@routes/AssetVault/Tokens/Tokens";
 import { Account } from "@tari-project/ootle-ts-bindings";
@@ -47,7 +50,7 @@ function TabPanel(props: TabPanelProps) {
       {...other}
     >
       {value === index && (
-        <Box sx={{ p: 3 }}>
+        <Box>
           <Typography component="div">{children}</Typography>
         </Box>
       )}

--- a/applications/tari_walletd/web_ui/src/routes/AssetVault/Components/ClaimBurn.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/AssetVault/Components/ClaimBurn.tsx
@@ -36,7 +36,7 @@ import useAccountStore from "@store/accountStore";
 import type { AccountInfo, ComponentAddress } from "@tari-project/ootle-ts-bindings";
 import { accountsClaimBurn, transactionsWaitResult } from "@utils/json_rpc";
 import { FormEvent, useState } from "react";
-import { Form } from "react-router-dom";
+import { Form } from "react-router";
 
 type FormState = {
   account: ComponentAddress;

--- a/applications/tari_walletd/web_ui/src/routes/AssetVault/Components/ClaimFees.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/AssetVault/Components/ClaimFees.tsx
@@ -43,7 +43,7 @@ import {
 } from "@tari-project/ootle-ts-bindings";
 import { validatorsClaimFees, validatorsGetFees } from "@utils/json_rpc";
 import React, { useEffect, useState } from "react";
-import { Form } from "react-router-dom";
+import { Form } from "react-router";
 
 interface FormState {
   account: string | null;

--- a/applications/tari_walletd/web_ui/src/routes/AssetVault/Components/MyAssets.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/AssetVault/Components/MyAssets.tsx
@@ -33,7 +33,7 @@ import Transactions from "@routes/Transactions/Transactions";
 import useAccountStore from "@store/accountStore";
 import { substateIdToString } from "@tari-project/ootle-ts-bindings";
 import { useEffect } from "react";
-import { Navigate } from "react-router-dom";
+import { Navigate } from "react-router";
 import AccountDetails from "./AccountDetails";
 import ActionMenu from "./ActionMenu";
 import Assets from "./Assets";

--- a/applications/tari_walletd/web_ui/src/routes/AssetVault/Components/PublishTemplate.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/AssetVault/Components/PublishTemplate.tsx
@@ -42,7 +42,7 @@ import {
 } from "@tari-project/ootle-ts-bindings";
 import { base64FromArrayBuffer } from "@utils/helpers";
 import { FormEvent, useEffect, useState } from "react";
-import { Form } from "react-router-dom";
+import { Form } from "react-router";
 import { useFilePicker } from "use-file-picker";
 import { FileContent } from "use-file-picker/types";
 import { FileAmountLimitValidator, FileSizeValidator, FileTypeValidator } from "use-file-picker/validators";

--- a/applications/tari_walletd/web_ui/src/routes/AssetVault/Components/ResourceTypeChip.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/AssetVault/Components/ResourceTypeChip.tsx
@@ -27,6 +27,7 @@ import { ResourceType } from "@tari-project/ootle-ts-bindings";
 interface TypeChipProps {
   type: ResourceType;
   symbol?: string;
+  compact?: boolean;
 }
 
 const colourOptions: Record<ResourceType, string> = {
@@ -35,9 +36,14 @@ const colourOptions: Record<ResourceType, string> = {
   Confidential: "rgba(81,125,137, 0.3)",
   Stealth: "rgba(100,95,236, 0.3)",
 };
-export default function TypeChip({ type, symbol }: TypeChipProps) {
+export default function TypeChip({ type, symbol, compact = false }: TypeChipProps) {
   const label = (
-    <Typography variant="label">
+    <Typography
+      variant="label"
+      sx={{
+        fontSize: compact ? undefined : 12,
+      }}
+    >
       {symbol && (
         <>
           <strong>{symbol}</strong>
@@ -50,11 +56,10 @@ export default function TypeChip({ type, symbol }: TypeChipProps) {
   return (
     <Chip
       label={label}
-      size="small"
+      size={compact ? "small" : "medium"}
       style={{
         background: colourOptions[type],
-        padding: "2px",
-        height: 20,
+        height: compact ? 20 : undefined,
         userSelect: "none",
         maxWidth: "min-content",
       }}

--- a/applications/tari_walletd/web_ui/src/routes/AssetVault/Components/ResourceTypeChip.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/AssetVault/Components/ResourceTypeChip.tsx
@@ -1,9 +1,32 @@
+//  Copyright 2026. The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 import Chip from "@mui/material/Chip";
 import Typography from "@mui/material/Typography";
 import { ResourceType } from "@tari-project/ootle-ts-bindings";
 
 interface TypeChipProps {
   type: ResourceType;
+  symbol?: string;
 }
 
 const colourOptions: Record<ResourceType, string> = {
@@ -12,9 +35,23 @@ const colourOptions: Record<ResourceType, string> = {
   Confidential: "rgba(81,125,137, 0.3)",
   Stealth: "rgba(100,95,236, 0.3)",
 };
-export default function TypeChip({ type }: TypeChipProps) {
-  const label = <Typography variant="label">{type}</Typography>;
+export default function TypeChip({ type, symbol }: TypeChipProps) {
+  const label = (
+    <Typography variant="label">
+      {symbol && (
+        <>
+          <strong>{symbol}</strong>
+          &#x0020;&#x0020;&#x25CA;&#x0020;&#x0020;
+        </>
+      )}
+      {type}
+    </Typography>
+  );
   return (
-    <Chip label={label} size="small" style={{ background: colourOptions[type], padding: "2px 4px", height: 20, userSelect:'none'}} />
+    <Chip
+      label={label}
+      size="small"
+      style={{ background: colourOptions[type], padding: "2px", height: 20, userSelect: "none" }}
+    />
   );
 }

--- a/applications/tari_walletd/web_ui/src/routes/AssetVault/Components/ResourceTypeChip.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/AssetVault/Components/ResourceTypeChip.tsx
@@ -51,7 +51,13 @@ export default function TypeChip({ type, symbol }: TypeChipProps) {
     <Chip
       label={label}
       size="small"
-      style={{ background: colourOptions[type], padding: "2px", height: 20, userSelect: "none" }}
+      style={{
+        background: colourOptions[type],
+        padding: "2px",
+        height: 20,
+        userSelect: "none",
+        maxWidth: "min-content",
+      }}
     />
   );
 }

--- a/applications/tari_walletd/web_ui/src/routes/AssetVault/Components/ResourceTypeChip.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/AssetVault/Components/ResourceTypeChip.tsx
@@ -1,0 +1,20 @@
+import Chip from "@mui/material/Chip";
+import Typography from "@mui/material/Typography";
+import { ResourceType } from "@tari-project/ootle-ts-bindings";
+
+interface TypeChipProps {
+  type: ResourceType;
+}
+
+const colourOptions: Record<ResourceType, string> = {
+  Fungible: "rgba(129,59,245, 0.3)",
+  NonFungible: "rgba(58,157,160, 0.3)",
+  Confidential: "rgba(81,125,137, 0.3)",
+  Stealth: "rgba(100,95,236, 0.3)",
+};
+export default function TypeChip({ type }: TypeChipProps) {
+  const label = <Typography variant="label">{type}</Typography>;
+  return (
+    <Chip label={label} size="small" style={{ background: colourOptions[type], padding: "2px 4px", height: 20, userSelect:'none'}} />
+  );
+}

--- a/applications/tari_walletd/web_ui/src/routes/AssetVault/NFTs/NFTList.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/AssetVault/NFTs/NFTList.tsx
@@ -22,20 +22,18 @@
 
 import type { ApiError } from "@api/helpers/types";
 import FetchStatusCheck from "@components/FetchStatusCheck";
-import {
-  Button,
-  Grid,
-  IconButton,
-  Stack,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TablePagination,
-  TableRow,
-  Typography,
-} from "@mui/material";
+import Button from "@mui/material/Button";
+import Grid from "@mui/material/Grid";
+import IconButton from "@mui/material/IconButton";
+import Stack from "@mui/material/Stack";
+import Table from "@mui/material/Table";
+import TableBody from "@mui/material/TableBody";
+import TableCell from "@mui/material/TableCell";
+import TableContainer from "@mui/material/TableContainer";
+import TableHead from "@mui/material/TableHead";
+import TablePagination from "@mui/material/TablePagination";
+import TableRow from "@mui/material/TableRow";
+import Typography from "@mui/material/Typography";
 import type { ListNftsResponse, NonFungibleToken } from "@tari-project/ootle-ts-bindings";
 import React, { useState } from "react";
 import { IoApps, IoList } from "react-icons/io5";

--- a/applications/tari_walletd/web_ui/src/routes/AssetVault/NFTs/components/ClaimNftsButton.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/AssetVault/NFTs/components/ClaimNftsButton.tsx
@@ -23,6 +23,8 @@
 import { useMintTestnetFaucetNfts } from "@api/hooks/useAccounts";
 import queryClient from "@api/queryClient";
 import Button from "@mui/material/Button";
+import { useTheme } from "@mui/material/styles";
+import useMediaQuery from "@mui/material/useMediaQuery";
 import useAccountStore from "@store/accountStore";
 import { substateIdToString } from "@tari-project/ootle-ts-bindings";
 import { useErrorNotification } from "../../../../contexts/ErrorNotificationContext";
@@ -31,7 +33,8 @@ function ClaimNftsButton() {
   const { mutate: claimTestnetFaucetNfts, isPending } = useMintTestnetFaucetNfts();
   const account = useAccountStore((state) => state.account);
   const { showError, showSuccess } = useErrorNotification();
-
+  const theme = useTheme();
+  const isLg = useMediaQuery(theme.breakpoints.up("md"));
   if (!account) {
     return <></>;
   }
@@ -71,7 +74,12 @@ function ClaimNftsButton() {
   };
 
   return (
-    <Button variant="outlined" onClick={() => onClaimTestnetNfts()} disabled={isPending}>
+    <Button
+      variant="outlined"
+      onClick={() => onClaimTestnetNfts()}
+      disabled={isPending}
+      size={isLg ? "large" : "small"}
+    >
       {isPending ? "Claiming..." : "Claim Testnet NFTs"}
     </Button>
   );

--- a/applications/tari_walletd/web_ui/src/routes/AssetVault/NFTs/components/NftParts.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/AssetVault/NFTs/components/NftParts.tsx
@@ -125,7 +125,6 @@ function NftRow({ nft }: { nft: NonFungibleToken }) {
             style={{
               width: 60,
               height: 60,
-              borderRadius: "shape.borderRadius",
               backgroundColor: "grey.200",
             }}
             variant="rounded"

--- a/applications/tari_walletd/web_ui/src/routes/AssetVault/NFTs/components/NftParts.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/AssetVault/NFTs/components/NftParts.tsx
@@ -71,9 +71,7 @@ function NftCard({ nft }: { nft: NonFungibleToken }) {
 
           <Divider />
           <Typography variant="subtitle2">Vault:</Typography>
-          <Typography variant="body2" color="text.secondary" gutterBottom>
-            <CopyAddress address={nft.vault_id} display={shortenSubstateId(nft.vault_id)} />
-          </Typography>
+          <CopyAddress address={nft.vault_id} display={shortenSubstateId(nft.vault_id)} />
 
           <Divider />
           {data ? <NftData data={data} /> : null}
@@ -93,9 +91,7 @@ function NftData({ data }: { data: Record<string, any> }) {
         return (
           <Fragment key={i}>
             <Typography variant="subtitle2">{key}</Typography>
-            <Typography variant="body2" color="text.secondary" gutterBottom>
-              <CopyAddress address={String(value)} />
-            </Typography>
+            <CopyAddress address={String(value)} />
           </Fragment>
         );
       })}
@@ -140,20 +136,16 @@ function NftRow({ nft }: { nft: NonFungibleToken }) {
             <Typography variant="subtitle2" fontWeight="bold">
               {displayNftId(nft.nft_id)}
             </Typography>
-            <Typography variant="body2" color="text.secondary">
-              <CopyAddress address={nft.vault_id} display={shortenSubstateId(nft.vault_id)} />
-            </Typography>
+            <CopyAddress address={nft.vault_id} display={shortenSubstateId(nft.vault_id)} />
           </Box>
         </Box>
       </DataTableCell>
       <DataTableCell>
-        <Typography variant="body2">
-          {metadata.map(([key, value], index) => (
-            <div key={index}>
-              <strong>{key}:</strong> {value}
-            </div>
-          ))}
-        </Typography>
+        {metadata.map(([key, value]) => (
+          <Typography variant="body2" key={`meta_item_${key.slice(0, 4)}:${value}`}>
+            <strong>{key}:</strong> {value}
+          </Typography>
+        ))}
       </DataTableCell>
       <DataTableCell>
         <Chip

--- a/applications/tari_walletd/web_ui/src/routes/AssetVault/NFTs/components/NftParts.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/AssetVault/NFTs/components/NftParts.tsx
@@ -24,12 +24,15 @@ import CopyAddress from "@components/CopyAddress";
 import { NftCard as Card, DataTableCell } from "@components/StyledComponents";
 import CancelRoundedIcon from "@mui/icons-material/CancelRounded";
 import CheckCircleRoundedIcon from "@mui/icons-material/CheckCircleRounded";
-import { Avatar, Box, CardContent, CardMedia, Chip, Divider, Grid, TableRow, Typography } from "@mui/material";
+import { Avatar, Box, CardContent, CardMedia, Chip, Divider, Grid, Stack, TableRow, Typography } from "@mui/material";
 import type { NonFungibleToken } from "@tari-project/ootle-ts-bindings";
 import { convertCborValue } from "@utils/cbor";
 import { displayNftId, shortenSubstateId } from "@utils/helpers";
 import { Fragment } from "react/jsx-runtime";
 import SendNft from "./SendNft";
+
+const ERR_IMG =
+  "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzAwIiBoZWlnaHQ9IjIwMCIgdmlld0JveD0iMCAwIDMwMCAyMDAiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CjxyZWN0IHdpZHRoPSIzMDAiIGhlaWdodD0iMjAwIiBmaWxsPSIjRjVGNUY1Ii8+CjxwYXRoIGQ9Ik0xMjUgNzVIMTc1VjEyNUgxMjVWNzVaIiBmaWxsPSIjRERERUREIi8+CjxwYXRoIGQ9Ik0xNDAgOTBIMTYwVjExMEgxNDBWOTBaIiBmaWxsPSIjQkJCQkJCIi8+Cjx0ZXh0IHg9IjE1MCIgeT0iMTQwIiBmb250LWZhbWlseT0iQXJpYWwiIGZvbnQtc2l6ZT0iMTIiIGZpbGw9IiM5OTk5OTkiIHRleHQtYW5jaG9yPSJtaWRkbGUiPk5GVDwvdGV4dD4KPC9zdmc+";
 
 function NftCard({ nft }: { nft: NonFungibleToken }) {
   const mutableData = convertCborValue(nft.mutable_data);
@@ -44,17 +47,13 @@ function NftCard({ nft }: { nft: NonFungibleToken }) {
           height="200"
           image={imageUrl || "/api/placeholder/300/200"}
           alt={`NFT ${displayNftId(nft.nft_id)}`}
-          sx={{
-            objectFit: "cover",
-            backgroundColor: "grey.200",
-          }}
+          style={{ objectFit: "cover", backgroundColor: "grey.200" }}
           onError={(e: any) => {
-            e.target.src =
-              "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzAwIiBoZWlnaHQ9IjIwMCIgdmlld0JveD0iMCAwIDMwMCAyMDAiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CjxyZWN0IHdpZHRoPSIzMDAiIGhlaWdodD0iMjAwIiBmaWxsPSIjRjVGNUY1Ii8+CjxwYXRoIGQ9Ik0xMjUgNzVIMTc1VjEyNUgxMjVWNzVaIiBmaWxsPSIjRERERUREIi8+CjxwYXRoIGQ9Ik0xNDAgOTBIMTYwVjExMEgxNDBWOTBaIiBmaWxsPSIjQkJCQkJCIi8+Cjx0ZXh0IHg9IjE1MCIgeT0iMTQwIiBmb250LWZhbWlseT0iQXJpYWwiIGZvbnQtc2l6ZT0iMTIiIGZpbGw9IiM5OTk5OTkiIHRleHQtYW5jaG9yPSJtaWRkbGUiPk5GVDwvdGV4dD4KPC9zdmc+";
+            e.target.src = ERR_IMG;
           }}
         />
-        <CardContent sx={{ flexGrow: 1, display: "flex", flexDirection: "column", gap: 1 }}>
-          <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center", mb: 1 }}>
+        <CardContent style={{ flexGrow: 1, display: "flex", flexDirection: "column", gap: 8 }}>
+          <Box>
             <Typography variant="h6" component="h2" fontWeight="bold" noWrap>
               {displayNftId(nft.nft_id)}
             </Typography>
@@ -68,10 +67,11 @@ function NftCard({ nft }: { nft: NonFungibleToken }) {
               />
             )}
           </Box>
-
           <Divider />
-          <Typography variant="subtitle2">Vault:</Typography>
-          <CopyAddress address={nft.vault_id} display={shortenSubstateId(nft.vault_id)} />
+          <Stack>
+            <Typography variant="subtitle2">Vault:</Typography>
+            <CopyAddress address={nft.vault_id} display={shortenSubstateId(nft.vault_id)} />
+          </Stack>
 
           <Divider />
           {data ? <NftData data={data} /> : null}
@@ -122,10 +122,10 @@ function NftRow({ nft }: { nft: NonFungibleToken }) {
         <Box sx={{ display: "flex", alignItems: "center", gap: 2 }}>
           <Avatar
             src={imageUrl}
-            sx={{
+            style={{
               width: 60,
               height: 60,
-              borderRadius: 1,
+              borderRadius: "shape.borderRadius",
               backgroundColor: "grey.200",
             }}
             variant="rounded"

--- a/applications/tari_walletd/web_ui/src/routes/AssetVault/NFTs/steps/FormStep.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/AssetVault/NFTs/steps/FormStep.tsx
@@ -33,7 +33,7 @@ import type { Account, NonFungibleId, NonFungibleToken } from "@tari-project/oot
 import { validateOotleAddress } from "@tari-project/ootle-ts-bindings/dist/helpers/ootleAddress";
 import { displayNftId, substateIdToString } from "@utils/helpers";
 import { FormEvent } from "react";
-import { Form } from "react-router-dom";
+import { Form } from "react-router";
 
 interface FormStepProps {
   account: Account;

--- a/applications/tari_walletd/web_ui/src/routes/AssetVault/Tokens/Tokens.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/AssetVault/Tokens/Tokens.tsx
@@ -36,7 +36,7 @@ import Button from "@mui/material/Button";
 import TypeChip from "@routes/AssetVault/Components/ResourceTypeChip";
 import useAccountStore from "@store/accountStore";
 import { Account, Amount, BalanceEntry, ResourceAddress, ResourceType, VaultId } from "@tari-project/ootle-ts-bindings";
-import { bigintToDecimalString, shortenSubstateId, substateIdToString } from "@utils/helpers";
+import { bigintToDecimalString, shortenString, substateIdToString } from "@utils/helpers";
 import { useState } from "react";
 import { IoWalletOutline } from "react-icons/io5";
 import { useNavigate } from "react-router-dom";
@@ -84,12 +84,25 @@ function BalanceRow({
 }: BalanceRowProps) {
   const showBalance = useAccountStore((state) => state.showBalance);
   const navigate = useNavigate();
+  const stealthUXTOs = resource_type === "Stealth" && (
+    <Tooltip title="View Stealth UTXOs">
+      <Button
+        variant="outlined"
+        size="small"
+        endIcon={<IoWalletOutline />}
+        onClick={() => navigate(`/stealth-utxos/${resource_address}`)}
+      >
+        View
+      </Button>
+    </Tooltip>
+  );
+
   return (
     <TableRow key={token_symbol || resource_address}>
       <DataTableCell>{vault_address ? <CopyAddress address={vault_address} /> : "--"}</DataTableCell>
       <DataTableCell>
-        <TypeChip type={resource_type} />
-        <CopyAddress address={resource_address} display={`${token_symbol || shortenSubstateId(resource_address)}`} />
+        <TypeChip type={resource_type} symbol={token_symbol} />
+        <CopyAddress address={resource_address} display={shortenString(resource_address, 3, 6)} />
       </DataTableCell>
       <DataTableCell>
         {showBalance ? bigintToDecimalString(balance, divisibility) + " " + token_symbol : "*************"}
@@ -108,18 +121,7 @@ function BalanceRow({
           <Button size="small" variant="outlined" onClick={() => onSendClicked?.(resource_address, resource_type)}>
             Send
           </Button>
-          {resource_type === "Stealth" && (
-            <Tooltip title="View Stealth UTXOs">
-              <Button
-                variant="outlined"
-                size="small"
-                endIcon={<IoWalletOutline />}
-                onClick={() => navigate(`/stealth-utxos/${resource_address}`)}
-              >
-                View
-              </Button>
-            </Tooltip>
-          )}
+          {stealthUXTOs}
         </Stack>
       </DataTableCell>
     </TableRow>

--- a/applications/tari_walletd/web_ui/src/routes/AssetVault/Tokens/Tokens.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/AssetVault/Tokens/Tokens.tsx
@@ -117,7 +117,7 @@ function BalanceRow({
             address={resource_address}
             display={shortenString(resource_address, isLg ? 3 : 1, isLg ? 6 : 4)}
           />
-          <TypeChip type={resource_type} symbol={token_symbol} />
+          <TypeChip type={resource_type} symbol={token_symbol} compact />
         </Stack>
       </FluidTableCell>
       <FluidTableCell align="right">

--- a/applications/tari_walletd/web_ui/src/routes/AssetVault/Tokens/Tokens.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/AssetVault/Tokens/Tokens.tsx
@@ -33,6 +33,7 @@ import { useAccountsGetBalances } from "@api/hooks/useAccounts";
 import FetchStatusCheck from "@components/FetchStatusCheck";
 import { DataTableCell } from "@components/StyledComponents";
 import Button from "@mui/material/Button";
+import TypeChip from "@routes/AssetVault/Components/ResourceTypeChip";
 import useAccountStore from "@store/accountStore";
 import { Account, Amount, BalanceEntry, ResourceAddress, ResourceType, VaultId } from "@tari-project/ootle-ts-bindings";
 import { bigintToDecimalString, shortenSubstateId, substateIdToString } from "@utils/helpers";
@@ -87,10 +88,8 @@ function BalanceRow({
     <TableRow key={token_symbol || resource_address}>
       <DataTableCell>{vault_address ? <CopyAddress address={vault_address} /> : "--"}</DataTableCell>
       <DataTableCell>
-        <CopyAddress
-          address={resource_address}
-          display={`${token_symbol || shortenSubstateId(resource_address)} ${resource_type}`}
-        />
+        <TypeChip type={resource_type} />
+        <CopyAddress address={resource_address} display={`${token_symbol || shortenSubstateId(resource_address)}`} />
       </DataTableCell>
       <DataTableCell>
         {showBalance ? bigintToDecimalString(balance, divisibility) + " " + token_symbol : "*************"}

--- a/applications/tari_walletd/web_ui/src/routes/AssetVault/Tokens/Tokens.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/AssetVault/Tokens/Tokens.tsx
@@ -41,7 +41,7 @@ import { Account, Amount, BalanceEntry, ResourceAddress, ResourceType, VaultId }
 import { bigintToDecimalString, shortenString, substateIdToString } from "@utils/helpers";
 import { useState } from "react";
 import { IoWalletOutline } from "react-icons/io5";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import ClaimCoinsButton from "./components/ClaimCoinsButton";
 import { SendMoneyDialog } from "./components/SendMoney";
 

--- a/applications/tari_walletd/web_ui/src/routes/AssetVault/Tokens/Tokens.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/AssetVault/Tokens/Tokens.tsx
@@ -31,8 +31,10 @@ import TableRow from "@mui/material/TableRow";
 
 import { useAccountsGetBalances } from "@api/hooks/useAccounts";
 import FetchStatusCheck from "@components/FetchStatusCheck";
-import { DataTableCell } from "@components/StyledComponents";
+import { FluidTableCell } from "@components/StyledComponents";
 import Button from "@mui/material/Button";
+import { useTheme } from "@mui/material/styles";
+import useMediaQuery from "@mui/material/useMediaQuery";
 import TypeChip from "@routes/AssetVault/Components/ResourceTypeChip";
 import useAccountStore from "@store/accountStore";
 import { Account, Amount, BalanceEntry, ResourceAddress, ResourceType, VaultId } from "@tari-project/ootle-ts-bindings";
@@ -66,7 +68,7 @@ function ConfidentialBalance({ show, resourceType, balance, divisibility, token_
   switch (resourceType) {
     case "Confidential":
     case "Stealth":
-      return <>{show ? bigintToDecimalString(balance, divisibility) + " " + token_symbol : "**************"}</>;
+      return <>{show ? bigintToDecimalString(balance, divisibility) + " " + token_symbol : "********"}</>;
     default:
       return <>--</>;
   }
@@ -82,8 +84,11 @@ function BalanceRow({
   divisibility,
   onSendClicked,
 }: BalanceRowProps) {
-  const showBalance = useAccountStore((state) => state.showBalance);
+  const theme = useTheme();
   const navigate = useNavigate();
+  const isLg = useMediaQuery(theme.breakpoints.up("md"));
+  const showBalance = useAccountStore((state) => state.showBalance);
+
   const stealthUXTOs = resource_type === "Stealth" && (
     <Tooltip title="View Stealth UTXOs">
       <Button
@@ -99,15 +104,26 @@ function BalanceRow({
 
   return (
     <TableRow key={token_symbol || resource_address}>
-      <DataTableCell>{vault_address ? <CopyAddress address={vault_address} /> : "--"}</DataTableCell>
-      <DataTableCell>
-        <TypeChip type={resource_type} symbol={token_symbol} />
-        <CopyAddress address={resource_address} display={shortenString(resource_address, 3, 6)} />
-      </DataTableCell>
-      <DataTableCell>
-        {showBalance ? bigintToDecimalString(balance, divisibility) + " " + token_symbol : "*************"}
-      </DataTableCell>
-      <DataTableCell>
+      <FluidTableCell>{vault_address ? <CopyAddress address={vault_address} /> : "--"}</FluidTableCell>
+      <FluidTableCell>
+        <Stack
+          direction={{
+            xs: "column-reverse",
+            md: "row",
+          }}
+          gap={isLg ? 1 : 0.3}
+        >
+          <CopyAddress
+            address={resource_address}
+            display={shortenString(resource_address, isLg ? 3 : 1, isLg ? 6 : 4)}
+          />
+          <TypeChip type={resource_type} symbol={token_symbol} />
+        </Stack>
+      </FluidTableCell>
+      <FluidTableCell align="right">
+        {showBalance ? `${bigintToDecimalString(balance, divisibility)} ${token_symbol}` : "********"}
+      </FluidTableCell>
+      <FluidTableCell align="right">
         <ConfidentialBalance
           show={showBalance}
           resourceType={resource_type}
@@ -115,20 +131,22 @@ function BalanceRow({
           divisibility={divisibility}
           token_symbol={token_symbol}
         />
-      </DataTableCell>
-      <DataTableCell>
-        <Stack direction="row" gap={1}>
+      </FluidTableCell>
+      <FluidTableCell align="right">
+        <Stack direction="row" gap={1} justifyContent="flex-end">
           <Button size="small" variant="outlined" onClick={() => onSendClicked?.(resource_address, resource_type)}>
             Send
           </Button>
           {stealthUXTOs}
         </Stack>
-      </DataTableCell>
+      </FluidTableCell>
     </TableRow>
   );
 }
 
 function Tokens({ account }: { account: Account }) {
+  const theme = useTheme();
+  const isLg = useMediaQuery(theme.breakpoints.up("md"));
   const [resourceToSend, setResourceToSend] = useState<{
     address: ResourceAddress;
     resource_type: ResourceType;
@@ -195,11 +213,15 @@ function Tokens({ account }: { account: Account }) {
               <Table>
                 <TableHead>
                   <TableRow>
-                    <TableCell>Vault</TableCell>
-                    <TableCell>Resource</TableCell>
-                    <TableCell>Revealed Balance</TableCell>
-                    <TableCell>Confidential Balance</TableCell>
-                    <TableCell></TableCell>
+                    <TableCell size="small">Vault</TableCell>
+                    <TableCell size="small">Resource</TableCell>
+                    <TableCell size="small" align="right">
+                      Revealed Balance
+                    </TableCell>
+                    <TableCell size="small" align="right">
+                      Confidential Balance
+                    </TableCell>
+                    <TableCell size="small" align="right"></TableCell>
                   </TableRow>
                 </TableHead>
                 <TableBody>

--- a/applications/tari_walletd/web_ui/src/routes/AssetVault/Tokens/components/ClaimCoinsButton.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/AssetVault/Tokens/components/ClaimCoinsButton.tsx
@@ -24,6 +24,8 @@ import { useErrorNotification } from "@/contexts/ErrorNotificationContext";
 import { useAccountsCreateFreeTestCoins } from "@api/hooks/useAccounts";
 import queryClient from "@api/queryClient";
 import Button from "@mui/material/Button";
+import { useTheme } from "@mui/material/styles";
+import useMediaQuery from "@mui/material/useMediaQuery";
 import useAccountStore from "@store/accountStore";
 import { AccountsCreateFreeTestCoinsResponse, substateIdToString } from "@tari-project/ootle-ts-bindings";
 
@@ -31,6 +33,9 @@ function ClaimCoinsButton() {
   const { mutate: claimTestnetFaucetFunds, isPending } = useAccountsCreateFreeTestCoins();
   const { account, setAccount, setOotleAddress } = useAccountStore();
   const { showError, showSuccess } = useErrorNotification();
+
+  const theme = useTheme();
+  const isLg = useMediaQuery(theme.breakpoints.up("md"));
 
   if (!account) {
     return <></>;
@@ -68,7 +73,7 @@ function ClaimCoinsButton() {
   };
 
   return (
-    <Button variant="outlined" onClick={() => onClaimFreeCoins()} disabled={isPending}>
+    <Button variant="outlined" onClick={() => onClaimFreeCoins()} disabled={isPending} size={isLg ? "large" : "small"}>
       {isPending ? "Claiming..." : "Claim Testnet Funds"}
     </Button>
   );

--- a/applications/tari_walletd/web_ui/src/routes/AssetVault/Tokens/components/SendMoney.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/AssetVault/Tokens/components/SendMoney.tsx
@@ -38,7 +38,7 @@ import {
 } from "@tari-project/ootle-ts-bindings";
 import { parseAmountToBaseUnits } from "@utils/helpers";
 import { transactionsWaitResult } from "@utils/json_rpc";
-import { SubmitEvent, useState } from "react";
+import { FormEvent, useState } from "react";
 import ConfirmationStep from "../steps/ConfirmationStep";
 import FormStep, { FormError, SendMoneyFormState } from "../steps/FormStep";
 import ResultStep, { TransferResult } from "../steps/ResultStep";
@@ -238,7 +238,7 @@ export function SendMoneyDialog(props: SendMoneyDialogProps) {
     }
   };
 
-  const handleFormSubmit = async (e: SubmitEvent) => {
+  const handleFormSubmit = async (e: FormEvent) => {
     e.preventDefault();
     if (!account) {
       return;

--- a/applications/tari_walletd/web_ui/src/routes/AssetVault/Tokens/components/SendMoney.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/AssetVault/Tokens/components/SendMoney.tsx
@@ -377,7 +377,7 @@ export function SendMoneyDialog(props: SendMoneyDialogProps) {
 
   return (
     <Dialog open={props.open} onClose={handleClose} maxWidth="md" fullWidth>
-      <PopupTitle onClose={handleClose} title="Send Tari" />
+      <PopupTitle onClose={handleClose} title="Send Funds" />
       <DialogContent>{renderStepContent()}</DialogContent>
     </Dialog>
   );

--- a/applications/tari_walletd/web_ui/src/routes/AssetVault/Tokens/components/SendMoney.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/AssetVault/Tokens/components/SendMoney.tsx
@@ -38,7 +38,7 @@ import {
 } from "@tari-project/ootle-ts-bindings";
 import { parseAmountToBaseUnits } from "@utils/helpers";
 import { transactionsWaitResult } from "@utils/json_rpc";
-import { FormEvent, useState } from "react";
+import { SubmitEvent, useState } from "react";
 import ConfirmationStep from "../steps/ConfirmationStep";
 import FormStep, { FormError, SendMoneyFormState } from "../steps/FormStep";
 import ResultStep, { TransferResult } from "../steps/ResultStep";
@@ -238,7 +238,7 @@ export function SendMoneyDialog(props: SendMoneyDialogProps) {
     }
   };
 
-  const handleFormSubmit = async (e: FormEvent) => {
+  const handleFormSubmit = async (e: SubmitEvent) => {
     e.preventDefault();
     if (!account) {
       return;

--- a/applications/tari_walletd/web_ui/src/routes/AssetVault/Tokens/steps/ConfirmationStep.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/AssetVault/Tokens/steps/ConfirmationStep.tsx
@@ -51,7 +51,7 @@ export default function ConfirmationStep({
     <Stack spacing={3} sx={{ py: 2 }}>
       <Stack spacing={2}>
         <Box>
-          <Typography variant="h6" color="text.primary" gutterBottom>
+          <Typography variant="h5" color="text.primary" gutterBottom>
             You are about to send:
           </Typography>
         </Box>
@@ -77,9 +77,7 @@ export default function ConfirmationStep({
           <Typography variant="subtitle2" color="text.secondary">
             To Address:
           </Typography>
-          <Typography variant="body1">
-            <CopyAddress address={transferFormState.address} />
-          </Typography>
+          <CopyAddress address={transferFormState.address} />
         </Box>
 
         <Box>

--- a/applications/tari_walletd/web_ui/src/routes/AssetVault/Tokens/steps/FormStep.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/AssetVault/Tokens/steps/FormStep.tsx
@@ -32,7 +32,7 @@ import TypeChip from "@routes/AssetVault/Components/ResourceTypeChip";
 import { Amount, ResourceAddress, ResourceType, validateOotleAddress } from "@tari-project/ootle-ts-bindings";
 import { XTR_CURRENCY } from "@utils/currency";
 import { formatCurrency, parseAmountToBaseUnits } from "@utils/helpers";
-import { SubmitEvent, useState } from "react";
+import { FormEvent, useState } from "react";
 import { Form } from "react-router";
 
 export interface SendMoneyFormState {
@@ -57,7 +57,7 @@ interface FormStepProps {
   token_symbol: string;
   divisibility: number;
   formError?: FormError | null;
-  onSubmit: (e: SubmitEvent) => void;
+  onSubmit: (e: FormEvent) => void;
   onCancel: () => void;
   onFormValueChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onSelectFormValueChange: (e: SelectChangeEvent<unknown>) => void;
@@ -123,6 +123,7 @@ export default function FormStep({
       maximumFractionDigits: divisibility,
     });
   };
+
   const currency = {
     symbol: token_symbol,
     decimals: divisibility,

--- a/applications/tari_walletd/web_ui/src/routes/AssetVault/Tokens/steps/FormStep.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/AssetVault/Tokens/steps/FormStep.tsx
@@ -20,19 +20,20 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, SUCH DAMAGE.
 
+import CopyAddress from "@components/CopyAddress";
 import { Divider, InputAdornment, InputLabel, Stack, Typography } from "@mui/material";
 import Button from "@mui/material/Button";
 import CheckBox from "@mui/material/Checkbox";
 import FormControlLabel from "@mui/material/FormControlLabel";
 import MenuItem from "@mui/material/MenuItem";
-import Select from "@mui/material/Select";
-import { SelectChangeEvent } from "@mui/material/Select";
+import Select, { SelectChangeEvent } from "@mui/material/Select";
 import TextField from "@mui/material/TextField";
+import TypeChip from "@routes/AssetVault/Components/ResourceTypeChip";
 import { Amount, ResourceAddress, ResourceType, validateOotleAddress } from "@tari-project/ootle-ts-bindings";
 import { XTR_CURRENCY } from "@utils/currency";
 import { formatCurrency, parseAmountToBaseUnits } from "@utils/helpers";
-import { FormEvent, useState } from "react";
-import { Form } from "react-router-dom";
+import { SubmitEvent, useState } from "react";
+import { Form } from "react-router";
 
 export interface SendMoneyFormState {
   address: string;
@@ -56,7 +57,7 @@ interface FormStepProps {
   token_symbol: string;
   divisibility: number;
   formError?: FormError | null;
-  onSubmit: (e: FormEvent) => void;
+  onSubmit: (e: SubmitEvent) => void;
   onCancel: () => void;
   onFormValueChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onSelectFormValueChange: (e: SelectChangeEvent<unknown>) => void;
@@ -122,7 +123,6 @@ export default function FormStep({
       maximumFractionDigits: divisibility,
     });
   };
-
   const currency = {
     symbol: token_symbol,
     decimals: divisibility,
@@ -130,13 +130,11 @@ export default function FormStep({
 
   return (
     <Form onSubmit={onSubmit}>
-      <Stack direction="column" spacing={2} sx={{ py: 2 }}>
+      <Stack direction="column" spacing={2}>
         {resource_address && (
-          <Stack direction="column" spacing={0.5}>
-            <Typography variant="subtitle2" color="text.secondary">
-              Resource Address:
-            </Typography>
-            <Typography variant="body1">{resource_address}</Typography>
+          <Stack direction="row" spacing={1} alignItems="center">
+            <TypeChip type={resource_type} symbol={token_symbol} />
+            <CopyAddress address={resource_address} />
           </Stack>
         )}
 
@@ -203,7 +201,9 @@ export default function FormStep({
               <TextField
                 name="memo"
                 label="Memo message (optional, max 253 characters)"
-                inputProps={{ maxLength: 253 }}
+                slotProps={{
+                  htmlInput: { maxLength: 253 },
+                }}
                 value={transferFormState.memo}
                 onChange={onFormValueChange}
                 style={{ flexGrow: 1 }}
@@ -239,6 +239,7 @@ export default function FormStep({
           style={{ flexGrow: 1 }}
           disabled={disabled}
           error={hasInsufficientFunds}
+          placeholder={"0" + (divisibility > 0 ? "." + "0".repeat(divisibility) : "")}
           helperText={
             hasInsufficientFunds
               ? `Insufficient funds. Available balance: ${formatCurrency(availableBalance || 0, currency)}`
@@ -246,9 +247,10 @@ export default function FormStep({
                 ? `Available balance: ${formatCurrency(availableBalance, currency)}`
                 : undefined
           }
-          InputProps={{
-            placeholder: "0" + (divisibility > 0 ? "." + "0".repeat(divisibility) : ""),
-            endAdornment: token_symbol ? <InputAdornment position="end">{token_symbol}</InputAdornment> : undefined,
+          slotProps={{
+            input: {
+              endAdornment: token_symbol ? <InputAdornment position="end">{token_symbol}</InputAdornment> : undefined,
+            },
           }}
         />
 
@@ -259,11 +261,13 @@ export default function FormStep({
           placeholder={isEstimatingFee ? "Estimating..." : "Auto-calculated"}
           onChange={onFormValueChange}
           style={{ flexGrow: 1 }}
-          InputProps={{
-            endAdornment:
-              !isEstimatingFee && token_symbol ? (
-                <InputAdornment position="end">µ{XTR_CURRENCY.symbol}</InputAdornment>
-              ) : null,
+          slotProps={{
+            input: {
+              endAdornment:
+                !isEstimatingFee && token_symbol ? (
+                  <InputAdornment position="end">µ{XTR_CURRENCY.symbol}</InputAdornment>
+                ) : null,
+            },
           }}
         />
 

--- a/applications/tari_walletd/web_ui/src/routes/ErrorPage.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/ErrorPage.tsx
@@ -23,7 +23,7 @@
 import { StyledPaper } from "@components/StyledComponents";
 import Grid from "@mui/material/Grid";
 import Typography from "@mui/material/Typography";
-import { isRouteErrorResponse, useRouteError } from "react-router-dom";
+import { isRouteErrorResponse, useRouteError } from "react-router";
 
 export default function ErrorPage() {
   let error: any = useRouteError();

--- a/applications/tari_walletd/web_ui/src/routes/Onboarding/Onboarding.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/Onboarding/Onboarding.tsx
@@ -30,7 +30,7 @@ import Typography from "@mui/material/Typography";
 import { useTheme } from "@mui/material/styles";
 import useAccountStore from "@store/accountStore";
 import { FormEvent, useEffect, useState } from "react";
-import { Form, Navigate } from "react-router-dom";
+import { Form, Navigate } from "react-router";
 
 function Onboarding() {
   const { mutate, isPending } = useAccountsCreate();

--- a/applications/tari_walletd/web_ui/src/routes/Settings/Components/IndexerSettings.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/Settings/Components/IndexerSettings.tsx
@@ -27,7 +27,7 @@ import TextField from "@mui/material/TextField";
 import Typography from "@mui/material/Typography";
 import { settingsGet, settingsSet } from "@utils/json_rpc";
 import React, { useEffect, useState } from "react";
-import { Form } from "react-router-dom";
+import { Form } from "react-router";
 
 function IndexerSettings() {
   // Keep the form and settings in the same format as the real settings in the wallet.

--- a/applications/tari_walletd/web_ui/src/routes/StealthUtxoList/StealthUtxoList.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/StealthUtxoList/StealthUtxoList.tsx
@@ -26,7 +26,7 @@ import {
   substateIdToString,
 } from "@utils/helpers";
 import { useState } from "react";
-import { useParams } from "react-router-dom";
+import { useParams } from "react-router";
 import PlaceHolder from "./components/PlaceHolder";
 import SortableHeader from "./components/SortableHeader";
 import StatusChip from "./components/StatusChip";

--- a/applications/tari_walletd/web_ui/src/routes/Transactions/TimeChip.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/Transactions/TimeChip.tsx
@@ -32,13 +32,7 @@ function TimeChip({ timestamp }: { timestamp: string | null | undefined }) {
 
   return (
     <Tooltip title={`Created at: ${formattedTime}`} placement="top" arrow>
-      <Chip
-        label={timeAgo}
-        color="default"
-        size="small"
-        variant="filled"
-        sx={{ padding: "2px 4px 0px 4px", marginTop: "4px" }}
-      />
+      <Chip label={timeAgo} color="default" size="small" variant="filled" style={{ maxWidth: 100 }} />
     </Tooltip>
   );
 }

--- a/applications/tari_walletd/web_ui/src/routes/Transactions/TimeChip.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/Transactions/TimeChip.tsx
@@ -31,10 +31,10 @@ function TimeChip({ timestamp }: { timestamp: string | null | undefined }) {
 
   if (!timeAgo) return null;
 
-  const label = <Typography variant="overline">{timeAgo}</Typography>;
+  const label = <Typography variant="label">{timeAgo}</Typography>;
   return (
     <Tooltip title={`Created at: ${formattedTime}`} placement="top" arrow>
-      <Chip label={label} color="default" size="small" variant="filled" />
+      <Chip label={label} color="default" size="small" variant="filled" style={{ paddingLeft: 2, paddingRight: 2 }} />
     </Tooltip>
   );
 }

--- a/applications/tari_walletd/web_ui/src/routes/Transactions/TimeChip.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/Transactions/TimeChip.tsx
@@ -22,6 +22,7 @@
 
 import { useTimeAgo } from "@hooks/useTimeAgo";
 import { Chip, Tooltip } from "@mui/material";
+import Typography from "@mui/material/Typography";
 import { formatTimestamp } from "@utils/helpers";
 
 function TimeChip({ timestamp }: { timestamp: string | null | undefined }) {
@@ -30,9 +31,10 @@ function TimeChip({ timestamp }: { timestamp: string | null | undefined }) {
 
   if (!timeAgo) return null;
 
+  const label = <Typography variant="overline">{timeAgo}</Typography>;
   return (
     <Tooltip title={`Created at: ${formattedTime}`} placement="top" arrow>
-      <Chip label={timeAgo} color="default" size="small" variant="filled" style={{ maxWidth: 100 }} />
+      <Chip label={label} color="default" size="small" variant="filled" />
     </Tooltip>
   );
 }

--- a/applications/tari_walletd/web_ui/src/routes/Transactions/TransactionDetails.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/Transactions/TransactionDetails.tsx
@@ -53,7 +53,7 @@ import { XTR_CURRENCY } from "@utils/currency";
 import { saveAs } from "file-saver";
 import { useState } from "react";
 import { BsQuestionCircle } from "react-icons/bs";
-import { useParams } from "react-router-dom";
+import { useParams } from "react-router";
 import Events from "./Events";
 import ExecutionResults from "./ExecutionResults";
 import FeeReceipt from "./FeeReceipt";

--- a/applications/tari_walletd/web_ui/src/routes/Transactions/Transactions.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/Transactions/Transactions.tsx
@@ -74,10 +74,10 @@ export default function Transactions({ account: _ }: TransactionsProps) {
           <Table>
             <TableHead>
               <TableRow>
-                <TableCell>Transaction Hash</TableCell>
-                <TableCell>Status</TableCell>
-                <TableCell>Total Fees</TableCell>
-                <TableCell>Details</TableCell>
+                <TableCell size="small">Transaction Hash</TableCell>
+                <TableCell size="small">Status</TableCell>
+                <TableCell size="small">Total Fees</TableCell>
+                <TableCell size="small">Details</TableCell>
               </TableRow>
             </TableHead>
             <TableBody>

--- a/applications/tari_walletd/web_ui/src/routes/Transactions/Transactions.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/Transactions/Transactions.tsx
@@ -74,10 +74,10 @@ export default function Transactions({ account: _ }: TransactionsProps) {
           <Table>
             <TableHead>
               <TableRow>
-                <TableCell size="small">Transaction Hash</TableCell>
-                <TableCell size="small">Status</TableCell>
-                <TableCell size="small">Total Fees</TableCell>
-                <TableCell size="small">Details</TableCell>
+                <TableCell size="medium">Transaction Hash</TableCell>
+                <TableCell size="medium">Status</TableCell>
+                <TableCell size="medium">Total Fees</TableCell>
+                <TableCell size="medium">Details</TableCell>
               </TableRow>
             </TableHead>
             <TableBody>

--- a/applications/tari_walletd/web_ui/src/routes/Transactions/Transactions.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/Transactions/Transactions.tsx
@@ -25,19 +25,17 @@ import FetchStatusCheck from "@components/FetchStatusCheck";
 import { DataTableCell } from "@components/StyledComponents";
 import TransactionsStatusChip from "@components/TransactionsStatusChip";
 import { ChevronRight } from "@mui/icons-material";
-import {
-  Fade,
-  IconButton,
-  Stack,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TablePagination,
-  TableRow,
-} from "@mui/material";
+import { Stack } from "@mui/material";
+import Fade from "@mui/material/Fade";
+import IconButton from "@mui/material/IconButton";
 import { useTheme } from "@mui/material/styles";
+import Table from "@mui/material/Table";
+import TableBody from "@mui/material/TableBody";
+import TableCell from "@mui/material/TableCell";
+import TableContainer from "@mui/material/TableContainer";
+import TableHead from "@mui/material/TableHead";
+import TablePagination from "@mui/material/TablePagination";
+import TableRow from "@mui/material/TableRow";
 import { Account, WalletTransaction } from "@tari-project/ootle-ts-bindings";
 import { XTR_CURRENCY } from "@utils/currency";
 import { emptyRows, formatCurrency, handleChangePage, handleChangeRowsPerPage } from "@utils/helpers";
@@ -45,7 +43,10 @@ import { useState } from "react";
 import { Link } from "react-router-dom";
 import TimeChip from "./TimeChip";
 
-export default function Transactions(_props: { account: Account }) {
+interface TransactionsProps {
+  account?: Account;
+}
+export default function Transactions({ account: _ }: TransactionsProps) {
   const [page, setPage] = useState(0);
   const [rowsPerPage, setRowsPerPage] = useState(10);
   const { data, isLoading, error, isError, isRefetching } = useGetAllTransactions({
@@ -85,11 +86,20 @@ export default function Transactions(_props: { account: Account }) {
                   return (
                     <TableRow key={hash}>
                       <DataTableCell>
-                        <Stack direction="row" spacing={2} alignItems="center">
+                        <Stack
+                          direction={{
+                            sm: "column",
+                            md: "row",
+                          }}
+                          spacing={2}
+                          style={{ maxWidth: `max(400px, max(90%, 600px))` }}
+                        >
                           <Link
                             to={`/transactions/${hash}`}
                             style={{
                               textDecoration: "none",
+                              wordBreak: "break-word",
+                              minWidth: `300px`,
                               color: theme.palette.text.secondary,
                             }}
                           >

--- a/applications/tari_walletd/web_ui/src/routes/Transactions/Transactions.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/Transactions/Transactions.tsx
@@ -36,9 +36,10 @@ import TableContainer from "@mui/material/TableContainer";
 import TableHead from "@mui/material/TableHead";
 import TablePagination from "@mui/material/TablePagination";
 import TableRow from "@mui/material/TableRow";
+import useMediaQuery from "@mui/material/useMediaQuery";
 import { Account, WalletTransaction } from "@tari-project/ootle-ts-bindings";
 import { XTR_CURRENCY } from "@utils/currency";
-import { emptyRows, formatCurrency, handleChangePage, handleChangeRowsPerPage } from "@utils/helpers";
+import { emptyRows, formatCurrency, handleChangePage, handleChangeRowsPerPage, shortenString } from "@utils/helpers";
 import { useState } from "react";
 import { Link } from "react-router-dom";
 import TimeChip from "./TimeChip";
@@ -59,7 +60,9 @@ export default function Transactions({ account: _ }: TransactionsProps) {
   });
 
   const theme = useTheme();
+  const isSm = useMediaQuery(theme.breakpoints.down("sm"));
 
+  const shortLen = isSm ? 4 : 6;
   return (
     <FetchStatusCheck
       isLoading={isLoading && !isRefetching}
@@ -88,28 +91,25 @@ export default function Transactions({ account: _ }: TransactionsProps) {
                       <DataTableCell>
                         <Stack
                           direction={{
-                            sm: "column",
-                            md: "row",
+                            xs: "column",
+                            sm: "row",
                           }}
-                          spacing={2}
-                          style={{ maxWidth: `max(400px, max(90%, 600px))` }}
+                          spacing={isSm ? 0.1 : 1.5}
                         >
                           <Link
                             to={`/transactions/${hash}`}
                             style={{
                               textDecoration: "none",
-                              wordBreak: "break-word",
-                              minWidth: `300px`,
                               color: theme.palette.text.secondary,
                             }}
                           >
-                            {hash}
+                            {shortenString(hash, shortLen, shortLen)}
                           </Link>
                           <TimeChip timestamp={transaction.last_update_time} />
                         </Stack>
                       </DataTableCell>
                       <DataTableCell>
-                        <TransactionsStatusChip status={status} showTitle />
+                        <TransactionsStatusChip status={status} />
                       </DataTableCell>
                       <DataTableCell>
                         {fee_receipt?.total_fees_paid

--- a/applications/tari_walletd/web_ui/src/routes/Transactions/Transactions.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/Transactions/Transactions.tsx
@@ -41,7 +41,7 @@ import { Account, WalletTransaction } from "@tari-project/ootle-ts-bindings";
 import { XTR_CURRENCY } from "@utils/currency";
 import { emptyRows, formatCurrency, handleChangePage, handleChangeRowsPerPage, shortenString } from "@utils/helpers";
 import { useState } from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import TimeChip from "./TimeChip";
 
 interface TransactionsProps {

--- a/applications/tari_walletd/web_ui/src/routes/Wallet/Components/Accounts.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/Wallet/Components/Accounts.tsx
@@ -39,7 +39,7 @@ import TableRow from "@mui/material/TableRow";
 import TextField from "@mui/material/TextField";
 import { AccountInfo, shortenSubstateId, substateIdToString } from "@tari-project/ootle-ts-bindings";
 import { useState } from "react";
-import { Form, Link } from "react-router-dom";
+import { Form, Link } from "react-router";
 
 function Account({ account }: { account: AccountInfo }) {
   const {

--- a/applications/tari_walletd/web_ui/src/routes/Wallet/Components/Keys.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/Wallet/Components/Keys.tsx
@@ -34,7 +34,7 @@ import TableHead from "@mui/material/TableHead";
 import TableRow from "@mui/material/TableRow";
 import { KeyId } from "@tari-project/ootle-ts-bindings";
 import { useState } from "react";
-import { Form } from "react-router-dom";
+import { Form } from "react-router";
 
 function Key([keyId, pk, active]: [KeyId, string, boolean], setActive: (key_id: KeyId) => void) {
   const rowKey =

--- a/applications/tari_walletd/web_ui/src/theme/LayoutMain.tsx
+++ b/applications/tari_walletd/web_ui/src/theme/LayoutMain.tsx
@@ -47,7 +47,7 @@ import useThemeStore from "@store/themeStore";
 import { lightAlpha } from "@theme/colors";
 import { componentSettings, dark, light } from "@theme/tokens";
 import { useState } from "react";
-import { Link, Outlet } from "react-router-dom";
+import { Link, Outlet } from "react-router";
 import "./theme.css";
 
 const DRAWER_WIDTH = 300;

--- a/applications/tari_walletd/web_ui/src/theme/augmentation.ts
+++ b/applications/tari_walletd/web_ui/src/theme/augmentation.ts
@@ -36,4 +36,13 @@ declare module "@mui/material/styles" {
       border?: string;
     };
   }
+
+  interface TypographyVariants {
+    poster: React.CSSProperties;
+  }
+
+  // allow configuration using `createTheme()`
+  interface TypographyVariantsOptions {
+    poster?: React.CSSProperties;
+  }
 }

--- a/applications/tari_walletd/web_ui/src/theme/augmentation.ts
+++ b/applications/tari_walletd/web_ui/src/theme/augmentation.ts
@@ -38,11 +38,17 @@ declare module "@mui/material/styles" {
   }
 
   interface TypographyVariants {
-    poster: React.CSSProperties;
+    label: React.CSSProperties;
   }
 
   // allow configuration using `createTheme()`
   interface TypographyVariantsOptions {
-    poster?: React.CSSProperties;
+    label?: React.CSSProperties;
+  }
+}
+
+declare module "@mui/material/Typography" {
+  interface TypographyPropsVariantOverrides {
+    label: true;
   }
 }

--- a/applications/tari_walletd/web_ui/src/theme/augmentation.ts
+++ b/applications/tari_walletd/web_ui/src/theme/augmentation.ts
@@ -39,16 +39,19 @@ declare module "@mui/material/styles" {
 
   interface TypographyVariants {
     label: React.CSSProperties;
+    span: React.CSSProperties;
   }
 
   // allow configuration using `createTheme()`
   interface TypographyVariantsOptions {
     label?: React.CSSProperties;
+    span?: React.CSSProperties;
   }
 }
 
 declare module "@mui/material/Typography" {
   interface TypographyPropsVariantOverrides {
     label: true;
+    span: true;
   }
 }

--- a/applications/tari_walletd/web_ui/src/theme/theme.css
+++ b/applications/tari_walletd/web_ui/src/theme/theme.css
@@ -68,6 +68,7 @@ body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   background-color: #f5f5f7;
+  font-size: 12px;
 }
 
 code {

--- a/applications/tari_walletd/web_ui/src/theme/tokens.ts
+++ b/applications/tari_walletd/web_ui/src/theme/tokens.ts
@@ -86,7 +86,11 @@ export const componentSettings: ThemeOptions = {
     },
     // custom
     label: {
-      fontSize: "0.8rem",
+      fontSize: 10,
+      fontWeight: 400,
+      lineHeight: "1",
+      letterSpacing: 0.1,
+      fontFamily: '"PoppinsRegular", sans-serif',
     },
   },
   transitions: {
@@ -224,6 +228,13 @@ export const componentSettings: ThemeOptions = {
           marginLeft: 1,
           borderRadius: 1,
           padding: "12px 8px",
+        },
+      },
+    },
+    MuiTypography: {
+      defaultProps: {
+        variantMapping: {
+          label: "span",
         },
       },
     },

--- a/applications/tari_walletd/web_ui/src/theme/tokens.ts
+++ b/applications/tari_walletd/web_ui/src/theme/tokens.ts
@@ -88,9 +88,12 @@ export const componentSettings: ThemeOptions = {
     label: {
       fontSize: 10,
       fontWeight: 400,
-      lineHeight: "1",
+      lineHeight: "10px",
       letterSpacing: 0.1,
       fontFamily: '"PoppinsRegular", sans-serif',
+    },
+    span: {
+      lineHeight: 1,
     },
   },
   transitions: {

--- a/applications/tari_walletd/web_ui/src/theme/tokens.ts
+++ b/applications/tari_walletd/web_ui/src/theme/tokens.ts
@@ -20,9 +20,10 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import "./augmentation";
+
 import { ThemeOptions } from "@mui/material/styles";
 import { blue, gothic, green, grey, orange, red, tariBg, tariPurple, teal } from "@theme/colors";
-import "./augmentation";
 import PoppinsBoldTTF from "./fonts/poppins/Poppins-Bold.ttf";
 import PoppinsMediumTTF from "./fonts/poppins/Poppins-Medium.ttf";
 import PoppinsRegularTTF from "./fonts/poppins/Poppins-Regular.ttf";
@@ -82,6 +83,10 @@ export const componentSettings: ThemeOptions = {
       lineHeight: "1.8rem",
       fontWeight: 600,
       fontFamily: '"PoppinsSemiBold", sans-serif',
+    },
+    // custom
+    label: {
+      fontSize: "0.8rem",
     },
   },
   transitions: {

--- a/applications/tari_walletd/web_ui/src/utils/helpers.tsx
+++ b/applications/tari_walletd/web_ui/src/utils/helpers.tsx
@@ -232,23 +232,29 @@ export function base64FromArrayBuffer(arrayBuffer: ArrayBuffer) {
 export function bigintToDecimalString(int: bigint | Amount, decimalPlaces: number, locale: string = "en-US"): string {
   const number = typeof int === "bigint" ? int : BigInt(int);
 
-  if (decimalPlaces == 0) {
-    return number.toLocaleString(locale, {
-      minimumFractionDigits: 0,
-      maximumFractionDigits: 0,
-    });
-  }
-  const wholeValues = (number / BigInt(10 ** decimalPlaces)).toLocaleString(locale, {
+  const noDigitFormatter = new Intl.NumberFormat(locale, {
     minimumFractionDigits: 0,
     maximumFractionDigits: 0,
   });
-  const fractionalValues = number.toString().slice(-decimalPlaces);
+
+  if (decimalPlaces == 0) {
+    return noDigitFormatter.format(number);
+  }
+
+  let fractionalValues = number.toString().slice(-decimalPlaces);
+  const fractionalIsZero = [...fractionalValues].every((c) => c === "0");
+
+  const wholeValues = noDigitFormatter.format(number / BigInt(10 ** decimalPlaces));
+
+  if (fractionalIsZero) {
+    fractionalValues = "0";
+  }
   if (wholeValues === "0" && fractionalValues === "0") {
     return "0";
   }
 
   const padding = "0".repeat(decimalPlaces - fractionalValues.length);
-  return `${wholeValues}.${padding}${fractionalValues}`;
+  return fractionalIsZero ? wholeValues : `${wholeValues}.${padding}${fractionalValues}`;
 }
 
 export const formatCurrency = (amount: bigint | Amount, currency: Currency): string => {

--- a/applications/tari_walletd/web_ui/tsconfig.node.json
+++ b/applications/tari_walletd/web_ui/tsconfig.node.json
@@ -3,6 +3,10 @@
     "composite": true,
     "module": "ESNext",
     "moduleResolution": "Bundler",
+    "lib": ["es6", "dom"],
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "strictNullChecks": true,
     "allowSyntheticDefaultImports": true
   },
   "include": ["vite.config.ts"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -250,7 +250,7 @@ importers:
       react-qr-code:
         specifier: ^2.0.18
         version: 2.0.18(react@19.2.4)
-      react-router-dom:
+      react-router:
         specifier: ^7.13.1
         version: 7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       use-file-picker:


### PR DESCRIPTION
Description
---
- fix balance formatter
- table UI fixes
- fix `Send` dialog title (`Send Tari` -> `Send Funds`)
- use the new resource type chip in the send flow instead of just the address
- removed `react-router-dom` and added `react-router` (`react-router-dom` was just meant for upgrading) - majority of the file changes were the import updates from this change

Motivation and Context
---

- ✨ makin' pretty ✨ 

How Has This Been Tested?
---

- locally:

**table stuff old vs new:**

https://github.com/user-attachments/assets/21513da6-b63d-4c05-b503-49d4838f1709


**send flow + still works post `react-router` package change:**

https://github.com/user-attachments/assets/5d64a0fd-3674-4a24-a4bc-0d488e2d6ec0

**resource address side-by-side:**

<img width="3456" height="2234" alt="Screenshot 2026-03-02 at 11 53 02" src="https://github.com/user-attachments/assets/45eb8b23-32df-4f48-8769-28079ee06cd0" />



What process can a PR reviewer use to test or verify this change?
---
-  look at the tables under `My Assets`
-  send a resource

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify