### PR TITLE
fix(indexer): use shorter cache TTL for dry run substates

### DIFF
--- a/applications/tari_indexer/src/bootstrap.rs
+++ b/applications/tari_indexer/src/bootstrap.rs
@@ -235,7 +235,9 @@ pub async fn spawn_services(
     let template_manager = TemplateManager::initialize(global_db.clone(), substate_manager.clone())?;
 
     // Dry run - use a shorter cache TTL for more accurate fee estimates
-    let dry_run_substate_manager = substate_manager.clone().with_cache_ttl(config.indexer.dry_run_cache_ttl);
+    let dry_run_substate_manager = substate_manager
+        .clone()
+        .with_cache_ttl(config.indexer.dry_run_cache_ttl);
     let fee_table = get_fee_table_by_network(config.network);
     let dry_run_transaction_processor = DryRunTransactionProcessor::new(
         fee_table.clone(),

--- a/applications/tari_indexer/src/bootstrap.rs
+++ b/applications/tari_indexer/src/bootstrap.rs
@@ -234,17 +234,8 @@ pub async fn spawn_services(
     // Template manager
     let template_manager = TemplateManager::initialize(global_db.clone(), substate_manager.clone())?;
 
-    // Dry run - use a separate substate manager with a shorter cache TTL for more accurate fee estimates
-    let dry_run_substate_cache_dir = config.to_data_dir().join("substate_cache");
-    let dry_run_substate_cache =
-        SubstateFileCache::new(dry_run_substate_cache_dir).context("Failed to create dry run substate cache")?;
-    let dry_run_substate_manager = SubstateManager::new(
-        store.clone(),
-        epoch_manager.clone(),
-        validator_node_client_factory.clone(),
-        dry_run_substate_cache,
-    )
-    .with_cache_ttl(config.indexer.dry_run_cache_ttl);
+    // Dry run - use a shorter cache TTL for more accurate fee estimates
+    let dry_run_substate_manager = substate_manager.clone().with_cache_ttl(config.indexer.dry_run_cache_ttl);
     let fee_table = get_fee_table_by_network(config.network);
     let dry_run_transaction_processor = DryRunTransactionProcessor::new(
         fee_table.clone(),

--- a/applications/tari_indexer/src/bootstrap.rs
+++ b/applications/tari_indexer/src/bootstrap.rs
@@ -234,13 +234,23 @@ pub async fn spawn_services(
     // Template manager
     let template_manager = TemplateManager::initialize(global_db.clone(), substate_manager.clone())?;
 
-    // dry run
+    // Dry run - use a separate substate manager with a shorter cache TTL for more accurate fee estimates
+    let dry_run_substate_cache_dir = config.to_data_dir().join("substate_cache");
+    let dry_run_substate_cache =
+        SubstateFileCache::new(dry_run_substate_cache_dir).context("Failed to create dry run substate cache")?;
+    let dry_run_substate_manager = SubstateManager::new(
+        store.clone(),
+        epoch_manager.clone(),
+        validator_node_client_factory.clone(),
+        dry_run_substate_cache,
+    )
+    .with_cache_ttl(config.indexer.dry_run_cache_ttl);
     let fee_table = get_fee_table_by_network(config.network);
     let dry_run_transaction_processor = DryRunTransactionProcessor::new(
         fee_table.clone(),
         epoch_manager.clone(),
         template_manager.clone(),
-        substate_manager.clone(),
+        dry_run_substate_manager,
         // We do not verify the kernel merkle proof, since that requires syncing L1 headers
         // TODO: maybe at least validate the well-formedness of the proof
         KnowledgeProofVerifier::new(config.network),

--- a/applications/tari_indexer/src/config.rs
+++ b/applications/tari_indexer/src/config.rs
@@ -119,6 +119,10 @@ pub struct IndexerConfig {
     pub templates_sidechain_id: Option<RistrettoPublicKey>,
     /// The burnt utxos sidechain id
     pub burnt_utxo_sidechain_id: Option<RistrettoPublicKey>,
+    /// Cache TTL for substates fetched during dry run transaction processing.
+    /// A shorter TTL reduces the chance of stale fee estimates.
+    #[serde(with = "serializers::seconds")]
+    pub dry_run_cache_ttl: Duration,
     /// The event filtering configuration
     pub event_filters: Vec<EventFilter>,
 }
@@ -140,6 +144,7 @@ impl Default for IndexerConfig {
             sidechain_id: None,
             templates_sidechain_id: None,
             burnt_utxo_sidechain_id: None,
+            dry_run_cache_ttl: Duration::from_secs(10),
             event_filters: vec![],
         }
     }

--- a/applications/tari_indexer/src/substate_manager.rs
+++ b/applications/tari_indexer/src/substate_manager.rs
@@ -20,7 +20,10 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::collections::{HashMap, HashSet};
+use std::{
+    collections::{HashMap, HashSet},
+    time::Duration,
+};
 
 use serde::{Deserialize, Serialize};
 use tari_engine_types::{
@@ -85,6 +88,11 @@ impl SubstateManager {
             cache_manager: cached_substates,
             substate_store,
         }
+    }
+
+    pub fn with_cache_ttl(mut self, ttl: Duration) -> Self {
+        self.cache_manager = self.cache_manager.with_cache_ttl(ttl);
+        self
     }
 
     #[cfg(feature = "metrics")]

--- a/crates/indexer_lib/src/cached_substate_manager.rs
+++ b/crates/indexer_lib/src/cached_substate_manager.rs
@@ -20,7 +20,10 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::{collections::HashMap, time::SystemTime};
+use std::{
+    collections::HashMap,
+    time::{Duration, SystemTime},
+};
 
 use log::*;
 use tari_engine_types::substate::{Substate, SubstateId};
@@ -44,11 +47,14 @@ use crate::{
 
 const LOG_TARGET: &str = "tari::indexer::scanner";
 
+const DEFAULT_CACHE_TTL: Duration = Duration::from_secs(300);
+
 #[derive(Debug, Clone)]
 pub struct CachedSubstateManager<TEpochManager, TVnClient, TSubstateCache> {
     committee_provider: TEpochManager,
     validator_node_client_factory: TVnClient,
     substate_cache: TSubstateCache,
+    cache_ttl: Duration,
     #[cfg(feature = "metrics")]
     metrics: Option<crate::metrics::Metrics>,
 }
@@ -69,9 +75,15 @@ where
             committee_provider,
             validator_node_client_factory,
             substate_cache,
+            cache_ttl: DEFAULT_CACHE_TTL,
             #[cfg(feature = "metrics")]
             metrics: None,
         }
+    }
+
+    pub fn with_cache_ttl(mut self, ttl: Duration) -> Self {
+        self.cache_ttl = ttl;
+        self
     }
 
     #[cfg(feature = "metrics")]
@@ -101,8 +113,7 @@ where
                 }
             } else {
                 let now = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH)?.as_secs();
-                const CACHE_STALE_SECS: u64 = 300; // 5 minutes
-                if now.saturating_sub(entry.cached_at) > CACHE_STALE_SECS {
+                if now.saturating_sub(entry.cached_at) > self.cache_ttl.as_secs() {
                     debug!(target: LOG_TARGET, "Cached substate {} is stale. Fetching fresh copy.", substate_id);
                 } else {
                     debug!(target: LOG_TARGET, "Substate cache hit for {} with version {}", substate_id, entry.version);


### PR DESCRIPTION
## Summary
- Dry runs were returning stale fee estimates because the indexer's substate cache (5 min TTL) could serve outdated state, causing transactions to fail with `InsufficientFeesPaid` when submitted using the dry run fee
- Give the dry run processor its own `SubstateManager` with a separate, shorter cache TTL (default 10s)
- Add `dry_run_cache_ttl` config option to `IndexerConfig` so operators can tune it

## Test plan
- [ ] Deploy indexer with default config, verify dry run fees match actual execution fees under concurrent transaction load
- [ ] Verify `dry_run_cache_ttl` is respected when set in the indexer config file
- [ ] Verify existing REST API substate lookups still use the default 5 min cache