### PR TITLE
fix(walletd): improve error for dry runs

### DIFF
--- a/applications/tari_walletd/src/handlers/transaction.rs
+++ b/applications/tari_walletd/src/handlers/transaction.rs
@@ -178,32 +178,23 @@ pub async fn handle_submit(
         .transaction_service()
         .submit_transaction(transaction)
         .await
-        .map_err(|e| {
-            error!(target: LOG_TARGET, "Transaction submission failed: {}", e);
-            match &e {
-                TransactionServiceError::TransactionApiError(TransactionApiError::NetworkInterfaceError {
-                    status,
-                    message,
-                }) => match &status {
-                    ResponseErrorStatus::TransactionRejected { .. } => transaction_rejected(message),
-                    ResponseErrorStatus::NotFound { message } => not_found(message),
-                    _ => JsonRpcError::new(
-                        JsonRpcErrorReason::ApplicationError(1),
-                        format!("Failed to submit transaction: {}", e),
-                        serde_json::Value::Null,
-                    )
-                    .into(),
-                },
-                _ => JsonRpcError::new(
-                    JsonRpcErrorReason::ApplicationError(1),
-                    format!("Failed to submit transaction: {}", e),
-                    serde_json::Value::Null,
-                )
-                .into(),
-            }
-        })?;
+        .map_err(map_transaction_submission_error)?;
 
     Ok(TransactionSubmitResponse { transaction_id })
+}
+
+fn map_transaction_submission_error(e: TransactionServiceError) -> anyhow::Error {
+    error!(target: LOG_TARGET, "Transaction submission failed: {}", e);
+    match &e {
+        TransactionServiceError::TransactionApiError(TransactionApiError::NetworkInterfaceError { status, .. }) => {
+            match &status {
+                ResponseErrorStatus::TransactionRejected { message } => transaction_rejected(message),
+                ResponseErrorStatus::NotFound { message } => not_found(message),
+                ResponseErrorStatus::InternalError { message } => anyhow!("Failed to submit transaction: {}", message),
+            }
+        },
+        _ => anyhow!("Failed to submit transaction: {}", e),
+    }
 }
 
 pub async fn handle_submit_dry_run(
@@ -262,7 +253,8 @@ pub async fn handle_submit_dry_run(
     let exec_result = context
         .transaction_service()
         .submit_dry_run_transaction(transaction)
-        .await?;
+        .await
+        .map_err(map_transaction_submission_error)?;
 
     Ok(TransactionSubmitDryRunResponse {
         transaction_id: exec_result.finalize.transaction_hash.into_array().into(),

--- a/crates/wallet/sdk_services/src/indexer_rest_api.rs
+++ b/crates/wallet/sdk_services/src/indexer_rest_api.rs
@@ -342,11 +342,11 @@ impl TransactionStatusResponseError for IndexerRestApiNetworkInterfaceError {
                     IndexerRestClientError::ErrorResponse { source, details } => {
                         if source.status().map(|s| s.as_u16()) == Some(INVALID_REQUEST_CODE as u16) {
                             ResponseErrorStatus::TransactionRejected {
-                                message: format!("Indexer error response: {}. Details: {}", source, details.display()),
+                                message: format!("{}. Details: {}", source, details.display()),
                             }
                         } else {
                             ResponseErrorStatus::InternalError {
-                                message: format!("Indexer error response: {}", source),
+                                message: format!("Indexer error: {}", source),
                             }
                         }
                     },

--- a/crates/wallet/sdk_services/src/transaction_service/error.rs
+++ b/crates/wallet/sdk_services/src/transaction_service/error.rs
@@ -9,8 +9,8 @@ pub enum TransactionServiceError {
     ServiceShutdown,
     #[error("Transaction API error: {0}")]
     TransactionApiError(#[from] TransactionApiError),
-    #[error("Dry run transaction failed: {details}")]
-    DryRunTransactionFailed { details: String },
+    #[error("BUG: {details}")]
+    InvariantError { details: String },
     #[error("Lock API error: {0}")]
     LockApiError(#[from] LocksApiError),
 }

--- a/crates/wallet/sdk_services/src/transaction_service/service.rs
+++ b/crates/wallet/sdk_services/src/transaction_service/service.rs
@@ -133,11 +133,14 @@ where
                 transaction_api.release_all_locks_for_transaction(transaction_id)?;
                 match transaction_api.submit_dry_run_transaction(transaction).await {
                     Ok(finalized_transaction) => {
-                        let finalize = finalized_transaction.finalize.ok_or_else(|| {
-                            TransactionServiceError::DryRunTransactionFailed {
-                                details: "Transaction was not finalized".to_string(),
-                            }
-                        });
+                        let finalize =
+                            finalized_transaction
+                                .finalize
+                                .ok_or_else(|| TransactionServiceError::InvariantError {
+                                    details: format!(
+                                        "Dry run transaction {transaction_id} succeeded but was not finalized"
+                                    ),
+                                });
                         reply
                             .send(finalize.map(|finalize| ExecuteResult {
                                 finalize,


### PR DESCRIPTION
Description
---
fix(walletd): improve error for dry runs

Motivation and Context
---
Shorten errors for dry run. This was done when transactions were submitted but not for dry runs


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify