### PR TITLE
feat(faucet)!: bind claim NFT to component address instead of signer key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1692,7 +1692,7 @@ dependencies = [
 
 [[package]]
 name = "consensus_tests"
-version = "0.28.5"
+version = "0.28.6"
 dependencies = [
  "fern",
  "futures 0.3.31",
@@ -2671,7 +2671,7 @@ dependencies = [
 
 [[package]]
 name = "db-inspector"
-version = "0.28.5"
+version = "0.28.6"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -4899,7 +4899,7 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "integration_tests"
-version = "0.28.5"
+version = "0.28.6"
 dependencies = [
  "anyhow",
  "config",
@@ -5615,7 +5615,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-messaging"
-version = "0.28.5"
+version = "0.28.6"
 dependencies = [
  "async-trait",
  "futures-bounded",
@@ -5794,7 +5794,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-substream"
-version = "0.28.5"
+version = "0.28.6"
 dependencies = [
  "libp2p",
  "prometheus-client",
@@ -7402,7 +7402,7 @@ dependencies = [
 
 [[package]]
 name = "ootle-wasm"
-version = "0.28.5"
+version = "0.28.6"
 dependencies = [
  "console_error_panic_hook",
  "getrandom 0.2.17",
@@ -7412,7 +7412,7 @@ dependencies = [
 
 [[package]]
 name = "ootle-wasm-core"
-version = "0.28.5"
+version = "0.28.6"
 dependencies = [
  "base64 0.22.1",
  "ootle_byte_type",
@@ -7430,7 +7430,7 @@ dependencies = [
 
 [[package]]
 name = "ootle_byte_type"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "tari_crypto",
  "tari_template_lib_types",
@@ -8407,7 +8407,7 @@ dependencies = [
 
 [[package]]
 name = "proto_builder"
-version = "0.28.5"
+version = "0.28.6"
 dependencies = [
  "prost-build 0.14.3",
  "sha2 0.10.9",
@@ -10215,7 +10215,7 @@ dependencies = [
 
 [[package]]
 name = "sqlite_message_logger"
-version = "0.28.5"
+version = "0.28.6"
 dependencies = [
  "chrono",
  "diesel",
@@ -10588,7 +10588,7 @@ dependencies = [
 
 [[package]]
 name = "tari_base_node_client"
-version = "0.28.5"
+version = "0.28.6"
 dependencies = [
  "futures-util",
  "log",
@@ -10813,7 +10813,7 @@ dependencies = [
 
 [[package]]
 name = "tari_consensus"
-version = "0.28.5"
+version = "0.28.6"
 dependencies = [
  "anyhow",
  "indexmap 2.13.0",
@@ -10838,7 +10838,7 @@ dependencies = [
 
 [[package]]
 name = "tari_consensus_types"
-version = "0.28.5"
+version = "0.28.6"
 dependencies = [
  "borsh",
  "ootle_serde",
@@ -10940,7 +10940,7 @@ dependencies = [
 
 [[package]]
 name = "tari_engine"
-version = "0.28.5"
+version = "0.28.6"
 dependencies = [
  "blake2",
  "criterion",
@@ -10968,7 +10968,7 @@ dependencies = [
 
 [[package]]
 name = "tari_engine_types"
-version = "0.28.5"
+version = "0.28.6"
 dependencies = [
  "bincode 2.0.1",
  "blake2",
@@ -10996,7 +10996,7 @@ dependencies = [
 
 [[package]]
 name = "tari_epoch_manager"
-version = "0.28.5"
+version = "0.28.6"
 dependencies = [
  "anyhow",
  "log",
@@ -11016,7 +11016,7 @@ dependencies = [
 
 [[package]]
 name = "tari_epoch_oracles"
-version = "0.28.5"
+version = "0.28.6"
 dependencies = [
  "anyhow",
  "blake2",
@@ -11069,7 +11069,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer"
-version = "0.28.5"
+version = "0.28.6"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -11139,7 +11139,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer_client"
-version = "0.28.5"
+version = "0.28.6"
 dependencies = [
  "anyhow",
  "bounded-vec",
@@ -11168,7 +11168,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer_lib"
-version = "0.28.5"
+version = "0.28.6"
 dependencies = [
  "log",
  "prometheus-client",
@@ -11260,7 +11260,7 @@ dependencies = [
 
 [[package]]
 name = "tari_networking"
-version = "0.28.5"
+version = "0.28.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11296,7 +11296,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_address"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "bech32",
  "bincode 2.0.1",
@@ -11312,7 +11312,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_app_utilities"
-version = "0.28.5"
+version = "0.28.6"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -11351,7 +11351,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_common_types"
-version = "0.28.5"
+version = "0.28.6"
 dependencies = [
  "blake2",
  "borsh",
@@ -11378,7 +11378,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_p2p"
-version = "0.28.5"
+version = "0.28.6"
 dependencies = [
  "anyhow",
  "libp2p-identity",
@@ -11402,7 +11402,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_storage"
-version = "0.28.5"
+version = "0.28.6"
 dependencies = [
  "anyhow",
  "bitflags 2.10.0",
@@ -11429,7 +11429,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_storage_sqlite"
-version = "0.28.5"
+version = "0.28.6"
 dependencies = [
  "diesel",
  "diesel_migrations",
@@ -11476,7 +11476,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_transaction"
-version = "0.28.5"
+version = "0.28.6"
 dependencies = [
  "bincode 2.0.1",
  "borsh",
@@ -11501,7 +11501,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_cli"
-version = "0.28.5"
+version = "0.28.6"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -11530,7 +11530,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_crypto"
-version = "0.28.5"
+version = "0.28.6"
 dependencies = [
  "argon2 0.5.3",
  "blake2",
@@ -11559,7 +11559,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_sdk"
-version = "0.28.5"
+version = "0.28.6"
 dependencies = [
  "anyhow",
  "digest 0.10.7",
@@ -11624,7 +11624,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_storage_sqlite"
-version = "0.28.5"
+version = "0.28.6"
 dependencies = [
  "bigdecimal",
  "diesel",
@@ -11648,7 +11648,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_walletd"
-version = "0.28.5"
+version = "0.28.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11765,7 +11765,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_framework"
-version = "0.28.5"
+version = "0.28.6"
 dependencies = [
  "async-trait",
  "bitflags 2.10.0",
@@ -11789,7 +11789,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_macros"
-version = "0.28.5"
+version = "0.28.6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11798,7 +11798,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_state_sync"
-version = "0.28.5"
+version = "0.28.6"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -11875,7 +11875,7 @@ dependencies = [
 
 [[package]]
 name = "tari_state_store_rocksdb"
-version = "0.28.5"
+version = "0.28.6"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -11906,7 +11906,7 @@ dependencies = [
 
 [[package]]
 name = "tari_state_tree"
-version = "0.28.5"
+version = "0.28.6"
 dependencies = [
  "indexmap 2.13.0",
  "log",
@@ -11932,7 +11932,7 @@ dependencies = [
 
 [[package]]
 name = "tari_swarm"
-version = "0.28.5"
+version = "0.28.6"
 dependencies = [
  "libp2p",
  "libp2p-messaging",
@@ -11943,7 +11943,7 @@ dependencies = [
 
 [[package]]
 name = "tari_swarm_daemon"
-version = "0.28.5"
+version = "0.28.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11998,7 +11998,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_builtin"
-version = "0.28.5"
+version = "0.28.6"
 dependencies = [
  "anyhow",
  "tari_engine_types",
@@ -12010,7 +12010,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_lib"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "borsh",
  "serde",
@@ -12024,7 +12024,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_lib_types"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "bincode 2.0.1",
  "bnum",
@@ -12052,7 +12052,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_test_tooling"
-version = "0.28.5"
+version = "0.28.6"
 dependencies = [
  "anyhow",
  "cargo_toml 0.22.3",
@@ -12167,7 +12167,7 @@ dependencies = [
 
 [[package]]
 name = "tari_transaction_manifest"
-version = "0.28.5"
+version = "0.28.6"
 dependencies = [
  "proc-macro2",
  "serde_json",
@@ -12201,7 +12201,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node"
-version = "0.28.5"
+version = "0.28.6"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -12267,7 +12267,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node_client"
-version = "0.28.5"
+version = "0.28.6"
 dependencies = [
  "indexmap 2.13.0",
  "multiaddr 0.18.3",
@@ -12291,7 +12291,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node_rpc"
-version = "0.28.5"
+version = "0.28.6"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -12327,7 +12327,7 @@ dependencies = [
 
 [[package]]
 name = "tari_watcher"
-version = "0.28.5"
+version = "0.28.6"
 dependencies = [
  "anyhow",
  "clap 3.2.25",
@@ -12355,7 +12355,7 @@ dependencies = [
 
 [[package]]
 name = "tariswap_bench"
-version = "0.28.5"
+version = "0.28.6"
 dependencies = [
  "anyhow",
  "clap 4.5.54",
@@ -13035,7 +13035,7 @@ dependencies = [
 
 [[package]]
 name = "traffic-sim"
-version = "0.28.5"
+version = "0.28.6"
 dependencies = [
  "anyhow",
  "clap 4.5.54",
@@ -13057,7 +13057,7 @@ dependencies = [
 
 [[package]]
 name = "transaction_generator"
-version = "0.28.5"
+version = "0.28.6"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -13068,17 +13068,15 @@ dependencies = [
  "rand 0.8.5",
  "rayon",
  "tari_crypto",
- "tari_engine_types",
  "tari_ootle_common_types",
  "tari_ootle_transaction",
- "tari_template_builtin",
  "tari_template_lib_types",
  "tari_transaction_manifest",
 ]
 
 [[package]]
 name = "transaction_submitter"
-version = "0.28.5"
+version = "0.28.6"
 dependencies = [
  "anyhow",
  "clap 4.5.54",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7373,7 +7373,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "ootle-rs"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -11711,7 +11711,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_walletd_client"
-version = "0.28.5"
+version = "0.29.0"
 dependencies = [
  "hex",
  "ootle_serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.28.5"
+version = "0.28.6"
 edition = "2024"
 authors = ["The Tari Development Community"]
 repository = "https://github.com/tari-project/tari-ootle"
@@ -85,7 +85,7 @@ tari_ootle_app_utilities = { path = "applications/tari_ootle_app_utilities" }
 
 # core crates
 tari_consensus = { path = "crates/consensus" }
-tari_ootle_address = { path = "crates/ootle_address", version = "0.3" }
+tari_ootle_address = { path = "crates/ootle_address", version = "0.4" }
 tari_engine = { path = "crates/engine", version = "0.28" }
 tari_ootle_p2p = { path = "crates/p2p" }
 tari_ootle_storage = { path = "crates/storage" }
@@ -124,13 +124,13 @@ tari_ootle_transaction = { path = "crates/transaction", version = "0.28" }
 # Template lib
 tari_ootle_template_build = { path = "crates/template_build", version = "0.4" }
 tari_ootle_template_metadata = { path = "crates/template_metadata", version = "0.4" }
-tari_template_lib = { version = "0.23", path = "crates/template_lib" }
-tari_template_lib_types = { version = "0.23", path = "crates/template_lib_types", default-features = false }
+tari_template_lib = { version = "0.24", path = "crates/template_lib" }
+tari_template_lib_types = { version = "0.24", path = "crates/template_lib_types", default-features = false }
 tari_template_abi = { version = "0.16", path = "crates/template_abi", default-features = false }
 tari_template_macros = { version = "0.18", path = "crates/template_macros" }
 tari_bor = { version = "0.13", path = "crates/tari_bor", default-features = false }
 
-ootle_byte_type = { path = "crates/ootle_byte_type", version = "0.5" }
+ootle_byte_type = { path = "crates/ootle_byte_type", version = "0.6" }
 ootle_serde = { path = "crates/ootle_serde", version = "0.2" }
 
 # external minotari/tari dependencies

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,7 +111,7 @@ tari_rpc_framework = { path = "networking/rpc_framework" }
 tari_rpc_macros = { path = "networking/rpc_macros" }
 tari_swarm = { path = "networking/swarm" }
 tari_validator_node_client = { path = "clients/validator_node_client" }
-tari_ootle_walletd_client = { path = "clients/wallet_daemon_client", version = "0.28" }
+tari_ootle_walletd_client = { path = "clients/wallet_daemon_client", version = "0.29" }
 transaction_generator = { path = "utilities/transaction_generator" }
 
 # Dependency crates on crates.io (update versions here as well when updating the workspace version)

--- a/applications/tari_walletd/src/handlers/accounts.rs
+++ b/applications/tari_walletd/src/handlers/accounts.rs
@@ -730,10 +730,9 @@ pub async fn handle_create_free_test_coins(
         .transaction_builder()
         .with_fee_instructions_builder(|fee_builder| {
             fee_builder
-                .call_method(XTR_FAUCET_COMPONENT_ADDRESS, "take", args![])
-                .put_last_instruction_output_on_workspace("faucet_funds")
-                .create_account_with_bucket(*account.address.account_public_key(), "faucet_funds")
+                .create_account(*account.address.account_public_key())
                 .put_last_instruction_output_on_workspace("new_account")
+                .call_method(XTR_FAUCET_COMPONENT_ADDRESS, "take", args![Workspace("new_account")])
                 .call_method("new_account", "pay_fee", args![max_fee])
         })
         .with_inputs(inputs.into_iter().map(|input| input.into_unversioned()))

--- a/clients/wallet_daemon_client/Cargo.toml
+++ b/clients/wallet_daemon_client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_ootle_walletd_client"
 description = "Tari wallet daemon client library"
-version = "0.28.5"
+version = "0.29.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/engine/tests/account.rs
+++ b/crates/engine/tests/account.rs
@@ -6,12 +6,7 @@ use tari_crypto::{keys::PublicKey, ristretto::RistrettoPublicKey};
 use tari_engine::runtime::{ActionIdent, RuntimeError};
 use tari_ootle_transaction::{Transaction, args};
 use tari_template_builtin::ACCOUNT_TEMPLATE_ADDRESS;
-use tari_template_lib::types::{
-    Amount,
-    access_rules::ComponentAccessRules,
-    constants::{TARI_TOKEN, XTR_FAUCET_COMPONENT_ADDRESS},
-    rule,
-};
+use tari_template_lib::types::{Amount, access_rules::ComponentAccessRules, constants::TARI_TOKEN, rule};
 use tari_template_test_tooling::{
     TemplateTest,
     support::assert_error::{assert_access_denied_for_action, assert_reject_reason},
@@ -25,18 +20,8 @@ fn basic_faucet_transfer() {
     let mut template_test = TemplateTest::new(CRATE_PATH, Vec::<&str>::new());
 
     // Create sender and receiver accounts
-    let (sender_address, sender_proof, _) = template_test.create_empty_account();
+    let (sender_address, sender_proof, _) = template_test.create_funded_account();
     let (receiver_address, _, _) = template_test.create_empty_account();
-
-    let _result = template_test
-        .build_and_execute(
-            Transaction::builder_localnet()
-                .call_method(XTR_FAUCET_COMPONENT_ADDRESS, "take", args![])
-                .put_last_instruction_output_on_workspace("free_coins")
-                .call_method(sender_address, "deposit", args![Workspace("free_coins")]),
-            vec![template_test.owner_proof()],
-        )
-        .unwrap_success();
 
     let result = template_test
         .build_and_execute(
@@ -67,23 +52,6 @@ fn withdraw_from_account_prevented() {
 
     // Create sender and receiver accounts
     let (source_account, _, _) = test.create_funded_account();
-
-    let _result = test
-        .execute_and_commit_manifest(
-            r#"
-                let source_account = var!["source_account"];
-                let faucet_component = var!["faucet_component"];
-                
-                let free_coins = faucet_component.take();
-                source_account.deposit(free_coins);
-            "#,
-            [
-                ("source_account", source_account.into()),
-                ("faucet_component", XTR_FAUCET_COMPONENT_ADDRESS.into()),
-            ],
-            vec![],
-        )
-        .unwrap();
 
     let (dest_address, non_owning_token, non_owning_key) = test.create_empty_account();
 
@@ -189,10 +157,10 @@ fn create_account_is_idempotent_with_deposit() {
 
     let result = test.execute_expect_success(
         Transaction::builder_localnet()
-            .call_method(xtr_faucet_component(), "take", args![])
-            .put_last_instruction_output_on_workspace("bucket")
             // Create component with the same ID
-            .create_account_with_bucket(source_account_pk.to_byte_type(), "bucket")
+            .create_account(source_account_pk.to_byte_type())
+            .put_last_instruction_output_on_workspace("account")
+            .call_method(xtr_faucet_component(), "take", args![Workspace("account")])
             // Signed by source account so that it can pay the fees for the new account creation
             .build_and_seal(&source_account_sk),
         vec![source_account_proof],
@@ -261,16 +229,15 @@ fn custom_access_rules() {
 
     test.execute_expect_success(
         Transaction::builder_localnet()
-            .call_method(xtr_faucet_component(), "take", args![])
-            .put_last_instruction_output_on_workspace("bucket")
             // Create component with the same ID
-            .create_account_custom(
+            .create_account_custom::<&str>(
                 public_key.to_byte_type(),
                 None,
                 Some(access_rules),
-                Some("bucket"),
+                None
             )
-            // Signed by source account so that it can pay the fees for the new account creation
+            .put_last_instruction_output_on_workspace("account")
+            .call_method(xtr_faucet_component(), "take", args![Workspace("account")])
             .build_and_seal(&secret_key),
         vec![owner_proof],
     );
@@ -298,20 +265,21 @@ fn custom_access_rules() {
 fn take_from_bucket() {
     let mut test = TemplateTest::new(CRATE_PATH, Vec::<&str>::new());
 
-    let (alice, _proof, _alice_sk) = test.create_empty_account();
+    let (alice, _proof, alice_sk) = test.create_funded_account();
     let (bob, _proof, _bob_sk) = test.create_empty_account();
 
     test.execute_expect_success(
         Transaction::builder_localnet()
-            .call_method(XTR_FAUCET_COMPONENT_ADDRESS, "take", args![])
-            .put_last_instruction_output_on_workspace("free_coins")
-            .take_from_bucket("free_coins", 100u64, "foo_bucket")
+            .call_method(alice, "withdraw_all", args![TARI_TOKEN])
+            .put_last_instruction_output_on_workspace("coins")
+            .take_from_bucket("coins", 100u64, "foo_bucket")
             // Take all remaining coins — tests that an empty bucket does not cause a dangling bucket error
-            .take_from_bucket("free_coins", 999_999_900u64, "bar_bucket")
+            .take_from_bucket("coins", 999_999_900u64, "bar_bucket")
             .call_method(alice, "deposit", args![Workspace("foo_bucket")])
             .call_method(bob, "deposit", args![Workspace("bar_bucket")])
-            .build_and_seal(test.secret_key()),
-        vec![test.owner_proof()],
+            .add_signer(&test.to_public_key_bytes(), &alice_sk)
+            .seal(test.secret_key()),
+        vec![],
     );
 
     let alice_acc = test.read_only_state_store().get_account(alice).unwrap();

--- a/crates/engine/tests/address_allocation.rs
+++ b/crates/engine/tests/address_allocation.rs
@@ -188,13 +188,11 @@ fn it_allows_calls_to_component_using_a_component_on_the_workspace() {
 
     test.execute_expect_success(
         Transaction::builder_localnet()
-            .call_method(xtr_faucet_component(), "take", args![])
-            .put_last_instruction_output_on_workspace("bucket")
             .create_account(test.to_public_key_bytes())
             // Put the created account address on the workspace, and
             .put_last_instruction_output_on_workspace("account")
-            // use it to call deposit
-            .call_method("account", "deposit", args![Workspace("bucket")])
+            // use it to call "take"
+            .call_method(xtr_faucet_component(), "take", args![Workspace("account")])
             .build_and_seal(test.secret_key()),
         vec![],
     );

--- a/crates/engine/tests/events.rs
+++ b/crates/engine/tests/events.rs
@@ -4,7 +4,7 @@
 use tari_engine::runtime::RuntimeError;
 use tari_ootle_transaction::{Transaction, args};
 use tari_template_builtin::ACCOUNT_TEMPLATE_ADDRESS;
-use tari_template_lib::types::{Amount, constants::XTR_FAUCET_COMPONENT_ADDRESS};
+use tari_template_lib::types::Amount;
 use tari_template_test_tooling::{
     TemplateTest,
     support::assert_error::assert_reject_reason,
@@ -59,16 +59,8 @@ fn builtin_vault_events() {
     let mut test = TemplateTest::new(CRATE_PATH, Vec::<&str>::new());
 
     // Create sender and receiver accounts
-    let (sender_address, sender_proof, _) = test.create_empty_account();
+    let (sender_address, sender_proof, _) = test.create_funded_account();
     let (receiver_address, _, _) = test.create_empty_account();
-    test.build_and_execute(
-        Transaction::builder_localnet()
-            .call_method(XTR_FAUCET_COMPONENT_ADDRESS, "take", args![])
-            .put_last_instruction_output_on_workspace("free_coins")
-            .call_method(sender_address, "deposit", args![Workspace("free_coins")]),
-        vec![test.owner_proof()],
-    )
-    .expect_success();
 
     // transfer some tokens between accounts
     let amount = Amount::from(100u64);

--- a/crates/engine/tests/fees.rs
+++ b/crates/engine/tests/fees.rs
@@ -85,9 +85,7 @@ fn deposit_from_faucet_then_pay() {
             .with_fee_instructions_builder(|builder| {
                 builder
                     // Faucet deposits free coins into the account
-                    .call_method(xtr_faucet_component(), "take", args![])
-                    .put_last_instruction_output_on_workspace("bucket")
-                    .call_method(account, "deposit", args![Workspace("bucket")])
+                    .call_method(xtr_faucet_component(), "take", args![account])
                     .call_method(account, "pay_fee", args![1000])
             })
             .call_function(test.get_template_address("State"), "new", args![])
@@ -123,9 +121,7 @@ fn another_account_pays_partially_for_fees() {
             .pay_fee_from_component(account_fee, Amount::from(200u64))
             // Account pays the rest
             .pay_fee_from_component(account_fee2, Amount::from(1000u64))
-            .call_method(xtr_faucet_component(), "take", args![])
-            .put_last_instruction_output_on_workspace("bucket")
-            .call_method(account, "deposit", args![Workspace("bucket")])
+            .call_method(xtr_faucet_component(), "take", args![account])
             // NOTE: the test harness provides the virtual proofs as provided, so the transaction signer does not matter
             .build_and_seal(test.secret_key()),
         vec![owner_token_fee, owner_token_fee2],

--- a/crates/engine/tests/reentrancy.rs
+++ b/crates/engine/tests/reentrancy.rs
@@ -4,7 +4,10 @@
 use tari_engine::runtime::{LockError, LockState};
 use tari_engine_types::lock::LockFlag;
 use tari_ootle_transaction::{Transaction, args};
-use tari_template_lib::types::{ComponentAddress, constants::XTR_FAUCET_COMPONENT_ADDRESS};
+use tari_template_lib::{
+    prelude::TARI_TOKEN,
+    types::{ComponentAddress, constants::TARI},
+};
 use tari_template_test_tooling::{TemplateTest, support::assert_error::assert_reject_reason};
 
 const CRATE_PATH: &str = env!("CARGO_MANIFEST_DIR");
@@ -13,14 +16,14 @@ const CRATE_PATH: &str = env!("CARGO_MANIFEST_DIR");
 fn it_prevents_reentrant_withdraw() {
     let mut test = TemplateTest::new(CRATE_PATH, ["tests/templates/reentrancy"]);
     let template_addr = test.get_template_address("Reentrancy");
-    let (account, _, _) = test.create_empty_account();
+    let (account, _, account_secret) = test.create_funded_account();
 
     let result = test.execute_expect_success(
         Transaction::builder_localnet()
-            .call_method(XTR_FAUCET_COMPONENT_ADDRESS, "take", args![])
+            .call_method(account, "withdraw", args![TARI_TOKEN, 1000 * TARI])
             .put_last_instruction_output_on_workspace("bucket")
             .call_function(template_addr, "with_bucket", args![Workspace("bucket")])
-            .build_and_seal(test.secret_key()),
+            .build_and_seal(&account_secret),
         vec![],
     );
 
@@ -30,10 +33,8 @@ fn it_prevents_reentrant_withdraw() {
 
     let reason = test.execute_expect_failure(
         Transaction::builder_localnet()
-            .call_method(reentrancy, "get_balance", args![])
             .call_method(reentrancy, "reentrant_withdraw", args![1000])
             .put_last_instruction_output_on_workspace("bucket")
-            .call_method(reentrancy, "get_balance", args![])
             .call_method(account, "deposit", args![Workspace("bucket")])
             .build_and_seal(test.secret_key()),
         vec![],

--- a/crates/ootle_address/Cargo.toml
+++ b/crates/ootle_address/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_ootle_address"
 description = "Tari Ootle address using bech32 encoding"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/ootle_byte_type/Cargo.toml
+++ b/crates/ootle_byte_type/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ootle_byte_type"
-version = "0.5.0"
+version = "0.6.0"
 description = "Conversion traits that define conversions to/from light-weight byte types"
 edition.workspace = true
 authors.workspace = true

--- a/crates/template_builtin/templates/account/src/lib.rs
+++ b/crates/template_builtin/templates/account/src/lib.rs
@@ -97,6 +97,11 @@ mod account_template {
             v.withdraw(amount)
         }
 
+        pub fn withdraw_all(&mut self, resource: ResourceAddress) -> Bucket {
+            let v = self.get_vault_mut(resource);
+            v.withdraw_all()
+        }
+
         pub fn withdraw_non_fungible(&mut self, resource: ResourceAddress, nf_id: NonFungibleId) -> Bucket {
             // An event is emitted by the vault.withdraw_non_fungibles method
             let v = self.get_vault_mut(resource);

--- a/crates/template_builtin/templates/faucet/src/lib.rs
+++ b/crates/template_builtin/templates/faucet/src/lib.rs
@@ -16,40 +16,32 @@ mod template {
     impl XtrFaucet {
         /// Mints a claim-receipt NFT keyed to the caller's public key, then immediately burns it.
         /// The burned substate key persists on-chain, so a second attempt panics with DuplicateNonFungibleId.
-        fn record_claim(&self) {
-            let pk = CallerContext::transaction_signer_public_key();
-            let receipt = ResourceManager::get(XTR_FAUCET_CLAIM_RESOURCE_ADDRESS)
-                .mint_non_fungible(NonFungibleId::from_public_key(pk), &(), &());
+        fn record_claim(&self, address: ComponentAddress) {
+            let receipt = ResourceManager::get(XTR_FAUCET_CLAIM_RESOURCE_ADDRESS).mint_non_fungible(
+                NonFungibleId::from_u256(address.as_object_key().into_array()),
+                &(),
+                &(),
+            );
             receipt.burn();
         }
 
-        /// Gives exactly 1,000 TARI to the caller. Can only be called once per signing public key.
-        pub fn take(&self) -> Bucket {
-            self.record_claim();
+        /// Gives exactly 1,000 TARI to the caller. Can only be called once per component.
+        pub fn take(&self, component: ComponentManager) {
+            self.record_claim(component.component_address());
             emit_event("take", metadata!["amount" => FAUCET_AMOUNT.to_string()]);
-            self.vault.withdraw(FAUCET_AMOUNT)
+            let bucket = self.vault.withdraw(FAUCET_AMOUNT);
+            component.invoke("deposit", args!(bucket));
         }
 
-        pub fn take_confidential(&self, transfer: StealthTransferStatement) -> Option<Bucket> {
-            let amount = transfer.inputs_statement.revealed_amount;
-            assert!(
-                amount <= FAUCET_AMOUNT,
-                "Requested amount {} exceeds faucet max of {}",
-                amount,
-                FAUCET_AMOUNT
-            );
-
-            self.record_claim();
-            emit_event("take", metadata![
-                "amount" => amount.to_string(),
-                "confidential" => "true".to_string()
-            ]);
-
-            // The faucet adds the revealed amount to the transfer
-            let revealed_bucket = self.vault.withdraw(amount);
-            self.vault
-                .get_resource_manager()
-                .stealth_transfer_with_opt_input_bucket(transfer, Some(revealed_bucket))
+        /// Gives exactly 1,000 TARI to the caller using a proof to authorize the deposit. Can only be called once per
+        /// component.
+        pub fn take_with_proof(&self, proof: Proof, component: ComponentManager) {
+            self.record_claim(component.component_address());
+            emit_event("take", metadata!["amount" => FAUCET_AMOUNT.to_string()]);
+            let bucket = self.vault.withdraw(FAUCET_AMOUNT);
+            proof.authorize_with(|| {
+                component.invoke("deposit", args!(bucket));
+            })
         }
     }
 }

--- a/crates/template_builtin/tests/xtr_faucet.rs
+++ b/crates/template_builtin/tests/xtr_faucet.rs
@@ -38,16 +38,14 @@ fn different_signers_can_each_claim_once() {
 fn second_claim_by_same_signer_is_rejected() {
     let mut test = TemplateTest::new_builtin_only();
     // First claim: succeeds and commits state (including the claim-receipt burned NFT)
-    let (account, owner_proof, secret_key) = test.create_funded_account();
+    let (account, _owner_proof, secret_key) = test.create_funded_account();
 
     // Second claim: same signing key → same claim-receipt NFT ID → DuplicateNonFungibleId
     let reject_reason = test.execute_expect_failure(
         Transaction::builder_localnet()
-            .call_method(XTR_FAUCET_COMPONENT_ADDRESS, "take", args![])
-            .put_last_instruction_output_on_workspace("bucket")
-            .call_method(account, "deposit", args![Workspace("bucket")])
+            .call_method(XTR_FAUCET_COMPONENT_ADDRESS, "take", args![account])
             .build_and_seal(&secret_key),
-        vec![owner_proof],
+        vec![],
     );
     assert_reject_reason(&reject_reason, "Duplicate NFT token id");
 }

--- a/crates/template_builtin/tests/xtr_faucet.rs
+++ b/crates/template_builtin/tests/xtr_faucet.rs
@@ -3,10 +3,7 @@
 
 use tari_ootle_transaction::{Transaction, args};
 use tari_template_lib::types::constants::{STEALTH_TARI_RESOURCE_ADDRESS, XTR_FAUCET_COMPONENT_ADDRESS};
-use tari_template_test_tooling::{
-    TemplateTest,
-    support::{assert_error::assert_reject_reason, stealth, stealth::NO_INPUTS},
-};
+use tari_template_test_tooling::{TemplateTest, support::assert_error::assert_reject_reason};
 
 /// A brand-new signer can call take() and receive tokens.
 #[test]
@@ -46,29 +43,6 @@ fn second_claim_by_same_signer_is_rejected() {
             .call_method(XTR_FAUCET_COMPONENT_ADDRESS, "take", args![account])
             .build_and_seal(&secret_key),
         vec![],
-    );
-    assert_reject_reason(&reject_reason, "Duplicate NFT token id");
-}
-
-/// After claiming with take(), calling take_confidential() with the same signer is also rejected.
-/// Both methods share the same claim-receipt resource, enforcing a single combined limit per public key.
-#[test]
-fn take_blocks_subsequent_take_confidential_for_same_signer() {
-    let mut test = TemplateTest::new_builtin_only();
-    // Use create_funded_account which calls take() — consumes the single allowed claim
-    let (_account, owner_proof, secret_key) = test.create_funded_account();
-
-    // Build a minimal valid StealthTransferStatement requesting 1 TARI (revealed)
-    let transfer = stealth::generate_transfer_data(NO_INPUTS, 1_000_000u64, Vec::<u64>::new(), 1_000_000u64);
-
-    // Attempting take_confidential() with the same key must fail at record_claim() before any vault access
-    let reject_reason = test.execute_expect_failure(
-        Transaction::builder_localnet()
-            .call_method(XTR_FAUCET_COMPONENT_ADDRESS, "take_confidential", args![
-                transfer.statement
-            ])
-            .build_and_seal(&secret_key),
-        vec![owner_proof],
     );
     assert_reject_reason(&reject_reason, "Duplicate NFT token id");
 }

--- a/crates/template_lib/Cargo.toml
+++ b/crates/template_lib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_template_lib"
 description = "Tari template library provides abstrations that interface with the Tari validator engine"
-version = "0.23.0"
+version = "0.24.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/template_lib/src/component/manager.rs
+++ b/crates/template_lib/src/component/manager.rs
@@ -33,19 +33,18 @@ use crate::{
 
 /// Utility for managing components inside templates
 #[derive(serde::Serialize, serde::Deserialize, Clone)]
-pub struct ComponentManager {
-    address: ComponentAddress,
-}
+#[serde(transparent)]
+pub struct ComponentManager(ComponentAddress);
 
 impl ComponentManager {
     /// Returns a new `ComponentManager` for the component specified by `address`
     pub(crate) fn new(address: ComponentAddress) -> Self {
-        Self { address }
+        Self(address)
     }
 
     /// Returns the address of the component that is being managed
     pub fn get(address: ComponentAddress) -> Self {
-        Self { address }
+        Self(address)
     }
 
     /// Returns the address of the component that is being called in the current instruction.
@@ -59,7 +58,7 @@ impl ComponentManager {
     /// context.
     pub fn call<T: Into<String>, R: DeserializeOwned, B: Into<Bytes>>(&self, method: T, args: Vec<B>) -> R {
         self.call_internal(CallMethodArg {
-            component_address: self.address,
+            component_address: self.0,
             method: method.into(),
             args: args.into_iter().map(Into::into).collect(),
         })
@@ -83,7 +82,7 @@ impl ComponentManager {
     /// Get the component state
     pub fn get_state<T: DeserializeOwned>(&self) -> T {
         let result = call_engine::<_, InvokeResult>(EngineOp::ComponentInvoke, &ComponentInvokeArg {
-            component_ref: ComponentRef::Ref(self.address),
+            component_ref: ComponentRef::Ref(self.0),
             action: ComponentAction::GetState,
             args: invoke_args![],
         });
@@ -95,7 +94,7 @@ impl ComponentManager {
     pub fn set_state<T: Serialize>(&self, state: T) {
         let state = to_value(&state).expect("Failed to encode component state");
         let _result = call_engine::<_, InvokeResult>(EngineOp::ComponentInvoke, &ComponentInvokeArg {
-            component_ref: ComponentRef::Ref(self.address),
+            component_ref: ComponentRef::Ref(self.0),
             action: ComponentAction::SetState,
             args: invoke_args![state],
         });
@@ -105,7 +104,7 @@ impl ComponentManager {
     /// It will panic if the caller doesn't have permissions for updating access rules
     pub fn set_access_rules(&self, access_rules: ComponentAccessRules) {
         call_engine::<_, InvokeResult>(EngineOp::ComponentInvoke, &ComponentInvokeArg {
-            component_ref: ComponentRef::Ref(self.address),
+            component_ref: ComponentRef::Ref(self.0),
             action: ComponentAction::SetAccessRules,
             args: invoke_args![access_rules],
         });
@@ -114,7 +113,7 @@ impl ComponentManager {
     /// Returns the template address of the component that is being managed
     pub fn get_template_address(&self) -> TemplateAddress {
         let result = call_engine::<_, InvokeResult>(EngineOp::ComponentInvoke, &ComponentInvokeArg {
-            component_ref: ComponentRef::Ref(self.address),
+            component_ref: ComponentRef::Ref(self.0),
             action: ComponentAction::GetTemplateAddress,
             args: invoke_args![],
         });
@@ -124,7 +123,7 @@ impl ComponentManager {
 
     pub fn get_owner_proof(&self) -> Proof {
         let result = call_engine::<_, InvokeResult>(EngineOp::ComponentInvoke, &ComponentInvokeArg {
-            component_ref: ComponentRef::Ref(self.address),
+            component_ref: ComponentRef::Ref(self.0),
             action: ComponentAction::GetOwnerProof,
             args: invoke_args![],
         });
@@ -133,6 +132,6 @@ impl ComponentManager {
     }
 
     pub fn component_address(&self) -> ComponentAddress {
-        self.address
+        self.0
     }
 }

--- a/crates/template_lib_types/Cargo.toml
+++ b/crates/template_lib_types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_template_lib_types"
-version = "0.23.0"
+version = "0.24.0"
 edition.workspace = true
 authors.workspace = true
 description = "Tari template library types"

--- a/crates/template_test_tooling/src/compile.rs
+++ b/crates/template_test_tooling/src/compile.rs
@@ -91,6 +91,6 @@ where
         .join(wasm_name)
         .with_extension("wasm");
 
-    let code = fs::read(path)?;
+    let code = fs::read(path).map_err(|e| io::Error::other(format!("Failed to read wasm file: {}", e)))?;
     Ok(WasmModule::from_code(code))
 }

--- a/crates/template_test_tooling/src/package_builder.rs
+++ b/crates/template_test_tooling/src/package_builder.rs
@@ -111,9 +111,10 @@ impl PackageBuilder {
         K: AsRef<OsStr>,
         V: AsRef<OsStr>,
     {
-        let wasm = compile_template_with_envs(path, features, envs).unwrap();
+        let wasm = compile_template_with_envs(path.as_ref(), features, envs)
+            .unwrap_or_else(|e| panic!("Failed to compile template {}: {}", path.as_ref().display(), e));
         let template_addr = hash_template_code(wasm.code());
-        let wasm = wasm.load_template().unwrap();
+        let wasm = wasm.load_template().expect("failed to load template");
         self.add_loaded_template(template_addr, wasm);
         template_addr
     }

--- a/crates/template_test_tooling/src/template_test.rs
+++ b/crates/template_test_tooling/src/template_test.rs
@@ -569,9 +569,9 @@ impl TemplateTest {
         self.enable_fees = false;
         self.execute_expect_success(
             Transaction::builder_localnet()
-                .call_method(xtr_faucet_component(), "take", args![])
-                .put_last_instruction_output_on_workspace("bucket")
-                .create_account_with_bucket(public_key.to_byte_type(), "bucket")
+                .create_account(public_key.to_byte_type())
+                .put_last_instruction_output_on_workspace("account")
+                .call_method(xtr_faucet_component(), "take", args![Workspace("account")])
                 .build_and_seal(&secret_key),
             vec![owner_proof.clone()],
         );
@@ -602,9 +602,9 @@ impl TemplateTest {
         let public_key_bytes = public_key.to_byte_type();
         self.execute_expect_success(
             Transaction::builder_localnet()
-                .call_method(xtr_faucet_component(), "take", args![])
-                .put_last_instruction_output_on_workspace("bucket")
-                .create_account_with_bucket(public_key_bytes, "bucket")
+                .create_account(public_key_bytes)
+                .put_last_instruction_output_on_workspace("account")
+                .call_method(xtr_faucet_component(), "take", args![Workspace("account")])
                 .build_and_seal(&secret_key),
             vec![owner_proof.clone()],
         );

--- a/crates/wallet/ootle-rs/Cargo.toml
+++ b/crates/wallet/ootle-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ootle-rs"
-version = "0.5.0"
+version = "0.6.0"
 description = "A Rust library for interacting with the Tari Ootle network."
 edition.workspace = true
 authors.workspace = true

--- a/crates/wallet/ootle-rs/examples/stealth_transfer.rs
+++ b/crates/wallet/ootle-rs/examples/stealth_transfer.rs
@@ -2,7 +2,6 @@
 //   SPDX-License-Identifier: BSD-3-Clause
 
 use ootle_rs::{
-    Network,
     ToAccountAddress,
     TransactionRequest,
     address,
@@ -30,15 +29,12 @@ async fn main() {
     //     .filter_level(tracing::log::LevelFilter::Debug)
     //     .init();
 
-    const NETWORK: Network = Network::LocalNet;
-
-    let indexer_api_url = default_indexer_url(NETWORK);
     // This is the address that we will transfer to (Feel free to change this another address!)
-    let recipient = address!(
-        "otl_loc_1d3jdxcdxvxgqh6pxj4ux50uumwhzdaajzmpapya75yq6xztsqdu6efgxnlngf72rky6vwannpwp9ctj8hmwpus2sgq7000krlxz8csg9w6ntm"
-    );
+    let recipient = address!( "otl_loc_1c370ayp9849gzmj9gwelyyd086ntrt84w5nkclu32tzyr2pvcfpre43z8z2xvupm6wltw9k5e8tzay3qqf9nfj9v5xuxwcpcxmg22vqlvz86l" );
 
-    let sender_secret = PrivateKeyProvider::random(NETWORK);
+    let indexer_api_url = default_indexer_url(recipient.network());
+
+    let sender_secret = PrivateKeyProvider::random(recipient.network());
     let sender_address = sender_secret.address().clone();
     println!("Sender address: {sender_address}");
     // Don't print secrets in production code!

--- a/crates/wallet/ootle-rs/examples/stealth_transfer.rs
+++ b/crates/wallet/ootle-rs/examples/stealth_transfer.rs
@@ -35,7 +35,7 @@ async fn main() {
     let indexer_api_url = default_indexer_url(NETWORK);
     // This is the address that we will transfer to (Feel free to change this another address!)
     let recipient = address!(
-        "otl_loc_1xfack4y62u3jr57q9j6kwuc5g78v9ckcasdzp6l9l9xknp2nrq0k9pvjkgutzsydtdw6ev64crqz9r8m2m7u3ms6z6dsu9p6shpkvvcnxtx79"
+        "otl_loc_1d3jdxcdxvxgqh6pxj4ux50uumwhzdaajzmpapya75yq6xztsqdu6efgxnlngf72rky6vwannpwp9ctj8hmwpus2sgq7000krlxz8csg9w6ntm"
     );
 
     let sender_secret = PrivateKeyProvider::random(NETWORK);
@@ -70,7 +70,7 @@ async fn main() {
     let tari_token = TARI_TOKEN; // resource_address!("resource_0123456789abcdef...");
 
     const INPUT_AMOUNT: u64 = 10 * TARI + 1000 - 500;
-    // This builder creates a stealth transfer statement (spend proof). This is added to the transaction later.
+    // // This builder creates a stealth transfer statement (spend proof). This is added to the transaction later.
     let (faucet_transfer, required_signers) = StealthTransfer::new(tari_token, &provider)
         // Tell the transfer to expect 10 TARI (+1000 to cover fees) as revealed funds from a bucket (the faucet looks at this value and automatically provides the bucket).
         .spend_revealed_input(10 * TARI + 1000)
@@ -91,7 +91,9 @@ async fn main() {
 
     // First let's transfer some faucet TARI to our account to have funds for fees and transfers.
     let unsigned_tx = IFaucet::new(&provider)
-        .take_faucet_funds_stealth(faucet_transfer, true)
+        .take_faucet_funds()
+        .into_stealth_transfer(faucet_transfer)
+        .and_pay_fee_from_revealed_output()
         .prepare()
         .await
         .expect("Failed to prepare faucet transaction");

--- a/crates/wallet/ootle-rs/examples/template_invoke.rs
+++ b/crates/wallet/ootle-rs/examples/template_invoke.rs
@@ -18,7 +18,7 @@ use ootle_rs::{
     TransactionRequest,
     builtin_templates::{
         UnsignedTransactionBuilder,
-        component::{IComponent, OotleInvoke},
+        component::{IComponent, TransactionBuildable},
         faucet::IFaucet,
     },
     default_indexer_url,

--- a/crates/wallet/ootle-rs/src/builtin_templates/component.rs
+++ b/crates/wallet/ootle-rs/src/builtin_templates/component.rs
@@ -37,7 +37,7 @@ pub struct ComponentInterface {
 
 /// Trait for extracting the inner builder and want list from any ootle builder.
 ///
-/// This enables [`OotleInvoke::chain`] to merge instructions from one builder into another,
+/// This enables [`TransactionBuildable::chain`] to merge instructions from one builder into another,
 /// allowing cross-template transaction composition.
 pub trait IntoBuildParts {
     fn into_build_parts(self) -> (TransactionBuilder, HashSet<WantInput>);
@@ -45,7 +45,7 @@ pub trait IntoBuildParts {
 
 /// Shared builder operations available on both macro-generated template structs and
 /// [`ComponentInvokeBuilder`]. All methods return `Self` for fluent chaining.
-pub trait OotleInvoke: Sized {
+pub trait TransactionBuildable: Sized {
     /// Pay fees from the default signer's account.
     fn pay_fee<A: Into<Amount>>(self, amount: A) -> Self;
 
@@ -80,7 +80,7 @@ pub trait OotleInvoke: Sized {
     ///
     /// Note: workspace references do NOT cross `chain` boundaries. If you need to
     /// reference a workspace item from the outer builder inside the chained builder,
-    /// use [`OotleInvoke::then`] instead.
+    /// use [`TransactionBuildable::then`] instead.
     fn chain<B: IntoBuildParts>(self, other: B) -> Self;
 }
 
@@ -119,7 +119,7 @@ impl<'a, P: Provider> IntoBuildParts for ComponentInvokeBuilder<'a, P> {
     }
 }
 
-impl<'a, P: Provider> OotleInvoke for ComponentInvokeBuilder<'a, P> {
+impl<'a, P: Provider> TransactionBuildable for ComponentInvokeBuilder<'a, P> {
     fn pay_fee<A: Into<Amount>>(mut self, amount: A) -> Self {
         let component_addr = self.provider.default_signer_address().to_account_address();
         self.want_list.insert(WantInput::VaultForResource {

--- a/crates/wallet/ootle-rs/src/builtin_templates/faucet.rs
+++ b/crates/wallet/ootle-rs/src/builtin_templates/faucet.rs
@@ -119,7 +119,7 @@ impl<'a, P: Provider> FaucetInvokeBuilder<'a, P> {
             builder
                 .call_method(account_name, "withdraw", args![TARI_TOKEN, amount])
                 .put_last_instruction_output_on_workspace(&bucket_name)
-                .stealth_transfer(TARI_TOKEN, transfer)
+                .stealth_transfer_with_input_bucket(TARI_TOKEN, transfer, bucket_name)
         });
         self
     }

--- a/crates/wallet/ootle-rs/src/builtin_templates/faucet.rs
+++ b/crates/wallet/ootle-rs/src/builtin_templates/faucet.rs
@@ -7,6 +7,8 @@ use tari_ootle_common_types::SubstateRequirement;
 use tari_ootle_transaction::{TransactionBuilder, UnsignedTransaction, args};
 use tari_template_lib_types::{
     Amount,
+    ComponentAddress,
+    ResourceAddress,
     UtxoAddress,
     constants::{
         TARI_TOKEN,
@@ -20,7 +22,11 @@ use tari_template_lib_types::{
 use crate::{
     Address,
     ToAccountAddress,
-    builtin_templates::UnsignedTransactionBuilder,
+    builtin_templates::{
+        UnsignedTransactionBuilder,
+        component::{IntoBuildParts, TransactionBuildable},
+    },
+    macros::_macro_exports::SubstateId,
     provider::{Provider, ProviderError, WantInput},
 };
 
@@ -86,24 +92,19 @@ impl<'a, P: Provider> FaucetInvokeBuilder<'a, P> {
         format!("__AccountInvokeBuilder_{}", self.builder.next_workspace_id())
     }
 
-    pub fn take_faucet_funds_stealth(
-        mut self,
-        transfer: StealthTransferStatement,
-        pay_revealed_amount_as_fees: bool,
-    ) -> Self {
+    pub fn into_stealth_transfer(mut self, transfer: StealthTransferStatement) -> Self {
         let amount = transfer.inputs_statement.revealed_amount;
         if !amount.is_positive() {
             panic!("Transfer amount must be positive");
         }
 
-        let has_revealed_output = transfer.outputs_statement.revealed_output_amount.is_positive();
-        let workspace_names = has_revealed_output.then(|| {
-            (
-                (!pay_revealed_amount_as_fees).then(|| self.next_workspace_name()),
-                self.next_workspace_name(),
-            )
-        });
-        let recipient_account_pk = *self.default_signer_address().account_public_key();
+        let Some(account_name) = self.account_workspace_name.as_ref() else {
+            // TODO: make this panic impossible
+            panic!(
+                "Call take_faucet_funds() before converting to a stealth transfer to ensure the builder has the \
+                 necessary workspace for revealed outputs and fee payment"
+            );
+        };
 
         // Request all UTXO inputs
         for input in &transfer.inputs_statement.inputs {
@@ -112,37 +113,29 @@ impl<'a, P: Provider> FaucetInvokeBuilder<'a, P> {
                 required: true,
             });
         }
+        let bucket_name = self.next_workspace_name();
 
         self.builder = self.builder.with_fee_instructions_builder(|builder| {
             builder
-                .add_input(XTR_FAUCET_VAULT_ADDRESS)
-                .add_input(XTR_FAUCET_CLAIM_RESOURCE_ADDRESS)
-                .call_method(XTR_FAUCET_COMPONENT_ADDRESS, "take_confidential", args![transfer])
-                .then(|builder| {
-                    if let Some((account_ws_name, bucket_name)) = &workspace_names {
-                        if let Some(account_ws_name) = account_ws_name {
-                            builder
-                                .put_last_instruction_output_on_workspace(bucket_name)
-                                // Create the recipient account if it doesn't exist
-                                .create_account_with_bucket(recipient_account_pk, bucket_name)
-                                .put_last_instruction_output_on_workspace(account_ws_name)
-                        } else {
-                            builder
-                                .put_last_instruction_output_on_workspace(bucket_name)
-                                .pay_fee_from_bucket(bucket_name)
-                        }
-                    } else {
-                        builder
-                    }
-                })
+                .call_method(account_name, "withdraw", args![TARI_TOKEN, amount])
+                .put_last_instruction_output_on_workspace(&bucket_name)
+                .stealth_transfer(TARI_TOKEN, transfer)
         });
-        self.account_workspace_name = workspace_names.and_then(|(account_ws_name, _)| account_ws_name);
+        self
+    }
+
+    pub fn and_pay_fee_from_revealed_output<A: Into<Amount>>(mut self) -> Self {
+        let bucket_name = self.next_workspace_name();
+        self.builder = self.builder.with_fee_instructions_builder(|builder| {
+            builder
+                .put_last_instruction_output_on_workspace(&bucket_name)
+                .pay_fee_from_bucket(bucket_name)
+        });
         self
     }
 
     /// Takes the fixed faucet amount (1,000 TARI) and deposits them into the default signer's account.
     pub fn take_faucet_funds(mut self) -> Self {
-        let bucket_name = self.next_workspace_name();
         let recipient_account_pk = *self.default_signer_address().account_public_key();
         let recipient_account_addr = self.default_signer_address().to_account_address();
         self.want_list.insert(WantInput::VaultForResource {
@@ -159,15 +152,75 @@ impl<'a, P: Provider> FaucetInvokeBuilder<'a, P> {
         let account_name = self.next_workspace_name();
         self.builder = self.builder.with_fee_instructions_builder(|builder| {
             builder
-                .call_method(XTR_FAUCET_COMPONENT_ADDRESS, "take", args![])
+                // Create the recipient account if it doesn't exist
+                .create_account(recipient_account_pk)
+                .put_last_instruction_output_on_workspace(&account_name)
+                .call_method(XTR_FAUCET_COMPONENT_ADDRESS, "take", args![Workspace(account_name)])
                 .add_input(XTR_FAUCET_VAULT_ADDRESS)
                 .add_input(XTR_FAUCET_CLAIM_RESOURCE_ADDRESS)
-                .put_last_instruction_output_on_workspace(&bucket_name)
-                // Create the recipient account if it doesn't exist
-                .create_account_with_bucket(recipient_account_pk, &bucket_name)
-                .put_last_instruction_output_on_workspace(&account_name)
         });
         self.account_workspace_name = Some(account_name);
+        self
+    }
+}
+
+impl<P: Provider> TransactionBuildable for FaucetInvokeBuilder<'_, P> {
+    fn pay_fee<A: Into<Amount>>(mut self, amount: A) -> Self {
+        let component_addr = self.provider.default_signer_address().to_account_address();
+        self.want_list.insert(WantInput::VaultForResource {
+            component_address: component_addr,
+            resource_address: TARI_TOKEN,
+            required: true,
+        });
+        self.builder = self.builder.pay_fee_from_component(component_addr, amount);
+        self
+    }
+
+    fn want_vault_for(
+        mut self,
+        component_address: ComponentAddress,
+        resource_address: ResourceAddress,
+        required: bool,
+    ) -> Self {
+        self.want_list.insert(WantInput::VaultForResource {
+            component_address,
+            resource_address,
+            required,
+        });
+        self
+    }
+
+    fn want_substate(mut self, substate_id: SubstateId, required: bool) -> Self {
+        self.want_list
+            .insert(WantInput::SpecificSubstate { substate_id, required });
+        self
+    }
+
+    fn want_all_vaults(mut self, component_address: ComponentAddress) -> Self {
+        self.want_list
+            .insert(WantInput::AllComponentVaults { component_address });
+        self
+    }
+
+    fn put_last_instruction_output_on_workspace<T: Into<String>>(mut self, label: T) -> Self {
+        self.builder = self.builder.put_last_instruction_output_on_workspace(label);
+        self
+    }
+
+    fn add_input<S: Into<SubstateRequirement>>(mut self, substate_id: S) -> Self {
+        self.builder = self.builder.add_input(substate_id);
+        self
+    }
+
+    fn then<F: FnOnce(TransactionBuilder) -> TransactionBuilder>(mut self, f: F) -> Self {
+        self.builder = f(self.builder);
+        self
+    }
+
+    fn chain<B: IntoBuildParts>(mut self, other: B) -> Self {
+        let (other_builder, other_wants) = other.into_build_parts();
+        self.builder = self.builder.merge(other_builder);
+        self.want_list.extend(other_wants);
         self
     }
 }

--- a/crates/wallet/ootle-rs/src/builtin_templates/faucet.rs
+++ b/crates/wallet/ootle-rs/src/builtin_templates/faucet.rs
@@ -97,6 +97,7 @@ impl<'a, P: Provider> FaucetInvokeBuilder<'a, P> {
         if !amount.is_positive() {
             panic!("Transfer amount must be positive");
         }
+        let bucket_name = self.next_workspace_name();
 
         let Some(account_name) = self.account_workspace_name.as_ref() else {
             // TODO: make this panic impossible
@@ -113,7 +114,6 @@ impl<'a, P: Provider> FaucetInvokeBuilder<'a, P> {
                 required: true,
             });
         }
-        let bucket_name = self.next_workspace_name();
 
         self.builder = self.builder.with_fee_instructions_builder(|builder| {
             builder
@@ -124,7 +124,7 @@ impl<'a, P: Provider> FaucetInvokeBuilder<'a, P> {
         self
     }
 
-    pub fn and_pay_fee_from_revealed_output<A: Into<Amount>>(mut self) -> Self {
+    pub fn and_pay_fee_from_revealed_output(mut self) -> Self {
         let bucket_name = self.next_workspace_name();
         self.builder = self.builder.with_fee_instructions_builder(|builder| {
             builder
@@ -155,7 +155,7 @@ impl<'a, P: Provider> FaucetInvokeBuilder<'a, P> {
                 // Create the recipient account if it doesn't exist
                 .create_account(recipient_account_pk)
                 .put_last_instruction_output_on_workspace(&account_name)
-                .call_method(XTR_FAUCET_COMPONENT_ADDRESS, "take", args![Workspace(account_name)])
+                .call_method(XTR_FAUCET_COMPONENT_ADDRESS, "take", args![Workspace(&account_name)])
                 .add_input(XTR_FAUCET_VAULT_ADDRESS)
                 .add_input(XTR_FAUCET_CLAIM_RESOURCE_ADDRESS)
         });

--- a/crates/wallet/ootle-rs/src/macros.rs
+++ b/crates/wallet/ootle-rs/src/macros.rs
@@ -21,7 +21,13 @@ pub mod _macro_exports {
     pub use crate::{
         builtin_templates::{
             UnsignedTransactionBuilder,
-            component::{ComponentInterface, ComponentInvokeBuilder, IntoBuildParts, OotleInvoke, TemplateInterface},
+            component::{
+                ComponentInterface,
+                ComponentInvokeBuilder,
+                IntoBuildParts,
+                TemplateInterface,
+                TransactionBuildable,
+            },
         },
         provider::{Provider, ProviderError, WantInput},
     };
@@ -194,7 +200,7 @@ macro_rules! __ootle_template_inner {
         }
 
         impl<'a, P: $crate::macros::_macro_exports::Provider>
-            $crate::macros::_macro_exports::OotleInvoke
+            $crate::macros::_macro_exports::TransactionBuildable
             for $name<'a, P, $crate::macros::_macro_exports::ComponentInterface>
         {
             $crate::__ootle_invoke_impl!();
@@ -257,7 +263,7 @@ macro_rules! __ootle_template_inner {
         }
 
         impl<'a, P: $crate::macros::_macro_exports::Provider>
-            $crate::macros::_macro_exports::OotleInvoke
+            $crate::macros::_macro_exports::TransactionBuildable
             for $name<'a, P, $crate::macros::_macro_exports::TemplateInterface>
         {
             $crate::__ootle_invoke_impl!();
@@ -280,7 +286,7 @@ macro_rules! __ootle_invoke_impl {
         fn pay_fee<A: Into<$crate::macros::_macro_exports::Amount>>(self, amount: A) -> Self {
             let Self { interface, builder } = self;
             Self {
-                builder: $crate::macros::_macro_exports::OotleInvoke::pay_fee(builder, amount),
+                builder: $crate::macros::_macro_exports::TransactionBuildable::pay_fee(builder, amount),
                 interface,
             }
         }
@@ -293,7 +299,7 @@ macro_rules! __ootle_invoke_impl {
         ) -> Self {
             let Self { interface, builder } = self;
             Self {
-                builder: $crate::macros::_macro_exports::OotleInvoke::want_vault_for(
+                builder: $crate::macros::_macro_exports::TransactionBuildable::want_vault_for(
                     builder,
                     component_address,
                     resource_address,
@@ -306,7 +312,11 @@ macro_rules! __ootle_invoke_impl {
         fn want_substate(self, substate_id: $crate::macros::_macro_exports::SubstateId, required: bool) -> Self {
             let Self { interface, builder } = self;
             Self {
-                builder: $crate::macros::_macro_exports::OotleInvoke::want_substate(builder, substate_id, required),
+                builder: $crate::macros::_macro_exports::TransactionBuildable::want_substate(
+                    builder,
+                    substate_id,
+                    required,
+                ),
                 interface,
             }
         }
@@ -314,7 +324,10 @@ macro_rules! __ootle_invoke_impl {
         fn want_all_vaults(self, component_address: $crate::macros::_macro_exports::ComponentAddress) -> Self {
             let Self { interface, builder } = self;
             Self {
-                builder: $crate::macros::_macro_exports::OotleInvoke::want_all_vaults(builder, component_address),
+                builder: $crate::macros::_macro_exports::TransactionBuildable::want_all_vaults(
+                    builder,
+                    component_address,
+                ),
                 interface,
             }
         }
@@ -322,7 +335,7 @@ macro_rules! __ootle_invoke_impl {
         fn put_last_instruction_output_on_workspace<T: Into<String>>(self, label: T) -> Self {
             let Self { interface, builder } = self;
             Self {
-                builder: $crate::macros::_macro_exports::OotleInvoke::put_last_instruction_output_on_workspace(
+                builder: $crate::macros::_macro_exports::TransactionBuildable::put_last_instruction_output_on_workspace(
                     builder, label,
                 ),
                 interface,
@@ -332,7 +345,7 @@ macro_rules! __ootle_invoke_impl {
         fn add_input<S: Into<$crate::macros::_macro_exports::SubstateRequirement>>(self, substate_id: S) -> Self {
             let Self { interface, builder } = self;
             Self {
-                builder: $crate::macros::_macro_exports::OotleInvoke::add_input(builder, substate_id),
+                builder: $crate::macros::_macro_exports::TransactionBuildable::add_input(builder, substate_id),
                 interface,
             }
         }
@@ -347,7 +360,7 @@ macro_rules! __ootle_invoke_impl {
         ) -> Self {
             let Self { interface, builder } = self;
             Self {
-                builder: $crate::macros::_macro_exports::OotleInvoke::then(builder, f),
+                builder: $crate::macros::_macro_exports::TransactionBuildable::then(builder, f),
                 interface,
             }
         }
@@ -355,7 +368,7 @@ macro_rules! __ootle_invoke_impl {
         fn chain<B: $crate::macros::_macro_exports::IntoBuildParts>(self, other: B) -> Self {
             let Self { interface, builder } = self;
             Self {
-                builder: $crate::macros::_macro_exports::OotleInvoke::chain(builder, other),
+                builder: $crate::macros::_macro_exports::TransactionBuildable::chain(builder, other),
                 interface,
             }
         }
@@ -372,7 +385,7 @@ macro_rules! __ootle_unsigned_tx_builder_impl {
         }
 
         fn add_input<S: Into<$crate::macros::_macro_exports::SubstateRequirement>>(self, substate_id: S) -> Self {
-            $crate::macros::_macro_exports::OotleInvoke::add_input(self, substate_id)
+            $crate::macros::_macro_exports::TransactionBuildable::add_input(self, substate_id)
         }
 
         async fn prepare(
@@ -398,7 +411,7 @@ macro_rules! const_nonzero_u64 {
 mod tests {
     use tari_template_lib_types::Amount;
 
-    use crate::builtin_templates::component::OotleInvoke;
+    use crate::builtin_templates::component::TransactionBuildable;
 
     #[test]
     fn it_generates_a_non_zero() {

--- a/utilities/tariswap_test_bench/src/accounts.rs
+++ b/utilities/tariswap_test_bench/src/accounts.rs
@@ -29,19 +29,15 @@ impl Runner {
             .key_manager_api()
             .get_public_key(KeyId::derived(KeyBranch::Account, 0))?;
         let owner_public_key = owner_key.public_key.to_byte_type();
-        let account_address = self
-            .sdk
-            .accounts_api()
-            .derive_account_address_from_public_key(&owner_public_key);
 
         let transaction = self
             .new_transaction_builder()
             .with_fee_instructions_builder(|builder| {
                 builder
-                    .call_method(XTR_FAUCET_COMPONENT_ADDRESS, "take", args![])
-                    .put_last_instruction_output_on_workspace("coins")
-                    .create_account_with_bucket(owner_public_key, "coins")
-                    .pay_fee_from_component(account_address, 1000u64)
+                    .create_account(owner_public_key)
+                    .put_last_instruction_output_on_workspace("account")
+                    .call_method(XTR_FAUCET_COMPONENT_ADDRESS, "take", args![Workspace("account")])
+                    .pay_fee_from_component("account", 1000u64)
             })
             .with_inputs([
                 SubstateRequirement::unversioned(XTR_FAUCET_COMPONENT_ADDRESS),
@@ -107,19 +103,15 @@ impl Runner {
         let mut pending = Vec::with_capacity(num_accounts);
         for (owner_key, account_key) in &owners {
             let owner_public_key = owner_key.public_key.to_byte_type();
-            let account_address = self
-                .sdk
-                .accounts_api()
-                .derive_account_address_from_public_key(&owner_public_key);
 
             let transaction = self
                 .new_transaction_builder()
                 .with_fee_instructions_builder(|builder| {
                     builder
-                        .call_method(XTR_FAUCET_COMPONENT_ADDRESS, "take", args![])
-                        .put_last_instruction_output_on_workspace("coins")
-                        .create_account_with_bucket(owner_public_key, "coins")
-                        .pay_fee_from_component(account_address, 1000u64)
+                        .create_account(owner_public_key)
+                        .put_last_instruction_output_on_workspace("account")
+                        .call_method(XTR_FAUCET_COMPONENT_ADDRESS, "take", args![Workspace("account")])
+                        .pay_fee_from_component("account", 1000u64)
                 })
                 .with_inputs([
                     SubstateRequirement::unversioned(XTR_FAUCET_COMPONENT_ADDRESS),

--- a/utilities/transaction_generator/Cargo.toml
+++ b/utilities/transaction_generator/Cargo.toml
@@ -9,8 +9,6 @@ license.workspace = true
 [dependencies]
 tari_template_lib_types = { workspace = true }
 tari_ootle_transaction = { workspace = true }
-tari_engine_types = { workspace = true }
-tari_template_builtin = { workspace = true }
 tari_transaction_manifest = { workspace = true }
 tari_ootle_common_types = { workspace = true }
 tari_crypto = { workspace = true }

--- a/utilities/transaction_generator/src/transaction_builders/free_coins.rs
+++ b/utilities/transaction_generator/src/transaction_builders/free_coins.rs
@@ -4,10 +4,8 @@
 use ootle_byte_type::ToByteType;
 use rand::rngs::OsRng;
 use tari_crypto::{keys::PublicKey, ristretto::RistrettoPublicKey};
-use tari_engine_types::component::derive_component_address_from_public_key;
 use tari_ootle_common_types::{Network, SubstateRequirement};
 use tari_ootle_transaction::{Transaction, args};
-use tari_template_builtin::ACCOUNT_TEMPLATE_ADDRESS;
 use tari_template_lib_types::constants::{
     TARI_TOKEN,
     XTR_FAUCET_CLAIM_RESOURCE_ADDRESS,
@@ -20,15 +18,13 @@ pub fn builder(network: Network) -> impl Fn(u64) -> Transaction {
         let (signer_secret_key, signer_public_key) = RistrettoPublicKey::random_keypair(&mut OsRng);
         let signer_public_key = signer_public_key.to_byte_type();
 
-        let account_address = derive_component_address_from_public_key(&ACCOUNT_TEMPLATE_ADDRESS, &signer_public_key);
-
         Transaction::builder(network.as_byte())
             .with_fee_instructions_builder(|builder| {
                 builder
-                    .call_method(XTR_FAUCET_COMPONENT_ADDRESS, "take", args![])
-                    .put_last_instruction_output_on_workspace("free_coins")
-                    .create_account_with_bucket(signer_public_key, "free_coins")
-                    .call_method(account_address, "pay_fee", args![1000])
+                    .create_account(signer_public_key)
+                    .put_last_instruction_output_on_workspace("account")
+                    .call_method(XTR_FAUCET_COMPONENT_ADDRESS, "take", args![Workspace("account")])
+                    .call_method("account", "pay_fee", args![1000])
             })
             .with_inputs([
                 SubstateRequirement::unversioned(TARI_TOKEN),


### PR DESCRIPTION
## Summary

- Faucet `take` now accepts a `ComponentManager` and deposits directly into the provided component, removing the need for callers to handle the returned bucket
- Claim NFT is keyed by component address instead of signer public key, preventing double deposits to the same component even if the signing key changes
- Removes `take_confidential` 
- adds `take_with_proof` which accepts a proof for authorized deposits
- Makes `ComponentManager` `serde(transparent)` so it can be passed as a ComponentAddress nstruction argument
- Adds `withdraw_all` to the account template
- Renames `OotleInvoke` trait to `TransactionBuildable` and implements it for `FaucetInvokeBuilder`

## BREAKING CHANGE

`Faucet::take` signature changed from `take() -> Bucket` to `take(component: ComponentManager)`. `take_confidential` removed

## Test plan

- [ ] Existing `xtr_faucet` tests pass with updated call signatures
- [ ] Engine tests (account, fees, events, reentrancy, address_allocation) pass
- [ ] Duplicate claim test verifies rejection by component address