### PR TITLE
feat(template_lib_types): add fast hash map types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12034,7 +12034,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_lib"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "borsh",
  "serde",
@@ -12048,11 +12048,12 @@ dependencies = [
 
 [[package]]
 name = "tari_template_lib_types"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "bincode 2.0.1",
  "bnum",
  "borsh",
+ "indexmap 2.13.0",
  "num-integer",
  "serde",
  "serde_json",
@@ -12060,6 +12061,7 @@ dependencies = [
  "tari_crypto",
  "tari_template_abi",
  "ts-rs",
+ "xxhash-rust",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,8 +124,8 @@ tari_ootle_transaction = { path = "crates/transaction", version = "0.28" }
 # Template lib
 tari_ootle_template_build = { path = "crates/template_build", version = "0.5" }
 tari_ootle_template_metadata = { path = "crates/template_metadata", version = "0.5" }
-tari_template_lib = { version = "0.24", path = "crates/template_lib" }
-tari_template_lib_types = { version = "0.24", path = "crates/template_lib_types", default-features = false }
+tari_template_lib = { version = "0.25", path = "crates/template_lib" }
+tari_template_lib_types = { version = "0.25", path = "crates/template_lib_types", default-features = false }
 tari_template_abi = { version = "0.16", path = "crates/template_abi", default-features = false }
 tari_template_macros = { version = "0.18", path = "crates/template_macros" }
 tari_bor = { version = "0.13", path = "crates/tari_bor", default-features = false }

--- a/crates/template_builtin/templates/account/Cargo.toml
+++ b/crates/template_builtin/templates/account/Cargo.toml
@@ -5,7 +5,6 @@ version = "0.9.2"
 edition = "2024"
 
 [dependencies]
-tari_template_abi = { path = "../../../template_abi" }
 tari_template_lib = { path = "../../../template_lib", features = ["extra-maps"] }
 
 [lib]

--- a/crates/template_builtin/templates/account/Cargo.toml
+++ b/crates/template_builtin/templates/account/Cargo.toml
@@ -1,12 +1,12 @@
 [workspace]
 [package]
 name = "account"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2024"
 
 [dependencies]
 tari_template_abi = { path = "../../../template_abi" }
-tari_template_lib = { path = "../../../template_lib" }
+tari_template_lib = { path = "../../../template_lib", features = ["extra-maps"] }
 
 [lib]
 crate-type = ["cdylib"]

--- a/crates/template_builtin/templates/account/src/lib.rs
+++ b/crates/template_builtin/templates/account/src/lib.rs
@@ -20,19 +20,21 @@
 //   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //   USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use tari_template_abi::rust::collections::BTreeMap;
 use tari_template_lib::prelude::*;
+
+type VaultMap = PrehashedMap<ResourceAddress, Vault>;
+type ApprovalMap = PrehashedMap<(ResourceAddress, NonFungibleAddress), Amount>;
 
 #[template]
 mod account_template {
     use super::*;
 
     pub struct Account {
-        vaults: BTreeMap<ResourceAddress, Vault>,
+        vaults: VaultMap,
         #[serde(default)]
         /// Approvals for other accounts to withdraw from this account. The key is a tuple of (approved resource,
         /// required spender_badge), and the value is the approved amount.
-        approvals: BTreeMap<(ResourceAddress, NonFungibleAddress), Amount>,
+        approvals: ApprovalMap,
     }
 
     impl Account {
@@ -64,14 +66,14 @@ mod account_template {
             );
 
             // add the funds from the (optional) bucket
-            let mut vaults = BTreeMap::new();
+            let mut vaults = VaultMap::default();
             if let Some(b) = bucket {
                 vaults.insert(b.resource_address(), Vault::from_bucket(b));
             }
 
             Component::new(Self {
                 vaults,
-                approvals: BTreeMap::new(),
+                approvals: ApprovalMap::default(),
             })
             .with_access_rules(access_rules)
             .with_public_key_address(public_key)
@@ -230,7 +232,7 @@ mod account_template {
         pub fn approve(&mut self, spender_badge: NonFungibleAddress, resource: ResourceAddress, amount: Amount) {
             if amount.is_zero() {
                 let key = (resource, spender_badge);
-                if self.approvals.remove(&key).is_some() {
+                if self.approvals.swap_remove(&key).is_some() {
                     emit_event("revoke_approval", [
                         ("resource", key.0.to_string()),
                         ("spender_badge", key.1.to_string()),
@@ -274,7 +276,7 @@ mod account_template {
                 .unwrap_or_else(|| panic!("Amount exceeds approval (max: {}, attempted: {})", approval, amount));
             // Clean up zero approvals
             if approval.is_zero() {
-                self.approvals.remove(&(resource, badge));
+                self.approvals.swap_remove(&(resource, badge));
             }
 
             emit_event("withdraw_approved", [

--- a/crates/template_lib/Cargo.toml
+++ b/crates/template_lib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_template_lib"
 description = "Tari template library provides abstrations that interface with the Tari validator engine"
-version = "0.24.0"
+version = "0.25.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true
@@ -30,3 +30,4 @@ borsh = ["dep:borsh", "tari_template_lib_types/borsh", "tari_bor/borsh"]
 extra-arith = ["tari_template_lib_types/extra-arith"]
 precision = ["tari_template_lib_types/precision"]
 bincode-compat = ["tari_template_lib_types/bincode-compat"]
+extra-maps = ["tari_template_lib_types/extra-maps"]

--- a/crates/template_lib/src/prelude.rs
+++ b/crates/template_lib/src/prelude.rs
@@ -26,6 +26,8 @@
 pub use tari_bor;
 #[expect(deprecated)]
 pub use tari_template_lib_types::constants::XTR;
+#[cfg(feature = "extra-maps")]
+pub use tari_template_lib_types::fast_hash::{FastMap, PrehashedMap};
 pub use tari_template_lib_types::{
     AccessRule,
     AuthHookCaller,

--- a/crates/template_lib_types/Cargo.toml
+++ b/crates/template_lib_types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_template_lib_types"
-version = "0.24.0"
+version = "0.25.0"
 edition.workspace = true
 authors.workspace = true
 description = "Tari template library types"
@@ -14,6 +14,7 @@ alloc = ["serde/alloc", "tari_template_abi/alloc"]
 precision = ["dep:bnum"]
 extra-arith = ["dep:num-integer", "bnum?/numtraits"]
 borsh = ["dep:borsh", "tari_bor/borsh", "bnum?/borsh"]
+extra-maps = ["dep:indexmap", "dep:xxhash-rust"]
 ts = ["std", "ts-rs", "tari_template_abi/ts", "tari_bor/ts"]
 # This feature removes the ability to deserialize Amounts as an integer/string (using deserialize_any), as formats like bincode do not support this.
 # DO NOT USE if authoring contracts/templates as this will force transactions to convert integers to Amounts in instruction calls to your template.
@@ -26,8 +27,10 @@ tari_bor = { workspace = true }
 bnum = { workspace = true, optional = true }
 num-integer = { workspace = true, optional = true, default-features = false }
 borsh = { workspace = true, optional = true, default-features = false, features = ["derive"] }
+indexmap = { workspace = true, optional = true, features = ["serde"] }
 serde = { workspace = true, default-features = false, features = ["derive"] }
 ts-rs = { workspace = true, optional = true }
+xxhash-rust = { workspace = true, optional = true, features = ["xxh3"] }
 
 [dev-dependencies]
 serde_json = { workspace = true }

--- a/crates/template_lib_types/src/fast_hash.rs
+++ b/crates/template_lib_types/src/fast_hash.rs
@@ -1,0 +1,72 @@
+//   Copyright 2025 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+use core::hash::{BuildHasherDefault, Hasher};
+
+use indexmap::IndexMap;
+use xxhash_rust::xxh3::Xxh3Builder;
+
+/// A no-op hasher designed for keys that are already high-quality hashes
+/// (e.g. SHA-256 digests, Pedersen commitment bytes, or any 32-byte hash output).
+///
+/// # How it works
+/// XOR-folds the raw key bytes into a single `u64` for use as the HashMap bucket
+/// discriminant. This is not cryptographic — it is purely a bucket distribution
+/// function. The quality of distribution depends on the entropy already present
+/// in the key, which is assumed to be high.
+///
+/// # Invariants
+/// - The key type `K` must have uniformly distributed byte representations.
+///   Using this hasher with low-entropy keys (e.g. small integers, sequential
+///   IDs) will produce poor bucket distribution and degrade lookup to O(n).
+/// - Keys must be at least 8 bytes. Shorter keys will still work but use less
+///   entropy for the fold, increasing collision probability.
+/// - This hasher provides NO DoS resistance. It must only be used when the
+///   caller controls or trusts all inserted keys.
+#[derive(Default)]
+pub struct PassthroughHasher(u64);
+
+impl Hasher for PassthroughHasher {
+    /// XOR-folds `bytes` into a `u64` in 8-byte chunks.
+    ///
+    /// For a 32-byte key this performs 4 XOR operations, giving good avalanche
+    /// across the full key without any multiplication or branching.
+    #[inline]
+    fn write(&mut self, bytes: &[u8]) {
+        let mut h = 0u64;
+        for chunk in bytes.chunks(8) {
+            let mut buf = [0u8; 8];
+            buf[..chunk.len()].copy_from_slice(chunk);
+            h ^= u64::from_le_bytes(buf);
+        }
+        self.0 = h;
+    }
+
+    #[inline]
+    fn finish(&self) -> u64 {
+        self.0
+    }
+}
+
+/// General purpose map — safe for any key type, good performance.
+///
+/// Uses XXH3 as the hasher, which is fast and has excellent distribution
+/// for both short and long keys. Suitable when:
+/// - Keys are low-entropy (sequential IDs, small integers, short strings)
+/// - Key type or entropy level is unknown
+/// - DoS resistance is not required but key quality is uncertain
+pub type FastMap<K, V> = IndexMap<K, V, Xxh3Builder>;
+
+/// Optimised map for keys that are already high-entropy hash outputs.
+///
+/// Uses a passthrough XOR-fold hasher, skipping any real hash computation
+/// on the assumption that the key already has sufficient entropy for bucket
+/// distribution. Suitable when:
+/// - Keys are cryptographic hash outputs (SHA-256, Blake2, Poseidon, etc.)
+/// - Keys are Pedersen commitments or similar 32-byte hash-typed values
+/// - You want to avoid double-hashing an already-hashed key
+///
+/// # Warning
+/// Do NOT use with low-entropy keys — will degrade to O(n) lookup.
+/// When in doubt, use [`FastMap`] instead.
+pub type PrehashedMap<K, V> = IndexMap<K, V, BuildHasherDefault<PassthroughHasher>>;

--- a/crates/template_lib_types/src/fast_hash.rs
+++ b/crates/template_lib_types/src/fast_hash.rs
@@ -16,13 +16,11 @@ use xxhash_rust::xxh3::Xxh3Builder;
 /// in the key, which is assumed to be high.
 ///
 /// # Invariants
-/// - The key type `K` must have uniformly distributed byte representations.
-///   Using this hasher with low-entropy keys (e.g. small integers, sequential
-///   IDs) will produce poor bucket distribution and degrade lookup to O(n).
-/// - Keys must be at least 8 bytes. Shorter keys will still work but use less
-///   entropy for the fold, increasing collision probability.
-/// - This hasher provides NO DoS resistance. It must only be used when the
-///   caller controls or trusts all inserted keys.
+/// - The key type `K` must have uniformly distributed byte representations. Using this hasher with low-entropy keys
+///   (e.g. small integers, sequential IDs) will produce poor bucket distribution and degrade lookup to O(n).
+/// - Keys must be at least 8 bytes. Shorter keys will still work but use less entropy for the fold, increasing
+///   collision probability.
+/// - This hasher provides NO DoS resistance. It must only be used when the caller controls or trusts all inserted keys.
 #[derive(Default)]
 pub struct PassthroughHasher(u64);
 

--- a/crates/template_lib_types/src/lib.rs
+++ b/crates/template_lib_types/src/lib.rs
@@ -56,6 +56,8 @@ mod auth_hook;
 pub mod confidential;
 mod log_level;
 mod owner_rule;
+#[cfg(feature = "extra-maps")]
+pub mod fast_hash;
 #[cfg(feature = "precision")]
 pub mod precision;
 pub mod stealth;

--- a/crates/template_lib_types/src/lib.rs
+++ b/crates/template_lib_types/src/lib.rs
@@ -54,10 +54,10 @@ pub mod access_rules;
 pub mod address_prefixes;
 mod auth_hook;
 pub mod confidential;
-mod log_level;
-mod owner_rule;
 #[cfg(feature = "extra-maps")]
 pub mod fast_hash;
+mod log_level;
+mod owner_rule;
 #[cfg(feature = "precision")]
 pub mod precision;
 pub mod stealth;


### PR DESCRIPTION
## Summary
- Add `PassthroughHasher`, `FastMap` (XXH3), and `PrehashedMap` (XOR-fold passthrough) to `tari_template_lib_types` behind an `extra-maps` feature gate
- Use `PrehashedMap` for vaults and approvals in the account builtin template, replacing `BTreeMap` for faster lookups on hash-typed keys
- Bump `tari_template_lib_types` and `tari_template_lib` to 0.25.0, account template to 0.9.2

```
create_and_fund_account/
                        time:   [346.19 µs 347.73 µs 349.39 µs]
                        change: [−3.7333% −2.9574% −2.0898%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  2 (2.00%) high mild
  4 (4.00%) high severe
```
NOTE: benchmark isnt testing lookups (only one vault), but this at least shows that performance has not unexpectedly regressed (Previous time: 347 us)

This is a non-breaking change since the CBOR map representation is preserved

## Test plan
- [x] `cargo check -p tari_template_lib --features extra-maps` passes
- [x] Account template compiles with `extra-maps` enabled
- [x] Existing account template tests pass
- [x] Verify wasm build of account template