### PR TITLE
chore: publish various crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1692,7 +1692,7 @@ dependencies = [
 
 [[package]]
 name = "consensus_tests"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "fern",
  "futures 0.3.31",
@@ -2671,7 +2671,7 @@ dependencies = [
 
 [[package]]
 name = "db-inspector"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -3806,7 +3806,7 @@ checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 
 [[package]]
 name = "generate_ristretto_value_lookup"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "clap 3.2.25",
  "futures 0.3.31",
@@ -4912,7 +4912,7 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "integration_tests"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "anyhow",
  "config",
@@ -5628,7 +5628,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-messaging"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "async-trait",
  "futures-bounded",
@@ -5807,7 +5807,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-substream"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "libp2p",
  "prometheus-client",
@@ -7386,7 +7386,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "ootle-rs"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7441,7 +7441,7 @@ dependencies = [
 
 [[package]]
 name = "ootle_byte_type"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "tari_crypto",
  "tari_template_lib_types",
@@ -8418,7 +8418,7 @@ dependencies = [
 
 [[package]]
 name = "proto_builder"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "prost-build 0.14.3",
  "sha2 0.10.9",
@@ -10226,7 +10226,7 @@ dependencies = [
 
 [[package]]
 name = "sqlite_message_logger"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "chrono",
  "diesel",
@@ -10599,7 +10599,7 @@ dependencies = [
 
 [[package]]
 name = "tari_base_node_client"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "futures-util",
  "log",
@@ -10824,7 +10824,7 @@ dependencies = [
 
 [[package]]
 name = "tari_consensus"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "anyhow",
  "indexmap 2.13.0",
@@ -10849,7 +10849,7 @@ dependencies = [
 
 [[package]]
 name = "tari_consensus_types"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "borsh",
  "ootle_serde",
@@ -10951,7 +10951,7 @@ dependencies = [
 
 [[package]]
 name = "tari_engine"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "blake2",
  "criterion",
@@ -10978,7 +10978,7 @@ dependencies = [
 
 [[package]]
 name = "tari_engine_types"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "bincode 2.0.1",
  "blake2",
@@ -11005,7 +11005,7 @@ dependencies = [
 
 [[package]]
 name = "tari_epoch_manager"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "anyhow",
  "log",
@@ -11025,7 +11025,7 @@ dependencies = [
 
 [[package]]
 name = "tari_epoch_oracles"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -11078,7 +11078,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -11147,7 +11147,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer_client"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "anyhow",
  "bounded-vec",
@@ -11175,7 +11175,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer_lib"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "log",
  "prometheus-client",
@@ -11267,7 +11267,7 @@ dependencies = [
 
 [[package]]
 name = "tari_networking"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11319,7 +11319,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_app_utilities"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -11358,7 +11358,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_common_types"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "blake2",
  "borsh",
@@ -11384,7 +11384,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_p2p"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "anyhow",
  "libp2p-identity",
@@ -11408,7 +11408,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_storage"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "anyhow",
  "bitflags 2.10.0",
@@ -11435,7 +11435,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_storage_sqlite"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "diesel",
  "diesel_migrations",
@@ -11456,7 +11456,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_transaction"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "bincode 2.0.1",
  "borsh",
@@ -11480,7 +11480,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_cli"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -11509,7 +11509,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_crypto"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "argon2 0.5.3",
  "blake2",
@@ -11603,7 +11603,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_storage_sqlite"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "bigdecimal",
  "diesel",
@@ -11627,7 +11627,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_walletd"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11740,7 +11740,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_framework"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "async-trait",
  "bitflags 2.10.0",
@@ -11764,7 +11764,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_macros"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11773,7 +11773,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_state_sync"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -11850,7 +11850,7 @@ dependencies = [
 
 [[package]]
 name = "tari_state_store_rocksdb"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -11881,7 +11881,7 @@ dependencies = [
 
 [[package]]
 name = "tari_state_tree"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "indexmap 2.13.0",
  "log",
@@ -11907,7 +11907,7 @@ dependencies = [
 
 [[package]]
 name = "tari_swarm"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "libp2p",
  "libp2p-messaging",
@@ -11918,7 +11918,7 @@ dependencies = [
 
 [[package]]
 name = "tari_swarm_daemon"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11973,7 +11973,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_builtin"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "anyhow",
  "ootle_byte_type",
@@ -11987,7 +11987,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_lib"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "borsh",
  "serde",
@@ -12001,7 +12001,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_lib_types"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "bincode 2.0.1",
  "bnum",
@@ -12029,7 +12029,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_test_tooling"
-version = "0.26.0"
+version = "0.26.2"
 dependencies = [
  "anyhow",
  "cargo_toml 0.22.3",
@@ -12144,7 +12144,7 @@ dependencies = [
 
 [[package]]
 name = "tari_transaction_manifest"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "proc-macro2",
  "serde_json",
@@ -12178,7 +12178,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -12244,7 +12244,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node_client"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "indexmap 2.13.0",
  "multiaddr 0.18.3",
@@ -12268,7 +12268,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node_rpc"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -12291,7 +12291,7 @@ dependencies = [
 
 [[package]]
 name = "tari_watcher"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "anyhow",
  "clap 3.2.25",
@@ -12319,7 +12319,7 @@ dependencies = [
 
 [[package]]
 name = "tariswap_bench"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "anyhow",
  "clap 4.5.54",
@@ -12999,7 +12999,7 @@ dependencies = [
 
 [[package]]
 name = "traffic-sim"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "anyhow",
  "clap 4.5.54",
@@ -13021,7 +13021,7 @@ dependencies = [
 
 [[package]]
 name = "transaction_generator"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -13042,7 +13042,7 @@ dependencies = [
 
 [[package]]
 name = "transaction_submitter"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "anyhow",
  "clap 4.5.54",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.26.0"
+version = "0.26.1"
 edition = "2024"
 authors = ["The Tari Development Community"]
 repository = "https://github.com/tari-project/tari-ootle"
@@ -88,7 +88,7 @@ tari_engine = { path = "crates/engine", version = "0.26" }
 tari_ootle_p2p = { path = "crates/p2p" }
 tari_ootle_storage = { path = "crates/storage" }
 tari_ootle_storage_sqlite = { path = "crates/storage_sqlite" }
-tari_ootle_wallet_crypto = { path = "crates/wallet/crypto", version = "0.1" }
+tari_ootle_wallet_crypto = { path = "crates/wallet/crypto", version = "0.2" }
 tari_ootle_wallet_sdk = { path = "crates/wallet/sdk", version = "0.1.0" }
 tari_ootle_wallet_sdk_services = { path = "crates/wallet/sdk_services" }
 tari_ootle_wallet_storage_sqlite = { path = "crates/wallet/storage_sqlite" }
@@ -121,7 +121,7 @@ tari_ootle_transaction = { path = "crates/transaction", version = "0.26" }
 
 # Template lib
 tari_template_lib = { version = "0.21", path = "crates/template_lib" }
-tari_template_lib_types = { version = "0.20", path = "crates/template_lib_types", default-features = false }
+tari_template_lib_types = { version = "0.21", path = "crates/template_lib_types", default-features = false }
 tari_template_abi = { version = "0.16", path = "crates/template_abi", default-features = false }
 tari_template_macros = { version = "0.16", path = "crates/template_macros" }
 tari_bor = { version = "0.13", path = "crates/tari_bor", default-features = false }

--- a/crates/ootle_byte_type/Cargo.toml
+++ b/crates/ootle_byte_type/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ootle_byte_type"
-version = "0.3.0"
+version = "0.3.1"
 description = "Conversion traits that define conversions to/from light-weight byte types"
 edition.workspace = true
 authors.workspace = true

--- a/crates/template_builtin/Cargo.toml
+++ b/crates/template_builtin/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_template_builtin"
 description = "Tari Ootle built-in templates"
-version = "0.26.0"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/template_lib/Cargo.toml
+++ b/crates/template_lib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_template_lib"
 description = "Tari template library provides abstrations that interface with the Tari validator engine"
-version = "0.21.0"
+version = "0.21.1"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/template_lib_types/Cargo.toml
+++ b/crates/template_lib_types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_template_lib_types"
-version = "0.20.1"
+version = "0.21.0"
 edition.workspace = true
 authors.workspace = true
 description = "Tari template library types"

--- a/crates/template_test_tooling/Cargo.toml
+++ b/crates/template_test_tooling/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_template_test_tooling"
 description = "Test tooling for Tari template development"
-version = "0.26.0"
+version = "0.26.2"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/wallet/crypto/Cargo.toml
+++ b/crates/wallet/crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_ootle_wallet_crypto"
-version = "0.1.2"
+version = "0.2.0"
 description = "Cryptographic utilities and types for Tari Ootle wallet"
 edition.workspace = true
 authors.workspace = true

--- a/crates/wallet/ootle-rs/Cargo.toml
+++ b/crates/wallet/ootle-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ootle-rs"
-version = "0.1.1"
+version = "0.2.0"
 description = "A Rust library for interacting with the Tari Ootle network."
 edition.workspace = true
 authors.workspace = true

--- a/scripts/publish_crates.py
+++ b/scripts/publish_crates.py
@@ -32,15 +32,18 @@ CRATES = [
     ("tari_template_lib", "crates/template_lib"),
     ("tari_engine_types", "crates/engine_types"),
     ("tari_ootle_common_types", "crates/common_types"),
+    ("tari_ootle_wallet_crypto", "crates/wallet/crypto"),
     ("tari_ootle_address", "crates/ootle_address"),
     ("tari_ootle_transaction", "crates/transaction"),
-    ("tari_transaction_manifest", "crates/transaction_manifest"),
     ("tari_template_builtin", "crates/template_builtin"),
+    ("tari_transaction_manifest", "crates/transaction_manifest"),
     ("tari_engine", "crates/engine"),
     ("tari_consensus_types", "crates/consensus_types"),
+    ("tari_indexer_client", "clients/tari_indexer_client"),
     ("ootle-wasm-core", "crates/ootle_wasm/core"),
     ("ootle-wasm", "crates/ootle_wasm/wasm"),
     ("tari_template_test_tooling", "crates/template_test_tooling"),
+    ("ootle-rs", "crates/wallet/ootle-rs"),
 ]
 
 WAIT_SECS = 30
@@ -171,7 +174,7 @@ def main():
         print(f"{YELLOW}=== DRY RUN (pass --execute to publish for real) ==={NC}")
         print()
 
-    published = 0
+    published_crates = []
     skipped = 0
     last_name = crates_to_publish[-1][0] if crates_to_publish else ""
 
@@ -187,7 +190,7 @@ def main():
             print(f"  {YELLOW}▶{NC} Publishing {name} {ver} ...")
             if cargo_publish(name):
                 print(f"  {GREEN}✓{NC} {name} {ver} — published")
-                published += 1
+                published_crates.append((name, ver))
                 if name != last_name:
                     print(f"    {YELLOW}Waiting {args.wait}s for crates.io indexing...{NC}")
                     time.sleep(args.wait)
@@ -199,11 +202,17 @@ def main():
                 sys.exit(1)
         else:
             print(f"  {YELLOW}▶{NC} {name} {ver} — would publish")
-            published += 1
+            published_crates.append((name, ver))
 
     print()
-    print(f"{GREEN}Done.{NC} Published: {published}, Skipped: {skipped}")
-    if not args.execute and published > 0:
+    print(f"{GREEN}Done.{NC} Published: {len(published_crates)}, Skipped: {skipped}")
+    if published_crates:
+        print()
+        print("Published crates:")
+        for name, ver in published_crates:
+            print(f"  - {name} {ver}")
+    if not args.execute and published_crates:
+        print()
         print(f"{YELLOW}Add --execute to publish for real.{NC}")
 
 


### PR DESCRIPTION
Description
---
Version bumps:
  - tari_template_lib_types 0.20.1 → 0.21.0
  - tari_template_lib 0.21.0 → 0.21.1
  - ootle_byte_type 0.3.0 → 0.3.1
  - tari_ootle_wallet_crypto 0.1.2 → 0.2.0
  - ootle-rs 0.1.1 → 0.2.0
  - tari_template_test_tooling 0.26.0 → 0.26.2
  - Workspace version 0.26.0 → 0.26.1

  Workspace dep fixes:
  - tari_template_lib_types version requirement bumped from ^0.20 to ^0.21
  - tari_ootle_wallet_crypto version requirement bumped from ^0.1 to ^0.2
  - tari_template_builtin switched to version.workspace = true

  Publish script updates:
  - Added tari_ootle_wallet_crypto, tari_indexer_client, and ootle-rs to the publish list
  - Fixed ordering: tari_template_builtin moved before tari_transaction_manifest
  - Added published crates summary at end of run
