### PR TITLE
fix(template-macros): suppress dead_code warnings on non-wasm template module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12005,7 +12005,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_macros"
-version = "0.17.2"
+version = "0.17.3"
 dependencies = [
  "indoc",
  "proc-macro2",

--- a/crates/template_macros/Cargo.toml
+++ b/crates/template_macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_template_macros"
 description = "Tari template macro"
-version = "0.17.2"
+version = "0.17.3"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/template_macros/src/lib.rs
+++ b/crates/template_macros/src/lib.rs
@@ -66,5 +66,5 @@ pub fn template_non_wasm(_attr: TokenStream, item: TokenStream) -> TokenStream {
         module.content = Some((*brace, new_items));
     }
 
-    quote::quote!(#module).into()
+    quote::quote!(#[allow(dead_code)] #module).into()
 }


### PR DESCRIPTION
## Description

Adds `#[allow(dead_code)]` to the module emitted by the `#[template]` macro's non-wasm codepath. Template structs and methods are only used on wasm32 targets, so these warnings are expected on native builds.

## Motivation

When building templates for non-wasm targets (e.g. in tests or native tooling), the compiler emits `dead_code` warnings for the generated module contents. These warnings are spurious — the code is intentionally unused outside of wasm32 — and suppressing them at the macro level avoids noise for all downstream template crates.

## Changes

- Add `#[allow(dead_code)]` attribute to the module emitted by `template_non_wasm` proc-macro
- Bump `tari_template_macros` version 0.17.2 → 0.17.3