### PR TITLE
feat(engine)!: add UpdateMetadata resource action

### DIFF
--- a/bindings/src/types/ResourceAccessRules.ts
+++ b/bindings/src/types/ResourceAccessRules.ts
@@ -13,4 +13,10 @@ export type ResourceAccessRules = {
   update_non_fungible_data: AccessRule;
   update_access_rules: AccessRule;
   freeze: AccessRule;
+  /**
+   * Added post-launch. Appended last to keep bincode field positions stable for prior fields;
+   * this is still a breaking change for pre-existing substates because bincode cannot read a
+   * missing trailing field, so the chain must be reset or data migrated on upgrade.
+   */
+  update_metadata: AccessRule;
 };

--- a/crates/engine/src/runtime/impl.rs
+++ b/crates/engine/src/runtime/impl.rs
@@ -1239,7 +1239,11 @@ where
                 self.tracker.write_with(|state_mut| {
                     let resource_mut = state_mut.get_resource_mut(&resource_lock)?;
                     resource_mut.set_metadata(new_metadata);
-                    let payload = Metadata::from_iter([("resource_type", resource_mut.resource_type().to_string())]);
+                    let mut payload =
+                        Metadata::from_iter([("resource_type", resource_mut.resource_type().to_string())]);
+                    if let Some(symbol) = resource_mut.token_symbol() {
+                        payload.insert(TOKEN_SYMBOL, symbol);
+                    }
                     Self::emit_std_event("resource", "update_metadata", resource_address, payload, state_mut)?;
 
                     state_mut.unlock_substate(resource_lock)?;

--- a/crates/engine/src/runtime/impl.rs
+++ b/crates/engine/src/runtime/impl.rs
@@ -253,6 +253,22 @@ impl<TStore: StateReader + Clone + 'static, TTemplateProvider: TemplateProvider<
         })
     }
 
+    fn check_token_symbol_length(metadata: &Metadata) -> Result<(), RuntimeError> {
+        if let Some(symbol) = metadata.get(TOKEN_SYMBOL) &&
+            symbol.len() > limits::MAX_TOKEN_SYMBOL_LEN
+        {
+            return Err(RuntimeError::InvalidArgument {
+                argument: "metadata",
+                reason: format!(
+                    "token symbol exceeds {} bytes (got {})",
+                    limits::MAX_TOKEN_SYMBOL_LEN,
+                    symbol.len()
+                ),
+            });
+        }
+        Ok(())
+    }
+
     fn emit_std_event<T: Into<SubstateId>>(
         object_name: &str,
         action: &str,
@@ -856,6 +872,8 @@ where
                     });
                 }
 
+                Self::check_token_symbol_length(&arg.metadata)?;
+
                 let owner_rule = match arg.owner_rule {
                     OwnerRule::OwnedBySigner => SubstateOwnerRule::ByPublicKey(self.seal_signer_public_key),
                     OwnerRule::ByPublicKey(key) => SubstateOwnerRule::ByPublicKey(key),
@@ -1206,6 +1224,8 @@ where
                             reason: "UpdateMetadata resource action requires a resource address".to_string(),
                         })?;
                 let new_metadata: Metadata = args.assert_one_arg()?;
+
+                Self::check_token_symbol_length(&new_metadata)?;
 
                 let (resource_lock, maybe_auth_hook, auth_caller) = self.tracker.write_with(|state_mut| {
                     let resource_lock = state_mut.write_lock_substate(SubstateId::Resource(resource_address))?;

--- a/crates/engine/src/runtime/impl.rs
+++ b/crates/engine/src/runtime/impl.rs
@@ -1197,6 +1197,56 @@ where
                     Ok(InvokeResult::unit())
                 })
             },
+            ResourceAction::UpdateMetadata => {
+                let resource_address =
+                    resource_ref
+                        .as_resource_address()
+                        .ok_or_else(|| RuntimeError::InvalidArgument {
+                            argument: "resource_ref",
+                            reason: "UpdateMetadata resource action requires a resource address".to_string(),
+                        })?;
+                let new_metadata: Metadata = args.assert_one_arg()?;
+
+                let (resource_lock, maybe_auth_hook, auth_caller) = self.tracker.write_with(|state_mut| {
+                    let resource_lock = state_mut.write_lock_substate(SubstateId::Resource(resource_address))?;
+
+                    let resource = state_mut.get_resource(&resource_lock)?;
+
+                    state_mut.authorization().check_resource_access_rules(
+                        ResourceAuthAction::UpdateMetadata,
+                        resource.as_ownership(),
+                        resource.access_rules(),
+                    )?;
+
+                    // The token symbol is immutable once set.
+                    if let Some(existing_symbol) = resource.token_symbol() &&
+                        new_metadata.get(TOKEN_SYMBOL) != Some(existing_symbol)
+                    {
+                        return Err(RuntimeError::InvalidArgument {
+                            argument: "metadata",
+                            reason: "cannot update an existing token symbol".to_string(),
+                        });
+                    }
+
+                    let auth_caller = state_mut.get_auth_caller()?;
+                    Ok::<_, RuntimeError>((resource_lock, resource.auth_hook().cloned(), auth_caller))
+                })?;
+
+                if let Some(auth_hook) = maybe_auth_hook {
+                    self.invoke_resource_access_hook(auth_hook, auth_caller, ResourceAuthAction::UpdateMetadata)?;
+                }
+
+                self.tracker.write_with(|state_mut| {
+                    let resource_mut = state_mut.get_resource_mut(&resource_lock)?;
+                    resource_mut.set_metadata(new_metadata);
+                    let payload = Metadata::from_iter([("resource_type", resource_mut.resource_type().to_string())]);
+                    Self::emit_std_event("resource", "update_metadata", resource_address, payload, state_mut)?;
+
+                    state_mut.unlock_substate(resource_lock)?;
+
+                    Ok(InvokeResult::unit())
+                })
+            },
             ResourceAction::SetVaultFreeze => {
                 let resource_address =
                     resource_ref

--- a/crates/engine/tests/access_rules.rs
+++ b/crates/engine/tests/access_rules.rs
@@ -1130,4 +1130,79 @@ mod resource_access_rules {
             });
         })
     }
+
+    #[test]
+    fn update_metadata_denied_for_non_owner() {
+        let mut test = TemplateTest::new(CRATE_PATH, ["tests/templates/access_rules"]);
+
+        let (_, owner_proof, owner_key) = test.create_empty_account();
+        let (user_proof, _, user_key) = test.create_owner_proof();
+
+        let access_rules_template = test.get_template_address("AccessRulesTest");
+
+        let result = test.execute_expect_success(
+            Transaction::builder_localnet()
+                .call_function(access_rules_template, "with_configured_rules", args![
+                    OwnerRule::OwnedBySigner,
+                    ComponentAccessRules::new().default(AccessRule::AllowAll),
+                    // default update_metadata is DenyAll -> only owner may update
+                    ResourceAccessRules::new(),
+                    AccessRule::DenyAll,
+                ])
+                .build_and_seal(&owner_key),
+            vec![owner_proof],
+        );
+
+        let component_address = result.finalize.execution_results[0]
+            .decode::<ComponentAddress>()
+            .unwrap();
+
+        let mut new_metadata = Metadata::new();
+        new_metadata.insert("description", "updated");
+
+        let reason = test.execute_expect_failure(
+            Transaction::builder_localnet()
+                .call_method(component_address, "set_tokens_metadata", args![new_metadata])
+                .build_and_seal(&user_key),
+            vec![user_proof],
+        );
+
+        assert_access_denied_for_action(reason, ResourceAuthAction::UpdateMetadata);
+    }
+
+    #[test]
+    fn update_metadata_allowed_by_custom_rule() {
+        let mut test = TemplateTest::new(CRATE_PATH, ["tests/templates/access_rules"]);
+
+        let (_, owner_proof, owner_key) = test.create_empty_account();
+        let (user_proof, _, user_key) = test.create_owner_proof();
+
+        let access_rules_template = test.get_template_address("AccessRulesTest");
+
+        let result = test.execute_expect_success(
+            Transaction::builder_localnet()
+                .call_function(access_rules_template, "with_configured_rules", args![
+                    OwnerRule::OwnedBySigner,
+                    ComponentAccessRules::new().default(AccessRule::AllowAll),
+                    ResourceAccessRules::new().update_metadata(rule!(non_fungible(user_proof.clone()))),
+                    AccessRule::DenyAll,
+                ])
+                .build_and_seal(&owner_key),
+            vec![owner_proof],
+        );
+
+        let component_address = result.finalize.execution_results[0]
+            .decode::<ComponentAddress>()
+            .unwrap();
+
+        let mut new_metadata = Metadata::new();
+        new_metadata.insert("description", "updated by user");
+
+        test.execute_expect_success(
+            Transaction::builder_localnet()
+                .call_method(component_address, "set_tokens_metadata", args![new_metadata])
+                .build_and_seal(&user_key),
+            vec![user_proof],
+        );
+    }
 }

--- a/crates/engine/tests/resource.rs
+++ b/crates/engine/tests/resource.rs
@@ -86,6 +86,49 @@ fn update_metadata_rejects_symbol_drop() {
 }
 
 #[test]
+fn create_rejects_oversized_token_symbol() {
+    let mut test = TemplateTest::new(CRATE_PATH, vec!["tests/templates/resource", "tests/templates/metadata"]);
+    let key = test.secret_key().clone();
+    // 11 bytes — one over the 10-byte limit
+    let symbol = "OVERSIZEDSY".to_string();
+    let reason = test.execute_expect_failure(
+        test.transaction()
+            .call_function(
+                test.get_template_address("MetadataTest"),
+                "new_with_custom_symbol",
+                args![symbol],
+            )
+            .build_and_seal(&key),
+        vec![],
+    );
+    assert!(
+        reason.to_string().to_lowercase().contains("token symbol"),
+        "expected token-symbol-length reason, got: {reason}"
+    );
+}
+
+#[test]
+fn update_metadata_rejects_oversized_token_symbol() {
+    let mut test = TemplateTest::new(CRATE_PATH, vec!["tests/templates/resource", "tests/templates/metadata"]);
+    let component: ComponentAddress = test.call_function("MetadataTest", "new_without_symbol", args![], vec![]);
+
+    let mut new_metadata = Metadata::new();
+    // 11 bytes — one over the 10-byte limit
+    new_metadata.insert("SYMBOL", "OVERSIZEDSY");
+    let key = test.secret_key().clone();
+    let reason = test.execute_expect_failure(
+        test.transaction()
+            .call_method(component, "set_metadata", args![new_metadata])
+            .build_and_seal(&key),
+        vec![],
+    );
+    assert!(
+        reason.to_string().to_lowercase().contains("token symbol"),
+        "expected token-symbol-length reason, got: {reason}"
+    );
+}
+
+#[test]
 fn update_metadata_can_set_symbol_when_not_previously_set() {
     let mut test = TemplateTest::new(CRATE_PATH, vec!["tests/templates/resource", "tests/templates/metadata"]);
     let component: ComponentAddress = test.call_function("MetadataTest", "new_without_symbol", args![], vec![]);

--- a/crates/engine/tests/resource.rs
+++ b/crates/engine/tests/resource.rs
@@ -2,7 +2,7 @@
 //   SPDX-License-Identifier: BSD-3-Clause
 
 use tari_ootle_transaction::args;
-use tari_template_lib::types::ComponentAddress;
+use tari_template_lib::types::{ComponentAddress, Metadata, ResourceAddress};
 use tari_template_test_tooling::{TemplateTest, support::confidential::generate_confidential_output_statement};
 
 const CRATE_PATH: &str = env!("CARGO_MANIFEST_DIR");
@@ -27,4 +27,89 @@ fn confidential_join() {
     let component: ComponentAddress = test.call_function("ResourceTest", "new", args![], vec![]);
     let (output, _, _) = generate_confidential_output_statement(1000, None);
     test.call_method::<()>(component, "confidential_join", args![output], vec![]);
+}
+
+#[test]
+fn update_metadata_succeeds() {
+    let mut test = TemplateTest::new(CRATE_PATH, vec!["tests/templates/resource", "tests/templates/metadata"]);
+    let component: ComponentAddress = test.call_function("MetadataTest", "new_with_symbol", args![], vec![]);
+    let resource_address: ResourceAddress = test.call_method(component, "resource_address", args![], vec![]);
+
+    let mut new_metadata = Metadata::new();
+    new_metadata.insert("SYMBOL", "FOO");
+    new_metadata.insert("description", "A fine token");
+    test.call_method::<()>(component, "set_metadata", args![new_metadata], vec![]);
+
+    let resource = test.read_only_state_store().get_resource(&resource_address).unwrap();
+    assert_eq!(resource.metadata().get("description"), Some("A fine token"));
+    assert_eq!(resource.metadata().get("SYMBOL"), Some("FOO"));
+}
+
+#[test]
+fn update_metadata_rejects_symbol_change() {
+    let mut test = TemplateTest::new(CRATE_PATH, vec!["tests/templates/resource", "tests/templates/metadata"]);
+    let component: ComponentAddress = test.call_function("MetadataTest", "new_with_symbol", args![], vec![]);
+
+    let mut new_metadata = Metadata::new();
+    new_metadata.insert("SYMBOL", "BAR");
+    let key = test.secret_key().clone();
+    let reason = test.execute_expect_failure(
+        test.transaction()
+            .call_method(component, "set_metadata", args![new_metadata])
+            .build_and_seal(&key),
+        vec![],
+    );
+    assert!(
+        reason.to_string().to_lowercase().contains("token symbol"),
+        "expected symbol-immutability reason, got: {reason}"
+    );
+}
+
+#[test]
+fn update_metadata_rejects_symbol_drop() {
+    let mut test = TemplateTest::new(CRATE_PATH, vec!["tests/templates/resource", "tests/templates/metadata"]);
+    let component: ComponentAddress = test.call_function("MetadataTest", "new_with_symbol", args![], vec![]);
+
+    let mut new_metadata = Metadata::new();
+    new_metadata.insert("description", "symbol-less");
+    let key = test.secret_key().clone();
+    let reason = test.execute_expect_failure(
+        test.transaction()
+            .call_method(component, "set_metadata", args![new_metadata])
+            .build_and_seal(&key),
+        vec![],
+    );
+    assert!(
+        reason.to_string().to_lowercase().contains("token symbol"),
+        "expected symbol-immutability reason, got: {reason}"
+    );
+}
+
+#[test]
+fn update_metadata_can_set_symbol_when_not_previously_set() {
+    let mut test = TemplateTest::new(CRATE_PATH, vec!["tests/templates/resource", "tests/templates/metadata"]);
+    let component: ComponentAddress = test.call_function("MetadataTest", "new_without_symbol", args![], vec![]);
+    let resource_address: ResourceAddress = test.call_method(component, "resource_address", args![], vec![]);
+
+    let mut first = Metadata::new();
+    first.insert("SYMBOL", "NEW");
+    test.call_method::<()>(component, "set_metadata", args![first], vec![]);
+
+    let resource = test.read_only_state_store().get_resource(&resource_address).unwrap();
+    assert_eq!(resource.metadata().get("SYMBOL"), Some("NEW"));
+
+    // Now it's set, further changes must be rejected.
+    let mut second = Metadata::new();
+    second.insert("SYMBOL", "CHANGED");
+    let key = test.secret_key().clone();
+    let reason = test.execute_expect_failure(
+        test.transaction()
+            .call_method(component, "set_metadata", args![second])
+            .build_and_seal(&key),
+        vec![],
+    );
+    assert!(
+        reason.to_string().to_lowercase().contains("token symbol"),
+        "expected symbol-immutability reason, got: {reason}"
+    );
 }

--- a/crates/engine/tests/templates/access_rules/src/lib.rs
+++ b/crates/engine/tests/templates/access_rules/src/lib.rs
@@ -314,6 +314,10 @@ mod access_rules_template {
             ResourceManager::get(self.tokens.resource_address()).set_access_rules(access_rules);
         }
 
+        pub fn set_tokens_metadata(&mut self, metadata: Metadata) {
+            ResourceManager::get(self.tokens.resource_address()).set_metadata(metadata);
+        }
+
         pub fn create_proof_from_bucket(bucket: Bucket) -> Proof {
             bucket.create_proof()
         }

--- a/crates/engine/tests/templates/metadata/Cargo.toml
+++ b/crates/engine/tests/templates/metadata/Cargo.toml
@@ -1,0 +1,11 @@
+[workspace]
+[package]
+name = "metadata"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+tari_template_lib = { path = "../../../../template_lib" }
+
+[lib]
+crate-type = ["cdylib"]

--- a/crates/engine/tests/templates/metadata/src/lib.rs
+++ b/crates/engine/tests/templates/metadata/src/lib.rs
@@ -1,0 +1,46 @@
+//   Copyright 2024 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+use tari_template_lib::prelude::*;
+
+#[template]
+mod template {
+    use super::*;
+
+    pub struct MetadataTest {
+        fungible: Vault,
+    }
+
+    impl MetadataTest {
+        pub fn new_with_symbol() -> Component<Self> {
+            let fungible = ResourceBuilder::public_fungible()
+                .with_token_symbol("FOO")
+                .update_metadata(rule!(allow_all))
+                .initial_supply(1000u32);
+            Component::new(Self {
+                fungible: Vault::from_bucket(fungible),
+            })
+            .with_access_rules(AccessRules::allow_all())
+            .create()
+        }
+
+        pub fn new_without_symbol() -> Component<Self> {
+            let fungible = ResourceBuilder::public_fungible()
+                .update_metadata(rule!(allow_all))
+                .initial_supply(1000u32);
+            Component::new(Self {
+                fungible: Vault::from_bucket(fungible),
+            })
+            .with_access_rules(AccessRules::allow_all())
+            .create()
+        }
+
+        pub fn resource_address(&self) -> ResourceAddress {
+            self.fungible.resource_address()
+        }
+
+        pub fn set_metadata(&self, metadata: Metadata) {
+            ResourceManager::get(self.fungible.resource_address()).set_metadata(metadata);
+        }
+    }
+}

--- a/crates/engine/tests/templates/metadata/src/lib.rs
+++ b/crates/engine/tests/templates/metadata/src/lib.rs
@@ -24,6 +24,18 @@ mod template {
             .create()
         }
 
+        pub fn new_with_custom_symbol(symbol: String) -> Component<Self> {
+            let fungible = ResourceBuilder::public_fungible()
+                .with_token_symbol(symbol)
+                .update_metadata(rule!(allow_all))
+                .initial_supply(1000u32);
+            Component::new(Self {
+                fungible: Vault::from_bucket(fungible),
+            })
+            .with_access_rules(AccessRules::allow_all())
+            .create()
+        }
+
         pub fn new_without_symbol() -> Component<Self> {
             let fungible = ResourceBuilder::public_fungible()
                 .update_metadata(rule!(allow_all))

--- a/crates/engine_types/src/limits.rs
+++ b/crates/engine_types/src/limits.rs
@@ -49,6 +49,8 @@ pub const ENGINE_LIMITS: EngineLimits = EngineLimits {
 
 pub const MAX_DIVISIBILITY: u8 = 18;
 
+pub const MAX_TOKEN_SYMBOL_LEN: usize = 10;
+
 pub struct StealthLimits {
     pub max_inputs: usize,
     pub max_outputs: usize,

--- a/crates/engine_types/src/resource.rs
+++ b/crates/engine_types/src/resource.rs
@@ -202,6 +202,10 @@ impl Resource {
         &mut self.metadata
     }
 
+    pub fn set_metadata(&mut self, metadata: Metadata) {
+        self.metadata = metadata;
+    }
+
     pub fn token_symbol(&self) -> Option<&str> {
         self.metadata.get(TOKEN_SYMBOL)
     }

--- a/crates/template_lib/src/args/types.rs
+++ b/crates/template_lib/src/args/types.rs
@@ -196,6 +196,9 @@ pub enum ResourceAction {
     SetStealthUtxosFreeze,
     /// Burns a stealth UTXO of a resource
     StealthUtxoBurn,
+    /// Update the metadata of a resource (token symbol remains immutable once set).
+    /// Appended at the end to keep bincode discriminants stable for prior variants.
+    UpdateMetadata,
 }
 
 /// All the possible minting operation types

--- a/crates/template_lib/src/resource/builder/confidential.rs
+++ b/crates/template_lib/src/resource/builder/confidential.rs
@@ -170,6 +170,13 @@ impl ConfidentialResourceBuilder {
         self
     }
 
+    /// Sets up who (apart from the owner) can update the resource's metadata. The token symbol
+    /// remains immutable once set.
+    pub fn update_metadata(mut self, rule: AccessRule) -> Self {
+        self.access_rules = self.access_rules.update_metadata(rule);
+        self
+    }
+
     /// Sets up the specified `symbol` as the token symbol in the metadata of the resource
     pub fn with_token_symbol<S: Into<String>>(mut self, symbol: S) -> Self {
         self.token_symbol = Some(symbol.into());

--- a/crates/template_lib/src/resource/builder/fungible.rs
+++ b/crates/template_lib/src/resource/builder/fungible.rs
@@ -262,6 +262,13 @@ impl FungibleResourceBuilder {
         self
     }
 
+    /// Sets up who (apart from the owner) can update the resource's metadata. The token symbol
+    /// remains immutable once set.
+    pub fn update_metadata(mut self, rule: AccessRule) -> Self {
+        self.access_rules = self.access_rules.update_metadata(rule);
+        self
+    }
+
     /// Sets up the specified `symbol` as the token symbol in the metadata of the resource
     ///
     /// # Examples

--- a/crates/template_lib/src/resource/builder/non_fungible.rs
+++ b/crates/template_lib/src/resource/builder/non_fungible.rs
@@ -140,6 +140,13 @@ impl NonFungibleResourceBuilder {
         self
     }
 
+    /// Sets up who (apart from the owner) can update the resource's metadata. The token symbol
+    /// remains immutable once set.
+    pub fn update_metadata(mut self, rule: AccessRule) -> Self {
+        self.access_rules = self.access_rules.update_metadata(rule);
+        self
+    }
+
     /// Sets up the specified `symbol` as the token symbol in the metadata of the resource
     pub fn with_token_symbol<S: Into<String>>(mut self, symbol: S) -> Self {
         self.token_symbol = Some(symbol.into());

--- a/crates/template_lib/src/resource/builder/stealth.rs
+++ b/crates/template_lib/src/resource/builder/stealth.rs
@@ -154,6 +154,13 @@ impl StealthResourceBuilder {
         self
     }
 
+    /// Sets up whom (apart from the owner) can update the resource's metadata. The token symbol
+    /// remains immutable once set.
+    pub fn update_metadata(mut self, rule: AccessRule) -> Self {
+        self.access_rules = self.access_rules.update_metadata(rule);
+        self
+    }
+
     /// Sets up the specified `symbol` as the token symbol in the metadata of the resource
     pub fn with_token_symbol<S: Into<String>>(mut self, symbol: S) -> Self {
         self.token_symbol = Some(symbol.into());

--- a/crates/template_lib/src/resource/manager.rs
+++ b/crates/template_lib/src/resource/manager.rs
@@ -937,6 +937,26 @@ impl ResourceManager {
         resp.decode().expect("[set_access_rules] Failed")
     }
 
+    /// Replaces the resource's metadata map.
+    ///
+    /// The token symbol (`SYMBOL` key) is immutable once set: if the resource already has a symbol,
+    /// `metadata` must carry that exact same symbol or the transaction is rejected. If the resource
+    /// has no symbol yet, the caller may set one for the first time, and it becomes immutable thereafter.
+    ///
+    /// # Panics
+    ///
+    /// - The caller does not have the necessary [`ResourceAccessRules`] or [`OwnerRule`] to update the metadata.
+    /// - The new metadata would change or drop an existing token symbol.
+    pub fn set_metadata(&self, metadata: Metadata) {
+        let resp: InvokeResult = call_engine(EngineOp::ResourceInvoke, &ResourceInvokeArg {
+            resource_ref: self.resource_address.into(),
+            action: ResourceAction::UpdateMetadata,
+            args: invoke_args![metadata],
+        });
+
+        resp.decode().expect("[set_metadata] Failed")
+    }
+
     /// Freezes all withdrawals, deposits and burns for the specified vault.
     pub fn freeze_vault(&self, vault_id: VaultId) {
         self.set_freeze_vault_flags(vault_id, VaultFreezeFlags::all());

--- a/crates/template_lib_types/src/access_rules.rs
+++ b/crates/template_lib_types/src/access_rules.rs
@@ -204,6 +204,8 @@ pub enum ResourceAuthAction {
     UpdateNonFungibleData,
     UpdateAccessRules,
     Freeze,
+    /// Appended at the end to keep bincode discriminants stable for prior variants.
+    UpdateMetadata,
 }
 
 impl ResourceAuthAction {
@@ -225,6 +227,10 @@ pub struct ResourceAccessRules {
     update_non_fungible_data: AccessRule,
     update_access_rules: AccessRule,
     freeze: AccessRule,
+    /// Added post-launch. Appended last to keep bincode field positions stable for prior fields;
+    /// this is still a breaking change for pre-existing substates because bincode cannot read a
+    /// missing trailing field, so the chain must be reset or data migrated on upgrade.
+    update_metadata: AccessRule,
 }
 
 impl ResourceAccessRules {
@@ -241,6 +247,7 @@ impl ResourceAccessRules {
             burnable: AccessRule::DenyAll,
             recallable: AccessRule::DenyAll,
             update_access_rules: AccessRule::DenyAll,
+            update_metadata: AccessRule::DenyAll,
             freeze: AccessRule::DenyAll,
             // But explicitly disable withdrawing, updating and/or depositing
             withdrawable: AccessRule::AllowAll,
@@ -256,6 +263,7 @@ impl ResourceAccessRules {
             burnable: AccessRule::DenyAll,
             recallable: AccessRule::DenyAll,
             update_access_rules: AccessRule::DenyAll,
+            update_metadata: AccessRule::DenyAll,
             withdrawable: AccessRule::DenyAll,
             depositable: AccessRule::DenyAll,
             update_non_fungible_data: AccessRule::DenyAll,
@@ -313,6 +321,12 @@ impl ResourceAccessRules {
         self
     }
 
+    /// Sets up who can update the resource's metadata. The token symbol remains immutable once set.
+    pub fn update_metadata(mut self, rule: AccessRule) -> Self {
+        self.update_metadata = rule;
+        self
+    }
+
     /// Returns a reference to the access rule for the specified action
     pub fn get_access_rule(&self, action: &ResourceAuthAction) -> &AccessRule {
         match action {
@@ -323,6 +337,7 @@ impl ResourceAccessRules {
             ResourceAuthAction::Deposit => &self.depositable,
             ResourceAuthAction::UpdateNonFungibleData => &self.update_non_fungible_data,
             ResourceAuthAction::UpdateAccessRules => &self.update_access_rules,
+            ResourceAuthAction::UpdateMetadata => &self.update_metadata,
             ResourceAuthAction::Freeze => &self.freeze,
         }
     }


### PR DESCRIPTION
## Summary

- Adds a runtime path for templates to update a resource's metadata after creation via `ResourceManager::set_metadata`.
- New `ResourceAction::UpdateMetadata` / `ResourceAuthAction::UpdateMetadata` plus an `update_metadata` field on `ResourceAccessRules` (defaults to `DenyAll`, with owner-rule fallback) — wired through the four resource builders.
- Token-symbol immutability: once set, attempts to change or drop `SYMBOL` fail loudly with `InvalidArgument { reason: "cannot update an existing token symbol" }`. If no symbol was previously set, one may be set and becomes immutable thereafter.

## Notes

This is a breaking substate-shape change: `ResourceAccessRules` gains a trailing field, and since the RocksDB codec uses non-self-describing bincode, pre-upgrade resource substates will not decode. Acceptable for the current state of the chain, but a proper non-breaking mechanism would need schema versioning baked into the substate hash preimage and wire format (not just the DB codec).

## Test plan

- [x] `cargo test -p tari_engine --test resource` — new symbol-immutability tests
- [x] `cargo test -p tari_engine --test access_rules` — new DenyAll + custom-rule auth tests
- [x] `cargo check --workspace`
- [x] `cargo clippy --workspace --all-targets`
- [x] `cargo +nightly-2025-06-25 fmt --all`