### PR TITLE
fix: add state store migration for limited faucet claim resource

### DIFF
--- a/applications/tari_validator_node/src/genesis_state.rs
+++ b/applications/tari_validator_node/src/genesis_state.rs
@@ -30,7 +30,6 @@ use tari_ootle_storage::{
     StorageError,
     consensus_models::{SubstateRecord, SubstateTransition, SubstateUpdateBatch},
 };
-use tari_state_tree::Version;
 use tari_template_lib::types::{
     EntityId,
     Metadata,
@@ -50,8 +49,6 @@ use tari_template_lib::types::{
     rule,
 };
 
-const INITIAL_STATE_VERSION: Version = 0;
-
 pub fn has_bootstrapped<TTx: StateStoreReadTransaction>(tx: &TTx) -> Result<bool, StorageError> {
     // Assume that if the public identity resource exists, then the rest of the state has been bootstrapped
     SubstateRecord::exists(
@@ -61,20 +58,6 @@ pub fn has_bootstrapped<TTx: StateStoreReadTransaction>(tx: &TTx) -> Result<bool
 }
 
 pub fn create_genesis_state<TTx>(
-    tx: &mut TTx,
-    network: Network,
-    num_preshards: NumPreshards,
-) -> Result<(), StorageError>
-where
-    TTx: StateStoreWriteTransaction + Deref,
-    TTx::Target: StateStoreReadTransaction,
-    TTx::Addr: NodeAddressable + Serialize,
-{
-    migrate_genesis_state_v1(tx, network, num_preshards)?;
-    Ok(())
-}
-
-pub fn migrate_genesis_state_v1<TTx>(
     tx: &mut TTx,
     network: Network,
     num_preshards: NumPreshards,
@@ -204,13 +187,11 @@ where
     let substate_id = substate_id.into();
     let shard = VersionedSubstateIdRef::new(&substate_id, 0).to_shard(num_preshards);
     let mut batch = SubstateUpdateBatch::new(Epoch::zero());
-    batch
-        .with_transition(shard, INITIAL_STATE_VERSION)
-        .push(SubstateTransition::Up {
-            id: substate_id,
-            version: 0,
-            substate_or_hash: value.into().into(),
-        });
+    batch.with_transition(shard, 0).push(SubstateTransition::Up {
+        id: substate_id,
+        version: 0,
+        substate_or_hash: value.into().into(),
+    });
 
     SubstateRecord::commit_batch(tx, batch)?;
 

--- a/applications/tari_validator_node/src/migrations/common.rs
+++ b/applications/tari_validator_node/src/migrations/common.rs
@@ -1,0 +1,41 @@
+//    Copyright 2026 The Tari Project
+//    SPDX-License-Identifier: BSD-3-Clause
+
+use std::ops::Deref;
+
+use serde::Serialize;
+use tari_engine_types::substate::{SubstateId, SubstateValue};
+use tari_ootle_common_types::{Epoch, NodeAddressable, NumPreshards, VersionedSubstateIdRef};
+use tari_ootle_storage::{
+    StateStoreReadTransaction,
+    StateStoreWriteTransaction,
+    StorageError,
+    consensus_models::{SubstateRecord, SubstateTransition, SubstateUpdateBatch},
+};
+
+pub(super) fn create_substate<TTx, TId, TVal>(
+    tx: &mut TTx,
+    num_preshards: NumPreshards,
+    substate_id: TId,
+    value: TVal,
+) -> Result<(), StorageError>
+where
+    TTx: StateStoreWriteTransaction + Deref,
+    TTx::Target: StateStoreReadTransaction,
+    TTx::Addr: NodeAddressable + Serialize,
+    TId: Into<SubstateId>,
+    TVal: Into<SubstateValue>,
+{
+    let substate_id = substate_id.into();
+    let shard = VersionedSubstateIdRef::new(&substate_id, 0).to_shard(num_preshards);
+    let mut batch = SubstateUpdateBatch::new(Epoch::zero());
+    batch.with_transition(shard, 0).push(SubstateTransition::Up {
+        id: substate_id,
+        version: 0,
+        substate_or_hash: value.into().into(),
+    });
+
+    SubstateRecord::commit_batch(tx, batch)?;
+
+    Ok(())
+}

--- a/applications/tari_validator_node/src/migrations/mod.rs
+++ b/applications/tari_validator_node/src/migrations/mod.rs
@@ -12,7 +12,9 @@ use tari_state_store_rocksdb::{
 
 use crate::genesis_state::create_genesis_state;
 
+pub mod common;
 pub mod v1;
+pub mod v2;
 
 const LOG_TARGET: &str = "tari::validator::migrations";
 
@@ -22,7 +24,7 @@ pub fn migrate<TAddr: NodeAddressable + 'static>(
     consensus_constants: &ConsensusConstants,
 ) -> anyhow::Result<()> {
     const OPERATION: &str = "migrate";
-    const CURRENT_VERSION: u64 = 1;
+    const CURRENT_VERSION: u64 = 2;
     let maybe_version = {
         let db = tx.db();
         db.cf(DatabaseMigrationVersion)?
@@ -32,7 +34,6 @@ pub fn migrate<TAddr: NodeAddressable + 'static>(
 
     match maybe_version {
         Some(mut version) => {
-            let db = tx.db();
             info!(
                 target: LOG_TARGET,
                 "🔨 Migration required from version {version} to {CURRENT_VERSION}"
@@ -40,7 +41,11 @@ pub fn migrate<TAddr: NodeAddressable + 'static>(
             while version < CURRENT_VERSION {
                 match version {
                     0 => {
+                        let db = tx.db();
                         v1::migrate(&db, network)?;
+                    },
+                    1 => {
+                        v2::migrate(tx, network, consensus_constants.num_preshards)?;
                     },
                     _ => unreachable!("version somehow went over CURRENT_VERSION. This is a bug"),
                 }
@@ -51,7 +56,9 @@ pub fn migrate<TAddr: NodeAddressable + 'static>(
                     version + 1
                 );
                 version += 1;
-                db.cf(DatabaseMigrationVersion)?.put(&ByteColumn, &version, OPERATION)?;
+                tx.db()
+                    .cf(DatabaseMigrationVersion)?
+                    .put(&ByteColumn, &version, OPERATION)?;
             }
         },
         None => {

--- a/applications/tari_validator_node/src/migrations/v2.rs
+++ b/applications/tari_validator_node/src/migrations/v2.rs
@@ -1,0 +1,47 @@
+//   Copyright 2026 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+use std::ops::Deref;
+
+use serde::Serialize;
+use tari_engine_types::resource::Resource;
+use tari_ootle_common_types::{Network, NodeAddressable, NumPreshards};
+use tari_ootle_storage::{StateStoreReadTransaction, StateStoreWriteTransaction, StorageError};
+use tari_template_lib::{
+    prelude::{Metadata, ResourceAccessRules, ResourceType, rule},
+    types::{
+        SubstateOwnerRule,
+        constants::{XTR_FAUCET_CLAIM_RESOURCE_ADDRESS, XTR_FAUCET_COMPONENT_ADDRESS},
+    },
+};
+
+use crate::migrations::common::create_substate;
+
+/// This migration adds the XTR faucet claim resource needed for the limited faucet.
+pub fn migrate<TTx>(tx: &mut TTx, network: Network, num_preshards: NumPreshards) -> Result<(), StorageError>
+where
+    TTx: StateStoreWriteTransaction + Deref,
+    TTx::Target: StateStoreReadTransaction,
+    TTx::Addr: NodeAddressable + Serialize,
+{
+    if !network.is_testnet() {
+        return Ok(());
+    }
+
+    // Add the claim receipt resource for the limited faucet (one NFT per claimant public key).
+    let claim_resource = Resource::new(
+        ResourceType::NonFungible,
+        SubstateOwnerRule::None,
+        ResourceAccessRules::new()
+            .mintable(rule!(component(XTR_FAUCET_COMPONENT_ADDRESS)))
+            .burnable(rule!(component(XTR_FAUCET_COMPONENT_ADDRESS))),
+        Metadata::new(),
+        None,
+        None,
+        0,
+        false,
+    );
+    create_substate(tx, num_preshards, XTR_FAUCET_CLAIM_RESOURCE_ADDRESS, claim_resource)?;
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- Adds a v2 state store migration that creates the `XTR_FAUCET_CLAIM_RESOURCE_ADDRESS` substate for existing testnet databases
- Extracts a shared `create_substate` helper into `migrations::common` for reuse across migrations
- Simplifies `genesis_state.rs` by merging `create_genesis_state`/`migrate_genesis_state_v1` into a single function

## Test plan
- [ ] Verify existing testnet VN database migrates successfully (v1 -> v2)
- [ ] Verify fresh database bootstraps with claim resource and version set to 2
- [ ] Verify mainnet databases skip the v2 migration (testnet-only)