### PR TITLE
fix(template_lib): enforce FunctionName type for auth hook method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12043,7 +12043,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_lib"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "borsh",
  "serde",

--- a/crates/engine/tests/templates/access_rules/src/lib.rs
+++ b/crates/engine/tests/templates/access_rules/src/lib.rs
@@ -19,6 +19,8 @@ pub fn create_badge_resource(recall_rule: AccessRule) -> Bucket {
 
 #[template]
 mod access_rules_template {
+    use tari_template_lib::types::FunctionName;
+
     use super::*;
 
     pub struct AccessRulesTest {
@@ -70,7 +72,7 @@ mod access_rules_template {
             })
         }
 
-        pub fn with_auth_hook(allowed: bool, hook: String) -> Component<AccessRulesTest> {
+        pub fn with_auth_hook(allowed: bool, hook: FunctionName) -> Component<AccessRulesTest> {
             let badges = create_badge_resource(rule!(deny_all));
 
             let address_alloc = CallerContext::allocate_component_address(None);
@@ -208,7 +210,7 @@ mod access_rules_template {
             debug!("malicious_auth_hook_set_state: action = {:?}", action);
             let caller = caller.component().unwrap();
             // Try to write component state - this should fail.
-            // Typically a transaction would have write access to the caller component. However the caller component
+            // Typically, a transaction would have write access to the caller component. However, the caller component
             // will always have at least a read lock during the hook call, preventing this from working.
 
             ComponentManager::get(*caller).set_state(&());

--- a/crates/template_lib/Cargo.toml
+++ b/crates/template_lib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_template_lib"
 description = "Tari template library provides abstrations that interface with the Tari validator engine"
-version = "0.25.0"
+version = "0.25.1"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/template_lib/src/component/manager.rs
+++ b/crates/template_lib/src/component/manager.rs
@@ -90,6 +90,11 @@ impl ComponentManager {
         result.decode().expect(ERR_ENGINE_DECODE_FAIL)
     }
 
+    /// Gets the component state as a CBOR value enum
+    pub fn get_state_value(&self) -> tari_bor::Value {
+        self.get_state()
+    }
+
     /// Update the component state
     pub fn set_state<T: Serialize>(&self, state: T) {
         let state = to_value(&state).expect("Failed to encode component state");

--- a/crates/template_lib/src/error_variants.rs
+++ b/crates/template_lib/src/error_variants.rs
@@ -4,7 +4,9 @@
 //! Error variants used in the template library. These are used as error messages in panics and as error codes
 //! and reduce WASM binary size by avoiding the including long error messages in the binary.
 
-/// Error message for when the engine fails to decode a value
+/// The engine fails to decode a value
 pub const ERR_ENGINE_DECODE_FAIL: &str = "EngDcdFail";
-/// Error message for when a function that requires a component context is called outside of a component context
+/// A function that requires a component context is called outside of a component context
 pub const ERR_NOT_IN_COMPONENT_CONTEXT: &str = "NotInCpntCtx";
+/// The auth hook function name exceeds the maximum length
+pub const ERR_AUTH_HOOK_FN_NAME_LEN: &str = "AuthHookFnNameLen";

--- a/crates/template_lib/src/resource/builder/confidential.rs
+++ b/crates/template_lib/src/resource/builder/confidential.rs
@@ -4,6 +4,7 @@ use tari_template_abi::rust::prelude::*;
 use tari_template_lib_types::{
     AuthHook,
     ComponentAddress,
+    FunctionName,
     Metadata,
     OwnerRule,
     ResourceAddress,
@@ -250,8 +251,17 @@ impl ConfidentialResourceBuilder {
     ///     .with_authorization_hook(*alloc.address(), "my_hook")
     ///     .build();
     /// ```
-    pub fn with_authorization_hook<T: Into<String>>(mut self, address: ComponentAddress, auth_callback: T) -> Self {
-        self.authorize_hook = Some(AuthHook::new(address, auth_callback.into()));
+    pub fn with_authorization_hook<T: TryInto<FunctionName>>(
+        mut self,
+        address: ComponentAddress,
+        auth_callback: T,
+    ) -> Self {
+        self.authorize_hook = Some(AuthHook::new(
+            address,
+            auth_callback
+                .try_into()
+                .unwrap_or_else(|_| panic!("AUTHHOOK_FN_NAME_LEN")),
+        ));
         self
     }
 

--- a/crates/template_lib/src/resource/builder/confidential.rs
+++ b/crates/template_lib/src/resource/builder/confidential.rs
@@ -15,6 +15,7 @@ use tari_template_lib_types::{
 
 use crate::{
     args::MintArg,
+    error_variants::ERR_AUTH_HOOK_FN_NAME_LEN,
     models::{Bucket, ResourceAddressAllocation},
     resource::ResourceManager,
     types::{ResourceType, crypto::RistrettoPublicKeyBytes},
@@ -260,7 +261,7 @@ impl ConfidentialResourceBuilder {
             address,
             auth_callback
                 .try_into()
-                .unwrap_or_else(|_| panic!("AUTHHOOK_FN_NAME_LEN")),
+                .unwrap_or_else(|_| panic!("{}", ERR_AUTH_HOOK_FN_NAME_LEN)),
         ));
         self
     }

--- a/crates/template_lib/src/resource/builder/fungible.rs
+++ b/crates/template_lib/src/resource/builder/fungible.rs
@@ -4,6 +4,7 @@ use tari_template_abi::rust::prelude::*;
 use tari_template_lib_types::{
     AuthHook,
     ComponentAddress,
+    FunctionName,
     Metadata,
     OwnerRule,
     ResourceAddress,
@@ -406,8 +407,17 @@ impl FungibleResourceBuilder {
     ///     .with_authorization_hook(*alloc.address(), "my_hook")
     ///     .build();
     /// ```
-    pub fn with_authorization_hook<T: Into<String>>(mut self, address: ComponentAddress, auth_callback: T) -> Self {
-        self.authorize_hook = Some(AuthHook::new(address, auth_callback.into()));
+    pub fn with_authorization_hook<T: TryInto<FunctionName>>(
+        mut self,
+        address: ComponentAddress,
+        auth_callback: T,
+    ) -> Self {
+        self.authorize_hook = Some(AuthHook::new(
+            address,
+            auth_callback
+                .try_into()
+                .unwrap_or_else(|_| panic!("AUTHHOOK_FN_NAME_LEN")),
+        ));
         self
     }
 

--- a/crates/template_lib/src/resource/builder/fungible.rs
+++ b/crates/template_lib/src/resource/builder/fungible.rs
@@ -15,10 +15,12 @@ use tari_template_lib_types::{
 
 use crate::{
     args::MintArg,
+    error_variants::ERR_AUTH_HOOK_FN_NAME_LEN,
     models::{Bucket, ResourceAddressAllocation},
     resource::ResourceManager,
     types::Amount,
 };
+
 /// A builder for creating fungible resources (tokens) inside templates.
 ///
 /// This builder provides a fluent API to configure and create fungible tokens with
@@ -416,7 +418,7 @@ impl FungibleResourceBuilder {
             address,
             auth_callback
                 .try_into()
-                .unwrap_or_else(|_| panic!("AUTHHOOK_FN_NAME_LEN")),
+                .unwrap_or_else(|_| panic!("{}", ERR_AUTH_HOOK_FN_NAME_LEN)),
         ));
         self
     }

--- a/crates/template_lib/src/resource/builder/non_fungible.rs
+++ b/crates/template_lib/src/resource/builder/non_fungible.rs
@@ -5,6 +5,7 @@ use tari_bor::to_value;
 use tari_template_abi::rust::prelude::*;
 use tari_template_lib_types::{
     ComponentAddress,
+    FunctionName,
     Metadata,
     NonFungibleId,
     ResourceAddress,
@@ -210,8 +211,17 @@ impl NonFungibleResourceBuilder {
     ///     .with_authorization_hook(*alloc.address(), "my_hook")
     ///     .build();
     /// ```
-    pub fn with_authorization_hook<T: Into<String>>(mut self, address: ComponentAddress, auth_callback: T) -> Self {
-        self.authorize_hook = Some(AuthHook::new(address, auth_callback.into()));
+    pub fn with_authorization_hook<T: TryInto<FunctionName>>(
+        mut self,
+        address: ComponentAddress,
+        auth_callback: T,
+    ) -> Self {
+        self.authorize_hook = Some(AuthHook::new(
+            address,
+            auth_callback
+                .try_into()
+                .unwrap_or_else(|_| panic!("AUTHHOOK_FN_NAME_LEN")),
+        ));
         self
     }
 

--- a/crates/template_lib/src/resource/builder/non_fungible.rs
+++ b/crates/template_lib/src/resource/builder/non_fungible.rs
@@ -16,6 +16,7 @@ use tari_template_lib_types::{
 
 use crate::{
     args::MintArg,
+    error_variants::ERR_AUTH_HOOK_FN_NAME_LEN,
     models::{Bucket, ResourceAddressAllocation},
     resource::ResourceManager,
     types::{AccessRule, AuthHook, OwnerRule},
@@ -220,7 +221,7 @@ impl NonFungibleResourceBuilder {
             address,
             auth_callback
                 .try_into()
-                .unwrap_or_else(|_| panic!("AUTHHOOK_FN_NAME_LEN")),
+                .unwrap_or_else(|_| panic!("{}", ERR_AUTH_HOOK_FN_NAME_LEN)),
         ));
         self
     }

--- a/crates/template_lib/src/resource/builder/stealth.rs
+++ b/crates/template_lib/src/resource/builder/stealth.rs
@@ -17,6 +17,7 @@ use tari_template_lib_types::{
 
 use crate::{
     args::MintArg,
+    error_variants::ERR_AUTH_HOOK_FN_NAME_LEN,
     models::{Bucket, ResourceAddressAllocation},
     resource::ResourceManager,
 };
@@ -245,7 +246,7 @@ impl StealthResourceBuilder {
             address,
             auth_callback
                 .try_into()
-                .unwrap_or_else(|_| panic!("AUTHHOOK_FN_NAME_LEN")),
+                .unwrap_or_else(|_| panic!("{}", ERR_AUTH_HOOK_FN_NAME_LEN)),
         ));
         self
     }

--- a/crates/template_lib/src/resource/builder/stealth.rs
+++ b/crates/template_lib/src/resource/builder/stealth.rs
@@ -5,6 +5,7 @@ use tari_template_lib_types::{
     Amount,
     AuthHook,
     ComponentAddress,
+    FunctionName,
     Metadata,
     OwnerRule,
     ResourceAddress,
@@ -235,8 +236,17 @@ impl StealthResourceBuilder {
     ///     .with_authorization_hook(*alloc.address(), "my_hook")
     ///     .build();
     /// ```
-    pub fn with_authorization_hook<T: Into<String>>(mut self, address: ComponentAddress, auth_callback: T) -> Self {
-        self.authorize_hook = Some(AuthHook::new(address, auth_callback.into()));
+    pub fn with_authorization_hook<T: TryInto<FunctionName>>(
+        mut self,
+        address: ComponentAddress,
+        auth_callback: T,
+    ) -> Self {
+        self.authorize_hook = Some(AuthHook::new(
+            address,
+            auth_callback
+                .try_into()
+                .unwrap_or_else(|_| panic!("AUTHHOOK_FN_NAME_LEN")),
+        ));
         self
     }
 

--- a/crates/template_lib_types/src/auth_hook.rs
+++ b/crates/template_lib_types/src/auth_hook.rs
@@ -3,18 +3,19 @@
 
 use tari_template_abi::rust::{fmt, prelude::*};
 
-use crate::{ComponentAddress, TemplateAddress};
+use crate::{ComponentAddress, FunctionName, TemplateAddress};
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export))]
 #[cfg_attr(feature = "borsh", derive(borsh::BorshSerialize))]
 pub struct AuthHook {
     pub component_address: ComponentAddress,
-    pub method: String,
+    #[cfg_attr(feature = "ts", ts(type = "string"))]
+    pub method: FunctionName,
 }
 
 impl AuthHook {
-    pub fn new(component_address: ComponentAddress, method: String) -> Self {
+    pub fn new(component_address: ComponentAddress, method: FunctionName) -> Self {
         Self {
             component_address,
             method,


### PR DESCRIPTION
## Summary
- Replace `String` with strongly-typed `FunctionName` on `AuthHook::method`, so length/validity is enforced at construction instead of at runtime
- Update all resource builders (`fungible`, `non_fungible`, `confidential`, `stealth`) to accept `TryInto<FunctionName>` for `with_authorization_hook`
- Add `ComponentManager::get_state_value` helper to fetch state as a raw CBOR value
- Bump `tari_template_lib` to `0.25.1`

## Test plan
- [x] `cargo build -p tari_template_lib -p tari_template_lib_types`
- [x] `cargo test -p tari_engine --test templates` (access_rules template)
- [x] Confirm wasm templates using `with_authorization_hook` still compile