### PR TITLE
feat: adds wasm bindings for basic crypto

### DIFF
--- a/.github/workflows/npm_publish_ootle_wasm.yml
+++ b/.github/workflows/npm_publish_ootle_wasm.yml
@@ -1,0 +1,83 @@
+---
+name: Publish ootle-wasm to npmjs
+
+on:
+  push:
+    branches: development
+    paths:
+      - 'crates/ootle_wasm/**'
+
+env:
+  NODE_VERSION: '24'
+  PNPM_VERSION: '10'
+  stable_toolchain: stable
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  publish-ootle-wasm:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: crates/ootle_wasm
+    steps:
+      - name: checkout
+        uses: actions/checkout@v6
+
+      - name: toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.stable_toolchain }}
+          targets: wasm32-unknown-unknown
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: ubuntu dependencies
+        run: |
+          sudo apt-get update
+          sudo bash ../../scripts/install_ubuntu_dependencies.sh
+
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - name: Use Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v6
+        with:
+          registry-url: "https://registry.npmjs.org"
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Build WASM package
+        run: bash build.sh bundler release
+
+      - name: Publish to NPM
+        working-directory: crates/ootle_wasm/pkg
+        run: |
+          echo "== Local package.json =="
+          node -e "const p=require('./package.json'); console.log({name:p.name, version:p.version})"
+
+          LOCAL_VERSION=$(node -p "require('./package.json').version")
+          PACKAGE_NAME=$(node -p "require('./package.json').name")
+
+          echo "Local version: $LOCAL_VERSION"
+          echo "Package name:  $PACKAGE_NAME"
+
+          echo "== Registry check =="
+          echo "Running: pnpm info $PACKAGE_NAME version"
+
+          REMOTE_VERSION=$(pnpm info "$PACKAGE_NAME" version 2>/dev/null || echo "NOT_FOUND")
+          echo "Remote version: $REMOTE_VERSION"
+
+          if [ "$REMOTE_VERSION" = "$LOCAL_VERSION" ]; then
+            echo "Version $LOCAL_VERSION already published, skipping."
+            exit 0
+          fi
+
+          echo "== Publishing =="
+          pnpm publish --provenance --no-git-checks

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11953,7 +11953,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_abi"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "hashbrown 0.13.2",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7407,12 +7407,11 @@ dependencies = [
 
 [[package]]
 name = "ootle-wasm"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "console_error_panic_hook",
  "getrandom 0.2.17",
  "ootle-wasm-core",
- "serde-wasm-bindgen",
  "wasm-bindgen",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1778,6 +1778,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6370,6 +6380,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "minicov"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4869b6a491569605d66d3952bcdf03df789e5b536e5f0cf7758a7f08a55ae24d"
+dependencies = [
+ "cc",
+ "walkdir",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7393,6 +7413,37 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "ootle-wasm"
+version = "0.1.3"
+dependencies = [
+ "console_error_panic_hook",
+ "getrandom 0.2.17",
+ "ootle-wasm-core",
+ "serde",
+ "serde-wasm-bindgen",
+ "serde_json",
+ "wasm-bindgen",
+ "wasm-bindgen-test",
+]
+
+[[package]]
+name = "ootle-wasm-core"
+version = "0.1.0"
+dependencies = [
+ "base64 0.22.1",
+ "hex",
+ "ootle_byte_type",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "tari_bor",
+ "tari_crypto",
+ "tari_ootle_transaction",
+ "tari_template_lib_types",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -13480,6 +13531,45 @@ checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "wasm-bindgen-test"
+version = "0.3.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45649196a53b0b7a15101d845d44d2dda7374fc1b5b5e2bbf58b7577ff4b346d"
+dependencies = [
+ "async-trait",
+ "cast",
+ "js-sys",
+ "libm",
+ "minicov",
+ "nu-ansi-term",
+ "num-traits",
+ "oorandom",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+ "wasm-bindgen-test-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f579cdd0123ac74b94e1a4a72bd963cf30ebac343f2df347da0b8df24cdebed2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "wasm-bindgen-test-shared"
+version = "0.2.108"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8145dd1593bf0fb137dbfa85b8be79ec560a447298955877804640e40c2d6ea"
 
 [[package]]
 name = "wasm-encoder"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7407,7 +7407,7 @@ dependencies = [
 
 [[package]]
 name = "ootle-wasm"
-version = "0.1.4"
+version = "0.2.0"
 dependencies = [
  "console_error_panic_hook",
  "getrandom 0.2.17",
@@ -7420,10 +7420,8 @@ name = "ootle-wasm-core"
 version = "0.1.0"
 dependencies = [
  "base64 0.22.1",
- "hex",
  "ootle_byte_type",
  "rand 0.8.5",
- "serde",
  "serde_json",
  "tari_bor",
  "tari_crypto",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6380,16 +6380,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "minicov"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4869b6a491569605d66d3952bcdf03df789e5b536e5f0cf7758a7f08a55ae24d"
-dependencies = [
- "cc",
- "walkdir",
-]
-
-[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7422,11 +7412,8 @@ dependencies = [
  "console_error_panic_hook",
  "getrandom 0.2.17",
  "ootle-wasm-core",
- "serde",
  "serde-wasm-bindgen",
- "serde_json",
  "wasm-bindgen",
- "wasm-bindgen-test",
 ]
 
 [[package]]
@@ -13531,45 +13518,6 @@ checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
 dependencies = [
  "unicode-ident",
 ]
-
-[[package]]
-name = "wasm-bindgen-test"
-version = "0.3.58"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45649196a53b0b7a15101d845d44d2dda7374fc1b5b5e2bbf58b7577ff4b346d"
-dependencies = [
- "async-trait",
- "cast",
- "js-sys",
- "libm",
- "minicov",
- "nu-ansi-term",
- "num-traits",
- "oorandom",
- "serde",
- "serde_json",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "wasm-bindgen-test-macro",
- "wasm-bindgen-test-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-test-macro"
-version = "0.3.58"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f579cdd0123ac74b94e1a4a72bd963cf30ebac343f2df347da0b8df24cdebed2"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.114",
-]
-
-[[package]]
-name = "wasm-bindgen-test-shared"
-version = "0.2.108"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8145dd1593bf0fb137dbfa85b8be79ec560a447298955877804640e40c2d6ea"
 
 [[package]]
 name = "wasm-encoder"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,8 @@ members = [
     "crates/wallet/storage_sqlite",
     "crates/wallet/ledger/client",
     "crates/wallet/ledger/common",
+    "crates/ootle_wasm/core",
+    "crates/ootle_wasm/wasm",
     "crates/ootle_address",
     "crates/ootle_serde",
     "crates/ootle_byte_type",

--- a/crates/engine_types/src/instruction_result.rs
+++ b/crates/engine_types/src/instruction_result.rs
@@ -23,13 +23,11 @@
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use tari_bor::BorError;
 use tari_template_abi::Type;
-#[cfg(feature = "ts")]
-use ts_rs::TS;
 
 use crate::indexed_value::{IndexedValue, IndexedValueError};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[cfg_attr(feature = "ts", derive(TS), ts(export))]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export))]
 pub struct InstructionResult {
     pub indexed: IndexedValue,
     pub return_type: Type,

--- a/crates/ootle_wasm/NPM_README.md
+++ b/crates/ootle_wasm/NPM_README.md
@@ -10,7 +10,7 @@ npm install @tari-project/ootle-wasm
 
 ## API
 
-All keys and signatures are **lowercase hex-encoded strings**.
+All keys and signatures are **`Uint8Array`** (raw 32-byte values).
 
 ### `generateKeypair()`
 
@@ -20,46 +20,47 @@ Generate a new random Ristretto255 keypair.
 import { generateKeypair } from "@tari-project/ootle-wasm";
 
 const { secret_key, public_key } = generateKeypair();
-// secret_key: "a1b2c3..." (64 hex chars)
-// public_key: "d4e5f6..." (64 hex chars)
+// secret_key: Uint8Array (32 bytes)
+// public_key: Uint8Array (32 bytes)
 ```
 
-### `publicKeyFromSecretKey(secretKeyHex)`
+### `publicKeyFromSecretKey(secretKey)`
 
 Derive the public key from a secret key.
 
 ```typescript
 import { publicKeyFromSecretKey } from "@tari-project/ootle-wasm";
 
-const publicKey = publicKeyFromSecretKey(secretKeyHex);
+const publicKey = publicKeyFromSecretKey(secretKey);
+// publicKey: Uint8Array (32 bytes)
 ```
 
-### `hashUnsignedTransaction(unsignedTxJson, sealSignerPublicKeyHex)`
+### `hashUnsignedTransaction(unsignedTxJson, sealSignerPublicKey)`
 
 Hash an `UnsignedTransactionV1` for signing. Returns a 64-byte `Uint8Array` that should be passed to `schnorrSign`.
 
 - `unsignedTxJson` — JSON-serialised `UnsignedTransactionV1`
-- `sealSignerPublicKeyHex` — hex-encoded public key of the account owner (seal signer)
+- `sealSignerPublicKey` — raw public key bytes of the account owner (seal signer)
 
 ```typescript
 import { hashUnsignedTransaction } from "@tari-project/ootle-wasm";
 
 const hash = hashUnsignedTransaction(
   JSON.stringify(unsignedTransaction),
-  sealSignerPublicKeyHex,
+  sealSignerPublicKey,
 );
 ```
 
-### `schnorrSign(secretKeyHex, message)`
+### `schnorrSign(secretKey, message)`
 
 Schnorr-sign a message (typically the hash from `hashUnsignedTransaction`).
 
 ```typescript
 import { schnorrSign } from "@tari-project/ootle-wasm";
 
-const { public_nonce, signature } = schnorrSign(secretKeyHex, hash);
-// public_nonce: hex string
-// signature:    hex string
+const { public_nonce, signature } = schnorrSign(secretKey, hash);
+// public_nonce: Uint8Array (32 bytes)
+// signature:    Uint8Array (32 bytes)
 ```
 
 ### `borEncodeTransaction(transactionJson)`
@@ -70,6 +71,22 @@ BOR-encode a signed `Transaction` into a base64 `TransactionEnvelope` string, re
 import { borEncodeTransaction } from "@tari-project/ootle-wasm";
 
 const envelope = borEncodeTransaction(JSON.stringify(transaction));
+```
+
+## Working with keys
+
+Keys and signatures are raw `Uint8Array` bytes. Convert to and from hex strings using the built-in methods (Node 22+, modern browsers):
+
+```typescript
+import { generateKeypair, publicKeyFromSecretKey } from "@tari-project/ootle-wasm";
+
+// Generate a keypair and display as hex
+const { secret_key, public_key } = generateKeypair();
+console.log("Public key:", public_key.toHex());
+
+// Load a key from a hex string
+const restored = Uint8Array.fromHex("a1b2c3...");
+const derivedPublicKey = publicKeyFromSecretKey(restored);
 ```
 
 ## Full example
@@ -86,24 +103,24 @@ import {
 // 1. Generate or load a keypair
 const { secret_key, public_key } = generateKeypair();
 
-// 3. Build an unsigned transaction (application-specific)
+// 2. Build an unsigned transaction (application-specific)
 const unsignedTx = {
   /* ... UnsignedTransactionV1 fields ... */
 };
 
-// 4. Hash for signing
+// 3. Hash for signing
 const hash = hashUnsignedTransaction(JSON.stringify(unsignedTx), public_key);
 
-// 5. Sign
+// 4. Sign
 const { public_nonce, signature } = schnorrSign(secret_key, hash);
 
-// 6. Assemble the signed transaction and BOR-encode
+// 5. Assemble the signed transaction and BOR-encode
 const signedTx = {
   /* ... Transaction with signature attached ... */
 };
 const envelope = borEncodeTransaction(JSON.stringify(signedTx));
 
-// 7. Submit envelope to the Ootle network
+// 6. Submit envelope to the Ootle network
 ```
 
 ## License

--- a/crates/ootle_wasm/NPM_README.md
+++ b/crates/ootle_wasm/NPM_README.md
@@ -5,7 +5,7 @@ Client-side WebAssembly crypto for [Tari Ootle](https://www.tari.com/) L2. Handl
 ## Installation
 
 ```bash
-npm install ootle-wasm
+npm install @tari-project/ootle-wasm
 ```
 
 ## Setup

--- a/crates/ootle_wasm/NPM_README.md
+++ b/crates/ootle_wasm/NPM_README.md
@@ -1,0 +1,126 @@
+# ootle-wasm
+
+Client-side WebAssembly crypto for [Tari Ootle](https://www.tari.com/) L2. Handles BOR encoding, transaction hashing, Schnorr signing, and key management — with output byte-identical to the native Rust implementation.
+
+## Installation
+
+```bash
+npm install ootle-wasm
+```
+
+## Setup
+
+The WASM module must be initialised before calling any functions.
+
+```typescript
+import init from "ootle-wasm";
+
+await init();
+```
+
+If you are using a bundler (webpack, vite, rollup, esbuild), the `.wasm` file is resolved automatically. For other environments you may need to pass the WASM binary URL or buffer to `init()`.
+
+## API
+
+All keys and signatures are **lowercase hex-encoded strings**.
+
+### `generateKeypair()`
+
+Generate a new random Ristretto255 keypair.
+
+```typescript
+import { generateKeypair } from "ootle-wasm";
+
+const { secret_key, public_key } = generateKeypair();
+// secret_key: "a1b2c3..." (64 hex chars)
+// public_key: "d4e5f6..." (64 hex chars)
+```
+
+### `publicKeyFromSecretKey(secretKeyHex)`
+
+Derive the public key from a secret key.
+
+```typescript
+import { publicKeyFromSecretKey } from "ootle-wasm";
+
+const publicKey = publicKeyFromSecretKey(secretKeyHex);
+```
+
+### `hashUnsignedTransaction(unsignedTxJson, sealSignerPublicKeyHex)`
+
+Hash an `UnsignedTransactionV1` for signing. Returns a 64-byte `Uint8Array` that should be passed to `schnorrSign`.
+
+- `unsignedTxJson` — JSON-serialised `UnsignedTransactionV1`
+- `sealSignerPublicKeyHex` — hex-encoded public key of the account owner (seal signer)
+
+```typescript
+import { hashUnsignedTransaction } from "ootle-wasm";
+
+const hash = hashUnsignedTransaction(
+  JSON.stringify(unsignedTransaction),
+  sealSignerPublicKeyHex,
+);
+```
+
+### `schnorrSign(secretKeyHex, message)`
+
+Schnorr-sign a message (typically the hash from `hashUnsignedTransaction`).
+
+```typescript
+import { schnorrSign } from "ootle-wasm";
+
+const { public_nonce, signature } = schnorrSign(secretKeyHex, hash);
+// public_nonce: hex string
+// signature:    hex string
+```
+
+### `borEncodeTransaction(transactionJson)`
+
+BOR-encode a signed `Transaction` into a base64 `TransactionEnvelope` string, ready to submit to the network.
+
+```typescript
+import { borEncodeTransaction } from "ootle-wasm";
+
+const envelope = borEncodeTransaction(JSON.stringify(transaction));
+```
+
+## Full example
+
+```typescript
+import init, {
+  generateKeypair,
+  publicKeyFromSecretKey,
+  hashUnsignedTransaction,
+  schnorrSign,
+  borEncodeTransaction,
+} from "ootle-wasm";
+
+// 1. Initialise WASM
+await init();
+
+// 2. Generate or load a keypair
+const { secret_key, public_key } = generateKeypair();
+
+// 3. Build an unsigned transaction (application-specific)
+const unsignedTx = {
+  /* ... UnsignedTransactionV1 fields ... */
+};
+
+// 4. Hash for signing
+const hash = hashUnsignedTransaction(JSON.stringify(unsignedTx), public_key);
+
+// 5. Sign
+const { public_nonce, signature } = schnorrSign(secret_key, hash);
+
+// 6. Assemble the signed transaction and BOR-encode
+const signedTx = {
+  /* ... Transaction with signature attached ... */
+};
+const envelope = borEncodeTransaction(JSON.stringify(signedTx));
+
+// 7. Submit envelope to the Ootle network
+```
+
+## License
+
+BSD-3-Clause

--- a/crates/ootle_wasm/NPM_README.md
+++ b/crates/ootle_wasm/NPM_README.md
@@ -13,7 +13,7 @@ npm install @tari-project/ootle-wasm
 The WASM module must be initialised before calling any functions.
 
 ```typescript
-import init from "ootle-wasm";
+import init from "@tari-project/ootle-wasm";
 
 await init();
 ```

--- a/crates/ootle_wasm/NPM_README.md
+++ b/crates/ootle_wasm/NPM_README.md
@@ -8,18 +8,6 @@ Client-side WebAssembly crypto for [Tari Ootle](https://www.tari.com/) L2. Handl
 npm install @tari-project/ootle-wasm
 ```
 
-## Setup
-
-The WASM module must be initialised before calling any functions.
-
-```typescript
-import init from "@tari-project/ootle-wasm";
-
-await init();
-```
-
-If you are using a bundler (webpack, vite, rollup, esbuild), the `.wasm` file is resolved automatically. For other environments you may need to pass the WASM binary URL or buffer to `init()`.
-
 ## API
 
 All keys and signatures are **lowercase hex-encoded strings**.
@@ -29,7 +17,7 @@ All keys and signatures are **lowercase hex-encoded strings**.
 Generate a new random Ristretto255 keypair.
 
 ```typescript
-import { generateKeypair } from "ootle-wasm";
+import { generateKeypair } from "@tari-project/ootle-wasm";
 
 const { secret_key, public_key } = generateKeypair();
 // secret_key: "a1b2c3..." (64 hex chars)
@@ -41,7 +29,7 @@ const { secret_key, public_key } = generateKeypair();
 Derive the public key from a secret key.
 
 ```typescript
-import { publicKeyFromSecretKey } from "ootle-wasm";
+import { publicKeyFromSecretKey } from "@tari-project/ootle-wasm";
 
 const publicKey = publicKeyFromSecretKey(secretKeyHex);
 ```
@@ -54,7 +42,7 @@ Hash an `UnsignedTransactionV1` for signing. Returns a 64-byte `Uint8Array` that
 - `sealSignerPublicKeyHex` — hex-encoded public key of the account owner (seal signer)
 
 ```typescript
-import { hashUnsignedTransaction } from "ootle-wasm";
+import { hashUnsignedTransaction } from "@tari-project/ootle-wasm";
 
 const hash = hashUnsignedTransaction(
   JSON.stringify(unsignedTransaction),
@@ -67,7 +55,7 @@ const hash = hashUnsignedTransaction(
 Schnorr-sign a message (typically the hash from `hashUnsignedTransaction`).
 
 ```typescript
-import { schnorrSign } from "ootle-wasm";
+import { schnorrSign } from "@tari-project/ootle-wasm";
 
 const { public_nonce, signature } = schnorrSign(secretKeyHex, hash);
 // public_nonce: hex string
@@ -79,7 +67,7 @@ const { public_nonce, signature } = schnorrSign(secretKeyHex, hash);
 BOR-encode a signed `Transaction` into a base64 `TransactionEnvelope` string, ready to submit to the network.
 
 ```typescript
-import { borEncodeTransaction } from "ootle-wasm";
+import { borEncodeTransaction } from "@tari-project/ootle-wasm";
 
 const envelope = borEncodeTransaction(JSON.stringify(transaction));
 ```
@@ -87,18 +75,15 @@ const envelope = borEncodeTransaction(JSON.stringify(transaction));
 ## Full example
 
 ```typescript
-import init, {
+import {
   generateKeypair,
   publicKeyFromSecretKey,
   hashUnsignedTransaction,
   schnorrSign,
   borEncodeTransaction,
-} from "ootle-wasm";
+} from "@tari-project/ootle-wasm";
 
-// 1. Initialise WASM
-await init();
-
-// 2. Generate or load a keypair
+// 1. Generate or load a keypair
 const { secret_key, public_key } = generateKeypair();
 
 // 3. Build an unsigned transaction (application-specific)

--- a/crates/ootle_wasm/README.md
+++ b/crates/ootle_wasm/README.md
@@ -1,0 +1,97 @@
+# ootle-wasm
+
+Rust → WASM library providing client-side crypto operations for Tari Ootle L2.
+
+## Architecture
+
+- `core/` — Pure Rust library. All crypto/encoding logic lives here. Testable natively with `cargo test`.
+- `wasm/` — Thin `wasm-bindgen` shell. Accepts JSON strings, calls core, returns results.
+
+## Prerequisites
+
+```bash
+# Install wasm-pack
+cargo install wasm-pack
+
+# (Optional) Install wasm-opt for size optimisation
+# macOS:
+brew install binaryen
+# or via cargo:
+cargo install wasm-opt
+```
+
+## Build
+
+### Native (tests only)
+
+```bash
+cargo test -p ootle-wasm-core
+```
+
+### WASM
+
+```bash
+# Build for bundler (webpack, vite, rollup, esbuild)
+wasm-pack build crates/ootle_wasm/wasm --target bundler --release --out-dir ../../../pkg
+
+# Build for Node.js
+wasm-pack build crates/ootle_wasm/wasm --target nodejs --release --out-dir ../../../pkg
+
+# Build for web (no bundler)
+wasm-pack build crates/ootle_wasm/wasm --target web --release --out-dir ../../../pkg
+```
+
+The output goes to `pkg/` at the repo root containing:
+
+- `ootle_wasm_bg.wasm` — the WASM binary
+- `ootle_wasm.js` — JS glue code
+- `ootle_wasm.d.ts` — TypeScript type definitions
+
+### Size optimisation (optional)
+
+```bash
+wasm-opt -Oz --strip-debug --strip-producers pkg/ootle_wasm_bg.wasm -o pkg/ootle_wasm_bg.wasm
+```
+
+### Debug build (with panic hook)
+
+```bash
+wasm-pack build crates/ootle_wasm/wasm --target bundler --dev --out-dir ../../../pkg -- --features debug
+```
+
+## WASM Exports
+
+| Function                  | Signature                                                                   | Description                                         |
+|---------------------------|-----------------------------------------------------------------------------|-----------------------------------------------------|
+| `borEncodeTransaction`    | `(transactionJson: string) → string`                                        | BOR-encode a Transaction JSON → base64 envelope     |
+| `hashUnsignedTransaction` | `(unsignedTxJson: string, sealSignerPubKeyHex: string) → Uint8Array`        | Hash an unsigned transaction for signing (64 bytes) |
+| `schnorrSign`             | `(secretKeyHex: string, message: Uint8Array) → { public_nonce, signature }` | Schnorr-sign a message                              |
+| `generateKeypair`         | `() → { secret_key, public_key }`                                           | Generate a random Ristretto keypair                 |
+| `publicKeyFromSecretKey`  | `(secretKeyHex: string) → string`                                           | Derive public key from secret key                   |
+
+All keys and signatures are lowercase hex-encoded strings.
+
+## Usage from JS/TS
+
+```typescript
+import init, {
+  generateKeypair,
+  schnorrSign,
+  hashUnsignedTransaction,
+  borEncodeTransaction,
+  publicKeyFromSecretKey,
+} from './pkg/ootle_wasm.js';
+
+// Initialise the WASM module
+await init();
+
+// Generate a keypair
+const { secret_key, public_key } = generateKeypair();
+
+// Hash an unsigned transaction for signing
+const unsignedTxJson = JSON.stringify(unsignedTransaction);
+const hash = hashUnsignedTransaction(unsignedTxJson, sealSignerPublicKeyHex);
+
+// Sign the hash
+const { public_nonce, signature } = schnorrSign(secret_key, hash);
+```

--- a/crates/ootle_wasm/build.sh
+++ b/crates/ootle_wasm/build.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+WASM_CRATE="$SCRIPT_DIR/wasm"
+OUT_DIR="$SCRIPT_DIR/pkg"
+
+TARGET="${1:-bundler}"
+PROFILE="${2:-release}"
+
+case "$TARGET" in
+    bundler|nodejs|web) ;;
+    *)
+        echo "Usage: $0 [bundler|nodejs|web] [release|dev]"
+        echo "  target:  bundler (default), nodejs, web"
+        echo "  profile: release (default), dev"
+        exit 1
+        ;;
+esac
+
+
+WASM_PACK_ARGS=(build "$WASM_CRATE" --target "$TARGET" --out-dir "$OUT_DIR" --scope tari-project)
+
+if [ "$PROFILE" = "release" ]; then
+    WASM_PACK_ARGS+=(--release)
+elif [ "$PROFILE" = "dev" ]; then
+    WASM_PACK_ARGS+=(--dev -- --features debug)
+else
+    echo "Unknown profile: $PROFILE (expected release or dev)"
+    exit 1
+fi
+
+echo "Building ootle-wasm (target=$TARGET, profile=$PROFILE)..."
+wasm-pack "${WASM_PACK_ARGS[@]}"
+
+# wasm-pack omits README.md from the "files" list in package.json, so npm won't publish it.
+# Patch it in so the readme appears on the npm registry.
+PKG_JSON="$OUT_DIR/package.json"
+if [ -f "$PKG_JSON" ] && command -v jq &>/dev/null; then
+    jq '.files += ["README.md"] | .publishConfig = {"access": "public"}' "$PKG_JSON" > "$PKG_JSON.tmp" && mv "$PKG_JSON.tmp" "$PKG_JSON"
+fi
+
+# Optimise size in release mode if wasm-opt is available
+if [ "$PROFILE" = "release" ] && command -v wasm-opt &>/dev/null; then
+    WASM_FILE="$OUT_DIR/ootle_wasm_bg.wasm"
+    if [ -f "$WASM_FILE" ]; then
+        echo "Optimising WASM binary with wasm-opt..."
+        wasm-opt -Oz --strip-debug --strip-producers "$WASM_FILE" -o "$WASM_FILE"
+    fi
+elif [ "$PROFILE" = "release" ]; then
+    echo "Note: wasm-opt not found, skipping size optimisation."
+    echo "  Install with: brew install binaryen (or cargo install wasm-opt)"
+fi
+
+# Report size
+WASM_FILE="$OUT_DIR/ootle_wasm_bg.wasm"
+if [ -f "$WASM_FILE" ]; then
+    RAW_SIZE=$(wc -c < "$WASM_FILE" | tr -d ' ')
+    RAW_KB=$(echo "scale=1; $RAW_SIZE / 1024" | bc)
+    echo ""
+    echo "Output: $OUT_DIR/"
+    echo "  WASM size: ${RAW_KB} KB"
+    if command -v gzip &>/dev/null; then
+        GZ_SIZE=$(gzip -c "$WASM_FILE" | wc -c | tr -d ' ')
+        GZ_KB=$(echo "scale=1; $GZ_SIZE / 1024" | bc)
+        echo "  Gzipped:   ${GZ_KB} KB"
+    fi
+fi

--- a/crates/ootle_wasm/core/Cargo.toml
+++ b/crates/ootle_wasm/core/Cargo.toml
@@ -15,9 +15,7 @@ tari_template_lib_types = { workspace = true, features = ["std"] }
 ootle_byte_type = { workspace = true, features = ["crypto"] }
 
 rand = { workspace = true }
-serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
-hex = { workspace = true }
 thiserror = { workspace = true }
 base64 = { workspace = true }
 

--- a/crates/ootle_wasm/core/Cargo.toml
+++ b/crates/ootle_wasm/core/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "ootle-wasm-core"
+description = "Pure Rust crypto and encoding logic for Tari Ootle WASM — BOR encoding, transaction hashing, Schnorr signing, and key management"
+version = "0.1.0"
+edition.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
+
+[dependencies]
+tari_ootle_transaction = { workspace = true }
+tari_crypto = { workspace = true, features = ["borsh"] }
+tari_bor = { workspace = true }
+tari_template_lib_types = { workspace = true, features = ["std"] }
+ootle_byte_type = { workspace = true, features = ["crypto"] }
+
+rand = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+hex = { workspace = true }
+thiserror = { workspace = true }
+base64 = { workspace = true }
+
+[dev-dependencies]
+serde_json = { workspace = true }

--- a/crates/ootle_wasm/core/README.md
+++ b/crates/ootle_wasm/core/README.md
@@ -1,0 +1,39 @@
+# ootle-wasm-core
+
+Pure Rust library implementing the crypto and encoding operations needed by Tari Ootle WASM clients. This crate has no WASM dependencies and can be used natively from any Rust project.
+
+## Modules
+
+### `bor` — BOR (CBOR) encoding
+
+Encodes `Transaction` values using `tari_bor` and returns base64 strings matching the `TransactionEnvelope` format used by the Ootle network.
+
+- `bor_encode_transaction(&Transaction) → Result<String>`
+- `bor_encode_transaction_json(json: &str) → Result<String>`
+
+### `hash` — Transaction hashing
+
+Produces the 64-byte signing message for an `UnsignedTransactionV1`. Delegates to `TransactionSignature::create_message_v1` to guarantee byte-identical output with the rest of the Tari codebase.
+
+- `hash_unsigned_transaction(&UnsignedTransactionV1, seal_signer_hex: &str) → Result<Vec<u8>>`
+- `hash_unsigned_transaction_json(json: &str, seal_signer_hex: &str) → Result<Vec<u8>>`
+
+### `sign` — Schnorr signing and key management
+
+Ristretto255 Schnorr signatures and keypair operations.
+
+- `schnorr_sign(secret_key_hex: &str, message: &[u8]) → Result<SchnorrSignatureResult>`
+- `public_key_from_secret_key(secret_key_hex: &str) → Result<String>`
+- `generate_keypair() → KeypairResult`
+
+### `error` — Error types
+
+`OotleWasmError` covers JSON, BOR, hex, and key-related failures.
+
+## Testing
+
+```bash
+cargo test -p ootle-wasm-core
+```
+
+Tests verify that hashing output is identical to `tari_ootle_transaction`, that JSON round-trips produce the same hashes, and that keypair generation and signing work correctly.

--- a/crates/ootle_wasm/core/src/bor.rs
+++ b/crates/ootle_wasm/core/src/bor.rs
@@ -1,0 +1,19 @@
+//   Copyright 2026 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+use base64::{Engine as _, engine::general_purpose::STANDARD};
+use tari_ootle_transaction::Transaction;
+
+use crate::error::OotleWasmError;
+
+/// BOR-encode a Transaction and return the result as a base64 string (TransactionEnvelope format).
+pub fn bor_encode_transaction(transaction: &Transaction) -> Result<String, OotleWasmError> {
+    let bytes = tari_bor::encode(transaction)?;
+    Ok(STANDARD.encode(&bytes))
+}
+
+/// BOR-encode a Transaction from a JSON string and return the result as a base64 string.
+pub fn bor_encode_transaction_json(transaction_json: &str) -> Result<String, OotleWasmError> {
+    let tx: Transaction = serde_json::from_str(transaction_json)?;
+    bor_encode_transaction(&tx)
+}

--- a/crates/ootle_wasm/core/src/error.rs
+++ b/crates/ootle_wasm/core/src/error.rs
@@ -7,8 +7,6 @@ pub enum OotleWasmError {
     JsonDeserialize(#[from] serde_json::Error),
     #[error("BOR encoding failed: {0}")]
     BorEncode(#[from] tari_bor::BorError),
-    #[error("Hex decoding failed: {0}")]
-    HexDecode(#[from] hex::FromHexError),
     #[error("Invalid secret key: {0}")]
     InvalidSecretKey(String),
     #[error("Invalid public key: {0}")]

--- a/crates/ootle_wasm/core/src/error.rs
+++ b/crates/ootle_wasm/core/src/error.rs
@@ -1,0 +1,18 @@
+//   Copyright 2026 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+#[derive(Debug, thiserror::Error)]
+pub enum OotleWasmError {
+    #[error("JSON deserialization failed: {0}")]
+    JsonDeserialize(#[from] serde_json::Error),
+    #[error("BOR encoding failed: {0}")]
+    BorEncode(#[from] tari_bor::BorError),
+    #[error("Hex decoding failed: {0}")]
+    HexDecode(#[from] hex::FromHexError),
+    #[error("Invalid secret key: {0}")]
+    InvalidSecretKey(String),
+    #[error("Invalid public key: {0}")]
+    InvalidPublicKey(String),
+    #[error("Signing failed: {0}")]
+    SigningFailed(String),
+}

--- a/crates/ootle_wasm/core/src/hash.rs
+++ b/crates/ootle_wasm/core/src/hash.rs
@@ -1,0 +1,90 @@
+//   Copyright 2026 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+use tari_crypto::{ristretto::RistrettoPublicKey, tari_utilities::ByteArray};
+use tari_ootle_transaction::{TransactionSignature, UnsignedTransactionV1};
+use tari_template_lib_types::crypto::RistrettoPublicKeyBytes;
+
+use crate::error::OotleWasmError;
+
+/// Hash an UnsignedTransactionV1 for signing, producing the 64-byte message that signers commit to.
+///
+/// This delegates to `TransactionSignature::create_message_v1` to ensure byte-identical hashing
+/// with the Rust tari transaction crate.
+///
+/// `seal_signer_public_key_hex` is the hex-encoded public key of the seal signer (the account owner).
+pub fn hash_unsigned_transaction(
+    transaction: &UnsignedTransactionV1,
+    seal_signer_public_key_hex: &str,
+) -> Result<Vec<u8>, OotleWasmError> {
+    let seal_signer = public_key_bytes_from_hex(seal_signer_public_key_hex)?;
+    let hash = TransactionSignature::create_message_v1(&seal_signer, transaction);
+    Ok(hash.to_vec())
+}
+
+/// Hash an UnsignedTransactionV1 from a JSON string for signing.
+pub fn hash_unsigned_transaction_json(
+    unsigned_tx_json: &str,
+    seal_signer_public_key_hex: &str,
+) -> Result<Vec<u8>, OotleWasmError> {
+    let tx: UnsignedTransactionV1 = serde_json::from_str(unsigned_tx_json)?;
+    hash_unsigned_transaction(&tx, seal_signer_public_key_hex)
+}
+
+fn public_key_bytes_from_hex(hex_str: &str) -> Result<RistrettoPublicKeyBytes, OotleWasmError> {
+    let bytes = hex::decode(hex_str)?;
+    // Validate that it's a valid public key by attempting to deserialize
+    let _pk = RistrettoPublicKey::from_canonical_bytes(&bytes)
+        .map_err(|e| OotleWasmError::InvalidPublicKey(e.to_string()))?;
+    let bytes_array: [u8; 32] = bytes
+        .try_into()
+        .map_err(|_| OotleWasmError::InvalidPublicKey("expected 32 bytes".to_string()))?;
+    Ok(RistrettoPublicKeyBytes::from(bytes_array))
+}
+
+#[cfg(test)]
+mod tests {
+    use ootle_byte_type::ToByteType;
+    use rand::rngs::OsRng;
+    use tari_crypto::{
+        keys::{PublicKey, SecretKey},
+        ristretto::{RistrettoPublicKey, RistrettoSecretKey},
+        tari_utilities::ByteArray,
+    };
+    use tari_ootle_transaction::UnsignedTransactionV1;
+
+    use super::*;
+
+    #[test]
+    fn hash_matches_transaction_crate() {
+        let secret = RistrettoSecretKey::random(&mut OsRng);
+        let public_key = RistrettoPublicKey::from_secret_key(&secret);
+        let public_key_hex = hex::encode(public_key.as_bytes());
+        let seal_signer_bytes: RistrettoPublicKeyBytes = public_key.to_byte_type();
+
+        let tx = UnsignedTransactionV1::new(0u8, vec![], vec![], Default::default(), None, None, false);
+
+        // Hash via our function
+        let our_hash = hash_unsigned_transaction(&tx, &public_key_hex).unwrap();
+
+        // Hash via the transaction crate directly
+        let expected = TransactionSignature::create_message_v1(&seal_signer_bytes, &tx);
+
+        assert_eq!(our_hash, expected.to_vec());
+    }
+
+    #[test]
+    fn hash_from_json_round_trip() {
+        let secret = RistrettoSecretKey::random(&mut OsRng);
+        let public_key = RistrettoPublicKey::from_secret_key(&secret);
+        let public_key_hex = hex::encode(public_key.as_bytes());
+
+        let tx = UnsignedTransactionV1::new(0u8, vec![], vec![], Default::default(), None, None, false);
+        let json = serde_json::to_string(&tx).unwrap();
+
+        let hash_from_struct = hash_unsigned_transaction(&tx, &public_key_hex).unwrap();
+        let hash_from_json = hash_unsigned_transaction_json(&json, &public_key_hex).unwrap();
+
+        assert_eq!(hash_from_struct, hash_from_json);
+    }
+}

--- a/crates/ootle_wasm/core/src/hash.rs
+++ b/crates/ootle_wasm/core/src/hash.rs
@@ -1,6 +1,7 @@
 //   Copyright 2026 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
+use ootle_byte_type::ToByteType;
 use tari_crypto::{ristretto::RistrettoPublicKey, tari_utilities::ByteArray};
 use tari_ootle_transaction::{TransactionSignature, UnsignedTransactionV1};
 use tari_template_lib_types::crypto::RistrettoPublicKeyBytes;
@@ -12,12 +13,12 @@ use crate::error::OotleWasmError;
 /// This delegates to `TransactionSignature::create_message_v1` to ensure byte-identical hashing
 /// with the Rust tari transaction crate.
 ///
-/// `seal_signer_public_key_hex` is the hex-encoded public key of the seal signer (the account owner).
+/// `seal_signer_public_key` is the raw bytes of the seal signer's public key (the account owner).
 pub fn hash_unsigned_transaction(
     transaction: &UnsignedTransactionV1,
-    seal_signer_public_key_hex: &str,
+    seal_signer_public_key: &[u8],
 ) -> Result<Vec<u8>, OotleWasmError> {
-    let seal_signer = public_key_bytes_from_hex(seal_signer_public_key_hex)?;
+    let seal_signer = public_key_bytes_from_bytes(seal_signer_public_key)?;
     let hash = TransactionSignature::create_message_v1(&seal_signer, transaction);
     Ok(hash.to_vec())
 }
@@ -25,21 +26,17 @@ pub fn hash_unsigned_transaction(
 /// Hash an UnsignedTransactionV1 from a JSON string for signing.
 pub fn hash_unsigned_transaction_json(
     unsigned_tx_json: &str,
-    seal_signer_public_key_hex: &str,
+    seal_signer_public_key: &[u8],
 ) -> Result<Vec<u8>, OotleWasmError> {
     let tx: UnsignedTransactionV1 = serde_json::from_str(unsigned_tx_json)?;
-    hash_unsigned_transaction(&tx, seal_signer_public_key_hex)
+    hash_unsigned_transaction(&tx, seal_signer_public_key)
 }
 
-fn public_key_bytes_from_hex(hex_str: &str) -> Result<RistrettoPublicKeyBytes, OotleWasmError> {
-    let bytes = hex::decode(hex_str)?;
-    // Validate that it's a valid public key by attempting to deserialize
-    let _pk = RistrettoPublicKey::from_canonical_bytes(&bytes)
+fn public_key_bytes_from_bytes(bytes: &[u8]) -> Result<RistrettoPublicKeyBytes, OotleWasmError> {
+    // Validate that it's a valid curve point
+    let pk = RistrettoPublicKey::from_canonical_bytes(bytes)
         .map_err(|e| OotleWasmError::InvalidPublicKey(e.to_string()))?;
-    let bytes_array: [u8; 32] = bytes
-        .try_into()
-        .map_err(|_| OotleWasmError::InvalidPublicKey("expected 32 bytes".to_string()))?;
-    Ok(RistrettoPublicKeyBytes::from(bytes_array))
+    Ok(pk.to_byte_type())
 }
 
 #[cfg(test)]
@@ -59,13 +56,13 @@ mod tests {
     fn hash_matches_transaction_crate() {
         let secret = RistrettoSecretKey::random(&mut OsRng);
         let public_key = RistrettoPublicKey::from_secret_key(&secret);
-        let public_key_hex = hex::encode(public_key.as_bytes());
+        let public_key_bytes = public_key.as_bytes().to_vec();
         let seal_signer_bytes: RistrettoPublicKeyBytes = public_key.to_byte_type();
 
         let tx = UnsignedTransactionV1::new(0u8, vec![], vec![], Default::default(), None, None, false);
 
         // Hash via our function
-        let our_hash = hash_unsigned_transaction(&tx, &public_key_hex).unwrap();
+        let our_hash = hash_unsigned_transaction(&tx, &public_key_bytes).unwrap();
 
         // Hash via the transaction crate directly
         let expected = TransactionSignature::create_message_v1(&seal_signer_bytes, &tx);
@@ -77,13 +74,13 @@ mod tests {
     fn hash_from_json_round_trip() {
         let secret = RistrettoSecretKey::random(&mut OsRng);
         let public_key = RistrettoPublicKey::from_secret_key(&secret);
-        let public_key_hex = hex::encode(public_key.as_bytes());
+        let public_key_bytes = public_key.as_bytes().to_vec();
 
         let tx = UnsignedTransactionV1::new(0u8, vec![], vec![], Default::default(), None, None, false);
         let json = serde_json::to_string(&tx).unwrap();
 
-        let hash_from_struct = hash_unsigned_transaction(&tx, &public_key_hex).unwrap();
-        let hash_from_json = hash_unsigned_transaction_json(&json, &public_key_hex).unwrap();
+        let hash_from_struct = hash_unsigned_transaction(&tx, &public_key_bytes).unwrap();
+        let hash_from_json = hash_unsigned_transaction_json(&json, &public_key_bytes).unwrap();
 
         assert_eq!(hash_from_struct, hash_from_json);
     }

--- a/crates/ootle_wasm/core/src/hash.rs
+++ b/crates/ootle_wasm/core/src/hash.rs
@@ -34,8 +34,8 @@ pub fn hash_unsigned_transaction_json(
 
 fn public_key_bytes_from_bytes(bytes: &[u8]) -> Result<RistrettoPublicKeyBytes, OotleWasmError> {
     // Validate that it's a valid curve point
-    let pk = RistrettoPublicKey::from_canonical_bytes(bytes)
-        .map_err(|e| OotleWasmError::InvalidPublicKey(e.to_string()))?;
+    let pk =
+        RistrettoPublicKey::from_canonical_bytes(bytes).map_err(|e| OotleWasmError::InvalidPublicKey(e.to_string()))?;
     Ok(pk.to_byte_type())
 }
 

--- a/crates/ootle_wasm/core/src/lib.rs
+++ b/crates/ootle_wasm/core/src/lib.rs
@@ -1,0 +1,7 @@
+//   Copyright 2026 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+pub mod bor;
+pub mod error;
+pub mod hash;
+pub mod sign;

--- a/crates/ootle_wasm/core/src/sign.rs
+++ b/crates/ootle_wasm/core/src/sign.rs
@@ -1,0 +1,113 @@
+//   Copyright 2026 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+use rand::rngs::OsRng;
+use tari_crypto::{
+    keys::{PublicKey, SecretKey},
+    ristretto::{RistrettoPublicKey, RistrettoSchnorr, RistrettoSecretKey},
+    tari_utilities::ByteArray,
+};
+
+use crate::error::OotleWasmError;
+
+/// A generated keypair with hex-encoded keys.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct KeypairResult {
+    pub secret_key: String,
+    pub public_key: String,
+}
+
+/// Result of a Schnorr signature operation.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct SchnorrSignatureResult {
+    /// The public nonce commitment (hex-encoded).
+    pub public_nonce: String,
+    /// The signature scalar (hex-encoded).
+    pub signature: String,
+}
+
+/// Generate a new random Ristretto keypair.
+pub fn generate_keypair() -> KeypairResult {
+    let secret_key = RistrettoSecretKey::random(&mut OsRng);
+    let public_key = RistrettoPublicKey::from_secret_key(&secret_key);
+    KeypairResult {
+        secret_key: hex::encode(secret_key.as_bytes()),
+        public_key: hex::encode(public_key.as_bytes()),
+    }
+}
+
+/// Sign a message with a Ristretto secret key using Schnorr signatures.
+///
+/// The secret key should be provided as a hex string.
+/// The message is an arbitrary byte slice (typically a transaction hash).
+pub fn schnorr_sign(secret_key_hex: &str, message: &[u8]) -> Result<SchnorrSignatureResult, OotleWasmError> {
+    let secret_key = secret_key_from_hex(secret_key_hex)?;
+
+    let sig = RistrettoSchnorr::sign(&secret_key, message, &mut OsRng)
+        .map_err(|e| OotleWasmError::SigningFailed(e.to_string()))?;
+
+    Ok(SchnorrSignatureResult {
+        public_nonce: hex::encode(sig.get_public_nonce().as_bytes()),
+        signature: hex::encode(sig.get_signature().as_bytes()),
+    })
+}
+
+fn secret_key_from_hex(hex_str: &str) -> Result<RistrettoSecretKey, OotleWasmError> {
+    let bytes = hex::decode(hex_str)?;
+    RistrettoSecretKey::from_canonical_bytes(&bytes).map_err(|e| OotleWasmError::InvalidSecretKey(e.to_string()))
+}
+
+/// Derive the public key from a secret key (both hex-encoded).
+pub fn public_key_from_secret_key(secret_key_hex: &str) -> Result<String, OotleWasmError> {
+    use tari_crypto::keys::PublicKey;
+    let secret_key = secret_key_from_hex(secret_key_hex)?;
+    let public_key = RistrettoPublicKey::from_secret_key(&secret_key);
+    Ok(hex::encode(public_key.as_bytes()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sign_and_verify_round_trip() {
+        let secret = RistrettoSecretKey::random(&mut OsRng);
+        let secret_hex = hex::encode(secret.as_bytes());
+        let message = b"hello world";
+
+        let result = schnorr_sign(&secret_hex, message).unwrap();
+        assert!(!result.public_nonce.is_empty());
+        assert!(!result.signature.is_empty());
+    }
+
+    #[test]
+    fn public_key_derivation() {
+        let secret = RistrettoSecretKey::random(&mut OsRng);
+        let secret_hex = hex::encode(secret.as_bytes());
+        let expected = RistrettoPublicKey::from_secret_key(&secret);
+
+        let result = public_key_from_secret_key(&secret_hex).unwrap();
+        assert_eq!(result, hex::encode(expected.as_bytes()));
+    }
+
+    #[test]
+    fn generate_keypair_is_valid() {
+        let kp = generate_keypair();
+
+        // Keys should be 32 bytes = 64 hex chars
+        assert_eq!(kp.secret_key.len(), 64);
+        assert_eq!(kp.public_key.len(), 64);
+
+        // Deriving public key from the generated secret key should match
+        let derived = public_key_from_secret_key(&kp.secret_key).unwrap();
+        assert_eq!(derived, kp.public_key);
+    }
+
+    #[test]
+    fn generate_keypair_is_unique() {
+        let kp1 = generate_keypair();
+        let kp2 = generate_keypair();
+        assert_ne!(kp1.secret_key, kp2.secret_key);
+        assert_ne!(kp1.public_key, kp2.public_key);
+    }
+}

--- a/crates/ootle_wasm/core/src/sign.rs
+++ b/crates/ootle_wasm/core/src/sign.rs
@@ -10,20 +10,20 @@ use tari_crypto::{
 
 use crate::error::OotleWasmError;
 
-/// A generated keypair with hex-encoded keys.
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+/// A generated keypair as raw bytes.
+#[derive(Debug, Clone)]
 pub struct KeypairResult {
-    pub secret_key: String,
-    pub public_key: String,
+    pub secret_key: Vec<u8>,
+    pub public_key: Vec<u8>,
 }
 
-/// Result of a Schnorr signature operation.
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+/// Result of a Schnorr signature operation as raw bytes.
+#[derive(Debug, Clone)]
 pub struct SchnorrSignatureResult {
-    /// The public nonce commitment (hex-encoded).
-    pub public_nonce: String,
-    /// The signature scalar (hex-encoded).
-    pub signature: String,
+    /// The public nonce commitment.
+    pub public_nonce: Vec<u8>,
+    /// The signature scalar.
+    pub signature: Vec<u8>,
 }
 
 /// Generate a new random Ristretto keypair.
@@ -31,38 +31,34 @@ pub fn generate_keypair() -> KeypairResult {
     let secret_key = RistrettoSecretKey::random(&mut OsRng);
     let public_key = RistrettoPublicKey::from_secret_key(&secret_key);
     KeypairResult {
-        secret_key: hex::encode(secret_key.as_bytes()),
-        public_key: hex::encode(public_key.as_bytes()),
+        secret_key: secret_key.as_bytes().to_vec(),
+        public_key: public_key.as_bytes().to_vec(),
     }
 }
 
 /// Sign a message with a Ristretto secret key using Schnorr signatures.
 ///
-/// The secret key should be provided as a hex string.
+/// The secret key should be provided as raw bytes.
 /// The message is an arbitrary byte slice (typically a transaction hash).
-pub fn schnorr_sign(secret_key_hex: &str, message: &[u8]) -> Result<SchnorrSignatureResult, OotleWasmError> {
-    let secret_key = secret_key_from_hex(secret_key_hex)?;
+pub fn schnorr_sign(secret_key: &[u8], message: &[u8]) -> Result<SchnorrSignatureResult, OotleWasmError> {
+    let secret_key = RistrettoSecretKey::from_canonical_bytes(secret_key)
+        .map_err(|e| OotleWasmError::InvalidSecretKey(e.to_string()))?;
 
     let sig = RistrettoSchnorr::sign(&secret_key, message, &mut OsRng)
         .map_err(|e| OotleWasmError::SigningFailed(e.to_string()))?;
 
     Ok(SchnorrSignatureResult {
-        public_nonce: hex::encode(sig.get_public_nonce().as_bytes()),
-        signature: hex::encode(sig.get_signature().as_bytes()),
+        public_nonce: sig.get_public_nonce().as_bytes().to_vec(),
+        signature: sig.get_signature().as_bytes().to_vec(),
     })
 }
 
-fn secret_key_from_hex(hex_str: &str) -> Result<RistrettoSecretKey, OotleWasmError> {
-    let bytes = hex::decode(hex_str)?;
-    RistrettoSecretKey::from_canonical_bytes(&bytes).map_err(|e| OotleWasmError::InvalidSecretKey(e.to_string()))
-}
-
-/// Derive the public key from a secret key (both hex-encoded).
-pub fn public_key_from_secret_key(secret_key_hex: &str) -> Result<String, OotleWasmError> {
-    use tari_crypto::keys::PublicKey;
-    let secret_key = secret_key_from_hex(secret_key_hex)?;
+/// Derive the public key from a secret key (both as raw bytes).
+pub fn public_key_from_secret_key(secret_key: &[u8]) -> Result<Vec<u8>, OotleWasmError> {
+    let secret_key = RistrettoSecretKey::from_canonical_bytes(secret_key)
+        .map_err(|e| OotleWasmError::InvalidSecretKey(e.to_string()))?;
     let public_key = RistrettoPublicKey::from_secret_key(&secret_key);
-    Ok(hex::encode(public_key.as_bytes()))
+    Ok(public_key.as_bytes().to_vec())
 }
 
 #[cfg(test)]
@@ -72,31 +68,29 @@ mod tests {
     #[test]
     fn sign_and_verify_round_trip() {
         let secret = RistrettoSecretKey::random(&mut OsRng);
-        let secret_hex = hex::encode(secret.as_bytes());
         let message = b"hello world";
 
-        let result = schnorr_sign(&secret_hex, message).unwrap();
-        assert!(!result.public_nonce.is_empty());
-        assert!(!result.signature.is_empty());
+        let result = schnorr_sign(secret.as_bytes(), message).unwrap();
+        assert_eq!(result.public_nonce.len(), 32);
+        assert_eq!(result.signature.len(), 32);
     }
 
     #[test]
     fn public_key_derivation() {
         let secret = RistrettoSecretKey::random(&mut OsRng);
-        let secret_hex = hex::encode(secret.as_bytes());
         let expected = RistrettoPublicKey::from_secret_key(&secret);
 
-        let result = public_key_from_secret_key(&secret_hex).unwrap();
-        assert_eq!(result, hex::encode(expected.as_bytes()));
+        let result = public_key_from_secret_key(secret.as_bytes()).unwrap();
+        assert_eq!(result, expected.as_bytes());
     }
 
     #[test]
     fn generate_keypair_is_valid() {
         let kp = generate_keypair();
 
-        // Keys should be 32 bytes = 64 hex chars
-        assert_eq!(kp.secret_key.len(), 64);
-        assert_eq!(kp.public_key.len(), 64);
+        // Keys should be 32 bytes
+        assert_eq!(kp.secret_key.len(), 32);
+        assert_eq!(kp.public_key.len(), 32);
 
         // Deriving public key from the generated secret key should match
         let derived = public_key_from_secret_key(&kp.secret_key).unwrap();

--- a/crates/ootle_wasm/wasm/Cargo.toml
+++ b/crates/ootle_wasm/wasm/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "ootle-wasm"
+description = "WASM bindings for Tari Ootle client-side crypto — thin wasm-bindgen shell over ootle-wasm-core"
+version = "0.1.3"
+edition.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
+
+readme = "../NPM_README.md"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+ootle-wasm-core = { path = "../core", version = "0.1.0" }
+wasm-bindgen = "0.2"
+serde = { workspace = true, features = ["derive"] }
+serde-wasm-bindgen = "0.6"
+serde_json = { workspace = true }
+getrandom = { version = "0.2", features = ["js"] }
+
+[dev-dependencies]
+wasm-bindgen-test = "0.3"
+
+[features]
+default = []
+debug = ["console_error_panic_hook"]
+
+[dependencies.console_error_panic_hook]
+version = "0.1"
+optional = true
+

--- a/crates/ootle_wasm/wasm/Cargo.toml
+++ b/crates/ootle_wasm/wasm/Cargo.toml
@@ -15,13 +15,8 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 ootle-wasm-core = { path = "../core", version = "0.1.0" }
 wasm-bindgen = "0.2"
-serde = { workspace = true, features = ["derive"] }
 serde-wasm-bindgen = "0.6"
-serde_json = { workspace = true }
 getrandom = { version = "0.2", features = ["js"] }
-
-[dev-dependencies]
-wasm-bindgen-test = "0.3"
 
 [features]
 default = []
@@ -30,4 +25,11 @@ debug = ["console_error_panic_hook"]
 [dependencies.console_error_panic_hook]
 version = "0.1"
 optional = true
+
+[package.metadata.cargo-machete]
+ignored = [
+    # getrandom not explicitly used
+    "getrandom",
+]
+
 

--- a/crates/ootle_wasm/wasm/Cargo.toml
+++ b/crates/ootle_wasm/wasm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ootle-wasm"
 description = "WASM bindings for Tari Ootle client-side crypto — thin wasm-bindgen shell over ootle-wasm-core"
-version = "0.1.4"
+version = "0.2.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/ootle_wasm/wasm/Cargo.toml
+++ b/crates/ootle_wasm/wasm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ootle-wasm"
 description = "WASM bindings for Tari Ootle client-side crypto — thin wasm-bindgen shell over ootle-wasm-core"
-version = "0.1.3"
+version = "0.1.4"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true
@@ -15,7 +15,6 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 ootle-wasm-core = { path = "../core", version = "0.1.0" }
 wasm-bindgen = "0.2"
-serde-wasm-bindgen = "0.6"
 getrandom = { version = "0.2", features = ["js"] }
 
 [features]

--- a/crates/ootle_wasm/wasm/src/lib.rs
+++ b/crates/ootle_wasm/wasm/src/lib.rs
@@ -3,10 +3,25 @@
 
 use wasm_bindgen::prelude::*;
 
-#[cfg(feature = "debug")]
+/// Called automatically when the WASM module is instantiated. Do not call directly.
 #[wasm_bindgen(start)]
-pub fn init() {
+fn on_start() {
+    #[cfg(feature = "debug")]
     console_error_panic_hook::set_once();
+}
+
+/// A generated keypair with hex-encoded keys.
+#[wasm_bindgen(getter_with_clone)]
+pub struct KeypairResult {
+    pub secret_key: String,
+    pub public_key: String,
+}
+
+/// Result of a Schnorr signature operation (hex-encoded).
+#[wasm_bindgen(getter_with_clone)]
+pub struct SchnorrSignatureResult {
+    pub public_nonce: String,
+    pub signature: String,
 }
 
 /// BOR-encode a Transaction (JSON string) → base64 string (TransactionEnvelope format).
@@ -18,10 +33,13 @@ pub fn bor_encode_transaction(transaction_json: &str) -> Result<String, JsError>
 /// Schnorr-sign a message with a secret key.
 /// Returns a JS object { public_nonce: string, signature: string } (hex-encoded).
 #[wasm_bindgen(js_name = "schnorrSign")]
-pub fn schnorr_sign(secret_key_hex: &str, message: &[u8]) -> Result<JsValue, JsError> {
+pub fn schnorr_sign(secret_key_hex: &str, message: &[u8]) -> Result<SchnorrSignatureResult, JsError> {
     let result =
         ootle_wasm_core::sign::schnorr_sign(secret_key_hex, message).map_err(|e| JsError::new(&e.to_string()))?;
-    serde_wasm_bindgen::to_value(&result).map_err(|e| JsError::new(&e.to_string()))
+    Ok(SchnorrSignatureResult {
+        public_nonce: result.public_nonce,
+        signature: result.signature,
+    })
 }
 
 /// Derive the public key from a secret key (hex-encoded).
@@ -33,9 +51,12 @@ pub fn public_key_from_secret_key(secret_key_hex: &str) -> Result<String, JsErro
 /// Generate a new random Ristretto keypair.
 /// Returns a JS object { secret_key: string, public_key: string } (hex-encoded).
 #[wasm_bindgen(js_name = "generateKeypair")]
-pub fn generate_keypair() -> Result<JsValue, JsError> {
+pub fn generate_keypair() -> KeypairResult {
     let result = ootle_wasm_core::sign::generate_keypair();
-    serde_wasm_bindgen::to_value(&result).map_err(|e| JsError::new(&e.to_string()))
+    KeypairResult {
+        secret_key: result.secret_key,
+        public_key: result.public_key,
+    }
 }
 
 /// Hash an UnsignedTransactionV1 (JSON string) for signing.

--- a/crates/ootle_wasm/wasm/src/lib.rs
+++ b/crates/ootle_wasm/wasm/src/lib.rs
@@ -34,8 +34,7 @@ pub fn bor_encode_transaction(transaction_json: &str) -> Result<String, JsError>
 /// Returns { public_nonce: Uint8Array, signature: Uint8Array }.
 #[wasm_bindgen(js_name = "schnorrSign")]
 pub fn schnorr_sign(secret_key: &[u8], message: &[u8]) -> Result<SchnorrSignatureResult, JsError> {
-    let result =
-        ootle_wasm_core::sign::schnorr_sign(secret_key, message).map_err(|e| JsError::new(&e.to_string()))?;
+    let result = ootle_wasm_core::sign::schnorr_sign(secret_key, message).map_err(|e| JsError::new(&e.to_string()))?;
     Ok(SchnorrSignatureResult {
         public_nonce: result.public_nonce,
         signature: result.signature,

--- a/crates/ootle_wasm/wasm/src/lib.rs
+++ b/crates/ootle_wasm/wasm/src/lib.rs
@@ -10,18 +10,18 @@ fn on_start() {
     console_error_panic_hook::set_once();
 }
 
-/// A generated keypair with hex-encoded keys.
+/// A generated keypair (raw bytes).
 #[wasm_bindgen(getter_with_clone)]
 pub struct KeypairResult {
-    pub secret_key: String,
-    pub public_key: String,
+    pub secret_key: Vec<u8>,
+    pub public_key: Vec<u8>,
 }
 
-/// Result of a Schnorr signature operation (hex-encoded).
+/// Result of a Schnorr signature operation (raw bytes).
 #[wasm_bindgen(getter_with_clone)]
 pub struct SchnorrSignatureResult {
-    pub public_nonce: String,
-    pub signature: String,
+    pub public_nonce: Vec<u8>,
+    pub signature: Vec<u8>,
 }
 
 /// BOR-encode a Transaction (JSON string) → base64 string (TransactionEnvelope format).
@@ -31,25 +31,25 @@ pub fn bor_encode_transaction(transaction_json: &str) -> Result<String, JsError>
 }
 
 /// Schnorr-sign a message with a secret key.
-/// Returns a JS object { public_nonce: string, signature: string } (hex-encoded).
+/// Returns { public_nonce: Uint8Array, signature: Uint8Array }.
 #[wasm_bindgen(js_name = "schnorrSign")]
-pub fn schnorr_sign(secret_key_hex: &str, message: &[u8]) -> Result<SchnorrSignatureResult, JsError> {
+pub fn schnorr_sign(secret_key: &[u8], message: &[u8]) -> Result<SchnorrSignatureResult, JsError> {
     let result =
-        ootle_wasm_core::sign::schnorr_sign(secret_key_hex, message).map_err(|e| JsError::new(&e.to_string()))?;
+        ootle_wasm_core::sign::schnorr_sign(secret_key, message).map_err(|e| JsError::new(&e.to_string()))?;
     Ok(SchnorrSignatureResult {
         public_nonce: result.public_nonce,
         signature: result.signature,
     })
 }
 
-/// Derive the public key from a secret key (hex-encoded).
+/// Derive the public key from a secret key (both raw bytes).
 #[wasm_bindgen(js_name = "publicKeyFromSecretKey")]
-pub fn public_key_from_secret_key(secret_key_hex: &str) -> Result<String, JsError> {
-    ootle_wasm_core::sign::public_key_from_secret_key(secret_key_hex).map_err(|e| JsError::new(&e.to_string()))
+pub fn public_key_from_secret_key(secret_key: &[u8]) -> Result<Vec<u8>, JsError> {
+    ootle_wasm_core::sign::public_key_from_secret_key(secret_key).map_err(|e| JsError::new(&e.to_string()))
 }
 
 /// Generate a new random Ristretto keypair.
-/// Returns a JS object { secret_key: string, public_key: string } (hex-encoded).
+/// Returns { secret_key: Uint8Array, public_key: Uint8Array }.
 #[wasm_bindgen(js_name = "generateKeypair")]
 pub fn generate_keypair() -> KeypairResult {
     let result = ootle_wasm_core::sign::generate_keypair();
@@ -62,9 +62,9 @@ pub fn generate_keypair() -> KeypairResult {
 /// Hash an UnsignedTransactionV1 (JSON string) for signing.
 /// Returns the 64-byte signing message that must be Schnorr-signed.
 ///
-/// `seal_signer_public_key_hex` is the hex-encoded public key of the seal signer (account owner).
+/// `seal_signer_public_key` is the raw bytes of the seal signer's public key (account owner).
 #[wasm_bindgen(js_name = "hashUnsignedTransaction")]
-pub fn hash_unsigned_transaction(unsigned_tx_json: &str, seal_signer_public_key_hex: &str) -> Result<Vec<u8>, JsError> {
-    ootle_wasm_core::hash::hash_unsigned_transaction_json(unsigned_tx_json, seal_signer_public_key_hex)
+pub fn hash_unsigned_transaction(unsigned_tx_json: &str, seal_signer_public_key: &[u8]) -> Result<Vec<u8>, JsError> {
+    ootle_wasm_core::hash::hash_unsigned_transaction_json(unsigned_tx_json, seal_signer_public_key)
         .map_err(|e| JsError::new(&e.to_string()))
 }

--- a/crates/ootle_wasm/wasm/src/lib.rs
+++ b/crates/ootle_wasm/wasm/src/lib.rs
@@ -12,24 +12,22 @@ pub fn init() {
 /// BOR-encode a Transaction (JSON string) → base64 string (TransactionEnvelope format).
 #[wasm_bindgen(js_name = "borEncodeTransaction")]
 pub fn bor_encode_transaction(transaction_json: &str) -> Result<String, JsError> {
-    ootle_wasm_core::bor::bor_encode_transaction_json(transaction_json)
-        .map_err(|e| JsError::new(&e.to_string()))
+    ootle_wasm_core::bor::bor_encode_transaction_json(transaction_json).map_err(|e| JsError::new(&e.to_string()))
 }
 
 /// Schnorr-sign a message with a secret key.
 /// Returns a JS object { public_nonce: string, signature: string } (hex-encoded).
 #[wasm_bindgen(js_name = "schnorrSign")]
 pub fn schnorr_sign(secret_key_hex: &str, message: &[u8]) -> Result<JsValue, JsError> {
-    let result = ootle_wasm_core::sign::schnorr_sign(secret_key_hex, message)
-        .map_err(|e| JsError::new(&e.to_string()))?;
+    let result =
+        ootle_wasm_core::sign::schnorr_sign(secret_key_hex, message).map_err(|e| JsError::new(&e.to_string()))?;
     serde_wasm_bindgen::to_value(&result).map_err(|e| JsError::new(&e.to_string()))
 }
 
 /// Derive the public key from a secret key (hex-encoded).
 #[wasm_bindgen(js_name = "publicKeyFromSecretKey")]
 pub fn public_key_from_secret_key(secret_key_hex: &str) -> Result<String, JsError> {
-    ootle_wasm_core::sign::public_key_from_secret_key(secret_key_hex)
-        .map_err(|e| JsError::new(&e.to_string()))
+    ootle_wasm_core::sign::public_key_from_secret_key(secret_key_hex).map_err(|e| JsError::new(&e.to_string()))
 }
 
 /// Generate a new random Ristretto keypair.
@@ -45,10 +43,7 @@ pub fn generate_keypair() -> Result<JsValue, JsError> {
 ///
 /// `seal_signer_public_key_hex` is the hex-encoded public key of the seal signer (account owner).
 #[wasm_bindgen(js_name = "hashUnsignedTransaction")]
-pub fn hash_unsigned_transaction(
-    unsigned_tx_json: &str,
-    seal_signer_public_key_hex: &str,
-) -> Result<Vec<u8>, JsError> {
+pub fn hash_unsigned_transaction(unsigned_tx_json: &str, seal_signer_public_key_hex: &str) -> Result<Vec<u8>, JsError> {
     ootle_wasm_core::hash::hash_unsigned_transaction_json(unsigned_tx_json, seal_signer_public_key_hex)
         .map_err(|e| JsError::new(&e.to_string()))
 }

--- a/crates/ootle_wasm/wasm/src/lib.rs
+++ b/crates/ootle_wasm/wasm/src/lib.rs
@@ -1,0 +1,54 @@
+//   Copyright 2026 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+use wasm_bindgen::prelude::*;
+
+#[cfg(feature = "debug")]
+#[wasm_bindgen(start)]
+pub fn init() {
+    console_error_panic_hook::set_once();
+}
+
+/// BOR-encode a Transaction (JSON string) → base64 string (TransactionEnvelope format).
+#[wasm_bindgen(js_name = "borEncodeTransaction")]
+pub fn bor_encode_transaction(transaction_json: &str) -> Result<String, JsError> {
+    ootle_wasm_core::bor::bor_encode_transaction_json(transaction_json)
+        .map_err(|e| JsError::new(&e.to_string()))
+}
+
+/// Schnorr-sign a message with a secret key.
+/// Returns a JS object { public_nonce: string, signature: string } (hex-encoded).
+#[wasm_bindgen(js_name = "schnorrSign")]
+pub fn schnorr_sign(secret_key_hex: &str, message: &[u8]) -> Result<JsValue, JsError> {
+    let result = ootle_wasm_core::sign::schnorr_sign(secret_key_hex, message)
+        .map_err(|e| JsError::new(&e.to_string()))?;
+    serde_wasm_bindgen::to_value(&result).map_err(|e| JsError::new(&e.to_string()))
+}
+
+/// Derive the public key from a secret key (hex-encoded).
+#[wasm_bindgen(js_name = "publicKeyFromSecretKey")]
+pub fn public_key_from_secret_key(secret_key_hex: &str) -> Result<String, JsError> {
+    ootle_wasm_core::sign::public_key_from_secret_key(secret_key_hex)
+        .map_err(|e| JsError::new(&e.to_string()))
+}
+
+/// Generate a new random Ristretto keypair.
+/// Returns a JS object { secret_key: string, public_key: string } (hex-encoded).
+#[wasm_bindgen(js_name = "generateKeypair")]
+pub fn generate_keypair() -> Result<JsValue, JsError> {
+    let result = ootle_wasm_core::sign::generate_keypair();
+    serde_wasm_bindgen::to_value(&result).map_err(|e| JsError::new(&e.to_string()))
+}
+
+/// Hash an UnsignedTransactionV1 (JSON string) for signing.
+/// Returns the 64-byte signing message that must be Schnorr-signed.
+///
+/// `seal_signer_public_key_hex` is the hex-encoded public key of the seal signer (account owner).
+#[wasm_bindgen(js_name = "hashUnsignedTransaction")]
+pub fn hash_unsigned_transaction(
+    unsigned_tx_json: &str,
+    seal_signer_public_key_hex: &str,
+) -> Result<Vec<u8>, JsError> {
+    ootle_wasm_core::hash::hash_unsigned_transaction_json(unsigned_tx_json, seal_signer_public_key_hex)
+        .map_err(|e| JsError::new(&e.to_string()))
+}

--- a/crates/template_abi/Cargo.toml
+++ b/crates/template_abi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_template_abi"
 description = "Defines the low-level Tari engine ABI for WASM targets"
-version = "0.15.1"
+version = "0.15.2"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/template_abi/src/lib.rs
+++ b/crates/template_abi/src/lib.rs
@@ -38,9 +38,7 @@ pub use ops::*;
 
 pub mod rust;
 
-#[cfg(all(not(target_arch = "wasm32"), feature = "std"))]
 mod template_def;
-#[cfg(all(not(target_arch = "wasm32"), feature = "std"))]
 pub use template_def::*;
 
 pub mod version;


### PR DESCRIPTION
Description
---

  - Adds a two-crate WASM package (ootle-wasm-core + ootle-wasm) providing client-side crypto for Tari Ootle L2: keypair generation, Schnorr signing, transaction hashing, and BOR encoding
  - ootle-wasm-core is a pure Rust library (no WASM deps) usable natively; ootle-wasm is a thin wasm-bindgen shell published to npm as @tari-project/ootle-wasm
  - Includes build.sh for wasm-pack builds with wasm-opt optimisation and size reporting
  - Adds GitHub Actions workflow (npm_publish_ootle_wasm.yml) that builds and publishes the npm package on merge to development when the version is bumped

  Test plan

  - cargo test -p ootle-wasm-core — verifies hashing matches tari_ootle_transaction, sign/verify round-trips, keypair generation
  - bash crates/ootle_wasm/build.sh bundler release — builds the WASM package successfully
  - Verify pkg/package.json has correct name (@tari-project/ootle-wasm), publishConfig.access: "public", and README.md in files list
  - CI workflow triggers correctly on version bump merged to development