### PR TITLE
fix(indexer): allow template_ prefix for template address

### DIFF
--- a/applications/tari_indexer/web_ui/src/routes/Templates/Templates.tsx
+++ b/applications/tari_indexer/web_ui/src/routes/Templates/Templates.tsx
@@ -38,16 +38,22 @@ import {
 } from "@mui/material";
 import React, { useState, useCallback, useEffect } from "react";
 import { useSearchParams } from "react-router-dom";
+import { useQueryClient } from "@tanstack/react-query";
 import CopyToClipboard from "../../Components/CopyToClipboard";
 import { useGetTemplateDefinition } from "../../api/hooks/useTemplates";
 import type { FunctionDef, Type } from "@tari-project/ootle-ts-bindings";
 import SearchIcon from "@mui/icons-material/Search";
 import ClearIcon from "@mui/icons-material/Clear";
 
+function stripTemplatePrefix(id: string): string {
+  return id.startsWith("template_") ? id.slice("template_".length) : id;
+}
+
 function validateTemplateAddress(id: string): string | null {
   if (!id) return null;
-  if (!/^[a-fA-F0-9]{64}$/.test(id)) {
-    return "Template address must be a 64-character hex string.";
+  const hex = stripTemplatePrefix(id);
+  if (!/^[a-fA-F0-9]{64}$/.test(hex)) {
+    return "Template address must be a 64-character hex string, optionally prefixed with 'template_'.";
   }
   return null;
 }
@@ -176,6 +182,7 @@ function TemplateDetails({ data }: { data: any }) {
 
 function TemplatesLayout() {
   const [searchParams, setSearchParams] = useSearchParams();
+  const queryClient = useQueryClient();
   const initialAddress = searchParams.get("address") || "";
   const [addressInput, setAddressInput] = useState(initialAddress);
   const [fetchAddress, setFetchAddress] = useState<string | null>(initialAddress || null);
@@ -183,7 +190,6 @@ function TemplatesLayout() {
 
   const { data, isLoading, isError, error } = useGetTemplateDefinition({
     address: fetchAddress,
-    enabled: !!fetchAddress,
   });
 
   useEffect(() => {
@@ -198,15 +204,18 @@ function TemplatesLayout() {
   const handleFetch = useCallback(() => {
     const trimmed = addressInput.trim();
     if (!trimmed) return;
-    const error = validateTemplateAddress(trimmed);
-    if (error) {
-      setValidationError(error);
+    const err = validateTemplateAddress(trimmed);
+    if (err) {
+      setValidationError(err);
       return;
     }
     setValidationError(null);
-    setFetchAddress(trimmed);
-    setSearchParams({ address: trimmed });
-  }, [addressInput, setSearchParams]);
+    const hex = stripTemplatePrefix(trimmed);
+    // Remove any cached (possibly errored) query so it always refetches
+    queryClient.removeQueries({ queryKey: ["templateDefinition", hex] });
+    setFetchAddress(hex);
+    setSearchParams({ address: hex });
+  }, [addressInput, setSearchParams, queryClient]);
 
   const handleClear = useCallback(() => {
     setAddressInput("");

--- a/docs/developer-docs/src/content/docs/guides/play-the-guessing-game.mdx
+++ b/docs/developer-docs/src/content/docs/guides/play-the-guessing-game.mdx
@@ -22,10 +22,8 @@ If you haven't completed those steps yet, start there before continuing.
   if you want to interact with the existing game without building and publishing your own.
 
   Head to the <a href="#full-working-example">Full Working Example</a> to find a complete Rust example that interacts
-  with the
-  published template.
-  When it asks for the template address, use
-  `template_ad47408f6285935af044d9db7e5d9a3c1fc341a33b2ea16027d8b9a9eceb9a6b`.
+  with the published template. When it asks for the template address, use
+  `template_1310cfc415e33dc27a52633214ed2ad0afb956d86daf258a8cddeb68162997a7`.
 </Aside>
 
 ### What we'll cover


### PR DESCRIPTION
Description
---
fix(indexer): allow template_ prefix for template address

Motivation and Context
---
UI accepts template hash and address (with prefix)

How Has This Been Tested?
---

What process can a PR reviewer use to test or verify this change?
---


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify