### PR TITLE
chore: bump versions for publishing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7393,7 +7393,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "ootle-rs"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7450,7 +7450,7 @@ dependencies = [
 
 [[package]]
 name = "ootle_byte_type"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "tari_crypto",
  "tari_template_lib_types",
@@ -11316,7 +11316,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_address"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "bech32",
  "bincode 2.0.1",

--- a/crates/ootle_address/Cargo.toml
+++ b/crates/ootle_address/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_ootle_address"
 description = "Tari Ootle address using bech32 encoding"
-version = "0.4.0"
+version = "0.4.1"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/ootle_byte_type/Cargo.toml
+++ b/crates/ootle_byte_type/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ootle_byte_type"
-version = "0.6.0"
+version = "0.6.1"
 description = "Conversion traits that define conversions to/from light-weight byte types"
 edition.workspace = true
 authors.workspace = true

--- a/crates/wallet/ootle-rs/Cargo.toml
+++ b/crates/wallet/ootle-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ootle-rs"
-version = "0.6.0"
+version = "0.6.1"
 description = "A Rust library for interacting with the Tari Ootle network."
 edition.workspace = true
 authors.workspace = true


### PR DESCRIPTION
Description
---

  - tari_template_lib_types 0.25.0
  - ootle_byte_type 0.6.1
  - tari_template_lib 0.25.0
  - tari_ootle_template_metadata 0.5.1
  - tari_ootle_template_build 0.5.1
  - tari_engine_types 0.28.10
  - tari_ootle_common_types 0.28.10
  - tari_ootle_wallet_crypto 0.28.10
  - tari_ootle_address 0.4.1
  - tari_ootle_transaction 0.28.10
  - tari_template_builtin 0.28.10
  - tari_transaction_manifest 0.28.10
  - tari_engine 0.28.10
  - tari_consensus_types 0.28.10
  - tari_indexer_client 0.28.10
  - ootle-wasm-core 0.28.10
  - ootle-wasm 0.28.10
  - tari_template_test_tooling 0.28.10
  - ootle-rs 0.6.1
  - tari_ootle_wallet_sdk 0.28.10
  - tari_ootle_wallet_storage_sqlite 0.28.10
  - tari_ootle_walletd_client 0.29.3
