### PR TITLE
chore: update template metadata/build READMEs and bump to 0.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11470,7 +11470,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_template_build"
-version = "0.4.0"
+version = "0.5.1"
 dependencies = [
  "tari_ootle_template_metadata",
  "tempfile",
@@ -11480,7 +11480,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_template_metadata"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "borsh",
  "cargo_toml 0.22.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,7 +122,7 @@ tari_template_builtin = { path = "crates/template_builtin", version = "0.28" }
 tari_ootle_transaction = { path = "crates/transaction", version = "0.28" }
 
 # Template lib
-tari_ootle_template_build = { path = "crates/template_build", version = "0.4" }
+tari_ootle_template_build = { path = "crates/template_build", version = "0.5" }
 tari_ootle_template_metadata = { path = "crates/template_metadata", version = "0.5" }
 tari_template_lib = { version = "0.24", path = "crates/template_lib" }
 tari_template_lib_types = { version = "0.24", path = "crates/template_lib_types", default-features = false }

--- a/crates/template_build/Cargo.toml
+++ b/crates/template_build/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_ootle_template_build"
 description = "Build-time metadata generation for Tari Ootle templates"
-version = "0.4.0"
+version = "0.5.1"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/template_build/README.md
+++ b/crates/template_build/README.md
@@ -12,7 +12,7 @@ Add to your template's `Cargo.toml`:
 
 ```toml
 [build-dependencies]
-tari_ootle_template_build = "0.4"
+tari_ootle_template_build = "0.5"
 ```
 
 Create a `build.rs`:
@@ -61,6 +61,8 @@ fn main() {
 
 ## Output
 
+URL fields (`repository`, `documentation`, `homepage`, `logo_url`) are parsed and validated at build time. Invalid URLs will cause a build error.
+
 On a successful `build()`:
 
 - Writes `template_metadata.cbor` to `OUT_DIR`
@@ -86,6 +88,7 @@ category = "token"
 documentation = "https://docs.example.com/fungible-token"
 homepage = "https://example.com"
 logo_url = "https://example.com/logo.png"
+supersedes = "0000000000000000000000000000000000000000000000000000000000000000"
 
 [package.metadata.tari-template.extra]
 audit = "https://example.com/audit-report"

--- a/crates/template_metadata/Cargo.toml
+++ b/crates/template_metadata/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_ootle_template_metadata"
 description = "Template metadata types, serialization, and hashing for Tari Ootle templates"
-version = "0.5.0"
+version = "0.5.1"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/template_metadata/README.md
+++ b/crates/template_metadata/README.md
@@ -73,18 +73,21 @@ println!("Hash: {hash}");
 | `version` | `[package] version` |
 | `description` | `[package] description` |
 | `license` | `[package] license` |
-| `repository` | `[package] repository` |
+| `repository` | `[package] repository` (parsed as `Url`) |
 | `tags` | `[package.metadata.tari-template] tags` |
 | `category` | `[package.metadata.tari-template] category` |
-| `documentation` | `[package.metadata.tari-template] documentation` |
-| `homepage` | `[package.metadata.tari-template] homepage` |
-| `logo_url` | `[package.metadata.tari-template] logo_url` |
+| `commit_hash` | `[package.metadata.tari-template] commit_hash` (full 40-char hex SHA-1 git object ID) |
+| `documentation` | `[package.metadata.tari-template] documentation` (parsed as `Url`) |
+| `homepage` | `[package.metadata.tari-template] homepage` (parsed as `Url`) |
+| `logo_url` | `[package.metadata.tari-template] logo_url` (parsed as `Url`) |
+| `supersedes` | `[package.metadata.tari-template] supersedes` (64-char hex template address) |
 | `extra` | `[package.metadata.tari-template] extra` |
 
 ## Features
 
 - **`json`** — enables `to_json()` / `from_json()` on `TemplateMetadata`
 - **`borsh`** — enables `BorshSerialize` for `MetadataHash`
+- **`ts`** — enables TypeScript type generation via `ts-rs`
 
 ## Hash details
 


### PR DESCRIPTION
## Summary
- Document new `commit_hash` and `supersedes` fields in template_metadata README
- Document typed URL validation in template_build README
- Add `ts` feature to template_metadata features list
- Bump `template_metadata` to 0.5.1 and `template_build` to 0.5.1
- Update workspace template_build version reference from 0.4 to 0.5

## Test plan
- [x] `cargo test -p tari_ootle_template_metadata --features json` passes
- [x] `cargo test -p tari_ootle_template_build` passes