### PR TITLE
Add per-IP rate limiting to indexer REST API endpoints

### DIFF
--- a/applications/tari_indexer/config_rate_limits_example.toml
+++ b/applications/tari_indexer/config_rate_limits_example.toml
@@ -1,0 +1,35 @@
+# Example configuration for Tari Indexer Rate Limiting
+# Add these settings to your indexer configuration file
+
+[indexer.rate_limits]
+# Rate limit for POST /transactions (requests per minute per IP)
+# Default: 20
+submit_transaction = 20
+
+# Rate limit for POST /transactions/dry-run (requests per minute per IP)
+# Default: 10
+# Note: This endpoint also has a legacy global rate limit of 10 req/5sec
+dry_run_transaction = 10
+
+# Rate limit for POST /substates/fetch (requests per minute per IP)
+# Default: 30
+fetch_substates = 30
+
+# Rate limit for POST /utxos/fetch (requests per minute per IP)
+# Default: 15
+fetch_utxos = 15
+
+# Rate limit for GET /non-fungibles (requests per minute per IP)
+# Default: 30
+get_non_fungibles = 30
+
+# Rate limit for GET /transactions/recent (requests per minute per IP)
+# Default: 30
+list_recent_transactions = 30
+
+# Maximum concurrent SSE connections per IP address
+# Default: 3
+# Applies to:
+#   - GET /events
+#   - GET /transactions/events/stream
+max_sse_connections_per_ip = 3

--- a/applications/tari_indexer/src/bootstrap.rs
+++ b/applications/tari_indexer/src/bootstrap.rs
@@ -252,6 +252,7 @@ pub async fn spawn_services(
     // changed by comms during initialization when using tor.
     save_identities(config, &keypair)?;
     Ok(Services {
+        config: config.clone(),
         network: config.network,
         keypair,
         networking,
@@ -269,6 +270,7 @@ pub async fn spawn_services(
 }
 
 pub struct Services {
+    pub config: ApplicationConfig,
     pub network: Network,
     pub keypair: RistrettoKeypair,
     pub networking: NetworkingHandle<TariMessagingSpec>,

--- a/applications/tari_indexer/src/config.rs
+++ b/applications/tari_indexer/src/config.rs
@@ -121,6 +121,42 @@ pub struct IndexerConfig {
     pub burnt_utxo_sidechain_id: Option<RistrettoPublicKey>,
     /// The event filtering configuration
     pub event_filters: Vec<EventFilter>,
+    /// Rate limiting configuration
+    #[serde(default)]
+    pub rate_limits: RateLimitConfig,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct RateLimitConfig {
+    /// Rate limit for POST /transactions (requests per minute per IP)
+    pub submit_transaction: u32,
+    /// Rate limit for POST /transactions/dry-run (requests per minute per IP)
+    pub dry_run_transaction: u32,
+    /// Rate limit for POST /substates/fetch (requests per minute per IP)
+    pub fetch_substates: u32,
+    /// Rate limit for POST /utxos/fetch (requests per minute per IP)
+    pub fetch_utxos: u32,
+    /// Rate limit for GET /non-fungibles (requests per minute per IP)
+    pub get_non_fungibles: u32,
+    /// Rate limit for GET /transactions/recent (requests per minute per IP)
+    pub list_recent_transactions: u32,
+    /// Maximum concurrent SSE connections per IP
+    pub max_sse_connections_per_ip: usize,
+}
+
+impl Default for RateLimitConfig {
+    fn default() -> Self {
+        Self {
+            submit_transaction: 20,
+            dry_run_transaction: 10,
+            fetch_substates: 30,
+            fetch_utxos: 15,
+            get_non_fungibles: 30,
+            list_recent_transactions: 30,
+            max_sse_connections_per_ip: 3,
+        }
+    }
 }
 
 impl Default for IndexerConfig {
@@ -141,6 +177,7 @@ impl Default for IndexerConfig {
             templates_sidechain_id: None,
             burnt_utxo_sidechain_id: None,
             event_filters: vec![],
+            rate_limits: RateLimitConfig::default(),
         }
     }
 }

--- a/applications/tari_indexer/src/rest_api/context.rs
+++ b/applications/tari_indexer/src/rest_api/context.rs
@@ -23,7 +23,7 @@ use crate::{
     bootstrap::Services,
     dry_run::processor::DryRunTransactionProcessor,
     notify::Subscriber,
-    rest_api::cache::HttpCacheConfig,
+    rest_api::{cache::HttpCacheConfig, rate_limit::{IpRateLimiter, SseConnectionLimiter}},
     storage_sqlite::SqliteIndexerStore,
     store::ReadOnlyStore,
     substate_manager::SubstateManager,
@@ -34,10 +34,18 @@ use crate::{
 #[derive(Clone)]
 pub struct HandlerContext {
     inner: Arc<InnerContext>,
+    pub submit_transaction_limiter: IpRateLimiter,
+    pub dry_run_limiter: IpRateLimiter,
+    pub fetch_substates_limiter: IpRateLimiter,
+    pub fetch_utxos_limiter: IpRateLimiter,
+    pub get_non_fungibles_limiter: IpRateLimiter,
+    pub list_recent_transactions_limiter: IpRateLimiter,
+    pub sse_connection_limiter: SseConnectionLimiter,
 }
 
 impl HandlerContext {
     pub fn from_services(services: &Services) -> Self {
+        let rate_limits = &services.config.indexer.rate_limits;
         Self {
             inner: Arc::new(InnerContext {
                 cache_control_enabled: true,
@@ -54,6 +62,13 @@ impl HandlerContext {
                 subscriber: services.event_notifier.to_subscriber(),
                 transaction_event_subscriber: services.transaction_event_notifier.to_subscriber(),
             }),
+            submit_transaction_limiter: IpRateLimiter::new(rate_limits.submit_transaction),
+            dry_run_limiter: IpRateLimiter::new(rate_limits.dry_run_transaction),
+            fetch_substates_limiter: IpRateLimiter::new(rate_limits.fetch_substates),
+            fetch_utxos_limiter: IpRateLimiter::new(rate_limits.fetch_utxos),
+            get_non_fungibles_limiter: IpRateLimiter::new(rate_limits.get_non_fungibles),
+            list_recent_transactions_limiter: IpRateLimiter::new(rate_limits.list_recent_transactions),
+            sse_connection_limiter: SseConnectionLimiter::new(rate_limits.max_sse_connections_per_ip),
         }
     }
 

--- a/applications/tari_indexer/src/rest_api/handlers/indexer_events.rs
+++ b/applications/tari_indexer/src/rest_api/handlers/indexer_events.rs
@@ -28,11 +28,17 @@ pub async fn sse_events(
         Ok(guard) => guard,
         Err(()) => {
             warn!(target: LOG_TARGET, "SSE connection limit exceeded for IP: {}", addr.ip());
-            return (
+            let mut response = (
                 StatusCode::TOO_MANY_REQUESTS,
                 "Too many concurrent SSE connections from this IP",
             )
                 .into_response();
+            // Add Retry-After header suggesting to retry in 60 seconds
+            response.headers_mut().insert(
+                axum::http::header::RETRY_AFTER,
+                axum::http::HeaderValue::from_static("60"),
+            );
+            return response;
         },
     };
 

--- a/applications/tari_indexer/src/rest_api/handlers/indexer_events.rs
+++ b/applications/tari_indexer/src/rest_api/handlers/indexer_events.rs
@@ -1,30 +1,51 @@
 //   Copyright 2025 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
+use std::net::SocketAddr;
+
 use axum::{
     Extension,
-    response::{Sse, sse},
+    extract::ConnectInfo,
+    http::StatusCode,
+    response::{IntoResponse, Response, Sse, sse},
 };
 use futures::Stream;
-use log::info;
+use log::*;
 use tari_indexer_client::event::IndexerEvent;
 use tokio_stream::StreamExt;
 
-use crate::rest_api::{context::HandlerContext, handlers::HandlerResult};
+use crate::rest_api::context::HandlerContext;
 
 const LOG_TARGET: &str = "tari::indexer::rest_api::handlers::events";
 
 #[utoipa::path(get, path = "/events", description = "SSE events")]
 pub async fn sse_events(
+    ConnectInfo(addr): ConnectInfo<SocketAddr>,
     Extension(context): Extension<HandlerContext>,
-) -> HandlerResult<Sse<impl Stream<Item = Result<sse::Event, axum::Error>>>> {
+) -> Response {
+    // Check connection limit
+    let _guard = match context.sse_connection_limiter.try_acquire(addr.ip()) {
+        Ok(guard) => guard,
+        Err(()) => {
+            warn!(target: LOG_TARGET, "SSE connection limit exceeded for IP: {}", addr.ip());
+            return (
+                StatusCode::TOO_MANY_REQUESTS,
+                "Too many concurrent SSE connections from this IP",
+            )
+                .into_response();
+        },
+    };
+
     info!(target: LOG_TARGET, "Client connected to SSE event stream");
     let event_stream = tokio_stream::wrappers::BroadcastStream::new(context.subscribe_events())
         .take_while(|res| res.is_ok())
         .map(|res| res.expect("take_while should prevent errors here"))
-        .map(|event| encode_event(&event));
+        .map(move |event| {
+            let _ = &_guard; // Keep guard alive
+            encode_event(&event)
+        });
 
-    Ok(Sse::new(event_stream).keep_alive(sse::KeepAlive::new()))
+    Sse::new(event_stream).keep_alive(sse::KeepAlive::new()).into_response()
 }
 
 fn encode_event(event: &IndexerEvent) -> Result<sse::Event, axum::Error> {

--- a/applications/tari_indexer/src/rest_api/handlers/transaction_events.rs
+++ b/applications/tari_indexer/src/rest_api/handlers/transaction_events.rs
@@ -1,13 +1,13 @@
 //   Copyright 2026 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use std::{pin::Pin, sync::Arc};
+use std::{net::SocketAddr, pin::Pin, sync::Arc};
 
 use axum::{
     Extension,
-    extract::Query,
-    http::HeaderMap,
-    response::{Sse, sse},
+    extract::{ConnectInfo, Query},
+    http::{HeaderMap, StatusCode},
+    response::{IntoResponse, Response, Sse, sse},
 };
 use futures::Stream;
 use log::*;
@@ -41,10 +41,24 @@ const REPLAY_PAGE_SIZE: u32 = 500;
     )
 )]
 pub async fn sse_transaction_events(
+    ConnectInfo(addr): ConnectInfo<SocketAddr>,
     Extension(context): Extension<HandlerContext>,
     headers: HeaderMap,
     Query(req): Query<StreamTransactionEventsRequest>,
-) -> HandlerResult<Sse<impl Stream<Item = Result<sse::Event, axum::Error>>>> {
+) -> Response {
+    // Check connection limit
+    let _guard = match context.sse_connection_limiter.try_acquire(addr.ip()) {
+        Ok(guard) => guard,
+        Err(()) => {
+            warn!(target: LOG_TARGET, "SSE connection limit exceeded for IP: {}", addr.ip());
+            return (
+                StatusCode::TOO_MANY_REQUESTS,
+                "Too many concurrent SSE connections from this IP",
+            )
+                .into_response();
+        },
+    };
+
     // Resolve after_id: prefer Last-Event-ID header (SSE spec), fall back to query param
     let after_id = headers
         .get("Last-Event-ID")
@@ -74,12 +88,12 @@ pub async fn sse_transaction_events(
     let event_stream: SseStream = match after_id {
         Some(after_id) => {
             let store = context.read_only_store().clone();
-            Box::pin(replay_then_live_stream(store, broadcast_rx, filter, after_id))
+            Box::pin(replay_then_live_stream(store, broadcast_rx, filter, after_id, _guard))
         },
-        None => Box::pin(live_only_stream(broadcast_rx, filter)),
+        None => Box::pin(live_only_stream(broadcast_rx, filter, _guard)),
     };
 
-    Ok(Sse::new(event_stream).keep_alive(sse::KeepAlive::new()))
+    Sse::new(event_stream).keep_alive(sse::KeepAlive::new()).into_response()
 }
 
 /// Stream that only forwards live broadcast events (no replay).
@@ -87,15 +101,19 @@ pub async fn sse_transaction_events(
 fn live_only_stream(
     broadcast_rx: tokio::sync::broadcast::Receiver<TransactionEvent>,
     filter: EventFilter,
+    _guard: crate::rest_api::rate_limit::SseConnectionGuard,
 ) -> impl Stream<Item = Result<sse::Event, axum::Error>> {
-    tokio_stream::wrappers::BroadcastStream::new(broadcast_rx).filter_map(move |res| match res {
-        Ok(tx_event) if filter.matches(&tx_event.event) => Some(encode_transaction_event(&tx_event)),
-        Ok(_) => None,
-        // Lagged: events were dropped from the broadcast buffer, skip and continue
-        Err(tokio_stream::wrappers::errors::BroadcastStreamRecvError::Lagged(_)) => {
-            warn!(target: LOG_TARGET, "Live-only SSE client lagged, some events were dropped");
-            None
-        },
+    tokio_stream::wrappers::BroadcastStream::new(broadcast_rx).filter_map(move |res| {
+        let _ = &_guard; // Keep guard alive
+        match res {
+            Ok(tx_event) if filter.matches(&tx_event.event) => Some(encode_transaction_event(&tx_event)),
+            Ok(_) => None,
+            // Lagged: events were dropped from the broadcast buffer, skip and continue
+            Err(tokio_stream::wrappers::errors::BroadcastStreamRecvError::Lagged(_)) => {
+                warn!(target: LOG_TARGET, "Live-only SSE client lagged, some events were dropped");
+                None
+            },
+        }
     })
 }
 
@@ -106,15 +124,17 @@ fn replay_then_live_stream(
     broadcast_rx: tokio::sync::broadcast::Receiver<TransactionEvent>,
     filter: EventFilter,
     after_id: i64,
+    _guard: crate::rest_api::rate_limit::SseConnectionGuard,
 ) -> impl Stream<Item = Result<sse::Event, axum::Error>> {
     let (tx, rx) = tokio::sync::mpsc::channel::<Result<sse::Event, axum::Error>>(256);
 
     tokio::spawn(async move {
+        let _guard = _guard; // Move guard into task
         let result = run_replay_then_live(store, broadcast_rx, filter, after_id, &tx).await;
         if let Err(e) = result {
             warn!(target: LOG_TARGET, "SSE replay-then-live stream error: {}", e);
         }
-        // tx is dropped here, which closes the stream
+        // tx and _guard are dropped here, which closes the stream and releases the connection
     });
 
     tokio_stream::wrappers::ReceiverStream::new(rx)

--- a/applications/tari_indexer/src/rest_api/handlers/transaction_events.rs
+++ b/applications/tari_indexer/src/rest_api/handlers/transaction_events.rs
@@ -51,11 +51,17 @@ pub async fn sse_transaction_events(
         Ok(guard) => guard,
         Err(()) => {
             warn!(target: LOG_TARGET, "SSE connection limit exceeded for IP: {}", addr.ip());
-            return (
+            let mut response = (
                 StatusCode::TOO_MANY_REQUESTS,
                 "Too many concurrent SSE connections from this IP",
             )
                 .into_response();
+            // Add Retry-After header suggesting to retry in 60 seconds
+            response.headers_mut().insert(
+                axum::http::header::RETRY_AFTER,
+                axum::http::HeaderValue::from_static("60"),
+            );
+            return response;
         },
     };
 

--- a/applications/tari_indexer/src/rest_api/mod.rs
+++ b/applications/tari_indexer/src/rest_api/mod.rs
@@ -8,6 +8,7 @@ mod error;
 mod handlers;
 #[cfg(feature = "metrics")]
 mod metrics;
+mod rate_limit;
 mod server;
 mod streaming;
 

--- a/applications/tari_indexer/src/rest_api/rate_limit.rs
+++ b/applications/tari_indexer/src/rest_api/rate_limit.rs
@@ -55,10 +55,13 @@ impl TokenBucket {
     pub fn time_until_next_token(&self) -> Duration {
         if self.tokens >= 1.0 {
             Duration::from_secs(0)
-        } else {
+        } else if self.refill_rate > 0.0 {
             let tokens_needed = 1.0 - self.tokens;
             let seconds = tokens_needed / self.refill_rate;
             Duration::from_secs_f64(seconds.max(1.0))
+        } else {
+            // If refill_rate is 0, return a maximum fallback duration
+            Duration::from_secs(60)
         }
     }
 }

--- a/applications/tari_indexer/src/rest_api/rate_limit.rs
+++ b/applications/tari_indexer/src/rest_api/rate_limit.rs
@@ -1,0 +1,230 @@
+//   Copyright 2025 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+use std::{
+    collections::HashMap,
+    net::IpAddr,
+    sync::{Arc, Mutex},
+    time::{Duration, Instant},
+};
+
+use axum::{
+    body::Body,
+    extract::{ConnectInfo, Request},
+    http::{HeaderValue, StatusCode, header},
+    middleware::Next,
+    response::{IntoResponse, Response},
+};
+
+/// Token bucket rate limiter for per-IP rate limiting
+#[derive(Debug, Clone)]
+pub struct TokenBucket {
+    tokens: f64,
+    capacity: f64,
+    refill_rate: f64, // tokens per second
+    last_refill: Instant,
+}
+
+impl TokenBucket {
+    pub fn new(capacity: u32, refill_rate: f64) -> Self {
+        Self {
+            tokens: capacity as f64,
+            capacity: capacity as f64,
+            refill_rate,
+            last_refill: Instant::now(),
+        }
+    }
+
+    pub fn try_consume(&mut self) -> bool {
+        self.refill();
+        if self.tokens >= 1.0 {
+            self.tokens -= 1.0;
+            true
+        } else {
+            false
+        }
+    }
+
+    fn refill(&mut self) {
+        let now = Instant::now();
+        let elapsed = now.duration_since(self.last_refill).as_secs_f64();
+        self.tokens = (self.tokens + elapsed * self.refill_rate).min(self.capacity);
+        self.last_refill = now;
+    }
+
+    pub fn time_until_next_token(&self) -> Duration {
+        if self.tokens >= 1.0 {
+            Duration::from_secs(0)
+        } else {
+            let tokens_needed = 1.0 - self.tokens;
+            let seconds = tokens_needed / self.refill_rate;
+            Duration::from_secs_f64(seconds.max(1.0))
+        }
+    }
+}
+
+/// Per-IP rate limiter using token bucket algorithm
+#[derive(Clone)]
+pub struct IpRateLimiter {
+    buckets: Arc<Mutex<HashMap<IpAddr, TokenBucket>>>,
+    capacity: u32,
+    refill_rate: f64,
+}
+
+impl IpRateLimiter {
+    pub fn new(requests_per_minute: u32) -> Self {
+        let capacity = requests_per_minute;
+        let refill_rate = requests_per_minute as f64 / 60.0; // tokens per second
+        Self {
+            buckets: Arc::new(Mutex::new(HashMap::new())),
+            capacity,
+            refill_rate,
+        }
+    }
+
+    pub fn check_rate_limit(&self, ip: IpAddr) -> Result<(), Duration> {
+        let mut buckets = self.buckets.lock().unwrap();
+        let bucket = buckets
+            .entry(ip)
+            .or_insert_with(|| TokenBucket::new(self.capacity, self.refill_rate));
+
+        if bucket.try_consume() {
+            Ok(())
+        } else {
+            Err(bucket.time_until_next_token())
+        }
+    }
+
+    /// Cleanup old entries periodically to prevent memory leaks
+    pub fn cleanup_old_entries(&self) {
+        let mut buckets = self.buckets.lock().unwrap();
+        buckets.retain(|_, bucket| {
+            let elapsed = Instant::now().duration_since(bucket.last_refill);
+            elapsed < Duration::from_secs(300) // Keep entries active in last 5 minutes
+        });
+    }
+}
+
+/// Middleware for per-IP rate limiting
+pub async fn rate_limit_middleware(
+    ConnectInfo(addr): ConnectInfo<std::net::SocketAddr>,
+    request: Request,
+    next: Next,
+) -> Response {
+    let limiter = request
+        .extensions()
+        .get::<IpRateLimiter>()
+        .expect("IpRateLimiter not found in request extensions");
+
+    match limiter.check_rate_limit(addr.ip()) {
+        Ok(()) => next.run(request).await,
+        Err(retry_after) => {
+            let mut response = Response::new(Body::from("Too Many Requests"));
+            *response.status_mut() = StatusCode::TOO_MANY_REQUESTS;
+            response.headers_mut().insert(
+                header::RETRY_AFTER,
+                HeaderValue::from_str(&retry_after.as_secs().to_string()).unwrap(),
+            );
+            response
+        },
+    }
+}
+
+/// Connection counter for SSE streams
+#[derive(Clone)]
+pub struct SseConnectionLimiter {
+    connections: Arc<Mutex<HashMap<IpAddr, usize>>>,
+    max_connections_per_ip: usize,
+}
+
+impl SseConnectionLimiter {
+    pub fn new(max_connections_per_ip: usize) -> Self {
+        Self {
+            connections: Arc::new(Mutex::new(HashMap::new())),
+            max_connections_per_ip,
+        }
+    }
+
+    pub fn try_acquire(&self, ip: IpAddr) -> Result<SseConnectionGuard, ()> {
+        let mut connections = self.connections.lock().unwrap();
+        let count = connections.entry(ip).or_insert(0);
+
+        if *count >= self.max_connections_per_ip {
+            return Err(());
+        }
+
+        *count += 1;
+        Ok(SseConnectionGuard {
+            limiter: self.clone(),
+            ip,
+        })
+    }
+
+    fn release(&self, ip: IpAddr) {
+        let mut connections = self.connections.lock().unwrap();
+        if let Some(count) = connections.get_mut(&ip) {
+            *count = count.saturating_sub(1);
+            if *count == 0 {
+                connections.remove(&ip);
+            }
+        }
+    }
+}
+
+/// RAII guard for SSE connections
+pub struct SseConnectionGuard {
+    limiter: SseConnectionLimiter,
+    ip: IpAddr,
+}
+
+impl Drop for SseConnectionGuard {
+    fn drop(&mut self) {
+        self.limiter.release(self.ip);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_token_bucket_basic() {
+        let mut bucket = TokenBucket::new(10, 1.0);
+        assert!(bucket.try_consume());
+        assert_eq!(bucket.tokens as u32, 9);
+    }
+
+    #[test]
+    fn test_token_bucket_exhaustion() {
+        let mut bucket = TokenBucket::new(2, 1.0);
+        assert!(bucket.try_consume());
+        assert!(bucket.try_consume());
+        assert!(!bucket.try_consume()); // Should fail
+    }
+
+    #[test]
+    fn test_ip_rate_limiter() {
+        let limiter = IpRateLimiter::new(60); // 60 req/min
+        let ip: IpAddr = "127.0.0.1".parse().unwrap();
+
+        // Should succeed
+        assert!(limiter.check_rate_limit(ip).is_ok());
+    }
+
+    #[test]
+    fn test_sse_connection_limiter() {
+        let limiter = SseConnectionLimiter::new(3);
+        let ip: IpAddr = "127.0.0.1".parse().unwrap();
+
+        let _guard1 = limiter.try_acquire(ip).unwrap();
+        let _guard2 = limiter.try_acquire(ip).unwrap();
+        let _guard3 = limiter.try_acquire(ip).unwrap();
+
+        // Fourth connection should fail
+        assert!(limiter.try_acquire(ip).is_err());
+
+        // After dropping a guard, should succeed again
+        drop(_guard1);
+        assert!(limiter.try_acquire(ip).is_ok());
+    }
+}

--- a/applications/tari_indexer/src/rest_api/server.rs
+++ b/applications/tari_indexer/src/rest_api/server.rs
@@ -6,6 +6,11 @@ use std::{net::SocketAddr, time::Duration};
 use axum::{
     Extension,
     Router,
+    body::Body,
+    extract::{ConnectInfo, Request},
+    http::{HeaderValue, StatusCode, header},
+    middleware::{self, Next},
+    response::Response,
     routing::{get, post},
 };
 use log::*;
@@ -20,13 +25,36 @@ use utoipa_swagger_ui::SwaggerUi;
 use crate::rest_api::metrics;
 use crate::{
     bootstrap::Services,
-    rest_api::{context::HandlerContext, handlers},
+    rest_api::{context::HandlerContext, handlers, rate_limit::IpRateLimiter},
 };
 
 const LOG_TARGET: &str = "tari::ootle::indexer::rest_api::server";
 
 // Limit the body size to 4MB to allow for large transactions (wasm uploads)
 const REQUEST_BODY_LIMIT: usize = 4 * 1024 * 1024; // 4 MB
+
+/// Middleware for per-IP rate limiting
+async fn rate_limit_middleware(
+    limiter: IpRateLimiter,
+) -> impl Fn(ConnectInfo<SocketAddr>, Request, Next) -> std::pin::Pin<Box<dyn std::future::Future<Output = Response> + Send>> + Clone {
+    move |ConnectInfo(addr): ConnectInfo<SocketAddr>, request: Request, next: Next| {
+        let limiter = limiter.clone();
+        Box::pin(async move {
+            match limiter.check_rate_limit(addr.ip()) {
+                Ok(()) => next.run(request).await,
+                Err(retry_after) => {
+                    let mut response = Response::new(Body::from("Too Many Requests"));
+                    *response.status_mut() = StatusCode::TOO_MANY_REQUESTS;
+                    response.headers_mut().insert(
+                        header::RETRY_AFTER,
+                        HeaderValue::from_str(&retry_after.as_secs().to_string()).unwrap(),
+                    );
+                    response
+                },
+            }
+        })
+    }
+}
 
 #[derive(OpenApi)]
 #[openapi(paths(
@@ -93,11 +121,19 @@ impl Server {
             .route("/network/stats", get(handlers::network::get_network_sync_stats))
             .route("/network/connections", get(handlers::network::get_connections))
             .nest("/substates", Router::new()
-                .route("/fetch", post(handlers::substates::fetch_substates))
+                .route("/fetch", post(handlers::substates::fetch_substates)
+                    .layer(middleware::from_fn({
+                        let limiter = context.fetch_substates_limiter.clone();
+                        move |addr, req, next| rate_limit_middleware(limiter.clone())(addr, req, next)
+                    })))
                 .route("/{substate_id}", get(handlers::substates::get_substate))
             )
             .nest("/transactions", Router::new()
-                .route("/", post(handlers::transactions::submit_transaction))
+                .route("/", post(handlers::transactions::submit_transaction)
+                    .layer(middleware::from_fn({
+                        let limiter = context.submit_transaction_limiter.clone();
+                        move |addr, req, next| rate_limit_middleware(limiter.clone())(addr, req, next)
+                    })))
                 .route("/dry-run", post(handlers::transactions::submit_transaction_dry_run)
                     .layer(ServiceBuilder::new()
                         .layer(axum::error_handling::HandleErrorLayer::new(|err: axum::BoxError| async move {
@@ -108,10 +144,18 @@ impl Server {
                         }))
                         .layer(BufferLayer::new(1024))
                         .layer(RateLimitLayer::new(10, Duration::from_secs(5)))
-                    ))
+                    )
+                    .layer(middleware::from_fn({
+                        let limiter = context.dry_run_limiter.clone();
+                        move |addr, req, next| rate_limit_middleware(limiter.clone())(addr, req, next)
+                    })))
                 .route(
                     "/recent",
-                    get(handlers::transactions::list_recent_transactions),
+                    get(handlers::transactions::list_recent_transactions)
+                        .layer(middleware::from_fn({
+                            let limiter = context.list_recent_transactions_limiter.clone();
+                            move |addr, req, next| rate_limit_middleware(limiter.clone())(addr, req, next)
+                        })),
                 )
                 .route(
                     "/{transaction_id}/result",
@@ -132,10 +176,18 @@ impl Server {
                     get(handlers::templates::get_template_definition),
                 )
             )
-            .route("/non-fungibles", get(handlers::nfts::get_non_fungibles)) // Placeholder for future non-fungible endpoints
+            .route("/non-fungibles", get(handlers::nfts::get_non_fungibles)
+                .layer(middleware::from_fn({
+                    let limiter = context.get_non_fungibles_limiter.clone();
+                    move |addr, req, next| rate_limit_middleware(limiter.clone())(addr, req, next)
+                })))
             .nest("/utxos", Router::new()
                 .route("/", get(handlers::utxos::list_utxos))
-                .route("/fetch", post(handlers::utxos::fetch_utxos))
+                .route("/fetch", post(handlers::utxos::fetch_utxos)
+                    .layer(middleware::from_fn({
+                        let limiter = context.fetch_utxos_limiter.clone();
+                        move |addr, req, next| rate_limit_middleware(limiter.clone())(addr, req, next)
+                    })))
                 .route("/stream", post(handlers::utxos::stream_utxo_updates))
             )
             .nest(

--- a/applications/tari_indexer/src/rest_api/server.rs
+++ b/applications/tari_indexer/src/rest_api/server.rs
@@ -33,29 +33,6 @@ const LOG_TARGET: &str = "tari::ootle::indexer::rest_api::server";
 // Limit the body size to 4MB to allow for large transactions (wasm uploads)
 const REQUEST_BODY_LIMIT: usize = 4 * 1024 * 1024; // 4 MB
 
-/// Middleware for per-IP rate limiting
-async fn rate_limit_middleware(
-    limiter: IpRateLimiter,
-) -> impl Fn(ConnectInfo<SocketAddr>, Request, Next) -> std::pin::Pin<Box<dyn std::future::Future<Output = Response> + Send>> + Clone {
-    move |ConnectInfo(addr): ConnectInfo<SocketAddr>, request: Request, next: Next| {
-        let limiter = limiter.clone();
-        Box::pin(async move {
-            match limiter.check_rate_limit(addr.ip()) {
-                Ok(()) => next.run(request).await,
-                Err(retry_after) => {
-                    let mut response = Response::new(Body::from("Too Many Requests"));
-                    *response.status_mut() = StatusCode::TOO_MANY_REQUESTS;
-                    response.headers_mut().insert(
-                        header::RETRY_AFTER,
-                        HeaderValue::from_str(&retry_after.as_secs().to_string()).unwrap(),
-                    );
-                    response
-                },
-            }
-        })
-    }
-}
-
 #[derive(OpenApi)]
 #[openapi(paths(
     handlers::misc::get_identity,
@@ -111,6 +88,133 @@ impl Server {
     ) -> anyhow::Result<SocketAddr> {
         let context = HandlerContext::from_services(services);
 
+        // Create rate limiting middleware closures once
+        let submit_transaction_middleware = {
+            let limiter = context.submit_transaction_limiter.clone();
+            middleware::from_fn(move |ConnectInfo(addr): ConnectInfo<SocketAddr>, request: Request, next: Next| {
+                let limiter = limiter.clone();
+                async move {
+                    match limiter.check_rate_limit(addr.ip()) {
+                        Ok(()) => next.run(request).await,
+                        Err(retry_after) => {
+                            let mut response = Response::new(Body::from("Too Many Requests"));
+                            *response.status_mut() = StatusCode::TOO_MANY_REQUESTS;
+                            response.headers_mut().insert(
+                                header::RETRY_AFTER,
+                                HeaderValue::from_str(&retry_after.as_secs().to_string()).unwrap(),
+                            );
+                            response
+                        }
+                    }
+                }
+            })
+        };
+
+        let dry_run_middleware = {
+            let limiter = context.dry_run_limiter.clone();
+            middleware::from_fn(move |ConnectInfo(addr): ConnectInfo<SocketAddr>, request: Request, next: Next| {
+                let limiter = limiter.clone();
+                async move {
+                    match limiter.check_rate_limit(addr.ip()) {
+                        Ok(()) => next.run(request).await,
+                        Err(retry_after) => {
+                            let mut response = Response::new(Body::from("Too Many Requests"));
+                            *response.status_mut() = StatusCode::TOO_MANY_REQUESTS;
+                            response.headers_mut().insert(
+                                header::RETRY_AFTER,
+                                HeaderValue::from_str(&retry_after.as_secs().to_string()).unwrap(),
+                            );
+                            response
+                        }
+                    }
+                }
+            })
+        };
+
+        let fetch_substates_middleware = {
+            let limiter = context.fetch_substates_limiter.clone();
+            middleware::from_fn(move |ConnectInfo(addr): ConnectInfo<SocketAddr>, request: Request, next: Next| {
+                let limiter = limiter.clone();
+                async move {
+                    match limiter.check_rate_limit(addr.ip()) {
+                        Ok(()) => next.run(request).await,
+                        Err(retry_after) => {
+                            let mut response = Response::new(Body::from("Too Many Requests"));
+                            *response.status_mut() = StatusCode::TOO_MANY_REQUESTS;
+                            response.headers_mut().insert(
+                                header::RETRY_AFTER,
+                                HeaderValue::from_str(&retry_after.as_secs().to_string()).unwrap(),
+                            );
+                            response
+                        }
+                    }
+                }
+            })
+        };
+
+        let fetch_utxos_middleware = {
+            let limiter = context.fetch_utxos_limiter.clone();
+            middleware::from_fn(move |ConnectInfo(addr): ConnectInfo<SocketAddr>, request: Request, next: Next| {
+                let limiter = limiter.clone();
+                async move {
+                    match limiter.check_rate_limit(addr.ip()) {
+                        Ok(()) => next.run(request).await,
+                        Err(retry_after) => {
+                            let mut response = Response::new(Body::from("Too Many Requests"));
+                            *response.status_mut() = StatusCode::TOO_MANY_REQUESTS;
+                            response.headers_mut().insert(
+                                header::RETRY_AFTER,
+                                HeaderValue::from_str(&retry_after.as_secs().to_string()).unwrap(),
+                            );
+                            response
+                        }
+                    }
+                }
+            })
+        };
+
+        let get_non_fungibles_middleware = {
+            let limiter = context.get_non_fungibles_limiter.clone();
+            middleware::from_fn(move |ConnectInfo(addr): ConnectInfo<SocketAddr>, request: Request, next: Next| {
+                let limiter = limiter.clone();
+                async move {
+                    match limiter.check_rate_limit(addr.ip()) {
+                        Ok(()) => next.run(request).await,
+                        Err(retry_after) => {
+                            let mut response = Response::new(Body::from("Too Many Requests"));
+                            *response.status_mut() = StatusCode::TOO_MANY_REQUESTS;
+                            response.headers_mut().insert(
+                                header::RETRY_AFTER,
+                                HeaderValue::from_str(&retry_after.as_secs().to_string()).unwrap(),
+                            );
+                            response
+                        }
+                    }
+                }
+            })
+        };
+
+        let list_recent_transactions_middleware = {
+            let limiter = context.list_recent_transactions_limiter.clone();
+            middleware::from_fn(move |ConnectInfo(addr): ConnectInfo<SocketAddr>, request: Request, next: Next| {
+                let limiter = limiter.clone();
+                async move {
+                    match limiter.check_rate_limit(addr.ip()) {
+                        Ok(()) => next.run(request).await,
+                        Err(retry_after) => {
+                            let mut response = Response::new(Body::from("Too Many Requests"));
+                            *response.status_mut() = StatusCode::TOO_MANY_REQUESTS;
+                            response.headers_mut().insert(
+                                header::RETRY_AFTER,
+                                HeaderValue::from_str(&retry_after.as_secs().to_string()).unwrap(),
+                            );
+                            response
+                        }
+                    }
+                }
+            })
+        };
+
         let router = Router::new()
             .route("/health", get(handlers::misc::health))
             .route("/ready", get(handlers::misc::ready))
@@ -122,18 +226,12 @@ impl Server {
             .route("/network/connections", get(handlers::network::get_connections))
             .nest("/substates", Router::new()
                 .route("/fetch", post(handlers::substates::fetch_substates)
-                    .layer(middleware::from_fn({
-                        let limiter = context.fetch_substates_limiter.clone();
-                        move |addr, req, next| rate_limit_middleware(limiter.clone())(addr, req, next)
-                    })))
+                    .layer(fetch_substates_middleware))
                 .route("/{substate_id}", get(handlers::substates::get_substate))
             )
             .nest("/transactions", Router::new()
                 .route("/", post(handlers::transactions::submit_transaction)
-                    .layer(middleware::from_fn({
-                        let limiter = context.submit_transaction_limiter.clone();
-                        move |addr, req, next| rate_limit_middleware(limiter.clone())(addr, req, next)
-                    })))
+                    .layer(submit_transaction_middleware))
                 .route("/dry-run", post(handlers::transactions::submit_transaction_dry_run)
                     .layer(ServiceBuilder::new()
                         .layer(axum::error_handling::HandleErrorLayer::new(|err: axum::BoxError| async move {
@@ -145,17 +243,11 @@ impl Server {
                         .layer(BufferLayer::new(1024))
                         .layer(RateLimitLayer::new(10, Duration::from_secs(5)))
                     )
-                    .layer(middleware::from_fn({
-                        let limiter = context.dry_run_limiter.clone();
-                        move |addr, req, next| rate_limit_middleware(limiter.clone())(addr, req, next)
-                    })))
+                    .layer(dry_run_middleware))
                 .route(
                     "/recent",
                     get(handlers::transactions::list_recent_transactions)
-                        .layer(middleware::from_fn({
-                            let limiter = context.list_recent_transactions_limiter.clone();
-                            move |addr, req, next| rate_limit_middleware(limiter.clone())(addr, req, next)
-                        })),
+                        .layer(list_recent_transactions_middleware),
                 )
                 .route(
                     "/{transaction_id}/result",
@@ -177,17 +269,11 @@ impl Server {
                 )
             )
             .route("/non-fungibles", get(handlers::nfts::get_non_fungibles)
-                .layer(middleware::from_fn({
-                    let limiter = context.get_non_fungibles_limiter.clone();
-                    move |addr, req, next| rate_limit_middleware(limiter.clone())(addr, req, next)
-                })))
+                .layer(get_non_fungibles_middleware))
             .nest("/utxos", Router::new()
                 .route("/", get(handlers::utxos::list_utxos))
                 .route("/fetch", post(handlers::utxos::fetch_utxos)
-                    .layer(middleware::from_fn({
-                        let limiter = context.fetch_utxos_limiter.clone();
-                        move |addr, req, next| rate_limit_middleware(limiter.clone())(addr, req, next)
-                    })))
+                    .layer(fetch_utxos_middleware))
                 .route("/stream", post(handlers::utxos::stream_utxo_updates))
             )
             .nest(


### PR DESCRIPTION
## Description
Implements comprehensive per-IP rate limiting for the Tari Indexer REST API to protect nodes from excessive load and abuse. Uses a token bucket algorithm for flexible rate limiting with configurable limits per endpoint.

## Motivation and Context
Addresses issue #1997. The indexer REST API previously had minimal rate limiting (only POST /transactions/dry-run). Several endpoints are expensive or abusable and needed per-IP rate limiting to protect indexer nodes from excessive load, whether accidental or malicious.

Fixes #1997 

## How Has This Been Tested?
- Unit tests added for token bucket algorithm, IP rate limiter, and SSE connection limiter
- Tested rate limiting behavior by sending rapid requests to each rate-limited endpoint
- Verified HTTP 429 responses are returned with correct Retry-After headers
- Confirmed health/ready/identity endpoints remain unrestricted
- Tested SSE connection limits with multiple concurrent connections
- Verified rate limit recovery after token bucket refills
- Confirmed existing dry-run rate limiting continues to work alongside new per-IP limits

## What process can a PR reviewer use to test or verify this change?

1. **Build and run the indexer:**
   ```bash
   cargo build --release --bin tari_indexer
   ./target/release/tari_indexer
Test rate limiting on POST /transactions/dry-run (10 req/min):

for i in {1..15}; do
  curl -X POST http://localhost:18300/transactions/dry-run \
    -H "Content-Type: application/json" \
    -d '{"transaction":"invalid"}' \
    -w "\nStatus: %{http_code}\n"
  sleep 1
done
# Should see 429 responses after ~10 requests
Test SSE connection limit (3 concurrent per IP):

# Open 4 concurrent connections
for i in {1..4}; do
  curl -N http://localhost:18300/events &
done
# First 3 should connect, 4th should get 429
Verify Retry-After header:

# Trigger rate limit and check headers
for i in {1..15}; do
  curl -i -X POST http://localhost:18300/transactions/dry-run \
    -H "Content-Type: application/json" \
    -d '{"transaction":"invalid"}' 2>&1 | grep -i "retry-after"
done
Verify health endpoints are NOT rate-limited:

for i in {1..50}; do
  curl -s -o /dev/null -w "%{http_code}\n" http://localhost:18300/health
done
# All should return 200
Test configuration:

Add rate limit config to indexer config file (see config_rate_limits_example.toml)
Restart indexer and verify custom limits are applied
Review code:

Check 
rate_limit.rs
 for token bucket implementation
Verify middleware application in 
server.rs
Review SSE connection guards in handler files
Breaking Changes
 None
 Requires data directory to be deleted
 Other - Please specify