### PR TITLE
feat(engine): dedupe template-load fee per template per transaction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12239,7 +12239,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_builtin"
-version = "0.30.2"
+version = "0.30.3"
 dependencies = [
  "anyhow",
  "tari_engine_types",

--- a/crates/engine/src/fees/fee_module.rs
+++ b/crates/engine/src/fees/fee_module.rs
@@ -3,6 +3,7 @@
 
 use tari_bor::{ByteCounter, encode_into_writer};
 use tari_engine_types::fees::FeeSource;
+use tari_template_lib::types::TemplateAddress;
 
 use super::FeeTable;
 use crate::{
@@ -45,8 +46,18 @@ impl<TStore: StateReader> RuntimeModule<TStore> for FeeModule {
     fn on_template_loaded(
         &self,
         track: &mut StateTracker<TStore>,
+        template_address: &TemplateAddress,
         bytes_loaded: usize,
     ) -> Result<(), RuntimeModuleError> {
+        // Dedupe per template per transaction: the validator's compile/deserialise cost is paid
+        // once per template per process (in-memory + on-disk caches), so subsequent loads within
+        // the same transaction (cross-template calls, repeated method invocations on the same
+        // component, etc.) carry no incremental load cost. Per-call dispatch overhead is already
+        // captured by `per_module_call_cost`.
+        if !track.record_template_load_charge(*template_address) {
+            return Ok(());
+        }
+
         const TEMPLATE_BYTES_LOADED_COST_DIVISOR: u64 = 3000; // 3 KB = 1 cost unit
         let template_load_cost_unit =
             u64::try_from(bytes_loaded).unwrap_or(u64::MAX) / TEMPLATE_BYTES_LOADED_COST_DIVISOR;

--- a/crates/engine/src/runtime/impl.rs
+++ b/crates/engine/src/runtime/impl.rs
@@ -3085,17 +3085,10 @@ where
             return Ok(());
         }
 
-        // Dedupe per template per transaction: the validator's compile/deserialise cost is paid
-        // once per template per process (in-memory + on-disk caches), so subsequent loads within
-        // the same transaction (cross-template calls, repeated method invocations on the same
-        // component, etc.) carry no incremental load cost. Per-call dispatch overhead is already
-        // captured by `per_module_call_cost`.
-        if !self.tracker.record_template_load_charge(*template_address) {
-            return Ok(());
-        }
-
+        // Note: per-transaction dedup is intentionally pushed into the modules that want it (see
+        // `FeeModule::on_template_loaded`), so observer-style modules continue to see every load.
         for module in self.modules.iter() {
-            module.on_template_loaded(&mut self.tracker, bytes_loaded)?;
+            module.on_template_loaded(&mut self.tracker, template_address, bytes_loaded)?;
         }
         Ok(())
     }

--- a/crates/engine/src/runtime/impl.rs
+++ b/crates/engine/src/runtime/impl.rs
@@ -3085,6 +3085,15 @@ where
             return Ok(());
         }
 
+        // Dedupe per template per transaction: the validator's compile/deserialise cost is paid
+        // once per template per process (in-memory + on-disk caches), so subsequent loads within
+        // the same transaction (cross-template calls, repeated method invocations on the same
+        // component, etc.) carry no incremental load cost. Per-call dispatch overhead is already
+        // captured by `per_module_call_cost`.
+        if !self.tracker.record_template_load_charge(*template_address) {
+            return Ok(());
+        }
+
         for module in self.modules.iter() {
             module.on_template_loaded(&mut self.tracker, bytes_loaded)?;
         }

--- a/crates/engine/src/runtime/module.rs
+++ b/crates/engine/src/runtime/module.rs
@@ -1,6 +1,8 @@
 //   Copyright 2023 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
+use tari_template_lib::types::TemplateAddress;
+
 use crate::runtime::StateTracker;
 
 pub trait RuntimeModule<TStore>: Send + Sync {
@@ -16,9 +18,15 @@ pub trait RuntimeModule<TStore>: Send + Sync {
         Ok(())
     }
 
+    /// Invoked once for every entry into a template within the current transaction (e.g. each
+    /// `call_function` / `call_method` / `update_component_template`). Modules that want to dedupe
+    /// per-transaction (notably the fee module) must do so themselves via
+    /// [`StateTracker::record_template_load_charge`]; the runtime intentionally does not dedupe
+    /// here so observer-style modules can see every load.
     fn on_template_loaded(
         &self,
         _track: &mut StateTracker<TStore>,
+        _template_address: &TemplateAddress,
         _bytes_loaded: usize,
     ) -> Result<(), RuntimeModuleError> {
         Ok(())

--- a/crates/engine/src/runtime/tracker.rs
+++ b/crates/engine/src/runtime/tracker.rs
@@ -121,6 +121,14 @@ impl<TStore: StateReader> StateTracker<TStore> {
         self.write_with(|state| state.push_log(log))
     }
 
+    /// Returns `true` the first time a given template address is seen within this transaction's
+    /// state, `false` thereafter. Callers use this to dedupe `FeeSource::TemplateLoad` charges:
+    /// the validator pays the cold compile/deserialise cost at most once per template per
+    /// process, so charging it on every entry over-bills the user.
+    pub fn record_template_load_charge(&mut self, address: TemplateAddress) -> bool {
+        self.write_with(|state| state.record_template_load_charge(address))
+    }
+
     pub fn take_events(&mut self) -> Vec<Event> {
         self.write_with(|state| state.take_events())
     }

--- a/crates/engine/src/runtime/working_state.rs
+++ b/crates/engine/src/runtime/working_state.rs
@@ -106,6 +106,12 @@ pub(super) struct WorkingState<TStore> {
     initial_call_scope: CallScope,
 
     fee_state: FeeState,
+    /// Template addresses for which a load fee has already been charged in this transaction.
+    /// Used to dedupe `FeeSource::TemplateLoad` charges across repeated calls into the same
+    /// template (cross-template invocations, multiple instructions on the same component, etc.):
+    /// the validator pays the cold compile/deserialise cost at most once per template per process,
+    /// so charging it on every entry over-bills the user.
+    loaded_template_charges: HashSet<TemplateAddress>,
 }
 
 impl<TStore: StateReader> WorkingState<TStore> {
@@ -135,6 +141,7 @@ impl<TStore: StateReader> WorkingState<TStore> {
             call_frames: Vec::new(),
             initial_call_scope,
             fee_state: FeeState::new(),
+            loaded_template_charges: HashSet::new(),
             object_ids: ObjectIds::new(limits::ENGINE_LIMITS.max_substate_outputs),
         }
     }
@@ -1037,6 +1044,13 @@ impl<TStore: StateReader> WorkingState<TStore> {
 
     pub fn fee_state_mut(&mut self) -> &mut FeeState {
         &mut self.fee_state
+    }
+
+    /// Records that a template-load charge is being applied for `address`. Returns `true` if this
+    /// is the first time within the transaction (caller should charge), `false` if already
+    /// recorded (caller should skip).
+    pub fn record_template_load_charge(&mut self, address: TemplateAddress) -> bool {
+        self.loaded_template_charges.insert(address)
     }
 
     pub fn set_last_instruction_output(&mut self, output: IndexedValue) {

--- a/crates/engine/tests/fees.rs
+++ b/crates/engine/tests/fees.rs
@@ -1,7 +1,7 @@
 //   Copyright 2023 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use tari_engine_types::commit_result::RejectReason;
+use tari_engine_types::{commit_result::RejectReason, fees::FeeSource};
 use tari_ootle_transaction::{Transaction, args};
 use tari_template_lib::types::{Amount, ComponentAddress, constants::STEALTH_TARI_RESOURCE_ADDRESS};
 use tari_template_test_tooling::{TemplateTest, support::assert_error::assert_reject_reason, xtr_faucet_component};
@@ -438,4 +438,54 @@ fn dangling_bucket_pay_fees() {
         .balance();
     assert_ne!(payment.total_fees_paid(), 0);
     assert_eq!(orig_balance - new_balance, payment.total_fees_paid());
+}
+
+#[test]
+fn template_load_fee_charged_once_per_template_per_transaction() {
+    let mut test = TemplateTest::new(CRATE_PATH, TEMPLATE_PATHS);
+
+    let (account, owner_token, private_key) = test.create_funded_account();
+    let state: ComponentAddress = test.call_function("State", "new", args![], vec![]);
+
+    test.enable_fees();
+
+    // Single State call — establishes the baseline TemplateLoad fee for {Account, State}.
+    let single = test.execute_expect_success(
+        Transaction::builder_localnet()
+            .pay_fee_from_component(account, 1000u64)
+            .call_method(state, "set", args![1u32])
+            .build_and_seal(&private_key),
+        vec![owner_token.clone()],
+    );
+
+    // Five State calls — same template touched five extra times. Without dedup, TemplateLoad
+    // would scale with call count; with dedup it must match the single-call baseline.
+    let many = test.execute_expect_success(
+        Transaction::builder_localnet()
+            .pay_fee_from_component(account, 1000u64)
+            .call_method(state, "set", args![1u32])
+            .call_method(state, "set", args![2u32])
+            .call_method(state, "set", args![3u32])
+            .call_method(state, "get", args![])
+            .call_method(state, "get", args![])
+            .build_and_seal(&private_key),
+        vec![owner_token],
+    );
+
+    let template_load = |result: &tari_engine_types::commit_result::FinalizeResult| -> u64 {
+        result
+            .fee_receipt
+            .fee_breakdown()
+            .iter()
+            .find_map(|(s, amount)| (*s == FeeSource::TemplateLoad).then_some(*amount))
+            .expect("TemplateLoad charge present")
+    };
+
+    let single_load = template_load(&single.finalize);
+    let many_load = template_load(&many.finalize);
+    assert!(single_load > 0, "TemplateLoad fee should be non-zero");
+    assert_eq!(
+        single_load, many_load,
+        "TemplateLoad fee must be deduped per (template, transaction); single={single_load} many={many_load}",
+    );
 }

--- a/crates/template_builtin/Cargo.toml
+++ b/crates/template_builtin/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_template_builtin"
 description = "Tari Ootle built-in templates"
-version = "0.30.2"
+version = "0.30.3"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/template_builtin/templates/account/src/lib.rs
+++ b/crates/template_builtin/templates/account/src/lib.rs
@@ -177,22 +177,16 @@ mod account_template {
 
         /// Pay fees from previously revealed stealth resource.
         pub fn pay_fee(&mut self, amount: Amount) {
-            emit_event("pay_fee", [("amount", amount.to_string())]);
             self.get_vault_mut(STEALTH_TARI_RESOURCE_ADDRESS).pay_fee(amount);
         }
 
         /// Reveal stealth tokens and return the revealed bucket to pay fees.
         pub fn pay_fee_stealth(&mut self, transfer: StealthTransferStatement) {
-            emit_event("pay_fee", [
-                ("stealth", "true".to_string()),
-                ("num_inputs", transfer.inputs_statement.inputs.len().to_string()),
-            ]);
             self.get_vault_mut(STEALTH_TARI_RESOURCE_ADDRESS)
                 .pay_fee_stealth(transfer);
         }
 
         pub fn create_proof_for_resource(&mut self, resource: ResourceAddress) -> Proof {
-            emit_event("create_proof_for_resource", [("resource", resource.to_string())]);
             let v = self.get_vault_mut(resource);
             v.create_proof()
         }
@@ -206,19 +200,11 @@ mod account_template {
             resource: ResourceAddress,
             ids: Vec<NonFungibleId>,
         ) -> Proof {
-            emit_event("create_proof_by_non_fungible_ids", [
-                ("resource", resource.to_string()),
-                ("ids", ids.iter().map(ToString::to_string).collect::<Vec<_>>().join(",")),
-            ]);
             let v = self.get_vault_mut(resource);
             v.create_proof_by_non_fungible_ids(ids.into_iter().collect())
         }
 
         pub fn create_proof_by_amount(&mut self, resource: ResourceAddress, amount: Amount) -> Proof {
-            emit_event("create_proof_by_amount", [
-                ("resource", resource.to_string()),
-                ("amount", amount.to_string()),
-            ]);
             let v = self.get_vault_mut(resource);
             v.create_proof_by_amount(amount)
         }

--- a/integration_tests/tests/features/indexer.feature
+++ b/integration_tests/tests/features/indexer.feature
@@ -54,7 +54,7 @@ Feature: Indexer node
     Then I wait for the indexer INDEXER to sync with the network
 
     # Scan the network for the event emitted on ACC creation
-    When indexer INDEXER scans the network events for account ACC with topics std.component.created,Account.pay_fee,std.component.updated
+    When indexer INDEXER scans the network events for account ACC with topics std.component.created,std.component.updated
 
   Scenario: Indexer GraphQL requests work
     # Initialize a base node, wallet, miner and VN
@@ -75,10 +75,10 @@ Feature: Indexer node
     Then I wait for the indexer INDEXER to sync with the network
     ##### Scenario
     # Scan the network for the event emitted on ACC_1 creation
-    When indexer INDEXER scans the network events for account ACC_1 with topics std.component.created,Account.pay_fee
+    When indexer INDEXER scans the network events for account ACC_1 with topics std.component.created
 
     # Scan the network for the event emitted on ACC_2 creation
-    When indexer INDEXER scans the network events for account ACC_2 with topics std.component.created,Account.pay_fee
+    When indexer INDEXER scans the network events for account ACC_2 with topics std.component.created
 
   Scenario: Indexer GraphQL filtering and pagination of events
     Given a network with registered validator VN and wallet daemon WALLET_D


### PR DESCRIPTION
## Summary

- Charge `FeeSource::TemplateLoad` at most once per `(transaction, template_address)` instead of once per call. Cross-template calls and repeated method invocations on the same component no longer over-pay for a load that the validator services from cache.
- Drop redundant `emit_event` calls in the account builtin template (`pay_fee`, `pay_fee_stealth`, `create_proof_*`). They duplicated info on the transaction receipt and the per-event fee was the only user-visible effect; bump `tari_template_builtin` to `0.30.3`.
- Update the indexer cucumber scenarios that asserted on `Account.pay_fee` topics now that those events are gone.

### Why dedupe template loads

`StateStoreTemplateProvider` keeps an in-memory moka cache of `LoadedTemplate` plus an on-disk cache of compiled wasmer artifacts, so the validator pays the cold compile/deserialise cost at most once per template per process. Yet `track_template_loaded` was firing on every entry into `call_function` / `call_method` / `update_component_template`, charging the full `(bytes / 3000) × per_template_load_cost_unit` each time — about 7000 µT per call for a 2 MiB template. A transaction with 10 method calls into the same component was paying 10× the actual resource usage.

The dedup state lives on `WorkingState`, so it's cloned into the fee checkpoint for free: rollback restores the post-fee-intent set, while `*checkpoint_state.fee_state_mut() = state.fee_state().clone()` already preserves execution-time charges. Per-call dispatch overhead is still captured by `per_module_call_cost`.

## Test plan

- [x] `cargo test -p tari_engine --test fees` — new `template_load_fee_charged_once_per_template_per_transaction` asserts the breakdown's `TemplateLoad` value is identical for a 1-call vs 5-call transaction on the same component.
- [x] `cargo test -p tari_engine` — all 196 engine tests pass.
- [x] `cargo check -p tari_template_builtin` after event removal.
- [x] Re-run the indexer cucumber scenarios touched (`Indexer node`) in CI.