### PR TITLE
feat(indexer): add metadata_hash to template catalogue API

### DIFF
--- a/applications/tari_indexer/src/storage_sqlite/migrations/2026-04-03-000000_add_metadata_hash_to_template_catalogue/down.sql
+++ b/applications/tari_indexer/src/storage_sqlite/migrations/2026-04-03-000000_add_metadata_hash_to_template_catalogue/down.sql
@@ -1,0 +1,4 @@
+-- Copyright 2026. The Tari Project
+-- SPDX-License-Identifier: BSD-3-Clause
+
+ALTER TABLE template_catalogue DROP COLUMN metadata_hash;

--- a/applications/tari_indexer/src/storage_sqlite/migrations/2026-04-03-000000_add_metadata_hash_to_template_catalogue/up.sql
+++ b/applications/tari_indexer/src/storage_sqlite/migrations/2026-04-03-000000_add_metadata_hash_to_template_catalogue/up.sql
@@ -1,0 +1,4 @@
+-- Copyright 2026. The Tari Project
+-- SPDX-License-Identifier: BSD-3-Clause
+
+ALTER TABLE template_catalogue ADD COLUMN metadata_hash TEXT;

--- a/applications/tari_indexer/src/storage_sqlite/models/template_catalogue.rs
+++ b/applications/tari_indexer/src/storage_sqlite/models/template_catalogue.rs
@@ -4,6 +4,7 @@
 use tari_engine_types::published_template::PublishedTemplateMetadata;
 use tari_indexer_client::types::TemplateCatalogueItem;
 use tari_ootle_storage::time::PrimitiveDateTime;
+use tari_ootle_template_metadata::MetadataHash;
 use tari_template_lib_types::{Hash32, TemplateAddress, crypto::RistrettoPublicKeyBytes};
 
 use crate::storage_sqlite::schema::template_catalogue;
@@ -18,6 +19,7 @@ pub(crate) struct TemplateCatalogueRow {
     pub author_public_key: String,
     pub binary_hash: String,
     pub at_epoch: i64,
+    pub metadata_hash: Option<String>,
     #[allow(dead_code)]
     pub created_at: PrimitiveDateTime,
     #[allow(dead_code)]
@@ -33,6 +35,7 @@ pub(crate) struct NewTemplateCatalogueRow {
     pub author_public_key: String,
     pub binary_hash: String,
     pub at_epoch: i64,
+    pub metadata_hash: Option<String>,
 }
 
 /// Public type exposed through the store trait and REST API.
@@ -44,6 +47,7 @@ pub struct TemplateCatalogueEntry {
     pub author_public_key: RistrettoPublicKeyBytes,
     pub binary_hash: Hash32,
     pub at_epoch: u64,
+    pub metadata_hash: Option<MetadataHash>,
 }
 
 impl TryFrom<TemplateCatalogueRow> for TemplateCatalogueEntry {
@@ -63,6 +67,11 @@ impl TryFrom<TemplateCatalogueRow> for TemplateCatalogueEntry {
             binary_hash: Hash32::from_hex(&row.binary_hash)
                 .map_err(|e| anyhow::anyhow!("Invalid binary_hash hex: {e}"))?,
             at_epoch: row.at_epoch as u64,
+            metadata_hash: row
+                .metadata_hash
+                .map(|h| MetadataHash::from_hex(&h))
+                .transpose()
+                .map_err(|e| anyhow::anyhow!("Invalid metadata_hash hex: {e}"))?,
         })
     }
 }
@@ -75,6 +84,7 @@ impl From<TemplateCatalogueEntry> for TemplateCatalogueItem {
             author_public_key: e.author_public_key,
             binary_hash: e.binary_hash,
             at_epoch: e.at_epoch,
+            metadata_hash: e.metadata_hash,
         }
     }
 }
@@ -87,6 +97,7 @@ impl From<(TemplateAddress, &PublishedTemplateMetadata)> for NewTemplateCatalogu
             author_public_key: hex::encode(meta.author_public_key.as_bytes()),
             binary_hash: hex::encode(meta.binary_hash.as_slice()),
             at_epoch: meta.at_epoch as i64,
+            metadata_hash: meta.metadata_hash.as_ref().map(|h| h.to_hex()),
         }
     }
 }

--- a/applications/tari_indexer/src/storage_sqlite/schema.rs
+++ b/applications/tari_indexer/src/storage_sqlite/schema.rs
@@ -8,6 +8,7 @@ diesel::table! {
         author_public_key -> Text,
         binary_hash -> Text,
         at_epoch -> BigInt,
+        metadata_hash -> Nullable<Text>,
         created_at -> Timestamp,
         updated_at -> Timestamp,
     }

--- a/bindings/src/types/tari-indexer-client/TemplateCatalogueItem.ts
+++ b/bindings/src/types/tari-indexer-client/TemplateCatalogueItem.ts
@@ -8,4 +8,5 @@ export type TemplateCatalogueItem = {
   author_public_key: RistrettoPublicKeyBytes;
   binary_hash: Hash32;
   at_epoch: bigint;
+  metadata_hash: string | null;
 };

--- a/clients/tari_indexer_client/src/types.rs
+++ b/clients/tari_indexer_client/src/types.rs
@@ -235,6 +235,10 @@ pub struct TemplateCatalogueItem {
     #[cfg_attr(feature = "utoipa", schema(value_type = String))]
     pub binary_hash: Hash32,
     pub at_epoch: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "utoipa", schema(value_type = Option<String>))]
+    #[cfg_attr(feature = "ts", ts(type = "string | null"))]
+    pub metadata_hash: Option<MetadataHash>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
## Description

Adds `metadata_hash` (`Option<MetadataHash>`) to the indexer template catalogue API response. This field was already present in `PublishedTemplateMetadata` and the cached `TemplateMetadata` type but was missing from the catalogue endpoint.

## Changes

- Added `metadata_hash` to `TemplateCatalogueItem`, `TemplateCatalogueRow`, `NewTemplateCatalogueRow`, `TemplateCatalogueEntry` and all conversion impls
- New migration to add `metadata_hash` column to `template_catalogue` table
- Updated TypeScript binding