### PR TITLE
fix(ci): install docs deps standalone instead of via workspace

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -26,7 +26,7 @@ jobs:
           path: "docs/developer-docs"
           node-version: 24 # The specific version of Node that should be used to build your site. Defaults to 22. (optional)
           package-manager: pnpm@latest # The Node package manager that should be used to install dependencies and build your site. Automatically detected based on your lockfile. (optional)
-          # build-cmd: pnpm run build # The command to run to build your site. Runs the package build script/task by default. (optional)
+          install-cmd: pnpm install --dir docs/developer-docs
         # env:
         # PUBLIC_POKEAPI: 'https://pokeapi.co/api/v2' # Use single quotation marks for the variable value. (optional)
 


### PR DESCRIPTION
## Summary
- The `docs/developer-docs` package was removed from the pnpm workspace to isolate npm security issues
- This broke the CI docs deploy because `withastro/action@v6` runs `pnpm install` at the repo root, which no longer installs docs dependencies
- Fix by overriding `install-cmd` to install directly in `docs/developer-docs` which has its own lockfile

## Test plan
- [ ] Trigger the docs deploy workflow manually and verify it passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)