### PR TITLE
fix(abi)!: adds Option type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11962,7 +11962,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_abi"
-version = "0.15.2"
+version = "0.16.0"
 dependencies = [
  "hashbrown 0.13.2",
  "serde",
@@ -11988,7 +11988,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_lib"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "borsh",
  "serde",
@@ -12018,7 +12018,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_macros"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "indoc",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12024,6 +12024,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
+ "tari_bor",
  "tari_template_abi",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,10 +118,10 @@ tari_template_builtin = { path = "crates/template_builtin", version = "0.25" }
 tari_ootle_transaction = { path = "crates/transaction", version = "0.25" }
 
 # Template lib
-tari_template_lib = { version = "0.20", path = "crates/template_lib" }
+tari_template_lib = { version = "0.21", path = "crates/template_lib" }
 tari_template_lib_types = { version = "0.20", path = "crates/template_lib_types", default-features = false }
-tari_template_abi = { version = "0.15", path = "crates/template_abi", default-features = false }
-tari_template_macros = { version = "0.15", path = "crates/template_macros" }
+tari_template_abi = { version = "0.16", path = "crates/template_abi", default-features = false }
+tari_template_macros = { version = "0.16", path = "crates/template_macros" }
 tari_bor = { version = "0.13", path = "crates/tari_bor", default-features = false }
 
 ootle_byte_type = { path = "crates/ootle_byte_type", version = "0.3" }

--- a/applications/tari_wallet_cli/src/command/transaction.rs
+++ b/applications/tari_wallet_cli/src/command/transaction.rs
@@ -691,16 +691,7 @@ fn display_vec<W: fmt::Write>(writer: &mut W, ty: &Type, result: &InstructionRes
             write!(writer, "{}", str)?;
         },
         Type::Option(ty) => {
-            let mut vec_ty = String::new();
-            display_vec(&mut vec_ty, ty, result)?;
-            match &**ty {
-                Type::Other { name } => {
-                    write!(writer, "Option<{}>: {}", name, vec_ty)?;
-                },
-                _ => {
-                    write!(writer, "Option<{:?}>: {}", ty, vec_ty)?;
-                },
-            }
+            write!(writer, "Option<{}>: <not implemented>", ty)?;
         },
         Type::Other { name } if name == "Amount" => {
             write!(writer, "{}", stringify_slice(&result.decode::<Vec<Amount>>().unwrap()))?;

--- a/applications/tari_wallet_cli/src/command/transaction.rs
+++ b/applications/tari_wallet_cli/src/command/transaction.rs
@@ -690,6 +690,18 @@ fn display_vec<W: fmt::Write>(writer: &mut W, ty: &Type, result: &InstructionRes
             let str = format_tuple(subtypes, result);
             write!(writer, "{}", str)?;
         },
+        Type::Option(ty) => {
+            let mut vec_ty = String::new();
+            display_vec(&mut vec_ty, ty, result)?;
+            match &**ty {
+                Type::Other { name } => {
+                    write!(writer, "Option<{}>: {}", name, vec_ty)?;
+                },
+                _ => {
+                    write!(writer, "Option<{:?}>: {}", ty, vec_ty)?;
+                },
+            }
+        },
         Type::Other { name } if name == "Amount" => {
             write!(writer, "{}", stringify_slice(&result.decode::<Vec<Amount>>().unwrap()))?;
         },
@@ -768,6 +780,18 @@ pub fn print_execution_results(results: &[InstructionResult]) {
             Type::Tuple(subtypes) => {
                 let str = format_tuple(subtypes, result);
                 println!("{}", str);
+            },
+            Type::Option(ty) => {
+                let mut vec_ty = String::new();
+                display_vec(&mut vec_ty, ty, result).unwrap();
+                match &**ty {
+                    Type::Other { name } => {
+                        println!("Option<{}>: {}", name, vec_ty);
+                    },
+                    _ => {
+                        println!("Option<{:?}>: {}", ty, vec_ty);
+                    },
+                }
             },
             Type::Other { name } if name == "Amount" => {
                 println!("{}: {}", name, result.decode::<Amount>().unwrap());

--- a/bindings/src/types/Type.ts
+++ b/bindings/src/types/Type.ts
@@ -16,4 +16,5 @@ export type Type =
   | "String"
   | { Vec: Type }
   | { Tuple: Array<Type> }
-  | { Other: { name: string } };
+  | { Other: { name: string } }
+  | { Option: Type };

--- a/crates/engine/tests/test.rs
+++ b/crates/engine/tests/test.rs
@@ -266,7 +266,10 @@ fn test_tuples() {
     let module = template_test.get_module("Tuple");
     // the "new" constructor returns a tuple (Component, String)
     let fn_new = module.find_func_by_name("new").unwrap();
-    assert_eq!(fn_new.output.to_string(), "Tuple<Other { name: \"Component\" },String>");
+    assert_eq!(
+        fn_new.output.to_string(),
+        "Tuple<Other { name: \"Component<Tuple>\" },String>"
+    );
     // the "get" method returns a tuple (String, u32)
     let fn_get = module.find_func_by_name("get").unwrap();
     assert_eq!(fn_get.output.to_string(), "Tuple<String,U32>");

--- a/crates/template_abi/Cargo.toml
+++ b/crates/template_abi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_template_abi"
 description = "Defines the low-level Tari engine ABI for WASM targets"
-version = "0.15.2"
+version = "0.16.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/template_abi/src/template_def.rs
+++ b/crates/template_abi/src/template_def.rs
@@ -134,6 +134,7 @@ pub enum Type {
     Other {
         name: String,
     },
+    Option(Box<Type>),
 }
 
 impl Type {
@@ -163,6 +164,7 @@ impl std::fmt::Display for Type {
             Type::U128 => write!(f, "U128"),
             Type::String => write!(f, "String"),
             Type::Vec(t) => write!(f, "Vec<{}>", t),
+            Type::Option(t) => write!(f, "Option<{}>", t),
             Type::Tuple(types) => {
                 let type_list = types.iter().map(|t| format!("{:?}", t)).collect::<Vec<_>>().join(",");
                 write!(f, "Tuple<{}>", type_list)

--- a/crates/template_lib/Cargo.toml
+++ b/crates/template_lib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_template_lib"
 description = "Tari template library provides abstrations that interface with the Tari validator engine"
-version = "0.20.1"
+version = "0.21.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/template_macros/Cargo.toml
+++ b/crates/template_macros/Cargo.toml
@@ -19,3 +19,4 @@ syn = { workspace = true, features = ["full", "extra-traits"] }
 
 [dev-dependencies]
 indoc = { workspace = true }
+tari_bor = { workspace = true }

--- a/crates/template_macros/Cargo.toml
+++ b/crates/template_macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_template_macros"
 description = "Tari template macro"
-version = "0.15.1"
+version = "0.16.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/template_macros/src/template/abi.rs
+++ b/crates/template_macros/src/template/abi.rs
@@ -165,30 +165,54 @@ fn path_segment_to_arg_type(template_name: &str, segment: Option<&PathSegment>) 
             "u128" => ArgType::U128,
             "String" => ArgType::String,
             "Vec" => {
-                match &segment.expect("segment is some").arguments {
-                    PathArguments::AngleBracketed(AngleBracketedGenericArguments { args, .. }) => {
-                        match &args[0] {
-                            GenericArgument::Type(Type::Path(path)) => {
-                                let ty = path_segment_to_arg_type(template_name, path.path.segments.first());
-                                ArgType::Vec(Box::new(ty))
-                            },
-                            GenericArgument::Type(Type::Tuple(tuple)) => tuple_to_arg_type(template_name, tuple),
-                            // TODO: These should be errors
-                            a => panic!("Invalid vec generic argument {:?}", a),
-                        }
-                    },
-                    PathArguments::Parenthesized(_) | PathArguments::None => {
-                        panic!("Vec must specify a type {:?}", segment)
-                    },
-                }
+                let inner = extract_single_generic_arg(template_name, segment.expect("segment is some"));
+                ArgType::Vec(Box::new(inner))
+            },
+            "Option" => {
+                let inner = extract_single_generic_arg(template_name, segment.expect("segment is some"));
+                ArgType::Option(Box::new(inner))
             },
             "Self" => ArgType::Other {
                 name: format!("Component<{}>", template_name),
             },
-            type_name => ArgType::Other {
-                name: type_name.to_string(),
+            type_name => {
+                let seg = segment.expect("segment is some");
+                let name = match &seg.arguments {
+                    PathArguments::AngleBracketed(AngleBracketedGenericArguments { args, .. }) => {
+                        let generic_args = args
+                            .iter()
+                            .map(|arg| match arg {
+                                GenericArgument::Type(Type::Path(path)) => {
+                                    let inner = path_segment_to_arg_type(template_name, path.path.segments.first());
+                                    format!("{inner}")
+                                },
+                                GenericArgument::Type(Type::Tuple(tuple)) => {
+                                    format!("{}", tuple_to_arg_type(template_name, tuple))
+                                },
+                                a => format!("{:?}", a),
+                            })
+                            .collect::<Vec<_>>()
+                            .join(", ");
+                        format!("{type_name}<{generic_args}>")
+                    },
+                    _ => type_name.to_string(),
+                };
+                ArgType::Other { name }
             },
         },
+    }
+}
+
+fn extract_single_generic_arg(template_name: &str, segment: &PathSegment) -> ArgType {
+    match &segment.arguments {
+        PathArguments::AngleBracketed(AngleBracketedGenericArguments { args, .. }) => match &args[0] {
+            GenericArgument::Type(Type::Path(path)) => {
+                path_segment_to_arg_type(template_name, path.path.segments.first())
+            },
+            GenericArgument::Type(Type::Tuple(tuple)) => tuple_to_arg_type(template_name, tuple),
+            a => panic!("Invalid generic argument {:?}", a),
+        },
+        _ => panic!("{} must specify a type argument: {:?}", segment.ident, segment),
     }
 }
 
@@ -207,4 +231,245 @@ fn tuple_to_arg_type(template_name: &str, tuple: &TypeTuple) -> ArgType {
         .collect::<Vec<_>>();
 
     ArgType::Tuple(subtypes)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use indoc::indoc;
+    use proc_macro2::TokenStream;
+    use syn::parse2;
+    use tari_template_abi::{TemplateDef, Type as ArgType};
+
+    use super::generate_abi;
+    use crate::template::ast::TemplateAst;
+
+    fn parse_template_def(input: &str) -> TemplateDef {
+        let tokens = TokenStream::from_str(input).unwrap();
+        let ast = parse2::<TemplateAst>(tokens).unwrap();
+        let output = generate_abi(&ast).unwrap();
+
+        // The generated code is: pub static TEMPLATE_DEF: [u8; N] = [b0, b1, ...] ;
+        // Extract the byte array after "= ["
+        let output_str = output.to_string();
+        let eq_bracket = output_str.find("= [").unwrap();
+        let data_start = eq_bracket + 2;
+        let data_end = output_str[data_start..].find(']').unwrap() + data_start;
+        let byte_list = &output_str[data_start + 1..data_end];
+
+        let bytes: Vec<u8> = byte_list
+            .split(',')
+            .filter(|s| !s.trim().is_empty())
+            .map(|s| {
+                let s = s.trim();
+                // Handle suffixed literals like "128u8"
+                let s = s.strip_suffix("u8").unwrap_or(s);
+                s.parse::<u8>()
+                    .unwrap_or_else(|e| panic!("Failed to parse byte '{}': {}", s, e))
+            })
+            .collect();
+
+        // Skip the 4-byte length prefix
+        tari_bor::decode::<TemplateDef>(&bytes[4..]).unwrap()
+    }
+
+    fn get_functions(def: &TemplateDef) -> &[tari_template_abi::FunctionDef] {
+        match def {
+            TemplateDef::V1(v1) => &v1.functions,
+        }
+    }
+
+    #[test]
+    fn test_primitive_types() {
+        let def = parse_template_def(indoc! {"
+            mod test_template {
+                pub struct TestTemplate {}
+                impl TestTemplate {
+                    pub fn create(a: u32, b: String, c: bool, d: i64) -> u8 { }
+                }
+            }
+        "});
+
+        let funcs = get_functions(&def);
+        assert_eq!(funcs.len(), 1);
+        let f = &funcs[0];
+        assert_eq!(f.name, "create");
+        assert_eq!(f.arguments.len(), 4);
+        assert_eq!(f.arguments[0].name, "a");
+        assert_eq!(f.arguments[0].arg_type, ArgType::U32);
+        assert_eq!(f.arguments[1].name, "b");
+        assert_eq!(f.arguments[1].arg_type, ArgType::String);
+        assert_eq!(f.arguments[2].name, "c");
+        assert_eq!(f.arguments[2].arg_type, ArgType::Bool);
+        assert_eq!(f.arguments[3].name, "d");
+        assert_eq!(f.arguments[3].arg_type, ArgType::I64);
+        assert_eq!(f.output, ArgType::U8);
+    }
+
+    #[test]
+    fn test_option_type() {
+        let def = parse_template_def(indoc! {"
+            mod test_template {
+                pub struct TestTemplate {}
+                impl TestTemplate {
+                    pub fn create(a: Option<String>, b: Option<u64>) { }
+                }
+            }
+        "});
+
+        let funcs = get_functions(&def);
+        let f = &funcs[0];
+        assert_eq!(f.arguments.len(), 2);
+        assert_eq!(f.arguments[0].name, "a");
+        assert_eq!(f.arguments[0].arg_type, ArgType::Option(Box::new(ArgType::String)));
+        assert_eq!(f.arguments[1].name, "b");
+        assert_eq!(f.arguments[1].arg_type, ArgType::Option(Box::new(ArgType::U64)));
+    }
+
+    #[test]
+    fn test_vec_type() {
+        let def = parse_template_def(indoc! {"
+            mod test_template {
+                pub struct TestTemplate {}
+                impl TestTemplate {
+                    pub fn create(a: Vec<u8>, b: Vec<String>) { }
+                }
+            }
+        "});
+
+        let funcs = get_functions(&def);
+        let f = &funcs[0];
+        assert_eq!(f.arguments[0].arg_type, ArgType::Vec(Box::new(ArgType::U8)));
+        assert_eq!(f.arguments[1].arg_type, ArgType::Vec(Box::new(ArgType::String)));
+    }
+
+    #[test]
+    fn test_nested_generic_types() {
+        let def = parse_template_def(indoc! {"
+            mod test_template {
+                pub struct TestTemplate {}
+                impl TestTemplate {
+                    pub fn create(a: Vec<Option<String>>, b: Option<Vec<u32>>) { }
+                }
+            }
+        "});
+
+        let funcs = get_functions(&def);
+        let f = &funcs[0];
+        assert_eq!(
+            f.arguments[0].arg_type,
+            ArgType::Vec(Box::new(ArgType::Option(Box::new(ArgType::String))))
+        );
+        assert_eq!(
+            f.arguments[1].arg_type,
+            ArgType::Option(Box::new(ArgType::Vec(Box::new(ArgType::U32))))
+        );
+    }
+
+    #[test]
+    fn test_tuple_type() {
+        let def = parse_template_def(indoc! {"
+            mod test_template {
+                pub struct TestTemplate {}
+                impl TestTemplate {
+                    pub fn create(a: (u32, String)) { }
+                }
+            }
+        "});
+
+        let funcs = get_functions(&def);
+        let f = &funcs[0];
+        assert_eq!(
+            f.arguments[0].arg_type,
+            ArgType::Tuple(vec![ArgType::U32, ArgType::String])
+        );
+    }
+
+    #[test]
+    fn test_custom_types_with_generics() {
+        let def = parse_template_def(indoc! {"
+            mod test_template {
+                pub struct TestTemplate {}
+                impl TestTemplate {
+                    pub fn create(a: HashMap<String, u64>, b: ResourceAddress) { }
+                }
+            }
+        "});
+
+        let funcs = get_functions(&def);
+        let f = &funcs[0];
+        assert_eq!(f.arguments[0].arg_type, ArgType::Other {
+            name: "HashMap<String, U64>".to_string()
+        });
+        assert_eq!(f.arguments[1].arg_type, ArgType::Other {
+            name: "ResourceAddress".to_string()
+        });
+    }
+
+    #[test]
+    fn test_self_receiver() {
+        let def = parse_template_def(indoc! {"
+            mod test_template {
+                pub struct TestTemplate {}
+                impl TestTemplate {
+                    pub fn create() -> Self { }
+                    pub fn read(&self) -> u32 { }
+                    pub fn write(&mut self, value: u32) { }
+                }
+            }
+        "});
+
+        let funcs = get_functions(&def);
+        assert_eq!(funcs.len(), 3);
+
+        // Constructor returning Self
+        assert_eq!(funcs[0].name, "create");
+        assert!(!funcs[0].is_mut);
+        assert_eq!(funcs[0].output, ArgType::Other {
+            name: "Component<TestTemplate>".to_string()
+        });
+
+        // &self method
+        assert_eq!(funcs[1].name, "read");
+        assert!(!funcs[1].is_mut);
+        assert_eq!(funcs[1].arguments[0].name, "self");
+
+        // &mut self method
+        assert_eq!(funcs[2].name, "write");
+        assert!(funcs[2].is_mut);
+        assert_eq!(funcs[2].arguments[0].name, "self");
+        assert_eq!(funcs[2].arguments[1].name, "value");
+        assert_eq!(funcs[2].arguments[1].arg_type, ArgType::U32);
+    }
+
+    #[test]
+    fn test_option_return_type() {
+        let def = parse_template_def(indoc! {"
+            mod test_template {
+                pub struct TestTemplate {}
+                impl TestTemplate {
+                    pub fn find(name: String) -> Option<u64> { }
+                }
+            }
+        "});
+
+        let funcs = get_functions(&def);
+        assert_eq!(funcs[0].output, ArgType::Option(Box::new(ArgType::U64)));
+    }
+
+    #[test]
+    fn test_no_return_type() {
+        let def = parse_template_def(indoc! {"
+            mod test_template {
+                pub struct TestTemplate {}
+                impl TestTemplate {
+                    pub fn do_something(a: u32) { }
+                }
+            }
+        "});
+
+        let funcs = get_functions(&def);
+        assert_eq!(funcs[0].output, ArgType::Unit);
+    }
 }

--- a/crates/template_macros/src/template/mod.rs
+++ b/crates/template_macros/src/template/mod.rs
@@ -20,22 +20,27 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-mod abi;
 mod ast;
 mod definition;
 mod dispatcher;
+mod template_def;
 
 use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{Result, parse2};
 
-use self::{abi::generate_abi, ast::TemplateAst, definition::generate_definition, dispatcher::generate_dispatcher};
+use self::{
+    ast::TemplateAst,
+    definition::generate_definition,
+    dispatcher::generate_dispatcher,
+    template_def::generate_template_def,
+};
 
 pub fn generate_template(input: TokenStream) -> Result<TokenStream> {
     let ast = parse2::<TemplateAst>(input).unwrap();
 
     let definition = generate_definition(&ast);
-    let abi = generate_abi(&ast)?;
+    let template_def = generate_template_def(&ast)?;
     let dispatcher = generate_dispatcher(&ast)?;
 
     let output = quote! {
@@ -43,7 +48,7 @@ pub fn generate_template(input: TokenStream) -> Result<TokenStream> {
 
         #dispatcher
 
-        #abi
+        #template_def
     };
 
     // eprintln!("output = {}", output);

--- a/crates/template_macros/src/template/template_def.rs
+++ b/crates/template_macros/src/template/template_def.rs
@@ -35,7 +35,7 @@ use tari_template_abi::{
 
 use crate::template::ast::{TemplateAst, TypeAst};
 
-pub fn generate_abi(ast: &TemplateAst) -> Result<TokenStream> {
+pub fn generate_template_def(ast: &TemplateAst) -> Result<TokenStream> {
     let template_name_as_str = ast.template_name.to_string();
 
     let template_def = TemplateDef::V1(TemplateDefV1 {
@@ -173,7 +173,7 @@ fn path_segment_to_arg_type(template_name: &str, segment: Option<&PathSegment>) 
                 ArgType::Option(Box::new(inner))
             },
             "Self" => ArgType::Other {
-                name: format!("Component<{}>", template_name),
+                name: template_name.to_string(),
             },
             type_name => {
                 let seg = segment.expect("segment is some");
@@ -183,11 +183,10 @@ fn path_segment_to_arg_type(template_name: &str, segment: Option<&PathSegment>) 
                             .iter()
                             .map(|arg| match arg {
                                 GenericArgument::Type(Type::Path(path)) => {
-                                    let inner = path_segment_to_arg_type(template_name, path.path.segments.first());
-                                    format!("{inner}")
+                                    path_segment_to_arg_type(template_name, path.path.segments.last()).to_string()
                                 },
                                 GenericArgument::Type(Type::Tuple(tuple)) => {
-                                    format!("{}", tuple_to_arg_type(template_name, tuple))
+                                    tuple_to_arg_type(template_name, tuple).to_string()
                                 },
                                 a => format!("{:?}", a),
                             })
@@ -205,12 +204,21 @@ fn path_segment_to_arg_type(template_name: &str, segment: Option<&PathSegment>) 
 
 fn extract_single_generic_arg(template_name: &str, segment: &PathSegment) -> ArgType {
     match &segment.arguments {
-        PathArguments::AngleBracketed(AngleBracketedGenericArguments { args, .. }) => match &args[0] {
-            GenericArgument::Type(Type::Path(path)) => {
-                path_segment_to_arg_type(template_name, path.path.segments.first())
-            },
-            GenericArgument::Type(Type::Tuple(tuple)) => tuple_to_arg_type(template_name, tuple),
-            a => panic!("Invalid generic argument {:?}", a),
+        PathArguments::AngleBracketed(AngleBracketedGenericArguments { args, .. }) => {
+            if args.len() != 1 {
+                panic!(
+                    "{} must have exactly one generic type argument, but has {}",
+                    segment.ident,
+                    args.len()
+                );
+            }
+            match &args[0] {
+                GenericArgument::Type(Type::Path(path)) => {
+                    path_segment_to_arg_type(template_name, path.path.segments.last())
+                },
+                GenericArgument::Type(Type::Tuple(tuple)) => tuple_to_arg_type(template_name, tuple),
+                a => panic!("Invalid generic argument {:?}", a),
+            }
         },
         _ => panic!("{} must specify a type argument: {:?}", segment.ident, segment),
     }
@@ -242,13 +250,13 @@ mod tests {
     use syn::parse2;
     use tari_template_abi::{TemplateDef, Type as ArgType};
 
-    use super::generate_abi;
+    use super::generate_template_def;
     use crate::template::ast::TemplateAst;
 
     fn parse_template_def(input: &str) -> TemplateDef {
         let tokens = TokenStream::from_str(input).unwrap();
         let ast = parse2::<TemplateAst>(tokens).unwrap();
-        let output = generate_abi(&ast).unwrap();
+        let output = generate_template_def(&ast).unwrap();
 
         // The generated code is: pub static TEMPLATE_DEF: [u8; N] = [b0, b1, ...] ;
         // Extract the byte array after "= ["

--- a/crates/template_test_tooling/Cargo.toml
+++ b/crates/template_test_tooling/Cargo.toml
@@ -18,7 +18,7 @@ tari_template_builtin = { workspace = true, features = ["templates"] }
 tari_ootle_transaction = { workspace = true }
 tari_ootle_common_types = { workspace = true }
 tari_bor = { workspace = true, default-features = true }
-tari_ootle_wallet_crypto = { workspace = true }
+tari_ootle_wallet_crypto = { workspace = true, features = ["serde"] }
 ootle_byte_type = { workspace = true, features = ["crypto"] }
 
 anyhow = { workspace = true }


### PR DESCRIPTION
Description
---
fix(abi)!: adds Option type

Motivation and Context
---
Template def loses the type names for when used with generics (e.g `Foo<T>` would only have `Foo`)
Since `Option` is common in definitions, this PR adds a type variant for this case (instead of "Other")

How Has This Been Tested?
---
Manually

What process can a PR reviewer use to test or verify this change?
---


Breaking Changes
---

- [ ] None
- [ ] Requires data directory to be deleted
- [x] Other - Please specify

BREAKING CHANGE: a new variant added to Type in  template definition requires all validators and indexers to update NOTE: previous templates will still work on updated validators/indexers