### PR TITLE
fix(indexer): query template from network if not cached

### DIFF
--- a/applications/tari_indexer/src/rest_api/handlers/templates.rs
+++ b/applications/tari_indexer/src/rest_api/handlers/templates.rs
@@ -39,6 +39,7 @@ pub async fn get_template_definition(
     let template = context
         .template_manager()
         .fetch_and_load_template(&template_address)
+        .await
         .optional()
         .map_err(|err| {
             // If it's pending, we return a 404 to the client - this allows them to retry later
@@ -61,7 +62,7 @@ pub async fn get_template_definition(
         code_size: template.code_size(),
     });
 
-    Ok(context.apply_cache_control(resp, 1000))
+    Ok(context.apply_cache_control(resp, 120 * 60))
 }
 
 #[utoipa::path(

--- a/applications/tari_indexer/src/template_manager/manager.rs
+++ b/applications/tari_indexer/src/template_manager/manager.rs
@@ -53,7 +53,7 @@ use tari_template_builtin::{
 };
 use tari_template_lib_types::{TemplateAddress, crypto::RistrettoPublicKeyBytes};
 
-use super::{LoadedTemplateWithMetadata, Template, TemplateCode, TemplateMetadata};
+use super::{Template, TemplateCode, TemplateMetadata};
 use crate::{substate_manager::SubstateManager, template_manager::error::TemplateManagerError};
 
 #[derive(Debug, Clone)]
@@ -151,21 +151,15 @@ impl TemplateManager {
         Ok(template.try_into()?)
     }
 
-    pub fn fetch_and_load_template(
+    pub async fn fetch_and_load_template(
         &self,
         address: &TemplateAddress,
-    ) -> Result<LoadedTemplateWithMetadata, TemplateManagerError> {
-        let template = self.fetch_cached_template(address)?;
-        let wasm = template
-            .code
-            .as_wasm_code()
-            .ok_or(TemplateManagerError::UnsupportedTemplateType)?;
-        let module = WasmModule::from_code(wasm);
-        let loaded = module.load_template()?;
-        Ok(LoadedTemplateWithMetadata {
-            metadata: template.metadata,
-            loaded,
-        })
+    ) -> Result<LoadedTemplate, TemplateManagerError> {
+        let mut templates = self.fetch_and_load_templates([address]).await?;
+        let template = templates
+            .remove(address)
+            .ok_or(TemplateManagerError::TemplateNotFound { address: *address })?;
+        Ok(template)
     }
 
     pub fn fetch_template_metadata(&self, limit: usize) -> Result<Vec<TemplateMetadata>, TemplateManagerError> {

--- a/applications/tari_indexer/src/template_manager/types.rs
+++ b/applications/tari_indexer/src/template_manager/types.rs
@@ -3,7 +3,6 @@
 
 use std::borrow::Cow;
 
-use tari_engine::{abi::TemplateDef, template::LoadedTemplate};
 use tari_ootle_common_types::Epoch;
 use tari_ootle_storage::{StorageError, global::DbTemplate};
 use tari_template_lib_types::{Hash32, TemplateAddress, crypto::RistrettoPublicKeyBytes};
@@ -59,26 +58,6 @@ impl TemplateCode {
             TemplateCode::StaticWasm(code) => Cow::Borrowed(code),
             TemplateCode::CompiledWasm(code) => Cow::Owned(code.into_vec()),
         }
-    }
-}
-
-#[derive(Debug, Clone)]
-pub struct LoadedTemplateWithMetadata {
-    pub metadata: TemplateMetadata,
-    pub loaded: LoadedTemplate,
-}
-
-impl LoadedTemplateWithMetadata {
-    pub fn template_def(&self) -> &TemplateDef {
-        self.loaded.template_def()
-    }
-
-    pub fn code_size(&self) -> usize {
-        self.metadata.code_size
-    }
-
-    pub fn template_name(&self) -> &str {
-        &self.metadata.name
     }
 }
 


### PR DESCRIPTION
Description
---
fix(indexer): query template from network if not cached

Motivation and Context
---
Querying templates that were not already cached would return a 404. The indexer will now fetch and cache templates queried through the API

How Has This Been Tested?
---
Manually

What process can a PR reviewer use to test or verify this change?
---


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify