### PR TITLE
docs: add For Bots nav link to llms.txt

### DIFF
--- a/docs/developer-docs/astro.config.mjs
+++ b/docs/developer-docs/astro.config.mjs
@@ -34,6 +34,7 @@ export default defineConfig({
           label: "Reference",
           autogenerate: { directory: "reference" },
         },
+        { label: "For Bots", link: "/llms.txt", attrs: { target: "_blank" } },
       ],
       components: {
         Pagination: "./src/components/Pagination.astro",


### PR DESCRIPTION
Adds a direct 'For Bots' link in the sidebar navigation pointing to `/llms.txt`, making it discoverable by AI coding agents and crawlers browsing the docs.