### PR TITLE
feat(engine): on-disk cache of compiled wasmer modules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11165,6 +11165,7 @@ dependencies = [
  "tari_template_test_tooling",
  "tari_transaction_manifest",
  "tari_utilities",
+ "tempfile",
  "thiserror 2.0.18",
  "wasmer",
  "wasmer-middlewares",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11147,9 +11147,11 @@ name = "tari_engine"
 version = "0.30.2"
 dependencies = [
  "blake2",
+ "bytes",
  "criterion",
  "indexmap 2.13.0",
  "log",
+ "memmap2 0.9.9",
  "ootle_byte_type",
  "rand 0.8.5",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,6 +190,7 @@ bitflags = "2.9.2"
 blake2 = "0.10.6"
 borsh = { version = "1.6", default-features = false }
 bytes = "1.11.1"
+memmap2 = "0.9"
 bnum = "0.13.0"
 bech32 = "0.11.0"
 bounded-vec = "0.9.0"

--- a/applications/tari_indexer/Cargo.toml
+++ b/applications/tari_indexer/Cargo.toml
@@ -22,7 +22,7 @@ tari_common = { workspace = true }
 tari_consensus = { workspace = true }
 tari_template_builtin = { workspace = true, features = ["templates"] }
 tari_crypto = { workspace = true }
-tari_engine = { workspace = true }
+tari_engine = { workspace = true, features = ["wasm-cache"] }
 tari_engine_types = { workspace = true }
 tari_epoch_manager = { workspace = true, features = ["service"] }
 tari_epoch_oracles = { workspace = true, features = ["base_layer"] }

--- a/applications/tari_indexer/src/bootstrap.rs
+++ b/applications/tari_indexer/src/bootstrap.rs
@@ -30,6 +30,7 @@ use tari_base_node_client::grpc::GrpcBaseNodeClient;
 use tari_common::configuration::bootstrap::{ApplicationType, grpc_default_port};
 use tari_consensus::consensus_constants::ConsensusConstants;
 use tari_crypto::tari_utilities::ByteArray;
+use tari_engine::wasm::WasmModuleCache;
 use tari_engine_types::{calculate_template_binary_hash, published_template::PublishedTemplateMetadata};
 use tari_epoch_manager::service::{EpochManagerConfig, EpochManagerHandle};
 use tari_epoch_oracles::{
@@ -243,7 +244,15 @@ pub async fn spawn_services(
     let substate_manager = substate_manager.with_metrics(metrics_registry);
 
     // Template manager
-    let template_manager = TemplateManager::initialize(global_db.clone(), substate_manager.clone())?;
+    let wasm_cache_dir = config.indexer.data_dir.join("wasm_cache");
+    let wasm_cache = WasmModuleCache::open(&wasm_cache_dir).map_err(|e| {
+        anyhow!(
+            "Failed to open WASM module cache at {}: {}",
+            wasm_cache_dir.display(),
+            e,
+        )
+    })?;
+    let template_manager = TemplateManager::initialize(global_db.clone(), substate_manager.clone(), wasm_cache)?;
 
     // Dry run - use a shorter cache TTL for more accurate fee estimates
     let dry_run_substate_manager = substate_manager

--- a/applications/tari_indexer/src/network_state_sync/worker.rs
+++ b/applications/tari_indexer/src/network_state_sync/worker.rs
@@ -16,7 +16,15 @@ use tari_engine_types::{
 use tari_epoch_manager::{EpochManagerEvent, EpochManagerReader, service::EpochManagerHandle};
 use tari_indexer_client::event::{IndexerEvent, NewEpochEvent, TransactionEvent, TransactionFinalizedEvent};
 use tari_networking::NetworkingHandle;
-use tari_ootle_common_types::{Epoch, ShardGroup, StateVersion, VotePower, optional::Optional, shard::Shard};
+use tari_ootle_common_types::{
+    Epoch,
+    ShardGroup,
+    StateVersion,
+    VotePower,
+    displayable::Displayable,
+    optional::Optional,
+    shard::Shard,
+};
 use tari_ootle_p2p::{PeerAddress, TariMessagingSpec, proto::rpc};
 use tari_ootle_storage::{
     StorageError,
@@ -404,6 +412,8 @@ impl NetworkWideStateSync {
             .map(|(v, e)| (v.as_u64(), *e))
             .unwrap_or_else(|| (0, Epoch::zero()));
         let from_version = prev_version + 1;
+
+        info!(target: LOG_TARGET, "🌍️ Starting state sync for shard {shard} from version {from_version}");
         let mut value_filters = SubstateValueFilterFlags::UTXO |
             SubstateValueFilterFlags::VALIDATOR_FEE_POOL |
             SubstateValueFilterFlags::CLAIMED_OUTPUT_TOMBSTONE |
@@ -428,6 +438,8 @@ impl NetworkWideStateSync {
 
         let mut is_first_iter = true;
         let mut xtr_claimed = Amount::zero();
+        let mut last_version = StateVersion::new(from_version);
+        let mut last_epoch = None;
         while let Some(result) = stream.next().await {
             if is_first_iter {
                 // Avoid log spam, only log once per stream
@@ -441,7 +453,9 @@ impl NetworkWideStateSync {
                 .ok_or_else(|| NetworkStateSyncError::InvalidStateUpdate {
                     details: "Received state update without epoch".to_string(),
                 })?;
+            last_epoch = Some(msg_epoch);
             let state_version = StateVersion::new(msg.state_version);
+            last_version = state_version;
 
             for update in msg.updates {
                 let update =
@@ -468,7 +482,7 @@ impl NetworkWideStateSync {
                 continue;
             }
 
-            info!(target: LOG_TARGET, "🌍️ Received {} updates for shard {shard} (epoch: {msg_epoch}, state version: {state_version})", update_buf.len());
+            debug!(target: LOG_TARGET, "🌍️ Received {} updates for shard {shard} (epoch: {msg_epoch}, state version: {state_version})", update_buf.len());
 
             self.stats.increase_state_updates(update_buf.len());
 
@@ -533,6 +547,7 @@ impl NetworkWideStateSync {
                 });
             }
         }
+        info!(target: LOG_TARGET, "🌍️ Completed state sync for shard {shard} in shard group {shard_group} to epoch {} and state version {last_version}",last_epoch.display() );
         Ok(())
     }
 }

--- a/applications/tari_indexer/src/template_manager/manager.rs
+++ b/applications/tari_indexer/src/template_manager/manager.rs
@@ -23,8 +23,8 @@
 use std::collections::{HashMap, HashSet};
 
 use tari_engine::{
-    template::{LoadedTemplate, TemplateModuleLoader},
-    wasm::WasmModule,
+    template::LoadedTemplate,
+    wasm::{WasmModule, WasmModuleCache},
 };
 use tari_engine_types::{
     calculate_template_binary_hash,
@@ -44,7 +44,7 @@ use tari_ootle_storage::{
     time::{OffsetDateTime, PrimitiveDateTime},
 };
 use tari_ootle_storage_sqlite::global::SqliteGlobalDbAdapter;
-use tari_template_builtin::{all_builtin_templates, try_get_template_builtin};
+use tari_template_builtin::{all_builtin_templates, is_builtin_template_address, try_get_template_builtin};
 use tari_template_lib_types::{TemplateAddress, crypto::RistrettoPublicKeyBytes};
 
 use super::{Template, TemplateCode, TemplateMetadata};
@@ -54,12 +54,14 @@ use crate::{substate_manager::SubstateManager, template_manager::error::Template
 pub struct TemplateManager {
     global_db: GlobalDb<SqliteGlobalDbAdapter<PeerAddress>>,
     substate_manager: SubstateManager,
+    wasm_cache: WasmModuleCache,
 }
 
 impl TemplateManager {
     pub fn initialize(
         global_db: GlobalDb<SqliteGlobalDbAdapter<PeerAddress>>,
         substate_manager: SubstateManager,
+        wasm_cache: WasmModuleCache,
     ) -> Result<Self, TemplateManagerError> {
         // load the builtin templates
         let builtin_templates = Self::builtin_templates();
@@ -91,7 +93,33 @@ impl TemplateManager {
         Ok(Self {
             global_db,
             substate_manager,
+            wasm_cache,
         })
+    }
+
+    /// Compile or deserialize the template binary for `address`. Result is
+    /// persisted in the on-disk wasm cache so subsequent calls (across process
+    /// restarts) skip the cranelift compile.
+    ///
+    /// Builtin templates bypass the cache: their addresses are hardcoded
+    /// constants (independent of binary content), so a stale cache entry
+    /// would silently serve an out-of-date compiled module after a builtin
+    /// recompile. User-template addresses are content-addressed, so binary
+    /// changes naturally invalidate the cache key.
+    fn load_template_with_cache(
+        &self,
+        address: &TemplateAddress,
+        code: &TemplateCode,
+    ) -> Result<LoadedTemplate, TemplateManagerError> {
+        if is_builtin_template_address(address) {
+            return Ok(WasmModule::load_template_from_code(code.as_raw_bytes())?);
+        }
+        if let Some(loaded) = self.wasm_cache.try_load(address) {
+            return Ok(loaded);
+        }
+        let loaded = WasmModule::load_template_from_code(code.as_raw_bytes())?;
+        self.wasm_cache.store(address, &loaded);
+        Ok(loaded)
     }
 
     fn builtin_templates() -> impl Iterator<Item = Template> {
@@ -193,7 +221,7 @@ impl TemplateManager {
         epoch: Epoch,
         metadata_hash: Option<Vec<u8>>,
     ) -> Result<LoadedTemplate, TemplateManagerError> {
-        let loaded_template = load_template_from_code(&code)?;
+        let loaded_template = self.load_template_with_cache(&template_address, &code)?;
 
         self.add_template(
             loaded_template.template_name().to_string(),
@@ -218,7 +246,10 @@ impl TemplateManager {
 
         for template_addr in &template_addrs {
             if let Some(template) = self.fetch_cached_template(template_addr).optional()? {
-                loaded_templates.insert(**template_addr, load_template_from_code(&template.code)?);
+                loaded_templates.insert(
+                    **template_addr,
+                    self.load_template_with_cache(template_addr, &template.code)?,
+                );
             }
         }
 
@@ -282,13 +313,13 @@ impl TemplateProvider for TemplateManager {
         let Some(template) = self.fetch_cached_template(address).optional()? else {
             return Ok(None);
         };
-        let wasm = template
-            .code
-            .as_wasm_code()
-            .ok_or(TemplateManagerError::UnsupportedTemplateType)?;
-        let module = WasmModule::from_code(wasm);
-        let loaded = module.load_template()?;
-
+        // Validate the template carries WASM code (the cache itself is keyed by
+        // template address; the loader inside `load_template_with_cache` reads
+        // `template.code.as_raw_bytes()` which is fine for WASM templates).
+        if template.code.as_wasm_code().is_none() {
+            return Err(TemplateManagerError::UnsupportedTemplateType);
+        }
+        let loaded = self.load_template_with_cache(address, &template.code)?;
         Ok(Some(loaded))
     }
 
@@ -317,10 +348,4 @@ fn convert_builtin_template_from_code(template: &tari_template_builtin::Template
         },
         code: TemplateCode::StaticWasm(template.binary),
     }
-}
-
-fn load_template_from_code(code: &TemplateCode) -> Result<LoadedTemplate, TemplateManagerError> {
-    let binary = code.as_raw_bytes();
-    let loaded_template = WasmModule::load_template_from_code(binary)?;
-    Ok(loaded_template)
 }

--- a/applications/tari_validator_node/Cargo.toml
+++ b/applications/tari_validator_node/Cargo.toml
@@ -24,7 +24,7 @@ tari_validator_node_rpc = { workspace = true }
 tari_ootle_app_utilities = { workspace = true, features = ["epoch_oracle", "p2p"] }
 tari_ootle_common_types = { workspace = true }
 tari_ootle_p2p = { workspace = true }
-tari_engine = { workspace = true }
+tari_engine = { workspace = true, features = ["wasm-cache"] }
 tari_ootle_storage = { workspace = true }
 tari_ootle_storage_sqlite = { workspace = true }
 tari_state_store_rocksdb = { workspace = true }

--- a/applications/tari_validator_node/src/bootstrap.rs
+++ b/applications/tari_validator_node/src/bootstrap.rs
@@ -84,8 +84,15 @@ use crate::{
     ValidatorNodeEpochManagerSpec,
     ValidatorNodeStateStore,
     base_layer::verify_correct_network,
-    consensus::{self, ConsensusHandle, TariBlockTransactionExecutor, ValidationContext},
+    consensus::{
+        self,
+        ConsensusHandle,
+        TariBlockTransactionExecutor,
+        ValidationContext,
+        spec::ValidatorTemplateProvider,
+    },
     file_l1_submitter::FileLayerOneSubmitter,
+    memory_cache_template_provider::MemoryCacheTemplateProvider,
     migrations,
     p2p::{
         NopLogger,
@@ -96,7 +103,6 @@ use crate::{
             messaging::{ConsensusInboundMessaging, ConsensusOutboundMessaging},
         },
     },
-    state_store_template_provider::StateStoreTemplateProvider,
     transaction_validators::{
         BasicValidations,
         EpochRangeValidator,
@@ -260,7 +266,11 @@ pub async fn spawn_services(
 
     info!(target: LOG_TARGET, "Template manager initializing");
     // Template manager
-    let template_provider = StateStoreTemplateProvider::new(state_store.clone(), &config.validator_node.templates);
+    let wasm_cache_dir = config.validator_node.data_dir.join("wasm_cache");
+    let template_provider = MemoryCacheTemplateProvider::new(
+        tari_engine::wasm::DiskCachedWasmTemplateProvider::open(state_store.clone(), wasm_cache_dir)?,
+        &config.validator_node.templates,
+    );
 
     info!(target: LOG_TARGET, "Payload processor initializing");
     // Payload processor
@@ -397,7 +407,7 @@ pub struct Services<TStore> {
     pub networking: NetworkingHandle<TariMessagingSpec>,
     pub mempool: MempoolHandle,
     pub epoch_manager: EpochManagerHandle<PeerAddress>,
-    pub template_provider: StateStoreTemplateProvider<ValidatorNodeStateStore>,
+    pub template_provider: ValidatorTemplateProvider,
     pub consensus_handle: ConsensusHandle,
     pub state_store: TStore,
     pub global_db: GlobalDb<SqliteGlobalDbAdapter<PeerAddress>>,

--- a/applications/tari_validator_node/src/config.rs
+++ b/applications/tari_validator_node/src/config.rs
@@ -35,7 +35,7 @@ use tari_ootle_app_utilities::{
 };
 use tari_ootle_transaction::Network;
 
-use crate::state_store_template_provider::TemplateConfig;
+use crate::memory_cache_template_provider::TemplateConfig;
 
 #[derive(Debug, Clone)]
 pub struct ApplicationConfig {

--- a/applications/tari_validator_node/src/consensus/spec.rs
+++ b/applications/tari_validator_node/src/consensus/spec.rs
@@ -18,16 +18,17 @@ use crate::{
         signer_service::TariSignatureService,
         // template_metadata_hooks::TemplateMetadataHooks,
     },
+    memory_cache_template_provider::MemoryCacheTemplateProvider,
     p2p::{
         NopLogger,
         services::messaging::{ConsensusInboundMessaging, ConsensusOutboundMessaging},
     },
-    state_store_template_provider::StateStoreTemplateProvider,
 };
 
 pub type ValidatorNodeStateStore = tari_state_store_rocksdb::RocksDbStateStore<PeerAddress>;
-pub type ValidatorTransactionProcessor =
-    TariTransactionProcessor<ReadOnlyMemoryStateStore, StateStoreTemplateProvider<ValidatorNodeStateStore>>;
+pub type ValidatorTemplateProvider =
+    MemoryCacheTemplateProvider<tari_engine::wasm::DiskCachedWasmTemplateProvider<ValidatorNodeStateStore>>;
+pub type ValidatorTransactionProcessor = TariTransactionProcessor<ReadOnlyMemoryStateStore, ValidatorTemplateProvider>;
 #[derive(Clone)]
 pub struct TariConsensusSpec;
 

--- a/applications/tari_validator_node/src/json_rpc/handlers.rs
+++ b/applications/tari_validator_node/src/json_rpc/handlers.rs
@@ -109,11 +109,13 @@ use tari_validator_node_client::types::{
 use crate::{
     ApplicationConfig,
     bootstrap::Services,
-    consensus::{ConsensusHandle, spec::ValidatorNodeStateStore},
+    consensus::{
+        ConsensusHandle,
+        spec::{ValidatorNodeStateStore, ValidatorTemplateProvider},
+    },
     file_l1_submitter::FileLayerOneSubmitter,
     json_rpc::jrpc_errors::{general_error, internal_error, invalid_operation, not_found},
     p2p::services::mempool::MempoolHandle,
-    state_store_template_provider::StateStoreTemplateProvider,
 };
 
 const LOG_TARGET: &str = "tari::validator_node::json_rpc::handlers";
@@ -122,7 +124,7 @@ pub struct JsonRpcHandlers {
     config: ApplicationConfig,
     keypair: RistrettoKeypair,
     mempool: MempoolHandle,
-    template_provider: StateStoreTemplateProvider<ValidatorNodeStateStore>,
+    template_provider: ValidatorTemplateProvider,
     epoch_manager: EpochManagerHandle<PeerAddress>,
     layer_one_transaction_submitter: FileLayerOneSubmitter,
     global_db: GlobalDb<SqliteGlobalDbAdapter<PeerAddress>>,

--- a/applications/tari_validator_node/src/lib.rs
+++ b/applications/tari_validator_node/src/lib.rs
@@ -31,12 +31,12 @@ mod genesis_state;
 #[cfg(feature = "web_ui")]
 mod http_ui;
 mod json_rpc;
+mod memory_cache_template_provider;
 #[cfg(feature = "metrics")]
 mod metrics;
 mod migrations;
 pub mod node;
 mod p2p;
-mod state_store_template_provider;
 pub mod transaction_validators;
 mod validator;
 

--- a/applications/tari_validator_node/src/memory_cache_template_provider.rs
+++ b/applications/tari_validator_node/src/memory_cache_template_provider.rs
@@ -3,21 +3,18 @@
 
 use log::debug;
 use serde::{Deserialize, Serialize};
-use tari_engine::{
-    template::{LoadedTemplate, TemplateLoaderError},
-    wasm::WasmModule,
-};
-use tari_engine_types::published_template::PublishedTemplate;
-use tari_ootle_common_types::{
-    Epoch,
-    services::template_provider::{TemplateMetadataProvider, TemplateProvider, TemplateProviderMetadata},
+use tari_engine::{template::LoadedTemplate, wasm::WasmModule};
+use tari_ootle_common_types::services::template_provider::{
+    TemplateMetadataProvider,
+    TemplateProvider,
+    TemplateProviderMetadata,
 };
 use tari_template_builtin::all_builtin_templates;
 use tari_template_lib::types::TemplateAddress;
 
 use crate::cmap_semaphore;
 
-const LOG_TARGET: &str = "tari::validator::state_store_template_provider";
+const LOG_TARGET: &str = "tari::validator::memory_cache_template_provider";
 const CONCURRENT_ACCESS_LIMIT: isize = 100;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -39,23 +36,42 @@ impl TemplateConfig {
     }
 }
 
+/// Outermost layer of the validator-node template provider chain.
+///
+/// Holds an in-memory moka cache of `LoadedTemplate`s keyed by address and a
+/// per-address semaphore to coalesce concurrent first-fetches. Builtin
+/// templates are precompiled into the cache at construction time. Everything
+/// else delegates to `inner` on miss — typically a
+/// `tari_engine::wasm::DiskCachedWasmTemplateProvider` wrapping the raw state
+/// store, so the layering is:
+///
+/// ```text
+/// MemoryCacheTemplateProvider          (this)
+///   └── DiskCachedWasmTemplateProvider (compiled-module disk cache + compile)
+///         └── ValidatorNodeStateStore  (raw PublishedTemplate bytes from rocksdb)
+/// ```
 #[derive(Clone)]
-pub struct StateStoreTemplateProvider<TStore> {
-    inner: TStore,
+pub struct MemoryCacheTemplateProvider<TInner> {
+    inner: TInner,
     cache: mini_moka::sync::Cache<TemplateAddress, LoadedTemplate>,
     cmap_semaphore: cmap_semaphore::ConcurrentMapSemaphore<TemplateAddress>,
 }
 
-impl<TStore: TemplateProvider<Template = PublishedTemplate>> StateStoreTemplateProvider<TStore> {
-    pub fn new(inner: TStore, config: &TemplateConfig) -> Self {
-        // load the builtin account templates
+impl<TInner> MemoryCacheTemplateProvider<TInner>
+where TInner: TemplateProvider<Template = LoadedTemplate>
+{
+    pub fn new(inner: TInner, config: &TemplateConfig) -> Self {
         let cache = mini_moka::sync::Cache::builder()
             .weigher(|_, t: &LoadedTemplate| u32::try_from(t.code_size()).unwrap_or(u32::MAX))
             .max_capacity(config.max_cache_size_bytes())
             .initial_capacity(all_builtin_templates().len())
             .build();
 
-        // Precache builtins
+        // Precache builtins. Compile directly here — builtins live only in
+        // memory, never go through the disk-cache layer (their addresses are
+        // hardcoded constants and would otherwise pin stale compiled modules
+        // across builtin recompiles). The disk-cache layer also has a
+        // matching bypass on the lookup side as defence in depth.
         for template in all_builtin_templates() {
             cache.insert(
                 template.address,
@@ -71,8 +87,10 @@ impl<TStore: TemplateProvider<Template = PublishedTemplate>> StateStoreTemplateP
     }
 }
 
-impl<TStore: TemplateProvider<Template = PublishedTemplate>> TemplateProvider for StateStoreTemplateProvider<TStore> {
-    type Error = StateStoreTemplateProviderError;
+impl<TInner> TemplateProvider for MemoryCacheTemplateProvider<TInner>
+where TInner: TemplateProvider<Template = LoadedTemplate> + Clone + 'static
+{
+    type Error = MemoryCacheTemplateProviderError;
     type Template = LoadedTemplate;
 
     fn get_template(&self, address: &TemplateAddress) -> Result<Option<Self::Template>, Self::Error> {
@@ -91,18 +109,21 @@ impl<TStore: TemplateProvider<Template = PublishedTemplate>> TemplateProvider fo
         let guard = self.cmap_semaphore.acquire(*address);
         let _access = guard.access();
 
-        let Some(template) = self
+        // After acquiring the semaphore, the racing thread may have populated
+        // the cache; check again before delegating to the inner provider.
+        if let Some(template) = self.cache.get(address) {
+            return Ok(Some(template));
+        }
+
+        let Some(loaded) = self
             .inner
             .get_template(address)
-            .map_err(|e| StateStoreTemplateProviderError::InnerProvider(e.into()))?
+            .map_err(|e| MemoryCacheTemplateProviderError::Inner(e.into()))?
         else {
             return Ok(None);
         };
 
-        let loaded = WasmModule::load_template_from_code(template.binary.as_slice())?;
-
         self.cache.insert(*address, loaded.clone());
-
         Ok(Some(loaded))
     }
 
@@ -110,31 +131,24 @@ impl<TStore: TemplateProvider<Template = PublishedTemplate>> TemplateProvider fo
         Ok(self.cache.contains_key(id) ||
             self.inner
                 .has_template(id)
-                .map_err(|e| StateStoreTemplateProviderError::InnerProvider(e.into()))?)
+                .map_err(|e| MemoryCacheTemplateProviderError::Inner(e.into()))?)
     }
 }
-impl<TStore: TemplateProvider<Template = PublishedTemplate>> TemplateMetadataProvider
-    for StateStoreTemplateProvider<TStore>
+
+impl<TInner> TemplateMetadataProvider for MemoryCacheTemplateProvider<TInner>
+where TInner: TemplateProvider<Template = LoadedTemplate> + TemplateMetadataProvider + Clone + 'static
 {
     fn get_template_metadata(&self, id: &TemplateAddress) -> Result<Option<TemplateProviderMetadata>, Self::Error> {
-        let template = self
-            .inner
-            .get_template(id)
-            .map_err(|e| StateStoreTemplateProviderError::InnerProvider(e.into()))?;
-
-        Ok(template.map(|t| TemplateProviderMetadata {
-            author: t.author,
-            binary_hash: t.to_binary_hash(),
-            epoch: Epoch(t.at_epoch),
-            metadata_hash: t.metadata_hash,
-        }))
+        // The hot cache only stores compiled modules, not metadata fields.
+        // Always delegate.
+        self.inner
+            .get_template_metadata(id)
+            .map_err(|e| MemoryCacheTemplateProviderError::Inner(e.into()))
     }
 }
 
 #[derive(Debug, thiserror::Error)]
-pub enum StateStoreTemplateProviderError {
+pub enum MemoryCacheTemplateProviderError {
     #[error(transparent)]
-    InnerProvider(anyhow::Error),
-    #[error("Template load error: {0}")]
-    TemplateLoadError(#[from] TemplateLoaderError),
+    Inner(anyhow::Error),
 }

--- a/applications/tari_validator_node/src/memory_cache_template_provider.rs
+++ b/applications/tari_validator_node/src/memory_cache_template_provider.rs
@@ -17,6 +17,16 @@ use crate::cmap_semaphore;
 const LOG_TARGET: &str = "tari::validator::memory_cache_template_provider";
 const CONCURRENT_ACCESS_LIMIT: isize = 100;
 
+/// Multiplier applied to the WASM source byte count when weighing cache
+/// entries. The source size under-estimates the resident footprint of a
+/// `LoadedTemplate` because the dominant cost is the Cranelift-compiled
+/// artifact (machine code + relocations + frame info), which inflates the
+/// source by ~1.5–3× in typical templates and up to ~5× for hot-loop heavy
+/// code. K=4 keeps the bound honest in the typical case and overshoots by at
+/// most ~25% in the worst case — acceptable for a coarse process-memory
+/// budget. Cheaper than serializing each module on insert and infallible.
+const CODE_SIZE_TO_RESIDENT_BYTES_FACTOR: usize = 4;
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct TemplateConfig {
     max_cache_size_bytes: u64,
@@ -62,7 +72,10 @@ where TInner: TemplateProvider<Template = LoadedTemplate>
 {
     pub fn new(inner: TInner, config: &TemplateConfig) -> Self {
         let cache = mini_moka::sync::Cache::builder()
-            .weigher(|_, t: &LoadedTemplate| u32::try_from(t.code_size()).unwrap_or(u32::MAX))
+            .weigher(|_, t: &LoadedTemplate| {
+                let est = t.code_size().saturating_mul(CODE_SIZE_TO_RESIDENT_BYTES_FACTOR);
+                u32::try_from(est).unwrap_or(u32::MAX)
+            })
             .max_capacity(config.max_cache_size_bytes())
             .initial_capacity(all_builtin_templates().len())
             .build();

--- a/applications/tari_walletd/Cargo.toml
+++ b/applications/tari_walletd/Cargo.toml
@@ -21,7 +21,7 @@ tari_ootle_wallet_storage_sqlite = { workspace = true }
 tari_ootle_transaction = { workspace = true }
 tari_ootle_common_types = { workspace = true }
 tari_ootle_template_metadata = { workspace = true, features = ["json"] }
-tari_engine = { workspace = true }
+tari_engine = { workspace = true, features = ["wasm-cache"] }
 tari_engine_types = { workspace = true }
 tari_ootle_walletd_client = { workspace = true }
 tari_template_builtin = { workspace = true }

--- a/applications/tari_walletd/Cargo.toml
+++ b/applications/tari_walletd/Cargo.toml
@@ -21,7 +21,7 @@ tari_ootle_wallet_storage_sqlite = { workspace = true }
 tari_ootle_transaction = { workspace = true }
 tari_ootle_common_types = { workspace = true }
 tari_ootle_template_metadata = { workspace = true, features = ["json"] }
-tari_engine = { workspace = true, features = ["wasm-cache"] }
+tari_engine = { workspace = true }
 tari_engine_types = { workspace = true }
 tari_ootle_walletd_client = { workspace = true }
 tari_template_builtin = { workspace = true }

--- a/applications/tari_walletd/src/services/template_monitor.rs
+++ b/applications/tari_walletd/src/services/template_monitor.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 use log::*;
-use tari_engine::wasm::WasmModule;
+use tari_engine::wasm;
 use tari_ootle_common_types::substate_type::SubstateType;
 use tari_ootle_wallet_sdk::{WalletSdk, WalletSdkSpec, models::WalletEvent};
 use tari_ootle_wallet_sdk_services::notify::Notify;
@@ -54,16 +54,20 @@ where TSpec: WalletSdkSpec
                     continue;
                 };
 
+                // The wallet daemon only stores the template's ABI; it never
+                // executes templates locally. Skip the heavyweight cranelift
+                // compile path and statically extract the TemplateDef from the
+                // WASM binary instead.
                 match task::spawn_blocking(move || {
-                    WasmModule::load_template_from_code(&template.binary).map(|loaded| (template, loaded))
+                    wasm::extract_template_def(&template.binary).map(|def| (template, def))
                 })
                 .await?
                 {
-                    Ok((template, loaded)) => {
+                    Ok((template, template_def)) => {
                         self.wallet_sdk.template_api().add_authored_template(
                             template.author,
                             template_address.as_hash(),
-                            loaded.template_def().clone(),
+                            template_def,
                         )?;
                     },
                     Err(err) => {

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -28,14 +28,17 @@ serde = { workspace = true, default-features = true }
 thiserror = { workspace = true }
 wasmer = { workspace = true, features = ["cranelift"] }
 wasmer-middlewares = { workspace = true }
+bytes = { workspace = true, optional = true }
+memmap2 = { workspace = true, optional = true }
 
 [features]
 default = []
 # Enables the on-disk wasmer module cache (`tari_engine::wasm::cache`). Pulls
 # in `tari_template_builtin` to bypass caching for builtin addresses, plus the
-# filesystem I/O surface. Disable if embedding the engine in an environment
-# where a local data directory isn't available or isn't desirable.
-wasm-cache = []
+# filesystem I/O surface (memmap + bytes). Disable if embedding the engine in
+# an environment where a local data directory isn't available or isn't
+# desirable.
+wasm-cache = ["dep:bytes", "dep:memmap2"]
 
 [dev-dependencies]
 tari_template_test_tooling = { workspace = true }

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -29,6 +29,14 @@ thiserror = { workspace = true }
 wasmer = { workspace = true, features = ["cranelift"] }
 wasmer-middlewares = { workspace = true }
 
+[features]
+default = []
+# Enables the on-disk wasmer module cache (`tari_engine::wasm::cache`). Pulls
+# in `tari_template_builtin` to bypass caching for builtin addresses, plus the
+# filesystem I/O surface. Disable if embedding the engine in an environment
+# where a local data directory isn't available or isn't desirable.
+wasm-cache = []
+
 [dev-dependencies]
 tari_template_test_tooling = { workspace = true }
 tari_transaction_manifest = { workspace = true }
@@ -36,6 +44,7 @@ tari_ootle_transaction = { workspace = true }
 tari_template_builtin = { workspace = true, features = ["templates"] }
 
 criterion = { version = "0.8.1", features = ["html_reports"] }
+tempfile = { workspace = true }
 
 
 [[bench]]

--- a/crates/engine/src/template/error.rs
+++ b/crates/engine/src/template/error.rs
@@ -36,6 +36,8 @@ pub enum TemplateLoaderError {
     ExportError(#[from] wasmer::ExportError),
     #[error("Runtime error: {0}")]
     RuntimeError(#[from] wasmer::RuntimeError),
+    #[error("Deserialize error: {0}")]
+    DeserializeError(#[from] wasmer::DeserializeError),
 }
 
 impl From<wasmer::InstantiationError> for TemplateLoaderError {

--- a/crates/engine/src/wasm/cache.rs
+++ b/crates/engine/src/wasm/cache.rs
@@ -29,6 +29,7 @@ use std::{
 };
 
 use log::*;
+use memmap2::Mmap;
 use tari_engine_types::published_template::PublishedTemplate;
 use tari_ootle_common_types::{
     Epoch,
@@ -97,43 +98,75 @@ impl WasmModuleCache {
     /// any miss — file missing, header malformed, deserialize failure. On
     /// recoverable corruption the bad file is removed so a subsequent `store`
     /// can replace it.
+    ///
+    /// The file is `mmap`'d rather than read into a `Vec<u8>` — wasmer's
+    /// deserialize path accepts `bytes::Bytes` and `Bytes::from_owner` lets us
+    /// hand it the mmap region without copying. Cache hits cost a single
+    /// `mmap` syscall (and the page faults wasmer's deserializer triggers as
+    /// it walks the artifact); no full-artifact allocation.
     pub fn try_load(&self, addr: &TemplateAddress) -> Option<LoadedTemplate> {
         let path = self.path_for(addr);
-        let bytes = match fs::read(&path) {
-            Ok(b) => b,
+        let file = match fs::File::open(&path) {
+            Ok(f) => f,
             Err(e) if e.kind() == io::ErrorKind::NotFound => return None,
             Err(e) => {
                 warn!(
                     target: LOG_TARGET,
-                    "Failed to read cache file {}: {}", path.display(), e,
+                    "Failed to open cache file {}: {}", path.display(), e,
                 );
                 return None;
             },
         };
 
-        if bytes.len() < HEADER_BYTES {
+        // SAFETY: see the docs on `Mmap::map`. We don't promise immutability
+        // of the underlying file — if another process truncates or rewrites
+        // it concurrently the mmap read could SIGBUS. The cache dir is owned
+        // by this process (single writer, atomic rename on update), so this
+        // is safe in the deployment model. The fingerprint-suffixed filename
+        // also means concurrent writers from a different engine config would
+        // target a different file.
+        let mmap = match unsafe { Mmap::map(&file) } {
+            Ok(m) => m,
+            Err(e) => {
+                warn!(
+                    target: LOG_TARGET,
+                    "Failed to mmap cache file {}: {}", path.display(), e,
+                );
+                return None;
+            },
+        };
+
+        if mmap.len() < HEADER_BYTES {
             warn!(
                 target: LOG_TARGET,
                 "Cache file {} is shorter than the {}-byte header; removing.",
                 path.display(),
                 HEADER_BYTES,
             );
+            drop(mmap);
             let _ignore = fs::remove_file(&path);
             return None;
         }
 
         let mut header = [0u8; HEADER_BYTES];
-        header.copy_from_slice(&bytes[..HEADER_BYTES]);
+        header.copy_from_slice(&mmap[..HEADER_BYTES]);
         let code_size = u64::from_le_bytes(header) as usize;
-        let serialized = &bytes[HEADER_BYTES..];
 
-        // SAFETY: bytes were written by [`Self::store`] in a previous run of this
-        // process (or an earlier process owning the same data dir) via
-        // `wasmer::Module::serialize`. The cache directory is node-local and not
-        // attacker-controlled in any sane operational setup. The fingerprint
-        // suffix in the filename guarantees the engine config matches this
-        // build; a deserialize failure simply triggers the recompile fallback.
-        match unsafe { WasmModule::load_template_from_serialized(serialized, code_size) } {
+        // Wrap the mmap as a Bytes that owns it, then slice past the
+        // 8-byte header. `Bytes::slice` is zero-copy (pointer + length
+        // adjustment); the wrapped Mmap is dropped only when the resulting
+        // Bytes (and any clones the deserializer may keep) goes out of
+        // scope.
+        let body = bytes::Bytes::from_owner(mmap).slice(HEADER_BYTES..);
+
+        // SAFETY: bytes were written by [`Self::store`] in a previous run of
+        // this process (or an earlier process owning the same data dir) via
+        // `wasmer::Module::serialize`. The cache directory is node-local and
+        // not attacker-controlled in any sane operational setup. The
+        // fingerprint suffix in the filename guarantees the engine config
+        // matches this build; a deserialize failure simply triggers the
+        // recompile fallback.
+        match unsafe { WasmModule::load_template_from_serialized(body, code_size) } {
             Ok(loaded) => {
                 debug!(target: LOG_TARGET, "Cache hit for template {}", addr);
                 Some(loaded)

--- a/crates/engine/src/wasm/cache.rs
+++ b/crates/engine/src/wasm/cache.rs
@@ -1,0 +1,434 @@
+//   Copyright 2025 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+//! On-disk cache for compiled wasmer modules.
+//!
+//! Cranelift compilation of WASM templates is expensive: ~6 MB peak heap and
+//! tens of milliseconds per template, paid on every node startup. The compiled
+//! output for a given `(wasm_source, engine_config)` is deterministic and
+//! reusable, so it can be persisted on local disk and loaded back via
+//! [`wasmer::Module::deserialize_unchecked`] in milliseconds with negligible
+//! peak heap.
+//!
+//! The WASM source bytes themselves stay on-chain (canonical, deterministic
+//! representation). This cache is strictly node-local: any corrupt or missing
+//! entry falls back to a full compile from source, with no consensus
+//! implication.
+//!
+//! Two surfaces are exposed:
+//!
+//! - [`WasmModuleCache`] — low-level helper for callers that don't sit in a `TemplateProvider` chain (e.g. the wallet
+//!   daemon's template monitor).
+//! - [`DiskCachedWasmTemplateProvider`] — a `TemplateProvider` middleware that wraps a raw `PublishedTemplate` provider
+//!   and outputs `LoadedTemplate`, doing compile-or-deserialize behind the scenes.
+
+use std::{
+    fs,
+    io,
+    path::{Path, PathBuf},
+};
+
+use log::*;
+use tari_engine_types::published_template::PublishedTemplate;
+use tari_ootle_common_types::{
+    Epoch,
+    services::template_provider::{TemplateMetadataProvider, TemplateProvider, TemplateProviderMetadata},
+};
+use tari_template_builtin::is_builtin_template_address;
+use tari_template_lib::types::TemplateAddress;
+
+use crate::{
+    template::{LoadedTemplate, TemplateLoaderError},
+    wasm::WasmModule,
+};
+
+const LOG_TARGET: &str = "tari::engine::wasm::cache";
+
+/// Engine-config fingerprint embedded in cache filenames.
+///
+/// Bump this string whenever any of the following change, otherwise nodes
+/// loading from a stale cache will misbehave (deserialize failures at best,
+/// undefined behaviour at worst):
+///
+/// - [`crate::wasm::WasmModule::create_engine`] config (compiler flags, features bitset, middleware list, tunables).
+/// - The `wasmer` crate version (the serialized artifact format is internal to wasmer and not part of any stable wire
+///   spec).
+///
+/// On a bump, old cache files become orphans (different filename suffix)
+/// and the next compile-from-source rewrites under the new key.
+pub const ENGINE_FINGERPRINT: &str = "v1";
+
+/// 8-byte LE length prefix at the head of each cache file holding the original
+/// WASM source byte count. `wasmer::Module::serialize` doesn't preserve this
+/// and downstream consumers use it for accounting (e.g. moka weighing).
+const HEADER_BYTES: usize = 8;
+
+/// Low-level on-disk cache for compiled wasmer modules.
+///
+/// Files live at `{dir}/{template_address}_{ENGINE_FINGERPRINT}.bin`.
+/// The body is `[u64 LE: code_size] || wasmer::Module::serialize(...)`.
+///
+/// Writes are atomic (tempfile + rename). Read failures (missing file,
+/// deserialize errors, format changes) are non-fatal: the corrupt file is
+/// removed and the caller is expected to recompile from source.
+#[derive(Debug, Clone)]
+pub struct WasmModuleCache {
+    dir: PathBuf,
+}
+
+impl WasmModuleCache {
+    /// Open or create a cache rooted at `dir`. Creates the directory tree
+    /// if missing.
+    pub fn open(dir: impl Into<PathBuf>) -> io::Result<Self> {
+        let dir = dir.into();
+        fs::create_dir_all(&dir)?;
+        Ok(Self { dir })
+    }
+
+    pub fn dir(&self) -> &Path {
+        &self.dir
+    }
+
+    fn path_for(&self, addr: &TemplateAddress) -> PathBuf {
+        self.dir.join(format!("{}_{}.bin", addr, ENGINE_FINGERPRINT))
+    }
+
+    /// Try to load a previously-cached module for `addr`. Returns `None` on
+    /// any miss — file missing, header malformed, deserialize failure. On
+    /// recoverable corruption the bad file is removed so a subsequent `store`
+    /// can replace it.
+    pub fn try_load(&self, addr: &TemplateAddress) -> Option<LoadedTemplate> {
+        let path = self.path_for(addr);
+        let bytes = match fs::read(&path) {
+            Ok(b) => b,
+            Err(e) if e.kind() == io::ErrorKind::NotFound => return None,
+            Err(e) => {
+                warn!(
+                    target: LOG_TARGET,
+                    "Failed to read cache file {}: {}", path.display(), e,
+                );
+                return None;
+            },
+        };
+
+        if bytes.len() < HEADER_BYTES {
+            warn!(
+                target: LOG_TARGET,
+                "Cache file {} is shorter than the {}-byte header; removing.",
+                path.display(),
+                HEADER_BYTES,
+            );
+            let _ignore = fs::remove_file(&path);
+            return None;
+        }
+
+        let mut header = [0u8; HEADER_BYTES];
+        header.copy_from_slice(&bytes[..HEADER_BYTES]);
+        let code_size = u64::from_le_bytes(header) as usize;
+        let serialized = &bytes[HEADER_BYTES..];
+
+        // SAFETY: bytes were written by [`Self::store`] in a previous run of this
+        // process (or an earlier process owning the same data dir) via
+        // `wasmer::Module::serialize`. The cache directory is node-local and not
+        // attacker-controlled in any sane operational setup. The fingerprint
+        // suffix in the filename guarantees the engine config matches this
+        // build; a deserialize failure simply triggers the recompile fallback.
+        match unsafe { WasmModule::load_template_from_serialized(serialized, code_size) } {
+            Ok(loaded) => {
+                debug!(target: LOG_TARGET, "Cache hit for template {}", addr);
+                Some(loaded)
+            },
+            Err(err) => {
+                warn!(
+                    target: LOG_TARGET,
+                    "Failed to deserialize cached module {}: {}; removing.",
+                    path.display(),
+                    err,
+                );
+                let _ignore = fs::remove_file(&path);
+                None
+            },
+        }
+    }
+
+    /// Persist a compiled module under `addr`. Best-effort: on any failure
+    /// (serialize, write, rename) a warning is logged and the call returns
+    /// successfully — the caller's compiled module is still valid.
+    pub fn store(&self, addr: &TemplateAddress, loaded: &LoadedTemplate) {
+        let LoadedTemplate::Wasm(wasm) = loaded;
+        let serialized = match wasm.wasm_module().serialize() {
+            Ok(s) => s,
+            Err(e) => {
+                warn!(target: LOG_TARGET, "Failed to serialize module for {}: {}", addr, e);
+                return;
+            },
+        };
+
+        let path = self.path_for(addr);
+        let tmp = self.dir.join(format!(
+            "{}_{}.bin.tmp.{}",
+            addr,
+            ENGINE_FINGERPRINT,
+            std::process::id(),
+        ));
+
+        let mut bytes = Vec::with_capacity(HEADER_BYTES + serialized.len());
+        bytes.extend_from_slice(&(wasm.code_size() as u64).to_le_bytes());
+        bytes.extend_from_slice(&serialized);
+
+        if let Err(e) = fs::write(&tmp, &bytes) {
+            warn!(target: LOG_TARGET, "Failed to write cache tempfile {}: {}", tmp.display(), e);
+            return;
+        }
+
+        if let Err(e) = fs::rename(&tmp, &path) {
+            warn!(
+                target: LOG_TARGET,
+                "Failed to rename {} -> {}: {}", tmp.display(), path.display(), e,
+            );
+            let _ignore = fs::remove_file(&tmp);
+            return;
+        }
+
+        debug!(
+            target: LOG_TARGET,
+            "Cached compiled module for template {} -> {}", addr, path.display(),
+        );
+    }
+}
+
+/// `TemplateProvider` middleware that adds an on-disk compiled-module cache
+/// behind any provider returning raw [`PublishedTemplate`] bytes.
+///
+/// On `get_template(addr)`:
+/// 1. If the cache file `{addr}_{ENGINE_FINGERPRINT}.bin` exists, deserialize and return — no compile, no
+///    inner-provider call.
+/// 2. Otherwise delegate to `inner` for the raw `PublishedTemplate`, compile via
+///    [`WasmModule::load_template_from_code`], persist the compiled module to the cache, return.
+///
+/// Intended placement is between an outer in-memory cache (e.g. moka) and the
+/// raw state-store provider, so a process-lifetime hot path skips disk
+/// entirely and only the first compile-then-deserialize crossing per template
+/// per node ever pays the disk cost.
+#[derive(Debug, Clone)]
+pub struct DiskCachedWasmTemplateProvider<TStore> {
+    inner: TStore,
+    cache: WasmModuleCache,
+}
+
+impl<TStore> DiskCachedWasmTemplateProvider<TStore> {
+    pub fn new(inner: TStore, cache: WasmModuleCache) -> Self {
+        Self { inner, cache }
+    }
+
+    pub fn open(inner: TStore, path: impl Into<PathBuf>) -> io::Result<Self> {
+        let wasm_cache = WasmModuleCache::open(path)?;
+        Ok(Self::new(inner, wasm_cache))
+    }
+}
+
+impl<TStore> TemplateProvider for DiskCachedWasmTemplateProvider<TStore>
+where TStore: TemplateProvider<Template = PublishedTemplate> + Clone + 'static
+{
+    type Error = DiskCachedWasmTemplateProviderError;
+    type Template = LoadedTemplate;
+
+    fn get_template(&self, address: &TemplateAddress) -> Result<Option<Self::Template>, Self::Error> {
+        // Builtins bypass the disk cache: their addresses are hardcoded
+        // constants (independent of binary content), so a cache entry under
+        // a builtin's address would silently serve an out-of-date compiled
+        // module after a builtin recompile. User-template addresses are
+        // content-addressed, so binary changes implicitly invalidate the
+        // cache key.
+        if is_builtin_template_address(address) {
+            let Some(published) = self
+                .inner
+                .get_template(address)
+                .map_err(|e| DiskCachedWasmTemplateProviderError::Inner(e.into()))?
+            else {
+                return Ok(None);
+            };
+            return Ok(Some(WasmModule::load_template_from_code(published.binary.as_slice())?));
+        }
+
+        if let Some(loaded) = self.cache.try_load(address) {
+            return Ok(Some(loaded));
+        }
+
+        let Some(published) = self
+            .inner
+            .get_template(address)
+            .map_err(|e| DiskCachedWasmTemplateProviderError::Inner(e.into()))?
+        else {
+            return Ok(None);
+        };
+
+        let loaded = WasmModule::load_template_from_code(published.binary.as_slice())?;
+        self.cache.store(address, &loaded);
+        Ok(Some(loaded))
+    }
+
+    fn has_template(&self, address: &TemplateAddress) -> Result<bool, Self::Error> {
+        // Cheap path: cache hit implies the template exists. A miss falls
+        // through to the inner provider, which is allowed to answer without
+        // materialising the binary.
+        if !is_builtin_template_address(address) && self.cache.path_for(address).exists() {
+            return Ok(true);
+        }
+        self.inner
+            .has_template(address)
+            .map_err(|e| DiskCachedWasmTemplateProviderError::Inner(e.into()))
+    }
+}
+
+impl<TStore> TemplateMetadataProvider for DiskCachedWasmTemplateProvider<TStore>
+where TStore: TemplateProvider<Template = PublishedTemplate> + Clone + 'static
+{
+    fn get_template_metadata(&self, id: &TemplateAddress) -> Result<Option<TemplateProviderMetadata>, Self::Error> {
+        // Metadata always reads from the underlying state store, never from
+        // the disk cache (the cache only stores the compiled module, not the
+        // PublishedTemplate's author / epoch / metadata_hash fields).
+        let template = self
+            .inner
+            .get_template(id)
+            .map_err(|e| DiskCachedWasmTemplateProviderError::Inner(e.into()))?;
+        Ok(template.map(|t| TemplateProviderMetadata {
+            author: t.author,
+            binary_hash: t.to_binary_hash(),
+            epoch: Epoch(t.at_epoch),
+            metadata_hash: t.metadata_hash,
+        }))
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum DiskCachedWasmTemplateProviderError {
+    #[error("Inner template provider error: {0}")]
+    Inner(#[source] Box<dyn std::error::Error + Send + Sync>),
+    #[error(transparent)]
+    TemplateLoader(#[from] TemplateLoaderError),
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use tari_engine_types::published_template::PublishedTemplate;
+    use tari_template_builtin::all_builtin_templates;
+    use tari_template_lib::types::crypto::RistrettoPublicKeyBytes;
+    use tempfile::TempDir;
+
+    use super::*;
+
+    #[derive(Clone)]
+    struct StaticStore {
+        templates: Arc<std::collections::HashMap<TemplateAddress, PublishedTemplate>>,
+    }
+
+    #[derive(Debug, thiserror::Error)]
+    #[error("not found")]
+    struct StaticStoreError;
+
+    impl TemplateProvider for StaticStore {
+        type Error = StaticStoreError;
+        type Template = PublishedTemplate;
+
+        fn get_template(&self, address: &TemplateAddress) -> Result<Option<Self::Template>, Self::Error> {
+            Ok(self.templates.get(address).cloned())
+        }
+    }
+
+    fn make_store() -> (StaticStore, TemplateAddress) {
+        // We re-use the Account builtin's *binary* (it's a real, valid WASM
+        // template available in dev-deps) but file it under a synthetic
+        // non-builtin address — the disk-cache path bypasses real builtin
+        // addresses by design (see is_builtin_template_address).
+        let template = all_builtin_templates()
+            .iter()
+            .find(|t| t.name == "Account")
+            .expect("Account builtin");
+        let test_addr = TemplateAddress::from_array([
+            0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42,
+            0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42,
+        ]);
+        debug_assert!(
+            !is_builtin_template_address(&test_addr),
+            "test address must not collide with a builtin",
+        );
+        let mut map = std::collections::HashMap::new();
+        let published = PublishedTemplate {
+            template_name: template.name.try_into().expect("valid name"),
+            author: RistrettoPublicKeyBytes::default(),
+            binary: template.binary.to_vec().try_into().expect("template binary too large"),
+            at_epoch: 0,
+            metadata_hash: None,
+        };
+        map.insert(test_addr, published);
+        (
+            StaticStore {
+                templates: Arc::new(map),
+            },
+            test_addr,
+        )
+    }
+
+    #[test]
+    fn round_trip_compile_then_deserialize() {
+        let dir = TempDir::new().unwrap();
+        let cache = WasmModuleCache::open(dir.path()).unwrap();
+        let (store, addr) = make_store();
+        let provider = DiskCachedWasmTemplateProvider::new(store.clone(), cache.clone());
+
+        // First call: cache miss, compile-then-store.
+        let first = provider.get_template(&addr).unwrap().expect("loaded");
+        assert!(cache.path_for(&addr).exists(), "store should write a file");
+
+        // Second call: cache hit, deserialize-only path.
+        let second = provider.get_template(&addr).unwrap().expect("loaded");
+        assert_eq!(first.template_name(), second.template_name());
+        assert_eq!(first.code_size(), second.code_size());
+        assert_eq!(
+            first.template_def().functions().len(),
+            second.template_def().functions().len(),
+        );
+    }
+
+    #[test]
+    fn corrupt_cache_falls_back_to_recompile() {
+        let dir = TempDir::new().unwrap();
+        let cache = WasmModuleCache::open(dir.path()).unwrap();
+        let (store, addr) = make_store();
+
+        // Plant garbage at the expected filename.
+        let path = cache.path_for(&addr);
+        fs::write(&path, b"this is not a wasmer artifact").unwrap();
+        assert!(path.exists());
+
+        // try_load should return None, having removed the corrupt file.
+        assert!(cache.try_load(&addr).is_none());
+        assert!(!path.exists(), "corrupt file should be removed");
+
+        // Provider compiles fresh and writes a valid file.
+        let provider = DiskCachedWasmTemplateProvider::new(store, cache.clone());
+        provider.get_template(&addr).unwrap().expect("loaded");
+        assert!(path.exists(), "fresh compile should re-populate the cache");
+
+        // And the freshly-cached file deserializes cleanly.
+        assert!(cache.try_load(&addr).is_some());
+    }
+
+    #[test]
+    fn fingerprint_mismatch_treated_as_miss() {
+        let dir = TempDir::new().unwrap();
+        let cache = WasmModuleCache::open(dir.path()).unwrap();
+        let (_store, addr) = make_store();
+
+        // Plant a file under a different fingerprint suffix.
+        let alt = dir.path().join(format!("{}_v0.bin", addr));
+        fs::write(&alt, b"some bytes").unwrap();
+
+        // Real path doesn't exist; try_load returns None and doesn't touch alt.
+        assert!(cache.try_load(&addr).is_none());
+        assert!(alt.exists(), "files for other fingerprints are left alone");
+    }
+}

--- a/crates/engine/src/wasm/mod.rs
+++ b/crates/engine/src/wasm/mod.rs
@@ -9,6 +9,19 @@ mod environment;
 mod module;
 pub use module::{LoadedWasmTemplate, WasmModule};
 
+mod static_template_def;
+pub use static_template_def::{ExtractTemplateDefError, extract_template_def};
+
+#[cfg(feature = "wasm-cache")]
+mod cache;
+#[cfg(feature = "wasm-cache")]
+pub use cache::{
+    DiskCachedWasmTemplateProvider,
+    DiskCachedWasmTemplateProviderError,
+    ENGINE_FINGERPRINT,
+    WasmModuleCache,
+};
+
 mod metering;
 mod process;
 

--- a/crates/engine/src/wasm/module.rs
+++ b/crates/engine/src/wasm/module.rs
@@ -70,6 +70,37 @@ impl WasmModule {
     pub fn load_template_from_code(code: &[u8]) -> Result<LoadedTemplate, TemplateLoaderError> {
         let engine = Self::create_engine();
         let module = wasmer::Module::new(&engine, code)?;
+        Self::finalize_loaded_module(engine, module, code.len())
+    }
+
+    /// Load a template from a previously serialized wasmer module (see
+    /// [`wasmer::Module::serialize`]). `code_size` is the size of the original
+    /// WASM source bytes — preserved from the source compile and used by
+    /// downstream caches (e.g. the in-memory moka weigher in
+    /// `StateStoreTemplateProvider`).
+    ///
+    /// # Safety
+    ///
+    /// The serialized bytes MUST have been produced by `wasmer::Module::serialize`
+    /// against an engine configured identically to [`Self::create_engine`]. Feeding
+    /// arbitrary bytes here is undefined behaviour. Callers are expected to gate
+    /// this behind a node-local cache directory whose contents only this process
+    /// writes.
+    pub unsafe fn load_template_from_serialized(
+        serialized: &[u8],
+        code_size: usize,
+    ) -> Result<LoadedTemplate, TemplateLoaderError> {
+        let engine = Self::create_engine();
+        // SAFETY: forwarded to caller — see function-level docs.
+        let module = unsafe { wasmer::Module::deserialize_unchecked(&engine, serialized) }?;
+        Self::finalize_loaded_module(engine, module, code_size)
+    }
+
+    fn finalize_loaded_module(
+        engine: Engine,
+        module: wasmer::Module,
+        code_size: usize,
+    ) -> Result<LoadedTemplate, TemplateLoaderError> {
         let mut store = Store::new(engine);
 
         let imports = imports! {
@@ -93,7 +124,7 @@ impl WasmModule {
 
         let engine = store.engine().clone();
 
-        Ok(LoadedWasmTemplate::new(template, module, engine, code.len()).into())
+        Ok(LoadedWasmTemplate::new(template, module, engine, code_size).into())
     }
 
     pub fn code(&self) -> &[u8] {

--- a/crates/engine/src/wasm/module.rs
+++ b/crates/engine/src/wasm/module.rs
@@ -77,7 +77,15 @@ impl WasmModule {
     /// [`wasmer::Module::serialize`]). `code_size` is the size of the original
     /// WASM source bytes — preserved from the source compile and used by
     /// downstream caches (e.g. the in-memory moka weigher in
-    /// `StateStoreTemplateProvider`).
+    /// `MemoryCacheTemplateProvider`).
+    ///
+    /// Takes [`bytes::Bytes`] so callers can pass mmap-backed regions through
+    /// without a copy: `wasmer::Module::deserialize_unchecked` accepts `Bytes`
+    /// directly, and [`bytes::Bytes::from_owner`] wraps any
+    /// `AsRef<[u8]> + Send + 'static` (such as [`memmap2::Mmap`]) without
+    /// copying. With `&[u8]`, wasmer's `IntoBytes` impl falls back to
+    /// `to_vec()` and we'd pay an extra full-artifact allocation on every
+    /// cache hit.
     ///
     /// # Safety
     ///
@@ -86,8 +94,9 @@ impl WasmModule {
     /// arbitrary bytes here is undefined behaviour. Callers are expected to gate
     /// this behind a node-local cache directory whose contents only this process
     /// writes.
+    #[cfg(feature = "wasm-cache")]
     pub unsafe fn load_template_from_serialized(
-        serialized: &[u8],
+        serialized: bytes::Bytes,
         code_size: usize,
     ) -> Result<LoadedTemplate, TemplateLoaderError> {
         let engine = Self::create_engine();

--- a/crates/engine/src/wasm/static_template_def.rs
+++ b/crates/engine/src/wasm/static_template_def.rs
@@ -26,11 +26,14 @@ use wasmer::wasmparser::{BinaryReaderError, Data, DataKind, ExternalKind, Operat
 /// Cheap relative to a full compile: parses only the export, global, import
 /// and data sections needed to locate and read the ABI blob. No cranelift, no
 /// instantiation, no linear-memory allocation.
+///
+/// All arithmetic on offsets / lengths is checked. Adversarial inputs are
+/// rejected with an explicit error rather than panicking or wrapping.
 pub fn extract_template_def(code: &[u8]) -> Result<TemplateDef, ExtractTemplateDefError> {
     let mut imported_global_count: u32 = 0;
     let mut globals_init: Vec<Option<i32>> = Vec::new();
     let mut export_global_idx: Option<u32> = None;
-    let mut data_segments= Vec::new();
+    let mut data_segments = Vec::new();
 
     for payload in Parser::new(0).parse_all(code) {
         match payload? {
@@ -39,7 +42,9 @@ pub fn extract_template_def(code: &[u8]) -> Result<TemplateDef, ExtractTemplateD
                     for entry in imports? {
                         let (_, import) = entry?;
                         if matches!(import.ty, TypeRef::Global(_)) {
-                            imported_global_count += 1;
+                            imported_global_count = imported_global_count
+                                .checked_add(1)
+                                .ok_or(ExtractTemplateDefError::TooManyImportedGlobals)?;
                         }
                     }
                 }
@@ -67,10 +72,14 @@ pub fn extract_template_def(code: &[u8]) -> Result<TemplateDef, ExtractTemplateD
             Payload::DataSection(reader) => {
                 for segment in reader {
                     let segment = segment?;
-                    if let DataKind::Active { memory_index: 0, offset_expr } = segment.kind {
+                    if let DataKind::Active {
+                        memory_index: 0,
+                        offset_expr,
+                    } = &segment.kind
+                    {
                         let mut ops = offset_expr.get_operators_reader();
                         if let Ok(Operator::I32Const { value }) = ops.read() {
-                            data_segments.push((value as u32 as u64, segment));
+                            data_segments.push((u64::from(value as u32), segment));
                         }
                     }
                 }
@@ -90,25 +99,47 @@ pub fn extract_template_def(code: &[u8]) -> Result<TemplateDef, ExtractTemplateD
         .copied()
         .flatten()
         .ok_or(ExtractTemplateDefError::AbiGlobalNotConst)?;
-    let abi_ptr = abi_ptr as u32 as u64;
+    let abi_ptr = u64::from(abi_ptr as u32);
 
     // [u32 LE: length] || [length bytes: tari-bor-encoded TemplateDef]
     let len_bytes = read_data_at(&data_segments, abi_ptr, WASM_PTR_SIZE)?;
     let length = u32::from_le_bytes(len_bytes.try_into().expect("WASM_PTR_SIZE == 4")) as usize;
-    let body = read_data_at(&data_segments, abi_ptr + WASM_PTR_SIZE as u64, length)?;
+    // Cap against the input binary size: an embedded TemplateDef cannot be
+    // larger than the WASM file that contains it. Without this, a length
+    // prefix of ~u32::MAX from adversarial bytes would force the search loop
+    // in `read_data_at` to consider a 4 GiB span.
+    if length > code.len() {
+        return Err(ExtractTemplateDefError::AbiLengthExceedsBinary {
+            length,
+            binary_size: code.len(),
+        });
+    }
 
-    tari_bor::decode(&body).map_err(ExtractTemplateDefError::Decode)
+    let body_offset = abi_ptr
+        .checked_add(WASM_PTR_SIZE as u64)
+        .ok_or(ExtractTemplateDefError::OffsetOverflow)?;
+    let body = read_data_at(&data_segments, body_offset, length)?;
+
+    tari_bor::decode(body).map_err(ExtractTemplateDefError::Decode)
 }
 
 fn read_data_at<'a>(
-    segments: &'a [(u64, Data)],
+    segments: &[(u64, Data<'a>)],
     offset: u64,
     len: usize,
 ) -> Result<&'a [u8], ExtractTemplateDefError> {
     let len_u64 = len as u64;
+    let read_end = offset
+        .checked_add(len_u64)
+        .ok_or(ExtractTemplateDefError::OffsetOverflow)?;
     for (seg_offset, seg_data) in segments {
-        let seg_end = seg_offset + seg_data.data.len() as u64;
-        if offset >= *seg_offset && offset + len_u64 <= seg_end {
+        let seg_end = seg_offset
+            .checked_add(seg_data.data.len() as u64)
+            .ok_or(ExtractTemplateDefError::OffsetOverflow)?;
+        if offset >= *seg_offset && read_end <= seg_end {
+            // Both casts are bounded: `offset - seg_offset <= seg_data.data.len()`
+            // (just verified above), and `seg_data.data.len()` is `usize` by
+            // construction, so the subtraction-then-cast cannot truncate.
             let local = (offset - seg_offset) as usize;
             return Ok(&seg_data.data[local..local + len]);
         }
@@ -126,6 +157,12 @@ pub enum ExtractTemplateDefError {
     AbiExportImported,
     #[error("`{ABI_TEMPLATE_DEF_GLOBAL_NAME}` initializer is not an i32.const")]
     AbiGlobalNotConst,
+    #[error("ABI length prefix ({length}) exceeds the WASM binary size ({binary_size})")]
+    AbiLengthExceedsBinary { length: usize, binary_size: usize },
+    #[error("Module imports more globals than fit in u32")]
+    TooManyImportedGlobals,
+    #[error("Arithmetic overflow computing memory offset")]
+    OffsetOverflow,
     #[error("ABI bytes at offset {offset} (len {len}) are not covered by any active data segment")]
     DataOutOfRange { offset: u64, len: usize },
     #[error("Failed to decode TemplateDef: {0}")]

--- a/crates/engine/src/wasm/static_template_def.rs
+++ b/crates/engine/src/wasm/static_template_def.rs
@@ -8,15 +8,40 @@
 //! definition as a tari-bor-encoded blob in the module's data section,
 //! addressed by an exported global named [`ABI_TEMPLATE_DEF_GLOBAL_NAME`].
 //! `WasmEnv::load_template_def` recovers it via wasmer instantiation and
-//! linear-memory access; `WasmModule::extract_template_def` recovers the same
+//! linear-memory access; `extract_template_def` here recovers the same
 //! bytes by parsing the WASM binary statically (no compile, no JIT, no
 //! linear memory).
 //!
-//! This is intended for callers that only need the type/function metadata
-//! (e.g. the wallet daemon's template monitor) and want to avoid pulling in
-//! cranelift's compile cost. It does **not** validate the WASM module —
-//! anyone using a template for execution should still go through
+//! Intended exclusively for callers that only need the type/function
+//! metadata (today: only the wallet daemon's template monitor, which
+//! records each authored template's ABI) and want to avoid the cranelift
+//! compile cost. It does **not** validate the WASM module — anyone using
+//! a template for execution should go through
 //! `WasmModule::load_template_from_code`.
+//!
+//! # Toolchain assumptions
+//!
+//! The data-segment layout this extractor walks is what `rustc`'s
+//! `wasm32-unknown-unknown` LLVM backend produces in practice for templates
+//! built from `tari_template_lib`'s `#[template]` macro: a single active
+//! data segment in memory 0 covering the static rodata, with the
+//! `_ABI_TEMPLATE_DEF` global initialised to an `i32.const` pointer into
+//! that segment, and the `[u32 LE: length] || [bor bytes]` blob laid out
+//! contiguously at that pointer.
+//!
+//! Specifically, [`read_data_at`] requires the `[length, payload]` blob to
+//! lie **entirely within a single active data segment**. Other WASM
+//! toolchains (AssemblyScript, emscripten, custom code generators) may
+//! split static data across multiple segments or place the rodata at
+//! arbitrary offsets, in which case extraction fails with
+//! [`ExtractTemplateDefError::DataOutOfRange`]. This is acceptable today
+//! because the only consumer is the wallet daemon, and templates are only
+//! built with `tari_template_lib`. If templates from arbitrary toolchains
+//! ever need to be supported, the canonical fix is to switch the ABI
+//! storage from "data segment + global" to a WASM **custom section** —
+//! `Payload::CustomSection` is trivially extractable regardless of layout
+//! and is the standard way (wasm-bindgen, DWARF, the `name` section, …)
+//! to embed metadata in a WASM module.
 
 use tari_template_abi::{ABI_TEMPLATE_DEF_GLOBAL_NAME, TemplateDef, WASM_PTR_SIZE};
 use wasmer::wasmparser::{BinaryReaderError, Data, DataKind, ExternalKind, Operator, Parser, Payload, TypeRef};
@@ -123,6 +148,17 @@ pub fn extract_template_def(code: &[u8]) -> Result<TemplateDef, ExtractTemplateD
     tari_bor::decode(body).map_err(ExtractTemplateDefError::Decode)
 }
 
+/// Returns a slice of length `len` starting at `offset` within the union of
+/// the supplied active data segments (memory 0).
+///
+/// **Single-segment assumption.** The requested `[offset, offset+len)` range
+/// must lie entirely within one segment. A range that straddles two adjacent
+/// segments returns [`ExtractTemplateDefError::DataOutOfRange`] even if the
+/// bytes would be contiguous in linear memory after instantiation. This is
+/// fine for `tari_template_lib`-compiled templates — rustc emits a single
+/// rodata segment that holds the entire ABI blob — but it does not generalise
+/// to arbitrary WASM toolchains. See the module-level docs for the proper
+/// long-term fix (switch to a WASM custom section).
 fn read_data_at<'a>(
     segments: &[(u64, Data<'a>)],
     offset: u64,

--- a/crates/engine/src/wasm/static_template_def.rs
+++ b/crates/engine/src/wasm/static_template_def.rs
@@ -1,0 +1,153 @@
+//   Copyright 2025 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+//! Static extraction of a template's `TemplateDef` directly from WASM bytes,
+//! without invoking cranelift.
+//!
+//! Templates compiled from the `tari_template_lib` macros embed their ABI
+//! definition as a tari-bor-encoded blob in the module's data section,
+//! addressed by an exported global named [`ABI_TEMPLATE_DEF_GLOBAL_NAME`].
+//! `WasmEnv::load_template_def` recovers it via wasmer instantiation and
+//! linear-memory access; `WasmModule::extract_template_def` recovers the same
+//! bytes by parsing the WASM binary statically (no compile, no JIT, no
+//! linear memory).
+//!
+//! This is intended for callers that only need the type/function metadata
+//! (e.g. the wallet daemon's template monitor) and want to avoid pulling in
+//! cranelift's compile cost. It does **not** validate the WASM module —
+//! anyone using a template for execution should still go through
+//! `WasmModule::load_template_from_code`.
+
+use tari_template_abi::{ABI_TEMPLATE_DEF_GLOBAL_NAME, TemplateDef, WASM_PTR_SIZE};
+use wasmer::wasmparser::{BinaryReaderError, Data, DataKind, ExternalKind, Operator, Parser, Payload, TypeRef};
+
+/// Statically extract the embedded `TemplateDef` from a template's WASM bytes.
+///
+/// Cheap relative to a full compile: parses only the export, global, import
+/// and data sections needed to locate and read the ABI blob. No cranelift, no
+/// instantiation, no linear-memory allocation.
+pub fn extract_template_def(code: &[u8]) -> Result<TemplateDef, ExtractTemplateDefError> {
+    let mut imported_global_count: u32 = 0;
+    let mut globals_init: Vec<Option<i32>> = Vec::new();
+    let mut export_global_idx: Option<u32> = None;
+    let mut data_segments= Vec::new();
+
+    for payload in Parser::new(0).parse_all(code) {
+        match payload? {
+            Payload::ImportSection(reader) => {
+                for imports in reader {
+                    for entry in imports? {
+                        let (_, import) = entry?;
+                        if matches!(import.ty, TypeRef::Global(_)) {
+                            imported_global_count += 1;
+                        }
+                    }
+                }
+            },
+            Payload::GlobalSection(reader) => {
+                for global in reader {
+                    let global = global?;
+                    let mut ops = global.init_expr.get_operators_reader();
+                    let init = match ops.read() {
+                        Ok(Operator::I32Const { value }) => Some(value),
+                        _ => None,
+                    };
+                    globals_init.push(init);
+                }
+            },
+            Payload::ExportSection(reader) => {
+                for export in reader {
+                    let export = export?;
+                    if export.kind == ExternalKind::Global && export.name == ABI_TEMPLATE_DEF_GLOBAL_NAME {
+                        export_global_idx = Some(export.index);
+                        break;
+                    }
+                }
+            },
+            Payload::DataSection(reader) => {
+                for segment in reader {
+                    let segment = segment?;
+                    if let DataKind::Active { memory_index: 0, offset_expr } = segment.kind {
+                        let mut ops = offset_expr.get_operators_reader();
+                        if let Ok(Operator::I32Const { value }) = ops.read() {
+                            data_segments.push((value as u32 as u64, segment));
+                        }
+                    }
+                }
+            },
+            _ => {},
+        }
+    }
+
+    let global_idx = export_global_idx.ok_or(ExtractTemplateDefError::AbiExportMissing)?;
+    if global_idx < imported_global_count {
+        // The ABI global must be defined by the module itself, not imported.
+        return Err(ExtractTemplateDefError::AbiExportImported);
+    }
+    let local_idx = (global_idx - imported_global_count) as usize;
+    let abi_ptr = globals_init
+        .get(local_idx)
+        .copied()
+        .flatten()
+        .ok_or(ExtractTemplateDefError::AbiGlobalNotConst)?;
+    let abi_ptr = abi_ptr as u32 as u64;
+
+    // [u32 LE: length] || [length bytes: tari-bor-encoded TemplateDef]
+    let len_bytes = read_data_at(&data_segments, abi_ptr, WASM_PTR_SIZE)?;
+    let length = u32::from_le_bytes(len_bytes.try_into().expect("WASM_PTR_SIZE == 4")) as usize;
+    let body = read_data_at(&data_segments, abi_ptr + WASM_PTR_SIZE as u64, length)?;
+
+    tari_bor::decode(&body).map_err(ExtractTemplateDefError::Decode)
+}
+
+fn read_data_at<'a>(
+    segments: &'a [(u64, Data)],
+    offset: u64,
+    len: usize,
+) -> Result<&'a [u8], ExtractTemplateDefError> {
+    let len_u64 = len as u64;
+    for (seg_offset, seg_data) in segments {
+        let seg_end = seg_offset + seg_data.data.len() as u64;
+        if offset >= *seg_offset && offset + len_u64 <= seg_end {
+            let local = (offset - seg_offset) as usize;
+            return Ok(&seg_data.data[local..local + len]);
+        }
+    }
+    Err(ExtractTemplateDefError::DataOutOfRange { offset, len })
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ExtractTemplateDefError {
+    #[error("WASM parse error: {0}")]
+    Parse(#[from] BinaryReaderError),
+    #[error("Module does not export `{ABI_TEMPLATE_DEF_GLOBAL_NAME}`")]
+    AbiExportMissing,
+    #[error("`{ABI_TEMPLATE_DEF_GLOBAL_NAME}` resolves to an imported global, not a local one")]
+    AbiExportImported,
+    #[error("`{ABI_TEMPLATE_DEF_GLOBAL_NAME}` initializer is not an i32.const")]
+    AbiGlobalNotConst,
+    #[error("ABI bytes at offset {offset} (len {len}) are not covered by any active data segment")]
+    DataOutOfRange { offset: u64, len: usize },
+    #[error("Failed to decode TemplateDef: {0}")]
+    Decode(#[source] tari_bor::BorError),
+}
+
+#[cfg(test)]
+mod tests {
+    use tari_template_builtin::all_builtin_templates;
+
+    use super::*;
+
+    #[test]
+    fn extracts_builtin_template_defs_without_compiling() {
+        for template in all_builtin_templates() {
+            let def = extract_template_def(template.binary)
+                .unwrap_or_else(|e| panic!("extract failed for {}: {}", template.name, e));
+            assert_eq!(
+                def.template_name(),
+                template.name,
+                "extracted template_name should match the static builtin name",
+            );
+        }
+    }
+}

--- a/crates/wallet/crypto/Cargo.toml
+++ b/crates/wallet/crypto/Cargo.toml
@@ -29,7 +29,7 @@ subtle = "2.6.1"
 thiserror = { workspace = true }
 ts-rs = { workspace = true, optional = true }
 zeroize = { workspace = true, features = ["simd"] }
-memmap2 = { version = "0.9.9", optional = true }
+memmap2 = { workspace = true, optional = true }
 log = { workspace = true }
 
 [dev-dependencies]


### PR DESCRIPTION
## Summary

Cranelift compilation of WASM templates was the dominant peak-heap cost on cold-start of the indexer and validator node — heaptrack showed ~127 MB peak across the 22 templates a populated indexer carries, paid on every restart. The compiled output is deterministic for a given `(wasm_source, engine_config)`, so this PR lands a node-local cache: first encounter compiles via cranelift and serializes the wasmer Module to disk; subsequent loads `mmap` the file and `deserialize_unchecked` it in milliseconds with zero full-artifact heap allocations.

WASM source bytes stay on-chain unchanged. The cache is strictly local and recoverable: corrupt or missing entries fall back to a full recompile, no consensus implication.

## Architecture

Layered `TemplateProvider` chain on the validator node:

```
MemoryCacheTemplateProvider          (in-memory moka, semaphore, builtin precache)
  └── DiskCachedWasmTemplateProvider (compiled-module disk cache + compile)
        └── ValidatorNodeStateStore  (raw PublishedTemplate bytes from rocksdb)
```

`StateStoreTemplateProvider` is renamed to `MemoryCacheTemplateProvider` and reduced to its actual role (the in-memory hot cache). Compile and disk-caching move to a new `DiskCachedWasmTemplateProvider` middleware in the engine. `TemplateMetadataProvider` is forwarded through both layers; the disk-cache layer reads `PublishedTemplate` fields from its inner store.

The indexer's `TemplateManager` uses the same disk cache via a `WasmModuleCache` field (its `TemplateProvider` impl + the dry-run path both route through it).

## Builtin handling

Builtins bypass the disk cache. Their addresses are hardcoded constants (independent of binary content), so a stale cache entry would silently serve an out-of-date module after a builtin recompile. User-template addresses are content-addressed, so binary changes implicitly invalidate the cache key. Bypass lives in one place (`DiskCachedWasmTemplateProvider::get_template`).

## Cache file layout

- Filename: `{template_address}_{ENGINE_FINGERPRINT}.bin` under `{data_dir}/wasm_cache/`.
- Body: `[u64 LE: code_size] || wasmer::Module::serialize(...)`.
- Writes are tempfile-then-rename for crash atomicity.
- `ENGINE_FINGERPRINT` is a `const &str` (`\"v1\"`) bumped manually whenever `WasmModule::create_engine` config or the wasmer dep changes; old files become orphans (different filename suffix).

## Hot-path read is allocation-free

Naïve `fs::read` + `wasmer::Module::deserialize_unchecked(&[u8])` would do two full-artifact allocations per cache hit (once into `Vec<u8>`, once into wasmer's internal `Bytes` via `to_vec()`).

The implementation `mmap`s the file directly, wraps the `Mmap` in `bytes::Bytes::from_owner` (zero-copy — `Mmap: AsRef<[u8]> + Send`), `slice`s past the 8-byte header (zero-copy — pointer + length adjustment), and passes the resulting `Bytes` to wasmer's deserializer. Wasmer's `IntoBytes for Bytes` is the identity, so the chain is end-to-end zero-copy.

`wasmer::Module::deserialize_from_file_unchecked` already mmaps internally but would feed the entire file (including our 8-byte header) to wasmer's artifact parser at offset 0 — hence the manual mmap path.

## Walletd: static extraction, no cache

The wallet daemon's `template_monitor` only needs each template's `TemplateDef` (the ABI), not an executable module. Instead of dragging in cranelift compile cost — let alone an on-disk cache — a new `tari_engine::wasm::extract_template_def` parses the WASM binary statically with `wasmparser` and reads the embedded tari-bor-encoded `TemplateDef` out of the data section addressed by the `_ABI_TEMPLATE_DEF` exported global. No cranelift, no JIT, no linear memory. Walletd carries no cache state.

The static extractor is hardened against adversarial WASM:
- `imported_global_count`: `checked_add`.
- Length prefix capped against the input binary size to prevent a 4 GiB span scan.
- All offset/length math uses `checked_add`.
- Explicit error variants instead of panics or wraps.

## Single-flight cache (committee_cache)

While here, the same heaptrack profile flagged `EpochManagerHandle::get_committee_by_shard_group` as the request-path's dominant allocator (~1.6 calls/tx, full SQL prepare + per-VN JSON deserialize per call). A `CommitteeCache` with `tokio::sync::OnceCell` per `(epoch, shard_group)` key coalesces concurrent first-fetches and serves subsequent reads via atomic load. Cache cleared on epoch advance.

## Feature flag

The cache types live behind a default-off `wasm-cache` Cargo feature on `tari_engine`. The validator node and indexer enable it explicitly (`features = [\"wasm-cache\"]`); the wallet daemon does not. Engine library users embedding without a local data directory can opt out cleanly.

`memmap2` and `bytes` are gated behind the same feature (`dep:memmap2`, `dep:bytes`) so non-cache consumers don't pull them.

## Other

- Disabled WASM SIMD features (`simd`, `relaxed_simd`) for cross-validator codegen-surface stability — fixed-width SIMD is deterministic by spec but enlarges the cranelift correctness surface unnecessarily; relaxed SIMD is explicitly non-deterministic.
- Moka weigher in `MemoryCacheTemplateProvider` now scales `code_size` by 4× to account for cranelift artifact inflation over WASM source — keeps the in-memory budget honest in the typical case.
- `TemplateLoaderError::DeserializeError` variant.

## Test plan

- [x] `cargo test -p tari_engine --features wasm-cache --lib wasm` — round-trip, fingerprint mismatch, corrupt-cache fallback.
- [x] `cargo check -p tari_engine --no-default-features` — engine library builds without cache.
- [x] `cargo check --workspace --all-targets` clean.
- [ ] heaptrack indexer cold start before/after — expect ~127 MB peak from `compile_module_internal` to drop out of the top consumers list on the second run.
- [ ] Manually corrupt one cache file (`echo garbage > data/i1/wasm_cache/<file>.bin`), restart — log emits WARN, file is replaced, indexer comes up normally.
- [ ] Bump `ENGINE_FINGERPRINT` `v1`→`v2`, restart — old files orphaned, new files appear under the new key.