### PR TITLE
fix(tests): cache builtin templates and optimize wasmer deps for faster template tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -275,8 +275,33 @@ utoipa-swagger-ui = { version = "9.0.2" }
 uuid = "1.15.0"
 xxhash-rust = "0.8.15"
 
-# Shutdown when panicking so we can see the error, specifically for the wallet
+# Optimize wasmer/cranelift even in dev/test builds (optional but highly recommended).
+#
+# The Cranelift JIT compiler that wasmer uses to compile WASM templates runs ~10x slower
+# when compiled without optimizations (the default for `cargo test`). Without these
+# overrides, each template test spends most of its time in Cranelift codegen rather than
+# actually testing template logic. With opt-level=2 on just these crates, the full
+# `tari_engine` test suite drops from ~150s to ~5s while keeping the rest of the build
+# in debug mode for fast compilation and good error messages.
+#
+# These lines only affect local dev builds — release/CI profiles already compile
+# everything with optimizations. You can safely remove them if you prefer uniform
+# debug builds, at the cost of much slower template tests.
+[profile.dev.package.wasmer]
+opt-level = 2
+[profile.dev.package.wasmer-compiler]
+opt-level = 2
+[profile.dev.package.wasmer-compiler-cranelift]
+opt-level = 2
+[profile.dev.package.cranelift-codegen]
+opt-level = 2
+[profile.dev.package.cranelift-frontend]
+opt-level = 2
+[profile.dev.package.cranelift-entity]
+opt-level = 2
+
 [profile.release]
+# Shutdown when panicking so we can see the error, specifically for the wallet
 panic = 'abort'
 # By default, Rust will wrap an integer in release mode instead of throwing the overflow error
 # seen in debug mode. Panicking at this time is better than silently using the wrong value.

--- a/crates/template_test_tooling/src/package_builder.rs
+++ b/crates/template_test_tooling/src/package_builder.rs
@@ -5,7 +5,7 @@ use std::{
     collections::HashMap,
     ffi::OsStr,
     path::Path,
-    sync::{Arc, Mutex},
+    sync::{Arc, LazyLock, Mutex},
 };
 
 use tari_engine::{
@@ -20,6 +20,22 @@ use tari_template_lib::types::TemplateAddress;
 use thiserror::Error;
 
 use crate::compile::compile_template_with_envs;
+
+static BUILTIN_TEMPLATES: LazyLock<Vec<(TemplateAddress, LoadedTemplate)>> = LazyLock::new(|| {
+    all_builtin_templates()
+        .iter()
+        .map(|(addr, code)| {
+            let template = WasmModule::from_code(*code)
+                .load_template()
+                .expect("failed to load builtin template");
+            (*addr, template)
+        })
+        .collect()
+});
+
+fn cached_builtin_templates() -> &'static [(TemplateAddress, LoadedTemplate)] {
+    &BUILTIN_TEMPLATES
+}
 
 #[derive(Debug, Clone)]
 pub struct Package {
@@ -66,9 +82,8 @@ impl PackageBuilder {
     }
 
     pub fn add_all_builtin_templates(&mut self) -> &mut Self {
-        for (addr, code) in all_builtin_templates() {
-            self.add_template_from_code(*addr, *code)
-                .expect("failed to add builtin template");
+        for (addr, template) in cached_builtin_templates() {
+            self.add_loaded_template(*addr, template.clone());
         }
         self
     }

--- a/docs/developer-docs/src/content/docs/guides/build-a-guessing-game.mdx
+++ b/docs/developer-docs/src/content/docs/guides/build-a-guessing-game.mdx
@@ -447,6 +447,39 @@ to check that the prize is awarded correctly.
 To run your tests, simply run `cargo test` in your template crate directory.
 The test harness will compile your template to WASM and run the tests against it.
 
+### Speeding up template tests
+
+Template tests use the wasmer runtime with the Cranelift JIT compiler to compile and execute WASM.
+In debug/test builds (the default for `cargo test`), these dependencies are compiled without
+optimizations, which makes the JIT compilation step roughly **10x slower** than it needs to be.
+
+You can fix this by adding the following to your `Cargo.toml`, which tells Cargo to
+optimize just the wasmer/cranelift crates even in debug builds:
+
+```toml
+# Optional but highly recommended — makes template tests ~10x faster.
+# Without this, each test spends most of its time in the Cranelift JIT
+# rather than actually testing your template logic.
+[profile.dev.package.wasmer]
+opt-level = 2
+[profile.dev.package.wasmer-compiler]
+opt-level = 2
+[profile.dev.package.wasmer-compiler-cranelift]
+opt-level = 2
+[profile.dev.package.cranelift-codegen]
+opt-level = 2
+[profile.dev.package.cranelift-frontend]
+opt-level = 2
+[profile.dev.package.cranelift-entity]
+opt-level = 2
+```
+
+<Aside type="note">
+  The first build after adding these lines will take a bit longer as Cargo recompiles
+  the affected crates with optimizations. Subsequent builds will be fast as usual, and
+  your template tests will run significantly faster.
+</Aside>
+
 ## Full annotated code
 
 <p>


### PR DESCRIPTION
## Summary
- Cache compiled builtin templates in a `LazyLock` so they're wasmer-compiled once per test binary instead of once per test
- Add `[profile.dev.package.*]` overrides for wasmer/cranelift crates with `opt-level=2` — Cranelift JIT runs ~10x slower unoptimized
- `tari_engine` test suite: **152s → 5s** (28.5x improvement); single test: **10.6s → 2.1s**

 ## Root Cause

  **92% of test time (9.75s/10.6s) was spent wasmer-compiling the 4 builtin templates** (account, faucet, nft_faucet, liquidity_pool — ~2.1MB total WASM). This happened from scratch on every `TemplateTest::new()`
  call. The Cranelift JIT compiler runs ~10x slower in debug mode.

  ## Fixes 

  1. **`LazyLock` cache for builtin templates** — compiled once per test binary, shared across all tests via cheap `Clone`
  2. **Profile overrides for wasmer/cranelift** — `opt-level=2` in dev builds so the JIT itself runs optimized
  3. **Documentation** — added a "Speeding up template tests" section to the guessing game guide

  ## Results

  | Scenario | Before | After | Speedup |
  |---|---|---|---|
  | Single test (`test_state`) | 10.6s | 2.1s | **5x** |
  | All 24 engine tests | 152s | 5s | **28.5x** |


## Test plan
- [x] `cargo test --package tari_engine --test test` — all 24 tests pass (5.35s)
- [x] `cargo test --package tari_template_builtin` — all tests pass
- [ ] CI passes

Fixes #1935