### PR TITLE
fix(walletd): fix PayRefDialog crash

### DIFF
--- a/applications/tari_walletd/web_ui/src/routes/AssetVault/Components/AccountDetails.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/AssetVault/Components/AccountDetails.tsx
@@ -52,7 +52,7 @@ import {
 } from "@tari-project/ootle-ts-bindings";
 import { useState } from "react";
 import { IoPaperPlaneOutline } from "react-icons/io5";
-import QRCode from "react-qr-code";
+import { QRCode } from "react-qr-code";
 
 function AccountDetails() {
   const [payRefDialogOpen, setPayRefDialogOpen] = useState(false);

--- a/applications/tari_walletd/web_ui/src/routes/StealthUtxoList/StealthUtxoList.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/StealthUtxoList/StealthUtxoList.tsx
@@ -88,7 +88,7 @@ function StealthUtxoList({ account }: { account: Account }) {
                     getDisplayName={getStatusDisplayName}
                   />
                 </TableCell>
-                <TableCell width={columnWidths[4]}>Memo</TableCell>
+                <TableCell width={columnWidths[4]}>Encrypted Memo</TableCell>
                 <TableCell width={columnWidths[5]}>Burnt</TableCell>
                 <TableCell width={columnWidths[6]}>Frozen</TableCell>
               </TableRow>


### PR DESCRIPTION
## Summary
- Fix `QRCode` import in `PayRefDialog` — `react-qr-code` exports it as a named export, not a default. The incorrect default import caused a React render crash.
- Rename "Memo" column header to "Encrypted Memo" in stealth UTXO list.

## Test plan
- [x] Open wallet web UI, navigate to account details
- [x] Click the PayRef button — dialog should render with QR code
- [x] Check stealth UTXO list column header shows "Encrypted Memo"