### PR TITLE
refactor(epoch-oracle): add helper methods and fix off-by-one in sync_blockchain

### DIFF
--- a/applications/tari_indexer/Cargo.toml
+++ b/applications/tari_indexer/Cargo.toml
@@ -29,7 +29,7 @@ tari_epoch_oracles = { workspace = true, features = ["base_layer"] }
 tari_indexer_client = { workspace = true, default-features = false, features = ["utoipa"] }
 tari_indexer_lib = { workspace = true }
 tari_networking = { workspace = true }
-tari_ootle_app_utilities = { workspace = true }
+tari_ootle_app_utilities = { workspace = true, features = ["epoch_oracle"] }
 tari_ootle_common_types = { workspace = true }
 tari_ootle_p2p = { workspace = true }
 tari_ootle_storage = { workspace = true }

--- a/applications/tari_ootle_app_utilities/Cargo.toml
+++ b/applications/tari_ootle_app_utilities/Cargo.toml
@@ -13,7 +13,7 @@ tari_crypto = { workspace = true, features = ["serde"] }
 tari_ootle_common_types = { workspace = true }
 tari_engine = { workspace = true }
 tari_ootle_storage = { workspace = true }
-tari_epoch_oracles = { workspace = true }
+tari_epoch_oracles = { workspace = true, optional = true }
 tari_engine_types = { workspace = true }
 tari_template_lib = { workspace = true }
 tari_ootle_transaction = { workspace = true }
@@ -41,3 +41,6 @@ tokio = { workspace = true, features = ["default", "macros", "time", "sync", "rt
 url = { workspace = true, features = ["serde"] }
 toml = { workspace = true }
 config = { workspace = true }
+
+[features]
+epoch_oracle = ["tari_epoch_oracles"]

--- a/applications/tari_ootle_app_utilities/src/lib.rs
+++ b/applications/tari_ootle_app_utilities/src/lib.rs
@@ -23,6 +23,7 @@
 pub mod claim_burn_proof_verifier;
 pub mod common_cli_args;
 pub mod configuration;
+#[cfg(feature = "epoch_oracle")]
 pub mod epoch_oracle_config;
 pub mod fee_tables;
 pub mod genesis_resources;

--- a/applications/tari_validator_node/Cargo.toml
+++ b/applications/tari_validator_node/Cargo.toml
@@ -21,7 +21,7 @@ tari_transaction_components = { workspace = true }
 tari_crypto = { workspace = true }
 tari_epoch_oracles = { workspace = true, features = ["base_layer"] }
 tari_validator_node_rpc = { workspace = true }
-tari_ootle_app_utilities = { workspace = true }
+tari_ootle_app_utilities = { workspace = true, features = ["epoch_oracle"] }
 tari_ootle_common_types = { workspace = true }
 tari_ootle_p2p = { workspace = true }
 tari_engine = { workspace = true }

--- a/crates/epoch_oracles/src/base_layer/oracle.rs
+++ b/crates/epoch_oracles/src/base_layer/oracle.rs
@@ -105,6 +105,18 @@ impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore + 'static> BaseLayerOr
 }
 
 impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore> BaseLayerOracleInner<TStore> {
+    /// The configured start height adjusted for the height lag. This is the minimum height
+    /// that the scanner will scan from.
+    fn lag_start_height(&self) -> u64 {
+        self.start_height.saturating_sub(self.height_lag)
+    }
+
+    /// The effective last scanned height, which is the maximum of the last scanned height and
+    /// the lag start height. This ensures that we never scan below the lag start height.
+    fn effective_last_scanned_height(&self) -> u64 {
+        self.last_scanned_height.max(self.lag_start_height())
+    }
+
     fn load_initial_state(&mut self) -> Result<(), BaseLayerOracleError> {
         self.last_scanned_tip = self
             .store
@@ -143,11 +155,12 @@ impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore> BaseLayerOracleInner<
 
         match self.get_blockchain_progression(&tip).await? {
             BlockchainProgression::Progressed => {
+                let next_scan_height = self.effective_last_scanned_height() + 1;
                 info!(
                     target: LOG_TARGET,
                     "⛓️ Blockchain has progressed to height {}. We last scanned {}/{}",
                     tip.height_of_longest_chain,
-                    self.last_scanned_height,
+                    next_scan_height,
                     tip.height_of_longest_chain
                         .saturating_sub(self.height_lag)
                 );
@@ -193,7 +206,7 @@ impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore> BaseLayerOracleInner<
         &mut self,
         tip: &BaseLayerMetadata,
     ) -> Result<BlockchainProgression, BaseLayerOracleError> {
-        if tip.height_of_longest_chain <= self.start_height {
+        if tip.height_of_longest_chain <= self.lag_start_height() {
             return Ok(BlockchainProgression::NoProgress);
         }
         match &self.last_scanned_tip {
@@ -212,17 +225,6 @@ impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore> BaseLayerOracleInner<
 
     #[allow(clippy::too_many_lines)]
     async fn sync_blockchain(&mut self, tip: BaseLayerMetadata) -> Result<bool, BaseLayerOracleError> {
-        let start_scan_height = self.last_scanned_height.max(self.start_height) + 1;
-        if tip.height_of_longest_chain <= start_scan_height {
-            info!(
-                target: LOG_TARGET,
-                "⛓️ Base layer blockchain has not progressed beyond the start scan height {}. Current tip height is {}.",
-                start_scan_height,
-                tip.height_of_longest_chain
-            );
-            return Ok(false);
-        }
-
         let Some(lag_tip_height) = tip.height_of_longest_chain.checked_sub(self.height_lag) else {
             debug!(
                 target: LOG_TARGET,
@@ -230,6 +232,17 @@ impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore> BaseLayerOracleInner<
             );
             return Ok(false);
         };
+        let start_scan_height = self.effective_last_scanned_height() + 1;
+        if lag_tip_height < start_scan_height {
+            info!(
+                target: LOG_TARGET,
+                "⛓️ Base layer blockchain has not progressed beyond the start scan height {}. Lagged tip height is {}.",
+                start_scan_height,
+                lag_tip_height
+            );
+            return Ok(false);
+        }
+
         let Some(num_blocks) = lag_tip_height.checked_sub(start_scan_height - 1) else {
             debug!(
                 target: LOG_TARGET,

--- a/crates/epoch_oracles/src/base_layer/oracle.rs
+++ b/crates/epoch_oracles/src/base_layer/oracle.rs
@@ -155,12 +155,11 @@ impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore> BaseLayerOracleInner<
 
         match self.get_blockchain_progression(&tip).await? {
             BlockchainProgression::Progressed => {
-                let next_scan_height = self.effective_last_scanned_height() + 1;
                 info!(
                     target: LOG_TARGET,
                     "⛓️ Blockchain has progressed to height {}. We last scanned {}/{}",
                     tip.height_of_longest_chain,
-                    next_scan_height,
+                    self.effective_last_scanned_height(),
                     tip.height_of_longest_chain
                         .saturating_sub(self.height_lag)
                 );

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -29,7 +29,7 @@ tari_shutdown = { workspace = true }
 tari_sidechain = { workspace = true }
 
 tari_crypto = { workspace = true }
-tari_ootle_app_utilities = { workspace = true }
+tari_ootle_app_utilities = { workspace = true, features = ["epoch_oracle"] }
 tari_ootle_common_types = { workspace = true }
 tari_engine = { workspace = true }
 tari_engine_types = { workspace = true }


### PR DESCRIPTION
## Description

Refactors `BaseLayerOracleInner` to eliminate repeated inline calculations and fixes an off-by-one bug that caused one available block to be silently skipped.

## Motivation

The expressions `start_height.saturating_sub(height_lag)` and `last_scanned_height.max(start_height)` appeared in multiple methods with no shared name. Adding named helpers makes the intent clearer and reduces the risk of the two copies drifting apart. The off-by-one was a correctness bug: when the lagged tip was exactly equal to `start_scan_height`, there was one new block ready to scan but the old `<=` guard caused it to be ignored.

## Changes

- Add `lag_start_height()` helper: `start_height.saturating_sub(height_lag)`
- Add `effective_last_scanned_height()` helper: `last_scanned_height.max(lag_start_height())`
- Replace all inline occurrences of those expressions with the new helpers
- Fix `lag_tip_height <= start_scan_height` → `lag_tip_height < start_scan_height` in `sync_blockchain`
- Move the early-return check to after `checked_sub` on `lag_tip_height` so it correctly compares against the lagged tip height rather than the raw chain tip