### PR TITLE
fix(tests): retry indexer substate lookup until available

### DIFF
--- a/integration_tests/src/indexer.rs
+++ b/integration_tests/src/indexer.rs
@@ -31,6 +31,7 @@ use tari_indexer::{
     run_indexer,
 };
 use tari_indexer_client::{
+    error::IndexerRestClientError,
     graphql_client::IndexerGraphQLClient,
     rest_api_client::IndexerRestApiClient,
     types::{
@@ -88,6 +89,22 @@ impl IndexerProcess {
             })
             .await
             .unwrap()
+    }
+
+    pub async fn try_get_substate(
+        &self,
+        world: &TariWorld,
+        output_ref: &str,
+        version: u32,
+    ) -> Result<GetSubstateResponse, IndexerRestClientError> {
+        let address = get_address_from_output(world, output_ref.to_string());
+        let client = self.get_indexer_client();
+        client
+            .get_substate(address, GetSubstateRequest {
+                version: Some(version),
+                local_search_only: true,
+            })
+            .await
     }
 
     pub async fn get_non_fungibles(

--- a/integration_tests/tests/steps/indexer.rs
+++ b/integration_tests/tests/steps/indexer.rs
@@ -184,12 +184,30 @@ async fn assert_indexer_substate_version(
 ) {
     let indexer = world.indexers.get(&indexer_name).unwrap();
     assert!(!indexer.handle.is_finished(), "Indexer {} is not running", indexer_name);
-    let substate = indexer.get_substate(world, output_ref, version).await;
-    eprintln!(
-        "indexer.get_substate result: {}",
-        serde_json::to_string_pretty(&substate).unwrap()
-    );
-    assert_eq!(substate.version, version);
+
+    let mut remaining = 30;
+    loop {
+        match indexer.try_get_substate(world, &output_ref, version).await {
+            Ok(substate) => {
+                eprintln!(
+                    "indexer.get_substate result: {}",
+                    serde_json::to_string_pretty(&substate).unwrap()
+                );
+                assert_eq!(substate.version, version);
+                return;
+            },
+            Err(e) => {
+                if remaining == 0 {
+                    panic!(
+                        "Indexer {} failed to return substate {} version {} after retries: {}",
+                        indexer_name, output_ref, version, e
+                    );
+                }
+                remaining -= 1;
+                tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+            },
+        }
+    }
 }
 
 #[then(expr = "the indexer {word} returns {int} non fungibles for resource {word}")]


### PR DESCRIPTION
## Summary
- The indexer substate lookup step called \`get_substate\` with \`local_search_only: true\` exactly once, so it failed immediately if the indexer hadn't cached the substate yet
- Added \`try_get_substate\` helper on \`IndexerProcess\` returning \`Result<GetSubstateResponse, IndexerRestClientError>\`
- Wrapped the cucumber step in a 30-second retry loop matching the existing codebase pattern

Closes #1976

## Test plan
- [ ] Run the indexer cucumber test and verify it no longer fails intermittently on substate lookup
- [ ] On a real failure, confirm the panic message still contains the output ref, version, and error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- bounty-payout-section:start -->
---

## Bounty payout

If this PR is accepted as a bounty submission, please direct funds to the following Tari wallet address:

**`123JbAxCZ4Vrh4jCjFLXTu4z8sLeggUR87fejwNunsB55NMBSH9RpkjNiw1WL2GkKr8JhqRZhbrsSREchGanchw2Nhb`**
<!-- bounty-payout-section:end -->
