### PR TITLE
fix(engine)!: tari_engine bug fixes from audit

### DIFF
--- a/crates/engine/src/fees/fee_module.rs
+++ b/crates/engine/src/fees/fee_module.rs
@@ -28,7 +28,12 @@ impl<TStore: StateReader> RuntimeModule<TStore> for FeeModule {
     fn on_initialize(&self, track: &mut StateTracker<TStore>) -> Result<(), RuntimeModuleError> {
         track.add_fee_charge(FeeSource::Initial, self.initial_cost);
         let transaction_weight = track.get_transaction_weight();
-        let transaction_weight_cost = transaction_weight.as_u64() * self.fee_table.per_transaction_weight_cost();
+        let transaction_weight_cost = transaction_weight
+            .as_u64()
+            .checked_mul(self.fee_table.per_transaction_weight_cost())
+            .ok_or_else(|| {
+                RuntimeModuleError::Overflow("Overflow calculating transaction weight cost".to_string())
+            })?;
         track.add_fee_charge(FeeSource::TransactionWeight, transaction_weight_cost);
 
         Ok(())
@@ -80,12 +85,15 @@ impl<TStore: StateReader> RuntimeModule<TStore> for FeeModule {
             cost / STORAGE_COST_REDUCTION_DIVISOR,
         );
 
-        track.add_fee_charge(FeeSource::Logs, track.num_logs() as u64 * self.fee_table.per_log_cost());
+        let log_cost = (track.num_logs() as u64)
+            .checked_mul(self.fee_table.per_log_cost())
+            .ok_or_else(|| RuntimeModuleError::Overflow("Overflow calculating log cost".to_string()))?;
+        track.add_fee_charge(FeeSource::Logs, log_cost);
 
-        track.add_fee_charge(
-            FeeSource::Events,
-            track.num_events() as u64 * self.fee_table.per_event_cost(),
-        );
+        let event_cost = (track.num_events() as u64)
+            .checked_mul(self.fee_table.per_event_cost())
+            .ok_or_else(|| RuntimeModuleError::Overflow("Overflow calculating event cost".to_string()))?;
+        track.add_fee_charge(FeeSource::Events, event_cost);
 
         Ok(())
     }

--- a/crates/engine/src/fees/fee_module.rs
+++ b/crates/engine/src/fees/fee_module.rs
@@ -31,9 +31,7 @@ impl<TStore: StateReader> RuntimeModule<TStore> for FeeModule {
         let transaction_weight_cost = transaction_weight
             .as_u64()
             .checked_mul(self.fee_table.per_transaction_weight_cost())
-            .ok_or_else(|| {
-                RuntimeModuleError::Overflow("Overflow calculating transaction weight cost".to_string())
-            })?;
+            .ok_or_else(|| RuntimeModuleError::Overflow("Overflow calculating transaction weight cost".to_string()))?;
         track.add_fee_charge(FeeSource::TransactionWeight, transaction_weight_cost);
 
         Ok(())

--- a/crates/engine/src/runtime/impl.rs
+++ b/crates/engine/src/runtime/impl.rs
@@ -613,8 +613,7 @@ where
                         .as_component_address()
                         .ok_or_else(|| RuntimeError::InvalidArgument {
                             argument: "component_ref",
-                            reason: "GetState component action should not define a specific component address"
-                                .to_string(),
+                            reason: "GetState component action requires a component address".to_string(),
                         })?;
                 args.assert_no_args("ComponentAction::GetState")?;
                 self.tracker.write_with(|state| {
@@ -745,23 +744,17 @@ where
                         .as_component_address()
                         .ok_or_else(|| RuntimeError::InvalidArgument {
                             argument: "component_ref",
-                            reason: "SetAccessRules component action requires a component address".to_string(),
+                            reason: "GetTemplateAddress component action requires a component address".to_string(),
                         })?;
 
                 args.assert_no_args("Component::GetTemplateAddress")?;
 
-                // The template can never change so we'll just fetch the component
-                self.tracker.read_with(|state| {
-                    let substate = state.store().get_unmodified_substate(&component_address.into())?;
-                    let component = substate
-                        .substate_value()
-                        .component()
-                        .ok_or(RuntimeError::InvariantError {
-                            function: "GetTemplateAddress",
-                            details: format!("Substate at {} is not a component", component_address),
-                        })?;
-
-                    Ok(InvokeResult::encode(&component.template_address)?)
+                self.tracker.write_with(|state| {
+                    let locked = state.read_lock_substate(SubstateId::Component(component_address))?;
+                    let component = state.get_component(&locked)?;
+                    let template_address = component.template_address;
+                    state.unlock_substate(locked)?;
+                    Ok(InvokeResult::encode(&template_address)?)
                 })
             },
             ComponentAction::GetOwnerProof => {
@@ -2143,6 +2136,13 @@ where
 
                 self.tracker.write_with(|state| {
                     let bucket = state.take_bucket(bucket_id)?;
+                    // It is invalid to burn a bucket that has locked funds (e.g. via a proof)
+                    if !bucket.locked_amount().is_zero() {
+                        return Err(RuntimeError::InvalidOpDepositLockedBucket {
+                            bucket_id,
+                            locked_amount: bucket.locked_amount(),
+                        });
+                    }
                     let burnt_amount = bucket.unlocked_amount();
                     state.burn_bucket(bucket)?;
 

--- a/crates/engine/src/runtime/tracker.rs
+++ b/crates/engine/src/runtime/tracker.rs
@@ -304,7 +304,7 @@ impl<TStore: StateReader> StateTracker<TStore> {
         }
 
         // Finalise will always reset the state
-        let mut state = self.take_working_state();
+        let mut state = self.take_working_state()?;
         // Resolve the transfers to the fee pool resource and vault refunds
         let mut substates_to_persist = state.take_mutated_substates();
         let fee_receipt = state.finalize_fees_and_refunds(&mut substates_to_persist)?;
@@ -333,8 +333,11 @@ impl<TStore: StateReader> StateTracker<TStore> {
         self.fee_checkpoint.take()
     }
 
-    fn take_working_state(&mut self) -> WorkingState<TStore> {
-        self.working_state.take().expect("Working state has been taken")
+    fn take_working_state(&mut self) -> Result<WorkingState<TStore>, RuntimeError> {
+        self.working_state.take().ok_or_else(|| RuntimeError::InvariantError {
+            function: "StateTracker::take_working_state",
+            details: "Working state has already been taken (double finalize?)".to_string(),
+        })
     }
 
     pub fn with_substates_to_persist<F: FnMut(&IndexMap<SubstateId, SubstateValue>) -> R, R>(&mut self, mut f: F) -> R {
@@ -358,11 +361,17 @@ impl<TStore: StateReader> StateTracker<TStore> {
     }
 
     pub(super) fn read_with<R, F: FnOnce(&WorkingState<TStore>) -> R>(&self, f: F) -> R {
-        f(self.working_state.as_ref().expect("Working state has been taken"))
+        f(self
+            .working_state
+            .as_ref()
+            .expect("BUG: read_with called after finalize consumed working state"))
     }
 
     pub(super) fn write_with<R, F: FnOnce(&mut WorkingState<TStore>) -> R>(&mut self, f: F) -> R {
-        f(self.working_state.as_mut().expect("Working state has been taken"))
+        f(self
+            .working_state
+            .as_mut()
+            .expect("BUG: write_with called after finalize consumed working state"))
     }
 
     pub(super) fn is_fee_intent_checkpointed(&self) -> bool {

--- a/crates/engine/src/runtime/tracker_auth.rs
+++ b/crates/engine/src/runtime/tracker_auth.rs
@@ -188,7 +188,11 @@ fn check_require_rule<TStore: StateReader>(
             Ok(true)
         },
         RequireRule::MOfN(n, requirements) => {
-            let mut satisfied = 0;
+            // 0-of-N is vacuously satisfied: no requirements need to be met
+            if *n == 0 {
+                return Ok(true);
+            }
+            let mut satisfied = 0u16;
             for requirement in requirements {
                 if check_requirement(state, scope, requirement)? {
                     satisfied += 1;

--- a/crates/engine/src/runtime/tracker_auth.rs
+++ b/crates/engine/src/runtime/tracker_auth.rs
@@ -152,6 +152,10 @@ fn check_restricted_access_rule<TStore: StateReader>(
             Ok(false)
         },
         RestrictedAccessRule::AllOf(rules) => {
+            // Empty AllOf is denied rather than vacuously true, to prevent accidental AllowAll
+            if rules.is_empty() {
+                return Ok(false);
+            }
             for rule in rules {
                 if !check_restricted_access_rule(state, scope, rule)? {
                     return Ok(false);
@@ -178,8 +182,12 @@ fn check_require_rule<TStore: StateReader>(
 
             Ok(false)
         },
-        RequireRule::AllOf(requirement) => {
-            for requirement in requirement {
+        RequireRule::AllOf(requirements) => {
+            // Empty AllOf is denied rather than vacuously true, to prevent accidental AllowAll
+            if requirements.is_empty() {
+                return Ok(false);
+            }
+            for requirement in requirements {
                 if !check_requirement(state, scope, requirement)? {
                     return Ok(false);
                 }

--- a/crates/engine/src/wasm/metering.rs
+++ b/crates/engine/src/wasm/metering.rs
@@ -221,6 +221,272 @@ fn cost_function(op: &Operator) -> u64 {
         Operator::MemoryAtomicWait64 { .. } => 3,
         Operator::AtomicFence { .. } => 2,
 
+        // SIMD (V128) instructions: cost 4x scalar equivalents since they operate on 128-bit
+        // vectors (4 lanes of 32-bit or 2 lanes of 64-bit values simultaneously).
+        //
+        // Memory: load/store cost matches scalar load(1)/store(2) scaled by 4x for wider access
+        Operator::V128Load { .. } |
+        Operator::V128Load8x8S { .. } |
+        Operator::V128Load8x8U { .. } |
+        Operator::V128Load16x4S { .. } |
+        Operator::V128Load16x4U { .. } |
+        Operator::V128Load32x2S { .. } |
+        Operator::V128Load32x2U { .. } |
+        Operator::V128Load8Splat { .. } |
+        Operator::V128Load16Splat { .. } |
+        Operator::V128Load32Splat { .. } |
+        Operator::V128Load64Splat { .. } |
+        Operator::V128Load32Zero { .. } |
+        Operator::V128Load64Zero { .. } |
+        Operator::V128Load8Lane { .. } |
+        Operator::V128Load16Lane { .. } |
+        Operator::V128Load32Lane { .. } |
+        Operator::V128Load64Lane { .. } => 4,
+        Operator::V128Store { .. } |
+        Operator::V128Store8Lane { .. } |
+        Operator::V128Store16Lane { .. } |
+        Operator::V128Store32Lane { .. } |
+        Operator::V128Store64Lane { .. } => 8,
+        // V128 const and bitwise: cheap lane-parallel ops
+        Operator::V128Const { .. } => 1,
+        Operator::V128Not |
+        Operator::V128And |
+        Operator::V128AndNot |
+        Operator::V128Or |
+        Operator::V128Xor |
+        Operator::V128Bitselect |
+        Operator::V128AnyTrue => 2,
+        // Integer SIMD arithmetic (4x scalar cost)
+        Operator::I8x16Splat |
+        Operator::I16x8Splat |
+        Operator::I32x4Splat |
+        Operator::I64x2Splat |
+        Operator::I8x16ExtractLaneS { .. } |
+        Operator::I8x16ExtractLaneU { .. } |
+        Operator::I8x16ReplaceLane { .. } |
+        Operator::I16x8ExtractLaneS { .. } |
+        Operator::I16x8ExtractLaneU { .. } |
+        Operator::I16x8ReplaceLane { .. } |
+        Operator::I32x4ExtractLane { .. } |
+        Operator::I32x4ReplaceLane { .. } |
+        Operator::I64x2ExtractLane { .. } |
+        Operator::I64x2ReplaceLane { .. } => 2,
+        Operator::I8x16Eq |
+        Operator::I8x16Ne |
+        Operator::I8x16LtS |
+        Operator::I8x16LtU |
+        Operator::I8x16GtS |
+        Operator::I8x16GtU |
+        Operator::I8x16LeS |
+        Operator::I8x16LeU |
+        Operator::I8x16GeS |
+        Operator::I8x16GeU |
+        Operator::I16x8Eq |
+        Operator::I16x8Ne |
+        Operator::I16x8LtS |
+        Operator::I16x8LtU |
+        Operator::I16x8GtS |
+        Operator::I16x8GtU |
+        Operator::I16x8LeS |
+        Operator::I16x8LeU |
+        Operator::I16x8GeS |
+        Operator::I16x8GeU |
+        Operator::I32x4Eq |
+        Operator::I32x4Ne |
+        Operator::I32x4LtS |
+        Operator::I32x4LtU |
+        Operator::I32x4GtS |
+        Operator::I32x4GtU |
+        Operator::I32x4LeS |
+        Operator::I32x4LeU |
+        Operator::I32x4GeS |
+        Operator::I32x4GeU |
+        Operator::I64x2Eq |
+        Operator::I64x2Ne |
+        Operator::I64x2LtS |
+        Operator::I64x2GtS |
+        Operator::I64x2LeS |
+        Operator::I64x2GeS => 4,
+        Operator::I8x16Abs |
+        Operator::I8x16Neg |
+        Operator::I8x16AllTrue |
+        Operator::I8x16Bitmask |
+        Operator::I8x16Popcnt |
+        Operator::I8x16Add |
+        Operator::I8x16AddSatS |
+        Operator::I8x16AddSatU |
+        Operator::I8x16Sub |
+        Operator::I8x16SubSatS |
+        Operator::I8x16SubSatU |
+        Operator::I8x16MinS |
+        Operator::I8x16MinU |
+        Operator::I8x16MaxS |
+        Operator::I8x16MaxU |
+        Operator::I8x16AvgrU |
+        Operator::I8x16Shl |
+        Operator::I8x16ShrS |
+        Operator::I8x16ShrU |
+        Operator::I8x16NarrowI16x8S |
+        Operator::I8x16NarrowI16x8U |
+        Operator::I8x16Swizzle |
+        Operator::I8x16Shuffle { .. } |
+        Operator::I16x8Abs |
+        Operator::I16x8Neg |
+        Operator::I16x8AllTrue |
+        Operator::I16x8Bitmask |
+        Operator::I16x8Add |
+        Operator::I16x8AddSatS |
+        Operator::I16x8AddSatU |
+        Operator::I16x8Sub |
+        Operator::I16x8SubSatS |
+        Operator::I16x8SubSatU |
+        Operator::I16x8Mul |
+        Operator::I16x8MinS |
+        Operator::I16x8MinU |
+        Operator::I16x8MaxS |
+        Operator::I16x8MaxU |
+        Operator::I16x8AvgrU |
+        Operator::I16x8Shl |
+        Operator::I16x8ShrS |
+        Operator::I16x8ShrU |
+        Operator::I16x8NarrowI32x4S |
+        Operator::I16x8NarrowI32x4U |
+        Operator::I16x8Q15MulrSatS |
+        Operator::I16x8ExtAddPairwiseI8x16S |
+        Operator::I16x8ExtAddPairwiseI8x16U |
+        Operator::I16x8ExtendHighI8x16S |
+        Operator::I16x8ExtendHighI8x16U |
+        Operator::I16x8ExtendLowI8x16S |
+        Operator::I16x8ExtendLowI8x16U |
+        Operator::I16x8ExtMulHighI8x16S |
+        Operator::I16x8ExtMulHighI8x16U |
+        Operator::I16x8ExtMulLowI8x16S |
+        Operator::I16x8ExtMulLowI8x16U |
+        Operator::I32x4Abs |
+        Operator::I32x4Neg |
+        Operator::I32x4AllTrue |
+        Operator::I32x4Bitmask |
+        Operator::I32x4Add |
+        Operator::I32x4Sub |
+        Operator::I32x4Mul |
+        Operator::I32x4MinS |
+        Operator::I32x4MinU |
+        Operator::I32x4MaxS |
+        Operator::I32x4MaxU |
+        Operator::I32x4Shl |
+        Operator::I32x4ShrS |
+        Operator::I32x4ShrU |
+        Operator::I32x4DotI16x8S |
+        Operator::I32x4ExtAddPairwiseI16x8S |
+        Operator::I32x4ExtAddPairwiseI16x8U |
+        Operator::I32x4ExtendHighI16x8S |
+        Operator::I32x4ExtendHighI16x8U |
+        Operator::I32x4ExtendLowI16x8S |
+        Operator::I32x4ExtendLowI16x8U |
+        Operator::I32x4ExtMulHighI16x8S |
+        Operator::I32x4ExtMulHighI16x8U |
+        Operator::I32x4ExtMulLowI16x8S |
+        Operator::I32x4ExtMulLowI16x8U |
+        Operator::I64x2Abs |
+        Operator::I64x2Neg |
+        Operator::I64x2AllTrue |
+        Operator::I64x2Bitmask |
+        Operator::I64x2Add |
+        Operator::I64x2Sub |
+        Operator::I64x2Mul |
+        Operator::I64x2Shl |
+        Operator::I64x2ShrS |
+        Operator::I64x2ShrU |
+        Operator::I64x2ExtendHighI32x4S |
+        Operator::I64x2ExtendHighI32x4U |
+        Operator::I64x2ExtendLowI32x4S |
+        Operator::I64x2ExtendLowI32x4U |
+        Operator::I64x2ExtMulHighI32x4S |
+        Operator::I64x2ExtMulHighI32x4U |
+        Operator::I64x2ExtMulLowI32x4S |
+        Operator::I64x2ExtMulLowI32x4U => 4,
+        // Conversion between integer SIMD types
+        Operator::I32x4TruncSatF32x4S |
+        Operator::I32x4TruncSatF32x4U |
+        Operator::I32x4TruncSatF64x2SZero |
+        Operator::I32x4TruncSatF64x2UZero => 4,
+        // Float SIMD (4x scalar float cost)
+        Operator::F32x4Splat |
+        Operator::F32x4ExtractLane { .. } |
+        Operator::F32x4ReplaceLane { .. } |
+        Operator::F64x2Splat |
+        Operator::F64x2ExtractLane { .. } |
+        Operator::F64x2ReplaceLane { .. } => 4,
+        Operator::F32x4Eq |
+        Operator::F32x4Ne |
+        Operator::F32x4Lt |
+        Operator::F32x4Gt |
+        Operator::F32x4Le |
+        Operator::F32x4Ge |
+        Operator::F64x2Eq |
+        Operator::F64x2Ne |
+        Operator::F64x2Lt |
+        Operator::F64x2Gt |
+        Operator::F64x2Le |
+        Operator::F64x2Ge => 16,
+        Operator::F32x4Abs |
+        Operator::F32x4Neg |
+        Operator::F32x4Ceil |
+        Operator::F32x4Floor |
+        Operator::F32x4Trunc |
+        Operator::F32x4Nearest |
+        Operator::F32x4Add |
+        Operator::F32x4Sub |
+        Operator::F32x4Mul |
+        Operator::F32x4Div |
+        Operator::F32x4Min |
+        Operator::F32x4Max |
+        Operator::F32x4PMin |
+        Operator::F32x4PMax |
+        Operator::F64x2Abs |
+        Operator::F64x2Neg |
+        Operator::F64x2Ceil |
+        Operator::F64x2Floor |
+        Operator::F64x2Trunc |
+        Operator::F64x2Nearest |
+        Operator::F64x2Add |
+        Operator::F64x2Sub |
+        Operator::F64x2Mul |
+        Operator::F64x2Div |
+        Operator::F64x2Min |
+        Operator::F64x2Max |
+        Operator::F64x2PMin |
+        Operator::F64x2PMax |
+        Operator::F32x4ConvertI32x4S |
+        Operator::F32x4ConvertI32x4U |
+        Operator::F32x4DemoteF64x2Zero |
+        Operator::F64x2ConvertLowI32x4S |
+        Operator::F64x2ConvertLowI32x4U |
+        Operator::F64x2PromoteLowF32x4 => 16,
+        Operator::F32x4Sqrt |
+        Operator::F64x2Sqrt => 40,
+        // Relaxed SIMD instructions
+        Operator::I8x16RelaxedSwizzle |
+        Operator::I8x16RelaxedLaneselect |
+        Operator::I16x8RelaxedLaneselect |
+        Operator::I16x8RelaxedQ15mulrS |
+        Operator::I16x8RelaxedDotI8x16I7x16S |
+        Operator::I32x4RelaxedLaneselect |
+        Operator::I32x4RelaxedTruncF32x4S |
+        Operator::I32x4RelaxedTruncF32x4U |
+        Operator::I32x4RelaxedTruncF64x2SZero |
+        Operator::I32x4RelaxedTruncF64x2UZero |
+        Operator::I32x4RelaxedDotI8x16I7x16AddS |
+        Operator::I64x2RelaxedLaneselect |
+        Operator::F32x4RelaxedMadd |
+        Operator::F32x4RelaxedNmadd |
+        Operator::F32x4RelaxedMin |
+        Operator::F32x4RelaxedMax |
+        Operator::F64x2RelaxedMadd |
+        Operator::F64x2RelaxedNmadd |
+        Operator::F64x2RelaxedMin |
+        Operator::F64x2RelaxedMax => 8,
+
         Operator::Unreachable |
         Operator::Nop |
         Operator::Block { .. } |

--- a/crates/engine/src/wasm/metering.rs
+++ b/crates/engine/src/wasm/metering.rs
@@ -463,8 +463,7 @@ fn cost_function(op: &Operator) -> u64 {
         Operator::F64x2ConvertLowI32x4S |
         Operator::F64x2ConvertLowI32x4U |
         Operator::F64x2PromoteLowF32x4 => 16,
-        Operator::F32x4Sqrt |
-        Operator::F64x2Sqrt => 40,
+        Operator::F32x4Sqrt | Operator::F64x2Sqrt => 40,
         // Relaxed SIMD instructions
         Operator::I8x16RelaxedSwizzle |
         Operator::I8x16RelaxedLaneselect |


### PR DESCRIPTION
## Summary

- **SIMD metering bypass**: SIMD was enabled (`.simd(true)`) but all ~230 V128/SIMD operators fell through to cost 1 (same as scalar `i32.add`), allowing up to 4x computation per metering unit. Assigns proper costs proportional to scalar equivalents.
- **Empty `AllOf` access rules**: `AllOf([])` evaluated to `true` (vacuous truth), equivalent to `AllowAll`. Now explicitly denied to prevent accidental open access from empty rule lists.
- **`MOfN(0, _)` access rule**: Always returned `false` instead of `true`. 0-of-N is vacuously satisfied.
- **Fee overflow**: Transaction weight, log, and event fee calculations used unchecked `u64` multiplication. Now uses `checked_mul` consistent with storage/template load costs in the same module.
- **`GetTemplateAddress` stale after upgrade**: Read from unmodified backing store, returning pre-upgrade template address within the same transaction. Now reads via locked substate access.
- **`BucketAction::Burn` locked funds**: No check for locked amounts (unlike `Deposit`). Burning a bucket with proof-locked funds would miscount total supply.
- **`StateTracker` panic on double finalize**: `take_working_state()` panicked via `expect()`. Now returns `RuntimeError::InvariantError`.
- **Wrong error messages**: `GetTemplateAddress` error said "SetAccessRules"; `GetState` error had inverted meaning.

## Test plan

- [x] All 5 unit tests pass
- [x] All 24 main integration tests pass
- [x] All 9 template_upgrade tests pass
- [x] All 28 access_rules + fees tests pass
- [x] Clippy clean (no new warnings)