### PR TITLE
feat(tx-submitter)!: stress-test against the indexer REST API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13257,9 +13257,9 @@ version = "0.29.1"
 dependencies = [
  "anyhow",
  "clap 4.5.54",
+ "tari_indexer_client",
  "tari_ootle_common_types",
  "tari_ootle_transaction",
- "tari_validator_node_client",
  "tokio",
  "transaction_generator",
 ]

--- a/utilities/transaction_generator/src/cli.rs
+++ b/utilities/transaction_generator/src/cli.rs
@@ -42,7 +42,7 @@ pub struct WriteArgs {
     pub manifest_args_file: Option<PathBuf>,
     #[clap(long, short = 'k', alias = "signer")]
     pub signer_secret_key: Option<String>,
-    #[clap(long, short = 'n')]
+    #[clap(long, short = 't')]
     pub network: Option<Network>,
 }
 #[derive(Args, Debug)]

--- a/utilities/transaction_submitter/Cargo.toml
+++ b/utilities/transaction_submitter/Cargo.toml
@@ -10,11 +10,11 @@ license.workspace = true
 
 [dependencies]
 transaction_generator = { workspace = true }
-tari_validator_node_client = { workspace = true }
+tari_indexer_client = { workspace = true, features = ["client"] }
 tari_ootle_transaction = { workspace = true }
 tari_ootle_common_types = { workspace = true }
 
 anyhow = { workspace = true }
 # if we set clap version 4 in the workspace it would break other crates
 clap = "4.3.21"
-tokio = { workspace = true, default-features = true }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync", "time"] }

--- a/utilities/transaction_submitter/src/cli.rs
+++ b/utilities/transaction_submitter/src/cli.rs
@@ -1,7 +1,7 @@
 //   Copyright 2023 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use std::{net::SocketAddr, path::PathBuf};
+use std::path::PathBuf;
 
 use clap::{Args, Parser, Subcommand};
 
@@ -30,8 +30,8 @@ pub struct StressTestArgs {
     pub num_transactions: Option<u64>,
     #[clap(long, alias = "skip", short = 'k')]
     pub skip_transactions: Option<u64>,
-    #[clap(long, short = 'a')]
-    pub jrpc_addresses: Vec<SocketAddr>,
+    #[clap(long = "indexer-url", alias = "indexer", short = 'a')]
+    pub indexer_urls: Vec<String>,
     #[clap(long, short = 'f')]
     pub transaction_file: PathBuf,
     #[clap(long, short = 'y')]

--- a/utilities/transaction_submitter/src/main.rs
+++ b/utilities/transaction_submitter/src/main.rs
@@ -4,12 +4,18 @@
 use std::{cmp, fs::File, io::Write, time::Duration};
 
 use anyhow::bail;
-use tari_ootle_common_types::optional::Optional;
-use tari_ootle_transaction::TransactionId;
-use tari_validator_node_client::{
-    ValidatorNodeClient,
-    types::{GetTransactionResultRequest, SubmitTransactionRequest, SubmitTransactionResponse},
+use tari_indexer_client::{
+    rest_api_client::IndexerRestApiClient,
+    types::{
+        GetTransactionResultRequest,
+        GetTransactionResultResponse,
+        IndexerTransactionFinalizedResult,
+        SubmitTransactionRequest,
+        SubmitTransactionResponse,
+    },
 };
+use tari_ootle_common_types::optional::Optional;
+use tari_ootle_transaction::{TransactionEnvelope, TransactionId};
 use tokio::{
     sync::mpsc,
     task,
@@ -40,16 +46,20 @@ async fn main() -> anyhow::Result<()> {
 }
 
 async fn stress_test(args: StressTestArgs) -> anyhow::Result<Option<StressTestResultSummary>> {
-    if args.jrpc_addresses.is_empty() {
-        bail!("No validator nodes specified");
+    if args.indexer_urls.is_empty() {
+        bail!("No indexer URLs specified");
     }
-    let mut clients = Vec::with_capacity(args.jrpc_addresses.len());
-    for address in args.jrpc_addresses {
-        let mut client = ValidatorNodeClient::connect(format!("http://{}/json_rpc", address))?;
-        if let Err(e) = client.get_identity().await {
-            bail!("Failed to connect to {}: {}", address, e);
+    let mut clients = Vec::with_capacity(args.indexer_urls.len());
+    for url in &args.indexer_urls {
+        let endpoint = normalize_endpoint(url);
+        let client = IndexerRestApiClient::connect(endpoint.clone())?;
+        if let Err(e) = client.get_network_info().await {
+            bail!("Failed to connect to {}: {}", endpoint, e);
         }
-        clients.push(client);
+        clients.push(IndexerClient {
+            client,
+            endpoint: endpoint.clone(),
+        });
     }
 
     let num_transactions = read_number_of_transactions(&mut File::open(&args.transaction_file)?)?;
@@ -94,15 +104,23 @@ async fn stress_test(args: StressTestArgs) -> anyhow::Result<Option<StressTestRe
     let bounded_spawn = BoundedSpawn::new(clients.len() * 100);
     let (submitted_tx, submitted_rx) = mpsc::unbounded_channel();
     while let Ok(transaction) = transactions.recv() {
-        let mut client = clients[count % clients.len()].clone();
+        let client = clients[count % clients.len()].clone();
         let submitted_tx = submitted_tx.clone();
 
         // Bounded spawn prevents too many tasks from being spawned at once, to prevent opening too many sockets in the
         // OS.
         bounded_spawn
             .spawn(async move {
+                let envelope = match TransactionEnvelope::encode(transaction) {
+                    Ok(env) => env,
+                    Err(e) => {
+                        println!("Failed to encode transaction: {}", e);
+                        return;
+                    },
+                };
                 match client
-                    .submit_transaction(SubmitTransactionRequest { transaction })
+                    .client
+                    .submit_transaction(SubmitTransactionRequest { transaction: envelope })
                     .await
                 {
                     Ok(SubmitTransactionResponse { transaction_id, .. }) => {
@@ -132,7 +150,7 @@ async fn stress_test(args: StressTestArgs) -> anyhow::Result<Option<StressTestRe
 
 #[allow(clippy::too_many_lines)]
 async fn fetch_result_summary(
-    clients: Vec<ValidatorNodeClient>,
+    clients: Vec<IndexerClient>,
     mut submitted_rx: mpsc::UnboundedReceiver<TransactionId>,
 ) -> StressTestResultSummary {
     let bounded_spawn = BoundedSpawn::new(clients.len());
@@ -173,49 +191,71 @@ async fn fetch_result_summary(
 
     // Result emitter
     while let Some(transaction_id) = submitted_rx.recv().await {
-        let mut clients = clients.clone();
+        let clients = clients.clone();
         let num_clients = clients.len();
         let results_tx = results_tx.clone();
         bounded_spawn
             .spawn(async move {
                 let mut i = 0usize;
                 loop {
-                    let client = &mut clients[i % num_clients];
+                    let client = &clients[i % num_clients];
                     i += 1;
                     match client
+                        .client
                         .get_transaction_result(GetTransactionResultRequest { transaction_id })
                         .await
                         .optional()
                     {
-                        Ok(Some(result)) => {
-                            let exec_result = result.transaction_execution.result();
-                            let result = if let Some(diff) = exec_result.finalize.result.any_accept() {
-                                TxFinalized {
-                                    is_committed: true,
-                                    is_error: false,
-                                    num_up_substates: diff.up_len(),
-                                    num_down_substates: diff.down_len(),
-                                    execution_time: result.transaction_execution.execution_time(),
-                                }
-                            } else {
-                                TxFinalized {
+                        Ok(Some(GetTransactionResultResponse {
+                            result:
+                                IndexerTransactionFinalizedResult::Finalized {
+                                    execution_result,
+                                    execution_time,
+                                    ..
+                                },
+                        })) => {
+                            let result = match execution_result {
+                                Some(exec_result) => {
+                                    if let Some(diff) = exec_result.finalize.result.any_accept() {
+                                        TxFinalized {
+                                            is_committed: true,
+                                            is_error: false,
+                                            num_up_substates: diff.up_len(),
+                                            num_down_substates: diff.down_len(),
+                                            execution_time,
+                                        }
+                                    } else {
+                                        TxFinalized {
+                                            is_committed: false,
+                                            is_error: false,
+                                            num_up_substates: 0,
+                                            num_down_substates: 0,
+                                            execution_time,
+                                        }
+                                    }
+                                },
+                                None => TxFinalized {
                                     is_committed: false,
                                     is_error: false,
                                     num_up_substates: 0,
                                     num_down_substates: 0,
-                                    execution_time: result.transaction_execution.execution_time(),
-                                }
+                                    execution_time,
+                                },
                             };
 
                             results_tx.send(result).await.unwrap();
                             break;
                         },
+                        Ok(Some(GetTransactionResultResponse {
+                            result: IndexerTransactionFinalizedResult::Pending,
+                        })) => {
+                            sleep(Duration::from_secs(1)).await;
+                        },
                         Ok(None) => {
                             println!(
-                                "[{}] Result not found for transaction {}. This is likely due to a race condition or \
-                                 requesting the result from a non-involved validator (multi-shard). Retrying later...",
-                                client.endpoint(),
-                                transaction_id
+                                "[{}] Result not found for transaction {}. The indexer may not have seen it yet. \
+                                 Retrying later...",
+                                client.endpoint, transaction_id
                             );
                             sleep(Duration::from_secs(1)).await;
                         },
@@ -242,6 +282,24 @@ async fn fetch_result_summary(
     // Drop the remaining sender handle so that the result collector ends when all results have been received
     drop(results_tx);
     results_handle.await.unwrap()
+}
+
+#[derive(Clone)]
+struct IndexerClient {
+    client: IndexerRestApiClient,
+    endpoint: String,
+}
+
+fn normalize_endpoint(input: &str) -> String {
+    let mut url = if input.starts_with("http://") || input.starts_with("https://") {
+        input.to_string()
+    } else {
+        format!("http://{input}")
+    };
+    if !url.ends_with('/') {
+        url.push('/');
+    }
+    url
 }
 
 struct TxFinalized {


### PR DESCRIPTION
## Summary
- Migrate the `transaction_submitter` stress tester from the validator-node JSON-RPC to the indexer REST API so it can target a single entry point with a global view of transaction results.
- Replace `-a/--jrpc-addresses` with `-a/--indexer-url` (alias `--indexer`). Full URLs or bare `host:port` (auto-prefixed with `http://`) are both accepted; repeat the flag to load-balance across multiple indexers.
- Handle the indexer's tri-state result: `Finalized` is recorded, `Pending` and 404 trigger a retry. Execution time is read from the finalized response.
- Drive-by: fix a duplicate `-n` short flag in `transaction_generator`'s `write` subcommand by moving `network` to `-t`.

## Test plan
- [x] `cargo check -p transaction_submitter` (done locally)
- [x] `cargo clippy -p transaction_submitter` (done locally)
- [x] Run against a local indexer: `transaction_submitter stress-test -a http://127.0.0.1:18300 -f txs.bin -n 100 -y` and confirm submission + result summary.