### PR TITLE
fix(template-macros): derive Serialize/Deserialize on template structs in non-wasm codepath

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11975,7 +11975,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_lib"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "borsh",
  "serde",
@@ -12005,7 +12005,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_macros"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "indoc",
  "proc-macro2",

--- a/crates/template_lib/Cargo.toml
+++ b/crates/template_lib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_template_lib"
 description = "Tari template library provides abstrations that interface with the Tari validator engine"
-version = "0.22.0"
+version = "0.22.1"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/template_lib/src/lib.rs
+++ b/crates/template_lib/src/lib.rs
@@ -176,7 +176,7 @@ pub use engine::engine;
 pub mod panic_hook;
 pub mod prelude;
 // Re-export for macro
-pub use tari_bor::to_value;
+pub use tari_bor::{serde, to_value};
 
 #[macro_use]
 pub mod macros;

--- a/crates/template_macros/Cargo.toml
+++ b/crates/template_macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_template_macros"
 description = "Tari template macro"
-version = "0.17.0"
+version = "0.17.1"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/template_macros/src/lib.rs
+++ b/crates/template_macros/src/lib.rs
@@ -37,8 +37,32 @@ pub fn template(_attr: TokenStream, item: TokenStream) -> TokenStream {
 }
 
 /// Returns the template code without the wasm ABI code. This allows the code to compile for non-WASM targets and allows
-/// "intellisense" to work in IDEs.
+/// "intellisense" to work in IDEs. Struct items within the module get serde derives injected so that
+/// `Component::new` (which requires `T: serde::Serialize`) compiles on non-wasm targets.
 #[proc_macro_attribute]
 pub fn template_non_wasm(_attr: TokenStream, item: TokenStream) -> TokenStream {
-    item
+    let mut module: syn::ItemMod = match syn::parse(item.clone()) {
+        Ok(m) => m,
+        // If it doesn't parse as a module, return verbatim
+        Err(_) => return item,
+    };
+
+    if let Some((brace, items)) = &mut module.content {
+        let new_items = items
+            .drain(..)
+            .map(|item| match item {
+                syn::Item::Struct(mut s) => {
+                    let derive: syn::Attribute = syn::parse_quote! {
+                        #[derive(::tari_template_lib::serde::Serialize, ::tari_template_lib::serde::Deserialize)]
+                    };
+                    s.attrs.push(derive);
+                    syn::Item::Struct(s)
+                },
+                other => other,
+            })
+            .collect();
+        module.content = Some((*brace, new_items));
+    }
+
+    quote::quote!(#module).into()
 }


### PR DESCRIPTION
## Description

The `#[template]` proc macro's non-wasm codepath did not derive `Serialize`/`Deserialize` on template structs. This caused `cargo test` to fail because `Component::new` requires `T: serde::Serialize`.

## Motivation

Template authors writing tests with `#[cfg(test)]` blocks (the non-wasm codepath) would hit compile errors at `Component::new(state)` since the struct lacked the required serde bounds. This makes the `#[template]` macro unusable for unit testing.

## Changes

- `crates/template_macros/src/lib.rs` — `template_non_wasm` now parses the module, finds struct items, and injects `#[derive(::tari_template_lib::serde::Serialize, ::tari_template_lib::serde::Deserialize)]` on each before emitting
- `crates/template_lib/src/lib.rs` — Added `pub use tari_bor::serde` re-export so the `::tari_template_lib::serde` path resolves in the injected derive
- Version bumps: `tari_template_macros` 0.17.0 → 0.17.1, `tari_template_lib` 0.22.0 → 0.22.1