### PR TITLE
fix(engine): fix benchmark

### DIFF
--- a/crates/engine/benches/benchmarks.rs
+++ b/crates/engine/benches/benchmarks.rs
@@ -12,13 +12,15 @@ use tari_engine::{
     state_store::memory::ReadOnlyMemoryStateStore,
     transaction::TransactionProcessor,
 };
-use tari_engine_types::virtual_substate::{VirtualSubstate, VirtualSubstateId, VirtualSubstates};
-use tari_ootle_common_types::SubstateRequirementRef;
-use tari_ootle_transaction::{Instruction, TransactionId, TransactionWeight, args::WorkspaceOffsetId, call_args};
-use tari_template_lib::types::crypto::RistrettoPublicKeyBytes;
+use tari_engine_types::{
+    substate::SubstateId,
+    virtual_substate::{VirtualSubstate, VirtualSubstateId, VirtualSubstates},
+};
+use tari_ootle_transaction::{Instruction, TransactionId, TransactionWeight, call_args};
+use tari_template_lib::types::{constants::XTR_FAUCET_CLAIM_RESOURCE_ADDRESS, crypto::RistrettoPublicKeyBytes};
 use tari_template_test_tooling::{Package, mocks::AlwaysPassesProofVerifier};
 
-use crate::common::{FAUCET_COMPONENT_ADDRESS, setup_store};
+use crate::common::{FAUCET_COMPONENT_ADDRESS, FAUCET_VAULT_ID, setup_store};
 
 type BenchTxProcessor = TransactionProcessor<ReadOnlyMemoryStateStore, Package>;
 
@@ -29,8 +31,13 @@ impl Executable for CreateAndFundAccountExecutable {
         TransactionId::default()
     }
 
-    fn all_inputs_iter(&self) -> impl Iterator<Item = SubstateRequirementRef<'_>> + '_ {
-        iter::empty()
+    fn all_inputs_iter(&self) -> impl Iterator<Item = SubstateId> + '_ {
+        [
+            SubstateId::from(FAUCET_COMPONENT_ADDRESS),
+            SubstateId::from(FAUCET_VAULT_ID),
+            SubstateId::from(XTR_FAUCET_CLAIM_RESOURCE_ADDRESS),
+        ]
+        .into_iter()
     }
 
     fn signers_iter(&self) -> impl Iterator<Item = &RistrettoPublicKeyBytes> {
@@ -41,17 +48,17 @@ impl Executable for CreateAndFundAccountExecutable {
     fn into_instructions(self) -> Instructions {
         Instructions {
             fee: vec![
-                Instruction::CallMethod {
-                    call: FAUCET_COMPONENT_ADDRESS.into(),
-                    method: "take".try_into().unwrap(),
-                    args: call_args![],
-                },
-                Instruction::PutLastInstructionOutputOnWorkspace { key: 0 },
                 Instruction::CreateAccount {
                     owner_public_key: Default::default(),
                     owner_rule: None,
                     access_rules: None,
-                    bucket_workspace_id: Some(WorkspaceOffsetId::new(0)),
+                    bucket_workspace_id: None,
+                },
+                Instruction::PutLastInstructionOutputOnWorkspace { key: 0 },
+                Instruction::CallMethod {
+                    call: FAUCET_COMPONENT_ADDRESS.into(),
+                    method: "take".try_into().unwrap(),
+                    args: call_args![Workspace(0)],
                 },
             ],
             main: vec![],

--- a/crates/engine/benches/common/mod.rs
+++ b/crates/engine/benches/common/mod.rs
@@ -19,8 +19,9 @@ use tari_template_lib::types::{
     SubstateOwnerRule,
     VaultId,
     access_rules::{ComponentAccessRules, ResourceAccessRules},
-    constants::TARI_TOKEN,
+    constants::{TARI_TOKEN, XTR_FAUCET_CLAIM_RESOURCE_ADDRESS},
     metadata,
+    rule,
 };
 
 pub const FAUCET_COMPONENT_ADDRESS: ComponentAddress = ComponentAddress::from_array([0u8; 32]);
@@ -52,6 +53,26 @@ pub fn setup_store() -> MemoryStateStore {
 
     state_store
         .set_state(FAUCET_VAULT_ID.into(), Substate::new(0, vault))
+        .unwrap();
+
+    // Claim receipt resource: one NFT per claimant public key (minted then burned to record the claim).
+    let claim_resource = Resource::new(
+        ResourceType::NonFungible,
+        SubstateOwnerRule::None,
+        ResourceAccessRules::new()
+            .mintable(rule!(component(FAUCET_COMPONENT_ADDRESS)))
+            .burnable(rule!(allow_all)),
+        Default::default(),
+        None,
+        None,
+        0,
+        false,
+    );
+    state_store
+        .set_state(
+            XTR_FAUCET_CLAIM_RESOURCE_ADDRESS.into(),
+            Substate::new(0, claim_resource),
+        )
         .unwrap();
 
     let component = ComponentHeader {

--- a/crates/engine/src/executables/mod.rs
+++ b/crates/engine/src/executables/mod.rs
@@ -3,7 +3,7 @@
 
 mod transaction;
 
-use tari_ootle_common_types::SubstateRequirementRef;
+use tari_engine_types::substate::SubstateId;
 use tari_ootle_transaction::{Instruction, TransactionId, TransactionWeight};
 use tari_template_lib::types::crypto::RistrettoPublicKeyBytes;
 
@@ -15,7 +15,7 @@ pub struct Instructions {
 pub trait Executable {
     fn to_id(&self) -> TransactionId;
 
-    fn all_inputs_iter(&self) -> impl Iterator<Item = SubstateRequirementRef<'_>> + '_;
+    fn all_inputs_iter(&self) -> impl Iterator<Item = SubstateId> + '_;
 
     /// Returns the main signer of the executable, if any.
     fn main_signer(&self) -> Option<RistrettoPublicKeyBytes> {

--- a/crates/engine/src/executables/transaction.rs
+++ b/crates/engine/src/executables/transaction.rs
@@ -1,7 +1,7 @@
 //   Copyright 2025 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use tari_ootle_common_types::SubstateRequirementRef;
+use tari_engine_types::substate::SubstateId;
 use tari_ootle_transaction::{Transaction, TransactionId, TransactionWeight};
 use tari_template_lib::types::crypto::RistrettoPublicKeyBytes;
 
@@ -12,8 +12,8 @@ impl Executable for Transaction {
         self.calculate_id()
     }
 
-    fn all_inputs_iter(&self) -> impl Iterator<Item = SubstateRequirementRef<'_>> + '_ {
-        self.all_inputs_iter()
+    fn all_inputs_iter(&self) -> impl Iterator<Item = SubstateId> + '_ {
+        self.all_inputs_iter().map(|req| req.substate_id().clone())
     }
 
     fn signers_iter(&self) -> impl Iterator<Item = &RistrettoPublicKeyBytes> {

--- a/crates/engine/src/transaction/processor.rs
+++ b/crates/engine/src/transaction/processor.rs
@@ -147,13 +147,13 @@ where
         // Because XTR resource is immutable, we can make it available to every shard group (genesis state) and
         // transaction (payment of fees)
         initial_call_scope.add_substate_to_owned(STEALTH_TARI_RESOURCE_ADDRESS.into());
-        for input in executable.all_inputs_iter() {
+        for input_substate_id in executable.all_inputs_iter() {
             debug!(
                 target: LOG_TARGET,
                 "Adding substate to initial call scope: {}",
-                input.substate_id
+                input_substate_id
             );
-            initial_call_scope.add_substate_to_owned(input.substate_id.clone());
+            initial_call_scope.add_substate_to_owned(input_substate_id);
         }
 
         let transaction_weight = executable.calculate_weight();

--- a/crates/template_test_tooling/src/wrapped_transaction.rs
+++ b/crates/template_test_tooling/src/wrapped_transaction.rs
@@ -2,6 +2,7 @@
 //   SPDX-License-Identifier: BSD-3-Clause
 
 use tari_engine::executables::{Executable, Instructions, WeightedExecutable};
+use tari_engine_types::substate::SubstateId;
 use tari_ootle_common_types::SubstateRequirement;
 use tari_template_lib::types::crypto::RistrettoPublicKeyBytes;
 
@@ -29,12 +30,13 @@ impl Executable for WrappedTransaction {
         self.transaction.calculate_id()
     }
 
-    fn all_inputs_iter(&self) -> impl Iterator<Item = tari_ootle_common_types::SubstateRequirementRef<'_>> + '_ {
+    fn all_inputs_iter(&self) -> impl Iterator<Item = SubstateId> + '_ {
         // Combine the inputs from the transaction and the additional inputs
         // Note: duplicates are possible
         self.transaction
             .all_inputs_iter()
             .chain(self.inputs.iter().map(|id| id.as_ref()))
+            .map(|req| req.substate_id().clone())
     }
 
     fn main_signer(&self) -> Option<RistrettoPublicKeyBytes> {


### PR DESCRIPTION
This pull request refactors how input substates are handled throughout the engine and benchmarking code, moving from a requirement-based abstraction to directly using `SubstateId`. It also updates the faucet benchmark setup to include a claim receipt resource and adjusts the transaction instructions for account creation and funding. The most important changes are grouped below.

### Refactoring input substate handling

* The `Executable` trait and all its implementations now use `SubstateId` directly in the `all_inputs_iter` method instead of the previous `SubstateRequirementRef`, simplifying the interface and reducing indirection. This affects core engine modules, transaction processing, and test tooling. [[1]](diffhunk://#diff-3657f227866508ab12a9ac18afefce2df45e21930b43c33b93f350469029ee91L6-R6) [[2]](diffhunk://#diff-3657f227866508ab12a9ac18afefce2df45e21930b43c33b93f350469029ee91L18-R18) [[3]](diffhunk://#diff-a481fc0bfde5191b220d165f1c6710b74f215d19acda28ef28c5e74614733a5bL4-R4) [[4]](diffhunk://#diff-a481fc0bfde5191b220d165f1c6710b74f215d19acda28ef28c5e74614733a5bL15-R16) [[5]](diffhunk://#diff-1022823d092a27c53fe2cedc81c382517958b3baeb1de764b256ad63a412d38aR5) [[6]](diffhunk://#diff-1022823d092a27c53fe2cedc81c382517958b3baeb1de764b256ad63a412d38aL32-R39) [[7]](diffhunk://#diff-71fc1fb87e82d3d625651ee6254fb6831e83a24f3dcef8aada3de3bda197330fL150-R156) [[8]](diffhunk://#diff-33dc1b343f1d910c7bf19a534e2b77c2d5b2cdf5d57347f74a9a014d165dd909L32-R40)

### Faucet benchmark improvements

* The benchmark setup now creates a "claim receipt" resource (`XTR_FAUCET_CLAIM_RESOURCE_ADDRESS`) as an NFT, which is minted and burned to record claims, and adds it to the in-memory state store. [[1]](diffhunk://#diff-0aec9edc46f2eff3ff3ecac7077e30a7adfed8788be76e15b8bc53cfe6479876L22-R24) [[2]](diffhunk://#diff-0aec9edc46f2eff3ff3ecac7077e30a7adfed8788be76e15b8bc53cfe6479876R58-R77)
* The `CreateAndFundAccountExecutable` now explicitly includes the faucet component, faucet vault, and claim resource as required input substates.

### Transaction instruction adjustments

* The sequence of instructions for creating and funding an account in the benchmark is updated: account creation now happens before the faucet's `take` method is called, and the bucket workspace ID is set to `None` for account creation.

### Imports and code organization

* Imports are updated throughout the codebase to reflect the new usage of `SubstateId` and to include the new claim resource address constant where needed. [[1]](diffhunk://#diff-33dc1b343f1d910c7bf19a534e2b77c2d5b2cdf5d57347f74a9a014d165dd909L15-R23) [[2]](diffhunk://#diff-0aec9edc46f2eff3ff3ecac7077e30a7adfed8788be76e15b8bc53cfe6479876L22-R24)

These changes streamline substate input handling, improve the accuracy and realism of the faucet benchmark, and clarify the transaction execution flow.