### PR TITLE
fix(cucumber): fix indexer substate lookup in wallet daemon indexer test

### DIFF
--- a/integration_tests/src/base_node.rs
+++ b/integration_tests/src/base_node.rs
@@ -24,7 +24,7 @@ use std::{path::PathBuf, str::FromStr, sync::Arc};
 
 use minotari_node::{BaseNodeConfig, GrpcMethod, run_base_node};
 use rand::rngs::OsRng;
-use tari_base_node_client::grpc::GrpcBaseNodeClient;
+use tari_base_node_client::{BaseNodeClient, grpc::GrpcBaseNodeClient};
 use tari_common::{configuration::CommonConfig, exit_codes::ExitError};
 use tari_common_sqlite::connection::DbConnectionUrl;
 use tari_comms::{NodeIdentity, multiaddr::Multiaddr, peer_manager::PeerFeatures};
@@ -153,8 +153,31 @@ pub async fn spawn_base_node(world: &mut TariWorld, bn_name: String) {
         }
     });
 
-    // Wait for node to start up
+    // Wait for node to start up (TCP port open)
     let handle = wait_listener_on_local_port(handle, grpc_port).await;
+
+    // Wait for gRPC service to be fully ready (not just the readiness server)
+    let mut grpc_client = get_base_node_client(grpc_port);
+    let mut grpc_remaining = 30;
+    loop {
+        match grpc_client.get_tip_info().await {
+            Ok(_) => break,
+            Err(e) => {
+                if handle.is_finished() {
+                    panic!("Base node {} exited while waiting for gRPC readiness", bn_name);
+                }
+                grpc_remaining -= 1;
+                if grpc_remaining == 0 {
+                    panic!(
+                        "Base node {} gRPC service did not become ready within 30s: {}",
+                        bn_name, e
+                    );
+                }
+                tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+            },
+        }
+    }
+
     // make the new base node able to be referenced by other processes
     let node_process = BaseNodeProcess {
         name: bn_name.clone(),

--- a/integration_tests/src/base_node.rs
+++ b/integration_tests/src/base_node.rs
@@ -57,6 +57,7 @@ impl BaseNodeProcess {
     }
 }
 
+#[expect(clippy::too_many_lines)]
 pub async fn spawn_base_node(world: &mut TariWorld, bn_name: String) {
     // each spawned base node will use different ports
     let (port, grpc_port) = get_os_assigned_ports();

--- a/integration_tests/src/indexer.rs
+++ b/integration_tests/src/indexer.rs
@@ -78,16 +78,20 @@ impl IndexerProcess {
             .unwrap();
     }
 
-    pub async fn get_substate(&self, world: &TariWorld, output_ref: String, version: u32) -> GetSubstateResponse {
+    pub async fn get_substate(
+        &self,
+        world: &TariWorld,
+        output_ref: String,
+        version: u32,
+    ) -> Result<GetSubstateResponse, tari_indexer_client::error::IndexerRestClientError> {
         let address = get_address_from_output(world, output_ref);
         let client = self.get_indexer_client();
         client
             .get_substate(address, GetSubstateRequest {
                 version: Some(version),
-                local_search_only: true,
+                local_search_only: false,
             })
             .await
-            .unwrap()
     }
 
     pub async fn get_non_fungibles(

--- a/integration_tests/tests/features/indexer.feature
+++ b/integration_tests/tests/features/indexer.feature
@@ -160,7 +160,6 @@ Feature: Indexer node
     Then the indexer INDEXER has at least 3 templates in the catalogue
 
     # Pagination: one entry per page
-    Then the indexer INDEXER catalogue with limit 1 offset 0 returns 1 entries
-    Then the indexer INDEXER catalogue with limit 1 offset 1 returns 1 entries
+    Then the indexer INDEXER catalogue with limit 1 returns 1 entries
     # All entries in one page
-    Then the indexer INDEXER catalogue with limit 100 offset 0 returns at least 3 entries
+    Then the indexer INDEXER catalogue with limit 100 returns at least 3 entries

--- a/integration_tests/tests/steps/indexer.rs
+++ b/integration_tests/tests/steps/indexer.rs
@@ -184,12 +184,34 @@ async fn assert_indexer_substate_version(
 ) {
     let indexer = world.indexers.get(&indexer_name).unwrap();
     assert!(!indexer.handle.is_finished(), "Indexer {} is not running", indexer_name);
-    let substate = indexer.get_substate(world, output_ref, version).await;
-    eprintln!(
-        "indexer.get_substate result: {}",
-        serde_json::to_string_pretty(&substate).unwrap()
-    );
-    assert_eq!(substate.version, version);
+
+    let mut remaining_attempts = 10;
+    loop {
+        match indexer.get_substate(world, output_ref.clone(), version).await {
+            Ok(substate) => {
+                eprintln!(
+                    "indexer.get_substate result: {}",
+                    serde_json::to_string_pretty(&substate).unwrap()
+                );
+                assert_eq!(substate.version, version);
+                return;
+            },
+            Err(e) => {
+                if remaining_attempts == 0 {
+                    panic!(
+                        "Indexer {} did not return version {} for substate {} in time. Last error: {}",
+                        indexer_name, version, output_ref, e
+                    );
+                }
+                remaining_attempts -= 1;
+                eprintln!(
+                    "Waiting for indexer {} to sync substate {} (version {}), {} attempts remaining. Error: {}",
+                    indexer_name, output_ref, version, remaining_attempts, e
+                );
+                tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+            },
+        }
+    }
 }
 
 #[then(expr = "the indexer {word} returns {int} non fungibles for resource {word}")]


### PR DESCRIPTION
Description
---
- Wait for gRPC service readiness (not just TCP port) when spawning a base node, preventing race conditions where the gRPC endpoint is not yet serving (I'm not sure what changed compared to https://github.com/tari-project/tari-ootle/pull/1983, but when I started working on this PR, scenarios were consistently failing due to base node gRPC unavailability);
- Add retry polling to the indexer substate version assertion step to handle cases where the indexer has not yet synced the substate at query time;
- Change `get_substate` to return `Result` so callers can handle errors gracefully instead of panicking;
- Set `local_search_only: false` in indexer substate queries to allow network-wide lookups (required for tests to pass, otherwise would need a retry wrapper to handle cache misses with `local_search_only: true`);
- Fix indexer catalogue pagination test steps after the switch to cursor-based catalogue pagination;

Motivation and Context
---
Fixes #1976

How Has This Been Tested?
---
Locally with `cargo test --test cucumber -- --tags=@indexer`. Also attaching a file with 10 test runs:
[indexer_test_results_2.txt](https://github.com/user-attachments/files/26614340/indexer_test_results_2.txt). Still attaching as .txt this time 🫠

What process can a PR reviewer use to test or verify this change?
---
Run `cargo test --test cucumber -- --tags=@indexer`

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify
