### PR TITLE
fix(skills): include cargo.toml flags for wasm size reduction

### DIFF
--- a/docs/skills/aider/SKILL.md
+++ b/docs/skills/aider/SKILL.md
@@ -111,7 +111,7 @@ opt-level = 's'     # Optimize for size.
 lto = true          # Enable Link Time Optimization.
 codegen-units = 1   # Reduce number of codegen units to increase optimizations.
 panic = 'abort'     # Abort on panic.
-strip = "debuginfo" # Strip debug info.
+strip = true          # Strip symbols and debug info.
 ```
 
 > **CRITICAL:** The `crate-type = ["cdylib"]` is required for WASM compilation. Without it, the build will not produce a `.wasm` file.

--- a/docs/skills/aider/SKILL.md
+++ b/docs/skills/aider/SKILL.md
@@ -105,9 +105,18 @@ tari_template_lib = { git = "https://github.com/tari-project/tari-ootle.git", br
 
 [lib]
 crate-type = ["cdylib"]
+
+[profile.release]
+opt-level = 's'     # Optimize for size.
+lto = true          # Enable Link Time Optimization.
+codegen-units = 1   # Reduce number of codegen units to increase optimizations.
+panic = 'abort'     # Abort on panic.
+strip = "debuginfo" # Strip debug info.
 ```
 
 > **CRITICAL:** The `crate-type = ["cdylib"]` is required for WASM compilation. Without it, the build will not produce a `.wasm` file.
+
+> **Tip:** The `[profile.release]` section in `Cargo.toml` significantly reduces the size of the compiled WASM file, which lowers the fees required for on-chain storage and publishing.
 
 ### Compilation
 

--- a/docs/skills/amp/SKILL.md
+++ b/docs/skills/amp/SKILL.md
@@ -111,7 +111,7 @@ opt-level = 's'     # Optimize for size.
 lto = true          # Enable Link Time Optimization.
 codegen-units = 1   # Reduce number of codegen units to increase optimizations.
 panic = 'abort'     # Abort on panic.
-strip = "debuginfo" # Strip debug info.
+strip = true          # Strip symbols and debug info.
 ```
 
 > **CRITICAL:** The `crate-type = ["cdylib"]` is required for WASM compilation. Without it, the build will not produce a `.wasm` file.

--- a/docs/skills/amp/SKILL.md
+++ b/docs/skills/amp/SKILL.md
@@ -105,9 +105,18 @@ tari_template_lib = { git = "https://github.com/tari-project/tari-ootle.git", br
 
 [lib]
 crate-type = ["cdylib"]
+
+[profile.release]
+opt-level = 's'     # Optimize for size.
+lto = true          # Enable Link Time Optimization.
+codegen-units = 1   # Reduce number of codegen units to increase optimizations.
+panic = 'abort'     # Abort on panic.
+strip = "debuginfo" # Strip debug info.
 ```
 
 > **CRITICAL:** The `crate-type = ["cdylib"]` is required for WASM compilation. Without it, the build will not produce a `.wasm` file.
+
+> **Tip:** The `[profile.release]` section in `Cargo.toml` significantly reduces the size of the compiled WASM file, which lowers the fees required for on-chain storage and publishing.
 
 ### Compilation
 

--- a/docs/skills/antigravity/SKILL.md
+++ b/docs/skills/antigravity/SKILL.md
@@ -111,7 +111,7 @@ opt-level = 's'     # Optimize for size.
 lto = true          # Enable Link Time Optimization.
 codegen-units = 1   # Reduce number of codegen units to increase optimizations.
 panic = 'abort'     # Abort on panic.
-strip = "debuginfo" # Strip debug info.
+strip = true          # Strip symbols and debug info.
 ```
 
 > **CRITICAL:** The `crate-type = ["cdylib"]` is required for WASM compilation. Without it, the build will not produce a `.wasm` file.

--- a/docs/skills/antigravity/SKILL.md
+++ b/docs/skills/antigravity/SKILL.md
@@ -105,9 +105,18 @@ tari_template_lib = { git = "https://github.com/tari-project/tari-ootle.git", br
 
 [lib]
 crate-type = ["cdylib"]
+
+[profile.release]
+opt-level = 's'     # Optimize for size.
+lto = true          # Enable Link Time Optimization.
+codegen-units = 1   # Reduce number of codegen units to increase optimizations.
+panic = 'abort'     # Abort on panic.
+strip = "debuginfo" # Strip debug info.
 ```
 
 > **CRITICAL:** The `crate-type = ["cdylib"]` is required for WASM compilation. Without it, the build will not produce a `.wasm` file.
+
+> **Tip:** The `[profile.release]` section in `Cargo.toml` significantly reduces the size of the compiled WASM file, which lowers the fees required for on-chain storage and publishing.
 
 ### Compilation
 

--- a/docs/skills/claude-code/SKILL.md
+++ b/docs/skills/claude-code/SKILL.md
@@ -103,9 +103,18 @@ tari_template_lib = { git = "https://github.com/tari-project/tari-ootle.git", br
 
 [lib]
 crate-type = ["cdylib"]
+
+[profile.release]
+opt-level = 's'     # Optimize for size.
+lto = true          # Enable Link Time Optimization.
+codegen-units = 1   # Reduce number of codegen units to increase optimizations.
+panic = 'abort'     # Abort on panic.
+strip = "debuginfo" # Strip debug info.
 ```
 
 > **CRITICAL:** The `crate-type = ["cdylib"]` is required for WASM compilation. Without it, the build will not produce a `.wasm` file.
+
+> **Tip:** The `[profile.release]` section in `Cargo.toml` significantly reduces the size of the compiled WASM file, which lowers the fees required for on-chain storage and publishing.
 
 ### Compilation
 

--- a/docs/skills/claude-code/SKILL.md
+++ b/docs/skills/claude-code/SKILL.md
@@ -109,7 +109,7 @@ opt-level = 's'     # Optimize for size.
 lto = true          # Enable Link Time Optimization.
 codegen-units = 1   # Reduce number of codegen units to increase optimizations.
 panic = 'abort'     # Abort on panic.
-strip = "debuginfo" # Strip debug info.
+strip = true          # Strip symbols and debug info.
 ```
 
 > **CRITICAL:** The `crate-type = ["cdylib"]` is required for WASM compilation. Without it, the build will not produce a `.wasm` file.

--- a/docs/skills/cursor/SKILL.md
+++ b/docs/skills/cursor/SKILL.md
@@ -111,7 +111,7 @@ opt-level = 's'     # Optimize for size.
 lto = true          # Enable Link Time Optimization.
 codegen-units = 1   # Reduce number of codegen units to increase optimizations.
 panic = 'abort'     # Abort on panic.
-strip = "debuginfo" # Strip debug info.
+strip = true          # Strip symbols and debug info.
 ```
 
 > **CRITICAL:** The `crate-type = ["cdylib"]` is required for WASM compilation. Without it, the build will not produce a `.wasm` file.

--- a/docs/skills/cursor/SKILL.md
+++ b/docs/skills/cursor/SKILL.md
@@ -105,9 +105,18 @@ tari_template_lib = { git = "https://github.com/tari-project/tari-ootle.git", br
 
 [lib]
 crate-type = ["cdylib"]
+
+[profile.release]
+opt-level = 's'     # Optimize for size.
+lto = true          # Enable Link Time Optimization.
+codegen-units = 1   # Reduce number of codegen units to increase optimizations.
+panic = 'abort'     # Abort on panic.
+strip = "debuginfo" # Strip debug info.
 ```
 
 > **CRITICAL:** The `crate-type = ["cdylib"]` is required for WASM compilation. Without it, the build will not produce a `.wasm` file.
+
+> **Tip:** The `[profile.release]` section in `Cargo.toml` significantly reduces the size of the compiled WASM file, which lowers the fees required for on-chain storage and publishing.
 
 ### Compilation
 

--- a/docs/skills/github-copilot/SKILL.md
+++ b/docs/skills/github-copilot/SKILL.md
@@ -111,7 +111,7 @@ opt-level = 's'     # Optimize for size.
 lto = true          # Enable Link Time Optimization.
 codegen-units = 1   # Reduce number of codegen units to increase optimizations.
 panic = 'abort'     # Abort on panic.
-strip = "debuginfo" # Strip debug info.
+strip = true          # Strip symbols and debug info.
 ```
 
 > **CRITICAL:** The `crate-type = ["cdylib"]` is required for WASM compilation. Without it, the build will not produce a `.wasm` file.

--- a/docs/skills/github-copilot/SKILL.md
+++ b/docs/skills/github-copilot/SKILL.md
@@ -105,9 +105,18 @@ tari_template_lib = { git = "https://github.com/tari-project/tari-ootle.git", br
 
 [lib]
 crate-type = ["cdylib"]
+
+[profile.release]
+opt-level = 's'     # Optimize for size.
+lto = true          # Enable Link Time Optimization.
+codegen-units = 1   # Reduce number of codegen units to increase optimizations.
+panic = 'abort'     # Abort on panic.
+strip = "debuginfo" # Strip debug info.
 ```
 
 > **CRITICAL:** The `crate-type = ["cdylib"]` is required for WASM compilation. Without it, the build will not produce a `.wasm` file.
+
+> **Tip:** The `[profile.release]` section in `Cargo.toml` significantly reduces the size of the compiled WASM file, which lowers the fees required for on-chain storage and publishing.
 
 ### Compilation
 

--- a/docs/skills/google-gemini/SKILL.md
+++ b/docs/skills/google-gemini/SKILL.md
@@ -111,7 +111,7 @@ opt-level = 's'     # Optimize for size.
 lto = true          # Enable Link Time Optimization.
 codegen-units = 1   # Reduce number of codegen units to increase optimizations.
 panic = 'abort'     # Abort on panic.
-strip = "debuginfo" # Strip debug info.
+strip = true          # Strip symbols and debug info.
 ```
 
 > **CRITICAL:** The `crate-type = ["cdylib"]` is required for WASM compilation. Without it, the build will not produce a `.wasm` file.

--- a/docs/skills/google-gemini/SKILL.md
+++ b/docs/skills/google-gemini/SKILL.md
@@ -105,9 +105,18 @@ tari_template_lib = { git = "https://github.com/tari-project/tari-ootle.git", br
 
 [lib]
 crate-type = ["cdylib"]
+
+[profile.release]
+opt-level = 's'     # Optimize for size.
+lto = true          # Enable Link Time Optimization.
+codegen-units = 1   # Reduce number of codegen units to increase optimizations.
+panic = 'abort'     # Abort on panic.
+strip = "debuginfo" # Strip debug info.
 ```
 
 > **CRITICAL:** The `crate-type = ["cdylib"]` is required for WASM compilation. Without it, the build will not produce a `.wasm` file.
+
+> **Tip:** The `[profile.release]` section in `Cargo.toml` significantly reduces the size of the compiled WASM file, which lowers the fees required for on-chain storage and publishing.
 
 ### Compilation
 

--- a/docs/skills/openai-codex/SKILL.md
+++ b/docs/skills/openai-codex/SKILL.md
@@ -111,7 +111,7 @@ opt-level = 's'     # Optimize for size.
 lto = true          # Enable Link Time Optimization.
 codegen-units = 1   # Reduce number of codegen units to increase optimizations.
 panic = 'abort'     # Abort on panic.
-strip = "debuginfo" # Strip debug info.
+strip = true          # Strip symbols and debug info.
 ```
 
 > **CRITICAL:** The `crate-type = ["cdylib"]` is required for WASM compilation. Without it, the build will not produce a `.wasm` file.

--- a/docs/skills/openai-codex/SKILL.md
+++ b/docs/skills/openai-codex/SKILL.md
@@ -105,9 +105,18 @@ tari_template_lib = { git = "https://github.com/tari-project/tari-ootle.git", br
 
 [lib]
 crate-type = ["cdylib"]
+
+[profile.release]
+opt-level = 's'     # Optimize for size.
+lto = true          # Enable Link Time Optimization.
+codegen-units = 1   # Reduce number of codegen units to increase optimizations.
+panic = 'abort'     # Abort on panic.
+strip = "debuginfo" # Strip debug info.
 ```
 
 > **CRITICAL:** The `crate-type = ["cdylib"]` is required for WASM compilation. Without it, the build will not produce a `.wasm` file.
+
+> **Tip:** The `[profile.release]` section in `Cargo.toml` significantly reduces the size of the compiled WASM file, which lowers the fees required for on-chain storage and publishing.
 
 ### Compilation
 

--- a/docs/skills/windsurf/SKILL.md
+++ b/docs/skills/windsurf/SKILL.md
@@ -111,7 +111,7 @@ opt-level = 's'     # Optimize for size.
 lto = true          # Enable Link Time Optimization.
 codegen-units = 1   # Reduce number of codegen units to increase optimizations.
 panic = 'abort'     # Abort on panic.
-strip = "debuginfo" # Strip debug info.
+strip = true          # Strip symbols and debug info.
 ```
 
 > **CRITICAL:** The `crate-type = ["cdylib"]` is required for WASM compilation. Without it, the build will not produce a `.wasm` file.

--- a/docs/skills/windsurf/SKILL.md
+++ b/docs/skills/windsurf/SKILL.md
@@ -105,9 +105,18 @@ tari_template_lib = { git = "https://github.com/tari-project/tari-ootle.git", br
 
 [lib]
 crate-type = ["cdylib"]
+
+[profile.release]
+opt-level = 's'     # Optimize for size.
+lto = true          # Enable Link Time Optimization.
+codegen-units = 1   # Reduce number of codegen units to increase optimizations.
+panic = 'abort'     # Abort on panic.
+strip = "debuginfo" # Strip debug info.
 ```
 
 > **CRITICAL:** The `crate-type = ["cdylib"]` is required for WASM compilation. Without it, the build will not produce a `.wasm` file.
+
+> **Tip:** The `[profile.release]` section in `Cargo.toml` significantly reduces the size of the compiled WASM file, which lowers the fees required for on-chain storage and publishing.
 
 ### Compilation
 


### PR DESCRIPTION
Overview
  This PR updates the development instructions ("skills") for all supported AI agents to include recommended Cargo release profiles for Tari Ootle WASM templates. These optimizations significantly reduce the size of compiled .wasm files, leading to lower on-chain storage and publishing fees.


  Changes
   - Updated `SKILL.md` for all agents: Modified documentation for aider, amp, antigravity, claude-code, cursor, github-copilot, google-gemini, openai-codex, and windsurf.
   - Added `[profile.release]` to `Cargo.toml` examples: Included a standardized release profile optimized for size:

```
   1   [profile.release]
   2   opt-level = 's'     # Optimize for size.
   3   lto = true          # Enable Link Time Optimization.
   4   codegen-units = 1   # Reduce number of codegen units to increase optimizations.
   5   panic = 'abort'     # Abort on panic.
   6   strip = true # Strip symbols and debug info.
```
   - Added Optimization Tips: Inserted a tip in the Compilation section explaining that these flags reduce binary size and minimize on-chain costs.


  Impact
  Providing these defaults in the agent skills ensures that AI-generated projects are "production-ready" by default, preventing users from inadvertently publishing unoptimized, high-fee templates.
