### PR TITLE
fix(wallet): add missing features to wasm opt

### DIFF
--- a/applications/tari_walletd/src/services/wasm_optimizer.rs
+++ b/applications/tari_walletd/src/services/wasm_optimizer.rs
@@ -5,7 +5,7 @@ use std::io;
 
 use tempfile::tempdir;
 use thiserror::Error;
-use wasm_opt::{OptimizationError, OptimizationOptions};
+use wasm_opt::{Feature, OptimizationError, OptimizationOptions};
 
 #[derive(Debug, Error)]
 pub enum Error {
@@ -40,7 +40,11 @@ pub async fn optimize_wasm_template(template_binary: &[u8]) -> Result<Vec<u8>, E
     let output_file_path = temp_dir.path().join("output.wasm");
     tokio::fs::write(&input_file_path, template_binary).await?;
 
-    OptimizationOptions::new_optimize_for_size().run(input_file_path, output_file_path.as_path())?;
+    OptimizationOptions::new_optimize_for_size()
+        .enable_feature(Feature::BulkMemory)
+        .enable_feature(Feature::ReferenceTypes)
+        .enable_feature(Feature::Simd)
+        .run(input_file_path, output_file_path.as_path())?;
 
     let result = tokio::fs::read(output_file_path).await?;
 


### PR DESCRIPTION
Description
---
fix(wallet): add missing features to wasm opt

Motivation and Context
---
When using talc allocator with a fixed size arena, the wasm validator in the wallet (wasm opt) throws several errors relating the bulk memory feature. This PR aligns the features enabled in the wasm engine with wasm opt in walletd.

How Has This Been Tested?
---
Submitting a template with bulk memory

What process can a PR reviewer use to test or verify this change?
---


Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify