### PR TITLE
feat(manifest): skills and create_account! support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,47 @@
+# Tari Ootle - Claude Code Cheatsheet
+
+## Project Structure
+
+- The project is called "Ootle" or "Tari Ootle" (not "DAN" or "Tari DAN")
+- **Crates** are in `crates/`, applications in `applications/`, clients in `clients/`
+- Wallet daemon package: `tari_ootle_walletd` (in `applications/tari_walletd/`)
+- Wallet CLI: `tari_wallet_cli` (in `applications/tari_wallet_cli/`)
+- Transaction manifest parser: `tari_transaction_manifest` (in `crates/transaction_manifest/`)
+- Transaction types/instructions: `tari_ootle_transaction` (in `crates/transaction/`)
+- Template lib types (OwnerRule, RistrettoPublicKeyBytes, etc.): `tari_template_lib_types` (in
+  `crates/template_lib_types/`)
+- CBOR serialization: `tari_bor` (in `crates/tari_bor/`) - wraps ciborium, re-exports serde
+
+## Key Facts
+
+### Token Amounts
+
+- All amounts in code/manifests are in **microtari**: 1 TARI = 1,000,000 microtari
+- In manifests, use `TARI` as the resource identifier (not `XTR`, which is deprecated)
+- User-facing: use **tTARI** (testnet) or **$TARI** (mainnet)
+
+### Transaction Manifests
+
+- DSL parsed by `tari_transaction_manifest::parse_manifest()`
+- Parser is in `crates/transaction_manifest/src/parser.rs`, generator in `generator.rs`
+- Macros: `var!`/`arg!`/`global!`, `new_component_addr!`, `new_resource_addr!`, `create_account!`, `drop_all_proofs!`,
+  log macros
+- `create_account!(owner_pk)` generates `Instruction::CreateAccount` - idempotent account creation
+- Variables passed to manifests are parsed via `ManifestValue::FromStr` which handles: substate IDs (`component_<hex>`,
+  `resource_<hex>`, etc.), NFT IDs, Rust literals, and raw hex bytes (for public keys)
+
+### Wallet Daemon JSON-RPC
+
+- Default port: 5100, endpoint: `/json_rpc`, ask the user if the daemon is running on a different port
+- Auth: check `auth.method`, then `auth.request` with `credentials: "None"` for no-auth setups
+- JWT tokens expire after 5 minutes
+- Key endpoints: `accounts.get_default`, `accounts.list`, `transactions.submit_manifest`, `transactions.wait_result`
+- `transactions.submit_manifest` variables are strings parsed by `ManifestValue::FromStr`
+
+### PR Workflow
+
+- Base branch for PRs is `development`, not `main`
+
+### Building
+
+- Standard cargo workspace. Use `-p <package_name>` to build/test specific crates

--- a/crates/engine/src/transaction/processor.rs
+++ b/crates/engine/src/transaction/processor.rs
@@ -693,6 +693,9 @@ where
 
                 runtime.interface_mut().validate_return_value(&result.indexed)?;
                 runtime.interface_mut().pop_call_frame()?;
+                runtime
+                    .interface_mut()
+                    .set_last_instruction_output(IndexedValue::from_type(&account_address)?)?;
 
                 Ok(InstructionResult::empty())
             },

--- a/crates/transaction_manifest/src/generator.rs
+++ b/crates/transaction_manifest/src/generator.rs
@@ -11,7 +11,7 @@ use tari_ootle_transaction::{
     args::{InstructionArg, WorkspaceId, WorkspaceOffsetId},
     call_arg,
 };
-use tari_template_lib::types::{ComponentAddress, TemplateAddress};
+use tari_template_lib::types::{ComponentAddress, TemplateAddress, crypto::RistrettoPublicKeyBytes};
 
 use crate::{
     ManifestInstructions,
@@ -157,6 +157,42 @@ impl ManifestInstructionGenerator {
                     workspace_id,
                 }])
             },
+            ManifestIntent::CreateAccount(create_account) => {
+                let owner_public_key = self.extract_public_key(&create_account.owner_public_key.to_string())?;
+
+                let owner_rule = create_account
+                    .owner_rule
+                    .map(|ident| self.extract_from_global(&ident.to_string()))
+                    .transpose()?;
+
+                let access_rules = create_account
+                    .access_rules
+                    .map(|ident| self.extract_from_global(&ident.to_string()))
+                    .transpose()?;
+
+                let bucket_workspace_id = create_account
+                    .bucket
+                    .map(|ident| {
+                        let name = ident.to_string();
+                        self.workspace_ids
+                            .get(&name)
+                            .map(|id| WorkspaceOffsetId::new(*id))
+                            .ok_or_else(|| ManifestError::UndefinedVariable { name })
+                    })
+                    .transpose()?;
+
+                let mut instructions = vec![Instruction::CreateAccount {
+                    owner_public_key,
+                    owner_rule,
+                    access_rules,
+                    bucket_workspace_id,
+                }];
+                if let Some(var_name) = create_account.output_variable {
+                    let key = self.next_workspace_id(var_name.to_string());
+                    instructions.push(Instruction::PutLastInstructionOutputOnWorkspace { key });
+                }
+                Ok(instructions)
+            },
             ManifestIntent::AssignInput(assign) => {
                 self.global_aliases.insert(
                     assign.variable_name.to_string(),
@@ -252,6 +288,44 @@ impl ManifestInstructionGenerator {
             .ok_or_else(|| {
                 ManifestError::InvalidVariableType(format!("Expected component variable but got {:?}", value))
             })
+    }
+
+    fn extract_public_key(&self, name: &str) -> Result<RistrettoPublicKeyBytes, ManifestError> {
+        let value = self
+            .global_aliases
+            .get(name)
+            .or_else(|| self.globals.get(name))
+            .ok_or_else(|| ManifestError::UndefinedVariable {
+                name: name.to_string(),
+            })?;
+
+        match value {
+            ManifestValue::Value(tari_bor::Value::Bytes(bytes)) => {
+                RistrettoPublicKeyBytes::from_bytes(bytes).map_err(|e| ManifestError::InvalidVariableType(e.to_string()))
+            },
+            _ => Err(ManifestError::InvalidVariableType(format!(
+                "Expected public key bytes for variable '{name}' but got {value:?}"
+            ))),
+        }
+    }
+
+    fn extract_from_global<T: tari_bor::DeserializeOwned>(&self, name: &str) -> Result<T, ManifestError> {
+        let value = self
+            .global_aliases
+            .get(name)
+            .or_else(|| self.globals.get(name))
+            .ok_or_else(|| ManifestError::UndefinedVariable {
+                name: name.to_string(),
+            })?;
+
+        match value {
+            ManifestValue::Value(v) => tari_bor::from_value(v).map_err(|e| {
+                ManifestError::InvalidVariableType(format!("Failed to deserialize variable '{name}': {e}"))
+            }),
+            _ => Err(ManifestError::InvalidVariableType(format!(
+                "Expected serialized value for variable '{name}' but got {value:?}"
+            ))),
+        }
     }
 
     fn get_ident(&self, name: &str) -> Result<InstructionArg, ManifestError> {

--- a/crates/transaction_manifest/src/generator.rs
+++ b/crates/transaction_manifest/src/generator.rs
@@ -177,7 +177,7 @@ impl ManifestInstructionGenerator {
                         self.workspace_ids
                             .get(&name)
                             .map(|id| WorkspaceOffsetId::new(*id))
-                            .ok_or_else(|| ManifestError::UndefinedVariable { name })
+                            .ok_or(ManifestError::UndefinedVariable { name })
                     })
                     .transpose()?;
 
@@ -295,14 +295,11 @@ impl ManifestInstructionGenerator {
             .global_aliases
             .get(name)
             .or_else(|| self.globals.get(name))
-            .ok_or_else(|| ManifestError::UndefinedVariable {
-                name: name.to_string(),
-            })?;
+            .ok_or_else(|| ManifestError::UndefinedVariable { name: name.to_string() })?;
 
         match value {
-            ManifestValue::Value(tari_bor::Value::Bytes(bytes)) => {
-                RistrettoPublicKeyBytes::from_bytes(bytes).map_err(|e| ManifestError::InvalidVariableType(e.to_string()))
-            },
+            ManifestValue::Value(tari_bor::Value::Bytes(bytes)) => RistrettoPublicKeyBytes::from_bytes(bytes)
+                .map_err(|e| ManifestError::InvalidVariableType(e.to_string())),
             _ => Err(ManifestError::InvalidVariableType(format!(
                 "Expected public key bytes for variable '{name}' but got {value:?}"
             ))),
@@ -314,9 +311,7 @@ impl ManifestInstructionGenerator {
             .global_aliases
             .get(name)
             .or_else(|| self.globals.get(name))
-            .ok_or_else(|| ManifestError::UndefinedVariable {
-                name: name.to_string(),
-            })?;
+            .ok_or_else(|| ManifestError::UndefinedVariable { name: name.to_string() })?;
 
         match value {
             ManifestValue::Value(v) => tari_bor::from_value(v).map_err(|e| {

--- a/crates/transaction_manifest/src/parser.rs
+++ b/crates/transaction_manifest/src/parser.rs
@@ -51,6 +51,7 @@ pub enum ManifestIntent {
     InvokeComponent(InvokeIntent),
     AssignInput(AssignInputStmt),
     AllocateAddress(AllocateAddressStmt),
+    CreateAccount(CreateAccountIntent),
     Log(LogIntent),
     DropAllProofs,
     CallLocalFunction(Ident),
@@ -81,6 +82,15 @@ pub struct AssignInputStmt {
 pub struct AllocateAddressStmt {
     pub output_variable: Ident,
     pub allocatable_type: AllocatableAddressType,
+}
+
+#[derive(Debug, Clone)]
+pub struct CreateAccountIntent {
+    pub output_variable: Option<Ident>,
+    pub owner_public_key: Ident,
+    pub owner_rule: Option<Ident>,
+    pub access_rules: Option<Ident>,
+    pub bucket: Option<Ident>,
 }
 
 #[derive(Debug, Clone)]
@@ -385,6 +395,16 @@ fn assignment_from_macro(var_name: Ident, mac: &Ident, tokens: TokenStream) -> R
             output_variable: var_name,
             allocatable_type: AllocatableAddressType::Resource,
         })),
+        "create_account" => {
+            let args = parse_create_account_args(tokens)?;
+            Ok(ManifestIntent::CreateAccount(CreateAccountIntent {
+                output_variable: Some(var_name),
+                owner_public_key: args.owner_public_key,
+                owner_rule: args.owner_rule,
+                access_rules: args.access_rules,
+                bucket: args.bucket,
+            }))
+        },
         _ => Err(syn::Error::new_spanned(mac, "Invalid macro name")),
     }
 }
@@ -409,6 +429,16 @@ fn macro_call(mac: &Ident, tokens: TokenStream) -> Result<ManifestIntent, syn::E
             message: parse2::<LitStr>(tokens)?.value(),
         })),
         "drop_all_proofs" => Ok(ManifestIntent::DropAllProofs),
+        "create_account" => {
+            let args = parse_create_account_args(tokens)?;
+            Ok(ManifestIntent::CreateAccount(CreateAccountIntent {
+                output_variable: None,
+                owner_public_key: args.owner_public_key,
+                owner_rule: args.owner_rule,
+                access_rules: args.access_rules,
+                bucket: args.bucket,
+            }))
+        },
         _ => Err(syn::Error::new_spanned(mac, "Invalid macro name")),
     }
 }
@@ -618,6 +648,54 @@ fn handle_special_literals(name: &Ident, args: Punctuated<Expr, Comma>) -> Resul
             ),
         )),
     }
+}
+
+struct CreateAccountArgs {
+    owner_public_key: Ident,
+    owner_rule: Option<Ident>,
+    access_rules: Option<Ident>,
+    bucket: Option<Ident>,
+}
+
+fn parse_create_account_args(tokens: TokenStream) -> Result<CreateAccountArgs, syn::Error> {
+    syn::parse::Parser::parse2(
+        |input: ParseStream| {
+            let owner_public_key: Ident = input.parse()?;
+            let mut owner_rule = None;
+            let mut access_rules = None;
+            let mut bucket = None;
+
+            while input.peek(syn::Token![,]) {
+                input.parse::<syn::Token![,]>()?;
+                if input.is_empty() {
+                    break;
+                }
+                let key: Ident = input.parse()?;
+                input.parse::<syn::Token![=]>()?;
+                let value: Ident = input.parse()?;
+
+                match key.to_string().as_str() {
+                    "owner_rule" => owner_rule = Some(value),
+                    "access_rules" => access_rules = Some(value),
+                    "bucket" => bucket = Some(value),
+                    _ => {
+                        return Err(syn::Error::new_spanned(
+                            key,
+                            "Unknown create_account argument, expected 'owner_rule', 'access_rules', or 'bucket'",
+                        ));
+                    },
+                }
+            }
+
+            Ok(CreateAccountArgs {
+                owner_public_key,
+                owner_rule,
+                access_rules,
+                bucket,
+            })
+        },
+        tokens,
+    )
 }
 
 fn extract_single_var_name(expr: &Expr) -> Result<Ident, syn::Error> {

--- a/crates/transaction_manifest/src/value.rs
+++ b/crates/transaction_manifest/src/value.rs
@@ -7,7 +7,8 @@ use syn::{Lit, parse2};
 use tari_bor::{BorError, Serialize};
 use tari_engine_types::substate::SubstateId;
 use tari_ootle_transaction::{args::InstructionArg, call_arg};
-use tari_template_lib::{to_value, types::NonFungibleId};
+use tari_template_lib::types::{NonFungibleId, hex::bytes_from_hex};
+use tari_template_lib::to_value;
 
 use crate::error::ManifestError;
 
@@ -118,6 +119,11 @@ impl FromStr for ManifestValue {
                 let tokens = s.parse().ok()?;
                 let lit = parse2(tokens).ok()?;
                 Some(ManifestValue::Literal(lit))
+            })
+            .or_else(|| {
+                // Try parsing as hex bytes (e.g. public keys)
+                let bytes = bytes_from_hex(s).ok()?;
+                Some(ManifestValue::Value(tari_bor::Value::Bytes(bytes)))
             })
             .ok_or_else(|| ManifestParseError(s.to_string()))
     }

--- a/crates/transaction_manifest/src/value.rs
+++ b/crates/transaction_manifest/src/value.rs
@@ -7,8 +7,10 @@ use syn::{Lit, parse2};
 use tari_bor::{BorError, Serialize};
 use tari_engine_types::substate::SubstateId;
 use tari_ootle_transaction::{args::InstructionArg, call_arg};
-use tari_template_lib::types::{NonFungibleId, hex::bytes_from_hex};
-use tari_template_lib::to_value;
+use tari_template_lib::{
+    to_value,
+    types::{NonFungibleId, hex::bytes_from_hex},
+};
 
 use crate::error::ManifestError;
 

--- a/crates/transaction_manifest/tests/parser.rs
+++ b/crates/transaction_manifest/tests/parser.rs
@@ -24,7 +24,7 @@ use std::{collections::HashMap, fs, str::FromStr};
 
 use tari_bor::cbor;
 use tari_engine_types::substate::SubstateId;
-use tari_ootle_transaction::{AllocatableAddressType, ComponentReference, Instruction, call_args};
+use tari_ootle_transaction::{AllocatableAddressType, ComponentReference, Instruction, args::WorkspaceOffsetId, call_args};
 use tari_template_lib::types::{
     ComponentAddress,
     ObjectKey,
@@ -32,6 +32,7 @@ use tari_template_lib::types::{
     constants::TARI_TOKEN,
     crypto::RistrettoPublicKeyBytes,
 };
+use tari_transaction_manifest::ManifestValue;
 use tari_transaction_manifest::{ManifestInstructions, parse_manifest};
 
 #[test]
@@ -262,4 +263,118 @@ fn recursive_function_exceeds_call_depth() {
         err.to_string().contains("Maximum call depth"),
         "Expected MaxCallDepthExceeded error, got: {err}"
     );
+}
+
+#[test]
+fn create_account_simple() {
+    let manifest = r#"
+        fn main() {
+            let owner_pk = var!["owner_pk"];
+            let account = create_account!(owner_pk);
+        }
+    "#;
+
+    let pk_bytes = [42u8; 32];
+    let globals = HashMap::from([(
+        "owner_pk".to_string(),
+        ManifestValue::Value(tari_bor::Value::Bytes(pk_bytes.to_vec())),
+    )]);
+
+    let ManifestInstructions {
+        instructions,
+        fee_instructions,
+    } = parse_manifest(manifest, globals, Default::default()).unwrap();
+
+    let expected = vec![
+        Instruction::CreateAccount {
+            owner_public_key: RistrettoPublicKeyBytes::from(pk_bytes),
+            owner_rule: None,
+            access_rules: None,
+            bucket_workspace_id: None,
+        },
+        Instruction::PutLastInstructionOutputOnWorkspace { key: 0 },
+    ];
+
+    assert_eq!(instructions, expected);
+    assert_eq!(fee_instructions, vec![]);
+}
+
+#[test]
+fn create_account_with_bucket() {
+    let manifest = r#"
+        fn main() {
+            let owner_pk = var!["owner_pk"];
+            let source = var!["source"];
+            let bucket = source.withdraw(TARI, 10);
+            let account = create_account!(owner_pk, bucket = bucket);
+        }
+    "#;
+
+    let pk_bytes = [42u8; 32];
+    let source_component = ComponentAddress::new([1u8; ObjectKey::LENGTH].into());
+    let globals = HashMap::from([
+        (
+            "owner_pk".to_string(),
+            ManifestValue::Value(tari_bor::Value::Bytes(pk_bytes.to_vec())),
+        ),
+        (
+            "source".to_string(),
+            SubstateId::Component(source_component).into(),
+        ),
+    ]);
+
+    let ManifestInstructions {
+        instructions,
+        fee_instructions,
+    } = parse_manifest(manifest, globals, Default::default()).unwrap();
+
+    let expected = vec![
+        Instruction::CallMethod {
+            call: source_component.into(),
+            method: "withdraw".try_into().unwrap(),
+            args: call_args![TARI_TOKEN, 10],
+        },
+        Instruction::PutLastInstructionOutputOnWorkspace { key: 0 },
+        Instruction::CreateAccount {
+            owner_public_key: RistrettoPublicKeyBytes::from(pk_bytes),
+            owner_rule: None,
+            access_rules: None,
+            bucket_workspace_id: Some(WorkspaceOffsetId::new(0)),
+        },
+        Instruction::PutLastInstructionOutputOnWorkspace { key: 1 },
+    ];
+
+    assert_eq!(instructions, expected);
+    assert_eq!(fee_instructions, vec![]);
+}
+
+#[test]
+fn create_account_without_assignment() {
+    let manifest = r#"
+        fn main() {
+            let owner_pk = var!["owner_pk"];
+            create_account!(owner_pk);
+        }
+    "#;
+
+    let pk_bytes = [42u8; 32];
+    let globals = HashMap::from([(
+        "owner_pk".to_string(),
+        ManifestValue::Value(tari_bor::Value::Bytes(pk_bytes.to_vec())),
+    )]);
+
+    let ManifestInstructions {
+        instructions,
+        fee_instructions,
+    } = parse_manifest(manifest, globals, Default::default()).unwrap();
+
+    let expected = vec![Instruction::CreateAccount {
+        owner_public_key: RistrettoPublicKeyBytes::from(pk_bytes),
+        owner_rule: None,
+        access_rules: None,
+        bucket_workspace_id: None,
+    }];
+
+    assert_eq!(instructions, expected);
+    assert_eq!(fee_instructions, vec![]);
 }

--- a/crates/transaction_manifest/tests/parser.rs
+++ b/crates/transaction_manifest/tests/parser.rs
@@ -24,7 +24,13 @@ use std::{collections::HashMap, fs, str::FromStr};
 
 use tari_bor::cbor;
 use tari_engine_types::substate::SubstateId;
-use tari_ootle_transaction::{AllocatableAddressType, ComponentReference, Instruction, args::WorkspaceOffsetId, call_args};
+use tari_ootle_transaction::{
+    AllocatableAddressType,
+    ComponentReference,
+    Instruction,
+    args::WorkspaceOffsetId,
+    call_args,
+};
 use tari_template_lib::types::{
     ComponentAddress,
     ObjectKey,
@@ -32,8 +38,7 @@ use tari_template_lib::types::{
     constants::TARI_TOKEN,
     crypto::RistrettoPublicKeyBytes,
 };
-use tari_transaction_manifest::ManifestValue;
-use tari_transaction_manifest::{ManifestInstructions, parse_manifest};
+use tari_transaction_manifest::{ManifestInstructions, ManifestValue, parse_manifest};
 
 #[test]
 #[allow(clippy::too_many_lines)]
@@ -317,10 +322,7 @@ fn create_account_with_bucket() {
             "owner_pk".to_string(),
             ManifestValue::Value(tari_bor::Value::Bytes(pk_bytes.to_vec())),
         ),
-        (
-            "source".to_string(),
-            SubstateId::Component(source_component).into(),
-        ),
+        ("source".to_string(), SubstateId::Component(source_component).into()),
     ]);
 
     let ManifestInstructions {

--- a/docs/skills/claude-code/tari-manifest/SKILL.md
+++ b/docs/skills/claude-code/tari-manifest/SKILL.md
@@ -1,0 +1,353 @@
+---
+name: tari-manifest
+description: This skill should be used when the user asks to "write a manifest", "create a transaction manifest", "submit a transaction", "call a component method", "call a template function", "interact with a Tari component", "write Ootle manifest", "authenticate with wallet daemon", or needs to construct Tari Ootle transaction manifests for submitting transactions on the Tari network.
+---
+
+# Tari Ootle Transaction Manifests
+
+Tari Ootle manifests are a Rust-like DSL for defining transaction instructions. They are parsed by `tari_transaction_manifest::parse_manifest()` and compiled into `Vec<Instruction>` for execution on the Tari engine.
+
+## CRITICAL: User Confirmation Required Before Submission
+
+**NEVER submit a transaction without explicit user confirmation.** Before calling `transactions.submit_manifest` (with `dry_run: false`), ALWAYS:
+
+1. **Present a clear summary** of what the transaction will do, including:
+   - The action in plain language (e.g. "Transfer 100 tTARI from account A to account B")
+   - The manifest source code
+   - All variables and their resolved values (component addresses, amounts, etc.)
+   - The max fee
+   - Which account will sign/pay fees
+2. **Ask the user to confirm** before proceeding. Wait for explicit approval.
+3. **Do not batch or auto-submit** multiple transactions without per-transaction confirmation.
+
+Dry-run submissions (`dry_run: true`) may be performed without confirmation as they do not modify state.
+
+## Manifest Structure
+
+Every manifest has a `fn main()` block for transaction instructions and an optional `fn fee_main()` block for fee payment. Helper functions may be defined and are inlined at call sites.
+
+```rust
+// Optional: import templates by hash
+use template_<64-char-hex-hash> as TemplateName;
+
+// Optional: fee instructions (executed first)
+fn fee_main() {
+    let account = arg!["account"];
+    account.pay_fee(1000);
+}
+
+// Required: main transaction instructions
+fn main() {
+    let account = var!["account"];
+    let component = var!["component"];
+
+    let result = component.some_method(arg1, arg2);
+    account.deposit(result);
+}
+```
+
+## Core Concepts
+
+### Variables and Arguments
+
+Access runtime variables passed to the manifest via globals:
+
+```rust
+let my_var = var!["variable_name"];   // workspace variable
+let my_var = arg!["argument_name"];   // alias for var!
+let my_var = global!["global_name"];  // alias for var!
+```
+
+### Template Function Calls
+
+Call static functions on imported templates (constructors, etc.):
+
+```rust
+use template_<hash> as MyTemplate;
+let component = MyTemplate::new(arg1, arg2);
+```
+
+The `Account` template is always pre-imported.
+
+### Component Method Calls
+
+Call methods on component variables (from `var!` or prior call results):
+
+```rust
+let result = component.method_name(arg1, arg2);
+component.method_name_no_return(arg1);
+```
+
+### Chaining Results
+
+Method call results are stored in workspace variables and can be passed to subsequent calls:
+
+```rust
+let bucket = account.withdraw(TARI, 1000);
+let item = shop.buy(bucket);
+account.deposit(item);
+```
+
+## Supported Argument Types
+
+| Type | Syntax | Example |
+|------|--------|---------|
+| String | `"value"` | `"hello"` |
+| Integer | `123u64`, `42i32` | `1_000u64` (unsuffixed defaults to i128) |
+| Boolean | `true` / `false` | `true` |
+| Amount | `Amount(value)` | `Amount(1000)` |
+| Address | `Address("prefix_hex...")` or `Address(var)` | `Address("component_ab12...")` |
+| SubstateId | `SubstateId("prefix_hex...")` | `SubstateId("vault_ab12...")` |
+| NonFungibleId | `NonFungibleId("str")`, `NonFungibleId(1u32)`, `NonFungibleId(1u64)` | `NonFungibleId("MyNFT")` |
+| Metadata | `Metadata("key=value")` | `Metadata("name=Token")` |
+| PublicKey | `PublicKey("hex")` | `PublicKey("ab12...cd34")` |
+| HexBytes | `HexBytes("hex")` | `HexBytes("deadbeef")` |
+| CBOR | `Cbor("{json}")` or `cbor!({json})` | `cbor!({"key": [1, 2]})` |
+| Tari token | `TARI` | `account.withdraw(TARI, 100)` (`XTR` is a deprecated alias that still works but should not be used in new manifests; when describing transactions to users, call the token **tTARI** on testnet or **$TARI** on mainnet) |
+| Workspace var | bare identifier | `bucket` (from prior `let bucket = ...`) |
+
+## Built-in Macros
+
+```rust
+// Address allocation
+let addr = new_component_addr!();
+let addr = new_resource_addr!();
+
+// Logging
+info!("message");
+debug!("message");
+warn!("message");
+error!("message");
+
+// Proof management
+drop_all_proofs!();
+```
+
+## Writing Manifests Workflow
+
+1. **Identify the template and component addresses** the transaction will interact with. These are passed as variables.
+2. **Write `fee_main()`** if fees are not handled externally. Typically: `account.pay_fee(max_fee)`.
+3. **Write `main()`** with the transaction logic: retrieve variables, call methods, deposit results.
+4. **Pass variables** when submitting: map variable names to `ManifestValue` instances (component addresses, resource addresses, amounts, etc.).
+5. **Present a summary and ask the user to confirm** before submitting (see "User Confirmation Required" above). Only submit after receiving explicit approval.
+
+## Submitting Manifests via Wallet Daemon JSON-RPC
+
+The wallet daemon exposes a JSON-RPC 2.0 API. All requests are POSTed to the `/json_rpc` endpoint.
+
+### Step 1: Check Auth Method
+
+```bash
+curl -s -X POST http://localhost:12008/json_rpc \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"auth.method","params":{}}'
+```
+
+Response: `{"result":{"method":"none"}}` or `{"result":{"method":"webauthn"}}`.
+
+### Step 2: Authenticate and Get JWT Token
+
+**Available permissions:** `Admin`, `AccountInfo`, `AccountList`, `AccountBalance`, `KeyList`, `TransactionGet`, `TransactionSend`, `SubstatesRead`, `TemplatesRead`, `GetNft`, `NftGetOwnershipProof`. Use `Admin` for full access.
+
+JWT tokens expire after 5 minutes by default. Refresh with `auth.refresh` or request a new one.
+
+#### When `method` is `"none"`
+
+Authenticate directly with `AuthCredentials::None`:
+
+```bash
+curl -s -X POST http://localhost:12008/json_rpc \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc":"2.0","id":2,"method":"auth.request",
+    "params":{"permissions":["Admin"],"credentials":"None"}
+  }'
+```
+
+Response contains `{"result":{"token":"eyJ..."}}`. Store this JWT token.
+
+#### When `method` is `"webauthn"`
+
+WebAuthn requires a browser-based passkey interaction (biometric, hardware key, etc.) that cannot be performed by an agent directly. Ask the user to provide a JWT token. Instruct them to:
+
+1. Open the wallet daemon web UI in their browser
+2. Authenticate with their passkey
+3. Copy the JWT token from the browser (e.g. from the `Authorization` header in dev tools, or from the UI if it exposes one)
+4. Paste the token back to the agent
+
+Once the user provides the token, use it in the `Authorization: Bearer <token>` header for all subsequent requests. If the token expires, ask the user to provide a fresh one.
+
+### Step 3: Use Token for All Subsequent Requests
+
+Include the JWT in the `Authorization` header:
+
+```bash
+curl -s -X POST http://localhost:12008/json_rpc \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer eyJ..." \
+  -d '{"jsonrpc":"2.0","id":3,"method":"accounts.list","params":{"offset":0,"limit":10}}'
+```
+
+### Step 4: Summarize and Confirm with User
+
+**Before submitting**, present a human-readable summary to the user and wait for explicit confirmation. Example:
+
+> **Transaction Summary**
+> - **Action:** Transfer 100 tTARI from source account to destination account
+> - **Source:** `component_e61f...bf68` (account "dsfgdfg")
+> - **Destination:** `component_1642...c0c1` (account "sdfdf")
+> - **Max fee:** 1000
+> - **Signing key:** default
+>
+> Proceed? (yes/no)
+
+Only after the user confirms, submit the manifest.
+
+### Step 5: Submit the Manifest
+
+```bash
+curl -s -X POST http://localhost:12008/json_rpc \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer eyJ..." \
+  -d '{
+    "jsonrpc":"2.0","id":4,"method":"transactions.submit_manifest",
+    "params":{
+      "manifest": "fn fee_main() {\n  let account = var![\"account\"];\n  account.pay_fee(1000);\n}\n\nfn main() {\n  let account = var![\"account\"];\n  let dest = var![\"dest\"];\n  let bucket = account.withdraw(TARI, 100);\n  dest.deposit(bucket);\n}",
+      "variables": {
+        "account": "component_e61f...bf68",
+        "dest": "component_1642...c0c1"
+      },
+      "max_fee": 1000,
+      "dry_run": false
+    }
+  }'
+```
+
+**Request fields:**
+- `manifest` (string): The manifest source code. Newlines as `\n`, inner quotes escaped.
+- `variables` (object): Map of variable names to address/value strings (e.g. `component_<hex>`, `resource_<hex>`, `"1000u64"`).
+- `signing_key_id` (optional): Override the signing key. Omit to use default account key.
+- `max_fee` (u64): Maximum fee in microtari.
+- `dry_run` (bool): If `true`, executes without submitting to network. Returns result in response.
+
+**Response:**
+```json
+{
+  "result": {
+    "transaction_id": "tx_<hex>",
+    "result": null
+  }
+}
+```
+
+`result` is `null` for live submissions (use `transactions.wait_result` to poll). For `dry_run: true`, it contains the `ExecuteResult`.
+
+### Step 6: Wait for Result (optional)
+
+```bash
+curl -s -X POST http://localhost:12008/json_rpc \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer eyJ..." \
+  -d '{
+    "jsonrpc":"2.0","id":5,"method":"transactions.wait_result",
+    "params":{"transaction_id":"tx_<hex>","timeout_secs":120}
+  }'
+```
+
+### Useful Endpoints
+
+| Method | Description |
+|--------|-------------|
+| `auth.method` | Check auth type (no auth required) |
+| `auth.request` | Get JWT token |
+| `auth.refresh` | Refresh expired JWT token |
+| `accounts.list` | List accounts (`offset`, `limit`) |
+| `accounts.get_default` | Get default account |
+| `accounts.get_balances` | Get account balances |
+| `transactions.submit_manifest` | Submit a manifest transaction |
+| `transactions.wait_result` | Wait for transaction finalization |
+| `transactions.get_result` | Poll transaction result (non-blocking) |
+| `substates.get` | Fetch a substate by address |
+| `templates.get` | Fetch template function definitions |
+
+### Via Wallet CLI
+
+```bash
+tari_wallet_cli transaction submit-manifest manifest.tm \
+  -g account=component_<hex> \
+  -g resource=resource_<hex> \
+  --max-fee 1000
+```
+
+### Programmatically (Rust)
+
+```rust
+use tari_transaction_manifest::{parse_manifest, ManifestValue};
+
+let mut globals = HashMap::new();
+globals.insert("account".to_string(), ManifestValue::from(account_address));
+
+let instructions = parse_manifest(&manifest_str, globals, HashMap::new())?;
+// instructions.instructions     - main transaction instructions
+// instructions.fee_instructions - fee payment instructions
+```
+
+## Token Naming
+
+The native Tari token is referred to as `TARI` within manifest code. `XTR` is a deprecated alias that still works but should not be used in new manifests. When communicating with users, always use the proper token name:
+- **Testnet:** tTARI
+- **Mainnet:** $TARI
+
+Never refer to the token as "XTR" in user-facing summaries, descriptions, or new manifest code.
+
+## Common Patterns
+
+### Withdraw and Deposit
+
+```rust
+fn main() {
+    let source = var!["source_account"];
+    let dest = var!["dest_account"];
+    let resource = var!["resource"];
+
+    let bucket = source.withdraw(resource, 1000);
+    dest.deposit(bucket);
+}
+```
+
+### Create Proof and Call Protected Method
+
+```rust
+fn main() {
+    let account = var!["account"];
+    let admin_badge = var!["admin_badge"];
+    let component = var!["component"];
+
+    let proof = account.create_proof_by_amount(Address(admin_badge), 1);
+    component.admin_action();
+    drop_all_proofs!();
+}
+```
+
+### Instantiate a Component
+
+```rust
+use template_<hash> as MyTemplate;
+
+fn main() {
+    let new_component = MyTemplate::new("config_value", 42u64);
+}
+```
+
+## Additional Resources
+
+### Reference Files
+
+- **`references/manifest-syntax.md`** - Complete syntax reference with all supported constructs and edge cases
+- **`references/wallet-daemon-api.md`** - Full wallet daemon JSON-RPC API reference including all auth, transaction, account, and substate endpoints
+
+### Example Files
+
+- **`examples/token_swap.rs`** - Token swap between accounts via a DEX component
+- **`examples/initialize_component.rs`** - Component initialization from a template
+- **`examples/nft_mint_and_deposit.rs`** - Mint an NFT and deposit to account

--- a/docs/skills/claude-code/tari-manifest/examples/initialize_component.rs
+++ b/docs/skills/claude-code/tari-manifest/examples/initialize_component.rs
@@ -1,0 +1,23 @@
+//   Copyright 2024 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+// Initialize a StableCoin component from a template.
+// Requires the template hash to be known at manifest authoring time.
+
+use template_687b0d5b3bee2e987a72c0f8b0b9286968803eba9040ed67e3a85b8465ad294a as StableCoin;
+
+fn fee_main() {
+    let account = arg!["account"];
+    account.pay_fee(2000);
+}
+
+fn main() {
+    StableCoin::initialize(
+        "100000000000000000000000000",
+        "STC",
+        Metadata("provider_name=StableCoin Inc."),
+        8,
+        PublicKey("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"),
+        true,
+    );
+}

--- a/docs/skills/claude-code/tari-manifest/examples/nft_mint_and_deposit.rs
+++ b/docs/skills/claude-code/tari-manifest/examples/nft_mint_and_deposit.rs
@@ -1,0 +1,21 @@
+//   Copyright 2024 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+// Mint an NFT from a component and deposit it into an account.
+// Variables: account (component address), nft_component (component address)
+
+fn fee_main() {
+    let account = var!["account"];
+    account.pay_fee(1000);
+}
+
+fn main() {
+    let account = var!["account"];
+    let sparkle_nft = var!["nft_component"];
+
+    // Mint a new NFT with a specific ID
+    let nft_bucket = sparkle_nft.mint_specific(NonFungibleId("SpecialEdition"));
+
+    // Deposit the minted NFT into the account
+    account.deposit(nft_bucket);
+}

--- a/docs/skills/claude-code/tari-manifest/examples/token_swap.rs
+++ b/docs/skills/claude-code/tari-manifest/examples/token_swap.rs
@@ -1,0 +1,24 @@
+//   Copyright 2024 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+// Swap token_a for token_b via a TariSwap DEX component.
+// Variables: in_account, out_account, swap_component, token_a, token_b, amt
+
+fn fee_main() {
+    let in_account = arg!["in_account"];
+    in_account.pay_fee(1000);
+}
+
+fn main() {
+    let swap_component = arg!["swap_component"];
+    let in_account = arg!["in_account"];
+    let out_account = arg!["out_account"];
+    let amt = arg!["amt"];
+
+    let token_a = arg!["token_a"];
+    let token_b = arg!["token_b"];
+
+    let in_bucket = in_account.withdraw(token_a, amt);
+    let out_bucket = swap_component.swap(in_bucket, token_b);
+    out_account.deposit(out_bucket);
+}

--- a/docs/skills/claude-code/tari-manifest/references/manifest-syntax.md
+++ b/docs/skills/claude-code/tari-manifest/references/manifest-syntax.md
@@ -1,0 +1,296 @@
+# Tari Ootle Manifest Syntax Reference
+
+Complete reference for the Tari transaction manifest DSL. The manifest parser lives at `crates/transaction_manifest/`.
+
+## File Structure
+
+A manifest file contains:
+1. **Template imports** (optional) - `use template_<hex> as Alias;` or `use PredefinedTemplate;`
+2. **`fn fee_main() { ... }`** (optional) - Fee payment instructions, executed before main
+3. **`fn main() { ... }`** (required) - Main transaction instructions
+4. **Helper functions** (optional) - `fn helper() { ... }`, inlined at call sites (max depth 16)
+
+The `Account` template is always pre-imported automatically.
+
+## Template Imports
+
+### By hash (64-character hex)
+
+```rust
+use template_687b0d5b3bee2e987a72c0f8b0b9286968803eba9040ed67e3a85b8465ad294a as TestFaucet;
+```
+
+### Predefined templates
+
+```rust
+use Account;  // Already pre-imported, but can be explicit
+```
+
+### Via external template map
+
+Templates can also be provided programmatically via the `templates: HashMap<String, TemplateAddress>` parameter to `parse_manifest()`, avoiding the need for inline `use` statements. The test tooling (`TemplateTest`) does this automatically for all registered templates.
+
+## Statements
+
+### Variable Assignment from Globals
+
+Three equivalent macros for accessing runtime variables:
+
+```rust
+let my_var = var!["name"];      // Most common
+let my_var = arg!["name"];      // Alias
+let my_var = global!["name"];   // Alias
+```
+
+The string inside the macro is the key used to look up the value in the `globals` HashMap passed to `parse_manifest()`.
+
+### Template Function Calls
+
+Static function calls on imported templates:
+
+```rust
+// With return value
+let component = MyTemplate::new(arg1, arg2);
+
+// Without return value (fire-and-forget)
+MyTemplate::do_something(arg1);
+```
+
+### Component Method Calls
+
+Method calls on variables (components or workspace results):
+
+```rust
+// With return value
+let result = component.method(arg1, arg2);
+
+// Without return value
+component.method(arg1);
+```
+
+### Address Allocation
+
+Pre-allocate addresses for components or resources before they are created:
+
+```rust
+let addr = new_component_addr!();
+let addr = new_resource_addr!();
+let addr = allocate_component_address!();  // Alias
+```
+
+### Logging
+
+```rust
+info!("Informational message");
+debug!("Debug message");
+warn!("Warning message");
+error!("Error message");
+```
+
+Note: only string literals are supported (no format args).
+
+### Proof Management
+
+```rust
+drop_all_proofs!();
+```
+
+Drops all proofs currently in the workspace. Typically called after protected operations.
+
+### Local Function Calls
+
+Define helper functions and call them from `main()` or `fee_main()`:
+
+```rust
+fn setup() {
+    let faucet = var!["faucet"];
+    let coins = faucet.take_free_coins();
+    // ...
+}
+
+fn main() {
+    setup();
+    // ...
+}
+```
+
+Helper functions are inlined at call sites. Maximum nesting depth is 16.
+
+## Argument Types - Detailed Reference
+
+### Integer Literals
+
+Unsuffixed integers default to `i128`. Always use a suffix for explicit typing:
+
+| Suffix | Rust type | Example |
+|--------|-----------|---------|
+| `u8` | `u8` | `255u8` |
+| `u16` | `u16` | `1000u16` |
+| `u32` | `u32` | `42u32` |
+| `u64` | `u64` | `1_000_000u64` |
+| `u128` | `u128` | `100u128` |
+| `i8` | `i8` | `-1i8` |
+| `i16` | `i16` | `500i16` |
+| `i32` | `i32` | `42i32` |
+| `i64` | `i64` | `100i64` |
+| (none) or `i128` | `i128` | `100` or `100i128` |
+
+Underscores are allowed as visual separators: `1_000_000u64`.
+
+**Float literals are NOT supported.**
+
+### String Literals
+
+Standard Rust string literals:
+
+```rust
+"hello world"
+```
+
+### Boolean Literals
+
+```rust
+true
+false
+```
+
+### Byte String Literals
+
+```rust
+b"raw bytes"
+```
+
+### Amount
+
+Wraps an integer as a `tari_template_lib::types::Amount`:
+
+```rust
+Amount(1000)
+```
+
+### Address and SubstateId
+
+Reference a substate by its address string. Both accept either a string literal or a workspace variable:
+
+```rust
+// String literal form
+Address("component_0123456789abcdef...")
+SubstateId("vault_0123456789abcdef...")
+
+// Variable form (from a prior let binding)
+Address(my_var)
+SubstateId(my_var)
+```
+
+Address prefixes: `component_`, `resource_`, `vault_`, `nft_`, `txreceipt_`, `template_`, `validatorfeeclaim_`, `utxo_`, `tombstone_`.
+
+### NonFungibleId
+
+Three forms:
+
+```rust
+NonFungibleId("StringId")      // String-based NFT ID
+NonFungibleId(1u32)            // 32-bit integer ID
+NonFungibleId(42u64)           // 64-bit integer ID
+// Also: byte string for 256-bit ID
+```
+
+A suffix is required for integer forms.
+
+### Metadata
+
+Key-value metadata string:
+
+```rust
+Metadata("key=value")
+```
+
+Parsed as `tari_template_lib::types::Metadata`.
+
+### PublicKey and HexBytes
+
+Both parse a hex string into raw bytes:
+
+```rust
+PublicKey("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")
+HexBytes("deadbeef")
+```
+
+### CBOR Values
+
+Two forms for embedding arbitrary CBOR-encoded data:
+
+```rust
+// Function form: JSON string parsed to CBOR
+Cbor("{\"key\": \"value\"}")
+
+// Macro form: JSON literal parsed to CBOR
+cbor!({"key": {"nested": [1, 2, 3]}})
+```
+
+### TARI
+
+Constant representing the native Tari token resource address. Use `TARI` in all new manifests. `XTR` is a deprecated alias that still works but should not be used.
+
+```rust
+let bucket = account.withdraw(TARI, 1000);
+```
+
+### Workspace Variables
+
+Bare identifiers reference results from prior instructions:
+
+```rust
+let bucket = account.withdraw(TARI, 100);
+shop.buy(bucket);  // 'bucket' references the withdraw result
+```
+
+## ManifestValue (Rust API)
+
+When passing globals to `parse_manifest()`, construct `ManifestValue` instances:
+
+```rust
+use tari_transaction_manifest::ManifestValue;
+use tari_engine_types::substate::SubstateId;
+
+// From component/resource/vault addresses (anything Into<SubstateId>)
+let val = ManifestValue::from(component_address);  // ComponentAddress
+let val = ManifestValue::from(resource_address);    // ResourceAddress
+
+// From arbitrary serializable data
+let val = ManifestValue::new_value(&my_struct)?;
+
+// Parse from string (tries SubstateId, then NonFungibleId, then literal)
+let val: ManifestValue = "component_ab12...".parse()?;
+let val: ManifestValue = "1000u64".parse()?;
+```
+
+## Execution Model
+
+1. Fee instructions from `fee_main()` execute first
+2. If fees are accepted, main instructions from `main()` execute
+3. Each instruction that produces output stores it in a workspace slot (auto-assigned sequential IDs)
+4. Workspace variables in subsequent instructions reference these slots
+5. The workspace is shared across all instructions in the transaction
+
+## Error Types
+
+The parser produces `ManifestError` variants:
+- `LexError` - tokenization failure
+- `SyntaxError` - Rust parsing error
+- `TemplateNotImported` - using an unregistered template alias
+- `UndefinedGlobal` - referencing a variable not in globals map
+- `UndefinedVariable` - referencing a workspace variable that doesn't exist
+- `UndefinedFunction` - calling a helper function that doesn't exist
+- `MaxCallDepthExceeded` - helper function nesting exceeds 16
+- `InvalidVariableType` - type mismatch in variable usage
+
+## Crate Location
+
+The manifest parser is at `crates/transaction_manifest/`:
+- `src/lib.rs` - `parse_manifest()` entry point
+- `src/parser.rs` - Rust-syn based parser
+- `src/generator.rs` - AST to instruction compiler
+- `src/value.rs` - `ManifestValue` type and conversions
+- `src/ast.rs` - AST definitions
+- `src/error.rs` - Error types

--- a/docs/skills/claude-code/tari-manifest/references/wallet-daemon-api.md
+++ b/docs/skills/claude-code/tari-manifest/references/wallet-daemon-api.md
@@ -1,0 +1,253 @@
+# Wallet Daemon JSON-RPC API Reference
+
+The wallet daemon exposes a JSON-RPC 2.0 API. All requests are POST to the endpoint (e.g. `http://localhost:12008/json_rpc`).
+
+## Authentication
+
+### Auth Methods
+
+The daemon supports two authentication modes configured via `WalletDaemonAuth`:
+
+- **`none`** (default) - Anonymous authentication. Any client can obtain a JWT by sending `"credentials": "None"`.
+- **`webauthn`** - WebAuthn/passkey-based authentication. Requires a registered passkey to authenticate.
+
+### Authentication Flow (auth.method = "none")
+
+1. **Check method:** `auth.method` (no auth required)
+2. **Login:** `auth.request` with `{"permissions": ["Admin"], "credentials": "None"}`
+3. **Use token:** Include `Authorization: Bearer <token>` on all subsequent requests
+4. **Refresh:** When token expires (default 5 min), call `auth.refresh` (uses HttpOnly cookie set during login)
+
+### Authentication Flow (auth.method = "webauthn")
+
+WebAuthn requires a browser-based passkey interaction (biometric, hardware key, etc.) that **cannot be performed by an agent directly**. The full protocol flow is:
+
+1. **Check method:** `auth.method`
+2. **Start auth challenge:** `webauthn.auth_start` with `{"username": "..."}`
+3. **Complete auth:** Use the challenge to produce a WebAuthn credential response (requires browser/passkey device)
+4. **Login:** `auth.request` with `{"permissions": [...], "credentials": {"WebAuthN": <response>}}`
+5. **Use token:** Same as above
+
+**For agents:** Ask the user to authenticate via the wallet daemon web UI and provide the JWT token. Once received, use it in `Authorization: Bearer <token>` headers. If the token expires, ask the user for a fresh one.
+
+### JWT Token Details
+
+- Algorithm: HS256
+- Default expiry: 5 minutes (configurable via `jwt_expiry`)
+- Claims: `{ "permissions": [...], "exp": <unix_timestamp> }`
+- Refresh tokens: Stored as HttpOnly, SameSite=Strict cookies (`r-tkn`), expire after 1 hour
+
+### Permissions
+
+```
+Admin              - Full access (includes all other permissions)
+AccountInfo        - View wallet info
+AccountList        - List accounts (optionally scoped to a component address)
+AccountBalance     - View balances (scoped to a substate ID)
+KeyList            - List derived keys
+TransactionGet     - View transactions
+TransactionSend    - Submit transactions (optionally scoped to a substate ID)
+SubstatesRead      - Fetch substates
+TemplatesRead      - Fetch templates
+GetNft             - View NFTs
+NftGetOwnershipProof - Generate NFT ownership proofs
+StartWebrtc        - Initiate WebRTC sessions (UI internal use)
+```
+
+Use `Admin` for full access. For least-privilege, use `TransactionSend` + `AccountList` + `AccountInfo`.
+
+## Auth Endpoints
+
+### auth.method
+
+Check the configured authentication method. No token required.
+
+**Request:** `{"jsonrpc":"2.0","id":1,"method":"auth.method","params":{}}`
+
+**Response:** `{"result":{"method":"none"}}` or `{"result":{"method":"webauthn"}}`
+
+### auth.request
+
+Authenticate and receive a JWT token.
+
+**Request:**
+```json
+{
+  "jsonrpc":"2.0","id":2,"method":"auth.request",
+  "params":{
+    "permissions": ["Admin"],
+    "credentials": "None"
+  }
+}
+```
+
+For WebAuthn: `"credentials": {"WebAuthN": <WebauthnFinishAuthRequest>}`
+
+**Response:** `{"result":{"token":"eyJ..."}}`
+
+Also sets an HttpOnly `r-tkn` cookie for refresh.
+
+### auth.refresh
+
+Refresh an expired JWT token using the refresh cookie.
+
+**Request:** `{"jsonrpc":"2.0","id":3,"method":"auth.refresh","params":{}}`
+
+**Response:** `{"result":{"token":"eyJ..."}}`
+
+### auth.revoke
+
+Revoke a refresh token. Requires `Admin` permission.
+
+**Request:** `{"jsonrpc":"2.0","id":4,"method":"auth.revoke","params":{"refresh_token_id":"<hash>"}}`
+
+### auth.list_sessions
+
+List all active sessions. Requires `Admin` permission.
+
+**Request:** `{"jsonrpc":"2.0","id":5,"method":"auth.list_sessions","params":{}}`
+
+## Transaction Endpoints
+
+**CRITICAL: Before submitting any transaction (with `dry_run: false`), ALWAYS present a plain-language summary to the user and wait for explicit confirmation. Dry-run submissions do not require confirmation.**
+
+### transactions.submit_manifest
+
+Submit a transaction defined by a manifest.
+
+**Request:**
+```json
+{
+  "jsonrpc":"2.0","id":10,"method":"transactions.submit_manifest",
+  "params":{
+    "manifest": "<manifest source code>",
+    "variables": {
+      "account": "component_<64-char-hex>",
+      "resource": "resource_<64-char-hex>"
+    },
+    "max_fee": 1000,
+    "dry_run": false
+  }
+}
+```
+
+**Fields:**
+- `manifest` (string, required): Manifest source code. Escape inner quotes, use `\n` for newlines.
+- `variables` (object, required): Variable name to value string mapping. Values are parsed as `ManifestValue` (tries SubstateId, then NonFungibleId, then literal).
+- `signing_key_id` (object, optional): `{"Derived":{"index":0,"key_branch":"account"}}` to override signing key.
+- `max_fee` (number, required): Maximum fee in microtari.
+- `dry_run` (boolean, required): If true, simulate without submitting.
+
+**Response:**
+```json
+{
+  "result": {
+    "transaction_id": "<hex>",
+    "result": null
+  }
+}
+```
+
+For `dry_run: true`, `result` contains the `ExecuteResult` with logs, outputs, etc.
+
+### transactions.submit
+
+Submit a pre-built transaction with raw instructions.
+
+**Request:**
+```json
+{
+  "jsonrpc":"2.0","id":11,"method":"transactions.submit",
+  "params":{
+    "transaction": { ... },
+    "signing_key_id": null,
+    "detect_inputs": true,
+    "detect_inputs_use_unversioned": true
+  }
+}
+```
+
+### transactions.wait_result
+
+Block until a transaction is finalized or timeout.
+
+**Request:**
+```json
+{
+  "jsonrpc":"2.0","id":12,"method":"transactions.wait_result",
+  "params":{
+    "transaction_id": "<hex>",
+    "timeout_secs": 120
+  }
+}
+```
+
+### transactions.get_result
+
+Non-blocking poll for transaction result.
+
+**Request:**
+```json
+{
+  "jsonrpc":"2.0","id":13,"method":"transactions.get_result",
+  "params":{"transaction_id":"<hex>"}
+}
+```
+
+## Account Endpoints
+
+### accounts.list
+
+**Request:** `{"jsonrpc":"2.0","id":20,"method":"accounts.list","params":{"offset":0,"limit":10}}`
+
+### accounts.get_default
+
+**Request:** `{"jsonrpc":"2.0","id":21,"method":"accounts.get_default","params":{}}`
+
+### accounts.get
+
+**Request:** `{"jsonrpc":"2.0","id":22,"method":"accounts.get","params":{"name_or_address":"my-account"}}`
+
+Can use account name or component address.
+
+### accounts.get_balances
+
+**Request:** `{"jsonrpc":"2.0","id":23,"method":"accounts.get_balances","params":{"account":"my-account","refresh":true}}`
+
+### accounts.create_free_test_coins
+
+Create free test coins (test networks only).
+
+**Request:**
+```json
+{
+  "jsonrpc":"2.0","id":24,"method":"accounts.create_free_test_coins",
+  "params":{
+    "account": {"Name":"my-account"},
+    "amount": 1000000,
+    "max_fee": 1000
+  }
+}
+```
+
+## Substate and Template Endpoints
+
+### substates.get
+
+**Request:** `{"jsonrpc":"2.0","id":30,"method":"substates.get","params":{"substate_id":"component_<hex>"}}`
+
+### templates.get
+
+**Request:** `{"jsonrpc":"2.0","id":31,"method":"templates.get","params":{"template_address":"<hex>"}}`
+
+Returns template function definitions including argument types - useful for knowing what methods a component supports.
+
+## Source Code Locations
+
+- Wallet daemon: `applications/tari_walletd/`
+- Auth handlers: `applications/tari_walletd/src/handlers/auth/`
+- Transaction handlers: `applications/tari_walletd/src/handlers/transaction.rs`
+- Client library: `clients/wallet_daemon_client/src/lib.rs`
+- Client types: `clients/wallet_daemon_client/src/types.rs`
+- Permissions: `clients/wallet_daemon_client/src/permissions.rs`
+- Config: `applications/tari_walletd/src/config.rs`


### PR DESCRIPTION
This pull request introduces support for a new `create_account!` macro in the transaction manifest DSL, enabling more flexible and explicit account creation in manifests. It adds parsing, generation, and testing for this macro, supporting variable assignment, optional arguments, and integration with the manifest value system. Additionally, it improves public key handling and updates documentation for project structure and conventions.

**Manifest DSL and Account Creation Enhancements:**

* Added support for a `create_account!` macro in the manifest parser, allowing creation of accounts with explicit owner public key, and optional owner/access rules and funding bucket. The macro can be used with or without assignment, and its arguments are parsed and validated. [[1]](diffhunk://#diff-c9a346c08465043d6a0272679762e3928fe4d374cc9522de76bcf132604b9f70R54) [[2]](diffhunk://#diff-c9a346c08465043d6a0272679762e3928fe4d374cc9522de76bcf132604b9f70R87-R95) [[3]](diffhunk://#diff-c9a346c08465043d6a0272679762e3928fe4d374cc9522de76bcf132604b9f70R398-R407) [[4]](diffhunk://#diff-c9a346c08465043d6a0272679762e3928fe4d374cc9522de76bcf132604b9f70R432-R441) [[5]](diffhunk://#diff-c9a346c08465043d6a0272679762e3928fe4d374cc9522de76bcf132604b9f70R653-R700)
* Implemented handling for the new `CreateAccountIntent` in the manifest instruction generator, including extraction of the public key and optional arguments from globals/aliases, and appropriate instruction emission. [[1]](diffhunk://#diff-5bf74ae4639884fcf4a39fb266500eed8f82d25ec03c08682de7b9aa813b910aR160-R195) [[2]](diffhunk://#diff-5bf74ae4639884fcf4a39fb266500eed8f82d25ec03c08682de7b9aa813b910aR293-R330)
* Added comprehensive tests for the new macro, covering simple usage, usage with a funding bucket, and cases without assignment.

**Public Key and Value Handling Improvements:**

* Enhanced `ManifestValue` parsing to support hex-encoded byte strings (e.g., public keys), improving usability for cryptographic arguments in manifests. [[1]](diffhunk://#diff-49741782784cb99b1ae025f068ef91f0caedfd4d9023ea7ceff5e6d8c7354dc7L10-R11) [[2]](diffhunk://#diff-49741782784cb99b1ae025f068ef91f0caedfd4d9023ea7ceff5e6d8c7354dc7R123-R127)
* Updated imports and types to support new cryptographic types (`RistrettoPublicKeyBytes`) where needed. [[1]](diffhunk://#diff-5bf74ae4639884fcf4a39fb266500eed8f82d25ec03c08682de7b9aa813b910aL14-R14) [[2]](diffhunk://#diff-34917b292314c119a545e9c2793c0c22139db6f1d1302a67f6675004a8b8574dL27-R35)

**Documentation and Miscellaneous:**

* Added a new `CLAUDE.md` cheatsheet documenting project structure, conventions, manifest details, and workflow guidelines.
* Minor runtime change to set the last instruction output after validating a return value in the transaction processor.