### PR TITLE
chore: improve CI performance

### DIFF
--- a/.github/actions/rust-cache/action.yml
+++ b/.github/actions/rust-cache/action.yml
@@ -18,6 +18,7 @@ runs:
     - name: caching
       uses: Swatinem/rust-cache@v2
       with:
+        shared-key: ootle
         cache-all-crates: true
 
     - name: cache diagnostics (after restore)

--- a/.github/actions/rust-cache/action.yml
+++ b/.github/actions/rust-cache/action.yml
@@ -8,33 +8,9 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: cache diagnostics (before restore)
-      shell: bash
-      run: |
-        echo "=== Disk space ==="
-        df -h
-        echo "=== target/ ==="
-        du -sh target/ 2>/dev/null || echo "(no target dir)"
-        echo "=== ~/.cargo/registry/ ==="
-        du -sh ~/.cargo/registry/ 2>/dev/null || echo "(no cargo registry)"
-        echo "=== ~/.cargo/git/ ==="
-        du -sh ~/.cargo/git/ 2>/dev/null || echo "(no cargo git)"
-
     - name: caching
       uses: Swatinem/rust-cache@v2
       with:
         prefix-key: v0-rust-ci-build
         cache-all-crates: true
         save-if: ${{ inputs.save-if }}
-
-    - name: cache diagnostics (after restore)
-      shell: bash
-      run: |
-        echo "=== Disk space after cache restore ==="
-        df -h
-        echo "=== target/ ==="
-        du -sh target/ 2>/dev/null || echo "(no target dir — cache miss or not cached)"
-        echo "=== ~/.cargo/registry/ ==="
-        du -sh ~/.cargo/registry/ 2>/dev/null || echo "(no cargo registry)"
-        echo "=== ~/.cargo/git/ ==="
-        du -sh ~/.cargo/git/ 2>/dev/null || echo "(no cargo git)"

--- a/.github/actions/rust-cache/action.yml
+++ b/.github/actions/rust-cache/action.yml
@@ -1,5 +1,10 @@
 name: 'Rust Cache'
 description: 'Cache Rust build artifacts using Swatinem/rust-cache'
+inputs:
+  save-if:
+    description: 'Whether to save the cache after the job'
+    required: false
+    default: 'true'
 runs:
   using: composite
   steps:
@@ -18,8 +23,8 @@ runs:
     - name: caching
       uses: Swatinem/rust-cache@v2
       with:
-        shared-key: ootle
         cache-all-crates: true
+        save-if: ${{ inputs.save-if }}
 
     - name: cache diagnostics (after restore)
       shell: bash

--- a/.github/actions/rust-cache/action.yml
+++ b/.github/actions/rust-cache/action.yml
@@ -23,6 +23,7 @@ runs:
     - name: caching
       uses: Swatinem/rust-cache@v2
       with:
+        prefix-key: v0-rust-ci-build
         cache-all-crates: true
         save-if: ${{ inputs.save-if }}
 

--- a/.github/actions/rust-cache/action.yml
+++ b/.github/actions/rust-cache/action.yml
@@ -1,18 +1,33 @@
 name: 'Rust Cache'
-description: 'Cache Rust build artifacts using local cache with restoreKeys for partial hits'
+description: 'Cache Rust build artifacts using Swatinem/rust-cache'
 runs:
   using: composite
   steps:
+    - name: cache diagnostics (before restore)
+      shell: bash
+      run: |
+        echo "=== Disk space ==="
+        df -h
+        echo "=== target/ ==="
+        du -sh target/ 2>/dev/null || echo "(no target dir)"
+        echo "=== ~/.cargo/registry/ ==="
+        du -sh ~/.cargo/registry/ 2>/dev/null || echo "(no cargo registry)"
+        echo "=== ~/.cargo/git/ ==="
+        du -sh ~/.cargo/git/ 2>/dev/null || echo "(no cargo git)"
+
     - name: caching
-      uses: maxnowack/local-cache@v2
+      uses: Swatinem/rust-cache@v2
       with:
-        path: |
-          ~/.cargo/registry/index
-          ~/.cargo/registry/cache
-          ~/.cargo/registry/CACHEDIR.TAG
-          ~/.cargo/git
-          target
-        key: ootle-${{ runner.os }}-${{ runner.cpu-model }}-${{ env.stable_toolchain }}-${{ hashFiles('**/Cargo.lock') }}
-        restore-keys: |
-          ootle-${{ runner.os }}-${{ runner.cpu-model }}-${{ env.stable_toolchain }}-${{ hashFiles('**/Cargo.lock') }}
-          ootle-${{ runner.os }}-${{ runner.cpu-model }}-${{ env.stable_toolchain }}
+        cache-all-crates: true
+
+    - name: cache diagnostics (after restore)
+      shell: bash
+      run: |
+        echo "=== Disk space after cache restore ==="
+        df -h
+        echo "=== target/ ==="
+        du -sh target/ 2>/dev/null || echo "(no target dir — cache miss or not cached)"
+        echo "=== ~/.cargo/registry/ ==="
+        du -sh ~/.cargo/registry/ 2>/dev/null || echo "(no cargo registry)"
+        echo "=== ~/.cargo/git/ ==="
+        du -sh ~/.cargo/git/ 2>/dev/null || echo "(no cargo git)"

--- a/.github/actions/rust-cache/action.yml
+++ b/.github/actions/rust-cache/action.yml
@@ -1,0 +1,18 @@
+name: 'Rust Cache'
+description: 'Cache Rust build artifacts using local cache with restoreKeys for partial hits'
+runs:
+  using: composite
+  steps:
+    - name: caching
+      uses: maxnowack/local-cache@v2
+      with:
+        path: |
+          ~/.cargo/registry/index
+          ~/.cargo/registry/cache
+          ~/.cargo/registry/CACHEDIR.TAG
+          ~/.cargo/git
+          target
+        key: ootle-${{ runner.os }}-${{ runner.cpu-model }}-${{ env.stable_toolchain }}-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ootle-${{ runner.os }}-${{ runner.cpu-model }}-${{ env.stable_toolchain }}-${{ hashFiles('**/Cargo.lock') }}
+          ootle-${{ runner.os }}-${{ runner.cpu-model }}-${{ env.stable_toolchain }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,6 +181,8 @@ jobs:
         run: rustup show
 
       - uses: ./.github/actions/rust-cache
+        with:
+          save-if: ${{ matrix.partition == '1/3' }}
 
       - name: ubuntu dependencies
         run: |
@@ -198,7 +200,7 @@ jobs:
           tool: cargo-nextest
 
       - name: cargo test
-        run: cargo nextest run --all-features --release --profile ci --partition hash:${{ matrix.partition }}
+        run: cargo nextest run --all-features --cargo-profile ci-build --profile ci --partition hash:${{ matrix.partition }}
 
       - name: target dir size
         if: always()
@@ -274,7 +276,7 @@ jobs:
         run: rustup target add wasm32-unknown-unknown
 
       - name: cargo test cucumber
-        run: cargo test --release --package integration_tests --test cucumber
+        run: cargo test --profile ci-build --package integration_tests --test cucumber
 
       - name: target dir size
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,7 +230,7 @@ jobs:
 
   # Required status check placeholder — satisfies the "check stable" branch protection
   # rule. The full workspace is already compiled by the test shards on stable.
-  check stable:
+  check-stable:
     name: check stable
     if: always()
     needs: [ test-shards ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,9 @@ jobs:
           toolchain: ${{ env.stable_toolchain }}
           components: clippy
 
+      - name: rustup show
+        run: rustup show
+
       - uses: ./.github/actions/rust-cache
 
       - name: ubuntu dependencies
@@ -99,6 +102,10 @@ jobs:
       - name: Clippy check (with lints)
         run: cargo lints clippy --all-targets --all-features
 
+      - name: target dir size
+        if: always()
+        run: du -sh target/ 2>/dev/null || true
+
   machete:
     # Checks for unused dependencies.
     name: machete
@@ -114,6 +121,9 @@ jobs:
           toolchain: ${{ env.stable_toolchain }}
           components: clippy, rustfmt
 
+      - name: rustup show
+        run: rustup show
+
       - uses: ./.github/actions/rust-cache
 
       - name: ubuntu dependencies
@@ -126,39 +136,9 @@ jobs:
           cargo install cargo-machete
           cargo machete
 
-  build-stable:
-    name: check stable
-    runs-on: [ ubuntu-latest ]
-    env:
-      RUSTUP_PERMIT_COPY_RENAME: true
-
-    steps:
-      - name: checkout
-        uses: actions/checkout@v6
-
-      - name: toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: stable
-
-      - uses: ./.github/actions/rust-cache
-
-      - name: ubuntu dependencies
-        run: |
-          sudo apt-get update
-          sudo bash scripts/install_ubuntu_dependencies.sh
-
-      - uses: rui314/setup-mold@v1
-
-      - name: wasm target install
-        run: rustup target add wasm32-unknown-unknown
-
-      - name: rustup show
-        run: |
-          rustup show
-
-      - name: cargo check
-        run: cargo check --release --all-features --all-targets --locked
+      - name: target dir size
+        if: always()
+        run: du -sh target/ 2>/dev/null || true
 
   licenses:
     name: file licenses
@@ -182,8 +162,11 @@ jobs:
         run: ./scripts/file_license_check.sh
 
   test:
-    name: test
+    name: test (${{ matrix.partition }})
     runs-on: [ ubuntu-latest ]
+    strategy:
+      matrix:
+        partition: ["1/3", "2/3", "3/3"]
 
     steps:
       - name: checkout
@@ -193,6 +176,9 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ env.stable_toolchain }}
+
+      - name: rustup show
+        run: rustup show
 
       - uses: ./.github/actions/rust-cache
 
@@ -211,17 +197,18 @@ jobs:
         with:
           tool: cargo-nextest
 
-      - name: cargo test compile
-        run: cargo test --no-run --locked --all-features --release
-
       - name: cargo test
-        run: cargo nextest run --all-features --release --profile ci
+        run: cargo nextest run --all-features --release --profile ci --partition hash:${{ matrix.partition }}
+
+      - name: target dir size
+        if: always()
+        run: du -sh target/ 2>/dev/null || true
 
       - name: upload artifact
         uses: actions/upload-artifact@v7 # upload test results as artifact
         if: success() || failure()
         with:
-          name: test-results
+          name: test-results-${{ strategy.job-index }}
           path: ${{ github.workspace }}/target/nextest/ci/junit.xml
 
   integration-test:
@@ -237,6 +224,9 @@ jobs:
         with:
           toolchain: ${{ env.stable_toolchain }}
 
+      - name: rustup show
+        run: rustup show
+
       - uses: ./.github/actions/rust-cache
 
       - name: ubuntu dependencies
@@ -251,6 +241,10 @@ jobs:
 
       - name: cargo test cucumber
         run: cargo test --release --package integration_tests --test cucumber
+
+      - name: target dir size
+        if: always()
+        run: du -sh target/ 2>/dev/null || true
 
       - name: upload test result artifact
         uses: actions/upload-artifact@v7 # upload test results as artifact

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,7 @@ jobs:
       - name: run the license check
         run: ./scripts/file_license_check.sh
 
-  test:
+  test-shards:
     name: test (${{ matrix.partition }})
     runs-on: [ ubuntu-latest ]
     strategy:
@@ -210,6 +210,40 @@ jobs:
         with:
           name: test-results-${{ strategy.job-index }}
           path: ${{ github.workspace }}/target/nextest/ci/junit.xml
+
+  # Required status check aggregator — satisfies the branch protection rule named "test"
+  # without requiring branch protection rule changes.
+  test:
+    name: test
+    if: always()
+    needs: [ test-shards ]
+    runs-on: [ ubuntu-latest ]
+    steps:
+      - name: check shard results
+        run: |
+          result="${{ needs.test-shards.result }}"
+          echo "test-shards result: $result"
+          if [[ "$result" != "success" ]]; then
+            echo "One or more test shards failed or were cancelled"
+            exit 1
+          fi
+
+  # Required status check placeholder — satisfies the "check stable" branch protection
+  # rule. The full workspace is already compiled by the test shards on stable.
+  check stable:
+    name: check stable
+    if: always()
+    needs: [ test-shards ]
+    runs-on: [ ubuntu-latest ]
+    steps:
+      - name: check shard results
+        run: |
+          result="${{ needs.test-shards.result }}"
+          echo "test-shards result: $result"
+          if [[ "$result" != "success" ]]; then
+            echo "Compilation check failed (test shards did not pass)"
+            exit 1
+          fi
 
   integration-test:
     name: integration test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ env:
   stable_toolchain: stable
   CARGO_HTTP_MULTIPLEXING: false
   CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
   TARI_TARGET_NETWORK: localnet
   TARI_NETWORK: localnet
   # https://github.com/rust-lang/rustup/issues/2949#issuecomment-2584968659
@@ -46,14 +47,6 @@ jobs:
         with:
           toolchain: ${{ env.nightly_toolchain }}
           components: rustfmt
-
-      - name: ubuntu dependencies
-        run: |
-          sudo apt-get update
-          sudo bash scripts/install_ubuntu_dependencies.sh
-
-      - name: wasm target install
-        run: rustup target add wasm32-unknown-unknown
 
       - name: cargo format
         run: cargo +${{ env.nightly_toolchain }} fmt --all -- --check
@@ -88,6 +81,8 @@ jobs:
           toolchain: ${{ env.stable_toolchain }}
           components: clippy
 
+      - uses: ./.github/actions/rust-cache
+
       - name: ubuntu dependencies
         run: |
           sudo apt-get update
@@ -119,6 +114,8 @@ jobs:
           toolchain: ${{ env.stable_toolchain }}
           components: clippy, rustfmt
 
+      - uses: ./.github/actions/rust-cache
+
       - name: ubuntu dependencies
         run: |
           sudo apt-get update
@@ -144,7 +141,7 @@ jobs:
         with:
           toolchain: stable
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: ./.github/actions/rust-cache
 
       - name: ubuntu dependencies
         run: |
@@ -197,6 +194,8 @@ jobs:
         with:
           toolchain: ${{ env.stable_toolchain }}
 
+      - uses: ./.github/actions/rust-cache
+
       - name: ubuntu dependencies
         run: |
           sudo apt-get update
@@ -208,7 +207,9 @@ jobs:
         run: rustup target add wasm32-unknown-unknown
 
       - name: Install cargo-nextest
-        run: cargo install cargo-nextest --locked
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
 
       - name: cargo test compile
         run: cargo test --no-run --locked --all-features --release
@@ -222,6 +223,31 @@ jobs:
         with:
           name: test-results
           path: ${{ github.workspace }}/target/nextest/ci/junit.xml
+
+  integration-test:
+    name: integration test
+    runs-on: [ ubuntu-latest ]
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v6
+
+      - name: toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.stable_toolchain }}
+
+      - uses: ./.github/actions/rust-cache
+
+      - name: ubuntu dependencies
+        run: |
+          sudo apt-get update
+          sudo bash scripts/install_ubuntu_dependencies.sh
+
+      - uses: rui314/setup-mold@v1
+
+      - name: wasm target install
+        run: rustup target add wasm32-unknown-unknown
 
       - name: cargo test cucumber
         run: cargo test --release --package integration_tests --test cucumber

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,9 +81,6 @@ jobs:
           toolchain: ${{ env.stable_toolchain }}
           components: clippy
 
-      - name: rustup show
-        run: rustup show
-
       - uses: ./.github/actions/rust-cache
 
       - name: ubuntu dependencies
@@ -120,9 +117,6 @@ jobs:
         with:
           toolchain: ${{ env.stable_toolchain }}
           components: clippy, rustfmt
-
-      - name: rustup show
-        run: rustup show
 
       - uses: ./.github/actions/rust-cache
 
@@ -177,9 +171,6 @@ jobs:
         with:
           toolchain: ${{ env.stable_toolchain }}
 
-      - name: rustup show
-        run: rustup show
-
       - uses: ./.github/actions/rust-cache
         with:
           save-if: ${{ matrix.partition == '1/3' }}
@@ -223,9 +214,7 @@ jobs:
     steps:
       - name: check shard results
         run: |
-          result="${{ needs.test-shards.result }}"
-          echo "test-shards result: $result"
-          if [[ "$result" != "success" ]]; then
+          if [[ "${{ needs.test-shards.result }}" != "success" ]]; then
             echo "One or more test shards failed or were cancelled"
             exit 1
           fi
@@ -240,9 +229,7 @@ jobs:
     steps:
       - name: check shard results
         run: |
-          result="${{ needs.test-shards.result }}"
-          echo "test-shards result: $result"
-          if [[ "$result" != "success" ]]; then
+          if [[ "${{ needs.test-shards.result }}" != "success" ]]; then
             echo "Compilation check failed (test shards did not pass)"
             exit 1
           fi
@@ -259,9 +246,6 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ env.stable_toolchain }}
-
-      - name: rustup show
-        run: rustup show
 
       - uses: ./.github/actions/rust-cache
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -282,6 +282,12 @@ panic = 'abort'
 # seen in debug mode. Panicking at this time is better than silently using the wrong value.
 overflow-checks = true
 
+# CI profile: faster compilation than release (opt-level=1 vs 3), same safety settings.
+# Cuts compile time roughly in half at the cost of slightly slower test execution.
+[profile.ci-build]
+inherits = "release"
+opt-level = 1
+
 ## Make a copy of this code, uncomment and replace account and my-branch with the name of your fork and the branch you want to temporarily use
 #[patch."https://github.com/tari-project/tari.git"]
 #minotari_app_grpc = { git = "https://github.com/account/tari.git", branch = "my-branch" }


### PR DESCRIPTION
Description
---

Improve CI performance by removing unnecessary steps, adding proper caching, using faster tool installation, and running unit and integration tests in parallel.

  | Job | Before | After | Notes |
  |-----|-------:|------:|-------|
  | `fmt` | ~1m | ~1m | unchanged |
  | `prettier` | ~1m | ~1m | unchanged |
  | `file licenses` | ~1m | ~1m | unchanged |
  | `machete` | ~1m 30s | ~55s | + Rust cache |
  | `clippy` | ~17m | ~4m | + Rust cache |
  | `build-stable` (cargo check) | ~22m | — | removed — redundant, test shards already compile on stable |
  | `test` (unit tests, single job) | ~2h | — | replaced by shards below |
  | `test (1/3)` | — | ~21m | new: parallel shard |
  | `test (2/3)` | — | ~19m | new: parallel shard |
  | `test (3/3)` | — | ~18m | new: parallel shard |
  | `integration test` | _(part of `test` above)_ | ~34m | now a separate parallel job |
  | | | | |
  | **Wall clock** | **~2h** | **~34m** | **3.5× faster** |

Motivation and Context
---

- `fmt` job was installing system dependencies and wasm target. Neither is needed for `cargo fmt`
- No caching in most jobs, causing full recompilation on every run
- `cargo-nextest` was compiled from source on every run; replaced with `taiki-e/install-action` (prebuilt binary)
- Cucumber integration tests ran sequentially after unit tests; split into a separate `integration-test` job to run in parallel
- `CARGO_INCREMENTAL=0` reduces artifact size, better suited for CI

How Has This Been Tested?
---

CI pipeline execution.

What process can a PR reviewer use to test or verify this change?
---

Check that all CI jobs pass on this PR. Verify jobs run faster compared to previous runs.

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify