### PR TITLE
feat(app_utilities): feature-gate p2p/networking dependencies

### DIFF
--- a/applications/tari_indexer/Cargo.toml
+++ b/applications/tari_indexer/Cargo.toml
@@ -29,7 +29,7 @@ tari_epoch_oracles = { workspace = true, features = ["base_layer"] }
 tari_indexer_client = { workspace = true, default-features = false, features = ["utoipa"] }
 tari_indexer_lib = { workspace = true }
 tari_networking = { workspace = true }
-tari_ootle_app_utilities = { workspace = true, features = ["epoch_oracle"] }
+tari_ootle_app_utilities = { workspace = true, features = ["epoch_oracle", "p2p"] }
 tari_ootle_common_types = { workspace = true }
 tari_ootle_p2p = { workspace = true }
 tari_ootle_storage = { workspace = true }

--- a/applications/tari_ootle_app_utilities/Cargo.toml
+++ b/applications/tari_ootle_app_utilities/Cargo.toml
@@ -19,10 +19,10 @@ tari_template_lib = { workspace = true }
 tari_ootle_transaction = { workspace = true }
 tari_bor = { workspace = true, default-features = true }
 tari_mmr = { workspace = true }
-tari_networking = { workspace = true }
+tari_networking = { workspace = true, optional = true }
 tari_transaction_components = { workspace = true }
 tari_hashing = { workspace = true }
-tari_ootle_p2p = { workspace = true }
+tari_ootle_p2p = { workspace = true, optional = true }
 ootle_serde = { workspace = true }
 ootle_byte_type = { workspace = true, features = ["crypto"] }
 
@@ -30,9 +30,9 @@ anyhow = { workspace = true }
 blake2 = { workspace = true }
 bincode = { workspace = true, features = ["serde"] }
 clap = { workspace = true, features = ["derive", "env"] }
-libp2p-identity = { workspace = true }
+libp2p-identity = { workspace = true, optional = true }
 log = { workspace = true, features = ["std"] }
-multiaddr = { workspace = true }
+multiaddr = { workspace = true, optional = true }
 rand = { workspace = true }
 serde = { workspace = true, features = ["default", "derive", "rc"] }
 serde_json5 = { workspace = true }
@@ -43,4 +43,5 @@ toml = { workspace = true }
 config = { workspace = true }
 
 [features]
+p2p = ["tari_networking", "tari_ootle_p2p", "libp2p-identity", "multiaddr"]
 epoch_oracle = ["tari_epoch_oracles"]

--- a/applications/tari_ootle_app_utilities/src/keypair.rs
+++ b/applications/tari_ootle_app_utilities/src/keypair.rs
@@ -52,6 +52,7 @@ use tari_crypto::{
     keys::{PublicKey as _, SecretKey as _},
     ristretto::{RistrettoPublicKey, RistrettoSecretKey},
 };
+#[cfg(feature = "p2p")]
 use tari_ootle_p2p::PeerAddress;
 
 const REQUIRED_IDENTITY_PERMS: u32 = 0o100600;
@@ -80,6 +81,7 @@ impl RistrettoKeypair {
         &self.0.public_key
     }
 
+    #[cfg(feature = "p2p")]
     pub fn to_peer_address(&self) -> PeerAddress {
         self.public_key().clone().into()
     }
@@ -155,8 +157,7 @@ pub fn setup_keypair_prompt<P: AsRef<Path>>(identity_file: P, create_id: bool) -
                 Ok(id) => {
                     info!(
                         target: LOG_TARGET,
-                        "New node identity [{}] with public key {} has been created at {}.",
-                        id.to_peer_address(),
+                        "New node identity with public key {} has been created at {}.",
                         id.public_key(),
                         identity_file.as_ref().to_str().unwrap_or("?"),
                     );
@@ -187,11 +188,7 @@ fn load_keypair<P: AsRef<Path>>(path: P) -> Result<RistrettoKeypair, IdentityErr
 
     let mut file = fs::File::open(path)?;
     let id = serde_json5::from_reader::<_, RistrettoKeypair>(&mut file)?;
-    debug!(
-        "Node ID loaded with public key {} and Node id {}",
-        id.public_key(),
-        id.to_peer_address()
-    );
+    debug!("Node ID loaded with public key {}", id.public_key());
     Ok(id)
 }
 

--- a/applications/tari_ootle_app_utilities/src/lib.rs
+++ b/applications/tari_ootle_app_utilities/src/lib.rs
@@ -29,7 +29,9 @@ pub mod fee_tables;
 pub mod genesis_resources;
 pub mod identity_management;
 pub mod keypair;
+#[cfg(feature = "p2p")]
 pub mod p2p_config;
+#[cfg(feature = "p2p")]
 pub mod seed_peer;
 pub mod shared_consts;
 pub mod tcp;

--- a/applications/tari_validator_node/Cargo.toml
+++ b/applications/tari_validator_node/Cargo.toml
@@ -21,7 +21,7 @@ tari_transaction_components = { workspace = true }
 tari_crypto = { workspace = true }
 tari_epoch_oracles = { workspace = true, features = ["base_layer"] }
 tari_validator_node_rpc = { workspace = true }
-tari_ootle_app_utilities = { workspace = true, features = ["epoch_oracle"] }
+tari_ootle_app_utilities = { workspace = true, features = ["epoch_oracle", "p2p"] }
 tari_ootle_common_types = { workspace = true }
 tari_ootle_p2p = { workspace = true }
 tari_engine = { workspace = true }

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -29,7 +29,7 @@ tari_shutdown = { workspace = true }
 tari_sidechain = { workspace = true }
 
 tari_crypto = { workspace = true }
-tari_ootle_app_utilities = { workspace = true, features = ["epoch_oracle"] }
+tari_ootle_app_utilities = { workspace = true, features = ["epoch_oracle", "p2p"] }
 tari_ootle_common_types = { workspace = true }
 tari_engine = { workspace = true }
 tari_engine_types = { workspace = true }


### PR DESCRIPTION
## Summary

- Adds a `p2p` feature gate to `tari_ootle_app_utilities` that makes `tari_networking`, `tari_ootle_p2p`, `libp2p-identity`, and `multiaddr` optional dependencies
- Gates `p2p_config`, `seed_peer` modules and `keypair::to_peer_address()` behind `#[cfg(feature = "p2p")]`
- Enables the `p2p` feature in downstream crates that need it (validator node, indexer, integration tests)
- The wallet daemon (`tari_ootle_walletd`) no longer transitively pulls in `tari_swarm`/libp2p

## Motivation

The wallet daemon doesn't need p2p networking but was pulling in `tari_swarm` and all of libp2p transitively through `tari_ootle_app_utilities` -> `tari_networking` -> `tari_swarm`. This unnecessarily increased compile times and binary size.

## Test plan

- [x] `cargo check -p tari_ootle_walletd` compiles successfully
- [x] `cargo check -p tari_validator_node -p tari_indexer` compiles successfully
- [x] `cargo tree -p tari_ootle_walletd -i tari_swarm` confirms tari_swarm is no longer in the wallet daemon's dependency tree