### PR TITLE
fix(walletd): use ViewOnlyKey branch when recovering off-chain accounts

### DIFF
--- a/crates/wallet/sdk_services/src/account_recovery/service.rs
+++ b/crates/wallet/sdk_services/src/account_recovery/service.rs
@@ -174,7 +174,7 @@ where
                 self.wallet_sdk.accounts_api().add_account(
                     Some(format!("recovered-account-{}", key.key_index()).as_str()),
                     &account_addr,
-                    key.as_key_id(),
+                    KeyId::derived(KeyBranch::ViewOnlyKey, key.key_index()),
                     key.as_key_id(),
                     birthday_epoch,
                     false,


### PR DESCRIPTION
## Summary
- When `AccountRecoveryService::try_recover_account` added an account that wasn't yet on-chain, it stored `Derived(Account, N)` as the account's `view_only_key_id`. The on-chain branch already did the right thing with `Derived(ViewOnlyKey, N)`.
- Downstream, `AccountsApi::get_address_for_account` publishes the `OotleAddress` using whatever branch `view_only_key_id` names, so senders encrypted to the account key instead of the view-only key. `StealthOutputsApi::verify_and_update_outputs` only iterates `KeyBranch::ViewOnlyKey` secrets and couldn't decrypt, so incoming intra-wallet transfers were missed at finalization time and only got picked up later by the UTXO recovery path (which resolves the key id directly).

## Test plan
- [x] Fresh wallet recovery from seed where no accounts are on-chain yet.
- [x] Send a stealth transfer between two accounts on the same wallet; confirm `verify_and_update_outputs` logs `Found 1/N stealth outputs owned by this wallet` and the recipient balance updates immediately without waiting for UTXO recovery.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>