### PR TITLE
fix(indexer): add missing liquidity pool builtin template

### DIFF
--- a/applications/tari_indexer/src/template_manager/manager.rs
+++ b/applications/tari_indexer/src/template_manager/manager.rs
@@ -44,13 +44,7 @@ use tari_ootle_storage::{
     time::{OffsetDateTime, PrimitiveDateTime},
 };
 use tari_ootle_storage_sqlite::global::SqliteGlobalDbAdapter;
-use tari_template_builtin::{
-    ACCOUNT_TEMPLATE_ADDRESS,
-    NFT_FAUCET_TEMPLATE_ADDRESS,
-    XTR_FAUCET_TEMPLATE_ADDRESS,
-    get_template_builtin,
-    try_get_template_builtin,
-};
+use tari_template_builtin::{all_builtin_templates, try_get_template_builtin};
 use tari_template_lib_types::{TemplateAddress, crypto::RistrettoPublicKeyBytes};
 
 use super::{Template, TemplateCode, TemplateMetadata};
@@ -72,12 +66,12 @@ impl TemplateManager {
 
         // Load them into the database if they do not already exist
         let mut tx = global_db.create_transaction()?;
-        for (address, template) in builtin_templates {
+        for template in builtin_templates {
             let mut templates_db = global_db.templates(&mut tx);
-            if !templates_db.template_exists(&address, None)? {
+            if !templates_db.template_exists(template.address(), None)? {
                 let db_template = DbTemplate {
                     author_public_key: template.metadata.author_public_key,
-                    template_address: address,
+                    template_address: *template.address(),
                     template_name: template.metadata.name.clone(),
                     binary_hash: template.metadata.binary_sha,
                     status: TemplateStatus::Active,
@@ -100,22 +94,10 @@ impl TemplateManager {
         })
     }
 
-    fn builtin_templates() -> impl Iterator<Item = (TemplateAddress, Template)> {
-        [
-            (
-                ACCOUNT_TEMPLATE_ADDRESS,
-                convert_builtin_template("Account", ACCOUNT_TEMPLATE_ADDRESS),
-            ),
-            (
-                XTR_FAUCET_TEMPLATE_ADDRESS,
-                convert_builtin_template("XtrFaucet", XTR_FAUCET_TEMPLATE_ADDRESS),
-            ),
-            (
-                NFT_FAUCET_TEMPLATE_ADDRESS,
-                convert_builtin_template("NftFaucet", NFT_FAUCET_TEMPLATE_ADDRESS),
-            ),
-        ]
-        .into_iter()
+    fn builtin_templates() -> impl Iterator<Item = Template> {
+        all_builtin_templates()
+            .iter()
+            .map(|(address, code)| convert_builtin_template_from_code(*address, code))
     }
 
     pub fn template_exists(
@@ -323,12 +305,12 @@ fn now() -> PrimitiveDateTime {
     PrimitiveDateTime::new(now.date(), now.time())
 }
 
-fn convert_builtin_template(name: &str, address: TemplateAddress) -> Template {
-    let code = get_template_builtin(&address);
+fn convert_builtin_template_from_code(address: TemplateAddress, code: &'static [u8]) -> Template {
     let binary_sha = calculate_template_binary_hash(code);
+    let loaded = WasmModule::load_template_from_code(code).expect("Built-in template failed to load");
     Template {
         metadata: TemplateMetadata {
-            name: name.to_string(),
+            name: loaded.template_name().to_string(),
             address,
             binary_sha: binary_sha.into_array().into(),
             author_public_key: Default::default(),

--- a/applications/tari_indexer/src/template_manager/types.rs
+++ b/applications/tari_indexer/src/template_manager/types.rs
@@ -72,6 +72,12 @@ pub struct Template {
     pub code: TemplateCode,
 }
 
+impl Template {
+    pub fn address(&self) -> &TemplateAddress {
+        &self.metadata.address
+    }
+}
+
 // we encapsulate the db row format to not expose it to the caller
 impl TryFrom<DbTemplate> for Template {
     type Error = StorageError;

--- a/crates/template_builtin/src/lib.rs
+++ b/crates/template_builtin/src/lib.rs
@@ -36,6 +36,8 @@ pub const XTR_FAUCET_TEMPLATE_ADDRESS: TemplateAddress = TemplateAddress::from_a
     1, 2, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 ]);
 
+/// Address of the two-resource liquidity pool template
+/// 0000000000000000000000000000000000000000000000000000000000000002
 pub const LIQUIDITY_POOL_TEMPLATE_ADDRESS: TemplateAddress = TemplateAddress::from_array([
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2,
 ]);


### PR DESCRIPTION
## Summary
- The indexer's `TemplateManager` maintained its own hardcoded list of builtin templates that was missing the liquidity pool (`template_...0002`), causing 404s when querying for it
- Replaced the duplicate list with `all_builtin_templates()` from `tari_template_builtin` (the single source of truth already used by the validator node), so future builtins are automatically included
- Template names are now derived from the WASM module itself rather than being hardcoded

## Test plan
- [ ] Query the indexer for `template_0000000000000000000000000000000000000000000000000000000000000002` and verify it returns the liquidity pool template definition instead of 404
- [ ] Verify existing builtin templates (Account, NftFaucet, XtrFaucet) still resolve correctly