### PR TITLE
feat(fees)!: add per-substate-create cost and bump template-load rate

### DIFF
--- a/applications/tari_ootle_app_utilities/src/fee_tables.rs
+++ b/applications/tari_ootle_app_utilities/src/fee_tables.rs
@@ -73,7 +73,12 @@ const TESTNET_FEE_TABLE: FeeTable = FeeTable {
     per_event_cost: 1,
     per_log_cost: 1,
     per_signature_verification_cost: 10,
-    per_template_load_cost_unit: 1,
+    // Bumped from 1 to better reflect worst-case cold wasmer instantiation: a 2 MiB template (the
+    // current cap) costs ~7000 µT to load vs ~700 µT previously.
+    per_template_load_cost_unit: 10,
+    // Slot-allocation premium for newly-created substates, on top of `per_byte_storage_cost`.
+    // ~25 µT per new substate (~equivalent to 100 bytes of storage at the effective per-byte rate).
+    per_substate_create_cost: 25,
 };
 
 /// MainNet fee table - production values.
@@ -96,7 +101,8 @@ const MAINNET_FEE_TABLE: FeeTable = FeeTable {
     per_event_cost: 1,
     per_log_cost: 1,
     per_signature_verification_cost: 10,
-    per_template_load_cost_unit: 1,
+    per_template_load_cost_unit: 10,
+    per_substate_create_cost: 25,
 };
 
 /// Returns the appropriate fee table for the specified network.

--- a/bindings/src/types/FeeSource.ts
+++ b/bindings/src/types/FeeSource.ts
@@ -8,4 +8,5 @@ export type FeeSource =
   | "Logs"
   | "TransactionWeight"
   | "SignatureVerification"
-  | "TemplateLoad";
+  | "TemplateLoad"
+  | "SubstateCreate";

--- a/crates/engine/src/fees/fee_module.rs
+++ b/crates/engine/src/fees/fee_module.rs
@@ -83,6 +83,14 @@ impl<TStore: StateReader> RuntimeModule<TStore> for FeeModule {
             cost / STORAGE_COST_REDUCTION_DIVISOR,
         );
 
+        let new_substate_count = track
+            .count_newly_created_substates()
+            .map_err(|e| RuntimeModuleError::Runtime(e.to_string()))?;
+        let create_cost = (new_substate_count as u64)
+            .checked_mul(self.fee_table.per_substate_create_cost())
+            .ok_or_else(|| RuntimeModuleError::Overflow("Overflow calculating substate create cost".to_string()))?;
+        track.add_fee_charge(FeeSource::SubstateCreate, create_cost);
+
         let log_cost = (track.num_logs() as u64)
             .checked_mul(self.fee_table.per_log_cost())
             .ok_or_else(|| RuntimeModuleError::Overflow("Overflow calculating log cost".to_string()))?;

--- a/crates/engine/src/fees/fee_table.rs
+++ b/crates/engine/src/fees/fee_table.rs
@@ -10,6 +10,10 @@ pub struct FeeTable {
     pub per_log_cost: u64,
     pub per_signature_verification_cost: u64,
     pub per_template_load_cost_unit: u64,
+    /// Flat cost charged once per newly-created substate, on top of `per_byte_storage_cost`.
+    /// Reflects the slot-allocation cost of adding a new entry to permanent state, separate from
+    /// the byte cost of its contents.
+    pub per_substate_create_cost: u64,
 }
 
 impl FeeTable {
@@ -22,6 +26,7 @@ impl FeeTable {
             per_log_cost: 0,
             per_signature_verification_cost: 0,
             per_template_load_cost_unit: 0,
+            per_substate_create_cost: 0,
         }
     }
 
@@ -51,5 +56,9 @@ impl FeeTable {
 
     pub fn per_template_load_cost_unit(&self) -> u64 {
         self.per_template_load_cost_unit
+    }
+
+    pub fn per_substate_create_cost(&self) -> u64 {
+        self.per_substate_create_cost
     }
 }

--- a/crates/engine/src/runtime/module.rs
+++ b/crates/engine/src/runtime/module.rs
@@ -48,4 +48,6 @@ pub enum RuntimeModuleError {
     Bor(#[from] tari_bor::BorError),
     #[error("Overflow error: {0}")]
     Overflow(String),
+    #[error("Runtime error: {0}")]
+    Runtime(String),
 }

--- a/crates/engine/src/runtime/tracker.rs
+++ b/crates/engine/src/runtime/tracker.rs
@@ -349,6 +349,23 @@ impl<TStore: StateReader> StateTracker<TStore> {
         self.write_with(|state| f(state.mutated_substates()))
     }
 
+    /// Counts substates in the to-persist set that did not previously exist in the state store.
+    /// Used by the fee module to charge a slot-allocation premium on top of per-byte storage.
+    pub fn count_newly_created_substates(&self) -> Result<usize, RuntimeError> {
+        self.read_with(|state| {
+            let store = state.store();
+            let mut count = 0;
+            for id in store.mutated_substates().keys() {
+                match store.get_unmodified_substate(id) {
+                    Ok(_) => {},
+                    Err(RuntimeError::SubstateNotFound { .. }) => count += 1,
+                    Err(e) => return Err(e),
+                }
+            }
+            Ok(count)
+        })
+    }
+
     pub fn are_fees_paid_in_full(&self) -> bool {
         self.read_with(|state| {
             let total_payments = state.fee_state().total_payments();

--- a/crates/engine_types/src/fees.rs
+++ b/crates/engine_types/src/fees.rs
@@ -146,6 +146,7 @@ pub enum FeeSource {
     TransactionWeight,
     SignatureVerification,
     TemplateLoad,
+    SubstateCreate,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, borsh::BorshSerialize)]

--- a/crates/template_test_tooling/src/template_test.rs
+++ b/crates/template_test_tooling/src/template_test.rs
@@ -237,6 +237,7 @@ impl TemplateTest {
                 per_log_cost: 1,
                 per_signature_verification_cost: 1,
                 per_template_load_cost_unit: 1,
+                per_substate_create_cost: 1,
             },
             key_seed: 1,
             auto_add_proofs_from_signers: true,


### PR DESCRIPTION
## Summary

Two targeted fee additions for better alignment with node-operator costs. No broader recalibration of existing values — the abstract-unit/microtari conversion that would enable that is a larger structural change deferred to a separate discussion.

### 1. `per_template_load_cost_unit`: 1 → 10

Template load cost is charged at \`bytes / 3000 × per_template_load_cost_unit\`. The previous rate of 1 µT per 3 KiB priced a worst-case 2 MiB cold wasmer instantiation at ~700 µT, but the actual CPU cost of cold wasmer compilation of 2 MiB is ~200–500 ms — roughly 30× under-priced. Bumping to 10 closes most of that gap (worst case ~7000 µT) while leaving typical small templates at negligible cost. The fee is charged on every call regardless of validator cache state, since cache state is per-validator and fee calculation must be deterministic across the committee.

### 2. New `per_substate_create_cost` (25 µT per new substate)

Today \`per_byte_storage_cost\` is the only state-pricing knob — creating a new substate slot is priced identically to updating an existing one of the same size. This adds a flat slot-allocation premium charged once per newly-created substate at finalize, on top of the existing per-byte cost. Most chains separate these (EVM SSTORE for new slot is 4× the rate for an update); this gives Ootle a similar lever for pricing state-bloat attack shapes without crushing legitimate large-but-rare updates.

**Implementation:**
- New \`FeeSource::SubstateCreate\` variant for breakdown reporting (TS binding updated manually).
- New \`per_substate_create_cost: u64\` field on \`FeeTable\`.
- New \`StateTracker::count_newly_created_substates()\` helper that classifies the to-persist set against the unmodified store (mirrors the existing logic in \`generate_substate_diff\`).
- Charged in \`on_before_finalize\` after the existing storage-byte charge.
- Both testnet and mainnet tables get the same value; test-tooling fee-table fixture set to 1.

## Out of scope

- **Substate read fees** — flagged earlier as a real unpriced category; needs a new field plus a hook at substate-load sites in the runtime tracker. Worth a separate PR.
- **Abstract-unit/microtari conversion** — the only sub-µT pricing mechanism today is the \`/4\` divisor on storage. To get sub-µT granularity for any other category (e.g. tighter template-load tuning, per-byte read fees), a proper fixed-point conversion is needed. Bigger protocol change; deserves its own design discussion before any further value tweaks.

## Test plan

- [x] \`cargo check -p tari_engine -p tari_engine_types -p tari_ootle_app_utilities -p tari_template_test_tooling\` clean
- [x] \`cargo +nightly-2025-06-25 fmt --all\` clean
- [x] CI green
- [ ] Confirm new substate count is correctly classified vs updates in an integration test (manual review of \`count_newly_created_substates\` semantics vs \`generate_substate_diff\`)