### PR TITLE
feat(manifest): support workspace-based component references in method calls

### DIFF
--- a/crates/transaction_manifest/src/generator.rs
+++ b/crates/transaction_manifest/src/generator.rs
@@ -6,11 +6,12 @@ use std::collections::HashMap;
 use proc_macro2::Ident;
 use tari_engine_types::substate::SubstateId;
 use tari_ootle_transaction::{
+    ComponentReference,
     Instruction,
     args::{InstructionArg, WorkspaceId, WorkspaceOffsetId},
     call_arg,
 };
-use tari_template_lib::types::TemplateAddress;
+use tari_template_lib::types::{ComponentAddress, TemplateAddress};
 
 use crate::{
     ManifestInstructions,
@@ -115,18 +116,17 @@ impl ManifestInstructionGenerator {
                     .as_ref()
                     .expect("AST parse should have failed: no component ident for ComponentInvoke statement")
                     .to_string();
-                let component_address = self
-                    .get_variable(&component_ident)?
-                    .as_address()
-                    .and_then(|addr| addr.as_component_address())
-                    .ok_or_else(|| {
-                        ManifestError::InvalidVariableType(format!(
-                            "Expected component variable but got {:?}",
-                            self.get_variable(&component_ident)
-                        ))
-                    })?;
+                let call = if let Some(value) = self.global_aliases.get(&component_ident) {
+                    ComponentReference::Address(Self::extract_component_address(value)?)
+                } else if let Some(&workspace_id) = self.workspace_ids.get(&component_ident) {
+                    ComponentReference::Workspace(workspace_id)
+                } else if let Some(value) = self.globals.get(&component_ident) {
+                    ComponentReference::Address(Self::extract_component_address(value)?)
+                } else {
+                    return Err(ManifestError::UndefinedVariable { name: component_ident });
+                };
                 let mut instructions = vec![Instruction::CallMethod {
-                    call: component_address.into(),
+                    call,
                     method: function_name
                         .to_string()
                         .try_into()
@@ -205,16 +205,19 @@ impl ManifestInstructionGenerator {
             .ok_or_else(|| ManifestError::TemplateNotImported { name: name.to_string() })
     }
 
-    fn get_variable(&self, name: &str) -> Result<&ManifestValue, ManifestError> {
-        self.global_aliases
-            .get(name)
-            .ok_or_else(|| ManifestError::UndefinedVariable { name: name.to_string() })
-    }
-
     fn get_global(&self, name: &str) -> Result<&ManifestValue, ManifestError> {
         self.globals
             .get(name)
             .ok_or_else(|| ManifestError::UndefinedGlobal { name: name.to_string() })
+    }
+
+    fn extract_component_address(value: &ManifestValue) -> Result<ComponentAddress, ManifestError> {
+        value
+            .as_address()
+            .and_then(|addr| addr.as_component_address())
+            .ok_or_else(|| {
+                ManifestError::InvalidVariableType(format!("Expected component variable but got {:?}", value))
+            })
     }
 
     fn get_ident(&self, name: &str) -> Result<InstructionArg, ManifestError> {

--- a/crates/transaction_manifest/tests/examples/picture_seller.rs
+++ b/crates/transaction_manifest/tests/examples/picture_seller.rs
@@ -7,11 +7,8 @@ use template_c2b621869ec2929d3b9503ea41054f01b468ce99e50254b58e460f608ae377f7 as
 
 fn main() {
     // initialize the component
-    // TODO: This creates a new component but does not use it as a component input for call method
-    //       because this is not currently supported.
     let picture_seller = PictureSeller::new(1_000u64);
 
-    let picture_seller = var!["picture_seller_addr"];
     let faucet = var!["test_faucet"];
     // TODO: Implement sugar for the account component
     // e.g.  let account = default_account!();

--- a/crates/transaction_manifest/tests/parser.rs
+++ b/crates/transaction_manifest/tests/parser.rs
@@ -24,7 +24,7 @@ use std::{collections::HashMap, fs, str::FromStr};
 
 use tari_bor::cbor;
 use tari_engine_types::substate::SubstateId;
-use tari_ootle_transaction::{Instruction, call_args};
+use tari_ootle_transaction::{ComponentReference, Instruction, call_args};
 use tari_template_lib::types::{
     ComponentAddress,
     ObjectKey,
@@ -39,17 +39,12 @@ use tari_transaction_manifest::{ManifestInstructions, parse_manifest};
 fn manifest_smoke_test() {
     let input = fs::read_to_string("tests/examples/picture_seller.rs").unwrap();
     let account_component = ComponentAddress::new([0u8; ObjectKey::LENGTH].into());
-    let picture_seller_component = ComponentAddress::new([1u8; ObjectKey::LENGTH].into());
     let test_faucet_component = ComponentAddress::new([2u8; ObjectKey::LENGTH].into());
     let picture_seller_template =
         TemplateAddress::from_hex("c2b621869ec2929d3b9503ea41054f01b468ce99e50254b58e460f608ae377f7").unwrap();
 
     let globals = HashMap::from([
         ("account".to_string(), SubstateId::Component(account_component).into()),
-        (
-            "picture_seller_addr".to_string(),
-            SubstateId::Component(picture_seller_component).into(),
-        ),
         (
             "test_faucet".to_string(),
             SubstateId::Component(test_faucet_component).into(),
@@ -98,7 +93,7 @@ fn manifest_smoke_test() {
         },
         Instruction::PutLastInstructionOutputOnWorkspace { key: 2 },
         Instruction::CallMethod {
-            call: picture_seller_component.into(),
+            call: ComponentReference::Workspace(0),
             method: "buy".try_into().unwrap(),
             args: call_args![Workspace(2)],
         },
@@ -108,6 +103,44 @@ fn manifest_smoke_test() {
             method: "deposit".try_into().unwrap(),
             args: call_args![Workspace(3)],
         },
+    ];
+
+    assert_eq!(instructions, expected);
+    assert_eq!(fee_instructions, vec![]);
+}
+
+#[test]
+fn workspace_component_reference() {
+    let manifest = r#"
+        use template_c2b621869ec2929d3b9503ea41054f01b468ce99e50254b58e460f608ae377f7 as MyTemplate;
+
+        fn main() {
+            let comp = MyTemplate::new();
+            let result = comp.do_something();
+        }
+    "#;
+
+    let template_addr =
+        TemplateAddress::from_hex("c2b621869ec2929d3b9503ea41054f01b468ce99e50254b58e460f608ae377f7").unwrap();
+
+    let ManifestInstructions {
+        instructions,
+        fee_instructions,
+    } = parse_manifest(manifest, HashMap::new(), Default::default()).unwrap();
+
+    let expected = vec![
+        Instruction::CallFunction {
+            address: template_addr,
+            function: "new".try_into().unwrap(),
+            args: call_args![],
+        },
+        Instruction::PutLastInstructionOutputOnWorkspace { key: 0 },
+        Instruction::CallMethod {
+            call: ComponentReference::Workspace(0),
+            method: "do_something".try_into().unwrap(),
+            args: call_args![],
+        },
+        Instruction::PutLastInstructionOutputOnWorkspace { key: 1 },
     ];
 
     assert_eq!(instructions, expected);


### PR DESCRIPTION
Description
---

Previously, using a variable assigned from a template function call
(e.g. `let sc = MyTemplate::new(...)`) as a method receiver
(`sc.do_something()`) failed with "Variable 'sc' is not defined" because
the generator only resolved component variables from global aliases
(set via `var![]`), not from workspace IDs.

The InvokeComponent handler now checks workspace_ids and uses
ComponentReference::Workspace(id) when the variable was assigned from a
prior instruction output. Resolution order: global_aliases (explicit
var![]) > workspace_ids (script assignments) > globals (external), so
script-local assignments correctly shadow externally-provided globals.

How Has This Been Tested?
---
New tests

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify