### PR TITLE
feat(transaction_manifest): support tuple destructuring in manifests

### DIFF
--- a/applications/tari_walletd/web_ui/src/routes/AssetVault/Tokens/components/SendMoney.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/AssetVault/Tokens/components/SendMoney.tsx
@@ -149,6 +149,12 @@ export function SendMoneyDialog(props: SendMoneyDialogProps) {
   // Find the available balance for the resource we're trying to send
   const balanceEntry = data?.balances?.find((b: BalanceEntry) => b.resource_address === props.resource_address);
 
+  // Check if user has TARI balance available (for recommending direct fee payment)
+  const tariBalanceEntry = data?.balances?.find((b: BalanceEntry) => b.resource_address === TARI_TOKEN);
+  const hasTariBalance = tariBalanceEntry
+    ? BigInt(tariBalanceEntry.balance) + BigInt(tariBalanceEntry.confidential_balance) >= 500n
+    : false;
+
   if (!balanceEntry) {
     console.warn("No balance entry found for resource", props.resource_address);
     return null;
@@ -497,6 +503,7 @@ export function SendMoneyDialog(props: SendMoneyDialogProps) {
             onCheckboxFormValueChange={setCheckboxFormValue}
             onUseBadgeChange={handleUseBadgeChange}
             onPoolSelect={handlePoolSelect}
+            hasTariBalance={hasTariBalance}
           />
         );
       case 1:

--- a/applications/tari_walletd/web_ui/src/routes/AssetVault/Tokens/steps/FormStep.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/AssetVault/Tokens/steps/FormStep.tsx
@@ -22,7 +22,7 @@
 
 import CopyAddress from "@components/CopyAddress";
 import HelpOutlineIcon from "@mui/icons-material/HelpOutline";
-import { Alert, CircularProgress, Divider, InputAdornment, InputLabel, Stack, Typography } from "@mui/material";
+import { Alert, Chip, CircularProgress, Divider, InputAdornment, InputLabel, Stack, Typography } from "@mui/material";
 import Button from "@mui/material/Button";
 import CheckBox from "@mui/material/Checkbox";
 import FormControlLabel from "@mui/material/FormControlLabel";
@@ -88,6 +88,7 @@ interface FormStepProps {
   onCheckboxFormValueChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onUseBadgeChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onPoolSelect: (poolAddress: string) => void;
+  hasTariBalance?: boolean;
 }
 
 export type FormError = {
@@ -139,6 +140,7 @@ export default function FormStep({
   onCheckboxFormValueChange,
   onUseBadgeChange,
   onPoolSelect,
+  hasTariBalance,
 }: FormStepProps) {
   const isConfidential = resource_type === "Confidential";
   const isStealth = resource_type === "Stealth";
@@ -151,13 +153,16 @@ export default function FormStep({
   const isNaNAmount = isNaN(enteredAmount);
   const enteredAmountInBaseUnits = isNaNAmount ? 0n : parseAmountToBaseUnits(transferFormState.amount, divisibility);
   const hasInsufficientFunds = availableBalance !== undefined && enteredAmountInBaseUnits > BigInt(availableBalance);
+  const poolHasNoLiquidity =
+    !!transferFormState.swapPoolAddress && poolRate !== null && (poolRate.balance_a === 0n || poolRate.balance_b === 0n);
 
   const isFormValid =
     !isNaNAmount &&
     validateOotleAddress(transferFormState.address) &&
     transferFormState.amount &&
     !hasInsufficientFunds &&
-    !poolError;
+    !poolError &&
+    !poolHasNoLiquidity;
 
   // Format amount for display
   const formatAmountValue = (amount: string) => {
@@ -358,7 +363,7 @@ export default function FormStep({
                   Loading pools...
                 </Typography>
               </Stack>
-            ) : relevantPools.length > 0 ? (
+            ) : (
               <>
                 <InputLabel id="select-pool">Select Pool</InputLabel>
                 <Select
@@ -380,7 +385,12 @@ export default function FormStep({
                     }
                   }}
                 >
-                  <MenuItem value="">None (pay fee in TARI)</MenuItem>
+                  <MenuItem value="">
+                    <Stack direction="row" spacing={1} alignItems="center">
+                      <span>None (pay fee in TARI)</span>
+                      {hasTariBalance && <Chip label="Recommended" size="small" color="success" variant="outlined" />}
+                    </Stack>
+                  </MenuItem>
                   {relevantPools.map((pool) => {
                     const isTokenA = pool.resource_a === resource_address;
                     const tokenBalance = isTokenA ? BigInt(pool.balance_a) : BigInt(pool.balance_b);
@@ -388,16 +398,16 @@ export default function FormStep({
                     const rate = tokenBalance > 0n ? Number(tariBalance) / Number(tokenBalance) : 0;
                     return (
                       <MenuItem key={pool.pool_address} value={pool.pool_address}>
-                        {pool.pool_address.substring(0, 16)}... (1 {token_symbol} = {rate.toFixed(4)} TARI)
+                        Swap: {pool.pool_address.substring(0, 16)}... (1 {token_symbol} = {rate.toFixed(4)} TARI)
                       </MenuItem>
                     );
                   })}
                   <MenuItem value="__custom__">Custom pool address...</MenuItem>
                 </Select>
               </>
-            ) : null}
+            )}
 
-            {(showCustomPool || relevantPools.length === 0) && (
+            {showCustomPool && (
               <TextField
                 name="swapPoolAddress"
                 label="Swap Pool Address"
@@ -428,12 +438,14 @@ export default function FormStep({
             )}
 
             {poolRate && transferFormState.swapPoolAddress && !poolError && (
-              <Alert severity="info" variant="outlined">
-                Pool exchange rate: {formatPoolRate(poolRate, token_symbol)}
+              <Alert severity={poolHasNoLiquidity ? "warning" : "info"} variant="outlined">
+                {poolHasNoLiquidity
+                  ? "This pool has no liquidity. Please select a different pool."
+                  : `Pool exchange rate: ${formatPoolRate(poolRate, token_symbol)}`}
               </Alert>
             )}
 
-            {poolError && !showCustomPool && relevantPools.length > 0 && (
+            {poolError && !showCustomPool && (
               <Alert severity="error" variant="outlined">
                 {poolError}
               </Alert>

--- a/crates/transaction_manifest/src/error.rs
+++ b/crates/transaction_manifest/src/error.rs
@@ -46,4 +46,6 @@ pub enum ManifestError {
     InvalidInstruction { reason: String },
     #[error("Maximum call depth of {max} exceeded")]
     MaxCallDepthExceeded { max: usize },
+    #[error("Failed to serialize CBOR literal: {0}")]
+    CborSerializationError(#[from] tari_bor::BorError),
 }

--- a/crates/transaction_manifest/src/generator.rs
+++ b/crates/transaction_manifest/src/generator.rs
@@ -265,9 +265,7 @@ impl ManifestInstructionGenerator {
                 },
                 ManifestLiteral::Special(SpecialLiteral::Amount(amount)) => Ok(call_arg!(amount)),
                 ManifestLiteral::Special(SpecialLiteral::NonFungibleId(id)) => Ok(call_arg!(id)),
-                ManifestLiteral::Special(SpecialLiteral::Cbor(value)) => {
-                    Ok(InstructionArg::literal(value).expect("CBOR literal serialization should not fail"))
-                },
+                ManifestLiteral::Special(SpecialLiteral::Cbor(value)) => Ok(InstructionArg::literal(value)?),
                 ManifestLiteral::Special(SpecialLiteral::Metadata(metadata)) => Ok(call_arg!(metadata)),
                 ManifestLiteral::Special(SpecialLiteral::SubstateId(id_or_var)) => match id_or_var {
                     OrVar::Var(ident) => self.get_ident(&ident.to_string()),

--- a/crates/transaction_manifest/src/generator.rs
+++ b/crates/transaction_manifest/src/generator.rs
@@ -109,8 +109,7 @@ impl ManifestInstructionGenerator {
                     args: self.process_args(arguments)?,
                 }];
                 if let Some(binding) = output_variable {
-                    let key = self.current_workspace_id;
-                    self.current_workspace_id += 1;
+                    let key = self.next_workspace_id_raw();
                     instructions.push(Instruction::PutLastInstructionOutputOnWorkspace { key });
                     self.register_output_binding(binding, key);
                 }
@@ -130,6 +129,14 @@ impl ManifestInstructionGenerator {
                 let call = if let Some(value) = self.global_aliases.get(&component_ident) {
                     ComponentReference::Address(Self::extract_component_address(value)?)
                 } else if let Some(workspace_offset) = self.workspace_ids.get(&component_ident) {
+                    if workspace_offset.offset().is_some() {
+                        return Err(ManifestError::InvalidInstruction {
+                            reason: format!(
+                                "Tuple-destructured variable '{component_ident}' cannot be used as a component \
+                                 reference. Use a single variable binding instead."
+                            ),
+                        });
+                    }
                     ComponentReference::Workspace(workspace_offset.id())
                 } else if let Some(value) = self.globals.get(&component_ident) {
                     ComponentReference::Address(Self::extract_component_address(value)?)
@@ -147,8 +154,7 @@ impl ManifestInstructionGenerator {
                     args: self.process_args(arguments)?,
                 }];
                 if let Some(binding) = output_variable {
-                    let key = self.current_workspace_id;
-                    self.current_workspace_id += 1;
+                    let key = self.next_workspace_id_raw();
                     instructions.push(Instruction::PutLastInstructionOutputOnWorkspace { key });
                     self.register_output_binding(binding, key);
                 }
@@ -232,10 +238,15 @@ impl ManifestInstructionGenerator {
         }
     }
 
-    fn next_workspace_id(&mut self, name: String) -> WorkspaceId {
+    fn next_workspace_id_raw(&mut self) -> WorkspaceId {
         let id = self.current_workspace_id;
-        self.workspace_ids.insert(name, WorkspaceOffsetId::new(id));
         self.current_workspace_id += 1;
+        id
+    }
+
+    fn next_workspace_id(&mut self, name: String) -> WorkspaceId {
+        let id = self.next_workspace_id_raw();
+        self.workspace_ids.insert(name, WorkspaceOffsetId::new(id));
         id
     }
 

--- a/crates/transaction_manifest/src/generator.rs
+++ b/crates/transaction_manifest/src/generator.rs
@@ -18,7 +18,7 @@ use crate::{
     ManifestValue,
     ast::ManifestAst,
     error::ManifestError,
-    parser::{InvokeIntent, ManifestIntent, ManifestLiteral, OrVar, SpecialLiteral},
+    parser::{InvokeIntent, ManifestIntent, ManifestLiteral, OrVar, OutputBinding, SpecialLiteral},
     value::lit_to_arg,
 };
 
@@ -29,7 +29,7 @@ pub struct ManifestInstructionGenerator {
     global_aliases: HashMap<String, ManifestValue>,
     globals: HashMap<String, ManifestValue>,
     current_workspace_id: WorkspaceId,
-    workspace_ids: HashMap<String, WorkspaceId>,
+    workspace_ids: HashMap<String, WorkspaceOffsetId>,
     templates: HashMap<String, TemplateAddress>,
     functions: HashMap<String, Vec<ManifestIntent>>,
     call_depth: usize,
@@ -108,9 +108,11 @@ impl ManifestInstructionGenerator {
                         })?,
                     args: self.process_args(arguments)?,
                 }];
-                if let Some(var_name) = output_variable {
-                    let key = self.next_workspace_id(var_name.to_string());
+                if let Some(binding) = output_variable {
+                    let key = self.current_workspace_id;
+                    self.current_workspace_id += 1;
                     instructions.push(Instruction::PutLastInstructionOutputOnWorkspace { key });
+                    self.register_output_binding(binding, key);
                 }
                 Ok(instructions)
             },
@@ -127,8 +129,8 @@ impl ManifestInstructionGenerator {
                     .to_string();
                 let call = if let Some(value) = self.global_aliases.get(&component_ident) {
                     ComponentReference::Address(Self::extract_component_address(value)?)
-                } else if let Some(&workspace_id) = self.workspace_ids.get(&component_ident) {
-                    ComponentReference::Workspace(workspace_id)
+                } else if let Some(workspace_offset) = self.workspace_ids.get(&component_ident) {
+                    ComponentReference::Workspace(workspace_offset.id())
                 } else if let Some(value) = self.globals.get(&component_ident) {
                     ComponentReference::Address(Self::extract_component_address(value)?)
                 } else {
@@ -144,9 +146,11 @@ impl ManifestInstructionGenerator {
                         })?,
                     args: self.process_args(arguments)?,
                 }];
-                if let Some(var_name) = output_variable {
-                    let key = self.next_workspace_id(var_name.to_string());
+                if let Some(binding) = output_variable {
+                    let key = self.current_workspace_id;
+                    self.current_workspace_id += 1;
                     instructions.push(Instruction::PutLastInstructionOutputOnWorkspace { key });
+                    self.register_output_binding(binding, key);
                 }
                 Ok(instructions)
             },
@@ -176,7 +180,7 @@ impl ManifestInstructionGenerator {
                         let name = ident.to_string();
                         self.workspace_ids
                             .get(&name)
-                            .map(|id| WorkspaceOffsetId::new(*id))
+                            .copied()
                             .ok_or(ManifestError::UndefinedVariable { name })
                     })
                     .transpose()?;
@@ -230,9 +234,24 @@ impl ManifestInstructionGenerator {
 
     fn next_workspace_id(&mut self, name: String) -> WorkspaceId {
         let id = self.current_workspace_id;
-        self.workspace_ids.insert(name, id);
+        self.workspace_ids.insert(name, WorkspaceOffsetId::new(id));
         self.current_workspace_id += 1;
         id
+    }
+
+    fn register_output_binding(&mut self, binding: OutputBinding, workspace_id: WorkspaceId) {
+        match binding {
+            OutputBinding::Single(ident) => {
+                self.workspace_ids
+                    .insert(ident.to_string(), WorkspaceOffsetId::new(workspace_id));
+            },
+            OutputBinding::Tuple(idents) => {
+                for (i, ident) in idents.into_iter().enumerate() {
+                    self.workspace_ids
+                        .insert(ident.to_string(), WorkspaceOffsetId::new(workspace_id).with_offset(i));
+                }
+            },
+        }
     }
 
     fn process_args(&self, args: Vec<ManifestLiteral>) -> Result<Vec<InstructionArg>, ManifestError> {
@@ -336,8 +355,7 @@ impl ManifestInstructionGenerator {
                 // Or is it a variable on the worktop?
                 self.workspace_ids
                     .get(name)
-                    // TODO: support offsets
-                    .map(|id| Ok(InstructionArg::Workspace(WorkspaceOffsetId::new(*id))))
+                    .map(|id| Ok(InstructionArg::Workspace(*id)))
             })
             .ok_or_else(|| {
                 // Or undefined

--- a/crates/transaction_manifest/src/parser.rs
+++ b/crates/transaction_manifest/src/parser.rs
@@ -21,6 +21,7 @@ use syn::{
     Macro,
     Pat,
     PatIdent,
+    PatTuple,
     Path,
     Signature,
     Stmt,
@@ -64,8 +65,14 @@ pub struct ManifestImport {
 }
 
 #[derive(Debug, Clone)]
+pub enum OutputBinding {
+    Single(Ident),
+    Tuple(Vec<Ident>),
+}
+
+#[derive(Debug, Clone)]
 pub struct InvokeIntent {
-    pub output_variable: Option<Ident>,
+    pub output_variable: Option<OutputBinding>,
     pub component_variable: Option<Ident>,
     pub template_variable: Option<Ident>,
     pub function_name: Ident,
@@ -236,17 +243,29 @@ impl ManifestParser {
     }
 
     fn handle_local(&self, local: Local) -> Result<ManifestIntent, syn::Error> {
-        // Parse let variable ident
-        let var_ident = match local.pat {
-            Pat::Ident(PatIdent { ref ident, .. }) => ident,
-            // Pat::Tuple(pat) => return Ok(ManifestStmt::Todo),
-            // Pat::Type(_) => {}
-            // Pat::Macro(_) => {}
-            // Pat::Reference(_) => {}
-            // Pat::Slice(_) => {}
-            // Pat::Struct(_) => {}
-            // Pat::TupleStruct(_) => {}
-            p => unimplemented!("{:?} not supported", p),
+        // Parse let variable binding
+        let output_binding = match &local.pat {
+            Pat::Ident(PatIdent { ident, .. }) => OutputBinding::Single(ident.clone()),
+            Pat::Tuple(PatTuple { elems, .. }) => {
+                let idents = elems
+                    .iter()
+                    .map(|p| match p {
+                        Pat::Ident(PatIdent { ident, .. }) => Ok(ident.clone()),
+                        _ => Err(syn::Error::new_spanned(
+                            p,
+                            "Only identifiers are supported in tuple destructuring patterns",
+                        )),
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
+                if idents.is_empty() {
+                    return Err(syn::Error::new_spanned(
+                        &local.pat,
+                        "Empty tuple pattern is not supported",
+                    ));
+                }
+                OutputBinding::Tuple(idents)
+            },
+            p => return Err(syn::Error::new_spanned(p, format!("{:?} pattern is not supported", p))),
         };
 
         let expr = local.init.as_ref().map(|init| &init.expr).ok_or_else(|| {
@@ -269,7 +288,7 @@ impl ManifestParser {
                         if let Some(second) = iter.next() {
                             // Two segments: Template::function()
                             ManifestIntent::InvokeTemplate(InvokeIntent {
-                                output_variable: Some(var_ident.clone()),
+                                output_variable: Some(output_binding),
                                 component_variable: None,
                                 template_variable: Some(first.ident.clone()),
                                 function_name: second.ident.clone(),
@@ -288,7 +307,7 @@ impl ManifestParser {
             }) => {
                 let receiver = extract_single_var_name(&receiver)?;
                 ManifestIntent::InvokeComponent(InvokeIntent {
-                    output_variable: Some(var_ident.clone()),
+                    output_variable: Some(output_binding),
                     component_variable: Some(receiver),
                     template_variable: None,
                     function_name: method,
@@ -304,8 +323,18 @@ impl ManifestParser {
                     return Err(syn::Error::new_spanned(path, "macro path must have a single segment"));
                 }
 
+                let var_ident = match output_binding {
+                    OutputBinding::Single(ident) => ident,
+                    OutputBinding::Tuple(_) => {
+                        return Err(syn::Error::new_spanned(
+                            &local.pat,
+                            "Tuple destructuring is not supported for macro assignments",
+                        ));
+                    },
+                };
+
                 assignment_from_macro(
-                    var_ident.clone(),
+                    var_ident,
                     &path
                         .segments
                         .first()

--- a/crates/transaction_manifest/tests/parser.rs
+++ b/crates/transaction_manifest/tests/parser.rs
@@ -497,3 +497,83 @@ fn empty_metadata_function_call_syntax() {
     assert_eq!(instructions, expected);
     assert_eq!(fee_instructions, vec![]);
 }
+
+#[test]
+fn tuple_destructuring() {
+    let manifest = r#"
+        use template_c2b621869ec2929d3b9503ea41054f01b468ce99e50254b58e460f608ae377f7 as MyTemplate;
+
+        fn main() {
+            let comp = var!["comp"];
+            let (a, b) = comp.redeem(100);
+            comp.deposit(a);
+            comp.deposit(b);
+        }
+    "#;
+
+    let comp_address = ComponentAddress::new([5u8; ObjectKey::LENGTH].into());
+    let globals = HashMap::from([("comp".to_string(), SubstateId::Component(comp_address).into())]);
+
+    let ManifestInstructions {
+        instructions,
+        fee_instructions,
+    } = parse_manifest(manifest, globals, Default::default()).unwrap();
+
+    use tari_ootle_transaction::args::InstructionArg;
+
+    let expected = vec![
+        // comp.redeem(100) -> workspace key 0
+        Instruction::CallMethod {
+            call: comp_address.into(),
+            method: "redeem".try_into().unwrap(),
+            args: call_args![100],
+        },
+        Instruction::PutLastInstructionOutputOnWorkspace { key: 0 },
+        // comp.deposit(a) where a = workspace 0, offset 0
+        Instruction::CallMethod {
+            call: comp_address.into(),
+            method: "deposit".try_into().unwrap(),
+            args: vec![InstructionArg::Workspace(WorkspaceOffsetId::new(0).with_offset(0))],
+        },
+        // comp.deposit(b) where b = workspace 0, offset 1
+        Instruction::CallMethod {
+            call: comp_address.into(),
+            method: "deposit".try_into().unwrap(),
+            args: vec![InstructionArg::Workspace(WorkspaceOffsetId::new(0).with_offset(1))],
+        },
+    ];
+
+    assert_eq!(instructions, expected);
+    assert_eq!(fee_instructions, vec![]);
+}
+
+#[test]
+fn tuple_destructuring_template_call() {
+    let manifest = r#"
+        use template_c2b621869ec2929d3b9503ea41054f01b468ce99e50254b58e460f608ae377f7 as MyTemplate;
+
+        fn main() {
+            let (x, y, z) = MyTemplate::split(42);
+        }
+    "#;
+
+    let template_addr =
+        TemplateAddress::from_hex("c2b621869ec2929d3b9503ea41054f01b468ce99e50254b58e460f608ae377f7").unwrap();
+
+    let ManifestInstructions {
+        instructions,
+        fee_instructions,
+    } = parse_manifest(manifest, HashMap::new(), Default::default()).unwrap();
+
+    let expected = vec![
+        Instruction::CallFunction {
+            address: template_addr,
+            function: "split".try_into().unwrap(),
+            args: call_args![42],
+        },
+        Instruction::PutLastInstructionOutputOnWorkspace { key: 0 },
+    ];
+
+    assert_eq!(instructions, expected);
+    assert_eq!(fee_instructions, vec![]);
+}


### PR DESCRIPTION
## Summary

- Support `let (a, b) = comp.method(args)` syntax in transaction manifests
- Each tuple element is registered with a workspace offset (a=0, b=1, etc.) using the existing `WorkspaceOffsetId` mechanism
- Replaces the `unimplemented!()` panic at `parser.rs:249` that crashed the wallet daemon when a manifest used tuple patterns

## Test plan

- [x] Added `tuple_destructuring` test — verifies method call with tuple binding produces correct workspace offset references
- [x] Added `tuple_destructuring_template_call` test — verifies template function calls with tuple binding
- [x] All 14 existing tests pass
- [x] `cargo check -p tari_ootle_walletd` compiles cleanly