### PR TITLE
chore: add wallet SDK and wallet daemon client to publish script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,4 +69,6 @@ clients/validator_node_grpc_client/package-lock.json
 
 
 # agents
-.claude
+.claude/
+.rtk/
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11675,7 +11675,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_walletd_client"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "hex",
  "ootle_serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11526,7 +11526,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_sdk"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "digest 0.10.7",
@@ -11675,7 +11675,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_walletd_client"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "hex",
  "ootle_serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,7 @@ tari_ootle_p2p = { path = "crates/p2p" }
 tari_ootle_storage = { path = "crates/storage" }
 tari_ootle_storage_sqlite = { path = "crates/storage_sqlite" }
 tari_ootle_wallet_crypto = { path = "crates/wallet/crypto", version = "0.2" }
-tari_ootle_wallet_sdk = { path = "crates/wallet/sdk", version = "0.1.0" }
+tari_ootle_wallet_sdk = { path = "crates/wallet/sdk", version = "0.2.0" }
 tari_ootle_wallet_sdk_services = { path = "crates/wallet/sdk_services" }
 tari_ootle_wallet_storage_sqlite = { path = "crates/wallet/storage_sqlite" }
 tari_epoch_manager = { path = "crates/epoch_manager" }

--- a/clients/wallet_daemon_client/Cargo.toml
+++ b/clients/wallet_daemon_client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_ootle_walletd_client"
 description = "Tari wallet daemon client library"
-version = "0.3.1"
+version = "0.4.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/clients/wallet_daemon_client/Cargo.toml
+++ b/clients/wallet_daemon_client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_ootle_walletd_client"
 description = "Tari wallet daemon client library"
-version = "0.4.0"
+version = "0.4.1"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/wallet/sdk/Cargo.toml
+++ b/crates/wallet/sdk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_ootle_wallet_sdk"
 description = "The Tari wallet library"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/scripts/publish_crates.py
+++ b/scripts/publish_crates.py
@@ -45,6 +45,8 @@ CRATES = [
     ("ootle-wasm", "crates/ootle_wasm/wasm"),
     ("tari_template_test_tooling", "crates/template_test_tooling"),
     ("ootle-rs", "crates/wallet/ootle-rs"),
+    ("tari_ootle_wallet_sdk", "crates/wallet/sdk"),
+    ("tari_ootle_walletd_client", "clients/wallet_daemon_client"),
 ]
 
 WAIT_SECS = 20

--- a/scripts/publish_crates.py
+++ b/scripts/publish_crates.py
@@ -46,6 +46,7 @@ CRATES = [
     ("tari_template_test_tooling", "crates/template_test_tooling"),
     ("ootle-rs", "crates/wallet/ootle-rs"),
     ("tari_ootle_wallet_sdk", "crates/wallet/sdk"),
+    ("tari_ootle_wallet_storage_sqlite", "crates/wallet/storage_sqlite"),
     ("tari_ootle_walletd_client", "clients/wallet_daemon_client"),
 ]
 


### PR DESCRIPTION
## Summary
- Add `tari_ootle_wallet_sdk` and `tari_ootle_walletd_client` to the `publish_crates.py` publish list
- Bump `tari_ootle_walletd_client` version to `0.4.0`
- All in-repo dependencies were already present in the list