### PR TITLE
feat(indexer): add per-IP token-bucket rate limiting to REST API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11080,6 +11080,7 @@ dependencies = [
  "cacache",
  "clap 3.2.25",
  "config",
+ "dashmap 5.5.3",
  "diesel",
  "diesel_migrations",
  "futures 0.3.31",

--- a/applications/tari_indexer/Cargo.toml
+++ b/applications/tari_indexer/Cargo.toml
@@ -49,6 +49,7 @@ async-graphql-axum = { workspace = true }
 bytes = { workspace = true }
 bincode = { workspace = true, features = ["serde"] }
 clap = { workspace = true, features = ["derive", "env"] }
+dashmap = { workspace = true }
 config = { workspace = true }
 diesel = { workspace = true, default-features = false, features = [
     "sqlite",
@@ -84,7 +85,7 @@ tokio = { workspace = true, features = [
     "rt-multi-thread",
 ] }
 tokio-stream = { workspace = true }
-tower = { workspace = true, features = ["limit"] }
+tower = { workspace = true }
 tower-http = { workspace = true, features = ["default", "cors", "limit", "trace"] }
 url = { workspace = true, features = ["serde"] }
 cacache = { version = "13.1.0", default-features = false, features = ["mmap", "tokio-runtime"] }

--- a/applications/tari_indexer/src/config.rs
+++ b/applications/tari_indexer/src/config.rs
@@ -24,6 +24,48 @@ use std::{net::SocketAddr, path::PathBuf, time::Duration};
 
 use config::Config;
 use serde::{Deserialize, Serialize};
+
+/// Rate limiting configuration for the indexer REST API.
+///
+/// All request-count limits are per-IP. Set a value to `0` to disable that
+/// limit entirely (the middleware skips rate checking when capacity is 0).
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct RateLimitConfig {
+    /// `POST /transactions`: maximum requests per minute per IP (default: 20).
+    pub transactions_submit_per_min: u64,
+    /// `POST /transactions/dry-run`: maximum requests per 5 seconds per IP (default: 10).
+    pub dry_run_per_5s: u64,
+    /// `POST /substates/fetch`: maximum requests per minute per IP (default: 30).
+    pub substates_fetch_per_min: u64,
+    /// `POST /utxos/fetch`: maximum requests per minute per IP (default: 15).
+    pub utxos_fetch_per_min: u64,
+    /// `GET /non-fungibles`: maximum requests per minute per IP (default: 30).
+    pub non_fungibles_per_min: u64,
+    /// `GET /transactions/recent`: maximum requests per minute per IP (default: 60).
+    pub recent_transactions_per_min: u64,
+    /// SSE stream endpoints (`/events`, `/events/stream`, `/utxos/stream`):
+    /// maximum concurrent connections per IP (default: 3).
+    pub sse_max_connections_per_ip: usize,
+    /// If `true`, the `X-Forwarded-For` header is used to determine the
+    /// client IP instead of the TCP peer address.  Enable this when the
+    /// indexer runs behind a trusted reverse proxy (default: false).
+    pub trust_proxy_headers: bool,
+}
+
+impl Default for RateLimitConfig {
+    fn default() -> Self {
+        Self {
+            transactions_submit_per_min: 20,
+            dry_run_per_5s: 10,
+            substates_fetch_per_min: 30,
+            utxos_fetch_per_min: 15,
+            non_fungibles_per_min: 30,
+            recent_transactions_per_min: 60,
+            sse_max_connections_per_ip: 3,
+            trust_proxy_headers: false,
+        }
+    }
+}
 use tari_common::{
     ConfigurationError,
     DefaultConfigLoader,
@@ -125,6 +167,8 @@ pub struct IndexerConfig {
     pub dry_run_cache_ttl: Duration,
     /// The event filtering configuration
     pub event_filters: Vec<EventFilter>,
+    /// Rate limiting configuration for the REST API.
+    pub rate_limit: RateLimitConfig,
 }
 
 impl Default for IndexerConfig {
@@ -146,6 +190,7 @@ impl Default for IndexerConfig {
             burnt_utxo_sidechain_id: None,
             dry_run_cache_ttl: Duration::from_secs(10),
             event_filters: vec![],
+            rate_limit: RateLimitConfig::default(),
         }
     }
 }

--- a/applications/tari_indexer/src/lib.rs
+++ b/applications/tari_indexer/src/lib.rs
@@ -136,7 +136,12 @@ where
         #[cfg(feature = "metrics")]
         let server = rest_api::Server::new(registry);
         let listen_address = server
-            .spawn(listen_addr, &services, shutdown_signal.clone())
+            .spawn(
+                listen_addr,
+                &services,
+                config.indexer.rate_limit.clone(),
+                shutdown_signal.clone(),
+            )
             .await
             .map_err(|e| ExitError::new(ExitCode::ConfigError, e))?;
         debug!(target: LOG_TARGET, "API address {}", listen_address);

--- a/applications/tari_indexer/src/rest_api/mod.rs
+++ b/applications/tari_indexer/src/rest_api/mod.rs
@@ -8,6 +8,7 @@ mod error;
 mod handlers;
 #[cfg(feature = "metrics")]
 mod metrics;
+pub mod rate_limit;
 mod server;
 mod streaming;
 

--- a/applications/tari_indexer/src/rest_api/rate_limit.rs
+++ b/applications/tari_indexer/src/rest_api/rate_limit.rs
@@ -1,0 +1,291 @@
+//   Copyright 2025 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+//! Per-IP token-bucket rate limiting and SSE concurrent connection limiting
+//! for the indexer REST API.
+//!
+//! ## Design
+//!
+//! Each `IpRateLimiter` holds a `DashMap<IpAddr, BucketState>` — one entry per
+//! observed client IP. On every request the entry is updated in-place: elapsed
+//! time since the last check refills tokens at the configured rate, then one
+//! token is consumed. If no token is available the middleware returns
+//! `429 Too Many Requests` with a `Retry-After` header (integer seconds).
+//!
+//! `SseConnectionLimiter` tracks concurrent SSE connections per IP using a
+//! `DashMap<IpAddr, Arc<tokio::sync::Semaphore>>`.  The middleware acquires an
+//! owned permit before running the handler; the permit is moved into a
+//! `GuardedStream` that wraps the response body, so it is not released until
+//! the SSE stream is actually closed by the client or server.
+
+use std::{
+    net::{IpAddr, SocketAddr},
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+use axum::{
+    body::Body,
+    extract::{ConnectInfo, Request},
+    http::{HeaderValue, StatusCode, header},
+    middleware::Next,
+    response::Response,
+};
+use dashmap::DashMap;
+use futures::Stream;
+use log::debug;
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+
+const LOG_TARGET: &str = "tari::ootle::indexer::rest_api::rate_limit";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Returns the current time as milliseconds since the Unix epoch.
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}
+
+/// Extracts the client IP from the request.
+///
+/// If `trust_proxy` is true and an `X-Forwarded-For` header is present, the
+/// first (leftmost) address in the header is used.  Otherwise the peer address
+/// from the TCP connection (`ConnectInfo<SocketAddr>`) is used.
+fn extract_ip(req: &Request, trust_proxy: bool) -> IpAddr {
+    if trust_proxy {
+        if let Some(forwarded) = req.headers().get("x-forwarded-for") {
+            if let Ok(s) = forwarded.to_str() {
+                if let Some(first) = s.split(',').next() {
+                    if let Ok(ip) = first.trim().parse::<IpAddr>() {
+                        return ip;
+                    }
+                }
+            }
+        }
+    }
+    req.extensions()
+        .get::<ConnectInfo<SocketAddr>>()
+        .map(|ci| ci.0.ip())
+        .unwrap_or(IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED))
+}
+
+fn too_many_requests(retry_after_secs: u64) -> Response {
+    let mut res = Response::new(Body::from(
+        r#"{"error":"Too Many Requests","message":"Rate limit exceeded, see Retry-After header"}"#,
+    ));
+    *res.status_mut() = StatusCode::TOO_MANY_REQUESTS;
+    let secs_str = retry_after_secs.to_string();
+    if let Ok(v) = HeaderValue::from_str(&secs_str) {
+        res.headers_mut().insert(header::RETRY_AFTER, v);
+    }
+    res.headers_mut()
+        .insert(header::CONTENT_TYPE, HeaderValue::from_static("application/json"));
+    res
+}
+
+// ---------------------------------------------------------------------------
+// IpRateLimiter — per-IP token-bucket
+// ---------------------------------------------------------------------------
+
+struct BucketState {
+    /// Tokens currently available (can be fractional during refill).
+    tokens: f64,
+    /// Timestamp of the last refill/check in milliseconds since Unix epoch.
+    last_ms: u64,
+}
+
+/// Per-IP token-bucket rate limiter.
+///
+/// Create one instance per endpoint group (not shared between groups) to
+/// prevent "starvation" where high load on one endpoint exhausts tokens for
+/// another that happens to share the same limiter.
+pub struct IpRateLimiter {
+    buckets: DashMap<IpAddr, BucketState>,
+    /// Burst capacity — also the initial token count for a new IP.
+    capacity: f64,
+    /// Tokens replenished per millisecond.
+    tokens_per_ms: f64,
+    /// Whether to trust `X-Forwarded-For` headers for IP extraction.
+    trust_proxy: bool,
+}
+
+impl IpRateLimiter {
+    /// `max_per_min` requests per minute, burst up to `max_per_min` tokens.
+    pub fn per_min(max_per_min: u64, trust_proxy: bool) -> Arc<Self> {
+        let cap = max_per_min as f64;
+        Arc::new(Self {
+            buckets: DashMap::new(),
+            capacity: cap,
+            tokens_per_ms: cap / 60_000.0,
+            trust_proxy,
+        })
+    }
+
+    /// `max_per_window` requests per `window`.
+    pub fn per_window(max_per_window: u64, window: Duration, trust_proxy: bool) -> Arc<Self> {
+        let cap = max_per_window as f64;
+        Arc::new(Self {
+            buckets: DashMap::new(),
+            capacity: cap,
+            tokens_per_ms: cap / window.as_millis() as f64,
+            trust_proxy,
+        })
+    }
+
+    /// Check and consume one token for `ip`.
+    ///
+    /// Returns `Ok(())` when a token is available, or `Err(retry_after)` when
+    /// the bucket is empty.
+    pub fn check(&self, ip: IpAddr) -> Result<(), Duration> {
+        let now = now_ms();
+        let mut entry = self.buckets.entry(ip).or_insert_with(|| BucketState {
+            tokens: self.capacity,
+            last_ms: now,
+        });
+
+        let elapsed_ms = now.saturating_sub(entry.last_ms);
+        let refill = elapsed_ms as f64 * self.tokens_per_ms;
+        entry.tokens = (entry.tokens + refill).min(self.capacity);
+        entry.last_ms = now;
+
+        if entry.tokens >= 1.0 {
+            entry.tokens -= 1.0;
+            Ok(())
+        } else {
+            // How many ms until 1 token is available
+            let ms_until = ((1.0 - entry.tokens) / self.tokens_per_ms).ceil() as u64;
+            Err(Duration::from_millis(ms_until))
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Axum middleware function for IpRateLimiter
+// ---------------------------------------------------------------------------
+
+/// Axum middleware that applies `limiter` to every request.
+///
+/// Usage:
+/// ```ignore
+/// .layer(axum::middleware::from_fn_with_state(limiter, ip_rate_limit))
+/// ```
+pub async fn ip_rate_limit(
+    axum::extract::State(limiter): axum::extract::State<Arc<IpRateLimiter>>,
+    req: Request,
+    next: Next,
+) -> Response {
+    let ip = extract_ip(&req, limiter.trust_proxy);
+    match limiter.check(ip) {
+        Ok(()) => {
+            debug!(target: LOG_TARGET, "Rate limit ok for {}", ip);
+            next.run(req).await
+        },
+        Err(retry_after) => {
+            let secs = retry_after.as_secs().max(1);
+            debug!(target: LOG_TARGET, "Rate limit exceeded for {} — retry after {}s", ip, secs);
+            too_many_requests(secs)
+        },
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SseConnectionLimiter — per-IP concurrent connection cap
+// ---------------------------------------------------------------------------
+
+/// Per-IP concurrent SSE connection limiter.
+///
+/// Uses a `DashMap<IpAddr, Arc<Semaphore>>` so each IP has its own semaphore
+/// with `max_per_ip` permits.  The middleware acquires an `OwnedSemaphorePermit`
+/// before running the SSE handler and moves it into a `GuardedStream` wrapper
+/// around the response body, so the permit is held for the full duration of the
+/// SSE stream and released when the connection closes.
+pub struct SseConnectionLimiter {
+    semaphores: DashMap<IpAddr, Arc<Semaphore>>,
+    max_per_ip: usize,
+    trust_proxy: bool,
+}
+
+impl SseConnectionLimiter {
+    pub fn new(max_per_ip: usize, trust_proxy: bool) -> Arc<Self> {
+        Arc::new(Self {
+            semaphores: DashMap::new(),
+            max_per_ip,
+            trust_proxy,
+        })
+    }
+
+    fn try_acquire(&self, ip: IpAddr) -> Option<OwnedSemaphorePermit> {
+        let sem = self
+            .semaphores
+            .entry(ip)
+            .or_insert_with(|| Arc::new(Semaphore::new(self.max_per_ip)))
+            .clone();
+        sem.try_acquire_owned().ok()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// GuardedStream — holds a semaphore permit until the body stream ends
+// ---------------------------------------------------------------------------
+
+/// A `Stream` adapter that holds a `OwnedSemaphorePermit` until the inner
+/// stream is exhausted or dropped.  This ensures an SSE connection slot is
+/// only released when the connection actually closes.
+struct GuardedStream<S> {
+    inner: S,
+    /// Permit is held here; dropped when `GuardedStream` is dropped.
+    _permit: OwnedSemaphorePermit,
+}
+
+impl<S: Stream + Unpin> Stream for GuardedStream<S> {
+    type Item = S::Item;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        Pin::new(&mut self.inner).poll_next(cx)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Axum middleware function for SseConnectionLimiter
+// ---------------------------------------------------------------------------
+
+pub async fn sse_connection_limit(
+    axum::extract::State(limiter): axum::extract::State<Arc<SseConnectionLimiter>>,
+    req: Request,
+    next: Next,
+) -> Response {
+    let ip = extract_ip(&req, limiter.trust_proxy);
+    match limiter.try_acquire(ip) {
+        None => {
+            debug!(target: LOG_TARGET, "SSE connection limit exceeded for {}", ip);
+            too_many_requests(5)
+        },
+        Some(permit) => {
+            let response = next.run(req).await;
+            // Wrap the response body so the semaphore permit is held until
+            // the stream is fully consumed (i.e. the SSE connection closes).
+            let (parts, body) = response.into_parts();
+            let data_stream = body.into_data_stream();
+            // GuardedStream holds the permit; Body::from_stream drives it.
+            // The permit is released when GuardedStream is dropped, which
+            // happens when the response body is fully consumed or the
+            // connection is aborted — i.e. when the SSE session ends.
+            let guarded = GuardedStream {
+                inner: data_stream,
+                _permit: permit,
+            };
+            let new_body = Body::from_stream(guarded);
+            Response::from_parts(parts, new_body)
+        },
+    }
+}

--- a/applications/tari_indexer/src/rest_api/rate_limit.rs
+++ b/applications/tari_indexer/src/rest_api/rate_limit.rs
@@ -11,6 +11,8 @@
 //! time since the last check refills tokens at the configured rate, then one
 //! token is consumed. If no token is available the middleware returns
 //! `429 Too Many Requests` with a `Retry-After` header (integer seconds).
+//! When `trust_proxy` is enabled, the **rightmost** `X-Forwarded-For` entry is
+//! used — it is appended by the adjacent trusted proxy and cannot be spoofed.
 //!
 //! `SseConnectionLimiter` tracks concurrent SSE connections per IP using a
 //! `DashMap<IpAddr, Arc<tokio::sync::Semaphore>>`.  The middleware acquires an
@@ -55,14 +57,17 @@ fn now_ms() -> u64 {
 /// Extracts the client IP from the request.
 ///
 /// If `trust_proxy` is true and an `X-Forwarded-For` header is present, the
-/// first (leftmost) address in the header is used.  Otherwise the peer address
+/// **rightmost** (last) address in the header is used.  The rightmost entry is
+/// appended by the immediately-adjacent trusted reverse proxy and cannot be
+/// spoofed by the remote client; leftmost entries are client-controlled and
+/// must not be trusted for rate-limiting purposes.  Otherwise the peer address
 /// from the TCP connection (`ConnectInfo<SocketAddr>`) is used.
 fn extract_ip(req: &Request, trust_proxy: bool) -> IpAddr {
     if trust_proxy {
         if let Some(forwarded) = req.headers().get("x-forwarded-for") {
             if let Ok(s) = forwarded.to_str() {
-                if let Some(first) = s.split(',').next() {
-                    if let Ok(ip) = first.trim().parse::<IpAddr>() {
+                if let Some(last) = s.split(',').last() {
+                    if let Ok(ip) = last.trim().parse::<IpAddr>() {
                         return ip;
                     }
                 }

--- a/applications/tari_indexer/src/rest_api/rate_limit.rs
+++ b/applications/tari_indexer/src/rest_api/rate_limit.rs
@@ -140,9 +140,14 @@ impl IpRateLimiter {
 
     /// Check and consume one token for `ip`.
     ///
-    /// Returns `Ok(())` when a token is available, or `Err(retry_after)` when
-    /// the bucket is empty.
+    /// Returns `Ok(())` when a token is available or when the limiter is
+    /// disabled (capacity == 0), or `Err(retry_after)` when the bucket is
+    /// empty.
     pub fn check(&self, ip: IpAddr) -> Result<(), Duration> {
+        // capacity == 0 means "no rate limit" for this endpoint group.
+        if self.capacity == 0.0 {
+            return Ok(());
+        }
         let now = now_ms();
         let mut entry = self.buckets.entry(ip).or_insert_with(|| BucketState {
             tokens: self.capacity,
@@ -220,11 +225,19 @@ impl SseConnectionLimiter {
         })
     }
 
+    /// Returns `None` when the per-IP limit is reached, `Some(permit)` when a
+    /// slot is available.  If `max_per_ip == 0` the limiter is disabled and
+    /// always returns a permit (uses a semaphore with `usize::MAX` permits).
     fn try_acquire(&self, ip: IpAddr) -> Option<OwnedSemaphorePermit> {
+        let max = if self.max_per_ip == 0 {
+            usize::MAX
+        } else {
+            self.max_per_ip
+        };
         let sem = self
             .semaphores
             .entry(ip)
-            .or_insert_with(|| Arc::new(Semaphore::new(self.max_per_ip)))
+            .or_insert_with(|| Arc::new(Semaphore::new(max)))
             .clone();
         sem.try_acquire_owned().ok()
     }

--- a/applications/tari_indexer/src/rest_api/server.rs
+++ b/applications/tari_indexer/src/rest_api/server.rs
@@ -6,12 +6,12 @@ use std::{net::SocketAddr, time::Duration};
 use axum::{
     Extension,
     Router,
+    middleware,
     routing::{get, post},
 };
 use log::*;
 use tari_ootle_app_utilities::tcp::try_bind_with_fallback;
 use tari_shutdown::ShutdownSignal;
-use tower::{ServiceBuilder, buffer::BufferLayer, limit::RateLimitLayer};
 use tower_http::{cors::CorsLayer, limit::RequestBodyLimitLayer, trace::TraceLayer};
 use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
@@ -20,7 +20,12 @@ use utoipa_swagger_ui::SwaggerUi;
 use crate::rest_api::metrics;
 use crate::{
     bootstrap::Services,
-    rest_api::{context::HandlerContext, handlers},
+    config::RateLimitConfig,
+    rest_api::{
+        context::HandlerContext,
+        handlers,
+        rate_limit::{IpRateLimiter, SseConnectionLimiter, ip_rate_limit, sse_connection_limit},
+    },
 };
 
 const LOG_TARGET: &str = "tari::ootle::indexer::rest_api::server";
@@ -79,11 +84,29 @@ impl Server {
         #[allow(unused_mut)] mut self,
         preferred_addr: SocketAddr,
         services: &Services,
+        rate_limit_config: RateLimitConfig,
         shutdown: ShutdownSignal,
     ) -> anyhow::Result<SocketAddr> {
         let context = HandlerContext::from_services(services);
+        let trust_proxy = rate_limit_config.trust_proxy_headers;
+
+        // ---------------------------------------------------------------------------
+        // Rate limiters — one independent instance per endpoint group so that load
+        // on one group cannot starve another (sdbondi review feedback).
+        // ---------------------------------------------------------------------------
+        let txn_submit_limiter =
+            IpRateLimiter::per_min(rate_limit_config.transactions_submit_per_min, trust_proxy);
+        let dry_run_limiter =
+            IpRateLimiter::per_window(rate_limit_config.dry_run_per_5s, Duration::from_secs(5), trust_proxy);
+        let substates_fetch_limiter =
+            IpRateLimiter::per_min(rate_limit_config.substates_fetch_per_min, trust_proxy);
+        let utxos_fetch_limiter = IpRateLimiter::per_min(rate_limit_config.utxos_fetch_per_min, trust_proxy);
+        let non_fungibles_limiter = IpRateLimiter::per_min(rate_limit_config.non_fungibles_per_min, trust_proxy);
+        let recent_txns_limiter = IpRateLimiter::per_min(rate_limit_config.recent_transactions_per_min, trust_proxy);
+        let sse_limiter = SseConnectionLimiter::new(rate_limit_config.sse_max_connections_per_ip, trust_proxy);
 
         let router = Router::new()
+            // Health / ready / identity — NOT rate-limited (per acceptance criteria)
             .route("/health", get(handlers::misc::health))
             .route("/ready", get(handlers::misc::ready))
             .route("/identity", get(handlers::misc::get_identity))
@@ -92,34 +115,56 @@ impl Server {
             .route("/network", get(handlers::network::get))
             .route("/network/stats", get(handlers::network::get_network_sync_stats))
             .route("/network/connections", get(handlers::network::get_connections))
+            // Substates — rate-limited fetch, unrestricted single-substate GET
             .nest("/substates", Router::new()
-                .route("/fetch", post(handlers::substates::fetch_substates))
+                .route(
+                    "/fetch",
+                    post(handlers::substates::fetch_substates)
+                        .layer(middleware::from_fn_with_state(
+                            substates_fetch_limiter,
+                            ip_rate_limit,
+                        )),
+                )
                 .route("/{substate_id}", get(handlers::substates::get_substate))
             )
+            // Transactions
             .nest("/transactions", Router::new()
-                .route("/", post(handlers::transactions::submit_transaction))
-                .route("/dry-run", post(handlers::transactions::submit_transaction_dry_run)
-                    .layer(ServiceBuilder::new()
-                        .layer(axum::error_handling::HandleErrorLayer::new(|err: axum::BoxError| async move {
-                            (
-                                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                                format!("Unhandled error: {}", err),
-                            )
-                        }))
-                        .layer(BufferLayer::new(1024))
-                        .layer(RateLimitLayer::new(10, Duration::from_secs(5)))
-                    ))
+                .route(
+                    "/",
+                    post(handlers::transactions::submit_transaction)
+                        .layer(middleware::from_fn_with_state(
+                            txn_submit_limiter,
+                            ip_rate_limit,
+                        )),
+                )
+                .route(
+                    "/dry-run",
+                    post(handlers::transactions::submit_transaction_dry_run)
+                        .layer(middleware::from_fn_with_state(
+                            dry_run_limiter,
+                            ip_rate_limit,
+                        )),
+                )
                 .route(
                     "/recent",
-                    get(handlers::transactions::list_recent_transactions),
+                    get(handlers::transactions::list_recent_transactions)
+                        .layer(middleware::from_fn_with_state(
+                            recent_txns_limiter,
+                            ip_rate_limit,
+                        )),
                 )
-                .route(
-                    "/{transaction_id}/result",
-                    get(handlers::transactions::get_transaction_result),
-                )
+                .route("/{transaction_id}/result", get(handlers::transactions::get_transaction_result))
                 .route("/events", get(handlers::transactions::query_transaction_events))
-                .route("/events/stream", get(handlers::transaction_events::sse_transaction_events))
+                .route(
+                    "/events/stream",
+                    get(handlers::transaction_events::sse_transaction_events)
+                        .layer(middleware::from_fn_with_state(
+                            sse_limiter.clone(),
+                            sse_connection_limit,
+                        )),
+                )
             )
+            // Templates — unrestricted reads
             .nest("/templates", Router::new()
                 .route("/cached", get(handlers::templates::list_cached_templates))
                 .route("/catalogue", get(handlers::templates::list_template_catalogue))
@@ -127,17 +172,38 @@ impl Server {
                     "/catalogue/{template_address}",
                     get(handlers::templates::get_template_catalogue_entry),
                 )
-                .route(
-                    "/{template_address}",
-                    get(handlers::templates::get_template_definition),
-                )
+                .route("/{template_address}", get(handlers::templates::get_template_definition))
             )
-            .route("/non-fungibles", get(handlers::nfts::get_non_fungibles)) // Placeholder for future non-fungible endpoints
+            // Non-fungibles — rate-limited
+            .route(
+                "/non-fungibles",
+                get(handlers::nfts::get_non_fungibles)
+                    .layer(middleware::from_fn_with_state(
+                        non_fungibles_limiter,
+                        ip_rate_limit,
+                    )),
+            )
+            // UTXOs
             .nest("/utxos", Router::new()
                 .route("/", get(handlers::utxos::list_utxos))
-                .route("/fetch", post(handlers::utxos::fetch_utxos))
-                .route("/stream", post(handlers::utxos::stream_utxo_updates))
+                .route(
+                    "/fetch",
+                    post(handlers::utxos::fetch_utxos)
+                        .layer(middleware::from_fn_with_state(
+                            utxos_fetch_limiter,
+                            ip_rate_limit,
+                        )),
+                )
+                .route(
+                    "/stream",
+                    post(handlers::utxos::stream_utxo_updates)
+                        .layer(middleware::from_fn_with_state(
+                            sse_limiter.clone(),
+                            sse_connection_limit,
+                        )),
+                )
             )
+            // Transaction receipts — unrestricted
             .nest(
                 "/transaction-receipts",
                 Router::new()
@@ -147,12 +213,21 @@ impl Server {
                         get(handlers::transaction_receipts::get_transaction_receipt),
                     ),
             )
+            // Resources — unrestricted convenience endpoints
             .nest("/resources/", Router::new()
-                // Convenience Shortcut
-                .route("/xtr" , get(handlers::resources::get_tari))
-                .route("/tari" , get(handlers::resources::get_tari))
-                .route("/{resource_address}" , get(handlers::resources::get_resource)))
-            .route("/events", get(handlers::indexer_events::sse_events))
+                .route("/xtr", get(handlers::resources::get_tari))
+                .route("/tari", get(handlers::resources::get_tari))
+                .route("/{resource_address}", get(handlers::resources::get_resource))
+            )
+            // Global events SSE — rate-limited concurrent connections
+            .route(
+                "/events",
+                get(handlers::indexer_events::sse_events)
+                    .layer(middleware::from_fn_with_state(
+                        sse_limiter,
+                        sse_connection_limit,
+                    )),
+            )
             .layer(CorsLayer::permissive())
             .layer(RequestBodyLimitLayer::new(REQUEST_BODY_LIMIT))
             .merge(SwaggerUi::new("/swagger-ui").url("/openapi.json", ApiDoc::openapi()))
@@ -173,7 +248,13 @@ impl Server {
         let listen_addr = listener.local_addr()?;
         info!(target: LOG_TARGET, "🌐 Indexer REST API server listening on {listen_addr}");
         tokio::spawn(async move {
-            if let Err(error) = axum::serve(listener, router).with_graceful_shutdown(shutdown).await {
+            if let Err(error) = axum::serve(
+                listener,
+                router.into_make_service_with_connect_info::<SocketAddr>(),
+            )
+            .with_graceful_shutdown(shutdown)
+            .await
+            {
                 error!(target: LOG_TARGET, "Wallet query HTTP server error: {error}");
             }
         });


### PR DESCRIPTION
## Summary

Implements configurable per-IP token-bucket rate limiting for the indexer REST API, addressing bounty #1997.

- **`IpRateLimiter`**: token-bucket per IP using `DashMap<IpAddr, BucketState>` — no external crates added (`dashmap` already in workspace). Tokens refill continuously based on elapsed time.
- **`SseConnectionLimiter`**: per-IP concurrent SSE connection cap via `DashMap<IpAddr, Arc<Semaphore>>`. An `OwnedSemaphorePermit` is moved into a `GuardedStream` body wrapper so the slot is only released when the SSE stream closes (not when response headers are sent).
- **Separate limiter instance per endpoint group** — `POST /transactions` and `GET /transactions/recent` use independent limiters so neither can starve the other.
- **429 `TOO_MANY_REQUESTS` + `Retry-After` header** (integer seconds until next token available).
- **`trust_proxy_headers` flag**: use `X-Forwarded-For` instead of TCP peer address (configurable, default `false`).
- **`axum::serve` → `into_make_service_with_connect_info`** so `ConnectInfo<SocketAddr>` is available in middleware for IP extraction.

### Default limits (all configurable via `[indexer.rate_limit]`)

| Endpoint | Limit |
|---|---|
| `POST /transactions` | 20 req/min per IP |
| `POST /transactions/dry-run` | 10 req/5s per IP (existing default preserved) |
| `POST /substates/fetch` | 30 req/min per IP |
| `POST /utxos/fetch` | 15 req/min per IP |
| `GET /non-fungibles` | 30 req/min per IP |
| `GET /transactions/recent` | 60 req/min per IP |
| SSE (`/events`, `/events/stream`, `/utxos/stream`) | 3 concurrent connections per IP |

Health, ready, and identity endpoints are not rate-limited.

## Acceptance criteria

- [x] `POST /transactions` rate-limited (20 req/min per IP)
- [x] `POST /substates/fetch` (30/min) and `POST /utxos/fetch` (15/min) rate-limited
- [x] `GET /non-fungibles` rate-limited (30/min)
- [x] SSE endpoints have per-IP concurrent connection limit (3 per IP)
- [x] All limits configurable in `[indexer.rate_limit]` section of config
- [x] Existing `POST /transactions/dry-run` rate limiting preserved
- [x] Health, ready, identity endpoints not rate-limited
- [x] Rate-limited responses return HTTP 429 with `Retry-After` header

Closes #1997

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- bounty-payout-section:start -->
---

## Bounty payout

If this PR is accepted as a bounty submission, please direct funds to the following Tari wallet address:

``123JbAxCZ4Vrh4jCjFLXTu4z8sLeggUR87fejwNunsB55NMBSH9RpkjNiw1WL2GkKr8JhqRZhbrsSREchGanchw2Nhb``
<!-- bounty-payout-section:end -->