### PR TITLE
fix!: include "ootle" in default base path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1691,7 +1691,7 @@ dependencies = [
 
 [[package]]
 name = "consensus_tests"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "fern",
  "futures 0.3.31",
@@ -2670,7 +2670,7 @@ dependencies = [
 
 [[package]]
 name = "db-inspector"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -4962,7 +4962,7 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "integration_tests"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "anyhow",
  "config",
@@ -5744,7 +5744,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-messaging"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "async-trait",
  "futures-bounded",
@@ -5923,7 +5923,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-substream"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "libp2p",
  "prometheus-client",
@@ -7522,7 +7522,7 @@ dependencies = [
 
 [[package]]
 name = "ootle-wasm"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "console_error_panic_hook",
  "getrandom 0.2.17",
@@ -7532,7 +7532,7 @@ dependencies = [
 
 [[package]]
 name = "ootle-wasm-core"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "base64 0.22.1",
  "ootle_byte_type",
@@ -8528,7 +8528,7 @@ dependencies = [
 
 [[package]]
 name = "proto_builder"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "prost-build 0.14.3",
  "sha2 0.10.9",
@@ -10369,7 +10369,7 @@ dependencies = [
 
 [[package]]
 name = "sqlite_message_logger"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "chrono",
  "diesel",
@@ -10741,7 +10741,7 @@ dependencies = [
 
 [[package]]
 name = "tari_base_node_client"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "futures-util",
  "log",
@@ -10966,7 +10966,7 @@ dependencies = [
 
 [[package]]
 name = "tari_consensus"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "anyhow",
  "indexmap 2.13.0",
@@ -10991,7 +10991,7 @@ dependencies = [
 
 [[package]]
 name = "tari_consensus_types"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "borsh",
  "ootle_serde",
@@ -11093,7 +11093,7 @@ dependencies = [
 
 [[package]]
 name = "tari_engine"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "blake2",
  "criterion",
@@ -11121,7 +11121,7 @@ dependencies = [
 
 [[package]]
 name = "tari_engine_types"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "bincode 2.0.1",
  "blake2",
@@ -11149,7 +11149,7 @@ dependencies = [
 
 [[package]]
 name = "tari_epoch_manager"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "anyhow",
  "log",
@@ -11169,7 +11169,7 @@ dependencies = [
 
 [[package]]
 name = "tari_epoch_oracles"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -11222,7 +11222,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -11292,7 +11292,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer_client"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "anyhow",
  "bounded-vec",
@@ -11321,7 +11321,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer_lib"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "log",
  "prometheus-client",
@@ -11413,7 +11413,7 @@ dependencies = [
 
 [[package]]
 name = "tari_networking"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11465,7 +11465,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_app_utilities"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -11505,7 +11505,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_common_types"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "blake2",
  "borsh",
@@ -11532,7 +11532,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_p2p"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "anyhow",
  "libp2p-identity 0.2.13 (git+https://github.com/tari-project/rust-libp2p.git?rev=470c41380d6c5140b52ef65becf4f643e4769e66)",
@@ -11556,7 +11556,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_storage"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "anyhow",
  "bitflags 2.10.0",
@@ -11583,7 +11583,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_storage_sqlite"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "diesel",
  "diesel_migrations",
@@ -11634,7 +11634,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_transaction"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "bincode 2.0.1",
  "borsh",
@@ -11659,7 +11659,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_cli"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -11688,7 +11688,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_crypto"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "argon2 0.5.3",
  "blake2",
@@ -11717,7 +11717,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_sdk"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "anyhow",
  "digest 0.10.7",
@@ -11782,7 +11782,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_storage_sqlite"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "bigdecimal",
  "diesel",
@@ -11806,7 +11806,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_walletd"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11924,7 +11924,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_framework"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "async-trait",
  "bitflags 2.10.0",
@@ -11948,7 +11948,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_macros"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11957,7 +11957,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_state_sync"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -12034,7 +12034,7 @@ dependencies = [
 
 [[package]]
 name = "tari_state_store_rocksdb"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -12065,7 +12065,7 @@ dependencies = [
 
 [[package]]
 name = "tari_state_tree"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "indexmap 2.13.0",
  "log",
@@ -12091,7 +12091,7 @@ dependencies = [
 
 [[package]]
 name = "tari_swarm"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "libp2p",
  "libp2p-messaging",
@@ -12102,7 +12102,7 @@ dependencies = [
 
 [[package]]
 name = "tari_swarm_daemon"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12157,7 +12157,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_builtin"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "anyhow",
  "tari_engine_types",
@@ -12213,7 +12213,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_test_tooling"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "anyhow",
  "cargo_toml 0.22.3",
@@ -12326,7 +12326,7 @@ dependencies = [
 
 [[package]]
 name = "tari_transaction_manifest"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "proc-macro2",
  "serde_json",
@@ -12360,7 +12360,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -12426,7 +12426,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node_client"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "indexmap 2.13.0",
  "multiaddr 0.18.3",
@@ -12450,7 +12450,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node_rpc"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -12486,7 +12486,7 @@ dependencies = [
 
 [[package]]
 name = "tari_watcher"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "anyhow",
  "clap 3.2.25",
@@ -12514,7 +12514,7 @@ dependencies = [
 
 [[package]]
 name = "tariswap_bench"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "anyhow",
  "clap 4.5.54",
@@ -13194,7 +13194,7 @@ dependencies = [
 
 [[package]]
 name = "traffic-sim"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "anyhow",
  "clap 4.5.54",
@@ -13216,7 +13216,7 @@ dependencies = [
 
 [[package]]
 name = "transaction_generator"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -13235,7 +13235,7 @@ dependencies = [
 
 [[package]]
 name = "transaction_submitter"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "anyhow",
  "clap 4.5.54",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11472,6 +11472,7 @@ dependencies = [
  "blake2",
  "clap 3.2.25",
  "config",
+ "dirs-next 2.0.0",
  "libp2p-identity 0.2.13 (git+https://github.com/tari-project/rust-libp2p.git?rev=470c41380d6c5140b52ef65becf4f643e4769e66)",
  "log",
  "multiaddr 0.18.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.29.0"
+version = "0.29.1"
 edition = "2024"
 authors = ["The Tari Development Community"]
 repository = "https://github.com/tari-project/tari-ootle"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -197,6 +197,7 @@ dashmap = "5.5.0"
 diesel = { version = "2.2.12", default-features = false }
 diesel_migrations = "2.2.0"
 digest = "0.10"
+dirs-next = "2.0.0"
 env_logger = "0.10.0"
 ethnum = "1.5.0"
 either = "1.13.0"

--- a/applications/tari_ootle_app_utilities/Cargo.toml
+++ b/applications/tari_ootle_app_utilities/Cargo.toml
@@ -30,6 +30,7 @@ anyhow = { workspace = true }
 blake2 = { workspace = true }
 bincode = { workspace = true, features = ["serde"] }
 clap = { workspace = true, features = ["derive", "env"] }
+dirs-next = { workspace = true }
 libp2p-identity = { workspace = true, optional = true }
 log = { workspace = true, features = ["std"] }
 multiaddr = { workspace = true, optional = true }

--- a/applications/tari_ootle_app_utilities/src/common_cli_args.rs
+++ b/applications/tari_ootle_app_utilities/src/common_cli_args.rs
@@ -125,12 +125,17 @@ impl ConfigOverrideProvider for CommonCliArgs {
 }
 
 mod defaults {
-    use tari_common::dir_utils;
+    use std::path::PathBuf;
 
     const DEFAULT_CONFIG: &str = "config/config.toml";
 
     pub(super) fn base_path() -> String {
-        dir_utils::default_path("", None).to_string_lossy().to_string()
+        dirs_next::home_dir()
+            .unwrap_or_else(|| PathBuf::from("."))
+            .join(".tari")
+            .join("ootle")
+            .to_string_lossy()
+            .into_owned()
     }
 
     pub(super) fn config() -> String {

--- a/applications/tari_walletd/Cargo.toml
+++ b/applications/tari_walletd/Cargo.toml
@@ -38,7 +38,7 @@ axum = { workspace = true }
 axum-extra = { workspace = true, features = ["typed-header", "cookie"] }
 axum-jrpc = { workspace = true, features = ["anyhow_error"] }
 clap = { workspace = true, features = ["derive", "env"] }
-dirs-next = "2.0.0"
+dirs-next = { workspace = true }
 notify = "8.2.0"
 config = { workspace = true }
 either = { workspace = true }


### PR DESCRIPTION
Description
---
Include "ootle" in default base path (`~/.tari/ootle/{network}`) for all apps

Previously we used `~/.tari/{network}` without separating for ootle

BREAKING CHANGE: wallets using the default path will be reset - this should have been part of the 0.29 breaking release. (released just before this PR). I'll create a new release shortly to limit (likely avoid completely) any impact.