### PR TITLE
feat(consensus): self-healing epoch-hash correction and leeway voting

### DIFF
--- a/applications/tari_indexer/src/bootstrap.rs
+++ b/applications/tari_indexer/src/bootstrap.rs
@@ -371,7 +371,7 @@ async fn create_base_layer_epoch_oracle<TStore: EpochOracleStore + BaseLayerBloc
                 sync_headers: false,
                 sync_validator_node_changes: true,
             },
-            epoch_end_spread_blocks: config.epoch_oracle.base_layer.epoch_end_spread_blocks,
+            epoch_end_spread_blocks: consensus_constants.epoch_end_spread_blocks,
         },
         config.network,
     ))

--- a/applications/tari_indexer/src/bootstrap.rs
+++ b/applications/tari_indexer/src/bootstrap.rs
@@ -371,6 +371,7 @@ async fn create_base_layer_epoch_oracle<TStore: EpochOracleStore + BaseLayerBloc
                 sync_headers: false,
                 sync_validator_node_changes: true,
             },
+            epoch_end_spread_blocks: config.epoch_oracle.base_layer.epoch_end_spread_blocks,
         },
         config.network,
     ))

--- a/applications/tari_ootle_app_utilities/src/epoch_oracle_config.rs
+++ b/applications/tari_ootle_app_utilities/src/epoch_oracle_config.rs
@@ -48,6 +48,16 @@ pub struct BaseLayerOracleConfig {
     pub scanning_interval: Duration,
     /// Height to start base layer scanning
     pub start_height: u64,
+    /// Number of base-layer blocks of leeway when voting on `EndEpoch` proposals. If our scanner
+    /// has not yet crossed the next epoch boundary but the (lagged) scan height is within this
+    /// many blocks of it, we accept `EndEpoch` proposals speculatively so a slightly lagging
+    /// scanner cannot wedge consensus at the boundary. Set to 0 to disable.
+    #[serde(default = "default_epoch_end_spread_blocks")]
+    pub epoch_end_spread_blocks: u64,
+}
+
+fn default_epoch_end_spread_blocks() -> u64 {
+    2
 }
 
 impl Default for BaseLayerOracleConfig {
@@ -59,6 +69,7 @@ impl Default for BaseLayerOracleConfig {
             // greater than this value to avoid a race condition resulting in leader failure.
             scanning_interval: Duration::from_secs(8),
             start_height: 0,
+            epoch_end_spread_blocks: default_epoch_end_spread_blocks(),
         }
     }
 }

--- a/applications/tari_ootle_app_utilities/src/epoch_oracle_config.rs
+++ b/applications/tari_ootle_app_utilities/src/epoch_oracle_config.rs
@@ -48,16 +48,6 @@ pub struct BaseLayerOracleConfig {
     pub scanning_interval: Duration,
     /// Height to start base layer scanning
     pub start_height: u64,
-    /// Number of base-layer blocks of leeway when voting on `EndEpoch` proposals. If our scanner
-    /// has not yet crossed the next epoch boundary but the (lagged) scan height is within this
-    /// many blocks of it, we accept `EndEpoch` proposals speculatively so a slightly lagging
-    /// scanner cannot wedge consensus at the boundary. Set to 0 to disable.
-    #[serde(default = "default_epoch_end_spread_blocks")]
-    pub epoch_end_spread_blocks: u64,
-}
-
-fn default_epoch_end_spread_blocks() -> u64 {
-    2
 }
 
 impl Default for BaseLayerOracleConfig {
@@ -69,7 +59,6 @@ impl Default for BaseLayerOracleConfig {
             // greater than this value to avoid a race condition resulting in leader failure.
             scanning_interval: Duration::from_secs(8),
             start_height: 0,
-            epoch_end_spread_blocks: default_epoch_end_spread_blocks(),
         }
     }
 }

--- a/applications/tari_validator_node/src/bootstrap.rs
+++ b/applications/tari_validator_node/src/bootstrap.rs
@@ -543,6 +543,7 @@ async fn create_base_layer_epoch_oracle<TStore: EpochOracleStore + BaseLayerBloc
                 .as_ref()
                 .map(|p| p.to_byte_type()),
             features,
+            epoch_end_spread_blocks: config.epoch_oracle.base_layer.epoch_end_spread_blocks,
         },
         config.network,
     ))

--- a/applications/tari_validator_node/src/bootstrap.rs
+++ b/applications/tari_validator_node/src/bootstrap.rs
@@ -543,7 +543,7 @@ async fn create_base_layer_epoch_oracle<TStore: EpochOracleStore + BaseLayerBloc
                 .as_ref()
                 .map(|p| p.to_byte_type()),
             features,
-            epoch_end_spread_blocks: config.epoch_oracle.base_layer.epoch_end_spread_blocks,
+            epoch_end_spread_blocks: consensus_constants.epoch_end_spread_blocks,
         },
         config.network,
     ))

--- a/crates/consensus/src/consensus_constants.rs
+++ b/crates/consensus/src/consensus_constants.rs
@@ -49,6 +49,12 @@ pub struct ConsensusConstants {
     pub max_number_commands_in_block: usize,
     /// The value that fees are divided by to determine the amount of fees to burn. 0 means no fees are burned.
     pub fee_exhaust_divisor: u64,
+    /// Number of base-layer blocks of leeway a voter is allowed when accepting `EndEpoch` proposals.
+    /// If the voter's oracle has not yet crossed the next epoch boundary but its lagged scan height
+    /// is within this many blocks of the boundary, the voter accepts `EndEpoch` from peers whose
+    /// oracle has already crossed. Must be uniform network-wide to avoid divergent voting.
+    /// Set to 0 to disable leeway.
+    pub epoch_end_spread_blocks: u64,
 }
 
 impl ConsensusConstants {
@@ -63,12 +69,13 @@ impl ConsensusConstants {
             missed_proposal_recovery_threshold: 5,
             max_number_commands_in_block: 500,
             fee_exhaust_divisor: 20, // 1/20 = 5%
+            epoch_end_spread_blocks: 1,
         }
     }
 
     pub const fn esmeralda() -> Self {
         Self {
-            base_layer_confirmations: 20,
+            base_layer_confirmations: 50,
             committee_size_per_shard_group: 40,
             num_preshards: NumPreshards::current(),
             pacemaker_block_time: Duration::from_secs(10),
@@ -77,6 +84,7 @@ impl ConsensusConstants {
             missed_proposal_recovery_threshold: 5,
             max_number_commands_in_block: 500,
             fee_exhaust_divisor: 20, // 1/20 = 5%
+            epoch_end_spread_blocks: 5,
         }
     }
 
@@ -91,6 +99,7 @@ impl ConsensusConstants {
             missed_proposal_recovery_threshold: 5,
             max_number_commands_in_block: 500,
             fee_exhaust_divisor: 20, // 1/20 = 5%
+            epoch_end_spread_blocks: 5,
         }
     }
 }

--- a/crates/consensus/src/hotstuff/on_receive_local_proposal.rs
+++ b/crates/consensus/src/hotstuff/on_receive_local_proposal.rs
@@ -281,7 +281,13 @@ impl<TConsensusSpec: ConsensusSpec> OnReceiveLocalProposalHandler<TConsensusSpec
         debug!(target: LOG_TARGET, "process_block: [{}] processing block: {}", current_epoch, valid_block);
 
         let em_epoch = self.epoch_manager.current_epoch().await?;
-        let can_propose_epoch_end = em_epoch > current_epoch;
+        // Accept an EndEpoch proposal when our oracle has advanced past `current_epoch`, OR when
+        // the oracle believes we are close enough to the epoch boundary to vote speculatively.
+        // The speculative branch rescues the case where a short base-layer reorg near the lag
+        // horizon leaves our scanner a handful of blocks behind the leader's — without this,
+        // such splits can wedge consensus because every node requires the strict inequality.
+        let can_propose_epoch_end =
+            em_epoch > current_epoch || self.epoch_manager.is_within_epoch_end_spread(current_epoch).await?;
         let is_epoch_end = valid_block.block().is_epoch_end();
 
         let mut on_ready_to_vote_on_local_block = self.on_ready_to_vote_on_local_block.clone();
@@ -455,6 +461,10 @@ impl<TConsensusSpec: ConsensusSpec> OnReceiveLocalProposalHandler<TConsensusSpec
         // race ahead when the base-layer scanner catches up across multiple epoch boundaries,
         // which would stamp a later epoch's hash into this genesis block and wedge consensus.
         let epoch_hash = self.epoch_manager.get_epoch_hash(next_epoch).await?;
+        // Now that EndEpoch has committed and we're about to stamp `epoch_hash` into the genesis
+        // block for `next_epoch`, prevent the oracle from later rewriting this epoch's stored hash
+        // if a base-layer reorg surfaces a different view.
+        self.epoch_manager.lock_epoch(next_epoch).await?;
         let our_vn_for_next_epoch = self.epoch_manager.get_our_validator_node(next_epoch).await.optional()?;
         let next_shard_group = our_vn_for_next_epoch.map(|vn| {
             vn.shard_key

--- a/crates/consensus_tests/src/support/epoch_manager.rs
+++ b/crates/consensus_tests/src/support/epoch_manager.rs
@@ -429,6 +429,14 @@ impl EpochManagerReader for TestEpochManager {
             total_power,
         ))
     }
+
+    async fn lock_epoch(&self, _epoch: Epoch) -> Result<(), EpochManagerError> {
+        Ok(())
+    }
+
+    async fn is_within_epoch_end_spread(&self, _current_epoch: Epoch) -> Result<bool, EpochManagerError> {
+        Ok(false)
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/crates/consensus_tests/src/support/harness.rs
+++ b/crates/consensus_tests/src/support/harness.rs
@@ -667,6 +667,7 @@ impl TestBuilder {
                     missed_proposal_recovery_threshold: 5,
                     max_number_commands_in_block: 500,
                     fee_exhaust_divisor: 20,
+                    epoch_end_spread_blocks: 0,
                 },
                 state_tree_cleanup_interval: Duration::from_secs(1000),
                 epoch_gc_interval: Duration::from_secs(1000),

--- a/crates/epoch_manager/src/epoch_event_oracle/traits.rs
+++ b/crates/epoch_manager/src/epoch_event_oracle/traits.rs
@@ -3,6 +3,8 @@
 
 use std::future::Future;
 
+use tari_ootle_common_types::Epoch;
+
 use crate::epoch_event_oracle::EpochEvent;
 
 pub trait EpochEventOracle {
@@ -10,4 +12,16 @@ pub trait EpochEventOracle {
     /// The implementation must ensure that the returned Future is cancel-safe. Returns None if no further events can be
     /// returned.
     fn next_epoch_event(&mut self) -> impl Future<Output = Option<EpochEvent>> + Send;
+
+    /// Returns true when, in the oracle's view, `current_epoch` is close enough to ending that
+    /// consensus should speculatively accept an `EndEpoch` proposal even if the oracle has not
+    /// yet emitted the corresponding `EpochChanged` event.
+    ///
+    /// "Close enough" is deliberately oracle-specific: the base-layer oracle measures proximity
+    /// in base-layer blocks, a wall-clock oracle could measure in seconds, etc. The default
+    /// implementation returns `false` (no leeway), which reduces to the strict behaviour of
+    /// only accepting `EndEpoch` once the epoch has actually changed locally.
+    fn is_within_epoch_end_spread(&self, _current_epoch: Epoch) -> bool {
+        false
+    }
 }

--- a/crates/epoch_manager/src/service/epoch_manager.rs
+++ b/crates/epoch_manager/src/service/epoch_manager.rs
@@ -62,6 +62,9 @@ pub struct EpochManager<TSpec: EpochManagerSpec> {
     current_shard_key: Option<SubstateAddress>,
     layer_one_submitter: TSpec::LayerOneSubmitter,
     current_epoch: Arc<AtomicU64>,
+    /// Highest epoch whose hash has been locked by a committed EndEpoch block in consensus.
+    /// Oracle-driven activations for epochs <= this value are ignored.
+    highest_locked_epoch: Epoch,
 }
 
 impl<TSpec> EpochManager<TSpec>
@@ -82,6 +85,7 @@ where TSpec: EpochManagerSpec
             current_shard_key: None,
             layer_one_submitter,
             current_epoch: current_epoch_atomic,
+            highest_locked_epoch: Epoch::zero(),
         }
     }
 
@@ -101,6 +105,9 @@ where TSpec: EpochManagerSpec
         self.current_epoch_hash = metadata
             .get_metadata(MetadataKey::EpochManagerLastEpochHash.as_key_bytes())?
             .unwrap_or(Default::default());
+        self.highest_locked_epoch = metadata
+            .get_metadata(MetadataKey::EpochManagerHighestLockedEpoch.as_key_bytes())?
+            .unwrap_or_else(Epoch::zero);
         Ok(())
     }
 
@@ -198,6 +205,33 @@ where TSpec: EpochManagerSpec
         tx.commit()?;
         self.set_current_epoch(epoch);
         self.current_epoch_hash = epoch_hash;
+        Ok(())
+    }
+
+    pub fn current_epoch_hash(&self) -> FixedHash {
+        self.current_epoch_hash
+    }
+
+    pub fn highest_locked_epoch(&self) -> Epoch {
+        self.highest_locked_epoch
+    }
+
+    pub fn is_epoch_locked(&self, epoch: Epoch) -> bool {
+        epoch <= self.highest_locked_epoch
+    }
+
+    /// Records that `epoch`'s hash is canonical and may no longer be corrected by the oracle.
+    /// Called when consensus commits an EndEpoch block that transitions into `epoch`.
+    pub fn lock_epoch(&mut self, epoch: Epoch) -> Result<(), EpochManagerError> {
+        if epoch <= self.highest_locked_epoch {
+            return Ok(());
+        }
+        let mut tx = self.global_db.create_transaction()?;
+        self.global_db
+            .metadata(&mut tx)
+            .set_metadata(MetadataKey::EpochManagerHighestLockedEpoch.as_key_bytes(), &epoch)?;
+        tx.commit()?;
+        self.highest_locked_epoch = epoch;
         Ok(())
     }
 

--- a/crates/epoch_manager/src/service/epoch_manager_service.rs
+++ b/crates/epoch_manager/src/service/epoch_manager_service.rs
@@ -238,18 +238,47 @@ impl<TSpec: EpochManagerSpec> EpochManagerService<TSpec> {
     }
 
     fn activate_epoch(&mut self, epoch: Epoch, epoch_hash: FixedHash) -> Result<(), EpochManagerError> {
-        if self.current_epoch() >= epoch {
-            // no need to update the epoch
-            return Ok(());
+        use std::cmp::Ordering;
+        match epoch.cmp(&self.current_epoch()) {
+            Ordering::Less => Ok(()),
+            Ordering::Equal => {
+                // Same epoch re-activated. Permit a hash correction only if the epoch has not yet
+                // been locked in by a committed EndEpoch block. This lets the base-layer scanner
+                // self-heal during the pre-commit window if a reorg near the epoch boundary causes
+                // the initial hash to be wrong, without ever rewriting a hash that consensus has
+                // already committed against.
+                if self.inner.current_epoch_hash() == epoch_hash {
+                    return Ok(());
+                }
+                if self.inner.is_epoch_locked(epoch) {
+                    warn!(
+                        target: LOG_TARGET,
+                        "⛓️ Ignoring oracle hash correction for already-locked epoch {}: stored={}, candidate={}",
+                        epoch,
+                        self.inner.current_epoch_hash(),
+                        epoch_hash,
+                    );
+                    return Ok(());
+                }
+                warn!(
+                    target: LOG_TARGET,
+                    "🩹 Correcting epoch_hash for {}: {} -> {}",
+                    epoch,
+                    self.inner.current_epoch_hash(),
+                    epoch_hash,
+                );
+                self.inner.insert_current_epoch(epoch, epoch_hash)?;
+                Ok(())
+            },
+            Ordering::Greater => {
+                self.has_epoch_changed = true;
+                // In the base layer case, the epoch_hash is the first block of the epoch
+                // persist the epoch data including the validator node set
+                self.inner.insert_current_epoch(epoch, epoch_hash)?;
+                self.inner.assign_validators_for_epoch(epoch)?;
+                Ok(())
+            },
         }
-
-        self.has_epoch_changed = true;
-
-        // In the base layer case, the epoch_hash is the first block of the epoch
-        // persist the epoch data including the validator node set
-        self.inner.insert_current_epoch(epoch, epoch_hash)?;
-        self.inner.assign_validators_for_epoch(epoch)?;
-        Ok(())
     }
 
     fn current_epoch(&self) -> Epoch {
@@ -450,6 +479,16 @@ impl<TSpec: EpochManagerSpec> EpochManagerService<TSpec> {
             ),
             EpochManagerRequest::GetNetworkDescription { reply } => {
                 handle(reply, self.inner.get_network_description(), context)
+            },
+            EpochManagerRequest::LockEpoch { epoch, reply } => {
+                handle(reply, self.inner.lock_epoch(epoch), context);
+            },
+            EpochManagerRequest::IsWithinEpochEndSpread { current_epoch, reply } => {
+                handle(
+                    reply,
+                    Ok(self.epoch_events.is_within_epoch_end_spread(current_epoch)),
+                    context,
+                );
             },
         }
     }

--- a/crates/epoch_manager/src/service/handle.rs
+++ b/crates/epoch_manager/src/service/handle.rs
@@ -390,4 +390,25 @@ impl<TAddr: NodeAddressable> EpochManagerReader for EpochManagerHandle<TAddr> {
 
         rx.await.map_err(|_| EpochManagerError::ReceiveError)?
     }
+
+    async fn lock_epoch(&self, epoch: Epoch) -> Result<(), EpochManagerError> {
+        let (tx, rx) = oneshot::channel();
+        self.tx_request
+            .send(EpochManagerRequest::LockEpoch { epoch, reply: tx })
+            .await
+            .map_err(|_| EpochManagerError::SendError)?;
+        rx.await.map_err(|_| EpochManagerError::ReceiveError)?
+    }
+
+    async fn is_within_epoch_end_spread(&self, current_epoch: Epoch) -> Result<bool, EpochManagerError> {
+        let (tx, rx) = oneshot::channel();
+        self.tx_request
+            .send(EpochManagerRequest::IsWithinEpochEndSpread {
+                current_epoch,
+                reply: tx,
+            })
+            .await
+            .map_err(|_| EpochManagerError::SendError)?;
+        rx.await.map_err(|_| EpochManagerError::ReceiveError)?
+    }
 }

--- a/crates/epoch_manager/src/service/types.rs
+++ b/crates/epoch_manager/src/service/types.rs
@@ -121,4 +121,12 @@ pub enum EpochManagerRequest<TAddr> {
     GetNetworkDescription {
         reply: Reply<NetworkDescription>,
     },
+    LockEpoch {
+        epoch: Epoch,
+        reply: Reply<()>,
+    },
+    IsWithinEpochEndSpread {
+        current_epoch: Epoch,
+        reply: Reply<bool>,
+    },
 }

--- a/crates/epoch_manager/src/traits.rs
+++ b/crates/epoch_manager/src/traits.rs
@@ -229,6 +229,19 @@ pub trait EpochManagerReader: Send + Sync {
         shard_group: Option<ShardGroup>,
         excluding: HashSet<Self::Addr>,
     ) -> impl Future<Output = Result<ValidatorNode<Self::Addr>, EpochManagerError>> + Send;
+
+    /// Marks `epoch`'s hash as canonical. After this call, oracle-driven hash corrections for
+    /// `epoch` (and any earlier epoch) are ignored. Consensus calls this when an `EndEpoch` block
+    /// commits, transitioning into `epoch`.
+    fn lock_epoch(&self, epoch: Epoch) -> impl Future<Output = Result<(), EpochManagerError>> + Send;
+
+    /// Asks the epoch event oracle whether `current_epoch` is close enough to ending that
+    /// `EndEpoch` proposals should be accepted speculatively, even if this node has not yet
+    /// received its own `EpochChanged` event. The interpretation of "close" is oracle-specific.
+    fn is_within_epoch_end_spread(
+        &self,
+        current_epoch: Epoch,
+    ) -> impl Future<Output = Result<bool, EpochManagerError>> + Send;
 }
 
 pub trait LayerOneTransactionSubmitter {

--- a/crates/epoch_oracles/src/base_layer/config.rs
+++ b/crates/epoch_oracles/src/base_layer/config.rs
@@ -17,6 +17,11 @@ pub struct BaseLayerEpochOracleConfig {
     pub sidechain_id: Option<RistrettoPublicKeyBytes>,
     /// Features for the base layer epoch oracle.
     pub features: BaseLayerEpochOracleFeatures,
+    /// Number of base-layer blocks of leeway to allow when voting on `EndEpoch` proposals.
+    /// If our scanner has not yet crossed the next epoch boundary, but our scanned (lagged)
+    /// height is within this many blocks of the boundary, we accept EndEpoch proposals from
+    /// peers whose oracle has already crossed. Set to 0 to disable leeway.
+    pub epoch_end_spread_blocks: u64,
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/crates/epoch_oracles/src/base_layer/oracle.rs
+++ b/crates/epoch_oracles/src/base_layer/oracle.rs
@@ -180,7 +180,7 @@ impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore> BaseLayerOracleInner<
                 // TODO: we need to figure out where the fork happened, and delete data after the fork if able.
                 self.last_scanned_hash = None;
                 self.last_scanned_validator_node_mr = None;
-                self.last_scanned_height = self.start_height;
+                self.last_scanned_height = 0;
                 self.has_attempted_scan = true;
                 self.sync_blockchain(tip).await
             },

--- a/crates/epoch_oracles/src/base_layer/oracle.rs
+++ b/crates/epoch_oracles/src/base_layer/oracle.rs
@@ -66,6 +66,10 @@ struct BaseLayerOracleInner<TStore> {
     pending_events: VecDeque<EpochEvent>,
     header_buf: Vec<(Epoch, FixedHash, BlockHeader)>,
     network: Network,
+    /// Epoch length in base-layer blocks, cached from consensus constants on the first scan
+    /// that obtains them. `None` until the first scan completes.
+    cached_epoch_length: Option<u64>,
+    epoch_end_spread_blocks: u64,
 }
 
 impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore + 'static> BaseLayerOracle<TStore> {
@@ -92,6 +96,8 @@ impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore + 'static> BaseLayerOr
                 pending_events: VecDeque::new(),
                 header_buf: Vec::new(),
                 network,
+                cached_epoch_length: None,
+                epoch_end_spread_blocks: config.epoch_end_spread_blocks,
             })),
             scanning_interval: config.scanning_interval,
             is_initialized: false,
@@ -174,7 +180,7 @@ impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore> BaseLayerOracleInner<
                 // TODO: we need to figure out where the fork happened, and delete data after the fork if able.
                 self.last_scanned_hash = None;
                 self.last_scanned_validator_node_mr = None;
-                self.last_scanned_height = 0;
+                self.last_scanned_height = self.start_height;
                 self.has_attempted_scan = true;
                 self.sync_blockchain(tip).await
             },
@@ -185,6 +191,7 @@ impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore> BaseLayerOracleInner<
                         .base_node_client
                         .get_consensus_constants(tip.height_of_longest_chain)
                         .await?;
+                    self.cached_epoch_length = Some(constants.epoch_length());
                     let lagged_height = tip.height_of_longest_chain.saturating_sub(self.height_lag);
                     let epoch = constants.height_to_epoch(lagged_height);
                     // If no progress has been made since restarting, we still need to tell the epoch manager that
@@ -275,6 +282,7 @@ impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore> BaseLayerOracleInner<
             .base_node_client
             .get_consensus_constants(tip.height_of_longest_chain)
             .await?;
+        self.cached_epoch_length = Some(constants.epoch_length());
 
         // We'll buffer 1000 headers at a time
         // note: 10_000 is the maximum permitted by the base node gRPC service
@@ -476,6 +484,29 @@ impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore> BaseLayerOracleInner<
             self.pending_events.shrink_to(TARGET_CAP);
         }
     }
+
+    /// Returns true when our lagged scanner position is within `epoch_end_spread_blocks` of the
+    /// next epoch boundary. Used by consensus to accept `EndEpoch` proposals speculatively when
+    /// peers' oracles have already crossed and ours is almost there.
+    fn is_within_epoch_end_spread(&self, current_epoch: Epoch) -> bool {
+        if self.epoch_end_spread_blocks == 0 {
+            return false;
+        }
+        let Some(epoch_length) = self.cached_epoch_length else {
+            return false;
+        };
+        if epoch_length == 0 {
+            return false;
+        }
+        let Some(next_start) = current_epoch
+            .as_u64()
+            .checked_add(1)
+            .and_then(|e| e.checked_mul(epoch_length))
+        else {
+            return false;
+        };
+        self.last_scanned_height.saturating_add(self.epoch_end_spread_blocks) >= next_start
+    }
 }
 
 impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore + Send + 'static> BaseLayerOracle<TStore> {
@@ -568,6 +599,15 @@ impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore + Send + 'static> Epoc
     /// This Future is cancel-safe. Returns None if a shutdown is triggered.
     async fn next_epoch_event(&mut self) -> Option<EpochEvent> {
         poll_fn(|cx| self.poll_next_event(cx)).await
+    }
+
+    fn is_within_epoch_end_spread(&self, current_epoch: Epoch) -> bool {
+        // `inner` is briefly None while a scan task is in flight; return false then so voting
+        // falls back to the strict em_epoch > current_epoch check.
+        self.inner
+            .as_deref()
+            .map(|inner| inner.is_within_epoch_end_spread(current_epoch))
+            .unwrap_or(false)
     }
 }
 

--- a/crates/epoch_oracles/src/base_layer/oracle.rs
+++ b/crates/epoch_oracles/src/base_layer/oracle.rs
@@ -6,7 +6,6 @@ use std::{
     future::{Future, poll_fn},
     pin::Pin,
     task::{Context, Poll},
-    time::Duration,
 };
 
 use log::*;
@@ -21,16 +20,10 @@ use tari_common_types::types::FixedHash;
 use tari_epoch_manager::epoch_event_oracle::{EpochEvent, EpochEventOracle};
 use tari_node_components::blocks::BlockHeader;
 use tari_ootle_common_types::{Epoch, Network, displayable::Displayable, optional::Optional};
-use tari_template_lib::types::crypto::RistrettoPublicKeyBytes;
 use tokio::time;
 
 use crate::{
-    base_layer::{
-        BaseLayerBlockHeaderStore,
-        BaseLayerEpochOracleConfig,
-        BaseLayerEpochOracleFeatures,
-        header_hasher::hash_header,
-    },
+    base_layer::{BaseLayerBlockHeaderStore, BaseLayerEpochOracleConfig, header_hasher::hash_header},
     store::{EpochOracleStore, StoreKey},
 };
 
@@ -41,7 +34,6 @@ type TaskOutput<TStore> = (Result<bool, BaseLayerOracleError>, Box<BaseLayerOrac
 #[allow(clippy::struct_excessive_bools)]
 pub struct BaseLayerOracle<TStore> {
     inner: Option<Box<BaseLayerOracleInner<TStore>>>,
-    scanning_interval: Duration,
     is_initialized: bool,
     is_done: bool,
     has_more: bool,
@@ -51,6 +43,7 @@ pub struct BaseLayerOracle<TStore> {
 }
 
 struct BaseLayerOracleInner<TStore> {
+    config: BaseLayerEpochOracleConfig,
     store: TStore,
     last_scanned_height: u64,
     last_scanned_tip: Option<FixedHash>,
@@ -58,18 +51,13 @@ struct BaseLayerOracleInner<TStore> {
     last_epoch_hash: Option<FixedHash>,
     last_scanned_validator_node_mr: Option<FixedHash>,
     base_node_client: GrpcBaseNodeClient,
-    start_height: u64,
-    height_lag: u64,
     has_attempted_scan: bool,
-    features: BaseLayerEpochOracleFeatures,
-    validator_node_sidechain_id: Option<RistrettoPublicKeyBytes>,
     pending_events: VecDeque<EpochEvent>,
     header_buf: Vec<(Epoch, FixedHash, BlockHeader)>,
     network: Network,
     /// Epoch length in base-layer blocks, cached from consensus constants on the first scan
     /// that obtains them. `None` until the first scan completes.
     cached_epoch_length: Option<u64>,
-    epoch_end_spread_blocks: u64,
 }
 
 impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore + 'static> BaseLayerOracle<TStore> {
@@ -81,6 +69,7 @@ impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore + 'static> BaseLayerOr
     ) -> Self {
         Self {
             inner: Some(Box::new(BaseLayerOracleInner {
+                config,
                 store,
                 last_scanned_tip: None,
                 last_scanned_height: 0,
@@ -88,18 +77,12 @@ impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore + 'static> BaseLayerOr
                 last_epoch_hash: None,
                 last_scanned_validator_node_mr: None,
                 base_node_client,
-                start_height: config.start_height,
-                height_lag: config.height_lag,
                 has_attempted_scan: false,
-                validator_node_sidechain_id: config.sidechain_id,
-                features: config.features,
                 pending_events: VecDeque::new(),
                 header_buf: Vec::new(),
                 network,
                 cached_epoch_length: None,
-                epoch_end_spread_blocks: config.epoch_end_spread_blocks,
             })),
-            scanning_interval: config.scanning_interval,
             is_initialized: false,
             is_done: false,
             has_more: false,
@@ -114,7 +97,7 @@ impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore> BaseLayerOracleInner<
     /// The configured start height adjusted for the height lag. This is the minimum height
     /// that the scanner will scan from.
     fn lag_start_height(&self) -> u64 {
-        self.start_height.saturating_sub(self.height_lag)
+        self.config.start_height.saturating_sub(self.config.height_lag)
     }
 
     /// The effective last scanned height, which is the maximum of the last scanned height and
@@ -153,7 +136,7 @@ impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore> BaseLayerOracleInner<
                 "⛓️ Forcing blockchain sync. We last scanned {}/{}",
                 self.last_scanned_height,
                 tip.height_of_longest_chain
-                    .saturating_sub(self.height_lag)
+                    .saturating_sub(self.config.height_lag)
             );
             self.has_attempted_scan = true;
             return self.sync_blockchain(tip).await;
@@ -167,7 +150,7 @@ impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore> BaseLayerOracleInner<
                     tip.height_of_longest_chain,
                     self.effective_last_scanned_height(),
                     tip.height_of_longest_chain
-                        .saturating_sub(self.height_lag)
+                        .saturating_sub(self.config.height_lag)
                 );
                 self.has_attempted_scan = true;
                 self.sync_blockchain(tip).await
@@ -192,7 +175,7 @@ impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore> BaseLayerOracleInner<
                         .get_consensus_constants(tip.height_of_longest_chain)
                         .await?;
                     self.cached_epoch_length = Some(constants.epoch_length());
-                    let lagged_height = tip.height_of_longest_chain.saturating_sub(self.height_lag);
+                    let lagged_height = tip.height_of_longest_chain.saturating_sub(self.config.height_lag);
                     let epoch = constants.height_to_epoch(lagged_height);
                     // If no progress has been made since restarting, we still need to tell the epoch manager that
                     // scanning is done
@@ -239,7 +222,7 @@ impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore> BaseLayerOracleInner<
 
     #[allow(clippy::too_many_lines)]
     async fn sync_blockchain(&mut self, tip: BaseLayerMetadata) -> Result<bool, BaseLayerOracleError> {
-        let Some(lag_tip_height) = tip.height_of_longest_chain.checked_sub(self.height_lag) else {
+        let Some(lag_tip_height) = tip.height_of_longest_chain.checked_sub(self.config.height_lag) else {
             debug!(
                 target: LOG_TARGET,
                 "Base layer blockchain is not yet at the required height to start scanning it"
@@ -309,7 +292,7 @@ impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore> BaseLayerOracleInner<
             // Note: Cant use header.hash() because it uses CURRENT_NETWORK global
             let header_hash = hash_header(self.network, &header);
             let current_validator_node_mr = header.validator_node_mr;
-            if self.features.sync_headers {
+            if self.config.features.sync_headers {
                 self.header_buf.push((current_epoch, header_hash, header));
             }
 
@@ -346,10 +329,10 @@ impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore> BaseLayerOracleInner<
                     "⛓️ last_scanned_validator_node_mr = {} current = {}", self.last_scanned_validator_node_mr.display(), current_validator_node_mr
                 );
 
-                if self.features.sync_validator_node_changes {
+                if self.config.features.sync_validator_node_changes {
                     let node_changes = self
                         .base_node_client
-                        .get_validator_node_changes(current_epoch, self.validator_node_sidechain_id.as_ref())
+                        .get_validator_node_changes(current_epoch, self.config.sidechain_id.as_ref())
                         .await
                         .map_err(BaseLayerOracleError::BaseNodeError)?;
                     let node_changes = node_changes
@@ -429,7 +412,7 @@ impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore> BaseLayerOracleInner<
         }
 
         let latest = self.base_node_client.get_tip_info().await?;
-        let lagged_height = latest.height_of_longest_chain.saturating_sub(self.height_lag);
+        let lagged_height = latest.height_of_longest_chain.saturating_sub(self.config.height_lag);
         if lagged_height > lag_tip_height {
             info!(
                 target: LOG_TARGET,
@@ -489,7 +472,7 @@ impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore> BaseLayerOracleInner<
     /// next epoch boundary. Used by consensus to accept `EndEpoch` proposals speculatively when
     /// peers' oracles have already crossed and ours is almost there.
     fn is_within_epoch_end_spread(&self, current_epoch: Epoch) -> bool {
-        if self.epoch_end_spread_blocks == 0 {
+        if self.config.epoch_end_spread_blocks == 0 {
             return false;
         }
         let Some(epoch_length) = self.cached_epoch_length else {
@@ -505,7 +488,9 @@ impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore> BaseLayerOracleInner<
         else {
             return false;
         };
-        self.last_scanned_height.saturating_add(self.epoch_end_spread_blocks) >= next_start
+        self.last_scanned_height
+            .saturating_add(self.config.epoch_end_spread_blocks) >=
+            next_start
     }
 }
 
@@ -567,8 +552,14 @@ impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore + Send + 'static> Base
 
             // On the first call of this method, sleep_or_shutdown is false and scanning will immediately begin
             if !self.has_more && self.sleep_or_shutdown && self.sleep_task.is_none() {
-                trace!(target: LOG_TARGET, "Starting sleep task {:?}", self.scanning_interval);
-                self.sleep_task = Some(Box::pin(time::sleep(self.scanning_interval)));
+                let scanning_interval = self
+                    .inner
+                    .as_ref()
+                    .expect("inner must be Some when starting sleep task")
+                    .config
+                    .scanning_interval;
+                trace!(target: LOG_TARGET, "Starting sleep task {:?}", scanning_interval);
+                self.sleep_task = Some(Box::pin(time::sleep(scanning_interval)));
             }
 
             if let Some(sleep) = self.sleep_task.as_mut() {

--- a/crates/epoch_oracles/src/configured/oracle.rs
+++ b/crates/epoch_oracles/src/configured/oracle.rs
@@ -308,11 +308,8 @@ mod tests {
         let waker = Waker::noop();
         let mut cx = Context::from_waker(waker);
         let mut events = vec![];
-        loop {
-            match oracle.poll(&mut cx) {
-                Poll::Ready(Some(e)) => events.push(e),
-                Poll::Ready(None) | Poll::Pending => break,
-            }
+        while let Poll::Ready(Some(event)) = oracle.poll(&mut cx) {
+            events.push(event);
         }
         events
     }

--- a/crates/epoch_oracles/src/configured/oracle.rs
+++ b/crates/epoch_oracles/src/configured/oracle.rs
@@ -72,23 +72,25 @@ impl<TStore: EpochOracleStore + Send, TTicker: EpochTicker> ConfiguredEpochOracl
             .get(StoreKey::ConfiguredCurrentEpoch.as_key_bytes())?
             .unwrap_or_else(Epoch::zero);
 
+        let mut skipped = 0usize;
         for vn in &self.config.validators {
             let activation_epoch = vn.registration_epoch + Epoch(1);
-            // If the activation epoch has already passed, activate on the next epoch we process.
-            // Use Epoch(1) as a sentinel so they are picked up by prepare_next_epoch's <= check.
-            let queue_epoch = if activation_epoch <= epoch {
-                Epoch(1)
-            } else {
-                activation_epoch
-            };
+            // Skip validators whose activation epoch has already been processed in a previous run.
+            // Re-queuing them would emit a duplicate ActiveValidatorNodeSetChanged on the next tick,
+            // causing duplicate rows in the validator_nodes table. Config changes are only supported
+            // when starting from a fresh oracle store.
+            if activation_epoch <= epoch {
+                skipped += 1;
+                continue;
+            }
 
-            let vns = self.queued_validators.entry(queue_epoch).or_default();
+            let vns = self.queued_validators.entry(activation_epoch).or_default();
             vns.push(vn.clone());
         }
 
         info!(
             target: LOG_TARGET,
-            "☘️ Starting Configured epoch oracle from {epoch}. Epoch time is {}. {} validator(s) queued",
+            "☘️ Starting Configured epoch oracle from {epoch}. Epoch time is {}. {} validator(s) queued, {skipped} already activated",
             self.config.epoch_time.as_ref().map(|d| d.display()).display(),
             self.queued_validators.values().map(|vns| vns.len()).sum::<usize>(),
         );
@@ -221,5 +223,195 @@ impl<TStore: EpochOracleStore + Send, TTicker: EpochTicker + Send> EpochEventOra
 {
     async fn next_epoch_event(&mut self) -> Option<EpochEvent> {
         poll_fn(|cx| self.poll(cx)).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::{HashMap, VecDeque},
+        sync::Mutex,
+        task::{Context, Poll, Waker},
+        time::Duration,
+    };
+
+    use serde::{Serialize, de::DeserializeOwned};
+    use tari_common_types::types::FixedHash;
+    use tari_epoch_manager::epoch_event_oracle::EpochEvent;
+    use tari_ootle_common_types::{Epoch, ShardGroup};
+    use tari_template_lib::types::crypto::RistrettoPublicKeyBytes;
+
+    use super::ConfiguredEpochOracle;
+    use crate::{
+        configured::{Config, EpochTicker, EpochTickerData, Validator},
+        store::{EpochOracleStore, StoreKey},
+    };
+
+    #[derive(Default)]
+    struct TestStore {
+        data: Mutex<HashMap<Vec<u8>, Vec<u8>>>,
+    }
+
+    impl EpochOracleStore for TestStore {
+        fn get<T: DeserializeOwned>(&self, key: &[u8]) -> anyhow::Result<Option<T>> {
+            let data = self.data.lock().unwrap();
+            data.get(key).map(|v| Ok(serde_json::from_slice(v)?)).transpose()
+        }
+
+        fn set<T: Serialize>(&self, key: &[u8], value: &T) -> anyhow::Result<()> {
+            let mut data = self.data.lock().unwrap();
+            data.insert(key.to_vec(), serde_json::to_vec(value)?);
+            Ok(())
+        }
+    }
+
+    struct ScriptedTicker {
+        data: VecDeque<EpochTickerData>,
+    }
+
+    impl ScriptedTicker {
+        fn new(data: Vec<EpochTickerData>) -> Self {
+            Self { data: data.into() }
+        }
+    }
+
+    impl EpochTicker for ScriptedTicker {
+        fn poll_tick(&mut self, _cx: &mut Context) -> Poll<Option<EpochTickerData>> {
+            match self.data.pop_front() {
+                Some(d) => Poll::Ready(Some(d)),
+                None => Poll::Pending,
+            }
+        }
+    }
+
+    fn mk_validator(public_seed: u8, registration_epoch: Epoch) -> Validator {
+        Validator {
+            public_key: RistrettoPublicKeyBytes::from_bytes(&[public_seed; 32]).unwrap(),
+            claim_key: RistrettoPublicKeyBytes::from_bytes(&[public_seed.wrapping_add(1); 32]).unwrap(),
+            shard_group: ShardGroup::new(1, 256),
+            registration_epoch,
+        }
+    }
+
+    fn mk_config(validators: Vec<Validator>) -> Config {
+        Config {
+            epoch_time: Some(Duration::from_secs(1)),
+            initial_epoch: Epoch(0),
+            base_time: time::OffsetDateTime::now_utc(),
+            validators,
+        }
+    }
+
+    fn drive_events<T: EpochOracleStore + Send, TT: EpochTicker>(
+        oracle: &mut ConfiguredEpochOracle<T, TT>,
+    ) -> Vec<EpochEvent> {
+        let waker = Waker::noop();
+        let mut cx = Context::from_waker(waker);
+        let mut events = vec![];
+        loop {
+            match oracle.poll(&mut cx) {
+                Poll::Ready(Some(e)) => events.push(e),
+                Poll::Ready(None) | Poll::Pending => break,
+            }
+        }
+        events
+    }
+
+    #[test]
+    fn restart_does_not_reactivate_already_activated_validators() {
+        let config = mk_config(vec![mk_validator(1, Epoch(10))]);
+        let store = TestStore::default();
+        // Simulate prior run having processed the validator's activation_epoch (11) already.
+        store
+            .set(StoreKey::ConfiguredCurrentEpoch.as_key_bytes(), &Epoch(11))
+            .unwrap();
+
+        // Ticker re-emits the last-processed epoch on restart.
+        let ticker = ScriptedTicker::new(vec![EpochTickerData {
+            epoch: Epoch(11),
+            epoch_hash: FixedHash::zero(),
+            done_for_now: true,
+        }]);
+        let mut oracle = ConfiguredEpochOracle::with_custom_ticker(config, store, ticker);
+
+        let events = drive_events(&mut oracle);
+
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e, EpochEvent::ActiveValidatorNodeSetChanged { .. })),
+            "restart must not re-emit ActiveValidatorNodeSetChanged; got {events:?}"
+        );
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e, EpochEvent::NewValidatorRegistered { .. })),
+            "restart must not re-emit NewValidatorRegistered; got {events:?}"
+        );
+    }
+
+    #[test]
+    fn fresh_start_activates_validators_at_activation_epoch() {
+        let config = mk_config(vec![mk_validator(1, Epoch(10))]);
+        let store = TestStore::default();
+        let ticker = ScriptedTicker::new(
+            (0..=11)
+                .map(|e| EpochTickerData {
+                    epoch: Epoch(e),
+                    epoch_hash: FixedHash::zero(),
+                    done_for_now: e == 11,
+                })
+                .collect(),
+        );
+        let mut oracle = ConfiguredEpochOracle::with_custom_ticker(config, store, ticker);
+
+        let events = drive_events(&mut oracle);
+
+        let activations: Vec<_> = events
+            .iter()
+            .filter_map(|e| match e {
+                EpochEvent::ActiveValidatorNodeSetChanged { epoch, node_changes } => Some((*epoch, node_changes.len())),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            activations,
+            vec![(Epoch(10), 1)],
+            "validator should activate exactly once, announced at epoch 10"
+        );
+
+        let announces = events
+            .iter()
+            .filter(|e| matches!(e, EpochEvent::NewValidatorRegistered { .. }))
+            .count();
+        assert_eq!(announces, 1, "should announce exactly once");
+    }
+
+    #[test]
+    fn config_added_after_activation_epoch_is_skipped_on_restart() {
+        // User adds a validator with a past registration_epoch and restarts without clearing
+        // the oracle store. We skip rather than retroactively activate, since config changes
+        // are only supported when starting from a fresh store.
+        let config = mk_config(vec![mk_validator(1, Epoch(5))]);
+        let store = TestStore::default();
+        store
+            .set(StoreKey::ConfiguredCurrentEpoch.as_key_bytes(), &Epoch(20))
+            .unwrap();
+
+        let ticker = ScriptedTicker::new(vec![EpochTickerData {
+            epoch: Epoch(21),
+            epoch_hash: FixedHash::zero(),
+            done_for_now: true,
+        }]);
+        let mut oracle = ConfiguredEpochOracle::with_custom_ticker(config, store, ticker);
+
+        let events = drive_events(&mut oracle);
+
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e, EpochEvent::ActiveValidatorNodeSetChanged { .. })),
+            "stale-config validator must not be retroactively activated; got {events:?}"
+        );
     }
 }

--- a/crates/epoch_oracles/src/hybrid/oracle.rs
+++ b/crates/epoch_oracles/src/hybrid/oracle.rs
@@ -3,6 +3,7 @@
 
 use log::*;
 use tari_epoch_manager::epoch_event_oracle::{EpochEvent, EpochEventOracle};
+use tari_ootle_common_types::Epoch;
 use tokio::sync::mpsc;
 
 use crate::{
@@ -75,5 +76,10 @@ impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore + Send + 'static> Epoc
                 },
             }
         }
+    }
+
+    fn is_within_epoch_end_spread(&self, current_epoch: Epoch) -> bool {
+        // Epoch timing in hybrid mode is driven by the base-layer scanner; defer to it.
+        self.base_layer.is_within_epoch_end_spread(current_epoch)
     }
 }

--- a/crates/epoch_oracles/src/store.rs
+++ b/crates/epoch_oracles/src/store.rs
@@ -21,7 +21,7 @@ pub enum StoreKey {
 }
 
 impl StoreKey {
-    pub fn as_key_bytes(&self) -> &'static [u8] {
+    pub const fn as_key_bytes(&self) -> &'static [u8] {
         match self {
             Self::BaseLayerLastScannedTip => b"base_layer.last_scanned_tip",
             Self::BaseLayerLastScannedBlockHash => b"base_layer.last_scanned_block_hash",

--- a/crates/storage/src/global/metadata_db.rs
+++ b/crates/storage/src/global/metadata_db.rs
@@ -52,6 +52,9 @@ pub enum MetadataKey {
     EpochManagerLastEpochHash,
     EpochManagerLastSyncedEpoch,
     EpochManagerFeeClaimPublicKey,
+    /// Highest epoch whose hash has been locked in by a committed EndEpoch block.
+    /// Epochs <= this value can no longer have their hash corrected by the oracle.
+    EpochManagerHighestLockedEpoch,
 }
 
 impl MetadataKey {
@@ -62,6 +65,7 @@ impl MetadataKey {
             MetadataKey::EpochManagerLastSyncedEpoch => b"epoch_manager.last_synced_epoch",
             MetadataKey::EpochManagerFeeClaimPublicKey => b"epoch_manager.fee_claim_public_key",
             MetadataKey::EpochManagerLastEpochHash => b"epoch_manager.last_epoch_hash",
+            MetadataKey::EpochManagerHighestLockedEpoch => b"epoch_manager.highest_locked_epoch",
         }
     }
 }


### PR DESCRIPTION
## Summary

Two layered, non-breaking fixes for epoch-change robustness after a base-layer reorg near the lag horizon caused a 2-2 split on Epoch 7541 that halted a 4-node esmeralda testnet. Each node's oracle first crossed the boundary at a slightly different moment during the fork window, and today's strict guards prevented the cluster from healing once the L1 stabilised.

### Fix 1 — pre-commit epoch-hash correction

- `EpochManagerService::activate_epoch` now upserts the oracle's hash for the *current* epoch while the epoch is still unlocked, letting the scanner self-heal if the first hash written was from a short-lived fork.
- `process_end_of_epoch` calls a new `lock_epoch(next_epoch)` right after stamping the canonical `epoch_hash` into the next genesis block — after that point, oracle corrections for that epoch (and earlier) are ignored.
- Lock state is persisted via a new `EpochManagerHighestLockedEpoch` metadata key, so the lock survives restarts.

### Fix 2 — oracle-agnostic leeway voting on `EndEpoch`

- New `EpochEventOracle::is_within_epoch_end_spread` (default: `false`), surfaced through `EpochManagerReader` via a new `EpochManagerRequest` variant and `EpochManagerHandle` method.
- Base-layer oracle implementation uses a cached `epoch_length` (captured during scans) and a new `BaseLayerEpochOracleConfig::epoch_end_spread_blocks` (default 2) — returns true when `last_scanned_height + spread >= next_epoch_start_height`.
- Hybrid oracle delegates to the base-layer side; configured/other oracles inherit the `false` default.
- Consensus voter check in `on_receive_local_proposal::process_block` now accepts `EndEpoch` when `em_epoch > current_epoch` OR the oracle reports we're within the spread.

The two fixes compose: Fix 2 makes a lagging-scanner vote speculatively, and Fix 1 ensures the speculative vote is safe because the committed hash becomes canonical and the oracle can no longer rewrite it.

## Test plan

- [x] `cargo check --workspace --all-targets` — clean
- [x] `cargo test -p tari_epoch_manager -p tari_epoch_oracles` — 4 passed
- [x] `cargo test -p consensus_tests` — 47 passed
- [x] Formatted with pinned nightly (`cargo +nightly-2025-06-25 fmt --all`)
- [ ] Manual: 4-node local testnet with an L1 fork crossing an epoch boundary — verify `EndEpoch` commits and all nodes converge on the same `epoch_hash`