### PR TITLE
feat(ootle-wasm): add sealTransaction and addTransactionSigner WASM bindings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7401,7 +7401,7 @@ dependencies = [
 
 [[package]]
 name = "ootle-wasm"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "console_error_panic_hook",
  "getrandom 0.2.17",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7411,11 +7411,12 @@ dependencies = [
 
 [[package]]
 name = "ootle-wasm-core"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "base64 0.22.1",
  "ootle_byte_type",
  "rand 0.8.5",
+ "serde",
  "serde_json",
  "tari_bor",
  "tari_crypto",

--- a/crates/ootle_wasm/core/Cargo.toml
+++ b/crates/ootle_wasm/core/Cargo.toml
@@ -17,6 +17,7 @@ tari_template_lib_types = { workspace = true, features = ["std"] }
 ootle_byte_type = { workspace = true, features = ["crypto"] }
 
 rand = { workspace = true }
+serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 base64 = { workspace = true }

--- a/crates/ootle_wasm/core/Cargo.toml
+++ b/crates/ootle_wasm/core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ootle-wasm-core"
 description = "Pure Rust crypto and encoding logic for Tari Ootle WASM — BOR encoding, transaction hashing, Schnorr signing, and key management"
-version = "0.3.1"
+version = "0.4.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/ootle_wasm/core/src/hash.rs
+++ b/crates/ootle_wasm/core/src/hash.rs
@@ -32,7 +32,7 @@ pub fn hash_unsigned_transaction_json(
     hash_unsigned_transaction(&tx, seal_signer_public_key)
 }
 
-fn public_key_bytes_from_bytes(bytes: &[u8]) -> Result<RistrettoPublicKeyBytes, OotleWasmError> {
+pub(crate) fn public_key_bytes_from_bytes(bytes: &[u8]) -> Result<RistrettoPublicKeyBytes, OotleWasmError> {
     // Validate that it's a valid curve point
     let pk =
         RistrettoPublicKey::from_canonical_bytes(bytes).map_err(|e| OotleWasmError::InvalidPublicKey(e.to_string()))?;

--- a/crates/ootle_wasm/core/src/lib.rs
+++ b/crates/ootle_wasm/core/src/lib.rs
@@ -6,3 +6,4 @@ pub mod bor;
 pub mod error;
 pub mod hash;
 pub mod sign;
+pub mod transaction;

--- a/crates/ootle_wasm/core/src/transaction.rs
+++ b/crates/ootle_wasm/core/src/transaction.rs
@@ -1,0 +1,160 @@
+//   Copyright 2026 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+use tari_crypto::{ristretto::RistrettoSecretKey, tari_utilities::ByteArray};
+use tari_ootle_transaction::{UnsealedTransactionV1, UnsignedTransactionV1};
+
+use crate::{error::OotleWasmError, hash::public_key_bytes_from_bytes};
+
+/// An unsigned or unsealed transaction parsed from JSON.
+enum TransactionInput {
+    Unsigned(UnsignedTransactionV1),
+    Unsealed(UnsealedTransactionV1),
+}
+
+impl TransactionInput {
+    fn into_unsealed(self) -> UnsealedTransactionV1 {
+        match self {
+            Self::Unsigned(tx) => UnsealedTransactionV1::new(tx, vec![]),
+            Self::Unsealed(tx) => tx,
+        }
+    }
+}
+
+/// Parse JSON as either an UnsealedTransactionV1 or UnsignedTransactionV1.
+fn parse_transaction_json(tx_json: &str) -> Result<TransactionInput, OotleWasmError> {
+    if let Ok(unsealed) = serde_json::from_str::<UnsealedTransactionV1>(tx_json) {
+        return Ok(TransactionInput::Unsealed(unsealed));
+    }
+    let unsigned: UnsignedTransactionV1 = serde_json::from_str(tx_json)?;
+    Ok(TransactionInput::Unsigned(unsigned))
+}
+
+fn secret_key_from_bytes(bytes: &[u8]) -> Result<RistrettoSecretKey, OotleWasmError> {
+    RistrettoSecretKey::from_canonical_bytes(bytes).map_err(|e| OotleWasmError::InvalidSecretKey(e.to_string()))
+}
+
+/// Seal a transaction (accepts unsigned or unsealed JSON) with the seal signer's secret key.
+///
+/// Returns the sealed `Transaction` as a JSON string.
+pub fn seal_transaction_json(tx_json: &str, seal_signer_secret_key: &[u8]) -> Result<String, OotleWasmError> {
+    let unsealed = parse_transaction_json(tx_json)?.into_unsealed();
+    let secret = secret_key_from_bytes(seal_signer_secret_key)?;
+    let sealed = unsealed.seal(&secret);
+    Ok(serde_json::to_string(&sealed)?)
+}
+
+/// Add a signer to a transaction (accepts unsigned or unsealed JSON).
+///
+/// Returns the unsealed transaction (with the new signature appended) as a JSON string.
+pub fn add_transaction_signer_json(
+    tx_json: &str,
+    signer_secret_key: &[u8],
+    seal_signer_public_key: &[u8],
+) -> Result<String, OotleWasmError> {
+    let unsealed = parse_transaction_json(tx_json)?.into_unsealed();
+    let secret = secret_key_from_bytes(signer_secret_key)?;
+    let seal_signer = public_key_bytes_from_bytes(seal_signer_public_key)?;
+    let unsealed = unsealed.add_signer(&seal_signer, &secret);
+    Ok(serde_json::to_string(&unsealed)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use ootle_byte_type::ToByteType;
+    use rand::rngs::OsRng;
+    use tari_crypto::{
+        keys::{PublicKey, SecretKey},
+        ristretto::{RistrettoPublicKey, RistrettoSecretKey},
+        tari_utilities::ByteArray,
+    };
+    use tari_ootle_transaction::{Transaction, UnsignedTransactionV1};
+
+    use super::*;
+
+    fn make_unsigned_tx() -> UnsignedTransactionV1 {
+        UnsignedTransactionV1::new(0u8, vec![], vec![], Default::default(), None, None, false)
+    }
+
+    #[test]
+    fn seal_unsigned_transaction() {
+        let secret = RistrettoSecretKey::random(&mut OsRng);
+        let unsigned_json = serde_json::to_string(&make_unsigned_tx()).unwrap();
+
+        let sealed_json = seal_transaction_json(&unsigned_json, secret.as_bytes()).unwrap();
+        let sealed: Transaction = serde_json::from_str(&sealed_json).unwrap();
+        assert!(sealed.verify_all_signatures());
+    }
+
+    #[test]
+    fn seal_unsealed_transaction() {
+        let seal_secret = RistrettoSecretKey::random(&mut OsRng);
+        let signer_secret = RistrettoSecretKey::random(&mut OsRng);
+        let seal_pk = RistrettoPublicKey::from_secret_key(&seal_secret);
+
+        // First add a signer to get an unsealed tx
+        let unsigned_json = serde_json::to_string(&make_unsigned_tx()).unwrap();
+        let unsealed_json = add_transaction_signer_json(
+            &unsigned_json,
+            signer_secret.as_bytes(),
+            seal_pk.as_bytes(),
+        )
+        .unwrap();
+
+        // Now seal the unsealed tx
+        let sealed_json = seal_transaction_json(&unsealed_json, seal_secret.as_bytes()).unwrap();
+        let sealed: Transaction = serde_json::from_str(&sealed_json).unwrap();
+        assert!(sealed.verify_all_signatures());
+    }
+
+    #[test]
+    fn add_signer_to_unsigned_transaction() {
+        let seal_secret = RistrettoSecretKey::random(&mut OsRng);
+        let seal_pk = RistrettoPublicKey::from_secret_key(&seal_secret);
+        let signer_secret = RistrettoSecretKey::random(&mut OsRng);
+
+        let unsigned_json = serde_json::to_string(&make_unsigned_tx()).unwrap();
+        let unsealed_json = add_transaction_signer_json(
+            &unsigned_json,
+            signer_secret.as_bytes(),
+            seal_pk.as_bytes(),
+        )
+        .unwrap();
+
+        let unsealed: UnsealedTransactionV1 = serde_json::from_str(&unsealed_json).unwrap();
+        assert_eq!(unsealed.signatures().len(), 1);
+        assert!(unsealed.verify_all_signatures(&seal_pk.to_byte_type()));
+    }
+
+    #[test]
+    fn add_multiple_signers() {
+        let seal_secret = RistrettoSecretKey::random(&mut OsRng);
+        let seal_pk = RistrettoPublicKey::from_secret_key(&seal_secret);
+        let signer1 = RistrettoSecretKey::random(&mut OsRng);
+        let signer2 = RistrettoSecretKey::random(&mut OsRng);
+
+        let unsigned_json = serde_json::to_string(&make_unsigned_tx()).unwrap();
+
+        // Add first signer (unsigned → unsealed)
+        let unsealed_json = add_transaction_signer_json(
+            &unsigned_json,
+            signer1.as_bytes(),
+            seal_pk.as_bytes(),
+        )
+        .unwrap();
+
+        // Add second signer (unsealed → unsealed)
+        let unsealed_json = add_transaction_signer_json(
+            &unsealed_json,
+            signer2.as_bytes(),
+            seal_pk.as_bytes(),
+        )
+        .unwrap();
+
+        // Seal and verify
+        let sealed_json = seal_transaction_json(&unsealed_json, seal_secret.as_bytes()).unwrap();
+        let sealed: Transaction = serde_json::from_str(&sealed_json).unwrap();
+        assert!(sealed.verify_all_signatures());
+        assert_eq!(sealed.signatures().len(), 2);
+    }
+}

--- a/crates/ootle_wasm/core/src/transaction.rs
+++ b/crates/ootle_wasm/core/src/transaction.rs
@@ -1,15 +1,18 @@
 //   Copyright 2026 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
+use serde::Deserialize;
 use tari_crypto::{ristretto::RistrettoSecretKey, tari_utilities::ByteArray};
 use tari_ootle_transaction::{UnsealedTransactionV1, UnsignedTransactionV1};
 
 use crate::{error::OotleWasmError, hash::public_key_bytes_from_bytes};
 
 /// An unsigned or unsealed transaction parsed from JSON.
+#[derive(Deserialize)]
+#[serde(untagged)]
 enum TransactionInput {
-    Unsigned(UnsignedTransactionV1),
     Unsealed(UnsealedTransactionV1),
+    Unsigned(UnsignedTransactionV1),
 }
 
 impl TransactionInput {
@@ -21,13 +24,8 @@ impl TransactionInput {
     }
 }
 
-/// Parse JSON as either an UnsealedTransactionV1 or UnsignedTransactionV1.
 fn parse_transaction_json(tx_json: &str) -> Result<TransactionInput, OotleWasmError> {
-    if let Ok(unsealed) = serde_json::from_str::<UnsealedTransactionV1>(tx_json) {
-        return Ok(TransactionInput::Unsealed(unsealed));
-    }
-    let unsigned: UnsignedTransactionV1 = serde_json::from_str(tx_json)?;
-    Ok(TransactionInput::Unsigned(unsigned))
+    serde_json::from_str(tx_json).map_err(Into::into)
 }
 
 fn secret_key_from_bytes(bytes: &[u8]) -> Result<RistrettoSecretKey, OotleWasmError> {
@@ -94,12 +92,8 @@ mod tests {
 
         // First add a signer to get an unsealed tx
         let unsigned_json = serde_json::to_string(&make_unsigned_tx()).unwrap();
-        let unsealed_json = add_transaction_signer_json(
-            &unsigned_json,
-            signer_secret.as_bytes(),
-            seal_pk.as_bytes(),
-        )
-        .unwrap();
+        let unsealed_json =
+            add_transaction_signer_json(&unsigned_json, signer_secret.as_bytes(), seal_pk.as_bytes()).unwrap();
 
         // Now seal the unsealed tx
         let sealed_json = seal_transaction_json(&unsealed_json, seal_secret.as_bytes()).unwrap();
@@ -114,12 +108,8 @@ mod tests {
         let signer_secret = RistrettoSecretKey::random(&mut OsRng);
 
         let unsigned_json = serde_json::to_string(&make_unsigned_tx()).unwrap();
-        let unsealed_json = add_transaction_signer_json(
-            &unsigned_json,
-            signer_secret.as_bytes(),
-            seal_pk.as_bytes(),
-        )
-        .unwrap();
+        let unsealed_json =
+            add_transaction_signer_json(&unsigned_json, signer_secret.as_bytes(), seal_pk.as_bytes()).unwrap();
 
         let unsealed: UnsealedTransactionV1 = serde_json::from_str(&unsealed_json).unwrap();
         assert_eq!(unsealed.signatures().len(), 1);
@@ -136,20 +126,12 @@ mod tests {
         let unsigned_json = serde_json::to_string(&make_unsigned_tx()).unwrap();
 
         // Add first signer (unsigned → unsealed)
-        let unsealed_json = add_transaction_signer_json(
-            &unsigned_json,
-            signer1.as_bytes(),
-            seal_pk.as_bytes(),
-        )
-        .unwrap();
+        let unsealed_json =
+            add_transaction_signer_json(&unsigned_json, signer1.as_bytes(), seal_pk.as_bytes()).unwrap();
 
         // Add second signer (unsealed → unsealed)
-        let unsealed_json = add_transaction_signer_json(
-            &unsealed_json,
-            signer2.as_bytes(),
-            seal_pk.as_bytes(),
-        )
-        .unwrap();
+        let unsealed_json =
+            add_transaction_signer_json(&unsealed_json, signer2.as_bytes(), seal_pk.as_bytes()).unwrap();
 
         // Seal and verify
         let sealed_json = seal_transaction_json(&unsealed_json, seal_secret.as_bytes()).unwrap();

--- a/crates/ootle_wasm/wasm/Cargo.toml
+++ b/crates/ootle_wasm/wasm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ootle-wasm"
 description = "WASM bindings for Tari Ootle client-side crypto — thin wasm-bindgen shell over ootle-wasm-core"
-version = "0.3.1"
+version = "0.4.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/ootle_wasm/wasm/Cargo.toml
+++ b/crates/ootle_wasm/wasm/Cargo.toml
@@ -13,7 +13,7 @@ readme = "../NPM_README.md"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-ootle-wasm-core = { path = "../core", version = "0.3.0" }
+ootle-wasm-core = { path = "../core", version = "0.4.0" }
 wasm-bindgen = "0.2"
 getrandom = { version = "0.2", features = ["js"] }
 

--- a/crates/ootle_wasm/wasm/src/lib.rs
+++ b/crates/ootle_wasm/wasm/src/lib.rs
@@ -55,6 +55,30 @@ pub struct ParsedOotleAddress {
     pub memo: Option<Vec<u8>>,
 }
 
+/// Seal a transaction (unsigned or unsealed JSON) with the seal signer's secret key.
+///
+/// Accepts either an `UnsignedTransactionV1` or `UnsealedTransactionV1` JSON string.
+/// Returns the sealed `Transaction` as a JSON string.
+#[wasm_bindgen(js_name = "sealTransaction")]
+pub fn seal_transaction(tx_json: &str, seal_signer_secret_key: &[u8]) -> Result<String, JsError> {
+    ootle_wasm_core::transaction::seal_transaction_json(tx_json, seal_signer_secret_key)
+        .map_err(|e| JsError::new(&e.to_string()))
+}
+
+/// Add a signer to a transaction (unsigned or unsealed JSON).
+///
+/// Accepts either an `UnsignedTransactionV1` or `UnsealedTransactionV1` JSON string.
+/// Returns the `UnsealedTransactionV1` (with the new signature appended) as a JSON string.
+#[wasm_bindgen(js_name = "addTransactionSigner")]
+pub fn add_transaction_signer(
+    tx_json: &str,
+    signer_secret_key: &[u8],
+    seal_signer_public_key: &[u8],
+) -> Result<String, JsError> {
+    ootle_wasm_core::transaction::add_transaction_signer_json(tx_json, signer_secret_key, seal_signer_public_key)
+        .map_err(|e| JsError::new(&e.to_string()))
+}
+
 /// BOR-encode a Transaction (JSON string) → base64 string (TransactionEnvelope format).
 #[wasm_bindgen(js_name = "borEncodeTransaction")]
 pub fn bor_encode_transaction(transaction_json: &str) -> Result<String, JsError> {


### PR DESCRIPTION
## Description

Adds two new WASM-exported functions to `ootle_wasm` for signing transactions in browser/JS environments.

## Motivation

Browser and JS clients need to be able to sign transactions client-side without depending on native code. These bindings expose the existing Rust signing logic through the WASM interface.

## Changes

- Add `sealTransaction(tx_json, seal_signer_secret_key)` — seals an unsigned or unsealed transaction with the seal signer's secret key, returning the sealed `Transaction` as JSON
- Add `addTransactionSigner(tx_json, signer_secret_key, seal_signer_public_key)` — appends a co-signer signature to an unsigned or unsealed transaction, returning the `UnsealedTransactionV1` as JSON
- Both functions accept either `UnsignedTransactionV1` or `UnsealedTransactionV1` JSON input
- Core logic extracted into `ootle_wasm_core::transaction` module with full unit test coverage (seal unsigned, seal unsealed, add single signer, add multiple signers)