### PR TITLE
fix(epoch-oracle): hook up start scan height to config

### DIFF
--- a/applications/tari_indexer/src/bootstrap.rs
+++ b/applications/tari_indexer/src/bootstrap.rs
@@ -343,7 +343,7 @@ async fn create_base_layer_epoch_oracle<TStore: EpochOracleStore + BaseLayerBloc
         store,
         base_node_client,
         BaseLayerEpochOracleConfig {
-            start_height: 0,
+            start_height: config.epoch_oracle.base_layer.start_height,
             height_lag: consensus_constants.base_layer_confirmations,
             scanning_interval: config.epoch_oracle.base_layer.scanning_interval,
             sidechain_id: config.indexer.sidechain_id.as_ref().map(|p| p.to_byte_type()),

--- a/applications/tari_ootle_app_utilities/src/epoch_oracle_config.rs
+++ b/applications/tari_ootle_app_utilities/src/epoch_oracle_config.rs
@@ -1,12 +1,17 @@
 //   Copyright 2025 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use std::{path::PathBuf, time::Duration};
+use std::{
+    fmt::{Display, Formatter},
+    path::PathBuf,
+    time::Duration,
+};
 
 use anyhow::{Context, anyhow, bail};
 use tari_bor::{Deserialize, Serialize};
 use tari_common::SubConfigPath;
 use tari_epoch_oracles::configured;
+use tari_ootle_common_types::displayable::Displayable;
 use tokio::{fs::File, io::AsyncReadExt};
 use url::Url;
 
@@ -41,6 +46,8 @@ pub struct BaseLayerOracleConfig {
     /// Interval between base layer scans in seconds.
     #[serde(with = "ootle_serde::duration::seconds")]
     pub scanning_interval: Duration,
+    /// Height to start base layer scanning
+    pub start_height: u64,
 }
 
 impl Default for BaseLayerOracleConfig {
@@ -51,7 +58,20 @@ impl Default for BaseLayerOracleConfig {
             // epoch change. Therefore, the `epoch_end_grace_period` in consensus settings should always be
             // greater than this value to avoid a race condition resulting in leader failure.
             scanning_interval: Duration::from_secs(8),
+            start_height: 0,
         }
+    }
+}
+
+impl Display for BaseLayerOracleConfig {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "url[{}], {:.2?}, start[{}]",
+            self.base_node_grpc_url.as_ref().display(),
+            self.scanning_interval,
+            self.start_height
+        )
     }
 }
 

--- a/applications/tari_validator_node/src/bootstrap.rs
+++ b/applications/tari_validator_node/src/bootstrap.rs
@@ -527,13 +527,14 @@ async fn create_base_layer_epoch_oracle<TStore: EpochOracleStore + BaseLayerBloc
     consensus_constants: &ConsensusConstants,
     features: BaseLayerEpochOracleFeatures,
 ) -> anyhow::Result<BaseLayerOracle<TStore>> {
+    info!(target: LOG_TARGET, "🔮Base layer epoch oracle: {}", config.epoch_oracle.base_layer);
     let mut base_node_client = create_base_layer_client(config.network, &config.epoch_oracle.base_layer).await?;
     verify_correct_network(&mut base_node_client, config.network).await?;
     Ok(BaseLayerOracle::new(
         store,
         base_node_client,
         BaseLayerEpochOracleConfig {
-            start_height: 0,
+            start_height: config.epoch_oracle.base_layer.start_height,
             height_lag: consensus_constants.base_layer_confirmations,
             scanning_interval: config.epoch_oracle.base_layer.scanning_interval,
             sidechain_id: config
@@ -552,6 +553,7 @@ async fn create_configured_epoch_oracle<TStore: EpochOracleStore + Send>(
     store: TStore,
 ) -> anyhow::Result<ConfiguredEpochOracle<TStore, RealTimeEpochTicker>> {
     let oracle_config = config.epoch_oracle.configured.load().await?;
+    info!(target: LOG_TARGET, "🔮Configured epoch oracle: {}", oracle_config);
     let oracle = ConfiguredEpochOracle::create(oracle_config, store)?;
     Ok(oracle)
 }
@@ -569,6 +571,8 @@ async fn create_hybrid_epoch_oracle<TStore: EpochOracleStore + BaseLayerBlockHea
     let base_layer_oracle =
         create_base_layer_epoch_oracle(config, store.clone(), consensus_constants, features).await?;
     let oracle_config = config.epoch_oracle.configured.load().await?;
+
+    info!(target: LOG_TARGET, "🔮Hybrid epoch oracle initializing: {}", oracle_config);
     let (ticker, trigger) = watch_ticker();
     let configured_oracle = ConfiguredEpochOracle::with_custom_ticker(oracle_config, store, ticker);
     Ok(HybridEpochOracle::new(configured_oracle, base_layer_oracle, trigger))

--- a/crates/epoch_oracles/src/base_layer/oracle.rs
+++ b/crates/epoch_oracles/src/base_layer/oracle.rs
@@ -213,6 +213,16 @@ impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore> BaseLayerOracleInner<
     #[allow(clippy::too_many_lines)]
     async fn sync_blockchain(&mut self, tip: BaseLayerMetadata) -> Result<bool, BaseLayerOracleError> {
         let start_scan_height = self.last_scanned_height.max(self.start_height) + 1;
+        if tip.height_of_longest_chain <= start_scan_height {
+            info!(
+                target: LOG_TARGET,
+                "⛓️ Base layer blockchain has not progressed beyond the start scan height {}. Current tip height is {}.",
+                start_scan_height,
+                tip.height_of_longest_chain
+            );
+            return Ok(false);
+        }
+
         let Some(lag_tip_height) = tip.height_of_longest_chain.checked_sub(self.height_lag) else {
             debug!(
                 target: LOG_TARGET,
@@ -253,6 +263,10 @@ impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore> BaseLayerOracleInner<
         let limit = 1_000.min(num_blocks);
 
         let mut base_node_client = self.base_node_client.clone();
+        info!(
+            target: LOG_TARGET,
+            "⛓️Starting header stream from {}-{}", start_scan_height, start_scan_height + limit
+        );
         let mut stream = base_node_client.stream_headers(start_scan_height, limit).await?;
 
         if let Some(additional) = usize::try_from(limit)

--- a/crates/epoch_oracles/src/configured/config.rs
+++ b/crates/epoch_oracles/src/configured/config.rs
@@ -2,11 +2,12 @@
 //   SPDX-License-Identifier: BSD-3-Clause
 
 use std::{
+    fmt::Display,
     hash::{DefaultHasher, Hasher},
     time::Duration,
 };
 
-use tari_ootle_common_types::{Epoch, NumPreshards, ShardGroup, SubstateAddress};
+use tari_ootle_common_types::{Epoch, NumPreshards, ShardGroup, SubstateAddress, displayable::Displayable};
 use tari_template_lib::types::crypto::RistrettoPublicKeyBytes;
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -28,6 +29,19 @@ impl Default for Config {
             base_time: time::OffsetDateTime::now_utc(),
             validators: vec![],
         }
+    }
+}
+
+impl Display for Config {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            fmt,
+            "Epoch time: {}, initial_epoch: {}, btime: {}, validators: {}",
+            self.epoch_time.as_ref().map(|d| d.as_secs()).display(),
+            self.initial_epoch,
+            self.base_time,
+            self.validators.len()
+        )
     }
 }
 


### PR DESCRIPTION
Description
---
fix(epoch-oracle): hook up start scan height to config

Motivation and Context
---
Start height config was not hooked up to the base layer oracle. This PR fixes that.
 
How Has This Been Tested?
---
Manually 

What process can a PR reviewer use to test or verify this change?
---


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify