### PR TITLE
chore(publish): three-tier versioning and publish prep for 0.28

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7373,7 +7373,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "ootle-rs"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -11556,7 +11556,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_sdk"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "digest 0.10.7",
@@ -11705,7 +11705,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_walletd_client"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "hex",
  "ootle_serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11449,7 +11449,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_template_build"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "tari_ootle_template_metadata",
  "tempfile",
@@ -11458,7 +11458,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_template_metadata"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "borsh",
  "cargo_toml 0.22.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7373,7 +7373,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "ootle-rs"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -11296,7 +11296,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_address"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "bech32",
  "bincode 2.0.1",
@@ -11527,7 +11527,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_crypto"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "argon2 0.5.3",
  "blake2",
@@ -11556,7 +11556,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_sdk"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "digest 0.10.7",
@@ -11705,7 +11705,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_walletd_client"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "hex",
  "ootle_serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1692,7 +1692,7 @@ dependencies = [
 
 [[package]]
 name = "consensus_tests"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "fern",
  "futures 0.3.31",
@@ -2671,7 +2671,7 @@ dependencies = [
 
 [[package]]
 name = "db-inspector"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -4899,7 +4899,7 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "integration_tests"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "anyhow",
  "config",
@@ -5615,7 +5615,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-messaging"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "async-trait",
  "futures-bounded",
@@ -5794,7 +5794,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-substream"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "libp2p",
  "prometheus-client",
@@ -7402,7 +7402,7 @@ dependencies = [
 
 [[package]]
 name = "ootle-wasm"
-version = "0.4.0"
+version = "0.28.1"
 dependencies = [
  "console_error_panic_hook",
  "getrandom 0.2.17",
@@ -7412,7 +7412,7 @@ dependencies = [
 
 [[package]]
 name = "ootle-wasm-core"
-version = "0.4.0"
+version = "0.28.1"
 dependencies = [
  "base64 0.22.1",
  "ootle_byte_type",
@@ -8407,7 +8407,7 @@ dependencies = [
 
 [[package]]
 name = "proto_builder"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "prost-build 0.14.3",
  "sha2 0.10.9",
@@ -10215,7 +10215,7 @@ dependencies = [
 
 [[package]]
 name = "sqlite_message_logger"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "chrono",
  "diesel",
@@ -10588,7 +10588,7 @@ dependencies = [
 
 [[package]]
 name = "tari_base_node_client"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "futures-util",
  "log",
@@ -10813,7 +10813,7 @@ dependencies = [
 
 [[package]]
 name = "tari_consensus"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "anyhow",
  "indexmap 2.13.0",
@@ -10838,7 +10838,7 @@ dependencies = [
 
 [[package]]
 name = "tari_consensus_types"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "borsh",
  "ootle_serde",
@@ -10940,7 +10940,7 @@ dependencies = [
 
 [[package]]
 name = "tari_engine"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "blake2",
  "criterion",
@@ -10968,7 +10968,7 @@ dependencies = [
 
 [[package]]
 name = "tari_engine_types"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "bincode 2.0.1",
  "blake2",
@@ -10996,7 +10996,7 @@ dependencies = [
 
 [[package]]
 name = "tari_epoch_manager"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "anyhow",
  "log",
@@ -11016,7 +11016,7 @@ dependencies = [
 
 [[package]]
 name = "tari_epoch_oracles"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -11069,7 +11069,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -11139,7 +11139,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer_client"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "anyhow",
  "bounded-vec",
@@ -11168,7 +11168,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer_lib"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "log",
  "prometheus-client",
@@ -11260,7 +11260,7 @@ dependencies = [
 
 [[package]]
 name = "tari_networking"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11312,7 +11312,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_app_utilities"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -11351,7 +11351,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_common_types"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "blake2",
  "borsh",
@@ -11377,7 +11377,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_p2p"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "anyhow",
  "libp2p-identity",
@@ -11401,7 +11401,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_storage"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "anyhow",
  "bitflags 2.10.0",
@@ -11428,7 +11428,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_storage_sqlite"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "diesel",
  "diesel_migrations",
@@ -11473,7 +11473,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_transaction"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "bincode 2.0.1",
  "borsh",
@@ -11498,7 +11498,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_cli"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -11527,7 +11527,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_crypto"
-version = "0.3.0"
+version = "0.28.1"
 dependencies = [
  "argon2 0.5.3",
  "blake2",
@@ -11556,7 +11556,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_sdk"
-version = "0.3.1"
+version = "0.28.1"
 dependencies = [
  "anyhow",
  "digest 0.10.7",
@@ -11621,7 +11621,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_storage_sqlite"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "bigdecimal",
  "diesel",
@@ -11645,7 +11645,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_walletd"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11705,7 +11705,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_walletd_client"
-version = "0.5.1"
+version = "0.28.1"
 dependencies = [
  "hex",
  "ootle_serde",
@@ -11759,7 +11759,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_framework"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "async-trait",
  "bitflags 2.10.0",
@@ -11783,7 +11783,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_macros"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11792,7 +11792,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_state_sync"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -11869,7 +11869,7 @@ dependencies = [
 
 [[package]]
 name = "tari_state_store_rocksdb"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -11900,7 +11900,7 @@ dependencies = [
 
 [[package]]
 name = "tari_state_tree"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "indexmap 2.13.0",
  "log",
@@ -11926,7 +11926,7 @@ dependencies = [
 
 [[package]]
 name = "tari_swarm"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "libp2p",
  "libp2p-messaging",
@@ -11937,7 +11937,7 @@ dependencies = [
 
 [[package]]
 name = "tari_swarm_daemon"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11992,7 +11992,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_builtin"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "anyhow",
  "tari_engine_types",
@@ -12046,7 +12046,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_test_tooling"
-version = "0.26.4"
+version = "0.28.1"
 dependencies = [
  "anyhow",
  "cargo_toml 0.22.3",
@@ -12161,7 +12161,7 @@ dependencies = [
 
 [[package]]
 name = "tari_transaction_manifest"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "proc-macro2",
  "serde_json",
@@ -12195,7 +12195,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -12261,7 +12261,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node_client"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "indexmap 2.13.0",
  "multiaddr 0.18.3",
@@ -12285,7 +12285,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node_rpc"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -12321,7 +12321,7 @@ dependencies = [
 
 [[package]]
 name = "tari_watcher"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "anyhow",
  "clap 3.2.25",
@@ -12349,7 +12349,7 @@ dependencies = [
 
 [[package]]
 name = "tariswap_bench"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "anyhow",
  "clap 4.5.54",
@@ -13029,7 +13029,7 @@ dependencies = [
 
 [[package]]
 name = "traffic-sim"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "anyhow",
  "clap 4.5.54",
@@ -13051,7 +13051,7 @@ dependencies = [
 
 [[package]]
 name = "transaction_generator"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -13072,7 +13072,7 @@ dependencies = [
 
 [[package]]
 name = "transaction_submitter"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "anyhow",
  "clap 4.5.54",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11449,7 +11449,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_template_build"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "tari_ootle_template_metadata",
  "tempfile",
@@ -11458,7 +11458,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_template_metadata"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "borsh",
  "cargo_toml 0.22.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1692,7 +1692,7 @@ dependencies = [
 
 [[package]]
 name = "consensus_tests"
-version = "0.28.2"
+version = "0.28.3"
 dependencies = [
  "fern",
  "futures 0.3.31",
@@ -2671,7 +2671,7 @@ dependencies = [
 
 [[package]]
 name = "db-inspector"
-version = "0.28.2"
+version = "0.28.3"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -4899,7 +4899,7 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "integration_tests"
-version = "0.28.2"
+version = "0.28.3"
 dependencies = [
  "anyhow",
  "config",
@@ -5615,7 +5615,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-messaging"
-version = "0.28.2"
+version = "0.28.3"
 dependencies = [
  "async-trait",
  "futures-bounded",
@@ -5794,7 +5794,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-substream"
-version = "0.28.2"
+version = "0.28.3"
 dependencies = [
  "libp2p",
  "prometheus-client",
@@ -7402,7 +7402,7 @@ dependencies = [
 
 [[package]]
 name = "ootle-wasm"
-version = "0.28.2"
+version = "0.28.3"
 dependencies = [
  "console_error_panic_hook",
  "getrandom 0.2.17",
@@ -7412,7 +7412,7 @@ dependencies = [
 
 [[package]]
 name = "ootle-wasm-core"
-version = "0.28.2"
+version = "0.28.3"
 dependencies = [
  "base64 0.22.1",
  "ootle_byte_type",
@@ -8407,7 +8407,7 @@ dependencies = [
 
 [[package]]
 name = "proto_builder"
-version = "0.28.2"
+version = "0.28.3"
 dependencies = [
  "prost-build 0.14.3",
  "sha2 0.10.9",
@@ -10215,7 +10215,7 @@ dependencies = [
 
 [[package]]
 name = "sqlite_message_logger"
-version = "0.28.2"
+version = "0.28.3"
 dependencies = [
  "chrono",
  "diesel",
@@ -10588,7 +10588,7 @@ dependencies = [
 
 [[package]]
 name = "tari_base_node_client"
-version = "0.28.2"
+version = "0.28.3"
 dependencies = [
  "futures-util",
  "log",
@@ -10813,7 +10813,7 @@ dependencies = [
 
 [[package]]
 name = "tari_consensus"
-version = "0.28.2"
+version = "0.28.3"
 dependencies = [
  "anyhow",
  "indexmap 2.13.0",
@@ -10838,7 +10838,7 @@ dependencies = [
 
 [[package]]
 name = "tari_consensus_types"
-version = "0.28.2"
+version = "0.28.3"
 dependencies = [
  "borsh",
  "ootle_serde",
@@ -10940,7 +10940,7 @@ dependencies = [
 
 [[package]]
 name = "tari_engine"
-version = "0.28.2"
+version = "0.28.3"
 dependencies = [
  "blake2",
  "criterion",
@@ -10968,7 +10968,7 @@ dependencies = [
 
 [[package]]
 name = "tari_engine_types"
-version = "0.28.2"
+version = "0.28.3"
 dependencies = [
  "bincode 2.0.1",
  "blake2",
@@ -10996,7 +10996,7 @@ dependencies = [
 
 [[package]]
 name = "tari_epoch_manager"
-version = "0.28.2"
+version = "0.28.3"
 dependencies = [
  "anyhow",
  "log",
@@ -11016,7 +11016,7 @@ dependencies = [
 
 [[package]]
 name = "tari_epoch_oracles"
-version = "0.28.2"
+version = "0.28.3"
 dependencies = [
  "anyhow",
  "blake2",
@@ -11069,7 +11069,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer"
-version = "0.28.2"
+version = "0.28.3"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -11139,7 +11139,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer_client"
-version = "0.28.2"
+version = "0.28.3"
 dependencies = [
  "anyhow",
  "bounded-vec",
@@ -11168,7 +11168,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer_lib"
-version = "0.28.2"
+version = "0.28.3"
 dependencies = [
  "log",
  "prometheus-client",
@@ -11260,7 +11260,7 @@ dependencies = [
 
 [[package]]
 name = "tari_networking"
-version = "0.28.2"
+version = "0.28.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11312,7 +11312,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_app_utilities"
-version = "0.28.2"
+version = "0.28.3"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -11351,7 +11351,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_common_types"
-version = "0.28.2"
+version = "0.28.3"
 dependencies = [
  "blake2",
  "borsh",
@@ -11377,7 +11377,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_p2p"
-version = "0.28.2"
+version = "0.28.3"
 dependencies = [
  "anyhow",
  "libp2p-identity",
@@ -11401,7 +11401,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_storage"
-version = "0.28.2"
+version = "0.28.3"
 dependencies = [
  "anyhow",
  "bitflags 2.10.0",
@@ -11428,7 +11428,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_storage_sqlite"
-version = "0.28.2"
+version = "0.28.3"
 dependencies = [
  "diesel",
  "diesel_migrations",
@@ -11473,7 +11473,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_transaction"
-version = "0.28.2"
+version = "0.28.3"
 dependencies = [
  "bincode 2.0.1",
  "borsh",
@@ -11498,7 +11498,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_cli"
-version = "0.28.2"
+version = "0.28.3"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -11527,7 +11527,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_crypto"
-version = "0.28.2"
+version = "0.28.3"
 dependencies = [
  "argon2 0.5.3",
  "blake2",
@@ -11556,7 +11556,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_sdk"
-version = "0.28.2"
+version = "0.28.3"
 dependencies = [
  "anyhow",
  "digest 0.10.7",
@@ -11621,7 +11621,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_storage_sqlite"
-version = "0.28.2"
+version = "0.28.3"
 dependencies = [
  "bigdecimal",
  "diesel",
@@ -11645,7 +11645,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_walletd"
-version = "0.28.2"
+version = "0.28.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11705,7 +11705,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_walletd_client"
-version = "0.28.2"
+version = "0.28.3"
 dependencies = [
  "hex",
  "ootle_serde",
@@ -11759,7 +11759,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_framework"
-version = "0.28.2"
+version = "0.28.3"
 dependencies = [
  "async-trait",
  "bitflags 2.10.0",
@@ -11783,7 +11783,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_macros"
-version = "0.28.2"
+version = "0.28.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11792,7 +11792,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_state_sync"
-version = "0.28.2"
+version = "0.28.3"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -11869,7 +11869,7 @@ dependencies = [
 
 [[package]]
 name = "tari_state_store_rocksdb"
-version = "0.28.2"
+version = "0.28.3"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -11900,7 +11900,7 @@ dependencies = [
 
 [[package]]
 name = "tari_state_tree"
-version = "0.28.2"
+version = "0.28.3"
 dependencies = [
  "indexmap 2.13.0",
  "log",
@@ -11926,7 +11926,7 @@ dependencies = [
 
 [[package]]
 name = "tari_swarm"
-version = "0.28.2"
+version = "0.28.3"
 dependencies = [
  "libp2p",
  "libp2p-messaging",
@@ -11937,7 +11937,7 @@ dependencies = [
 
 [[package]]
 name = "tari_swarm_daemon"
-version = "0.28.2"
+version = "0.28.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11992,7 +11992,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_builtin"
-version = "0.28.2"
+version = "0.28.3"
 dependencies = [
  "anyhow",
  "tari_engine_types",
@@ -12046,7 +12046,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_test_tooling"
-version = "0.28.2"
+version = "0.28.3"
 dependencies = [
  "anyhow",
  "cargo_toml 0.22.3",
@@ -12161,7 +12161,7 @@ dependencies = [
 
 [[package]]
 name = "tari_transaction_manifest"
-version = "0.28.2"
+version = "0.28.3"
 dependencies = [
  "proc-macro2",
  "serde_json",
@@ -12195,7 +12195,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node"
-version = "0.28.2"
+version = "0.28.3"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -12261,7 +12261,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node_client"
-version = "0.28.2"
+version = "0.28.3"
 dependencies = [
  "indexmap 2.13.0",
  "multiaddr 0.18.3",
@@ -12285,7 +12285,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node_rpc"
-version = "0.28.2"
+version = "0.28.3"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -12321,7 +12321,7 @@ dependencies = [
 
 [[package]]
 name = "tari_watcher"
-version = "0.28.2"
+version = "0.28.3"
 dependencies = [
  "anyhow",
  "clap 3.2.25",
@@ -12349,7 +12349,7 @@ dependencies = [
 
 [[package]]
 name = "tariswap_bench"
-version = "0.28.2"
+version = "0.28.3"
 dependencies = [
  "anyhow",
  "clap 4.5.54",
@@ -13029,7 +13029,7 @@ dependencies = [
 
 [[package]]
 name = "traffic-sim"
-version = "0.28.2"
+version = "0.28.3"
 dependencies = [
  "anyhow",
  "clap 4.5.54",
@@ -13051,7 +13051,7 @@ dependencies = [
 
 [[package]]
 name = "transaction_generator"
-version = "0.28.2"
+version = "0.28.3"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -13072,7 +13072,7 @@ dependencies = [
 
 [[package]]
 name = "transaction_submitter"
-version = "0.28.2"
+version = "0.28.3"
 dependencies = [
  "anyhow",
  "clap 4.5.54",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1692,7 +1692,7 @@ dependencies = [
 
 [[package]]
 name = "consensus_tests"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "fern",
  "futures 0.3.31",
@@ -2671,7 +2671,7 @@ dependencies = [
 
 [[package]]
 name = "db-inspector"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -4899,7 +4899,7 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "integration_tests"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "anyhow",
  "config",
@@ -5615,7 +5615,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-messaging"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "async-trait",
  "futures-bounded",
@@ -5794,7 +5794,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-substream"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "libp2p",
  "prometheus-client",
@@ -7402,7 +7402,7 @@ dependencies = [
 
 [[package]]
 name = "ootle-wasm"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "console_error_panic_hook",
  "getrandom 0.2.17",
@@ -7412,7 +7412,7 @@ dependencies = [
 
 [[package]]
 name = "ootle-wasm-core"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "base64 0.22.1",
  "ootle_byte_type",
@@ -8407,7 +8407,7 @@ dependencies = [
 
 [[package]]
 name = "proto_builder"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "prost-build 0.14.3",
  "sha2 0.10.9",
@@ -10215,7 +10215,7 @@ dependencies = [
 
 [[package]]
 name = "sqlite_message_logger"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "chrono",
  "diesel",
@@ -10588,7 +10588,7 @@ dependencies = [
 
 [[package]]
 name = "tari_base_node_client"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "futures-util",
  "log",
@@ -10813,7 +10813,7 @@ dependencies = [
 
 [[package]]
 name = "tari_consensus"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "anyhow",
  "indexmap 2.13.0",
@@ -10838,7 +10838,7 @@ dependencies = [
 
 [[package]]
 name = "tari_consensus_types"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "borsh",
  "ootle_serde",
@@ -10940,7 +10940,7 @@ dependencies = [
 
 [[package]]
 name = "tari_engine"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "blake2",
  "criterion",
@@ -10968,7 +10968,7 @@ dependencies = [
 
 [[package]]
 name = "tari_engine_types"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "bincode 2.0.1",
  "blake2",
@@ -10996,7 +10996,7 @@ dependencies = [
 
 [[package]]
 name = "tari_epoch_manager"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "anyhow",
  "log",
@@ -11016,7 +11016,7 @@ dependencies = [
 
 [[package]]
 name = "tari_epoch_oracles"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "anyhow",
  "blake2",
@@ -11069,7 +11069,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -11139,7 +11139,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer_client"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "anyhow",
  "bounded-vec",
@@ -11168,7 +11168,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer_lib"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "log",
  "prometheus-client",
@@ -11260,7 +11260,7 @@ dependencies = [
 
 [[package]]
 name = "tari_networking"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11312,7 +11312,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_app_utilities"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -11351,7 +11351,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_common_types"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "blake2",
  "borsh",
@@ -11377,7 +11377,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_p2p"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "anyhow",
  "libp2p-identity",
@@ -11401,7 +11401,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_storage"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "anyhow",
  "bitflags 2.10.0",
@@ -11428,7 +11428,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_storage_sqlite"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "diesel",
  "diesel_migrations",
@@ -11473,7 +11473,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_transaction"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "bincode 2.0.1",
  "borsh",
@@ -11498,7 +11498,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_cli"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -11527,7 +11527,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_crypto"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "argon2 0.5.3",
  "blake2",
@@ -11556,7 +11556,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_sdk"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "anyhow",
  "digest 0.10.7",
@@ -11621,7 +11621,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_storage_sqlite"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "bigdecimal",
  "diesel",
@@ -11645,7 +11645,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_walletd"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11705,7 +11705,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_walletd_client"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "hex",
  "ootle_serde",
@@ -11759,7 +11759,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_framework"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "async-trait",
  "bitflags 2.10.0",
@@ -11783,7 +11783,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_macros"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11792,7 +11792,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_state_sync"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -11869,7 +11869,7 @@ dependencies = [
 
 [[package]]
 name = "tari_state_store_rocksdb"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -11900,7 +11900,7 @@ dependencies = [
 
 [[package]]
 name = "tari_state_tree"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "indexmap 2.13.0",
  "log",
@@ -11926,7 +11926,7 @@ dependencies = [
 
 [[package]]
 name = "tari_swarm"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "libp2p",
  "libp2p-messaging",
@@ -11937,7 +11937,7 @@ dependencies = [
 
 [[package]]
 name = "tari_swarm_daemon"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11992,7 +11992,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_builtin"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "anyhow",
  "tari_engine_types",
@@ -12046,7 +12046,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_test_tooling"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "anyhow",
  "cargo_toml 0.22.3",
@@ -12161,7 +12161,7 @@ dependencies = [
 
 [[package]]
 name = "tari_transaction_manifest"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "proc-macro2",
  "serde_json",
@@ -12195,7 +12195,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -12261,7 +12261,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node_client"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "indexmap 2.13.0",
  "multiaddr 0.18.3",
@@ -12285,7 +12285,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node_rpc"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -12321,7 +12321,7 @@ dependencies = [
 
 [[package]]
 name = "tari_watcher"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "anyhow",
  "clap 3.2.25",
@@ -12349,7 +12349,7 @@ dependencies = [
 
 [[package]]
 name = "tariswap_bench"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "anyhow",
  "clap 4.5.54",
@@ -13029,7 +13029,7 @@ dependencies = [
 
 [[package]]
 name = "traffic-sim"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "anyhow",
  "clap 4.5.54",
@@ -13051,7 +13051,7 @@ dependencies = [
 
 [[package]]
 name = "transaction_generator"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -13072,7 +13072,7 @@ dependencies = [
 
 [[package]]
 name = "transaction_submitter"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "anyhow",
  "clap 4.5.54",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.28.0"
+version = "0.28.1"
 edition = "2024"
 authors = ["The Tari Development Community"]
 repository = "https://github.com/tari-project/tari-ootle"
@@ -90,10 +90,10 @@ tari_engine = { path = "crates/engine", version = "0.28" }
 tari_ootle_p2p = { path = "crates/p2p" }
 tari_ootle_storage = { path = "crates/storage" }
 tari_ootle_storage_sqlite = { path = "crates/storage_sqlite" }
-tari_ootle_wallet_crypto = { path = "crates/wallet/crypto", version = "0.3" }
-tari_ootle_wallet_sdk = { path = "crates/wallet/sdk", version = "0.3.1" }
+tari_ootle_wallet_crypto = { path = "crates/wallet/crypto", version = "0.28" }
+tari_ootle_wallet_sdk = { path = "crates/wallet/sdk", version = "0.28" }
 tari_ootle_wallet_sdk_services = { path = "crates/wallet/sdk_services" }
-tari_ootle_wallet_storage_sqlite = { path = "crates/wallet/storage_sqlite" }
+tari_ootle_wallet_storage_sqlite = { path = "crates/wallet/storage_sqlite", version = "0.28" }
 tari_epoch_manager = { path = "crates/epoch_manager" }
 tari_epoch_oracles = { path = "crates/epoch_oracles" }
 tari_indexer_lib = { path = "crates/indexer_lib" }
@@ -111,7 +111,7 @@ tari_rpc_framework = { path = "networking/rpc_framework" }
 tari_rpc_macros = { path = "networking/rpc_macros" }
 tari_swarm = { path = "networking/swarm" }
 tari_validator_node_client = { path = "clients/validator_node_client" }
-tari_ootle_walletd_client = { path = "clients/wallet_daemon_client" }
+tari_ootle_walletd_client = { path = "clients/wallet_daemon_client", version = "0.28" }
 transaction_generator = { path = "utilities/transaction_generator" }
 
 # Dependency crates on crates.io (update versions here as well when updating the workspace version)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.28.1"
+version = "0.28.2"
 edition = "2024"
 authors = ["The Tari Development Community"]
 repository = "https://github.com/tari-project/tari-ootle"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,7 +91,7 @@ tari_ootle_p2p = { path = "crates/p2p" }
 tari_ootle_storage = { path = "crates/storage" }
 tari_ootle_storage_sqlite = { path = "crates/storage_sqlite" }
 tari_ootle_wallet_crypto = { path = "crates/wallet/crypto", version = "0.2" }
-tari_ootle_wallet_sdk = { path = "crates/wallet/sdk", version = "0.2.1" }
+tari_ootle_wallet_sdk = { path = "crates/wallet/sdk", version = "0.3.0" }
 tari_ootle_wallet_sdk_services = { path = "crates/wallet/sdk_services" }
 tari_ootle_wallet_storage_sqlite = { path = "crates/wallet/storage_sqlite" }
 tari_epoch_manager = { path = "crates/epoch_manager" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,8 +122,8 @@ tari_template_builtin = { path = "crates/template_builtin", version = "0.28" }
 tari_ootle_transaction = { path = "crates/transaction", version = "0.28" }
 
 # Template lib
-tari_ootle_template_build = { path = "crates/template_build", version = "0.1" }
-tari_ootle_template_metadata = { path = "crates/template_metadata", version = "0.2" }
+tari_ootle_template_build = { path = "crates/template_build", version = "0.3" }
+tari_ootle_template_metadata = { path = "crates/template_metadata", version = "0.3" }
 tari_template_lib = { version = "0.22", path = "crates/template_lib" }
 tari_template_lib_types = { version = "0.22", path = "crates/template_lib_types", default-features = false }
 tari_template_abi = { version = "0.16", path = "crates/template_abi", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.28.2"
+version = "0.28.3"
 edition = "2024"
 authors = ["The Tari Development Community"]
 repository = "https://github.com/tari-project/tari-ootle"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,7 +123,7 @@ tari_ootle_transaction = { path = "crates/transaction", version = "0.28" }
 
 # Template lib
 tari_ootle_template_build = { path = "crates/template_build", version = "0.1" }
-tari_ootle_template_metadata = { path = "crates/template_metadata", version = "0.1" }
+tari_ootle_template_metadata = { path = "crates/template_metadata", version = "0.2" }
 tari_template_lib = { version = "0.22", path = "crates/template_lib" }
 tari_template_lib_types = { version = "0.22", path = "crates/template_lib_types", default-features = false }
 tari_template_abi = { version = "0.16", path = "crates/template_abi", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,7 +90,7 @@ tari_engine = { path = "crates/engine", version = "0.28" }
 tari_ootle_p2p = { path = "crates/p2p" }
 tari_ootle_storage = { path = "crates/storage" }
 tari_ootle_storage_sqlite = { path = "crates/storage_sqlite" }
-tari_ootle_wallet_crypto = { path = "crates/wallet/crypto", version = "0.2" }
+tari_ootle_wallet_crypto = { path = "crates/wallet/crypto", version = "0.3" }
 tari_ootle_wallet_sdk = { path = "crates/wallet/sdk", version = "0.3.1" }
 tari_ootle_wallet_sdk_services = { path = "crates/wallet/sdk_services" }
 tari_ootle_wallet_storage_sqlite = { path = "crates/wallet/storage_sqlite" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,13 +85,13 @@ tari_ootle_app_utilities = { path = "applications/tari_ootle_app_utilities" }
 
 # core crates
 tari_consensus = { path = "crates/consensus" }
-tari_ootle_address = { path = "crates/ootle_address", version = "0.1" }
+tari_ootle_address = { path = "crates/ootle_address", version = "0.2" }
 tari_engine = { path = "crates/engine", version = "0.28" }
 tari_ootle_p2p = { path = "crates/p2p" }
 tari_ootle_storage = { path = "crates/storage" }
 tari_ootle_storage_sqlite = { path = "crates/storage_sqlite" }
 tari_ootle_wallet_crypto = { path = "crates/wallet/crypto", version = "0.2" }
-tari_ootle_wallet_sdk = { path = "crates/wallet/sdk", version = "0.3.0" }
+tari_ootle_wallet_sdk = { path = "crates/wallet/sdk", version = "0.3.1" }
 tari_ootle_wallet_sdk_services = { path = "crates/wallet/sdk_services" }
 tari_ootle_wallet_storage_sqlite = { path = "crates/wallet/storage_sqlite" }
 tari_epoch_manager = { path = "crates/epoch_manager" }

--- a/clients/wallet_daemon_client/Cargo.toml
+++ b/clients/wallet_daemon_client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_ootle_walletd_client"
 description = "Tari wallet daemon client library"
-version = "0.4.2"
+version = "0.5.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/clients/wallet_daemon_client/Cargo.toml
+++ b/clients/wallet_daemon_client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_ootle_walletd_client"
 description = "Tari wallet daemon client library"
-version = "0.5.1"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/clients/wallet_daemon_client/Cargo.toml
+++ b/clients/wallet_daemon_client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_ootle_walletd_client"
 description = "Tari wallet daemon client library"
-version = "0.5.0"
+version = "0.5.1"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/clients/wallet_daemon_client/src/lib.rs
+++ b/clients/wallet_daemon_client/src/lib.rs
@@ -90,6 +90,7 @@ use crate::{
         AccountsListResponse,
         AccountsRenameRequest,
         AccountsRenameResponse,
+        AuthGetMethodRequest,
         AuthGetMethodResponse,
         AuthListSessionsRequest,
         AuthListSessionsResponse,
@@ -541,7 +542,7 @@ impl WalletDaemonClient {
 
     /// Requests the current required authentication method to use when authenticating with the wallet daemon.
     pub async fn get_auth_method(&mut self) -> Result<AuthGetMethodResponse, WalletDaemonClientError> {
-        self.send_request("auth.method", &()).await
+        self.send_request("auth.method", &AuthGetMethodRequest {}).await
     }
 
     /// Requests a JWT authentication token with the specified permissions.

--- a/crates/ootle_address/Cargo.toml
+++ b/crates/ootle_address/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_ootle_address"
 description = "Tari Ootle address using bech32 encoding"
-version = "0.1.2"
+version = "0.2.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/ootle_wasm/core/Cargo.toml
+++ b/crates/ootle_wasm/core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ootle-wasm-core"
 description = "Pure Rust crypto and encoding logic for Tari Ootle WASM — BOR encoding, transaction hashing, Schnorr signing, and key management"
-version = "0.4.0"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/ootle_wasm/wasm/Cargo.toml
+++ b/crates/ootle_wasm/wasm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ootle-wasm"
 description = "WASM bindings for Tari Ootle client-side crypto — thin wasm-bindgen shell over ootle-wasm-core"
-version = "0.4.0"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true
@@ -13,7 +13,7 @@ readme = "../NPM_README.md"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-ootle-wasm-core = { path = "../core", version = "0.4.0" }
+ootle-wasm-core = { path = "../core", version = "0.28" }
 wasm-bindgen = "0.2"
 getrandom = { version = "0.2", features = ["js"] }
 

--- a/crates/template_build/Cargo.toml
+++ b/crates/template_build/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_ootle_template_build"
 description = "Build-time metadata generation for Tari Ootle templates"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/template_build/Cargo.toml
+++ b/crates/template_build/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_ootle_template_build"
 description = "Build-time metadata generation for Tari Ootle templates"
-version = "0.2.0"
+version = "0.3.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/template_build/Cargo.toml
+++ b/crates/template_build/Cargo.toml
@@ -8,7 +8,7 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-tari_ootle_template_metadata = { path = "../template_metadata", features = ["json"] }
+tari_ootle_template_metadata = { workspace = true, features = ["json"] }
 thiserror = { workspace = true }
 
 [dev-dependencies]

--- a/crates/template_build/README.md
+++ b/crates/template_build/README.md
@@ -1,0 +1,94 @@
+# tari_ootle_template_build
+
+Build-time metadata generation for Tari Ootle templates.
+
+## Overview
+
+This crate is added as a `[build-dependencies]` entry in a template crate. It reads metadata from `Cargo.toml`, generates a CBOR metadata file, and emits the metadata hash as cargo metadata for downstream tooling.
+
+## Setup
+
+Add to your template's `Cargo.toml`:
+
+```toml
+[build-dependencies]
+tari_ootle_template_build = "0.2"
+```
+
+Create a `build.rs`:
+
+```rust
+fn main() {
+    tari_ootle_template_build::TemplateMetadataBuilder::new()
+        .build()
+        .expect("Failed to generate template metadata");
+}
+```
+
+## Builder options
+
+The builder reads metadata from `Cargo.toml` by default. Any field can be overridden programmatically:
+
+```rust
+fn main() {
+    tari_ootle_template_build::TemplateMetadataBuilder::new()
+        .description("My DeFi template")
+        .tags(vec!["defi", "token", "swap"])
+        .category("defi")
+        .homepage("https://example.com")
+        .extra_entry("audit", "https://example.com/audit-report")
+        .enable_json_output() // also generate a JSON file
+        .build()
+        .expect("Failed to generate template metadata");
+}
+```
+
+### Available overrides
+
+| Method | Description |
+|---|---|
+| `.description(...)` | Override description from Cargo.toml |
+| `.tags(...)` | Override tags |
+| `.category(...)` | Override category |
+| `.repository(...)` | Override repository URL |
+| `.documentation(...)` | Override documentation URL |
+| `.homepage(...)` | Override homepage URL |
+| `.license(...)` | Override license |
+| `.extra(map)` | Replace entire extra metadata map |
+| `.extra_entry(k, v)` | Add a single extra key-value pair |
+| `.enable_json_output()` | Also write `template_metadata.json` |
+
+## Output
+
+On a successful `build()`:
+
+- Writes `template_metadata.cbor` to `OUT_DIR`
+- Optionally writes `template_metadata.json` to `OUT_DIR`
+- Emits `cargo::metadata=TEMPLATE_METADATA_HASH=<hex>` for downstream tools
+- Returns `TemplateBuildOutput` with the hash, file paths, and resolved metadata
+
+## Cargo.toml metadata
+
+The builder reads from standard `[package]` fields and `[package.metadata.tari-template]`:
+
+```toml
+[package]
+name = "fungible-token"
+version = "1.2.0"
+description = "A standard fungible token"
+license = "BSD-3-Clause"
+repository = "https://github.com/example/fungible-token"
+
+[package.metadata.tari-template]
+tags = ["token", "fungible", "defi"]
+category = "token"
+documentation = "https://docs.example.com/fungible-token"
+homepage = "https://example.com"
+
+[package.metadata.tari-template.extra]
+audit = "https://example.com/audit-report"
+```
+
+## License
+
+BSD-3-Clause

--- a/crates/template_metadata/Cargo.toml
+++ b/crates/template_metadata/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_ootle_template_metadata"
 description = "Template metadata types, serialization, and hashing for Tari Ootle templates"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/template_metadata/Cargo.toml
+++ b/crates/template_metadata/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_ootle_template_metadata"
 description = "Template metadata types, serialization, and hashing for Tari Ootle templates"
-version = "0.2.0"
+version = "0.3.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/template_metadata/Cargo.toml
+++ b/crates/template_metadata/Cargo.toml
@@ -8,13 +8,14 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
+tari_bor = { workspace = true, features = ["std"] }
+
 borsh = { workspace = true, optional = true }
 cargo_toml = "0.22"
 multihash = { version = "0.19", default-features = false, features = ["alloc"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, optional = true }
 sha2 = { workspace = true }
-tari_bor = { workspace = true, features = ["std"] }
 thiserror = { workspace = true }
 
 [features]

--- a/crates/template_metadata/README.md
+++ b/crates/template_metadata/README.md
@@ -1,0 +1,100 @@
+# tari_ootle_template_metadata
+
+Shared types for off-chain Tari Ootle template metadata with on-chain hash anchoring.
+
+## Overview
+
+Template authors describe their templates with structured metadata (name, version, description, tags, etc.) stored off-chain as CBOR. A domain-separated SHA-256 multihash of the CBOR is published on-chain alongside the template binary, allowing anyone to verify that off-chain metadata matches the on-chain record.
+
+## Types
+
+- **`TemplateMetadata`** — the metadata struct with fields from `Cargo.toml` (`[package]` and `[package.metadata.tari-template]`)
+- **`MetadataHash`** — stack-allocated multihash (`Multihash<64>`) with no heap allocation. Serializes as hex string.
+- **`MetadataHashWriter`** — an `std::io::Write` implementation that hashes data directly with domain-separated SHA-256. Used to compute the hash without intermediate buffer allocation.
+
+## Usage
+
+### Parsing metadata from Cargo.toml
+
+```rust
+use tari_ootle_template_metadata::from_cargo_toml;
+
+let metadata = from_cargo_toml("path/to/Cargo.toml".as_ref())?;
+println!("{}: {}", metadata.name, metadata.version);
+```
+
+### Computing the hash (zero-alloc)
+
+```rust
+use tari_ootle_template_metadata::TemplateMetadata;
+
+let metadata = TemplateMetadata::new("my-template".into(), "1.0.0".into());
+let hash = metadata.hash()?; // CBOR streams directly into the hasher
+println!("Metadata hash: {hash}");
+```
+
+### Streaming CBOR to a file
+
+```rust
+use tari_ootle_template_metadata::TemplateMetadata;
+
+let metadata = TemplateMetadata::new("my-template".into(), "1.0.0".into());
+let mut file = std::fs::File::create("metadata.cbor")?;
+metadata.write_cbor_to(&mut file)?;
+```
+
+### Reading CBOR from a file
+
+```rust
+use tari_ootle_template_metadata::TemplateMetadata;
+
+let file = std::fs::File::open("metadata.cbor")?;
+let metadata = TemplateMetadata::read_cbor_from(std::io::BufReader::new(file))?;
+```
+
+### Using MetadataHashWriter directly
+
+```rust
+use std::io::Write;
+use tari_ootle_template_metadata::MetadataHashWriter;
+
+let mut writer = MetadataHashWriter::new();
+writer.write_all(b"some cbor bytes")?;
+let hash = writer.finalize();
+println!("Hash: {hash}");
+```
+
+## Cargo.toml field mapping
+
+| TemplateMetadata field | Cargo.toml source |
+|---|---|
+| `schema_version` | Hardcoded to `1` |
+| `name` | `[package] name` |
+| `version` | `[package] version` |
+| `description` | `[package] description` |
+| `license` | `[package] license` |
+| `repository` | `[package] repository` |
+| `tags` | `[package.metadata.tari-template] tags` |
+| `category` | `[package.metadata.tari-template] category` |
+| `documentation` | `[package.metadata.tari-template] documentation` |
+| `homepage` | `[package.metadata.tari-template] homepage` |
+| `extra` | `[package.metadata.tari-template] extra` |
+
+## Features
+
+- **`json`** — enables `to_json()` / `from_json()` on `TemplateMetadata`
+- **`borsh`** — enables `BorshSerialize` for `MetadataHash`
+
+## Hash details
+
+The metadata hash is computed as:
+
+```
+SHA-256("com.tari.ootle.TemplateMetadata" || cbor_bytes)
+```
+
+Encoded as a [multihash](https://multiformats.io/multihash/) (code `0x12`, compatible with IPFS CIDv1).
+
+## License
+
+BSD-3-Clause

--- a/crates/template_metadata/src/hash.rs
+++ b/crates/template_metadata/src/hash.rs
@@ -1,14 +1,17 @@
 //   Copyright 2026 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use std::fmt;
+use std::{fmt, io};
 
 use multihash::Multihash;
 use serde::{Deserialize, Serialize, de};
-use sha2::{Digest, Sha256};
+use sha2::{Digest, Sha256, digest::Update};
 
 /// Multihash function code for SHA-256 (IPFS CIDv1 default).
 const SHA2_256_CODE: u64 = 0x12;
+
+/// Domain separation label for template metadata hashing.
+const DOMAIN_LABEL: &str = "com.tari.ootle.TemplateMetadata";
 
 /// Maximum size of a metadata multihash digest in bytes.
 /// This allows SHA-512 (64 bytes) and is also the IPFS CID default size.
@@ -30,18 +33,14 @@ impl MetadataHash {
         Multihash::from_bytes(bytes).ok().map(Self)
     }
 
-    /// Compute a SHA-256 multihash of the given data.
-    pub fn hash_sha256(data: &[u8]) -> Self {
-        let digest = Sha256::digest(data);
-        Self(Multihash::wrap(SHA2_256_CODE, &digest).expect("SHA-256 digest fits in 64 bytes"))
-    }
-
-    /// Verify that this hash matches the given data.
+    /// Verify that this hash matches the given data by re-hashing with domain-separated SHA-256.
     /// Returns an error if the hash function is unsupported.
     pub fn verify(&self, data: &[u8]) -> Result<bool, MetadataHashError> {
         match self.0.code() {
             SHA2_256_CODE => {
-                let expected = Self::hash_sha256(data);
+                let mut writer = MetadataHashWriter::new();
+                io::Write::write_all(&mut writer, data).expect("infallible");
+                let expected = writer.finalize();
                 Ok(self == &expected)
             },
             code => Err(MetadataHashError::UnsupportedHashFunction(code)),
@@ -114,6 +113,48 @@ impl borsh::BorshSerialize for MetadataHash {
     }
 }
 
+/// A domain-separated SHA-256 hasher that implements [`std::io::Write`].
+///
+/// CBOR (or any data) can be written directly into this without intermediate allocation.
+/// Call [`finalize`](MetadataHashWriter::finalize) to produce the [`MetadataHash`].
+///
+/// The hash is computed as: `SHA-256("com.tari.ootle.TemplateMetadata" || data)`.
+pub struct MetadataHashWriter {
+    hasher: Sha256,
+}
+
+impl MetadataHashWriter {
+    /// Create a new writer with the domain separation label already fed into the hasher.
+    pub fn new() -> Self {
+        Self {
+            hasher: Sha256::new().chain(DOMAIN_LABEL),
+        }
+    }
+
+    /// Finalize the hash and return the [`MetadataHash`].
+    pub fn finalize(self) -> MetadataHash {
+        let digest = self.hasher.finalize();
+        MetadataHash(Multihash::wrap(SHA2_256_CODE, &digest).expect("SHA-256 digest fits in 64 bytes"))
+    }
+}
+
+impl Default for MetadataHashWriter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl io::Write for MetadataHashWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        Update::update(&mut self.hasher, buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
 #[derive(Debug, thiserror::Error)]
 pub enum MetadataHashError {
     #[error("Unsupported hash function code: 0x{0:02x}")]
@@ -144,44 +185,67 @@ fn hex_decode(hex: &str) -> Result<Vec<u8>, ()> {
 
 #[cfg(test)]
 mod tests {
+    use std::io::Write;
+
     use super::*;
 
+    fn hash_data(data: &[u8]) -> MetadataHash {
+        let mut writer = MetadataHashWriter::new();
+        writer.write_all(data).unwrap();
+        writer.finalize()
+    }
+
     #[test]
-    fn sha256_multihash_roundtrip() {
-        let data = b"hello world";
-        let hash = MetadataHash::hash_sha256(data);
+    fn writer_produces_valid_multihash() {
+        let hash = hash_data(b"hello world");
 
         // SHA-256 multihash: code=0x12, size=0x20 (32 bytes), then 32 bytes digest
         let bytes = hash.to_bytes();
         assert_eq!(bytes[0], 0x12);
         assert_eq!(bytes[1], 32);
         assert_eq!(bytes.len(), 34);
+    }
+
+    #[test]
+    fn writer_verify_roundtrip() {
+        let data = b"hello world";
+        let hash = hash_data(data);
 
         assert!(hash.verify(data).unwrap());
         assert!(!hash.verify(b"different data").unwrap());
     }
 
     #[test]
+    fn incremental_write_matches_single_write() {
+        let data = b"hello world, this is a longer message for testing";
+
+        let hash_single = hash_data(data);
+
+        let mut writer = MetadataHashWriter::new();
+        writer.write_all(&data[..5]).unwrap();
+        writer.write_all(&data[5..]).unwrap();
+        let hash_incremental = writer.finalize();
+
+        assert_eq!(hash_single, hash_incremental);
+    }
+
+    #[test]
     fn stack_allocated() {
-        // Multihash<64> is stack-allocated: 64 bytes buf + 8 bytes code + 1 byte len (approx)
-        let hash = MetadataHash::hash_sha256(b"test");
-        // Should be no larger than the Multihash struct itself
+        let hash = hash_data(b"test");
         assert!(std::mem::size_of_val(&hash) <= std::mem::size_of::<Multihash<MAX_DIGEST_SIZE>>());
     }
 
     #[test]
     fn from_bytes_rejects_invalid() {
-        // Too short
         assert!(MetadataHash::from_bytes(&[0x12]).is_none());
-        // Valid SHA-256 multihash should work
-        let hash = MetadataHash::hash_sha256(b"test");
+        let hash = hash_data(b"test");
         let bytes = hash.to_bytes();
         assert!(MetadataHash::from_bytes(&bytes).is_some());
     }
 
     #[test]
     fn hex_roundtrip() {
-        let hash = MetadataHash::hash_sha256(b"test");
+        let hash = hash_data(b"test");
         let hex = hash.to_hex();
         let parsed = MetadataHash::from_hex(&hex).unwrap();
         assert_eq!(hash, parsed);
@@ -189,7 +253,7 @@ mod tests {
 
     #[test]
     fn json_serde_roundtrip() {
-        let hash = MetadataHash::hash_sha256(b"test");
+        let hash = hash_data(b"test");
         let json = serde_json::to_string(&hash).unwrap();
         let parsed: MetadataHash = serde_json::from_str(&json).unwrap();
         assert_eq!(hash, parsed);
@@ -197,7 +261,7 @@ mod tests {
 
     #[test]
     fn cbor_serde_roundtrip() {
-        let hash = MetadataHash::hash_sha256(b"test");
+        let hash = hash_data(b"test");
         let cbor = tari_bor::encode(&hash).unwrap();
         let parsed: MetadataHash = tari_bor::decode(&cbor).unwrap();
         assert_eq!(hash, parsed);
@@ -205,7 +269,7 @@ mod tests {
 
     #[test]
     fn to_bytes_roundtrip() {
-        let hash = MetadataHash::hash_sha256(b"test");
+        let hash = hash_data(b"test");
         let bytes = hash.to_bytes();
         let parsed = MetadataHash::from_bytes(&bytes).unwrap();
         assert_eq!(hash, parsed);

--- a/crates/template_metadata/src/lib.rs
+++ b/crates/template_metadata/src/lib.rs
@@ -14,5 +14,5 @@ mod hash;
 mod metadata;
 
 pub use cargo_toml::{CargoTomlError, from_cargo_toml, from_cargo_toml_str};
-pub use hash::{MetadataHash, MetadataHashError};
+pub use hash::{MetadataHash, MetadataHashError, MetadataHashWriter};
 pub use metadata::{SCHEMA_VERSION, TemplateMetadata, TemplateMetadataError};

--- a/crates/template_metadata/src/metadata.rs
+++ b/crates/template_metadata/src/metadata.rs
@@ -5,7 +5,7 @@ use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
-use crate::MetadataHash;
+use crate::{MetadataHash, MetadataHashWriter};
 
 /// Current schema version for template metadata.
 pub const SCHEMA_VERSION: u32 = 1;
@@ -89,10 +89,13 @@ impl TemplateMetadata {
         serde_json::from_str(json).map_err(TemplateMetadataError::JsonDecode)
     }
 
-    /// Compute the SHA-256 multihash of the CBOR-encoded metadata.
+    /// Compute the domain-separated SHA-256 multihash of the CBOR-encoded metadata.
+    ///
+    /// CBOR is written directly into the hasher — no intermediate buffer allocation.
     pub fn hash(&self) -> Result<MetadataHash, TemplateMetadataError> {
-        let cbor = self.to_cbor()?;
-        Ok(MetadataHash::hash_sha256(&cbor))
+        let mut writer = MetadataHashWriter::new();
+        self.write_cbor_to(&mut writer)?;
+        Ok(writer.finalize())
     }
 }
 

--- a/crates/template_test_tooling/Cargo.toml
+++ b/crates/template_test_tooling/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_template_test_tooling"
 description = "Test tooling for Tari template development"
-version = "0.26.4"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/wallet/crypto/Cargo.toml
+++ b/crates/wallet/crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_ootle_wallet_crypto"
-version = "0.2.1"
+version = "0.3.0"
 description = "Cryptographic utilities and types for Tari Ootle wallet"
 edition.workspace = true
 authors.workspace = true

--- a/crates/wallet/crypto/Cargo.toml
+++ b/crates/wallet/crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_ootle_wallet_crypto"
-version = "0.3.0"
+version.workspace = true
 description = "Cryptographic utilities and types for Tari Ootle wallet"
 edition.workspace = true
 authors.workspace = true

--- a/crates/wallet/ootle-rs/Cargo.toml
+++ b/crates/wallet/ootle-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ootle-rs"
-version = "0.3.1"
+version = "0.4.0"
 description = "A Rust library for interacting with the Tari Ootle network."
 edition.workspace = true
 authors.workspace = true

--- a/crates/wallet/ootle-rs/Cargo.toml
+++ b/crates/wallet/ootle-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ootle-rs"
-version = "0.4.0"
+version = "0.4.1"
 description = "A Rust library for interacting with the Tari Ootle network."
 edition.workspace = true
 authors.workspace = true

--- a/crates/wallet/sdk/Cargo.toml
+++ b/crates/wallet/sdk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_ootle_wallet_sdk"
 description = "The Tari wallet library"
-version = "0.2.1"
+version = "0.3.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/wallet/sdk/Cargo.toml
+++ b/crates/wallet/sdk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_ootle_wallet_sdk"
 description = "The Tari wallet library"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/wallet/sdk/Cargo.toml
+++ b/crates/wallet/sdk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_ootle_wallet_sdk"
 description = "The Tari wallet library"
-version = "0.3.1"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/wallet/storage_sqlite/Cargo.toml
+++ b/crates/wallet/storage_sqlite/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_ootle_wallet_storage_sqlite"
 description = "The Tari wallet SQLite storage library"
-version.workspace = true
+version = "0.28.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/wallet/storage_sqlite/Cargo.toml
+++ b/crates/wallet/storage_sqlite/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_ootle_wallet_storage_sqlite"
 description = "The Tari wallet SQLite storage library"
-version = "0.28.0"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/scripts/publish_crates.py
+++ b/scripts/publish_crates.py
@@ -31,6 +31,7 @@ CRATES = [
     ("ootle_byte_type", "crates/ootle_byte_type"),
     ("tari_template_macros", "crates/template_macros"),
     ("tari_template_lib", "crates/template_lib"),
+    ("tari_ootle_template_metadata", "crates/template_metadata"),
     ("tari_engine_types", "crates/engine_types"),
     ("tari_ootle_common_types", "crates/common_types"),
     ("tari_ootle_wallet_crypto", "crates/wallet/crypto"),

--- a/scripts/publish_crates.py
+++ b/scripts/publish_crates.py
@@ -21,35 +21,42 @@ import time
 import urllib.request
 import urllib.error
 
+# Version tiers:
+#   1 = Stable/foundational — independently versioned, rarely changes
+#   2 = Template authoring & client SDK — independently versioned
+#   3 = Workspace-versioned — moves with the release
+#
 # Topological publish order — dependencies before dependents.
-# (crate_name, crate_directory)
+# (crate_name, crate_directory, tier)
 CRATES = [
-    ("tari_bor", "crates/tari_bor"),
-    ("ootle_serde", "crates/ootle_serde"),
-    ("tari_template_abi", "crates/template_abi"),
-    ("tari_template_lib_types", "crates/template_lib_types"),
-    ("ootle_byte_type", "crates/ootle_byte_type"),
-    ("tari_template_macros", "crates/template_macros"),
-    ("tari_template_lib", "crates/template_lib"),
-    ("tari_ootle_template_metadata", "crates/template_metadata"),
-    ("tari_engine_types", "crates/engine_types"),
-    ("tari_ootle_common_types", "crates/common_types"),
-    ("tari_ootle_wallet_crypto", "crates/wallet/crypto"),
-    ("tari_ootle_address", "crates/ootle_address"),
-    ("tari_ootle_transaction", "crates/transaction"),
-    ("tari_template_builtin", "crates/template_builtin"),
-    ("tari_transaction_manifest", "crates/transaction_manifest"),
-    ("tari_engine", "crates/engine"),
-    ("tari_consensus_types", "crates/consensus_types"),
-    ("tari_indexer_client", "clients/tari_indexer_client"),
-    ("ootle-wasm-core", "crates/ootle_wasm/core"),
-    ("ootle-wasm", "crates/ootle_wasm/wasm"),
-    ("tari_template_test_tooling", "crates/template_test_tooling"),
-    ("ootle-rs", "crates/wallet/ootle-rs"),
-    ("tari_ootle_wallet_sdk", "crates/wallet/sdk"),
-    ("tari_ootle_wallet_storage_sqlite", "crates/wallet/storage_sqlite"),
-    ("tari_ootle_walletd_client", "clients/wallet_daemon_client"),
+    ("tari_bor", "crates/tari_bor", 1),
+    ("ootle_serde", "crates/ootle_serde", 1),
+    ("tari_template_abi", "crates/template_abi", 2),
+    ("tari_template_lib_types", "crates/template_lib_types", 2),
+    ("ootle_byte_type", "crates/ootle_byte_type", 1),
+    ("tari_template_macros", "crates/template_macros", 2),
+    ("tari_template_lib", "crates/template_lib", 2),
+    ("tari_ootle_template_metadata", "crates/template_metadata", 2),
+    ("tari_engine_types", "crates/engine_types", 3),
+    ("tari_ootle_common_types", "crates/common_types", 3),
+    ("tari_ootle_wallet_crypto", "crates/wallet/crypto", 3),
+    ("tari_ootle_address", "crates/ootle_address", 1),
+    ("tari_ootle_transaction", "crates/transaction", 3),
+    ("tari_template_builtin", "crates/template_builtin", 3),
+    ("tari_transaction_manifest", "crates/transaction_manifest", 3),
+    ("tari_engine", "crates/engine", 3),
+    ("tari_consensus_types", "crates/consensus_types", 3),
+    ("tari_indexer_client", "clients/tari_indexer_client", 3),
+    ("ootle-wasm-core", "crates/ootle_wasm/core", 3),
+    ("ootle-wasm", "crates/ootle_wasm/wasm", 3),
+    ("tari_template_test_tooling", "crates/template_test_tooling", 3),
+    ("ootle-rs", "crates/wallet/ootle-rs", 2),
+    ("tari_ootle_wallet_sdk", "crates/wallet/sdk", 3),
+    ("tari_ootle_wallet_storage_sqlite", "crates/wallet/storage_sqlite", 3),
+    ("tari_ootle_walletd_client", "clients/wallet_daemon_client", 3),
 ]
+
+TIER_LABELS = {1: "stable", 2: "template/sdk", 3: "workspace"}
 
 WAIT_SECS = 20
 
@@ -152,29 +159,30 @@ def main():
     # --list mode
     if args.list:
         print("Publish order:")
-        for name, crate_dir in CRATES:
+        for name, crate_dir, tier in CRATES:
             ver = get_local_version(name, crate_dir)
-            print(f"  {name} ({ver}) — {crate_dir}")
+            label = TIER_LABELS[tier]
+            print(f"  {name} ({ver}) [{label}] — {crate_dir}")
         return
 
     # Build the list of crates to process
     crates_to_publish = []
     if args.from_crate:
         found = False
-        for name, crate_dir in CRATES:
+        for name, crate_dir, tier in CRATES:
             if name == args.from_crate:
                 found = True
             if found:
-                crates_to_publish.append((name, crate_dir))
+                crates_to_publish.append((name, crate_dir, tier))
         if not found:
             print(f"{RED}Error: crate '{args.from_crate}' not found in publish order{NC}")
             sys.exit(1)
     elif args.package:
         pkg_set = set(args.package)
-        for name, crate_dir in CRATES:
+        for name, crate_dir, tier in CRATES:
             if name in pkg_set:
-                crates_to_publish.append((name, crate_dir))
-        unknown = pkg_set - {name for name, _ in CRATES}
+                crates_to_publish.append((name, crate_dir, tier))
+        unknown = pkg_set - {name for name, _, _ in CRATES}
         if unknown:
             print(f"{RED}Error: unknown crate(s): {', '.join(unknown)}{NC}")
             sys.exit(1)
@@ -192,38 +200,39 @@ def main():
     skipped = 0
     last_name = crates_to_publish[-1][0] if crates_to_publish else ""
 
-    for name, crate_dir in crates_to_publish:
+    for name, crate_dir, tier in crates_to_publish:
         ver = get_local_version(name, crate_dir)
+        label = TIER_LABELS[tier]
 
         if is_published(name, ver):
-            print(f"  {GREEN}✓{NC} {name} {ver} — already published, skipping")
+            print(f"  {GREEN}✓{NC} {name} {ver} [{label}] — already published, skipping")
             skipped += 1
             continue
 
         if args.execute:
-            print(f"  {YELLOW}▶{NC} Publishing {name} {ver} ...")
+            print(f"  {YELLOW}▶{NC} Publishing {name} {ver} [{label}] ...")
             if cargo_publish(name):
-                print(f"  {GREEN}✓{NC} {name} {ver} — published")
+                print(f"  {GREEN}✓{NC} {name} {ver} [{label}] — published")
                 published_crates.append((name, ver))
                 if name != last_name:
                     print(f"    {YELLOW}Waiting {args.wait}s for crates.io indexing...{NC}")
                     time.sleep(args.wait)
             else:
-                print(f"  {RED}✗{NC} {name} {ver} — failed")
+                print(f"  {RED}✗{NC} {name} {ver} [{label}] — failed")
                 print()
                 print(f"{RED}Fix the issue and resume with:{NC}")
                 print(f"  ./scripts/publish_crates.py --from {name} --execute")
                 sys.exit(1)
         elif args.dry_run:
-            print(f"  {YELLOW}▶{NC} {name} {ver} — would publish, testing build...")
+            print(f"  {YELLOW}▶{NC} {name} {ver} [{label}] — would publish, testing build...")
             if cargo_publish(name, dry_run=True):
-                print(f"  {GREEN}✓{NC} {name} {ver} — build OK")
+                print(f"  {GREEN}✓{NC} {name} {ver} [{label}] — build OK")
                 published_crates.append((name, ver))
             else:
-                print(f"  {RED}✗{NC} {name} {ver} — build failed")
+                print(f"  {RED}✗{NC} {name} {ver} [{label}] — build failed")
                 failed_crates.append((name, ver))
         else:
-            print(f"  {YELLOW}▶{NC} {name} {ver} — would publish")
+            print(f"  {YELLOW}▶{NC} {name} {ver} [{label}] — would publish")
             published_crates.append((name, ver))
 
     print()

--- a/scripts/publish_crates.py
+++ b/scripts/publish_crates.py
@@ -37,6 +37,7 @@ CRATES = [
     ("tari_template_macros", "crates/template_macros", 2),
     ("tari_template_lib", "crates/template_lib", 2),
     ("tari_ootle_template_metadata", "crates/template_metadata", 2),
+    ("tari_ootle_template_build", "crates/template_build", 2),
     ("tari_engine_types", "crates/engine_types", 3),
     ("tari_ootle_common_types", "crates/common_types", 3),
     ("tari_ootle_wallet_crypto", "crates/wallet/crypto", 3),


### PR DESCRIPTION
## Summary

Introduces a three-tier versioning strategy for published crates and fixes publish issues for the 0.28 release.

### Version tiers
- **Tier 1 (stable):** `tari_bor`, `ootle_serde`, `ootle_byte_type`, `tari_ootle_address` — independently versioned, rarely change
- **Tier 2 (template/sdk):** `tari_template_lib`, `tari_template_lib_types`, `tari_template_abi`, `tari_template_macros`, `tari_ootle_template_metadata`, `ootle-rs` — independently versioned for template authors
- **Tier 3 (workspace):** everything else — uses `version.workspace = true`, moves with the release

### Changes
- Add missing `tari_ootle_template_metadata` to publish order in `scripts/publish_crates.py`
- Move tier 3 crates to `version.workspace = true`: `tari_ootle_wallet_crypto`, `tari_ootle_wallet_sdk`, `tari_ootle_wallet_storage_sqlite`, `tari_ootle_walletd_client`, `ootle-wasm-core`, `ootle-wasm`, `tari_template_test_tooling`
- Bump workspace version to 0.28.1 (tier 3 crates already published at 0.28.0 need republish)
- Add tier labels (`[stable]`, `[template/sdk]`, `[workspace]`) to publish script output
- Add explicit `version` fields to workspace deps needed for publishing

## Test plan
- [ ] `./scripts/publish_crates.py --list` shows correct tiers
- [ ] `./scripts/publish_crates.py --dry-run` passes for newly publishable crates
- [ ] `cargo check` passes