### PR TITLE
fix(ci): use build-cmd to install docs deps before building

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -24,9 +24,9 @@ jobs:
         uses: withastro/action@v6
         with:
           path: "docs/developer-docs"
-          node-version: 24 # The specific version of Node that should be used to build your site. Defaults to 22. (optional)
-          package-manager: pnpm@latest # The Node package manager that should be used to install dependencies and build your site. Automatically detected based on your lockfile. (optional)
-          install-cmd: pnpm install --dir docs/developer-docs
+          node-version: 24
+          package-manager: pnpm@latest
+          build-cmd: pnpm install && pnpm run build
         # env:
         # PUBLIC_POKEAPI: 'https://pokeapi.co/api/v2' # Use single quotation marks for the variable value. (optional)
 


### PR DESCRIPTION
## Summary
- `install-cmd` is not a valid input for `withastro/action@v6` (valid inputs: `node-version`, `package-manager`, `path`, `build-cmd`, `cache`, `cache-dir`, `out-dir`)
- Use `build-cmd` instead to run `pnpm install && pnpm run build` inside the `docs/developer-docs` directory, which has its own lockfile
- This ensures astro and other docs deps are installed before the build runs

## Test plan
- [ ] Trigger the docs deploy workflow manually and verify it passes