### PR TITLE
fix(docs): revert font-display optional to swap to fix missing fonts on cold cache

### DIFF
--- a/docs/developer-docs/src/fonts/font-face.css
+++ b/docs/developer-docs/src/fonts/font-face.css
@@ -3,7 +3,7 @@
     src: url("./DrukLCG-Medium.ttf") format("truetype");
     font-weight: 500;
     font-style: normal;
-    font-display: optional;
+    font-display: swap;
 }
 
 @font-face {
@@ -11,7 +11,7 @@
     src: url("./DrukLCG-MediumItalic.ttf") format("truetype");
     font-weight: 500;
     font-style: italic;
-    font-display: optional;
+    font-display: swap;
 }
 
 @font-face {
@@ -19,7 +19,7 @@
     src: url("./DrukLCG-Bold.ttf") format("truetype");
     font-weight: 700;
     font-style: normal;
-    font-display: optional;
+    font-display: swap;
 }
 
 @font-face {
@@ -27,7 +27,7 @@
     src: url("./DrukLCG-BoldItalic.ttf") format("truetype");
     font-weight: 700;
     font-style: italic;
-    font-display: optional;
+    font-display: swap;
 }
 
 @font-face {
@@ -35,7 +35,7 @@
     src: url("./DrukLCG-Heavy.ttf") format("truetype");
     font-weight: 800;
     font-style: normal;
-    font-display: optional;
+    font-display: swap;
 }
 
 @font-face {
@@ -43,7 +43,7 @@
     src: url("./DrukLCG-HeavyItalic.ttf") format("truetype");
     font-weight: 800;
     font-style: italic;
-    font-display: optional;
+    font-display: swap;
 }
 
 @font-face {
@@ -51,7 +51,7 @@
     src: url("./DrukWideLCG-Medium.ttf") format("truetype");
     font-weight: 500;
     font-style: normal;
-    font-display: optional;
+    font-display: swap;
 }
 
 @font-face {
@@ -59,7 +59,7 @@
     src: url("./DrukWideLCG-MediumItalic.ttf") format("truetype");
     font-weight: 500;
     font-style: italic;
-    font-display: optional;
+    font-display: swap;
 }
 
 @font-face {
@@ -67,7 +67,7 @@
     src: url("./DrukWideLCG-Bold.ttf") format("truetype");
     font-weight: 700;
     font-style: normal;
-    font-display: optional;
+    font-display: swap;
 }
 
 @font-face {
@@ -75,7 +75,7 @@
     src: url("./DrukWideLCG-BoldItalic.ttf") format("truetype");
     font-weight: 700;
     font-style: italic;
-    font-display: optional;
+    font-display: swap;
 }
 
 @font-face {
@@ -83,7 +83,7 @@
     src: url("./DrukWideLCG-Heavy.ttf") format("truetype");
     font-weight: 800;
     font-style: normal;
-    font-display: optional;
+    font-display: swap;
 }
 
 @font-face {
@@ -91,5 +91,5 @@
     src: url("./DrukWideLCG-HeavyItalic.ttf") format("truetype");
     font-weight: 800;
     font-style: italic;
-    font-display: optional;
+    font-display: swap;
 }


### PR DESCRIPTION
## Problem

The recent landing page commit changed `font-display: swap` to `font-display: optional` on all Druk `@font-face` declarations to fix a FOUT in dev mode.

However, `font-display: optional` gives the browser only ~100ms to load fonts before permanently falling back for that session. On any cold cache (new visitor, cleared cache, CDN edge node), the Druk fonts never load in time and the page renders in system fonts.

## Fix

Reverts all 12 `font-display: optional` declarations back to `font-display: swap`.