### PR TITLE
fix!: limit faucet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11963,8 +11963,6 @@ name = "tari_template_builtin"
 version = "0.27.0"
 dependencies = [
  "anyhow",
- "ootle_byte_type",
- "tari_crypto",
  "tari_engine_types",
  "tari_ootle_transaction",
  "tari_template_lib",

--- a/applications/tari_validator_node/src/genesis_state.rs
+++ b/applications/tari_validator_node/src/genesis_state.rs
@@ -140,7 +140,7 @@ where
         SubstateOwnerRule::None,
         ResourceAccessRules::new()
             .mintable(rule!(component(XTR_FAUCET_COMPONENT_ADDRESS)))
-            .burnable(rule!(allow_all)),
+            .burnable(rule!(component(XTR_FAUCET_COMPONENT_ADDRESS))),
         Metadata::new(),
         None,
         None,

--- a/applications/tari_validator_node/src/genesis_state.rs
+++ b/applications/tari_validator_node/src/genesis_state.rs
@@ -43,6 +43,7 @@ use tari_template_lib::types::{
         PUBLIC_IDENTITY_RESOURCE_ADDRESS,
         STEALTH_TARI_RESOURCE_ADDRESS,
         TOKEN_SYMBOL,
+        XTR_FAUCET_CLAIM_RESOURCE_ADDRESS,
         XTR_FAUCET_COMPONENT_ADDRESS,
         XTR_FAUCET_VAULT_ADDRESS,
     },
@@ -131,6 +132,22 @@ where
         ),
     };
     create_substate(tx, num_preshards, XTR_FAUCET_COMPONENT_ADDRESS, value)?;
+
+    // Create the claim receipt resource: one NFT per claimant public key, immediately burned after minting.
+    // The burned substate key persists on-chain, preventing duplicate claims.
+    let claim_resource = Resource::new(
+        ResourceType::NonFungible,
+        SubstateOwnerRule::None,
+        ResourceAccessRules::new()
+            .mintable(rule!(component(XTR_FAUCET_COMPONENT_ADDRESS)))
+            .burnable(rule!(allow_all)),
+        Metadata::new(),
+        None,
+        None,
+        0,
+        false,
+    );
+    create_substate(tx, num_preshards, XTR_FAUCET_CLAIM_RESOURCE_ADDRESS, claim_resource)?;
 
     Ok(())
 }

--- a/applications/tari_wallet_cli/src/command/account.rs
+++ b/applications/tari_wallet_cli/src/command/account.rs
@@ -78,8 +78,6 @@ pub struct GetArgs {
 #[derive(Debug, Args, Clone)]
 pub struct CreateFreeTestCoinsArgs {
     pub account: Option<ComponentAddressOrName>,
-    #[clap(long, short, alias = "amount")]
-    pub amount: Option<u64>,
     #[clap(long, short, alias = "fee")]
     pub fee: Option<u64>,
     #[clap(long, short, alias = "key")]
@@ -189,8 +187,6 @@ async fn handle_create_free_test_coins(
     let resp = client
         .create_free_test_coins(AccountsCreateFreeTestCoinsRequest {
             account: account.component_address.into(),
-            // Default 1 tXTR
-            amount: args.amount.unwrap_or(1_000_000).into(),
             max_fee: args.fee,
         })
         .await?;

--- a/applications/tari_walletd/src/handlers/accounts.rs
+++ b/applications/tari_walletd/src/handlers/accounts.rs
@@ -71,7 +71,13 @@ use tari_template_builtin::ACCOUNT_TEMPLATE_ADDRESS;
 use tari_template_lib_types::{
     Amount,
     ResourceType,
-    constants::{STEALTH_TARI_RESOURCE_ADDRESS, TARI_TOKEN, XTR_FAUCET_COMPONENT_ADDRESS, XTR_FAUCET_VAULT_ADDRESS},
+    constants::{
+        STEALTH_TARI_RESOURCE_ADDRESS,
+        TARI_TOKEN,
+        XTR_FAUCET_CLAIM_RESOURCE_ADDRESS,
+        XTR_FAUCET_COMPONENT_ADDRESS,
+        XTR_FAUCET_VAULT_ADDRESS,
+    },
     stealth::SpendCondition,
 };
 use tokio::task;
@@ -655,6 +661,7 @@ pub async fn handle_create_free_test_coins(
     let mut inputs = vec![
         SubstateRequirement::unversioned(XTR_FAUCET_COMPONENT_ADDRESS),
         SubstateRequirement::unversioned(XTR_FAUCET_VAULT_ADDRESS),
+        SubstateRequirement::unversioned(XTR_FAUCET_CLAIM_RESOURCE_ADDRESS),
     ];
 
     if account.is_confirmed_on_chain() {

--- a/applications/tari_walletd/src/handlers/accounts.rs
+++ b/applications/tari_walletd/src/handlers/accounts.rs
@@ -742,7 +742,9 @@ pub async fn handle_create_free_test_coins(
                 }
                 Err(transaction_rejected(reason))
             },
-            RejectReason::FailedToLockOutputs(reason) => {
+            // TODO: consensus can emit failed to lock inputs when an output fails to lock and vice versa because it
+            // locks them together in some cases. so we take both as meaning already claimed
+            RejectReason::FailedToLockOutputs(reason) | RejectReason::FailedToLockInputs(reason) => {
                 if reason.contains("is already UP and conflicts with an existing output") {
                     return Err(faucet_already_claimed());
                 }

--- a/applications/tari_walletd/src/handlers/accounts.rs
+++ b/applications/tari_walletd/src/handlers/accounts.rs
@@ -627,11 +627,9 @@ pub async fn handle_create_free_test_coins(
     let sdk = context.wallet_sdk();
     let accounts_api = sdk.accounts_api();
 
-    let AccountsCreateFreeTestCoinsRequest {
-        account,
-        amount,
-        max_fee,
-    } = req;
+    let AccountsCreateFreeTestCoinsRequest { account, max_fee } = req;
+    // Fixed amount: always 1,000 TARI (matches the on-chain faucet template constant)
+    let amount = Amount::from(1_000_000_000u64);
 
     let max_fee = max_fee.unwrap_or(DEFAULT_FEE);
 

--- a/applications/tari_walletd/src/handlers/accounts.rs
+++ b/applications/tari_walletd/src/handlers/accounts.rs
@@ -694,7 +694,7 @@ pub async fn handle_create_free_test_coins(
         .transaction_builder()
         .with_fee_instructions_builder(|fee_builder| {
             fee_builder
-                .call_method(XTR_FAUCET_COMPONENT_ADDRESS, "take", args![amount])
+                .call_method(XTR_FAUCET_COMPONENT_ADDRESS, "take", args![])
                 .put_last_instruction_output_on_workspace("faucet_funds")
                 .create_account_with_bucket(*account.address.account_public_key(), "faucet_funds")
                 .put_last_instruction_output_on_workspace("new_account")

--- a/applications/tari_walletd/src/handlers/accounts.rs
+++ b/applications/tari_walletd/src/handlers/accounts.rs
@@ -11,6 +11,7 @@ use ootle_byte_type::{FromByteType, ToByteType};
 use rand::rngs::OsRng;
 use tari_crypto::{keys::PublicKey as _, ristretto::RistrettoPublicKey};
 use tari_engine_types::{
+    commit_result::RejectReason,
     component::derive_component_address_from_public_key,
     confidential::ClaimBurnOutputData,
     substate::SubstateId,
@@ -733,18 +734,22 @@ pub async fn handle_create_free_test_coins(
 
     // Wait for the monitor to pick up the new or updated account
     let (finalized, _) = wait_for_result_and_account(&mut events, &tx_id, account.component_address()).await?;
-    if let Some(reject) = finalized.finalize.fee_reject() {
-        return Err(transaction_rejected(format!("Fee transaction rejected: {}", reject)));
-    }
     if let Some(reason) = finalized.finalize.any_reject() {
-        let reason_str = reason.to_string();
-        if reason_str.contains("Duplicate NFT token id") {
-            return Err(faucet_already_claimed());
-        }
-        return Err(anyhow::anyhow!(
-            "Fee transaction succeeded (fees charged) however, the transaction failed: {}",
-            reason
-        ));
+        return match reason {
+            RejectReason::ExecutionFailure(reason) => {
+                if reason.contains("Duplicate NFT token id") {
+                    return Err(faucet_already_claimed());
+                }
+                Err(anyhow::anyhow!("Transaction failed: {}", reason))
+            },
+            RejectReason::FailedToLockOutputs(reason) => {
+                if reason.contains("is already UP and conflicts with an existing output") {
+                    return Err(faucet_already_claimed());
+                }
+                Err(anyhow::anyhow!("Transaction failed: {}", reason))
+            },
+            _ => Err(anyhow::anyhow!("Transaction failed: {}", reason)),
+        };
     }
 
     info!(

--- a/applications/tari_walletd/src/handlers/accounts.rs
+++ b/applications/tari_walletd/src/handlers/accounts.rs
@@ -740,15 +740,15 @@ pub async fn handle_create_free_test_coins(
                 if reason.contains("Duplicate NFT token id") {
                     return Err(faucet_already_claimed());
                 }
-                Err(anyhow::anyhow!("Transaction failed: {}", reason))
+                Err(transaction_rejected(reason))
             },
             RejectReason::FailedToLockOutputs(reason) => {
                 if reason.contains("is already UP and conflicts with an existing output") {
                     return Err(faucet_already_claimed());
                 }
-                Err(anyhow::anyhow!("Transaction failed: {}", reason))
+                Err(transaction_rejected(reason))
             },
-            _ => Err(anyhow::anyhow!("Transaction failed: {}", reason)),
+            _ => Err(transaction_rejected(reason)),
         };
     }
 

--- a/applications/tari_walletd/src/handlers/accounts.rs
+++ b/applications/tari_walletd/src/handlers/accounts.rs
@@ -74,6 +74,7 @@ use tari_template_lib_types::{
     constants::{
         STEALTH_TARI_RESOURCE_ADDRESS,
         TARI_TOKEN,
+        XTR_FAUCET_AMOUNT,
         XTR_FAUCET_CLAIM_RESOURCE_ADDRESS,
         XTR_FAUCET_COMPONENT_ADDRESS,
         XTR_FAUCET_VAULT_ADDRESS,
@@ -87,6 +88,7 @@ use crate::{
     DEFAULT_FEE,
     handlers::helpers::{
         complete_burn_proof_to_contents,
+        faucet_already_claimed,
         general_error,
         get_account,
         get_account_by_key_index,
@@ -635,7 +637,7 @@ pub async fn handle_create_free_test_coins(
 
     let AccountsCreateFreeTestCoinsRequest { account, max_fee } = req;
     // Fixed amount: always 1,000 TARI (matches the on-chain faucet template constant)
-    let amount = Amount::from(1_000_000_000u64);
+    let amount = Amount::from(XTR_FAUCET_AMOUNT);
 
     let max_fee = max_fee.unwrap_or(DEFAULT_FEE);
 
@@ -735,6 +737,10 @@ pub async fn handle_create_free_test_coins(
         return Err(transaction_rejected(format!("Fee transaction rejected: {}", reject)));
     }
     if let Some(reason) = finalized.finalize.any_reject() {
+        let reason_str = reason.to_string();
+        if reason_str.contains("Duplicate NFT token id") {
+            return Err(faucet_already_claimed());
+        }
         return Err(anyhow::anyhow!(
             "Fee transaction succeeded (fees charged) however, the transaction failed: {}",
             reason

--- a/applications/tari_walletd/src/handlers/helpers.rs
+++ b/applications/tari_walletd/src/handlers/helpers.rs
@@ -193,6 +193,13 @@ pub(super) fn transaction_rejected<T: Display>(details: T) -> anyhow::Error {
     )
 }
 
+pub(super) fn faucet_already_claimed() -> anyhow::Error {
+    application_error(
+        ApplicationErrorCode::FaucetAlreadyClaimed,
+        "This account has already claimed testnet funds",
+    )
+}
+
 pub(super) fn general_error<T: Display>(details: T) -> anyhow::Error {
     application_error(ApplicationErrorCode::GeneralError, details)
 }

--- a/applications/tari_walletd/src/server.rs
+++ b/applications/tari_walletd/src/server.rs
@@ -346,5 +346,6 @@ pub enum ApplicationErrorCode {
     InvalidRequest = 400,
     Unauthorized = 401,
     TransactionRejected = 1000,
+    FaucetAlreadyClaimed = 1001,
     GeneralError = 500,
 }

--- a/applications/tari_walletd/web_ui/src/routes/AssetVault/Tokens/components/ClaimCoinsButton.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/AssetVault/Tokens/components/ClaimCoinsButton.tsx
@@ -45,7 +45,6 @@ function ClaimCoinsButton() {
     claimTestnetFaucetFunds(
       {
         account: { ComponentAddress: substateIdToString(account.component_address) },
-        amount: 1_000_000_000,
         fee: 1000,
       },
       {
@@ -65,7 +64,10 @@ function ClaimCoinsButton() {
         },
         onError: (error: any) => {
           console.error("Error claiming coins:", error);
-          const errorMessage = error?.message || "Failed to claim testnet funds. Please try again.";
+          const message: string = error?.message ?? "";
+          const errorMessage = message.includes("Duplicate NFT token id")
+            ? "You have already claimed your testnet funds. Each account can only claim once."
+            : message || "Failed to claim testnet funds. Please try again.";
           showError(errorMessage);
         },
       },

--- a/applications/tari_walletd/web_ui/src/routes/AssetVault/Tokens/components/ClaimCoinsButton.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/AssetVault/Tokens/components/ClaimCoinsButton.tsx
@@ -64,10 +64,10 @@ function ClaimCoinsButton() {
         },
         onError: (error: any) => {
           console.error("Error claiming coins:", error);
-          const message: string = error?.message ?? "";
-          const errorMessage = message.includes("Duplicate NFT token id")
-            ? "You have already claimed your testnet funds. Each account can only claim once."
-            : message || "Failed to claim testnet funds. Please try again.";
+          const errorMessage =
+            (error?.cause as any)?.code === 1001
+              ? "You have already claimed your testnet funds. Each account can only claim once."
+              : error?.message || "Failed to claim testnet funds. Please try again.";
           showError(errorMessage);
         },
       },

--- a/applications/tari_walletd/web_ui/src/services/api/hooks/useAccounts.ts
+++ b/applications/tari_walletd/web_ui/src/services/api/hooks/useAccounts.ts
@@ -213,16 +213,13 @@ export const useAccountsTransfer = () => {
 export const useAccountsCreateFreeTestCoins = () => {
   const createFreeTestCoins = async ({
     account,
-    amount,
     fee,
   }: {
     account: ComponentAddressOrName;
-    amount: number;
     fee: number | null;
   }) =>
     accountsCreateFreeTestCoins({
       account,
-      amount,
       max_fee: fee,
     });
 

--- a/bindings/src/types/wallet-types/AccountsCreateFreeTestCoinsRequest.ts
+++ b/bindings/src/types/wallet-types/AccountsCreateFreeTestCoinsRequest.ts
@@ -4,6 +4,5 @@ import type { ComponentAddressOrName } from "./ComponentAddressOrName";
 
 export type AccountsCreateFreeTestCoinsRequest = {
   account: ComponentAddressOrName;
-  amount: Amount;
   max_fee: number | null;
 };

--- a/clients/wallet_daemon_client/src/types.rs
+++ b/clients/wallet_daemon_client/src/types.rs
@@ -659,7 +659,6 @@ pub struct ProofsCancelResponse {}
 #[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export, export_to = "wallet-types/"))]
 pub struct AccountsCreateFreeTestCoinsRequest {
     pub account: ComponentAddressOrName,
-    pub amount: Amount,
     #[cfg_attr(feature = "ts", ts(type = "number | null"))]
     pub max_fee: Option<u64>,
 }

--- a/crates/engine/benches/benchmarks.rs
+++ b/crates/engine/benches/benchmarks.rs
@@ -44,7 +44,7 @@ impl Executable for CreateAndFundAccountExecutable {
                 Instruction::CallMethod {
                     call: FAUCET_COMPONENT_ADDRESS.into(),
                     method: "take".try_into().unwrap(),
-                    args: call_args![1000],
+                    args: call_args![],
                 },
                 Instruction::PutLastInstructionOutputOnWorkspace { key: 0 },
                 Instruction::CreateAccount {

--- a/crates/engine/tests/account.rs
+++ b/crates/engine/tests/account.rs
@@ -31,7 +31,7 @@ fn basic_faucet_transfer() {
     let _result = template_test
         .build_and_execute(
             Transaction::builder_localnet()
-                .call_method(XTR_FAUCET_COMPONENT_ADDRESS, "take", args![1000])
+                .call_method(XTR_FAUCET_COMPONENT_ADDRESS, "take", args![])
                 .put_last_instruction_output_on_workspace("free_coins")
                 .call_method(sender_address, "deposit", args![Workspace("free_coins")]),
             vec![template_test.owner_proof()],
@@ -53,7 +53,7 @@ fn basic_faucet_transfer() {
 
     assert_eq!(
         result.finalize.execution_results[3].decode::<Amount>().unwrap(),
-        Amount::from(900u64)
+        Amount::from(999_999_900u64)
     );
     assert_eq!(
         result.finalize.execution_results[4].decode::<Amount>().unwrap(),
@@ -74,7 +74,7 @@ fn withdraw_from_account_prevented() {
                 let source_account = var!["source_account"];
                 let faucet_component = var!["faucet_component"];
                 
-                let free_coins = faucet_component.take(1000);
+                let free_coins = faucet_component.take();
                 source_account.deposit(free_coins);
             "#,
             [
@@ -189,7 +189,7 @@ fn create_account_is_idempotent_with_deposit() {
 
     let result = test.execute_expect_success(
         Transaction::builder_localnet()
-            .call_method(xtr_faucet_component(), "take", args![1000])
+            .call_method(xtr_faucet_component(), "take", args![])
             .put_last_instruction_output_on_workspace("bucket")
             // Create component with the same ID
             .create_account_with_bucket(source_account_pk.to_byte_type(), "bucket")
@@ -210,7 +210,7 @@ fn create_account_is_idempotent_with_deposit() {
     let account = store.get_account(source_account).unwrap();
     let vault = account.get_vault_by_resource(&TARI_TOKEN).unwrap();
     let vault = store.get_vault(&vault.vault_id()).unwrap();
-    assert_eq!(vault.balance(), 1000u64);
+    assert_eq!(vault.balance(), 1_000_000_000u64);
 }
 
 #[test]
@@ -261,7 +261,7 @@ fn custom_access_rules() {
 
     test.execute_expect_success(
         Transaction::builder_localnet()
-            .call_method(xtr_faucet_component(), "take", args![1000])
+            .call_method(xtr_faucet_component(), "take", args![])
             .put_last_instruction_output_on_workspace("bucket")
             // Create component with the same ID
             .create_account_custom(
@@ -303,11 +303,11 @@ fn take_from_bucket() {
 
     test.execute_expect_success(
         Transaction::builder_localnet()
-            .call_method(XTR_FAUCET_COMPONENT_ADDRESS, "take", args![1000])
+            .call_method(XTR_FAUCET_COMPONENT_ADDRESS, "take", args![])
             .put_last_instruction_output_on_workspace("free_coins")
             .take_from_bucket("free_coins", 100u64, "foo_bucket")
-            // Take all to test what happens when free_coins is empty (should not fail due to dangling buckets)
-            .take_from_bucket("free_coins", 900u64, "bar_bucket")
+            // Take all remaining coins — tests that an empty bucket does not cause a dangling bucket error
+            .take_from_bucket("free_coins", 999_999_900u64, "bar_bucket")
             .call_method(alice, "deposit", args![Workspace("foo_bucket")])
             .call_method(bob, "deposit", args![Workspace("bar_bucket")])
             .build_and_seal(test.secret_key()),
@@ -327,6 +327,6 @@ fn take_from_bucket() {
         .unwrap()
         .balance();
 
-    assert_eq!(alice_balance, 100);
-    assert_eq!(bob_balance, 900);
+    assert_eq!(alice_balance, 100u64);
+    assert_eq!(bob_balance, 999_999_900u64);
 }

--- a/crates/engine/tests/address_allocation.rs
+++ b/crates/engine/tests/address_allocation.rs
@@ -188,7 +188,7 @@ fn it_allows_calls_to_component_using_a_component_on_the_workspace() {
 
     test.execute_expect_success(
         Transaction::builder_localnet()
-            .call_method(xtr_faucet_component(), "take", args![1000])
+            .call_method(xtr_faucet_component(), "take", args![])
             .put_last_instruction_output_on_workspace("bucket")
             .create_account(test.to_public_key_bytes())
             // Put the created account address on the workspace, and

--- a/crates/engine/tests/asserts.rs
+++ b/crates/engine/tests/asserts.rs
@@ -14,11 +14,7 @@ use tari_template_lib::types::{
     ResourceType,
     constants::{NFT_FAUCET_COMPONENT_ADDRESS, NFT_FAUCET_RESOURCE_ADDRESS, TARI_TOKEN},
 };
-use tari_template_test_tooling::{
-    TemplateTest,
-    support::assert_error::assert_reject_reason,
-    template_lib_types::constants::XTR_FAUCET_COMPONENT_ADDRESS,
-};
+use tari_template_test_tooling::{TemplateTest, support::assert_error::assert_reject_reason};
 
 const CRATE_PATH: &str = env!("CARGO_MANIFEST_DIR");
 const TEMPLATE_PATH: &str = "tests/templates/tariswap";
@@ -27,7 +23,6 @@ const FAUCET_WITHDRAWAL_AMOUNT: u32 = 1000;
 
 struct AssertTest {
     template_test: TemplateTest,
-    faucet_component: ComponentAddress,
     faucet_resource: ResourceAddress,
     account: ComponentAddress,
     account_proof: NonFungibleAddress,
@@ -42,7 +37,6 @@ fn setup() -> AssertTest {
 
     AssertTest {
         template_test,
-        faucet_component: XTR_FAUCET_COMPONENT_ADDRESS,
         faucet_resource: TARI_TOKEN,
         account,
         account_proof,
@@ -59,7 +53,7 @@ mod assert_bucket_contains {
 
         test.template_test.execute_expect_success(
             Transaction::builder_localnet()
-                .call_method(test.faucet_component, "take", args![1000])
+                .call_method(test.account, "withdraw", args![test.faucet_resource, 1000u64])
                 .put_last_instruction_output_on_workspace("faucet_bucket")
                 .assert_bucket_contains_at_least("faucet_bucket", test.faucet_resource, FAUCET_WITHDRAWAL_AMOUNT)
                 .assert_bucket_contains_exactly("faucet_bucket", test.faucet_resource, FAUCET_WITHDRAWAL_AMOUNT)
@@ -79,7 +73,7 @@ mod assert_bucket_contains {
 
         let reason = test.template_test.execute_expect_failure(
             Transaction::builder_localnet()
-                .call_method(test.faucet_component, "take", args![1000])
+                .call_method(test.account, "withdraw", args![test.faucet_resource, 1000u64])
                 .put_last_instruction_output_on_workspace("faucet_bucket")
                 .assert_bucket_contains_at_least("faucet_bucket", invalid_resource_address, FAUCET_WITHDRAWAL_AMOUNT)
                 .call_method(test.account, "deposit", args![Workspace("faucet_bucket")])
@@ -105,7 +99,7 @@ mod assert_bucket_contains {
 
         let reason = test.template_test.execute_expect_failure(
             Transaction::builder_localnet()
-                .call_method(test.faucet_component, "take", args![1000])
+                .call_method(test.account, "withdraw", args![test.faucet_resource, 1000u64])
                 .put_last_instruction_output_on_workspace("faucet_bucket")
                 // Passes
                 .assert_bucket_contains_exactly("faucet_bucket", test.faucet_resource, FAUCET_WITHDRAWAL_AMOUNT)
@@ -134,7 +128,7 @@ mod assert_bucket_contains {
 
         let reason = test.template_test.execute_expect_failure(
             Transaction::builder_localnet()
-                .call_method(test.faucet_component, "take", args![1000])
+                .call_method(test.account, "withdraw", args![test.faucet_resource, 1000u64])
                 // we are going to assert a workspace value that is NOT a bucket
                 .call_method(test.account, "get_balances", args![])
                 .put_last_instruction_output_on_workspace("invalid_bucket")
@@ -158,7 +152,7 @@ mod assert_bucket_contains {
 
         let reason = test.template_test.execute_expect_failure(
             Transaction::builder_localnet()
-                .call_method(test.faucet_component, "take", args![1000])
+                .call_method(test.account, "withdraw", args![test.faucet_resource, 1000u64])
                 .put_last_instruction_output_on_workspace("faucet_bucket")
                 // we are going to assert a key that does not exist in the workspace
                 // assert_bucket_contains would panic if called with a non-existing key
@@ -214,7 +208,7 @@ mod assert_is_not_null {
 
         let reason = test.template_test.execute_expect_failure(
             Transaction::builder_localnet()
-                .call_method(test.faucet_component, "take", args![1000])
+                .call_method(test.account, "withdraw", args![test.faucet_resource, 1000u64])
                 .put_last_instruction_output_on_workspace("faucet_bucket")
                 .assert_workspace_item_is_not_null("faucet_bucket")
                 .call_method(test.account, "deposit", args![Workspace("faucet_bucket")])
@@ -277,7 +271,7 @@ mod assert_bucket_contains_non_fungibles {
         // Take some tokens from the faucet to get a bucket with non-fungibles
         let reason = test.template_test.execute_expect_failure(
             Transaction::builder_localnet()
-                .call_method(test.faucet_component, "take", args![1000])
+                .call_method(test.account, "withdraw", args![test.faucet_resource, 1000u64])
                 .put_last_instruction_output_on_workspace("faucet_bucket")
                 .assert_bucket_contains_non_fungibles_all("faucet_bucket", test.faucet_resource, vec![])
                 .call_method(test.account, "deposit", args![Workspace("faucet_bucket")])

--- a/crates/engine/tests/events.rs
+++ b/crates/engine/tests/events.rs
@@ -63,7 +63,7 @@ fn builtin_vault_events() {
     let (receiver_address, _, _) = test.create_empty_account();
     test.build_and_execute(
         Transaction::builder_localnet()
-            .call_method(XTR_FAUCET_COMPONENT_ADDRESS, "take", args![1000])
+            .call_method(XTR_FAUCET_COMPONENT_ADDRESS, "take", args![])
             .put_last_instruction_output_on_workspace("free_coins")
             .call_method(sender_address, "deposit", args![Workspace("free_coins")]),
         vec![test.owner_proof()],

--- a/crates/engine/tests/fees.rs
+++ b/crates/engine/tests/fees.rs
@@ -85,7 +85,7 @@ fn deposit_from_faucet_then_pay() {
             .with_fee_instructions_builder(|builder| {
                 builder
                     // Faucet deposits free coins into the account
-                    .call_method(xtr_faucet_component(), "take", args![100000])
+                    .call_method(xtr_faucet_component(), "take", args![])
                     .put_last_instruction_output_on_workspace("bucket")
                     .call_method(account, "deposit", args![Workspace("bucket")])
                     .call_method(account, "pay_fee", args![1000])
@@ -103,7 +103,7 @@ fn deposit_from_faucet_then_pay() {
         .get(&STEALTH_TARI_RESOURCE_ADDRESS)
         .unwrap()
         .balance();
-    assert_eq!(new_balance, 100000 - payment.total_fees_paid());
+    assert_eq!(new_balance, 1_000_000_000 - payment.total_fees_paid());
 }
 
 #[test]
@@ -123,7 +123,7 @@ fn another_account_pays_partially_for_fees() {
             .pay_fee_from_component(account_fee, Amount::from(200u64))
             // Account pays the rest
             .pay_fee_from_component(account_fee2, Amount::from(1000u64))
-            .call_method(xtr_faucet_component(), "take", args![1000])
+            .call_method(xtr_faucet_component(), "take", args![])
             .put_last_instruction_output_on_workspace("bucket")
             .call_method(account, "deposit", args![Workspace("bucket")])
             // NOTE: the test harness provides the virtual proofs as provided, so the transaction signer does not matter
@@ -156,7 +156,7 @@ fn another_account_pays_partially_for_fees() {
         .get(&STEALTH_TARI_RESOURCE_ADDRESS)
         .unwrap()
         .balance();
-    assert_eq!(balance, Amount::from(1000u64));
+    assert_eq!(balance, Amount::from(1_000_000_000u64));
 }
 
 #[test]

--- a/crates/engine/tests/publish_template.rs
+++ b/crates/engine/tests/publish_template.rs
@@ -25,7 +25,7 @@ const CRATE_PATH: &str = env!("CARGO_MANIFEST_DIR");
 #[test]
 fn publish_template_success() {
     let mut test = TemplateTest::new(CRATE_PATH, &[] as &[&str]);
-    let (account_address, owner_proof, account_key, public_key) = test.create_custom_funded_account(250_000u64);
+    let (account_address, owner_proof, account_key, public_key) = test.create_funded_account_with_keypair();
     let template = compile_template("tests/templates/hello_world", &[]).unwrap();
     let expected_binary_hash = hash_template_code(template.code());
     let expected_template_address =
@@ -61,7 +61,7 @@ fn publish_template_success() {
 #[test]
 fn publish_template_invalid_binary() {
     let mut test = TemplateTest::new(CRATE_PATH, &[] as &[&str]);
-    let (account_address, owner_proof, account_key, _) = test.create_custom_funded_account(250_000u64);
+    let (account_address, owner_proof, account_key, _) = test.create_funded_account_with_keypair();
     let result = test.execute_expect_failure(
         Transaction::builder_localnet()
             .pay_fee_from_component(account_address, 200_000u64)
@@ -81,7 +81,7 @@ fn publish_template_invalid_binary() {
 #[test]
 fn publish_template_too_big_binary() {
     let mut test = TemplateTest::new(CRATE_PATH, &[] as &[&str]);
-    let (account_address, owner_proof, account_key, _) = test.create_custom_funded_account(250_000u64);
+    let (account_address, owner_proof, account_key, _) = test.create_funded_account_with_keypair();
     let random_wasm_binary = generate_random_binary(limits::ENGINE_LIMITS.max_template_binary_size_bytes + 1);
     let wasm_binary_size = random_wasm_binary.len();
     let reason = test.execute_expect_failure(

--- a/crates/engine/tests/reentrancy.rs
+++ b/crates/engine/tests/reentrancy.rs
@@ -17,7 +17,7 @@ fn it_prevents_reentrant_withdraw() {
 
     let result = test.execute_expect_success(
         Transaction::builder_localnet()
-            .call_method(XTR_FAUCET_COMPONENT_ADDRESS, "take", args![1000])
+            .call_method(XTR_FAUCET_COMPONENT_ADDRESS, "take", args![])
             .put_last_instruction_output_on_workspace("bucket")
             .call_function(template_addr, "with_bucket", args![Workspace("bucket")])
             .build_and_seal(test.secret_key()),

--- a/crates/template_builtin/Cargo.toml
+++ b/crates/template_builtin/Cargo.toml
@@ -17,9 +17,6 @@ tari_template_test_tooling = { workspace = true }
 tari_engine_types = { workspace = true }
 tari_template_lib = { workspace = true }
 tari_ootle_transaction = { workspace = true }
-ootle_byte_type = { workspace = true, features = ["crypto"] }
-
-tari_crypto = { workspace = true }
 
 [build-dependencies]
 anyhow = { workspace = true }

--- a/crates/template_builtin/templates/faucet/src/lib.rs
+++ b/crates/template_builtin/templates/faucet/src/lib.rs
@@ -1,11 +1,12 @@
 //   Copyright 2024 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use tari_template_lib::prelude::*;
+use tari_template_lib::{prelude::*, types::constants::XTR_FAUCET_CLAIM_RESOURCE_ADDRESS};
 
 #[template]
 mod template {
-    const FAUCET_MAX: u64 = 10_000 * 1_000_000;
+    /// Faucet amount in microtari: 1,000 TARI per claim. Fixed for take(), ceiling for take_confidential().
+    const FAUCET_AMOUNT: u64 = 1_000 * 1_000_000;
     use super::*;
 
     pub struct XtrFaucet {
@@ -13,26 +14,32 @@ mod template {
     }
 
     impl XtrFaucet {
-        pub fn take(&self, amount: Amount) -> Bucket {
-            assert!(
-                amount <= FAUCET_MAX,
-                "Requested amount {} exceeds faucet max of {}",
-                amount,
-                FAUCET_MAX
-            );
-            emit_event("take", metadata!["amount" => amount.to_string()]);
-            self.vault.withdraw(amount)
+        /// Mints a claim-receipt NFT keyed to the caller's public key, then immediately burns it.
+        /// The burned substate key persists on-chain, so a second attempt panics with DuplicateNonFungibleId.
+        fn record_claim(&self) {
+            let pk = CallerContext::transaction_signer_public_key();
+            let receipt = ResourceManager::get(XTR_FAUCET_CLAIM_RESOURCE_ADDRESS)
+                .mint_non_fungible(NonFungibleId::from_public_key(pk), &(), &());
+            receipt.burn();
+        }
+
+        /// Gives exactly 1,000 TARI to the caller. Can only be called once per signing public key.
+        pub fn take(&self) -> Bucket {
+            self.record_claim();
+            emit_event("take", metadata!["amount" => FAUCET_AMOUNT.to_string()]);
+            self.vault.withdraw(FAUCET_AMOUNT)
         }
 
         pub fn take_confidential(&self, transfer: StealthTransferStatement) -> Option<Bucket> {
             let amount = transfer.inputs_statement.revealed_amount;
             assert!(
-                amount <= FAUCET_MAX,
+                amount <= FAUCET_AMOUNT,
                 "Requested amount {} exceeds faucet max of {}",
                 amount,
-                FAUCET_MAX
+                FAUCET_AMOUNT
             );
 
+            self.record_claim();
             emit_event("take", metadata![
                 "amount" => amount.to_string(),
                 "confidential" => "true".to_string()

--- a/crates/template_builtin/tests/xtr_faucet.rs
+++ b/crates/template_builtin/tests/xtr_faucet.rs
@@ -13,12 +13,8 @@ fn first_claim_succeeds() {
     // create_funded_account calls faucet.take() internally and commits the result
     let (account, _proof, _sk) = test.create_funded_account();
 
-    let balance: tari_template_lib::types::Amount = test.call_method(
-        account,
-        "balance",
-        args![STEALTH_TARI_RESOURCE_ADDRESS],
-        vec![],
-    );
+    let balance: tari_template_lib::types::Amount =
+        test.call_method(account, "balance", args![STEALTH_TARI_RESOURCE_ADDRESS], vec![]);
     assert!(balance > tari_template_lib::types::Amount::zero());
 }
 

--- a/crates/template_builtin/tests/xtr_faucet.rs
+++ b/crates/template_builtin/tests/xtr_faucet.rs
@@ -24,8 +24,8 @@ fn first_claim_succeeds() {
 fn different_signers_can_each_claim_once() {
     let mut test = TemplateTest::new_builtin_only();
     // Each call uses a fresh key pair (auto-incrementing seed inside create_funded_account)
-    let _ = test.create_funded_account();
-    let _ = test.create_funded_account();
+    let _unused = test.create_funded_account();
+    let _unused = test.create_funded_account();
     // If we reach here without panic, both claims succeeded
 }
 

--- a/crates/template_builtin/tests/xtr_faucet.rs
+++ b/crates/template_builtin/tests/xtr_faucet.rs
@@ -3,7 +3,10 @@
 
 use tari_ootle_transaction::{Transaction, args};
 use tari_template_lib::types::constants::{STEALTH_TARI_RESOURCE_ADDRESS, XTR_FAUCET_COMPONENT_ADDRESS};
-use tari_template_test_tooling::{TemplateTest, support::assert_error::assert_reject_reason};
+use tari_template_test_tooling::{
+    TemplateTest,
+    support::{assert_error::assert_reject_reason, stealth, stealth::NO_INPUTS},
+};
 
 /// A brand-new signer can call take() and receive tokens.
 #[test]
@@ -57,10 +60,15 @@ fn take_blocks_subsequent_take_confidential_for_same_signer() {
     // Use create_funded_account which calls take() — consumes the single allowed claim
     let (_account, owner_proof, secret_key) = test.create_funded_account();
 
-    // Attempting take() again with the same key must fail
+    // Build a minimal valid StealthTransferStatement requesting 1 TARI (revealed)
+    let transfer = stealth::generate_transfer_data(NO_INPUTS, 1_000_000u64, Vec::<u64>::new(), 1_000_000u64);
+
+    // Attempting take_confidential() with the same key must fail at record_claim() before any vault access
     let reject_reason = test.execute_expect_failure(
         Transaction::builder_localnet()
-            .call_method(XTR_FAUCET_COMPONENT_ADDRESS, "take", args![])
+            .call_method(XTR_FAUCET_COMPONENT_ADDRESS, "take_confidential", args![
+                transfer.statement
+            ])
             .build_and_seal(&secret_key),
         vec![owner_proof],
     );

--- a/crates/template_builtin/tests/xtr_faucet.rs
+++ b/crates/template_builtin/tests/xtr_faucet.rs
@@ -1,0 +1,72 @@
+//   Copyright 2025 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+use tari_ootle_transaction::{Transaction, args};
+use tari_template_lib::types::constants::{STEALTH_TARI_RESOURCE_ADDRESS, XTR_FAUCET_COMPONENT_ADDRESS};
+use tari_template_test_tooling::{TemplateTest, support::assert_error::assert_reject_reason};
+
+/// A brand-new signer can call take() and receive tokens.
+#[test]
+fn first_claim_succeeds() {
+    let mut test = TemplateTest::new_builtin_only();
+
+    // create_funded_account calls faucet.take() internally and commits the result
+    let (account, _proof, _sk) = test.create_funded_account();
+
+    let balance: tari_template_lib::types::Amount = test.call_method(
+        account,
+        "balance",
+        args![STEALTH_TARI_RESOURCE_ADDRESS],
+        vec![],
+    );
+    assert!(balance > tari_template_lib::types::Amount::zero());
+}
+
+/// Two different signers can each claim once independently — they have different public keys,
+/// so their claim-receipt NFT IDs are different.
+#[test]
+fn different_signers_can_each_claim_once() {
+    let mut test = TemplateTest::new_builtin_only();
+    // Each call uses a fresh key pair (auto-incrementing seed inside create_funded_account)
+    let _ = test.create_funded_account();
+    let _ = test.create_funded_account();
+    // If we reach here without panic, both claims succeeded
+}
+
+/// The same signer cannot call take() twice.
+/// The second attempt is rejected with "Duplicate NFT token id".
+#[test]
+fn second_claim_by_same_signer_is_rejected() {
+    let mut test = TemplateTest::new_builtin_only();
+    // First claim: succeeds and commits state (including the claim-receipt burned NFT)
+    let (account, owner_proof, secret_key) = test.create_funded_account();
+
+    // Second claim: same signing key → same claim-receipt NFT ID → DuplicateNonFungibleId
+    let reject_reason = test.execute_expect_failure(
+        Transaction::builder_localnet()
+            .call_method(XTR_FAUCET_COMPONENT_ADDRESS, "take", args![])
+            .put_last_instruction_output_on_workspace("bucket")
+            .call_method(account, "deposit", args![Workspace("bucket")])
+            .build_and_seal(&secret_key),
+        vec![owner_proof],
+    );
+    assert_reject_reason(&reject_reason, "Duplicate NFT token id");
+}
+
+/// After claiming with take(), calling take_confidential() with the same signer is also rejected.
+/// Both methods share the same claim-receipt resource, enforcing a single combined limit per public key.
+#[test]
+fn take_blocks_subsequent_take_confidential_for_same_signer() {
+    let mut test = TemplateTest::new_builtin_only();
+    // Use create_funded_account which calls take() — consumes the single allowed claim
+    let (_account, owner_proof, secret_key) = test.create_funded_account();
+
+    // Attempting take() again with the same key must fail
+    let reject_reason = test.execute_expect_failure(
+        Transaction::builder_localnet()
+            .call_method(XTR_FAUCET_COMPONENT_ADDRESS, "take", args![])
+            .build_and_seal(&secret_key),
+        vec![owner_proof],
+    );
+    assert_reject_reason(&reject_reason, "Duplicate NFT token id");
+}

--- a/crates/template_lib_types/src/constants.rs
+++ b/crates/template_lib_types/src/constants.rs
@@ -42,6 +42,14 @@ pub const XTR_FAUCET_VAULT_ADDRESS: VaultId = VaultId::new(ObjectKey::from_array
     1, 2, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
 ]));
 
+/// Address of the NFT resource used by the XTR faucet to track which public keys have already claimed.
+/// Each claim mints an NFT with ID = claimant's public key, then immediately burns it.
+/// The burned substate key persists, preventing re-claims.
+/// resource_0102030000000000000000000000000000000000000000000000000000000002
+pub const XTR_FAUCET_CLAIM_RESOURCE_ADDRESS: ResourceAddress = ResourceAddress::new(ObjectKey::from_array([
+    1, 2, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2,
+]));
+
 /// Address of the NFT faucet component
 pub const NFT_FAUCET_COMPONENT_ADDRESS: ComponentAddress = ComponentAddress::new(ObjectKey::from_array([
     0xff, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,

--- a/crates/template_lib_types/src/constants.rs
+++ b/crates/template_lib_types/src/constants.rs
@@ -50,6 +50,10 @@ pub const XTR_FAUCET_CLAIM_RESOURCE_ADDRESS: ResourceAddress = ResourceAddress::
     1, 2, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2,
 ]));
 
+/// The fixed amount dispensed per faucet claim: 1,000 TARI in microtari.
+/// Matches the on-chain `FAUCET_AMOUNT` constant in the faucet template.
+pub const XTR_FAUCET_AMOUNT: u64 = 1_000 * TARI;
+
 /// Address of the NFT faucet component
 pub const NFT_FAUCET_COMPONENT_ADDRESS: ComponentAddress = ComponentAddress::new(ObjectKey::from_array([
     0xff, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,

--- a/crates/template_test_tooling/src/builtin_component_state.rs
+++ b/crates/template_test_tooling/src/builtin_component_state.rs
@@ -23,6 +23,7 @@ use tari_template_lib::types::{
         PUBLIC_IDENTITY_RESOURCE_ADDRESS,
         STEALTH_TARI_RESOURCE_ADDRESS,
         TOKEN_SYMBOL,
+        XTR_FAUCET_CLAIM_RESOURCE_ADDRESS,
         XTR_FAUCET_VAULT_ADDRESS,
     },
     metadata,
@@ -104,6 +105,26 @@ pub fn initialize_builtin_faucet_state<TStore: StateWriter>(store: &mut TStore) 
                 entity_id,
                 body: ComponentBody { state },
             }),
+        )
+        .unwrap();
+
+    // Claim receipt resource: one NFT per claimant public key (minted then burned to record the claim).
+    let claim_resource = Resource::new(
+        ResourceType::NonFungible,
+        SubstateOwnerRule::None,
+        ResourceAccessRules::new()
+            .mintable(rule!(component(xtr_faucet_component())))
+            .burnable(rule!(allow_all)),
+        Metadata::new(),
+        None,
+        None,
+        0,
+        false,
+    );
+    store
+        .set_state(
+            SubstateId::Resource(XTR_FAUCET_CLAIM_RESOURCE_ADDRESS),
+            Substate::new(0, claim_resource),
         )
         .unwrap();
 }

--- a/crates/template_test_tooling/src/template_test.rs
+++ b/crates/template_test_tooling/src/template_test.rs
@@ -570,9 +570,7 @@ impl TemplateTest {
         self.enable_fees = false;
         self.execute_expect_success(
             Transaction::builder_localnet()
-                .call_method(xtr_faucet_component(), "take", args![
-                    Self::FUNDED_ACCOUNT_INITIAL_BALANCE
-                ])
+                .call_method(xtr_faucet_component(), "take", args![])
                 .put_last_instruction_output_on_workspace("bucket")
                 .create_account_with_bucket(public_key.to_byte_type(), "bucket")
                 .build_and_seal(&secret_key),
@@ -593,7 +591,7 @@ impl TemplateTest {
     #[track_caller]
     pub fn create_custom_funded_account<A: Into<Amount>>(
         &mut self,
-        amount: A,
+        _amount: A,
     ) -> (
         ComponentAddress,
         NonFungibleAddress,
@@ -606,7 +604,7 @@ impl TemplateTest {
         let public_key_bytes = public_key.to_byte_type();
         self.execute_expect_success(
             Transaction::builder_localnet()
-                .call_method(xtr_faucet_component(), "take", args![amount.into()])
+                .call_method(xtr_faucet_component(), "take", args![])
                 .put_last_instruction_output_on_workspace("bucket")
                 .create_account_with_bucket(public_key_bytes, "bucket")
                 .build_and_seal(&secret_key),

--- a/crates/template_test_tooling/src/template_test.rs
+++ b/crates/template_test_tooling/src/template_test.rs
@@ -53,7 +53,6 @@ use tari_ootle_transaction::{
     },
 };
 use tari_template_lib::types::{
-    Amount,
     ComponentAddress,
     NonFungibleAddress,
     TemplateAddress,
@@ -583,15 +582,14 @@ impl TemplateTest {
         (account_address, owner_proof, secret_key)
     }
 
-    /// Creates a new account funded with a custom `amount` of tokens from the XTR faucet,
-    /// using a fresh key pair.
+    /// Creates a new account funded from the XTR faucet using a fresh key pair.
     /// Returns `(account_address, owner_proof, secret_key, public_key)`.
     ///
+    /// Unlike [`create_funded_account`], this also returns the public key.
     /// Fees are temporarily disabled for the account creation transaction.
     #[track_caller]
-    pub fn create_custom_funded_account<A: Into<Amount>>(
+    pub fn create_funded_account_with_keypair(
         &mut self,
-        _amount: A,
     ) -> (
         ComponentAddress,
         NonFungibleAddress,

--- a/crates/wallet/ootle-rs/examples/fungible_transfer.rs
+++ b/crates/wallet/ootle-rs/examples/fungible_transfer.rs
@@ -62,7 +62,7 @@ async fn main() {
 
     // First let's transfer some faucet TARI to our account to have funds for fees and transfers.
     let unsigned_tx = IFaucet::new(&provider)
-        .take_faucet_funds(10 * TARI)
+        .take_faucet_funds()
         // NOTE that pay fee must be called after the faucet funds are taken because fees are paid from the faucet funds
         .pay_fee(500u64)
         .prepare()

--- a/crates/wallet/ootle-rs/examples/template_invoke.rs
+++ b/crates/wallet/ootle-rs/examples/template_invoke.rs
@@ -26,7 +26,7 @@ use ootle_rs::{
     key_provider::PrivateKeyProvider,
     ootle_template,
     provider::{PendingTransaction, ProviderBuilder, WalletProvider},
-    template_types::{Amount, ComponentAddress, constants::TARI},
+    template_types::{Amount, ComponentAddress},
     transaction::TransactionSigner,
     wallet::OotleWallet,
 };
@@ -111,7 +111,7 @@ async fn main() {
 
     // Fund the account from faucet
     let unsigned_tx = IFaucet::new(&provider)
-        .take_faucet_funds(10 * TARI)
+        .take_faucet_funds()
         .pay_fee(500u64)
         .prepare()
         .await

--- a/crates/wallet/ootle-rs/src/builtin_templates/faucet.rs
+++ b/crates/wallet/ootle-rs/src/builtin_templates/faucet.rs
@@ -8,7 +8,12 @@ use tari_ootle_transaction::{TransactionBuilder, UnsignedTransaction, args};
 use tari_template_lib_types::{
     Amount,
     UtxoAddress,
-    constants::{TARI, TARI_TOKEN, XTR_FAUCET_COMPONENT_ADDRESS, XTR_FAUCET_VAULT_ADDRESS},
+    constants::{
+        TARI_TOKEN,
+        XTR_FAUCET_CLAIM_RESOURCE_ADDRESS,
+        XTR_FAUCET_COMPONENT_ADDRESS,
+        XTR_FAUCET_VAULT_ADDRESS,
+    },
     stealth::StealthTransferStatement,
 };
 
@@ -81,13 +86,6 @@ impl<'a, P: Provider> FaucetInvokeBuilder<'a, P> {
         format!("__AccountInvokeBuilder_{}", self.builder.next_workspace_id())
     }
 
-    /// Takes the maximum permitted funds from the faucet and deposits them into the default signer's account.
-    pub fn take_max_faucet_funds(self) -> Self {
-        // NOTE: that the actual maximum is currently 10_000, but we set it to 1_000 here to be conservative.
-        const FAUCET_MAX_TAKE_AMOUNT: u64 = 1_000 * TARI;
-        self.take_faucet_funds(FAUCET_MAX_TAKE_AMOUNT)
-    }
-
     pub fn take_faucet_funds_stealth(
         mut self,
         transfer: StealthTransferStatement,
@@ -118,6 +116,7 @@ impl<'a, P: Provider> FaucetInvokeBuilder<'a, P> {
         self.builder = self.builder.with_fee_instructions_builder(|builder| {
             builder
                 .add_input(XTR_FAUCET_VAULT_ADDRESS)
+                .add_input(XTR_FAUCET_CLAIM_RESOURCE_ADDRESS)
                 .call_method(XTR_FAUCET_COMPONENT_ADDRESS, "take_confidential", args![transfer])
                 .then(|builder| {
                     if let Some((account_ws_name, bucket_name)) = &workspace_names {
@@ -141,12 +140,8 @@ impl<'a, P: Provider> FaucetInvokeBuilder<'a, P> {
         self
     }
 
-    /// Takes the specified amount of funds from the faucet and deposits them into the default signer's account.
-    pub fn take_faucet_funds<A: Into<Amount>>(mut self, amount: A) -> Self {
-        let amount: Amount = amount.into();
-        if !amount.is_positive() {
-            panic!("Transfer amount must be positive");
-        }
+    /// Takes the fixed faucet amount (1,000 TARI) and deposits them into the default signer's account.
+    pub fn take_faucet_funds(mut self) -> Self {
         let bucket_name = self.next_workspace_name();
         let recipient_account_pk = *self.default_signer_address().account_public_key();
         let recipient_account_addr = self.default_signer_address().to_account_address();
@@ -166,6 +161,7 @@ impl<'a, P: Provider> FaucetInvokeBuilder<'a, P> {
             builder
                 .call_method(XTR_FAUCET_COMPONENT_ADDRESS, "take", args![])
                 .add_input(XTR_FAUCET_VAULT_ADDRESS)
+                .add_input(XTR_FAUCET_CLAIM_RESOURCE_ADDRESS)
                 .put_last_instruction_output_on_workspace(&bucket_name)
                 // Create the recipient account if it doesn't exist
                 .create_account_with_bucket(recipient_account_pk, &bucket_name)

--- a/crates/wallet/ootle-rs/src/builtin_templates/faucet.rs
+++ b/crates/wallet/ootle-rs/src/builtin_templates/faucet.rs
@@ -164,7 +164,7 @@ impl<'a, P: Provider> FaucetInvokeBuilder<'a, P> {
         let account_name = self.next_workspace_name();
         self.builder = self.builder.with_fee_instructions_builder(|builder| {
             builder
-                .call_method(XTR_FAUCET_COMPONENT_ADDRESS, "take", args![amount])
+                .call_method(XTR_FAUCET_COMPONENT_ADDRESS, "take", args![])
                 .add_input(XTR_FAUCET_VAULT_ADDRESS)
                 .put_last_instruction_output_on_workspace(&bucket_name)
                 // Create the recipient account if it doesn't exist

--- a/integration_tests/src/wallet_daemon_client.rs
+++ b/integration_tests/src/wallet_daemon_client.rs
@@ -235,7 +235,7 @@ pub async fn create_account_with_free_coins<A: Into<Amount>>(
     world: &mut TariWorld,
     account_name: String,
     wallet_daemon_name: String,
-    amount: A,
+    _amount: A,
 ) {
     let mut client = get_auth_wallet_daemon_client(world, &wallet_daemon_name).await;
 
@@ -267,7 +267,6 @@ pub async fn create_account_with_free_coins<A: Into<Amount>>(
 
     let request = AccountsCreateFreeTestCoinsRequest {
         account: account.account.component_address.into(),
-        amount: amount.into(),
         max_fee: None,
     };
 

--- a/integration_tests/src/wallet_daemon_client.rs
+++ b/integration_tests/src/wallet_daemon_client.rs
@@ -231,12 +231,7 @@ pub async fn create_account(
     account
 }
 
-pub async fn create_account_with_free_coins<A: Into<Amount>>(
-    world: &mut TariWorld,
-    account_name: String,
-    wallet_daemon_name: String,
-    _amount: A,
-) {
+pub async fn create_account_with_free_coins(world: &mut TariWorld, account_name: String, wallet_daemon_name: String) {
     let mut client = get_auth_wallet_daemon_client(world, &wallet_daemon_name).await;
 
     let account = world.wallet_accounts.get(&account_name).cloned();

--- a/integration_tests/tests/steps/wallet_daemon.rs
+++ b/integration_tests/tests/steps/wallet_daemon.rs
@@ -207,16 +207,11 @@ async fn when_i_create_account_via_wallet_daemon_with_free_coins(
     step: &Step,
     account_name: String,
     wallet_daemon_name: String,
-    amount: u64,
+    // TODO: remove
+    _amount: u64,
 ) {
     cucumber_log!("==== Step: {}", step.value);
-    wallet_daemon_client::create_account_with_free_coins(
-        world,
-        account_name,
-        wallet_daemon_name,
-        amount * 1_000_000u64,
-    )
-    .await;
+    wallet_daemon_client::create_account_with_free_coins(world, account_name, wallet_daemon_name).await;
 }
 
 #[when(expr = "I burn {int}T on wallet {word} for wallet daemon {word} into proof {word}")]

--- a/utilities/tariswap_test_bench/src/accounts.rs
+++ b/utilities/tariswap_test_bench/src/accounts.rs
@@ -12,7 +12,12 @@ use tari_ootle_wallet_sdk::models::{Account, KeyBranch, KeyId};
 use tari_template_lib_types::{
     Amount,
     ResourceType,
-    constants::{TARI_TOKEN, XTR_FAUCET_COMPONENT_ADDRESS, XTR_FAUCET_VAULT_ADDRESS},
+    constants::{
+        TARI_TOKEN,
+        XTR_FAUCET_CLAIM_RESOURCE_ADDRESS,
+        XTR_FAUCET_COMPONENT_ADDRESS,
+        XTR_FAUCET_VAULT_ADDRESS,
+    },
 };
 
 use crate::{faucet::Faucet, runner::Runner};
@@ -41,6 +46,7 @@ impl Runner {
             .with_inputs([
                 SubstateRequirement::unversioned(XTR_FAUCET_COMPONENT_ADDRESS),
                 SubstateRequirement::unversioned(XTR_FAUCET_VAULT_ADDRESS),
+                SubstateRequirement::unversioned(XTR_FAUCET_CLAIM_RESOURCE_ADDRESS),
             ])
             .finish();
 
@@ -185,7 +191,7 @@ impl Runner {
                             .call_method(faucet.component_address, "take_free_coins", args![])
                             .put_last_instruction_output_on_workspace("faucet")
                             .call_method(account.component_address, "deposit", args![Workspace("faucet")])
-                            .call_method(XTR_FAUCET_COMPONENT_ADDRESS, "take", args![1_000_000])
+                            .call_method(XTR_FAUCET_COMPONENT_ADDRESS, "take", args![])
                             .put_last_instruction_output_on_workspace("funds")
                             .call_method(account.component_address, "deposit", args![Workspace("funds")])
                             .add_input(SubstateRequirement::unversioned(account.component_address))
@@ -194,6 +200,7 @@ impl Runner {
                 .with_inputs([
                     SubstateRequirement::unversioned(XTR_FAUCET_COMPONENT_ADDRESS),
                     SubstateRequirement::unversioned(XTR_FAUCET_VAULT_ADDRESS),
+                    SubstateRequirement::unversioned(XTR_FAUCET_CLAIM_RESOURCE_ADDRESS),
                     SubstateRequirement::unversioned(faucet.component_address),
                     SubstateRequirement::unversioned(faucet.resource_address),
                     SubstateRequirement::unversioned(faucet.vault_address),

--- a/utilities/tariswap_test_bench/src/accounts.rs
+++ b/utilities/tariswap_test_bench/src/accounts.rs
@@ -86,78 +86,84 @@ impl Runner {
         Ok(account.account)
     }
 
-    pub async fn create_accounts(
-        &mut self,
-        pay_fee_account: &Account,
-        account_key_indexes: RangeInclusive<u64>,
-    ) -> anyhow::Result<Vec<Account>> {
-        let key = self
-            .sdk
-            .key_manager_api()
-            .get_public_key(KeyId::derived(KeyBranch::Account, 0))?;
-        let key_index_start = *account_key_indexes.start();
-        let num_accounts = *account_key_indexes.end() as usize - key_index_start as usize + 1;
+    /// Creates accounts and funds each with XTR faucet tokens.
+    /// Each account is created in its own transaction (signed by its owner key) so that the
+    /// faucet's one-claim-per-signer limit is respected. Transactions are submitted concurrently
+    /// and then waited on.
+    pub async fn create_accounts(&mut self, account_key_indexes: RangeInclusive<u64>) -> anyhow::Result<Vec<Account>> {
+        let num_accounts = *account_key_indexes.end() as usize - *account_key_indexes.start() as usize + 1;
         let owners = account_key_indexes
             .map(|idx| {
                 let key = self
                     .sdk
                     .key_manager_api()
                     .get_public_key(KeyId::derived(KeyBranch::Account, idx))?;
-                Ok(key)
+                let account_key = self.sdk.key_manager_api().derive_account_key(idx)?;
+                Ok((key, account_key))
             })
             .collect::<anyhow::Result<Vec<_>>>()?;
 
-        let pay_fee_vault = self
-            .sdk
-            .accounts_api()
-            .get_vault_by_resource(&pay_fee_account.component_address, &TARI_TOKEN)?;
+        // Submit all account-creation transactions concurrently.
+        let mut pending = Vec::with_capacity(num_accounts);
+        for (owner_key, account_key) in &owners {
+            let owner_public_key = owner_key.public_key.to_byte_type();
+            let account_address = self
+                .sdk
+                .accounts_api()
+                .derive_account_address_from_public_key(&owner_public_key);
 
-        let transaction = self
-            .new_transaction_builder()
-            .pay_fee_from_component(
-                pay_fee_account.component_address,
-                Amount::ONE_THOUSAND * Amount::from_usize(owners.len()),
-            )
-            .then(|builder| {
-                owners.iter().fold(builder, |builder, owner| {
-                    builder.create_account(owner.public_key.to_byte_type())
+            let transaction = self
+                .new_transaction_builder()
+                .with_fee_instructions_builder(|builder| {
+                    builder
+                        .call_method(XTR_FAUCET_COMPONENT_ADDRESS, "take", args![])
+                        .put_last_instruction_output_on_workspace("coins")
+                        .create_account_with_bucket(owner_public_key, "coins")
+                        .pay_fee_from_component(account_address, 1000u64)
                 })
-            })
-            .with_inputs([
-                SubstateRequirement::unversioned(pay_fee_account.component_address),
-                SubstateRequirement::unversioned(pay_fee_vault.id),
-                SubstateRequirement::unversioned(pay_fee_vault.resource_address),
-            ])
-            .finish();
+                .with_inputs([
+                    SubstateRequirement::unversioned(XTR_FAUCET_COMPONENT_ADDRESS),
+                    SubstateRequirement::unversioned(XTR_FAUCET_VAULT_ADDRESS),
+                    SubstateRequirement::unversioned(XTR_FAUCET_CLAIM_RESOURCE_ADDRESS),
+                ])
+                .build_and_seal(&account_key.key);
 
-        let transaction = self.sdk.signer_api().sign(key.key_id, transaction)?;
+            let tx_id = self.submit_transaction(transaction).await?;
+            pending.push((tx_id, owner_key));
+        }
 
-        let finalize = self.submit_transaction_and_wait(transaction).await?;
-        let diff = finalize.result.any_accept().unwrap();
+        // Wait for all transactions and register accounts.
         let mut accounts = Vec::with_capacity(num_accounts);
+        for (tx_id, owner_key) in pending {
+            let finalize = self.wait_for_transaction(tx_id).await?;
+            let diff = finalize.result.any_accept().unwrap();
 
-        for owner in owners {
             let account_addr = diff
                 .up_iter()
-                .map(|(addr, _)| addr)
-                .filter_map(|addr| addr.as_component_address())
-                .filter(|addr| *addr != pay_fee_account.component_address)
-                .find(|addr| {
-                    self.sdk
-                        .accounts_api()
-                        .derive_account_address_from_public_key(&owner.public_key.to_byte_type()) ==
-                        *addr
-                })
+                .find_map(|(addr, _)| addr.as_component_address())
                 .expect("New account not found in diff");
+            let vault = diff
+                .up_iter()
+                .filter_map(|(addr, _)| addr.as_vault_id())
+                .find(|vault_id| *vault_id != XTR_FAUCET_VAULT_ADDRESS)
+                .expect("New vault not found in diff");
 
             self.sdk.accounts_api().add_account(
                 None,
                 &account_addr,
-                owner.key_id,
-                owner.key_id,
+                owner_key.key_id,
+                owner_key.key_id,
                 Epoch::zero(),
                 true,
                 false,
+            )?;
+            self.sdk.accounts_api().add_vault(
+                account_addr,
+                vault,
+                TARI_TOKEN,
+                ResourceType::Stealth,
+                Some("tTARI".to_string()),
+                6,
             )?;
             let account = self.sdk.accounts_api().get_account_by_address(&account_addr)?;
             accounts.push(account.account);
@@ -191,16 +197,10 @@ impl Runner {
                             .call_method(faucet.component_address, "take_free_coins", args![])
                             .put_last_instruction_output_on_workspace("faucet")
                             .call_method(account.component_address, "deposit", args![Workspace("faucet")])
-                            .call_method(XTR_FAUCET_COMPONENT_ADDRESS, "take", args![])
-                            .put_last_instruction_output_on_workspace("funds")
-                            .call_method(account.component_address, "deposit", args![Workspace("funds")])
                             .add_input(SubstateRequirement::unversioned(account.component_address))
                     })
                 })
                 .with_inputs([
-                    SubstateRequirement::unversioned(XTR_FAUCET_COMPONENT_ADDRESS),
-                    SubstateRequirement::unversioned(XTR_FAUCET_VAULT_ADDRESS),
-                    SubstateRequirement::unversioned(XTR_FAUCET_CLAIM_RESOURCE_ADDRESS),
                     SubstateRequirement::unversioned(faucet.component_address),
                     SubstateRequirement::unversioned(faucet.resource_address),
                     SubstateRequirement::unversioned(faucet.vault_address),
@@ -210,7 +210,7 @@ impl Runner {
                 .build_and_seal(&key.key);
 
             log::debug!(
-                "Submitted transaction {} to fund {} accounts",
+                "Submitted transaction {} to fund {} accounts with custom faucet tokens",
                 transaction.calculate_id(),
                 accounts.len()
             );
@@ -220,11 +220,7 @@ impl Runner {
                 .any_accept()
                 .unwrap()
                 .up_iter()
-                .filter(|(addr, _)| {
-                    *addr != XTR_FAUCET_COMPONENT_ADDRESS &&
-                        *addr != faucet.component_address &&
-                        *addr != fee_account.component_address
-                })
+                .filter(|(addr, _)| *addr != faucet.component_address && *addr != fee_account.component_address)
                 .filter_map(|(addr, substate)| {
                     Some((addr.as_component_address()?, substate.substate_value().component()?))
                 })
@@ -254,7 +250,7 @@ impl Runner {
                     )?;
                 }
             }
-            info!("✅ Funded 25 accounts");
+            info!("✅ Funded {} accounts with custom faucet tokens", accounts.len());
         }
 
         Ok(())

--- a/utilities/tariswap_test_bench/src/accounts.rs
+++ b/utilities/tariswap_test_bench/src/accounts.rs
@@ -33,7 +33,7 @@ impl Runner {
             .new_transaction_builder()
             .with_fee_instructions_builder(|builder| {
                 builder
-                    .call_method(XTR_FAUCET_COMPONENT_ADDRESS, "take", args![1_000_000_000])
+                    .call_method(XTR_FAUCET_COMPONENT_ADDRESS, "take", args![])
                     .put_last_instruction_output_on_workspace("coins")
                     .create_account_with_bucket(owner_public_key, "coins")
                     .pay_fee_from_component(account_address, 1000u64)

--- a/utilities/tariswap_test_bench/src/main.rs
+++ b/utilities/tariswap_test_bench/src/main.rs
@@ -47,7 +47,7 @@ async fn run(cli: cli::CommonArgs, _args: cli::RunArgs) -> anyhow::Result<()> {
         // We have to break up the transactions into batches due to log and event limits
         let start = i * 50;
         let end = start + 50;
-        accounts.extend(runner.create_accounts(&primary_account, start + 1..=end).await?);
+        accounts.extend(runner.create_accounts(start + 1..=end).await?);
         info!("⏳️ Created {}/1000 accounts...", end);
     }
     info!("✅ Created all accounts");

--- a/utilities/traffic-sim/src/sim.rs
+++ b/utilities/traffic-sim/src/sim.rs
@@ -279,7 +279,6 @@ impl TrafficSim {
                     .client
                     .create_free_test_coins(AccountsCreateFreeTestCoinsRequest {
                         account: resp.account.component_address.into(),
-                        amount: 1_000_000_000u64.into(),
                         max_fee: None,
                     })
                     .await?;
@@ -418,7 +417,6 @@ impl TrafficSim {
                 client
                     .create_free_test_coins(AccountsCreateFreeTestCoinsRequest {
                         account: (*account.component_address()).into(),
-                        amount: 1_000_000_000u64.into(),
                         max_fee: None,
                     })
                     .await?;

--- a/utilities/transaction_generator/src/transaction_builders/free_coins.rs
+++ b/utilities/transaction_generator/src/transaction_builders/free_coins.rs
@@ -8,7 +8,12 @@ use tari_engine_types::component::derive_component_address_from_public_key;
 use tari_ootle_common_types::{Network, SubstateRequirement};
 use tari_ootle_transaction::{Transaction, args};
 use tari_template_builtin::ACCOUNT_TEMPLATE_ADDRESS;
-use tari_template_lib_types::constants::{TARI_TOKEN, XTR_FAUCET_COMPONENT_ADDRESS, XTR_FAUCET_VAULT_ADDRESS};
+use tari_template_lib_types::constants::{
+    TARI_TOKEN,
+    XTR_FAUCET_CLAIM_RESOURCE_ADDRESS,
+    XTR_FAUCET_COMPONENT_ADDRESS,
+    XTR_FAUCET_VAULT_ADDRESS,
+};
 
 pub fn builder(network: Network) -> impl Fn(u64) -> Transaction {
     move |_: u64| -> Transaction {
@@ -29,6 +34,7 @@ pub fn builder(network: Network) -> impl Fn(u64) -> Transaction {
                 SubstateRequirement::unversioned(TARI_TOKEN),
                 SubstateRequirement::unversioned(XTR_FAUCET_COMPONENT_ADDRESS),
                 SubstateRequirement::unversioned(XTR_FAUCET_VAULT_ADDRESS),
+                SubstateRequirement::unversioned(XTR_FAUCET_CLAIM_RESOURCE_ADDRESS),
             ])
             .build_and_seal(&signer_secret_key)
     }

--- a/utilities/transaction_generator/src/transaction_builders/free_coins.rs
+++ b/utilities/transaction_generator/src/transaction_builders/free_coins.rs
@@ -20,7 +20,7 @@ pub fn builder(network: Network) -> impl Fn(u64) -> Transaction {
         Transaction::builder(network.as_byte())
             .with_fee_instructions_builder(|builder| {
                 builder
-                    .call_method(XTR_FAUCET_COMPONENT_ADDRESS, "take", args![5000])
+                    .call_method(XTR_FAUCET_COMPONENT_ADDRESS, "take", args![])
                     .put_last_instruction_output_on_workspace("free_coins")
                     .create_account_with_bucket(signer_public_key, "free_coins")
                     .call_method(account_address, "pay_fee", args![1000])


### PR DESCRIPTION
Description
---

This PR limits the XTR faucet so each user can only claim once. Before this
change, anyone could call the faucet many times and take unlimited tokens. Now
 each public key can only claim 1,000 TARI total, one time.

The take() method no longer accepts an amount. It always gives exactly 1,000
TARI.

Motivation and Context
---

The testnet faucet was completely open. This PR adds a simple limit: one claim per signing key.

We use NFTs as a "claim receipt". When a user calls take(), the
faucet mints an NFT with ID equal to the caller's public key, then immediately
 burns it. Even after burning, the NFT's ID stays recorded on-chain. If the
same key tries to claim again, the engine rejects the transaction because that
 NFT ID already exists.

How Has This Been Tested?
---

New tests in crates/template_builtin/tests/xtr_faucet.rs:

- First claim by a new key succeeds and gives 1,000 TARI
- Two different keys can each claim once independently
- A second claim by the same key is rejected with "Duplicate NFT token id"
- Using take() blocks a subsequent take_confidential() call from the same key (shared limit across both methods)

What process can a PR reviewer use to test or verify this change?
---

`cargo test -p tari_template_builtin -p tari_engine`

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify