### PR TITLE
feat(template_metadata): add logo_url field

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11450,7 +11450,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_template_build"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "tari_ootle_template_metadata",
  "tempfile",
@@ -11459,7 +11459,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_template_metadata"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "borsh",
  "cargo_toml 0.22.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,8 +122,8 @@ tari_template_builtin = { path = "crates/template_builtin", version = "0.28" }
 tari_ootle_transaction = { path = "crates/transaction", version = "0.28" }
 
 # Template lib
-tari_ootle_template_build = { path = "crates/template_build", version = "0.3" }
-tari_ootle_template_metadata = { path = "crates/template_metadata", version = "0.3" }
+tari_ootle_template_build = { path = "crates/template_build", version = "0.4" }
+tari_ootle_template_metadata = { path = "crates/template_metadata", version = "0.4" }
 tari_template_lib = { version = "0.23", path = "crates/template_lib" }
 tari_template_lib_types = { version = "0.23", path = "crates/template_lib_types", default-features = false }
 tari_template_abi = { version = "0.16", path = "crates/template_abi", default-features = false }

--- a/crates/template_build/Cargo.toml
+++ b/crates/template_build/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_ootle_template_build"
 description = "Build-time metadata generation for Tari Ootle templates"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/template_build/README.md
+++ b/crates/template_build/README.md
@@ -12,7 +12,7 @@ Add to your template's `Cargo.toml`:
 
 ```toml
 [build-dependencies]
-tari_ootle_template_build = "0.2"
+tari_ootle_template_build = "0.4"
 ```
 
 Create a `build.rs`:
@@ -54,6 +54,7 @@ fn main() {
 | `.documentation(...)` | Override documentation URL |
 | `.homepage(...)` | Override homepage URL |
 | `.license(...)` | Override license |
+| `.logo_url(...)` | Override logo URL |
 | `.extra(map)` | Replace entire extra metadata map |
 | `.extra_entry(k, v)` | Add a single extra key-value pair |
 | `.enable_json_output()` | Also write `template_metadata.json` |
@@ -84,6 +85,7 @@ tags = ["token", "fungible", "defi"]
 category = "token"
 documentation = "https://docs.example.com/fungible-token"
 homepage = "https://example.com"
+logo_url = "https://example.com/logo.png"
 
 [package.metadata.tari-template.extra]
 audit = "https://example.com/audit-report"

--- a/crates/template_build/src/lib.rs
+++ b/crates/template_build/src/lib.rs
@@ -51,6 +51,7 @@ pub struct TemplateMetadataBuilder {
     documentation: Option<String>,
     homepage: Option<String>,
     license: Option<String>,
+    logo_url: Option<String>,
     extra: Option<BTreeMap<String, String>>,
 }
 
@@ -72,6 +73,7 @@ impl TemplateMetadataBuilder {
             documentation: None,
             homepage: None,
             license: None,
+            logo_url: None,
             extra: None,
         }
     }
@@ -124,6 +126,12 @@ impl TemplateMetadataBuilder {
         self
     }
 
+    /// Override the logo URL from Cargo.toml.
+    pub fn logo_url(mut self, logo_url: impl Into<String>) -> Self {
+        self.logo_url = Some(logo_url.into());
+        self
+    }
+
     /// Override the extra metadata map from Cargo.toml.
     pub fn extra(mut self, extra: BTreeMap<String, String>) -> Self {
         self.extra = Some(extra);
@@ -160,6 +168,9 @@ impl TemplateMetadataBuilder {
         }
         if let Some(ref license) = self.license {
             metadata.license = Some(license.clone());
+        }
+        if let Some(ref logo_url) = self.logo_url {
+            metadata.logo_url = Some(logo_url.clone());
         }
         if let Some(ref extra) = self.extra {
             metadata.extra = extra.clone();

--- a/crates/template_metadata/Cargo.toml
+++ b/crates/template_metadata/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_ootle_template_metadata"
 description = "Template metadata types, serialization, and hashing for Tari Ootle templates"
-version = "0.3.1"
+version = "0.4.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/template_metadata/README.md
+++ b/crates/template_metadata/README.md
@@ -78,6 +78,7 @@ println!("Hash: {hash}");
 | `category` | `[package.metadata.tari-template] category` |
 | `documentation` | `[package.metadata.tari-template] documentation` |
 | `homepage` | `[package.metadata.tari-template] homepage` |
+| `logo_url` | `[package.metadata.tari-template] logo_url` |
 | `extra` | `[package.metadata.tari-template] extra` |
 
 ## Features

--- a/crates/template_metadata/src/cargo_toml.rs
+++ b/crates/template_metadata/src/cargo_toml.rs
@@ -68,6 +68,11 @@ fn from_manifest(manifest: &Manifest) -> Result<TemplateMetadata, CargoTomlError
         .and_then(|v| v.as_str())
         .map(String::from);
 
+    let logo_url = tari_template
+        .and_then(|t| t.get("logo_url"))
+        .and_then(|v| v.as_str())
+        .map(String::from);
+
     let extra = tari_template
         .and_then(|t| t.get("extra"))
         .and_then(|v| v.as_table())
@@ -89,6 +94,7 @@ fn from_manifest(manifest: &Manifest) -> Result<TemplateMetadata, CargoTomlError
         documentation,
         homepage,
         license,
+        logo_url,
         extra,
     })
 }

--- a/crates/template_metadata/src/metadata.rs
+++ b/crates/template_metadata/src/metadata.rs
@@ -34,6 +34,8 @@ pub struct TemplateMetadata {
     pub homepage: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub license: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub logo_url: Option<String>,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub extra: BTreeMap<String, String>,
 }
@@ -52,6 +54,7 @@ impl TemplateMetadata {
             documentation: None,
             homepage: None,
             license: None,
+            logo_url: None,
             extra: BTreeMap::new(),
         }
     }
@@ -130,6 +133,7 @@ mod tests {
             documentation: None,
             homepage: None,
             license: Some("BSD-3-Clause".to_string()),
+            logo_url: None,
             extra: BTreeMap::new(),
         };
 
@@ -194,6 +198,7 @@ mod tests {
             documentation: None,
             homepage: None,
             license: None,
+            logo_url: None,
             extra: BTreeMap::new(),
         };
 


### PR DESCRIPTION
## Summary
- Add optional `logo_url: Option<String>` field to `TemplateMetadata` for template authors to specify a logo image URL
- Parse `logo_url` from `[package.metadata.tari-template]` in Cargo.toml
- Add `.logo_url()` builder method to `TemplateMetadataBuilder`
- Bump `tari_ootle_template_metadata` to 0.4.0 and `tari_ootle_template_build` to 0.4.0
- Update workspace dependency versions and READMEs

## Test plan
- [x] All existing tests pass (28/28)
- [ ] Verify CBOR backward compatibility (old blobs without `logo_url` deserialize with `None`)