### PR TITLE
fix(consensus): use epoch genesis for dummy block calculation

### DIFF
--- a/crates/consensus/src/hotstuff/on_propose.rs
+++ b/crates/consensus/src/hotstuff/on_propose.rs
@@ -317,7 +317,7 @@ where TConsensusSpec: ConsensusSpec
         can_propose_epoch_end: bool,
     ) -> Result<NextBlock, HotStuffError> {
         let high_qc_id = high_qc_certificate.calculate_id();
-        let justify_block = Block::get(tx, &high_qc_certificate.calculate_block_id())?;
+        let justify_block = Block::get_justified_block(tx, &high_qc_certificate, epoch)?;
         let start_of_chain_block = highest_seen_block;
         let parent_block = dummy_block.unwrap_or_else(|| highest_seen_block.as_leaf());
         let highest_seen_block = Block::get(tx, highest_seen_block.block_id())?;

--- a/crates/consensus/src/hotstuff/on_ready_to_vote_on_local_block.rs
+++ b/crates/consensus/src/hotstuff/on_ready_to_vote_on_local_block.rs
@@ -145,7 +145,7 @@ where TConsensusSpec: ConsensusSpec
         )?;
 
         // Process newly justified block
-        let mut justified_block = Block::get(&**tx, &valid_block.justify().calculate_block_id())?;
+        let mut justified_block = Block::get_justified_block(&**tx, valid_block.justify(), valid_block.epoch())?;
         // This comes before decide so that all evidence can be in place before LocalPrepare and LocalAccept
         if !justified_block.has_justify_qc() {
             // We need to process this before to ensure that we have the latest state when checking the new block

--- a/crates/consensus/src/hotstuff/worker.rs
+++ b/crates/consensus/src/hotstuff/worker.rs
@@ -981,7 +981,7 @@ impl<TConsensusSpec: ConsensusSpec> HotstuffWorker<TConsensusSpec> {
                 let high_tc = high_tc
                     .map(|tc| TimeoutCertificate::get(tx, tc.epoch(), tc.id()))
                     .transpose()?;
-                let justify_block = Block::get(tx, &high_qc.calculate_block_id())?;
+                let justify_block = Block::get_justified_block(tx, &high_qc, epoch_state.epoch())?;
                 Ok::<_, HotStuffError>((high_qc, high_tc, justify_block))
             })?;
 

--- a/crates/consensus_tests/src/dummy_blocks.rs
+++ b/crates/consensus_tests/src/dummy_blocks.rs
@@ -8,12 +8,14 @@ use tari_consensus::hotstuff::{
     calculate_dummy_blocks_from_justify,
     calculate_last_dummy_block,
 };
-use tari_consensus_types::ShardGroupAccumulatedData;
+use tari_consensus_types::{BlockId, ShardGroupAccumulatedData};
+use tari_crypto::tari_utilities::hex::Hex;
 use tari_ootle_common_types::{
     DerivableFromPublicKey,
     Epoch,
     Network,
     NodeHeight,
+    NumPreshards,
     ShardGroup,
     VotePower,
     committee::{Committee, CommitteeMember},
@@ -121,4 +123,111 @@ fn last_matches_generated_using_real_data() {
     .expect("last dummy block");
 
     assert_eq!(dummy.last().unwrap().id(), last.block_id());
+}
+
+/// Regression test: when the QC justifies the zero block (no blocks committed yet in the epoch),
+/// the proposer must use the epoch genesis block (which has a state_merkle_root and
+/// epoch_hash set from the previous epoch checkpoint) rather than the global zero block (all-zero fields). Using the
+/// wrong block causes every dummy block ID to diverge, making all proposals permanently invalid.
+#[test]
+fn dummy_blocks_from_epoch_genesis_vs_zero_block() {
+    let shard_group = ShardGroup::new(1, 256);
+    let non_zero_state_root =
+        FixedHash::from_hex("613a7a1b6b83edb2d49c4d740b8b0e7e4ee226b453b004b04d4812dbc51306d9").unwrap();
+    let non_zero_epoch_hash =
+        FixedHash::from_hex("7da2c68f183ed4a96109e5ebeb18f7e26082f928b9f9879685f90c0bee041451").unwrap();
+
+    // The epoch genesis has real state carried over from the previous epoch
+    let epoch_genesis = Block::genesis(
+        Network::LocalNet,
+        Epoch(100),
+        non_zero_epoch_hash,
+        shard_group,
+        non_zero_state_root,
+        None,
+    );
+
+    // The zero block has all-zero fields - this is what the buggy proposer was using
+    let zero_block = Block::zero_block(Network::LocalNet, NumPreshards::P256);
+
+    let committee: Committee<PeerAddress> = (0u8..4)
+        .map(create_key_pair_from_seed)
+        .map(|(_, pk)| CommitteeMember {
+            address: PeerAddress::derive_from_public_key(&pk),
+            public_key: pk.to_byte_type(),
+            vote_power: VotePower::of(1),
+        })
+        .collect();
+
+    let candidate_height = NodeHeight(50);
+    let qc = epoch_genesis.justify();
+
+    // Simulate the VALIDATOR path: uses epoch genesis (correct)
+    let validator_dummies = calculate_dummy_blocks(
+        epoch_genesis.height(),
+        candidate_height,
+        Network::LocalNet,
+        Epoch(100),
+        shard_group,
+        *epoch_genesis.id(),
+        qc,
+        &BlockId::zero(), // unused expected_parent - we'll check the last dummy directly
+        *epoch_genesis.state_merkle_root(),
+        &RoundRobinLeaderStrategy,
+        &committee,
+        epoch_genesis.timestamp(),
+        *epoch_genesis.header().accumulated_data(),
+        *epoch_genesis.epoch_hash(),
+    );
+
+    // Simulate the BUGGY PROPOSER path: uses zero block instead of epoch genesis
+    let buggy_proposer_last = calculate_last_dummy_block(
+        zero_block.height(),
+        candidate_height,
+        Network::LocalNet,
+        Epoch(100),
+        zero_block.shard_group(),
+        *zero_block.id(),
+        qc,
+        *zero_block.state_merkle_root(),
+        &RoundRobinLeaderStrategy,
+        &committee,
+        zero_block.timestamp(),
+        *zero_block.header().accumulated_data(),
+        *zero_block.epoch_hash(),
+    )
+    .unwrap();
+
+    // The buggy path produces different dummy block IDs - this was the cause of permanent
+    // proposal rejection after leader failure at the start of a new epoch
+    assert_ne!(
+        validator_dummies.last().unwrap().id(),
+        &buggy_proposer_last.block_id,
+        "zero block and epoch genesis should produce different dummy chains"
+    );
+
+    // Simulate the FIXED PROPOSER path: uses epoch genesis (matches validator)
+    let fixed_proposer_last = calculate_last_dummy_block(
+        epoch_genesis.height(),
+        candidate_height,
+        Network::LocalNet,
+        Epoch(100),
+        epoch_genesis.shard_group(),
+        *epoch_genesis.id(),
+        qc,
+        *epoch_genesis.state_merkle_root(),
+        &RoundRobinLeaderStrategy,
+        &committee,
+        epoch_genesis.timestamp(),
+        *epoch_genesis.header().accumulated_data(),
+        *epoch_genesis.epoch_hash(),
+    )
+    .unwrap();
+
+    // The fixed path matches the validator
+    assert_eq!(
+        validator_dummies.last().unwrap().id(),
+        &fixed_proposer_last.block_id,
+        "epoch genesis should produce matching dummy chains between proposer and validator"
+    );
 }

--- a/crates/consensus_tests/src/dummy_blocks.rs
+++ b/crates/consensus_tests/src/dummy_blocks.rs
@@ -131,7 +131,7 @@ fn last_matches_generated_using_real_data() {
 /// wrong block causes every dummy block ID to diverge, making all proposals permanently invalid.
 #[test]
 fn dummy_blocks_from_epoch_genesis_vs_zero_block() {
-    let shard_group = ShardGroup::new(1, 256);
+    let shard_group = ShardGroup::all_shards(NumPreshards::P256);
     let non_zero_state_root =
         FixedHash::from_hex("613a7a1b6b83edb2d49c4d740b8b0e7e4ee226b453b004b04d4812dbc51306d9").unwrap();
     let non_zero_epoch_hash =

--- a/crates/consensus_tests/src/leader_failure.rs
+++ b/crates/consensus_tests/src/leader_failure.rs
@@ -367,6 +367,43 @@ async fn multi_shard_node_goes_down() {
     test.assert_clean_shutdown_except(&[failure_node]).await;
 }
 
+/// Regression test: when the first leader in a new epoch fails before any block is committed,
+/// the HighQC still justifies the zero block. The proposer must use the epoch genesis block
+/// (not the global zero block) when calculating dummy blocks, otherwise the dummy chain
+/// diverges from what validators expect and all proposals are permanently rejected.
+///
+/// If the bug is present, no block will ever be committed and the test will timeout.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn first_leader_failure_at_epoch_start_recovers() {
+    setup_logger();
+    let mut test = Test::builder()
+        .with_test_timeout(Duration::from_secs(60))
+        .modify_consensus_constants(|config_mut| {
+            config_mut.missed_proposal_suspend_threshold = 10;
+            config_mut.missed_proposal_evict_threshold = 10;
+            config_mut.pacemaker_block_time = Duration::from_secs(5);
+        })
+        .add_committee(0, vec!["1", "2", "3", "4", "5"])
+        .start()
+        .await;
+
+    // Node "1" is at committee position 0, so it is the leader for view 0 (the first view in
+    // the epoch). Taking it offline ensures no blocks are committed before timeouts trigger,
+    // keeping the HighQC at the zero block QC.
+    let failure_node = TestAddress::new("1");
+    log::info!("😴 {failure_node} (first leader) is offline");
+    test.network().go_offline(failure_node.clone()).await;
+
+    test.start_epoch(Epoch(1)).await;
+
+    // Wait for at least one block to be committed. This proves that the remaining validators
+    // successfully proposed with dummy blocks from the epoch genesis.
+    test.on_block_committed().await;
+
+    test.stop();
+    test.assert_clean_shutdown_except(&[failure_node]).await;
+}
+
 /// Regression test for stale `pending_stage` after orphaned blocks.
 ///
 /// When a validator votes for a block that later ends up on a dead branch (no QC formed),

--- a/crates/storage/src/consensus_models/block.rs
+++ b/crates/storage/src/consensus_models/block.rs
@@ -474,6 +474,24 @@ impl Block {
         tx.blocks_get_all_ids_by_height(epoch, height)
     }
 
+    /// Returns the block justified by the given proposal certificate.
+    ///
+    /// When the QC justifies the zero block, `calculate_block_id()` returns `BlockId::zero()` which
+    /// is the global zero block (epoch 0, all-zero fields). However, the epoch-specific genesis block
+    /// has non-trivial fields (state_merkle_root, epoch_hash, etc.) that are needed for deterministic
+    /// dummy block computation. This method correctly resolves to the epoch genesis in that case.
+    pub fn get_justified_block<TTx: StateStoreReadTransaction>(
+        tx: &TTx,
+        justify: &ProposalCertificate,
+        epoch: Epoch,
+    ) -> Result<Self, StorageError> {
+        if justify.justifies_zero_block() {
+            Self::get_genesis_for_epoch(tx, epoch)
+        } else {
+            Self::get(tx, &justify.calculate_block_id())
+        }
+    }
+
     pub fn get_genesis_for_epoch<TTx: StateStoreReadTransaction>(tx: &TTx, epoch: Epoch) -> Result<Self, StorageError> {
         let ids = Self::get_ids_by_epoch_and_height(tx, epoch, NodeHeight::zero())?;
         if ids.is_empty() {


### PR DESCRIPTION
## Summary

- When the HighQC justifies the zero block (no blocks committed yet in an epoch), the proposer was loading the global zero block (all-zero fields) instead of the epoch genesis block (which carries `state_merkle_root` and `epoch_hash` from the previous epoch checkpoint). This caused dummy block IDs to diverge from what validators calculated, permanently rejecting all proposals after the first leader failure in a new epoch.
- Adds `Block::get_justified_block()` to encapsulate zero-block-vs-genesis resolution, applied to all 3 affected call sites (`worker.rs`, `on_propose.rs`, `on_ready_to_vote_on_local_block.rs`).
- Adds a unit test demonstrating the divergence and an integration test that times out without the fix.

## Test plan

- [x] Unit test `dummy_blocks_from_epoch_genesis_vs_zero_block` passes — verifies that zero block and epoch genesis produce different dummy chains, and that using epoch genesis for both produces matching chains
- [x] Integration test `first_leader_failure_at_epoch_start_recovers` passes (~37s) — starts an epoch, takes the first leader offline, and verifies a block still commits via dummy blocks
- [x] Confirmed integration test times out (fails) when the fix is reverted