### PR TITLE
feat(walletd): add public key to MyAssets account details

### DIFF
--- a/applications/tari_walletd/web_ui/src/routes/AssetVault/Components/AccountDetails.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/AssetVault/Components/AccountDetails.tsx
@@ -45,6 +45,7 @@ import Typography from "@mui/material/Typography";
 import useAccountStore, { setAccount } from "@store/accountStore";
 import {
   decodeOotleAddress,
+  decodeOotleAddressOrNull,
   encodeOotleAddress,
   OotleAddress,
   substateIdToString,
@@ -74,6 +75,7 @@ function AccountDetails() {
             <TableCell>Name</TableCell>
             <TableCell>Component</TableCell>
             <TableCell>Address</TableCell>
+            <TableCell>Public Key</TableCell>
           </TableRow>
         </TableHead>
         <TableBody>
@@ -97,6 +99,13 @@ function AccountDetails() {
                   </IconButton>
                 </Tooltip>
               </Stack>
+            </DataTableCell>
+            <DataTableCell>
+              {address && (
+                <CopyAddress
+                  address={decodeOotleAddressOrNull(address)?.accountPublicKey || "<decode error>"}
+                />
+              )}
             </DataTableCell>
           </TableRow>
         </TableBody>

--- a/applications/tari_walletd/web_ui/src/routes/AssetVault/Components/AccountDetails.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/AssetVault/Components/AccountDetails.tsx
@@ -66,6 +66,9 @@ function AccountDetails() {
     setAccount({ ...account, name: newName });
   };
 
+  const decodedAddress = address ? decodeOotleAddressOrNull(address) : null;
+  const accountPublicKey = decodedAddress?.accountPublicKey;
+
   return (
     <TableContainer>
       <PayRefDialog address={address} open={payRefDialogOpen} onClose={() => setPayRefDialogOpen(false)} />
@@ -101,11 +104,7 @@ function AccountDetails() {
               </Stack>
             </DataTableCell>
             <DataTableCell>
-              {address && decodeOotleAddressOrNull(address)?.accountPublicKey && (
-                <CopyAddress
-                  address={decodeOotleAddressOrNull(address)!.accountPublicKey}
-                />
-              )}
+              {accountPublicKey && <CopyAddress address={decodeOotleAddressOrNull(address)!.accountPublicKey} />}
             </DataTableCell>
           </TableRow>
         </TableBody>

--- a/applications/tari_walletd/web_ui/src/routes/AssetVault/Components/AccountDetails.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/AssetVault/Components/AccountDetails.tsx
@@ -101,9 +101,9 @@ function AccountDetails() {
               </Stack>
             </DataTableCell>
             <DataTableCell>
-              {address && (
+              {address && decodeOotleAddressOrNull(address)?.accountPublicKey && (
                 <CopyAddress
-                  address={decodeOotleAddressOrNull(address)?.accountPublicKey || "<decode error>"}
+                  address={decodeOotleAddressOrNull(address)!.accountPublicKey}
                 />
               )}
             </DataTableCell>


### PR DESCRIPTION
## Summary
- Adds a **Public Key** column to the Account Details table in the MyAssets view
- Decodes the public key from the account's Ootle address using `decodeOotleAddressOrNull`
- Uses the existing `CopyAddress` component for consistent copy-to-clipboard UX

## Test plan
- [ ] Open MyAssets page in the wallet web UI
- [ ] Verify the Public Key column appears in the Account Details table
- [ ] Verify the public key is correctly displayed (shortened) with full key on hover
- [ ] Verify clicking the copy icon copies the full public key to clipboard