### PR TITLE
feat(indexer): filter event stream by resource address

### DIFF
--- a/applications/tari_indexer/src/event_manager.rs
+++ b/applications/tari_indexer/src/event_manager.rs
@@ -23,6 +23,7 @@
 use log::*;
 use tari_engine_types::{events::Event, substate::SubstateId};
 use tari_ootle_transaction::TransactionId;
+use tari_template_lib_types::ResourceAddress;
 
 use crate::{
     storage_sqlite::SqliteIndexerStore,
@@ -45,12 +46,13 @@ impl EventManager {
         &self,
         topic: Option<&str>,
         substate_id: Option<&SubstateId>,
+        resource_address: Option<&ResourceAddress>,
         offset: u32,
         limit: u32,
     ) -> Result<Vec<(TransactionId, Event)>, anyhow::Error> {
         let events = self
             .substate_store
-            .with_read_tx(|tx| tx.get_events(substate_id, topic, offset, limit))?;
+            .with_read_tx(|tx| tx.get_events(substate_id, topic, resource_address, offset, limit))?;
 
         debug!(target: LOG_TARGET, "Found {} events", events.len());
         Ok(events)

--- a/applications/tari_indexer/src/graphql/model/events.rs
+++ b/applications/tari_indexer/src/graphql/model/events.rs
@@ -28,8 +28,9 @@ use serde::{Deserialize, Serialize};
 use tari_engine_types::substate::SubstateId;
 use tari_ootle_common_types::displayable::Displayable;
 use tari_ootle_transaction::TransactionId;
+use tari_template_lib_types::ResourceAddress;
 
-use crate::event_manager::EventManager;
+use crate::{event_manager::EventManager, network_state_sync::EventFilter};
 
 const LOG_TARGET: &str = "tari::indexer::graphql::events";
 
@@ -41,6 +42,7 @@ pub struct Event {
     pub tx_hash: [u8; 32],
     pub topic: String,
     pub payload: BTreeMap<String, String>,
+    pub resource_address: Option<String>,
 }
 
 impl Event {
@@ -48,12 +50,14 @@ impl Event {
         transaction_id: TransactionId,
         event: tari_engine_types::events::Event,
     ) -> Result<Self, anyhow::Error> {
+        let resource_address = EventFilter::event_resource_address(&event).map(|r| r.to_string());
         Ok(Self {
             substate_id: event.substate_id().map(|sub_id| sub_id.to_string()),
             template_address: event.template_address().into_array(),
             tx_hash: transaction_id.into_array(),
             topic: event.topic().to_string(),
             payload: event.into_payload().into_iter().collect(),
+            resource_address,
         })
     }
 }
@@ -69,14 +73,19 @@ impl EventQuery {
         ctx: &Context<'_>,
         topic: Option<String>,
         substate_id: Option<String>,
+        resource_address: Option<String>,
         offset: Option<u32>,
         limit: Option<u32>,
     ) -> Result<Vec<Event>, anyhow::Error> {
         info!(
             target: LOG_TARGET,
-            "Querying events. topic: {}, substate_id: {}, offset: {}, limit: {}, ", topic.display(), substate_id.display(), offset.display(), limit.display(),
+            "Querying events. topic: {}, substate_id: {}, resource_address: {}, offset: {}, limit: {}",
+            topic.display(), substate_id.display(), resource_address.display(), offset.display(), limit.display(),
         );
         let substate_id = substate_id.map(|str| SubstateId::from_str(&str)).transpose()?;
+        let resource_address = resource_address
+            .map(|str| ResourceAddress::from_str(&str))
+            .transpose()?;
         let event_manager = ctx.data_unchecked::<EventManager>();
         let limit = limit.unwrap_or(100);
         if limit == 0 {
@@ -87,7 +96,13 @@ impl EventQuery {
             return Err(anyhow::anyhow!("Limit cannot be greater than 1000"));
         }
         event_manager
-            .get_events_from_db(topic.as_deref(), substate_id.as_ref(), offset.unwrap_or(0), limit)
+            .get_events_from_db(
+                topic.as_deref(),
+                substate_id.as_ref(),
+                resource_address.as_ref(),
+                offset.unwrap_or(0),
+                limit,
+            )
             .await?
             .into_iter()
             .map(|(id, ev)| Event::from_engine_event(id, ev))

--- a/applications/tari_indexer/src/network_state_sync/event_filter.rs
+++ b/applications/tari_indexer/src/network_state_sync/event_filter.rs
@@ -1,9 +1,15 @@
 //   Copyright 2025 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
+use std::str::FromStr;
+
 use serde::{Deserialize, Serialize};
 use tari_engine_types::{events::Event, substate::SubstateId};
-use tari_template_lib_types::{EntityId, TemplateAddress};
+use tari_template_lib_types::{EntityId, ResourceAddress, TemplateAddress};
+
+/// Payload metadata key under which events (e.g. `std.vault.deposit`, `std.vault.withdraw`)
+/// carry the resource address of the resource being transferred.
+const PAYLOAD_RESOURCE_ADDRESS_KEY: &str = "resource_address";
 
 #[derive(Default, Debug, Serialize, Deserialize, Clone)]
 pub struct EventFilter {
@@ -11,6 +17,8 @@ pub struct EventFilter {
     pub entity_id: Option<EntityId>,
     pub substate_id: Option<SubstateId>,
     pub template_address: Option<TemplateAddress>,
+    #[serde(default)]
+    pub resource_address: Option<ResourceAddress>,
 }
 
 impl EventFilter {
@@ -39,12 +47,36 @@ impl EventFilter {
             return false;
         }
 
+        if let Some(filter_resource) = self.resource_address.as_ref() {
+            match Self::event_resource_address(event) {
+                Some(event_resource) if event_resource == *filter_resource => {},
+                _ => return false,
+            }
+        }
+
         self.entity_id.as_ref().is_none_or(|entity_id| {
             event
                 .substate_id()
                 .map(|s| s.to_object_key().as_entity_id() == *entity_id)
                 .unwrap_or(false)
         })
+    }
+
+    /// Derive the resource address an event refers to, if any.
+    ///
+    /// Two cases are recognised:
+    /// 1. The event's `substate_id` is a `Resource(..)` — the `std.resource.*` events (`create`, `mint`, `recall`,
+    ///    `freeze`, `unfreeze`, `update_access_rules`, `update_nonfungible_data`) all attach the resource address as
+    ///    the substate_id.
+    /// 2. The event payload contains a `resource_address` entry parseable as a `ResourceAddress` — `std.vault.deposit`
+    ///    and `std.vault.withdraw` both set this.
+    pub fn event_resource_address(event: &Event) -> Option<ResourceAddress> {
+        if let Some(addr) = event.substate_id().and_then(|s| s.as_resource_address()) {
+            return Some(addr);
+        }
+        event
+            .get_payload(PAYLOAD_RESOURCE_ADDRESS_KEY)
+            .and_then(|s| ResourceAddress::from_str(s).ok())
     }
 
     /// Convert a topic filter with `*` wildcards to a SQL LIKE pattern.
@@ -87,5 +119,134 @@ impl EventFilter {
 
         // Topic must not have extra trailing segments
         topic_segments.next().is_none()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tari_template_lib_types::{Metadata, ObjectKey, VaultId};
+
+    use super::*;
+
+    fn resource(byte: u8) -> ResourceAddress {
+        ResourceAddress::new(ObjectKey::from_array([byte; ObjectKey::LENGTH]))
+    }
+
+    fn template(byte: u8) -> TemplateAddress {
+        TemplateAddress::from_array([byte; 32])
+    }
+
+    fn vault_deposit_event(vault_byte: u8, resource: &ResourceAddress, template_addr: TemplateAddress) -> Event {
+        let vault_id = VaultId::new(ObjectKey::from_array([vault_byte; ObjectKey::LENGTH]));
+        let payload = Metadata::from_iter([("resource_address", resource.to_string())]);
+        Event::std(Some(vault_id.into()), template_addr, "vault", "deposit", payload)
+    }
+
+    fn resource_mint_event(resource: &ResourceAddress, template_addr: TemplateAddress) -> Event {
+        Event::std(
+            Some((*resource).into()),
+            template_addr,
+            "resource",
+            "mint",
+            Metadata::new(),
+        )
+    }
+
+    #[test]
+    fn matches_vault_deposit_by_resource_address_in_payload() {
+        let token = resource(1);
+        let other = resource(2);
+        let event = vault_deposit_event(9, &token, template(3));
+
+        let matching = EventFilter {
+            resource_address: Some(token),
+            ..Default::default()
+        };
+        assert!(matching.matches(&event));
+
+        let non_matching = EventFilter {
+            resource_address: Some(other),
+            ..Default::default()
+        };
+        assert!(!non_matching.matches(&event));
+    }
+
+    #[test]
+    fn matches_resource_mint_by_substate_id_resource() {
+        // For std.resource.* events, the resource address is the event's substate_id.
+        let token = resource(7);
+        let event = resource_mint_event(&token, template(4));
+
+        let filter = EventFilter {
+            resource_address: Some(token),
+            ..Default::default()
+        };
+        assert!(filter.matches(&event));
+
+        let wrong = EventFilter {
+            resource_address: Some(resource(8)),
+            ..Default::default()
+        };
+        assert!(!wrong.matches(&event));
+    }
+
+    #[test]
+    fn rejects_events_without_resource_when_filter_set() {
+        // An event that has neither a Resource substate_id nor a resource_address payload entry
+        // must not match a resource_address filter.
+        let template_addr = template(5);
+        let event = Event::std(None, template_addr, "component", "updated", Metadata::new());
+
+        let filter = EventFilter {
+            resource_address: Some(resource(1)),
+            ..Default::default()
+        };
+        assert!(!filter.matches(&event));
+    }
+
+    #[test]
+    fn combines_with_other_filters() {
+        let token = resource(1);
+        let tmpl = template(2);
+        let event = vault_deposit_event(9, &token, tmpl);
+
+        // All filters match
+        let filter = EventFilter {
+            topic: Some("std.vault.deposit".into()),
+            template_address: Some(tmpl),
+            resource_address: Some(token),
+            ..Default::default()
+        };
+        assert!(filter.matches(&event));
+
+        // Topic mismatches => no match even if resource matches
+        let filter = EventFilter {
+            topic: Some("std.vault.withdraw".into()),
+            resource_address: Some(token),
+            ..Default::default()
+        };
+        assert!(!filter.matches(&event));
+    }
+
+    #[test]
+    fn empty_filter_matches_any_event() {
+        let event = vault_deposit_event(9, &resource(1), template(2));
+        let filter = EventFilter::default();
+        assert!(filter.matches(&event));
+    }
+
+    #[test]
+    fn derives_resource_address_from_payload_only_when_parseable() {
+        let tmpl = template(1);
+        let payload = Metadata::from_iter([("resource_address", "not-a-valid-address".to_string())]);
+        let event = Event::std(None, tmpl, "vault", "deposit", payload);
+
+        assert!(EventFilter::event_resource_address(&event).is_none());
+
+        let filter = EventFilter {
+            resource_address: Some(resource(1)),
+            ..Default::default()
+        };
+        assert!(!filter.matches(&event));
     }
 }

--- a/applications/tari_indexer/src/rest_api/handlers/transaction_events.rs
+++ b/applications/tari_indexer/src/rest_api/handlers/transaction_events.rs
@@ -37,6 +37,9 @@ const REPLAY_PAGE_SIZE: u32 = 500;
         ("topic" = Option<String>, Query, description = "Filter by event topic"),
         ("substate_id" = Option<String>, Query, description = "Filter by substate ID"),
         ("template_address" = Option<String>, Query, description = "Filter by template address"),
+        ("resource_address" = Option<String>, Query, description = "Filter by resource address \
+            (derived from substate_id for std.resource.* events, or from the `resource_address` \
+            payload entry for std.vault.deposit / std.vault.withdraw)"),
         ("after_id" = Option<i64>, Query, description = "Resume from this event ID (exclusive)"),
     )
 )]
@@ -57,6 +60,7 @@ pub async fn sse_transaction_events(
         entity_id: None,
         substate_id: req.substate_id,
         template_address: req.template_address,
+        resource_address: req.resource_address,
     };
 
     if let Some(id) = after_id {
@@ -137,6 +141,7 @@ async fn run_replay_then_live(
             filter.topic.as_deref(),
             filter.substate_id.as_ref(),
             filter.template_address.as_ref(),
+            filter.resource_address.as_ref(),
             REPLAY_PAGE_SIZE,
         )?;
 
@@ -189,6 +194,7 @@ async fn run_replay_then_live(
                         filter.topic.as_deref(),
                         filter.substate_id.as_ref(),
                         filter.template_address.as_ref(),
+                        filter.resource_address.as_ref(),
                         REPLAY_PAGE_SIZE,
                     )?;
 

--- a/applications/tari_indexer/src/rest_api/handlers/transactions.rs
+++ b/applications/tari_indexer/src/rest_api/handlers/transactions.rs
@@ -211,7 +211,7 @@ pub async fn get_transaction_result(
 #[utoipa::path(
     get,
     path = "/transactions/events",
-    description = "Query and filter transaction events by substate ID and/or topic.",
+    description = "Query and filter transaction events by substate ID, topic, and/or resource address.",
     responses(
         (status = 200, description = "List of transaction events matching the filters", body = QueryTransactionEventsResponse),
         (status = BAD_REQUEST, description = "Invalid request parameters", body = ErrorResponse),
@@ -234,8 +234,8 @@ pub async fn query_transaction_events(
     let offset = req.offset.unwrap_or(0);
 
     debug!(target: LOG_TARGET,
-        "Querying transaction events with filters - substate_id: {}, topic: {}, offset: {}, limit: {}",
-        req.substate_id.display(), req.topic.display(), offset, limit
+        "Querying transaction events with filters - substate_id: {}, topic: {}, resource_address: {}, offset: {}, limit: {}",
+        req.substate_id.display(), req.topic.display(), req.resource_address.display(), offset, limit
     );
 
     let events = context
@@ -243,6 +243,7 @@ pub async fn query_transaction_events(
         .get_events(
             req.substate_id.as_ref(),
             req.topic.as_deref().map(|t| t.trim()).filter(|t| !t.is_empty()),
+            req.resource_address.as_ref(),
             offset,
             limit,
         )

--- a/applications/tari_indexer/src/storage_sqlite/migrations/2026-04-20-000000_add_events_resource_address/down.sql
+++ b/applications/tari_indexer/src/storage_sqlite/migrations/2026-04-20-000000_add_events_resource_address/down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS events_resource_address_idx;
+ALTER TABLE events DROP COLUMN resource_address;

--- a/applications/tari_indexer/src/storage_sqlite/migrations/2026-04-20-000000_add_events_resource_address/up.sql
+++ b/applications/tari_indexer/src/storage_sqlite/migrations/2026-04-20-000000_add_events_resource_address/up.sql
@@ -1,0 +1,8 @@
+-- Store the resource address (when present) an event refers to, so SSE
+-- consumers can filter a stream down to a single token's activity server-side.
+--
+-- Populated from event.substate_id for `std.resource.*` events (the substate_id
+-- is the resource address), or from the `resource_address` payload entry for
+-- `std.vault.deposit` / `std.vault.withdraw`.
+ALTER TABLE events ADD COLUMN resource_address TEXT NULL;
+CREATE INDEX events_resource_address_idx ON events (resource_address);

--- a/applications/tari_indexer/src/storage_sqlite/models/events.rs
+++ b/applications/tari_indexer/src/storage_sqlite/models/events.rs
@@ -67,6 +67,8 @@ pub struct EventData {
     pub payload: String,
     #[diesel(sql_type = Nullable<Text>)]
     pub substate_id: Option<String>,
+    #[diesel(sql_type = Nullable<Text>)]
+    pub resource_address: Option<String>,
 }
 
 impl TryFrom<EventData> for crate::graphql::model::events::Event {
@@ -87,6 +89,7 @@ impl TryFrom<EventData> for crate::graphql::model::events::Event {
             tx_hash,
             payload,
             topic: event_data.topic,
+            resource_address: event_data.resource_address,
         })
     }
 }

--- a/applications/tari_indexer/src/storage_sqlite/models/events.rs
+++ b/applications/tari_indexer/src/storage_sqlite/models/events.rs
@@ -39,6 +39,7 @@ pub struct EventRecord {
     pub topic: String,
     pub payload: String,
     pub substate_id: Option<String>,
+    pub resource_address: Option<String>,
     pub created_at: PrimitiveDateTime,
 }
 
@@ -51,6 +52,7 @@ pub struct NewEvent<'a> {
     pub topic: &'a str,
     pub payload: String,
     pub substate_id: Option<String>,
+    pub resource_address: Option<String>,
 }
 
 #[derive(Clone, Debug, QueryableByName, Deserialize, Serialize)]

--- a/applications/tari_indexer/src/storage_sqlite/reader.rs
+++ b/applications/tari_indexer/src/storage_sqlite/reader.rs
@@ -247,16 +247,17 @@ impl IndexerStoreReadTransaction for SqliteStoreReadTransaction<'_> {
         &mut self,
         substate_id_filter: Option<&SubstateId>,
         topic_filter: Option<&str>,
+        resource_address_filter: Option<&ResourceAddress>,
         offset: u32,
         limit: u32,
     ) -> Result<Vec<(TransactionId, Event)>, StorageError> {
-        // TODO: allow to query by payload as well, unifying all event methods into one
         info!(
             target: LOG_TARGET,
-            "Querying substate scanner database: get_events with substate_id_filter = {:?} and \
-            topic_filter = {:?}",
+            "Querying substate scanner database: get_events with substate_id_filter = {:?}, \
+            topic_filter = {:?}, resource_address_filter = {:?}",
             substate_id_filter,
-            topic_filter
+            topic_filter,
+            resource_address_filter
         );
         use crate::storage_sqlite::schema::events;
 
@@ -275,6 +276,10 @@ impl IndexerStoreReadTransaction for SqliteStoreReadTransaction<'_> {
                     query = query.filter(events::topic.eq(topic));
                 },
             }
+        }
+
+        if let Some(resource_address) = resource_address_filter {
+            query = query.filter(events::resource_address.eq(resource_address.to_string()));
         }
 
         let event_rows = query

--- a/applications/tari_indexer/src/storage_sqlite/reader.rs
+++ b/applications/tari_indexer/src/storage_sqlite/reader.rs
@@ -331,6 +331,7 @@ impl IndexerStoreReadTransaction for SqliteStoreReadTransaction<'_> {
         topic_filter: Option<&str>,
         substate_id_filter: Option<&SubstateId>,
         template_address_filter: Option<&TemplateAddress>,
+        resource_address_filter: Option<&ResourceAddress>,
         limit: u32,
     ) -> Result<Vec<(i64, TransactionId, Event)>, StorageError> {
         use crate::storage_sqlite::schema::events;
@@ -353,6 +354,9 @@ impl IndexerStoreReadTransaction for SqliteStoreReadTransaction<'_> {
         }
         if let Some(template_address) = template_address_filter {
             query = query.filter(events::template_address.eq(template_address.to_string()));
+        }
+        if let Some(resource_address) = resource_address_filter {
+            query = query.filter(events::resource_address.eq(resource_address.to_string()));
         }
 
         let event_rows = query

--- a/applications/tari_indexer/src/storage_sqlite/schema.rs
+++ b/applications/tari_indexer/src/storage_sqlite/schema.rs
@@ -33,6 +33,7 @@ diesel::table! {
         topic -> Text,
         payload -> Text,
         substate_id -> Nullable<Text>,
+        resource_address -> Nullable<Text>,
         created_at -> Timestamp,
     }
 }

--- a/applications/tari_indexer/src/storage_sqlite/writer.rs
+++ b/applications/tari_indexer/src/storage_sqlite/writer.rs
@@ -287,6 +287,7 @@ impl IndexerStoreWriteTransaction for SqliteStoreWriteTransaction<'_> {
                     topic: event.topic(),
                     payload: serialize_json(event.payload())?,
                     substate_id: event.substate_id().map(|s| s.to_string()),
+                    resource_address: EventFilter::event_resource_address(&event).map(|r| r.to_string()),
                 };
 
                 let id: i64 = diesel::insert_into(events::table)

--- a/applications/tari_indexer/src/store.rs
+++ b/applications/tari_indexer/src/store.rs
@@ -118,6 +118,7 @@ pub trait IndexerStoreReadTransaction {
         &mut self,
         substate_id_filter: Option<&SubstateId>,
         topic_filter: Option<&str>,
+        resource_address_filter: Option<&ResourceAddress>,
         offset: u32,
         limit: u32,
     ) -> Result<Vec<(TransactionId, Event)>, StorageError>;
@@ -332,11 +333,12 @@ impl<T: IndexerStoreReader> ReadOnlyStore<T> {
         &self,
         substate_id_filter: Option<&SubstateId>,
         topic_filter: Option<&str>,
+        resource_address_filter: Option<&ResourceAddress>,
         offset: u32,
         limit: u32,
     ) -> Result<Vec<(TransactionId, Event)>, StorageError> {
         self.inner
-            .with_read_tx(|tx| tx.get_events(substate_id_filter, topic_filter, offset, limit))
+            .with_read_tx(|tx| tx.get_events(substate_id_filter, topic_filter, resource_address_filter, offset, limit))
     }
 
     pub fn get_events_after_id(

--- a/applications/tari_indexer/src/store.rs
+++ b/applications/tari_indexer/src/store.rs
@@ -130,6 +130,7 @@ pub trait IndexerStoreReadTransaction {
         topic_filter: Option<&str>,
         substate_id_filter: Option<&SubstateId>,
         template_address_filter: Option<&TemplateAddress>,
+        resource_address_filter: Option<&ResourceAddress>,
         limit: u32,
     ) -> Result<Vec<(i64, TransactionId, Event)>, StorageError>;
 
@@ -344,6 +345,7 @@ impl<T: IndexerStoreReader> ReadOnlyStore<T> {
         topic_filter: Option<&str>,
         substate_id_filter: Option<&SubstateId>,
         template_address_filter: Option<&TemplateAddress>,
+        resource_address_filter: Option<&ResourceAddress>,
         limit: u32,
     ) -> Result<Vec<(i64, TransactionId, Event)>, StorageError> {
         self.inner.with_read_tx(|tx| {
@@ -352,6 +354,7 @@ impl<T: IndexerStoreReader> ReadOnlyStore<T> {
                 topic_filter,
                 substate_id_filter,
                 template_address_filter,
+                resource_address_filter,
                 limit,
             )
         })

--- a/clients/tari_indexer_client/src/types.rs
+++ b/clients/tari_indexer_client/src/types.rs
@@ -306,6 +306,12 @@ pub struct StreamTransactionEventsRequest {
     pub substate_id: Option<SubstateId>,
     #[cfg_attr(feature = "utoipa", schema(value_type = Option<String>))]
     pub template_address: Option<TemplateAddress>,
+    /// Filter by resource address. Matches when either the event's `substate_id` is the given
+    /// resource (std.resource.* events) or the event payload contains a `resource_address` entry
+    /// equal to the given address (std.vault.deposit / std.vault.withdraw).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "utoipa", schema(value_type = Option<String>))]
+    pub resource_address: Option<ResourceAddress>,
     /// Resume the event stream from this event ID (exclusive). Events with id > after_id will be
     /// replayed from the database before switching to the live stream.
     pub after_id: Option<i64>,

--- a/clients/tari_indexer_client/src/types.rs
+++ b/clients/tari_indexer_client/src/types.rs
@@ -284,6 +284,12 @@ pub struct QueryTransactionEventsRequest {
     pub topic: Option<String>,
     #[cfg_attr(feature = "utoipa", schema(value_type = Option<String>))]
     pub substate_id: Option<SubstateId>,
+    /// Filter by resource address. Matches when either the event's `substate_id` is the given
+    /// resource (std.resource.* events) or the event payload contains a `resource_address` entry
+    /// equal to the given address (std.vault.deposit / std.vault.withdraw).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "utoipa", schema(value_type = Option<String>))]
+    pub resource_address: Option<ResourceAddress>,
     pub limit: Option<u32>,
     pub offset: Option<u32>,
 }

--- a/crates/wallet/ootle-rs/examples/watch_component_events.rs
+++ b/crates/wallet/ootle-rs/examples/watch_component_events.rs
@@ -61,6 +61,7 @@ async fn main() {
             topic: TOPIC_FILTER.map(String::from),
             substate_id: Some(component.into()),
             template_address: None,
+            resource_address: None,
             after_id: last_event_id,
         };
 

--- a/crates/wallet/ootle-rs/src/provider/event_watcher.rs
+++ b/crates/wallet/ootle-rs/src/provider/event_watcher.rs
@@ -12,7 +12,7 @@ use tari_indexer_client::{
     types::StreamTransactionEventsRequest,
 };
 use tari_ootle_common_types::engine_types::substate::SubstateId;
-use tari_template_lib_types::TemplateAddress;
+use tari_template_lib_types::{ResourceAddress, TemplateAddress};
 use tracing::error;
 
 /// Filter for subscribing to transaction events via SSE.
@@ -21,6 +21,10 @@ pub struct TransactionEventFilter {
     pub topic: Option<String>,
     pub substate_id: Option<SubstateId>,
     pub template_address: Option<TemplateAddress>,
+    /// Filter by resource address. Useful for tracking all activity (deposits, withdrawals,
+    /// mints, burns, freezes, etc.) for a specific token regardless of which template
+    /// orchestrated the call.
+    pub resource_address: Option<ResourceAddress>,
     /// Resume the event stream from this event ID (exclusive).
     /// Events with id > after_id will be replayed from the database before switching to live.
     pub after_id: Option<i64>,
@@ -32,6 +36,7 @@ impl TransactionEventFilter {
             topic: self.topic,
             substate_id: self.substate_id,
             template_address: self.template_address,
+            resource_address: self.resource_address,
             after_id: self.after_id,
         }
     }

--- a/integration_tests/tests/features/indexer.feature
+++ b/integration_tests/tests/features/indexer.feature
@@ -143,7 +143,7 @@ Feature: Indexer node
     Then the indexer INDEXER catalogue name filter nonexistent_xyz returns 0 results
 
     # Non-existent template address should return 404
-    Then the indexer INDEXER catalogue entry for address "template_0000000000000000000000000000000000000000000000000000000000000000" is not found
+    Then the indexer INDEXER catalogue entry for address "template_deadbeefcafef00d0badc0de0feedface1234567890abcdef0123456789abcd" is not found
 
   @catalogue_pagination
   Scenario: Indexer template catalogue pagination works


### PR DESCRIPTION
## Summary
- Adds a `resource_address` query param to `/transactions/events/stream` so SSE consumers can subscribe to all activity for a specific token server-side.
- Derives the address from `substate_id` for `std.resource.*` events (create/mint/recall/freeze/unfreeze/update_access_rules/update_nonfungible_data) or the `resource_address` payload entry for `std.vault.deposit` / `std.vault.withdraw`.
- New nullable indexed `resource_address` column on `events`, populated at insert time using the same derivation so DB replay/catch-up matches the live filter.
- `TransactionEventFilter` in `ootle-rs` and `StreamTransactionEventsRequest` in the indexer client updated to forward the new field.

## Motivation
Previously, to track all deposits of a specific token (e.g. exchange deposit detection), a consumer had to subscribe to `std.vault.deposit` unfiltered — the `template_address` on vault events is the executing template (typically the account template), not the resource's template, so there was no server-side way to narrow the stream to a single resource. Consumers had to pull every vault event on the network and filter client-side.

## Test plan
- [x] Unit tests cover: vault deposit match via payload, resource mint match via substate_id, rejection when event has no resource, composition with other filters, empty filter, and unparseable payload values.
- [x] `cargo check --workspace` clean.
- [x] `cargo test -p tari_indexer --lib network_state_sync::event_filter` — 6 passed.
- [x] Manual SSE check against a running indexer (reviewer / follow-up).

## Notes
- Existing rows on deployed indexers will have `NULL` in the new column — only events inserted after the migration are filterable. No backfill included; can be added later if historical filtering is needed.