### PR TITLE
fix(template-macros): add serde crate path attribute for non-wasm derive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11975,7 +11975,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_lib"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "borsh",
  "serde",
@@ -12005,7 +12005,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_macros"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "indoc",
  "proc-macro2",

--- a/crates/template_lib/Cargo.toml
+++ b/crates/template_lib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_template_lib"
 description = "Tari template library provides abstrations that interface with the Tari validator engine"
-version = "0.22.1"
+version = "0.22.2"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/template_macros/Cargo.toml
+++ b/crates/template_macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_template_macros"
 description = "Tari template macro"
-version = "0.17.1"
+version = "0.17.2"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/template_macros/src/lib.rs
+++ b/crates/template_macros/src/lib.rs
@@ -52,14 +52,12 @@ pub fn template_non_wasm(_attr: TokenStream, item: TokenStream) -> TokenStream {
             .drain(..)
             .map(|item| match item {
                 syn::Item::Struct(mut s) => {
-                    let derive: syn::Attribute = syn::parse_quote! {
+                    s.attrs.push(syn::parse_quote! {
                         #[derive(::tari_template_lib::serde::Serialize, ::tari_template_lib::serde::Deserialize)]
-                    };
-                    let serde_crate: syn::Attribute = syn::parse_quote! {
+                    });
+                    s.attrs.push(syn::parse_quote! {
                         #[serde(crate = "::tari_template_lib::serde")]
-                    };
-                    s.attrs.push(derive);
-                    s.attrs.push(serde_crate);
+                    });
                     syn::Item::Struct(s)
                 },
                 other => other,

--- a/crates/template_macros/src/lib.rs
+++ b/crates/template_macros/src/lib.rs
@@ -55,7 +55,11 @@ pub fn template_non_wasm(_attr: TokenStream, item: TokenStream) -> TokenStream {
                     let derive: syn::Attribute = syn::parse_quote! {
                         #[derive(::tari_template_lib::serde::Serialize, ::tari_template_lib::serde::Deserialize)]
                     };
+                    let serde_crate: syn::Attribute = syn::parse_quote! {
+                        #[serde(crate = "::tari_template_lib::serde")]
+                    };
                     s.attrs.push(derive);
+                    s.attrs.push(serde_crate);
                     syn::Item::Struct(s)
                 },
                 other => other,


### PR DESCRIPTION
## Summary

- Adds `#[serde(crate = "::tari_template_lib::serde")]` alongside the serde derive attributes injected by the `#[template]` macro's non-wasm codepath
- Fixes compile error where serde's derive macros generate code referencing `::serde::...` which fails because template crates don't depend on serde directly

## Motivation

PR #1925 added `Serialize`/`Deserialize` derives to template structs in the non-wasm codepath using the re-exported serde from `tari_template_lib`. However, serde's derive macros internally hard-code generated code that references `::serde::...`. The `#[serde(crate = "...")]` attribute redirects serde's generated code to use the re-exported path.