### PR TITLE
feat(wallet): support multiple signing keys in manifest submission

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1692,7 +1692,7 @@ dependencies = [
 
 [[package]]
 name = "consensus_tests"
-version = "0.28.8"
+version = "0.28.9"
 dependencies = [
  "fern",
  "futures 0.3.31",
@@ -2671,7 +2671,7 @@ dependencies = [
 
 [[package]]
 name = "db-inspector"
-version = "0.28.8"
+version = "0.28.9"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -4899,7 +4899,7 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "integration_tests"
-version = "0.28.8"
+version = "0.28.9"
 dependencies = [
  "anyhow",
  "config",
@@ -5615,7 +5615,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-messaging"
-version = "0.28.8"
+version = "0.28.9"
 dependencies = [
  "async-trait",
  "futures-bounded",
@@ -5794,7 +5794,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-substream"
-version = "0.28.8"
+version = "0.28.9"
 dependencies = [
  "libp2p",
  "prometheus-client",
@@ -7402,7 +7402,7 @@ dependencies = [
 
 [[package]]
 name = "ootle-wasm"
-version = "0.28.8"
+version = "0.28.9"
 dependencies = [
  "console_error_panic_hook",
  "getrandom 0.2.17",
@@ -7412,7 +7412,7 @@ dependencies = [
 
 [[package]]
 name = "ootle-wasm-core"
-version = "0.28.8"
+version = "0.28.9"
 dependencies = [
  "base64 0.22.1",
  "ootle_byte_type",
@@ -8407,7 +8407,7 @@ dependencies = [
 
 [[package]]
 name = "proto_builder"
-version = "0.28.8"
+version = "0.28.9"
 dependencies = [
  "prost-build 0.14.3",
  "sha2 0.10.9",
@@ -10215,7 +10215,7 @@ dependencies = [
 
 [[package]]
 name = "sqlite_message_logger"
-version = "0.28.8"
+version = "0.28.9"
 dependencies = [
  "chrono",
  "diesel",
@@ -10588,7 +10588,7 @@ dependencies = [
 
 [[package]]
 name = "tari_base_node_client"
-version = "0.28.8"
+version = "0.28.9"
 dependencies = [
  "futures-util",
  "log",
@@ -10813,7 +10813,7 @@ dependencies = [
 
 [[package]]
 name = "tari_consensus"
-version = "0.28.8"
+version = "0.28.9"
 dependencies = [
  "anyhow",
  "indexmap 2.13.0",
@@ -10838,7 +10838,7 @@ dependencies = [
 
 [[package]]
 name = "tari_consensus_types"
-version = "0.28.8"
+version = "0.28.9"
 dependencies = [
  "borsh",
  "ootle_serde",
@@ -10940,7 +10940,7 @@ dependencies = [
 
 [[package]]
 name = "tari_engine"
-version = "0.28.8"
+version = "0.28.9"
 dependencies = [
  "blake2",
  "criterion",
@@ -10968,7 +10968,7 @@ dependencies = [
 
 [[package]]
 name = "tari_engine_types"
-version = "0.28.8"
+version = "0.28.9"
 dependencies = [
  "bincode 2.0.1",
  "blake2",
@@ -10996,7 +10996,7 @@ dependencies = [
 
 [[package]]
 name = "tari_epoch_manager"
-version = "0.28.8"
+version = "0.28.9"
 dependencies = [
  "anyhow",
  "log",
@@ -11016,7 +11016,7 @@ dependencies = [
 
 [[package]]
 name = "tari_epoch_oracles"
-version = "0.28.8"
+version = "0.28.9"
 dependencies = [
  "anyhow",
  "blake2",
@@ -11069,7 +11069,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer"
-version = "0.28.8"
+version = "0.28.9"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -11139,7 +11139,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer_client"
-version = "0.28.8"
+version = "0.28.9"
 dependencies = [
  "anyhow",
  "bounded-vec",
@@ -11168,7 +11168,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer_lib"
-version = "0.28.8"
+version = "0.28.9"
 dependencies = [
  "log",
  "prometheus-client",
@@ -11260,7 +11260,7 @@ dependencies = [
 
 [[package]]
 name = "tari_networking"
-version = "0.28.8"
+version = "0.28.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11312,7 +11312,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_app_utilities"
-version = "0.28.8"
+version = "0.28.9"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -11351,7 +11351,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_common_types"
-version = "0.28.8"
+version = "0.28.9"
 dependencies = [
  "blake2",
  "borsh",
@@ -11378,7 +11378,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_p2p"
-version = "0.28.8"
+version = "0.28.9"
 dependencies = [
  "anyhow",
  "libp2p-identity",
@@ -11402,7 +11402,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_storage"
-version = "0.28.8"
+version = "0.28.9"
 dependencies = [
  "anyhow",
  "bitflags 2.10.0",
@@ -11429,7 +11429,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_storage_sqlite"
-version = "0.28.8"
+version = "0.28.9"
 dependencies = [
  "diesel",
  "diesel_migrations",
@@ -11476,7 +11476,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_transaction"
-version = "0.28.8"
+version = "0.28.9"
 dependencies = [
  "bincode 2.0.1",
  "borsh",
@@ -11501,7 +11501,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_cli"
-version = "0.28.8"
+version = "0.28.9"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -11530,7 +11530,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_crypto"
-version = "0.28.8"
+version = "0.28.9"
 dependencies = [
  "argon2 0.5.3",
  "blake2",
@@ -11559,7 +11559,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_sdk"
-version = "0.28.8"
+version = "0.28.9"
 dependencies = [
  "anyhow",
  "digest 0.10.7",
@@ -11624,7 +11624,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_storage_sqlite"
-version = "0.28.8"
+version = "0.28.9"
 dependencies = [
  "bigdecimal",
  "diesel",
@@ -11648,7 +11648,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_walletd"
-version = "0.28.8"
+version = "0.28.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11765,7 +11765,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_framework"
-version = "0.28.8"
+version = "0.28.9"
 dependencies = [
  "async-trait",
  "bitflags 2.10.0",
@@ -11789,7 +11789,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_macros"
-version = "0.28.8"
+version = "0.28.9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11798,7 +11798,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_state_sync"
-version = "0.28.8"
+version = "0.28.9"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -11875,7 +11875,7 @@ dependencies = [
 
 [[package]]
 name = "tari_state_store_rocksdb"
-version = "0.28.8"
+version = "0.28.9"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -11906,7 +11906,7 @@ dependencies = [
 
 [[package]]
 name = "tari_state_tree"
-version = "0.28.8"
+version = "0.28.9"
 dependencies = [
  "indexmap 2.13.0",
  "log",
@@ -11932,7 +11932,7 @@ dependencies = [
 
 [[package]]
 name = "tari_swarm"
-version = "0.28.8"
+version = "0.28.9"
 dependencies = [
  "libp2p",
  "libp2p-messaging",
@@ -11943,7 +11943,7 @@ dependencies = [
 
 [[package]]
 name = "tari_swarm_daemon"
-version = "0.28.8"
+version = "0.28.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11998,7 +11998,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_builtin"
-version = "0.28.8"
+version = "0.28.9"
 dependencies = [
  "anyhow",
  "tari_engine_types",
@@ -12052,7 +12052,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_test_tooling"
-version = "0.28.8"
+version = "0.28.9"
 dependencies = [
  "anyhow",
  "cargo_toml 0.22.3",
@@ -12167,7 +12167,7 @@ dependencies = [
 
 [[package]]
 name = "tari_transaction_manifest"
-version = "0.28.8"
+version = "0.28.9"
 dependencies = [
  "proc-macro2",
  "serde_json",
@@ -12201,7 +12201,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node"
-version = "0.28.8"
+version = "0.28.9"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -12267,7 +12267,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node_client"
-version = "0.28.8"
+version = "0.28.9"
 dependencies = [
  "indexmap 2.13.0",
  "multiaddr 0.18.3",
@@ -12291,7 +12291,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node_rpc"
-version = "0.28.8"
+version = "0.28.9"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -12327,7 +12327,7 @@ dependencies = [
 
 [[package]]
 name = "tari_watcher"
-version = "0.28.8"
+version = "0.28.9"
 dependencies = [
  "anyhow",
  "clap 3.2.25",
@@ -12355,7 +12355,7 @@ dependencies = [
 
 [[package]]
 name = "tariswap_bench"
-version = "0.28.8"
+version = "0.28.9"
 dependencies = [
  "anyhow",
  "clap 4.5.54",
@@ -13035,7 +13035,7 @@ dependencies = [
 
 [[package]]
 name = "traffic-sim"
-version = "0.28.8"
+version = "0.28.9"
 dependencies = [
  "anyhow",
  "clap 4.5.54",
@@ -13057,7 +13057,7 @@ dependencies = [
 
 [[package]]
 name = "transaction_generator"
-version = "0.28.8"
+version = "0.28.9"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -13076,7 +13076,7 @@ dependencies = [
 
 [[package]]
 name = "transaction_submitter"
-version = "0.28.8"
+version = "0.28.9"
 dependencies = [
  "anyhow",
  "clap 4.5.54",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.28.8"
+version = "0.28.9"
 edition = "2024"
 authors = ["The Tari Development Community"]
 repository = "https://github.com/tari-project/tari-ootle"

--- a/applications/tari_indexer/web_ui/src/routes/Transaction/components/FeeReceipt.tsx
+++ b/applications/tari_indexer/web_ui/src/routes/Transaction/components/FeeReceipt.tsx
@@ -41,22 +41,20 @@ export default function FeeReceipt({ data }: { data: FeeReceiptType }) {
     );
   }
 
-  const totalCost = Object.entries(data.cost_breakdown?.breakdown || {}).reduce(
+  const totalFeesCharged = Object.entries(data.cost_breakdown?.breakdown || {}).reduce(
     (sum, [_, value]) => BigInt(sum) + BigInt(value),
     BigInt(0),
+  );
+  const totalRefunded = unsignedSaturatingSub(
+    BigInt(data.total_fee_payment) - totalFeesCharged - BigInt(data.total_fee_overcharge),
   );
 
   const feeItems = [
     { label: "Total Fees Paid", value: formatCurrency(data.total_fee_payment, CURRENCY.DECIMALS, CURRENCY.SYMBOL) },
-    { label: "Total Fees Charged", value: formatCurrency(data.total_fees_paid, CURRENCY.DECIMALS, CURRENCY.SYMBOL) },
-    { label: "Total Fees Required", value: formatCurrency(totalCost, CURRENCY.DECIMALS, CURRENCY.SYMBOL) },
+    { label: "Total Fees Charged", value: formatCurrency(totalFeesCharged, CURRENCY.DECIMALS, CURRENCY.SYMBOL) },
     {
       label: "Fees Refunded",
-      value: formatCurrency(
-        unsignedSaturatingSub(BigInt(data.total_fee_payment) - totalCost),
-        CURRENCY.DECIMALS,
-        CURRENCY.SYMBOL,
-      ),
+      value: formatCurrency(totalRefunded, CURRENCY.DECIMALS, CURRENCY.SYMBOL),
     },
     { label: "Fees Overcharge", value: formatCurrency(data.total_fee_overcharge, CURRENCY.DECIMALS, CURRENCY.SYMBOL) },
   ];

--- a/applications/tari_walletd/src/handlers/transaction.rs
+++ b/applications/tari_walletd/src/handlers/transaction.rs
@@ -327,12 +327,14 @@ pub async fn handle_submit_manifest(
 
     // Sign with each additional signing key (not the seal signer, which seals the transaction)
     let mut transaction = transaction.finish();
-    for signing_key_id in &req.signing_key_ids {
-        if *signing_key_id != seal_signer_key_id {
-            transaction = sdk
-                .signer_api()
-                .with_context(default_account.owner_public_key())
-                .sign(*signing_key_id, transaction)?;
+    if !req.signing_key_ids.is_empty() {
+        let seal_signer_pk = sdk.key_manager_api().get_public_key(seal_signer_key_id)?;
+        let seal_signer_pk_bytes = seal_signer_pk.public_key.to_byte_type();
+        let signer = sdk.signer_api().with_context(&seal_signer_pk_bytes);
+        for signing_key_id in &req.signing_key_ids {
+            if *signing_key_id != seal_signer_key_id {
+                transaction = signer.sign(*signing_key_id, transaction)?;
+            }
         }
     }
 

--- a/applications/tari_walletd/src/handlers/transaction.rs
+++ b/applications/tari_walletd/src/handlers/transaction.rs
@@ -294,14 +294,14 @@ pub async fn handle_submit_manifest(
         .optional()?
         .ok_or_else(|| invalid_request("No default account found".to_string()))?;
 
-    let account_owner_key_id = default_account.owner_key_id().ok_or_else(|| {
+    let default_owner_key_id = default_account.owner_key_id().ok_or_else(|| {
         invalid_params(
-            "signing_key_id",
+            "seal_signer_key_id",
             Some("Default account does not have an owner key set".to_string()),
         )
     })?;
 
-    let signing_key_id = req.signing_key_id.unwrap_or(account_owner_key_id);
+    let seal_signer_key_id = req.seal_signer_key_id.unwrap_or(default_owner_key_id);
 
     let fee_amount = req.max_fee;
 
@@ -325,15 +325,18 @@ pub async fn handle_submit_manifest(
 
     let transaction = transaction.with_inputs(inputs);
 
-    let transaction = if signing_key_id == account_owner_key_id {
-        transaction.finish()
-    } else {
-        sdk.signer_api()
-            .with_context(default_account.owner_public_key())
-            .sign(signing_key_id, transaction)?
-    };
+    // Sign with each additional signing key (not the seal signer, which seals the transaction)
+    let mut transaction = transaction.finish();
+    for signing_key_id in &req.signing_key_ids {
+        if *signing_key_id != seal_signer_key_id {
+            transaction = sdk
+                .signer_api()
+                .with_context(default_account.owner_public_key())
+                .sign(*signing_key_id, transaction)?;
+        }
+    }
 
-    let transaction = sdk.signer_api().sign(account_owner_key_id, transaction)?;
+    let transaction = sdk.signer_api().sign(seal_signer_key_id, transaction)?;
 
     if req.dry_run {
         let exec_result = context

--- a/applications/tari_walletd/src/handlers/transaction.rs
+++ b/applications/tari_walletd/src/handlers/transaction.rs
@@ -388,6 +388,7 @@ pub async fn handle_get(
         transaction: transaction.transaction,
         result: transaction.finalize,
         status: transaction.status,
+        final_fee: transaction.final_fee,
         invalid_reason: transaction.invalid_reason,
         last_update_time: transaction.last_update_time,
     })

--- a/applications/tari_walletd/web_ui/src/routes/AssetVault/Tokens/components/SendMoney.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/AssetVault/Tokens/components/SendMoney.tsx
@@ -228,8 +228,8 @@ export function SendMoneyDialog(props: SendMoneyDialogProps) {
       }
 
       let fee = resp.final_fee;
-      if (props.resource_type === "Confidential") {
-        // TODO: Add extra amount for confidential transactions, since the bullet proof size is variable
+      if (props.resource_type === "Confidential" || props.resource_type === "Stealth") {
+        // Add extra amount for confidential/stealth transactions, since the bullet proof size is variable
         fee += 100;
       }
       setTransferFormState((prevState) => ({ ...prevState, fee: fee.toString() }));

--- a/applications/tari_walletd/web_ui/src/routes/AssetVault/Tokens/components/SendMoney.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/AssetVault/Tokens/components/SendMoney.tsx
@@ -227,12 +227,7 @@ export function SendMoneyDialog(props: SendMoneyDialogProps) {
         throw new Error(`Transaction rejected: ${rejectReasonToString(transactionResult.AcceptFeeRejectRest[1])}`);
       }
 
-      let fee = resp.final_fee;
-      if (props.resource_type === "Confidential" || props.resource_type === "Stealth") {
-        // Add extra amount for confidential/stealth transactions, since the bullet proof size is variable
-        fee += 100;
-      }
-      setTransferFormState((prevState) => ({ ...prevState, fee: fee.toString() }));
+      setTransferFormState((prevState) => ({ ...prevState, fee: resp.final_fee.toString() }));
     } finally {
       setIsEstimatingFee(false);
     }

--- a/applications/tari_walletd/web_ui/src/routes/Manifest/Manifest.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/Manifest/Manifest.tsx
@@ -52,12 +52,12 @@ import Grid from "@mui/material/Grid";
 import TextField from "@mui/material/TextField";
 import useManifestCodeStore from "@store/manifestStore";
 import type { ManifestTab } from "@store/manifestStore";
-import { FormatAlignLeft, LibraryAdd } from "@mui/icons-material";
+import { FileDownload, FileUpload, FormatAlignLeft, LibraryAdd } from "@mui/icons-material";
 import type { KeyId } from "@tari-project/ootle-ts-bindings";
 import { rejectReasonToString, substateIdToString } from "@tari-project/ootle-ts-bindings";
 import { useListTemplatesAuthored } from "@api/hooks/useTemplatesAuthored";
 import { Highlight, themes } from "prism-react-renderer";
-import { useRef, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 import EditorImport from "react-simple-code-editor";
 // Vite 8 dev pre-bundler doesn't unwrap exports.default for CJS packages
@@ -113,8 +113,59 @@ function ManifestEditor() {
   const theme = useTheme();
 
   const { mutateAsync: submitManifest, isPending: isSubmittingManifest, error } = useSubmitManifest();
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   const isDryRun = !fee;
+
+  const handleSave = useCallback(() => {
+    const data = manifest.tabs.map(({ name, code, variables, signingKeys }) => ({
+      name,
+      code,
+      variables,
+      signingKeys,
+    }));
+    const blob = new Blob([JSON.stringify(data, null, 2)], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "manifest.json";
+    a.click();
+    URL.revokeObjectURL(url);
+  }, [manifest.tabs]);
+
+  const handleLoad = useCallback(() => {
+    fileInputRef.current?.click();
+  }, []);
+
+  const handleFileChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      if (!file) return;
+      const reader = new FileReader();
+      reader.onload = () => {
+        try {
+          const parsed = JSON.parse(reader.result as string);
+          if (!Array.isArray(parsed) || parsed.length === 0) {
+            alert("Invalid manifest file: expected a non-empty array of tabs.");
+            return;
+          }
+          for (const tab of parsed) {
+            if (typeof tab.code !== "string" || typeof tab.name !== "string") {
+              alert("Invalid manifest file: each tab must have a name and code.");
+              return;
+            }
+          }
+          manifest.loadTabs(parsed);
+        } catch {
+          alert("Failed to parse manifest file.");
+        }
+      };
+      reader.readAsText(file);
+      // Reset so the same file can be loaded again
+      e.target.value = "";
+    },
+    [manifest.loadTabs],
+  );
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -155,6 +206,13 @@ function ManifestEditor() {
   return (
     <>
       <Grid size={12}>
+        <input
+          type="file"
+          accept=".json"
+          ref={fileInputRef}
+          onChange={handleFileChange}
+          style={{ display: "none" }}
+        />
         <form onSubmit={handleSubmit}>
           <ManifestTabBar
             tabs={manifest.tabs}
@@ -164,6 +222,8 @@ function ManifestEditor() {
             onRemove={manifest.removeTab}
             onRename={manifest.renameTab}
             onFormat={() => manifest.setCode(formatManifestCode(manifest.code))}
+            onSave={handleSave}
+            onLoad={handleLoad}
             onImportTemplate={(address, name) => {
               const importLine = `use template_${address} as ${name};`;
               if (manifest.code.includes(importLine)) return;
@@ -262,6 +322,8 @@ function ManifestTabBar({
   onRemove,
   onRename,
   onFormat,
+  onSave,
+  onLoad,
   onImportTemplate,
 }: {
   tabs: ManifestTab[];
@@ -271,6 +333,8 @@ function ManifestTabBar({
   onRemove: (id: string) => void;
   onRename: (id: string, name: string) => void;
   onFormat: () => void;
+  onSave: () => void;
+  onLoad: () => void;
   onImportTemplate: (address: string, name: string) => void;
 }) {
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
@@ -309,8 +373,14 @@ function ManifestTabBar({
       <IconButton size="small" onClick={onFormat} title="Format code">
         <FormatAlignLeft fontSize="small" />
       </IconButton>
-      <IconButton size="small" onClick={() => setImportOpen(true)} title="Import template" sx={{ mr: 1 }}>
+      <IconButton size="small" onClick={() => setImportOpen(true)} title="Import template">
         <LibraryAdd fontSize="small" />
+      </IconButton>
+      <IconButton size="small" onClick={onSave} title="Save manifests to file">
+        <FileDownload fontSize="small" />
+      </IconButton>
+      <IconButton size="small" onClick={onLoad} title="Load manifests from file" sx={{ mr: 1 }}>
+        <FileUpload fontSize="small" />
       </IconButton>
 
       <ImportTemplateDialog

--- a/applications/tari_walletd/web_ui/src/routes/Manifest/Manifest.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/Manifest/Manifest.tsx
@@ -53,6 +53,7 @@ import TextField from "@mui/material/TextField";
 import useManifestCodeStore from "@store/manifestStore";
 import type { ManifestTab } from "@store/manifestStore";
 import { FormatAlignLeft, LibraryAdd } from "@mui/icons-material";
+import type { KeyId } from "@tari-project/ootle-ts-bindings";
 import { rejectReasonToString, substateIdToString } from "@tari-project/ootle-ts-bindings";
 import { useListTemplatesAuthored } from "@api/hooks/useTemplatesAuthored";
 import { Highlight, themes } from "prism-react-renderer";
@@ -123,7 +124,8 @@ function ManifestEditor() {
       manifest: manifest.code,
       variables: manifest.variables,
       max_fee: isDryRun ? 3000 : Number(fee),
-      signing_key_id: null,
+      seal_signer_key_id: null,
+      signing_key_ids: manifest.signingKeys,
       dry_run: isDryRun,
     })
       .then((response) => {
@@ -214,6 +216,14 @@ function ManifestEditor() {
               onAdd={manifest.addVariable}
               onRemove={manifest.removeVariable}
               onRename={manifest.renameVariable}
+              onAddSigningKey={manifest.addSigningKey}
+            />
+          </Box>
+          <Box className="flex-container" style={{ justifyContent: "flex-start" }}>
+            <SigningKeysEditor
+              signingKeys={manifest.signingKeys}
+              onAdd={manifest.addSigningKey}
+              onRemove={manifest.removeSigningKey}
             />
           </Box>
           <Box className="flex-container" style={{ justifyContent: "flex-end" }}>
@@ -576,11 +586,13 @@ function VariableEditor({
   onAdd,
   onRemove,
   onRename,
+  onAddSigningKey,
 }: {
   variables: Record<string, string>;
   onAdd: (key: string, value: string) => void;
   onRemove: (key: string) => void;
   onRename: (oldKey: string, newKey: string) => void;
+  onAddSigningKey: (key: KeyId) => void;
 }) {
   const [showInputs, setShowInputs] = useState(false);
   const [key, setKey] = useState("");
@@ -593,6 +605,13 @@ function VariableEditor({
     if (!address) return;
     const varName = nextAccountVarName(variables);
     onAdd(varName, address);
+    // Auto-add the account's signing key
+    const accountInfo = accountsData?.accounts.find(
+      (a) => substateIdToString(a.account.component_address) === address,
+    );
+    if (accountInfo?.account.owner_key_id) {
+      onAddSigningKey(accountInfo.account.owner_key_id);
+    }
   };
 
   const handleAdd = () => {
@@ -712,6 +731,99 @@ function VariableEditor({
           )}
         </Stack>
       )}
+    </Grid>
+  );
+}
+
+function formatKeyId(key: KeyId): string {
+  if ("Derived" in key) {
+    return `${key.Derived.key_branch}/${key.Derived.index}`;
+  }
+  return `imported/${key.Imported.local_key_id}`;
+}
+
+function findAccountNameForKey(key: KeyId, accounts: { account: { name: string | null; owner_key_id: KeyId | null } }[]): string | null {
+  const match = accounts.find(
+    (a) => a.account.owner_key_id && JSON.stringify(a.account.owner_key_id) === JSON.stringify(key),
+  );
+  return match?.account.name || null;
+}
+
+function SigningKeysEditor({
+  signingKeys,
+  onAdd,
+  onRemove,
+}: {
+  signingKeys: KeyId[];
+  onAdd: (key: KeyId) => void;
+  onRemove: (index: number) => void;
+}) {
+  const { data: accountsData } = useAccountsList(0, 100);
+  const accounts = accountsData?.accounts || [];
+
+  const handleAddAccountKey = (e: SelectChangeEvent) => {
+    const address = e.target.value;
+    if (!address) return;
+    const accountInfo = accounts.find(
+      (a) => substateIdToString(a.account.component_address) === address,
+    );
+    if (accountInfo?.account.owner_key_id) {
+      onAdd(accountInfo.account.owner_key_id);
+    }
+  };
+
+  return (
+    <Grid size={12} mt={1}>
+      {signingKeys.length > 0 && (
+        <Table sx={{ marginBottom: 2 }}>
+          <TableHead>
+            <TableRow>
+              <TableCell>Signing Keys</TableCell>
+              <TableCell>Account</TableCell>
+              <TableCell />
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {signingKeys.map((key, index) => {
+              const accountName = findAccountNameForKey(key, accounts);
+              return (
+                <TableRow key={index}>
+                  <DataTableCell sx={{ fontFamily: "monospace", fontSize: "0.8rem" }}>
+                    {formatKeyId(key)}
+                  </DataTableCell>
+                  <DataTableCell>
+                    {accountName || "-"}
+                  </DataTableCell>
+                  <DataTableCell>
+                    <IconButton size="small" onClick={() => onRemove(index)} title="Remove signing key">
+                      &times;
+                    </IconButton>
+                  </DataTableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+      )}
+      <Stack direction="row" spacing={1} alignItems="center" marginBottom={2}>
+        {accounts.length > 0 && (
+          <FormControl style={{ minWidth: "200px" }}>
+            <InputLabel id="add-signing-key-label">Add Signing Key</InputLabel>
+            <Select labelId="add-signing-key-label" label="Add Signing Key" value="" onChange={handleAddAccountKey}>
+              {accounts
+                .filter((a) => a.account.owner_key_id)
+                .map(({ account }) => {
+                  const address = substateIdToString(account.component_address);
+                  return (
+                    <MenuItem key={address} value={address}>
+                      {account.name || address}
+                    </MenuItem>
+                  );
+                })}
+            </Select>
+          </FormControl>
+        )}
+      </Stack>
     </Grid>
   );
 }

--- a/applications/tari_walletd/web_ui/src/routes/Manifest/Manifest.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/Manifest/Manifest.tsx
@@ -857,7 +857,7 @@ function SigningKeysEditor({
             {signingKeys.map((key, index) => {
               const accountName = findAccountNameForKey(key, accounts);
               return (
-                <TableRow key={index}>
+                <TableRow key={JSON.stringify(key)}>
                   <DataTableCell sx={{ fontFamily: "monospace", fontSize: "0.8rem" }}>
                     {formatKeyId(key)}
                   </DataTableCell>

--- a/applications/tari_walletd/web_ui/src/routes/Transactions/FeeReceipt.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/Transactions/FeeReceipt.tsx
@@ -31,7 +31,7 @@ import { XTR_CURRENCY } from "@utils/currency";
 function unsignedSaturatingSub(a: bigint): bigint {
   return a < BigInt(0) ? BigInt(0) : a;
 }
-export default function FeeReceipt({ data }: { data: FeeReceiptProps }) {
+export default function FeeReceipt({ data, finalFee }: { data: FeeReceiptProps; finalFee?: number | null }) {
   if (!data) {
     return (
       <Box sx={{ p: 3, textAlign: "center" }}>
@@ -42,35 +42,35 @@ export default function FeeReceipt({ data }: { data: FeeReceiptProps }) {
     );
   }
 
-  const totalCost = Object.entries(data.cost_breakdown?.breakdown || {}).reduce(
+  const totalFeesCharged = Object.entries(data.cost_breakdown?.breakdown || {}).reduce(
     (sum, [_, value]) => BigInt(sum) + BigInt(value),
     BigInt(0),
   );
 
+  // If final_fee is available, use it as the actual fee paid to compute accurate overcharge/refund
+  const totalFeePayment = finalFee != null ? BigInt(finalFee) : BigInt(data.total_fee_payment);
+  const totalRefunded = unsignedSaturatingSub(totalFeePayment - totalFeesCharged - BigInt(data.total_fee_overcharge));
+  const overcharge = unsignedSaturatingSub(totalFeePayment - totalFeesCharged - totalRefunded);
+
   const feeItems = [
     {
       label: "Total Fees Paid",
-      value: formatCurrency(data.total_fee_payment, XTR_CURRENCY),
+      value: formatCurrency(totalFeePayment, XTR_CURRENCY),
       color: "primary" as const,
     },
     {
       label: "Total Fees Charged",
-      value: formatCurrency(data.total_fees_paid, XTR_CURRENCY),
-      color: "success" as const,
-    },
-    {
-      label: "Total Fees Required",
-      value: formatCurrency(totalCost, XTR_CURRENCY),
+      value: formatCurrency(totalFeesCharged, XTR_CURRENCY),
       color: "success" as const,
     },
     {
       label: "Fees Refunded",
-      value: formatCurrency(unsignedSaturatingSub(BigInt(data.total_fee_payment) - totalCost), XTR_CURRENCY),
+      value: formatCurrency(totalRefunded, XTR_CURRENCY),
       color: "success" as const,
     },
     {
       label: "Fees Overcharge",
-      value: formatCurrency(data.total_fee_overcharge, XTR_CURRENCY),
+      value: formatCurrency(overcharge, XTR_CURRENCY),
       color: "success" as const,
     },
   ];

--- a/applications/tari_walletd/web_ui/src/routes/Transactions/TransactionDetails.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/Transactions/TransactionDetails.tsx
@@ -163,7 +163,7 @@ export default function TransactionDetails() {
                   <TableRow>
                     <TableCell>Total Fees</TableCell>
                     <DataTableCell>
-                      {feeReceipt ? formatCurrency(feeReceipt.total_fees_paid, XTR_CURRENCY) : "0"}
+                      {data.final_fee != null ? formatCurrency(data.final_fee, XTR_CURRENCY) : feeReceipt ? formatCurrency(feeReceipt.total_fees_paid, XTR_CURRENCY) : "0"}
                       {feeReceipt?.total_fee_overcharge ? (
                         <>
                           {" "}
@@ -319,7 +319,7 @@ export default function TransactionDetails() {
                 <Typography variant="h5">Fee Receipt</Typography>
               </AccordionSummary>
               <AccordionDetails>
-                <FeeReceipt data={data.result.fee_receipt} />
+                <FeeReceipt data={data.result.fee_receipt} finalFee={data.final_fee} />
               </AccordionDetails>
             </Accordion>
           )}

--- a/applications/tari_walletd/web_ui/src/services/store/manifestStore.ts
+++ b/applications/tari_walletd/web_ui/src/services/store/manifestStore.ts
@@ -20,6 +20,7 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import type { KeyId } from "@tari-project/ootle-ts-bindings";
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 
@@ -37,6 +38,7 @@ export interface ManifestTab {
   name: string;
   code: string;
   variables: Record<string, string>;
+  signingKeys: KeyId[];
 }
 
 interface Store {
@@ -46,6 +48,7 @@ interface Store {
   // Active tab convenience accessors
   code: string;
   variables: Record<string, string>;
+  signingKeys: KeyId[];
 
   // Tab management
   addTab: () => void;
@@ -58,6 +61,8 @@ interface Store {
   addVariable: (key: string, value: string) => void;
   removeVariable: (key: string) => void;
   renameVariable: (oldKey: string, newKey: string) => void;
+  addSigningKey: (key: KeyId) => void;
+  removeSigningKey: (index: number) => void;
 }
 
 let nextId = 1;
@@ -66,7 +71,7 @@ function generateId(): string {
 }
 
 function createTab(name: string): ManifestTab {
-  return { id: generateId(), name, code: DEFAULT_CODE, variables: {} };
+  return { id: generateId(), name, code: DEFAULT_CODE, variables: {}, signingKeys: [] };
 }
 
 function nextTabName(tabs: ManifestTab[]): string {
@@ -79,7 +84,7 @@ function nextTabName(tabs: ManifestTab[]): string {
 function updateActiveTab(state: Store, patch: Partial<ManifestTab>): Partial<Store> {
   const tabs = state.tabs.map((t) => (t.id === state.activeTabId ? { ...t, ...patch } : t));
   const active = tabs.find((t) => t.id === state.activeTabId)!;
-  return { tabs, code: active.code, variables: active.variables };
+  return { tabs, code: active.code, variables: active.variables, signingKeys: active.signingKeys };
 }
 
 const defaultTab = createTab("Manifest 1");
@@ -91,6 +96,7 @@ const useManifestCodeStore = create<Store>()(
       activeTabId: defaultTab.id,
       code: defaultTab.code,
       variables: defaultTab.variables,
+      signingKeys: defaultTab.signingKeys,
 
       addTab: () =>
         set((state) => {
@@ -100,6 +106,7 @@ const useManifestCodeStore = create<Store>()(
             activeTabId: tab.id,
             code: tab.code,
             variables: tab.variables,
+            signingKeys: tab.signingKeys,
           };
         }),
 
@@ -114,14 +121,14 @@ const useManifestCodeStore = create<Store>()(
             activeTabId = tabs[newIdx].id;
           }
           const active = tabs.find((t) => t.id === activeTabId)!;
-          return { tabs, activeTabId, code: active.code, variables: active.variables };
+          return { tabs, activeTabId, code: active.code, variables: active.variables, signingKeys: active.signingKeys };
         }),
 
       setActiveTab: (id: string) =>
         set((state) => {
           const tab = state.tabs.find((t) => t.id === id);
           if (!tab) return state;
-          return { activeTabId: id, code: tab.code, variables: tab.variables };
+          return { activeTabId: id, code: tab.code, variables: tab.variables, signingKeys: tab.signingKeys };
         }),
 
       renameTab: (id: string, name: string) =>
@@ -151,27 +158,57 @@ const useManifestCodeStore = create<Store>()(
           const entries = Object.entries(active.variables).map(([k, v]) => (k === oldKey ? [newKey, v] : [k, v]));
           return updateActiveTab(state, { variables: Object.fromEntries(entries) });
         }),
+
+      addSigningKey: (key: KeyId) =>
+        set((state) => {
+          const active = state.tabs.find((t) => t.id === state.activeTabId)!;
+          // Avoid duplicates
+          const isDuplicate = active.signingKeys.some((k) => JSON.stringify(k) === JSON.stringify(key));
+          if (isDuplicate) return state;
+          return updateActiveTab(state, { signingKeys: [...active.signingKeys, key] });
+        }),
+
+      removeSigningKey: (index: number) =>
+        set((state) => {
+          const active = state.tabs.find((t) => t.id === state.activeTabId)!;
+          return updateActiveTab(state, { signingKeys: active.signingKeys.filter((_, i) => i !== index) });
+        }),
     }),
     {
       name: "manifest-code",
       migrate: (persisted: unknown, version: number) => {
         const state = persisted as Record<string, unknown>;
         // Migrate from single-tab format (no tabs array) to multi-tab format
-        if (version === 0 && state && !state.tabs) {
+        if (version < 1 && state && !state.tabs) {
           const code = (state.code as string) || DEFAULT_CODE;
           const variables = (state.variables as Record<string, string>) || {};
-          const tab: ManifestTab = { id: generateId(), name: "Manifest 1", code, variables };
+          const tab: ManifestTab = { id: generateId(), name: "Manifest 1", code, variables, signingKeys: [] };
           return {
             ...state,
             tabs: [tab],
             activeTabId: tab.id,
             code: tab.code,
             variables: tab.variables,
+            signingKeys: tab.signingKeys,
           } as Store;
+        }
+        // Add signingKeys to existing tabs
+        if (version < 2 && state && state.tabs) {
+          const tabs = (state.tabs as ManifestTab[]).map((t) => ({
+            ...t,
+            signingKeys: t.signingKeys || [],
+          }));
+          const activeTabId = state.activeTabId as string;
+          const active = tabs.find((t) => t.id === activeTabId) || tabs[0];
+          return {
+            ...state,
+            tabs,
+            signingKeys: active?.signingKeys || [],
+          } as unknown as Store;
         }
         return state as unknown as Store;
       },
-      version: 1,
+      version: 2,
     },
   ),
 );

--- a/applications/tari_walletd/web_ui/src/services/store/manifestStore.ts
+++ b/applications/tari_walletd/web_ui/src/services/store/manifestStore.ts
@@ -63,6 +63,7 @@ interface Store {
   renameVariable: (oldKey: string, newKey: string) => void;
   addSigningKey: (key: KeyId) => void;
   removeSigningKey: (index: number) => void;
+  loadTabs: (tabs: ManifestTab[]) => void;
 }
 
 let nextId = 1;
@@ -172,6 +173,20 @@ const useManifestCodeStore = create<Store>()(
         set((state) => {
           const active = state.tabs.find((t) => t.id === state.activeTabId)!;
           return updateActiveTab(state, { signingKeys: active.signingKeys.filter((_, i) => i !== index) });
+        }),
+
+      loadTabs: (loaded: ManifestTab[]) =>
+        set(() => {
+          // Assign fresh IDs to avoid collisions with existing tabs
+          const tabs = loaded.map((t) => ({ ...t, id: generateId(), signingKeys: t.signingKeys || [] }));
+          const first = tabs[0];
+          return {
+            tabs,
+            activeTabId: first.id,
+            code: first.code,
+            variables: first.variables,
+            signingKeys: first.signingKeys,
+          };
         }),
     }),
     {

--- a/bindings/package.json
+++ b/bindings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tari-project/ootle-ts-bindings",
-  "version": "1.31.0",
+  "version": "1.32.0",
   "private": false,
   "publishConfig": {
     "access": "public"

--- a/bindings/src/types/wallet-types/ClaimBurnResponse.ts
+++ b/bindings/src/types/wallet-types/ClaimBurnResponse.ts
@@ -2,4 +2,8 @@
 import type { ExecuteResult } from "../ExecuteResult";
 import type { TransactionId } from "../TransactionId";
 
-export type ClaimBurnResponse = { transaction_id: TransactionId; required_fees: number | null; dry_run_result: ExecuteResult | null };
+export type ClaimBurnResponse = {
+  transaction_id: TransactionId;
+  required_fees: number | null;
+  dry_run_result: ExecuteResult | null;
+};

--- a/bindings/src/types/wallet-types/TransactionGetResponse.ts
+++ b/bindings/src/types/wallet-types/TransactionGetResponse.ts
@@ -7,6 +7,7 @@ export type TransactionGetResponse = {
   transaction: Transaction;
   result: FinalizeResult | null;
   status: TransactionStatus;
+  final_fee: number | null;
   invalid_reason: string | null;
   last_update_time: string;
 };

--- a/bindings/src/types/wallet-types/TransactionSubmitDryRunResponse.ts
+++ b/bindings/src/types/wallet-types/TransactionSubmitDryRunResponse.ts
@@ -2,4 +2,8 @@
 import type { ExecuteResult } from "../ExecuteResult";
 import type { TransactionId } from "../TransactionId";
 
-export type TransactionSubmitDryRunResponse = { transaction_id: TransactionId; required_fees: number; result: ExecuteResult };
+export type TransactionSubmitDryRunResponse = {
+  transaction_id: TransactionId;
+  required_fees: number;
+  result: ExecuteResult;
+};

--- a/bindings/src/types/wallet-types/TransactionSubmitManifestRequest.ts
+++ b/bindings/src/types/wallet-types/TransactionSubmitManifestRequest.ts
@@ -4,7 +4,8 @@ import type { KeyId } from "./KeyId";
 export type TransactionSubmitManifestRequest = {
   manifest: string;
   variables: { [key in string]?: string };
-  signing_key_id: KeyId | null;
+  seal_signer_key_id: KeyId | null;
+  signing_key_ids: Array<KeyId>;
   max_fee: number;
   dry_run: boolean;
 };

--- a/bindings/src/types/wallet-types/TransactionSubmitManifestResponse.ts
+++ b/bindings/src/types/wallet-types/TransactionSubmitManifestResponse.ts
@@ -2,4 +2,8 @@
 import type { ExecuteResult } from "../ExecuteResult";
 import type { TransactionId } from "../TransactionId";
 
-export type TransactionSubmitManifestResponse = { transaction_id: TransactionId; required_fees: number | null; result: ExecuteResult | null };
+export type TransactionSubmitManifestResponse = {
+  transaction_id: TransactionId;
+  required_fees: number | null;
+  result: ExecuteResult | null;
+};

--- a/clients/wallet_daemon_client/src/types.rs
+++ b/clients/wallet_daemon_client/src/types.rs
@@ -247,6 +247,10 @@ pub struct TransactionGetResponse {
     pub transaction: Transaction,
     pub result: Option<FinalizeResult>,
     pub status: TransactionStatus,
+    /// The estimated fee required for the transaction. For dry runs, this is the minimum fee
+    /// that should be used as `max_fee` for the actual submission.
+    #[cfg_attr(feature = "ts", ts(type = "number | null"))]
+    pub final_fee: Option<u64>,
     pub invalid_reason: Option<String>,
     #[cfg_attr(feature = "ts", ts(type = "string"))]
     pub last_update_time: PrimitiveDateTime,

--- a/clients/wallet_daemon_client/src/types.rs
+++ b/clients/wallet_daemon_client/src/types.rs
@@ -167,7 +167,11 @@ pub struct TransactionSubmitDryRunResponse {
 pub struct TransactionSubmitManifestRequest {
     pub manifest: String,
     pub variables: HashMap<String, String>,
-    pub signing_key_id: Option<KeyId>,
+    /// The key used for the seal (owner) signature. If not provided, defaults to the default account's owner key.
+    pub seal_signer_key_id: Option<KeyId>,
+    /// Additional signing keys for accounts involved in the transaction (e.g. for multi-account manifests).
+    #[serde(default)]
+    pub signing_key_ids: Vec<KeyId>,
     #[cfg_attr(feature = "ts", ts(type = "number"))]
     pub max_fee: u64,
     pub dry_run: bool,

--- a/crates/engine_types/src/fees.rs
+++ b/crates/engine_types/src/fees.rs
@@ -81,16 +81,11 @@ impl FeeReceipt {
     }
 
     /// The minimum fee required to submit a transaction based on a dry run result.
-    /// This is `total_fees_charged + 1 - total_fee_overcharge` to account for:
-    /// 1. Potential rounding differences in the storage cost calculation. The storage fee depends on the vault balance
-    ///    at calculation time, which changes when a different max_fee is used in the actual submission vs the dry run —
-    ///    this can shift `floor(total_bytes / 4)` by 1 at a rounding boundary.
-    /// 2. Non-refundable overcharge from the dry run (e.g. stealth reveals where we cannot refund). Since the
-    ///    overcharge won't recur with a tighter max_fee, we subtract it.
+    /// This is `total_fees_charged + 1` to account for potential rounding differences in the storage cost calculation.
+    /// The storage fee depends on the vault balance at calculation time, which changes when a different max_fee is used
+    /// in the actual submission vs the dry run — this can shift `floor(total_bytes / 4)` by 1 at a rounding boundary.
     pub fn required_fees(&self) -> u64 {
-        self.total_fees_charged()
-            .saturating_add(1)
-            .saturating_sub(self.total_fee_overcharge)
+        self.total_fees_charged().saturating_add(1)
     }
 
     /// The total amount of fees refunded to the respective vaults

--- a/crates/transaction_manifest/src/parser.rs
+++ b/crates/transaction_manifest/src/parser.rs
@@ -685,13 +685,7 @@ fn handle_macro_argument(mac: Macro) -> Result<ManifestLiteral, syn::Error> {
             ))))
         },
         "address" | "substate_id" => {
-            let tokens_str = mac.tokens.to_string();
-            let trimmed = tokens_str.trim();
-            // Check if it looks like a string literal or an identifier (variable reference)
-            if trimmed.starts_with('"') {
-                let lit_str: LitStr = parse2(mac.tokens).map_err(|e| {
-                    syn::Error::new_spanned(name, format!("Expected string literal in {}!: {}", name, e))
-                })?;
+            if let Ok(lit_str) = parse2::<LitStr>(mac.tokens.clone()) {
                 let id: SubstateId = lit_str
                     .value()
                     .parse()
@@ -702,8 +696,12 @@ fn handle_macro_argument(mac: Macro) -> Result<ManifestLiteral, syn::Error> {
                     Ok(ManifestLiteral::Special(SpecialLiteral::SubstateId(OrVar::Value(id))))
                 }
             } else {
-                let ident: Ident = parse2(mac.tokens)
-                    .map_err(|e| syn::Error::new_spanned(name, format!("Expected identifier in {}!: {}", name, e)))?;
+                let ident: Ident = parse2(mac.tokens).map_err(|e| {
+                    syn::Error::new_spanned(
+                        name,
+                        format!("Expected identifier or string literal in {}!: {}", name, e),
+                    )
+                })?;
                 if name == "address" {
                     Ok(ManifestLiteral::Special(SpecialLiteral::Address(OrVar::Var(ident))))
                 } else {


### PR DESCRIPTION
## Summary
- Replace single `signing_key_id` with `seal_signer_key_id` (defaults to default account's owner key) and `signing_key_ids` (list of additional signers)
- Web UI manifest editor now shows signing keys as a table, with account name resolution
- Adding an account variable automatically adds its owner key as a signer
- Signing keys can be added/removed independently of variables via an "Add Signing Key" dropdown
- Save/Load buttons in the tab bar: save downloads all tabs (code, variables, signing keys) as JSON, load imports from a JSON file
- Store migration (v1 -> v2) adds `signingKeys: []` to existing tabs

## Test plan
- [ ] Submit a manifest with no signing keys (should behave same as before - default account signs)
- [ ] Add an account variable and verify its signing key appears automatically
- [ ] Add/remove signing keys manually via the dropdown
- [ ] Submit a multi-account manifest and verify both signatures are present
- [ ] Verify existing localStorage data migrates correctly (tabs gain `signingKeys: []`)
- [ ] Save manifests to file, verify JSON contains all tabs with code/variables/signingKeys
- [ ] Load a previously saved manifest file and verify tabs are restored