### PR TITLE
docs(ootle-rs): add crate docs, module docs, and examples README

### DIFF
--- a/crates/wallet/ootle-rs/examples/README.md
+++ b/crates/wallet/ootle-rs/examples/README.md
@@ -1,0 +1,51 @@
+# ootle.rs Examples
+
+Runnable examples demonstrating how to use `ootle-rs` to interact with the Tari Ootle network.
+
+## Prerequisites
+
+All examples require a running **localnet** with an indexer (default: `http://127.0.0.1:12500`).
+
+```bash
+cargo run --example <example_name>
+```
+
+## Examples
+
+### `fungible_transfer`
+
+End-to-end public fungible token transfer: create a wallet, fund from faucet,
+send multiple transfers in a single transaction, dry-run with fee estimation,
+and verify balances.
+
+### `stealth_transfer`
+
+Confidential stealth transfers with input/output commitments, encrypted memos,
+change handling, and stealth spending authorizers.
+
+### `balance_query`
+
+Query account balances and decrypt stealth UTXO values using ElGamal view keys.
+
+Requires updating constants in the example: resource address, view secret key,
+UTXO commitment, and max expected value.
+
+> **Note:** UTXO decryption with on-the-fly lookup generation is slow.
+> For production use, enable the `mmap-value-lookup` feature with pregenerated
+> lookup files.
+
+### `template_invoke`
+
+Type-safe template invocation using the `ootle_template!` macro. Shows how to
+define custom template interfaces, call template functions and component methods,
+chain calls with workspace piping, and fall back to raw `TransactionBuilder`.
+
+Requires updating template and component addresses in the example.
+
+### `watch_component_events`
+
+Real-time event monitoring via SSE (Server-Sent Events). Subscribe to events
+filtered by component address and optional topic, with automatic reconnection
+and resume-from-last-seen capability.
+
+Requires updating the component address in the example.

--- a/crates/wallet/ootle-rs/src/builtin_templates/account.rs
+++ b/crates/wallet/ootle-rs/src/builtin_templates/account.rs
@@ -18,8 +18,20 @@ use crate::{
     provider::{Provider, ProviderError, WantInput},
 };
 
+/// Alias for [`AccountInvokeBuilder`].
 pub type IAccount<'a, P> = AccountInvokeBuilder<'a, P>;
 
+/// Builder for constructing transactions against the built-in Account template.
+///
+/// Supports public transfers, fee payment, and template publishing.
+///
+/// ```rust,ignore
+/// let tx = IAccount::new(&provider)
+///     .pay_fee(1000u64)
+///     .public_transfer(&recipient, TARI_TOKEN, 1_000_000u64)
+///     .prepare()
+///     .await?;
+/// ```
 pub struct AccountInvokeBuilder<'a, P> {
     builder: TransactionBuilder,
     provider: &'a P,

--- a/crates/wallet/ootle-rs/src/builtin_templates/faucet.rs
+++ b/crates/wallet/ootle-rs/src/builtin_templates/faucet.rs
@@ -30,8 +30,18 @@ use crate::{
     provider::{Provider, ProviderError, WantInput},
 };
 
+/// Alias for [`FaucetInvokeBuilder`].
 pub type IFaucet<'a, P> = FaucetInvokeBuilder<'a, P>;
 
+/// Builder for claiming free tokens from the testnet faucet.
+///
+/// ```rust,ignore
+/// let tx = IFaucet::new(&provider)
+///     .pay_fee(1000u64)
+///     .take_free_coins(500_000_000u64)
+///     .prepare()
+///     .await?;
+/// ```
 pub struct FaucetInvokeBuilder<'a, P> {
     builder: TransactionBuilder,
     provider: &'a P,

--- a/crates/wallet/ootle-rs/src/builtin_templates/mod.rs
+++ b/crates/wallet/ootle-rs/src/builtin_templates/mod.rs
@@ -1,5 +1,12 @@
 //   Copyright 2026 The Tari Project
-//   SPDX-License-Identifier: BSD-3-Claus
+//   SPDX-License-Identifier: BSD-3-Clause
+
+//! Ergonomic builders for interacting with Ootle's built-in templates.
+//!
+//! - [`account::IAccount`] — public transfers, fee payment, and template publishing.
+//! - [`faucet::IFaucet`] — claim free testnet tokens from the faucet.
+//! - [`component`] — generic component and template invocation, including the
+//!   [`ootle_template!`](crate::ootle_template) macro for type-safe method calls.
 
 pub mod account;
 pub mod component;

--- a/crates/wallet/ootle-rs/src/helpers.rs
+++ b/crates/wallet/ootle-rs/src/helpers.rs
@@ -3,6 +3,10 @@
 
 use tari_ootle_common_types::Network;
 
+/// Returns the default indexer URL for the given network.
+///
+/// Currently configured for `LocalNet` (`http://localhost:12500`) and
+/// `Esmeralda` (`https://ootle-indexer-a.tari.com/`). Other networks are not yet configured.
 pub fn default_indexer_url(network: Network) -> &'static str {
     match network {
         Network::MainNet => unimplemented!("MainNet indexer URL is not set"),

--- a/crates/wallet/ootle-rs/src/key_provider/local/mod.rs
+++ b/crates/wallet/ootle-rs/src/key_provider/local/mod.rs
@@ -11,6 +11,10 @@ pub use private_key::*;
 
 use crate::Address;
 
+/// A key provider backed by local credentials.
+///
+/// Parameterized by the credential type `C`. The most common instantiation is
+/// [`PrivateKeyProvider`] (i.e. `LocalKeyProvider<OotleSecretKey>`).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LocalKeyProvider<C> {
     address: Address,

--- a/crates/wallet/ootle-rs/src/key_provider/mod.rs
+++ b/crates/wallet/ootle-rs/src/key_provider/mod.rs
@@ -1,6 +1,12 @@
 //   Copyright 2026 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
+//! Cryptographic key providers for output mask generation and key derivation.
+//!
+//! The main type is [`PrivateKeyProvider`] (alias [`PrivateKeySigner`]), a local key
+//! provider backed by a Ristretto secret key that can sign transactions, decrypt
+//! stealth inputs, and derive various stealth secrets.
+
 mod error;
 mod local;
 mod traits;

--- a/crates/wallet/ootle-rs/src/key_provider/traits.rs
+++ b/crates/wallet/ootle-rs/src/key_provider/traits.rs
@@ -8,11 +8,13 @@ use crate::key_provider::error::KeyProviderError;
 
 pub type Result<T> = std::result::Result<T, KeyProviderError>;
 
+/// Provider of random output masks (blinding factors) for Pedersen commitments.
 #[async_trait]
 pub trait OutputMaskProvider {
     async fn next_mask(&self) -> Result<RistrettoSecretKey>;
 }
 
+/// Provider of Diffie-Hellman KDF-derived secret keys for stealth address derivation.
 #[async_trait]
 pub trait DiffieHellmanKdfKeyProvider<H> {
     async fn create_kdf_dh_key(&self, hasher: H, public_key: &RistrettoPublicKey) -> Result<RistrettoSecretKey>;

--- a/crates/wallet/ootle-rs/src/lib.rs
+++ b/crates/wallet/ootle-rs/src/lib.rs
@@ -1,6 +1,140 @@
 // Copyright 2026 The Tari Project
 // SPDX-License-Identifier: BSD-3-Clause
 
+//! # ootle.rs
+//!
+//! A Rust library for interacting with the [Tari Ootle](https://www.tari.com/) (Layer 2) network.
+//!
+//! `ootle-rs` provides a high-level, type-safe API modelled after
+//! [alloy-rs](https://github.com/alloy-rs/alloy), using the familiar `Provider`, `Wallet`,
+//! and `Signer` architecture. It supports public and confidential (stealth) transfers,
+//! balance queries, template invocation, and real-time event streaming.
+//!
+//! # Quick start
+//!
+//! Connect to a local Ootle indexer, create a wallet, fund it from the faucet, and send
+//! a public transfer:
+//!
+//! ```rust,no_run
+//! use ootle_rs::{
+//!     address,
+//!     builtin_templates::{account::IAccount, faucet::IFaucet},
+//!     key_provider::PrivateKeyProvider,
+//!     provider::ProviderBuilder,
+//!     wallet::OotleWallet,
+//!     Network, TransactionRequest,
+//! };
+//! use tari_template_lib_types::constants::TARI_TOKEN;
+//!
+//! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+//! let network = Network::LocalNet;
+//!
+//! // 1. Create a wallet backed by a random keypair
+//! let signer = PrivateKeyProvider::random(network);
+//! let wallet = OotleWallet::from(signer);
+//!
+//! // 2. Connect to the indexer
+//! let provider = ProviderBuilder::new()
+//!     .wallet(wallet)
+//!     .connect("http://127.0.0.1:12500")
+//!     .await?;
+//!
+//! // 3. Fund our account from the faucet
+//! let faucet_tx = IFaucet::new(&provider)
+//!     .pay_fee(1000u64)
+//!     .take_free_coins(500_000_000u64)
+//!     .prepare()
+//!     .await?;
+//!
+//! let faucet_tx = TransactionRequest::default()
+//!     .with_transaction(faucet_tx)
+//!     .build(provider.wallet())
+//!     .await?;
+//! provider.send_transaction(faucet_tx).await?.watch().await?;
+//!
+//! // 4. Transfer tokens to a recipient
+//! let recipient = address!("otl_loc_10mc0v2lyy43kldl0ft4c2x5pe7j0ckduv8zej6jgr2z2g9m07fz7gl96ar5wwgu0qu0atmr5tl53ye7n38xr5u7ytlmudq0ruxcau0gge7rxk");
+//!
+//! let unsigned_tx = IAccount::new(&provider)
+//!     .pay_fee(1000u64)
+//!     .public_transfer(&recipient, TARI_TOKEN, 1_000_000u64)
+//!     .prepare()
+//!     .await?;
+//!
+//! let tx = TransactionRequest::default()
+//!     .with_transaction(unsigned_tx)
+//!     .build(provider.wallet())
+//!     .await?;
+//!
+//! let outcome = provider.send_transaction(tx).await?.watch().await?;
+//! println!("Transaction confirmed: {:?}", outcome);
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! # Architecture
+//!
+//! The crate follows the layered design of alloy:
+//!
+//! - **[`provider`]** — the main entry point for network interaction. [`provider::ProviderBuilder`] connects to an
+//!   Ootle indexer and provides methods for sending transactions, resolving inputs, and querying substates. The
+//!   [`provider::Provider`] and [`provider::WalletProvider`] traits define the interface.
+//!
+//! - **[`wallet`]** — manages keys and signing. [`wallet::OotleWallet`] holds one or more key providers and handles
+//!   transaction signing, authorization, and stealth proof generation.
+//!
+//! - **[`key_provider`]** — cryptographic key abstractions for output mask generation and Diffie-Hellman key
+//!   derivation. [`key_provider::PrivateKeyProvider`] is the default implementation backed by a Ristretto secret key.
+//!
+//! - **[`builtin_templates`]** — ergonomic builders for the built-in Ootle templates:
+//!   - [`builtin_templates::account::IAccount`] — public transfers, fee payment, template publishing.
+//!   - [`builtin_templates::faucet::IFaucet`] — claim free testnet tokens.
+//!   - [`builtin_templates::component`] — generic component/template invocation with the [`ootle_template!`] macro for
+//!     type-safe method calls.
+//!
+//! - **[`stealth`]** — confidential transfer support. [`stealth::StealthTransfer`] builds stealth transfer statements
+//!   with input/output commitments, encrypted memos, and change handling.
+//!
+//! - **[`transaction`]** — transaction signing traits ([`transaction::TransactionSigner`],
+//!   [`transaction::TransactionSealSigner`]) and the `TransactionRequest` builder for constructing signed transactions
+//!   ready for submission.
+//!
+//! # Type-safe template invocation
+//!
+//! The [`ootle_template!`] macro generates typed wrappers for custom templates:
+//!
+//! ```rust,ignore
+//! use ootle_rs::ootle_template;
+//! use tari_template_lib_types::Amount;
+//!
+//! ootle_template! {
+//!     template StableCoin {
+//!         fn instantiate(initial_supply: Amount);
+//!         fn mint(&mut self, amount: Amount);
+//!         fn balance(&self) -> Amount;
+//!     }
+//! }
+//!
+//! // Call a constructor
+//! let tx = StableCoin::for_template(template_addr, &provider)
+//!     .instantiate(Amount::new(1_000_000))
+//!     .pay_fee(1000)
+//!     .prepare()
+//!     .await?;
+//!
+//! // Call a component method
+//! let tx = StableCoin::for_component(component_addr, &provider)
+//!     .mint(Amount::new(500))
+//!     .pay_fee(1000)
+//!     .prepare()
+//!     .await?;
+//! ```
+//!
+//! # Features
+//!
+//! - **`mmap-value-lookup`** — enables memory-mapped pregenerated lookup tables for fast ElGamal UTXO value decryption.
+//!   Without this feature, values are decrypted via on-the-fly brute-force which is significantly slower.
+
 pub mod builtin_templates;
 pub mod key_provider;
 pub mod provider;

--- a/crates/wallet/ootle-rs/src/macros.rs
+++ b/crates/wallet/ootle-rs/src/macros.rs
@@ -43,7 +43,8 @@ pub mod _macro_exports {
 /// - `{Name}::for_component(addr, &provider)` → component interface
 /// - `{Name}::for_template(addr, &provider)` → template interface
 ///
-/// Each generated method returns a [`ComponentInvokeBuilder`] that you chain with
+/// Each generated method returns a
+/// [`ComponentInvokeBuilder`](crate::builtin_templates::component::ComponentInvokeBuilder) that you chain with
 /// `.pay_fee()`, `.want_vault_for()`, `.prepare()`, etc.
 ///
 /// # Syntax

--- a/crates/wallet/ootle-rs/src/provider/builder.rs
+++ b/crates/wallet/ootle-rs/src/provider/builder.rs
@@ -11,6 +11,16 @@ use crate::{
     wallet::{NetworkWallet, NoWallet},
 };
 
+/// Builder for constructing a [`Provider`](super::Provider) connected to an Ootle indexer.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// let provider = ProviderBuilder::new()
+///     .wallet(wallet)
+///     .connect("http://127.0.0.1:12500")
+///     .await?;
+/// ```
 #[derive(Debug)]
 pub struct ProviderBuilder<Wallet = NoWallet> {
     wallet: Wallet,

--- a/crates/wallet/ootle-rs/src/provider/mod.rs
+++ b/crates/wallet/ootle-rs/src/provider/mod.rs
@@ -1,6 +1,24 @@
 //   Copyright 2026 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
+//! Network provider for interacting with the Ootle indexer.
+//!
+//! The provider is the main entry point for sending transactions, querying balances,
+//! resolving transaction inputs, and streaming events.
+//!
+//! Use [`ProviderBuilder`] to connect to an indexer:
+//!
+//! ```rust,ignore
+//! let provider = ProviderBuilder::new()
+//!     .wallet(wallet)
+//!     .connect("http://127.0.0.1:12500")
+//!     .await?;
+//! ```
+//!
+//! The [`Provider`] trait defines the core interface (network info, input resolution,
+//! substate fetching), while [`WalletProvider`] extends it with wallet access for
+//! signing and submitting transactions.
+
 mod balance;
 mod builder;
 mod error;

--- a/crates/wallet/ootle-rs/src/provider/traits.rs
+++ b/crates/wallet/ootle-rs/src/provider/traits.rs
@@ -19,6 +19,11 @@ use crate::{
 };
 
 pub type ProviderResult<T> = Result<T, ProviderError>;
+
+/// Core provider trait for interacting with the Ootle network.
+///
+/// Provides network information, input resolution for transactions, and substate fetching.
+/// Implement this trait to create custom providers backed by different transports.
 pub trait Provider {
     type Client;
 
@@ -43,6 +48,7 @@ pub trait Provider {
     ) -> impl Future<Output = ProviderResult<HashMap<SubstateId, Substate>>> + Send;
 }
 
+/// Extension of [`Provider`] that includes wallet access for signing and submitting transactions.
 pub trait WalletProvider: Provider {
     type Wallet;
 

--- a/crates/wallet/ootle-rs/src/stealth/builder.rs
+++ b/crates/wallet/ootle-rs/src/stealth/builder.rs
@@ -30,6 +30,18 @@ use crate::{
     wallet::{OotleWallet, WalletResult},
 };
 
+/// Builder for constructing confidential stealth transfers.
+///
+/// Supports revealed and stealth inputs, stealth outputs with optional encrypted memos,
+/// change handling, and spending proof generation.
+///
+/// ```rust,ignore
+/// let (statement, sig_reqs) = StealthTransfer::new(TARI_TOKEN, &provider)
+///     .spend_revealed_input(commitment, mask, value)
+///     .to_stealth_output(&recipient, 500_000u64, None)
+///     .prepare()
+///     .await?;
+/// ```
 pub struct StealthTransfer<'a, P> {
     provider: &'a P,
     spec: StealthTransferSpec,

--- a/crates/wallet/ootle-rs/src/stealth/mod.rs
+++ b/crates/wallet/ootle-rs/src/stealth/mod.rs
@@ -1,6 +1,12 @@
 //   Copyright 2026 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
+//! Confidential (stealth) transfer support.
+//!
+//! [`StealthTransfer`] builds stealth transfer statements with Pedersen commitments,
+//! encrypted memos, and change outputs. It handles both revealed inputs (e.g. from
+//! the faucet) and stealth inputs with spending proofs.
+
 mod builder;
 mod error;
 mod spec;

--- a/crates/wallet/ootle-rs/src/transaction/mod.rs
+++ b/crates/wallet/ootle-rs/src/transaction/mod.rs
@@ -1,6 +1,14 @@
 //   Copyright 2026 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
+//! Transaction signing traits and ephemeral signers.
+//!
+//! Defines the signing interfaces used by wallets and key providers:
+//!
+//! - [`TransactionSigner`] — signs and authorizes transactions with a persistent key.
+//! - [`TransactionSealSigner`] — applies the final seal signature to a transaction.
+//! - [`TransactionStealthKeySigner`] — signs using derived stealth keys for confidential transactions.
+
 pub mod ephemeral_signer;
 mod signer;
 

--- a/crates/wallet/ootle-rs/src/transaction/signer.rs
+++ b/crates/wallet/ootle-rs/src/transaction/signer.rs
@@ -8,6 +8,7 @@ use tari_template_lib_types::crypto::RistrettoPublicKeyBytes;
 
 use crate::{signer, types::Address, wallet::TransactionAuthorization};
 
+/// Trait for signing and authorizing transactions with a persistent key.
 // NOTE: async_trait is required because returning impl Future is not currently dyn compatible
 #[async_trait::async_trait]
 pub trait TransactionSigner {
@@ -24,12 +25,17 @@ pub trait TransactionSigner {
     ) -> signer::Result<TransactionAuthorization>;
 }
 
+/// Trait for applying the final seal signature to a transaction.
+///
+/// The seal signature is the last signature applied, proving that the transaction
+/// originator approved the final set of instructions and authorizations.
 #[async_trait]
 pub trait TransactionSealSigner {
     /// Asynchronously sign (seal) an unsealed transaction.
     async fn seal_transaction(&self, transaction: UnsealedTransaction) -> signer::Result<Transaction>;
 }
 
+/// Trait for signing transactions using derived stealth keys for confidential transactions.
 #[async_trait]
 pub trait TransactionStealthKeySigner {
     async fn sign_authorization_with_stealth(

--- a/crates/wallet/ootle-rs/src/types/address.rs
+++ b/crates/wallet/ootle-rs/src/types/address.rs
@@ -5,8 +5,16 @@ use tari_ootle_common_types::engine_types::component::derive_component_address_f
 use tari_template_builtin::ACCOUNT_TEMPLATE_ADDRESS;
 use tari_template_lib_types::ComponentAddress;
 
+/// An Ootle network address, identifying an account by its public key and network.
+///
+/// Create addresses using the [`address!`](crate::address) macro:
+///
+/// ```rust,ignore
+/// let addr = address!("otl_loc_10mc0v2lyy43kldl...");
+/// ```
 pub type Address = tari_ootle_address::OotleAddress;
 
+/// Derives the on-chain component address for an account from its [`Address`].
 pub trait ToAccountAddress {
     fn to_account_address(&self) -> ComponentAddress;
 }

--- a/crates/wallet/ootle-rs/src/types/transaction/request.rs
+++ b/crates/wallet/ootle-rs/src/types/transaction/request.rs
@@ -12,6 +12,19 @@ use crate::{
 pub struct Initial;
 pub struct WithTx(UnsignedTransaction);
 
+/// A builder for constructing signed transactions ready for submission.
+///
+/// Follows a typestate pattern: start with [`TransactionRequest::new()`], attach an
+/// unsigned transaction with [`with_transaction()`](TransactionRequest::with_transaction),
+/// optionally add extra authorizations, then call [`build()`](TransactionRequest::build)
+/// to seal and sign.
+///
+/// ```rust,ignore
+/// let tx = TransactionRequest::default()
+///     .with_transaction(unsigned_tx)
+///     .build(provider.wallet())
+///     .await?;
+/// ```
 #[derive(Clone, Debug, Default)]
 pub struct TransactionRequest<State = Initial> {
     state: State,

--- a/crates/wallet/ootle-rs/src/wallet/mod.rs
+++ b/crates/wallet/ootle-rs/src/wallet/mod.rs
@@ -1,6 +1,18 @@
 //   Copyright 2026 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
+//! Wallet for managing keys and signing transactions.
+//!
+//! [`OotleWallet`] holds one or more key providers and handles transaction signing,
+//! authorization, stealth proof generation, and input decryption.
+//!
+//! ```rust,ignore
+//! use ootle_rs::{key_provider::PrivateKeyProvider, wallet::OotleWallet, Network};
+//!
+//! let signer = PrivateKeyProvider::random(Network::LocalNet);
+//! let wallet = OotleWallet::from(signer);
+//! ```
+
 mod error;
 mod none;
 mod ootle;

--- a/crates/wallet/ootle-rs/src/wallet/ootle.rs
+++ b/crates/wallet/ootle-rs/src/wallet/ootle.rs
@@ -25,6 +25,22 @@ use crate::{
 pub type WalletResult<T> = Result<T, WalletError>;
 type AddressHashMap<T> = HashMap<Address, T>;
 
+/// A wallet that manages multiple key providers and handles transaction signing.
+///
+/// `OotleWallet` can hold several key providers (each associated with an [`Address`]),
+/// with one designated as the default signer. It supports both standard account-key
+/// signing and stealth-key signing for confidential transactions.
+///
+/// Create a wallet from any type implementing [`WalletKeyProvider`]:
+///
+/// ```rust,ignore
+/// let signer = PrivateKeyProvider::random(Network::LocalNet);
+/// let mut wallet = OotleWallet::from(signer);
+///
+/// // Optionally register additional signers
+/// let second_signer = PrivateKeyProvider::random(Network::LocalNet);
+/// wallet.register_key_provider(second_signer);
+/// ```
 #[derive(Clone)]
 pub struct OotleWallet {
     default: Address,
@@ -65,8 +81,7 @@ impl OotleWallet {
     }
 
     /// Set the given signer as default.
-    /// This signer will be used to sign [`TransactionRequest`].
-    /// [`TransactionRequest`]: crate::types::TransactionRequest
+    /// This signer will be used to sign `TransactionRequest`s.
     pub fn set_default_signer(&mut self, address: &Address) -> WalletResult<()> {
         if self.key_providers.contains_key(address) {
             self.default = address.clone();

--- a/crates/wallet/ootle-rs/src/wallet/traits.rs
+++ b/crates/wallet/ootle-rs/src/wallet/traits.rs
@@ -12,6 +12,7 @@ use crate::{
     wallet::WalletResult,
 };
 
+/// Trait for wallets that can sign transactions on a specific network.
 pub trait NetworkWallet {
     fn default_address(&self) -> &Address;
 
@@ -19,6 +20,9 @@ pub trait NetworkWallet {
     -> impl Future<Output = WalletResult<Transaction>> + Send;
 }
 
+/// A key provider that can sign transactions, derive stealth keys, generate output
+/// statements, and decrypt stealth inputs. Automatically implemented for any type
+/// implementing all four constituent traits.
 pub trait WalletKeyProvider:
     TransactionSigner + TransactionStealthKeySigner + StealthOutputStatementFactory + InputDecryptor
 {


### PR DESCRIPTION
## Summary

- Add crate-level documentation with quick-start example, architecture overview, `ootle_template!` macro usage, and feature flag docs
- Add module-level docs for provider, wallet, key_provider, transaction, stealth, and builtin_templates
- Add doc comments to all key public types and traits (Provider, WalletProvider, ProviderBuilder, OotleWallet, TransactionRequest, IAccount, IFaucet, StealthTransfer, etc.)
- Add examples/README.md summarizing each runnable example
- Fix broken rustdoc intra-doc links

## Test plan

- [x] `cargo doc -p ootle-rs --no-deps` compiles with zero warnings
- [x] `cargo check -p ootle-rs` passes