### PR TITLE
feat(swarm): hot-reload config file for instance settings/envs

### DIFF
--- a/applications/tari_swarm_daemon/src/main.rs
+++ b/applications/tari_swarm_daemon/src/main.rs
@@ -200,6 +200,7 @@ fn get_base_config(cli: &Cli) -> anyhow::Result<Config> {
 }
 
 async fn start(cli: &Cli) -> anyhow::Result<()> {
+    let config_path = cli.get_config_path();
     let mut config = Config::load_with_cli(cli).await.context("failed to load config")?;
     if let Commands::Start(ref overrides) = cli.command {
         overrides.apply(&mut config).context("cli overrides")?;
@@ -219,7 +220,7 @@ async fn start(cli: &Cli) -> anyhow::Result<()> {
 
     let mut shutdown = Shutdown::new();
     let signal = shutdown.to_signal().select(exit_signal().context("exit_signal")?);
-    let (task_handle, pm_handle) = process_manager::spawn(&config, shutdown.to_signal());
+    let (task_handle, pm_handle) = process_manager::spawn(&config, config_path.clone(), shutdown.to_signal());
     let webserver = webserver::spawn(config, shutdown.to_signal(), pm_handle.clone());
 
     tokio::select! {

--- a/applications/tari_swarm_daemon/src/process_manager/handle.rs
+++ b/applications/tari_swarm_daemon/src/process_manager/handle.rs
@@ -79,6 +79,9 @@ pub struct InstanceInfo {
     pub instance_type: InstanceType,
     pub settings: HashMap<String, String>,
     pub is_running: bool,
+    /// True if the config file has been modified since this instance was last started.
+    /// The user should restart the instance to apply the new configuration.
+    pub is_config_dirty: bool,
 }
 
 impl InstanceInfo {
@@ -190,6 +193,7 @@ impl From<&Instance> for InstanceInfo {
             instance_type: instance.instance_type(),
             settings: instance.settings().clone(),
             is_running: instance.is_running(),
+            is_config_dirty: instance.is_config_dirty(),
         }
     }
 }

--- a/applications/tari_swarm_daemon/src/process_manager/instances/instance.rs
+++ b/applications/tari_swarm_daemon/src/process_manager/instances/instance.rs
@@ -19,6 +19,7 @@ pub struct Instance {
     settings: HashMap<String, String>,
     envs: Vec<(String, String)>,
     exit_status: Option<ExitStatus>,
+    is_config_dirty: bool,
 }
 
 impl Instance {
@@ -42,6 +43,7 @@ impl Instance {
             envs,
             settings,
             exit_status: None,
+            is_config_dirty: false,
         }
     }
 
@@ -79,6 +81,22 @@ impl Instance {
 
     pub fn settings(&self) -> &HashMap<String, String> {
         &self.settings
+    }
+
+    pub fn set_settings(&mut self, settings: HashMap<String, String>) {
+        self.settings = settings;
+    }
+
+    pub fn set_envs(&mut self, envs: Vec<(String, String)>) {
+        self.envs = envs;
+    }
+
+    pub fn is_config_dirty(&self) -> bool {
+        self.is_config_dirty
+    }
+
+    pub fn set_config_dirty(&mut self, dirty: bool) {
+        self.is_config_dirty = dirty;
     }
 
     pub fn is_running(&self) -> bool {

--- a/applications/tari_swarm_daemon/src/process_manager/instances/manager.rs
+++ b/applications/tari_swarm_daemon/src/process_manager/instances/manager.rs
@@ -461,6 +461,40 @@ impl InstanceManager {
             .chain(self.wallet_daemons.values().map(|x| x.instance()))
     }
 
+    /// Apply updated instance configs from a reloaded config file.
+    /// Updates settings and envs for matching instances and marks them as config dirty
+    /// so that the user knows to restart them.
+    pub fn apply_config_update(
+        &mut self,
+        new_global_settings: HashMap<String, String>,
+        new_instance_configs: &[InstanceConfig],
+    ) {
+        for instance_config in new_instance_configs {
+            for i in 0..instance_config.num_instances {
+                let expected_name = instance_config.instance_name(i);
+                let mut new_settings = new_global_settings.clone();
+                new_settings.extend(instance_config.settings.clone());
+
+                if let Some(instance) = self.instances_mut().find(|inst| inst.name() == expected_name) {
+                    let settings_changed = *instance.settings() != new_settings;
+                    let envs_changed = instance.envs() != instance_config.envs;
+                    if settings_changed || envs_changed {
+                        info!(
+                            "📝 Config changed for instance '{}' (settings_changed={}, envs_changed={}). Restart to \
+                             apply.",
+                            expected_name, settings_changed, envs_changed,
+                        );
+                        instance.set_settings(new_settings);
+                        instance.set_envs(instance_config.envs.clone());
+                        instance.set_config_dirty(true);
+                    }
+                }
+            }
+        }
+        self.global_settings = new_global_settings;
+        self.config = new_instance_configs.to_vec();
+    }
+
     fn next_instance_id(&mut self) -> InstanceId {
         let id = self.instance_id;
         self.instance_id += 1;

--- a/applications/tari_swarm_daemon/src/process_manager/manager.rs
+++ b/applications/tari_swarm_daemon/src/process_manager/manager.rs
@@ -5,7 +5,7 @@ use std::{
     collections::HashMap,
     path::PathBuf,
     pin::pin,
-    time::{Duration, Instant},
+    time::{Duration, Instant, SystemTime},
 };
 
 use anyhow::{Context, anyhow};
@@ -40,16 +40,21 @@ pub struct ProcessManager {
     skip_registration: bool,
     enable_manual_connect: bool,
     network: Network,
+    config_path: PathBuf,
+    config_last_modified: Option<SystemTime>,
 }
 
 impl ProcessManager {
-    pub fn new(config: &Config, shutdown_signal: ShutdownSignal) -> (Self, ProcessManagerHandle) {
+    pub fn new(config: &Config, config_path: PathBuf, shutdown_signal: ShutdownSignal) -> (Self, ProcessManagerHandle) {
         let (tx_request, rx_request) = mpsc::channel(1);
 
         let mut global_settings = config.settings.clone();
         if let Some(public_ip) = config.public_ip {
             global_settings.insert("public_ip".to_string(), public_ip.to_string());
         }
+
+        let config_last_modified = std::fs::metadata(&config_path).and_then(|m| m.modified()).ok();
+
         let this = Self {
             skip_registration: config.skip_registration,
             executable_manager: ExecutableManager::new(
@@ -67,6 +72,8 @@ impl ProcessManager {
             shutdown_signal,
             enable_manual_connect: config.enable_manual_validator_connect,
             network: config.network,
+            config_path,
+            config_last_modified,
         };
         (this, ProcessManagerHandle::new(tx_request))
     }
@@ -327,6 +334,7 @@ impl ProcessManager {
         layer_one_transaction_service: Option<&mut LayerOneTransactionService>,
     ) -> anyhow::Result<()> {
         self.clear_terminated_instances()?;
+        self.check_config_changed().await;
 
         let Some(layer_one_transaction_service) = layer_one_transaction_service else {
             debug!("🫙 No MinotariConsoleWallet available. Skipping layer one transaction processing");
@@ -347,6 +355,38 @@ impl ProcessManager {
         }
 
         Ok(())
+    }
+
+    async fn check_config_changed(&mut self) {
+        let current_mtime = match tokio::fs::metadata(&self.config_path).await.and_then(|m| m.modified()) {
+            Ok(mtime) => mtime,
+            Err(err) => {
+                debug!("Could not stat config file: {err}");
+                return;
+            },
+        };
+
+        if self.config_last_modified == Some(current_mtime) {
+            return;
+        }
+        self.config_last_modified = Some(current_mtime);
+
+        info!("📝 Config file changed, reloading...");
+        let config = match Config::load_from_file(&self.config_path).await {
+            Ok(config) => config,
+            Err(err) => {
+                log::error!("Failed to reload config file: {err}");
+                return;
+            },
+        };
+
+        let mut global_settings = config.settings.clone();
+        if let Some(public_ip) = config.public_ip {
+            global_settings.insert("public_ip".to_string(), public_ip.to_string());
+        }
+
+        self.instance_manager
+            .apply_config_update(global_settings, &config.processes.instances);
     }
 
     async fn create_layer_one_transaction_service(&self) -> anyhow::Result<Option<LayerOneTransactionService>> {

--- a/applications/tari_swarm_daemon/src/process_manager/mod.rs
+++ b/applications/tari_swarm_daemon/src/process_manager/mod.rs
@@ -1,6 +1,8 @@
 //   Copyright 2024 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
+use std::path::PathBuf;
+
 use tokio::task;
 
 use crate::config::Config;
@@ -20,9 +22,10 @@ pub use processes::*;
 
 pub fn spawn(
     config: &Config,
+    config_path: PathBuf,
     shutdown: tari_shutdown::ShutdownSignal,
 ) -> (task::JoinHandle<anyhow::Result<()>>, ProcessManagerHandle) {
-    let (manager, handle) = manager::ProcessManager::new(config, shutdown);
+    let (manager, handle) = manager::ProcessManager::new(config, config_path, shutdown);
     let task_handle = tokio::spawn(manager.start());
     (task_handle, handle)
 }

--- a/applications/tari_swarm_daemon/src/webserver/rpc/instances.rs
+++ b/applications/tari_swarm_daemon/src/webserver/rpc/instances.rs
@@ -148,6 +148,7 @@ pub struct InstanceInfo {
     pub base_path: PathBuf,
     pub instance_type: InstanceType,
     pub is_running: bool,
+    pub is_config_dirty: bool,
 }
 
 impl From<crate::process_manager::InstanceInfo> for InstanceInfo {
@@ -160,6 +161,7 @@ impl From<crate::process_manager::InstanceInfo> for InstanceInfo {
             base_path: value.base_path,
             instance_type: value.instance_type,
             is_running: value.is_running,
+            is_config_dirty: value.is_config_dirty,
         }
     }
 }


### PR DESCRIPTION
## Summary
- The swarm daemon now detects config file changes (by mtime) and reloads instance settings/envs automatically on the existing 5-second tick
- Users can restart individual instances to apply new config, without restarting the whole swarm
- `is_config_dirty` flag is surfaced through the list instances API so the web UI can indicate which instances need restarting

## Motivation
When users changed instance settings, envs, or other per-instance config in the swarm's TOML config file, they had to restart the entire swarm to pick up changes. This is disruptive in development workflows.

## Test plan
- [ ] Start swarm with a config file
- [ ] Modify instance settings/envs in the config TOML while running
- [ ] Verify logs show config reload detection within 5 seconds
- [ ] Verify `list_instances` API shows `is_config_dirty: true` for affected instances
- [ ] Restart an affected instance and verify it picks up new settings and `is_config_dirty` resets to false
- [ ] Verify unmodified instances are not marked dirty