### PR TITLE
feat(walletd): send multiple NFTs

### DIFF
--- a/applications/tari_walletd/web_ui/src/routes/AssetVault/NFTs/NFTList.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/AssetVault/NFTs/NFTList.tsx
@@ -75,23 +75,18 @@ export default function NFTList(props: NftListProps) {
 
   const [viewMode, setViewMode] = useState<"grid" | "list">("grid");
   const [selectedMap, setSelectedMap] = useState<Map<string, NonFungibleToken>>(new Map());
-  const [lockedResourceAddress, setLockedResourceAddress] = useState<string | null>(null);
   const [sendDialogOpen, setSendDialogOpen] = useState(false);
   const displayedNfts = nftsListData?.nfts || [];
-
-  const syncLockedAddress = useCallback((map: Map<string, NonFungibleToken>, fallback: string | null = null) => {
-    setLockedResourceAddress(map.size > 0 ? (lockedResourceAddress ?? fallback) : null);
-  }, [lockedResourceAddress]);
+  const lockedResourceAddress = selectedMap.size ? Array.from(selectedMap.values())[0].resource_address : null;
 
   const toggleSelect = useCallback((nft: NonFungibleToken) => {
     setSelectedMap((prev) => {
       const key = nftIdKey(nft.nft_id);
       const next = new Map(prev);
       next.has(key) ? next.delete(key) : next.set(key, nft);
-      syncLockedAddress(next, nft.resource_address);
       return next;
     });
-  }, [syncLockedAddress]);
+  }, []);
 
   const isSelectDisabled = useCallback(
     (nft: NonFungibleToken) => {
@@ -132,9 +127,9 @@ export default function NFTList(props: NftListProps) {
   const DisplayNFTs = () => {
     return viewMode === "grid" ? (
       <Grid container spacing={3}>
-        {displayedNfts.map((nft: NonFungibleToken, index: number) => (
+        {displayedNfts.map((nft: NonFungibleToken) => (
           <NftCard
-            key={`${nft.nft_id}-${index}`}
+            key={nftIdKey(nft.nft_id)}
             nft={nft}
             selected={selectedMap.has(nftIdKey(nft.nft_id))}
             selectDisabled={isSelectDisabled(nft)}
@@ -155,9 +150,9 @@ export default function NFTList(props: NftListProps) {
             </TableRow>
           </TableHead>
           <TableBody>
-            {displayedNfts.map((nft: NonFungibleToken, index: number) => (
+            {displayedNfts.map((nft: NonFungibleToken) => (
               <NftRow
-                key={`${nft.nft_id}-${index}`}
+                key={nftIdKey(nft.nft_id)}
                 nft={nft}
                 selected={selectedMap.has(nftIdKey(nft.nft_id))}
                 selectDisabled={isSelectDisabled(nft)}
@@ -238,7 +233,6 @@ export default function NFTList(props: NftListProps) {
         onSendComplete={() => {
           setSendDialogOpen(false);
           setSelectedMap(new Map());
-          setLockedResourceAddress(null);
         }}
         preSelectedNfts={selectedNfts}
       />

--- a/applications/tari_walletd/web_ui/src/routes/AssetVault/NFTs/NFTList.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/AssetVault/NFTs/NFTList.tsx
@@ -23,6 +23,7 @@
 import type { ApiError } from "@api/helpers/types";
 import FetchStatusCheck from "@components/FetchStatusCheck";
 import Button from "@mui/material/Button";
+import Checkbox from "@mui/material/Checkbox";
 import Grid from "@mui/material/Grid";
 import IconButton from "@mui/material/IconButton";
 import Stack from "@mui/material/Stack";
@@ -34,11 +35,12 @@ import TableHead from "@mui/material/TableHead";
 import TablePagination from "@mui/material/TablePagination";
 import TableRow from "@mui/material/TableRow";
 import Typography from "@mui/material/Typography";
-import type { ListNftsResponse, NonFungibleToken } from "@tari-project/ootle-ts-bindings";
-import React, { useState } from "react";
+import type { ListNftsResponse, NonFungibleId, NonFungibleToken } from "@tari-project/ootle-ts-bindings";
+import React, { useCallback, useState } from "react";
 import { IoApps, IoList } from "react-icons/io5";
 import ClaimNftsButton from "./components/ClaimNftsButton";
 import { NftCard, NftRow } from "./components/NftParts";
+import { TransferNftDialog } from "./components/SendNft";
 
 export interface NftListProps {
   nftsListIsError: boolean;
@@ -51,6 +53,10 @@ export interface NftListProps {
   onPageChange: (event: unknown, newPage: number) => void;
   onRowsPerPageChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
   onManualRefresh?: () => void;
+}
+
+function nftIdKey(nftId: NonFungibleId): string {
+  return JSON.stringify(nftId);
 }
 
 export default function NFTList(props: NftListProps) {
@@ -68,7 +74,38 @@ export default function NFTList(props: NftListProps) {
   } = props;
 
   const [viewMode, setViewMode] = useState<"grid" | "list">("grid");
+  const [selectedMap, setSelectedMap] = useState<Map<string, NonFungibleToken>>(new Map());
+  const [sendDialogOpen, setSendDialogOpen] = useState(false);
   const displayedNfts = nftsListData?.nfts || [];
+
+  const toggleSelect = useCallback((nft: NonFungibleToken) => {
+    setSelectedMap((prev) => {
+      const key = nftIdKey(nft.nft_id);
+      const next = new Map(prev);
+      if (next.has(key)) {
+        next.delete(key);
+      } else {
+        next.set(key, nft);
+      }
+      return next;
+    });
+  }, []);
+
+  const isAllPageSelected = displayedNfts.length > 0 && displayedNfts.every((nft) => selectedMap.has(nftIdKey(nft.nft_id)));
+
+  const toggleSelectAll = useCallback(() => {
+    setSelectedMap((prev) => {
+      const next = new Map(prev);
+      if (displayedNfts.every((nft) => next.has(nftIdKey(nft.nft_id)))) {
+        displayedNfts.forEach((nft) => next.delete(nftIdKey(nft.nft_id)));
+      } else {
+        displayedNfts.forEach((nft) => next.set(nftIdKey(nft.nft_id), nft));
+      }
+      return next;
+    });
+  }, [displayedNfts]);
+
+  const selectedNfts = Array.from(selectedMap.values());
 
   const EmptyPlaceHolder = () => (
     <Stack alignItems="center" justifyContent="center" sx={{ py: 8 }}>
@@ -101,7 +138,12 @@ export default function NFTList(props: NftListProps) {
     return viewMode === "grid" ? (
       <Grid container spacing={3}>
         {displayedNfts.map((nft: NonFungibleToken, index: number) => (
-          <NftCard key={`${nft.nft_id}-${index}`} nft={nft} />
+          <NftCard
+            key={`${nft.nft_id}-${index}`}
+            nft={nft}
+            selected={selectedMap.has(nftIdKey(nft.nft_id))}
+            onToggleSelect={() => toggleSelect(nft)}
+          />
         ))}
       </Grid>
     ) : (
@@ -109,6 +151,9 @@ export default function NFTList(props: NftListProps) {
         <Table>
           <TableHead>
             <TableRow>
+              <TableCell padding="checkbox">
+                <Checkbox checked={isAllPageSelected} onChange={toggleSelectAll} />
+              </TableCell>
               <TableCell>NFT</TableCell>
               <TableCell>Original Owner</TableCell>
               <TableCell>Status</TableCell>
@@ -117,7 +162,12 @@ export default function NFTList(props: NftListProps) {
           </TableHead>
           <TableBody>
             {displayedNfts.map((nft: NonFungibleToken, index: number) => (
-              <NftRow key={`${nft.nft_id}-${index}`} nft={nft} />
+              <NftRow
+                key={`${nft.nft_id}-${index}`}
+                nft={nft}
+                selected={selectedMap.has(nftIdKey(nft.nft_id))}
+                onToggleSelect={() => toggleSelect(nft)}
+              />
             ))}
           </TableBody>
         </Table>
@@ -157,6 +207,11 @@ export default function NFTList(props: NftListProps) {
           </Stack>
 
           <Stack direction="row" spacing={2} alignItems="center">
+            {selectedNfts.length >= 2 && (
+              <Button variant="contained" onClick={() => setSendDialogOpen(true)}>
+                Send Selected ({selectedNfts.length})
+              </Button>
+            )}
             <ClaimNftsButton />
           </Stack>
         </Stack>
@@ -181,6 +236,16 @@ export default function NFTList(props: NftListProps) {
           />
         )}
       </Stack>
+
+      <TransferNftDialog
+        open={sendDialogOpen}
+        handleClose={() => setSendDialogOpen(false)}
+        onSendComplete={() => {
+          setSendDialogOpen(false);
+          setSelectedMap(new Map());
+        }}
+        preSelectedNfts={selectedNfts}
+      />
     </FetchStatusCheck>
   );
 }

--- a/applications/tari_walletd/web_ui/src/routes/AssetVault/NFTs/NFTList.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/AssetVault/NFTs/NFTList.tsx
@@ -100,23 +100,6 @@ export default function NFTList(props: NftListProps) {
     [lockedResourceAddress, selectedMap],
   );
 
-  const selectablePageNfts = displayedNfts.filter((nft) => !isSelectDisabled(nft));
-  const isAllPageSelected =
-    selectablePageNfts.length > 0 && selectablePageNfts.every((nft) => selectedMap.has(nftIdKey(nft.nft_id)));
-
-  const toggleSelectAll = useCallback(() => {
-    setSelectedMap((prev) => {
-      const next = new Map(prev);
-      const selectable = displayedNfts.filter(
-        (nft) => lockedResourceAddress === null || nft.resource_address === lockedResourceAddress,
-      );
-      const allSelected = selectable.every((nft) => next.has(nftIdKey(nft.nft_id)));
-      selectable.forEach((nft) => (allSelected ? next.delete(nftIdKey(nft.nft_id)) : next.set(nftIdKey(nft.nft_id), nft)));
-      syncLockedAddress(next, selectable[0]?.resource_address ?? null);
-      return next;
-    });
-  }, [displayedNfts, lockedResourceAddress, syncLockedAddress]);
-
   const selectedNfts = Array.from(selectedMap.values());
 
   const EmptyPlaceHolder = () => (
@@ -164,9 +147,7 @@ export default function NFTList(props: NftListProps) {
         <Table>
           <TableHead>
             <TableRow>
-              <TableCell padding="checkbox">
-                <Checkbox checked={isAllPageSelected} onChange={toggleSelectAll} />
-              </TableCell>
+              <TableCell padding="checkbox" aria-hidden />
               <TableCell>NFT</TableCell>
               <TableCell>Original Owner</TableCell>
               <TableCell>Status</TableCell>
@@ -221,7 +202,7 @@ export default function NFTList(props: NftListProps) {
           </Stack>
 
           <Stack direction="row" spacing={2} alignItems="center">
-            {selectedNfts.length && (
+            {selectedNfts.length > 0 && (
               <Button variant="contained" onClick={() => setSendDialogOpen(true)}>
                 Send Selected ({selectedNfts.length})
               </Button>

--- a/applications/tari_walletd/web_ui/src/routes/AssetVault/NFTs/NFTList.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/AssetVault/NFTs/NFTList.tsx
@@ -36,7 +36,7 @@ import TableRow from "@mui/material/TableRow";
 import Typography from "@mui/material/Typography";
 import type { ListNftsResponse, NonFungibleToken } from "@tari-project/ootle-ts-bindings";
 import { nftIdToString } from "@utils/helpers";
-import React, { useCallback, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { IoApps, IoList } from "react-icons/io5";
 import ClaimNftsButton from "./components/ClaimNftsButton";
 import { NftCard, NftRow } from "./components/NftParts";
@@ -98,6 +98,22 @@ export default function NFTList(props: NftListProps) {
     },
     [lockedResourceAddress, selectedMap, nftKey],
   );
+
+  // Prune selections that are no longer in the displayed NFT list
+  useEffect(() => {
+    if (selectedMap.size === 0) return;
+    const currentKeys = new Set(displayedNfts.map((nft) => nftKey(nft)));
+    const staleKeys = Array.from(selectedMap.keys()).filter((key) => !currentKeys.has(key));
+    if (staleKeys.length > 0) {
+      setSelectedMap((prev) => {
+        const next = new Map(prev);
+        for (const key of staleKeys) {
+          next.delete(key);
+        }
+        return next;
+      });
+    }
+  }, [displayedNfts, selectedMap, nftKey]);
 
   const selectedNfts = useMemo(() => Array.from(selectedMap.values()), [selectedMap]);
 

--- a/applications/tari_walletd/web_ui/src/routes/AssetVault/NFTs/NFTList.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/AssetVault/NFTs/NFTList.tsx
@@ -75,24 +75,28 @@ export default function NFTList(props: NftListProps) {
   const displayedNfts = nftsListData?.nfts || [];
   const lockedResourceAddress = selectedMap.size ? Array.from(selectedMap.values())[0].resource_address : null;
 
+  const nftKey = useCallback((nft: NonFungibleToken) => {
+    return `${nft.resource_address}:${nftIdToString(nft.nft_id)}`;
+  }, []);
+
   const toggleSelect = useCallback((nft: NonFungibleToken) => {
     setSelectedMap((prev) => {
-      const key = nftIdToString(nft.nft_id);
+      const key = nftKey(nft);
       const next = new Map(prev);
       next.has(key) ? next.delete(key) : next.set(key, nft);
       return next;
     });
-  }, []);
+  }, [nftKey]);
 
   const isSelectDisabled = useCallback(
     (nft: NonFungibleToken) => {
       return (
         lockedResourceAddress !== null &&
-        !selectedMap.has(nftIdToString(nft.nft_id)) &&
+        !selectedMap.has(nftKey(nft)) &&
         nft.resource_address !== lockedResourceAddress
       );
     },
-    [lockedResourceAddress, selectedMap],
+    [lockedResourceAddress, selectedMap, nftKey],
   );
 
   const selectedNfts = useMemo(() => Array.from(selectedMap.values()), [selectedMap]);
@@ -131,7 +135,7 @@ export default function NFTList(props: NftListProps) {
           <NftCard
             key={i}
             nft={nft}
-            selected={selectedMap.has(nftIdToString(nft.nft_id))}
+            selected={selectedMap.has(nftKey(nft))}
             selectDisabled={isSelectDisabled(nft)}
             onToggleSelect={() => toggleSelect(nft)}
           />
@@ -154,7 +158,7 @@ export default function NFTList(props: NftListProps) {
               <NftRow
                 key={i}
                 nft={nft}
-                selected={selectedMap.has(nftIdToString(nft.nft_id))}
+                selected={selectedMap.has(nftKey(nft))}
                 selectDisabled={isSelectDisabled(nft)}
                 onToggleSelect={() => toggleSelect(nft)}
               />
@@ -235,6 +239,7 @@ export default function NFTList(props: NftListProps) {
           setSelectedMap(new Map());
         }}
         preSelectedNfts={selectedNfts}
+        preSelectedResourceAddress={lockedResourceAddress ?? undefined}
       />
     </FetchStatusCheck>
   );

--- a/applications/tari_walletd/web_ui/src/routes/AssetVault/NFTs/NFTList.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/AssetVault/NFTs/NFTList.tsx
@@ -75,35 +75,47 @@ export default function NFTList(props: NftListProps) {
 
   const [viewMode, setViewMode] = useState<"grid" | "list">("grid");
   const [selectedMap, setSelectedMap] = useState<Map<string, NonFungibleToken>>(new Map());
+  const [lockedResourceAddress, setLockedResourceAddress] = useState<string | null>(null);
   const [sendDialogOpen, setSendDialogOpen] = useState(false);
   const displayedNfts = nftsListData?.nfts || [];
+
+  const syncLockedAddress = useCallback((map: Map<string, NonFungibleToken>, fallback: string | null = null) => {
+    setLockedResourceAddress(map.size > 0 ? (lockedResourceAddress ?? fallback) : null);
+  }, [lockedResourceAddress]);
 
   const toggleSelect = useCallback((nft: NonFungibleToken) => {
     setSelectedMap((prev) => {
       const key = nftIdKey(nft.nft_id);
       const next = new Map(prev);
-      if (next.has(key)) {
-        next.delete(key);
-      } else {
-        next.set(key, nft);
-      }
+      next.has(key) ? next.delete(key) : next.set(key, nft);
+      syncLockedAddress(next, nft.resource_address);
       return next;
     });
-  }, []);
+  }, [syncLockedAddress]);
 
-  const isAllPageSelected = displayedNfts.length > 0 && displayedNfts.every((nft) => selectedMap.has(nftIdKey(nft.nft_id)));
+  const isSelectDisabled = useCallback(
+    (nft: NonFungibleToken) => {
+      return lockedResourceAddress !== null && !selectedMap.has(nftIdKey(nft.nft_id)) && nft.resource_address !== lockedResourceAddress;
+    },
+    [lockedResourceAddress, selectedMap],
+  );
+
+  const selectablePageNfts = displayedNfts.filter((nft) => !isSelectDisabled(nft));
+  const isAllPageSelected =
+    selectablePageNfts.length > 0 && selectablePageNfts.every((nft) => selectedMap.has(nftIdKey(nft.nft_id)));
 
   const toggleSelectAll = useCallback(() => {
     setSelectedMap((prev) => {
       const next = new Map(prev);
-      if (displayedNfts.every((nft) => next.has(nftIdKey(nft.nft_id)))) {
-        displayedNfts.forEach((nft) => next.delete(nftIdKey(nft.nft_id)));
-      } else {
-        displayedNfts.forEach((nft) => next.set(nftIdKey(nft.nft_id), nft));
-      }
+      const selectable = displayedNfts.filter(
+        (nft) => lockedResourceAddress === null || nft.resource_address === lockedResourceAddress,
+      );
+      const allSelected = selectable.every((nft) => next.has(nftIdKey(nft.nft_id)));
+      selectable.forEach((nft) => (allSelected ? next.delete(nftIdKey(nft.nft_id)) : next.set(nftIdKey(nft.nft_id), nft)));
+      syncLockedAddress(next, selectable[0]?.resource_address ?? null);
       return next;
     });
-  }, [displayedNfts]);
+  }, [displayedNfts, lockedResourceAddress, syncLockedAddress]);
 
   const selectedNfts = Array.from(selectedMap.values());
 
@@ -142,6 +154,7 @@ export default function NFTList(props: NftListProps) {
             key={`${nft.nft_id}-${index}`}
             nft={nft}
             selected={selectedMap.has(nftIdKey(nft.nft_id))}
+            selectDisabled={isSelectDisabled(nft)}
             onToggleSelect={() => toggleSelect(nft)}
           />
         ))}
@@ -166,6 +179,7 @@ export default function NFTList(props: NftListProps) {
                 key={`${nft.nft_id}-${index}`}
                 nft={nft}
                 selected={selectedMap.has(nftIdKey(nft.nft_id))}
+                selectDisabled={isSelectDisabled(nft)}
                 onToggleSelect={() => toggleSelect(nft)}
               />
             ))}
@@ -207,7 +221,7 @@ export default function NFTList(props: NftListProps) {
           </Stack>
 
           <Stack direction="row" spacing={2} alignItems="center">
-            {selectedNfts.length >= 2 && (
+            {selectedNfts.length && (
               <Button variant="contained" onClick={() => setSendDialogOpen(true)}>
                 Send Selected ({selectedNfts.length})
               </Button>
@@ -243,6 +257,7 @@ export default function NFTList(props: NftListProps) {
         onSendComplete={() => {
           setSendDialogOpen(false);
           setSelectedMap(new Map());
+          setLockedResourceAddress(null);
         }}
         preSelectedNfts={selectedNfts}
       />

--- a/applications/tari_walletd/web_ui/src/routes/AssetVault/NFTs/NFTList.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/AssetVault/NFTs/NFTList.tsx
@@ -23,7 +23,6 @@
 import type { ApiError } from "@api/helpers/types";
 import FetchStatusCheck from "@components/FetchStatusCheck";
 import Button from "@mui/material/Button";
-import Checkbox from "@mui/material/Checkbox";
 import Grid from "@mui/material/Grid";
 import IconButton from "@mui/material/IconButton";
 import Stack from "@mui/material/Stack";
@@ -35,8 +34,9 @@ import TableHead from "@mui/material/TableHead";
 import TablePagination from "@mui/material/TablePagination";
 import TableRow from "@mui/material/TableRow";
 import Typography from "@mui/material/Typography";
-import type { ListNftsResponse, NonFungibleId, NonFungibleToken } from "@tari-project/ootle-ts-bindings";
-import React, { useCallback, useState } from "react";
+import type { ListNftsResponse, NonFungibleToken } from "@tari-project/ootle-ts-bindings";
+import { nftIdToString } from "@utils/helpers";
+import React, { useCallback, useMemo, useState } from "react";
 import { IoApps, IoList } from "react-icons/io5";
 import ClaimNftsButton from "./components/ClaimNftsButton";
 import { NftCard, NftRow } from "./components/NftParts";
@@ -53,10 +53,6 @@ export interface NftListProps {
   onPageChange: (event: unknown, newPage: number) => void;
   onRowsPerPageChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
   onManualRefresh?: () => void;
-}
-
-function nftIdKey(nftId: NonFungibleId): string {
-  return JSON.stringify(nftId);
 }
 
 export default function NFTList(props: NftListProps) {
@@ -81,7 +77,7 @@ export default function NFTList(props: NftListProps) {
 
   const toggleSelect = useCallback((nft: NonFungibleToken) => {
     setSelectedMap((prev) => {
-      const key = nftIdKey(nft.nft_id);
+      const key = nftIdToString(nft.nft_id);
       const next = new Map(prev);
       next.has(key) ? next.delete(key) : next.set(key, nft);
       return next;
@@ -90,12 +86,16 @@ export default function NFTList(props: NftListProps) {
 
   const isSelectDisabled = useCallback(
     (nft: NonFungibleToken) => {
-      return lockedResourceAddress !== null && !selectedMap.has(nftIdKey(nft.nft_id)) && nft.resource_address !== lockedResourceAddress;
+      return (
+        lockedResourceAddress !== null &&
+        !selectedMap.has(nftIdToString(nft.nft_id)) &&
+        nft.resource_address !== lockedResourceAddress
+      );
     },
     [lockedResourceAddress, selectedMap],
   );
 
-  const selectedNfts = Array.from(selectedMap.values());
+  const selectedNfts = useMemo(() => Array.from(selectedMap.values()), [selectedMap]);
 
   const EmptyPlaceHolder = () => (
     <Stack alignItems="center" justifyContent="center" sx={{ py: 8 }}>
@@ -127,11 +127,11 @@ export default function NFTList(props: NftListProps) {
   const DisplayNFTs = () => {
     return viewMode === "grid" ? (
       <Grid container spacing={3}>
-        {displayedNfts.map((nft: NonFungibleToken) => (
+        {displayedNfts.map((nft: NonFungibleToken, i) => (
           <NftCard
-            key={nftIdKey(nft.nft_id)}
+            key={i}
             nft={nft}
-            selected={selectedMap.has(nftIdKey(nft.nft_id))}
+            selected={selectedMap.has(nftIdToString(nft.nft_id))}
             selectDisabled={isSelectDisabled(nft)}
             onToggleSelect={() => toggleSelect(nft)}
           />
@@ -150,11 +150,11 @@ export default function NFTList(props: NftListProps) {
             </TableRow>
           </TableHead>
           <TableBody>
-            {displayedNfts.map((nft: NonFungibleToken) => (
+            {displayedNfts.map((nft: NonFungibleToken, i) => (
               <NftRow
-                key={nftIdKey(nft.nft_id)}
+                key={i}
                 nft={nft}
-                selected={selectedMap.has(nftIdKey(nft.nft_id))}
+                selected={selectedMap.has(nftIdToString(nft.nft_id))}
                 selectDisabled={isSelectDisabled(nft)}
                 onToggleSelect={() => toggleSelect(nft)}
               />

--- a/applications/tari_walletd/web_ui/src/routes/AssetVault/NFTs/components/NftParts.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/AssetVault/NFTs/components/NftParts.tsx
@@ -50,20 +50,22 @@ const ERR_IMG =
 interface NftItemProps {
   nft: NonFungibleToken;
   selected?: boolean;
+  selectDisabled?: boolean;
   onToggleSelect?: () => void;
 }
 
-function NftCard({ nft, selected, onToggleSelect }: NftItemProps) {
+function NftCard({ nft, selected, selectDisabled, onToggleSelect }: NftItemProps) {
   const mutableData = convertCborValue(nft.mutable_data);
   const data = convertCborValue(nft.data) as Record<string, any> | undefined;
   const imageUrl = mutableData?.image_url;
 
   return (
     <Grid size={{ xs: 12, sm: 6, md: 4, lg: 3 }}>
-      <Card sx={{ position: "relative" }}>
+      <Card sx={{ position: "relative", opacity: selectDisabled ? 0.5 : 1 }}>
         {onToggleSelect && (
           <Checkbox
             checked={!!selected}
+            disabled={selectDisabled}
             onChange={onToggleSelect}
             sx={{
               position: "absolute",
@@ -130,7 +132,7 @@ function NftData({ data }: { data: Record<string, any> }) {
   );
 }
 
-function NftRow({ nft, selected, onToggleSelect }: NftItemProps) {
+function NftRow({ nft, selected, selectDisabled, onToggleSelect }: NftItemProps) {
   const mutableData = convertCborValue(nft.mutable_data);
   const data = convertCborValue(nft.data);
   const imageUrl = mutableData?.image_url;
@@ -151,7 +153,7 @@ function NftRow({ nft, selected, onToggleSelect }: NftItemProps) {
     <TableRow>
       {onToggleSelect && (
         <TableCell padding="checkbox">
-          <Checkbox checked={!!selected} onChange={onToggleSelect} />
+          <Checkbox checked={!!selected} disabled={selectDisabled} onChange={onToggleSelect} />
         </TableCell>
       )}
       <DataTableCell>

--- a/applications/tari_walletd/web_ui/src/routes/AssetVault/NFTs/components/NftParts.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/AssetVault/NFTs/components/NftParts.tsx
@@ -24,7 +24,20 @@ import CopyAddress from "@components/CopyAddress";
 import { NftCard as Card, DataTableCell } from "@components/StyledComponents";
 import CancelRoundedIcon from "@mui/icons-material/CancelRounded";
 import CheckCircleRoundedIcon from "@mui/icons-material/CheckCircleRounded";
-import { Avatar, Box, CardContent, CardMedia, Chip, Divider, Grid, Stack, TableRow, Typography } from "@mui/material";
+import {
+  Avatar,
+  Box,
+  CardContent,
+  CardMedia,
+  Checkbox,
+  Chip,
+  Divider,
+  Grid,
+  Stack,
+  TableCell,
+  TableRow,
+  Typography,
+} from "@mui/material";
 import type { NonFungibleToken } from "@tari-project/ootle-ts-bindings";
 import { convertCborValue } from "@utils/cbor";
 import { displayNftId, shortenSubstateId } from "@utils/helpers";
@@ -34,14 +47,32 @@ import SendNft from "./SendNft";
 const ERR_IMG =
   "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzAwIiBoZWlnaHQ9IjIwMCIgdmlld0JveD0iMCAwIDMwMCAyMDAiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CjxyZWN0IHdpZHRoPSIzMDAiIGhlaWdodD0iMjAwIiBmaWxsPSIjRjVGNUY1Ii8+CjxwYXRoIGQ9Ik0xMjUgNzVIMTc1VjEyNUgxMjVWNzVaIiBmaWxsPSIjRERERUREIi8+CjxwYXRoIGQ9Ik0xNDAgOTBIMTYwVjExMEgxNDBWOTBaIiBmaWxsPSIjQkJCQkJCIi8+Cjx0ZXh0IHg9IjE1MCIgeT0iMTQwIiBmb250LWZhbWlseT0iQXJpYWwiIGZvbnQtc2l6ZT0iMTIiIGZpbGw9IiM5OTk5OTkiIHRleHQtYW5jaG9yPSJtaWRkbGUiPk5GVDwvdGV4dD4KPC9zdmc+";
 
-function NftCard({ nft }: { nft: NonFungibleToken }) {
+interface NftItemProps {
+  nft: NonFungibleToken;
+  selected?: boolean;
+  onToggleSelect?: () => void;
+}
+
+function NftCard({ nft, selected, onToggleSelect }: NftItemProps) {
   const mutableData = convertCborValue(nft.mutable_data);
   const data = convertCborValue(nft.data) as Record<string, any> | undefined;
   const imageUrl = mutableData?.image_url;
 
   return (
     <Grid size={{ xs: 12, sm: 6, md: 4, lg: 3 }}>
-      <Card>
+      <Card sx={{ position: "relative" }}>
+        {onToggleSelect && (
+          <Checkbox
+            checked={!!selected}
+            onChange={onToggleSelect}
+            sx={{
+              position: "absolute",
+              top: 4,
+              left: 4,
+              zIndex: 1,
+            }}
+          />
+        )}
         <CardMedia
           component="img"
           height="200"
@@ -99,7 +130,7 @@ function NftData({ data }: { data: Record<string, any> }) {
   );
 }
 
-function NftRow({ nft }: { nft: NonFungibleToken }) {
+function NftRow({ nft, selected, onToggleSelect }: NftItemProps) {
   const mutableData = convertCborValue(nft.mutable_data);
   const data = convertCborValue(nft.data);
   const imageUrl = mutableData?.image_url;
@@ -118,6 +149,11 @@ function NftRow({ nft }: { nft: NonFungibleToken }) {
 
   return (
     <TableRow>
+      {onToggleSelect && (
+        <TableCell padding="checkbox">
+          <Checkbox checked={!!selected} onChange={onToggleSelect} />
+        </TableCell>
+      )}
       <DataTableCell>
         <Box sx={{ display: "flex", alignItems: "center", gap: 2 }}>
           <Avatar

--- a/applications/tari_walletd/web_ui/src/routes/AssetVault/NFTs/components/SendNft.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/AssetVault/NFTs/components/SendNft.tsx
@@ -292,9 +292,10 @@ export function TransferNftDialog(props: TransferNftDialogProps) {
 
   const handleClose = () => {
     resetState(preSelectedNftId, preSelectedResourceAddress);
-    props.handleClose?.();
     if (transferResult?.success) {
       props.onSendComplete?.();
+    } else {
+      props.handleClose?.();
     }
   };
 

--- a/applications/tari_walletd/web_ui/src/routes/AssetVault/NFTs/components/SendNft.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/AssetVault/NFTs/components/SendNft.tsx
@@ -23,6 +23,7 @@
 import PopupTitle from "@/components/PopupTitle";
 import { useAccountsList } from "@api/hooks/useAccounts";
 import { useNFTsList, useNftsTransfer } from "@api/hooks/useNfts";
+import queryClient from "@api/queryClient";
 import Button from "@mui/material/Button";
 import Dialog from "@mui/material/Dialog";
 import DialogContent from "@mui/material/DialogContent";
@@ -73,6 +74,7 @@ export interface TransferNftDialogProps {
   handleClose: () => void;
   preSelectedNftId?: NonFungibleId;
   preSelectedResourceAddress?: ResourceAddress;
+  preSelectedNfts?: NonFungibleToken[];
 }
 
 function getAccountSelector(account: Account): ComponentAddressOrName {
@@ -106,12 +108,14 @@ function getNftIdTypeAsName(nftId: NonFungibleId): string {
 }
 
 export function TransferNftDialog(props: TransferNftDialogProps) {
-  const { preSelectedNftId, preSelectedResourceAddress } = props;
+  const { preSelectedNftId, preSelectedResourceAddress, preSelectedNfts } = props;
   const { account, setPopup } = useAccountStore();
+  const hasBatchSelection = preSelectedNfts && preSelectedNfts.length > 0;
 
   const {
     currentStep,
     transferFormState,
+    transferResult,
     setCurrentStep,
     setDisabled,
     setTransferFormState,
@@ -225,7 +229,7 @@ export function TransferNftDialog(props: TransferNftDialogProps) {
     }
 
     // Check if NFTs are selected (if not pre-selected)
-    if (!preSelectedNftId && transferFormState.nfts.length === 0) {
+    if (!preSelectedNftId && !hasBatchSelection && transferFormState.nfts.length === 0) {
       setPopup({ title: "Missing NFTs", error: true, message: "Please select at least one NFT to transfer" });
       return;
     }
@@ -264,6 +268,14 @@ export function TransferNftDialog(props: TransferNftDialogProps) {
           message: "Your NFT has been successfully transferred!",
         });
 
+        // Refresh NFT list
+        queryClient.invalidateQueries({
+          predicate: (query) => {
+            const key = query.queryKey[0];
+            return typeof key === "string" && (key === "nfts" || key === "list_nfts" || key === "nfts_list");
+          },
+        });
+
         // Auto-close after 10 seconds
         const timeoutId = setTimeout(() => {
           handleAutoCloseAfterSuccess();
@@ -286,9 +298,13 @@ export function TransferNftDialog(props: TransferNftDialogProps) {
   };
 
   const handleClose = () => {
+    const wasSuccessful = transferResult?.success;
     resetState(preSelectedNftId, preSelectedResourceAddress);
     setCurrentStep("form");
     props.handleClose?.();
+    if (wasSuccessful) {
+      props.onSendComplete?.();
+    }
   };
 
   const handleAutoCloseAfterSuccess = () => {
@@ -337,6 +353,13 @@ export function TransferNftDialog(props: TransferNftDialogProps) {
     }
   };
 
+  const filteredNfts = useMemo(() => {
+    if (preSelectedResourceAddress && !preSelectedNftId) {
+      return availableNfts.filter((nft) => nft.resource_address === preSelectedResourceAddress);
+    }
+    return availableNfts;
+  }, [availableNfts, preSelectedResourceAddress, preSelectedNftId]);
+
   useEffect(() => {
     if (loadedNfts !== undefined) {
       setAvailableNfts(loadedNfts);
@@ -348,12 +371,24 @@ export function TransferNftDialog(props: TransferNftDialogProps) {
       // When dialog opens, always reset to ensure clean state
       resetState(preSelectedNftId, preSelectedResourceAddress);
       initializeFormState(preSelectedNftId, preSelectedResourceAddress, substateIdToString(account.component_address));
+
+      // If batch-selected NFTs are provided, pre-fill the form
+      if (hasBatchSelection) {
+        setTransferFormState({
+          nfts: preSelectedNfts.map((nft) => nft.nft_id),
+          resourceAddress: preSelectedNfts[0].resource_address,
+        });
+        setValidity({ nfts: true });
+      }
     }
-  }, [props.open, preSelectedNftId, preSelectedResourceAddress, account?.component_address]);
+  }, [props.open, preSelectedNftId, preSelectedResourceAddress, account?.component_address, hasBatchSelection]);
 
   return (
     <Dialog open={props.open} onClose={handleClose} maxWidth="sm" fullWidth>
-      <PopupTitle onClose={handleClose} title="Transfer NFT" />
+      <PopupTitle
+        onClose={handleClose}
+        title={preSelectedNftId ? "Transfer NFT" : `Transfer NFTs${hasBatchSelection ? ` (${preSelectedNfts.length})` : ""}`}
+      />
       <DialogContent>
         {!account ? (
           <div style={{ padding: "20px", textAlign: "center" }}>
@@ -365,8 +400,9 @@ export function TransferNftDialog(props: TransferNftDialogProps) {
               <FormStep
                 account={account}
                 accounts={accounts}
-                availableNfts={availableNfts}
+                availableNfts={filteredNfts}
                 preSelectedNftId={preSelectedNftId}
+                preSelectedNfts={preSelectedNfts}
                 isEstimatingFee={isEstimatingFee}
                 onSubmit={handleFormSubmit}
                 onCancel={handleClose}
@@ -379,7 +415,7 @@ export function TransferNftDialog(props: TransferNftDialogProps) {
               <ConfirmationStep
                 accounts={accounts}
                 preSelectedNftId={preSelectedNftId}
-                availableNfts={availableNfts}
+                availableNfts={filteredNfts}
                 onBack={() => setCurrentStep("form")}
                 onConfirm={onTransfer}
               />

--- a/applications/tari_walletd/web_ui/src/routes/AssetVault/NFTs/components/SendNft.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/AssetVault/NFTs/components/SendNft.tsx
@@ -23,7 +23,6 @@
 import PopupTitle from "@/components/PopupTitle";
 import { useAccountsList } from "@api/hooks/useAccounts";
 import { useNFTsList, useNftsTransfer } from "@api/hooks/useNfts";
-import queryClient from "@api/queryClient";
 import Button from "@mui/material/Button";
 import Dialog from "@mui/material/Dialog";
 import DialogContent from "@mui/material/DialogContent";
@@ -266,14 +265,6 @@ export function TransferNftDialog(props: TransferNftDialogProps) {
         setTransferResult({
           success: true,
           message: "Your NFT has been successfully transferred!",
-        });
-
-        // Refresh NFT list
-        queryClient.invalidateQueries({
-          predicate: (query) => {
-            const key = query.queryKey[0];
-            return typeof key === "string" && (key === "nfts" || key === "list_nfts" || key === "nfts_list");
-          },
         });
 
         // Auto-close after 10 seconds

--- a/applications/tari_walletd/web_ui/src/routes/AssetVault/NFTs/components/SendNft.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/AssetVault/NFTs/components/SendNft.tsx
@@ -289,11 +289,10 @@ export function TransferNftDialog(props: TransferNftDialogProps) {
   };
 
   const handleClose = () => {
-    const wasSuccessful = transferResult?.success;
     resetState(preSelectedNftId, preSelectedResourceAddress);
     setCurrentStep("form");
     props.handleClose?.();
-    if (wasSuccessful) {
+    if (transferResult?.success) {
       props.onSendComplete?.();
     }
   };

--- a/applications/tari_walletd/web_ui/src/routes/AssetVault/NFTs/components/SendNft.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/AssetVault/NFTs/components/SendNft.tsx
@@ -32,8 +32,10 @@ import { useNftTransferStore } from "@store/nftTransferStore";
 import {
   Account,
   ComponentAddressOrName,
+  getRejectReasonFromTransactionResult,
   NonFungibleId,
   NonFungibleToken,
+  rejectReasonToString,
   ResourceAddress,
 } from "@tari-project/ootle-ts-bindings";
 import { substateIdToString } from "@utils/helpers";
@@ -206,7 +208,8 @@ export function TransferNftDialog(props: TransferNftDialogProps) {
         return result.fee;
       } else {
         console.error("Fee estimation rejected:", result);
-        throw new Error("Could not estimate transfer fee");
+        const reason = result ? getRejectReasonFromTransactionResult(result.result.result) : undefined;
+        throw new Error(reason ? rejectReasonToString(reason) : "Transaction was rejected");
       }
     } catch (e: any) {
       console.error("Fee estimation error:", e);
@@ -241,7 +244,7 @@ export function TransferNftDialog(props: TransferNftDialogProps) {
         setPopup({
           title: "Fee estimation failed",
           error: true,
-          message: "Unable to estimate transaction fee. Please try again or check if you have sufficient funds.",
+          message: error instanceof Error ? error.message : String(error),
         });
         return;
       }

--- a/applications/tari_walletd/web_ui/src/routes/AssetVault/NFTs/components/SendNft.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/AssetVault/NFTs/components/SendNft.tsx
@@ -121,7 +121,6 @@ export function TransferNftDialog(props: TransferNftDialogProps) {
     setValidity,
     setTransferResult,
     setAutoCloseTimeoutId,
-    initializeFormState,
     resetState,
   } = useNftTransferStore();
 
@@ -290,7 +289,6 @@ export function TransferNftDialog(props: TransferNftDialogProps) {
 
   const handleClose = () => {
     resetState(preSelectedNftId, preSelectedResourceAddress);
-    setCurrentStep("form");
     props.handleClose?.();
     if (transferResult?.success) {
       props.onSendComplete?.();
@@ -359,8 +357,7 @@ export function TransferNftDialog(props: TransferNftDialogProps) {
   useEffect(() => {
     if (props.open && account) {
       // When dialog opens, always reset to ensure clean state
-      resetState(preSelectedNftId, preSelectedResourceAddress);
-      initializeFormState(preSelectedNftId, preSelectedResourceAddress, substateIdToString(account.component_address));
+      resetState(preSelectedNftId, preSelectedResourceAddress, substateIdToString(account.component_address));
 
       // If batch-selected NFTs are provided, pre-fill the form
       if (hasBatchSelection) {
@@ -371,7 +368,7 @@ export function TransferNftDialog(props: TransferNftDialogProps) {
         setValidity({ nfts: true });
       }
     }
-  }, [props.open, preSelectedNftId, preSelectedResourceAddress, account?.component_address, hasBatchSelection]);
+  }, [props.open, preSelectedNftId, preSelectedResourceAddress, account?.component_address, hasBatchSelection, preSelectedNfts]);
 
   return (
     <Dialog open={props.open} onClose={handleClose} maxWidth="sm" fullWidth>

--- a/applications/tari_walletd/web_ui/src/routes/AssetVault/NFTs/steps/ConfirmationStep.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/AssetVault/NFTs/steps/ConfirmationStep.tsx
@@ -102,7 +102,16 @@ export default function ConfirmationStep({
                 </Avatar>
               </Stack>
             ) : (
-              <Typography>{preSelectedNftId ? displayNftId(preSelectedNftId) : "Multiple NFTs"}</Typography>
+              <Stack spacing={1}>
+                <Typography variant="subtitle2" color="text.secondary">
+                  You are about to send {transferFormState.nfts.length} NFT(s):
+                </Typography>
+                {transferFormState.nfts.map((nftId, index) => (
+                  <Typography key={index} variant="body2">
+                    • {displayNftId(nftId)}
+                  </Typography>
+                ))}
+              </Stack>
             )}
           </Stack>
           <Stack spacing={2} direction={"column"}>

--- a/applications/tari_walletd/web_ui/src/routes/AssetVault/NFTs/steps/ConfirmationStep.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/AssetVault/NFTs/steps/ConfirmationStep.tsx
@@ -106,8 +106,8 @@ export default function ConfirmationStep({
                 <Typography variant="subtitle2" color="text.secondary">
                   You are about to send {transferFormState.nfts.length} NFT(s):
                 </Typography>
-                {transferFormState.nfts.map((nftId, index) => (
-                  <Typography key={index} variant="body2">
+                {transferFormState.nfts.map((nftId) => (
+                  <Typography key={nftIdToString(nftId)} variant="body2">
                     • {displayNftId(nftId)}
                   </Typography>
                 ))}

--- a/applications/tari_walletd/web_ui/src/routes/AssetVault/NFTs/steps/FormStep.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/AssetVault/NFTs/steps/FormStep.tsx
@@ -33,7 +33,7 @@ import type { Account, NonFungibleId, NonFungibleToken } from "@tari-project/oot
 import { validateOotleAddress } from "@tari-project/ootle-ts-bindings/dist/helpers/ootleAddress";
 import { convertCborValue } from "@utils/cbor";
 import { displayNftId, substateIdToString } from "@utils/helpers";
-import { FormEvent, useState } from "react";
+import { FormEvent, useMemo, useState } from "react";
 import { Form } from "react-router";
 
 interface FormStepProps {
@@ -85,6 +85,7 @@ export default function FormStep({
 }: FormStepProps) {
   const hasBatchSelection = preSelectedNfts?.length;
   const { transferFormState, disabled, updateFormValue } = useNftTransferStore();
+  const selectedNftIds = useMemo(() => new Set(transferFormState.nfts.map(nftIdToString)), [transferFormState.nfts]);
   const [submitted, setSubmitted] = useState(false);
 
   const setFormValue = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -196,13 +197,13 @@ export default function FormStep({
               onChange={onNftsChange}
               renderValue={(selected) => selected.map((item) => displayNftId(JSON.parse(item))).join(", ")}
             >
-              {availableNfts.map((nft, index) => {
+              {availableNfts.map((nft) => {
                 const mutableData = convertCborValue(nft.mutable_data);
                 const imageUrl = mutableData?.image_url;
                 return (
-                  <MenuItem key={index} value={JSON.stringify(nft.nft_id)}>
+                  <MenuItem key={nftIdToString(nft.nft_id)} value={JSON.stringify(nft.nft_id)}>
                     <Checkbox
-                      checked={transferFormState.nfts.some((id) => nftIdToString(id) == nftIdToString(nft.nft_id))}
+                      checked={selectedNftIds.has(nftIdToString(nft.nft_id))}
                     />
                     <Avatar
                       src={imageUrl}

--- a/applications/tari_walletd/web_ui/src/routes/AssetVault/NFTs/steps/FormStep.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/AssetVault/NFTs/steps/FormStep.tsx
@@ -20,7 +20,7 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import { Alert, Divider, InputLabel, Stack } from "@mui/material";
+import { Alert, Avatar, Divider, InputLabel, Stack } from "@mui/material";
 import Button from "@mui/material/Button";
 import Checkbox from "@mui/material/Checkbox";
 import ListItemText from "@mui/material/ListItemText";
@@ -31,8 +31,9 @@ import TextField from "@mui/material/TextField";
 import { useNftTransferStore } from "@store/nftTransferStore";
 import type { Account, NonFungibleId, NonFungibleToken } from "@tari-project/ootle-ts-bindings";
 import { validateOotleAddress } from "@tari-project/ootle-ts-bindings/dist/helpers/ootleAddress";
+import { convertCborValue } from "@utils/cbor";
 import { displayNftId, substateIdToString } from "@utils/helpers";
-import { FormEvent } from "react";
+import { FormEvent, useState } from "react";
 import { Form } from "react-router";
 
 interface FormStepProps {
@@ -40,6 +41,7 @@ interface FormStepProps {
   accounts: Array<{ account: Account }> | undefined;
   availableNfts: NonFungibleToken[];
   preSelectedNftId?: NonFungibleId;
+  preSelectedNfts?: NonFungibleToken[];
   isEstimatingFee: boolean;
   onSubmit: (e: FormEvent) => void;
   onCancel: () => void;
@@ -75,12 +77,15 @@ export default function FormStep({
   accounts,
   availableNfts,
   preSelectedNftId,
+  preSelectedNfts,
   onSubmit,
   onCancel,
   onNftsChange,
   onPayerAccountChange,
 }: FormStepProps) {
+  const hasBatchSelection = preSelectedNfts?.length;
   const { transferFormState, disabled, updateFormValue } = useNftTransferStore();
+  const [submitted, setSubmitted] = useState(false);
 
   const setFormValue = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
@@ -104,10 +109,19 @@ export default function FormStep({
 
   const formErrors = getFormErrors();
 
+  const handleSubmit = (e: FormEvent) => {
+    setSubmitted(true);
+    if (formErrors.length) {
+      e.preventDefault();
+      return;
+    }
+    onSubmit(e);
+  };
+
   return (
-    <Form onSubmit={onSubmit}>
+    <Form onSubmit={handleSubmit}>
       <Stack direction="column" spacing={2} sx={{ py: 2 }}>
-        {formErrors.length > 0 && (
+        {submitted && formErrors.length > 0 && (
           <Alert severity="error" sx={{ mb: 2 }}>
             <strong>Please fix the following errors:</strong>
             <ul style={{ margin: "8px 0 0 0", paddingLeft: "20px" }}>
@@ -158,7 +172,17 @@ export default function FormStep({
           }
         />
 
-        {!preSelectedNftId ? (
+        {hasBatchSelection ? (
+          <TextField
+            label={`Selected NFTs (${preSelectedNfts.length})`}
+            value={preSelectedNfts.map((nft) => displayNftId(nft.nft_id)).join(", ")}
+            disabled
+            variant="outlined"
+            style={{ flexGrow: 1 }}
+            multiline
+            maxRows={4}
+          />
+        ) : !preSelectedNftId ? (
           <>
             <InputLabel id="nft-select-label">Select NFT(s)</InputLabel>
             <Select
@@ -170,16 +194,27 @@ export default function FormStep({
               required
               disabled={disabled}
               onChange={onNftsChange}
-              renderValue={(selected) => selected.map((item) => item).join(", ")}
+              renderValue={(selected) => selected.map((item) => displayNftId(JSON.parse(item))).join(", ")}
             >
-              {availableNfts.map((nft, index) => (
-                <MenuItem key={index} value={JSON.stringify(nft.nft_id)}>
-                  <Checkbox
-                    checked={transferFormState.nfts.some((id) => nftIdToString(id) == nftIdToString(nft.nft_id))}
-                  />
-                  <ListItemText primary={displayNftId(nft.nft_id)} />
-                </MenuItem>
-              ))}
+              {availableNfts.map((nft, index) => {
+                const mutableData = convertCborValue(nft.mutable_data);
+                const imageUrl = mutableData?.image_url;
+                return (
+                  <MenuItem key={index} value={JSON.stringify(nft.nft_id)}>
+                    <Checkbox
+                      checked={transferFormState.nfts.some((id) => nftIdToString(id) == nftIdToString(nft.nft_id))}
+                    />
+                    <Avatar
+                      src={imageUrl}
+                      variant="rounded"
+                      sx={{ width: 32, height: 32, mr: 1, backgroundColor: "grey.200" }}
+                    >
+                      NFT
+                    </Avatar>
+                    <ListItemText primary={displayNftId(nft.nft_id)} />
+                  </MenuItem>
+                );
+              })}
             </Select>
           </>
         ) : (

--- a/applications/tari_walletd/web_ui/src/routes/AssetVault/Tokens/Tokens.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/AssetVault/Tokens/Tokens.tsx
@@ -36,6 +36,7 @@ import Button from "@mui/material/Button";
 import { useTheme } from "@mui/material/styles";
 import useMediaQuery from "@mui/material/useMediaQuery";
 import TypeChip from "@routes/AssetVault/Components/ResourceTypeChip";
+import { TransferNftDialog } from "@routes/AssetVault/NFTs/components/SendNft";
 import useAccountStore from "@store/accountStore";
 import { Account, Amount, BalanceEntry, ResourceAddress, ResourceType, VaultId } from "@tari-project/ootle-ts-bindings";
 import { bigintToDecimalString, shortenString, substateIdToString } from "@utils/helpers";
@@ -151,6 +152,7 @@ function Tokens({ account }: { account: Account }) {
     address: ResourceAddress;
     resource_type: ResourceType;
   } | null>(null);
+  const [nftResourceToSend, setNftResourceToSend] = useState<ResourceAddress | null>(null);
 
   const {
     data: balancesData,
@@ -160,7 +162,11 @@ function Tokens({ account }: { account: Account }) {
   } = useAccountsGetBalances(substateIdToString(account.component_address));
 
   const handleSendResourceClicked = (address: ResourceAddress, resource_type: ResourceType) => {
-    setResourceToSend({ address, resource_type });
+    if (resource_type === "NonFungible") {
+      setNftResourceToSend(address);
+    } else {
+      setResourceToSend({ address, resource_type });
+    }
   };
 
   const hasBalances = balancesData?.balances && balancesData.balances.length > 0;
@@ -178,6 +184,14 @@ function Tokens({ account }: { account: Account }) {
             balancesData?.balances.find((b: BalanceEntry) => b.resource_address === resourceToSend?.address)
               ?.token_symbol || ""
           }
+        />
+      )}
+      {nftResourceToSend != null && (
+        <TransferNftDialog
+          open={true}
+          handleClose={() => setNftResourceToSend(null)}
+          onSendComplete={() => setNftResourceToSend(null)}
+          preSelectedResourceAddress={nftResourceToSend}
         />
       )}
       <FetchStatusCheck

--- a/applications/tari_walletd/web_ui/src/services/store/nftTransferStore.ts
+++ b/applications/tari_walletd/web_ui/src/services/store/nftTransferStore.ts
@@ -80,7 +80,7 @@ interface NftTransferState {
     preSelectedResourceAddress?: ResourceAddress,
     accountAddress?: string,
   ) => void;
-  resetState: (preSelectedNftId?: NonFungibleId, preSelectedResourceAddress?: ResourceAddress) => void;
+  resetState: (preSelectedNftId?: NonFungibleId, preSelectedResourceAddress?: ResourceAddress, accountAddress?: string) => void;
   isFormValid: () => boolean;
 }
 
@@ -146,7 +146,7 @@ export const useNftTransferStore = create<NftTransferState>((set, get) => ({
     });
   },
 
-  resetState: (preSelectedNftId, preSelectedResourceAddress) => {
+  resetState: (preSelectedNftId, preSelectedResourceAddress, accountAddress) => {
     const { autoCloseTimeoutId } = get();
 
     // Clear any active timeout
@@ -157,7 +157,7 @@ export const useNftTransferStore = create<NftTransferState>((set, get) => ({
     set({
       currentStep: "form",
       disabled: false,
-      transferFormState: createInitialFormState(preSelectedNftId, preSelectedResourceAddress),
+      transferFormState: createInitialFormState(preSelectedNftId, preSelectedResourceAddress, accountAddress),
       validity: createInitialValidity(preSelectedNftId),
       estimatedFee: null,
       isEstimatingFee: false,

--- a/applications/tari_walletd/web_ui/src/services/store/nftTransferStore.ts
+++ b/applications/tari_walletd/web_ui/src/services/store/nftTransferStore.ts
@@ -80,7 +80,11 @@ interface NftTransferState {
     preSelectedResourceAddress?: ResourceAddress,
     accountAddress?: string,
   ) => void;
-  resetState: (preSelectedNftId?: NonFungibleId, preSelectedResourceAddress?: ResourceAddress, accountAddress?: string) => void;
+  resetState: (
+    preSelectedNftId?: NonFungibleId,
+    preSelectedResourceAddress?: ResourceAddress,
+    accountAddress?: string,
+  ) => void;
   isFormValid: () => boolean;
 }
 
@@ -98,7 +102,7 @@ const createInitialFormState = (
 
 const createInitialValidity = (preSelectedNftId?: NonFungibleId): Validity => ({
   payerAccount: true,
-  nfts: preSelectedNftId ? true : false,
+  nfts: !!preSelectedNftId,
   targetAccountPublicKey: false,
 });
 

--- a/applications/tari_walletd/web_ui/src/utils/helpers.tsx
+++ b/applications/tari_walletd/web_ui/src/utils/helpers.tsx
@@ -327,6 +327,24 @@ export const parseTimestamp = (rawTimestamp: string | null | undefined): Date | 
   return normalizeTimestamp(rawTimestamp);
 };
 
+export function nftIdToString(nftId: NonFungibleId) {
+  if ("U256" in nftId) {
+    return `U256:${toHexString(nftId.U256)}`;
+  }
+  if ("Uint64" in nftId) {
+    return `Uint64:${nftId.Uint64}`;
+  }
+  if ("Uint32" in nftId) {
+    return `Uint32:${nftId.Uint32}`;
+  }
+  if ("String" in nftId) {
+    return `String:${nftId.String}`;
+  }
+
+  console.warn("Unknown nft id ", nftId);
+  return JSON.stringify(nftId);
+}
+
 export function displayNftId(nftId: NonFungibleId): string {
   if ("U256" in nftId) {
     return `NFT #${shortenString(toHexString(nftId.U256))}`;


### PR DESCRIPTION
Description
Add support for selecting and sending multiple NFTs in a single transaction

Motivation and Context
Closes #1883 

How Has This Been Tested?
locally
https://github.com/user-attachments/assets/212f0897-17a1-4166-b0b8-dc46c5e6e7c9

What process can a PR reviewer use to test or verify this change?
- Claim NFTs
- Try to send 1 or more of them

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify