### PR TITLE
fix(ci): use --ignore-workspace for docs dep install

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -26,7 +26,7 @@ jobs:
           path: "docs/developer-docs"
           node-version: 24
           package-manager: pnpm@latest
-          build-cmd: pnpm install && pnpm run build
+          build-cmd: pnpm install --ignore-workspace && pnpm run build
         # env:
         # PUBLIC_POKEAPI: 'https://pokeapi.co/api/v2' # Use single quotation marks for the variable value. (optional)
 


### PR DESCRIPTION
## Summary
- `pnpm install` in `docs/developer-docs` walks up to the repo root `pnpm-workspace.yaml` and does a workspace-scoped install, never installing the standalone docs deps
- Use `pnpm install --ignore-workspace` in the `build-cmd` so pnpm treats the docs directory as an independent project with its own lockfile

## Test plan
- [ ] Trigger the docs deploy workflow manually and verify it passes