### PR TITLE
docs: add Claude Code skill install command to README and getting-started guide

### DIFF
--- a/docs/developer-docs/README.md
+++ b/docs/developer-docs/README.md
@@ -8,7 +8,21 @@ site, built with Astro and Starlight.
 The documentation content is located in `src/content/docs/`.
 Images and other static assets are in `src/assets/` and `public/`.
 
-## 🧞 Commands
+## � AI Coding Agent Skills
+
+If you are using **Claude Code** (or another AI coding agent) to build Ootle templates,
+install the Ootle skill so the agent understands the SDK, CLI workflow, and common pitfalls:
+
+```bash
+# Install the Ootle skill for Claude Code
+mkdir -p .claude/skills/ootle && curl -fsSo .claude/skills/ootle/SKILL.md \
+  https://ootle.tari.com/.well-known/skills/claude-code/SKILL.md
+```
+
+Skills for other agents (Cursor, Windsurf, Aider) are listed at
+[ootle.tari.com/llms.txt](https://ootle.tari.com/llms.txt).
+
+## �🧞 Commands
 
 All commands are run from the root of the project, from a terminal:
 

--- a/docs/developer-docs/src/content/docs/guides/getting-started.mdx
+++ b/docs/developer-docs/src/content/docs/guides/getting-started.mdx
@@ -3,6 +3,19 @@ title: Getting Started
 description: Set up your development environment and create your first Tari Ootle Template.
 ---
 import { basePath } from '../../../helpers/path';
+import { Aside } from '@astrojs/starlight/components';
+
+<Aside type="tip" title="Using an AI coding agent?">
+Install the Ootle skill so Claude Code (or another agent) understands the SDK, CLI
+workflow, and common pitfalls:
+
+```bash
+mkdir -p .claude/skills/ootle && curl -fsSo .claude/skills/ootle/SKILL.md \
+  https://ootle.tari.com/.well-known/skills/claude-code/SKILL.md
+```
+
+Skills for Cursor, Windsurf, and Aider are listed at [ootle.tari.com/llms.txt](https://ootle.tari.com/llms.txt).
+</Aside>
 
 ### Prerequisites
 


### PR DESCRIPTION
## Summary

Adds a one-liner skill install command for Claude Code to two places in the docs:

1. `docs/developer-docs/README.md` -- new AI Coding Agent Skills section
2. `docs/developer-docs/src/content/docs/guides/getting-started.mdx` -- tip callout

## Why

Claude Code does not auto-fetch skills from URLs; they must be present locally in `.claude/skills/`. Surfacing the install command closes the discovery gap.
