### PR TITLE
feat(walletd): add reset subcommand to clear the wallet database

### DIFF
--- a/applications/tari_walletd/src/cli.rs
+++ b/applications/tari_walletd/src/cli.rs
@@ -170,4 +170,14 @@ pub enum Subcommand {
         about = "Get current seed words of wallet (used for wallet retrieval)"
     )]
     SeedWords,
+    #[clap(
+        name = "reset",
+        about = "Reset the wallet by deleting all on-chain state. Intended for testnet resets only. The seed key is \
+                 preserved in the OS keyring."
+    )]
+    Reset {
+        /// Skip the interactive confirmation prompt
+        #[clap(long)]
+        confirm: bool,
+    },
 }

--- a/applications/tari_walletd/src/main.rs
+++ b/applications/tari_walletd/src/main.rs
@@ -200,7 +200,7 @@ async fn main() -> Result<(), anyhow::Error> {
 
             let timestamp = std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
+                .context("System time is before the UNIX epoch")?
                 .as_secs();
             let bak_path = db_path.with_extension(format!("sqlite.{timestamp}.bak"));
             match tokio::fs::rename(&db_path, &bak_path).await {

--- a/applications/tari_walletd/src/main.rs
+++ b/applications/tari_walletd/src/main.rs
@@ -170,6 +170,52 @@ async fn main() -> Result<(), anyhow::Error> {
 
             return Ok(());
         },
+        Some(Subcommand::Reset { confirm }) => {
+            let network = cli.network();
+            if !network.is_testnet() {
+                anyhow::bail!("The reset command is not available on mainnet");
+            }
+
+            let db_path = config.to_data_dir().join("wallet.sqlite");
+
+            println!(
+                "This command is intended for testnet resets only.\nIt will move the wallet database at '{}' to a \
+                 .bak file, removing all accounts,\ntransactions, balances and other on-chain state.\nYour seed key \
+                 is preserved in the OS keyring and can be used to recover accounts.",
+                db_path.display()
+            );
+
+            if !confirm {
+                eprint!("\nAre you sure you want to reset the wallet? Type 'yes' to continue: ");
+                let mut input = String::new();
+                tokio::io::AsyncBufReadExt::read_line(&mut tokio::io::BufReader::new(tokio::io::stdin()), &mut input)
+                    .await?;
+                if input.trim() != "yes" {
+                    println!("Reset cancelled.");
+                    return Ok(());
+                }
+            }
+
+            let timestamp = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_secs();
+            let bak_path = db_path.with_extension(format!("sqlite.{timestamp}.bak"));
+            match tokio::fs::rename(&db_path, &bak_path).await {
+                Ok(()) => println!(
+                    "Wallet database moved to '{}'.\nThe wallet will be recreated on next startup.",
+                    bak_path.display()
+                ),
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                    println!("No wallet database found at '{}'. Nothing to reset.", db_path.display());
+                },
+                Err(e) => {
+                    anyhow::bail!("Failed to move wallet database: {}", e);
+                },
+            }
+
+            return Ok(());
+        },
         Some(Subcommand::SeedWords) => {
             let wallet_store = init_wallet_store(&config)?;
             let mut sdk = initialize_wallet_sdk(&config, wallet_store)?;

--- a/applications/tari_walletd/src/main.rs
+++ b/applications/tari_walletd/src/main.rs
@@ -186,7 +186,9 @@ async fn main() -> Result<(), anyhow::Error> {
             );
 
             if !confirm {
-                eprint!("\nAre you sure you want to reset the wallet? Type 'yes' to continue: ");
+                use std::io::Write;
+                print!("\nAre you sure you want to reset the wallet? Type 'yes' to continue: ");
+                std::io::stdout().flush()?;
                 let mut input = String::new();
                 tokio::io::AsyncBufReadExt::read_line(&mut tokio::io::BufReader::new(tokio::io::stdin()), &mut input)
                     .await?;

--- a/docs/developer-docs/src/content/docs/guides/setup-a-wallet.mdx
+++ b/docs/developer-docs/src/content/docs/guides/setup-a-wallet.mdx
@@ -131,6 +131,36 @@ This will require you to register a passkey for the wallet.
 ./tari_ootle_walletd --network esme --auth webauthn
 ```
 
+## 6. Resetting your wallet (testnet only)
+
+During testnet development, the network may be reset, which invalidates all on-chain state. When this happens,
+your wallet's local database will be out of sync with the network.
+
+To reset your wallet and clear all local on-chain state (accounts, transactions, balances, etc.), run:
+
+```bash
+./tari_ootle_walletd --network esme reset
+```
+
+This will move your wallet database to a timestamped backup file (e.g. `wallet.sqlite.1711540000.bak`) and
+print a confirmation. The next time you start the wallet daemon, a fresh database will be created automatically.
+
+<Aside type="tip">
+  Your seed key is stored in the OS keyring and is **not** affected by the reset. After resetting, your
+  wallet will derive the same addresses from the seed, so your send addresses remain the same. However,
+  since the network itself was reset, previous accounts and balances no longer exist on-chain.
+</Aside>
+
+<Aside type="caution">
+  The reset command is only available on testnet networks. It will refuse to run on mainnet.
+</Aside>
+
+To skip the interactive confirmation prompt (useful for scripts), pass `--confirm`:
+
+```bash
+./tari_ootle_walletd --network esme reset --confirm
+```
+
 ## We're done
 
 Congratulations! If everything went smoothly you've successfully set up a wallet and connected it to the `esmeralda` testnet.


### PR DESCRIPTION
## Summary
- Adds `tari_walletd reset` subcommand that moves the wallet SQLite database to a timestamped `.bak` file
- Clears all on-chain state (accounts, transactions, balances) while preserving the seed key in the OS keyring
- Only available on testnet networks (bails with error on mainnet)
- Shows explanation and interactive confirmation prompt (skippable with `--confirm`)

## Test plan
- [ ] Run `tari_walletd reset` on a testnet config — verify explanation and prompt appear, typing "yes" moves the DB
- [ ] Run `tari_walletd reset` and type "no" — verify reset is cancelled
- [ ] Run `tari_walletd reset --confirm` — verify no prompt, DB is moved directly
- [ ] Run `tari_walletd reset --network mainnet` — verify it bails with error
- [ ] Verify `.bak` file has unix timestamp in name (e.g. `wallet.sqlite.1711540000.bak`)
- [ ] Start daemon after reset — verify fresh DB is created and wallet works