### PR TITLE
chore: fix clippy lints

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,3 +45,8 @@
 ### Building
 
 - Standard cargo workspace. Use `-p <package_name>` to build/test specific crates
+
+### Formatting
+
+Use `cargo  +nightly-2025-06-25 fmt --all` to format all code with the specified nightly version before pushing commits
+involving rust code. 

--- a/crates/engine/src/wasm/module.rs
+++ b/crates/engine/src/wasm/module.rs
@@ -274,24 +274,20 @@ fn validate_functions(template_def: &TemplateDef) -> Result<(), WasmExecutionErr
                         .into());
                     }
                     match &arg.arg_type {
-                        Type::Tuple(tuple) => {
-                            if tuple.len() > limits::WASM_LIMITS.max_function_arguments {
-                                return Err(WasmValidationError::FunctionTooManyTupleReturn {
-                                    name: func.name.clone(),
-                                    max_tuple_size: limits::WASM_LIMITS.max_function_arguments,
-                                    tuple_size: tuple.len(),
-                                }
-                                .into());
+                        Type::Tuple(tuple) if tuple.len() > limits::WASM_LIMITS.max_function_arguments => {
+                            return Err(WasmValidationError::FunctionTooManyTupleReturn {
+                                name: func.name.clone(),
+                                max_tuple_size: limits::WASM_LIMITS.max_function_arguments,
+                                tuple_size: tuple.len(),
                             }
+                            .into());
                         },
-                        Type::Other { name } => {
-                            if name.len() > limits::WASM_LIMITS.max_function_name_length {
-                                return Err(WasmValidationError::FunctionNameTooLong {
-                                    name: name.clone(),
-                                    max_length: limits::WASM_LIMITS.max_function_name_length,
-                                }
-                                .into());
+                        Type::Other { name } if name.len() > limits::WASM_LIMITS.max_function_name_length => {
+                            return Err(WasmValidationError::FunctionNameTooLong {
+                                name: name.clone(),
+                                max_length: limits::WASM_LIMITS.max_function_name_length,
                             }
+                            .into());
                         },
                         _ => {},
                     }

--- a/crates/epoch_manager/src/service/epoch_manager.rs
+++ b/crates/epoch_manager/src/service/epoch_manager.rs
@@ -324,7 +324,7 @@ where TSpec: EpochManagerSpec
                 })?;
             res.push(vn);
         }
-        res.sort_by(|a, b| a.shard_key.cmp(&b.shard_key));
+        res.sort_by_key(|a| a.shard_key);
         Ok(res)
     }
 

--- a/crates/epoch_oracles/src/hybrid/oracle.rs
+++ b/crates/epoch_oracles/src/hybrid/oracle.rs
@@ -61,15 +61,13 @@ impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore + Send + 'static> Epoc
                                 done_for_now: self.has_initial_sync_completed,
                             });
                         },
-                        EpochEvent::DoneForNow {epoch, epoch_hash} => {
-                            if !self.has_initial_sync_completed {
-                                let _ignore = self.trigger.send(EpochTickerData{
-                                    epoch,
-                                    epoch_hash,
-                                    done_for_now: true,
-                                });
-                                self.has_initial_sync_completed = true;
-                            }
+                        EpochEvent::DoneForNow {epoch, epoch_hash} if !self.has_initial_sync_completed => {
+                            let _ignore = self.trigger.send(EpochTickerData{
+                                epoch,
+                                epoch_hash,
+                                done_for_now: true,
+                            });
+                            self.has_initial_sync_completed = true;
                         },
                         // Ignore other events that are not epoch changes
                         _ => {},

--- a/crates/storage_sqlite/src/global/backend_adapter.rs
+++ b/crates/storage_sqlite/src/global/backend_adapter.rs
@@ -979,7 +979,7 @@ fn distinct_validators_sorted<TAddr: NodeAddressable>(
     sqlite_vns: Vec<DbValidatorNode>,
 ) -> Result<Vec<ValidatorNode<TAddr>>, SqliteStorageError> {
     let mut db_vns = distinct_validators(sqlite_vns)?;
-    db_vns.sort_by(|a, b| a.shard_key.cmp(&b.shard_key));
+    db_vns.sort_by_key(|a| a.shard_key);
     Ok(db_vns)
 }
 

--- a/crates/wallet/sdk/src/models/input_selection/branch_and_bound.rs
+++ b/crates/wallet/sdk/src/models/input_selection/branch_and_bound.rs
@@ -70,7 +70,7 @@ pub fn select<A: Into<Amount>, K: Clone>(
     // Sort descending to improve pruning efficiency
     // Collect references to avoid cloning keys/values unnecessarily
     let mut items = inputs.iter().collect::<Vec<_>>();
-    items.sort_by(|a, b| b.value.cmp(&a.value));
+    items.sort_by_key(|b| std::cmp::Reverse(b.value));
 
     let mut best_sum: Option<Amount> = None;
     let mut best_keys = Vec::new();

--- a/networking/libp2p-peersync/src/behaviour.rs
+++ b/networking/libp2p-peersync/src/behaviour.rs
@@ -265,19 +265,19 @@ where TPeerStore: PeerStore
             FromSwarm::ConnectionEstablished(_) => {},
             FromSwarm::ConnectionClosed(connection_closed) => self.on_connection_closed(connection_closed),
             FromSwarm::AddressChange(_) => {},
-            FromSwarm::ExternalAddrConfirmed(addr_confirmed) => {
-                if self.local_peer_record.add_address(addr_confirmed.addr.clone()) {
-                    self.handle_update_local_record();
-                    self.pending_events
-                        .push_back(ToSwarm::GenerateEvent(Event::LocalPeerRecordUpdated));
-                }
+            FromSwarm::ExternalAddrConfirmed(addr_confirmed)
+                if self.local_peer_record.add_address(addr_confirmed.addr.clone()) =>
+            {
+                self.handle_update_local_record();
+                self.pending_events
+                    .push_back(ToSwarm::GenerateEvent(Event::LocalPeerRecordUpdated));
             },
-            FromSwarm::ExternalAddrExpired(addr_expired) => {
-                if self.local_peer_record.remove_address(addr_expired.addr) {
-                    self.handle_update_local_record();
-                    self.pending_events
-                        .push_back(ToSwarm::GenerateEvent(Event::LocalPeerRecordUpdated));
-                }
+            FromSwarm::ExternalAddrExpired(addr_expired)
+                if self.local_peer_record.remove_address(addr_expired.addr) =>
+            {
+                self.handle_update_local_record();
+                self.pending_events
+                    .push_back(ToSwarm::GenerateEvent(Event::LocalPeerRecordUpdated));
             },
             _ => {},
         }

--- a/networking/rpc_macros/src/expand.rs
+++ b/networking/rpc_macros/src/expand.rs
@@ -294,22 +294,17 @@ impl Fold for TraitInfoCollector {
     }
 
     fn fold_trait_item(&mut self, mut node: TraitItem) -> TraitItem {
-        match &mut node {
-            TraitItem::Fn(fn_item) => {
-                if self.is_rpc_method(fn_item) {
-                    let info = match self.parse_trait_item_method(fn_item) {
-                        Ok(i) => i,
-                        Err(err) => {
-                            panic!("{}", err);
-                        },
-                    };
+        if let TraitItem::Fn(fn_item) = &mut node &&
+            self.is_rpc_method(fn_item)
+        {
+            let info = match self.parse_trait_item_method(fn_item) {
+                Ok(i) => i,
+                Err(err) => {
+                    panic!("{}", err);
+                },
+            };
 
-                    self.rpc_methods.push(info);
-                }
-            },
-            _ => {
-                // Nothing
-            },
+            self.rpc_methods.push(info);
         }
 
         fold::fold_trait_item(self, node)


### PR DESCRIPTION
## Summary
- Collapsed nested `if` blocks into outer `match` guards to satisfy `clippy::collapsible_match`.
- Replaced `sort_by(|a, b| a.x.cmp(&b.x))` calls with `sort_by_key` to satisfy `clippy::unnecessary_sort_by`.

## Test plan
- [x] `cargo lints clippy --all-targets` passes without errors or warnings