### PR TITLE
fix(walletd): defer burn proof file move until transaction is finalized

### DIFF
--- a/applications/tari_walletd/src/handlers/accounts.rs
+++ b/applications/tari_walletd/src/handlers/accounts.rs
@@ -26,7 +26,7 @@ use tari_ootle_wallet_sdk::{
         stealth_transfer::{StealthTransferParams, TransferOutput},
         substate::ValidatorScanResult,
     },
-    models::{KeyBranch, NewAccountData, StealthUtxoSpendKeyId, TransactionSubmittedEvent},
+    models::{KeyBranch, NewAccountData, StealthUtxoSpendKeyId, TransactionContext, TransactionSubmittedEvent},
 };
 use tari_ootle_walletd_client::{
     ComponentAddressOrName,
@@ -596,12 +596,11 @@ pub async fn handle_claim_burn(
         });
     }
 
-    let tx_id = context.transaction_service().submit_transaction(transaction).await?;
-
-    if let Some(file_name) = proof_file_name {
-        let proof_dir = context.config().get_burn_proof_dir(network);
-        super::burn_proofs::mark_as_claimed(&proof_dir, &file_name);
-    }
+    let tx_context = proof_file_name.map(|file_name| TransactionContext::ClaimBurn { file_name });
+    let tx_id = context
+        .transaction_service()
+        .submit_transaction_with_opts(transaction, tx_context, None)
+        .await?;
 
     Ok(ClaimBurnResponse {
         transaction_id: tx_id,
@@ -725,8 +724,10 @@ pub async fn handle_create_free_test_coins(
         .transaction_service()
         .submit_transaction_with_opts(
             transaction,
-            account.is_confirmed_on_chain().then(|| NewAccountData {
-                address: *account.component_address(),
+            account.is_confirmed_on_chain().then(|| {
+                TransactionContext::NewAccount(NewAccountData {
+                    address: *account.component_address(),
+                })
             }),
             None,
         )
@@ -993,7 +994,7 @@ pub async fn handle_confidential_transfer(
 
         notifier.notify(TransactionSubmittedEvent {
             transaction_id: tx_id,
-            new_account: None,
+            context: None,
         });
 
         Ok(ConfidentialTransferResponse { transaction_id: tx_id })
@@ -1123,7 +1124,7 @@ pub async fn handle_stealth_transfer(
 
         notifier.notify(TransactionSubmittedEvent {
             transaction_id: tx_id,
-            new_account: None,
+            context: None,
         });
 
         Ok(StealthTransferResponse { transaction_id: tx_id })

--- a/applications/tari_walletd/src/handlers/burn_proofs.rs
+++ b/applications/tari_walletd/src/handlers/burn_proofs.rs
@@ -133,36 +133,3 @@ pub async fn handle_get(
 
     Ok(BurnProofsGetResponse { proof })
 }
-
-/// Moves a burn proof file into the `claimed` subdirectory of the burn proof directory.
-/// This is called after a claim transaction has been successfully submitted.
-pub fn mark_as_claimed(burn_proof_dir: &Path, file_name: &str) {
-    let claimed_dir = burn_proof_dir.join("claimed");
-    if let Err(e) = fs::create_dir_all(&claimed_dir) {
-        warn!(
-            target: LOG_TARGET,
-            "Failed to create claimed directory {}: {}",
-            claimed_dir.display(),
-            e
-        );
-        return;
-    }
-
-    let src = burn_proof_dir.join(file_name);
-    let dst = claimed_dir.join(file_name);
-    if let Err(e) = fs::rename(&src, &dst) {
-        warn!(
-            target: LOG_TARGET,
-            "Failed to move claimed burn proof {} -> {}: {}",
-            src.display(),
-            dst.display(),
-            e
-        );
-    } else {
-        info!(
-            target: LOG_TARGET,
-            "Burn proof {} marked as claimed",
-            file_name
-        );
-    }
-}

--- a/applications/tari_walletd/src/lib.rs
+++ b/applications/tari_walletd/src/lib.rs
@@ -108,7 +108,13 @@ pub async fn run_tari_ootle_walletd(
     wallet_sdk.resources_api().upsert_resource(&addr, &resx)?;
 
     let notify = Notify::new(100);
-    let services = spawn_services(shutdown_signal.clone(), notify.clone(), wallet_sdk.clone());
+    let burn_proof_dir = config.ootle_wallet_daemon.get_burn_proof_dir(wallet_sdk.network());
+    let services = spawn_services(
+        shutdown_signal.clone(),
+        notify.clone(),
+        wallet_sdk.clone(),
+        burn_proof_dir,
+    );
 
     // trigger account scanning if needed
     if needs_seed_recovery {

--- a/applications/tari_walletd/src/services/claim_burn_monitor.rs
+++ b/applications/tari_walletd/src/services/claim_burn_monitor.rs
@@ -1,0 +1,127 @@
+//   Copyright 2025 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+use std::{collections::HashMap, fs, path::PathBuf};
+
+use log::*;
+use tari_ootle_transaction::TransactionId;
+use tari_ootle_wallet_sdk::models::{TransactionContext, WalletEvent};
+use tari_ootle_wallet_sdk_services::notify::Notify;
+use tari_shutdown::ShutdownSignal;
+use tokio::sync::broadcast;
+
+const LOG_TARGET: &str = "tari::ootle::wallet_daemon::claim_burn_monitor";
+
+pub struct ClaimBurnMonitor {
+    notify_subscription: broadcast::Receiver<WalletEvent>,
+    burn_proof_dir: PathBuf,
+    pending_claims: HashMap<TransactionId, String>,
+    shutdown_signal: ShutdownSignal,
+}
+
+impl ClaimBurnMonitor {
+    pub fn new(notify: Notify<WalletEvent>, burn_proof_dir: PathBuf, shutdown_signal: ShutdownSignal) -> Self {
+        Self {
+            notify_subscription: notify.subscribe(),
+            burn_proof_dir,
+            pending_claims: HashMap::new(),
+            shutdown_signal,
+        }
+    }
+
+    pub async fn run(mut self) -> Result<(), anyhow::Error> {
+        info!(target: LOG_TARGET, "🔥 Claim burn monitor started");
+
+        loop {
+            tokio::select! {
+                _ = self.shutdown_signal.wait() => {
+                    info!(target: LOG_TARGET, "🔥 Claim burn monitor shutting down");
+                    break Ok(());
+                }
+
+                Ok(event) = self.notify_subscription.recv() => {
+                    self.on_event(event);
+                },
+            }
+        }
+    }
+
+    fn on_event(&mut self, event: WalletEvent) {
+        match event {
+            WalletEvent::TransactionSubmitted(event) => {
+                if let Some(TransactionContext::ClaimBurn { file_name }) = event.context {
+                    info!(
+                        target: LOG_TARGET,
+                        "Tracking claim burn transaction {} for proof file {}",
+                        event.transaction_id,
+                        file_name,
+                    );
+                    self.pending_claims.insert(event.transaction_id, file_name);
+                }
+            },
+            WalletEvent::TransactionFinalized(event) => {
+                if let Some(file_name) = self.pending_claims.remove(&event.transaction_id) {
+                    if event.finalize.result.any_accept().is_some() {
+                        info!(
+                            target: LOG_TARGET,
+                            "Claim burn transaction {} accepted, marking proof {} as claimed",
+                            event.transaction_id,
+                            file_name,
+                        );
+                        self.mark_as_claimed(&file_name);
+                    } else {
+                        warn!(
+                            target: LOG_TARGET,
+                            "Claim burn transaction {} was not accepted. Proof file {} remains available for retry.",
+                            event.transaction_id,
+                            file_name,
+                        );
+                    }
+                }
+            },
+            WalletEvent::TransactionInvalid(event) => {
+                if let Some(file_name) = self.pending_claims.remove(&event.transaction_id) {
+                    warn!(
+                        target: LOG_TARGET,
+                        "Claim burn transaction {} is invalid ({}). Proof file {} remains available for retry.",
+                        event.transaction_id,
+                        event.status,
+                        file_name,
+                    );
+                }
+            },
+            _ => {},
+        }
+    }
+
+    fn mark_as_claimed(&self, file_name: &str) {
+        let claimed_dir = self.burn_proof_dir.join("claimed");
+        if let Err(e) = fs::create_dir_all(&claimed_dir) {
+            warn!(
+                target: LOG_TARGET,
+                "Failed to create claimed directory {}: {}",
+                claimed_dir.display(),
+                e
+            );
+            return;
+        }
+
+        let src = self.burn_proof_dir.join(file_name);
+        let dst = claimed_dir.join(file_name);
+        if let Err(e) = fs::rename(&src, &dst) {
+            warn!(
+                target: LOG_TARGET,
+                "Failed to move claimed burn proof {} -> {}: {}",
+                src.display(),
+                dst.display(),
+                e
+            );
+        } else {
+            info!(
+                target: LOG_TARGET,
+                "Burn proof {} marked as claimed",
+                file_name
+            );
+        }
+    }
+}

--- a/applications/tari_walletd/src/services/claim_burn_monitor.rs
+++ b/applications/tari_walletd/src/services/claim_burn_monitor.rs
@@ -12,6 +12,14 @@ use tokio::sync::broadcast;
 
 const LOG_TARGET: &str = "tari::ootle::wallet_daemon::claim_burn_monitor";
 
+/// Monitors wallet events to move burn proof files to the "claimed" directory
+/// only after the claim burn transaction is finalized and accepted.
+///
+/// NOTE: Pending claim context is held in-memory and is not persisted to the database.
+/// If the daemon restarts while a claim burn transaction is pending, the context is lost
+/// and the proof file will remain in the unclaimed directory. This is by design — the user
+/// can simply retry the claim. This is strictly better than the previous behavior where the
+/// file was moved immediately on submission, making it unrecoverable if the transaction failed.
 pub struct ClaimBurnMonitor {
     notify_subscription: broadcast::Receiver<WalletEvent>,
     burn_proof_dir: PathBuf,
@@ -39,8 +47,22 @@ impl ClaimBurnMonitor {
                     break Ok(());
                 }
 
-                Ok(event) = self.notify_subscription.recv() => {
-                    self.on_event(event);
+                result = self.notify_subscription.recv() => {
+                    match result {
+                        Ok(event) => self.on_event(event),
+                        Err(broadcast::error::RecvError::Lagged(n)) => {
+                            warn!(
+                                target: LOG_TARGET,
+                                "Claim burn monitor lagged behind by {} events. \
+                                 Some claim burn proofs may not be moved automatically.",
+                                n
+                            );
+                        },
+                        Err(broadcast::error::RecvError::Closed) => {
+                            info!(target: LOG_TARGET, "🔥 Event channel closed, shutting down");
+                            break Ok(());
+                        },
+                    }
                 },
             }
         }

--- a/applications/tari_walletd/src/services/mod.rs
+++ b/applications/tari_walletd/src/services/mod.rs
@@ -6,6 +6,7 @@ pub use webauthn_session_store::*;
 
 pub mod wasm_optimizer;
 
+mod claim_burn_monitor;
 mod webauthn;
 pub use webauthn::*;
 
@@ -14,6 +15,8 @@ mod template_monitor;
 mod webauthn_session_store;
 
 // -------------------------------- Spawn -------------------------------- //
+use std::path::PathBuf;
+
 use anyhow::anyhow;
 use futures::{FutureExt, future, future::BoxFuture};
 use tari_ootle_wallet_sdk::{WalletSdk, models::WalletEvent};
@@ -26,12 +29,16 @@ use tari_ootle_wallet_sdk_services::{
 use tari_shutdown::ShutdownSignal;
 use tokio::task::JoinHandle;
 
-use crate::{OotleWalletDaemonSpec, services::template_monitor::TemplateMonitor};
+use crate::{
+    OotleWalletDaemonSpec,
+    services::{claim_burn_monitor::ClaimBurnMonitor, template_monitor::TemplateMonitor},
+};
 
 pub fn spawn_services(
     shutdown_signal: ShutdownSignal,
     notify: Notify<WalletEvent>,
     wallet_sdk: WalletSdk<OotleWalletDaemonSpec>,
+    burn_proof_dir: PathBuf,
 ) -> Services {
     let (transaction_service, transaction_service_handle) =
         TransactionService::new(notify.clone(), wallet_sdk.clone(), shutdown_signal.clone());
@@ -39,6 +46,9 @@ pub fn spawn_services(
 
     let template_monitor = TemplateMonitor::new(notify.clone(), wallet_sdk.clone(), shutdown_signal.clone());
     let template_monitor_join_handle = tokio::spawn(template_monitor.run());
+
+    let claim_burn_monitor = ClaimBurnMonitor::new(notify.clone(), burn_proof_dir, shutdown_signal.clone());
+    let claim_burn_monitor_join_handle = tokio::spawn(claim_burn_monitor.run());
 
     let utxo_scanner = StealthUtxoScannerWorker::new(wallet_sdk.clone(), notify.clone());
     let (utxo_scanner_join_handle, utxo_scanner_handle) = utxo_scanner.spawn();
@@ -60,6 +70,7 @@ pub fn spawn_services(
             transaction_service_join_handle,
             account_monitor_join_handle,
             template_monitor_join_handle,
+            claim_burn_monitor_join_handle,
             utxo_scanner_join_handle,
             utxo_recovery_join_handle,
         ])

--- a/applications/tari_walletd/web_ui/src/routes/AssetVault/Components/ClaimBurn.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/AssetVault/Components/ClaimBurn.tsx
@@ -38,11 +38,17 @@ import Tabs from "@mui/material/Tabs";
 import TextField from "@mui/material/TextField";
 import Typography from "@mui/material/Typography";
 import useAccountStore from "@store/accountStore";
-import type { AccountInfo, BurnProofFileInfo, ClaimBurnProof, ComponentAddress } from "@tari-project/ootle-ts-bindings";
+import type {
+  AccountInfo,
+  BurnProofFileInfo,
+  ClaimBurnProof,
+  ClaimBurnProofContents,
+  ComponentAddress,
+} from "@tari-project/ootle-ts-bindings";
 import { rejectReasonToString } from "@tari-project/ootle-ts-bindings";
 import { XTR_CURRENCY } from "@utils/currency";
 import { formatCurrency } from "@utils/helpers";
-import { accountsClaimBurn, burnProofsList, transactionsWaitResult } from "@utils/json_rpc";
+import { accountsClaimBurn, burnProofsGet, burnProofsList, transactionsWaitResult } from "@utils/json_rpc";
 import { FormEvent, useEffect, useState } from "react";
 import { Form } from "react-router";
 
@@ -73,6 +79,8 @@ export default function ClaimBurn() {
   const [isLoadingProofs, setIsLoadingProofs] = useState(false);
   const [isEstimating, setIsEstimating] = useState(false);
   const [proofError, setProofError] = useState<string | null>(null);
+  const [proofDetails, setProofDetails] = useState<ClaimBurnProofContents | null>(null);
+  const [isLoadingDetails, setIsLoadingDetails] = useState(false);
 
   const { data: accountsList } = useAccountsList(0, 10);
   const { setPopup } = useAccountStore();
@@ -100,6 +108,9 @@ export default function ClaimBurn() {
       setIsLoadingProofs(false);
     }
   };
+
+  const truncateHex = (hex: string, chars: number = 8): string =>
+    hex.length > chars * 2 + 2 ? `${hex.slice(0, chars)}...${hex.slice(-chars)}` : hex;
 
   /** Extracts the commitment hex from a filename like `{pubkey}-{commitment}.json` */
   const extractCommitment = (fileName: string): string => {
@@ -147,15 +158,31 @@ export default function ClaimBurn() {
 
   const onAccountChange = (e: SelectChangeEvent) => {
     setFormState({ ...formState, account: e.target.value, selectedFile: "" });
+    setProofDetails(null);
   };
 
   const onTabChange = (_: React.SyntheticEvent, newValue: ProofSource) => {
     setFormState({ ...formState, proofSource: newValue });
     setProofError(null);
+    setProofDetails(null);
   };
 
-  const onFileSelect = (e: SelectChangeEvent) => {
-    setFormState({ ...formState, selectedFile: e.target.value });
+  const onFileSelect = async (e: SelectChangeEvent) => {
+    const fileName = e.target.value;
+    setFormState({ ...formState, selectedFile: fileName });
+    setProofDetails(null);
+
+    if (!fileName) return;
+
+    setIsLoadingDetails(true);
+    try {
+      const resp = await burnProofsGet({ file_name: fileName });
+      setProofDetails(resp.proof);
+    } catch (err: any) {
+      console.warn("Failed to load burn proof details:", err.message);
+    } finally {
+      setIsLoadingDetails(false);
+    }
   };
 
   const onPastedProofChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -250,6 +277,7 @@ export default function ClaimBurn() {
   const handleClickOpen = () => {
     setFormState(INITIAL_FORM_STATE);
     setProofError(null);
+    setProofDetails(null);
     setOpen(true);
   };
 
@@ -335,6 +363,52 @@ export default function ClaimBurn() {
                 error={proofError !== null}
                 helperText={proofError}
               />
+            )}
+
+            {isLoadingDetails && (
+              <Box display="flex" alignItems="center" gap={1} py={1}>
+                <CircularProgress size={16} />
+                <Typography variant="body2">Loading proof details...</Typography>
+              </Box>
+            )}
+
+            {proofDetails && !isLoadingDetails && (
+              <Box
+                sx={{
+                  border: 1,
+                  borderColor: "divider",
+                  borderRadius: 1,
+                  p: 1.5,
+                  display: "flex",
+                  flexDirection: "column",
+                  gap: 0.5,
+                }}
+              >
+                <Typography variant="subtitle2">Burn Proof Summary</Typography>
+                <Typography variant="body2">
+                  <strong>Amount:</strong> {formatCurrency(BigInt(proofDetails.claim_proof.value), XTR_CURRENCY)}
+                </Typography>
+                <Typography variant="body2">
+                  <strong>Commitment:</strong>{" "}
+                  <span style={{ fontFamily: "monospace" }}>{truncateHex(proofDetails.claim_proof.commitment)}</span>
+                </Typography>
+                <Typography variant="body2">
+                  <strong>L1 Block:</strong>{" "}
+                  <span style={{ fontFamily: "monospace" }}>
+                    {truncateHex(proofDetails.claim_proof.encoded_merkle_proof.block_hash)}
+                  </span>
+                </Typography>
+                {selectedAccount &&
+                  (proofDetails.claim_proof.burn_public_key === selectedAccount.account.owner_public_key ? (
+                    <Alert severity="success" sx={{ mt: 0.5 }}>
+                      Account matches burn proof
+                    </Alert>
+                  ) : (
+                    <Alert severity="warning" sx={{ mt: 0.5 }}>
+                      This burn proof was created for a different account
+                    </Alert>
+                  ))}
+              </Box>
             )}
 
             <TextField

--- a/applications/tari_walletd/web_ui/src/utils/json_rpc.ts
+++ b/applications/tari_walletd/web_ui/src/utils/json_rpc.ts
@@ -46,6 +46,8 @@ import type {
   AuthListSessionsResponse,
   AuthRevokeTokenRequest,
   AuthRevokeTokenResponse,
+  BurnProofsGetRequest,
+  BurnProofsGetResponse,
   BurnProofsListRequest,
   BurnProofsListResponse,
   ClaimBurnRequest,
@@ -218,6 +220,8 @@ export const transactionsSubmitManifest = (
 // burn proofs
 export const burnProofsList = (request: BurnProofsListRequest): Promise<BurnProofsListResponse> =>
   client().then((c) => c.burnProofsList(request));
+export const burnProofsGet = (request: BurnProofsGetRequest): Promise<BurnProofsGetResponse> =>
+  client().then((c) => c.burnProofsGet(request));
 
 // accounts
 export const accountsClaimBurn = (request: ClaimBurnRequest): Promise<ClaimBurnResponse> =>

--- a/clients/javascript/wallet_daemon_client/package.json
+++ b/clients/javascript/wallet_daemon_client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tari-project/wallet_jrpc_client",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "description": "Tari wallet JSON-RPC client library",
   "homepage": "https://github.com/tari-project/tari-ootle#readme",
   "bugs": {

--- a/clients/javascript/wallet_daemon_client/src/index.ts
+++ b/clients/javascript/wallet_daemon_client/src/index.ts
@@ -32,6 +32,8 @@ import type {
   AuthLoginResponse,
   AuthRevokeTokenRequest,
   AuthRevokeTokenResponse,
+  BurnProofsGetRequest,
+  BurnProofsGetResponse,
   BurnProofsListRequest,
   BurnProofsListResponse,
   ClaimBurnRequest,
@@ -191,6 +193,10 @@ export class WalletDaemonClient<T extends RpcTransport = FetchRpcTransport> {
 
   public burnProofsList(params: BurnProofsListRequest): Promise<BurnProofsListResponse> {
     return this.sendRequest("burn_proofs.list", params);
+  }
+
+  public burnProofsGet(params: BurnProofsGetRequest): Promise<BurnProofsGetResponse> {
+    return this.sendRequest("burn_proofs.get", params);
   }
 
   public accountsClaimBurn(params: ClaimBurnRequest): Promise<ClaimBurnResponse> {

--- a/clients/wallet_daemon_client/src/lib.rs
+++ b/clients/wallet_daemon_client/src/lib.rs
@@ -96,6 +96,8 @@ use crate::{
         AuthListSessionsResponse,
         AuthRevokeTokenRequest,
         AuthRevokeTokenResponse,
+        BurnProofsGetRequest,
+        BurnProofsGetResponse,
         BurnProofsListRequest,
         BurnProofsListResponse,
         ClaimValidatorFeesRequest,
@@ -446,6 +448,14 @@ impl WalletDaemonClient {
         req: T,
     ) -> Result<BurnProofsListResponse, WalletDaemonClientError> {
         self.send_request("burn_proofs.list", req.borrow()).await
+    }
+
+    /// Gets the full contents of a specific burn proof file.
+    pub async fn get_burn_proof<T: Borrow<BurnProofsGetRequest>>(
+        &mut self,
+        req: T,
+    ) -> Result<BurnProofsGetResponse, WalletDaemonClientError> {
+        self.send_request("burn_proofs.get", req.borrow()).await
     }
 
     /// Claims a burn transaction, converting burned Minotari into Ootle funds.

--- a/crates/wallet/sdk/src/models/account.rs
+++ b/crates/wallet/sdk/src/models/account.rs
@@ -131,6 +131,21 @@ pub struct NewAccountData {
     pub address: ComponentAddress,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum TransactionContext {
+    NewAccount(NewAccountData),
+    ClaimBurn { file_name: String },
+}
+
+impl TransactionContext {
+    pub fn new_account_data(&self) -> Option<&NewAccountData> {
+        match self {
+            TransactionContext::NewAccount(data) => Some(data),
+            _ => None,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct AccountUpdate<'a> {
     pub name: Option<&'a str>,

--- a/crates/wallet/sdk/src/models/event.rs
+++ b/crates/wallet/sdk/src/models/event.rs
@@ -7,7 +7,7 @@ use tari_engine_types::commit_result::FinalizeResult;
 use tari_ootle_transaction::TransactionId;
 use tari_template_lib::types::{ComponentAddress, UtxoAddress};
 
-use crate::models::{Account, NewAccountData, TransactionStatus};
+use crate::models::{Account, TransactionContext, TransactionStatus};
 
 #[derive(Debug, Clone)]
 pub enum WalletEvent {
@@ -98,8 +98,7 @@ impl Display for WalletEvent {
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct TransactionSubmittedEvent {
     pub transaction_id: TransactionId,
-    /// Set to Some if this transaction results in a new account
-    pub new_account: Option<NewAccountData>,
+    pub context: Option<TransactionContext>,
 }
 
 #[derive(Debug, Clone, serde::Serialize)]

--- a/crates/wallet/sdk_services/src/account_monitor/monitor.rs
+++ b/crates/wallet/sdk_services/src/account_monitor/monitor.rs
@@ -252,7 +252,7 @@ where
         }
         match event {
             WalletEvent::TransactionSubmitted(event) => {
-                if let Some(account) = event.new_account {
+                if let Some(account) = event.context.and_then(|c| c.new_account_data().cloned()) {
                     self.pending_accounts.insert(event.transaction_id, account);
                 }
             },

--- a/crates/wallet/sdk_services/src/transaction_service/handle.rs
+++ b/crates/wallet/sdk_services/src/transaction_service/handle.rs
@@ -3,7 +3,7 @@
 
 use tari_engine_types::commit_result::ExecuteResult;
 use tari_ootle_transaction::{Transaction, TransactionId};
-use tari_ootle_wallet_sdk::models::{NewAccountData, WalletLockId};
+use tari_ootle_wallet_sdk::models::{TransactionContext, WalletLockId};
 use tokio::sync::{mpsc, oneshot};
 
 use super::TransactionServiceError;
@@ -13,7 +13,7 @@ use crate::Reply;
 pub(super) enum TransactionServiceRequest {
     SubmitTransaction {
         transaction: Transaction,
-        new_account_info: Option<NewAccountData>,
+        context: Option<TransactionContext>,
         lock_id: Option<WalletLockId>,
         reply: Reply<Result<TransactionId, TransactionServiceError>>,
     },
@@ -58,14 +58,14 @@ impl TransactionServiceHandle {
     pub async fn submit_transaction_with_opts(
         &self,
         transaction: Transaction,
-        new_account_info: Option<NewAccountData>,
+        context: Option<TransactionContext>,
         lock_id: Option<WalletLockId>,
     ) -> Result<TransactionId, TransactionServiceError> {
         let (reply_tx, reply_rx) = oneshot::channel();
         self.sender
             .send(TransactionServiceRequest::SubmitTransaction {
                 transaction,
-                new_account_info,
+                context,
                 lock_id,
                 reply: reply_tx,
             })

--- a/crates/wallet/sdk_services/src/transaction_service/service.rs
+++ b/crates/wallet/sdk_services/src/transaction_service/service.rs
@@ -258,6 +258,9 @@ where
             );
             let transaction_id = transaction.id;
             if transaction_api.submit_transaction(transaction_id).await? {
+                // Only NewAccountData is persisted in the DB, so only that context is recoverable on
+                // resubmit. Other context variants (e.g. ClaimBurn) are in-memory only — if the daemon
+                // restarts, that context is lost and the caller must retry.
                 notify.notify(TransactionSubmittedEvent {
                     transaction_id,
                     context: transaction.new_account_info.map(TransactionContext::NewAccount),

--- a/crates/wallet/sdk_services/src/transaction_service/service.rs
+++ b/crates/wallet/sdk_services/src/transaction_service/service.rs
@@ -11,7 +11,7 @@ use tari_ootle_wallet_sdk::{
     WalletSdk,
     WalletSdkSpec,
     models::{
-        NewAccountData,
+        TransactionContext,
         TransactionFinalizedEvent,
         TransactionInvalidEvent,
         TransactionStatus,
@@ -115,15 +115,12 @@ where
         match request {
             TransactionServiceRequest::SubmitTransaction {
                 transaction,
-                new_account_info,
+                context,
                 lock_id,
                 reply,
             } => {
                 reply
-                    .send(
-                        self.handle_submit_transaction(transaction, new_account_info, lock_id)
-                            .await,
-                    )
+                    .send(self.handle_submit_transaction(transaction, context, lock_id).await)
                     .map_err(|_| TransactionServiceError::ServiceShutdown)?;
             },
             TransactionServiceRequest::SubmitDryRunTransaction { transaction, reply } => {
@@ -163,11 +160,12 @@ where
     async fn handle_submit_transaction(
         &self,
         transaction: Transaction,
-        new_account_info: Option<NewAccountData>,
+        context: Option<TransactionContext>,
         lock_id: Option<WalletLockId>,
     ) -> Result<TransactionId, TransactionServiceError> {
         let transaction_api = self.wallet_sdk.transaction_api();
-        let transaction_id = transaction_api.insert_new_transaction(transaction, new_account_info.clone(), false)?;
+        let new_account_info = context.as_ref().and_then(|c| c.new_account_data()).cloned();
+        let transaction_id = transaction_api.insert_new_transaction(transaction, new_account_info, false)?;
 
         if let Some(lock_id) = lock_id {
             transaction_api.locks_set_transaction_id(lock_id, transaction_id)?;
@@ -176,7 +174,7 @@ where
         if transaction_api.submit_transaction(transaction_id).await? {
             self.notify.notify(TransactionSubmittedEvent {
                 transaction_id,
-                new_account: new_account_info,
+                context,
             });
             Ok(transaction_id)
         } else {
@@ -262,7 +260,7 @@ where
             if transaction_api.submit_transaction(transaction_id).await? {
                 notify.notify(TransactionSubmittedEvent {
                     transaction_id,
-                    new_account: transaction.new_account_info,
+                    context: transaction.new_account_info.map(TransactionContext::NewAccount),
                 });
             } else {
                 notify.notify(TransactionInvalidEvent {

--- a/crates/wallet/storage_sqlite/src/writer.rs
+++ b/crates/wallet/storage_sqlite/src/writer.rs
@@ -1670,7 +1670,11 @@ impl WalletEventStoreWriter for WriteTransaction<'_> {
 
         let (maybe_account, payload) = match event {
             WalletEvent::TransactionSubmitted(payload) => (
-                payload.new_account.as_ref().map(|a| a.address),
+                payload
+                    .context
+                    .as_ref()
+                    .and_then(|c| c.new_account_data())
+                    .map(|a| a.address),
                 serialize_json(payload)?,
             ),
             WalletEvent::TransactionFinalized(payload) => (None, serialize_json(payload)?),


### PR DESCRIPTION
## Summary

- Burn proofs were moved to the `claimed/` directory immediately after submitting the claim burn transaction — if the transaction was rejected, the proof was permanently consumed and couldn't be retried
- Introduces `TransactionContext` enum to generalize the per-transaction context pattern (previously `Option<NewAccountData>`), adding a `ClaimBurn` variant
- New `ClaimBurnMonitor` service moves the proof file only after the transaction is confirmed on-chain

## Test plan

- [x] `cargo build -p tari_ootle_walletd` compiles
- [ ] Existing `claim_burn.feature` integration test passes
- [ ] Manual: submit claim burn with insufficient fee → transaction rejected → proof file remains in unclaimed directory → retry succeeds