### PR TITLE
feat(indexer): add transaction receipts UI

### DIFF
--- a/applications/tari_indexer/web_ui/src/App.tsx
+++ b/applications/tari_indexer/web_ui/src/App.tsx
@@ -29,6 +29,8 @@ import Events from "./routes/Events/Events";
 import Substates from "./routes/Substates/Substates";
 import Templates from "./routes/Templates/Templates";
 import TransactionDetails from "./routes/Transaction/TransactionDetails";
+import TransactionReceipts from "./routes/TransactionReceipts/TransactionReceiptsLayout";
+import TransactionReceiptDetails from "./routes/TransactionReceipts/TransactionReceiptDetailsLayout";
 import ErrorPage from "./routes/ErrorPage";
 import Layout from "./theme/LayoutMain";
 
@@ -74,6 +76,16 @@ export const breadcrumbRoutes = [
     dynamic: false,
   },
   {
+    label: "Transaction Receipts",
+    path: "/transaction-receipts",
+    dynamic: false,
+  },
+  {
+    label: "Transaction Receipt",
+    path: "/transaction-receipts/:receipt_address",
+    dynamic: true,
+  },
+  {
     label: "Error",
     path: "*",
     dynamic: false,
@@ -92,6 +104,8 @@ export default function App() {
           <Route path="events" element={<Events />} />
           <Route path="substates" element={<Substates />} />
           <Route path="templates" element={<Templates />} />
+          <Route path="transaction-receipts" element={<TransactionReceipts />} />
+          <Route path="transaction-receipts/:receipt_address" element={<TransactionReceiptDetails />} />
           <Route path="*" element={<ErrorPage />} />
         </Route>
       </Routes>

--- a/applications/tari_indexer/web_ui/src/Components/MenuItems.tsx
+++ b/applications/tari_indexer/web_ui/src/Components/MenuItems.tsx
@@ -35,6 +35,8 @@ import {
   IoGitNetworkOutline,
   IoHome,
   IoHomeOutline,
+  IoReceipt,
+  IoReceiptOutline,
 } from "react-icons/io5";
 import { TbTimelineEventText, TbTemplate } from "react-icons/tb";
 
@@ -63,6 +65,12 @@ const mainItems = [
     icon: <IoBarChartOutline style={iconStyle} />,
     activeIcon: <IoBarChart style={activeIconStyle} />,
     link: "transactions",
+  },
+  {
+    title: "Transaction Receipts",
+    icon: <IoReceiptOutline style={iconStyle} />,
+    activeIcon: <IoReceipt style={activeIconStyle} />,
+    link: "transaction-receipts",
   },
   {
     title: "Events",

--- a/applications/tari_indexer/web_ui/src/api/hooks/useTransactionReceipts.tsx
+++ b/applications/tari_indexer/web_ui/src/api/hooks/useTransactionReceipts.tsx
@@ -1,0 +1,21 @@
+//   Copyright 2026 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+import { useQuery } from "@tanstack/react-query";
+import type { TransactionReceiptAddress } from "@tari-project/ootle-ts-bindings";
+import { listTransactionReceipts, getTransactionReceipt } from "../../utils/api";
+
+export const useListTransactionReceipts = (limit: number) => {
+  return useQuery({
+    queryKey: ["transaction_receipts", limit],
+    queryFn: () => listTransactionReceipts({ ordering: "Descending", limit }),
+    refetchInterval: 30 * 1000,
+  });
+};
+
+export const useGetTransactionReceipt = (address: TransactionReceiptAddress) => {
+  return useQuery({
+    queryKey: ["transaction_receipt", address],
+    queryFn: () => getTransactionReceipt(address),
+    enabled: !!address,
+  });
+};

--- a/applications/tari_indexer/web_ui/src/routes/TransactionReceipts/TransactionReceiptDetailsLayout.tsx
+++ b/applications/tari_indexer/web_ui/src/routes/TransactionReceipts/TransactionReceiptDetailsLayout.tsx
@@ -1,0 +1,25 @@
+//   Copyright 2026 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+import PageHeading from "../../Components/PageHeading";
+import Grid from "@mui/material/Grid";
+import { StyledPaper } from "../../Components/StyledComponents";
+import { useParams } from "react-router-dom";
+import TransactionReceiptDetails from "./components/TransactionReceiptDetails";
+
+function TransactionReceiptDetailsLayout() {
+  const { receipt_address } = useParams();
+  return (
+    <>
+      <Grid size={12}>
+        <PageHeading>Transaction Receipt</PageHeading>
+      </Grid>
+      <Grid size={12}>
+        <StyledPaper>
+          <TransactionReceiptDetails address={receipt_address || ""} />
+        </StyledPaper>
+      </Grid>
+    </>
+  );
+}
+
+export default TransactionReceiptDetailsLayout;

--- a/applications/tari_indexer/web_ui/src/routes/TransactionReceipts/TransactionReceiptsLayout.tsx
+++ b/applications/tari_indexer/web_ui/src/routes/TransactionReceipts/TransactionReceiptsLayout.tsx
@@ -1,0 +1,23 @@
+//   Copyright 2026 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+import PageHeading from "../../Components/PageHeading";
+import Grid from "@mui/material/Grid";
+import { StyledPaper } from "../../Components/StyledComponents";
+import TransactionReceiptsList from "./components/TransactionReceiptsList";
+
+function TransactionReceiptsLayout() {
+  return (
+    <>
+      <Grid size={12}>
+        <PageHeading>Transaction Receipts</PageHeading>
+      </Grid>
+      <Grid size={12}>
+        <StyledPaper>
+          <TransactionReceiptsList />
+        </StyledPaper>
+      </Grid>
+    </>
+  );
+}
+
+export default TransactionReceiptsLayout;

--- a/applications/tari_indexer/web_ui/src/routes/TransactionReceipts/components/SubstateChanges.tsx
+++ b/applications/tari_indexer/web_ui/src/routes/TransactionReceipts/components/SubstateChanges.tsx
@@ -1,0 +1,40 @@
+//   Copyright 2026 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+import { Stack, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Typography } from "@mui/material";
+import type { UpSubstate } from "@tari-project/ootle-ts-bindings";
+import { substateIdToString } from "@tari-project/ootle-ts-bindings";
+import CopyToClipboard from "../../../Components/CopyToClipboard";
+import { DataTableCell } from "../../../Components/StyledComponents";
+
+export default function SubstateChanges({ upped }: { upped: UpSubstate[] }) {
+  return (
+    <TableContainer>
+      <Table>
+        <TableHead>
+          <TableRow>
+            <TableCell>Substate ID</TableCell>
+            <TableCell>Version</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {upped.map((up, index) => {
+            const idStr = substateIdToString(up.substate_id);
+            return (
+              <TableRow key={index}>
+                <DataTableCell>
+                  <Stack direction="row" alignItems="center">
+                    <Typography variant="body2" sx={{ fontFamily: "monospace", wordBreak: "break-all" }}>
+                      {idStr}
+                    </Typography>
+                    <CopyToClipboard copy={idStr} />
+                  </Stack>
+                </DataTableCell>
+                <DataTableCell>{up.version}</DataTableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+}

--- a/applications/tari_indexer/web_ui/src/routes/TransactionReceipts/components/TransactionReceiptDetails.tsx
+++ b/applications/tari_indexer/web_ui/src/routes/TransactionReceipts/components/TransactionReceiptDetails.tsx
@@ -1,0 +1,194 @@
+//   Copyright 2026 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
+import KeyboardArrowUpIcon from "@mui/icons-material/KeyboardArrowUp";
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  Fade,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableRow,
+  Typography,
+} from "@mui/material";
+import { saveAs } from "file-saver";
+import { useState } from "react";
+import { useGetTransactionReceipt } from "../../../api/hooks/useTransactionReceipts";
+import { Accordion, AccordionDetails, AccordionSummary } from "../../../Components/Accordion";
+import FetchStatusCheck from "../../../Components/FetchStatusCheck";
+import { DataTableCell } from "../../../Components/StyledComponents";
+import { CURRENCY } from "../../../utils/constants";
+import { formatCurrency } from "../../../utils/helpers";
+import EventsContent from "../../Transaction/components/EventsContent";
+import FeeReceipt from "../../Transaction/components/FeeReceipt";
+import LogsContent from "../../Transaction/components/LogsContent";
+import SubstateChanges from "./SubstateChanges";
+
+function TransactionReceiptDetails({ address }: { address: string }) {
+  const [expandedPanels, setExpandedPanels] = useState<string[]>([]);
+  const { data, isLoading, error, isError } = useGetTransactionReceipt(address);
+
+  if (!address) {
+    return <Alert severity="error">No receipt address provided</Alert>;
+  }
+
+  const handleChange = (panel: string) => (_event: React.SyntheticEvent, isExpanded: boolean) => {
+    setExpandedPanels((prev) => (isExpanded ? [...prev, panel] : prev.filter((p) => p !== panel)));
+  };
+
+  const expandAll = () => setExpandedPanels(["p1", "p2", "p3", "p4", "p5"]);
+  const collapseAll = () => setExpandedPanels([]);
+
+  const receipt = data?.receipt;
+
+  return (
+    <FetchStatusCheck
+      isLoading={isLoading}
+      isError={isError}
+      errorMessage={error ? error.message : "Error fetching transaction receipt."}
+    >
+      <Fade in={!isLoading && !isError}>
+        <Box>
+          {receipt ? (
+            <>
+              <TableContainer sx={{ mb: 2 }}>
+                <Table>
+                  <TableBody>
+                    <TableRow>
+                      <TableCell>Receipt Address</TableCell>
+                      <DataTableCell sx={{ wordBreak: "break-all" }}>{address}</DataTableCell>
+                    </TableRow>
+                    <TableRow>
+                      <TableCell>Outcome</TableCell>
+                      <DataTableCell>
+                        <Chip
+                          label={receipt.outcome}
+                          color={receipt.outcome === "Commit" || receipt.outcome === "FeeIntentCommit" ? "success" : "error"}
+                          size="small"
+                          variant="outlined"
+                        />
+                      </DataTableCell>
+                    </TableRow>
+                    <TableRow>
+                      <TableCell>Epoch</TableCell>
+                      <DataTableCell>{String(receipt.epoch)}</DataTableCell>
+                    </TableRow>
+                    <TableRow>
+                      <TableCell>Total Fees Paid</TableCell>
+                      <DataTableCell>
+                        {formatCurrency(receipt.fee_receipt.total_fees_paid, CURRENCY.DECIMALS, CURRENCY.SYMBOL)}
+                      </DataTableCell>
+                    </TableRow>
+                    <TableRow>
+                      <TableCell>Download</TableCell>
+                      <DataTableCell>
+                        <Button
+                          variant="outlined"
+                          size="small"
+                          onClick={() => {
+                            const json = JSON.stringify({ address, receipt }, null, 2);
+                            const blob = new Blob([json], { type: "application/json" });
+                            saveAs(blob, `receipt-${address}.json`);
+                          }}
+                        >
+                          Download JSON
+                        </Button>
+                      </DataTableCell>
+                    </TableRow>
+                  </TableBody>
+                </Table>
+              </TableContainer>
+
+              <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ px: 1, pb: 1 }}>
+                <Typography variant="h5">Details</Typography>
+                <Stack direction="row" spacing={1}>
+                  <Button size="small" startIcon={<KeyboardArrowDownIcon />} onClick={expandAll}>
+                    Expand All
+                  </Button>
+                  <Button
+                    size="small"
+                    startIcon={<KeyboardArrowUpIcon />}
+                    onClick={collapseAll}
+                    disabled={expandedPanels.length === 0}
+                  >
+                    Collapse All
+                  </Button>
+                </Stack>
+              </Stack>
+
+              {receipt.events.length > 0 && (
+                <Accordion expanded={expandedPanels.includes("p1")} onChange={handleChange("p1")}>
+                  <AccordionSummary>
+                    <Typography variant="h5">Events ({receipt.events.length})</Typography>
+                  </AccordionSummary>
+                  <AccordionDetails>
+                    <EventsContent data={receipt.events} />
+                  </AccordionDetails>
+                </Accordion>
+              )}
+
+              {receipt.logs.length > 0 && (
+                <Accordion expanded={expandedPanels.includes("p2")} onChange={handleChange("p2")}>
+                  <AccordionSummary>
+                    <Typography variant="h5">Logs ({receipt.logs.length})</Typography>
+                  </AccordionSummary>
+                  <AccordionDetails>
+                    <LogsContent data={receipt.logs} />
+                  </AccordionDetails>
+                </Accordion>
+              )}
+
+              {receipt.diff_summary.upped.length > 0 && (
+                <Accordion expanded={expandedPanels.includes("p3")} onChange={handleChange("p3")}>
+                  <AccordionSummary>
+                    <Typography variant="h5">Substate Changes ({receipt.diff_summary.upped.length})</Typography>
+                  </AccordionSummary>
+                  <AccordionDetails>
+                    <SubstateChanges upped={receipt.diff_summary.upped} />
+                  </AccordionDetails>
+                </Accordion>
+              )}
+
+              <Accordion expanded={expandedPanels.includes("p4")} onChange={handleChange("p4")}>
+                <AccordionSummary>
+                  <Typography variant="h5">Fee Receipt</Typography>
+                </AccordionSummary>
+                <AccordionDetails>
+                  <FeeReceipt data={receipt.fee_receipt} />
+                </AccordionDetails>
+              </Accordion>
+
+              {receipt.fee_withdrawals.length > 0 && (
+                <Accordion expanded={expandedPanels.includes("p5")} onChange={handleChange("p5")}>
+                  <AccordionSummary>
+                    <Typography variant="h5">Fee Withdrawals ({receipt.fee_withdrawals.length})</Typography>
+                  </AccordionSummary>
+                  <AccordionDetails>
+                    <Table>
+                      <TableBody>
+                        {receipt.fee_withdrawals.map((withdrawal, i) => (
+                          <TableRow key={i}>
+                            <DataTableCell>{JSON.stringify(withdrawal)}</DataTableCell>
+                          </TableRow>
+                        ))}
+                      </TableBody>
+                    </Table>
+                  </AccordionDetails>
+                </Accordion>
+              )}
+            </>
+          ) : (
+            <Alert severity="info">No receipt found</Alert>
+          )}
+        </Box>
+      </Fade>
+    </FetchStatusCheck>
+  );
+}
+
+export default TransactionReceiptDetails;

--- a/applications/tari_indexer/web_ui/src/routes/TransactionReceipts/components/TransactionReceiptsList.tsx
+++ b/applications/tari_indexer/web_ui/src/routes/TransactionReceipts/components/TransactionReceiptsList.tsx
@@ -1,0 +1,162 @@
+//   Copyright 2026 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+import { ChevronRight } from "@mui/icons-material";
+import { Chip, Stack } from "@mui/material";
+import Fade from "@mui/material/Fade";
+import IconButton from "@mui/material/IconButton";
+import { useTheme } from "@mui/material/styles";
+import Table from "@mui/material/Table";
+import TableBody from "@mui/material/TableBody";
+import TableCell from "@mui/material/TableCell";
+import TableContainer from "@mui/material/TableContainer";
+import TableHead from "@mui/material/TableHead";
+import TablePagination from "@mui/material/TablePagination";
+import TableRow from "@mui/material/TableRow";
+import useMediaQuery from "@mui/material/useMediaQuery";
+import type { TransactionReceipt, TransactionReceiptAddress } from "@tari-project/ootle-ts-bindings";
+import { useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import { useListTransactionReceipts } from "../../../api/hooks/useTransactionReceipts";
+import FetchStatusCheck from "../../../Components/FetchStatusCheck";
+import { DataTableCell } from "../../../Components/StyledComponents";
+import { CURRENCY } from "../../../utils/constants";
+import { formatCurrency } from "../../../utils/helpers";
+import { shortenString } from "../../VN/Components/helpers";
+import TransactionFilter from "../../RecentTransactions/components/SearchFilter";
+
+type ReceiptEntry = {
+  id: string;
+  address: TransactionReceiptAddress;
+  receipt: TransactionReceipt;
+  show?: boolean;
+};
+
+function OutcomeChip({ outcome }: { outcome: string }) {
+  if (outcome === "Commit" || outcome === "FeeIntentCommit") {
+    return <Chip label={outcome} color="success" size="small" variant="outlined" />;
+  }
+  return <Chip label={outcome} color="error" size="small" variant="outlined" />;
+}
+
+function ReceiptRow({ entry }: { entry: ReceiptEntry }) {
+  const { address, receipt } = entry;
+  const theme = useTheme();
+  const isSm = useMediaQuery(theme.breakpoints.down("sm"));
+  const shortLen = isSm ? 4 : 8;
+
+  return (
+    <TableRow>
+      <DataTableCell>
+        <Link
+          to={`/transaction-receipts/${encodeURIComponent(address)}`}
+          style={{ textDecoration: "none", color: theme.palette.text.secondary }}
+        >
+          {shortenString(address, shortLen, shortLen)}
+        </Link>
+      </DataTableCell>
+      <DataTableCell>
+        <OutcomeChip outcome={receipt.outcome} />
+      </DataTableCell>
+      <DataTableCell>
+        {formatCurrency(receipt.fee_receipt.total_fees_paid, CURRENCY.DECIMALS, CURRENCY.SYMBOL)}
+      </DataTableCell>
+      <DataTableCell>{receipt.events.length}</DataTableCell>
+      <DataTableCell>{String(receipt.epoch)}</DataTableCell>
+      <DataTableCell>
+        <IconButton
+          component={Link}
+          to={`/transaction-receipts/${encodeURIComponent(address)}`}
+          style={{ color: theme.palette.text.secondary }}
+        >
+          <ChevronRight />
+        </IconButton>
+      </DataTableCell>
+    </TableRow>
+  );
+}
+
+function TransactionReceiptsList() {
+  const [page, setPage] = useState(0);
+  const [rowsPerPage, setRowsPerPage] = useState(10);
+  const [filteredReceipts, setFilteredReceipts] = useState<ReceiptEntry[]>([]);
+
+  const { data, isLoading, isError, error } = useListTransactionReceipts(100);
+
+  const receipts = useMemo(
+    () =>
+      (data?.receipts || []).map(([address, receipt]) => ({
+        id: address,
+        address,
+        receipt,
+      })),
+    [data?.receipts],
+  );
+
+  const visibleReceipts = filteredReceipts.filter((r) => r.show !== false);
+  const paginatedReceipts = visibleReceipts.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage);
+
+  const handleChangePage = (_event: React.MouseEvent<HTMLButtonElement> | null, newPage: number) => {
+    setPage(newPage);
+  };
+  const handleChangeRowsPerPage = (event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    setRowsPerPage(parseInt(event.target.value, 10));
+    setPage(0);
+  };
+
+  return (
+    <FetchStatusCheck
+      isLoading={isLoading}
+      isError={isError}
+      errorMessage={error ? error.message : "Error fetching transaction receipts."}
+    >
+      <Stack spacing={1}>
+        <TransactionFilter
+          setPage={setPage}
+          stateObject={receipts}
+          setStateObject={setFilteredReceipts}
+          filterItems={[
+            {
+              title: "Receipt Address",
+              value: "id",
+              filterFn: (value, row) => row.address.toLowerCase().includes(value.toLowerCase()),
+            },
+          ]}
+          placeholder="Search receipts"
+          defaultSearch="id"
+        />
+        <Fade in={!isLoading && !isError}>
+          <TableContainer>
+            <Table>
+              <TableHead>
+                <TableRow>
+                  <TableCell>Receipt Address</TableCell>
+                  <TableCell>Outcome</TableCell>
+                  <TableCell>Total Fees</TableCell>
+                  <TableCell>Events</TableCell>
+                  <TableCell>Epoch</TableCell>
+                  <TableCell>Details</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {paginatedReceipts.map((entry) => (
+                  <ReceiptRow key={entry.address} entry={entry} />
+                ))}
+              </TableBody>
+            </Table>
+            <TablePagination
+              component="div"
+              count={visibleReceipts.length}
+              page={page}
+              onPageChange={handleChangePage}
+              rowsPerPage={rowsPerPage}
+              onRowsPerPageChange={handleChangeRowsPerPage}
+              rowsPerPageOptions={[5, 10, 25, 50]}
+            />
+          </TableContainer>
+        </Fade>
+      </Stack>
+    </FetchStatusCheck>
+  );
+}
+
+export default TransactionReceiptsList;

--- a/applications/tari_indexer/web_ui/src/utils/api.ts
+++ b/applications/tari_indexer/web_ui/src/utils/api.ts
@@ -25,12 +25,18 @@ import type {
   IndexerGetIdentityResponse,
   GetNonFungiblesRequest,
   GetNonFungiblesResponse,
+  GetTransactionReceiptResponse,
   IndexerGetSubstateResponse,
   IndexerGetTransactionResultRequest,
   IndexerGetTransactionResultResponse,
   ListRecentTransactionsRequest,
   ListRecentTransactionsResponse,
-   SubstateId, QueryTransactionEventsRequest, QueryTransactionEventsResponse,
+  ListTransactionReceiptsRequest,
+  ListTransactionReceiptsResponse,
+  SubstateId,
+  TransactionReceiptAddress,
+  QueryTransactionEventsRequest,
+  QueryTransactionEventsResponse,
 } from "@tari-project/ootle-ts-bindings";
 import { IndexerClient } from "@tari-project/indexer-client";
 
@@ -108,6 +114,16 @@ export const listRecentTransactions = (
 
 export const queryTransactionEvents = (req: QueryTransactionEventsRequest): Promise<QueryTransactionEventsResponse> =>
   client().then((c) => c.queryTransactionEvents(req));
+
+export const listTransactionReceipts = (
+  request: ListTransactionReceiptsRequest,
+): Promise<ListTransactionReceiptsResponse> =>
+  client().then((c) => c.listTransactionReceipts(request));
+
+export const getTransactionReceipt = (
+  address: TransactionReceiptAddress,
+): Promise<GetTransactionReceiptResponse> =>
+  client().then((c) => c.getTransactionReceipt(address));
 
 export const getTemplateDefinition = (templateAddress: string): Promise<any> =>
   client().then((c) => c.templatesGet(templateAddress));


### PR DESCRIPTION
## Summary
- Add transaction receipts list page with filtering, pagination, and outcome/fee display
- Add transaction receipt detail page with expandable sections for events, logs, substate changes, fee receipt, and fee withdrawals
- Add API hooks and client calls for `listTransactionReceipts` and `getTransactionReceipt`

## Test plan
- [ ] Navigate to Transaction Receipts in the sidebar menu
- [ ] Verify receipt list loads with correct columns (address, outcome, fees, events, epoch)
- [ ] Test search/filter functionality on the list
- [ ] Click a receipt to view details
- [ ] Verify expand/collapse all works on detail sections
- [ ] Test the Download JSON button

🤖 Generated with [Claude Code](https://claude.com/claude-code)