### PR TITLE
fix(walletd): only mark burn proof as claimed on successful transaction

### DIFF
--- a/applications/tari_walletd/src/handlers/accounts.rs
+++ b/applications/tari_walletd/src/handlers/accounts.rs
@@ -587,7 +587,20 @@ pub async fn handle_claim_burn(
         });
     }
 
+    let mut events = context.notifier().subscribe();
     let tx_id = context.transaction_service().submit_transaction(transaction).await?;
+
+    let finalized = wait_for_result(&mut events, tx_id).await?;
+
+    if let Some(reject) = finalized.finalize.result.fee_reject() {
+        return Err(anyhow::anyhow!("Claim burn fee transaction rejected: {}", reject));
+    }
+    if let Some(reason) = finalized.finalize.any_reject() {
+        return Err(anyhow::anyhow!(
+            "Claim burn fee transaction succeeded (fees charged) however the transaction failed: {}",
+            reason
+        ));
+    }
 
     if let Some(file_name) = proof_file_name {
         let proof_dir = context.config().get_burn_proof_dir(network);


### PR DESCRIPTION
## Description

Fix a bug in `handle_claim_burn` where burn proofs were moved to the "claimed" directory immediately after submitting the transaction, without waiting for it to succeed. If the transaction was rejected, the proof was permanently consumed and could not be retried.

## Motivation

A failed claim burn transaction should be retryable. The burn proof should only be marked as claimed once the transaction has been confirmed on-chain.

## Changes

- Subscribe to events before submitting the transaction
- Await `wait_for_result` to get the finalized transaction outcome
- Return an error if the transaction is fee-rejected or otherwise rejected
- Only mark the burn proof as claimed after confirming success