### PR TITLE
feat(indexer): enable WAL journal mode for sqlite store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2724,6 +2724,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-diesel"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "590573e9e29c5190a5ff782136f871e6e652e35d598a349888e028693601adf1"
+dependencies = [
+ "deadpool",
+ "deadpool-sync",
+ "diesel",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+dependencies = [
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-sync"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524bc3df0d57e98ecd022e21ba31166c2625e7d3e5bcc4510efaeeab4abcab04"
+dependencies = [
+ "deadpool-runtime",
+]
+
+[[package]]
 name = "decimal-rs"
 version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3401,7 +3442,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4573,7 +4614,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "system-configuration 0.6.1",
  "tokio",
  "tower-service",
@@ -5094,7 +5135,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7262,7 +7303,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8437,7 +8478,7 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools 0.14.0",
  "log",
  "multimap 0.10.1",
@@ -8457,7 +8498,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools 0.14.0",
  "log",
  "multimap 0.10.1",
@@ -8684,7 +8725,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -8722,9 +8763,9 @@ dependencies = [
  "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9430,7 +9471,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9489,7 +9530,7 @@ dependencies = [
  "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9510,7 +9551,7 @@ dependencies = [
  "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10305,7 +10346,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -11239,6 +11280,8 @@ dependencies = [
  "anyhow",
  "async-graphql",
  "async-graphql-axum",
+ "async-stream",
+ "async-trait",
  "axum 0.8.8",
  "bincode 2.0.1",
  "bytes",
@@ -11246,6 +11289,7 @@ dependencies = [
  "clap 3.2.25",
  "config",
  "dashmap 5.5.3",
+ "deadpool-diesel",
  "diesel",
  "diesel_migrations",
  "futures 0.3.31",
@@ -12604,7 +12648,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -14376,7 +14420,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -199,6 +199,7 @@ clap = "3.2.25"
 chacha20poly1305 = "0.10.1"
 config = "0.14.0"
 dashmap = "5.5.0"
+deadpool-diesel = { version = "0.6", default-features = false }
 diesel = { version = "2.2.12", default-features = false }
 diesel_migrations = "2.2.0"
 digest = "0.10"

--- a/applications/tari_indexer/Cargo.toml
+++ b/applications/tari_indexer/Cargo.toml
@@ -55,6 +55,7 @@ diesel = { workspace = true, default-features = false, features = [
     "sqlite",
     "returning_clauses_for_sqlite_3_35",
     "time",
+    "r2d2",
 ] }
 indexmap = { workspace = true }
 diesel_migrations = { workspace = true }

--- a/applications/tari_indexer/Cargo.toml
+++ b/applications/tari_indexer/Cargo.toml
@@ -43,19 +43,21 @@ tari_validator_node_rpc = { workspace = true }
 ootle_byte_type = { workspace = true, features = ["crypto"] }
 
 anyhow = { workspace = true }
+async-trait = { workspace = true }
 axum = { workspace = true, features = ["query", "matched-path"] }
 dashmap = { workspace = true }
 async-graphql = { workspace = true }
 async-graphql-axum = { workspace = true }
+async-stream = { workspace = true }
 bytes = { workspace = true }
 bincode = { workspace = true, features = ["serde"] }
 clap = { workspace = true, features = ["derive", "env"] }
 config = { workspace = true }
+deadpool-diesel = { workspace = true, default-features = false, features = ["sqlite", "rt_tokio_1"] }
 diesel = { workspace = true, default-features = false, features = [
     "sqlite",
     "returning_clauses_for_sqlite_3_35",
     "time",
-    "r2d2",
 ] }
 indexmap = { workspace = true }
 diesel_migrations = { workspace = true }

--- a/applications/tari_indexer/src/bootstrap.rs
+++ b/applications/tari_indexer/src/bootstrap.rs
@@ -169,13 +169,13 @@ pub async fn spawn_services(
 
     // Connect to substate db
     let store = SqliteIndexerStore::try_create(config.state_db_path())?;
-    check_store(config, &store)?;
+    check_store(config, &store).await?;
 
-    seed_builtin_template_catalogue(&store)?;
+    seed_builtin_template_catalogue(&store).await?;
 
     if config.network.is_testnet() {
         // TODO: We happen to know that the testnet faucet mints u64::MAX tXTR. This is hacky.
-        hack_xtr_initial_supply(&store)?;
+        hack_xtr_initial_supply(&store).await?;
     }
 
     // Epoch event oracle
@@ -403,56 +403,63 @@ async fn create_hybrid_epoch_oracle<TStore: EpochOracleStore + BaseLayerBlockHea
     Ok(HybridEpochOracle::new(configured_oracle, base_layer_oracle, trigger))
 }
 
-fn check_store<TStore: IndexerStore>(config: &ApplicationConfig, store: &TStore) -> anyhow::Result<()> {
-    store.with_write_tx(|tx| {
-        match tx.key_value_get_value::<_, Network>(Key::Network).optional()? {
-            Some(network) => {
-                if network != config.network {
-                    return Err(anyhow!(
-                        "The network in the database ({}) does not match the configured network ({})",
-                        network,
-                        config.network
-                    ));
-                }
-                Ok(())
-            },
-            None => {
-                // If the network is not set, we can assume this is a new store and we can set it
-                tx.key_value_set(Key::Network, config.network)
-                    .map_err(|e| anyhow!("Failed to set network in the store: {}", e))
-            },
-        }
-    })
+async fn check_store<TStore: IndexerStore>(config: &ApplicationConfig, store: &TStore) -> anyhow::Result<()> {
+    let configured_network = config.network;
+    store
+        .with_write_tx(move |tx| {
+            match tx.key_value_get_value::<_, Network>(Key::Network).optional()? {
+                Some(network) => {
+                    if network != configured_network {
+                        return Err(anyhow!(
+                            "The network in the database ({}) does not match the configured network ({})",
+                            network,
+                            configured_network
+                        ));
+                    }
+                    Ok(())
+                },
+                None => {
+                    // If the network is not set, we can assume this is a new store and we can set it
+                    tx.key_value_set(Key::Network, configured_network)
+                        .map_err(|e| anyhow!("Failed to set network in the store: {}", e))
+                },
+            }
+        })
+        .await
 }
 
-fn seed_builtin_template_catalogue<TStore: IndexerStore>(store: &TStore) -> anyhow::Result<()> {
-    store.with_write_tx(|tx| {
-        for (address, code) in all_builtin_templates() {
-            let loaded = WasmModule::load_template_from_code(code)
-                .map_err(|e| anyhow!("Failed to load built-in template: {e}"))?;
-            let binary_hash = calculate_template_binary_hash(code);
-            let metadata = PublishedTemplateMetadata {
-                template_name: loaded.template_name().to_string(),
-                author_public_key: RistrettoPublicKeyBytes::default(),
-                binary_hash,
-                at_epoch: 0,
-                metadata_hash: None,
-            };
-            tx.upsert_template_catalogue(address, &metadata)?;
-        }
-        Ok(())
-    })
+async fn seed_builtin_template_catalogue<TStore: IndexerStore>(store: &TStore) -> anyhow::Result<()> {
+    store
+        .with_write_tx(|tx| {
+            for (address, code) in all_builtin_templates() {
+                let loaded = WasmModule::load_template_from_code(code)
+                    .map_err(|e| anyhow!("Failed to load built-in template: {e}"))?;
+                let binary_hash = calculate_template_binary_hash(code);
+                let metadata = PublishedTemplateMetadata {
+                    template_name: loaded.template_name().to_string(),
+                    author_public_key: RistrettoPublicKeyBytes::default(),
+                    binary_hash,
+                    at_epoch: 0,
+                    metadata_hash: None,
+                };
+                tx.upsert_template_catalogue(address, &metadata)?;
+            }
+            Ok(())
+        })
+        .await
 }
 
-fn hack_xtr_initial_supply<TStore: IndexerStore>(store: &TStore) -> anyhow::Result<()> {
-    store.with_write_tx(|tx| {
-        // Check if the initial supply is already set
-        let existing_supply: Option<Amount> = tx.key_value_get_value(Key::XtrAccumulatedClaimed).optional()?;
-        if existing_supply.is_some() {
-            return Ok(());
-        }
+async fn hack_xtr_initial_supply<TStore: IndexerStore>(store: &TStore) -> anyhow::Result<()> {
+    store
+        .with_write_tx(|tx| {
+            // Check if the initial supply is already set
+            let existing_supply: Option<Amount> = tx.key_value_get_value(Key::XtrAccumulatedClaimed).optional()?;
+            if existing_supply.is_some() {
+                return Ok(());
+            }
 
-        tx.key_value_set(Key::XtrAccumulatedClaimed, TXTR_FAUCET_INITIAL_SUPPLY)
-            .map_err(|e| anyhow!("Failed to set XTR initial supply in the store: {}", e))
-    })
+            tx.key_value_set(Key::XtrAccumulatedClaimed, TXTR_FAUCET_INITIAL_SUPPLY)
+                .map_err(|e| anyhow!("Failed to set XTR initial supply in the store: {}", e))
+        })
+        .await
 }

--- a/applications/tari_indexer/src/event_manager.rs
+++ b/applications/tari_indexer/src/event_manager.rs
@@ -50,9 +50,21 @@ impl EventManager {
         offset: u32,
         limit: u32,
     ) -> Result<Vec<(TransactionId, Event)>, anyhow::Error> {
+        let topic = topic.map(str::to_owned);
+        let substate_id = substate_id.cloned();
+        let resource_address = resource_address.copied();
         let events = self
             .substate_store
-            .with_read_tx(|tx| tx.get_events(substate_id, topic, resource_address, offset, limit))?;
+            .with_read_tx(move |tx| {
+                tx.get_events(
+                    substate_id.as_ref(),
+                    topic.as_deref(),
+                    resource_address.as_ref(),
+                    offset,
+                    limit,
+                )
+            })
+            .await?;
 
         debug!(target: LOG_TARGET, "Found {} events", events.len());
         Ok(events)

--- a/applications/tari_indexer/src/network_state_sync/worker.rs
+++ b/applications/tari_indexer/src/network_state_sync/worker.rs
@@ -377,6 +377,7 @@ impl NetworkWideStateSync {
         Ok(())
     }
 
+    #[expect(clippy::too_many_lines)]
     async fn sync_shard_state(
         &mut self,
         shard: Shard,
@@ -500,7 +501,7 @@ impl NetworkWideStateSync {
                     debug!(target: LOG_TARGET, "✅ Committing {} transactions for shard {shard} (epoch: {msg_epoch})", transactions_len);
                     let inserted = tx.batch_insert_transaction_receipts(transactions, &event_filters)?;
                     if !watched_templates.is_empty() {
-                        process_watched_substate_events(tx, &inserted, &*watched_templates)?;
+                        process_watched_substate_events(tx, &inserted, &watched_templates)?;
                     }
 
                     if !template_catalogue.is_empty() {

--- a/applications/tari_indexer/src/network_state_sync/worker.rs
+++ b/applications/tari_indexer/src/network_state_sync/worker.rs
@@ -490,7 +490,7 @@ impl NetworkWideStateSync {
 
     fn persist_transaction_receipts<I: IntoIterator<Item = (TransactionReceiptAddress, TransactionReceipt)>>(
         &self,
-        tx: &mut SqliteStoreWriteTransaction<'_>,
+        tx: &mut SqliteStoreWriteTransaction,
         receipts: I,
     ) -> Result<(), StorageError> {
         // Insert into DB first so events get assigned their auto-increment IDs,
@@ -515,7 +515,7 @@ impl NetworkWideStateSync {
 
     fn process_watched_substate_events(
         &self,
-        tx: &mut SqliteStoreWriteTransaction<'_>,
+        tx: &mut SqliteStoreWriteTransaction,
         events: &[InsertedEvent],
     ) -> Result<(), StorageError> {
         use crate::store::IndexerStoreWriteTransaction;

--- a/applications/tari_indexer/src/network_state_sync/worker.rs
+++ b/applications/tari_indexer/src/network_state_sync/worker.rs
@@ -1,7 +1,10 @@
 //   Copyright 2025 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use std::{collections::HashMap, pin::pin};
+use std::{
+    collections::{HashMap, HashSet},
+    pin::pin,
+};
 
 use futures::StreamExt;
 use log::*;
@@ -162,6 +165,7 @@ impl NetworkWideStateSync {
         let sync_progress = self
             .store
             .with_read_tx(|tx| tx.key_value_get_value::<_, SyncProgress>(Key::SyncProgress))
+            .await
             .optional()?
             .unwrap_or_default();
 
@@ -240,8 +244,10 @@ impl NetworkWideStateSync {
             if checkpoints.is_empty() {
                 info!(target: LOG_TARGET, "🌍️ No checkpoints found for shard group {shard_group} from epoch {from_epoch} (prev_epoch {prev_epoch})");
                 sync_plan_mut.add_checkpoint_sync_progress(shard_group, prev_epoch);
+                let sync_progress_snapshot = sync_plan_mut.sync_progress().clone();
                 self.store
-                    .with_write_tx(|tx| tx.key_value_set(Key::SyncProgress, sync_plan_mut.sync_progress()))?;
+                    .with_write_tx(move |tx| tx.key_value_set(Key::SyncProgress, sync_progress_snapshot))
+                    .await?;
                 continue;
             }
 
@@ -292,19 +298,23 @@ impl NetworkWideStateSync {
                 self.stats.increment_checkpoints();
                 sync_plan_mut.add_checkpoint_sync_progress(shard_group, checkpoint.epoch());
                 let xtr_exhausted = Amount::from(checkpoint.header().accumulated_data().total_exhaust_burn);
-                self.store.with_write_tx(|tx| {
-                    if !tx.epoch_checkpoint_exists(shard_group, checkpoint.epoch())? {
-                        tx.insert_or_ignore_epoch_checkpoint(&checkpoint)?;
+                let checkpoint_epoch = checkpoint.epoch();
+                let sync_progress_snapshot = sync_plan_mut.sync_progress().clone();
+                self.store
+                    .with_write_tx(move |tx| {
+                        if !tx.epoch_checkpoint_exists(shard_group, checkpoint_epoch)? {
+                            tx.insert_or_ignore_epoch_checkpoint(&checkpoint)?;
 
-                        let exhausted = tx
-                            .key_value_get_value::<_, Amount>(Key::XtrAccumulatedExhaustBurn)
-                            .optional()?;
+                            let exhausted = tx
+                                .key_value_get_value::<_, Amount>(Key::XtrAccumulatedExhaustBurn)
+                                .optional()?;
 
-                        let new_exhausted = exhausted.unwrap_or_else(Amount::zero) + xtr_exhausted;
-                        tx.key_value_set(Key::XtrAccumulatedExhaustBurn, new_exhausted)?;
-                    }
-                    tx.key_value_set(Key::SyncProgress, sync_plan_mut.sync_progress())
-                })?;
+                            let new_exhausted = exhausted.unwrap_or_else(Amount::zero) + xtr_exhausted;
+                            tx.key_value_set(Key::XtrAccumulatedExhaustBurn, new_exhausted)?;
+                        }
+                        tx.key_value_set(Key::SyncProgress, sync_progress_snapshot)
+                    })
+                    .await?;
             }
         }
 
@@ -455,124 +465,128 @@ impl NetworkWideStateSync {
 
             self.stats.increase_state_updates(update_buf.len());
 
-            self.store.clone().with_write_tx(|tx| {
-                debug!(target: LOG_TARGET, "✅ Committing {} updates for shard {shard} (epoch: {msg_epoch}, state version: {state_version})", update_buf.len());
-                // TODO: this is not currently used. Consider removing.
-                tx.batch_insert_substate_transitions(shard, state_version, update_buf.drain(..))?;
-                debug!(target: LOG_TARGET, "✅ Committing {} UTXOs for shard {shard} (epoch: {msg_epoch})", utxos_buf.len());
-                tx.batch_insert_utxo_updates(msg_epoch, utxos_buf.drain(..))?;
-                // There are many ways to do this. This might not be the best way.
-                // This allows wallet to query for validator fee pool values when preparing a claim fee transaction.
-                for substate_data in validator_fee_pools_buf.drain(..) {
-                    tx.upsert_substate(&substate_data)?;
-                }
-                debug!(target: LOG_TARGET, "✅ Committing {} transactions for shard {shard} (epoch: {msg_epoch})", transactions_buf.len());
-                self.stats.increase_events(transactions_buf.iter().map(|(_, t)| t.events.len()).sum());
-                self.persist_transaction_receipts(tx, transactions_buf.drain(..))?;
+            let updates = std::mem::take(update_buf);
+            let utxos = std::mem::take(utxos_buf);
+            let transactions = std::mem::take(transactions_buf);
+            let validator_fee_pools = std::mem::take(validator_fee_pools_buf);
+            let template_catalogue = std::mem::take(template_catalogue_buf);
 
-                if !template_catalogue_buf.is_empty() {
-                    debug!(target: LOG_TARGET, "✅ Upserting {} template catalogue entries for shard {shard} (epoch: {msg_epoch})", template_catalogue_buf.len());
-                    for (template_addr, metadata) in template_catalogue_buf.drain(..) {
-                        tx.upsert_template_catalogue(&template_addr, &metadata)?;
+            let updates_len = updates.len();
+            let utxos_len = utxos.len();
+            let transactions_len = transactions.len();
+            let template_catalogue_len = template_catalogue.len();
+            let event_count: usize = transactions.iter().map(|(_, t)| t.events.len()).sum();
+            self.stats.increase_events(event_count);
+
+            sync_plan_mut.add_state_sync_progress(shard, state_version, msg_epoch);
+            let sync_progress_snapshot = sync_plan_mut.sync_progress().clone();
+
+            let event_filters = self.config.event_filters.clone();
+            let watched_templates = self.config.watched_templates.clone();
+            let xtr_claimed_snapshot = xtr_claimed;
+
+            let inserted_events = self
+                .store
+                .clone()
+                .with_write_tx(move |tx| -> Result<Vec<InsertedEvent>, StorageError> {
+                    debug!(target: LOG_TARGET, "✅ Committing {} updates for shard {shard} (epoch: {msg_epoch}, state version: {state_version})", updates_len);
+                    // TODO: this is not currently used. Consider removing.
+                    tx.batch_insert_substate_transitions(shard, state_version, updates)?;
+                    debug!(target: LOG_TARGET, "✅ Committing {} UTXOs for shard {shard} (epoch: {msg_epoch})", utxos_len);
+                    tx.batch_insert_utxo_updates(msg_epoch, utxos)?;
+                    for substate_data in validator_fee_pools {
+                        tx.upsert_substate(&substate_data)?;
                     }
-                }
-
-                // All done - write the sync progress
-                sync_plan_mut.add_state_sync_progress(shard, state_version, msg_epoch);
-                tx.key_value_set(Key::SyncProgress, sync_plan_mut.sync_progress())?;
-                let claimed = tx.key_value_get_value(Key::XtrAccumulatedClaimed).optional()?;
-                let new_claimed = claimed.unwrap_or_else(Amount::zero) + xtr_claimed;
-                tx.key_value_set(Key::XtrAccumulatedClaimed, new_claimed)
-            })?;
-        }
-        Ok(())
-    }
-
-    fn persist_transaction_receipts<I: IntoIterator<Item = (TransactionReceiptAddress, TransactionReceipt)>>(
-        &self,
-        tx: &mut SqliteStoreWriteTransaction,
-        receipts: I,
-    ) -> Result<(), StorageError> {
-        // Insert into DB first so events get assigned their auto-increment IDs,
-        // then broadcast with IDs attached. This ensures SSE clients can use
-        // the ID for catch-up/replay.
-        let inserted_events = tx.batch_insert_transaction_receipts(receipts, &self.config.event_filters)?;
-
-        if !self.config.watched_templates.is_empty() {
-            self.process_watched_substate_events(tx, &inserted_events)?;
-        }
-
-        for inserted in inserted_events {
-            self.transaction_event_notify.notify(TransactionEvent {
-                id: inserted.id,
-                transaction_id: inserted.transaction_id,
-                event: inserted.event,
-            });
-        }
-
-        Ok(())
-    }
-
-    fn process_watched_substate_events(
-        &self,
-        tx: &mut SqliteStoreWriteTransaction,
-        events: &[InsertedEvent],
-    ) -> Result<(), StorageError> {
-        use crate::store::IndexerStoreWriteTransaction;
-
-        for inserted in events {
-            let event = &inserted.event;
-            match event.topic() {
-                "std.component.created" => {
-                    if self.config.watched_templates.contains(&event.template_address()) &&
-                        let Some(substate_id) = event.substate_id()
-                    {
-                        debug!(
-                            target: LOG_TARGET,
-                            "📌 Watched component created: {} (template: {})",
-                            substate_id,
-                            event.template_address()
-                        );
-                        tx.insert_watched_substate(substate_id, &event.template_address())?;
+                    debug!(target: LOG_TARGET, "✅ Committing {} transactions for shard {shard} (epoch: {msg_epoch})", transactions_len);
+                    let inserted = tx.batch_insert_transaction_receipts(transactions, &event_filters)?;
+                    if !watched_templates.is_empty() {
+                        process_watched_substate_events(tx, &inserted, &*watched_templates)?;
                     }
-                },
-                "std.component.template_update" => {
-                    if let Some(substate_id) = event.substate_id() {
-                        let prev_template = event
-                            .payload()
-                            .get("prev_template")
-                            .and_then(|v| TemplateAddress::from_hex(v).ok());
 
-                        let prev_was_watched = prev_template
-                            .as_ref()
-                            .is_some_and(|t| self.config.watched_templates.contains(t));
-                        let new_is_watched = self.config.watched_templates.contains(&event.template_address());
-
-                        if prev_was_watched && !new_is_watched {
-                            debug!(
-                                target: LOG_TARGET,
-                                "📌 Watched component removed (template update): {}",
-                                substate_id
-                            );
-                            tx.delete_watched_substate(substate_id)?;
-                        } else if new_is_watched {
-                            debug!(
-                                target: LOG_TARGET,
-                                "📌 Watched component updated: {} (template: {})",
-                                substate_id,
-                                event.template_address()
-                            );
-                            tx.insert_watched_substate(substate_id, &event.template_address())?;
-                        } else {
-                            // N/A
+                    if !template_catalogue.is_empty() {
+                        debug!(target: LOG_TARGET, "✅ Upserting {} template catalogue entries for shard {shard} (epoch: {msg_epoch})", template_catalogue_len);
+                        for (template_addr, metadata) in template_catalogue {
+                            tx.upsert_template_catalogue(&template_addr, &metadata)?;
                         }
                     }
-                },
-                _ => {},
+
+                    tx.key_value_set(Key::SyncProgress, sync_progress_snapshot)?;
+                    let claimed = tx.key_value_get_value(Key::XtrAccumulatedClaimed).optional()?;
+                    let new_claimed = claimed.unwrap_or_else(Amount::zero) + xtr_claimed_snapshot;
+                    tx.key_value_set(Key::XtrAccumulatedClaimed, new_claimed)?;
+                    Ok(inserted)
+                })
+                .await?;
+
+            for inserted in inserted_events {
+                self.transaction_event_notify.notify(TransactionEvent {
+                    id: inserted.id,
+                    transaction_id: inserted.transaction_id,
+                    event: inserted.event,
+                });
             }
         }
         Ok(())
     }
+}
+
+fn process_watched_substate_events(
+    tx: &mut SqliteStoreWriteTransaction<'_>,
+    events: &[InsertedEvent],
+    watched_templates: &HashSet<TemplateAddress>,
+) -> Result<(), StorageError> {
+    use crate::store::IndexerStoreWriteTransaction;
+
+    for inserted in events {
+        let event = &inserted.event;
+        match event.topic() {
+            "std.component.created" => {
+                if watched_templates.contains(&event.template_address()) &&
+                    let Some(substate_id) = event.substate_id()
+                {
+                    debug!(
+                        target: LOG_TARGET,
+                        "📌 Watched component created: {} (template: {})",
+                        substate_id,
+                        event.template_address()
+                    );
+                    tx.insert_watched_substate(substate_id, &event.template_address())?;
+                }
+            },
+            "std.component.template_update" => {
+                if let Some(substate_id) = event.substate_id() {
+                    let prev_template = event
+                        .payload()
+                        .get("prev_template")
+                        .and_then(|v| TemplateAddress::from_hex(v).ok());
+
+                    let prev_was_watched = prev_template.as_ref().is_some_and(|t| watched_templates.contains(t));
+                    let new_is_watched = watched_templates.contains(&event.template_address());
+
+                    if prev_was_watched && !new_is_watched {
+                        debug!(
+                            target: LOG_TARGET,
+                            "📌 Watched component removed (template update): {}",
+                            substate_id
+                        );
+                        tx.delete_watched_substate(substate_id)?;
+                    } else if new_is_watched {
+                        debug!(
+                            target: LOG_TARGET,
+                            "📌 Watched component updated: {} (template: {})",
+                            substate_id,
+                            event.template_address()
+                        );
+                        tx.insert_watched_substate(substate_id, &event.template_address())?;
+                    } else {
+                        // N/A
+                    }
+                }
+            },
+            _ => {},
+        }
+    }
+    Ok(())
 }
 
 fn extend_bufs_from_substate_update(

--- a/applications/tari_indexer/src/rest_api/handlers/epoch_checkpoints.rs
+++ b/applications/tari_indexer/src/rest_api/handlers/epoch_checkpoints.rs
@@ -37,6 +37,7 @@ pub async fn list_epoch_checkpoints(
     let checkpoints = context
         .read_only_store()
         .epoch_checkpoint_get_all(from_epoch, u64::from(limit))
+        .await
         .map_err(ErrorResponse::anyhow)?;
 
     let checkpoints = checkpoints
@@ -64,6 +65,7 @@ pub async fn get_latest_epoch_checkpoint(
     let checkpoint = context
         .read_only_store()
         .epoch_checkpoint_get_latest()
+        .await
         .map_err(ErrorResponse::anyhow)?;
 
     let checkpoint = serde_json::to_value(checkpoint).map_err(ErrorResponse::anyhow)?;

--- a/applications/tari_indexer/src/rest_api/handlers/network.rs
+++ b/applications/tari_indexer/src/rest_api/handlers/network.rs
@@ -52,6 +52,7 @@ pub async fn get_network_sync_stats(
     let sync_progress = context
         .read_only_store()
         .get_sync_progress()
+        .await
         .optional()
         .map_err(ErrorResponse::anyhow)?;
 

--- a/applications/tari_indexer/src/rest_api/handlers/nfts.rs
+++ b/applications/tari_indexer/src/rest_api/handlers/nfts.rs
@@ -37,6 +37,7 @@ pub async fn get_non_fungibles(
     let non_fungibles = context
         .substate_manager()
         .get_non_fungibles_by_resource_address(req.address, limit, offset)
+        .await
         .map_err(ErrorResponse::anyhow)?;
 
     Ok(Json(GetNonFungiblesResponse { non_fungibles }))

--- a/applications/tari_indexer/src/rest_api/handlers/resources.rs
+++ b/applications/tari_indexer/src/rest_api/handlers/resources.rs
@@ -62,6 +62,7 @@ pub async fn get_resource(
         let amount = context
             .read_only_store()
             .get_xtr_total_supply()
+            .await
             .map_err(ErrorResponse::anyhow)?;
         Some(amount)
     } else {

--- a/applications/tari_indexer/src/rest_api/handlers/templates.rs
+++ b/applications/tari_indexer/src/rest_api/handlers/templates.rs
@@ -142,6 +142,7 @@ pub async fn list_template_catalogue(
     let entries = context
         .read_only_store()
         .list_template_catalogue(req.name_filter.as_deref(), req.after.as_ref(), limit)
+        .await
         .map_err(ErrorResponse::anyhow)?
         .into_iter()
         .map(TemplateCatalogueItem::from)
@@ -167,6 +168,7 @@ pub async fn get_template_catalogue_entry(
     let entry = context
         .read_only_store()
         .get_template_catalogue_entry(&template_address)
+        .await
         .map_err(ErrorResponse::anyhow)?
         .ok_or_else(|| ErrorResponse::not_found(format!("Template {} not found in the catalogue", template_address)))?;
 

--- a/applications/tari_indexer/src/rest_api/handlers/templates.rs
+++ b/applications/tari_indexer/src/rest_api/handlers/templates.rs
@@ -169,6 +169,7 @@ pub async fn get_template_catalogue_entry(
         .read_only_store()
         .get_template_catalogue_entry(&template_address)
         .await
+        .optional()
         .map_err(ErrorResponse::anyhow)?
         .ok_or_else(|| ErrorResponse::not_found(format!("Template {} not found in the catalogue", template_address)))?;
 

--- a/applications/tari_indexer/src/rest_api/handlers/transaction_events.rs
+++ b/applications/tari_indexer/src/rest_api/handlers/transaction_events.rs
@@ -136,14 +136,16 @@ async fn run_replay_then_live(
     let mut total_replayed = 0u32;
 
     loop {
-        let batch = store.get_events_after_id(
-            highest_id,
-            filter.topic.as_deref(),
-            filter.substate_id.as_ref(),
-            filter.template_address.as_ref(),
-            filter.resource_address.as_ref(),
-            REPLAY_PAGE_SIZE,
-        )?;
+        let batch = store
+            .get_events_after_id(
+                highest_id,
+                filter.topic.as_deref(),
+                filter.substate_id.as_ref(),
+                filter.template_address.as_ref(),
+                filter.resource_address.as_ref(),
+                REPLAY_PAGE_SIZE,
+            )
+            .await?;
 
         if batch.is_empty() {
             break;
@@ -189,14 +191,16 @@ async fn run_replay_then_live(
                 warn!(target: LOG_TARGET, "SSE broadcast lagged by {} events, catching up from DB (highest_id={})", n, highest_id);
                 // Iteratively catch up from DB in pages until we've replayed everything
                 loop {
-                    let batch = store.get_events_after_id(
-                        highest_id,
-                        filter.topic.as_deref(),
-                        filter.substate_id.as_ref(),
-                        filter.template_address.as_ref(),
-                        filter.resource_address.as_ref(),
-                        REPLAY_PAGE_SIZE,
-                    )?;
+                    let batch = store
+                        .get_events_after_id(
+                            highest_id,
+                            filter.topic.as_deref(),
+                            filter.substate_id.as_ref(),
+                            filter.template_address.as_ref(),
+                            filter.resource_address.as_ref(),
+                            REPLAY_PAGE_SIZE,
+                        )
+                        .await?;
 
                     if batch.is_empty() {
                         break;

--- a/applications/tari_indexer/src/rest_api/handlers/transaction_receipts.rs
+++ b/applications/tari_indexer/src/rest_api/handlers/transaction_receipts.rs
@@ -44,6 +44,7 @@ pub async fn list_transaction_receipts(
     let receipts = context
         .read_only_store()
         .list_transaction_receipts(req.last_id, u64::from(limit), ordering)
+        .await
         .map_err(ErrorResponse::anyhow)?;
 
     Ok(context.apply_cache_control(Json(ListTransactionReceiptsResponse { receipts }), 10))
@@ -66,6 +67,7 @@ pub async fn get_transaction_receipt(
     let receipt = context
         .read_only_store()
         .get_transaction_receipt(&receipt_addr)
+        .await
         .optional()
         .map_err(ErrorResponse::anyhow)?
         .ok_or_else(|| ErrorResponse::not_found(format!("Transaction receipt {receipt_addr} not found")))?;

--- a/applications/tari_indexer/src/rest_api/handlers/transactions.rs
+++ b/applications/tari_indexer/src/rest_api/handlers/transactions.rs
@@ -163,6 +163,7 @@ pub async fn list_recent_transactions(
     let transactions = context
         .transaction_manager()
         .list_recent_transactions(req.last_id, limit as usize)
+        .await
         .map_err(ErrorResponse::anyhow)?;
 
     Ok(context.apply_cache_control(Json(ListRecentTransactionsResponse { transactions }), 30))
@@ -247,6 +248,7 @@ pub async fn query_transaction_events(
             offset,
             limit,
         )
+        .await
         .map_err(|e| {
             error!(target: LOG_TARGET, "DB error when fetching events: {}", e);
             ErrorResponse::internal_error("DB error when fetching events")

--- a/applications/tari_indexer/src/rest_api/handlers/utxos.rs
+++ b/applications/tari_indexer/src/rest_api/handlers/utxos.rs
@@ -120,6 +120,7 @@ pub async fn fetch_utxos(
     let utxos = context
         .substate_manager()
         .get_unspent_utxos(&req.resource_address, &req.tag_and_nonce_pairs)
+        .await
         .map_err(ErrorResponse::anyhow)?;
 
     Ok(Json(GetUtxosResponse { utxos }))
@@ -144,6 +145,7 @@ pub async fn list_utxos(
     let utxos = context
         .substate_manager()
         .list_utxos(&req.resource_address, req.from_id, req.limit)
+        .await
         .map_err(ErrorResponse::anyhow)?;
 
     Ok(Json(ListUtxosResponse { utxos }))

--- a/applications/tari_indexer/src/rest_api/handlers/watched.rs
+++ b/applications/tari_indexer/src/rest_api/handlers/watched.rs
@@ -9,6 +9,7 @@ use tari_indexer_client::types::{
     WatchedSubstateItem,
     WatchedTemplateItem,
 };
+use tari_ootle_common_types::optional::Optional;
 
 use crate::rest_api::{context::HandlerContext, error::ErrorResponse, handlers::HandlerResult};
 
@@ -64,14 +65,17 @@ pub async fn list_watched_templates(
     let store = context.read_only_store();
     let mut templates = Vec::with_capacity(context.watched_templates().len());
     for addr in context.watched_templates() {
-        let template = store
+        if let Some(template) = store
             .get_template_catalogue_entry(addr)
             .await
-            .map_err(ErrorResponse::anyhow)?;
-        templates.push(WatchedTemplateItem {
-            template_address: *addr,
-            template_name: Some(template.template_name),
-        });
+            .optional()
+            .map_err(ErrorResponse::anyhow)?
+        {
+            templates.push(WatchedTemplateItem {
+                template_address: *addr,
+                template_name: Some(template.template_name),
+            });
+        }
     }
     Ok(Json(ListWatchedTemplatesResponse { templates }))
 }

--- a/applications/tari_indexer/src/rest_api/handlers/watched.rs
+++ b/applications/tari_indexer/src/rest_api/handlers/watched.rs
@@ -62,17 +62,15 @@ pub async fn list_watched_templates(
     Extension(context): Extension<HandlerContext>,
 ) -> HandlerResult<Json<ListWatchedTemplatesResponse>> {
     let store = context.read_only_store();
-    let mut templates = Vec::new();
-    for addr in context.watched_templates().iter() {
-        let template_name = store
+    let mut templates = Vec::with_capacity(context.watched_templates().len());
+    for addr in context.watched_templates() {
+        let template = store
             .get_template_catalogue_entry(addr)
             .await
-            .ok()
-            .flatten()
-            .map(|e| e.template_name);
+            .map_err(ErrorResponse::anyhow)?;
         templates.push(WatchedTemplateItem {
             template_address: *addr,
-            template_name,
+            template_name: Some(template.template_name),
         });
     }
     Ok(Json(ListWatchedTemplatesResponse { templates }))

--- a/applications/tari_indexer/src/rest_api/handlers/watched.rs
+++ b/applications/tari_indexer/src/rest_api/handlers/watched.rs
@@ -36,6 +36,7 @@ pub async fn list_watched_substates(
     let entries = context
         .read_only_store()
         .list_watched_substates(req.template_address.as_ref(), limit, offset)
+        .await
         .map_err(ErrorResponse::anyhow)?;
 
     let substates = entries
@@ -61,20 +62,18 @@ pub async fn list_watched_templates(
     Extension(context): Extension<HandlerContext>,
 ) -> HandlerResult<Json<ListWatchedTemplatesResponse>> {
     let store = context.read_only_store();
-    let templates = context
-        .watched_templates()
-        .iter()
-        .map(|addr| {
-            let template_name = store
-                .get_template_catalogue_entry(addr)
-                .ok()
-                .flatten()
-                .map(|e| e.template_name);
-            WatchedTemplateItem {
-                template_address: *addr,
-                template_name,
-            }
-        })
-        .collect();
+    let mut templates = Vec::new();
+    for addr in context.watched_templates().iter() {
+        let template_name = store
+            .get_template_catalogue_entry(addr)
+            .await
+            .ok()
+            .flatten()
+            .map(|e| e.template_name);
+        templates.push(WatchedTemplateItem {
+            template_address: *addr,
+            template_name,
+        });
+    }
     Ok(Json(ListWatchedTemplatesResponse { templates }))
 }

--- a/applications/tari_indexer/src/rest_api/streaming/utxo_stream.rs
+++ b/applications/tari_indexer/src/rest_api/streaming/utxo_stream.rs
@@ -6,9 +6,10 @@ use std::{
     task::{Context, Poll},
 };
 
+use async_stream::try_stream;
 use axum::response::{IntoResponse, Response};
 use bytes::{Bytes, BytesMut};
-use futures::Stream;
+use futures::{Stream, StreamExt};
 use log::*;
 use tari_indexer_client::{
     protobuf,
@@ -24,138 +25,14 @@ use crate::{
 const LOG_TARGET: &str = "tari::indexer::rest_api::streaming::utxo_stream";
 
 pub struct UtxoUpdateStream {
-    substate_manager: SubstateManager,
-    request: GetUtxoUpdatesRequest,
-    requested_shard_index: usize,
-    buffer: BytesMut,
-    pending_updates: Option<PendingUpdates>,
-    is_done: bool,
-    encoder: MimeTypeEncoder,
+    inner: Pin<Box<dyn Stream<Item = anyhow::Result<Bytes>> + Send>>,
 }
 
 impl UtxoUpdateStream {
     pub fn new(substate_manager: SubstateManager, request: GetUtxoUpdatesRequest, encoder: MimeTypeEncoder) -> Self {
-        Self {
-            substate_manager,
-            request,
-            requested_shard_index: 0,
-            pending_updates: None,
-            buffer: BytesMut::with_capacity(1024),
-            is_done: false,
-            encoder,
-        }
-    }
-
-    fn current_requested_state_shard(&self) -> Option<(Shard, StateVersion)> {
-        self.request
-            .shard_state_versions
-            .get(self.requested_shard_index)
-            .copied()
-    }
-
-    fn encode_to_buffer(&mut self) -> anyhow::Result<()> {
-        let mut pending_updates = self
-            .pending_updates
-            .take()
-            .expect("BUG: no pending updates in encode_to_buffer");
-
-        let mut payload = protobuf::UtxoUpdatePayload::default();
-
-        if !pending_updates.sos_emitted {
-            payload.sos = Some(protobuf::StartOfShard {
-                shard: pending_updates.shard.as_u32(),
-                max_state_version: pending_updates.updates_state_version.as_u64(),
-                num_updates: u32::try_from(pending_updates.updates_len()).expect("loaded more than u32::MAX updates"),
-            });
-            pending_updates.sos_emitted = true;
-        }
-
-        if let Some(update) = pending_updates.next() {
-            payload.update = Some(wallet_utxo_update_to_protobuf(update));
-        }
-
-        if pending_updates.is_empty() {
-            // No more updates in this batch
-            payload.eos = Some(protobuf::EndOfShard {
-                max_state_version: pending_updates.high_watermark_state_version.as_u64(),
-            });
-        }
-
-        // This should be a max of about 60 bytes for protobuf (observed max 54 bytes)
-        self.encoder.encode_into(&payload, &mut self.buffer)?;
-
-        debug!(
-            target: LOG_TARGET,
-            "Encoded payload size: {}, pending updates remaining in batch: {}",
-            self.buffer.len(),
-            pending_updates.updates_len()
-        );
-
-        if payload.eos.is_none() {
-            // Put pending updates back for next call
-            self.pending_updates = Some(pending_updates);
-        }
-
-        Ok(())
-    }
-
-    pub fn next_batch(&mut self, shard: Shard, state_version: StateVersion) -> anyhow::Result<bool> {
-        let UtxoStateUpdateSet {
-            updates,
-            max_state_version,
-            max_epoch,
-        } = self.substate_manager.get_utxo_updates(
-            self.request.resource_address,
-            self.request.from_epoch,
-            shard,
-            state_version,
-            self.request.unspent_only,
-            self.request.per_shard_limit,
-        )?;
-        let high_watermark_state_version = self
-            .substate_manager
-            .get_max_state_version(&self.request.resource_address, shard)?;
-        if updates.is_empty() {
-            return Ok(false);
-        }
-        debug!(
-            target: LOG_TARGET,
-            "Received {} updates for shard {shard}, max_epoch = {max_epoch}, max_state_version {max_state_version} -> {high_watermark_state_version}",
-            updates.len(),
-        );
-        self.pending_updates = Some(PendingUpdates {
-            sos_emitted: false,
-            shard,
-            updates_state_version: max_state_version,
-            high_watermark_state_version,
-            updates,
-            index: 0,
-        });
-
-        Ok(true)
-    }
-}
-
-impl Stream for UtxoUpdateStream {
-    type Item = anyhow::Result<Bytes>;
-
-    fn poll_next(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        if self.is_done {
-            return Poll::Ready(None);
-        }
-
-        let this = self.get_mut();
-        loop {
-            if this.pending_updates.is_none() {
-                let (shard, state_version) = match this.current_requested_state_shard() {
-                    Some(v) => v,
-                    None => {
-                        debug!(target: LOG_TARGET, "No more shards to request");
-                        this.is_done = true;
-                        return Poll::Ready(None);
-                    },
-                };
-
+        let inner = try_stream! {
+            let mut buffer = BytesMut::with_capacity(1024);
+            for &(shard, state_version) in &request.shard_state_versions {
                 debug!(
                     target: LOG_TARGET,
                     "Requesting UTXO updates for shard {} from state version {}",
@@ -163,51 +40,96 @@ impl Stream for UtxoUpdateStream {
                     state_version
                 );
 
-                // Get more updates
-                match this.next_batch(shard, state_version) {
-                    Ok(true) => {
-                        // start sending updates
-                    },
-                    Ok(false) => {
-                        // No updates in this shard, move to next
-                        this.requested_shard_index += 1;
-                        debug!(
-                            target: LOG_TARGET,
-                            "No updates found for shard {}, moving to next shard",
-                            shard
-                        );
-                        continue;
-                    },
-                    Err(e) => {
-                        error!(target: LOG_TARGET, "Error fetching UTXO updates: {}", e);
-                        this.is_done = true;
-                        break Poll::Ready(Some(Err(anyhow::anyhow!(e))));
-                    },
+                let UtxoStateUpdateSet {
+                    updates,
+                    max_state_version,
+                    max_epoch,
+                } = substate_manager
+                    .get_utxo_updates(
+                        request.resource_address,
+                        request.from_epoch,
+                        shard,
+                        state_version,
+                        request.unspent_only,
+                        request.per_shard_limit,
+                    )
+                    .await
+                    .map_err(anyhow::Error::from)?;
+
+                if updates.is_empty() {
+                    debug!(target: LOG_TARGET, "No updates found for shard {}, moving to next shard", shard);
+                    continue;
+                }
+
+                let high_watermark_state_version = substate_manager
+                    .get_max_state_version(&request.resource_address, shard)
+                    .await
+                    .map_err(anyhow::Error::from)?;
+
+                debug!(
+                    target: LOG_TARGET,
+                    "Received {} updates for shard {shard}, max_epoch = {max_epoch}, max_state_version {max_state_version} -> {high_watermark_state_version}",
+                    updates.len(),
+                );
+
+                let mut pending = PendingUpdates {
+                    sos_emitted: false,
+                    shard,
+                    updates_state_version: max_state_version,
+                    high_watermark_state_version,
+                    updates,
+                    index: 0,
+                };
+
+                loop {
+                    let mut payload = protobuf::UtxoUpdatePayload::default();
+
+                    if !pending.sos_emitted {
+                        payload.sos = Some(protobuf::StartOfShard {
+                            shard: pending.shard.as_u32(),
+                            max_state_version: pending.updates_state_version.as_u64(),
+                            num_updates: u32::try_from(pending.updates_len()).expect("loaded more than u32::MAX updates"),
+                        });
+                        pending.sos_emitted = true;
+                    }
+
+                    if let Some(update) = pending.next() {
+                        payload.update = Some(wallet_utxo_update_to_protobuf(update));
+                    }
+
+                    if pending.is_empty() {
+                        payload.eos = Some(protobuf::EndOfShard {
+                            max_state_version: pending.high_watermark_state_version.as_u64(),
+                        });
+                    }
+
+                    encoder.encode_into(&payload, &mut buffer)?;
+
+                    debug!(
+                        target: LOG_TARGET,
+                        "Encoded payload size: {}, pending updates remaining in batch: {}",
+                        buffer.len(),
+                        pending.updates_len()
+                    );
+
+                    yield buffer.split().freeze();
+
+                    if payload.eos.is_some() {
+                        break;
+                    }
                 }
             }
+        };
 
-            if let Err(e) = this.encode_to_buffer() {
-                error!(target: LOG_TARGET, "Error encoding UTXO update: {}", e);
-                this.is_done = true;
-                return Poll::Ready(Some(Err(anyhow::anyhow!(e))));
-            }
+        Self { inner: Box::pin(inner) }
+    }
+}
 
-            debug!(
-                target: LOG_TARGET,
-                "Buffer size after encoding: {} bytes",
-                this.buffer.len()
-            );
+impl Stream for UtxoUpdateStream {
+    type Item = anyhow::Result<Bytes>;
 
-            if this.pending_updates.is_none() {
-                // Finished this shard, move to next
-                // Note that the client has requested a maximum number of updates per shard, so we may not have sent all
-                // updates, but it is up to the client to request again with updated state versions
-                this.requested_shard_index += 1;
-            }
-
-            // Drain and send the buffer
-            break Poll::Ready(Some(Ok(this.buffer.split().freeze())));
-        }
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.inner.poll_next_unpin(cx)
     }
 }
 
@@ -233,7 +155,6 @@ struct PendingUpdates {
 }
 
 impl PendingUpdates {
-    #[allow(dead_code)]
     pub fn is_done(&self) -> bool {
         self.index >= self.updates.len()
     }

--- a/applications/tari_indexer/src/storage_sqlite/reader.rs
+++ b/applications/tari_indexer/src/storage_sqlite/reader.rs
@@ -848,7 +848,7 @@ impl IndexerStoreReadTransaction for SqliteStoreReadTransaction<'_> {
     fn get_template_catalogue_entry(
         &mut self,
         template_address: &TemplateAddress,
-    ) -> Result<Option<TemplateCatalogueEntry>, StorageError> {
+    ) -> Result<TemplateCatalogueEntry, StorageError> {
         const OPERATION: &str = "get_template_catalogue_entry";
         use crate::storage_sqlite::schema::template_catalogue;
 
@@ -859,16 +859,17 @@ impl IndexerStoreReadTransaction for SqliteStoreReadTransaction<'_> {
             .optional()
             .map_err(|e| StorageError::QueryError {
                 reason: format!("{OPERATION}: {e}"),
+            })?
+            .ok_or_else(|| StorageError::NotFound {
+                item: "template_catalogue_entry",
+                key: template_address.to_string(),
             })?;
 
-        row.map(|r| {
-            TemplateCatalogueEntry::try_from(r).map_err(|e| StorageError::DecodingError {
-                operation: OPERATION,
-                item: "TemplateCatalogueEntry",
-                details: e.to_string(),
-            })
+        TemplateCatalogueEntry::try_from(row).map_err(|e| StorageError::DecodingError {
+            operation: OPERATION,
+            item: "TemplateCatalogueEntry",
+            details: e.to_string(),
         })
-        .transpose()
     }
 
     fn list_watched_substates(

--- a/applications/tari_indexer/src/storage_sqlite/reader.rs
+++ b/applications/tari_indexer/src/storage_sqlite/reader.rs
@@ -58,6 +58,7 @@ use crate::{
             WatchedSubstateRow,
         },
         serialization::{deserialize_hex_try_from, deserialize_json, serialize_hex},
+        store_factory::SqlitePooledConnection,
     },
     store::IndexerStoreReadTransaction,
     substate_manager::SubstateResponse,
@@ -65,12 +66,12 @@ use crate::{
 
 const LOG_TARGET: &str = "tari::indexer::storage_sqlite::reader";
 
-pub struct SqliteStoreReadTransaction<'a> {
-    pub(super) transaction: SqliteTransaction<'a>,
+pub struct SqliteStoreReadTransaction {
+    pub(super) transaction: SqliteTransaction<SqlitePooledConnection>,
 }
 
-impl<'a> SqliteStoreReadTransaction<'a> {
-    pub(super) fn new(transaction: SqliteTransaction<'a>) -> Self {
+impl SqliteStoreReadTransaction {
+    pub(super) fn new(transaction: SqliteTransaction<SqlitePooledConnection>) -> Self {
         Self { transaction }
     }
 
@@ -79,7 +80,7 @@ impl<'a> SqliteStoreReadTransaction<'a> {
     }
 }
 
-impl IndexerStoreReadTransaction for SqliteStoreReadTransaction<'_> {
+impl IndexerStoreReadTransaction for SqliteStoreReadTransaction {
     fn list_substates(
         &mut self,
         by_id: Option<&SubstateId>,

--- a/applications/tari_indexer/src/storage_sqlite/reader.rs
+++ b/applications/tari_indexer/src/storage_sqlite/reader.rs
@@ -58,7 +58,6 @@ use crate::{
             WatchedSubstateRow,
         },
         serialization::{deserialize_hex_try_from, deserialize_json, serialize_hex},
-        store_factory::SqlitePooledConnection,
     },
     store::IndexerStoreReadTransaction,
     substate_manager::SubstateResponse,
@@ -66,12 +65,12 @@ use crate::{
 
 const LOG_TARGET: &str = "tari::indexer::storage_sqlite::reader";
 
-pub struct SqliteStoreReadTransaction {
-    pub(super) transaction: SqliteTransaction<SqlitePooledConnection>,
+pub struct SqliteStoreReadTransaction<'a> {
+    pub(super) transaction: SqliteTransaction<&'a mut SqliteConnection>,
 }
 
-impl SqliteStoreReadTransaction {
-    pub(super) fn new(transaction: SqliteTransaction<SqlitePooledConnection>) -> Self {
+impl<'a> SqliteStoreReadTransaction<'a> {
+    pub(super) fn new(transaction: SqliteTransaction<&'a mut SqliteConnection>) -> Self {
         Self { transaction }
     }
 
@@ -80,7 +79,7 @@ impl SqliteStoreReadTransaction {
     }
 }
 
-impl IndexerStoreReadTransaction for SqliteStoreReadTransaction {
+impl IndexerStoreReadTransaction for SqliteStoreReadTransaction<'_> {
     fn list_substates(
         &mut self,
         by_id: Option<&SubstateId>,

--- a/applications/tari_indexer/src/storage_sqlite/store_factory.rs
+++ b/applications/tari_indexer/src/storage_sqlite/store_factory.rs
@@ -1,14 +1,15 @@
 //   Copyright 2022 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use std::{
-    fmt::Debug,
-    fs::create_dir_all,
-    path::PathBuf,
-    sync::{Arc, Mutex},
-};
+use std::{fmt::Debug, fs::create_dir_all, path::PathBuf, time::Duration};
 
-use diesel::{Connection, RunQueryDsl, SqliteConnection, sql_query};
+use diesel::{
+    Connection,
+    RunQueryDsl,
+    SqliteConnection,
+    r2d2::{ConnectionManager, CustomizeConnection, Error as R2D2Error, Pool, PooledConnection},
+    sql_query,
+};
 use diesel_migrations::{EmbeddedMigrations, MigrationHarness};
 use tari_ootle_storage::StorageError;
 use tari_ootle_storage_sqlite::{SqliteTransaction, error::SqliteStorageError};
@@ -19,10 +20,15 @@ use crate::{
 };
 
 const LOG_TARGET: &str = "tari::indexer::storage_sqlite";
+const POOL_MAX_SIZE: u32 = 16;
+const BUSY_TIMEOUT: Duration = Duration::from_secs(5);
+
+type SqlitePool = Pool<ConnectionManager<SqliteConnection>>;
+pub(super) type SqlitePooledConnection = PooledConnection<ConnectionManager<SqliteConnection>>;
 
 #[derive(Clone)]
 pub struct SqliteIndexerStore {
-    connection: Arc<Mutex<SqliteConnection>>,
+    pool: SqlitePool,
 }
 
 impl SqliteIndexerStore {
@@ -30,51 +36,77 @@ impl SqliteIndexerStore {
         create_dir_all(path.parent().unwrap()).map_err(|_| StorageError::FileSystemPathDoesNotExist)?;
 
         let database_url = path.to_str().expect("database_url utf-8 error").to_string();
-        let mut connection = SqliteConnection::establish(&database_url).map_err(SqliteStorageError::from)?;
 
-        for pragma in [
-            "PRAGMA journal_mode = WAL;",
-            "PRAGMA synchronous = NORMAL;",
-            "PRAGMA foreign_keys = ON;",
-        ] {
-            sql_query(pragma)
-                .execute(&mut connection)
-                .map_err(|source| SqliteStorageError::DieselError {
-                    source,
-                    operation: "set pragma",
-                })?;
-        }
-
+        // Run migrations on a one-shot connection before opening the pool, so pooled connections
+        // never observe a partially-migrated schema.
+        let mut migration_conn = SqliteConnection::establish(&database_url).map_err(SqliteStorageError::from)?;
+        apply_pragmas(&mut migration_conn).map_err(|source| SqliteStorageError::DieselError {
+            source,
+            operation: "set pragma",
+        })?;
         pub const MIGRATIONS: EmbeddedMigrations = embed_migrations!("./src/storage_sqlite/migrations");
-        if let Err(err) = connection.run_pending_migrations(MIGRATIONS) {
+        if let Err(err) = migration_conn.run_pending_migrations(MIGRATIONS) {
             log::error!(target: LOG_TARGET, "Error running migrations: {}", err);
         }
+        drop(migration_conn);
 
-        Ok(Self {
-            connection: Arc::new(Mutex::new(connection)),
+        let manager = ConnectionManager::<SqliteConnection>::new(database_url);
+        let pool = Pool::builder()
+            .max_size(POOL_MAX_SIZE)
+            .connection_customizer(Box::new(SqliteCustomizer))
+            .build(manager)
+            .map_err(|e| StorageError::General {
+                details: format!("Failed to build sqlite connection pool: {}", e),
+            })?;
+
+        Ok(Self { pool })
+    }
+
+    fn get_connection(&self) -> Result<SqlitePooledConnection, StorageError> {
+        self.pool.get().map_err(|e| StorageError::General {
+            details: format!("Failed to acquire sqlite connection from pool: {}", e),
         })
     }
 }
+
 impl Debug for SqliteIndexerStore {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "SqliteIndexerStore {{ connection: ... }}")
+        write!(f, "SqliteIndexerStore {{ pool: ... }}")
     }
 }
 
 impl IndexerStoreReader for SqliteIndexerStore {
-    type ReadTransaction<'a> = SqliteStoreReadTransaction<'a>;
+    type ReadTransaction<'a> = SqliteStoreReadTransaction;
 
     fn create_read_tx(&self) -> Result<Self::ReadTransaction<'_>, StorageError> {
-        let tx = SqliteTransaction::begin(self.connection.lock().unwrap())?;
+        let tx = SqliteTransaction::begin(self.get_connection()?)?;
         Ok(SqliteStoreReadTransaction::new(tx))
     }
 }
 
 impl IndexerStore for SqliteIndexerStore {
-    type WriteTransaction<'a> = SqliteStoreWriteTransaction<'a>;
+    type WriteTransaction<'a> = SqliteStoreWriteTransaction;
 
     fn create_write_tx(&self) -> Result<Self::WriteTransaction<'_>, StorageError> {
-        let tx = SqliteTransaction::begin(self.connection.lock().unwrap())?;
+        let tx = SqliteTransaction::begin_immediate(self.get_connection()?)?;
         Ok(SqliteStoreWriteTransaction::new(tx))
     }
+}
+
+#[derive(Debug)]
+struct SqliteCustomizer;
+
+impl CustomizeConnection<SqliteConnection, R2D2Error> for SqliteCustomizer {
+    fn on_acquire(&self, conn: &mut SqliteConnection) -> Result<(), R2D2Error> {
+        apply_pragmas(conn).map_err(R2D2Error::QueryError)
+    }
+}
+
+fn apply_pragmas(conn: &mut SqliteConnection) -> Result<(), diesel::result::Error> {
+    let busy_timeout_ms = BUSY_TIMEOUT.as_millis();
+    sql_query("PRAGMA journal_mode = WAL;").execute(conn)?;
+    sql_query("PRAGMA synchronous = NORMAL;").execute(conn)?;
+    sql_query("PRAGMA foreign_keys = ON;").execute(conn)?;
+    sql_query(format!("PRAGMA busy_timeout = {};", busy_timeout_ms)).execute(conn)?;
+    Ok(())
 }

--- a/applications/tari_indexer/src/storage_sqlite/store_factory.rs
+++ b/applications/tari_indexer/src/storage_sqlite/store_factory.rs
@@ -32,16 +32,23 @@ impl SqliteIndexerStore {
         let database_url = path.to_str().expect("database_url utf-8 error").to_string();
         let mut connection = SqliteConnection::establish(&database_url).map_err(SqliteStorageError::from)?;
 
+        for pragma in [
+            "PRAGMA journal_mode = WAL;",
+            "PRAGMA synchronous = NORMAL;",
+            "PRAGMA foreign_keys = ON;",
+        ] {
+            sql_query(pragma)
+                .execute(&mut connection)
+                .map_err(|source| SqliteStorageError::DieselError {
+                    source,
+                    operation: "set pragma",
+                })?;
+        }
+
         pub const MIGRATIONS: EmbeddedMigrations = embed_migrations!("./src/storage_sqlite/migrations");
         if let Err(err) = connection.run_pending_migrations(MIGRATIONS) {
             log::error!(target: LOG_TARGET, "Error running migrations: {}", err);
         }
-        sql_query("PRAGMA foreign_keys = ON;")
-            .execute(&mut connection)
-            .map_err(|source| SqliteStorageError::DieselError {
-                source,
-                operation: "set pragma",
-            })?;
 
         Ok(Self {
             connection: Arc::new(Mutex::new(connection)),

--- a/applications/tari_indexer/src/storage_sqlite/store_factory.rs
+++ b/applications/tari_indexer/src/storage_sqlite/store_factory.rs
@@ -3,32 +3,28 @@
 
 use std::{fmt::Debug, fs::create_dir_all, path::PathBuf, time::Duration};
 
-use diesel::{
-    Connection,
-    RunQueryDsl,
-    SqliteConnection,
-    r2d2::{ConnectionManager, CustomizeConnection, Error as R2D2Error, Pool, PooledConnection},
-    sql_query,
+use async_trait::async_trait;
+use deadpool_diesel::{
+    Runtime,
+    sqlite::{Hook, HookError, Manager, Pool},
 };
+use diesel::{Connection, RunQueryDsl, SqliteConnection, sql_query};
 use diesel_migrations::{EmbeddedMigrations, MigrationHarness};
 use tari_ootle_storage::StorageError;
 use tari_ootle_storage_sqlite::{SqliteTransaction, error::SqliteStorageError};
 
 use crate::{
     storage_sqlite::{reader::SqliteStoreReadTransaction, writer::SqliteStoreWriteTransaction},
-    store::{IndexerStore, IndexerStoreReader},
+    store::{IndexerStore, IndexerStoreReader, IndexerStoreWriteTransaction},
 };
 
 const LOG_TARGET: &str = "tari::indexer::storage_sqlite";
-const POOL_MAX_SIZE: u32 = 16;
+const POOL_MAX_SIZE: usize = 16;
 const BUSY_TIMEOUT: Duration = Duration::from_secs(5);
-
-type SqlitePool = Pool<ConnectionManager<SqliteConnection>>;
-pub(super) type SqlitePooledConnection = PooledConnection<ConnectionManager<SqliteConnection>>;
 
 #[derive(Clone)]
 pub struct SqliteIndexerStore {
-    pool: SqlitePool,
+    pool: Pool,
 }
 
 impl SqliteIndexerStore {
@@ -50,11 +46,19 @@ impl SqliteIndexerStore {
         }
         drop(migration_conn);
 
-        let manager = ConnectionManager::<SqliteConnection>::new(database_url);
-        let pool = Pool::builder()
+        let manager = Manager::new(database_url, Runtime::Tokio1);
+        let pool = Pool::builder(manager)
             .max_size(POOL_MAX_SIZE)
-            .connection_customizer(Box::new(SqliteCustomizer))
-            .build(manager)
+            .post_create(Hook::async_fn(|conn, _metrics| {
+                Box::pin(async move {
+                    conn.interact(apply_pragmas)
+                        .await
+                        .map_err(|e| HookError::message(format!("post_create panicked: {e}")))?
+                        .map_err(|e| HookError::message(format!("apply_pragmas failed: {e}")))?;
+                    Ok(())
+                })
+            }))
+            .build()
             .map_err(|e| StorageError::General {
                 details: format!("Failed to build sqlite connection pool: {}", e),
             })?;
@@ -62,8 +66,8 @@ impl SqliteIndexerStore {
         Ok(Self { pool })
     }
 
-    fn get_connection(&self) -> Result<SqlitePooledConnection, StorageError> {
-        self.pool.get().map_err(|e| StorageError::General {
+    async fn acquire(&self) -> Result<deadpool_diesel::sqlite::Connection, StorageError> {
+        self.pool.get().await.map_err(|e| StorageError::General {
             details: format!("Failed to acquire sqlite connection from pool: {}", e),
         })
     }
@@ -75,30 +79,68 @@ impl Debug for SqliteIndexerStore {
     }
 }
 
+#[async_trait]
 impl IndexerStoreReader for SqliteIndexerStore {
-    type ReadTransaction<'a> = SqliteStoreReadTransaction;
+    type ReadTransaction<'a> = SqliteStoreReadTransaction<'a>;
 
-    fn create_read_tx(&self) -> Result<Self::ReadTransaction<'_>, StorageError> {
-        let tx = SqliteTransaction::begin(self.get_connection()?)?;
-        Ok(SqliteStoreReadTransaction::new(tx))
+    async fn with_read_tx<F, R, E>(&self, f: F) -> Result<R, E>
+    where
+        F: for<'a> FnOnce(&mut Self::ReadTransaction<'a>) -> Result<R, E> + Send + 'static,
+        R: Send + 'static,
+        E: From<StorageError> + Send + 'static,
+    {
+        let conn = self.acquire().await?;
+        let result: Result<R, E> = conn
+            .interact(move |c| -> Result<R, E> {
+                let inner = SqliteTransaction::begin(c)
+                    .map_err(StorageError::from)
+                    .map_err(E::from)?;
+                let mut tx = SqliteStoreReadTransaction::new(inner);
+                f(&mut tx)
+            })
+            .await
+            .map_err(|e| StorageError::General {
+                details: format!("Pool interact panicked: {}", e),
+            })?;
+        result
     }
 }
 
+#[async_trait]
 impl IndexerStore for SqliteIndexerStore {
-    type WriteTransaction<'a> = SqliteStoreWriteTransaction;
+    type WriteTransaction<'a> = SqliteStoreWriteTransaction<'a>;
 
-    fn create_write_tx(&self) -> Result<Self::WriteTransaction<'_>, StorageError> {
-        let tx = SqliteTransaction::begin_immediate(self.get_connection()?)?;
-        Ok(SqliteStoreWriteTransaction::new(tx))
-    }
-}
-
-#[derive(Debug)]
-struct SqliteCustomizer;
-
-impl CustomizeConnection<SqliteConnection, R2D2Error> for SqliteCustomizer {
-    fn on_acquire(&self, conn: &mut SqliteConnection) -> Result<(), R2D2Error> {
-        apply_pragmas(conn).map_err(R2D2Error::QueryError)
+    async fn with_write_tx<F, R, E>(&self, f: F) -> Result<R, E>
+    where
+        F: for<'a> FnOnce(&mut Self::WriteTransaction<'a>) -> Result<R, E> + Send + 'static,
+        R: Send + 'static,
+        E: From<StorageError> + Send + 'static,
+    {
+        let conn = self.acquire().await?;
+        let result: Result<R, E> = conn
+            .interact(move |c| -> Result<R, E> {
+                let inner = SqliteTransaction::begin_immediate(c)
+                    .map_err(StorageError::from)
+                    .map_err(E::from)?;
+                let mut tx = SqliteStoreWriteTransaction::new(inner);
+                match f(&mut tx) {
+                    Ok(r) => {
+                        tx.commit().map_err(E::from)?;
+                        Ok(r)
+                    },
+                    Err(e) => {
+                        if let Err(err) = tx.rollback() {
+                            log::error!(target: LOG_TARGET, "Failed to rollback transaction: {}", err);
+                        }
+                        Err(e)
+                    },
+                }
+            })
+            .await
+            .map_err(|e| StorageError::General {
+                details: format!("Pool interact panicked: {}", e),
+            })?;
+        result
     }
 }
 

--- a/applications/tari_indexer/src/storage_sqlite/writer.rs
+++ b/applications/tari_indexer/src/storage_sqlite/writer.rs
@@ -39,20 +39,19 @@ use crate::{
         },
         reader::SqliteStoreReadTransaction,
         serialization::{serialize_bincode, serialize_hex, serialize_json},
-        store_factory::SqlitePooledConnection,
     },
     store::{IndexerStoreWriteTransaction, InsertedEvent},
 };
 
 const LOG_TARGET: &str = "tari::indexer::storage_sqlite::writer";
 
-pub struct SqliteStoreWriteTransaction {
+pub struct SqliteStoreWriteTransaction<'a> {
     /// None indicates if the transaction has been explicitly committed/rolled back
-    transaction: Option<SqliteStoreReadTransaction>,
+    transaction: Option<SqliteStoreReadTransaction<'a>>,
 }
 
-impl SqliteStoreWriteTransaction {
-    pub fn new(transaction: SqliteTransaction<SqlitePooledConnection>) -> Self {
+impl<'a> SqliteStoreWriteTransaction<'a> {
+    pub fn new(transaction: SqliteTransaction<&'a mut SqliteConnection>) -> Self {
         Self {
             transaction: Some(SqliteStoreReadTransaction::new(transaction)),
         }
@@ -62,7 +61,7 @@ impl SqliteStoreWriteTransaction {
         self.transaction.as_mut().unwrap().connection()
     }
 }
-impl IndexerStoreWriteTransaction for SqliteStoreWriteTransaction {
+impl IndexerStoreWriteTransaction for SqliteStoreWriteTransaction<'_> {
     fn commit(mut self) -> Result<(), StorageError> {
         self.transaction.take().unwrap().transaction.commit()?;
         Ok(())
@@ -404,21 +403,21 @@ impl IndexerStoreWriteTransaction for SqliteStoreWriteTransaction {
     }
 }
 
-impl Deref for SqliteStoreWriteTransaction {
-    type Target = SqliteStoreReadTransaction;
+impl<'a> Deref for SqliteStoreWriteTransaction<'a> {
+    type Target = SqliteStoreReadTransaction<'a>;
 
     fn deref(&self) -> &Self::Target {
         self.transaction.as_ref().unwrap()
     }
 }
 
-impl DerefMut for SqliteStoreWriteTransaction {
+impl DerefMut for SqliteStoreWriteTransaction<'_> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.transaction.as_mut().unwrap()
     }
 }
 
-impl Drop for SqliteStoreWriteTransaction {
+impl Drop for SqliteStoreWriteTransaction<'_> {
     fn drop(&mut self) {
         if self.transaction.is_some() {
             warn!(

--- a/applications/tari_indexer/src/storage_sqlite/writer.rs
+++ b/applications/tari_indexer/src/storage_sqlite/writer.rs
@@ -39,19 +39,20 @@ use crate::{
         },
         reader::SqliteStoreReadTransaction,
         serialization::{serialize_bincode, serialize_hex, serialize_json},
+        store_factory::SqlitePooledConnection,
     },
     store::{IndexerStoreWriteTransaction, InsertedEvent},
 };
 
 const LOG_TARGET: &str = "tari::indexer::storage_sqlite::writer";
 
-pub struct SqliteStoreWriteTransaction<'a> {
+pub struct SqliteStoreWriteTransaction {
     /// None indicates if the transaction has been explicitly committed/rolled back
-    transaction: Option<SqliteStoreReadTransaction<'a>>,
+    transaction: Option<SqliteStoreReadTransaction>,
 }
 
-impl<'a> SqliteStoreWriteTransaction<'a> {
-    pub fn new(transaction: SqliteTransaction<'a>) -> Self {
+impl SqliteStoreWriteTransaction {
+    pub fn new(transaction: SqliteTransaction<SqlitePooledConnection>) -> Self {
         Self {
             transaction: Some(SqliteStoreReadTransaction::new(transaction)),
         }
@@ -61,7 +62,7 @@ impl<'a> SqliteStoreWriteTransaction<'a> {
         self.transaction.as_mut().unwrap().connection()
     }
 }
-impl IndexerStoreWriteTransaction for SqliteStoreWriteTransaction<'_> {
+impl IndexerStoreWriteTransaction for SqliteStoreWriteTransaction {
     fn commit(mut self) -> Result<(), StorageError> {
         self.transaction.take().unwrap().transaction.commit()?;
         Ok(())
@@ -403,21 +404,21 @@ impl IndexerStoreWriteTransaction for SqliteStoreWriteTransaction<'_> {
     }
 }
 
-impl<'a> Deref for SqliteStoreWriteTransaction<'a> {
-    type Target = SqliteStoreReadTransaction<'a>;
+impl Deref for SqliteStoreWriteTransaction {
+    type Target = SqliteStoreReadTransaction;
 
     fn deref(&self) -> &Self::Target {
         self.transaction.as_ref().unwrap()
     }
 }
 
-impl DerefMut for SqliteStoreWriteTransaction<'_> {
+impl DerefMut for SqliteStoreWriteTransaction {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.transaction.as_mut().unwrap()
     }
 }
 
-impl Drop for SqliteStoreWriteTransaction<'_> {
+impl Drop for SqliteStoreWriteTransaction {
     fn drop(&mut self) {
         if self.transaction.is_some() {
             warn!(

--- a/applications/tari_indexer/src/store.rs
+++ b/applications/tari_indexer/src/store.rs
@@ -196,7 +196,7 @@ pub trait IndexerStoreReadTransaction {
     fn get_template_catalogue_entry(
         &mut self,
         template_address: &TemplateAddress,
-    ) -> Result<Option<TemplateCatalogueEntry>, StorageError>;
+    ) -> Result<TemplateCatalogueEntry, StorageError>;
 
     // -------------------------------- Watched Substates -------------------------------- //
 
@@ -389,7 +389,7 @@ impl<T: IndexerStoreReader> ReadOnlyStore<T> {
     pub async fn get_template_catalogue_entry(
         &self,
         template_address: &TemplateAddress,
-    ) -> Result<Option<crate::storage_sqlite::models::TemplateCatalogueEntry>, StorageError> {
+    ) -> Result<TemplateCatalogueEntry, StorageError> {
         let template_address = *template_address;
         self.inner
             .with_read_tx(move |tx| tx.get_template_catalogue_entry(&template_address))

--- a/applications/tari_indexer/src/store.rs
+++ b/applications/tari_indexer/src/store.rs
@@ -7,6 +7,7 @@ use std::{
     sync::Arc,
 };
 
+use async_trait::async_trait;
 use serde::{Serialize, de::DeserializeOwned};
 use tari_engine_types::{
     Utxo,
@@ -51,44 +52,31 @@ use crate::{
     },
 };
 
-const LOG_TARGET: &str = "tari::indexer::store";
-
+#[async_trait]
 pub trait IndexerStore: IndexerStoreReader {
-    type WriteTransaction<'a>: IndexerStoreWriteTransaction + Deref<Target = Self::ReadTransaction<'a>> + DerefMut
+    type WriteTransaction<'a>: IndexerStoreWriteTransaction
+        + Deref<Target = Self::ReadTransaction<'a>>
+        + DerefMut
+        + Send
     where Self: 'a;
 
-    fn create_write_tx(&self) -> Result<Self::WriteTransaction<'_>, StorageError>;
-
-    fn with_write_tx<F: FnOnce(&mut Self::WriteTransaction<'_>) -> Result<R, E>, R, E>(&self, f: F) -> Result<R, E>
-    where E: From<StorageError> {
-        let mut tx = self.create_write_tx()?;
-        match f(&mut tx) {
-            Ok(r) => {
-                tx.commit()?;
-                Ok(r)
-            },
-            Err(e) => {
-                if let Err(err) = tx.rollback() {
-                    log::error!(target: LOG_TARGET, "Failed to rollback transaction: {}", err);
-                }
-                Err(e)
-            },
-        }
-    }
+    async fn with_write_tx<F, R, E>(&self, f: F) -> Result<R, E>
+    where
+        F: for<'a> FnOnce(&mut Self::WriteTransaction<'a>) -> Result<R, E> + Send + 'static,
+        R: Send + 'static,
+        E: From<StorageError> + Send + 'static;
 }
 
-pub trait IndexerStoreReader {
-    type ReadTransaction<'a>: IndexerStoreReadTransaction
+#[async_trait]
+pub trait IndexerStoreReader: Send + Sync + 'static {
+    type ReadTransaction<'a>: IndexerStoreReadTransaction + Send
     where Self: 'a;
 
-    fn create_read_tx(&self) -> Result<Self::ReadTransaction<'_>, StorageError>;
-
-    fn with_read_tx<F: FnOnce(&mut Self::ReadTransaction<'_>) -> Result<R, E>, R, E>(&self, f: F) -> Result<R, E>
-    where E: From<StorageError> {
-        let mut tx = self.create_read_tx()?;
-        let ret = f(&mut tx)?;
-        Ok(ret)
-    }
+    async fn with_read_tx<F, R, E>(&self, f: F) -> Result<R, E>
+    where
+        F: for<'a> FnOnce(&mut Self::ReadTransaction<'a>) -> Result<R, E> + Send + 'static,
+        R: Send + 'static,
+        E: From<StorageError> + Send + 'static;
 }
 
 pub trait IndexerStoreReadTransaction {
@@ -283,53 +271,58 @@ impl<T: IndexerStoreReader> ReadOnlyStore<T> {
         Self { inner }
     }
 
-    pub fn list_transaction_receipts(
+    pub async fn list_transaction_receipts(
         &self,
         last_id: Option<TransactionReceiptAddress>,
         limit: u64,
         ordering: Ordering,
     ) -> Result<Vec<(TransactionReceiptAddress, TransactionReceipt)>, StorageError> {
         self.inner
-            .with_read_tx(|tx| tx.list_transaction_receipts(last_id, limit, ordering))
+            .with_read_tx(move |tx| tx.list_transaction_receipts(last_id, limit, ordering))
+            .await
     }
 
-    pub fn get_transaction_receipt(
+    pub async fn get_transaction_receipt(
         &self,
         address: &TransactionReceiptAddress,
     ) -> Result<TransactionReceipt, StorageError> {
-        self.inner.with_read_tx(|tx| tx.get_transaction_receipt(address))
+        let address = *address;
+        self.inner
+            .with_read_tx(move |tx| tx.get_transaction_receipt(&address))
+            .await
     }
 
-    pub fn get_xtr_total_supply(&self) -> Result<Amount, StorageError> {
-        self.inner.with_read_tx(|tx| {
-            let claimed = tx
-                .key_value_get_value::<_, Amount>(Key::XtrAccumulatedClaimed)
-                .optional()?
-                .unwrap_or_default();
-            let burnt = tx
-                .key_value_get_value::<_, Amount>(Key::XtrAccumulatedExhaustBurn)
-                .optional()?
-                .unwrap_or_default();
+    pub async fn get_xtr_total_supply(&self) -> Result<Amount, StorageError> {
+        self.inner
+            .with_read_tx(|tx| {
+                let claimed = tx
+                    .key_value_get_value::<_, Amount>(Key::XtrAccumulatedClaimed)
+                    .optional()?
+                    .unwrap_or_default();
+                let burnt = tx
+                    .key_value_get_value::<_, Amount>(Key::XtrAccumulatedExhaustBurn)
+                    .optional()?
+                    .unwrap_or_default();
 
-            claimed
-                .checked_sub(burnt)
-                .ok_or_else(|| StorageError::DataInconsistency {
-                    details: format!(
-                        "XTR total supply underflow: claimed {} < total exhaust {}",
-                        claimed, burnt
-                    ),
-                })
-        })
+                claimed
+                    .checked_sub(burnt)
+                    .ok_or_else(|| StorageError::DataInconsistency {
+                        details: format!(
+                            "XTR total supply underflow: claimed {} < total exhaust {}",
+                            claimed, burnt
+                        ),
+                    })
+            })
+            .await
     }
 
-    pub fn get_sync_progress(&self) -> Result<SyncProgress, StorageError> {
-        let progress = self
-            .inner
-            .with_read_tx(|tx| tx.key_value_get_value(Key::SyncProgress))?;
-        Ok(progress)
+    pub async fn get_sync_progress(&self) -> Result<SyncProgress, StorageError> {
+        self.inner
+            .with_read_tx(|tx| tx.key_value_get_value(Key::SyncProgress))
+            .await
     }
 
-    pub fn get_events(
+    pub async fn get_events(
         &self,
         substate_id_filter: Option<&SubstateId>,
         topic_filter: Option<&str>,
@@ -337,11 +330,23 @@ impl<T: IndexerStoreReader> ReadOnlyStore<T> {
         offset: u32,
         limit: u32,
     ) -> Result<Vec<(TransactionId, Event)>, StorageError> {
+        let substate_id_filter = substate_id_filter.cloned();
+        let topic_filter = topic_filter.map(str::to_owned);
+        let resource_address_filter = resource_address_filter.copied();
         self.inner
-            .with_read_tx(|tx| tx.get_events(substate_id_filter, topic_filter, resource_address_filter, offset, limit))
+            .with_read_tx(move |tx| {
+                tx.get_events(
+                    substate_id_filter.as_ref(),
+                    topic_filter.as_deref(),
+                    resource_address_filter.as_ref(),
+                    offset,
+                    limit,
+                )
+            })
+            .await
     }
 
-    pub fn get_events_after_id(
+    pub async fn get_events_after_id(
         &self,
         after_id: i64,
         topic_filter: Option<&str>,
@@ -350,56 +355,70 @@ impl<T: IndexerStoreReader> ReadOnlyStore<T> {
         resource_address_filter: Option<&ResourceAddress>,
         limit: u32,
     ) -> Result<Vec<(i64, TransactionId, Event)>, StorageError> {
-        self.inner.with_read_tx(|tx| {
-            tx.get_events_after_id(
-                after_id,
-                topic_filter,
-                substate_id_filter,
-                template_address_filter,
-                resource_address_filter,
-                limit,
-            )
-        })
+        let topic_filter = topic_filter.map(str::to_owned);
+        let substate_id_filter = substate_id_filter.cloned();
+        let template_address_filter = template_address_filter.copied();
+        let resource_address_filter = resource_address_filter.copied();
+        self.inner
+            .with_read_tx(move |tx| {
+                tx.get_events_after_id(
+                    after_id,
+                    topic_filter.as_deref(),
+                    substate_id_filter.as_ref(),
+                    template_address_filter.as_ref(),
+                    resource_address_filter.as_ref(),
+                    limit,
+                )
+            })
+            .await
     }
 
-    pub fn list_template_catalogue(
+    pub async fn list_template_catalogue(
         &self,
         name_filter: Option<&str>,
         after: Option<&TemplateAddress>,
         limit: u64,
     ) -> Result<Vec<crate::storage_sqlite::models::TemplateCatalogueEntry>, StorageError> {
+        let name_filter = name_filter.map(str::to_owned);
+        let after = after.copied();
         self.inner
-            .with_read_tx(|tx| tx.list_template_catalogue(name_filter, after, limit))
+            .with_read_tx(move |tx| tx.list_template_catalogue(name_filter.as_deref(), after.as_ref(), limit))
+            .await
     }
 
-    pub fn get_template_catalogue_entry(
+    pub async fn get_template_catalogue_entry(
         &self,
         template_address: &TemplateAddress,
     ) -> Result<Option<crate::storage_sqlite::models::TemplateCatalogueEntry>, StorageError> {
+        let template_address = *template_address;
         self.inner
-            .with_read_tx(|tx| tx.get_template_catalogue_entry(template_address))
+            .with_read_tx(move |tx| tx.get_template_catalogue_entry(&template_address))
+            .await
     }
 
-    pub fn epoch_checkpoint_get_all(
+    pub async fn epoch_checkpoint_get_all(
         &self,
         from_epoch: Epoch,
         limit: u64,
     ) -> Result<Vec<EpochCheckpoint>, StorageError> {
         self.inner
-            .with_read_tx(|tx| tx.epoch_checkpoint_get_all(from_epoch, limit))
+            .with_read_tx(move |tx| tx.epoch_checkpoint_get_all(from_epoch, limit))
+            .await
     }
 
-    pub fn epoch_checkpoint_get_latest(&self) -> Result<EpochCheckpoint, StorageError> {
-        self.inner.with_read_tx(|tx| tx.epoch_checkpoint_get_latest())
+    pub async fn epoch_checkpoint_get_latest(&self) -> Result<EpochCheckpoint, StorageError> {
+        self.inner.with_read_tx(|tx| tx.epoch_checkpoint_get_latest()).await
     }
 
-    pub fn list_watched_substates(
+    pub async fn list_watched_substates(
         &self,
         template_address: Option<&TemplateAddress>,
         limit: u64,
         offset: u64,
     ) -> Result<Vec<WatchedSubstateEntry>, StorageError> {
+        let template_address = template_address.copied();
         self.inner
-            .with_read_tx(|tx| tx.list_watched_substates(template_address, limit, offset))
+            .with_read_tx(move |tx| tx.list_watched_substates(template_address.as_ref(), limit, offset))
+            .await
     }
 }

--- a/applications/tari_indexer/src/substate_manager.rs
+++ b/applications/tari_indexer/src/substate_manager.rs
@@ -104,7 +104,7 @@ impl SubstateManager {
         }
     }
 
-    pub fn get_stored_substates_by_filters(
+    pub async fn get_stored_substates_by_filters(
         &self,
         by_id: Option<&SubstateId>,
         filter_by_type: Option<SubstateType>,
@@ -112,13 +112,17 @@ impl SubstateManager {
         limit: Option<u64>,
         offset: Option<u64>,
     ) -> Result<Vec<ListSubstateItem>, SubstateManagerError> {
+        let by_id = by_id.cloned();
         let substates = self
             .substate_store
-            .with_read_tx(|tx| tx.list_substates(by_id, filter_by_type, filter_by_template, limit, offset))?;
+            .with_read_tx(move |tx| {
+                tx.list_substates(by_id.as_ref(), filter_by_type, filter_by_template, limit, offset)
+            })
+            .await?;
         Ok(substates)
     }
 
-    pub fn get_utxo_updates(
+    pub async fn get_utxo_updates(
         &self,
         resource_address: ResourceAddress,
         from_epoch: Epoch,
@@ -127,50 +131,62 @@ impl SubstateManager {
         unspent_only: bool,
         limit: u32,
     ) -> Result<UtxoStateUpdateSet, SubstateManagerError> {
-        let updates = self.substate_store.with_read_tx(|tx| {
-            tx.utxos_get_updates(
-                resource_address,
-                from_epoch,
-                shard,
-                from_state_version,
-                unspent_only,
-                limit,
-            )
-        })?;
+        let updates = self
+            .substate_store
+            .with_read_tx(move |tx| {
+                tx.utxos_get_updates(
+                    resource_address,
+                    from_epoch,
+                    shard,
+                    from_state_version,
+                    unspent_only,
+                    limit,
+                )
+            })
+            .await?;
         Ok(updates)
     }
 
-    pub fn get_max_state_version(
+    pub async fn get_max_state_version(
         &self,
         resource_address: &ResourceAddress,
         shard: Shard,
     ) -> Result<StateVersion, SubstateManagerError> {
+        let resource_address = *resource_address;
         let max_version = self
             .substate_store
-            .with_read_tx(|tx| tx.utxos_get_max_state_version(*resource_address, shard))?;
+            .with_read_tx(move |tx| tx.utxos_get_max_state_version(resource_address, shard))
+            .await?;
         Ok(max_version)
     }
 
-    pub fn get_unspent_utxos(
+    pub async fn get_unspent_utxos(
         &self,
         resource_address: &ResourceAddress,
         public_nonce_and_tag: &[(UtxoTag, RistrettoPublicKeyBytes)],
     ) -> Result<Vec<(UtxoId, Utxo)>, SubstateManagerError> {
+        let resource_address = *resource_address;
+        let public_nonce_and_tag = public_nonce_and_tag.to_vec();
         let utxos = self
             .substate_store
-            .with_read_tx(|tx| tx.utxos_get_unspent_by_public_nonce_and_tag(resource_address, public_nonce_and_tag))?;
+            .with_read_tx(move |tx| {
+                tx.utxos_get_unspent_by_public_nonce_and_tag(&resource_address, &public_nonce_and_tag)
+            })
+            .await?;
         Ok(utxos)
     }
 
-    pub fn list_utxos(
+    pub async fn list_utxos(
         &self,
         resource_address: &ResourceAddress,
         from_id: Option<UtxoId>,
         limit: u32,
     ) -> Result<Vec<(UtxoId, Utxo)>, SubstateManagerError> {
+        let resource_address = *resource_address;
         let utxos = self
             .substate_store
-            .with_read_tx(|tx| tx.utxos_list(resource_address, from_id, limit))?;
+            .with_read_tx(move |tx| tx.utxos_list(&resource_address, from_id, limit))
+            .await?;
         Ok(utxos)
     }
 
@@ -202,7 +218,7 @@ impl SubstateManager {
 
         for req in &substate_req {
             if let Some(version) = req.version() &&
-                let Some(substate) = self.get_substate_from_db(req.substate_id(), Some(version))?
+                let Some(substate) = self.get_substate_from_db(req.substate_id(), Some(version)).await?
             {
                 found_in_cache.insert(*req);
                 results.insert(
@@ -248,7 +264,11 @@ impl SubstateManager {
     ) -> Result<HashMap<SubstateId, Substate>, SubstateManagerError> {
         let mut substate_set = substates.iter().collect::<HashSet<_>>();
 
-        let mut substates = self.substate_store.with_read_tx(|tx| tx.get_substates(substates))?;
+        let substates_arg = substates.to_vec();
+        let mut substates = self
+            .substate_store
+            .with_read_tx(move |tx| tx.get_substates(&substates_arg))
+            .await?;
 
         for k in substates.keys() {
             substate_set.remove(k);
@@ -279,30 +299,32 @@ impl SubstateManager {
         Ok(result)
     }
 
-    fn get_substate_from_db(
+    async fn get_substate_from_db(
         &self,
         substate_address: &SubstateId,
         version: Option<u32>,
     ) -> Result<Option<SubstateResponse>, SubstateManagerError> {
-        let mut tx = self.substate_store.create_read_tx()?;
-        if let Some(row) = tx.get_substate(substate_address, version)? {
-            // the substate is present in db and the version matches the requested version
-            let substate_resp = row.try_into()?;
-            return Ok(Some(substate_resp));
-        };
-
-        // the substate is not present in db
-        Ok(None)
+        let substate_address = substate_address.clone();
+        let row = self
+            .substate_store
+            .with_read_tx(move |tx| tx.get_substate(&substate_address, version))
+            .await?;
+        match row {
+            Some(row) => Ok(Some(row.try_into()?)),
+            None => Ok(None),
+        }
     }
 
-    pub fn get_non_fungibles_by_resource_address(
+    pub async fn get_non_fungibles_by_resource_address(
         &self,
         address: ResourceAddress,
         limit: usize,
         offset: usize,
     ) -> Result<Vec<NonFungibleSubstate>, SubstateManagerError> {
-        let mut tx = self.substate_store.create_read_tx()?;
-        let nfts = tx.get_non_fungibles_by_resource_address(address, limit, offset)?;
+        let nfts = self
+            .substate_store
+            .with_read_tx(move |tx| tx.get_non_fungibles_by_resource_address(address, limit, offset))
+            .await?;
         Ok(nfts)
     }
 }

--- a/applications/tari_indexer/src/transaction_manager/mod.rs
+++ b/applications/tari_indexer/src/transaction_manager/mod.rs
@@ -60,8 +60,10 @@ where
                 details: "Transaction has one or more invalid signature(s)".to_string(),
             });
         }
+        let transaction_for_db = transaction.clone();
         self.store
-            .with_write_tx(|tx| tx.insert_or_ignore_transaction(&transaction))?;
+            .with_write_tx(move |tx| tx.insert_or_ignore_transaction(&transaction_for_db))
+            .await?;
         let id = self.network_client.submit_transaction(transaction).await?;
         Ok(id)
     }
@@ -82,14 +84,15 @@ where
             })
     }
 
-    pub fn list_recent_transactions(
+    pub async fn list_recent_transactions(
         &self,
         last_id: Option<TransactionId>,
         limit: usize,
     ) -> Result<Vec<TransactionEntry>, TransactionManagerError> {
         let transactions = self
             .store
-            .with_read_tx(|tx| tx.list_recent_transactions(last_id, limit))?;
+            .with_read_tx(move |tx| tx.list_recent_transactions(last_id, limit))
+            .await?;
         Ok(transactions)
     }
 }

--- a/applications/tari_indexer/web_ui/src/routes/Substates/Substates.tsx
+++ b/applications/tari_indexer/web_ui/src/routes/Substates/Substates.tsx
@@ -47,7 +47,7 @@ import { renderJson } from "../../utils/helpers";
 import { convertCborValue } from "../../utils/cbor";
 import CopyToClipboard from "../../Components/CopyToClipboard";
 import { useGetSubstate } from "../../api/hooks/useSubstates";
-import type { SubstateValue } from "@tari-project/ootle-ts-bindings";
+import type { Component, SubstateValue } from "@tari-project/ootle-ts-bindings";
 import SearchIcon from "@mui/icons-material/Search";
 import ClearIcon from "@mui/icons-material/Clear";
 
@@ -95,7 +95,7 @@ function SubstateDetails({ substate, version }: { substate: SubstateValue; versi
 function renderSubstateByType(type: string, data: unknown): React.ReactNode {
   switch (type) {
     case "Component":
-      return <ComponentView data={data as any} />;
+      return <ComponentView data={data as Component} />;
     case "Resource":
       return <ResourceView data={data as any} />;
     case "Vault":
@@ -136,18 +136,17 @@ function FieldTable({ fields }: { fields: Array<{ label: string; value: React.Re
   );
 }
 
-function ComponentView({ data }: { data: any }) {
+function ComponentView({ data }: { data: Component }) {
   const decodedState = data.body?.state ? convertCborValue(data.body.state) : data.body;
 
   return (
     <Stack spacing={2}>
       <FieldTable
         fields={[
-          { label: "Template Address", value: data.template_address },
-          { label: "Module", value: data.module_name },
-          { label: "Entity ID", value: String(data.entity_id) },
-          { label: "Owner Rule", value: <CodeBlock>{renderJson(data.owner_rule)}</CodeBlock> },
-          { label: "Access Rules", value: <CodeBlock>{renderJson(data.access_rules)}</CodeBlock> },
+          { label: "Template Address", value: data.header.template_address },
+          { label: "Entity ID", value: String(data.header.entity_id) },
+          { label: "Owner Rule", value: <CodeBlock>{renderJson(data.header.owner_rule)}</CodeBlock> },
+          { label: "Access Rules", value: <CodeBlock>{renderJson(data.header.access_rules)}</CodeBlock> },
         ]}
       />
       <Typography variant="subtitle2">State</Typography>

--- a/applications/tari_walletd/web_ui/src/routes/Manifest/Manifest.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/Manifest/Manifest.tsx
@@ -21,9 +21,18 @@
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import { useAccountsList } from "@api/hooks/useAccounts";
+import { useListTemplatesAuthored } from "@api/hooks/useTemplatesAuthored";
 import { useSubmitManifest } from "@api/hooks/useTransactions";
 import PageHeading from "@components/PageHeading";
 import { DataTableCell, StyledPaper } from "@components/StyledComponents";
+import {
+  Description as DescriptionIcon,
+  FileDownload,
+  FileUpload,
+  FormatAlignLeft,
+  LibraryAdd,
+} from "@mui/icons-material";
+import type { SelectChangeEvent } from "@mui/material";
 import {
   Dialog,
   DialogActions,
@@ -45,17 +54,14 @@ import {
   Tabs,
   useTheme,
 } from "@mui/material";
-import type { SelectChangeEvent } from "@mui/material";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import Grid from "@mui/material/Grid";
 import TextField from "@mui/material/TextField";
-import useManifestCodeStore from "@store/manifestStore";
 import type { ManifestTab } from "@store/manifestStore";
-import { Description as DescriptionIcon, FileDownload, FileUpload, FormatAlignLeft, LibraryAdd } from "@mui/icons-material";
+import useManifestCodeStore from "@store/manifestStore";
 import type { KeyId } from "@tari-project/ootle-ts-bindings";
 import { rejectReasonToString, substateIdToString } from "@tari-project/ootle-ts-bindings";
-import { useListTemplatesAuthored } from "@api/hooks/useTemplatesAuthored";
 import { Highlight, themes } from "prism-react-renderer";
 import { useCallback, useRef, useState } from "react";
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -175,7 +181,7 @@ function ManifestEditor() {
     submitManifest({
       manifest: manifest.code,
       variables: manifest.variables,
-      max_fee: isDryRun ? 3000 : Number(fee),
+      max_fee: isDryRun ? 5000 : Number(fee),
       seal_signer_key_id: null,
       signing_key_ids: manifest.signingKeys,
       dry_run: isDryRun,
@@ -208,13 +214,7 @@ function ManifestEditor() {
   return (
     <>
       <Grid size={12}>
-        <input
-          type="file"
-          accept=".json"
-          ref={fileInputRef}
-          onChange={handleFileChange}
-          style={{ display: "none" }}
-        />
+        <input type="file" accept=".json" ref={fileInputRef} onChange={handleFileChange} style={{ display: "none" }} />
         <form onSubmit={handleSubmit}>
           <ManifestTabBar
             tabs={manifest.tabs}
@@ -289,11 +289,7 @@ function ManifestEditor() {
             />
           </Box>
           <Box className="flex-container" style={{ justifyContent: "flex-start" }}>
-            <BlobsEditor
-              blobs={manifest.blobs}
-              onSet={manifest.setBlob}
-              onRemove={manifest.removeBlob}
-            />
+            <BlobsEditor blobs={manifest.blobs} onSet={manifest.setBlob} onRemove={manifest.removeBlob} />
           </Box>
           <Box className="flex-container" style={{ justifyContent: "flex-end" }}>
             <TextField
@@ -554,12 +550,12 @@ function TabLabel({
             onClose();
           }}
           sx={{
-            ml: 0.5,
-            px: 0.5,
-            lineHeight: 1,
-            fontSize: "1rem",
-            cursor: "pointer",
-            borderRadius: "50%",
+            "ml": 0.5,
+            "px": 0.5,
+            "lineHeight": 1,
+            "fontSize": "1rem",
+            "cursor": "pointer",
+            "borderRadius": "50%",
             "&:hover": { backgroundColor: "action.hover" },
           }}
         >
@@ -614,13 +610,21 @@ function EditableKeyCell({ varKey, onRename }: { varKey: string; onRename: (oldK
   }
 
   return (
-    <Box onClick={() => setEditing(true)} sx={{ cursor: "pointer", "&:hover": { textDecoration: "underline" } }}>
+    <Box onClick={() => setEditing(true)} sx={{ "cursor": "pointer", "&:hover": { textDecoration: "underline" } }}>
       {varKey}
     </Box>
   );
 }
 
-function EditableValueCell({ varKey, value, onUpdate }: { varKey: string; value: string; onUpdate: (key: string, value: string) => void }) {
+function EditableValueCell({
+  varKey,
+  value,
+  onUpdate,
+}: {
+  varKey: string;
+  value: string;
+  onUpdate: (key: string, value: string) => void;
+}) {
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(value);
 
@@ -654,7 +658,13 @@ function EditableValueCell({ varKey, value, onUpdate }: { varKey: string; value:
   }
 
   return (
-    <Box onClick={() => { setDraft(value); setEditing(true); }} sx={{ cursor: "pointer", "&:hover": { textDecoration: "underline" } }}>
+    <Box
+      onClick={() => {
+        setDraft(value);
+        setEditing(true);
+      }}
+      sx={{ "cursor": "pointer", "&:hover": { textDecoration: "underline" } }}
+    >
       {value}
     </Box>
   );
@@ -685,9 +695,7 @@ function VariableEditor({
     const varName = nextAccountVarName(variables);
     onAdd(varName, address);
     // Auto-add the account's signing key
-    const accountInfo = accountsData?.accounts.find(
-      (a) => substateIdToString(a.account.component_address) === address,
-    );
+    const accountInfo = accountsData?.accounts.find((a) => substateIdToString(a.account.component_address) === address);
     if (accountInfo?.account.owner_key_id) {
       onAddSigningKey(accountInfo.account.owner_key_id);
     }
@@ -768,12 +776,7 @@ function VariableEditor({
               }
             }}
           />
-          <Button
-            variant="contained"
-            color="primary"
-            onClick={handleAdd}
-            style={{ minHeight: "52px" }}
-          >
+          <Button variant="contained" color="primary" onClick={handleAdd} style={{ minHeight: "52px" }}>
             Add
           </Button>
           <Button
@@ -821,7 +824,10 @@ function formatKeyId(key: KeyId): string {
   return `imported/${key.Imported.local_key_id}`;
 }
 
-function findAccountNameForKey(key: KeyId, accounts: { account: { name: string | null; owner_key_id: KeyId | null } }[]): string | null {
+function findAccountNameForKey(
+  key: KeyId,
+  accounts: { account: { name: string | null; owner_key_id: KeyId | null } }[],
+): string | null {
   const match = accounts.find(
     (a) => a.account.owner_key_id && JSON.stringify(a.account.owner_key_id) === JSON.stringify(key),
   );
@@ -886,8 +892,8 @@ function SigningKeysDialog({
       <DialogTitle>Signing Keys</DialogTitle>
       <DialogContent>
         <DialogContentText sx={{ mb: 2 }}>
-          Extra signers attached to this transaction (in addition to the seal signer). Each
-          signer commits to the unsigned transaction including its blob commitments.
+          Extra signers attached to this transaction (in addition to the seal signer). Each signer commits to the
+          unsigned transaction including its blob commitments.
         </DialogContentText>
         {signingKeys.length > 0 ? (
           <Table size="small" sx={{ marginBottom: 2 }}>
@@ -1038,12 +1044,7 @@ function BlobsEditor({
         </Table>
       )}
       <Stack direction="row" spacing={1} alignItems="center" marginBottom={2}>
-        <Button
-          variant="outlined"
-          size="small"
-          startIcon={<DescriptionIcon fontSize="small" />}
-          onClick={openAdd}
-        >
+        <Button variant="outlined" size="small" startIcon={<DescriptionIcon fontSize="small" />} onClick={openAdd}>
           Add Blob ({entries.length})
         </Button>
       </Stack>
@@ -1156,8 +1157,8 @@ function BlobDialog({
       <DialogTitle>{editingName ? "Edit blob" : "Add blob"}</DialogTitle>
       <DialogContent>
         <DialogContentText sx={{ mb: 2 }}>
-          Blobs are referenced from the manifest via <code>blob!(name)</code>. Provide the bytes
-          either by uploading a file or by pasting base64-encoded data.
+          Blobs are referenced from the manifest via <code>blob!(name)</code>. Provide the bytes either by uploading a
+          file or by pasting base64-encoded data.
         </DialogContentText>
         <Stack spacing={2} mt={1}>
           <TextField
@@ -1200,9 +1201,7 @@ function BlobDialog({
               },
             }}
           />
-          <Box sx={{ color: "text.secondary", fontSize: "0.875rem" }}>
-            Decoded size: {formatBytes(size)}
-          </Box>
+          <Box sx={{ color: "text.secondary", fontSize: "0.875rem" }}>Decoded size: {formatBytes(size)}</Box>
           {error && <Box sx={{ color: "error.main", fontSize: "0.875rem" }}>{error}</Box>}
         </Stack>
       </DialogContent>

--- a/crates/storage_sqlite/src/global/backend_adapter.rs
+++ b/crates/storage_sqlite/src/global/backend_adapter.rs
@@ -25,7 +25,7 @@ use std::{
     convert::{TryFrom, TryInto},
     fmt::{Debug, Formatter},
     marker::PhantomData,
-    sync::{Arc, Mutex},
+    sync::{Arc, Mutex, MutexGuard},
 };
 
 use diesel::{
@@ -101,7 +101,11 @@ impl<TAddr> SqliteGlobalDbAdapter<TAddr> {
         }
     }
 
-    fn exists(&self, tx: &mut SqliteTransaction<'_>, key: &[u8]) -> Result<bool, SqliteStorageError> {
+    fn exists(
+        &self,
+        tx: &mut SqliteTransaction<MutexGuard<'_, SqliteConnection>>,
+        key: &[u8],
+    ) -> Result<bool, SqliteStorageError> {
         use crate::global::schema::metadata;
         let result = metadata::table
             .filter(metadata::key_name.eq(key))
@@ -127,7 +131,7 @@ impl<TAddr> SqliteGlobalDbAdapter<TAddr> {
 }
 
 impl<TAddr> AtomicDb for SqliteGlobalDbAdapter<TAddr> {
-    type DbTransaction<'a> = SqliteTransaction<'a>;
+    type DbTransaction<'a> = SqliteTransaction<MutexGuard<'a, SqliteConnection>>;
     type Error = SqliteStorageError;
 
     fn create_transaction(&self) -> Result<Self::DbTransaction<'_>, Self::Error> {

--- a/crates/storage_sqlite/src/sqlite_transaction.rs
+++ b/crates/storage_sqlite/src/sqlite_transaction.rs
@@ -20,7 +20,7 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::sync::MutexGuard;
+use std::ops::DerefMut;
 
 use diesel::{RunQueryDsl, SqliteConnection, sql_query};
 
@@ -28,18 +28,31 @@ use crate::error::SqliteStorageError;
 
 const _LOG_TARGET: &str = "tari::ootle::storage::sqlite::transaction";
 
-pub struct SqliteTransaction<'a> {
-    connection: MutexGuard<'a, SqliteConnection>,
+pub struct SqliteTransaction<C: DerefMut<Target = SqliteConnection>> {
+    connection: C,
     is_done: bool,
 }
 
-impl<'a> SqliteTransaction<'a> {
-    pub fn begin(connection: MutexGuard<'a, SqliteConnection>) -> Result<Self, SqliteStorageError> {
+impl<C> SqliteTransaction<C>
+where C: DerefMut<Target = SqliteConnection>
+{
+    /// Begins a deferred transaction. Locks are acquired lazily on first read/write.
+    pub fn begin(connection: C) -> Result<Self, SqliteStorageError> {
+        Self::begin_with(connection, "BEGIN DEFERRED")
+    }
+
+    /// Begins an immediate transaction, acquiring the write lock up front. Use this for writers
+    /// when multiple connections share the database to avoid deadlock on lock upgrade.
+    pub fn begin_immediate(connection: C) -> Result<Self, SqliteStorageError> {
+        Self::begin_with(connection, "BEGIN IMMEDIATE")
+    }
+
+    fn begin_with(connection: C, sql: &str) -> Result<Self, SqliteStorageError> {
         let mut this = Self {
             connection,
             is_done: false,
         };
-        this.execute_sql("BEGIN TRANSACTION")?;
+        this.execute_sql(sql)?;
         Ok(this)
     }
 
@@ -75,7 +88,9 @@ impl<'a> SqliteTransaction<'a> {
     }
 }
 
-impl Drop for SqliteTransaction<'_> {
+impl<C> Drop for SqliteTransaction<C>
+where C: DerefMut<Target = SqliteConnection>
+{
     fn drop(&mut self) {
         if !self.is_done {
             let _ignore = self.rollback_inner();


### PR DESCRIPTION
## Summary
Three layered changes that together make the indexer's sqlite path concurrent and non-blocking on the tokio runtime:

### 1. WAL journal mode
`PRAGMA journal_mode = WAL` (with `synchronous = NORMAL`, `foreign_keys = ON`, `busy_timeout = 5s`). WAL is persisted in the DB header — existing indexer DBs upgrade automatically on first open.

### 2. Connection pool
Replaced the single `Arc<Mutex<SqliteConnection>>` with a connection pool (max 16). Writers use `BEGIN IMMEDIATE` to avoid lock-upgrade deadlocks; `busy_timeout` makes contending writers wait politely instead of failing with `SQLITE_BUSY`. Migrations run once at startup on a one-shot connection before the pool opens.

### 3. Async store via deadpool-diesel
Switched from `r2d2` to `deadpool-diesel`. `with_read_tx` and `with_write_tx` are now async and route the closure through `interact()`, so the sync diesel work runs on tokio's `spawn_blocking` pool while async callers yield back to the runtime. This is the actual win for an indexer-under-load: under concurrent traffic, we no longer occupy runtime workers for DB work.

`SqliteTransaction` is generic over the connection holder (`DerefMut<Target = SqliteConnection>`) so the validator/walletd global backend adapter keeps its existing `MutexGuard` path while the indexer uses borrowed connections from the pool.

### Caller migration
- Closures passed to `with_*_tx` must now be `Send + 'static`; borrowed args (`&SubstateId`, `&str`, etc.) are cloned/copied outside before the move into the closure.
- `UtxoUpdateStream` was rewritten on top of `async-stream::try_stream!` since its hand-written `Stream::poll_next` couldn't await the now-async substate manager.
- `bootstrap::check_store`, `seed_builtin_template_catalogue`, `hack_xtr_initial_supply` and the various `SubstateManager` and `TransactionManager` helpers became async.
- `network_state_sync::worker` extracts the side-effecting `transaction_event_notify` calls outside the transaction (DB returns the inserted events, notifications fire after commit) so the closure no longer needs to capture `&self`.

## Test plan
- [ ] `cargo build -p tari_indexer`
- [ ] `cargo test -p tari_ootle_storage_sqlite`
- [ ] Start an indexer against an existing DB and confirm `*-wal` / `*-shm` files appear next to the sqlite file.
- [ ] `sqlite3 <db> 'PRAGMA journal_mode;'` returns `wal`.
- [ ] Under concurrent REST traffic, indexer keeps tokio workers responsive (no head-of-line blocking on DB).
- [ ] Verify the SSE event stream and the UTXO update stream still emit chunks correctly end-to-end.