### PR TITLE
chore(deps): bump diesel to 2.3.9 (RUSTSEC-2026-0111)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3017,9 +3017,9 @@ dependencies = [
 
 [[package]]
 name = "diesel"
-version = "2.3.5"
+version = "2.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e130c806dccc85428c564f2dc5a96e05b6615a27c9a28776bd7761a9af4bb552"
+checksum = "9940fb8467a0a06312218ed384185cb8536aa10d8ec017d0ce7fad2c1bd882d5"
 dependencies = [
  "bigdecimal",
  "chrono",


### PR DESCRIPTION
## Summary

- Bumps `diesel` from 2.3.5 → 2.3.9 in `Cargo.lock` to pick up the fix for [RUSTSEC-2026-0111](https://rustsec.org/advisories/RUSTSEC-2026-0111.html).
- Diesel <2.3.8 called `str::from_utf8_unchecked` on bytes returned by SQLite's `sqlite3_value_text`, which can contain arbitrary (non-UTF-8) data when the underlying SQLite storage type is `BLOB` — undefined behavior. 2.3.8 added the missing UTF-8 validation.
- Workspace `Cargo.toml` constraint (`^2.2.12`) already permits 2.3.9; only the lockfile changes.

Closes #2069

## Test plan

- [x] `cargo check --workspace` passes