### PR TITLE
feat(manifest): add None literal and macro-style argument syntax

### DIFF
--- a/crates/template_lib_types/src/substates/metadata.rs
+++ b/crates/template_lib_types/src/substates/metadata.rs
@@ -79,6 +79,9 @@ impl FromStr for Metadata {
     type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.trim().is_empty() {
+            return Ok(Self::new());
+        }
         let pairs = s.split(',').map(|pair| {
             let (key, value) = pair
                 .split_once('=')

--- a/crates/transaction_manifest/src/generator.rs
+++ b/crates/transaction_manifest/src/generator.rs
@@ -240,6 +240,10 @@ impl ManifestInstructionGenerator {
             .map(|arg| match arg {
                 ManifestLiteral::Lit(lit) => lit_to_arg(&lit),
                 ManifestLiteral::Workspace(ident) => self.get_ident(&ident.to_string()),
+                ManifestLiteral::Special(SpecialLiteral::Null) => {
+                    Ok(InstructionArg::literal(tari_bor::Value::Null)
+                        .expect("Null literal serialization should not fail"))
+                },
                 ManifestLiteral::Special(SpecialLiteral::Amount(amount)) => Ok(call_arg!(amount)),
                 ManifestLiteral::Special(SpecialLiteral::NonFungibleId(id)) => Ok(call_arg!(id)),
                 ManifestLiteral::Special(SpecialLiteral::Cbor(value)) => {

--- a/crates/transaction_manifest/src/parser.rs
+++ b/crates/transaction_manifest/src/parser.rs
@@ -108,6 +108,7 @@ pub enum ManifestLiteral {
 
 #[derive(Debug, Clone)]
 pub enum SpecialLiteral {
+    Null,
     Amount(Amount),
     NonFungibleId(NonFungibleId),
     Cbor(tari_bor::Value),
@@ -450,7 +451,9 @@ fn build_arguments(args: Punctuated<Expr, Comma>) -> Result<Vec<ManifestLiteral>
 
             Expr::Path(ExprPath { path, .. }) => {
                 if let Some(seg) = path.segments.first() {
-                    if seg.ident == "XTR" || seg.ident == "TARI" {
+                    if seg.ident == "None" {
+                        Ok(ManifestLiteral::Special(SpecialLiteral::Null))
+                    } else if seg.ident == "XTR" || seg.ident == "TARI" {
                         Ok(ManifestLiteral::Special(SpecialLiteral::Address(OrVar::Value(
                             TARI_TOKEN.into(),
                         ))))
@@ -483,21 +486,7 @@ fn build_arguments(args: Punctuated<Expr, Comma>) -> Result<Vec<ManifestLiteral>
                     ))
                 }
             },
-            Expr::Macro(ExprMacro { mac, .. }) => match mac.path.get_ident() {
-                Some(name) if name == "cbor" => {
-                    let cbor_value: serde_json::Value = serde_json::from_str(&mac.tokens.to_string()).map_err(|e| {
-                        syn::Error::new_spanned(&mac.tokens, format!("Failed to parse CBOR JSON value: {}", e))
-                    })?;
-                    let cbor = convert_json_to_cbor(cbor_value).map_err(|e| {
-                        syn::Error::new_spanned(&mac.tokens, format!("Failed to convert JSON to CBOR value: {}", e))
-                    })?;
-                    Ok(ManifestLiteral::Special(SpecialLiteral::Cbor(cbor)))
-                },
-                _ => Err(syn::Error::new_spanned(
-                    mac,
-                    "Invalid argument, only literals and variables are supported",
-                )),
-            },
+            Expr::Macro(ExprMacro { mac, .. }) => Ok(handle_macro_argument(mac)?),
             _ => Err(syn::Error::new_spanned(
                 arg,
                 "Invalid argument, only literals and variables are supported",
@@ -645,6 +634,95 @@ fn handle_special_literals(name: &Ident, args: Punctuated<Expr, Comma>) -> Resul
             format!(
                 "Invalid function call '{s}', only Amount, SubstateId, Address, NonFungibleId, Metadata, HexBytes, \
                  Cbor and PublicKey are supported"
+            ),
+        )),
+    }
+}
+
+fn handle_macro_argument(mac: Macro) -> Result<ManifestLiteral, syn::Error> {
+    let name = mac
+        .path
+        .get_ident()
+        .ok_or_else(|| syn::Error::new_spanned(&mac.path, "macro path must have a single segment"))?;
+
+    match name.to_string().as_str() {
+        "cbor" => {
+            let cbor_value: serde_json::Value = serde_json::from_str(&mac.tokens.to_string())
+                .map_err(|e| syn::Error::new_spanned(&mac.tokens, format!("Failed to parse CBOR JSON value: {}", e)))?;
+            let cbor = convert_json_to_cbor(cbor_value).map_err(|e| {
+                syn::Error::new_spanned(&mac.tokens, format!("Failed to convert JSON to CBOR value: {}", e))
+            })?;
+            Ok(ManifestLiteral::Special(SpecialLiteral::Cbor(cbor)))
+        },
+        "metadata" => {
+            let tokens_str = mac.tokens.to_string();
+            let trimmed = tokens_str.trim();
+            if trimmed.is_empty() {
+                Ok(ManifestLiteral::Special(SpecialLiteral::Metadata(Metadata::new())))
+            } else {
+                let lit_str: LitStr = parse2(mac.tokens).map_err(|e| {
+                    syn::Error::new_spanned(name, format!("Expected string literal in metadata!: {}", e))
+                })?;
+                let metadata: Metadata = lit_str
+                    .value()
+                    .parse()
+                    .map_err(|e| syn::Error::new_spanned(&lit_str, format!("Failed to parse Metadata value: {}", e)))?;
+                Ok(ManifestLiteral::Special(SpecialLiteral::Metadata(metadata)))
+            }
+        },
+        "amount" => {
+            let lit: syn::LitInt = parse2(mac.tokens)
+                .map_err(|e| syn::Error::new_spanned(name, format!("Expected integer literal in amount!: {}", e)))?;
+            Ok(ManifestLiteral::Special(SpecialLiteral::Amount(lit.base10_parse()?)))
+        },
+        "hex_bytes" | "public_key" | "bytes" => {
+            let lit_str: LitStr = parse2(mac.tokens)
+                .map_err(|e| syn::Error::new_spanned(name, format!("Expected string literal in {}!: {}", name, e)))?;
+            let bytes = bytes_from_hex(&lit_str.value())
+                .map_err(|e| syn::Error::new_spanned(&lit_str, format!("Failed to parse hex bytes: {}", e)))?;
+            Ok(ManifestLiteral::Special(SpecialLiteral::Cbor(tari_bor::Value::Bytes(
+                bytes,
+            ))))
+        },
+        "address" | "substate_id" => {
+            let tokens_str = mac.tokens.to_string();
+            let trimmed = tokens_str.trim();
+            // Check if it looks like a string literal or an identifier (variable reference)
+            if trimmed.starts_with('"') {
+                let lit_str: LitStr = parse2(mac.tokens).map_err(|e| {
+                    syn::Error::new_spanned(name, format!("Expected string literal in {}!: {}", name, e))
+                })?;
+                let id: SubstateId = lit_str
+                    .value()
+                    .parse()
+                    .map_err(|e| syn::Error::new_spanned(&lit_str, format!("Failed to parse substate id: {}", e)))?;
+                if name == "address" {
+                    Ok(ManifestLiteral::Special(SpecialLiteral::Address(OrVar::Value(id))))
+                } else {
+                    Ok(ManifestLiteral::Special(SpecialLiteral::SubstateId(OrVar::Value(id))))
+                }
+            } else {
+                let ident: Ident = parse2(mac.tokens)
+                    .map_err(|e| syn::Error::new_spanned(name, format!("Expected identifier in {}!: {}", name, e)))?;
+                if name == "address" {
+                    Ok(ManifestLiteral::Special(SpecialLiteral::Address(OrVar::Var(ident))))
+                } else {
+                    Ok(ManifestLiteral::Special(SpecialLiteral::SubstateId(OrVar::Var(ident))))
+                }
+            }
+        },
+        "non_fungible_id" => {
+            let lit: Lit = parse2(mac.tokens)
+                .map_err(|e| syn::Error::new_spanned(name, format!("Expected literal in non_fungible_id!: {}", e)))?;
+            let id = lit_to_nonfungible_id(&lit)
+                .map_err(|e| syn::Error::new_spanned(&lit, format!("Failed to parse NonFungibleId: {}", e)))?;
+            Ok(ManifestLiteral::Special(SpecialLiteral::NonFungibleId(id)))
+        },
+        _ => Err(syn::Error::new_spanned(
+            name,
+            format!(
+                "Invalid argument macro '{name}', supported macros: cbor!, metadata!, amount!, hex_bytes!, bytes!, \
+                 public_key!, address!, substate_id!, non_fungible_id!"
             ),
         )),
     }

--- a/crates/transaction_manifest/tests/parser.rs
+++ b/crates/transaction_manifest/tests/parser.rs
@@ -380,3 +380,120 @@ fn create_account_without_assignment() {
     assert_eq!(instructions, expected);
     assert_eq!(fee_instructions, vec![]);
 }
+
+#[test]
+fn none_literal() {
+    let manifest = r#"
+        use template_c2b621869ec2929d3b9503ea41054f01b468ce99e50254b58e460f608ae377f7 as MyTemplate;
+
+        fn main() {
+            MyTemplate::create("hello", None, 42);
+        }
+    "#;
+
+    let ManifestInstructions {
+        instructions,
+        fee_instructions,
+    } = parse_manifest(manifest, HashMap::new(), Default::default()).unwrap();
+
+    let template_addr =
+        TemplateAddress::from_hex("c2b621869ec2929d3b9503ea41054f01b468ce99e50254b58e460f608ae377f7").unwrap();
+
+    let expected = vec![Instruction::CallFunction {
+        address: template_addr,
+        function: "create".try_into().unwrap(),
+        args: call_args!["hello", Literal(Option::<()>::None), 42],
+    }];
+
+    assert_eq!(instructions, expected);
+    assert_eq!(fee_instructions, vec![]);
+}
+
+#[test]
+fn metadata_macro_empty() {
+    let manifest = r#"
+        use template_c2b621869ec2929d3b9503ea41054f01b468ce99e50254b58e460f608ae377f7 as MyTemplate;
+
+        fn main() {
+            MyTemplate::create(metadata![]);
+        }
+    "#;
+
+    let ManifestInstructions {
+        instructions,
+        fee_instructions,
+    } = parse_manifest(manifest, HashMap::new(), Default::default()).unwrap();
+
+    let template_addr =
+        TemplateAddress::from_hex("c2b621869ec2929d3b9503ea41054f01b468ce99e50254b58e460f608ae377f7").unwrap();
+
+    use tari_template_lib_types::Metadata;
+    let expected = vec![Instruction::CallFunction {
+        address: template_addr,
+        function: "create".try_into().unwrap(),
+        args: call_args![Metadata::new()],
+    }];
+
+    assert_eq!(instructions, expected);
+    assert_eq!(fee_instructions, vec![]);
+}
+
+#[test]
+fn metadata_macro_with_values() {
+    let manifest = r#"
+        use template_c2b621869ec2929d3b9503ea41054f01b468ce99e50254b58e460f608ae377f7 as MyTemplate;
+
+        fn main() {
+            MyTemplate::create(metadata!["key=value"]);
+        }
+    "#;
+
+    let ManifestInstructions {
+        instructions,
+        fee_instructions,
+    } = parse_manifest(manifest, HashMap::new(), Default::default()).unwrap();
+
+    let template_addr =
+        TemplateAddress::from_hex("c2b621869ec2929d3b9503ea41054f01b468ce99e50254b58e460f608ae377f7").unwrap();
+
+    use tari_template_lib_types::Metadata;
+    let expected_metadata: Metadata = "key=value".parse().unwrap();
+    let expected = vec![Instruction::CallFunction {
+        address: template_addr,
+        function: "create".try_into().unwrap(),
+        args: call_args![expected_metadata],
+    }];
+
+    assert_eq!(instructions, expected);
+    assert_eq!(fee_instructions, vec![]);
+}
+
+#[test]
+fn empty_metadata_function_call_syntax() {
+    // Metadata("") should also work now
+    let manifest = r#"
+        use template_c2b621869ec2929d3b9503ea41054f01b468ce99e50254b58e460f608ae377f7 as MyTemplate;
+
+        fn main() {
+            MyTemplate::create(Metadata(""));
+        }
+    "#;
+
+    let ManifestInstructions {
+        instructions,
+        fee_instructions,
+    } = parse_manifest(manifest, HashMap::new(), Default::default()).unwrap();
+
+    let template_addr =
+        TemplateAddress::from_hex("c2b621869ec2929d3b9503ea41054f01b468ce99e50254b58e460f608ae377f7").unwrap();
+
+    use tari_template_lib_types::Metadata;
+    let expected = vec![Instruction::CallFunction {
+        address: template_addr,
+        function: "create".try_into().unwrap(),
+        args: call_args![Metadata::new()],
+    }];
+
+    assert_eq!(instructions, expected);
+    assert_eq!(fee_instructions, vec![]);
+}


### PR DESCRIPTION
## Summary
- Support `None` as a literal argument in manifests, serialized as CBOR null (for `Option::None` parameters)
- Add macro-style argument syntax as alternatives to capitalized function calls: `metadata![]`, `amount![]`, `bytes![]`, `public_key![]`, `hex_bytes![]`, `address![]`, `substate_id![]`, `non_fungible_id![]`
- Fix `Metadata::from_str("")` to return empty metadata instead of erroring on "Invalid key=value pair"
- Backward compatible: existing `Metadata("...")`, `Amount(...)` etc. syntax still works

## Motivation
Creating a liquidity pool via manifest was failing because:
1. `None` was parsed as a variable reference, giving "Variable 'None' is not defined"
2. `Metadata("")` failed with "Invalid key=value pair"  
3. `Metadata()` (no args) failed with "Invalid function call"

The new syntax allows:
```rust
Lp::create("None", "AllowAll", resx_a, resx_b, metadata![], None);
```

## Test plan
- [x] Existing parser tests pass (8 tests)
- [x] New tests for `None` literal, empty `metadata![]`, `metadata!["key=value"]`, and `Metadata("")`
- [x] Metadata FromStr empty string test passes