### PR TITLE
test(engine): replace usages of call_args!

### DIFF
--- a/crates/engine/tests/account.rs
+++ b/crates/engine/tests/account.rs
@@ -4,7 +4,7 @@
 use ootle_byte_type::ToByteType;
 use tari_crypto::{keys::PublicKey, ristretto::RistrettoPublicKey};
 use tari_engine::runtime::{ActionIdent, RuntimeError};
-use tari_ootle_transaction::{Instruction, Transaction, args, call_args};
+use tari_ootle_transaction::{Transaction, args};
 use tari_template_builtin::ACCOUNT_TEMPLATE_ADDRESS;
 use tari_template_lib::types::{Amount, ComponentAddress, access_rules::ComponentAccessRules, constants::XTR, rule};
 use tari_template_test_tooling::{
@@ -60,21 +60,17 @@ fn basic_faucet_transfer() {
 
 #[test]
 fn withdraw_from_account_prevented() {
-    let mut template_test = TemplateTest::new(CRATE_PATH, Vec::<&str>::new());
+    let mut test = TemplateTest::new(CRATE_PATH, Vec::<&str>::new());
 
-    let faucet_template = template_test.get_template_address("TestFaucet");
+    let faucet_template = test.get_template_address("TestFaucet");
 
     let initial_supply = Amount::from(1_000_000_000_000u64);
-    let result = template_test
-        .execute_and_commit(
-            vec![Instruction::CallFunction {
-                address: faucet_template,
-                function: "mint".try_into().unwrap(),
-                args: call_args![initial_supply],
-            }],
-            vec![template_test.owner_proof()],
-        )
-        .unwrap();
+    let result = test.execute_expect_success(
+        test.transaction()
+            .call_function(faucet_template, "mint", args![initial_supply])
+            .build_and_seal(test.secret_key()),
+        vec![test.owner_proof()],
+    );
     let faucet_component: ComponentAddress = result.finalize.execution_results[0].decode().unwrap();
     let faucet_resource = result
         .finalize
@@ -85,9 +81,9 @@ fn withdraw_from_account_prevented() {
         .unwrap();
 
     // Create sender and receiver accounts
-    let (source_account, _, _) = template_test.create_funded_account();
+    let (source_account, _, _) = test.create_funded_account();
 
-    let _result = template_test
+    let _result = test
         .execute_and_commit_manifest(
             r#"
                 let source_account = var!["source_account"];
@@ -104,9 +100,9 @@ fn withdraw_from_account_prevented() {
         )
         .unwrap();
 
-    let (dest_address, non_owning_token, non_owning_key) = template_test.create_funded_account();
+    let (dest_address, non_owning_token, non_owning_key) = test.create_funded_account();
 
-    let reason = template_test.execute_expect_failure(
+    let reason = test.execute_expect_failure(
         Transaction::builder_localnet()
             .call_method(source_account, "withdraw", args![faucet_resource, 100])
             .put_last_instruction_output_on_workspace("stolen_coins")
@@ -121,7 +117,7 @@ fn withdraw_from_account_prevented() {
         method: "withdraw".to_string(),
     });
 
-    let result = template_test
+    let result = test
         .execute_and_commit_manifest(
             r#"
                 let dest_account = var!["dest_account"];

--- a/crates/engine/tests/airdrop.rs
+++ b/crates/engine/tests/airdrop.rs
@@ -4,7 +4,7 @@
 use ootle_byte_type::ToByteType;
 use tari_engine_types::substate::SubstateId;
 use tari_ootle_common_types::substate_type::SubstateType;
-use tari_ootle_transaction::{Transaction, args, call_args};
+use tari_ootle_transaction::{Transaction, args};
 use tari_template_lib::types::{Amount, ComponentAddress};
 use tari_template_test_tooling::TemplateTest;
 
@@ -12,7 +12,7 @@ const CRATE_PATH: &str = env!("CARGO_MANIFEST_DIR");
 
 fn setup() -> (TemplateTest, ComponentAddress, SubstateId) {
     let mut template_test = TemplateTest::new(CRATE_PATH, vec!["tests/templates/nft/airdrop"]);
-    let airdrop: ComponentAddress = template_test.call_function("Airdrop", "new", call_args![], vec![]);
+    let airdrop: ComponentAddress = template_test.call_function("Airdrop", "new", args![], vec![]);
     let airdrop_resx = template_test.get_previous_output_address(SubstateType::Resource);
     (template_test, airdrop, airdrop_resx)
 }
@@ -21,7 +21,7 @@ fn setup() -> (TemplateTest, ComponentAddress, SubstateId) {
 fn airdrop() {
     let (mut test, airdrop, airdrop_resx) = setup();
 
-    let total_supply: Amount = test.call_method(airdrop, "total_supply", call_args![], vec![test.owner_proof()]);
+    let total_supply: Amount = test.call_method(airdrop, "total_supply", args![], vec![test.owner_proof()]);
     assert_eq!(total_supply, Amount::from(100u64));
 
     let builder = Transaction::builder_localnet().then(|builder| {
@@ -42,7 +42,7 @@ fn airdrop() {
         .into_keys()
         .collect::<Vec<_>>();
 
-    test.call_method::<()>(airdrop, "open_airdrop", call_args![], vec![test.owner_proof()]);
+    test.call_method::<()>(airdrop, "open_airdrop", args![], vec![test.owner_proof()]);
 
     test.build_and_execute(
         Transaction::builder_localnet().then(|builder| {

--- a/crates/engine/tests/asserts.rs
+++ b/crates/engine/tests/asserts.rs
@@ -5,7 +5,7 @@ use std::vec;
 
 use tari_crypto::ristretto::RistrettoSecretKey;
 use tari_engine::runtime::{AssertError, RuntimeError};
-use tari_ootle_transaction::{Assertion, CheckOrd, Instruction, Transaction, args, args::WorkspaceOffsetId, call_args};
+use tari_ootle_transaction::{Assertion, CheckOrd, Instruction, Transaction, args, args::WorkspaceOffsetId};
 use tari_template_lib::types::{
     Amount,
     ComponentAddress,
@@ -37,16 +37,13 @@ fn setup() -> AssertTest {
     let faucet_template = template_test.get_template_address("TestFaucet");
 
     let initial_supply = Amount::from(1_000_000_000_000u64);
-    let result = template_test
-        .execute_and_commit(
-            vec![Instruction::CallFunction {
-                address: faucet_template,
-                function: "mint".try_into().unwrap(),
-                args: call_args![initial_supply],
-            }],
-            vec![template_test.owner_proof()],
-        )
-        .unwrap();
+    let result = template_test.execute_expect_success(
+        template_test
+            .transaction()
+            .call_function(faucet_template, "mint", args![initial_supply])
+            .build_and_seal(template_test.secret_key()),
+        vec![template_test.owner_proof()],
+    );
 
     let faucet_component: ComponentAddress = result.finalize.execution_results.first().unwrap().decode().unwrap();
 

--- a/crates/engine/tests/confidential.rs
+++ b/crates/engine/tests/confidential.rs
@@ -14,7 +14,7 @@ use tari_engine_types::{
     substate::SubstateId,
 };
 use tari_ootle_common_types::substate_type::SubstateType;
-use tari_ootle_transaction::{Transaction, args, call_args};
+use tari_ootle_transaction::{Transaction, args};
 use tari_template_lib::{
     models::Account,
     types::{
@@ -58,13 +58,11 @@ fn setup(
             template_test.call_function(
                 "ConfidentialFaucet",
                 "mint_with_view_key",
-                call_args![initial_supply, vk],
+                args![initial_supply, vk],
                 vec![],
             )
         })
-        .unwrap_or_else(|| {
-            template_test.call_function("ConfidentialFaucet", "mint", call_args![initial_supply], vec![])
-        });
+        .unwrap_or_else(|| template_test.call_function("ConfidentialFaucet", "mint", args![initial_supply], vec![]));
 
     let resx = template_test.get_previous_output_address(SubstateType::Resource);
 
@@ -90,7 +88,7 @@ fn mint_more_later() {
     let (mut template_test, faucet, _faucet_resx) = setup(confidential_proof, None);
 
     let (confidential_proof, mask, _change) = generate_confidential_output_statement(100, None);
-    template_test.call_method::<()>(faucet, "mint_more", call_args![confidential_proof], vec![]);
+    template_test.call_method::<()>(faucet, "mint_more", args![confidential_proof], vec![]);
 
     let (user_account, user_proof, user_key) = template_test.create_empty_account();
 
@@ -433,8 +431,8 @@ fn mint_and_transfer_revealed() {
 
     let (user_account, _, _) = test.create_empty_account();
 
-    test.call_method::<()>(faucet, "mint_revealed", call_args![123], vec![]);
-    let balance: Amount = test.call_method(faucet, "vault_balance", call_args![], vec![]);
+    test.call_method::<()>(faucet, "mint_revealed", args![123], vec![]);
+    let balance: Amount = test.call_method(faucet, "vault_balance", args![], vec![]);
     assert_eq!(balance, Amount::from(123u64));
 
     // Convert 100 revealed funds to confidential and the remaining 23 to revealed
@@ -506,7 +504,7 @@ fn mint_with_view_key() {
     let faucet_entity_id = faucet.entity_id();
 
     let (confidential_proof, mask, _change) = generate_confidential_proof_with_view_key(100, None, view_key);
-    test.call_method::<()>(faucet, "mint_more", call_args![confidential_proof], vec![]);
+    test.call_method::<()>(faucet, "mint_more", args![confidential_proof], vec![]);
 
     let (user_account, user_proof, user_key) = test.create_empty_account();
     let user_account_entity_id = user_account.entity_id();

--- a/crates/engine/tests/cross_template.rs
+++ b/crates/engine/tests/cross_template.rs
@@ -7,7 +7,7 @@ use tari_engine_types::{
     commit_result::{ExecuteResult, RejectReason},
     limits,
 };
-use tari_ootle_transaction::{Instruction, Transaction, args, call_args};
+use tari_ootle_transaction::{Transaction, args};
 use tari_template_lib::types::{Amount, ComponentAddress, ResourceAddress, TemplateAddress};
 use tari_template_test_tooling::{
     TemplateTest,
@@ -52,17 +52,13 @@ fn setup() -> CrossTemplateTest {
 
 fn initialize_composability(test: &mut CrossTemplateTest) -> ComponentInfo {
     // the cross_template template "new" function should create a new "state" component as well
-    let res = test
-        .template_test
-        .execute_and_commit(
-            vec![Instruction::CallFunction {
-                address: test.cross_call_template,
-                function: "new".try_into().unwrap(),
-                args: call_args![test.state_template],
-            }],
-            vec![],
-        )
-        .unwrap();
+    let res = test.template_test.execute_expect_success(
+        test.template_test
+            .transaction()
+            .call_function(test.cross_call_template, "new", args![test.state_template])
+            .build_and_seal(test.secret_key()),
+        vec![],
+    );
 
     // extract the newly created component addresses
     let composability_component = extract_component_address_from_result(&res, TEMPLATE_NAME);
@@ -200,7 +196,7 @@ fn it_allows_method_to_function_calls() {
     test.template_test.call_method::<()>(
         components.cross_template_component,
         "replace_state_component",
-        call_args![test.state_template],
+        args![test.state_template],
         vec![],
     );
 
@@ -299,7 +295,7 @@ fn it_allows_multiple_recursion_levels() {
     test.template_test.call_method::<()>(
         composability_1,
         "set_nested_composability",
-        call_args![composability_0],
+        args![composability_0],
         vec![],
     );
 
@@ -326,7 +322,7 @@ fn it_fails_when_surpassing_recursion_limit_with_many_nested_components() {
         test.template_test.call_method::<()>(
             components.cross_template_component,
             "set_nested_composability",
-            call_args![last_composability_component],
+            args![last_composability_component],
             vec![],
         );
         last_composability_component = components.cross_template_component;

--- a/crates/engine/tests/events.rs
+++ b/crates/engine/tests/events.rs
@@ -2,7 +2,7 @@
 //   SPDX-License-Identifier: BSD-3-Clause
 
 use tari_engine::runtime::RuntimeError;
-use tari_ootle_transaction::{Instruction, Transaction, args, call_args};
+use tari_ootle_transaction::{Transaction, args};
 use tari_template_builtin::ACCOUNT_TEMPLATE_ADDRESS;
 use tari_template_lib::types::{Amount, ComponentAddress};
 use tari_template_test_tooling::{TemplateTest, support::assert_error::assert_reject_reason};
@@ -14,16 +14,13 @@ fn basic_emit_event() {
     let mut template_test = TemplateTest::new(CRATE_PATH, vec!["tests/templates/events"]);
     let event_emitter_template = template_test.get_template_address("EventEmitter");
     let topic = "Hello_world";
-    let result = template_test
-        .execute_and_commit(
-            vec![Instruction::CallFunction {
-                address: event_emitter_template,
-                function: "test_function".try_into().unwrap(),
-                args: call_args![topic],
-            }],
-            vec![],
-        )
-        .expect("Failed to emit test event");
+    let result = template_test.execute_expect_success(
+        template_test
+            .transaction()
+            .call_function(event_emitter_template, "test_function", args![topic])
+            .build_and_seal(template_test.secret_key()),
+        vec![],
+    );
     assert!(result.finalize.is_accept());
     assert_eq!(result.finalize.events.len(), 1);
     assert_eq!(result.finalize.events[0].topic(), format!("EventEmitter.{}", topic));
@@ -55,21 +52,17 @@ fn cannot_use_standard_topic() {
 
 #[test]
 fn builtin_vault_events() {
-    let mut template_test = TemplateTest::new(CRATE_PATH, Vec::<&str>::new());
+    let mut test = TemplateTest::new(CRATE_PATH, Vec::<&str>::new());
 
     // create a fungible resource for transfer
-    let faucet_template = template_test.get_template_address("TestFaucet");
+    let faucet_template = test.get_template_address("TestFaucet");
     let initial_supply = Amount::from(1_000_000_000_000u64);
-    let result = template_test
-        .execute_and_commit(
-            vec![Instruction::CallFunction {
-                address: faucet_template,
-                function: "mint".try_into().unwrap(),
-                args: call_args![initial_supply],
-            }],
-            vec![template_test.owner_proof()],
-        )
-        .unwrap();
+    let result = test.execute_expect_success(
+        test.transaction()
+            .call_function(faucet_template, "mint", args![initial_supply])
+            .build_and_seal(test.secret_key()),
+        vec![test.owner_proof()],
+    );
     let faucet_component: ComponentAddress = result.finalize.execution_results[0].decode().unwrap();
     let faucet_resource = result
         .finalize
@@ -80,21 +73,20 @@ fn builtin_vault_events() {
         .unwrap();
 
     // Create sender and receiver accounts
-    let (sender_address, sender_proof, _) = template_test.create_funded_account();
-    let (receiver_address, _, _) = template_test.create_funded_account();
-    template_test
-        .build_and_execute(
-            Transaction::builder_localnet()
-                .call_method(faucet_component, "take_free_coins", args![])
-                .put_last_instruction_output_on_workspace("free_coins")
-                .call_method(sender_address, "deposit", args![Workspace("free_coins")]),
-            vec![template_test.owner_proof()],
-        )
-        .expect_success();
+    let (sender_address, sender_proof, _) = test.create_funded_account();
+    let (receiver_address, _, _) = test.create_funded_account();
+    test.build_and_execute(
+        Transaction::builder_localnet()
+            .call_method(faucet_component, "take_free_coins", args![])
+            .put_last_instruction_output_on_workspace("free_coins")
+            .call_method(sender_address, "deposit", args![Workspace("free_coins")]),
+        vec![test.owner_proof()],
+    )
+    .expect_success();
 
     // transfer some tokens between accounts
     let amount = Amount::from(100u64);
-    let result = template_test.build_and_execute(
+    let result = test.build_and_execute(
         Transaction::builder_localnet()
             .call_method(sender_address, "withdraw", args![faucet_resource, amount])
             .put_last_instruction_output_on_workspace("foo_bucket")

--- a/crates/engine/tests/fees.rs
+++ b/crates/engine/tests/fees.rs
@@ -2,7 +2,7 @@
 //   SPDX-License-Identifier: BSD-3-Clause
 
 use tari_engine_types::commit_result::RejectReason;
-use tari_ootle_transaction::{Transaction, args, call_args};
+use tari_ootle_transaction::{Transaction, args};
 use tari_template_lib::types::{Amount, ComponentAddress, constants::STEALTH_TARI_RESOURCE_ADDRESS};
 use tari_template_test_tooling::{TemplateTest, support::assert_error::assert_reject_reason, xtr_faucet_component};
 
@@ -14,7 +14,7 @@ fn deducts_fees_from_payments_and_refunds_the_rest() {
     let mut test = TemplateTest::new(CRATE_PATH, TEMPLATE_PATHS);
 
     let (account, owner_token, private_key) = test.create_funded_account();
-    let orig_balance: Amount = test.call_method(account, "balance", call_args![STEALTH_TARI_RESOURCE_ADDRESS], vec![]);
+    let orig_balance: Amount = test.call_method(account, "balance", args![STEALTH_TARI_RESOURCE_ADDRESS], vec![]);
 
     test.enable_fees();
 
@@ -113,12 +113,7 @@ fn another_account_pays_partially_for_fees() {
     let (account, _, _) = test.create_empty_account();
     let (account_fee, owner_token_fee, _) = test.create_funded_account();
     let (account_fee2, owner_token_fee2, _) = test.create_funded_account();
-    let orig_balance: Amount = test.call_method(
-        account_fee,
-        "balance",
-        call_args![STEALTH_TARI_RESOURCE_ADDRESS],
-        vec![],
-    );
+    let orig_balance: Amount = test.call_method(account_fee, "balance", args![STEALTH_TARI_RESOURCE_ADDRESS], vec![]);
 
     test.enable_fees();
 
@@ -169,8 +164,7 @@ fn failed_fee_transaction() {
     let mut test = TemplateTest::new(CRATE_PATH, TEMPLATE_PATHS);
 
     let (account, owner_token, private_key) = test.create_funded_account();
-    let initial_balance: Amount =
-        test.call_method(account, "balance", call_args![STEALTH_TARI_RESOURCE_ADDRESS], vec![]);
+    let initial_balance: Amount = test.call_method(account, "balance", args![STEALTH_TARI_RESOURCE_ADDRESS], vec![]);
 
     test.enable_fees();
     let result = test
@@ -208,7 +202,7 @@ fn fail_partial_paid_fees() {
 
     let (account, owner_token, private_key) = test.create_funded_account();
     let (account2, owner_token2, _) = test.create_funded_account();
-    let orig_balance: Amount = test.call_method(account, "balance", call_args![STEALTH_TARI_RESOURCE_ADDRESS], vec![]);
+    let orig_balance: Amount = test.call_method(account, "balance", args![STEALTH_TARI_RESOURCE_ADDRESS], vec![]);
     test.enable_fees();
 
     let result = test.execute_expect_commit(
@@ -277,7 +271,7 @@ fn fail_pay_less_fees_than_fee_transaction() {
 
     let (account, owner_token, private_key) = test.create_funded_account();
     let (account2, owner_token2, _) = test.create_funded_account();
-    let orig_balance: Amount = test.call_method(account, "balance", call_args![STEALTH_TARI_RESOURCE_ADDRESS], vec![]);
+    let orig_balance: Amount = test.call_method(account, "balance", args![STEALTH_TARI_RESOURCE_ADDRESS], vec![]);
     let state: ComponentAddress = test.call_function("State", "new", args![], vec![]);
 
     test.enable_fees();
@@ -351,7 +345,7 @@ fn fail_pay_too_little_no_fee_instruction() {
 
     let (account, owner_token, private_key) = test.create_funded_account();
     let (account2, owner_token2, _) = test.create_funded_account();
-    let orig_balance: Amount = test.call_method(account, "balance", call_args![STEALTH_TARI_RESOURCE_ADDRESS], vec![]);
+    let orig_balance: Amount = test.call_method(account, "balance", args![STEALTH_TARI_RESOURCE_ADDRESS], vec![]);
 
     test.enable_fees();
 
@@ -416,7 +410,7 @@ fn dangling_bucket_pay_fees() {
     let mut test = TemplateTest::new(CRATE_PATH, TEMPLATE_PATHS);
 
     let (account, owner_token, private_key) = test.create_funded_account();
-    let orig_balance: Amount = test.call_method(account, "balance", call_args![STEALTH_TARI_RESOURCE_ADDRESS], vec![]);
+    let orig_balance: Amount = test.call_method(account, "balance", args![STEALTH_TARI_RESOURCE_ADDRESS], vec![]);
 
     test.enable_fees();
 

--- a/crates/engine/tests/resource.rs
+++ b/crates/engine/tests/resource.rs
@@ -1,7 +1,7 @@
 //   Copyright 2024 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use tari_ootle_transaction::call_args;
+use tari_ootle_transaction::args;
 use tari_template_lib::types::ComponentAddress;
 use tari_template_test_tooling::{TemplateTest, support::confidential::generate_confidential_output_statement};
 
@@ -10,21 +10,21 @@ const CRATE_PATH: &str = env!("CARGO_MANIFEST_DIR");
 #[test]
 fn fungible_join() {
     let mut test = TemplateTest::new(CRATE_PATH, vec!["tests/templates/resource"]);
-    let component: ComponentAddress = test.call_function("ResourceTest", "new", call_args![], vec![]);
-    test.call_method::<()>(component, "fungible_join", call_args![], vec![]);
+    let component: ComponentAddress = test.call_function("ResourceTest", "new", args![], vec![]);
+    test.call_method::<()>(component, "fungible_join", args![], vec![]);
 }
 
 #[test]
 fn non_fungible_join() {
     let mut test = TemplateTest::new(CRATE_PATH, vec!["tests/templates/resource"]);
-    let component: ComponentAddress = test.call_function("ResourceTest", "new", call_args![], vec![]);
-    test.call_method::<()>(component, "non_fungible_join", call_args![], vec![]);
+    let component: ComponentAddress = test.call_function("ResourceTest", "new", args![], vec![]);
+    test.call_method::<()>(component, "non_fungible_join", args![], vec![]);
 }
 
 #[test]
 fn confidential_join() {
     let mut test = TemplateTest::new(CRATE_PATH, vec!["tests/templates/resource"]);
-    let component: ComponentAddress = test.call_function("ResourceTest", "new", call_args![], vec![]);
+    let component: ComponentAddress = test.call_function("ResourceTest", "new", args![], vec![]);
     let (output, _, _) = generate_confidential_output_statement(1000, None);
-    test.call_method::<()>(component, "confidential_join", call_args![output], vec![]);
+    test.call_method::<()>(component, "confidential_join", args![output], vec![]);
 }

--- a/crates/engine/tests/stealth.rs
+++ b/crates/engine/tests/stealth.rs
@@ -17,7 +17,7 @@ use tari_engine_types::{
     resource_container::ResourceError,
 };
 use tari_ootle_common_types::{crypto::create_key_pair_from_seed, substate_type::SubstateType};
-use tari_ootle_transaction::{Transaction, args, call_args};
+use tari_ootle_transaction::{Transaction, args};
 use tari_template_lib::types::{
     AccessRule,
     ComponentAddress,
@@ -89,7 +89,7 @@ fn mint_more_later() {
     let mint = stealth::generate_mint_statement([1200], 0u64, None);
     let (faucet, faucet_resx) = setup(&mut test, &mint, None);
 
-    test.call_method::<()>(faucet, "mint", call_args![11100], vec![]);
+    test.call_method::<()>(faucet, "mint", args![11100], vec![]);
 
     let resource = test.read_only_state_store().get_resource(&faucet_resx).unwrap();
     let total_supply = resource.total_supply().unwrap();

--- a/crates/engine/tests/tariswap.rs
+++ b/crates/engine/tests/tariswap.rs
@@ -2,8 +2,8 @@
 //   SPDX-License-Identifier: BSD-3-Clause
 
 use tari_ootle_common_types::substate_type::SubstateType;
-use tari_ootle_transaction::{Instruction, Transaction, args, call_args};
-use tari_template_lib::types::{Amount, ComponentAddress, FunctionName, NonFungibleAddress, ResourceAddress};
+use tari_ootle_transaction::{Transaction, args};
+use tari_template_lib::types::{Amount, ComponentAddress, NonFungibleAddress, ResourceAddress};
 use tari_template_test_tooling::TemplateTest;
 
 const CRATE_PATH: &str = env!("CARGO_MANIFEST_DIR");
@@ -44,12 +44,8 @@ fn setup(fee: u16) -> TariSwapTest {
 
 fn create_faucet_component(template_test: &mut TemplateTest, symbol: String) -> (ComponentAddress, ResourceAddress) {
     let initial_supply = Amount::from(1_000_000_000_000u64);
-    let component_address: ComponentAddress = template_test.call_function(
-        "TestFaucet",
-        "mint_with_symbol",
-        call_args![initial_supply, symbol],
-        vec![],
-    );
+    let component_address: ComponentAddress =
+        template_test.call_function("TestFaucet", "mint_with_symbol", args![initial_supply, symbol], vec![]);
 
     let resource_address = template_test
         .get_previous_output_address(SubstateType::Resource)
@@ -68,16 +64,13 @@ fn create_tariswap_component(
     let module_name = "TariSwapPool";
     let tariswap_template = template_test.get_template_address(module_name);
 
-    let res = template_test
-        .execute_and_commit(
-            vec![Instruction::CallFunction {
-                address: tariswap_template,
-                function: FunctionName::new_checked("new").unwrap(),
-                args: call_args![a_resource, b_resource, fee],
-            }],
-            vec![],
-        )
-        .unwrap();
+    let res = template_test.execute_expect_success(
+        template_test
+            .transaction()
+            .call_function(tariswap_template, "new", args![a_resource, b_resource, fee])
+            .build_and_seal(template_test.secret_key()),
+        vec![],
+    );
 
     // extract the component address
     let (substate_addr, _) = res
@@ -171,12 +164,12 @@ fn remove_liquidity(test: &mut TariSwapTest, lp_amount: Amount) {
 
 fn get_pool_balance(test: &mut TariSwapTest, resource_address: ResourceAddress) -> Amount {
     test.template_test
-        .call_method(test.tariswap, "get_pool_balance", call_args![resource_address], vec![])
+        .call_method(test.tariswap, "get_pool_balance", args![resource_address], vec![])
 }
 
 fn get_account_balance(test: &mut TariSwapTest, resource_address: ResourceAddress) -> Amount {
     test.template_test
-        .call_method(test.account_address, "balance", call_args![resource_address], vec![])
+        .call_method(test.account_address, "balance", args![resource_address], vec![])
 }
 
 fn assert_swap(

--- a/crates/engine/tests/test.rs
+++ b/crates/engine/tests/test.rs
@@ -32,7 +32,7 @@ use tari_engine_types::{
     virtual_substate::{VirtualSubstate, VirtualSubstateId},
 };
 use tari_ootle_common_types::substate_type::SubstateType;
-use tari_ootle_transaction::{Transaction, args, call_args};
+use tari_ootle_transaction::{Transaction, args};
 use tari_template_builtin::{ACCOUNT_TEMPLATE_ADDRESS, NFT_FAUCET_TEMPLATE_ADDRESS};
 use tari_template_lib::{
     models::NonFungible,
@@ -50,7 +50,7 @@ const CRATE_PATH: &str = env!("CARGO_MANIFEST_DIR");
 #[test]
 fn test_hello_world() {
     let mut template_test = TemplateTest::new(CRATE_PATH, vec!["tests/templates/hello_world"]);
-    let result: String = template_test.call_function("HelloWorld", "greet", call_args![], vec![]);
+    let result: String = template_test.call_function("HelloWorld", "greet", args![], vec![]);
 
     assert_eq!(result, "Hello World!");
 }
@@ -60,7 +60,7 @@ fn test_state() {
     let mut template_test = TemplateTest::new(CRATE_PATH, vec!["tests/templates/state"]);
 
     // constructor
-    let component_address1: ComponentAddress = template_test.call_function("State", "new", call_args![], vec![]);
+    let component_address1: ComponentAddress = template_test.call_function("State", "new", args![], vec![]);
     template_test.assert_calls(&[
         "workspace_invoke",
         "component_invoke",
@@ -68,7 +68,7 @@ fn test_state() {
         "finalize",
     ]);
 
-    let component_address2: ComponentAddress = template_test.call_function("State", "new", call_args![], vec![]);
+    let component_address2: ComponentAddress = template_test.call_function("State", "new", args![], vec![]);
     assert_ne!(component_address1, component_address2);
 
     let store = template_test.read_only_state_store();
@@ -81,10 +81,10 @@ fn test_state() {
 
     // call the "set" method to update the instance value
     let new_value = 20_u32;
-    template_test.call_method::<()>(component_address2, "set", call_args![new_value], vec![]);
+    template_test.call_method::<()>(component_address2, "set", args![new_value], vec![]);
 
     // call the "get" method to get the current value
-    let value: u32 = template_test.call_method(component_address2, "get", call_args![], vec![]);
+    let value: u32 = template_test.call_method(component_address2, "get", args![], vec![]);
 
     assert_eq!(value, new_value);
 }
@@ -94,7 +94,7 @@ fn state_create_multiple_in_one_call() {
     let mut template_test = TemplateTest::new(CRATE_PATH, ["tests/templates/state"]);
 
     // constructor
-    template_test.call_function::<()>("State", "create_multiple", call_args![10u32], vec![]);
+    template_test.call_function::<()>("State", "create_multiple", args![10u32], vec![]);
 
     let template_address = template_test.get_template_address("State");
     let mut count = 0usize;
@@ -135,18 +135,18 @@ fn test_composed() {
         .collect::<Vec<_>>();
     assert_eq!(functions, vec!["new", "create_multiple", "restricted", "set", "get"]);
 
-    let component_state: ComponentAddress = template_test.call_function("State", "new", call_args![], vec![]);
-    let component_hw: ComponentAddress = template_test.call_function("HelloWorld", "new", call_args!["أهلا"], vec![]);
+    let component_state: ComponentAddress = template_test.call_function("State", "new", args![], vec![]);
+    let component_hw: ComponentAddress = template_test.call_function("HelloWorld", "new", args!["أهلا"], vec![]);
 
-    let result: String = template_test.call_method(component_hw, "custom_greeting", call_args!["Wasm"], vec![]);
+    let result: String = template_test.call_method(component_hw, "custom_greeting", args!["Wasm"], vec![]);
     assert_eq!(result, "أهلا Wasm!");
 
     // call the "set" method to update the instance value
     let new_value = 20_u32;
-    template_test.call_method::<()>(component_state, "set", call_args![new_value], vec![]);
+    template_test.call_method::<()>(component_state, "set", args![new_value], vec![]);
 
     // call the "get" method to get the current value
-    let value: u32 = template_test.call_method(component_state, "get", call_args![], vec![]);
+    let value: u32 = template_test.call_method(component_state, "get", args![], vec![]);
 
     assert_eq!(value, new_value);
 }
@@ -228,9 +228,9 @@ fn test_private_function() {
     assert_eq!(functions, vec!["new", "get", "increase"]);
 
     // check that public methods can still internally call private ones
-    let component: ComponentAddress = template_test.call_function("PrivateCounter", "new", call_args![], vec![]);
-    template_test.call_method::<()>(component, "increase", call_args![], vec![]);
-    let value: u32 = template_test.call_method(component, "get", call_args![], vec![]);
+    let component: ComponentAddress = template_test.call_function("PrivateCounter", "new", args![], vec![]);
+    template_test.call_method::<()>(component, "increase", args![], vec![]);
+    let value: u32 = template_test.call_method(component, "get", args![], vec![]);
     assert_eq!(value, 1);
 }
 
@@ -276,19 +276,19 @@ fn test_tuples() {
 
     // tuples returned in a constructor
     let (component_id, message): (ComponentAddress, String) =
-        template_test.call_function("Tuple", "new", call_args![], vec![]);
+        template_test.call_function("Tuple", "new", args![], vec![]);
     assert_eq!(message, "Hello World!");
 
     // tuples returned in a method
-    let (message, number): (String, u32) = template_test.call_method(component_id, "get", call_args![], vec![]);
+    let (message, number): (String, u32) = template_test.call_method(component_id, "get", args![], vec![]);
     assert_eq!(message, "Hello World!");
     assert_eq!(number, 0);
 
     // tuples passed as arguments to methods
     let new_value = ("New String".to_string(), 1);
-    template_test.call_method::<()>(component_id, "set", call_args![new_value], vec![]);
+    template_test.call_method::<()>(component_id, "set", args![new_value], vec![]);
     // check that the component state was actually updated
-    let value: (String, u32) = template_test.call_method(component_id, "get", call_args![], vec![]);
+    let value: (String, u32) = template_test.call_method(component_id, "get", args![], vec![]);
     assert_eq!(value, new_value);
 }
 
@@ -300,7 +300,7 @@ fn test_get_template_address() {
     let addr: TemplateAddress = template_test.call_function(
         "ComponentManagerTest",
         "get_template_address_for_component",
-        call_args![account],
+        args![account],
         vec![],
     );
     assert_eq!(addr, template_test.get_template_address("Account"));
@@ -310,14 +310,14 @@ fn test_get_template_address() {
 fn test_random() {
     let mut template_test = TemplateTest::new(CRATE_PATH, vec!["tests/templates/random"]);
     let component_address: ComponentAddress = template_test.call_function("RandomTest", "create", args![], vec![]);
-    let value: u32 = template_test.call_method(component_address, "get_random", call_args![], vec![]);
+    let value: u32 = template_test.call_method(component_address, "get_random", args![], vec![]);
     assert_ne!(value, 0);
 
-    let value: Vec<u8> = template_test.call_method(component_address, "get_random_bytes", call_args![], vec![]);
+    let value: Vec<u8> = template_test.call_method(component_address, "get_random_bytes", args![], vec![]);
     assert_eq!(value.len(), 32);
     assert_ne!(value, vec![0; 32]);
 
-    let value: Vec<u8> = template_test.call_method(component_address, "get_random_long_bytes", call_args![], vec![]);
+    let value: Vec<u8> = template_test.call_method(component_address, "get_random_long_bytes", args![], vec![]);
     assert_eq!(value.len(), 300);
     assert_ne!(value, vec![0; 300]);
 }
@@ -365,34 +365,21 @@ mod errors {
 
     #[test]
     fn invalid_args() {
-        let mut template_test = TemplateTest::new(CRATE_PATH, vec!["tests/templates/errors"]);
+        let mut test = TemplateTest::new(CRATE_PATH, vec!["tests/templates/errors"]);
 
         let text = "this isn't an amount";
-        let result = template_test
-            .try_execute_instructions(
-                vec![],
-                vec![Instruction::CallFunction {
-                    address: template_test.get_template_address("Errors"),
-                    function: "please_pass_invalid_args".try_into().unwrap(),
-                    args: call_args![text],
-                }],
-                vec![],
-            )
-            .unwrap();
-        println!("{:?}", result.finalize.result);
-        match result.finalize.result.any_reject().unwrap() {
-            RejectReason::ExecutionFailure(message) => {
-                assert!(
-                    message.contains(
-                        "Panic! failed to decode argument at position 0 (Amount) for function \
-                         'please_pass_invalid_args':"
-                    ),
-                    "Got a different error: {}",
-                    message
-                );
-            },
-            reason => panic!("Unexpected failure reason: {}", reason),
-        }
+        let reason = test.execute_expect_failure(
+            test.transaction()
+                .call_function(test.get_template_address("Errors"), "please_pass_invalid_args", args![
+                    text
+                ])
+                .build_and_seal(test.secret_key()),
+            vec![],
+        );
+        assert_reject_reason(
+            reason,
+            "Panic! failed to decode argument at position 0 (Amount) for function 'please_pass_invalid_args'",
+        )
     }
 }
 
@@ -416,40 +403,34 @@ mod consensus {
 }
 
 mod fungible {
-    use tari_ootle_transaction::Instruction;
-    use tari_template_lib::types::Amount;
 
     use super::*;
 
     #[test]
     fn fungible_mint_and_burn() {
-        let mut template_test = TemplateTest::new(CRATE_PATH, Vec::<&str>::new());
+        let mut test = TemplateTest::new_builtin_only();
 
-        let faucet_template = template_test.get_template_address("TestFaucet");
+        let faucet_template = test.get_template_address("TestFaucet");
 
         let initial_supply = Amount::from(1_000_000_000_000u64);
-        template_test
-            .execute_and_commit(
-                vec![Instruction::CallFunction {
-                    address: faucet_template,
-                    function: "mint".try_into().unwrap(),
-                    args: call_args![initial_supply],
-                }],
-                vec![],
-            )
-            .unwrap();
+        test.execute_expect_success(
+            test.transaction()
+                .call_function(faucet_template, "mint", args![initial_supply])
+                .build_and_seal(test.secret_key()),
+            vec![],
+        );
 
-        let faucet_component = template_test
+        let faucet_component = test
             .get_previous_output_address(SubstateType::Component)
             .as_component_address()
             .unwrap();
 
-        let total_supply: Amount = template_test.call_method(faucet_component, "total_supply", args![], vec![]);
+        let total_supply: Amount = test.call_method(faucet_component, "total_supply", args![], vec![]);
 
         assert_eq!(total_supply, initial_supply);
 
-        let owner_proof = template_test.owner_proof();
-        let result = template_test.build_and_execute(
+        let owner_proof = test.owner_proof();
+        let result = test.build_and_execute(
             Transaction::builder_localnet()
                 .call_method(faucet_component, "burn_coins", args![500])
                 .call_method(faucet_component, "total_supply", args![]),
@@ -462,7 +443,7 @@ mod fungible {
             initial_supply - Amount::from(500u64)
         );
 
-        let result = template_test.build_and_execute(
+        let result = test.build_and_execute(
             Transaction::builder_localnet()
                 .call_method(faucet_component, "burn_coins", args![
                     initial_supply - Amount::from(500u64)
@@ -477,17 +458,15 @@ mod fungible {
             Amount::zero()
         );
 
-        template_test
-            .build_and_execute(
-                Transaction::builder_localnet().call_method(faucet_component, "burn_coins", args![1]),
-                vec![],
-            )
-            .expect_failure();
+        test.build_and_execute(
+            Transaction::builder_localnet().call_method(faucet_component, "burn_coins", args![1]),
+            vec![],
+        )
+        .expect_failure();
     }
 }
 
 mod basic_nft {
-    use tari_template_lib::types::Amount;
 
     use super::*;
 
@@ -963,10 +942,10 @@ mod emoji_id {
         .unwrap();
 
         // the supply of emoji ids should have increased
-        let total_supply: Amount = test.call_method(emoji_id_minter, "total_supply", call_args![], vec![]);
+        let total_supply: Amount = test.call_method(emoji_id_minter, "total_supply", args![], vec![]);
         assert_eq!(total_supply, 1);
         // check that the account holds the newly minted nft
-        let nft_balance: Amount = test.call_method(account_address, "balance", call_args![emoji_id_resource], vec![]);
+        let nft_balance: Amount = test.call_method(account_address, "balance", args![emoji_id_resource], vec![]);
         assert_eq!(nft_balance, 1);
 
         // emoji id are unique, so minting the same emojis again must fail

--- a/crates/template_test_tooling/src/template_test.rs
+++ b/crates/template_test_tooling/src/template_test.rs
@@ -48,8 +48,10 @@ use tari_ootle_transaction::{
     Transaction,
     TransactionBuilder,
     args,
-    args::InstructionArg,
-    builder::{MainIntent, named_args::BuilderWorkspaceKey},
+    builder::{
+        MainIntent,
+        named_args::{BuilderWorkspaceKey, NamedArg},
+    },
 };
 use tari_template_lib::types::{
     Amount,
@@ -374,22 +376,19 @@ impl TemplateTest {
         &mut self,
         template_name: &str,
         func_name: &str,
-        args: Vec<InstructionArg>,
+        args: Vec<NamedArg>,
         proofs: Vec<NonFungibleAddress>,
     ) -> T
     where
         T: DeserializeOwned,
     {
-        let result = self
-            .execute_and_commit(
-                vec![Instruction::CallFunction {
-                    address: self.get_template_address(template_name),
-                    function: func_name.to_string().try_into().unwrap(),
-                    args,
-                }],
-                proofs,
-            )
-            .unwrap();
+        let address = self.get_template_address(template_name);
+        let result = self.execute_expect_success(
+            self.transaction()
+                .call_function(address, func_name, args)
+                .build_and_seal(&self.secret_key),
+            proofs,
+        );
         result
             .finalize
             .execution_results
@@ -404,22 +403,18 @@ impl TemplateTest {
         &mut self,
         component_address: ComponentAddress,
         method_name: &str,
-        args: Vec<InstructionArg>,
+        args: Vec<NamedArg>,
         proofs: Vec<NonFungibleAddress>,
     ) -> T
     where
         T: DeserializeOwned,
     {
-        let result = self
-            .execute_and_commit(
-                vec![Instruction::CallMethod {
-                    call: component_address.into(),
-                    method: method_name.try_into().unwrap(),
-                    args,
-                }],
-                proofs,
-            )
-            .unwrap();
+        let result = self.execute_expect_success(
+            self.transaction()
+                .call_method(component_address, method_name, args)
+                .build_and_seal(&self.secret_key),
+            proofs,
+        );
 
         result
             .finalize


### PR DESCRIPTION
Description
---
tests(engine): replace usages of call_args!

Motivation and Context
---
`call_args!` is used to create arguments directly on instructions and is generally only used publicly for cross-template calls. This PR updates the `call_method` and `call_function` functions in the template test harness to use the more familiar `args!` macro, as you would when using the transaction builder. 

How Has This Been Tested?
---
Existing tests updated

What process can a PR reviewer use to test or verify this change?
---


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify