### PR TITLE
feat: many improvements to manifest

### DIFF
--- a/applications/tari_walletd/web_ui/package.json
+++ b/applications/tari_walletd/web_ui/package.json
@@ -35,6 +35,7 @@
     "react-icons": "^5.5.0",
     "react-qr-code": "^2.0.18",
     "react-router": "^7.13.1",
+    "react-simple-code-editor": "^0.14.1",
     "use-file-picker": "^2.1.4",
     "use-react-router-breadcrumbs": "^4.0.1",
     "zustand": "catalog:",

--- a/applications/tari_walletd/web_ui/src/routes/Manifest/Manifest.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/Manifest/Manifest.tsx
@@ -25,16 +25,24 @@ import { useSubmitManifest } from "@api/hooks/useTransactions";
 import PageHeading from "@components/PageHeading";
 import { DataTableCell, StyledPaper } from "@components/StyledComponents";
 import {
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
   FormControl,
+  IconButton,
   InputLabel,
   MenuItem,
   Select,
   Stack,
+  Tab,
   Table,
   TableBody,
   TableCell,
   TableHead,
   TableRow,
+  Tabs,
   TextareaAutosize,
   useTheme,
 } from "@mui/material";
@@ -44,8 +52,9 @@ import Button from "@mui/material/Button";
 import Grid from "@mui/material/Grid";
 import TextField from "@mui/material/TextField";
 import useManifestCodeStore from "@store/manifestStore";
+import type { ManifestTab } from "@store/manifestStore";
 import { rejectReasonToString, substateIdToString } from "@tari-project/ootle-ts-bindings";
-import { useState } from "react";
+import { useRef, useState } from "react";
 
 function Manifest() {
   return (
@@ -110,18 +119,15 @@ function ManifestEditor() {
   return (
     <>
       <Grid size={12}>
-        {error && (
-          <Box sx={{ color: "red" }}>
-            <p>{error.message}</p>
-          </Box>
-        )}
-        {finalizeError && (
-          <Box sx={{ color: "red" }}>
-            <p>{finalizeError}</p>
-          </Box>
-        )}
-
         <form onSubmit={handleSubmit}>
+          <ManifestTabBar
+            tabs={manifest.tabs}
+            activeTabId={manifest.activeTabId}
+            onSelect={manifest.setActiveTab}
+            onAdd={manifest.addTab}
+            onRemove={manifest.removeTab}
+            onRename={manifest.renameTab}
+          />
           <TextareaAutosize
             minRows={25}
             aria-label="Manifest code editor"
@@ -130,10 +136,11 @@ function ManifestEditor() {
             onChange={(e) => manifest.setCode(e.target.value)}
             style={{
               width: "100%",
-              borderRadius: 8,
+              borderRadius: "0 0 8px 8px",
               padding: "8px 32px",
               fontFamily: "monospace",
               backgroundColor: theme.palette.accent.background,
+              color: theme.palette.text.primary,
             }}
           />
           <Box className="flex-container" style={{ justifyContent: "flex-start" }}>
@@ -144,7 +151,7 @@ function ManifestEditor() {
               onRename={manifest.renameVariable}
             />
           </Box>
-          <Box className="flex-container" style={{ justifyContent: "flex-start" }}>
+          <Box className="flex-container" style={{ justifyContent: "flex-end" }}>
             <TextField
               name="max-fee"
               placeholder="Max fee"
@@ -156,9 +163,179 @@ function ManifestEditor() {
               {isSubmittingManifest ? "Submitting..." : fee ? "Submit" : "Estimate fee"}
             </Button>
           </Box>
+          {error && (
+            <Box sx={{ color: "red" }}>
+              <p>{error.message}</p>
+            </Box>
+          )}
+          {finalizeError && (
+            <Box sx={{ color: "red" }}>
+              <p>{finalizeError}</p>
+            </Box>
+          )}
         </form>
       </Grid>
     </>
+  );
+}
+
+function ManifestTabBar({
+  tabs,
+  activeTabId,
+  onSelect,
+  onAdd,
+  onRemove,
+  onRename,
+}: {
+  tabs: ManifestTab[];
+  activeTabId: string;
+  onSelect: (id: string) => void;
+  onAdd: () => void;
+  onRemove: (id: string) => void;
+  onRename: (id: string, name: string) => void;
+}) {
+  const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
+  const tabToDelete = confirmDeleteId ? tabs.find((t) => t.id === confirmDeleteId) : null;
+
+  return (
+    <Box sx={{ display: "flex", alignItems: "center", borderBottom: 1, borderColor: "divider" }}>
+      <Tabs
+        value={activeTabId}
+        onChange={(_, id) => onSelect(id)}
+        variant="scrollable"
+        scrollButtons="auto"
+        sx={{ flexGrow: 1 }}
+      >
+        {tabs.map((tab) => (
+          <Tab
+            key={tab.id}
+            value={tab.id}
+            label={
+              <TabLabel
+                tab={tab}
+                isActive={tab.id === activeTabId}
+                canClose={tabs.length > 1}
+                onClose={() => setConfirmDeleteId(tab.id)}
+                onRename={(name) => onRename(tab.id, name)}
+              />
+            }
+            sx={{ textTransform: "none", minHeight: 42, py: 0 }}
+          />
+        ))}
+      </Tabs>
+      <IconButton size="small" onClick={onAdd} title="New tab" sx={{ ml: 0.5, mr: 1 }}>
+        +
+      </IconButton>
+
+      <Dialog open={!!confirmDeleteId} onClose={() => setConfirmDeleteId(null)}>
+        <DialogTitle>Delete tab</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            Delete &quot;{tabToDelete?.name}&quot;? Any unsaved manifest code in this tab will be lost.
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setConfirmDeleteId(null)}>Cancel</Button>
+          <Button
+            color="error"
+            variant="contained"
+            onClick={() => {
+              onRemove(confirmDeleteId!);
+              setConfirmDeleteId(null);
+            }}
+          >
+            Delete Tab
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  );
+}
+
+function TabLabel({
+  tab,
+  isActive,
+  canClose,
+  onClose,
+  onRename,
+}: {
+  tab: ManifestTab;
+  isActive: boolean;
+  canClose: boolean;
+  onClose: () => void;
+  onRename: (name: string) => void;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(tab.name);
+
+  const commit = () => {
+    setEditing(false);
+    const trimmed = draft.trim();
+    if (trimmed && trimmed !== tab.name) {
+      onRename(trimmed);
+    } else {
+      setDraft(tab.name);
+    }
+  };
+
+  if (editing) {
+    return (
+      <TextField
+        size="small"
+        variant="standard"
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        onBlur={commit}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") commit();
+          if (e.key === "Escape") {
+            setDraft(tab.name);
+            setEditing(false);
+          }
+        }}
+        onClick={(e) => e.stopPropagation()}
+        autoFocus
+        sx={{ minWidth: 80, maxWidth: 160 }}
+        inputProps={{ style: { fontSize: "0.875rem", padding: "2px 0" } }}
+      />
+    );
+  }
+
+  return (
+    <Stack direction="row" alignItems="center" spacing={0.5}>
+      <Box
+        component="span"
+        onDoubleClick={(e) => {
+          if (isActive) {
+            e.stopPropagation();
+            setDraft(tab.name);
+            setEditing(true);
+          }
+        }}
+      >
+        {tab.name}
+      </Box>
+      {canClose && (
+        <Box
+          component="span"
+          onClick={(e) => {
+            e.stopPropagation();
+            onClose();
+          }}
+          sx={{
+            ml: 0.5,
+            px: 0.5,
+            lineHeight: 1,
+            fontSize: "1rem",
+            cursor: "pointer",
+            borderRadius: "50%",
+            "&:hover": { backgroundColor: "action.hover" },
+          }}
+        >
+          &times;
+        </Box>
+      )}
+    </Stack>
   );
 }
 
@@ -223,8 +400,10 @@ function VariableEditor({
   onRemove: (key: string) => void;
   onRename: (oldKey: string, newKey: string) => void;
 }) {
+  const [showInputs, setShowInputs] = useState(false);
   const [key, setKey] = useState("");
   const [value, setValue] = useState("");
+  const keyRef = useRef<HTMLInputElement>(null);
   const { data: accountsData } = useAccountsList(0, 100);
 
   const handleAddAccount = (e: SelectChangeEvent) => {
@@ -234,52 +413,16 @@ function VariableEditor({
     onAdd(varName, address);
   };
 
+  const handleAdd = () => {
+    if (!key.trim()) return;
+    onAdd(key, value);
+    setKey("");
+    setValue("");
+    setShowInputs(false);
+  };
+
   return (
     <Grid size={12} mt={2}>
-      <Stack direction="row" spacing={1} alignItems="center" marginBottom={2}>
-        <TextField
-          name="variable-key"
-          placeholder="Variable key"
-          value={key}
-          onChange={(e) => setKey(e.target.value)}
-        />
-        <TextField
-          name="variable-value"
-          placeholder="Variable value"
-          value={value}
-          onChange={(e) => setValue(e.target.value)}
-        />
-        <Button
-          variant="contained"
-          color="primary"
-          onClick={() => {
-            onAdd(key, value);
-            setKey("");
-            setValue("");
-          }}
-          style={{
-            minHeight: "52px",
-          }}
-        >
-          Add Variable
-        </Button>
-        {accountsData?.accounts && accountsData.accounts.length > 0 && (
-          <FormControl style={{ minWidth: "200px" }}>
-            <InputLabel id="add-account-label">Add Account</InputLabel>
-            <Select labelId="add-account-label" label="Add Account" value="" onChange={handleAddAccount}>
-              {accountsData.accounts.map(({ account }) => {
-                const address = substateIdToString(account.component_address);
-                return (
-                  <MenuItem key={address} value={address}>
-                    {account.name || address}
-                  </MenuItem>
-                );
-              })}
-            </Select>
-          </FormControl>
-        )}
-      </Stack>
-
       {Object.keys(variables).length > 0 && (
         <Table
           sx={{
@@ -290,7 +433,7 @@ function VariableEditor({
             <TableRow>
               <TableCell>Key</TableCell>
               <TableCell>Value</TableCell>
-              <TableCell>Actions</TableCell>
+              <TableCell />
             </TableRow>
           </TableHead>
           <TableBody>
@@ -301,14 +444,89 @@ function VariableEditor({
                 </DataTableCell>
                 <DataTableCell>{v}</DataTableCell>
                 <DataTableCell>
-                  <Button variant="outlined" color="error" onClick={() => onRemove(k)}>
-                    Remove
-                  </Button>
+                  <IconButton size="small" onClick={() => onRemove(k)} title="Remove variable">
+                    &times;
+                  </IconButton>
                 </DataTableCell>
               </TableRow>
             ))}
           </TableBody>
         </Table>
+      )}
+
+      {showInputs ? (
+        <Stack direction="row" spacing={1} alignItems="center" marginBottom={2}>
+          <TextField
+            name="variable-key"
+            placeholder="Variable key"
+            value={key}
+            onChange={(e) => setKey(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") handleAdd();
+              if (e.key === "Escape") {
+                setShowInputs(false);
+                setKey("");
+                setValue("");
+              }
+            }}
+            inputRef={keyRef}
+            autoFocus
+          />
+          <TextField
+            name="variable-value"
+            placeholder="Variable value"
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") handleAdd();
+              if (e.key === "Escape") {
+                setShowInputs(false);
+                setKey("");
+                setValue("");
+              }
+            }}
+          />
+          <Button
+            variant="contained"
+            color="primary"
+            onClick={handleAdd}
+            style={{ minHeight: "52px" }}
+          >
+            Add
+          </Button>
+          <Button
+            variant="outlined"
+            onClick={() => {
+              setShowInputs(false);
+              setKey("");
+              setValue("");
+            }}
+            style={{ minHeight: "52px" }}
+          >
+            Cancel
+          </Button>
+        </Stack>
+      ) : (
+        <Stack direction="row" spacing={1} alignItems="center" marginBottom={2}>
+          <IconButton size="small" onClick={() => setShowInputs(true)} title="Add variable">
+            +
+          </IconButton>
+          {accountsData?.accounts && accountsData.accounts.length > 0 && (
+            <FormControl style={{ minWidth: "200px" }}>
+              <InputLabel id="add-account-label">Add Account</InputLabel>
+              <Select labelId="add-account-label" label="Add Account" value="" onChange={handleAddAccount}>
+                {accountsData.accounts.map(({ account }) => {
+                  const address = substateIdToString(account.component_address);
+                  return (
+                    <MenuItem key={address} value={address}>
+                      {account.name || address}
+                    </MenuItem>
+                  );
+                })}
+              </Select>
+            </FormControl>
+          )}
+        </Stack>
       )}
     </Grid>
   );

--- a/applications/tari_walletd/web_ui/src/routes/Manifest/Manifest.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/Manifest/Manifest.tsx
@@ -43,7 +43,6 @@ import {
   TableHead,
   TableRow,
   Tabs,
-  TextareaAutosize,
   useTheme,
 } from "@mui/material";
 import type { SelectChangeEvent } from "@mui/material";
@@ -53,8 +52,39 @@ import Grid from "@mui/material/Grid";
 import TextField from "@mui/material/TextField";
 import useManifestCodeStore from "@store/manifestStore";
 import type { ManifestTab } from "@store/manifestStore";
+import { FormatAlignLeft } from "@mui/icons-material";
 import { rejectReasonToString, substateIdToString } from "@tari-project/ootle-ts-bindings";
+import { Highlight, themes } from "prism-react-renderer";
 import { useRef, useState } from "react";
+import Editor from "react-simple-code-editor";
+
+function formatManifestCode(code: string): string {
+  const lines = code.split("\n");
+  const formatted: string[] = [];
+  let indent = 0;
+
+  for (const rawLine of lines) {
+    const trimmed = rawLine.trim();
+    if (!trimmed) {
+      formatted.push("");
+      continue;
+    }
+
+    // Decrease indent for closing braces
+    if (trimmed.startsWith("}")) {
+      indent = Math.max(0, indent - 1);
+    }
+
+    formatted.push("    ".repeat(indent) + trimmed);
+
+    // Increase indent after opening braces (that aren't closed on the same line)
+    const opens = (trimmed.match(/{/g) || []).length;
+    const closes = (trimmed.match(/}/g) || []).length;
+    indent = Math.max(0, indent + opens - closes);
+  }
+
+  return formatted.join("\n");
+}
 
 function Manifest() {
   return (
@@ -127,21 +157,40 @@ function ManifestEditor() {
             onAdd={manifest.addTab}
             onRemove={manifest.removeTab}
             onRename={manifest.renameTab}
+            onFormat={() => manifest.setCode(formatManifestCode(manifest.code))}
           />
-          <TextareaAutosize
-            minRows={25}
-            aria-label="Manifest code editor"
-            name="manifest-code"
+          <Editor
             value={manifest.code}
-            onChange={(e) => manifest.setCode(e.target.value)}
+            onValueChange={manifest.setCode}
+            highlight={(code) => (
+              <Highlight
+                theme={theme.palette.mode === "dark" ? themes.vsDark : themes.vsLight}
+                code={code}
+                language="rust"
+              >
+                {({ tokens, getTokenProps }) =>
+                  tokens.map((line, i) => (
+                    <span key={i}>
+                      {line.map((token, key) => (
+                        <span key={key} {...getTokenProps({ token })} />
+                      ))}
+                      {i < tokens.length - 1 ? "\n" : ""}
+                    </span>
+                  ))
+                }
+              </Highlight>
+            )}
+            padding={32}
             style={{
               width: "100%",
               borderRadius: "0 0 8px 8px",
-              padding: "8px 32px",
-              fontFamily: "monospace",
+              fontFamily: "'Fira Code', 'Fira Mono', Consolas, Menlo, monospace",
+              fontSize: 14,
               backgroundColor: theme.palette.accent.background,
               color: theme.palette.text.primary,
+              minHeight: 400,
             }}
+            textareaClassName="manifest-code-textarea"
           />
           <Box className="flex-container" style={{ justifyContent: "flex-start" }}>
             <VariableEditor
@@ -186,6 +235,7 @@ function ManifestTabBar({
   onAdd,
   onRemove,
   onRename,
+  onFormat,
 }: {
   tabs: ManifestTab[];
   activeTabId: string;
@@ -193,6 +243,7 @@ function ManifestTabBar({
   onAdd: () => void;
   onRemove: (id: string) => void;
   onRename: (id: string, name: string) => void;
+  onFormat: () => void;
 }) {
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
   const tabToDelete = confirmDeleteId ? tabs.find((t) => t.id === confirmDeleteId) : null;
@@ -223,8 +274,11 @@ function ManifestTabBar({
           />
         ))}
       </Tabs>
-      <IconButton size="small" onClick={onAdd} title="New tab" sx={{ ml: 0.5, mr: 1 }}>
+      <IconButton size="small" onClick={onAdd} title="New tab" sx={{ ml: 0.5 }}>
         +
+      </IconButton>
+      <IconButton size="small" onClick={onFormat} title="Format code" sx={{ mr: 1 }}>
+        <FormatAlignLeft fontSize="small" />
       </IconButton>
 
       <Dialog open={!!confirmDeleteId} onClose={() => setConfirmDeleteId(null)}>

--- a/applications/tari_walletd/web_ui/src/routes/Manifest/Manifest.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/Manifest/Manifest.tsx
@@ -52,8 +52,10 @@ import Grid from "@mui/material/Grid";
 import TextField from "@mui/material/TextField";
 import useManifestCodeStore from "@store/manifestStore";
 import type { ManifestTab } from "@store/manifestStore";
-import { FormatAlignLeft } from "@mui/icons-material";
-import { rejectReasonToString, substateIdToString } from "@tari-project/ootle-ts-bindings";
+import { FormatAlignLeft, LibraryAdd } from "@mui/icons-material";
+import { rejectReasonToString, substateIdToString, decodeOotleAddress } from "@tari-project/ootle-ts-bindings";
+import { useListTemplatesAuthored } from "@api/hooks/useTemplatesAuthored";
+import useAccountStore from "@store/accountStore";
 import { Highlight, themes } from "prism-react-renderer";
 import { useRef, useState } from "react";
 import Editor from "react-simple-code-editor";
@@ -158,6 +160,18 @@ function ManifestEditor() {
             onRemove={manifest.removeTab}
             onRename={manifest.renameTab}
             onFormat={() => manifest.setCode(formatManifestCode(manifest.code))}
+            onImportTemplate={(address, name) => {
+              const importLine = `use template_${address} as ${name};`;
+              if (manifest.code.includes(importLine)) return;
+              // Insert after any existing use statements, or at the top
+              const lines = manifest.code.split("\n");
+              let lastUseIdx = -1;
+              for (let i = 0; i < lines.length; i++) {
+                if (lines[i].trimStart().startsWith("use ")) lastUseIdx = i;
+              }
+              lines.splice(lastUseIdx + 1, 0, importLine);
+              manifest.setCode(lines.join("\n"));
+            }}
           />
           <Editor
             value={manifest.code}
@@ -236,6 +250,7 @@ function ManifestTabBar({
   onRemove,
   onRename,
   onFormat,
+  onImportTemplate,
 }: {
   tabs: ManifestTab[];
   activeTabId: string;
@@ -244,8 +259,10 @@ function ManifestTabBar({
   onRemove: (id: string) => void;
   onRename: (id: string, name: string) => void;
   onFormat: () => void;
+  onImportTemplate: (address: string, name: string) => void;
 }) {
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
+  const [importOpen, setImportOpen] = useState(false);
   const tabToDelete = confirmDeleteId ? tabs.find((t) => t.id === confirmDeleteId) : null;
 
   return (
@@ -277,9 +294,21 @@ function ManifestTabBar({
       <IconButton size="small" onClick={onAdd} title="New tab" sx={{ ml: 0.5 }}>
         +
       </IconButton>
-      <IconButton size="small" onClick={onFormat} title="Format code" sx={{ mr: 1 }}>
+      <IconButton size="small" onClick={onFormat} title="Format code">
         <FormatAlignLeft fontSize="small" />
       </IconButton>
+      <IconButton size="small" onClick={() => setImportOpen(true)} title="Import template" sx={{ mr: 1 }}>
+        <LibraryAdd fontSize="small" />
+      </IconButton>
+
+      <ImportTemplateDialog
+        open={importOpen}
+        onClose={() => setImportOpen(false)}
+        onImport={(address, name) => {
+          onImportTemplate(address, name);
+          setImportOpen(false);
+        }}
+      />
 
       <Dialog open={!!confirmDeleteId} onClose={() => setConfirmDeleteId(null)}>
         <DialogTitle>Delete tab</DialogTitle>
@@ -303,6 +332,66 @@ function ManifestTabBar({
         </DialogActions>
       </Dialog>
     </Box>
+  );
+}
+
+function ImportTemplateDialog({
+  open,
+  onClose,
+  onImport,
+}: {
+  open: boolean;
+  onClose: () => void;
+  onImport: (address: string, name: string) => void;
+}) {
+  const ootleAddress = useAccountStore((s) => s.address);
+  const decoded = ootleAddress ? decodeOotleAddress(ootleAddress) : null;
+
+  const { data, isLoading } = useListTemplatesAuthored({
+    author_public_key: decoded?.accountPublicKey || "",
+    page: 0,
+    page_size: 100,
+  });
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>Import Template</DialogTitle>
+      <DialogContent>
+        {isLoading && <DialogContentText>Loading templates...</DialogContentText>}
+        {!isLoading && (!data?.templates || data.templates.length === 0) && (
+          <DialogContentText>No templates found for the current account.</DialogContentText>
+        )}
+        {data?.templates && data.templates.length > 0 && (
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell>Name</TableCell>
+                <TableCell>Address</TableCell>
+                <TableCell />
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {data.templates.map((t) => (
+                <TableRow key={t.address} hover sx={{ cursor: "pointer" }} onClick={() => onImport(t.address, t.name)}>
+                  <TableCell>{t.name}</TableCell>
+                  <TableCell sx={{ fontFamily: "monospace", fontSize: "0.75rem" }}>
+                    {t.address.slice(0, 8)}...{t.address.slice(-8)}
+                  </TableCell>
+                  <TableCell>
+                    <Button size="small" variant="outlined">
+                      Import
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+      </DialogActions>
+    </Dialog>
   );
 }
 

--- a/applications/tari_walletd/web_ui/src/routes/Manifest/Manifest.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/Manifest/Manifest.tsx
@@ -20,16 +20,31 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import { useAccountsList } from "@api/hooks/useAccounts";
 import { useSubmitManifest } from "@api/hooks/useTransactions";
 import PageHeading from "@components/PageHeading";
 import { DataTableCell, StyledPaper } from "@components/StyledComponents";
-import { Stack, Table, TableBody, TableCell, TableHead, TableRow, TextareaAutosize, useTheme } from "@mui/material";
+import {
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  TextareaAutosize,
+  useTheme,
+} from "@mui/material";
+import type { SelectChangeEvent } from "@mui/material";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import Grid from "@mui/material/Grid";
 import TextField from "@mui/material/TextField";
 import useManifestCodeStore from "@store/manifestStore";
-import { rejectReasonToString } from "@tari-project/ootle-ts-bindings";
+import { rejectReasonToString, substateIdToString } from "@tari-project/ootle-ts-bindings";
 import { useState } from "react";
 
 function Manifest() {
@@ -126,6 +141,7 @@ function ManifestEditor() {
               variables={manifest.variables}
               onAdd={manifest.addVariable}
               onRemove={manifest.removeVariable}
+              onRename={manifest.renameVariable}
             />
           </Box>
           <Box className="flex-container" style={{ justifyContent: "flex-start" }}>
@@ -146,17 +162,77 @@ function ManifestEditor() {
   );
 }
 
+function nextAccountVarName(variables: Record<string, string>): string {
+  let i = 1;
+  while (`account_${i}` in variables) {
+    i++;
+  }
+  return `account_${i}`;
+}
+
+function EditableKeyCell({ varKey, onRename }: { varKey: string; onRename: (oldKey: string, newKey: string) => void }) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(varKey);
+
+  const commit = () => {
+    setEditing(false);
+    const trimmed = draft.trim();
+    if (trimmed && trimmed !== varKey) {
+      onRename(varKey, trimmed);
+    } else {
+      setDraft(varKey);
+    }
+  };
+
+  if (editing) {
+    return (
+      <TextField
+        size="small"
+        variant="standard"
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        onBlur={commit}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") commit();
+          if (e.key === "Escape") {
+            setDraft(varKey);
+            setEditing(false);
+          }
+        }}
+        autoFocus
+        sx={{ minWidth: 120 }}
+      />
+    );
+  }
+
+  return (
+    <Box onClick={() => setEditing(true)} sx={{ cursor: "pointer", "&:hover": { textDecoration: "underline" } }}>
+      {varKey}
+    </Box>
+  );
+}
+
 function VariableEditor({
   variables,
   onAdd,
   onRemove,
+  onRename,
 }: {
   variables: Record<string, string>;
   onAdd: (key: string, value: string) => void;
   onRemove: (key: string) => void;
+  onRename: (oldKey: string, newKey: string) => void;
 }) {
   const [key, setKey] = useState("");
   const [value, setValue] = useState("");
+  const { data: accountsData } = useAccountsList(0, 100);
+
+  const handleAddAccount = (e: SelectChangeEvent) => {
+    const address = e.target.value;
+    if (!address) return;
+    const varName = nextAccountVarName(variables);
+    onAdd(varName, address);
+  };
 
   return (
     <Grid size={12} mt={2}>
@@ -187,6 +263,21 @@ function VariableEditor({
         >
           Add Variable
         </Button>
+        {accountsData?.accounts && accountsData.accounts.length > 0 && (
+          <FormControl style={{ minWidth: "200px" }}>
+            <InputLabel id="add-account-label">Add Account</InputLabel>
+            <Select labelId="add-account-label" label="Add Account" value="" onChange={handleAddAccount}>
+              {accountsData.accounts.map(({ account }) => {
+                const address = substateIdToString(account.component_address);
+                return (
+                  <MenuItem key={address} value={address}>
+                    {account.name || address}
+                  </MenuItem>
+                );
+              })}
+            </Select>
+          </FormControl>
+        )}
       </Stack>
 
       {Object.keys(variables).length > 0 && (
@@ -205,7 +296,9 @@ function VariableEditor({
           <TableBody>
             {Object.entries(variables).map(([k, v]) => (
               <TableRow key={k}>
-                <DataTableCell>{k}</DataTableCell>
+                <DataTableCell>
+                  <EditableKeyCell varKey={k} onRename={onRename} />
+                </DataTableCell>
                 <DataTableCell>{v}</DataTableCell>
                 <DataTableCell>
                   <Button variant="outlined" color="error" onClick={() => onRemove(k)}>

--- a/applications/tari_walletd/web_ui/src/services/store/manifestStore.ts
+++ b/applications/tari_walletd/web_ui/src/services/store/manifestStore.ts
@@ -32,41 +32,147 @@ fn main() {
    // let bucket = account.withdraw(1000);
 }`;
 
-interface Store {
+export interface ManifestTab {
+  id: string;
+  name: string;
   code: string;
-  setCode: (code: string) => void;
   variables: Record<string, string>;
+}
+
+interface Store {
+  tabs: ManifestTab[];
+  activeTabId: string;
+
+  // Active tab convenience accessors
+  code: string;
+  variables: Record<string, string>;
+
+  // Tab management
+  addTab: () => void;
+  removeTab: (id: string) => void;
+  setActiveTab: (id: string) => void;
+  renameTab: (id: string, name: string) => void;
+
+  // Active tab code/variable operations
+  setCode: (code: string) => void;
   addVariable: (key: string, value: string) => void;
   removeVariable: (key: string) => void;
   renameVariable: (oldKey: string, newKey: string) => void;
 }
 
+let nextId = 1;
+function generateId(): string {
+  return `tab_${Date.now()}_${nextId++}`;
+}
+
+function createTab(name: string): ManifestTab {
+  return { id: generateId(), name, code: DEFAULT_CODE, variables: {} };
+}
+
+function nextTabName(tabs: ManifestTab[]): string {
+  let i = 1;
+  const names = new Set(tabs.map((t) => t.name));
+  while (names.has(`Manifest ${i}`)) i++;
+  return `Manifest ${i}`;
+}
+
+function updateActiveTab(state: Store, patch: Partial<ManifestTab>): Partial<Store> {
+  const tabs = state.tabs.map((t) => (t.id === state.activeTabId ? { ...t, ...patch } : t));
+  const active = tabs.find((t) => t.id === state.activeTabId)!;
+  return { tabs, code: active.code, variables: active.variables };
+}
+
+const defaultTab = createTab("Manifest 1");
+
 const useManifestCodeStore = create<Store>()(
   persist<Store>(
     (set) => ({
-      code: DEFAULT_CODE,
-      setCode: (code: string) => set(() => ({ code })),
-      variables: {},
-      addVariable: (key: string, value: string) =>
+      tabs: [defaultTab],
+      activeTabId: defaultTab.id,
+      code: defaultTab.code,
+      variables: defaultTab.variables,
+
+      addTab: () =>
+        set((state) => {
+          const tab = createTab(nextTabName(state.tabs));
+          return {
+            tabs: [...state.tabs, tab],
+            activeTabId: tab.id,
+            code: tab.code,
+            variables: tab.variables,
+          };
+        }),
+
+      removeTab: (id: string) =>
+        set((state) => {
+          if (state.tabs.length <= 1) return state;
+          const idx = state.tabs.findIndex((t) => t.id === id);
+          const tabs = state.tabs.filter((t) => t.id !== id);
+          let activeTabId = state.activeTabId;
+          if (activeTabId === id) {
+            const newIdx = Math.min(idx, tabs.length - 1);
+            activeTabId = tabs[newIdx].id;
+          }
+          const active = tabs.find((t) => t.id === activeTabId)!;
+          return { tabs, activeTabId, code: active.code, variables: active.variables };
+        }),
+
+      setActiveTab: (id: string) =>
+        set((state) => {
+          const tab = state.tabs.find((t) => t.id === id);
+          if (!tab) return state;
+          return { activeTabId: id, code: tab.code, variables: tab.variables };
+        }),
+
+      renameTab: (id: string, name: string) =>
         set((state) => ({
-          variables: {
-            ...state.variables,
-            [key]: value,
-          },
+          tabs: state.tabs.map((t) => (t.id === id ? { ...t, name } : t)),
         })),
+
+      setCode: (code: string) => set((state) => updateActiveTab(state, { code })),
+
+      addVariable: (key: string, value: string) =>
+        set((state) => {
+          const active = state.tabs.find((t) => t.id === state.activeTabId)!;
+          return updateActiveTab(state, { variables: { ...active.variables, [key]: value } });
+        }),
+
       removeVariable: (key: string) =>
         set((state) => {
-          const { [key]: _, ...rest } = state.variables;
-          return { variables: rest };
+          const active = state.tabs.find((t) => t.id === state.activeTabId)!;
+          const { [key]: _, ...rest } = active.variables;
+          return updateActiveTab(state, { variables: rest });
         }),
+
       renameVariable: (oldKey: string, newKey: string) =>
         set((state) => {
-          if (oldKey === newKey || !(oldKey in state.variables)) return state;
-          const entries = Object.entries(state.variables).map(([k, v]) => (k === oldKey ? [newKey, v] : [k, v]));
-          return { variables: Object.fromEntries(entries) };
+          const active = state.tabs.find((t) => t.id === state.activeTabId)!;
+          if (oldKey === newKey || !(oldKey in active.variables)) return state;
+          const entries = Object.entries(active.variables).map(([k, v]) => (k === oldKey ? [newKey, v] : [k, v]));
+          return updateActiveTab(state, { variables: Object.fromEntries(entries) });
         }),
     }),
-    { name: "manifest-code" },
+    {
+      name: "manifest-code",
+      migrate: (persisted: unknown, version: number) => {
+        const state = persisted as Record<string, unknown>;
+        // Migrate from single-tab format (no tabs array) to multi-tab format
+        if (version === 0 && state && !state.tabs) {
+          const code = (state.code as string) || DEFAULT_CODE;
+          const variables = (state.variables as Record<string, string>) || {};
+          const tab: ManifestTab = { id: generateId(), name: "Manifest 1", code, variables };
+          return {
+            ...state,
+            tabs: [tab],
+            activeTabId: tab.id,
+            code: tab.code,
+            variables: tab.variables,
+          } as Store;
+        }
+        return state as unknown as Store;
+      },
+      version: 1,
+    },
   ),
 );
 

--- a/applications/tari_walletd/web_ui/src/services/store/manifestStore.ts
+++ b/applications/tari_walletd/web_ui/src/services/store/manifestStore.ts
@@ -38,6 +38,7 @@ interface Store {
   variables: Record<string, string>;
   addVariable: (key: string, value: string) => void;
   removeVariable: (key: string) => void;
+  renameVariable: (oldKey: string, newKey: string) => void;
 }
 
 const useManifestCodeStore = create<Store>()(
@@ -57,6 +58,12 @@ const useManifestCodeStore = create<Store>()(
         set((state) => {
           const { [key]: _, ...rest } = state.variables;
           return { variables: rest };
+        }),
+      renameVariable: (oldKey: string, newKey: string) =>
+        set((state) => {
+          if (oldKey === newKey || !(oldKey in state.variables)) return state;
+          const entries = Object.entries(state.variables).map(([k, v]) => (k === oldKey ? [newKey, v] : [k, v]));
+          return { variables: Object.fromEntries(entries) };
         }),
     }),
     { name: "manifest-code" },

--- a/crates/transaction_manifest/src/error.rs
+++ b/crates/transaction_manifest/src/error.rs
@@ -36,10 +36,14 @@ pub enum ManifestError {
     UndefinedGlobal { name: String },
     #[error("Variable '{name}' is not defined")]
     UndefinedVariable { name: String },
+    #[error("Function '{name}' is not defined")]
+    UndefinedFunction { name: String },
     #[error("Invalid variable type: {0}")]
     InvalidVariableType(String),
     #[error("Template alias '{alias}' not defined")]
     TemplateAliasNotDefined { alias: String },
     #[error("Invalid instruction: {reason}")]
     InvalidInstruction { reason: String },
+    #[error("Maximum call depth of {max} exceeded")]
+    MaxCallDepthExceeded { max: usize },
 }

--- a/crates/transaction_manifest/src/generator.rs
+++ b/crates/transaction_manifest/src/generator.rs
@@ -29,6 +29,7 @@ pub struct ManifestInstructionGenerator {
     current_workspace_id: WorkspaceId,
     workspace_ids: HashMap<String, WorkspaceId>,
     templates: HashMap<String, TemplateAddress>,
+    functions: HashMap<String, Vec<ManifestIntent>>,
 }
 
 impl ManifestInstructionGenerator {
@@ -40,6 +41,7 @@ impl ManifestInstructionGenerator {
             current_workspace_id: WorkspaceId::default(),
             workspace_ids: HashMap::new(),
             templates,
+            functions: HashMap::new(),
         }
     }
 
@@ -60,6 +62,8 @@ impl ManifestInstructionGenerator {
                 },
             })
             .collect::<Result<_, _>>()?;
+
+        self.functions = ast.parsed.functions;
 
         let mut instructions = Vec::with_capacity(ast.parsed.instruction_intents.len());
         for intent in ast.parsed.instruction_intents {
@@ -162,6 +166,19 @@ impl ManifestInstructionGenerator {
                 })?,
             }]),
             ManifestIntent::DropAllProofs => Ok(vec![Instruction::DropAllProofsInWorkspace]),
+            ManifestIntent::CallLocalFunction(ident) => {
+                let name = ident.to_string();
+                let body = self
+                    .functions
+                    .get(&name)
+                    .ok_or_else(|| ManifestError::UndefinedVariable { name: name.clone() })?
+                    .clone();
+                let mut instructions = Vec::new();
+                for intent in body {
+                    instructions.extend(self.translate_intent(intent)?);
+                }
+                Ok(instructions)
+            },
         }
     }
 

--- a/crates/transaction_manifest/src/generator.rs
+++ b/crates/transaction_manifest/src/generator.rs
@@ -141,6 +141,13 @@ impl ManifestInstructionGenerator {
                 }
                 Ok(instructions)
             },
+            ManifestIntent::AllocateAddress(alloc) => {
+                let workspace_id = self.next_workspace_id(alloc.output_variable.to_string());
+                Ok(vec![Instruction::AllocateAddress {
+                    allocatable_type: alloc.allocatable_type,
+                    workspace_id,
+                }])
+            },
             ManifestIntent::AssignInput(assign) => {
                 self.global_aliases.insert(
                     assign.variable_name.to_string(),

--- a/crates/transaction_manifest/src/generator.rs
+++ b/crates/transaction_manifest/src/generator.rs
@@ -22,6 +22,8 @@ use crate::{
     value::lit_to_arg,
 };
 
+const MAX_CALL_DEPTH: usize = 16;
+
 pub struct ManifestInstructionGenerator {
     imported_templates: HashMap<Ident, TemplateAddress>,
     global_aliases: HashMap<String, ManifestValue>,
@@ -30,6 +32,7 @@ pub struct ManifestInstructionGenerator {
     workspace_ids: HashMap<String, WorkspaceId>,
     templates: HashMap<String, TemplateAddress>,
     functions: HashMap<String, Vec<ManifestIntent>>,
+    call_depth: usize,
 }
 
 impl ManifestInstructionGenerator {
@@ -42,6 +45,7 @@ impl ManifestInstructionGenerator {
             workspace_ids: HashMap::new(),
             templates,
             functions: HashMap::new(),
+            call_depth: 0,
         }
     }
 
@@ -81,6 +85,7 @@ impl ManifestInstructionGenerator {
         })
     }
 
+    #[expect(clippy::too_many_lines)]
     fn translate_intent(&mut self, intent: ManifestIntent) -> Result<Vec<Instruction>, ManifestError> {
         match intent {
             ManifestIntent::InvokeTemplate(InvokeIntent {
@@ -167,16 +172,21 @@ impl ManifestInstructionGenerator {
             }]),
             ManifestIntent::DropAllProofs => Ok(vec![Instruction::DropAllProofsInWorkspace]),
             ManifestIntent::CallLocalFunction(ident) => {
+                if self.call_depth >= MAX_CALL_DEPTH {
+                    return Err(ManifestError::MaxCallDepthExceeded { max: MAX_CALL_DEPTH });
+                }
                 let name = ident.to_string();
                 let body = self
                     .functions
                     .get(&name)
-                    .ok_or_else(|| ManifestError::UndefinedVariable { name: name.clone() })?
+                    .ok_or_else(|| ManifestError::UndefinedFunction { name: name.clone() })?
                     .clone();
-                let mut instructions = Vec::new();
+                self.call_depth += 1;
+                let mut instructions = Vec::with_capacity(body.len());
                 for intent in body {
                     instructions.extend(self.translate_intent(intent)?);
                 }
+                self.call_depth -= 1;
                 Ok(instructions)
             },
         }

--- a/crates/transaction_manifest/src/parser.rs
+++ b/crates/transaction_manifest/src/parser.rs
@@ -1,6 +1,8 @@
 //   Copyright 2022 The Tari Project
 //   SPDX-License-Identifier: BSD-3-clause
 
+use std::collections::HashMap;
+
 use proc_macro2::{Ident, TokenStream};
 use syn::{
     Block,
@@ -29,6 +31,7 @@ use syn::{
     token::Comma,
 };
 use tari_engine_types::{json_cbor::convert_json_to_cbor, substate::SubstateId};
+use tari_ootle_transaction::AllocatableAddressType;
 use tari_template_builtin::ACCOUNT_TEMPLATE_ADDRESS;
 use tari_template_lib::types::{
     Amount,
@@ -40,8 +43,6 @@ use tari_template_lib::types::{
     hex::bytes_from_hex,
 };
 
-use tari_ootle_transaction::AllocatableAddressType;
-
 use crate::error::ManifestError;
 
 #[derive(Debug, Clone)]
@@ -52,6 +53,7 @@ pub enum ManifestIntent {
     AllocateAddress(AllocateAddressStmt),
     Log(LogIntent),
     DropAllProofs,
+    CallLocalFunction(Ident),
 }
 
 #[derive(Debug, Clone)]
@@ -117,6 +119,7 @@ pub struct ParsedManifest {
     pub defines: Vec<ManifestImport>,
     pub instruction_intents: Vec<ManifestIntent>,
     pub fee_instruction_intents: Vec<ManifestIntent>,
+    pub functions: HashMap<String, Vec<ManifestIntent>>,
 }
 
 impl ManifestParser {
@@ -127,6 +130,7 @@ impl ManifestParser {
     pub fn parse(&self, input: ParseStream) -> Result<ParsedManifest, syn::Error> {
         let mut instruction_intents = vec![];
         let mut fee_instruction_intents = vec![];
+        let mut functions = HashMap::new();
         let mut defines = vec![];
         defines.push(ManifestImport {
             template_address: Some(ACCOUNT_TEMPLATE_ADDRESS),
@@ -171,13 +175,9 @@ impl ManifestParser {
                     } else if ident == "main" {
                         instruction_intents.extend(self.parse_block(*block)?);
                     } else {
-                        return Err(syn::Error::new_spanned(
-                            block,
-                            format!(
-                                "Invalid function declaration {}. Only main or fee_main are allowed.",
-                                ident
-                            ),
-                        ));
+                        let name = ident.to_string();
+                        let body = self.parse_block(*block)?;
+                        functions.insert(name, body);
                     }
                 },
                 _ => {
@@ -193,6 +193,7 @@ impl ManifestParser {
             defines,
             instruction_intents,
             fee_instruction_intents,
+            functions,
         })
     }
 
@@ -247,27 +248,29 @@ impl ManifestParser {
 
         let result = match *expr.clone() {
             Expr::Call(call) => {
-                let (template_ident, function_ident) = match &*call.func {
+                match &*call.func {
                     Expr::Path(path) => {
                         let mut iter = path.path.segments.iter();
-                        let template_name = iter.next().ok_or_else(|| {
-                            syn::Error::new_spanned(path, "Invalid template function call, no template name")
-                        })?;
+                        let first = iter
+                            .next()
+                            .ok_or_else(|| syn::Error::new_spanned(path, "Invalid function call, empty path"))?;
 
-                        let function_name = iter.next().ok_or_else(|| {
-                            syn::Error::new_spanned(path, "Invalid template function call, no function name")
-                        })?;
-                        (&template_name.ident, &function_name.ident)
+                        if let Some(second) = iter.next() {
+                            // Two segments: Template::function()
+                            ManifestIntent::InvokeTemplate(InvokeIntent {
+                                output_variable: Some(var_ident.clone()),
+                                component_variable: None,
+                                template_variable: Some(first.ident.clone()),
+                                function_name: second.ident.clone(),
+                                arguments: build_arguments(call.args)?,
+                            })
+                        } else {
+                            // Single segment: local function call
+                            ManifestIntent::CallLocalFunction(first.ident.clone())
+                        }
                     },
                     _ => return Err(syn::Error::new_spanned(call.func, "Invalid function call")),
-                };
-                ManifestIntent::InvokeTemplate(InvokeIntent {
-                    output_variable: Some(var_ident.clone()),
-                    component_variable: None,
-                    template_variable: Some(template_ident.clone()),
-                    function_name: function_ident.clone(),
-                    arguments: build_arguments(call.args)?,
-                })
+                }
             },
             Expr::MethodCall(ExprMethodCall {
                 receiver, method, args, ..
@@ -314,27 +317,29 @@ impl ManifestParser {
     fn handle_semi_expr(&self, expr: Expr) -> Result<ManifestIntent, syn::Error> {
         match expr {
             Expr::Call(call) => {
-                let (template_ident, function_ident) = match &*call.func {
+                match &*call.func {
                     Expr::Path(path) => {
                         let mut iter = path.path.segments.iter();
-                        let template_name = iter.next().ok_or_else(|| {
-                            syn::Error::new_spanned(path, "Invalid template function call, no template name")
-                        })?;
+                        let first = iter
+                            .next()
+                            .ok_or_else(|| syn::Error::new_spanned(path, "Invalid function call, empty path"))?;
 
-                        let function_name = iter.next().ok_or_else(|| {
-                            syn::Error::new_spanned(path, "Invalid template function call, no function name")
-                        })?;
-                        (&template_name.ident, &function_name.ident)
+                        if let Some(second) = iter.next() {
+                            // Two segments: Template::function()
+                            Ok(ManifestIntent::InvokeTemplate(InvokeIntent {
+                                output_variable: None,
+                                component_variable: None,
+                                template_variable: Some(first.ident.clone()),
+                                function_name: second.ident.clone(),
+                                arguments: build_arguments(call.args)?,
+                            }))
+                        } else {
+                            // Single segment: local function call
+                            Ok(ManifestIntent::CallLocalFunction(first.ident.clone()))
+                        }
                     },
                     _ => return Err(syn::Error::new_spanned(call.func, "Invalid function call")),
-                };
-                Ok(ManifestIntent::InvokeTemplate(InvokeIntent {
-                    output_variable: None,
-                    component_variable: None,
-                    template_variable: Some(template_ident.clone()),
-                    function_name: function_ident.clone(),
-                    arguments: build_arguments(call.args)?,
-                }))
+                }
             },
             Expr::MethodCall(ExprMethodCall {
                 receiver, method, args, ..

--- a/crates/transaction_manifest/src/parser.rs
+++ b/crates/transaction_manifest/src/parser.rs
@@ -338,7 +338,7 @@ impl ManifestParser {
                             Ok(ManifestIntent::CallLocalFunction(first.ident.clone()))
                         }
                     },
-                    _ => return Err(syn::Error::new_spanned(call.func, "Invalid function call")),
+                    _ => Err(syn::Error::new_spanned(call.func, "Invalid function call")),
                 }
             },
             Expr::MethodCall(ExprMethodCall {

--- a/crates/transaction_manifest/src/parser.rs
+++ b/crates/transaction_manifest/src/parser.rs
@@ -40,6 +40,8 @@ use tari_template_lib::types::{
     hex::bytes_from_hex,
 };
 
+use tari_ootle_transaction::AllocatableAddressType;
+
 use crate::error::ManifestError;
 
 #[derive(Debug, Clone)]
@@ -47,6 +49,7 @@ pub enum ManifestIntent {
     InvokeTemplate(InvokeIntent),
     InvokeComponent(InvokeIntent),
     AssignInput(AssignInputStmt),
+    AllocateAddress(AllocateAddressStmt),
     Log(LogIntent),
     DropAllProofs,
 }
@@ -70,6 +73,12 @@ pub struct InvokeIntent {
 pub struct AssignInputStmt {
     pub variable_name: Ident,
     pub global_variable_name: LitStr,
+}
+
+#[derive(Debug, Clone)]
+pub struct AllocateAddressStmt {
+    pub output_variable: Ident,
+    pub allocatable_type: AllocatableAddressType,
 }
 
 #[derive(Debug, Clone)]
@@ -362,6 +371,14 @@ fn assignment_from_macro(var_name: Ident, mac: &Ident, tokens: TokenStream) -> R
         "global" | "var" | "arg" => Ok(ManifestIntent::AssignInput(AssignInputStmt {
             variable_name: var_name,
             global_variable_name: parse2(tokens)?,
+        })),
+        "new_component_addr" => Ok(ManifestIntent::AllocateAddress(AllocateAddressStmt {
+            output_variable: var_name,
+            allocatable_type: AllocatableAddressType::Component,
+        })),
+        "new_resource_addr" => Ok(ManifestIntent::AllocateAddress(AllocateAddressStmt {
+            output_variable: var_name,
+            allocatable_type: AllocatableAddressType::Resource,
         })),
         _ => Err(syn::Error::new_spanned(mac, "Invalid macro name")),
     }

--- a/crates/transaction_manifest/tests/parser.rs
+++ b/crates/transaction_manifest/tests/parser.rs
@@ -238,3 +238,28 @@ fn local_function_inlining() {
     assert_eq!(instructions, expected);
     assert_eq!(fee_instructions, vec![]);
 }
+
+#[test]
+fn recursive_function_exceeds_call_depth() {
+    let manifest = r#"
+        use template_c2b621869ec2929d3b9503ea41054f01b468ce99e50254b58e460f608ae377f7 as MyTemplate;
+
+        fn recurse() {
+            recurse();
+        }
+
+        fn main() {
+            recurse();
+        }
+    "#;
+
+    let result = parse_manifest(manifest, HashMap::new(), Default::default());
+    let err = match result {
+        Ok(_) => panic!("Expected MaxCallDepthExceeded error, but got Ok"),
+        Err(e) => e,
+    };
+    assert!(
+        err.to_string().contains("Maximum call depth"),
+        "Expected MaxCallDepthExceeded error, got: {err}"
+    );
+}

--- a/crates/transaction_manifest/tests/parser.rs
+++ b/crates/transaction_manifest/tests/parser.rs
@@ -24,7 +24,7 @@ use std::{collections::HashMap, fs, str::FromStr};
 
 use tari_bor::cbor;
 use tari_engine_types::substate::SubstateId;
-use tari_ootle_transaction::{ComponentReference, Instruction, call_args};
+use tari_ootle_transaction::{AllocatableAddressType, ComponentReference, Instruction, call_args};
 use tari_template_lib::types::{
     ComponentAddress,
     ObjectKey,
@@ -141,6 +141,47 @@ fn workspace_component_reference() {
             args: call_args![],
         },
         Instruction::PutLastInstructionOutputOnWorkspace { key: 1 },
+    ];
+
+    assert_eq!(instructions, expected);
+    assert_eq!(fee_instructions, vec![]);
+}
+
+#[test]
+fn allocate_address_macros() {
+    let manifest = r#"
+        use template_c2b621869ec2929d3b9503ea41054f01b468ce99e50254b58e460f608ae377f7 as MyTemplate;
+
+        fn main() {
+            let component_addr = new_component_addr!();
+            let resx_addr = new_resource_addr!();
+            let comp = MyTemplate::with_address(component_addr, resx_addr);
+        }
+    "#;
+
+    let template_addr =
+        TemplateAddress::from_hex("c2b621869ec2929d3b9503ea41054f01b468ce99e50254b58e460f608ae377f7").unwrap();
+
+    let ManifestInstructions {
+        instructions,
+        fee_instructions,
+    } = parse_manifest(manifest, HashMap::new(), Default::default()).unwrap();
+
+    let expected = vec![
+        Instruction::AllocateAddress {
+            allocatable_type: AllocatableAddressType::Component,
+            workspace_id: 0,
+        },
+        Instruction::AllocateAddress {
+            allocatable_type: AllocatableAddressType::Resource,
+            workspace_id: 1,
+        },
+        Instruction::CallFunction {
+            address: template_addr,
+            function: "with_address".try_into().unwrap(),
+            args: call_args![Workspace(0), Workspace(1)],
+        },
+        Instruction::PutLastInstructionOutputOnWorkspace { key: 2 },
     ];
 
     assert_eq!(instructions, expected);

--- a/crates/transaction_manifest/tests/parser.rs
+++ b/crates/transaction_manifest/tests/parser.rs
@@ -187,3 +187,54 @@ fn allocate_address_macros() {
     assert_eq!(instructions, expected);
     assert_eq!(fee_instructions, vec![]);
 }
+
+#[test]
+fn local_function_inlining() {
+    let manifest = r#"
+        use template_c2b621869ec2929d3b9503ea41054f01b468ce99e50254b58e460f608ae377f7 as MyTemplate;
+
+        fn setup() {
+            let comp = MyTemplate::new();
+            let result = comp.do_something();
+        }
+
+        fn main() {
+            setup();
+            MyTemplate::final_step();
+        }
+    "#;
+
+    let template_addr =
+        TemplateAddress::from_hex("c2b621869ec2929d3b9503ea41054f01b468ce99e50254b58e460f608ae377f7").unwrap();
+
+    let ManifestInstructions {
+        instructions,
+        fee_instructions,
+    } = parse_manifest(manifest, HashMap::new(), Default::default()).unwrap();
+
+    // setup() should be inlined: its instructions appear first, then final_step()
+    let expected = vec![
+        // From setup():
+        Instruction::CallFunction {
+            address: template_addr,
+            function: "new".try_into().unwrap(),
+            args: call_args![],
+        },
+        Instruction::PutLastInstructionOutputOnWorkspace { key: 0 },
+        Instruction::CallMethod {
+            call: ComponentReference::Workspace(0),
+            method: "do_something".try_into().unwrap(),
+            args: call_args![],
+        },
+        Instruction::PutLastInstructionOutputOnWorkspace { key: 1 },
+        // From main() after setup():
+        Instruction::CallFunction {
+            address: template_addr,
+            function: "final_step".try_into().unwrap(),
+            args: call_args![],
+        },
+    ];
+
+    assert_eq!(instructions, expected);
+    assert_eq!(fee_instructions, vec![]);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -253,6 +253,9 @@ importers:
       react-router:
         specifier: ^7.13.1
         version: 7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react-simple-code-editor:
+        specifier: ^0.14.1
+        version: 0.14.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       use-file-picker:
         specifier: ^2.1.4
         version: 2.1.4(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react@19.2.4)
@@ -1040,105 +1043,89 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -1407,42 +1394,36 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.6':
     resolution: {integrity: sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.6':
     resolution: {integrity: sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.6':
     resolution: {integrity: sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.6':
     resolution: {integrity: sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.6':
     resolution: {integrity: sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-win32-arm64@2.5.6':
     resolution: {integrity: sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==}
@@ -1521,79 +1502,66 @@ packages:
     resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.59.0':
     resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.59.0':
     resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.59.0':
     resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.59.0':
     resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.59.0':
     resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.59.0':
     resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.59.0':
     resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.59.0':
     resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.59.0':
     resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.59.0':
     resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.59.0':
     resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.59.0':
     resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.59.0':
     resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==}
@@ -1681,28 +1649,24 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.15.13':
     resolution: {integrity: sha512-SmZ9m+XqCB35NddHCctvHFLqPZDAs5j8IgD36GoutufDJmeq2VNfgk5rQoqNqKmAK3Y7iFdEmI76QoHIWiCLyw==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.15.13':
     resolution: {integrity: sha512-5rij+vB9a29aNkHq72EXI2ihDZPszJb4zlApJY4aCC/q6utgqFA6CkrfTfIb+O8hxtG3zP5KERETz8mfFK6A0A==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.15.13':
     resolution: {integrity: sha512-OlSlaOK9JplQ5qn07WiBLibkOw7iml2++ojEXhhR3rbWrNEKCD7sd8+6wSavsInyFdw4PhLA+Hy6YyDBIE23Yw==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.15.13':
     resolution: {integrity: sha512-zwQii5YVdsfG8Ti9gIKgBKZg8qMkRZxl+OlYWUT5D93Jl4NuNBRausP20tfEkQdAPSRrMCSUZBM6FhW7izAZRg==}
@@ -3449,6 +3413,12 @@ packages:
     peerDependenciesMeta:
       react-dom:
         optional: true
+
+  react-simple-code-editor@0.14.1:
+    resolution: {integrity: sha512-BR5DtNRy+AswWJECyA17qhUDvrrCZ6zXOCfkQY5zSmb96BVUbpVAv03WpcjcwtCwiLbIANx3gebHOcXYn1EHow==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
 
   react-transition-group@4.4.5:
     resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}
@@ -7847,6 +7817,11 @@ snapshots:
       react: 19.2.4
       set-cookie-parser: 2.7.2
     optionalDependencies:
+      react-dom: 19.2.4(react@19.2.4)
+
+  react-simple-code-editor@0.14.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
   react-transition-group@4.4.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4):


### PR DESCRIPTION
  Summary
                                                                                                                                                                                                                                                                                                                                                
  - new_component_addr!() and new_resource_addr!() macros for the transaction manifest parser, allowing pre-allocation of component and resource addresses in manifest code
  - User-defined function support in manifests — functions declared alongside main are inlined at call sites during instruction generation
  - Wallet UI manifest editor overhaul:
    - Multi-tab editor with add/delete (with confirmation)/rename tabs, each with independent code and variables, all persisted automatically
    - Syntax-highlighted code editor using react-simple-code-editor + prism-react-renderer (Rust grammar), with dark/light theme support
    - One-click "Add Account" dropdown to inject wallet accounts as manifest variables with auto-generated names (account_1, account_2, ...)
    - Inline-editable variable names (click to edit, Enter/Escape/blur to save/cancel)
    - "Import Template" dialog that lists templates from the wallet and inserts use template_<addr> as <Name>; into the active tab
    - Format button for auto-indenting manifest code



Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify