### PR TITLE
feat(ootle-wasm): adds OotleAddress support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7412,7 +7412,7 @@ dependencies = [
 
 [[package]]
 name = "ootle-wasm"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "console_error_panic_hook",
  "getrandom 0.2.17",
@@ -7422,7 +7422,7 @@ dependencies = [
 
 [[package]]
 name = "ootle-wasm-core"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "base64 0.22.1",
  "ootle_byte_type",
@@ -7430,6 +7430,8 @@ dependencies = [
  "serde_json",
  "tari_bor",
  "tari_crypto",
+ "tari_ootle_address",
+ "tari_ootle_common_types",
  "tari_ootle_transaction",
  "tari_template_lib_types",
  "thiserror 2.0.18",

--- a/crates/ootle_wasm/core/Cargo.toml
+++ b/crates/ootle_wasm/core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ootle-wasm-core"
 description = "Pure Rust crypto and encoding logic for Tari Ootle WASM — BOR encoding, transaction hashing, Schnorr signing, and key management"
-version = "0.1.0"
+version = "0.3.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true
@@ -9,6 +9,8 @@ license.workspace = true
 
 [dependencies]
 tari_ootle_transaction = { workspace = true }
+tari_ootle_address = { workspace = true }
+tari_ootle_common_types = { workspace = true }
 tari_crypto = { workspace = true, features = ["borsh"] }
 tari_bor = { workspace = true }
 tari_template_lib_types = { workspace = true, features = ["std"] }

--- a/crates/ootle_wasm/core/src/address.rs
+++ b/crates/ootle_wasm/core/src/address.rs
@@ -41,7 +41,9 @@ pub fn generate_ootle_secret_key() -> OotleSecretKeyResult {
 }
 
 /// Derive the public keys from a pair of Ootle secret keys.
-pub fn ootle_public_key_from_secret_key(secret_key: &OotleSecretKeyResult) -> Result<OotlePublicKeyResult, OotleWasmError> {
+pub fn ootle_public_key_from_secret_key(
+    secret_key: &OotleSecretKeyResult,
+) -> Result<OotlePublicKeyResult, OotleWasmError> {
     let owner_secret = RistrettoSecretKey::from_canonical_bytes(&secret_key.owner_key)
         .map_err(|e| OotleWasmError::InvalidSecretKey(e.to_string()))?;
     let view_secret = RistrettoSecretKey::from_canonical_bytes(&secret_key.view_key)
@@ -103,7 +105,7 @@ pub fn generate_ootle_address(
 
     if let Some(memo_bytes) = memo {
         let pay_ref =
-            PayRef::new_checked(memo_bytes.to_vec()).ok_or_else(|| OotleWasmError::InvalidPayRef(memo_bytes.len()))?;
+            PayRef::new_checked(memo_bytes.to_vec()).ok_or(OotleWasmError::InvalidPayRef(memo_bytes.len()))?;
         address = address.with_pay_ref(pay_ref);
     }
 
@@ -162,8 +164,7 @@ mod tests {
         let pk = ootle_public_key_from_secret_key(&sk).unwrap();
 
         let memo = b"invoice-12345";
-        let address =
-            generate_ootle_address(&pk.owner_key, &pk.view_key, Network::LocalNet as u8, Some(memo)).unwrap();
+        let address = generate_ootle_address(&pk.owner_key, &pk.view_key, Network::LocalNet as u8, Some(memo)).unwrap();
         assert!(address.starts_with("otl_loc_"));
 
         let parsed: OotleAddress = address.parse().unwrap();

--- a/crates/ootle_wasm/core/src/address.rs
+++ b/crates/ootle_wasm/core/src/address.rs
@@ -1,0 +1,230 @@
+//   Copyright 2026 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+use rand::rngs::OsRng;
+use tari_crypto::{
+    keys::{PublicKey, SecretKey},
+    ristretto::{RistrettoPublicKey, RistrettoSecretKey},
+    tari_utilities::ByteArray,
+};
+use tari_ootle_address::{OotleAddress, PayRef};
+use tari_ootle_common_types::Network;
+
+use crate::error::OotleWasmError;
+
+/// The two secret keys (owner and view) that form an Ootle wallet identity.
+#[derive(Debug, Clone)]
+pub struct OotleSecretKeyResult {
+    /// The owner (spending) secret key bytes.
+    pub owner_key: Vec<u8>,
+    /// The view-only secret key bytes.
+    pub view_key: Vec<u8>,
+}
+
+/// The two public keys derived from the secret keys.
+#[derive(Debug, Clone)]
+pub struct OotlePublicKeyResult {
+    /// The owner (spending) public key bytes.
+    pub owner_key: Vec<u8>,
+    /// The view-only public key bytes.
+    pub view_key: Vec<u8>,
+}
+
+/// Generate a new random pair of Ootle secret keys (owner + view).
+pub fn generate_ootle_secret_key() -> OotleSecretKeyResult {
+    let owner_key = RistrettoSecretKey::random(&mut OsRng);
+    let view_key = RistrettoSecretKey::random(&mut OsRng);
+    OotleSecretKeyResult {
+        owner_key: owner_key.as_bytes().to_vec(),
+        view_key: view_key.as_bytes().to_vec(),
+    }
+}
+
+/// Derive the public keys from a pair of Ootle secret keys.
+pub fn ootle_public_key_from_secret_key(secret_key: &OotleSecretKeyResult) -> Result<OotlePublicKeyResult, OotleWasmError> {
+    let owner_secret = RistrettoSecretKey::from_canonical_bytes(&secret_key.owner_key)
+        .map_err(|e| OotleWasmError::InvalidSecretKey(e.to_string()))?;
+    let view_secret = RistrettoSecretKey::from_canonical_bytes(&secret_key.view_key)
+        .map_err(|e| OotleWasmError::InvalidSecretKey(e.to_string()))?;
+
+    let owner_public = RistrettoPublicKey::from_secret_key(&owner_secret);
+    let view_public = RistrettoPublicKey::from_secret_key(&view_secret);
+
+    Ok(OotlePublicKeyResult {
+        owner_key: owner_public.as_bytes().to_vec(),
+        view_key: view_public.as_bytes().to_vec(),
+    })
+}
+
+/// Parsed components of an Ootle address.
+#[derive(Debug, Clone)]
+pub struct ParsedOotleAddress {
+    /// The owner (spending) public key bytes.
+    pub owner_key: Vec<u8>,
+    /// The view-only public key bytes.
+    pub view_key: Vec<u8>,
+    /// The network byte.
+    pub network: u8,
+    /// Optional pay reference / memo bytes.
+    pub memo: Option<Vec<u8>>,
+}
+
+/// Parse a bech32m Ootle address string into its components.
+pub fn parse_ootle_address(address: &str) -> Result<ParsedOotleAddress, OotleWasmError> {
+    let parsed = OotleAddress::decode_bech32(address).map_err(|e| OotleWasmError::InvalidAddress(e.to_string()))?;
+
+    Ok(ParsedOotleAddress {
+        owner_key: parsed.account_public_key().as_bytes().to_vec(),
+        view_key: parsed.view_only_key().as_bytes().to_vec(),
+        network: parsed.network() as u8,
+        memo: parsed.pay_ref().map(|pr| pr.as_bytes().to_vec()),
+    })
+}
+
+/// Generate an Ootle address (bech32m string) from public keys.
+///
+/// `network` is the network byte (see `Network` enum).
+/// `memo` is an optional pay reference (max 64 bytes).
+pub fn generate_ootle_address(
+    owner_public_key: &[u8],
+    view_public_key: &[u8],
+    network: u8,
+    memo: Option<&[u8]>,
+) -> Result<String, OotleWasmError> {
+    let network = Network::try_from(network).map_err(|e| OotleWasmError::InvalidNetwork(e.to_string()))?;
+
+    let owner_pk = RistrettoPublicKey::from_canonical_bytes(owner_public_key)
+        .map_err(|e| OotleWasmError::InvalidPublicKey(e.to_string()))?;
+    let view_pk = RistrettoPublicKey::from_canonical_bytes(view_public_key)
+        .map_err(|e| OotleWasmError::InvalidPublicKey(e.to_string()))?;
+
+    use ootle_byte_type::ToByteType;
+    let mut address = OotleAddress::new(network, view_pk.to_byte_type(), owner_pk.to_byte_type());
+
+    if let Some(memo_bytes) = memo {
+        let pay_ref =
+            PayRef::new_checked(memo_bytes.to_vec()).ok_or_else(|| OotleWasmError::InvalidPayRef(memo_bytes.len()))?;
+        address = address.with_pay_ref(pay_ref);
+    }
+
+    Ok(address.to_bech32_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generate_secret_key_produces_valid_keys() {
+        let sk = generate_ootle_secret_key();
+        assert_eq!(sk.owner_key.len(), 32);
+        assert_eq!(sk.view_key.len(), 32);
+    }
+
+    #[test]
+    fn generate_secret_key_is_unique() {
+        let sk1 = generate_ootle_secret_key();
+        let sk2 = generate_ootle_secret_key();
+        assert_ne!(sk1.owner_key, sk2.owner_key);
+        assert_ne!(sk1.view_key, sk2.view_key);
+    }
+
+    #[test]
+    fn derive_public_keys_from_secret_keys() {
+        let sk = generate_ootle_secret_key();
+        let pk = ootle_public_key_from_secret_key(&sk).unwrap();
+        assert_eq!(pk.owner_key.len(), 32);
+        assert_eq!(pk.view_key.len(), 32);
+
+        // Deriving again should produce the same result
+        let pk2 = ootle_public_key_from_secret_key(&sk).unwrap();
+        assert_eq!(pk.owner_key, pk2.owner_key);
+        assert_eq!(pk.view_key, pk2.view_key);
+    }
+
+    #[test]
+    fn generate_address_without_memo() {
+        let sk = generate_ootle_secret_key();
+        let pk = ootle_public_key_from_secret_key(&sk).unwrap();
+
+        let address = generate_ootle_address(&pk.owner_key, &pk.view_key, Network::LocalNet as u8, None).unwrap();
+        assert!(address.starts_with("otl_loc_"));
+
+        // Should be parseable back
+        let parsed: OotleAddress = address.parse().unwrap();
+        assert_eq!(parsed.network(), Network::LocalNet);
+        assert_eq!(parsed.pay_ref(), None);
+    }
+
+    #[test]
+    fn generate_address_with_memo() {
+        let sk = generate_ootle_secret_key();
+        let pk = ootle_public_key_from_secret_key(&sk).unwrap();
+
+        let memo = b"invoice-12345";
+        let address =
+            generate_ootle_address(&pk.owner_key, &pk.view_key, Network::LocalNet as u8, Some(memo)).unwrap();
+        assert!(address.starts_with("otl_loc_"));
+
+        let parsed: OotleAddress = address.parse().unwrap();
+        assert_eq!(parsed.pay_ref().unwrap().as_bytes(), memo);
+    }
+
+    #[test]
+    fn generate_address_rejects_oversized_memo() {
+        let sk = generate_ootle_secret_key();
+        let pk = ootle_public_key_from_secret_key(&sk).unwrap();
+
+        let memo = vec![0u8; PayRef::MAX_LEN + 1];
+        let result = generate_ootle_address(&pk.owner_key, &pk.view_key, Network::LocalNet as u8, Some(&memo));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_address_round_trip() {
+        let sk = generate_ootle_secret_key();
+        let pk = ootle_public_key_from_secret_key(&sk).unwrap();
+
+        let address = generate_ootle_address(&pk.owner_key, &pk.view_key, Network::LocalNet as u8, None).unwrap();
+        let parsed = parse_ootle_address(&address).unwrap();
+
+        assert_eq!(parsed.owner_key, pk.owner_key);
+        assert_eq!(parsed.view_key, pk.view_key);
+        assert_eq!(parsed.network, Network::LocalNet as u8);
+        assert_eq!(parsed.memo, None);
+    }
+
+    #[test]
+    fn parse_address_with_memo_round_trip() {
+        let sk = generate_ootle_secret_key();
+        let pk = ootle_public_key_from_secret_key(&sk).unwrap();
+
+        let memo = b"payment-ref-42";
+        let address =
+            generate_ootle_address(&pk.owner_key, &pk.view_key, Network::Esmeralda as u8, Some(memo)).unwrap();
+        let parsed = parse_ootle_address(&address).unwrap();
+
+        assert_eq!(parsed.owner_key, pk.owner_key);
+        assert_eq!(parsed.view_key, pk.view_key);
+        assert_eq!(parsed.network, Network::Esmeralda as u8);
+        assert_eq!(parsed.memo.as_deref(), Some(memo.as_slice()));
+    }
+
+    #[test]
+    fn parse_invalid_address_fails() {
+        assert!(parse_ootle_address("not_a_valid_address").is_err());
+    }
+
+    #[test]
+    fn generate_address_different_networks() {
+        let sk = generate_ootle_secret_key();
+        let pk = ootle_public_key_from_secret_key(&sk).unwrap();
+
+        let addr_esm = generate_ootle_address(&pk.owner_key, &pk.view_key, Network::Esmeralda as u8, None).unwrap();
+        assert!(addr_esm.starts_with("otl_esm_"));
+
+        let addr_main = generate_ootle_address(&pk.owner_key, &pk.view_key, Network::MainNet as u8, None).unwrap();
+        assert!(addr_main.starts_with("otl_"));
+        assert!(!addr_main.starts_with("otl_loc_"));
+    }
+}

--- a/crates/ootle_wasm/core/src/error.rs
+++ b/crates/ootle_wasm/core/src/error.rs
@@ -13,4 +13,10 @@ pub enum OotleWasmError {
     InvalidPublicKey(String),
     #[error("Signing failed: {0}")]
     SigningFailed(String),
+    #[error("Invalid network: {0}")]
+    InvalidNetwork(String),
+    #[error("Invalid pay reference: length {0} (must be 1-64 bytes)")]
+    InvalidPayRef(usize),
+    #[error("Invalid address: {0}")]
+    InvalidAddress(String),
 }

--- a/crates/ootle_wasm/core/src/lib.rs
+++ b/crates/ootle_wasm/core/src/lib.rs
@@ -1,6 +1,7 @@
 //   Copyright 2026 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
+pub mod address;
 pub mod bor;
 pub mod error;
 pub mod hash;

--- a/crates/ootle_wasm/wasm/Cargo.toml
+++ b/crates/ootle_wasm/wasm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ootle-wasm"
 description = "WASM bindings for Tari Ootle client-side crypto — thin wasm-bindgen shell over ootle-wasm-core"
-version = "0.2.0"
+version = "0.3.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true
@@ -13,7 +13,7 @@ readme = "../NPM_README.md"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-ootle-wasm-core = { path = "../core", version = "0.1.0" }
+ootle-wasm-core = { path = "../core", version = "0.3.0" }
 wasm-bindgen = "0.2"
 getrandom = { version = "0.2", features = ["js"] }
 

--- a/crates/ootle_wasm/wasm/src/lib.rs
+++ b/crates/ootle_wasm/wasm/src/lib.rs
@@ -24,6 +24,37 @@ pub struct SchnorrSignatureResult {
     pub signature: Vec<u8>,
 }
 
+/// A pair of Ootle secret keys (owner + view).
+#[wasm_bindgen(getter_with_clone)]
+pub struct OotleSecretKey {
+    /// The owner (spending) secret key bytes.
+    pub owner_key: Vec<u8>,
+    /// The view-only secret key bytes.
+    pub view_key: Vec<u8>,
+}
+
+/// A pair of Ootle public keys derived from an OotleSecretKey.
+#[wasm_bindgen(getter_with_clone)]
+pub struct OotlePublicKey {
+    /// The owner (spending) public key bytes.
+    pub owner_key: Vec<u8>,
+    /// The view-only public key bytes.
+    pub view_key: Vec<u8>,
+}
+
+/// Parsed components of an Ootle address.
+#[wasm_bindgen(getter_with_clone)]
+pub struct ParsedOotleAddress {
+    /// The owner (spending) public key bytes.
+    pub owner_key: Vec<u8>,
+    /// The view-only public key bytes.
+    pub view_key: Vec<u8>,
+    /// The network byte.
+    pub network: u8,
+    /// Optional pay reference / memo bytes.
+    pub memo: Option<Vec<u8>>,
+}
+
 /// BOR-encode a Transaction (JSON string) → base64 string (TransactionEnvelope format).
 #[wasm_bindgen(js_name = "borEncodeTransaction")]
 pub fn bor_encode_transaction(transaction_json: &str) -> Result<String, JsError> {
@@ -66,4 +97,65 @@ pub fn generate_keypair() -> KeypairResult {
 pub fn hash_unsigned_transaction(unsigned_tx_json: &str, seal_signer_public_key: &[u8]) -> Result<Vec<u8>, JsError> {
     ootle_wasm_core::hash::hash_unsigned_transaction_json(unsigned_tx_json, seal_signer_public_key)
         .map_err(|e| JsError::new(&e.to_string()))
+}
+
+/// Generate a new random pair of Ootle secret keys (owner + view).
+/// Returns { owner_key: Uint8Array, view_key: Uint8Array }.
+#[wasm_bindgen(js_name = "generateOotleSecretKey")]
+pub fn generate_ootle_secret_key() -> OotleSecretKey {
+    let result = ootle_wasm_core::address::generate_ootle_secret_key();
+    OotleSecretKey {
+        owner_key: result.owner_key,
+        view_key: result.view_key,
+    }
+}
+
+/// Derive the Ootle public keys from a pair of secret keys.
+/// Returns { owner_key: Uint8Array, view_key: Uint8Array }.
+#[wasm_bindgen(js_name = "ootlePublicKeyFromSecretKey")]
+pub fn ootle_public_key_from_secret_key(owner_key: &[u8], view_key: &[u8]) -> Result<OotlePublicKey, JsError> {
+    let secret = ootle_wasm_core::address::OotleSecretKeyResult {
+        owner_key: owner_key.to_vec(),
+        view_key: view_key.to_vec(),
+    };
+    let result =
+        ootle_wasm_core::address::ootle_public_key_from_secret_key(&secret).map_err(|e| JsError::new(&e.to_string()))?;
+    Ok(OotlePublicKey {
+        owner_key: result.owner_key,
+        view_key: result.view_key,
+    })
+}
+
+/// Generate an Ootle address (bech32m string) from public keys.
+///
+/// `network` is the network byte (0x00 = MainNet, 0x10 = LocalNet, 0x26 = Esmeralda, etc.).
+/// `memo` is an optional pay reference (max 64 bytes).
+#[wasm_bindgen(js_name = "generateOotleAddress")]
+pub fn generate_ootle_address(
+    owner_public_key: &[u8],
+    view_public_key: &[u8],
+    network: u8,
+    memo: Option<Vec<u8>>,
+) -> Result<String, JsError> {
+    ootle_wasm_core::address::generate_ootle_address(
+        owner_public_key,
+        view_public_key,
+        network,
+        memo.as_deref(),
+    )
+    .map_err(|e| JsError::new(&e.to_string()))
+}
+
+/// Parse a bech32m Ootle address string into its components.
+/// Returns { owner_key: Uint8Array, view_key: Uint8Array, network: number, memo: Uint8Array | undefined }.
+#[wasm_bindgen(js_name = "parseOotleAddress")]
+pub fn parse_ootle_address(address: &str) -> Result<ParsedOotleAddress, JsError> {
+    let result =
+        ootle_wasm_core::address::parse_ootle_address(address).map_err(|e| JsError::new(&e.to_string()))?;
+    Ok(ParsedOotleAddress {
+        owner_key: result.owner_key,
+        view_key: result.view_key,
+        network: result.network,
+        memo: result.memo,
+    })
 }

--- a/crates/ootle_wasm/wasm/src/lib.rs
+++ b/crates/ootle_wasm/wasm/src/lib.rs
@@ -118,8 +118,8 @@ pub fn ootle_public_key_from_secret_key(owner_key: &[u8], view_key: &[u8]) -> Re
         owner_key: owner_key.to_vec(),
         view_key: view_key.to_vec(),
     };
-    let result =
-        ootle_wasm_core::address::ootle_public_key_from_secret_key(&secret).map_err(|e| JsError::new(&e.to_string()))?;
+    let result = ootle_wasm_core::address::ootle_public_key_from_secret_key(&secret)
+        .map_err(|e| JsError::new(&e.to_string()))?;
     Ok(OotlePublicKey {
         owner_key: result.owner_key,
         view_key: result.view_key,
@@ -137,21 +137,15 @@ pub fn generate_ootle_address(
     network: u8,
     memo: Option<Vec<u8>>,
 ) -> Result<String, JsError> {
-    ootle_wasm_core::address::generate_ootle_address(
-        owner_public_key,
-        view_public_key,
-        network,
-        memo.as_deref(),
-    )
-    .map_err(|e| JsError::new(&e.to_string()))
+    ootle_wasm_core::address::generate_ootle_address(owner_public_key, view_public_key, network, memo.as_deref())
+        .map_err(|e| JsError::new(&e.to_string()))
 }
 
 /// Parse a bech32m Ootle address string into its components.
 /// Returns { owner_key: Uint8Array, view_key: Uint8Array, network: number, memo: Uint8Array | undefined }.
 #[wasm_bindgen(js_name = "parseOotleAddress")]
 pub fn parse_ootle_address(address: &str) -> Result<ParsedOotleAddress, JsError> {
-    let result =
-        ootle_wasm_core::address::parse_ootle_address(address).map_err(|e| JsError::new(&e.to_string()))?;
+    let result = ootle_wasm_core::address::parse_ootle_address(address).map_err(|e| JsError::new(&e.to_string()))?;
     Ok(ParsedOotleAddress {
         owner_key: result.owner_key,
         view_key: result.view_key,


### PR DESCRIPTION
Description
---
Summary

  - Add WASM bindings for Ootle address key management: secret key generation (owner + view), public key derivation, bech32m address generation with optional memo, and address parsing
  - All logic lives in ootle-wasm-core (pure Rust, fully tested) with a thin wasm-bindgen shell in ootle-wasm

  New WASM Exports

  - generateOotleSecretKey() — Generate random owner + view secret keys
  - ootlePublicKeyFromSecretKey(ownerKey, viewKey) — Derive public keys from secret keys
  - generateOotleAddress(ownerPk, viewPk, network, memo?) — Create bech32m address string
  - parseOotleAddress(address) — Parse bech32m address into components