### PR TITLE
fix(ci): allow pnpm publish from detached HEAD on release

### DIFF
--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -66,7 +66,10 @@ jobs:
           fi
 
           echo "== Publishing =="
-          pnpm publish --provenance
+          # --no-git-checks: the `release: published` trigger checks out the
+          # release tag's commit, leaving HEAD detached. pnpm would otherwise
+          # abort because HEAD isn't on the configured publish-branch.
+          pnpm publish --provenance --no-git-checks
 
   # Publish the Tari Wallet Daemon client to the NPM registry
   publish-wallet-daemon-client:
@@ -117,7 +120,10 @@ jobs:
           fi
 
           echo "== Publishing =="
-          pnpm publish --provenance
+          # --no-git-checks: the `release: published` trigger checks out the
+          # release tag's commit, leaving HEAD detached. pnpm would otherwise
+          # abort because HEAD isn't on the configured publish-branch.
+          pnpm publish --provenance --no-git-checks
 
   # Publish the Tari Indexer client to the NPM registry
   publish-indexer-client:
@@ -168,4 +174,7 @@ jobs:
           fi
 
           echo "== Publishing =="
-          pnpm publish --provenance
+          # --no-git-checks: the `release: published` trigger checks out the
+          # release tag's commit, leaving HEAD detached. pnpm would otherwise
+          # abort because HEAD isn't on the configured publish-branch.
+          pnpm publish --provenance --no-git-checks


### PR DESCRIPTION
## Summary
- The `Publish Packages to npmjs` workflow fails on the `release: published` trigger because `actions/checkout` checks out the tag's commit (detached HEAD), and pnpm 10's `publish` aborts when HEAD isn't on the configured `publish-branch` (defaults to `development`).
- Pass `--no-git-checks` to all three `pnpm publish` invocations so releases can publish, and add a short comment above each line explaining why.

Failing run for reference: https://github.com/tari-project/tari-ootle/actions/runs/24766852742/job/72463093588

## Test plan
- [ ] Trigger the workflow via `workflow_dispatch` (or wait for the next release) and confirm the publish step no longer errors with `ERR_PNPM_GIT_UNKNOWN_BRANCH`.