### PR TITLE
fix(tests): use correct topic names for account pay_fee events

### DIFF
--- a/integration_tests/tests/features/indexer.feature
+++ b/integration_tests/tests/features/indexer.feature
@@ -54,7 +54,7 @@ Feature: Indexer node
     Then I wait for the indexer INDEXER to sync with the network
 
     # Scan the network for the event emitted on ACC creation
-    When indexer INDEXER scans the network events for account ACC with topics std.component.created,std.vault.pay_fee,std.component.updated
+    When indexer INDEXER scans the network events for account ACC with topics std.component.created,Account.pay_fee,std.component.updated
 
   Scenario: Indexer GraphQL requests work
     # Initialize a base node, wallet, miner and VN
@@ -75,10 +75,10 @@ Feature: Indexer node
     Then I wait for the indexer INDEXER to sync with the network
     ##### Scenario
     # Scan the network for the event emitted on ACC_1 creation
-    When indexer INDEXER scans the network events for account ACC_1 with topics std.component.created,std.vault.pay_fee
+    When indexer INDEXER scans the network events for account ACC_1 with topics std.component.created,Account.pay_fee
 
     # Scan the network for the event emitted on ACC_2 creation
-    When indexer INDEXER scans the network events for account ACC_2 with topics std.component.created,std.vault.pay_fee
+    When indexer INDEXER scans the network events for account ACC_2 with topics std.component.created,Account.pay_fee
 
   Scenario: Indexer GraphQL filtering and pagination of events
     Given a network with registered validator VN and wallet daemon WALLET_D

--- a/integration_tests/tests/steps/indexer.rs
+++ b/integration_tests/tests/steps/indexer.rs
@@ -109,30 +109,46 @@ async fn indexer_scans_network_events(
     let account = world.wallet_accounts.get(&account_name).unwrap_or_else(|| {
         panic!("No wallet account found with name {}", account_name);
     });
-    let mut graphql_client = indexer.get_graphql_indexer_client().await;
-    let query = r#"{ getEvents { substateId, templateAddress, txHash, topic, payload } }"#.to_string();
-    let res = graphql_client
-        .send_request::<HashMap<String, Vec<tari_indexer::graphql::model::events::Event>>>(&query, None, None)
-        .await
-        .expect("Failed to obtain getEvents query result");
+    let component_address = account.component_address().to_string();
+    let expected_topics: Vec<&str> = topics_str.split(',').collect();
 
-    let events = res.get("getEvents").unwrap();
-    let topics_for_component = events
-        .iter()
-        .filter(|e| e.substate_id == Some(account.component_address().to_string()))
-        .map(|e| e.topic.as_str())
-        .collect::<HashSet<_>>();
+    let mut remaining = 30;
+    loop {
+        let mut graphql_client = indexer.get_graphql_indexer_client().await;
+        let query = r#"{ getEvents { substateId, templateAddress, txHash, topic, payload } }"#.to_string();
+        let res = graphql_client
+            .send_request::<HashMap<String, Vec<tari_indexer::graphql::model::events::Event>>>(&query, None, None)
+            .await
+            .expect("Failed to obtain getEvents query result");
 
-    let expected_topics = topics_str.split(',');
-    for (ind, topic) in expected_topics.enumerate() {
-        assert!(
-            topics_for_component.contains(topic),
-            "Unexpected topic at index {}. Events emitted were {}. Expected topic {} (ALL {:?})",
-            ind,
-            topics_for_component.display(),
-            topic,
-            events
-        );
+        let events = res.get("getEvents").unwrap();
+        let topics_for_component = events
+            .iter()
+            .filter(|e| e.substate_id == Some(component_address.clone()))
+            .map(|e| e.topic.as_str())
+            .collect::<HashSet<_>>();
+
+        let all_found = expected_topics.iter().all(|topic| topics_for_component.contains(topic));
+        if all_found {
+            return;
+        }
+
+        if remaining == 0 {
+            // Report which topics were missing
+            for (ind, topic) in expected_topics.iter().enumerate() {
+                assert!(
+                    topics_for_component.contains(topic),
+                    "Unexpected topic at index {}. Events emitted were {}. Expected topic {} (ALL {:?})",
+                    ind,
+                    topics_for_component.display(),
+                    topic,
+                    events
+                );
+            }
+            unreachable!();
+        }
+        remaining -= 1;
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
     }
 }
 


### PR DESCRIPTION
## Description

Fixes #1975.

The feature file `integration_tests/tests/features/indexer.feature` was asserting that the indexer saw `std.vault.pay_fee` topics for the account component. The step definition `indexer_scans_network_events` filters events by `substate_id == component_address`, but the runtime emits `std.vault.pay_fee` with `substate_id = vault_id` (see `crates/engine/src/runtime/impl.rs:1784-1790`). The filter therefore can never match, and the assertion fails every run.

The `Account.pay_fee` custom event (emitted via `emit_event` in `crates/template_builtin/templates/account/src/lib.rs:178`) is recorded with the account component's substate id (see the custom `emit_event` path in `crates/engine/src/runtime/impl.rs:466`) and does match the filter.

## Fix

1. Revert the topic names in the three affected scenarios from `std.vault.pay_fee` back to `Account.pay_fee`.
2. Keep the 30-second retry loop added in an earlier commit on this branch as defence-in-depth against indexer catch-up timing.

## Why the previous attempt on this branch was insufficient

The first commit on this branch (`fix(tests): retry event topic assertion until indexer has scanned`) wrapped the assertion in a retry. That masks indexer timing flakiness but does not address the root cause: with the filter looking for component-scoped events and the expected topics being vault-scoped, the retry simply sleeps until the timeout. The topic-name revert is the actual fix.

## Verification

- Traced the event emission paths in `crates/engine/src/runtime/impl.rs` for both `emit_std_event` (line 256) and custom `emit_event` (line 466).
- Confirmed `Account.pay_fee` is still emitted by the account template (unchanged).
- `cargo check -p tari_ootle_wallet_storage_sqlite` and `-p tari_ootle_walletd` both clean (touching unrelated crates just to spot-check).