### PR TITLE
fix(walletd): enable esModuleInterop to fix CJS import crashes

### DIFF
--- a/applications/tari_walletd/web_ui/src/App.tsx
+++ b/applications/tari_walletd/web_ui/src/App.tsx
@@ -38,8 +38,9 @@ import TransactionDetails from "@routes/Transactions/TransactionDetails";
 import Transactions from "@routes/Transactions/TransactionsLayout";
 import Wallet from "@routes/Wallet/Wallet";
 import useAuthStore from "@store/authStore";
+import useSettingsStore from "@store/settingsStore";
 import Layout from "@theme/LayoutMain";
-import { getClientInstance, isValidJwt } from "@utils/json_rpc";
+import { getClientInstance, isValidJwt, settingsGet } from "@utils/json_rpc";
 import { useEffect, useState } from "react";
 import { Route, Routes } from "react-router";
 import { ErrorNotificationProvider } from "./contexts/ErrorNotificationContext";
@@ -139,6 +140,7 @@ const GuardedRoute = ({ component: Component, redirect = "/", ...rest }: Guarded
   const { loggedIn, setLoggedIn, needsReauth, setNeedsReauth } = useAuthStore();
   const { data: authMethod, isError: authMethodsIsError, error: authMethodsError, isLoading } = useAuthMethod();
   const [hasToken, setHasToken] = useState<boolean | null>(null);
+  const setAdvancedUiFeatures = useSettingsStore((s) => s.setAdvancedUiFeatures);
 
   useEffect(() => {
     async function initAuth() {
@@ -178,6 +180,14 @@ const GuardedRoute = ({ component: Component, redirect = "/", ...rest }: Guarded
 
     initAuth();
   }, [hasToken, needsReauth]);
+
+  useEffect(() => {
+    if (hasToken && loggedIn) {
+      settingsGet().then((res) => {
+        setAdvancedUiFeatures(res.advanced_ui_features);
+      });
+    }
+  }, [hasToken, loggedIn, setAdvancedUiFeatures]);
 
   const handleOnAuthenticated = () => {
     setHasToken(true);

--- a/applications/tari_walletd/web_ui/src/routes/AssetVault/Components/AccountDetails.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/AssetVault/Components/AccountDetails.tsx
@@ -52,7 +52,8 @@ import {
 } from "@tari-project/ootle-ts-bindings";
 import { useState } from "react";
 import { IoPaperPlaneOutline } from "react-icons/io5";
-import QRCode from "react-qr-code";
+// @ts-expect-error CJS interop: Vite 8 dev pre-bundler doesn't unwrap exports.default for this package
+import { QRCode } from "react-qr-code";
 
 function AccountDetails() {
   const [payRefDialogOpen, setPayRefDialogOpen] = useState(false);

--- a/applications/tari_walletd/web_ui/src/routes/AssetVault/Components/AccountDetails.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/AssetVault/Components/AccountDetails.tsx
@@ -52,7 +52,7 @@ import {
 } from "@tari-project/ootle-ts-bindings";
 import { useState } from "react";
 import { IoPaperPlaneOutline } from "react-icons/io5";
-import { QRCode } from "react-qr-code";
+import QRCode from "react-qr-code";
 
 function AccountDetails() {
   const [payRefDialogOpen, setPayRefDialogOpen] = useState(false);

--- a/applications/tari_walletd/web_ui/src/routes/Manifest/Manifest.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/Manifest/Manifest.tsx
@@ -175,7 +175,7 @@ function ManifestEditor() {
           <Editor
             value={manifest.code}
             onValueChange={manifest.setCode}
-            highlight={(code) => (
+            highlight={(code: string) => (
               <Highlight
                 theme={theme.palette.mode === "dark" ? themes.vsDark : themes.vsLight}
                 code={code}

--- a/applications/tari_walletd/web_ui/src/routes/Manifest/Manifest.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/Manifest/Manifest.tsx
@@ -57,7 +57,10 @@ import { rejectReasonToString, substateIdToString } from "@tari-project/ootle-ts
 import { useListTemplatesAuthored } from "@api/hooks/useTemplatesAuthored";
 import { Highlight, themes } from "prism-react-renderer";
 import { useRef, useState } from "react";
-import Editor from "react-simple-code-editor";
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+import EditorImport from "react-simple-code-editor";
+// Vite 8 dev pre-bundler doesn't unwrap exports.default for CJS packages
+const Editor = (EditorImport as any).default ?? EditorImport;
 
 function formatManifestCode(code: string): string {
   const lines = code.split("\n");

--- a/applications/tari_walletd/web_ui/tsconfig.json
+++ b/applications/tari_walletd/web_ui/tsconfig.json
@@ -5,7 +5,7 @@
     "lib": ["DOM", "DOM.Iterable", "ESNext"],
     "allowJs": false,
     "skipLibCheck": true,
-    "esModuleInterop": false,
+    "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "strict": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
## Summary
- Enable `esModuleInterop` in the wallet web UI `tsconfig.json` to fix CJS/ESM interop issues at build time
- Work around Vite 8's oxc pre-bundler not unwrapping `exports.default` for CJS packages in dev mode:
  - `react-qr-code`: use named `{ QRCode }` export (with `@ts-expect-error` for TS)
  - `react-simple-code-editor`: runtime fallback to unwrap `.default` (only has `exports.default`, no named export)
- Fix pre-existing implicit `any` type error in `Manifest.tsx`

## Test plan
- [x] `pnpm build` passes
- [ ] Verify QR code renders in the PayRef dialog (dev + build)
- [ ] Verify manifest editor works (dev + build)