### PR TITLE
fix(consensus): remove eager pending_stage writes to prevent stale stage after leader failure

### DIFF
--- a/crates/state_store_rocksdb/src/reader.rs
+++ b/crates/state_store_rocksdb/src/reader.rs
@@ -1325,7 +1325,7 @@ impl<'tx, TAddr: NodeAddressable + Serialize + DeserializeOwned + 'tx> StateStor
                 };
 
                 if let Some(stage) = stage &&
-                    tx_pool_rec.pending_stage() != Some(stage)
+                    tx_pool_rec.current_stage() != stage
                 {
                     continue;
                 }

--- a/crates/state_store_rocksdb/src/writer.rs
+++ b/crates/state_store_rocksdb/src/writer.rs
@@ -875,13 +875,13 @@ impl<'tx, TAddr: NodeAddressable + 'tx> StateStoreWriteTransaction for RocksDbSt
             )?;
         }
 
-        // Set is_ready and pending_stage to the updated values. This allows has_uncommitted_transactions to return an
-        // accurate value without querying records in the updates table.
+        // Update the last_updated timestamp on the base record for informational purposes.
+        // NOTE: We intentionally do NOT eagerly write pending_stage or is_ready to the base record here.
+        // The pending state is resolved from the pending chain when needed (via get_for_blocks / get_many_ready).
+        // Eagerly writing these fields caused stale state when blocks ended up on dead branches (leader failures),
+        // leading to permanent "Stage disagreement" no-votes.
         let cf = self.db().cf(TransactionPoolCf)?;
         let mut tx_pool_value = cf.get(update.transaction_id(), OPERATION)?;
-
-        tx_pool_value.set_is_ready(update.is_ready_now());
-        tx_pool_value.set_pending_stage(Some(update.stage()));
         tx_pool_value.set_last_updated(*block.block_id(), time::OffsetDateTime::now_utc());
         cf.put(update.transaction_id(), &tx_pool_value, OPERATION)?;
 


### PR DESCRIPTION
## Summary

- Fixes a consensus bug where stale `pending_stage` on the transaction pool base record causes permanent "Stage disagreement" no-votes after leader failures, permanently stalling affected transactions
- Removes eager writes of `pending_stage` and `is_ready` to the base record in `transaction_pool_add_pending_update` — pending state is correctly resolved from the pending chain via `get_for_blocks`/`get_many_ready`
- Fixes `transaction_pool_count` to use `current_stage()` instead of `pending_stage()` for stage filtering

## Motivation

When a validator votes to accept a block, `transaction_pool_add_pending_update` eagerly wrote `pending_stage` and `is_ready` to the base `TransactionPoolCf` record. When that block ended up on a dead branch (leader failure/timeouts), the state update entry in `TransactionPoolStateUpdateCf` was cleaned up by orphan removal, but the eagerly-written base record fields were NOT reset. This caused `current_stage()` to return a stale stage (e.g. `LocalOnly` instead of `New`), leading to "Stage disagreement" no-votes on every subsequent proposal containing that transaction.

## Test plan

- [x] `cargo test -p tari_state_store_rocksdb` — 32 tests pass
- [x] `cargo test -p consensus_tests` — 42 tests pass
- [x] `cargo build -p tari_validator_node` — compiles cleanly