### PR TITLE
[FIX] Add per-IP rate limiting to indexer REST API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11093,6 +11093,7 @@ dependencies = [
  "logroller",
  "mediatype",
  "mime_guess",
+ "mini-moka",
  "ootle_byte_type",
  "prometheus-client",
  "prost 0.14.3",

--- a/applications/tari_indexer/Cargo.toml
+++ b/applications/tari_indexer/Cargo.toml
@@ -71,6 +71,7 @@ log4rs = { workspace = true, features = [
 ] }
 mime_guess = { workspace = true }
 mediatype = "0.20.0"
+mini-moka = { workspace = true }
 serde = { workspace = true, features = ["default", "derive"] }
 serde_json = { workspace = true }
 serde_with = { workspace = true, features = ["indexmap_2"] }

--- a/applications/tari_indexer/src/bootstrap.rs
+++ b/applications/tari_indexer/src/bootstrap.rs
@@ -253,6 +253,7 @@ pub async fn spawn_services(
     save_identities(config, &keypair)?;
     Ok(Services {
         network: config.network,
+        config: config.clone(),
         keypair,
         networking,
         epoch_manager,
@@ -270,6 +271,7 @@ pub async fn spawn_services(
 
 pub struct Services {
     pub network: Network,
+    pub config: ApplicationConfig,
     pub keypair: RistrettoKeypair,
     pub networking: NetworkingHandle<TariMessagingSpec>,
     pub epoch_manager: EpochManagerHandle<PeerAddress>,

--- a/applications/tari_indexer/src/config.rs
+++ b/applications/tari_indexer/src/config.rs
@@ -87,6 +87,30 @@ impl ApplicationConfig {
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(deny_unknown_fields)]
+pub struct RateLimitConfig {
+    pub transactions_per_min: u64,
+    pub substates_fetch_per_min: u64,
+    pub utxos_fetch_per_min: u64,
+    pub non_fungibles_per_min: u64,
+    pub dry_run_per_min: u64,
+    pub sse_max_concurrent: u32,
+}
+
+impl Default for RateLimitConfig {
+    fn default() -> Self {
+        Self {
+            transactions_per_min: 20,
+            substates_fetch_per_min: 30,
+            utxos_fetch_per_min: 15,
+            non_fungibles_per_min: 30,
+            dry_run_per_min: 120,
+            sse_max_concurrent: 3,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
 #[allow(clippy::struct_excessive_bools)]
 pub struct IndexerConfig {
     override_from: Option<String>,
@@ -121,6 +145,8 @@ pub struct IndexerConfig {
     pub burnt_utxo_sidechain_id: Option<RistrettoPublicKey>,
     /// The event filtering configuration
     pub event_filters: Vec<EventFilter>,
+    /// Rate limit configuration for the REST API
+    pub rate_limit: RateLimitConfig,
 }
 
 impl Default for IndexerConfig {
@@ -141,6 +167,7 @@ impl Default for IndexerConfig {
             templates_sidechain_id: None,
             burnt_utxo_sidechain_id: None,
             event_filters: vec![],
+            rate_limit: RateLimitConfig::default(),
         }
     }
 }

--- a/applications/tari_indexer/src/rest_api/context.rs
+++ b/applications/tari_indexer/src/rest_api/context.rs
@@ -23,7 +23,7 @@ use crate::{
     bootstrap::Services,
     dry_run::processor::DryRunTransactionProcessor,
     notify::Subscriber,
-    rest_api::cache::HttpCacheConfig,
+    rest_api::{cache::HttpCacheConfig, rate_limit::RateLimitManager},
     storage_sqlite::SqliteIndexerStore,
     store::ReadOnlyStore,
     substate_manager::SubstateManager,
@@ -37,7 +37,7 @@ pub struct HandlerContext {
 }
 
 impl HandlerContext {
-    pub fn from_services(services: &Services) -> Self {
+    pub fn from_services(services: &Services, rate_limit_manager: RateLimitManager) -> Self {
         Self {
             inner: Arc::new(InnerContext {
                 cache_control_enabled: true,
@@ -53,6 +53,7 @@ impl HandlerContext {
                 dry_run_transaction_processor: services.dry_run_transaction_processor.clone(),
                 subscriber: services.event_notifier.to_subscriber(),
                 transaction_event_subscriber: services.transaction_event_notifier.to_subscriber(),
+                rate_limit_manager,
             }),
         }
     }
@@ -104,6 +105,10 @@ impl HandlerContext {
         &self.inner.dry_run_transaction_processor
     }
 
+    pub fn rate_limit_manager(&self) -> &RateLimitManager {
+        &self.inner.rate_limit_manager
+    }
+
     pub fn apply_cache_control(&self, body: impl IntoResponse, max_age: u32) -> Response {
         let mut response = body.into_response();
         let headers = response.headers_mut();
@@ -141,4 +146,5 @@ struct InnerContext {
     dry_run_transaction_processor: DryRunTransactionProcessor,
     subscriber: Subscriber<IndexerEvent>,
     transaction_event_subscriber: Subscriber<TransactionEvent>,
+    rate_limit_manager: RateLimitManager,
 }

--- a/applications/tari_indexer/src/rest_api/mod.rs
+++ b/applications/tari_indexer/src/rest_api/mod.rs
@@ -8,6 +8,7 @@ mod error;
 mod handlers;
 #[cfg(feature = "metrics")]
 mod metrics;
+mod rate_limit;
 mod server;
 mod streaming;
 

--- a/applications/tari_indexer/src/rest_api/rate_limit.rs
+++ b/applications/tari_indexer/src/rest_api/rate_limit.rs
@@ -1,0 +1,251 @@
+//   Copyright 2025 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+use std::{
+    net::IpAddr,
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+use axum::{
+    extract::ConnectInfo,
+    http::{Request, StatusCode},
+    middleware::Next,
+    response::{IntoResponse, Response},
+    Json,
+};
+use mini_moka::sync::Cache;
+use serde_json::json;
+use tokio::sync::{Mutex, OwnedSemaphorePermit, Semaphore};
+
+#[derive(Clone)]
+pub struct RateLimitManager {
+    limits: Arc<RateLimitCaches>,
+    config: RateLimitConfig,
+}
+
+#[derive(Clone)]
+#[allow(dead_code)]
+pub struct SsePermit(Arc<Mutex<Option<OwnedSemaphorePermit>>>);
+
+struct RateLimitCaches {
+    transactions: Cache<IpAddr, Arc<Mutex<Bucket>>>,
+    substates_fetch: Cache<IpAddr, Arc<Mutex<Bucket>>>,
+    utxos_fetch: Cache<IpAddr, Arc<Mutex<Bucket>>>,
+    non_fungibles: Cache<IpAddr, Arc<Mutex<Bucket>>>,
+    dry_run: Cache<IpAddr, Arc<Mutex<Bucket>>>,
+    sse_concurrency: Cache<IpAddr, Arc<Semaphore>>,
+}
+
+#[derive(Clone, Copy)]
+pub struct RateLimitConfig {
+    pub transactions_per_min: u64,
+    pub substates_fetch_per_min: u64,
+    pub utxos_fetch_per_min: u64,
+    pub non_fungibles_per_min: u64,
+    pub dry_run_per_min: u64,
+    pub sse_max_concurrent: u32,
+}
+
+struct Bucket {
+    count: u64,
+    start_time: Instant,
+}
+
+impl RateLimitManager {
+    pub fn new(config: crate::config::RateLimitConfig) -> Self {
+        let cache_config = || {
+            Cache::builder()
+                .time_to_idle(Duration::from_secs(60))
+                .build()
+        };
+
+        Self {
+            limits: Arc::new(RateLimitCaches {
+                transactions: cache_config(),
+                substates_fetch: cache_config(),
+                utxos_fetch: cache_config(),
+                non_fungibles: cache_config(),
+                dry_run: cache_config(),
+                sse_concurrency: Cache::builder()
+                    .time_to_idle(Duration::from_secs(3600))
+                    .build(),
+            }),
+            config: RateLimitConfig {
+                transactions_per_min: config.transactions_per_min,
+                substates_fetch_per_min: config.substates_fetch_per_min,
+                utxos_fetch_per_min: config.utxos_fetch_per_min,
+                non_fungibles_per_min: config.non_fungibles_per_min,
+                dry_run_per_min: config.dry_run_per_min,
+                sse_max_concurrent: config.sse_max_concurrent,
+            },
+        }
+    }
+
+    async fn check_limit(
+        &self,
+        ip: IpAddr,
+        cache: &Cache<IpAddr, Arc<Mutex<Bucket>>>,
+        limit: u64,
+    ) -> Result<(), Duration> {
+        if limit == 0 {
+            return Ok(());
+        }
+
+        let bucket_arc = if let Some(bucket) = cache.get(&ip) {
+            bucket
+        } else {
+            let bucket = Arc::new(Mutex::new(Bucket {
+                count: 0,
+                start_time: Instant::now(),
+            }));
+            cache.insert(ip, bucket.clone());
+            bucket
+        };
+
+        let mut bucket = bucket_arc.lock().await;
+        let now = Instant::now();
+        if now.duration_since(bucket.start_time) > Duration::from_secs(60) {
+            bucket.count = 1;
+            bucket.start_time = now;
+            Ok(())
+        } else if bucket.count < limit {
+            bucket.count += 1;
+            Ok(())
+        } else {
+            Err(Duration::from_secs(60).saturating_sub(now.duration_since(bucket.start_time)))
+        }
+    }
+
+    pub async fn acquire_sse_permit(&self, ip: IpAddr) -> Option<SsePermit> {
+        if self.config.sse_max_concurrent == 0 {
+            return None;
+        }
+
+        let semaphore = if let Some(semaphore) = self.limits.sse_concurrency.get(&ip) {
+            semaphore
+        } else {
+            let semaphore = Arc::new(Semaphore::new(self.config.sse_max_concurrent as usize));
+            self.limits.sse_concurrency.insert(ip, semaphore.clone());
+            semaphore
+        };
+
+        let permit: OwnedSemaphorePermit = semaphore.acquire_owned().await.ok()?;
+        Some(SsePermit(Arc::new(Mutex::new(Some(permit)))))
+    }
+}
+
+pub async fn transactions_limit(
+    ConnectInfo(addr): ConnectInfo<std::net::SocketAddr>,
+    axum::extract::State(context): axum::extract::State<crate::rest_api::context::HandlerContext>,
+    request: Request<axum::body::Body>,
+    next: Next,
+) -> Response {
+    let manager = context.rate_limit_manager();
+    match manager
+        .check_limit(addr.ip(), &manager.limits.transactions, manager.config.transactions_per_min)
+        .await
+    {
+        Ok(_) => next.run(request).await,
+        Err(wait) => too_many_requests(wait),
+    }
+}
+
+pub async fn substates_fetch_limit(
+    ConnectInfo(addr): ConnectInfo<std::net::SocketAddr>,
+    axum::extract::State(context): axum::extract::State<crate::rest_api::context::HandlerContext>,
+    request: Request<axum::body::Body>,
+    next: Next,
+) -> Response {
+    let manager = context.rate_limit_manager();
+    match manager
+        .check_limit(
+            addr.ip(),
+            &manager.limits.substates_fetch,
+            manager.config.substates_fetch_per_min,
+        )
+        .await
+    {
+        Ok(_) => next.run(request).await,
+        Err(wait) => too_many_requests(wait),
+    }
+}
+
+pub async fn utxos_fetch_limit(
+    ConnectInfo(addr): ConnectInfo<std::net::SocketAddr>,
+    axum::extract::State(context): axum::extract::State<crate::rest_api::context::HandlerContext>,
+    request: Request<axum::body::Body>,
+    next: Next,
+) -> Response {
+    let manager = context.rate_limit_manager();
+    match manager
+        .check_limit(addr.ip(), &manager.limits.utxos_fetch, manager.config.utxos_fetch_per_min)
+        .await
+    {
+        Ok(_) => next.run(request).await,
+        Err(wait) => too_many_requests(wait),
+    }
+}
+
+pub async fn non_fungibles_limit(
+    ConnectInfo(addr): ConnectInfo<std::net::SocketAddr>,
+    axum::extract::State(context): axum::extract::State<crate::rest_api::context::HandlerContext>,
+    request: Request<axum::body::Body>,
+    next: Next,
+) -> Response {
+    let manager = context.rate_limit_manager();
+    match manager
+        .check_limit(
+            addr.ip(),
+            &manager.limits.non_fungibles,
+            manager.config.non_fungibles_per_min,
+        )
+        .await
+    {
+        Ok(_) => next.run(request).await,
+        Err(wait) => too_many_requests(wait),
+    }
+}
+
+pub async fn dry_run_limit(
+    ConnectInfo(addr): ConnectInfo<std::net::SocketAddr>,
+    axum::extract::State(context): axum::extract::State<crate::rest_api::context::HandlerContext>,
+    request: Request<axum::body::Body>,
+    next: Next,
+) -> Response {
+    let manager = context.rate_limit_manager();
+    match manager
+        .check_limit(addr.ip(), &manager.limits.dry_run, manager.config.dry_run_per_min)
+        .await
+    {
+        Ok(_) => next.run(request).await,
+        Err(wait) => too_many_requests(wait),
+    }
+}
+
+pub async fn sse_limit(
+    ConnectInfo(addr): ConnectInfo<std::net::SocketAddr>,
+    axum::extract::State(context): axum::extract::State<crate::rest_api::context::HandlerContext>,
+    request: Request<axum::body::Body>,
+    next: Next,
+) -> Response {
+    let manager = context.rate_limit_manager();
+    if let Some(permit) = manager.acquire_sse_permit(addr.ip()).await {
+        let mut response = next.run(request).await;
+        response.extensions_mut().insert(permit);
+        response
+    } else {
+        too_many_requests(Duration::from_secs(60))
+    }
+}
+
+fn too_many_requests(wait: Duration) -> Response {
+    (
+        StatusCode::TOO_MANY_REQUESTS,
+        [("Retry-After", wait.as_secs().to_string())],
+        Json(json!({
+            "error": format!("Too many requests. Please try again in {} seconds", wait.as_secs()),
+        })),
+    )
+        .into_response()
+}

--- a/applications/tari_indexer/src/rest_api/server.rs
+++ b/applications/tari_indexer/src/rest_api/server.rs
@@ -1,17 +1,17 @@
 //   Copyright 2025 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use std::{net::SocketAddr, time::Duration};
+use std::net::SocketAddr;
 
 use axum::{
     Extension,
     Router,
+    middleware,
     routing::{get, post},
 };
 use log::*;
 use tari_ootle_app_utilities::tcp::try_bind_with_fallback;
 use tari_shutdown::ShutdownSignal;
-use tower::{ServiceBuilder, buffer::BufferLayer, limit::RateLimitLayer};
 use tower_http::{cors::CorsLayer, limit::RequestBodyLimitLayer, trace::TraceLayer};
 use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
@@ -20,7 +20,11 @@ use utoipa_swagger_ui::SwaggerUi;
 use crate::rest_api::metrics;
 use crate::{
     bootstrap::Services,
-    rest_api::{context::HandlerContext, handlers},
+    rest_api::{
+        context::HandlerContext,
+        handlers,
+        rate_limit::{self, RateLimitManager},
+    },
 };
 
 const LOG_TARGET: &str = "tari::ootle::indexer::rest_api::server";
@@ -81,7 +85,8 @@ impl Server {
         services: &Services,
         shutdown: ShutdownSignal,
     ) -> anyhow::Result<SocketAddr> {
-        let context = HandlerContext::from_services(services);
+        let rate_limit_manager = RateLimitManager::new(services.config.indexer.rate_limit.clone());
+        let context = HandlerContext::from_services(services, rate_limit_manager);
 
         let router = Router::new()
             .route("/health", get(handlers::misc::health))
@@ -93,22 +98,18 @@ impl Server {
             .route("/network/stats", get(handlers::network::get_network_sync_stats))
             .route("/network/connections", get(handlers::network::get_connections))
             .nest("/substates", Router::new()
-                .route("/fetch", post(handlers::substates::fetch_substates))
+                .route("/fetch", post(handlers::substates::fetch_substates)
+                    .layer(middleware::from_fn_with_state(context.clone(), rate_limit::substates_fetch_limit))
+                )
                 .route("/{substate_id}", get(handlers::substates::get_substate))
             )
             .nest("/transactions", Router::new()
-                .route("/", post(handlers::transactions::submit_transaction))
+                .route("/", post(handlers::transactions::submit_transaction)
+                    .layer(middleware::from_fn_with_state(context.clone(), rate_limit::transactions_limit))
+                )
                 .route("/dry-run", post(handlers::transactions::submit_transaction_dry_run)
-                    .layer(ServiceBuilder::new()
-                        .layer(axum::error_handling::HandleErrorLayer::new(|err: axum::BoxError| async move {
-                            (
-                                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                                format!("Unhandled error: {}", err),
-                            )
-                        }))
-                        .layer(BufferLayer::new(1024))
-                        .layer(RateLimitLayer::new(10, Duration::from_secs(5)))
-                    ))
+                    .layer(middleware::from_fn_with_state(context.clone(), rate_limit::dry_run_limit))
+                )
                 .route(
                     "/recent",
                     get(handlers::transactions::list_recent_transactions),
@@ -118,7 +119,9 @@ impl Server {
                     get(handlers::transactions::get_transaction_result),
                 )
                 .route("/events", get(handlers::transactions::query_transaction_events))
-                .route("/events/stream", get(handlers::transaction_events::sse_transaction_events))
+                .route("/events/stream", get(handlers::transaction_events::sse_transaction_events)
+                    .layer(middleware::from_fn_with_state(context.clone(), rate_limit::sse_limit))
+                )
             )
             .nest("/templates", Router::new()
                 .route("/cached", get(handlers::templates::list_cached_templates))
@@ -132,11 +135,17 @@ impl Server {
                     get(handlers::templates::get_template_definition),
                 )
             )
-            .route("/non-fungibles", get(handlers::nfts::get_non_fungibles)) // Placeholder for future non-fungible endpoints
+            .route("/non-fungibles", get(handlers::nfts::get_non_fungibles)
+                .layer(middleware::from_fn_with_state(context.clone(), rate_limit::non_fungibles_limit))
+            )
             .nest("/utxos", Router::new()
                 .route("/", get(handlers::utxos::list_utxos))
-                .route("/fetch", post(handlers::utxos::fetch_utxos))
-                .route("/stream", post(handlers::utxos::stream_utxo_updates))
+                .route("/fetch", post(handlers::utxos::fetch_utxos)
+                    .layer(middleware::from_fn_with_state(context.clone(), rate_limit::utxos_fetch_limit))
+                )
+                .route("/stream", post(handlers::utxos::stream_utxo_updates)
+                    .layer(middleware::from_fn_with_state(context.clone(), rate_limit::sse_limit))
+                )
             )
             .nest(
                 "/transaction-receipts",
@@ -152,11 +161,13 @@ impl Server {
                 .route("/xtr" , get(handlers::resources::get_tari))
                 .route("/tari" , get(handlers::resources::get_tari))
                 .route("/{resource_address}" , get(handlers::resources::get_resource)))
-            .route("/events", get(handlers::indexer_events::sse_events))
+            .route("/events", get(handlers::indexer_events::sse_events)
+                .layer(middleware::from_fn_with_state(context.clone(), rate_limit::sse_limit))
+            )
             .layer(CorsLayer::permissive())
             .layer(RequestBodyLimitLayer::new(REQUEST_BODY_LIMIT))
             .merge(SwaggerUi::new("/swagger-ui").url("/openapi.json", ApiDoc::openapi()))
-            .layer(Extension(context))
+            .layer(Extension(context.clone()))
             .layer(TraceLayer::new_for_http());
 
         #[cfg(feature = "metrics")]


### PR DESCRIPTION
This PR adds per-IP rate limiting to several indexer REST API endpoints as requested in issue #1997. 

### Changes:
- Added RateLimitConfig to IndexerConfig.
- Implemented RateLimitManager using mini-moka for per-IP tracking.
- Added middlewares for:
  - POST /transactions (20 req/min)
  - POST /substates/fetch (30 req/min)
  - POST /utxos/fetch (15 req/min)
  - GET /non-fungibles (30 req/min)
  - POST /transactions/dry-run (120 req/min - 10 per 5s)
  - SSE endpoints (3 max concurrent connections)
- Integrated middlewares into the Axum router.

Closes #1997