### PR TITLE
feat(walletd): template lookup and function display improvements

### DIFF
--- a/applications/tari_walletd/web_ui/src/components/AccountPicker.tsx
+++ b/applications/tari_walletd/web_ui/src/components/AccountPicker.tsx
@@ -9,13 +9,21 @@ import Select from "@mui/material/Select";
 import Stack from "@mui/material/Stack";
 import useAccountStore, { setAccount, setOotleAddress } from "@store/accountStore";
 import { substateIdToString } from "@tari-project/ootle-ts-bindings";
+import { useEffect } from "react";
 
 // TODO - replace other file-specific account selectors with this component
 export default function AccountPicker() {
   const { data } = useAccountsList(0, 10);
   const currentAccount = useAccountStore((s) => s.account);
-  const defaultAccount = data?.accounts.find((a) => a.account.is_default)?.account;
-  const account = currentAccount || defaultAccount;
+  const defaultAccount = data?.accounts.find((a) => a.account.is_default);
+  const account = currentAccount || defaultAccount?.account;
+
+  useEffect(() => {
+    if (!currentAccount && defaultAccount) {
+      setAccount(defaultAccount.account);
+      setOotleAddress(defaultAccount.address);
+    }
+  }, [currentAccount, defaultAccount]);
 
   function onAccountChange(e: SelectChangeEvent) {
     const selected = data?.accounts.find((a) => substateIdToString(a.account.component_address) === e.target.value);

--- a/applications/tari_walletd/web_ui/src/routes/Templates/Templates.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/Templates/Templates.tsx
@@ -2,9 +2,11 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 import PageHeading from "@components/PageHeading";
-import { Stack } from "@mui/material";
+import { StyledPaper } from "@components/StyledComponents";
+import { Stack, Typography } from "@mui/material";
 import Grid from "@mui/material/Grid";
 import TemplateList from "./components/TemplateList";
+import TemplateLookup from "./components/TemplateLookup";
 import Wrapper from "./components/Wrapper";
 
 function Templates() {
@@ -18,6 +20,14 @@ function Templates() {
           <TemplateList />
         </Stack>
       </Wrapper>
+      <Grid size={12}>
+        <StyledPaper>
+          <Typography variant="h6" gutterBottom>
+            Lookup Template
+          </Typography>
+          <TemplateLookup />
+        </StyledPaper>
+      </Grid>
     </>
   );
 }

--- a/applications/tari_walletd/web_ui/src/routes/Templates/components/FunctionItem.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/Templates/components/FunctionItem.tsx
@@ -1,9 +1,8 @@
 //   Copyright 2026 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
-import { Table, TableBody, TableCell, TableContainer, TableHead, TableRow, useTheme } from "@mui/material";
+import { Chip, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Tooltip, useTheme } from "@mui/material";
 import { NestedCell } from "@routes/Templates/components/StyledTableComponents";
 import { FunctionDef, Type as FuncType } from "@tari-project/ootle-ts-bindings";
-import { SlCheck, SlClose } from "react-icons/sl";
 
 interface FunctionItemProps {
   functionDef: FunctionDef;
@@ -37,6 +36,8 @@ function getTypeAsString(funcType: FuncType): string {
 export default function FunctionItem({ functionDef }: FunctionItemProps) {
   const theme = useTheme();
   const { name, arguments: args, is_mut, output } = functionDef;
+  const is_migration = (functionDef as FunctionDef & { is_migration?: boolean }).is_migration;
+
   const argumentItems = args.map(({ name, arg_type }) => {
     if (name == "self") return;
     return (
@@ -79,8 +80,17 @@ export default function FunctionItem({ functionDef }: FunctionItemProps) {
     <TableRow>
       <NestedCell>
         <code>{name}</code>
+        {is_mut && (
+          <Tooltip title="This method mutates the component state">
+            <Chip label="mut" size="small" color="warning" sx={{ ml: 1 }} />
+          </Tooltip>
+        )}
+        {is_migration && (
+          <Tooltip title="This is a migration function">
+            <Chip label="migration" size="small" color="info" sx={{ ml: 1 }} />
+          </Tooltip>
+        )}
       </NestedCell>
-      <NestedCell align="center">{is_mut ? <SlCheck size={18} /> : <SlClose size={18} />}</NestedCell>
       <NestedCell>{argsTable}</NestedCell>
       <NestedCell align="right">
         <code>{getTypeAsString(output)}</code>

--- a/applications/tari_walletd/web_ui/src/routes/Templates/components/FunctionItem.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/Templates/components/FunctionItem.tsx
@@ -35,8 +35,7 @@ function getTypeAsString(funcType: FuncType): string {
 
 export default function FunctionItem({ functionDef }: FunctionItemProps) {
   const theme = useTheme();
-  const { name, arguments: args, is_mut, output } = functionDef;
-  const is_migration = (functionDef as FunctionDef & { is_migration?: boolean }).is_migration;
+  const { name, arguments: args, is_mut, is_migration, output } = functionDef;
 
   const argumentItems = args.map(({ name, arg_type }) => {
     if (name == "self") return;

--- a/applications/tari_walletd/web_ui/src/routes/Templates/components/TemplateItem.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/Templates/components/TemplateItem.tsx
@@ -1,7 +1,7 @@
 //   Copyright 2026 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 import { FluidTableCell } from "@components/StyledComponents";
-import { Collapse, Table, TableBody, TableContainer, TableHead, TableRow } from "@mui/material";
+import { Collapse, Table, TableBody, TableContainer, TableHead, TableRow, Typography } from "@mui/material";
 import FunctionItem from "@routes/Templates/components/FunctionItem";
 import { NestedCell } from "@routes/Templates/components/StyledTableComponents";
 import { AuthoredTemplate } from "@tari-project/ootle-ts-bindings";
@@ -39,7 +39,7 @@ export default function TemplateItem({ template, isOpen = false }: TemplateItemP
     <TableRow>
       <FluidTableCell colSpan={4} style={{ borderBottom: "none" }}>
         <Collapse in={isOpen} timeout="auto" unmountOnExit>
-          <h3>Functions</h3>
+          <Typography variant="h6" component="h3" sx={{ mt: 2 }}>Functions</Typography>
           {functionTable}
         </Collapse>
       </FluidTableCell>

--- a/applications/tari_walletd/web_ui/src/routes/Templates/components/TemplateItem.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/Templates/components/TemplateItem.tsx
@@ -11,7 +11,7 @@ interface TemplateItemProps {
   isOpen?: boolean;
 }
 
-const COLUMNS = ["Name", "Mutable", "Arguments", "Output"];
+const COLUMNS = ["Name", "Arguments", "Output"];
 
 export default function TemplateItem({ template, isOpen = false }: TemplateItemProps) {
   const { functions } = template;
@@ -26,7 +26,6 @@ export default function TemplateItem({ template, isOpen = false }: TemplateItemP
         <TableHead>
           <TableRow>
             <NestedCell>Name</NestedCell>
-            <NestedCell align="center">Mutable</NestedCell>
             <NestedCell>Arguments</NestedCell>
             <NestedCell align="right">Output Type</NestedCell>
           </TableRow>

--- a/applications/tari_walletd/web_ui/src/routes/Templates/components/TemplateLookup.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/Templates/components/TemplateLookup.tsx
@@ -1,7 +1,7 @@
 // Copyright 2026 The Tari Project
 // SPDX-License-Identifier: BSD-3-Clause
 import { useTemplateGet } from "@api/hooks/useTemplate";
-import { Alert, Box, Button, Collapse, IconButton, InputAdornment, Table, TableBody, TableContainer, TableHead, TableRow, TextField } from "@mui/material";
+import { Alert, Box, Button, Collapse, IconButton, InputAdornment, Table, TableBody, TableContainer, TableHead, TableRow, TextField, Typography } from "@mui/material";
 import ClearIcon from "@mui/icons-material/Clear";
 import FunctionItem from "@routes/Templates/components/FunctionItem";
 import { NestedCell } from "@routes/Templates/components/StyledTableComponents";
@@ -64,7 +64,7 @@ export default function TemplateLookup() {
       )}
 
       <Collapse in={functions.length > 0} timeout="auto">
-        <h3>Functions</h3>
+        <Typography variant="h6" component="h3" sx={{ mt: 2 }}>Functions</Typography>
         <TableContainer>
           <Table>
             <TableHead>

--- a/applications/tari_walletd/web_ui/src/routes/Templates/components/TemplateLookup.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/Templates/components/TemplateLookup.tsx
@@ -1,0 +1,87 @@
+// Copyright 2026 The Tari Project
+// SPDX-License-Identifier: BSD-3-Clause
+import { useTemplateGet } from "@api/hooks/useTemplate";
+import { Alert, Box, Button, Collapse, IconButton, InputAdornment, Table, TableBody, TableContainer, TableHead, TableRow, TextField } from "@mui/material";
+import ClearIcon from "@mui/icons-material/Clear";
+import FunctionItem from "@routes/Templates/components/FunctionItem";
+import { NestedCell } from "@routes/Templates/components/StyledTableComponents";
+import { useState } from "react";
+
+export default function TemplateLookup() {
+  const [input, setInput] = useState("");
+  const [address, setAddress] = useState("");
+
+  const templateAddress = address.startsWith("template_") ? address.slice("template_".length) : address;
+
+  const { data, isLoading, isError, error } = useTemplateGet(
+    { template_address: templateAddress },
+    { enabled: !!templateAddress },
+  );
+
+  const functions = data?.template_definition?.V1?.functions || [];
+
+  function handleLookup() {
+    const trimmed = input.trim();
+    if (trimmed) {
+      setAddress(trimmed);
+    }
+  }
+
+  return (
+    <Box>
+      <Box sx={{ display: "flex", gap: 1, alignItems: "flex-start" }}>
+        <TextField
+          label="Template Address"
+          placeholder="template_abcd... or abcd..."
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") handleLookup();
+          }}
+          size="small"
+          fullWidth
+          slotProps={{
+            input: {
+              endAdornment: input ? (
+                <InputAdornment position="end">
+                  <IconButton size="small" onClick={() => { setInput(""); setAddress(""); }}>
+                    <ClearIcon fontSize="small" />
+                  </IconButton>
+                </InputAdornment>
+              ) : null,
+            },
+          }}
+        />
+        <Button variant="contained" onClick={handleLookup} disabled={!input.trim() || isLoading}>
+          {isLoading ? "Loading..." : "Fetch"}
+        </Button>
+      </Box>
+
+      {isError && (
+        <Alert severity="error" sx={{ mt: 1 }}>
+          {(error as Error)?.message || "Failed to fetch template"}
+        </Alert>
+      )}
+
+      <Collapse in={functions.length > 0} timeout="auto">
+        <h3>Functions</h3>
+        <TableContainer>
+          <Table>
+            <TableHead>
+              <TableRow>
+                <NestedCell>Name</NestedCell>
+                <NestedCell>Arguments</NestedCell>
+                <NestedCell align="right">Output Type</NestedCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {functions.map((fn) => (
+                <FunctionItem key={`lookup_fn_${fn.name}`} functionDef={fn} />
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      </Collapse>
+    </Box>
+  );
+}


### PR DESCRIPTION
## Summary
- Add a "Lookup Template" panel on the Templates page to fetch any template by address (hash or `template_` prefix) and display its functions
- Replace the Mutable column with inline `mut` and `migration` pills (with tooltips) on function names — only shown when true
- Fix AccountPicker not setting the default account in the store on page load, which caused the template list to be empty until switching accounts

## Test plan
- [ ] Navigate to Templates page — verify authored templates load immediately without needing to switch accounts
- [ ] Use the "Lookup Template" panel to fetch a template by address (with and without `template_` prefix)
- [ ] Verify the clear (X) button on the lookup input clears the input and results
- [ ] Verify `mut` and `migration` pills appear on appropriate functions with tooltips
- [ ] Verify no pills are shown for non-mutating, non-migration functions

🤖 Generated with [Claude Code](https://claude.com/claude-code)