### PR TITLE
feat(template_metadata): add supersedes field

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2666,7 +2666,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3402,7 +3402,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3480,6 +3480,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "495a39d30d624c2caabe6312bfead73e7717692b44e0b32df168c275a2e8e9e4"
 dependencies = [
  "ascii_utils",
+]
+
+[[package]]
+name = "faster-hex"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2a2b11eda1d40935b26cf18f6833c526845ae8c41e58d09af6adeb6f0269183"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -3903,6 +3912,17 @@ dependencies = [
  "libgit2-sys",
  "log",
  "url",
+]
+
+[[package]]
+name = "gix-hash"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5eccc17194ed0e67d49285e4853307e4147e95407f91c1c3e4a13ba9f4e4ce"
+dependencies = [
+ "faster-hex",
+ "serde",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5026,7 +5046,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7140,7 +7160,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8593,7 +8613,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.1",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9276,7 +9296,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9356,7 +9376,7 @@ dependencies = [
  "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs 1.0.5",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11463,6 +11483,7 @@ version = "0.5.0"
 dependencies = [
  "borsh",
  "cargo_toml 0.22.3",
+ "gix-hash",
  "hex",
  "multihash 0.19.3",
  "serde",
@@ -11473,6 +11494,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "ts-rs",
+ "url",
 ]
 
 [[package]]
@@ -12387,7 +12409,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -14152,7 +14174,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11459,7 +11459,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_template_metadata"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "borsh",
  "cargo_toml 0.22.3",
@@ -11469,6 +11469,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "tari_bor",
+ "tari_template_lib_types",
  "tempfile",
  "thiserror 2.0.18",
  "ts-rs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11475,6 +11475,7 @@ dependencies = [
  "tari_ootle_template_metadata",
  "tempfile",
  "thiserror 2.0.18",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -204,6 +204,7 @@ fern = "0.7.1"
 futures = "0.3.30"
 futures-util = "0.3"
 futures-bounded = "0.2.3"
+gix-hash = { version = "0.15", features = ["serde"] }
 jsonwebtoken = "10.3.0"
 hashbrown = { version = "0.13.2" }
 hex = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,7 +123,7 @@ tari_ootle_transaction = { path = "crates/transaction", version = "0.28" }
 
 # Template lib
 tari_ootle_template_build = { path = "crates/template_build", version = "0.4" }
-tari_ootle_template_metadata = { path = "crates/template_metadata", version = "0.4" }
+tari_ootle_template_metadata = { path = "crates/template_metadata", version = "0.5" }
 tari_template_lib = { version = "0.24", path = "crates/template_lib" }
 tari_template_lib_types = { version = "0.24", path = "crates/template_lib_types", default-features = false }
 tari_template_abi = { version = "0.16", path = "crates/template_abi", default-features = false }

--- a/bindings/src/types/TemplateMetadata.ts
+++ b/bindings/src/types/TemplateMetadata.ts
@@ -7,17 +7,12 @@
  * `[package.metadata.tari-template]` sections. The CBOR encoding of this struct is
  * hashed to produce a [`MetadataHash`] that is stored on-chain alongside the template binary.
  */
-export type TemplateMetadata = {
-  schema_version: number;
-  name: string;
-  version: string;
-  description?: string;
-  tags?: Array<string>;
-  category?: string | null;
-  repository?: string | null;
-  documentation?: string | null;
-  homepage?: string | null;
-  license?: string | null;
-  logo_url?: string | null;
-  extra?: { [key in string]?: string };
-};
+export type TemplateMetadata = { schema_version: number, name: string, version: string, description?: string, tags?: Array<string>, category?: string | null, repository?: string | null, 
+/**
+ * The commit hash of the source code used to build this template, for reproducible build verification.
+ */
+commit_hash?: { Sha1: string } | null, documentation?: string | null, homepage?: string | null, license?: string | null, logo_url?: string | null, 
+/**
+ * The template address of a previous version that this template supersedes.
+ */
+supersedes?: string | null, extra?: { [key in string]?: string }, };

--- a/crates/template_build/Cargo.toml
+++ b/crates/template_build/Cargo.toml
@@ -10,6 +10,7 @@ license.workspace = true
 [dependencies]
 tari_ootle_template_metadata = { workspace = true, features = ["json"] }
 thiserror = { workspace = true }
+url = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/template_build/src/lib.rs
+++ b/crates/template_build/src/lib.rs
@@ -24,6 +24,7 @@ use std::{collections::BTreeMap, path::PathBuf};
 
 pub use tari_ootle_template_metadata;
 use tari_ootle_template_metadata::{MetadataHash, TemplateMetadata, from_cargo_toml};
+use url::Url;
 
 /// Result of a successful metadata build.
 pub struct TemplateBuildOutput {
@@ -147,7 +148,7 @@ impl TemplateMetadataBuilder {
     }
 
     /// Apply builder overrides to the given metadata.
-    fn apply_overrides(&self, metadata: &mut TemplateMetadata) {
+    fn apply_overrides(&self, metadata: &mut TemplateMetadata) -> Result<(), TemplateBuildError> {
         if let Some(ref description) = self.description {
             metadata.description = description.clone();
         }
@@ -158,23 +159,26 @@ impl TemplateMetadataBuilder {
             metadata.category = Some(category.clone());
         }
         if let Some(ref repository) = self.repository {
-            metadata.repository = Some(repository.clone());
+            metadata.repository =
+                Some(Url::parse(repository).map_err(|e| TemplateBuildError::InvalidUrl("repository", e))?);
         }
         if let Some(ref documentation) = self.documentation {
-            metadata.documentation = Some(documentation.clone());
+            metadata.documentation =
+                Some(Url::parse(documentation).map_err(|e| TemplateBuildError::InvalidUrl("documentation", e))?);
         }
         if let Some(ref homepage) = self.homepage {
-            metadata.homepage = Some(homepage.clone());
+            metadata.homepage = Some(Url::parse(homepage).map_err(|e| TemplateBuildError::InvalidUrl("homepage", e))?);
         }
         if let Some(ref license) = self.license {
             metadata.license = Some(license.clone());
         }
         if let Some(ref logo_url) = self.logo_url {
-            metadata.logo_url = Some(logo_url.clone());
+            metadata.logo_url = Some(Url::parse(logo_url).map_err(|e| TemplateBuildError::InvalidUrl("logo_url", e))?);
         }
         if let Some(ref extra) = self.extra {
             metadata.extra = extra.clone();
         }
+        Ok(())
     }
 
     /// Generate metadata files from `Cargo.toml` with any builder overrides applied.
@@ -193,7 +197,7 @@ impl TemplateMetadataBuilder {
         let cargo_toml_path = PathBuf::from(manifest_dir).join("Cargo.toml");
         let mut metadata = from_cargo_toml(&cargo_toml_path)?;
 
-        self.apply_overrides(&mut metadata);
+        self.apply_overrides(&mut metadata)?;
 
         // Write CBOR
         let cbor = metadata.to_cbor()?;
@@ -234,6 +238,8 @@ pub enum TemplateBuildError {
     CargoToml(#[from] tari_ootle_template_metadata::CargoTomlError),
     #[error("Metadata error: {0}")]
     Metadata(#[from] tari_ootle_template_metadata::TemplateMetadataError),
+    #[error("Invalid URL in field '{0}': {1}")]
+    InvalidUrl(&'static str, url::ParseError),
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
 }
@@ -323,9 +329,15 @@ category = "utility"
         assert_eq!(m.description, "Overridden description");
         assert_eq!(m.tags, vec!["new-tag-1", "new-tag-2"]);
         assert_eq!(m.category.as_deref(), Some("defi"));
-        assert_eq!(m.repository.as_deref(), Some("https://github.com/example/overridden"));
-        assert_eq!(m.documentation.as_deref(), Some("https://docs.example.com"));
-        assert_eq!(m.homepage.as_deref(), Some("https://example.com"));
+        assert_eq!(
+            m.repository.as_ref().map(|u| u.as_str()),
+            Some("https://github.com/example/overridden")
+        );
+        assert_eq!(
+            m.documentation.as_ref().map(|u| u.as_str()),
+            Some("https://docs.example.com/")
+        );
+        assert_eq!(m.homepage.as_ref().map(|u| u.as_str()), Some("https://example.com/"));
         assert_eq!(m.license.as_deref(), Some("BSD-3-Clause"));
 
         // CBOR file should contain overridden values

--- a/crates/template_metadata/Cargo.toml
+++ b/crates/template_metadata/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_ootle_template_metadata"
 description = "Template metadata types, serialization, and hashing for Tari Ootle templates"
-version = "0.4.1"
+version = "0.5.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true
@@ -9,6 +9,7 @@ license.workspace = true
 
 [dependencies]
 tari_bor = { workspace = true, features = ["std"] }
+tari_template_lib_types = { workspace = true }
 
 borsh = { workspace = true, optional = true }
 cargo_toml = "0.22"

--- a/crates/template_metadata/Cargo.toml
+++ b/crates/template_metadata/Cargo.toml
@@ -13,12 +13,14 @@ tari_template_lib_types = { workspace = true }
 
 borsh = { workspace = true, optional = true }
 cargo_toml = "0.22"
+gix-hash = { workspace = true }
 hex = { workspace = true }
 multihash = { version = "0.19" }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, optional = true }
 sha2 = { workspace = true }
 thiserror = { workspace = true }
+url = { workspace = true, features = ["serde"] }
 ts-rs = { workspace = true, optional = true }
 
 [features]

--- a/crates/template_metadata/src/cargo_toml.rs
+++ b/crates/template_metadata/src/cargo_toml.rs
@@ -4,6 +4,7 @@
 use std::{collections::BTreeMap, path::Path};
 
 use cargo_toml::Manifest;
+use tari_template_lib_types::TemplateAddress;
 
 use crate::{TemplateMetadata, metadata::SCHEMA_VERSION};
 
@@ -73,6 +74,13 @@ fn from_manifest(manifest: &Manifest) -> Result<TemplateMetadata, CargoTomlError
         .and_then(|v| v.as_str())
         .map(String::from);
 
+    let supersedes = tari_template
+        .and_then(|t| t.get("supersedes"))
+        .and_then(|v| v.as_str())
+        .map(TemplateAddress::from_hex)
+        .transpose()
+        .map_err(|_| CargoTomlError::InvalidTemplateAddress("supersedes"))?;
+
     let extra = tari_template
         .and_then(|t| t.get("extra"))
         .and_then(|v| v.as_table())
@@ -95,6 +103,7 @@ fn from_manifest(manifest: &Manifest) -> Result<TemplateMetadata, CargoTomlError
         homepage,
         license,
         logo_url,
+        supersedes,
         extra,
     })
 }
@@ -107,6 +116,8 @@ pub enum CargoTomlError {
     MissingPackageSection,
     #[error("Field '{0}' uses workspace inheritance which is not supported in this context")]
     InheritedField(&'static str),
+    #[error("Invalid template address in field '{0}'")]
+    InvalidTemplateAddress(&'static str),
 }
 
 #[cfg(test)]

--- a/crates/template_metadata/src/cargo_toml.rs
+++ b/crates/template_metadata/src/cargo_toml.rs
@@ -5,6 +5,7 @@ use std::{collections::BTreeMap, path::Path};
 
 use cargo_toml::Manifest;
 use tari_template_lib_types::TemplateAddress;
+use url::Url;
 
 use crate::{TemplateMetadata, metadata::SCHEMA_VERSION};
 
@@ -39,7 +40,13 @@ fn from_manifest(manifest: &Manifest) -> Result<TemplateMetadata, CargoTomlError
         .cloned()
         .unwrap_or_default();
     let license = package.license.as_ref().and_then(|l| l.get().ok()).cloned();
-    let repository = package.repository.as_ref().and_then(|r| r.get().ok()).cloned();
+    let repository = package
+        .repository
+        .as_ref()
+        .and_then(|r| r.get().ok())
+        .map(|r| Url::parse(r))
+        .transpose()
+        .map_err(|e| CargoTomlError::InvalidUrl("repository", e))?;
 
     // Read [package.metadata.tari-template]
     let tari_template = package
@@ -62,22 +69,30 @@ fn from_manifest(manifest: &Manifest) -> Result<TemplateMetadata, CargoTomlError
     let commit_hash = tari_template
         .and_then(|t| t.get("commit_hash"))
         .and_then(|v| v.as_str())
-        .map(String::from);
+        .map(|s| gix_hash::ObjectId::from_hex(s.as_bytes()))
+        .transpose()
+        .map_err(CargoTomlError::InvalidCommitHash)?;
 
     let documentation = tari_template
         .and_then(|t| t.get("documentation"))
         .and_then(|v| v.as_str())
-        .map(String::from);
+        .map(Url::parse)
+        .transpose()
+        .map_err(|e| CargoTomlError::InvalidUrl("documentation", e))?;
 
     let homepage = tari_template
         .and_then(|t| t.get("homepage"))
         .and_then(|v| v.as_str())
-        .map(String::from);
+        .map(Url::parse)
+        .transpose()
+        .map_err(|e| CargoTomlError::InvalidUrl("homepage", e))?;
 
     let logo_url = tari_template
         .and_then(|t| t.get("logo_url"))
         .and_then(|v| v.as_str())
-        .map(String::from);
+        .map(Url::parse)
+        .transpose()
+        .map_err(|e| CargoTomlError::InvalidUrl("logo_url", e))?;
 
     let supersedes = tari_template
         .and_then(|t| t.get("supersedes"))
@@ -124,6 +139,10 @@ pub enum CargoTomlError {
     InheritedField(&'static str),
     #[error("Invalid template address in field '{0}'")]
     InvalidTemplateAddress(&'static str),
+    #[error("Invalid URL in field '{0}': {1}")]
+    InvalidUrl(&'static str, url::ParseError),
+    #[error("Invalid commit hash: {0}")]
+    InvalidCommitHash(gix_hash::decode::Error),
 }
 
 #[cfg(test)]
@@ -159,16 +178,19 @@ audit = "https://example.com/audit-report"
         );
         assert_eq!(metadata.license.as_deref(), Some("BSD-3-Clause"));
         assert_eq!(
-            metadata.repository.as_deref(),
+            metadata.repository.as_ref().map(|u| u.as_str()),
             Some("https://github.com/example/fungible-token")
         );
         assert_eq!(metadata.tags, vec!["token", "fungible", "defi"]);
         assert_eq!(metadata.category.as_deref(), Some("token"));
         assert_eq!(
-            metadata.documentation.as_deref(),
+            metadata.documentation.as_ref().map(|u| u.as_str()),
             Some("https://docs.example.com/fungible-token")
         );
-        assert_eq!(metadata.homepage.as_deref(), Some("https://example.com"));
+        assert_eq!(
+            metadata.homepage.as_ref().map(|u| u.as_str()),
+            Some("https://example.com/")
+        );
         assert_eq!(
             metadata.extra.get("audit").map(|s| s.as_str()),
             Some("https://example.com/audit-report")

--- a/crates/template_metadata/src/cargo_toml.rs
+++ b/crates/template_metadata/src/cargo_toml.rs
@@ -59,6 +59,11 @@ fn from_manifest(manifest: &Manifest) -> Result<TemplateMetadata, CargoTomlError
         .and_then(|v| v.as_str())
         .map(String::from);
 
+    let commit_hash = tari_template
+        .and_then(|t| t.get("commit_hash"))
+        .and_then(|v| v.as_str())
+        .map(String::from);
+
     let documentation = tari_template
         .and_then(|t| t.get("documentation"))
         .and_then(|v| v.as_str())
@@ -99,6 +104,7 @@ fn from_manifest(manifest: &Manifest) -> Result<TemplateMetadata, CargoTomlError
         tags,
         category,
         repository,
+        commit_hash,
         documentation,
         homepage,
         license,

--- a/crates/template_metadata/src/metadata.rs
+++ b/crates/template_metadata/src/metadata.rs
@@ -4,6 +4,7 @@
 use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
+use tari_template_lib_types::TemplateAddress;
 
 use crate::{MetadataHash, MetadataHashWriter};
 
@@ -37,6 +38,9 @@ pub struct TemplateMetadata {
     pub license: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub logo_url: Option<String>,
+    /// The template address of a previous version that this template supersedes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub supersedes: Option<TemplateAddress>,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub extra: BTreeMap<String, String>,
 }
@@ -56,6 +60,7 @@ impl TemplateMetadata {
             homepage: None,
             license: None,
             logo_url: None,
+            supersedes: None,
             extra: BTreeMap::new(),
         }
     }
@@ -135,6 +140,7 @@ mod tests {
             homepage: None,
             license: Some("BSD-3-Clause".to_string()),
             logo_url: None,
+            supersedes: None,
             extra: BTreeMap::new(),
         };
 
@@ -200,6 +206,7 @@ mod tests {
             homepage: None,
             license: None,
             logo_url: None,
+            supersedes: None,
             extra: BTreeMap::new(),
         };
 

--- a/crates/template_metadata/src/metadata.rs
+++ b/crates/template_metadata/src/metadata.rs
@@ -147,18 +147,13 @@ mod tests {
             tags: vec!["test".to_string(), "example".to_string()],
             category: Some("utility".to_string()),
             repository: Some(Url::parse("https://github.com/example/test").unwrap()),
-            commit_hash: Some(
-                gix_hash::ObjectId::from_hex(b"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa").unwrap(),
-            ),
+            commit_hash: Some(gix_hash::ObjectId::from_hex(b"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa").unwrap()),
             documentation: None,
             homepage: None,
             license: Some("BSD-3-Clause".to_string()),
             logo_url: None,
             supersedes: Some(
-                TemplateAddress::from_hex(
-                    "0000000000000000000000000000000000000000000000000000000000000001",
-                )
-                .unwrap(),
+                TemplateAddress::from_hex("0000000000000000000000000000000000000000000000000000000000000001").unwrap(),
             ),
             extra: BTreeMap::new(),
         };

--- a/crates/template_metadata/src/metadata.rs
+++ b/crates/template_metadata/src/metadata.rs
@@ -30,6 +30,9 @@ pub struct TemplateMetadata {
     pub category: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub repository: Option<String>,
+    /// The commit hash of the source code used to build this template, for reproducible build verification.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub commit_hash: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub documentation: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -56,6 +59,7 @@ impl TemplateMetadata {
             tags: Vec::new(),
             category: None,
             repository: None,
+            commit_hash: None,
             documentation: None,
             homepage: None,
             license: None,
@@ -136,6 +140,7 @@ mod tests {
             tags: vec!["test".to_string(), "example".to_string()],
             category: Some("utility".to_string()),
             repository: Some("https://github.com/example/test".to_string()),
+            commit_hash: None,
             documentation: None,
             homepage: None,
             license: Some("BSD-3-Clause".to_string()),
@@ -202,6 +207,7 @@ mod tests {
             tags: vec!["a".to_string()],
             category: Some("test".to_string()),
             repository: None,
+            commit_hash: None,
             documentation: None,
             homepage: None,
             license: None,

--- a/crates/template_metadata/src/metadata.rs
+++ b/crates/template_metadata/src/metadata.rs
@@ -30,20 +30,26 @@ pub struct TemplateMetadata {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub category: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "ts", ts(type = "string | null"))]
     pub repository: Option<Url>,
     /// The commit hash of the source code used to build this template, for reproducible build verification.
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "ts", ts(type = "{ Sha1: string } | null"))]
     pub commit_hash: Option<gix_hash::ObjectId>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "ts", ts(type = "string | null"))]
     pub documentation: Option<Url>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "ts", ts(type = "string | null"))]
     pub homepage: Option<Url>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub license: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "ts", ts(type = "string | null"))]
     pub logo_url: Option<Url>,
     /// The template address of a previous version that this template supersedes.
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "ts", ts(type = "string | null"))]
     pub supersedes: Option<TemplateAddress>,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub extra: BTreeMap<String, String>,

--- a/crates/template_metadata/src/metadata.rs
+++ b/crates/template_metadata/src/metadata.rs
@@ -147,12 +147,19 @@ mod tests {
             tags: vec!["test".to_string(), "example".to_string()],
             category: Some("utility".to_string()),
             repository: Some(Url::parse("https://github.com/example/test").unwrap()),
-            commit_hash: None,
+            commit_hash: Some(
+                gix_hash::ObjectId::from_hex(b"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa").unwrap(),
+            ),
             documentation: None,
             homepage: None,
             license: Some("BSD-3-Clause".to_string()),
             logo_url: None,
-            supersedes: None,
+            supersedes: Some(
+                TemplateAddress::from_hex(
+                    "0000000000000000000000000000000000000000000000000000000000000001",
+                )
+                .unwrap(),
+            ),
             extra: BTreeMap::new(),
         };
 

--- a/crates/template_metadata/src/metadata.rs
+++ b/crates/template_metadata/src/metadata.rs
@@ -5,6 +5,7 @@ use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 use tari_template_lib_types::TemplateAddress;
+use url::Url;
 
 use crate::{MetadataHash, MetadataHashWriter};
 
@@ -29,18 +30,18 @@ pub struct TemplateMetadata {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub category: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub repository: Option<String>,
+    pub repository: Option<Url>,
     /// The commit hash of the source code used to build this template, for reproducible build verification.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub commit_hash: Option<String>,
+    pub commit_hash: Option<gix_hash::ObjectId>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub documentation: Option<String>,
+    pub documentation: Option<Url>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub homepage: Option<String>,
+    pub homepage: Option<Url>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub license: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub logo_url: Option<String>,
+    pub logo_url: Option<Url>,
     /// The template address of a previous version that this template supersedes.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub supersedes: Option<TemplateAddress>,
@@ -139,7 +140,7 @@ mod tests {
             description: "A test template".to_string(),
             tags: vec!["test".to_string(), "example".to_string()],
             category: Some("utility".to_string()),
-            repository: Some("https://github.com/example/test".to_string()),
+            repository: Some(Url::parse("https://github.com/example/test").unwrap()),
             commit_hash: None,
             documentation: None,
             homepage: None,


### PR DESCRIPTION
## Summary
- Add `supersedes: Option<TemplateAddress>` field to `TemplateMetadata`, allowing template authors to declare the template address of a previous version that this template supersedes
- Add `commit_hash: Option<gix_hash::ObjectId>` field for reproducible build verification — verifiers can clone `repository` at `commit_hash` and reproduce the WASM build
- Use `url::Url` for URL fields (`repository`, `documentation`, `homepage`, `logo_url`) — invalid URLs are now caught at build time
- Bump crate version to 0.5.0

## Test plan
- [x] All 20 existing tests pass (CBOR roundtrip, JSON roundtrip, Cargo.toml parsing, hash determinism, backward compat)
- [ ] Verify downstream crates compile with the new field types