### PR TITLE
feat(engine): embed TemplateDef in `tari_tdef` WASM custom section

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1691,7 +1691,7 @@ dependencies = [
 
 [[package]]
 name = "consensus_tests"
-version = "0.30.2"
+version = "0.30.3"
 dependencies = [
  "fern",
  "futures 0.3.31",
@@ -2670,7 +2670,7 @@ dependencies = [
 
 [[package]]
 name = "db-inspector"
-version = "0.30.2"
+version = "0.30.3"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -5003,7 +5003,7 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "integration_tests"
-version = "0.30.2"
+version = "0.30.3"
 dependencies = [
  "anyhow",
  "config",
@@ -5787,7 +5787,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-messaging"
-version = "0.30.2"
+version = "0.30.3"
 dependencies = [
  "async-trait",
  "futures-bounded",
@@ -5966,7 +5966,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-substream"
-version = "0.30.2"
+version = "0.30.3"
 dependencies = [
  "libp2p",
  "prometheus-client",
@@ -7574,7 +7574,7 @@ dependencies = [
 
 [[package]]
 name = "ootle-wasm"
-version = "0.30.2"
+version = "0.30.3"
 dependencies = [
  "console_error_panic_hook",
  "getrandom 0.2.17",
@@ -7584,7 +7584,7 @@ dependencies = [
 
 [[package]]
 name = "ootle-wasm-core"
-version = "0.30.2"
+version = "0.30.3"
 dependencies = [
  "base64 0.22.1",
  "ootle_byte_type",
@@ -8579,7 +8579,7 @@ dependencies = [
 
 [[package]]
 name = "proto_builder"
-version = "0.30.2"
+version = "0.30.3"
 dependencies = [
  "prost-build 0.14.3",
  "sha2 0.10.9",
@@ -10420,7 +10420,7 @@ dependencies = [
 
 [[package]]
 name = "sqlite_message_logger"
-version = "0.30.2"
+version = "0.30.3"
 dependencies = [
  "chrono",
  "diesel",
@@ -10792,7 +10792,7 @@ dependencies = [
 
 [[package]]
 name = "tari_base_node_client"
-version = "0.30.2"
+version = "0.30.3"
 dependencies = [
  "futures-util",
  "log",
@@ -11017,7 +11017,7 @@ dependencies = [
 
 [[package]]
 name = "tari_consensus"
-version = "0.30.2"
+version = "0.30.3"
 dependencies = [
  "anyhow",
  "indexmap 2.13.0",
@@ -11042,7 +11042,7 @@ dependencies = [
 
 [[package]]
 name = "tari_consensus_types"
-version = "0.30.2"
+version = "0.30.3"
 dependencies = [
  "borsh",
  "ootle_serde",
@@ -11144,7 +11144,7 @@ dependencies = [
 
 [[package]]
 name = "tari_engine"
-version = "0.30.2"
+version = "0.30.3"
 dependencies = [
  "blake2",
  "bytes",
@@ -11175,7 +11175,7 @@ dependencies = [
 
 [[package]]
 name = "tari_engine_types"
-version = "0.30.2"
+version = "0.30.3"
 dependencies = [
  "bincode 2.0.1",
  "blake2",
@@ -11204,7 +11204,7 @@ dependencies = [
 
 [[package]]
 name = "tari_epoch_manager"
-version = "0.30.2"
+version = "0.30.3"
 dependencies = [
  "anyhow",
  "log",
@@ -11224,7 +11224,7 @@ dependencies = [
 
 [[package]]
 name = "tari_epoch_oracles"
-version = "0.30.2"
+version = "0.30.3"
 dependencies = [
  "anyhow",
  "blake2",
@@ -11278,7 +11278,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer"
-version = "0.30.2"
+version = "0.30.3"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -11380,7 +11380,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer_lib"
-version = "0.30.2"
+version = "0.30.3"
 dependencies = [
  "log",
  "prometheus-client",
@@ -11472,7 +11472,7 @@ dependencies = [
 
 [[package]]
 name = "tari_networking"
-version = "0.30.2"
+version = "0.30.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11524,7 +11524,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_app_utilities"
-version = "0.30.2"
+version = "0.30.3"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -11564,7 +11564,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_common_types"
-version = "0.30.2"
+version = "0.30.3"
 dependencies = [
  "blake2",
  "borsh",
@@ -11592,7 +11592,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_p2p"
-version = "0.30.2"
+version = "0.30.3"
 dependencies = [
  "anyhow",
  "libp2p-identity 0.2.13 (git+https://github.com/tari-project/rust-libp2p.git?rev=470c41380d6c5140b52ef65becf4f643e4769e66)",
@@ -11616,7 +11616,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_storage"
-version = "0.30.2"
+version = "0.30.3"
 dependencies = [
  "anyhow",
  "bitflags 2.10.0",
@@ -11643,7 +11643,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_storage_sqlite"
-version = "0.30.2"
+version = "0.30.3"
 dependencies = [
  "diesel",
  "diesel_migrations",
@@ -11694,7 +11694,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_transaction"
-version = "0.30.2"
+version = "0.30.3"
 dependencies = [
  "bincode 2.0.1",
  "borsh",
@@ -11720,7 +11720,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_cli"
-version = "0.30.2"
+version = "0.30.3"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -11749,7 +11749,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_crypto"
-version = "0.30.2"
+version = "0.30.3"
 dependencies = [
  "argon2 0.5.3",
  "blake2",
@@ -11779,7 +11779,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_sdk"
-version = "0.30.2"
+version = "0.30.3"
 dependencies = [
  "anyhow",
  "digest 0.10.7",
@@ -11842,7 +11842,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_sdk_tests"
-version = "0.30.2"
+version = "0.30.3"
 dependencies = [
  "digest 0.10.7",
  "ootle_byte_type",
@@ -11863,7 +11863,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_storage_sqlite"
-version = "0.30.2"
+version = "0.30.3"
 dependencies = [
  "bigdecimal",
  "diesel",
@@ -11887,7 +11887,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_walletd"
-version = "0.30.2"
+version = "0.30.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12005,7 +12005,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_framework"
-version = "0.30.2"
+version = "0.30.3"
 dependencies = [
  "async-trait",
  "bitflags 2.10.0",
@@ -12029,7 +12029,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_macros"
-version = "0.30.2"
+version = "0.30.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12038,7 +12038,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_state_sync"
-version = "0.30.2"
+version = "0.30.3"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -12115,7 +12115,7 @@ dependencies = [
 
 [[package]]
 name = "tari_state_store_rocksdb"
-version = "0.30.2"
+version = "0.30.3"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -12147,7 +12147,7 @@ dependencies = [
 
 [[package]]
 name = "tari_state_tree"
-version = "0.30.2"
+version = "0.30.3"
 dependencies = [
  "indexmap 2.13.0",
  "log",
@@ -12173,7 +12173,7 @@ dependencies = [
 
 [[package]]
 name = "tari_swarm"
-version = "0.30.2"
+version = "0.30.3"
 dependencies = [
  "libp2p",
  "libp2p-messaging",
@@ -12184,7 +12184,7 @@ dependencies = [
 
 [[package]]
 name = "tari_swarm_daemon"
-version = "0.30.2"
+version = "0.30.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12228,7 +12228,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_abi"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "hashbrown 0.13.2",
  "serde",
@@ -12251,7 +12251,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_lib"
-version = "0.25.2"
+version = "0.26.0"
 dependencies = [
  "borsh",
  "serde",
@@ -12283,7 +12283,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_macros"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "indoc",
  "proc-macro2",
@@ -12295,7 +12295,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_test_tooling"
-version = "0.30.2"
+version = "0.30.3"
 dependencies = [
  "anyhow",
  "cargo_toml 0.22.3",
@@ -12408,7 +12408,7 @@ dependencies = [
 
 [[package]]
 name = "tari_transaction_manifest"
-version = "0.30.2"
+version = "0.30.3"
 dependencies = [
  "proc-macro2",
  "serde_json",
@@ -12443,7 +12443,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node"
-version = "0.30.2"
+version = "0.30.3"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -12509,7 +12509,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node_client"
-version = "0.30.2"
+version = "0.30.3"
 dependencies = [
  "indexmap 2.13.0",
  "multiaddr 0.18.3",
@@ -12533,7 +12533,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node_rpc"
-version = "0.30.2"
+version = "0.30.3"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -12556,7 +12556,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_rollback"
-version = "0.30.2"
+version = "0.30.3"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12591,7 +12591,7 @@ dependencies = [
 
 [[package]]
 name = "tari_watcher"
-version = "0.30.2"
+version = "0.30.3"
 dependencies = [
  "anyhow",
  "clap 3.2.25",
@@ -12620,7 +12620,7 @@ dependencies = [
 
 [[package]]
 name = "tariswap_bench"
-version = "0.30.2"
+version = "0.30.3"
 dependencies = [
  "anyhow",
  "clap 4.5.54",
@@ -13300,7 +13300,7 @@ dependencies = [
 
 [[package]]
 name = "traffic-sim"
-version = "0.30.2"
+version = "0.30.3"
 dependencies = [
  "anyhow",
  "clap 4.5.54",
@@ -13322,7 +13322,7 @@ dependencies = [
 
 [[package]]
 name = "transaction_generator"
-version = "0.30.2"
+version = "0.30.3"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -13341,7 +13341,7 @@ dependencies = [
 
 [[package]]
 name = "transaction_submitter"
-version = "0.30.2"
+version = "0.30.3"
 dependencies = [
  "anyhow",
  "clap 4.5.54",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.30.2"
+version = "0.30.3"
 edition = "2024"
 authors = ["The Tari Development Community"]
 repository = "https://github.com/tari-project/tari-ootle"
@@ -129,10 +129,10 @@ tari_ootle_transaction = { path = "crates/transaction", version = "0.30" }
 # Template lib
 tari_ootle_template_build = { path = "crates/template_build", version = "0.5" }
 tari_ootle_template_metadata = { path = "crates/template_metadata", version = "0.5" }
-tari_template_lib = { version = "0.25", path = "crates/template_lib" }
+tari_template_lib = { version = "0.26", path = "crates/template_lib" }
 tari_template_lib_types = { version = "0.25", path = "crates/template_lib_types", default-features = false }
 tari_template_abi = { version = "0.16", path = "crates/template_abi", default-features = false }
-tari_template_macros = { version = "0.18", path = "crates/template_macros" }
+tari_template_macros = { version = "0.19", path = "crates/template_macros" }
 tari_bor = { version = "0.13", path = "crates/tari_bor", default-features = false }
 
 ootle_byte_type = { path = "crates/ootle_byte_type", version = "0.6" }

--- a/applications/tari_indexer/src/bootstrap.rs
+++ b/applications/tari_indexer/src/bootstrap.rs
@@ -66,6 +66,7 @@ use tari_shutdown::ShutdownSignal;
 use tari_template_builtin::all_builtin_templates;
 use tari_template_lib_types::{Amount, TemplateAddress, crypto::RistrettoPublicKeyBytes};
 use tari_validator_node_rpc::client::TariValidatorNodeRpcClientFactory;
+use tokio::task;
 
 use crate::{
     ApplicationConfig,
@@ -245,14 +246,24 @@ pub async fn spawn_services(
 
     // Template manager
     let wasm_cache_dir = config.indexer.data_dir.join("wasm_cache");
-    let wasm_cache = WasmModuleCache::open(&wasm_cache_dir).map_err(|e| {
-        anyhow!(
-            "Failed to open WASM module cache at {}: {}",
-            wasm_cache_dir.display(),
-            e,
-        )
-    })?;
-    let template_manager = TemplateManager::initialize(global_db.clone(), substate_manager.clone(), wasm_cache)?;
+
+    let template_manager = task::spawn_blocking({
+        let global_db = global_db.clone();
+        let substate_manager = substate_manager.clone();
+        move || {
+            let wasm_cache = WasmModuleCache::open(&wasm_cache_dir).map_err(|e| {
+                anyhow!(
+                    "Failed to open WASM module cache at {}: {}",
+                    wasm_cache_dir.display(),
+                    e,
+                )
+            })?;
+            let manager = TemplateManager::initialize(global_db, substate_manager, wasm_cache)?;
+            anyhow::Ok(manager)
+        }
+    })
+    .await
+    .context("template manager init thread panicked")??;
 
     // Dry run - use a shorter cache TTL for more accurate fee estimates
     let dry_run_substate_manager = substate_manager

--- a/applications/tari_indexer/src/template_manager/manager.rs
+++ b/applications/tari_indexer/src/template_manager/manager.rs
@@ -44,7 +44,7 @@ use tari_ootle_storage::{
     time::{OffsetDateTime, PrimitiveDateTime},
 };
 use tari_ootle_storage_sqlite::global::SqliteGlobalDbAdapter;
-use tari_template_builtin::{all_builtin_templates, is_builtin_template_address, try_get_template_builtin};
+use tari_template_builtin::{all_builtin_templates, try_get_template_builtin};
 use tari_template_lib_types::{TemplateAddress, crypto::RistrettoPublicKeyBytes};
 
 use super::{Template, TemplateCode, TemplateMetadata};
@@ -55,6 +55,7 @@ pub struct TemplateManager {
     global_db: GlobalDb<SqliteGlobalDbAdapter<PeerAddress>>,
     substate_manager: SubstateManager,
     wasm_cache: WasmModuleCache,
+    build_in_template_cache: HashMap<TemplateAddress, LoadedTemplate>,
 }
 
 impl TemplateManager {
@@ -94,6 +95,17 @@ impl TemplateManager {
             global_db,
             substate_manager,
             wasm_cache,
+            // NOTE: this is fairly slow (100s of ms) but is paid once at startup
+            build_in_template_cache: all_builtin_templates()
+                .iter()
+                .map(|template| {
+                    (
+                        template.address,
+                        WasmModule::load_template_from_code(template.binary)
+                            .expect("builtin templates should always load"),
+                    )
+                })
+                .collect(),
         })
     }
 
@@ -111,8 +123,8 @@ impl TemplateManager {
         address: &TemplateAddress,
         code: &TemplateCode,
     ) -> Result<LoadedTemplate, TemplateManagerError> {
-        if is_builtin_template_address(address) {
-            return Ok(WasmModule::load_template_from_code(code.as_raw_bytes())?);
+        if let Some(template) = self.build_in_template_cache.get(address) {
+            return Ok(template.clone());
         }
         if let Some(loaded) = self.wasm_cache.try_load(address) {
             return Ok(loaded);

--- a/crates/engine/src/wasm/error.rs
+++ b/crates/engine/src/wasm/error.rs
@@ -47,6 +47,8 @@ pub enum WasmExecutionError {
     EngineArgDecodeFailed(BorError),
     #[error("Failed to decode template definition: {0:?}")]
     AbiTemplateDefDecodeError(BorError),
+    #[error("Malformed `tari_tdef` custom section: {reason}")]
+    AbiTemplateDefSectionMalformed { reason: String },
     #[error("Unexpected ABI function {name}")]
     UnexpectedAbiFunction { name: String },
     #[error("Encoding error: {0}")]

--- a/crates/engine/src/wasm/module.rs
+++ b/crates/engine/src/wasm/module.rs
@@ -268,9 +268,7 @@ impl fmt::Debug for LoadedWasmTemplate {
 /// Wasmer preserves custom sections through compile and `serialize` /
 /// `deserialize`, so this works on both freshly compiled modules and modules
 /// loaded from the disk cache.
-fn load_template_def_from_custom_section(
-    module: &wasmer::Module,
-) -> Result<Option<TemplateDef>, WasmExecutionError> {
+fn load_template_def_from_custom_section(module: &wasmer::Module) -> Result<Option<TemplateDef>, WasmExecutionError> {
     let mut sections = module.custom_sections(TEMPLATE_DEF_CUSTOM_SECTION);
     let Some(section) = sections.next() else {
         return Ok(None);

--- a/crates/engine/src/wasm/module.rs
+++ b/crates/engine/src/wasm/module.rs
@@ -23,7 +23,14 @@
 use std::{fmt, fmt::Formatter, sync::Arc};
 
 use tari_engine_types::limits;
-use tari_template_abi::{ABI_TEMPLATE_DEF_GLOBAL_NAME, FunctionDef, TemplateDef, Type};
+use tari_template_abi::{
+    ABI_TEMPLATE_DEF_GLOBAL_NAME,
+    FunctionDef,
+    TEMPLATE_DEF_CUSTOM_SECTION,
+    TemplateDef,
+    Type,
+    WASM_PTR_SIZE,
+};
 use wasmer::{
     AsStoreMut,
     Engine,
@@ -124,7 +131,15 @@ impl WasmModule {
         let memory = instance.exports.get_memory("memory")?.clone();
         env.set_memory(memory);
 
-        let template = env.load_template_def(&mut store, &instance)?;
+        // Prefer the `tari_tdef` custom section. New templates produced by the
+        // current `#[template]` macro embed the bor-encoded `TemplateDef`
+        // there. If the section is absent we treat the binary as legacy and
+        // fall back to reading the blob out of linear memory via the
+        // `_ABI_TEMPLATE_DEF` exported global.
+        let template = match load_template_def_from_custom_section(&module)? {
+            Some(def) => def,
+            None => env.load_template_def(&mut store, &instance)?,
+        };
         let main_fn = format!("{}_main", template.template_name());
 
         WasmProcess::validate_template_abi_version(&template)?;
@@ -244,6 +259,60 @@ impl fmt::Debug for LoadedWasmTemplate {
     }
 }
 
+/// Try to recover the `TemplateDef` directly from the `tari_tdef` custom
+/// section. Returns `Ok(None)` when the section is absent (legacy templates
+/// that only embed the ABI via the `_ABI_TEMPLATE_DEF` global+rodata
+/// pattern); the caller falls back to reading the blob out of linear memory
+/// in that case.
+///
+/// Wasmer preserves custom sections through compile and `serialize` /
+/// `deserialize`, so this works on both freshly compiled modules and modules
+/// loaded from the disk cache.
+fn load_template_def_from_custom_section(
+    module: &wasmer::Module,
+) -> Result<Option<TemplateDef>, WasmExecutionError> {
+    let mut sections = module.custom_sections(TEMPLATE_DEF_CUSTOM_SECTION);
+    let Some(section) = sections.next() else {
+        return Ok(None);
+    };
+    // The macro emits exactly one `tari_tdef` section per template. Multiple
+    // sections with this name would be ambiguous — refuse to guess which one
+    // is canonical.
+    if sections.next().is_some() {
+        return Err(WasmExecutionError::AbiTemplateDefSectionMalformed {
+            reason: format!(
+                "module contains more than one `{}` custom section",
+                TEMPLATE_DEF_CUSTOM_SECTION
+            ),
+        });
+    }
+    if section.len() < WASM_PTR_SIZE {
+        return Err(WasmExecutionError::AbiTemplateDefSectionMalformed {
+            reason: format!(
+                "section is {} bytes; expected at least {} for the length prefix",
+                section.len(),
+                WASM_PTR_SIZE
+            ),
+        });
+    }
+    let prefix: [u8; WASM_PTR_SIZE] = section[..WASM_PTR_SIZE]
+        .try_into()
+        .expect("section.len() >= WASM_PTR_SIZE checked above");
+    let full_len = u32::from_le_bytes(prefix) as usize;
+    if full_len < WASM_PTR_SIZE || full_len > section.len() {
+        return Err(WasmExecutionError::AbiTemplateDefSectionMalformed {
+            reason: format!(
+                "declared length {} is inconsistent with section size {}",
+                full_len,
+                section.len()
+            ),
+        });
+    }
+    let template = tari_bor::decode::<TemplateDef>(&section[WASM_PTR_SIZE..full_len])
+        .map_err(WasmExecutionError::AbiTemplateDefDecodeError)?;
+    Ok(Some(template))
+}
+
 fn validate_instance<S: AsStoreMut>(
     store: &mut S,
     instance: &Instance,
@@ -266,12 +335,17 @@ fn validate_instance<S: AsStoreMut>(
         return Err(WasmExecutionError::UnexpectedAbiFunction { name: name.to_string() });
     }
 
-    instance
-        .exports
-        .get_global(ABI_TEMPLATE_DEF_GLOBAL_NAME)?
-        .get(store)
-        .i32()
-        .ok_or(WasmExecutionError::ExportError(ExportError::IncompatibleType))?;
+    // The `_ABI_TEMPLATE_DEF` global is present in legacy templates (where
+    // the ABI lives in linear memory) and absent in templates produced by
+    // the current macro (which puts the ABI in the `tari_tdef` custom
+    // section). When present, sanity-check that it's an i32; when missing,
+    // we've already validated the ABI via the custom section.
+    if let Ok(global) = instance.exports.get_global(ABI_TEMPLATE_DEF_GLOBAL_NAME) {
+        global
+            .get(store)
+            .i32()
+            .ok_or(WasmExecutionError::ExportError(ExportError::IncompatibleType))?;
+    }
 
     // Check that the main function exists and it's signature is correct
     let _main: MainFunction = instance.exports.get_typed_function(store, main_fn)?;

--- a/crates/engine/src/wasm/static_template_def.rs
+++ b/crates/engine/src/wasm/static_template_def.rs
@@ -5,52 +5,54 @@
 //! without invoking cranelift.
 //!
 //! Templates compiled from the `tari_template_lib` macros embed their ABI
-//! definition as a tari-bor-encoded blob in the module's data section,
-//! addressed by an exported global named [`ABI_TEMPLATE_DEF_GLOBAL_NAME`].
-//! `WasmEnv::load_template_def` recovers it via wasmer instantiation and
-//! linear-memory access; `extract_template_def` here recovers the same
-//! bytes by parsing the WASM binary statically (no compile, no JIT, no
-//! linear memory).
+//! definition in two redundant places:
 //!
-//! Intended exclusively for callers that only need the type/function
-//! metadata (today: only the wallet daemon's template monitor, which
-//! records each authored template's ABI) and want to avoid the cranelift
-//! compile cost. It does **not** validate the WASM module — anyone using
-//! a template for execution should go through
+//! 1. **Custom WASM section** named [`TEMPLATE_DEF_CUSTOM_SECTION`] (`tari_tdef`). The bor-encoded `TemplateDef` is
+//!    written directly into the section as `[u32 LE: full_len] || [bor bytes]`. This is the canonical extraction path:
+//!    independent of linear-memory layout, requires no global / data-segment walk, and works for any WASM toolchain
+//!    that can emit a custom section.
+//! 2. **Exported i32 global** named [`ABI_TEMPLATE_DEF_GLOBAL_NAME`] (`_ABI_TEMPLATE_DEF`) pointing into a rodata data
+//!    segment. Legacy embedding, kept by the macro for backward compatibility with engines that don't read the custom
+//!    section.
+//!
+//! `extract_template_def` here prefers the custom section. If absent (older
+//! template binaries that pre-date the custom-section embedding), it falls
+//! back to walking the data segments via the global pointer. That fallback
+//! path is the more fragile one — see "Fallback toolchain assumptions" below.
+//!
+//! Intended exclusively for callers that only need the type/function metadata
+//! (today: only the wallet daemon's template monitor) and want to avoid the
+//! cranelift compile cost. It does **not** validate the WASM module — anyone
+//! using a template for execution should go through
 //! `WasmModule::load_template_from_code`.
 //!
-//! # Toolchain assumptions
+//! # Fallback toolchain assumptions
 //!
-//! The data-segment layout this extractor walks is what `rustc`'s
-//! `wasm32-unknown-unknown` LLVM backend produces in practice for templates
-//! built from `tari_template_lib`'s `#[template]` macro: a single active
-//! data segment in memory 0 covering the static rodata, with the
-//! `_ABI_TEMPLATE_DEF` global initialised to an `i32.const` pointer into
-//! that segment, and the `[u32 LE: length] || [bor bytes]` blob laid out
-//! contiguously at that pointer.
+//! The data-segment fallback is what `rustc`'s `wasm32-unknown-unknown` LLVM
+//! backend produces in practice for templates built from `tari_template_lib`'s
+//! `#[template]` macro: a single active data segment in memory 0 covering the
+//! static rodata, with the `_ABI_TEMPLATE_DEF` global initialised to an
+//! `i32.const` pointer into that segment, and the `[u32 LE: length] || [bor
+//! bytes]` blob laid out contiguously at that pointer.
 //!
-//! Specifically, [`read_data_at`] requires the `[length, payload]` blob to
-//! lie **entirely within a single active data segment**. Other WASM
-//! toolchains (AssemblyScript, emscripten, custom code generators) may
-//! split static data across multiple segments or place the rodata at
-//! arbitrary offsets, in which case extraction fails with
-//! [`ExtractTemplateDefError::DataOutOfRange`]. This is acceptable today
-//! because the only consumer is the wallet daemon, and templates are only
-//! built with `tari_template_lib`. If templates from arbitrary toolchains
-//! ever need to be supported, the canonical fix is to switch the ABI
-//! storage from "data segment + global" to a WASM **custom section** —
-//! `Payload::CustomSection` is trivially extractable regardless of layout
-//! and is the standard way (wasm-bindgen, DWARF, the `name` section, …)
-//! to embed metadata in a WASM module.
+//! Specifically, [`read_data_at`] requires the `[length, payload]` blob to lie
+//! **entirely within a single active data segment**. Other WASM toolchains
+//! (AssemblyScript, emscripten, custom code generators) may split static data
+//! across multiple segments or place rodata at arbitrary offsets, in which
+//! case the fallback fails with [`ExtractTemplateDefError::DataOutOfRange`].
+//! New templates avoid this entirely by using the custom-section path; the
+//! fallback only ever runs for legacy binaries built before the macro emitted
+//! the custom section.
 
-use tari_template_abi::{ABI_TEMPLATE_DEF_GLOBAL_NAME, TemplateDef, WASM_PTR_SIZE};
+use tari_template_abi::{ABI_TEMPLATE_DEF_GLOBAL_NAME, TEMPLATE_DEF_CUSTOM_SECTION, TemplateDef, WASM_PTR_SIZE};
 use wasmer::wasmparser::{BinaryReaderError, Data, DataKind, ExternalKind, Operator, Parser, Payload, TypeRef};
 
 /// Statically extract the embedded `TemplateDef` from a template's WASM bytes.
 ///
-/// Cheap relative to a full compile: parses only the export, global, import
-/// and data sections needed to locate and read the ABI blob. No cranelift, no
-/// instantiation, no linear-memory allocation.
+/// Cheap relative to a full compile: a single linear pass over the WASM
+/// payload collects the custom section (and, if needed, the global / data
+/// section state for the legacy fallback). No cranelift, no instantiation, no
+/// linear-memory allocation.
 ///
 /// All arithmetic on offsets / lengths is checked. Adversarial inputs are
 /// rejected with an explicit error rather than panicking or wrapping.
@@ -60,8 +62,12 @@ pub fn extract_template_def(code: &[u8]) -> Result<TemplateDef, ExtractTemplateD
     let mut export_global_idx: Option<u32> = None;
     let mut data_segments = Vec::new();
 
+    // TODO: deprecate the use of global sections once all templates are using >=0.26
     for payload in Parser::new(0).parse_all(code) {
         match payload? {
+            Payload::CustomSection(reader) if reader.name() == TEMPLATE_DEF_CUSTOM_SECTION => {
+                return decode_template_def_from_blob(reader.data());
+            },
             Payload::ImportSection(reader) => {
                 for imports in reader {
                     for entry in imports? {
@@ -113,6 +119,7 @@ pub fn extract_template_def(code: &[u8]) -> Result<TemplateDef, ExtractTemplateD
         }
     }
 
+    // Fallback: legacy rodata + global pointer embedding.
     let global_idx = export_global_idx.ok_or(ExtractTemplateDefError::AbiExportMissing)?;
     if global_idx < imported_global_count {
         // The ABI global must be defined by the module itself, not imported.
@@ -148,6 +155,27 @@ pub fn extract_template_def(code: &[u8]) -> Result<TemplateDef, ExtractTemplateD
     tari_bor::decode(body).map_err(ExtractTemplateDefError::Decode)
 }
 
+/// Decode a `[u32 LE: full_len] || [bor bytes]` blob (the format produced by
+/// `TemplateDef::encode_for_wasm_embedding`). `full_len` is the total length
+/// including the 4-byte prefix itself; the bor payload occupies
+/// `blob[4..full_len]`.
+fn decode_template_def_from_blob(blob: &[u8]) -> Result<TemplateDef, ExtractTemplateDefError> {
+    if blob.len() < WASM_PTR_SIZE {
+        return Err(ExtractTemplateDefError::SectionTooShort { len: blob.len() });
+    }
+    let prefix: [u8; WASM_PTR_SIZE] = blob[..WASM_PTR_SIZE]
+        .try_into()
+        .expect("blob.len() >= WASM_PTR_SIZE checked above");
+    let full_len = u32::from_le_bytes(prefix) as usize;
+    if full_len < WASM_PTR_SIZE || full_len > blob.len() {
+        return Err(ExtractTemplateDefError::SectionLengthMismatch {
+            declared: full_len,
+            actual: blob.len(),
+        });
+    }
+    tari_bor::decode(&blob[WASM_PTR_SIZE..full_len]).map_err(ExtractTemplateDefError::Decode)
+}
+
 /// Returns a slice of length `len` starting at `offset` within the union of
 /// the supplied active data segments (memory 0).
 ///
@@ -157,8 +185,8 @@ pub fn extract_template_def(code: &[u8]) -> Result<TemplateDef, ExtractTemplateD
 /// bytes would be contiguous in linear memory after instantiation. This is
 /// fine for `tari_template_lib`-compiled templates — rustc emits a single
 /// rodata segment that holds the entire ABI blob — but it does not generalise
-/// to arbitrary WASM toolchains. See the module-level docs for the proper
-/// long-term fix (switch to a WASM custom section).
+/// to arbitrary WASM toolchains. New templates avoid this fallback entirely
+/// by using the `tari_tdef` custom section; see the module-level docs.
 fn read_data_at<'a>(
     segments: &[(u64, Data<'a>)],
     offset: u64,
@@ -187,7 +215,10 @@ fn read_data_at<'a>(
 pub enum ExtractTemplateDefError {
     #[error("WASM parse error: {0}")]
     Parse(#[from] BinaryReaderError),
-    #[error("Module does not export `{ABI_TEMPLATE_DEF_GLOBAL_NAME}`")]
+    #[error(
+        "Module does not export `{ABI_TEMPLATE_DEF_GLOBAL_NAME}` and has no `{TEMPLATE_DEF_CUSTOM_SECTION}` custom \
+         section"
+    )]
     AbiExportMissing,
     #[error("`{ABI_TEMPLATE_DEF_GLOBAL_NAME}` resolves to an imported global, not a local one")]
     AbiExportImported,
@@ -201,18 +232,68 @@ pub enum ExtractTemplateDefError {
     OffsetOverflow,
     #[error("ABI bytes at offset {offset} (len {len}) are not covered by any active data segment")]
     DataOutOfRange { offset: u64, len: usize },
+    #[error("`{TEMPLATE_DEF_CUSTOM_SECTION}` custom section is too short ({len} bytes) to hold a length prefix")]
+    SectionTooShort { len: usize },
+    #[error("`{TEMPLATE_DEF_CUSTOM_SECTION}` declares length {declared} but the section is {actual} bytes")]
+    SectionLengthMismatch { declared: usize, actual: usize },
     #[error("Failed to decode TemplateDef: {0}")]
     Decode(#[source] tari_bor::BorError),
 }
 
 #[cfg(test)]
 mod tests {
+    use tari_template_abi::{TemplateDef, TemplateDefV1, version};
     use tari_template_builtin::all_builtin_templates;
 
     use super::*;
 
+    /// Encode an unsigned LEB128 integer into `out`. Just enough for the
+    /// ranges we use in tests (section sizes, name lengths up to 64 KiB).
+    fn write_uleb128(out: &mut Vec<u8>, mut value: u32) {
+        loop {
+            let mut byte = (value & 0x7f) as u8;
+            value >>= 7;
+            if value != 0 {
+                byte |= 0x80;
+            }
+            out.push(byte);
+            if value == 0 {
+                break;
+            }
+        }
+    }
+
+    /// Build a minimal valid WASM binary that contains a single custom section
+    /// with the given name and payload. No type/import/export/etc. sections —
+    /// the extractor only needs the custom section, and `wasmparser` accepts
+    /// modules that have just the magic+version header plus custom sections.
+    fn make_wasm_with_custom_section(name: &str, payload: &[u8]) -> Vec<u8> {
+        let mut wasm = Vec::with_capacity(8 + 16 + name.len() + payload.len());
+        // Magic + version
+        wasm.extend_from_slice(&[0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00]);
+        // Custom section: section id 0, size LEB, name length LEB, name bytes, data
+        let mut section_body = Vec::with_capacity(name.len() + payload.len() + 8);
+        write_uleb128(&mut section_body, name.len() as u32);
+        section_body.extend_from_slice(name.as_bytes());
+        section_body.extend_from_slice(payload);
+        wasm.push(0); // section id 0 = custom
+        write_uleb128(&mut wasm, section_body.len() as u32);
+        wasm.extend_from_slice(&section_body);
+        wasm
+    }
+
+    fn synthetic_template_def() -> TemplateDef {
+        TemplateDef::V1(TemplateDefV1 {
+            template_name: "Synthetic".to_string(),
+            abi_version: version::LATEST_TEMPLATE_VERSION,
+            functions: Vec::new(),
+        })
+    }
+
     #[test]
-    fn extracts_builtin_template_defs_without_compiling() {
+    fn extracts_legacy_builtin_template_defs() {
+        // The committed builtin .wasm files predate the custom-section
+        // embedding and exercise the legacy global+rodata fallback path.
         for template in all_builtin_templates() {
             let def = extract_template_def(template.binary)
                 .unwrap_or_else(|e| panic!("extract failed for {}: {}", template.name, e));
@@ -221,6 +302,26 @@ mod tests {
                 template.name,
                 "extracted template_name should match the static builtin name",
             );
+        }
+    }
+
+    #[test]
+    fn extracts_from_custom_section() {
+        let blob = synthetic_template_def().encode_for_wasm_embedding().expect("encode");
+        let wasm = make_wasm_with_custom_section(TEMPLATE_DEF_CUSTOM_SECTION, &blob);
+        let def = extract_template_def(&wasm).expect("extract from custom section");
+        assert_eq!(def.template_name(), "Synthetic");
+    }
+
+    #[test]
+    fn rejects_malformed_section_length() {
+        // Length prefix declares more bytes than the section actually holds.
+        let mut blob = vec![0u8; 16];
+        blob[..4].copy_from_slice(&u32::MAX.to_le_bytes());
+        let wasm = make_wasm_with_custom_section(TEMPLATE_DEF_CUSTOM_SECTION, &blob);
+        match extract_template_def(&wasm) {
+            Err(ExtractTemplateDefError::SectionLengthMismatch { .. }) => {},
+            other => panic!("expected SectionLengthMismatch, got {:?}", other),
         }
     }
 }

--- a/crates/template_abi/Cargo.toml
+++ b/crates/template_abi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_template_abi"
 description = "Defines the low-level Tari engine ABI for WASM targets"
-version = "0.16.0"
+version = "0.16.1"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/template_abi/src/lib.rs
+++ b/crates/template_abi/src/lib.rs
@@ -46,6 +46,24 @@ pub mod version;
 #[cfg(feature = "func-hasher")]
 pub mod func_hasher;
 
-/// The name of the global export that defines the template definition
+/// The name of the global export that defines the template definition.
+///
+/// NOTE: this is deprecated in favour  of the `tari_tdef' custom section and will be removed.
+///
+/// This is the legacy embedding path: the template's bor-encoded `TemplateDef`
+/// (with a 4-byte LE length prefix) is laid out in the WASM module's linear
+/// memory and an exported i32 global of this name holds the pointer to the
+/// length prefix. Engines read it via instance-time memory access.
 pub const ABI_TEMPLATE_DEF_GLOBAL_NAME: &str = "_ABI_TEMPLATE_DEF";
+
+/// The name of the WASM custom section that holds the template definition.
+///
+/// New templates additionally embed the same `[u32 LE length] || [bor bytes]`
+/// blob as a WASM custom section. This avoids any dependency on linear-memory
+/// layout, which makes static extraction trivial (no global / data-segment
+/// walk) and gives the JIT path a way to recover the ABI without instantiating
+/// the module. The legacy global+rodata embedding is kept alongside this for
+/// backward compatibility with engines that don't yet read custom sections.
+pub const TEMPLATE_DEF_CUSTOM_SECTION: &str = "tari_tdef";
+
 pub const WASM_PTR_SIZE: usize = 4; // 32-bit pointers in wasm

--- a/crates/template_lib/Cargo.toml
+++ b/crates/template_lib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_template_lib"
 description = "Tari template library provides abstrations that interface with the Tari validator engine"
-version = "0.25.2"
+version = "0.26.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/template_macros/Cargo.toml
+++ b/crates/template_macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_template_macros"
 description = "Tari template macro"
-version = "0.18.0"
+version = "0.19.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/template_macros/src/template/template_def.rs
+++ b/crates/template_macros/src/template/template_def.rs
@@ -21,12 +21,12 @@
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use proc_macro2::TokenStream;
-use quote::{format_ident, quote};
+use quote::quote;
 use syn::{AngleBracketedGenericArguments, GenericArgument, PathArguments, PathSegment, Result, Type, TypeTuple};
 use tari_template_abi::{
-    ABI_TEMPLATE_DEF_GLOBAL_NAME,
     ArgDef,
     FunctionDef,
+    TEMPLATE_DEF_CUSTOM_SECTION,
     TemplateDef,
     TemplateDefV1,
     Type as ArgType,
@@ -86,11 +86,17 @@ pub fn generate_template_def(ast: &TemplateAst) -> Result<TokenStream> {
         )
     })?;
     let len = template_def_data.len();
-    let template_def_name = format_ident!("{ABI_TEMPLATE_DEF_GLOBAL_NAME}");
+    let section_name = TEMPLATE_DEF_CUSTOM_SECTION;
 
+    // Embed the `[u32 LE length] || [bor bytes]` blob into a WASM custom
+    // section. Engines extract the bytes directly out of the section without
+    // any linear-memory access. `#[used]` keeps the linker from stripping it;
+    // LLVM's wasm backend preserves a non-standard `link_section` name as a
+    // WASM custom section in the output binary.
     let output = quote! {
-        #[unsafe(no_mangle)]
-        pub static #template_def_name: [u8;#len] = [#(#template_def_data),*];
+        #[used]
+        #[unsafe(link_section = #section_name)]
+        static _TARI_TEMPLATE_DEF: [u8; #len] = [#(#template_def_data),*];
     };
 
     Ok(output)


### PR DESCRIPTION
## Summary

- Switch the `#[template]` macro to emit a single `#[link_section = "tari_tdef"]` static instead of the `_ABI_TEMPLATE_DEF` exported global. New template binaries carry the bor-encoded `TemplateDef` directly in a WASM custom section — no `.rodata` blob, no linear-memory walk, no exported global.
- Engine reads the custom section first (both the static walletd path and the JIT compile path), falls back to the legacy `_ABI_TEMPLATE_DEF` global + rodata layout for templates already deployed on-chain. Both paths reject duplicate / malformed sections.
- `validate_instance` no longer requires the legacy global to exist; it's only sanity-checked when present.
- Indexer template manager: cache compiled builtins in-process and run `TemplateManager::initialize` via `spawn_blocking` so the cranelift compile doesn't stall the tokio runtime.

## Versioning

- workspace 0.30.2 → 0.30.3
- `tari_template_abi` 0.16.0 → 0.16.1 (additive const)
- `tari_template_macros` 0.18.0 → **0.19.0** (output format change)
- `tari_template_lib` 0.25.2 → **0.26.0** (tracks macro)

## Backward compatibility

New macro-emitted templates only embed the custom section — old engines won't read them. New engines read both:
- New format: `tari_tdef` custom section, prefer this path.
- Legacy format: `_ABI_TEMPLATE_DEF` exported global + rodata blob, fallback for already-deployed templates.

## Test plan

- [x] `cargo check --workspace --all-features`
- [x] `cargo test -p tari_engine --lib` (custom-section unit tests + legacy fallback against committed builtin .wasm)
- [x] `cargo test -p tari_engine --tests` (83 integration tests across 11 suites — all freshly compile templates with the new macro)
- [x] Verified rebuilt builtin (`account.wasm`) contains `tari_tdef` exactly once and no `_ABI_TEMPLATE_DEF` symbol
- [x] Smoke-test indexer/validator/walletd startup against a template set mixing legacy and new binaries