### PR TITLE
chore(deps): update libp2p fork, tari main, and rand to 0.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,26 +195,27 @@ dependencies = [
 
 [[package]]
 name = "argon2"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db4ce4441f99dbd377ca8a8f57b698c44d0d6e712d8329b5040da5a64aa1ce73"
-dependencies = [
- "base64ct",
- "blake2",
- "password-hash 0.4.2",
-]
-
-[[package]]
-name = "argon2"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
 dependencies = [
  "base64ct",
- "blake2",
+ "blake2 0.10.6",
  "cpufeatures 0.2.17",
  "password-hash 0.5.0",
  "zeroize",
+]
+
+[[package]]
+name = "argon2"
+version = "0.6.0-rc.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7af50940b73bf4e16c15c448a2b121c63f2d68e3e54b6a8731673cb4aa0cdff5"
+dependencies = [
+ "base64ct",
+ "blake2 0.11.0-rc.5",
+ "cpufeatures 0.3.0",
+ "password-hash 0.6.1",
 ]
 
 [[package]]
@@ -281,7 +282,7 @@ checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -293,7 +294,7 @@ checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -305,7 +306,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -393,7 +394,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strum 0.27.2",
- "syn 2.0.114",
+ "syn 2.0.117",
  "thiserror 2.0.18",
 ]
 
@@ -488,7 +489,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -499,7 +500,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -883,7 +884,7 @@ dependencies = [
  "regex",
  "rustc-hash 2.1.1",
  "shlex",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -918,7 +919,7 @@ checksum = "c09459e6af3016ea58af8332e31d5da117d33a621bad7019355eefccc4a567d4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
  "thiserror 2.0.18",
 ]
 
@@ -968,6 +969,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "blake2"
+version = "0.11.0-rc.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52965399b470437fc7f4d4b51134668dbc96573fea6f1b83318a420e4605745"
+dependencies = [
+ "digest 0.11.0-rc.11",
 ]
 
 [[package]]
@@ -1053,7 +1063,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1129,7 +1139,7 @@ checksum = "89385e82b5d1821d2219e0b095efa2cc1f246cbf99080f3be46a1a85c0d392d9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1569,7 +1579,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1617,6 +1627,12 @@ checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "cmov"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
 
 [[package]]
 name = "codespan-reporting"
@@ -1699,7 +1715,7 @@ dependencies = [
  "itertools 0.13.0",
  "log",
  "ootle_byte_type",
- "rand 0.8.6",
+ "rand 0.10.1",
  "serde",
  "serde_json",
  "tari_bor",
@@ -2220,7 +2236,7 @@ dependencies = [
  "filedescriptor",
  "futures-core",
  "libc",
- "mio 1.1.1",
+ "mio 1.2.0",
  "parking_lot",
  "rustix 0.38.44",
  "signal-hook",
@@ -2306,6 +2322,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
 name = "cucumber"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2329,7 +2354,7 @@ dependencies = [
  "lazy-regex",
  "linked-hash-map",
  "once_cell",
- "pin-project 1.1.10",
+ "pin-project 1.1.12",
  "regex",
  "sealed",
  "serde",
@@ -2349,7 +2374,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.114",
+ "syn 2.0.117",
  "synthez",
 ]
 
@@ -2377,10 +2402,26 @@ dependencies = [
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest 0.10.7",
- "fiat-crypto",
- "group",
- "rand_core 0.6.4",
+ "fiat-crypto 0.2.9",
  "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "5.0.0-pre.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "335f1947f241137a14106b6f5acc5918a5ede29c9d71d3f2cb1678d5075d9fc3"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "digest 0.11.0-rc.11",
+ "fiat-crypto 0.3.0",
+ "rand_core 0.10.1",
+ "rustc_version",
+ "rustcrypto-group",
  "serde",
  "subtle",
  "zeroize",
@@ -2394,7 +2435,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2441,7 +2482,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2455,7 +2496,7 @@ dependencies = [
  "indexmap 2.13.0",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2473,7 +2514,7 @@ dependencies = [
  "indexmap 2.13.0",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2541,7 +2582,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2555,7 +2596,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2568,7 +2609,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2590,7 +2631,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2601,7 +2642,7 @@ checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2612,7 +2653,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core 0.23.0",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2852,7 +2893,7 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2894,7 +2935,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2914,7 +2955,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core 0.20.2",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2927,7 +2968,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2949,7 +2990,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.114",
+ "syn 2.0.117",
  "unicode-xid",
 ]
 
@@ -3045,7 +3086,7 @@ dependencies = [
  "dsl_auto_type",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3065,7 +3106,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe2444076b48641147115697648dc743c2c00b61adade0f01ce67133c7babe8c"
 dependencies = [
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3089,6 +3130,7 @@ dependencies = [
  "block-buffer 0.11.0",
  "const-oid 0.10.2",
  "crypto-common 0.2.0",
+ "subtle",
 ]
 
 [[package]]
@@ -3130,7 +3172,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3196,7 +3238,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3291,16 +3333,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "ed25519"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29fcf32e6c73d1079f83ab4d782de2d81620346a5f38c6237a86a22f8368980a"
+dependencies = [
+ "signature 3.0.0",
+]
+
+[[package]]
 name = "ed25519-dalek"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
- "curve25519-dalek",
- "ed25519",
+ "curve25519-dalek 4.1.3",
+ "ed25519 2.2.3",
  "rand_core 0.6.4",
  "serde",
  "sha2 0.10.9",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "3.0.0-pre.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053618a4c3d3bc24f188aa660ae75a46eeab74ef07fb415c61431e5e7cd4749b"
+dependencies = [
+ "curve25519-dalek 5.0.0-pre.6",
+ "ed25519 3.0.0",
+ "sha2 0.11.0-rc.5",
  "subtle",
  "zeroize",
 ]
@@ -3366,7 +3430,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3386,7 +3450,7 @@ checksum = "685adfa4d6f3d765a26bc5dbc936577de9abf756c1feeb3089b01dd395034842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3407,7 +3471,7 @@ dependencies = [
  "darling 0.21.3",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3442,7 +3506,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3575,6 +3639,12 @@ name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "filedescriptor"
@@ -3745,6 +3815,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-bounded"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b604752cefc5aa3ab98992a107a8bd99465d2825c1584e0b60cb6957b21e19d7"
+dependencies = [
+ "futures-util",
+ "tokio",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3796,7 +3876,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3827,6 +3907,10 @@ name = "futures-timer"
 version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+dependencies = [
+ "gloo-timers",
+ "send_wrapper",
+]
 
 [[package]]
 name = "futures-util"
@@ -3898,11 +3982,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3914,7 +4000,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3938,7 +4024,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "syn 2.0.114",
+ "syn 2.0.117",
  "textwrap 0.16.2",
  "thiserror 1.0.69",
  "typed-builder",
@@ -4007,6 +4093,18 @@ dependencies = [
  "bitflags 2.10.0",
  "ignore",
  "walkdir",
+]
+
+[[package]]
+name = "gloo-timers"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -4120,11 +4218,11 @@ dependencies = [
 
 [[package]]
 name = "hashlink"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -4634,7 +4732,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -4653,7 +4751,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b17f1a5bd7d12ad30a21445cfa5f52fd7651cb3243ba866f9916b1ec112f12"
 dependencies = [
  "anyhow",
- "blake2",
+ "blake2 0.10.6",
  "blake3",
  "bytes",
  "hex",
@@ -4790,19 +4888,19 @@ dependencies = [
 
 [[package]]
 name = "if-addrs"
-version = "0.10.2"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cabb0019d51a643781ff15c9c8a3e5dedc365c47211270f4e8f82812fedd8f0a"
+checksum = "c0a05c691e1fae256cf7013d99dad472dc52d5543322761f83ec8d47eab40d2b"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "if-watch"
-version = "3.2.1"
+version = "3.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdf9d64cfcf380606e64f9a0bcf493616b65331199f984151a6fa11a7b3cde38"
+checksum = "71c02a5161c313f0cbdbadc511611893584a10a7b6153cb554bdf83ddce99ec2"
 dependencies = [
  "async-io",
  "core-foundation 0.9.4",
@@ -4816,9 +4914,9 @@ dependencies = [
  "netlink-proto",
  "netlink-sys",
  "rtnetlink",
- "system-configuration 0.6.1",
+ "system-configuration 0.7.0",
  "tokio",
- "windows 0.53.0",
+ "windows",
 ]
 
 [[package]]
@@ -4898,7 +4996,7 @@ checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5023,7 +5121,7 @@ dependencies = [
  "multiaddr 0.18.3",
  "notify",
  "ootle_byte_type",
- "rand 0.8.6",
+ "rand 0.10.1",
  "regex",
  "reqwest 0.13.2",
  "serde",
@@ -5135,7 +5233,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5252,7 +5350,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5277,7 +5375,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5318,7 +5416,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
 dependencies = [
  "base64 0.22.1",
- "ed25519-dalek",
+ "ed25519-dalek 2.2.0",
  "getrandom 0.2.17",
  "hmac",
  "js-sys",
@@ -5424,7 +5522,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5493,9 +5591,9 @@ checksum = "2c4a545a15244c7d945065b5d392b2d2d7f21526fba56ce51467b06ed445e8f7"
 
 [[package]]
 name = "libc"
-version = "0.2.180"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libdbus-sys"
@@ -5546,8 +5644,8 @@ checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libp2p"
-version = "0.56.1"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=470c41380d6c5140b52ef65becf4f643e4769e66#470c41380d6c5140b52ef65becf4f643e4769e66"
+version = "0.57.0"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a#76f31bc0ab4bd9f9f5383be6aa3fed873538e35a"
 dependencies = [
  "bytes",
  "either",
@@ -5562,7 +5660,7 @@ dependencies = [
  "libp2p-dns",
  "libp2p-gossipsub",
  "libp2p-identify",
- "libp2p-identity 0.2.13 (git+https://github.com/tari-project/rust-libp2p.git?rev=470c41380d6c5140b52ef65becf4f643e4769e66)",
+ "libp2p-identity 0.2.13 (git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a)",
  "libp2p-mdns",
  "libp2p-metrics",
  "libp2p-noise",
@@ -5575,38 +5673,37 @@ dependencies = [
  "libp2p-upnp",
  "libp2p-yamux",
  "multiaddr 0.18.3",
- "pin-project 1.1.10",
+ "pin-project 1.1.12",
  "rw-stream-sink",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "libp2p-allow-block-list"
-version = "0.6.0"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=470c41380d6c5140b52ef65becf4f643e4769e66#470c41380d6c5140b52ef65becf4f643e4769e66"
+version = "0.7.0"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a#76f31bc0ab4bd9f9f5383be6aa3fed873538e35a"
 dependencies = [
  "libp2p-core",
- "libp2p-identity 0.2.13 (git+https://github.com/tari-project/rust-libp2p.git?rev=470c41380d6c5140b52ef65becf4f643e4769e66)",
+ "libp2p-identity 0.2.13 (git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a)",
  "libp2p-swarm",
 ]
 
 [[package]]
 name = "libp2p-autonat"
-version = "0.15.0"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=470c41380d6c5140b52ef65becf4f643e4769e66#470c41380d6c5140b52ef65becf4f643e4769e66"
+version = "0.16.0"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a#76f31bc0ab4bd9f9f5383be6aa3fed873538e35a"
 dependencies = [
- "async-trait",
  "asynchronous-codec",
  "either",
  "futures 0.3.31",
- "futures-bounded",
+ "futures-bounded 0.3.0",
  "futures-timer",
  "libp2p-core",
- "libp2p-identity 0.2.13 (git+https://github.com/tari-project/rust-libp2p.git?rev=470c41380d6c5140b52ef65becf4f643e4769e66)",
+ "libp2p-identity 0.2.13 (git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a)",
  "libp2p-request-response",
  "libp2p-swarm",
  "quick-protobuf",
- "quick-protobuf-codec 0.3.1 (git+https://github.com/tari-project/rust-libp2p.git?rev=470c41380d6c5140b52ef65becf4f643e4769e66)",
+ "quick-protobuf-codec 0.4.0",
  "rand 0.8.6",
  "rand_core 0.6.4",
  "thiserror 2.0.18",
@@ -5616,29 +5713,29 @@ dependencies = [
 
 [[package]]
 name = "libp2p-connection-limits"
-version = "0.6.0"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=470c41380d6c5140b52ef65becf4f643e4769e66#470c41380d6c5140b52ef65becf4f643e4769e66"
+version = "0.7.0"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a#76f31bc0ab4bd9f9f5383be6aa3fed873538e35a"
 dependencies = [
  "libp2p-core",
- "libp2p-identity 0.2.13 (git+https://github.com/tari-project/rust-libp2p.git?rev=470c41380d6c5140b52ef65becf4f643e4769e66)",
+ "libp2p-identity 0.2.13 (git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a)",
  "libp2p-swarm",
 ]
 
 [[package]]
 name = "libp2p-core"
-version = "0.43.2"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=470c41380d6c5140b52ef65becf4f643e4769e66#470c41380d6c5140b52ef65becf4f643e4769e66"
+version = "0.44.0"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a#76f31bc0ab4bd9f9f5383be6aa3fed873538e35a"
 dependencies = [
  "either",
  "fnv",
  "futures 0.3.31",
  "futures-timer",
- "libp2p-identity 0.2.13 (git+https://github.com/tari-project/rust-libp2p.git?rev=470c41380d6c5140b52ef65becf4f643e4769e66)",
+ "libp2p-identity 0.2.13 (git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a)",
  "multiaddr 0.18.3",
  "multihash",
  "multistream-select",
  "parking_lot",
- "pin-project 1.1.10",
+ "pin-project 1.1.12",
  "quick-protobuf",
  "rand 0.8.6",
  "rw-stream-sink",
@@ -5650,20 +5747,20 @@ dependencies = [
 
 [[package]]
 name = "libp2p-dcutr"
-version = "0.14.0"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=470c41380d6c5140b52ef65becf4f643e4769e66#470c41380d6c5140b52ef65becf4f643e4769e66"
+version = "0.15.0"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a#76f31bc0ab4bd9f9f5383be6aa3fed873538e35a"
 dependencies = [
  "asynchronous-codec",
  "either",
  "futures 0.3.31",
- "futures-bounded",
+ "futures-bounded 0.3.0",
  "futures-timer",
- "hashlink 0.10.0",
+ "hashlink 0.11.0",
  "libp2p-core",
- "libp2p-identity 0.2.13 (git+https://github.com/tari-project/rust-libp2p.git?rev=470c41380d6c5140b52ef65becf4f643e4769e66)",
+ "libp2p-identity 0.2.13 (git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a)",
  "libp2p-swarm",
  "quick-protobuf",
- "quick-protobuf-codec 0.3.1 (git+https://github.com/tari-project/rust-libp2p.git?rev=470c41380d6c5140b52ef65becf4f643e4769e66)",
+ "quick-protobuf-codec 0.4.0",
  "thiserror 2.0.18",
  "tracing",
  "web-time",
@@ -5671,14 +5768,13 @@ dependencies = [
 
 [[package]]
 name = "libp2p-dns"
-version = "0.44.0"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=470c41380d6c5140b52ef65becf4f643e4769e66#470c41380d6c5140b52ef65becf4f643e4769e66"
+version = "0.45.0"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a#76f31bc0ab4bd9f9f5383be6aa3fed873538e35a"
 dependencies = [
- "async-trait",
  "futures 0.3.31",
  "hickory-resolver 0.25.2",
  "libp2p-core",
- "libp2p-identity 0.2.13 (git+https://github.com/tari-project/rust-libp2p.git?rev=470c41380d6c5140b52ef65becf4f643e4769e66)",
+ "libp2p-identity 0.2.13 (git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a)",
  "parking_lot",
  "smallvec 1.15.1",
  "tracing",
@@ -5687,7 +5783,7 @@ dependencies = [
 [[package]]
 name = "libp2p-gossipsub"
 version = "0.50.0"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=470c41380d6c5140b52ef65becf4f643e4769e66#470c41380d6c5140b52ef65becf4f643e4769e66"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a#76f31bc0ab4bd9f9f5383be6aa3fed873538e35a"
 dependencies = [
  "async-channel",
  "asynchronous-codec",
@@ -5699,14 +5795,14 @@ dependencies = [
  "futures 0.3.31",
  "futures-timer",
  "getrandom 0.2.17",
- "hashlink 0.10.0",
+ "hashlink 0.11.0",
  "hex_fmt",
  "libp2p-core",
- "libp2p-identity 0.2.13 (git+https://github.com/tari-project/rust-libp2p.git?rev=470c41380d6c5140b52ef65becf4f643e4769e66)",
+ "libp2p-identity 0.2.13 (git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a)",
  "libp2p-swarm",
  "prometheus-client",
  "quick-protobuf",
- "quick-protobuf-codec 0.3.1 (git+https://github.com/tari-project/rust-libp2p.git?rev=470c41380d6c5140b52ef65becf4f643e4769e66)",
+ "quick-protobuf-codec 0.4.0",
  "rand 0.8.6",
  "regex",
  "sha2 0.10.9",
@@ -5716,19 +5812,19 @@ dependencies = [
 
 [[package]]
 name = "libp2p-identify"
-version = "0.47.0"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=470c41380d6c5140b52ef65becf4f643e4769e66#470c41380d6c5140b52ef65becf4f643e4769e66"
+version = "0.48.0"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a#76f31bc0ab4bd9f9f5383be6aa3fed873538e35a"
 dependencies = [
  "asynchronous-codec",
  "either",
  "futures 0.3.31",
- "futures-bounded",
+ "futures-bounded 0.3.0",
  "futures-timer",
  "libp2p-core",
- "libp2p-identity 0.2.13 (git+https://github.com/tari-project/rust-libp2p.git?rev=470c41380d6c5140b52ef65becf4f643e4769e66)",
+ "libp2p-identity 0.2.13 (git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a)",
  "libp2p-swarm",
  "quick-protobuf",
- "quick-protobuf-codec 0.3.1 (git+https://github.com/tari-project/rust-libp2p.git?rev=470c41380d6c5140b52ef65becf4f643e4769e66)",
+ "quick-protobuf-codec 0.4.0",
  "smallvec 1.15.1",
  "thiserror 2.0.18",
  "tracing",
@@ -5751,14 +5847,14 @@ dependencies = [
 [[package]]
 name = "libp2p-identity"
 version = "0.2.13"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=470c41380d6c5140b52ef65becf4f643e4769e66#470c41380d6c5140b52ef65becf4f643e4769e66"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a#76f31bc0ab4bd9f9f5383be6aa3fed873538e35a"
 dependencies = [
  "bs58",
- "ed25519-dalek",
+ "ed25519-dalek 3.0.0-pre.6",
  "hkdf",
  "multihash",
  "quick-protobuf",
- "rand 0.8.6",
+ "rand 0.10.1",
  "serde",
  "sha2 0.10.9",
  "tari_crypto",
@@ -5769,18 +5865,18 @@ dependencies = [
 
 [[package]]
 name = "libp2p-mdns"
-version = "0.48.0"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=470c41380d6c5140b52ef65becf4f643e4769e66#470c41380d6c5140b52ef65becf4f643e4769e66"
+version = "0.49.0"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a#76f31bc0ab4bd9f9f5383be6aa3fed873538e35a"
 dependencies = [
  "futures 0.3.31",
  "hickory-proto 0.25.2",
  "if-watch",
  "libp2p-core",
- "libp2p-identity 0.2.13 (git+https://github.com/tari-project/rust-libp2p.git?rev=470c41380d6c5140b52ef65becf4f643e4769e66)",
+ "libp2p-identity 0.2.13 (git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a)",
  "libp2p-swarm",
  "rand 0.8.6",
  "smallvec 1.15.1",
- "socket2 0.6.1",
+ "socket2 0.6.3",
  "tokio",
  "tracing",
 ]
@@ -5790,7 +5886,7 @@ name = "libp2p-messaging"
 version = "0.30.3"
 dependencies = [
  "async-trait",
- "futures-bounded",
+ "futures-bounded 0.2.4",
  "libp2p",
  "prometheus-client",
  "prost 0.14.3",
@@ -5800,33 +5896,33 @@ dependencies = [
 
 [[package]]
 name = "libp2p-metrics"
-version = "0.17.1"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=470c41380d6c5140b52ef65becf4f643e4769e66#470c41380d6c5140b52ef65becf4f643e4769e66"
+version = "0.18.0"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a#76f31bc0ab4bd9f9f5383be6aa3fed873538e35a"
 dependencies = [
  "futures 0.3.31",
  "libp2p-core",
  "libp2p-dcutr",
  "libp2p-gossipsub",
  "libp2p-identify",
- "libp2p-identity 0.2.13 (git+https://github.com/tari-project/rust-libp2p.git?rev=470c41380d6c5140b52ef65becf4f643e4769e66)",
+ "libp2p-identity 0.2.13 (git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a)",
  "libp2p-ping",
  "libp2p-relay",
  "libp2p-swarm",
- "pin-project 1.1.10",
+ "pin-project 1.1.12",
  "prometheus-client",
  "web-time",
 ]
 
 [[package]]
 name = "libp2p-noise"
-version = "0.46.1"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=470c41380d6c5140b52ef65becf4f643e4769e66#470c41380d6c5140b52ef65becf4f643e4769e66"
+version = "0.47.0"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a#76f31bc0ab4bd9f9f5383be6aa3fed873538e35a"
 dependencies = [
  "asynchronous-codec",
  "bytes",
  "futures 0.3.31",
  "libp2p-core",
- "libp2p-identity 0.2.13 (git+https://github.com/tari-project/rust-libp2p.git?rev=470c41380d6c5140b52ef65becf4f643e4769e66)",
+ "libp2p-identity 0.2.13 (git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a)",
  "multiaddr 0.18.3",
  "multihash",
  "quick-protobuf",
@@ -5842,9 +5938,9 @@ dependencies = [
 [[package]]
 name = "libp2p-peer-store"
 version = "0.1.0"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=470c41380d6c5140b52ef65becf4f643e4769e66#470c41380d6c5140b52ef65becf4f643e4769e66"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a#76f31bc0ab4bd9f9f5383be6aa3fed873538e35a"
 dependencies = [
- "hashlink 0.10.0",
+ "hashlink 0.11.0",
  "libp2p-core",
  "libp2p-swarm",
 ]
@@ -5856,26 +5952,26 @@ dependencies = [
  "async-semaphore",
  "async-trait",
  "asynchronous-codec",
- "blake2",
- "futures-bounded",
+ "blake2 0.10.6",
+ "futures-bounded 0.2.4",
  "libp2p",
  "pb-rs",
  "prometheus-client",
  "quick-protobuf",
- "quick-protobuf-codec 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quick-protobuf-codec 0.3.1",
  "thiserror 2.0.18",
  "tracing",
 ]
 
 [[package]]
 name = "libp2p-ping"
-version = "0.47.0"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=470c41380d6c5140b52ef65becf4f643e4769e66#470c41380d6c5140b52ef65becf4f643e4769e66"
+version = "0.48.0"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a#76f31bc0ab4bd9f9f5383be6aa3fed873538e35a"
 dependencies = [
  "futures 0.3.31",
  "futures-timer",
  "libp2p-core",
- "libp2p-identity 0.2.13 (git+https://github.com/tari-project/rust-libp2p.git?rev=470c41380d6c5140b52ef65becf4f643e4769e66)",
+ "libp2p-identity 0.2.13 (git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a)",
  "libp2p-swarm",
  "rand 0.8.6",
  "tracing",
@@ -5884,20 +5980,20 @@ dependencies = [
 
 [[package]]
 name = "libp2p-quic"
-version = "0.13.0"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=470c41380d6c5140b52ef65becf4f643e4769e66#470c41380d6c5140b52ef65becf4f643e4769e66"
+version = "0.14.0"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a#76f31bc0ab4bd9f9f5383be6aa3fed873538e35a"
 dependencies = [
  "futures 0.3.31",
  "futures-timer",
  "if-watch",
  "libp2p-core",
- "libp2p-identity 0.2.13 (git+https://github.com/tari-project/rust-libp2p.git?rev=470c41380d6c5140b52ef65becf4f643e4769e66)",
+ "libp2p-identity 0.2.13 (git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a)",
  "libp2p-tls",
  "quinn",
  "rand 0.8.6",
  "ring",
  "rustls",
- "socket2 0.6.1",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -5905,20 +6001,20 @@ dependencies = [
 
 [[package]]
 name = "libp2p-relay"
-version = "0.21.1"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=470c41380d6c5140b52ef65becf4f643e4769e66#470c41380d6c5140b52ef65becf4f643e4769e66"
+version = "0.22.0"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a#76f31bc0ab4bd9f9f5383be6aa3fed873538e35a"
 dependencies = [
  "asynchronous-codec",
  "bytes",
  "either",
  "futures 0.3.31",
- "futures-bounded",
+ "futures-bounded 0.3.0",
  "futures-timer",
  "libp2p-core",
- "libp2p-identity 0.2.13 (git+https://github.com/tari-project/rust-libp2p.git?rev=470c41380d6c5140b52ef65becf4f643e4769e66)",
+ "libp2p-identity 0.2.13 (git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a)",
  "libp2p-swarm",
  "quick-protobuf",
- "quick-protobuf-codec 0.3.1 (git+https://github.com/tari-project/rust-libp2p.git?rev=470c41380d6c5140b52ef65becf4f643e4769e66)",
+ "quick-protobuf-codec 0.4.0",
  "rand 0.8.6",
  "static_assertions",
  "thiserror 2.0.18",
@@ -5928,20 +6024,20 @@ dependencies = [
 
 [[package]]
 name = "libp2p-rendezvous"
-version = "0.17.0"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=470c41380d6c5140b52ef65becf4f643e4769e66#470c41380d6c5140b52ef65becf4f643e4769e66"
+version = "0.18.0"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a#76f31bc0ab4bd9f9f5383be6aa3fed873538e35a"
 dependencies = [
- "async-trait",
  "asynchronous-codec",
  "bimap",
  "futures 0.3.31",
  "futures-timer",
+ "hashlink 0.11.0",
  "libp2p-core",
- "libp2p-identity 0.2.13 (git+https://github.com/tari-project/rust-libp2p.git?rev=470c41380d6c5140b52ef65becf4f643e4769e66)",
+ "libp2p-identity 0.2.13 (git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a)",
  "libp2p-request-response",
  "libp2p-swarm",
  "quick-protobuf",
- "quick-protobuf-codec 0.3.1 (git+https://github.com/tari-project/rust-libp2p.git?rev=470c41380d6c5140b52ef65becf4f643e4769e66)",
+ "quick-protobuf-codec 0.4.0",
  "rand 0.8.6",
  "thiserror 2.0.18",
  "tracing",
@@ -5950,14 +6046,13 @@ dependencies = [
 
 [[package]]
 name = "libp2p-request-response"
-version = "0.29.0"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=470c41380d6c5140b52ef65becf4f643e4769e66#470c41380d6c5140b52ef65becf4f643e4769e66"
+version = "0.30.0"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a#76f31bc0ab4bd9f9f5383be6aa3fed873538e35a"
 dependencies = [
- "async-trait",
  "futures 0.3.31",
- "futures-bounded",
+ "futures-bounded 0.3.0",
  "libp2p-core",
- "libp2p-identity 0.2.13 (git+https://github.com/tari-project/rust-libp2p.git?rev=470c41380d6c5140b52ef65becf4f643e4769e66)",
+ "libp2p-identity 0.2.13 (git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a)",
  "libp2p-swarm",
  "rand 0.8.6",
  "smallvec 1.15.1",
@@ -5976,59 +6071,61 @@ dependencies = [
 
 [[package]]
 name = "libp2p-swarm"
-version = "0.47.0"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=470c41380d6c5140b52ef65becf4f643e4769e66#470c41380d6c5140b52ef65becf4f643e4769e66"
+version = "0.48.0"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a#76f31bc0ab4bd9f9f5383be6aa3fed873538e35a"
 dependencies = [
  "either",
  "fnv",
  "futures 0.3.31",
  "futures-timer",
- "hashlink 0.10.0",
+ "getrandom 0.2.17",
+ "hashlink 0.11.0",
  "libp2p-core",
- "libp2p-identity 0.2.13 (git+https://github.com/tari-project/rust-libp2p.git?rev=470c41380d6c5140b52ef65becf4f643e4769e66)",
+ "libp2p-identity 0.2.13 (git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a)",
  "libp2p-swarm-derive",
  "multistream-select",
  "rand 0.8.6",
  "smallvec 1.15.1",
  "tokio",
  "tracing",
+ "wasm-bindgen-futures",
  "web-time",
 ]
 
 [[package]]
 name = "libp2p-swarm-derive"
-version = "0.35.1"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=470c41380d6c5140b52ef65becf4f643e4769e66#470c41380d6c5140b52ef65becf4f643e4769e66"
+version = "0.36.0"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a#76f31bc0ab4bd9f9f5383be6aa3fed873538e35a"
 dependencies = [
  "heck 0.5.0",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "libp2p-tcp"
-version = "0.44.1"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=470c41380d6c5140b52ef65becf4f643e4769e66#470c41380d6c5140b52ef65becf4f643e4769e66"
+version = "0.45.0"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a#76f31bc0ab4bd9f9f5383be6aa3fed873538e35a"
 dependencies = [
  "futures 0.3.31",
  "futures-timer",
  "if-watch",
  "libc",
  "libp2p-core",
- "socket2 0.6.1",
+ "socket2 0.6.3",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "libp2p-tls"
-version = "0.6.2"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=470c41380d6c5140b52ef65becf4f643e4769e66#470c41380d6c5140b52ef65becf4f643e4769e66"
+version = "0.7.0"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a#76f31bc0ab4bd9f9f5383be6aa3fed873538e35a"
 dependencies = [
  "futures 0.3.31",
  "futures-rustls",
  "libp2p-core",
- "libp2p-identity 0.2.13 (git+https://github.com/tari-project/rust-libp2p.git?rev=470c41380d6c5140b52ef65becf4f643e4769e66)",
+ "libp2p-identity 0.2.13 (git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a)",
  "rcgen 0.13.2",
  "ring",
  "rustls",
@@ -6040,8 +6137,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-upnp"
-version = "0.6.0"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=470c41380d6c5140b52ef65becf4f643e4769e66#470c41380d6c5140b52ef65becf4f643e4769e66"
+version = "0.7.0"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a#76f31bc0ab4bd9f9f5383be6aa3fed873538e35a"
 dependencies = [
  "futures 0.3.31",
  "futures-timer",
@@ -6054,8 +6151,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-yamux"
-version = "0.47.0"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=470c41380d6c5140b52ef65becf4f643e4769e66#470c41380d6c5140b52ef65becf4f643e4769e66"
+version = "0.48.0"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a#76f31bc0ab4bd9f9f5383be6aa3fed873538e35a"
 dependencies = [
  "either",
  "futures 0.3.31",
@@ -6452,18 +6549,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "merlin"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58c38e2799fc0978b65dfff8023ec7843e2330bb462f19198840b34b6582397d"
-dependencies = [
- "byteorder",
- "keccak",
- "rand_core 0.6.4",
- "zeroize",
-]
-
-[[package]]
 name = "miette"
 version = "5.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6483,7 +6568,7 @@ checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6556,15 +6641,15 @@ dependencies = [
 
 [[package]]
 name = "minotari_app_grpc"
-version = "5.3.0-rc.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.3.0-rc.0#55942473fd6654f654d69255a90da9be69a67523"
+version = "5.3.1-pre.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0#1f94bc8fdc909072a295ece3ace0f98bf1b2c3cc"
 dependencies = [
- "argon2 0.4.1",
+ "argon2 0.6.0-rc.8",
  "base64 0.22.1",
  "borsh",
  "log",
  "prost 0.13.5",
- "rand 0.8.6",
+ "rand 0.10.1",
  "rcgen 0.12.1",
  "subtle",
  "tari_common_types",
@@ -6587,15 +6672,15 @@ dependencies = [
 
 [[package]]
 name = "minotari_app_utilities"
-version = "5.3.0-rc.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.3.0-rc.0#55942473fd6654f654d69255a90da9be69a67523"
+version = "5.3.1-pre.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0#1f94bc8fdc909072a295ece3ace0f98bf1b2c3cc"
 dependencies = [
  "clap 4.5.54",
  "dialoguer 0.10.4",
  "futures 0.3.31",
  "json5",
  "log",
- "rand 0.8.6",
+ "rand 0.10.1",
  "serde",
  "tari_common",
  "tari_common_types",
@@ -6610,8 +6695,8 @@ dependencies = [
 
 [[package]]
 name = "minotari_console_wallet"
-version = "5.3.0-rc.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.3.0-rc.0#55942473fd6654f654d69255a90da9be69a67523"
+version = "5.3.1-pre.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0#1f94bc8fdc909072a295ece3ace0f98bf1b2c3cc"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6633,7 +6718,7 @@ dependencies = [
  "minotari_node_wallet_client",
  "minotari_wallet",
  "qrcode",
- "rand 0.8.6",
+ "rand 0.10.1",
  "regex",
  "rpassword",
  "rustyline",
@@ -6647,7 +6732,7 @@ dependencies = [
  "tari_core",
  "tari_crypto",
  "tari_features",
- "tari_hashing 5.3.0-rc.0 (git+https://github.com/tari-project/tari.git?tag=v5.3.0-rc.0)",
+ "tari_hashing 5.3.1-pre.0 (git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0)",
  "tari_p2p",
  "tari_script",
  "tari_shutdown",
@@ -6666,8 +6751,8 @@ dependencies = [
 
 [[package]]
 name = "minotari_ledger_wallet_common"
-version = "5.3.0-rc.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.3.0-rc.0#55942473fd6654f654d69255a90da9be69a67523"
+version = "5.3.1-pre.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0#1f94bc8fdc909072a295ece3ace0f98bf1b2c3cc"
 dependencies = [
  "bs58",
  "serde",
@@ -6675,8 +6760,8 @@ dependencies = [
 
 [[package]]
 name = "minotari_ledger_wallet_comms"
-version = "5.3.0-rc.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.3.0-rc.0#55942473fd6654f654d69255a90da9be69a67523"
+version = "5.3.1-pre.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0#1f94bc8fdc909072a295ece3ace0f98bf1b2c3cc"
 dependencies = [
  "borsh",
  "dialoguer 0.11.0",
@@ -6684,7 +6769,7 @@ dependencies = [
  "ledger-transport-hid",
  "log",
  "minotari_ledger_wallet_common",
- "rand 0.8.6",
+ "rand 0.10.1",
  "semver",
  "serde",
  "tari_common",
@@ -6697,8 +6782,8 @@ dependencies = [
 
 [[package]]
 name = "minotari_node"
-version = "5.3.0-rc.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.3.0-rc.0#55942473fd6654f654d69255a90da9be69a67523"
+version = "5.3.1-pre.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0#1f94bc8fdc909072a295ece3ace0f98bf1b2c3cc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6756,16 +6841,16 @@ dependencies = [
 
 [[package]]
 name = "minotari_node_grpc_client"
-version = "5.3.0-rc.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.3.0-rc.0#55942473fd6654f654d69255a90da9be69a67523"
+version = "5.3.1-pre.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0#1f94bc8fdc909072a295ece3ace0f98bf1b2c3cc"
 dependencies = [
  "minotari_app_grpc",
 ]
 
 [[package]]
 name = "minotari_node_wallet_client"
-version = "5.3.0-rc.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.3.0-rc.0#55942473fd6654f654d69255a90da9be69a67523"
+version = "5.3.1-pre.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0#1f94bc8fdc909072a295ece3ace0f98bf1b2c3cc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6782,14 +6867,14 @@ dependencies = [
 
 [[package]]
 name = "minotari_wallet"
-version = "5.3.0-rc.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.3.0-rc.0#55942473fd6654f654d69255a90da9be69a67523"
+version = "5.3.1-pre.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0#1f94bc8fdc909072a295ece3ace0f98bf1b2c3cc"
 dependencies = [
  "anyhow",
- "argon2 0.4.1",
+ "argon2 0.6.0-rc.8",
  "async-trait",
  "bincode 1.3.3",
- "blake2",
+ "blake2 0.10.6",
  "borsh",
  "chacha20poly1305",
  "chrono",
@@ -6805,8 +6890,9 @@ dependencies = [
  "log",
  "minotari_ledger_wallet_common",
  "minotari_node_wallet_client",
+ "phc",
  "prost 0.13.5",
- "rand 0.8.6",
+ "rand 0.10.1",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -6818,7 +6904,7 @@ dependencies = [
  "tari_comms",
  "tari_comms_dht",
  "tari_crypto",
- "tari_hashing 5.3.0-rc.0 (git+https://github.com/tari-project/tari.git?tag=v5.3.0-rc.0)",
+ "tari_hashing 5.3.1-pre.0 (git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0)",
  "tari_max_size",
  "tari_p2p",
  "tari_script",
@@ -6839,8 +6925,8 @@ dependencies = [
 
 [[package]]
 name = "minotari_wallet_grpc_client"
-version = "5.3.0-rc.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.3.0-rc.0#55942473fd6654f654d69255a90da9be69a67523"
+version = "5.3.1-pre.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0#1f94bc8fdc909072a295ece3ace0f98bf1b2c3cc"
 dependencies = [
  "minotari_app_grpc",
  "tari_common",
@@ -6869,9 +6955,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "log",
@@ -6915,7 +7001,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f25218523ad4a171ddda05251669afb788cdc2f0df94082aab856a2b09541c3f"
 dependencies = [
  "base58-monero",
- "curve25519-dalek",
+ "curve25519-dalek 4.1.3",
  "fixed-hash",
  "hex",
  "hex-literal 0.4.1",
@@ -6970,13 +7056,13 @@ dependencies = [
 [[package]]
 name = "multiaddr"
 version = "0.18.3"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=470c41380d6c5140b52ef65becf4f643e4769e66#470c41380d6c5140b52ef65becf4f643e4769e66"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a#76f31bc0ab4bd9f9f5383be6aa3fed873538e35a"
 dependencies = [
  "arrayref",
  "byteorder",
  "bytes",
  "data-encoding",
- "libp2p-identity 0.2.13 (git+https://github.com/tari-project/rust-libp2p.git?rev=470c41380d6c5140b52ef65becf4f643e4769e66)",
+ "libp2p-identity 0.2.13 (git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a)",
  "multibase",
  "multihash",
  "percent-encoding",
@@ -7000,11 +7086,10 @@ dependencies = [
 
 [[package]]
 name = "multihash"
-version = "0.19.4"
+version = "0.19.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ace881e3f514092ce9efbcb8f413d0ad9763860b828981c2de51ddc666936c"
+checksum = "577c63b00ad74d57e8c9aa870b5fccebf2fd64a308a5aee9f1bb88e4aea19447"
 dependencies = [
- "no_std_io2",
  "unsigned-varint",
 ]
 
@@ -7022,12 +7107,12 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "multistream-select"
-version = "0.13.0"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=470c41380d6c5140b52ef65becf4f643e4769e66#470c41380d6c5140b52ef65becf4f643e4769e66"
+version = "0.14.0"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a#76f31bc0ab4bd9f9f5383be6aa3fed873538e35a"
 dependencies = [
  "bytes",
  "futures 0.3.31",
- "pin-project 1.1.10",
+ "pin-project 1.1.12",
  "smallvec 1.15.1",
  "tracing",
  "unsigned-varint",
@@ -7050,7 +7135,7 @@ checksum = "4568f25ccbd45ab5d5603dc34318c1ec56b117531781260002151b8530a9f931"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7102,51 +7187,35 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "netlink-packet-core"
-version = "0.7.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72724faf704479d67b388da142b186f916188505e7e0b26719019c525882eda4"
+checksum = "3463cbb78394cb0141e2c926b93fc2197e473394b761986eca3b9da2c63ae0f4"
 dependencies = [
- "anyhow",
- "byteorder",
- "netlink-packet-utils",
+ "paste",
 ]
 
 [[package]]
 name = "netlink-packet-route"
-version = "0.17.1"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053998cea5a306971f88580d0829e90f270f940befd7cf928da179d4187a5a66"
+checksum = "4ce3636fa715e988114552619582b530481fd5ef176a1e5c1bf024077c2c9445"
 dependencies = [
- "anyhow",
- "bitflags 1.3.2",
- "byteorder",
+ "bitflags 2.10.0",
  "libc",
+ "log",
  "netlink-packet-core",
- "netlink-packet-utils",
-]
-
-[[package]]
-name = "netlink-packet-utils"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ede8a08c71ad5a95cdd0e4e52facd37190977039a4704eb82a283f713747d34"
-dependencies = [
- "anyhow",
- "byteorder",
- "paste",
- "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "netlink-proto"
-version = "0.11.5"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72452e012c2f8d612410d89eea01e2d9b56205274abb35d53f60200b2ec41d60"
+checksum = "b65d130ee111430e47eed7896ea43ca693c387f097dd97376bffafbf25812128"
 dependencies = [
  "bytes",
  "futures 0.3.31",
@@ -7158,12 +7227,12 @@ dependencies = [
 
 [[package]]
 name = "netlink-sys"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16c903aa70590cb93691bf97a767c8d1d6122d2cc9070433deb3bbf36ce8bd23"
+checksum = "cd6c30ed10fa69cc491d491b85cc971f6bdeb8e7367b7cde2ee6cc878d583fae"
 dependencies = [
  "bytes",
- "futures 0.3.31",
+ "futures-util",
  "libc",
  "log",
  "tokio",
@@ -7223,19 +7292,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "cfg_aliases 0.2.1",
+ "libc",
+]
+
+[[package]]
 name = "no-std-compat"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
-
-[[package]]
-name = "no_std_io2"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a3564ce7035b1e4778d8cb6cacebb5d766b5e8fe5a75b9e441e33fb61a872c6"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "nohash-hasher"
@@ -7285,7 +7357,7 @@ dependencies = [
  "kqueue",
  "libc",
  "log",
- "mio 1.1.1",
+ "mio 1.2.0",
  "notify-types",
  "walkdir",
  "windows-sys 0.60.2",
@@ -7303,7 +7375,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7358,7 +7430,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7456,7 +7528,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7553,10 +7625,10 @@ dependencies = [
  "futures 0.3.31",
  "indexmap 2.13.0",
  "ootle_byte_type",
- "rand 0.8.6",
+ "rand 0.10.1",
  "serde",
  "serde_json",
- "signature 3.0.0-rc.8",
+ "signature 3.0.0",
  "tari_bor",
  "tari_crypto",
  "tari_indexer_client",
@@ -7588,7 +7660,7 @@ version = "0.30.3"
 dependencies = [
  "base64 0.22.1",
  "ootle_byte_type",
- "rand 0.8.6",
+ "rand 0.10.1",
  "serde",
  "serde_json",
  "tari_bor",
@@ -7656,7 +7728,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7791,7 +7863,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7825,9 +7897,9 @@ dependencies = [
 
 [[package]]
 name = "password-hash"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
 dependencies = [
  "base64ct",
  "rand_core 0.6.4",
@@ -7836,13 +7908,12 @@ dependencies = [
 
 [[package]]
 name = "password-hash"
-version = "0.5.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+checksum = "aab41826031698d6ffcd9cff78ef56ef998e39dc7e5067cdfebe373842d4723b"
 dependencies = [
- "base64ct",
- "rand_core 0.6.4",
- "subtle",
+ "getrandom 0.4.2",
+ "phc",
 ]
 
 [[package]]
@@ -7979,7 +8050,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -8048,7 +8119,7 @@ dependencies = [
  "cipher 0.4.4",
  "const-oid 0.9.6",
  "crc24",
- "curve25519-dalek",
+ "curve25519-dalek 4.1.3",
  "cx448",
  "derive_builder 0.20.2",
  "derive_more 2.1.1",
@@ -8057,7 +8128,7 @@ dependencies = [
  "dsa",
  "eax",
  "ecdsa",
- "ed25519-dalek",
+ "ed25519-dalek 2.2.0",
  "elliptic-curve",
  "flate2",
  "generic-array",
@@ -8093,6 +8164,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "phc"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44dc769b75f93afdddd8c7fa12d685292ddeff1e66f7f0f3a234cf1818afe892"
+dependencies = [
+ "base64ct",
+ "ctutils",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "pin-project"
 version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8103,11 +8186,11 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.10"
+version = "1.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+checksum = "cbf0d9e68100b3a7989b4901972f265cd542e560a3a8a724e1e20322f4d06ce9"
 dependencies = [
- "pin-project-internal 1.1.10",
+ "pin-project-internal 1.1.12",
 ]
 
 [[package]]
@@ -8123,13 +8206,13 @@ dependencies = [
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.10"
+version = "1.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+checksum = "a990e22f43e84855daf260dded30524ef4a9021cc7541c26540500a50b624389"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -8294,7 +8377,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -8370,7 +8453,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -8417,7 +8500,7 @@ checksum = "9adf1691c04c0a5ff46ff8f262b58beb07b0dbb61f96f9f54f6cbd82106ed87f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -8478,7 +8561,7 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap 0.10.1",
@@ -8488,7 +8571,7 @@ dependencies = [
  "prost 0.13.5",
  "prost-types 0.13.5",
  "regex",
- "syn 2.0.114",
+ "syn 2.0.117",
  "tempfile",
 ]
 
@@ -8498,7 +8581,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap 0.10.1",
@@ -8507,7 +8590,7 @@ dependencies = [
  "prost 0.14.3",
  "prost-types 0.14.3",
  "regex",
- "syn 2.0.114",
+ "syn 2.0.117",
  "tempfile",
 ]
 
@@ -8534,7 +8617,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -8547,7 +8630,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -8628,7 +8711,7 @@ checksum = "7347867d0a7e1208d93b46767be83e2b8f978c3dad35f775ac8d8847551d6fe1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -8692,8 +8775,8 @@ dependencies = [
 
 [[package]]
 name = "quick-protobuf-codec"
-version = "0.3.1"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=470c41380d6c5140b52ef65becf4f643e4769e66#470c41380d6c5140b52ef65becf4f643e4769e66"
+version = "0.4.0"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a#76f31bc0ab4bd9f9f5383be6aa3fed873538e35a"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -8765,7 +8848,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8875,6 +8958,16 @@ checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e6af7f3e25ded52c41df4e0b1af2d047e45896c2f3281792ed68a1c243daedb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -9020,7 +9113,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -9032,7 +9125,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "rustix 1.1.3",
- "windows 0.62.2",
+ "windows",
 ]
 
 [[package]]
@@ -9051,9 +9144,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.2"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -9263,7 +9356,7 @@ checksum = "7f6dffea3c91fa91a3c0fc8a061b0e27fef25c6304728038a6d6bcb1c58ba9bd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -9331,18 +9424,18 @@ dependencies = [
 
 [[package]]
 name = "rtnetlink"
-version = "0.13.1"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a552eb82d19f38c3beed3f786bd23aa434ceb9ac43ab44419ca6d67a7e186c0"
+checksum = "4b960d5d873a75b5be9761b1e73b146f52dddcd27bac75263f40fba686d4d7b5"
 dependencies = [
- "futures 0.3.31",
+ "futures-channel",
+ "futures-util",
  "log",
  "netlink-packet-core",
  "netlink-packet-route",
- "netlink-packet-utils",
  "netlink-proto",
  "netlink-sys",
- "nix 0.26.4",
+ "nix 0.30.1",
  "thiserror 1.0.69",
  "tokio",
 ]
@@ -9382,7 +9475,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rust-embed-utils",
- "syn 2.0.114",
+ "syn 2.0.117",
  "walkdir",
 ]
 
@@ -9440,6 +9533,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustcrypto-ff"
+version = "0.14.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd2a8adb347447693cd2ba0d218c4b66c62da9b0a5672b17b981e4291ec65ff6"
+dependencies = [
+ "rand_core 0.10.1",
+ "subtle",
+]
+
+[[package]]
+name = "rustcrypto-group"
+version = "0.14.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "369f9b61aa45933c062c9f6b5c3c50ab710687eca83dd3802653b140b43f85ed"
+dependencies = [
+ "rand_core 0.10.1",
+ "rustcrypto-ff",
+ "subtle",
+]
+
+[[package]]
 name = "rusticata-macros"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9471,7 +9585,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9530,7 +9644,7 @@ dependencies = [
  "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9551,7 +9665,7 @@ dependencies = [
  "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9623,11 +9737,11 @@ dependencies = [
 
 [[package]]
 name = "rw-stream-sink"
-version = "0.4.0"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=470c41380d6c5140b52ef65becf4f643e4769e66#470c41380d6c5140b52ef65becf4f643e4769e66"
+version = "0.5.0"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a#76f31bc0ab4bd9f9f5383be6aa3fed873538e35a"
 dependencies = [
  "futures 0.3.31",
- "pin-project 1.1.10",
+ "pin-project 1.1.12",
  "static_assertions",
 ]
 
@@ -9721,7 +9835,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -9792,6 +9906,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "send_wrapper"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f638d531eccd6e23b980caf34876660d38e265409d8e99b397ab71eb3612fad0"
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9849,7 +9969,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -9905,7 +10025,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -9970,7 +10090,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -10011,7 +10131,7 @@ dependencies = [
  "darling 0.21.3",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -10167,7 +10287,7 @@ checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
 dependencies = [
  "libc",
  "mio 0.8.11",
- "mio 1.1.1",
+ "mio 1.2.0",
  "signal-hook",
 ]
 
@@ -10193,9 +10313,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "3.0.0-rc.8"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c04b70a14ee5f15e2e0c785a5fdb2e9a51138dfe13ba3cf8eab037a9e60b1879"
+checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
 
 [[package]]
 name = "simd-adler32"
@@ -10291,7 +10411,7 @@ checksum = "0eb01866308440fc64d6c44d9e86c5cc17adfe33c4d6eed55da9145044d0ffc1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -10346,10 +10466,10 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -10359,9 +10479,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "850948bee068e713b8ab860fe1adc4d109676ab4c3b621fd8147f06b261f2f85"
 dependencies = [
  "aes-gcm",
- "blake2",
+ "blake2 0.10.6",
  "chacha20poly1305",
- "curve25519-dalek",
+ "curve25519-dalek 4.1.3",
  "rand_core 0.6.4",
  "ring",
  "rustc_version",
@@ -10381,12 +10501,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10592,7 +10712,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -10648,9 +10768,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.114"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10674,7 +10794,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -10683,7 +10803,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3d2c2202510a1e186e63e596d9318c91a8cbe85cd1a56a7be0c333e5f59ec8d"
 dependencies = [
- "syn 2.0.114",
+ "syn 2.0.117",
  "synthez-codegen",
  "synthez-core",
 ]
@@ -10694,7 +10814,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f724aa6d44b7162f3158a57bccd871a77b39a4aef737e01bcdff41f4772c7746"
 dependencies = [
- "syn 2.0.114",
+ "syn 2.0.117",
  "synthez-core",
 ]
 
@@ -10707,7 +10827,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sealed",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -10826,29 +10946,30 @@ dependencies = [
 
 [[package]]
 name = "tari_bulletproofs_plus"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98e43bc4d522de252647e34e72aef4d5e33f845a6acc23fb7b1f4e877a7f9053"
+checksum = "4f2e5d22fc3d312561a24247689ac3ae180fb041e6ac11baf1317df3b1473ff8"
 dependencies = [
- "blake2",
+ "blake2 0.10.6",
  "byteorder",
- "curve25519-dalek",
+ "curve25519-dalek 5.0.0-pre.6",
  "digest 0.10.7",
- "ff",
+ "getrandom 0.4.2",
  "itertools 0.12.1",
- "merlin",
  "once_cell",
- "rand_core 0.6.4",
+ "rand_core 0.10.1",
+ "rustcrypto-ff",
  "serde",
  "sha3",
+ "tari_merlin",
  "thiserror-no-std",
  "zeroize",
 ]
 
 [[package]]
 name = "tari_common"
-version = "5.3.0-rc.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.3.0-rc.0#55942473fd6654f654d69255a90da9be69a67523"
+version = "5.3.1-pre.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0#1f94bc8fdc909072a295ece3ace0f98bf1b2c3cc"
 dependencies = [
  "anyhow",
  "cargo_toml 0.20.5",
@@ -10873,14 +10994,14 @@ dependencies = [
 
 [[package]]
 name = "tari_common_sqlite"
-version = "5.3.0-rc.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.3.0-rc.0#55942473fd6654f654d69255a90da9be69a67523"
+version = "5.3.1-pre.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0#1f94bc8fdc909072a295ece3ace0f98bf1b2c3cc"
 dependencies = [
  "diesel",
  "diesel_migrations",
  "lazy_static",
  "log",
- "rand 0.8.6",
+ "rand 0.10.1",
  "serde",
  "serde_json",
  "tari_utilities",
@@ -10890,13 +11011,13 @@ dependencies = [
 
 [[package]]
 name = "tari_common_types"
-version = "5.3.0-rc.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.3.0-rc.0#55942473fd6654f654d69255a90da9be69a67523"
+version = "5.3.1-pre.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0#1f94bc8fdc909072a295ece3ace0f98bf1b2c3cc"
 dependencies = [
- "argon2 0.4.1",
+ "argon2 0.6.0-rc.8",
  "base64 0.22.1",
  "bitflags 2.10.0",
- "blake2",
+ "blake2 0.10.6",
  "borsh",
  "bs58",
  "chacha20 0.7.3",
@@ -10904,11 +11025,12 @@ dependencies = [
  "crc32fast",
  "digest 0.10.7",
  "getrandom 0.2.17",
+ "getrandom 0.4.2",
  "js-sys",
  "newtype-ops",
  "once_cell",
  "primitive-types",
- "rand 0.8.6",
+ "rand 0.10.1",
  "serde",
  "serde_json",
  "strum 0.22.0",
@@ -10916,7 +11038,7 @@ dependencies = [
  "subtle",
  "tari_common",
  "tari_crypto",
- "tari_hashing 5.3.0-rc.0 (git+https://github.com/tari-project/tari.git?tag=v5.3.0-rc.0)",
+ "tari_hashing 5.3.1-pre.0 (git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0)",
  "tari_max_size",
  "tari_utilities",
  "thiserror 2.0.18",
@@ -10926,13 +11048,13 @@ dependencies = [
 
 [[package]]
 name = "tari_comms"
-version = "5.3.0-rc.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.3.0-rc.0#55942473fd6654f654d69255a90da9be69a67523"
+version = "5.3.1-pre.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0#1f94bc8fdc909072a295ece3ace0f98bf1b2c3cc"
 dependencies = [
  "anyhow",
  "async-trait",
  "bitflags 2.10.0",
- "blake2",
+ "blake2 0.10.6",
  "bytes",
  "chrono",
  "cidr",
@@ -10947,9 +11069,9 @@ dependencies = [
  "multiaddr 0.18.2",
  "nom 7.1.3",
  "once_cell",
- "pin-project 1.1.10",
+ "pin-project 1.1.12",
  "prost 0.13.5",
- "rand 0.8.6",
+ "rand 0.10.1",
  "serde",
  "serde_derive",
  "serde_json",
@@ -10973,12 +11095,12 @@ dependencies = [
 
 [[package]]
 name = "tari_comms_dht"
-version = "5.3.0-rc.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.3.0-rc.0#55942473fd6654f654d69255a90da9be69a67523"
+version = "5.3.1-pre.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0#1f94bc8fdc909072a295ece3ace0f98bf1b2c3cc"
 dependencies = [
  "anyhow",
  "bitflags 2.10.0",
- "blake2",
+ "blake2 0.10.6",
  "chacha20 0.7.3",
  "chacha20poly1305",
  "chrono",
@@ -10990,7 +11112,7 @@ dependencies = [
  "log",
  "pin-project 0.4.30",
  "prost 0.13.5",
- "rand 0.8.6",
+ "rand 0.10.1",
  "serde",
  "tari_common",
  "tari_common_sqlite",
@@ -11007,8 +11129,8 @@ dependencies = [
 
 [[package]]
 name = "tari_comms_rpc_macros"
-version = "5.3.0-rc.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.3.0-rc.0#55942473fd6654f654d69255a90da9be69a67523"
+version = "5.3.1-pre.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0#1f94bc8fdc909072a295ece3ace0f98bf1b2c3cc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11050,7 +11172,7 @@ dependencies = [
  "tari_common_types",
  "tari_crypto",
  "tari_engine_types",
- "tari_hashing 5.3.0-rc.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tari_hashing 5.3.1-pre.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tari_ootle_common_types",
  "tari_sidechain",
  "tari_template_lib",
@@ -11059,15 +11181,14 @@ dependencies = [
 
 [[package]]
 name = "tari_core"
-version = "5.3.0-rc.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.3.0-rc.0#55942473fd6654f654d69255a90da9be69a67523"
+version = "5.3.1-pre.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0#1f94bc8fdc909072a295ece3ace0f98bf1b2c3cc"
 dependencies = [
  "anyhow",
  "async-trait",
  "bincode 1.3.3",
- "blake2",
+ "blake2 0.10.6",
  "borsh",
- "chacha20poly1305",
  "chrono",
  "digest 0.10.7",
  "dirs-next 1.0.2",
@@ -11083,7 +11204,7 @@ dependencies = [
  "once_cell",
  "primitive-types",
  "prost 0.13.5",
- "rand 0.8.6",
+ "rand 0.10.1",
  "randomx-rs",
  "serde",
  "serde_json",
@@ -11100,7 +11221,7 @@ dependencies = [
  "tari_comms_rpc_macros",
  "tari_crypto",
  "tari_features",
- "tari_hashing 5.3.0-rc.0 (git+https://github.com/tari-project/tari.git?tag=v5.3.0-rc.0)",
+ "tari_hashing 5.3.1-pre.0 (git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0)",
  "tari_max_size",
  "tari_mmr",
  "tari_node_components",
@@ -11121,18 +11242,17 @@ dependencies = [
 
 [[package]]
 name = "tari_crypto"
-version = "0.22.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b74b1ee79be37e04fcdb307b2809e658f19e05f31a2b5263c128fc3a5e2dee16"
+checksum = "330e2160d7d72970e8fc5f7074cdad1b041e32e996bbb6799215c9ccd03d5310"
 dependencies = [
- "blake2",
+ "blake2 0.10.6",
  "borsh",
- "curve25519-dalek",
+ "curve25519-dalek 5.0.0-pre.6",
  "digest 0.10.7",
  "log",
- "merlin",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
+ "rand_chacha 0.10.0",
+ "rand_core 0.10.1",
  "serde",
  "sha3",
  "snafu 0.7.5",
@@ -11146,14 +11266,14 @@ dependencies = [
 name = "tari_engine"
 version = "0.30.3"
 dependencies = [
- "blake2",
+ "blake2 0.10.6",
  "bytes",
  "criterion",
  "indexmap 2.13.0",
  "log",
  "memmap2 0.9.9",
  "ootle_byte_type",
- "rand 0.8.6",
+ "rand 0.10.1",
  "serde",
  "tari_bor",
  "tari_crypto",
@@ -11178,7 +11298,7 @@ name = "tari_engine_types"
 version = "0.30.3"
 dependencies = [
  "bincode 2.0.1",
- "blake2",
+ "blake2 0.10.6",
  "borsh",
  "bounded-vec",
  "digest 0.10.7",
@@ -11189,12 +11309,12 @@ dependencies = [
  "newtype-ops",
  "ootle_byte_type",
  "ootle_serde",
- "rand 0.8.6",
+ "rand 0.10.1",
  "serde",
  "serde_json",
  "tari_bor",
  "tari_crypto",
- "tari_hashing 5.3.0-rc.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tari_hashing 5.3.1-pre.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tari_ootle_template_metadata",
  "tari_template_abi",
  "tari_template_lib",
@@ -11227,7 +11347,7 @@ name = "tari_epoch_oracles"
 version = "0.30.3"
 dependencies = [
  "anyhow",
- "blake2",
+ "blake2 0.10.6",
  "log",
  "ootle-network",
  "ootle_serde",
@@ -11236,7 +11356,7 @@ dependencies = [
  "tari_base_node_client",
  "tari_common_types",
  "tari_epoch_manager",
- "tari_hashing 5.3.0-rc.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tari_hashing 5.3.1-pre.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tari_node_components",
  "tari_ootle_common_types",
  "tari_ootle_storage",
@@ -11250,16 +11370,16 @@ dependencies = [
 
 [[package]]
 name = "tari_features"
-version = "5.3.0-rc.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.3.0-rc.0#55942473fd6654f654d69255a90da9be69a67523"
+version = "5.3.1-pre.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0#1f94bc8fdc909072a295ece3ace0f98bf1b2c3cc"
 
 [[package]]
 name = "tari_hashing"
-version = "5.3.0-rc.0"
+version = "5.3.1-pre.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b99ff66f7fae442e1daf1dfacf96c09888bbe09eb8fc2268988ba1d049a66a69"
+checksum = "60bca3ce500ae7dde4fe774a0ce56a34c2630a4ebf5fc380c0cbe4d9a2ef1775"
 dependencies = [
- "blake2",
+ "blake2 0.10.6",
  "borsh",
  "digest 0.10.7",
  "tari_crypto",
@@ -11267,10 +11387,10 @@ dependencies = [
 
 [[package]]
 name = "tari_hashing"
-version = "5.3.0-rc.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.3.0-rc.0#55942473fd6654f654d69255a90da9be69a67523"
+version = "5.3.1-pre.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0#1f94bc8fdc909072a295ece3ace0f98bf1b2c3cc"
 dependencies = [
- "blake2",
+ "blake2 0.10.6",
  "borsh",
  "digest 0.10.7",
  "tari_crypto",
@@ -11394,15 +11514,15 @@ dependencies = [
 
 [[package]]
 name = "tari_jellyfish"
-version = "5.3.0-rc.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.3.0-rc.0#55942473fd6654f654d69255a90da9be69a67523"
+version = "5.3.1-pre.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0#1f94bc8fdc909072a295ece3ace0f98bf1b2c3cc"
 dependencies = [
  "borsh",
  "digest 0.10.7",
  "indexmap 2.13.0",
  "serde",
  "tari_crypto",
- "tari_hashing 5.3.0-rc.0 (git+https://github.com/tari-project/tari.git?tag=v5.3.0-rc.0)",
+ "tari_hashing 5.3.1-pre.0 (git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0)",
  "thiserror 2.0.18",
 ]
 
@@ -11424,13 +11544,13 @@ dependencies = [
 
 [[package]]
 name = "tari_libtor"
-version = "5.3.0-rc.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.3.0-rc.0#55942473fd6654f654d69255a90da9be69a67523"
+version = "5.3.1-pre.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0#1f94bc8fdc909072a295ece3ace0f98bf1b2c3cc"
 dependencies = [
  "derivative",
  "libtor",
  "log",
- "rand 0.8.6",
+ "rand 0.10.1",
  "tari_common",
  "tari_p2p",
  "tor-hash-passwd",
@@ -11438,8 +11558,8 @@ dependencies = [
 
 [[package]]
 name = "tari_max_size"
-version = "5.3.0-rc.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.3.0-rc.0#55942473fd6654f654d69255a90da9be69a67523"
+version = "5.3.1-pre.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0#1f94bc8fdc909072a295ece3ace0f98bf1b2c3cc"
 dependencies = [
  "borsh",
  "serde",
@@ -11448,9 +11568,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tari_merlin"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e3a83eb69bafaa639abc3573614acaa47abd1fc9fc35d12cab2df8e45352b83"
+dependencies = [
+ "byteorder",
+ "keccak",
+ "rand_core 0.10.1",
+ "zeroize",
+]
+
+[[package]]
 name = "tari_metrics"
-version = "5.3.0-rc.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.3.0-rc.0#55942473fd6654f654d69255a90da9be69a67523"
+version = "5.3.1-pre.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0#1f94bc8fdc909072a295ece3ace0f98bf1b2c3cc"
 dependencies = [
  "once_cell",
  "prometheus",
@@ -11459,8 +11591,8 @@ dependencies = [
 
 [[package]]
 name = "tari_mmr"
-version = "5.3.0-rc.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.3.0-rc.0#55942473fd6654f654d69255a90da9be69a67523"
+version = "5.3.1-pre.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0#1f94bc8fdc909072a295ece3ace0f98bf1b2c3cc"
 dependencies = [
  "borsh",
  "digest 0.10.7",
@@ -11479,7 +11611,7 @@ dependencies = [
  "libp2p",
  "log",
  "prometheus-client",
- "rand 0.8.6",
+ "rand 0.10.1",
  "tari_rpc_framework",
  "tari_shutdown",
  "tari_swarm",
@@ -11489,18 +11621,19 @@ dependencies = [
 
 [[package]]
 name = "tari_node_components"
-version = "5.3.0-rc.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.3.0-rc.0#55942473fd6654f654d69255a90da9be69a67523"
+version = "5.3.1-pre.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0#1f94bc8fdc909072a295ece3ace0f98bf1b2c3cc"
 dependencies = [
- "blake2",
+ "blake2 0.10.6",
  "borsh",
  "chrono",
  "digest 0.10.7",
+ "getrandom 0.2.17",
  "js-sys",
  "primitive-types",
  "serde",
  "tari_common_types",
- "tari_hashing 5.3.0-rc.0 (git+https://github.com/tari-project/tari.git?tag=v5.3.0-rc.0)",
+ "tari_hashing 5.3.1-pre.0 (git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0)",
  "tari_transaction_components",
  "tari_utilities",
  "thiserror 2.0.18",
@@ -11528,16 +11661,16 @@ version = "0.30.3"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
- "blake2",
+ "blake2 0.10.6",
  "clap 3.2.25",
  "config",
  "dirs-next 2.0.0",
- "libp2p-identity 0.2.13 (git+https://github.com/tari-project/rust-libp2p.git?rev=470c41380d6c5140b52ef65becf4f643e4769e66)",
+ "libp2p-identity 0.2.13 (git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a)",
  "log",
  "multiaddr 0.18.3",
  "ootle_byte_type",
  "ootle_serde",
- "rand 0.8.6",
+ "rand 0.10.1",
  "serde",
  "serde_json5",
  "tari_bor",
@@ -11547,7 +11680,7 @@ dependencies = [
  "tari_engine",
  "tari_engine_types",
  "tari_epoch_oracles",
- "tari_hashing 5.3.0-rc.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tari_hashing 5.3.1-pre.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tari_mmr",
  "tari_networking",
  "tari_ootle_common_types",
@@ -11566,7 +11699,7 @@ dependencies = [
 name = "tari_ootle_common_types"
 version = "0.30.3"
 dependencies = [
- "blake2",
+ "blake2 0.10.6",
  "borsh",
  "bounded-vec",
  "digest 0.10.7",
@@ -11578,12 +11711,12 @@ dependencies = [
  "ootle_serde",
  "prost 0.14.3",
  "prost-types 0.14.3",
- "rand 0.8.6",
+ "rand 0.10.1",
  "serde",
  "tari_bor",
  "tari_crypto",
  "tari_engine_types",
- "tari_hashing 5.3.0-rc.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tari_hashing 5.3.1-pre.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tari_ootle_template_metadata",
  "tari_template_lib_types",
  "thiserror 2.0.18",
@@ -11595,10 +11728,10 @@ name = "tari_ootle_p2p"
 version = "0.30.3"
 dependencies = [
  "anyhow",
- "libp2p-identity 0.2.13 (git+https://github.com/tari-project/rust-libp2p.git?rev=470c41380d6c5140b52ef65becf4f643e4769e66)",
+ "libp2p-identity 0.2.13 (git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a)",
  "prost 0.14.3",
  "proto_builder",
- "rand 0.8.6",
+ "rand 0.10.1",
  "serde",
  "tari_bor",
  "tari_consensus",
@@ -11624,7 +11757,7 @@ dependencies = [
  "indexmap 2.13.0",
  "log",
  "ootle_serde",
- "rand 0.8.6",
+ "rand 0.10.1",
  "serde",
  "tari_common_types",
  "tari_consensus_types",
@@ -11649,7 +11782,7 @@ dependencies = [
  "diesel_migrations",
  "log",
  "ootle_byte_type",
- "rand 0.8.6",
+ "rand 0.10.1",
  "serde",
  "serde_json",
  "tari_common_types",
@@ -11704,13 +11837,13 @@ dependencies = [
  "ootle-network",
  "ootle_byte_type",
  "ootle_serde",
- "rand 0.8.6",
+ "rand 0.10.1",
  "serde",
  "serde_json",
  "tari_bor",
  "tari_crypto",
  "tari_engine_types",
- "tari_hashing 5.3.0-rc.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tari_hashing 5.3.1-pre.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tari_ootle_common_types",
  "tari_ootle_template_metadata",
  "tari_template_lib_types",
@@ -11752,7 +11885,7 @@ name = "tari_ootle_wallet_crypto"
 version = "0.30.3"
 dependencies = [
  "argon2 0.5.3",
- "blake2",
+ "blake2 0.10.6",
  "borsh",
  "chacha20poly1305",
  "crc32fast",
@@ -11761,14 +11894,14 @@ dependencies = [
  "memmap2 0.9.9",
  "ootle-network",
  "ootle_byte_type",
- "rand 0.8.6",
+ "rand 0.10.1",
  "serde",
  "serde_json",
  "subtle",
  "tari_bor",
  "tari_crypto",
  "tari_engine_types",
- "tari_hashing 5.3.0-rc.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tari_hashing 5.3.1-pre.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tari_ootle_common_types",
  "tari_template_lib_types",
  "tari_utilities",
@@ -11790,7 +11923,7 @@ dependencies = [
  "ootle_byte_type",
  "ootle_serde",
  "passwords",
- "rand 0.8.6",
+ "rand 0.10.1",
  "serde",
  "tari_bor",
  "tari_common_types",
@@ -11819,7 +11952,7 @@ version = "0.1.1"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
- "futures-bounded",
+ "futures-bounded 0.2.4",
  "log",
  "ootle_byte_type",
  "reqwest 0.13.2",
@@ -11846,6 +11979,7 @@ version = "0.30.3"
 dependencies = [
  "digest 0.10.7",
  "ootle_byte_type",
+ "rand 0.10.1",
  "tari_crypto",
  "tari_engine_types",
  "tari_indexer_client",
@@ -11893,7 +12027,7 @@ dependencies = [
  "axum 0.8.8",
  "axum-extra",
  "axum-jrpc",
- "blake2",
+ "blake2 0.10.6",
  "clap 3.2.25",
  "config",
  "dirs-next 2.0.0",
@@ -11910,7 +12044,7 @@ dependencies = [
  "mime_guess",
  "notify",
  "ootle_byte_type",
- "rand 0.8.6",
+ "rand 0.10.1",
  "reqwest 0.13.2",
  "serde",
  "serde_json",
@@ -11975,8 +12109,8 @@ dependencies = [
 
 [[package]]
 name = "tari_p2p"
-version = "5.3.0-rc.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.3.0-rc.0#55942473fd6654f654d69255a90da9be69a67523"
+version = "5.3.1-pre.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0#1f94bc8fdc909072a295ece3ace0f98bf1b2c3cc"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -11985,7 +12119,7 @@ dependencies = [
  "log",
  "pgp",
  "prost 0.13.5",
- "rand 0.8.6",
+ "rand 0.10.1",
  "reqwest 0.12.28",
  "semver",
  "serde",
@@ -12014,7 +12148,7 @@ dependencies = [
  "libp2p-substream",
  "log",
  "once_cell",
- "pin-project 1.1.10",
+ "pin-project 1.1.12",
  "prost 0.14.3",
  "proto_builder",
  "tari_metrics",
@@ -12032,7 +12166,7 @@ version = "0.30.3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -12056,10 +12190,10 @@ dependencies = [
 
 [[package]]
 name = "tari_script"
-version = "5.3.0-rc.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.3.0-rc.0#55942473fd6654f654d69255a90da9be69a67523"
+version = "5.3.1-pre.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0#1f94bc8fdc909072a295ece3ace0f98bf1b2c3cc"
 dependencies = [
- "blake2",
+ "blake2 0.10.6",
  "borsh",
  "digest 0.10.7",
  "integer-encoding",
@@ -12074,8 +12208,8 @@ dependencies = [
 
 [[package]]
 name = "tari_service_framework"
-version = "5.3.0-rc.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.3.0-rc.0#55942473fd6654f654d69255a90da9be69a67523"
+version = "5.3.1-pre.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0#1f94bc8fdc909072a295ece3ace0f98bf1b2c3cc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12089,16 +12223,16 @@ dependencies = [
 
 [[package]]
 name = "tari_shutdown"
-version = "5.3.0-rc.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.3.0-rc.0#55942473fd6654f654d69255a90da9be69a67523"
+version = "5.3.1-pre.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0#1f94bc8fdc909072a295ece3ace0f98bf1b2c3cc"
 dependencies = [
  "futures 0.3.31",
 ]
 
 [[package]]
 name = "tari_sidechain"
-version = "5.3.0-rc.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.3.0-rc.0#55942473fd6654f654d69255a90da9be69a67523"
+version = "5.3.1-pre.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0#1f94bc8fdc909072a295ece3ace0f98bf1b2c3cc"
 dependencies = [
  "borsh",
  "hex",
@@ -12106,7 +12240,7 @@ dependencies = [
  "serde",
  "tari_common_types",
  "tari_crypto",
- "tari_hashing 5.3.0-rc.0 (git+https://github.com/tari-project/tari.git?tag=v5.3.0-rc.0)",
+ "tari_hashing 5.3.1-pre.0 (git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0)",
  "tari_jellyfish",
  "tari_utilities",
  "thiserror 2.0.18",
@@ -12122,7 +12256,7 @@ dependencies = [
  "hex",
  "indexmap 2.13.0",
  "log",
- "rand 0.8.6",
+ "rand 0.10.1",
  "rocksdb",
  "serde",
  "smallvec 2.0.0-alpha.12",
@@ -12160,8 +12294,8 @@ dependencies = [
 
 [[package]]
 name = "tari_storage"
-version = "5.3.0-rc.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.3.0-rc.0#55942473fd6654f654d69255a90da9be69a67523"
+version = "5.3.1-pre.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0#1f94bc8fdc909072a295ece3ace0f98bf1b2c3cc"
 dependencies = [
  "bincode 1.3.3",
  "lmdb-zero",
@@ -12287,7 +12421,7 @@ dependencies = [
  "indoc",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
  "tari_bor",
  "tari_template_abi",
 ]
@@ -12299,7 +12433,7 @@ dependencies = [
  "anyhow",
  "cargo_toml 0.22.3",
  "ootle_byte_type",
- "rand 0.8.6",
+ "rand 0.10.1",
  "serde",
  "tari_bor",
  "tari_crypto",
@@ -12316,11 +12450,11 @@ dependencies = [
 
 [[package]]
 name = "tari_test_utils"
-version = "5.3.0-rc.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.3.0-rc.0#55942473fd6654f654d69255a90da9be69a67523"
+version = "5.3.1-pre.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0#1f94bc8fdc909072a295ece3ace0f98bf1b2c3cc"
 dependencies = [
  "futures 0.3.31",
- "rand 0.8.6",
+ "rand 0.10.1",
  "tari_shutdown",
  "tempfile",
  "tokio",
@@ -12328,13 +12462,13 @@ dependencies = [
 
 [[package]]
 name = "tari_transaction_components"
-version = "5.3.0-rc.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.3.0-rc.0#55942473fd6654f654d69255a90da9be69a67523"
+version = "5.3.1-pre.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0#1f94bc8fdc909072a295ece3ace0f98bf1b2c3cc"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
  "bitflags 2.10.0",
- "blake2",
+ "blake2 0.10.6",
  "borsh",
  "bytes",
  "chacha20poly1305",
@@ -12351,7 +12485,7 @@ dependencies = [
  "num-format",
  "num-traits",
  "primitive-types",
- "rand 0.8.6",
+ "rand 0.10.1",
  "semver",
  "serde",
  "serde_json",
@@ -12361,7 +12495,7 @@ dependencies = [
  "tari_common",
  "tari_common_types",
  "tari_crypto",
- "tari_hashing 5.3.0-rc.0 (git+https://github.com/tari-project/tari.git?tag=v5.3.0-rc.0)",
+ "tari_hashing 5.3.1-pre.0 (git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0)",
  "tari_max_size",
  "tari_script",
  "tari_sidechain",
@@ -12374,11 +12508,11 @@ dependencies = [
 
 [[package]]
 name = "tari_transaction_key_manager"
-version = "5.3.0-rc.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.3.0-rc.0#55942473fd6654f654d69255a90da9be69a67523"
+version = "5.3.1-pre.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0#1f94bc8fdc909072a295ece3ace0f98bf1b2c3cc"
 dependencies = [
  "async-trait",
- "blake2",
+ "blake2 0.10.6",
  "chacha20poly1305",
  "chrono",
  "derivative",
@@ -12388,14 +12522,14 @@ dependencies = [
  "futures 0.3.31",
  "log",
  "minotari_ledger_wallet_common",
- "rand 0.8.6",
+ "rand 0.10.1",
  "serde",
  "strum 0.22.0",
  "strum_macros 0.22.0",
  "tari_common_sqlite",
  "tari_common_types",
  "tari_crypto",
- "tari_hashing 5.3.0-rc.0 (git+https://github.com/tari-project/tari.git?tag=v5.3.0-rc.0)",
+ "tari_hashing 5.3.1-pre.0 (git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0)",
  "tari_script",
  "tari_service_framework",
  "tari_transaction_components",
@@ -12411,7 +12545,7 @@ version = "0.30.3"
 dependencies = [
  "proc-macro2",
  "serde_json",
- "syn 2.0.114",
+ "syn 2.0.117",
  "tari_bor",
  "tari_engine_types",
  "tari_ootle_template_metadata",
@@ -12423,9 +12557,9 @@ dependencies = [
 
 [[package]]
 name = "tari_utilities"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "539470532a8ca1a8a1aa26f6240586f7d0f7d90ab94ae67f092bcd75a1bb4060"
+checksum = "59020053bb363474087e5b170acbf0e1a848b1af5736e058a0332ce69b6dbf9e"
 dependencies = [
  "base58-monero",
  "base64 0.13.1",
@@ -12464,7 +12598,7 @@ dependencies = [
  "mini-moka",
  "ootle_byte_type",
  "prometheus-client",
- "rand 0.8.6",
+ "rand 0.10.1",
  "serde",
  "serde_json",
  "serde_json5",
@@ -12650,7 +12784,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12718,7 +12852,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -12729,7 +12863,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -12854,17 +12988,17 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.49.0"
+version = "1.52.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
 dependencies = [
  "bytes",
  "libc",
- "mio 1.1.1",
+ "mio 1.2.0",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.1",
+ "socket2 0.6.3",
  "tokio-macros",
  "tracing",
  "windows-sys 0.61.2",
@@ -12872,13 +13006,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -13074,7 +13208,7 @@ dependencies = [
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
- "pin-project 1.1.10",
+ "pin-project 1.1.12",
  "prost 0.13.5",
  "socket2 0.5.10",
  "tokio",
@@ -13103,7 +13237,7 @@ dependencies = [
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
- "pin-project 1.1.10",
+ "pin-project 1.1.12",
  "prost 0.13.5",
  "rustls-native-certs",
  "socket2 0.5.10",
@@ -13127,7 +13261,7 @@ dependencies = [
  "prost-build 0.13.5",
  "prost-types 0.13.5",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -13153,7 +13287,7 @@ dependencies = [
  "futures-util",
  "hdrhistogram",
  "indexmap 1.9.3",
- "pin-project 1.1.10",
+ "pin-project 1.1.12",
  "pin-project-lite",
  "rand 0.8.6",
  "slab",
@@ -13255,7 +13389,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -13306,7 +13440,7 @@ dependencies = [
  "csv",
  "env_logger",
  "log",
- "rand 0.8.6",
+ "rand 0.10.1",
  "reqwest 0.13.2",
  "serde",
  "serde_json",
@@ -13329,7 +13463,7 @@ dependencies = [
  "clap 4.5.54",
  "once_cell",
  "ootle_byte_type",
- "rand 0.8.6",
+ "rand 0.10.1",
  "rayon",
  "tari_crypto",
  "tari_ootle_common_types",
@@ -13383,7 +13517,7 @@ checksum = "ee6ff59666c9cbaec3533964505d39154dc4e0a56151fdea30a09ed0301f62e2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
  "termcolor",
 ]
 
@@ -13470,7 +13604,7 @@ checksum = "29a3151c41d0b13e3d011f98adc24434560ef06673a155a6c7f66b9879eecce2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -13648,7 +13782,7 @@ checksum = "6d79d08d92ab8af4c5e8a6da20c47ae3f61a0f1dabc1997cdf2d082b757ca08b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -13812,7 +13946,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -13999,7 +14133,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -14422,7 +14556,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -14433,22 +14567,12 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efc5cf48f83140dcaab716eeaea345f9e93d0018fb81162753a3f76c3397b538"
-dependencies = [
- "windows-core 0.53.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
  "windows-collections",
- "windows-core 0.62.2",
+ "windows-core",
  "windows-future",
  "windows-numerics",
 ]
@@ -14459,17 +14583,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-core 0.62.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcc5b895a6377f1ab9fa55acedab1fd5ac0db66ad1e6c7f47e28a22e446a5dd"
-dependencies = [
- "windows-result 0.1.2",
- "windows-targets 0.52.6",
+ "windows-core",
 ]
 
 [[package]]
@@ -14481,7 +14595,7 @@ dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-link",
- "windows-result 0.4.1",
+ "windows-result",
  "windows-strings",
 ]
 
@@ -14491,7 +14605,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "windows-core 0.62.2",
+ "windows-core",
  "windows-link",
  "windows-threading",
 ]
@@ -14504,7 +14618,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -14515,7 +14629,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -14530,7 +14644,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-core 0.62.2",
+ "windows-core",
  "windows-link",
 ]
 
@@ -14541,17 +14655,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
  "windows-link",
- "windows-result 0.4.1",
+ "windows-result",
  "windows-strings",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
-dependencies = [
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -14939,7 +15044,7 @@ dependencies = [
  "heck 0.5.0",
  "indexmap 2.13.0",
  "prettyplease 0.2.37",
- "syn 2.0.114",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -14955,7 +15060,7 @@ dependencies = [
  "prettyplease 0.2.37",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -15018,7 +15123,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
 dependencies = [
- "curve25519-dalek",
+ "curve25519-dalek 4.1.3",
  "rand_core 0.6.4",
  "serde",
  "zeroize",
@@ -15111,7 +15216,7 @@ dependencies = [
  "log",
  "nohash-hasher",
  "parking_lot",
- "pin-project 1.1.10",
+ "pin-project 1.1.12",
  "rand 0.8.6",
  "static_assertions",
 ]
@@ -15126,7 +15231,7 @@ dependencies = [
  "log",
  "nohash-hasher",
  "parking_lot",
- "pin-project 1.1.10",
+ "pin-project 1.1.12",
  "rand 0.9.4",
  "static_assertions",
  "web-time",
@@ -15160,7 +15265,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -15181,7 +15286,7 @@ checksum = "2c7962b26b0a8685668b671ee4b54d007a67d4eaf05fda79ac0ecf41e32270f1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -15201,7 +15306,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -15223,7 +15328,7 @@ checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -15256,7 +15361,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11915,7 +11915,6 @@ name = "tari_ootle_wallet_sdk"
 version = "0.30.3"
 dependencies = [
  "anyhow",
- "digest 0.10.7",
  "futures 0.3.31",
  "keyring",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,33 +139,33 @@ ootle_byte_type = { path = "crates/ootle_byte_type", version = "0.6" }
 ootle_serde = { path = "crates/ootle_serde", version = "0.2" }
 
 # external minotari/tari dependencies
-minotari_app_grpc = { git = "https://github.com/tari-project/tari.git", tag = "v5.3.0-rc.0" }
-minotari_app_utilities = { git = "https://github.com/tari-project/tari.git", tag = "v5.3.0-rc.0" }
-minotari_node_grpc_client = { git = "https://github.com/tari-project/tari.git", tag = "v5.3.0-rc.0" }
-minotari_wallet_grpc_client = { git = "https://github.com/tari-project/tari.git", tag = "v5.3.0-rc.0" }
-tari_common = { git = "https://github.com/tari-project/tari.git", tag = "v5.3.0-rc.0", version = "5.3.0-rc.0" }
-tari_common_sqlite = { git = "https://github.com/tari-project/tari.git", tag = "v5.3.0-rc.0", version = "5.3.0-rc.0" }
-tari_common_types = { git = "https://github.com/tari-project/tari.git", tag = "v5.3.0-rc.0", version = "5.3.0-rc.0" }
-tari_jellyfish = { git = "https://github.com/tari-project/tari.git", tag = "v5.3.0-rc.0", version = "5.3.0-rc.0" }
-tari_metrics = { git = "https://github.com/tari-project/tari.git", tag = "v5.3.0-rc.0" }
-tari_mmr = { git = "https://github.com/tari-project/tari.git", tag = "v5.3.0-rc.0", version = "5.3.0-rc.0" }
-tari_node_components = { git = "https://github.com/tari-project/tari.git", tag = "v5.3.0-rc.0" }
-tari_shutdown = { git = "https://github.com/tari-project/tari.git", tag = "v5.3.0-rc.0" }
-tari_sidechain = { git = "https://github.com/tari-project/tari.git", tag = "v5.3.0-rc.0", version = "5.3.0-rc.0" }
-tari_transaction_components = { git = "https://github.com/tari-project/tari.git", tag = "v5.3.0-rc.0" }
-minotari_console_wallet = { git = "https://github.com/tari-project/tari.git", tag = "v5.3.0-rc.0" }
-minotari_node = { git = "https://github.com/tari-project/tari.git", tag = "v5.3.0-rc.0" }
-minotari_wallet = { git = "https://github.com/tari-project/tari.git", tag = "v5.3.0-rc.0" }
-tari_comms = { git = "https://github.com/tari-project/tari.git", tag = "v5.3.0-rc.0" }
-tari_comms_dht = { git = "https://github.com/tari-project/tari.git", tag = "v5.3.0-rc.0" }
-tari_p2p = { git = "https://github.com/tari-project/tari.git", tag = "v5.3.0-rc.0" }
+minotari_app_grpc = { git = "https://github.com/tari-project/tari.git", tag = "v5.3.1-pre.0" }
+minotari_app_utilities = { git = "https://github.com/tari-project/tari.git", tag = "v5.3.1-pre.0" }
+minotari_node_grpc_client = { git = "https://github.com/tari-project/tari.git", tag = "v5.3.1-pre.0" }
+minotari_wallet_grpc_client = { git = "https://github.com/tari-project/tari.git", tag = "v5.3.1-pre.0" }
+tari_common = { git = "https://github.com/tari-project/tari.git", tag = "v5.3.1-pre.0", version = "5.3.1-pre.0" }
+tari_common_sqlite = { git = "https://github.com/tari-project/tari.git", tag = "v5.3.1-pre.0", version = "5.3.1-pre.0" }
+tari_common_types = { git = "https://github.com/tari-project/tari.git", tag = "v5.3.1-pre.0", version = "5.3.1-pre.0" }
+tari_jellyfish = { git = "https://github.com/tari-project/tari.git", tag = "v5.3.1-pre.0", version = "5.3.1-pre.0" }
+tari_metrics = { git = "https://github.com/tari-project/tari.git", tag = "v5.3.1-pre.0" }
+tari_mmr = { git = "https://github.com/tari-project/tari.git", tag = "v5.3.1-pre.0", version = "5.3.1-pre.0" }
+tari_node_components = { git = "https://github.com/tari-project/tari.git", tag = "v5.3.1-pre.0" }
+tari_shutdown = { git = "https://github.com/tari-project/tari.git", tag = "v5.3.1-pre.0" }
+tari_sidechain = { git = "https://github.com/tari-project/tari.git", tag = "v5.3.1-pre.0", version = "5.3.1-pre.0" }
+tari_transaction_components = { git = "https://github.com/tari-project/tari.git", tag = "v5.3.1-pre.0" }
+minotari_console_wallet = { git = "https://github.com/tari-project/tari.git", tag = "v5.3.1-pre.0" }
+minotari_node = { git = "https://github.com/tari-project/tari.git", tag = "v5.3.1-pre.0" }
+minotari_wallet = { git = "https://github.com/tari-project/tari.git", tag = "v5.3.1-pre.0" }
+tari_comms = { git = "https://github.com/tari-project/tari.git", tag = "v5.3.1-pre.0" }
+tari_comms_dht = { git = "https://github.com/tari-project/tari.git", tag = "v5.3.1-pre.0" }
+tari_p2p = { git = "https://github.com/tari-project/tari.git", tag = "v5.3.1-pre.0" }
 
-tari_crypto = "0.22"
-tari_utilities = "0.8"
-tari_hashing = "5.3.0-rc.0"
+tari_crypto = "0.23"
+tari_utilities = "0.10"
+tari_hashing = "5.3.1-pre.0"
 
 ## Ledger
-minotari_ledger_wallet_common = { git = "https://github.com/tari-project/tari.git", tag = "v5.3.0-rc.0" }
+minotari_ledger_wallet_common = { git = "https://github.com/tari-project/tari.git", tag = "v5.3.1-pre.0" }
 ootle_ledger_common = { path = "crates/wallet/ledger/common", version = "0.1.0" }
 
 # networking crates
@@ -222,9 +222,9 @@ indexmap = "2.11.4"
 indoc = "1.0.6"
 lazy_static = "1.4.0"
 # Use Tari's libp2p fork that adds support for Schnorr-Ristretto
-libp2p-identity = { git = "https://github.com/tari-project/rust-libp2p.git", rev = "470c41380d6c5140b52ef65becf4f643e4769e66" }
-libp2p = { git = "https://github.com/tari-project/rust-libp2p.git", rev = "470c41380d6c5140b52ef65becf4f643e4769e66", version = "0.56.0", default-features = false }
-libp2p-peer-store = { git = "https://github.com/tari-project/rust-libp2p.git", rev = "470c41380d6c5140b52ef65becf4f643e4769e66", version = "0.1.0", default-features = false }
+libp2p-identity = { git = "https://github.com/tari-project/rust-libp2p.git", rev = "76f31bc0ab4bd9f9f5383be6aa3fed873538e35a" }
+libp2p = { git = "https://github.com/tari-project/rust-libp2p.git", rev = "76f31bc0ab4bd9f9f5383be6aa3fed873538e35a", default-features = false }
+libp2p-peer-store = { git = "https://github.com/tari-project/rust-libp2p.git", rev = "76f31bc0ab4bd9f9f5383be6aa3fed873538e35a", default-features = false }
 #libp2p = "0.53.1"
 #libp2p-identity = "0.2.8"
 libsqlite3-sys = "0.30.1"
@@ -232,7 +232,7 @@ log = "0.4.20"
 log4rs = "1.3"
 mime_guess = "2.0.4"
 mini-moka = "0.10.0"
-multiaddr = { git = "https://github.com/tari-project/rust-libp2p.git", rev = "470c41380d6c5140b52ef65becf4f643e4769e66" }
+multiaddr = { git = "https://github.com/tari-project/rust-libp2p.git", rev = "76f31bc0ab4bd9f9f5383be6aa3fed873538e35a" }
 #multiaddr = "0.18"
 newtype-ops = "0.1.4"
 num-integer = { version = "0.1.46", default-features = false }
@@ -246,7 +246,7 @@ prost-types = "0.14"
 quick-protobuf = "0.8"
 quick-protobuf-codec = "0.3.1"
 quote = "1.0.7"
-rand = "0.8.5"
+rand = "0.10.1"
 rayon = "1.7.0"
 reqwest = "0.13.2"
 rocksdb = "0.24.0"

--- a/applications/tari_ootle_app_utilities/src/keypair.rs
+++ b/applications/tari_ootle_app_utilities/src/keypair.rs
@@ -42,7 +42,7 @@
 use std::{fs, io, path::Path, sync::Arc};
 
 use log::*;
-use rand::{CryptoRng, RngCore, rngs::OsRng};
+use rand::{CryptoRng, Rng};
 use serde::{Serialize, de::DeserializeOwned};
 use tari_common::{
     configuration::bootstrap::prompt,
@@ -63,7 +63,7 @@ const LOG_TARGET: &str = "tari::identity";
 pub struct RistrettoKeypair(Arc<KeyPairInner>);
 
 impl RistrettoKeypair {
-    pub fn random<R: RngCore + CryptoRng>(rng: &mut R) -> Self {
+    pub fn random<R: Rng + CryptoRng>(rng: &mut R) -> Self {
         let secret_key = RistrettoSecretKey::random(rng);
         Self::from_secret_key(secret_key)
     }
@@ -202,7 +202,7 @@ fn load_keypair<P: AsRef<Path>>(path: P) -> Result<RistrettoKeypair, IdentityErr
 /// ## Returns
 /// Result containing the node identity, string will indicate reason on error
 pub fn create_new_keypair<P: AsRef<Path>>(path: P) -> Result<RistrettoKeypair, IdentityError> {
-    let node_identity = RistrettoKeypair::random(&mut OsRng);
+    let node_identity = RistrettoKeypair::random(&mut rand::rng());
     save_as_json(&path, &node_identity)?;
     Ok(node_identity)
 }

--- a/applications/tari_validator_node/src/consensus/signer_service.rs
+++ b/applications/tari_validator_node/src/consensus/signer_service.rs
@@ -20,7 +20,12 @@ impl TariSignatureService {
 
 impl ValidatorSignerService for TariSignatureService {
     fn sign<M: ToSignatureMessage>(&self, message: &M) -> ValidatorSchnorrSignature {
-        ValidatorSchnorrSignature::sign(self.keypair.secret_key(), message.to_signature_message(), &mut rand::rng()).unwrap()
+        ValidatorSchnorrSignature::sign(
+            self.keypair.secret_key(),
+            message.to_signature_message(),
+            &mut rand::rng(),
+        )
+        .unwrap()
     }
 
     fn public_key(&self) -> &RistrettoPublicKey {

--- a/applications/tari_validator_node/src/consensus/signer_service.rs
+++ b/applications/tari_validator_node/src/consensus/signer_service.rs
@@ -2,7 +2,6 @@
 //    SPDX-License-Identifier: BSD-3-Clause
 
 use ootle_byte_type::ConvertFromByteType;
-use rand::rngs::OsRng;
 use tari_consensus::traits::{ValidatorSignatureVerifierService, ValidatorSignerService};
 use tari_consensus_types::{SignedMessage, ToSignatureMessage, ValidatorSchnorrSignature};
 use tari_crypto::ristretto::RistrettoPublicKey;
@@ -21,7 +20,7 @@ impl TariSignatureService {
 
 impl ValidatorSignerService for TariSignatureService {
     fn sign<M: ToSignatureMessage>(&self, message: &M) -> ValidatorSchnorrSignature {
-        ValidatorSchnorrSignature::sign(self.keypair.secret_key(), message.to_signature_message(), &mut OsRng).unwrap()
+        ValidatorSchnorrSignature::sign(self.keypair.secret_key(), message.to_signature_message(), &mut rand::rng()).unwrap()
     }
 
     fn public_key(&self) -> &RistrettoPublicKey {

--- a/applications/tari_validator_node/src/file_l1_submitter.rs
+++ b/applications/tari_validator_node/src/file_l1_submitter.rs
@@ -4,7 +4,7 @@
 use std::{io, path::PathBuf};
 
 use log::*;
-use rand::{RngCore, rngs::OsRng};
+use rand::Rng;
 use serde::Serialize;
 use tari_epoch_manager::traits::LayerOneTransactionSubmitter;
 use tari_ootle_common_types::layer_one_transaction::LayerOneTransactionDef;
@@ -32,7 +32,7 @@ impl LayerOneTransactionSubmitter for FileLayerOneSubmitter {
         transaction: LayerOneTransactionDef<T>,
     ) -> Result<Self::Output, Self::Error> {
         fs::create_dir_all(&self.path).await?;
-        let id = OsRng.next_u64();
+        let id = rand::rng().next_u64();
         let file_name = format!("{}-{}.json", transaction.payload_type, id);
         let path = self.path.join(file_name);
         info!(target: LOG_TARGET, "Saving layer transaction to {}", path.display());

--- a/applications/tari_walletd/src/handlers/accounts.rs
+++ b/applications/tari_walletd/src/handlers/accounts.rs
@@ -8,7 +8,6 @@ use axum_extra::headers::authorization::Bearer;
 use indexmap::{IndexMap, IndexSet};
 use log::*;
 use ootle_byte_type::{FromByteType, ToByteType};
-use rand::rngs::OsRng;
 use tari_crypto::{keys::PublicKey as _, ristretto::RistrettoPublicKey};
 use tari_engine_types::{
     commit_result::RejectReason,
@@ -542,7 +541,7 @@ pub(crate) async fn execute_claim_burn(
         return Err(invalid_params("max_fee", Some("fee equals or exceeds claimed amount")));
     }
 
-    let (nonce, output_public_nonce) = RistrettoPublicKey::random_keypair(&mut OsRng);
+    let (nonce, output_public_nonce) = RistrettoPublicKey::random_keypair(&mut rand::rng());
     let account_owner = sdk.key_manager_api().get_public_key(account_owner_key_id)?;
     let view_only = sdk.key_manager_api().get_public_key(account.view_only_key_id())?;
     let memo = Memo::new_message("Burnt funds claimed from L1").expect("valid memo");

--- a/applications/tari_walletd/src/handlers/confidential.rs
+++ b/applications/tari_walletd/src/handlers/confidential.rs
@@ -8,7 +8,6 @@ use axum_extra::headers::authorization::Bearer;
 use axum_jrpc::error::{JsonRpcError, JsonRpcErrorReason};
 use log::*;
 use ootle_byte_type::ToByteType;
-use rand::rngs::OsRng;
 use serde_json::json;
 use tari_crypto::{commitment::HomomorphicCommitmentFactory, keys::PublicKey as _, ristretto::RistrettoPublicKey};
 use tari_engine_types::crypto::{ValueLookupTable, get_commitment_factory};
@@ -89,7 +88,7 @@ pub async fn handle_create_transfer_proof(
     // TODO: Wrap up key/encrypted data handling in the wallet SDK
     let account_key = sdk.key_manager_api().get_key(account_owner_key_id)?;
     let output_mask = sdk.key_manager_api().next_key(KeyBranch::ConfidentialMask)?;
-    let (_, public_nonce) = RistrettoPublicKey::random_keypair(&mut OsRng);
+    let (_, public_nonce) = RistrettoPublicKey::random_keypair(&mut rand::rng());
 
     let confidential_amount = req.confidential_amount.to_u64_checked().ok_or_else(|| {
         invalid_request(format!(
@@ -139,7 +138,7 @@ pub async fn handle_create_transfer_proof(
 
     let maybe_change_statement = if change_amount_u64 > 0 {
         let change_mask = sdk.key_manager_api().next_key(KeyBranch::ConfidentialMask)?;
-        let (_, public_nonce) = RistrettoPublicKey::random_keypair(&mut OsRng);
+        let (_, public_nonce) = RistrettoPublicKey::random_keypair(&mut rand::rng());
 
         let encrypted_data = sdk.confidential_crypto_api().encrypt_value_and_mask(
             change_amount_u64,
@@ -271,7 +270,7 @@ pub async fn handle_create_output_proof(
     context.check_auth(token, &[JrpcPermission::Admin])?;
 
     let output_mask = sdk.key_manager_api().next_key(KeyBranch::ConfidentialMask)?;
-    let (_, public_nonce) = RistrettoPublicKey::random_keypair(&mut OsRng);
+    let (_, public_nonce) = RistrettoPublicKey::random_keypair(&mut rand::rng());
     let encrypted_data = sdk.confidential_crypto_api().encrypt_value_and_mask(
         req.amount,
         &output_mask.key,

--- a/applications/tari_walletd/src/handlers/templates.rs
+++ b/applications/tari_walletd/src/handlers/templates.rs
@@ -4,7 +4,6 @@
 use axum_extra::headers::authorization::Bearer;
 use blake2::{Blake2b512, Digest};
 use ootle_byte_type::ToByteType;
-use rand::rngs::OsRng;
 use tari_crypto::{
     keys::PublicKey as _,
     ristretto::{RistrettoPublicKey, RistrettoSchnorr},
@@ -92,7 +91,7 @@ pub async fn handle_sign_metadata(
     let metadata_hash = req.metadata.hash()?;
 
     // Generate random nonce keypair
-    let (nonce_secret, nonce_public) = RistrettoPublicKey::random_keypair(&mut OsRng);
+    let (nonce_secret, nonce_public) = RistrettoPublicKey::random_keypair(&mut rand::rng());
 
     // Compute Blake2b-512 challenge
     let challenge = Blake2b512::new()

--- a/applications/tari_walletd/src/lib.rs
+++ b/applications/tari_walletd/src/lib.rs
@@ -29,7 +29,6 @@ mod webrtc;
 
 use std::{fs, panic, pin, process};
 
-use jsonwebtoken::signature::rand_core::OsRng;
 use log::*;
 use tari_common_types::seeds::seed_words::SeedWords;
 use tari_crypto::{keys::SecretKey, ristretto::RistrettoSecretKey};
@@ -229,7 +228,7 @@ const fn get_epoch_birthday(network: Network) -> EpochBirthday {
 }
 
 fn create_secret_password() -> SafePassword {
-    let secret = RistrettoSecretKey::random(&mut OsRng);
+    let secret = RistrettoSecretKey::random(&mut rand::rng());
     // It is safe to use to_hex() since the String's underlying Vec is moved directly into SafePassword
     SafePassword::from(secret.to_hex())
 }

--- a/crates/common_types/src/committee.rs
+++ b/crates/common_types/src/committee.rs
@@ -3,7 +3,7 @@
 
 use std::{cmp, fmt::Display, ops::RangeInclusive};
 
-use rand::{rngs::OsRng, seq::SliceRandom};
+use rand::seq::{IndexedRandom, SliceRandom};
 use serde::{Deserialize, Serialize};
 use tari_engine_types::substate::SubstateId;
 use tari_template_lib_types::crypto::RistrettoPublicKeyBytes;
@@ -111,17 +111,15 @@ impl<TAddr: PartialEq> Committee<TAddr> {
     }
 
     pub fn shuffle(&mut self) {
-        self.members.shuffle(&mut OsRng);
+        self.members.shuffle(&mut rand::rng());
     }
 
     pub fn shuffled(&self) -> impl Iterator<Item = &CommitteeMember<TAddr>> + '_ {
-        self.members.choose_multiple(&mut OsRng, self.len())
+        self.members.sample(&mut rand::rng(), self.len())
     }
 
     pub fn select_n_random(&self, n: usize) -> impl Iterator<Item = &TAddr> + '_ {
-        self.members
-            .choose_multiple(&mut OsRng, n)
-            .map(|member| &member.address)
+        self.members.sample(&mut rand::rng(), n).map(|member| &member.address)
     }
 
     pub fn index_of(&self, member: &TAddr) -> Option<usize> {

--- a/crates/common_types/src/crypto.rs
+++ b/crates/common_types/src/crypto.rs
@@ -1,14 +1,13 @@
 //   Copyright 2023 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use rand::rngs::OsRng;
 use tari_crypto::{
     keys::{PublicKey as PublicKeyT, SecretKey},
     ristretto::{RistrettoPublicKey, RistrettoSecretKey},
 };
 
 pub fn create_key_pair() -> (RistrettoSecretKey, RistrettoPublicKey) {
-    RistrettoPublicKey::random_keypair(&mut OsRng)
+    RistrettoPublicKey::random_keypair(&mut rand::rng())
 }
 
 pub fn create_key_pair_from_seed(seed: u8) -> (RistrettoSecretKey, RistrettoPublicKey) {

--- a/crates/common_types/src/engine_signature.rs
+++ b/crates/common_types/src/engine_signature.rs
@@ -81,7 +81,6 @@ impl Verifier for RistrettoSchnorrBlake2bVerifier {
 
 #[cfg(test)]
 mod tests {
-    use rand::rngs::OsRng;
     use tari_crypto::{
         keys::PublicKey as _,
         ristretto::{RistrettoPublicKey, RistrettoSchnorr},
@@ -91,12 +90,13 @@ mod tests {
 
     #[test]
     fn it_verifies_a_valid_signature() {
-        let (secret_key, public_key) = RistrettoPublicKey::random_keypair(&mut OsRng);
+        let mut rng = rand::rng();
+        let (secret_key, public_key) = RistrettoPublicKey::random_keypair(&mut rng);
 
         let message = b"Hello, world!";
         let domain = b"Test domain";
 
-        let (nonce, public_nonce) = RistrettoPublicKey::random_keypair(&mut OsRng);
+        let (nonce, public_nonce) = RistrettoPublicKey::random_keypair(&mut rng);
 
         let hashed_message = RistrettoSchnorrBlake2bVerifier::compute_challenge(
             domain,

--- a/crates/common_types/src/fee_pool.rs
+++ b/crates/common_types/src/fee_pool.rs
@@ -21,7 +21,6 @@ pub fn derive_fee_pool_address(
 #[cfg(test)]
 mod tests {
     use ootle_byte_type::ToByteType;
-    use rand::rngs::OsRng;
     use tari_crypto::{keys::PublicKey, ristretto::RistrettoPublicKey};
 
     use super::*;
@@ -37,7 +36,7 @@ mod tests {
 
         assert_eq!(shard, Shard::from(1));
 
-        let (_, pk) = RistrettoPublicKey::random_keypair(&mut OsRng);
+        let (_, pk) = RistrettoPublicKey::random_keypair(&mut rand::rng());
         let fee_pool_address = derive_fee_pool_address(&pk.to_byte_type(), num_preshards, Shard::from(212));
         let addr = SubstateAddress::from_substate_id(&fee_pool_address.into(), 0);
         let shard = addr.to_shard(num_preshards);

--- a/crates/common_types/src/substate_address.rs
+++ b/crates/common_types/src/substate_address.rs
@@ -286,14 +286,14 @@ mod tests {
         ops::{Bound, RangeBounds, RangeInclusive},
     };
 
-    use rand::{RngCore, rngs::OsRng};
+    use rand::Rng;
 
     use super::*;
 
     #[test]
     fn substate_addresses_to_from_u256_endianness_matches() {
         let mut buf = [0u8; SubstateAddress::LENGTH];
-        OsRng.fill_bytes(&mut buf[..ObjectKey::LENGTH]);
+        rand::rng().fill_bytes(&mut buf[..ObjectKey::LENGTH]);
         let s = SubstateAddress(buf);
         let result = SubstateAddress::from_u256_zero_version(s.to_u256());
         assert_eq!(result, s);

--- a/crates/consensus_tests/src/support/epoch_manager.rs
+++ b/crates/consensus_tests/src/support/epoch_manager.rs
@@ -380,7 +380,7 @@ impl EpochManagerReader for TestEpochManager {
             None => state
                 .validator_nodes
                 .values()
-                .choose(&mut rand::thread_rng())
+                .choose(&mut rand::rng())
                 .map(|(vn, _)| vn)
                 .expect("No committees?"),
         };

--- a/crates/consensus_tests/src/support/helpers.rs
+++ b/crates/consensus_tests/src/support/helpers.rs
@@ -3,7 +3,7 @@
 
 use std::ops::RangeInclusive;
 
-use rand::{Rng, RngCore, rngs::OsRng};
+use rand::{Rng, RngExt};
 use tari_common_types::types::PrivateKey;
 use tari_crypto::{
     keys::{PublicKey, SecretKey},
@@ -24,7 +24,7 @@ pub(crate) fn random_substate_in_shard_group(shard_group: ShardGroup, num_shards
     let entity_id = EntityId::new(copy_fixed(
         &random_in_range.to_u256().to_be_bytes()[0..EntityId::LENGTH],
     ));
-    let rand_bytes = OsRng.r#gen::<[u8; ComponentKey::LENGTH]>();
+    let rand_bytes: [u8; ComponentKey::LENGTH] = rand::rng().random();
     let component_key = ComponentKey::new(copy_fixed(&rand_bytes));
     SubstateId::Component(ComponentAddress::new(ObjectKey::new(entity_id, component_key)))
 }
@@ -33,7 +33,7 @@ pub(crate) fn random_substate_in_shard_group(shard_group: ShardGroup, num_shards
 fn random_substate_address_range(range: RangeInclusive<SubstateAddress>) -> SubstateAddress {
     let start = range.start();
     let mut bytes = [0u8; 16];
-    OsRng.fill_bytes(&mut bytes);
+    rand::rng().fill_bytes(&mut bytes);
     let mut start = start.into_array();
     start[16..32].copy_from_slice(&bytes);
     SubstateAddress::from_bytes(&start).unwrap()

--- a/crates/consensus_tests/src/support/signing_service.rs
+++ b/crates/consensus_tests/src/support/signing_service.rs
@@ -1,7 +1,6 @@
 //   Copyright 2023 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use rand::rngs::OsRng;
 use tari_common_types::types::PrivateKey;
 use tari_consensus::traits::{ValidatorSignatureVerifierService, ValidatorSignerService};
 use tari_consensus_types::{ToSignatureMessage, ValidatorSchnorrSignature};
@@ -24,7 +23,7 @@ impl TestVoteSignatureService {
 
 impl ValidatorSignerService for TestVoteSignatureService {
     fn sign<M: ToSignatureMessage>(&self, message: &M) -> ValidatorSchnorrSignature {
-        ValidatorSchnorrSignature::sign(&self.secret_key, message.to_signature_message(), &mut OsRng).unwrap()
+        ValidatorSchnorrSignature::sign(&self.secret_key, message.to_signature_message(), &mut rand::rng()).unwrap()
     }
 
     fn public_key(&self) -> &RistrettoPublicKey {

--- a/crates/engine/tests/confidential.rs
+++ b/crates/engine/tests/confidential.rs
@@ -3,7 +3,6 @@
 
 use std::collections::BTreeMap;
 
-use rand::rngs::OsRng;
 use tari_crypto::{
     keys::PublicKey as _,
     ristretto::{RistrettoPublicKey, RistrettoSecretKey},
@@ -498,7 +497,7 @@ where
 
 #[test]
 fn mint_with_view_key() {
-    let (view_key_secret, ref view_key) = RistrettoPublicKey::random_keypair(&mut OsRng);
+    let (view_key_secret, ref view_key) = RistrettoPublicKey::random_keypair(&mut rand::rng());
     let (confidential_proof, _mask, _change) = generate_confidential_proof_with_view_key(123, None, view_key);
     let (mut test, faucet, _faucet_resx) = setup(confidential_proof, Some(view_key));
     let faucet_entity_id = faucet.entity_id();

--- a/crates/engine/tests/signature.rs
+++ b/crates/engine/tests/signature.rs
@@ -2,7 +2,6 @@
 //   SPDX-License-Identifier: BSD-3-Clause
 
 use ootle_byte_type::ToByteType;
-use rand::rngs::OsRng;
 use tari_crypto::{
     keys::PublicKey as _,
     ristretto::{RistrettoPublicKey, RistrettoSchnorr, RistrettoSecretKey},
@@ -36,7 +35,7 @@ fn sign_it(secret: &RistrettoSecretKey) -> Signature<NoSignatureDomain> {
 }
 
 fn sign_it_with(secret: &RistrettoSecretKey, message: &[u8]) -> Signature<NoSignatureDomain> {
-    let (nonce, nonce_pub) = RistrettoPublicKey::random_keypair(&mut OsRng);
+    let (nonce, nonce_pub) = RistrettoPublicKey::random_keypair(&mut rand::rng());
     let public_key = RistrettoPublicKey::from_secret_key(secret);
     let challenge = RistrettoSchnorrBlake2bVerifier::compute_challenge(
         TEST_DOMAIN,

--- a/crates/engine/tests/stealth.rs
+++ b/crates/engine/tests/stealth.rs
@@ -4,7 +4,6 @@
 use std::collections::BTreeMap;
 
 use ootle_byte_type::ToByteType;
-use rand::rngs::OsRng;
 use tari_crypto::{
     commitment::HomomorphicCommitmentFactory,
     keys::PublicKey,
@@ -459,7 +458,7 @@ where
 #[test]
 fn mint_with_view_key() {
     let mut test = TemplateTest::new(CRATE_PATH, TEMPLATE_PATHS);
-    let (view_key_secret, view_key) = RistrettoPublicKey::random_keypair(&mut OsRng);
+    let (view_key_secret, view_key) = RistrettoPublicKey::random_keypair(&mut rand::rng());
     let mint = stealth::generate_mint_statement([1000], 0u64, Some(&view_key));
     let (_faucet, faucet_resx) = setup(&mut test, &mint, Some(&view_key));
 

--- a/crates/engine_types/src/crypto/elgamal.rs
+++ b/crates/engine_types/src/crypto/elgamal.rs
@@ -265,8 +265,10 @@ impl ToByteType for ElgamalVerifiableBalance {
 mod tests {
     use std::convert::Infallible;
 
-    use rand::rngs::OsRng;
-    use tari_crypto::keys::SecretKey;
+    use tari_crypto::{
+        keys::{PublicKey, SecretKey},
+        ristretto::{RistrettoPublicKey, RistrettoSecretKey},
+    };
 
     use super::*;
 
@@ -290,18 +292,15 @@ mod tests {
     }
 
     mod brute_force_balance {
-        use tari_crypto::{
-            keys::PublicKey,
-            ristretto::{RistrettoPublicKey, RistrettoSecretKey},
-        };
 
         use super::*;
 
         #[test]
         fn it_finds_the_value() {
             const VALUE: u64 = 5242;
-            let view_sk = &RistrettoSecretKey::random(&mut OsRng);
-            let (nonce_sk, nonce_pk) = RistrettoPublicKey::random_keypair(&mut OsRng);
+            let mut rng = rand::rng();
+            let view_sk = &RistrettoSecretKey::random(&mut rng);
+            let (nonce_sk, nonce_pk) = RistrettoPublicKey::random_keypair(&mut rng);
 
             let rp = nonce_sk * view_sk;
 
@@ -319,8 +318,9 @@ mod tests {
 
         #[test]
         fn it_returns_the_value_equal_to_max_value() {
-            let view_sk = &RistrettoSecretKey::random(&mut OsRng);
-            let (nonce_sk, nonce_pk) = RistrettoPublicKey::random_keypair(&mut OsRng);
+            let mut rng = rand::rng();
+            let view_sk = &RistrettoSecretKey::random(&mut rng);
+            let (nonce_sk, nonce_pk) = RistrettoPublicKey::random_keypair(&mut rng);
 
             let rp = nonce_sk * view_sk;
 
@@ -361,11 +361,12 @@ mod tests {
 
         #[test]
         fn it_brute_forces_a_batch() {
-            let view_sk = &RistrettoSecretKey::random(&mut OsRng);
+            let mut rng = rand::rng();
+            let view_sk = &RistrettoSecretKey::random(&mut rng);
 
             let subject = (0..100)
                 .map(|v| {
-                    let (nonce_sk, nonce_pk) = RistrettoPublicKey::random_keypair(&mut OsRng);
+                    let (nonce_sk, nonce_pk) = RistrettoPublicKey::random_keypair(&mut rng);
                     let rp = nonce_sk * view_sk;
                     ElgamalVerifiableBalance {
                         encrypted: RistrettoPublicKey::from_secret_key(&rp) +

--- a/crates/engine_types/src/indexed_value.rs
+++ b/crates/engine_types/src/indexed_value.rs
@@ -605,7 +605,7 @@ fn get_value_by_path<'a>(value: &'a tari_bor::Value, path: &str) -> Option<&'a t
 mod tests {
     use std::collections::HashMap;
 
-    use rand::{RngCore, rngs::OsRng};
+    use rand::Rng;
     use tari_bor::cbor;
     use tari_template_lib::types::NonFungibleId;
 
@@ -614,7 +614,7 @@ mod tests {
 
     fn new_object_key() -> ObjectKey {
         hasher32(EngineHashDomainLabel::ComponentAddress)
-            .chain(&OsRng.next_u32())
+            .chain(&rand::rng().next_u32())
             .result()
             .trailing_bytes()
             .into()

--- a/crates/engine_types/src/stealth/value_proof.rs
+++ b/crates/engine_types/src/stealth/value_proof.rs
@@ -107,7 +107,6 @@ pub fn validate_value_proof(
 #[cfg(test)]
 mod tests {
     use ootle_byte_type::ToByteType;
-    use rand::rngs::OsRng;
     use tari_crypto::keys::SecretKey;
     use tari_template_lib::types::crypto::{StealthValueProof, ValueKnowledgeProof};
 
@@ -115,14 +114,15 @@ mod tests {
 
     #[test]
     fn it_proves_knowledge_of_the_value() {
-        let mask = RistrettoSecretKey::random(&mut OsRng);
+        let mut rng = rand::rng();
+        let mask = RistrettoSecretKey::random(&mut rng);
         let value = 100_321_123u128.into();
         let commitment = commit_amount(&mask, value).unwrap();
         let commitment_bytes = commitment.to_byte_type();
 
         // Create the proof of knowledge of the value
         let message = messages::value_proof_message(&commitment_bytes, &value);
-        let sig = RistrettoSchnorr::sign(&mask, message, &mut OsRng).unwrap();
+        let sig = RistrettoSchnorr::sign(&mask, message, &mut rng).unwrap();
 
         let proof = StealthValueProof {
             value,
@@ -138,7 +138,8 @@ mod tests {
 
     #[test]
     fn it_fails_if_the_value_differs() {
-        let mask = RistrettoSecretKey::random(&mut OsRng);
+        let mut rng = rand::rng();
+        let mask = RistrettoSecretKey::random(&mut rng);
         let value = 100_321_123u128.into();
         let commitment = commit_amount(&mask, value).unwrap();
         let commitment_bytes = commitment.to_byte_type();
@@ -147,7 +148,7 @@ mod tests {
 
         // Create the proof of knowledge of the value
         let message = messages::value_proof_message(&commitment_bytes, &other_value);
-        let sig = RistrettoSchnorr::sign(&mask, message, &mut OsRng).unwrap();
+        let sig = RistrettoSchnorr::sign(&mask, message, &mut rng).unwrap();
 
         let proof = StealthValueProof {
             value: other_value,

--- a/crates/ootle_wasm/core/src/address.rs
+++ b/crates/ootle_wasm/core/src/address.rs
@@ -1,7 +1,6 @@
 //   Copyright 2026 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use rand::rngs::OsRng;
 use tari_crypto::{
     keys::{PublicKey, SecretKey},
     ristretto::{RistrettoPublicKey, RistrettoSecretKey},
@@ -31,8 +30,8 @@ pub struct OotlePublicKeyResult {
 
 /// Generate a new random pair of Ootle secret keys (owner + view).
 pub fn generate_ootle_secret_key() -> OotleSecretKeyResult {
-    let owner_key = RistrettoSecretKey::random(&mut OsRng);
-    let view_key = RistrettoSecretKey::random(&mut OsRng);
+    let owner_key = RistrettoSecretKey::random(&mut rand::rng());
+    let view_key = RistrettoSecretKey::random(&mut rand::rng());
     OotleSecretKeyResult {
         owner_key: owner_key.as_bytes().to_vec(),
         view_key: view_key.as_bytes().to_vec(),

--- a/crates/ootle_wasm/core/src/hash.rs
+++ b/crates/ootle_wasm/core/src/hash.rs
@@ -42,7 +42,6 @@ pub(crate) fn public_key_bytes_from_bytes(bytes: &[u8]) -> Result<RistrettoPubli
 #[cfg(test)]
 mod tests {
     use ootle_byte_type::ToByteType;
-    use rand::rngs::OsRng;
     use tari_crypto::{
         keys::{PublicKey, SecretKey},
         ristretto::{RistrettoPublicKey, RistrettoSecretKey},
@@ -54,7 +53,7 @@ mod tests {
 
     #[test]
     fn hash_matches_transaction_crate() {
-        let secret = RistrettoSecretKey::random(&mut OsRng);
+        let secret = RistrettoSecretKey::random(&mut rand::rng());
         let public_key = RistrettoPublicKey::from_secret_key(&secret);
         let public_key_bytes = public_key.as_bytes().to_vec();
         let seal_signer_bytes: RistrettoPublicKeyBytes = public_key.to_byte_type();
@@ -72,7 +71,7 @@ mod tests {
 
     #[test]
     fn hash_from_json_round_trip() {
-        let secret = RistrettoSecretKey::random(&mut OsRng);
+        let secret = RistrettoSecretKey::random(&mut rand::rng());
         let public_key = RistrettoPublicKey::from_secret_key(&secret);
         let public_key_bytes = public_key.as_bytes().to_vec();
 

--- a/crates/ootle_wasm/core/src/sign.rs
+++ b/crates/ootle_wasm/core/src/sign.rs
@@ -1,7 +1,6 @@
 //   Copyright 2026 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use rand::rngs::OsRng;
 use tari_crypto::{
     keys::{PublicKey, SecretKey},
     ristretto::{RistrettoPublicKey, RistrettoSchnorr, RistrettoSecretKey},
@@ -28,7 +27,7 @@ pub struct SchnorrSignatureResult {
 
 /// Generate a new random Ristretto keypair.
 pub fn generate_keypair() -> KeypairResult {
-    let secret_key = RistrettoSecretKey::random(&mut OsRng);
+    let secret_key = RistrettoSecretKey::random(&mut rand::rng());
     let public_key = RistrettoPublicKey::from_secret_key(&secret_key);
     KeypairResult {
         secret_key: secret_key.as_bytes().to_vec(),
@@ -44,7 +43,7 @@ pub fn schnorr_sign(secret_key: &[u8], message: &[u8]) -> Result<SchnorrSignatur
     let secret_key = RistrettoSecretKey::from_canonical_bytes(secret_key)
         .map_err(|e| OotleWasmError::InvalidSecretKey(e.to_string()))?;
 
-    let sig = RistrettoSchnorr::sign(&secret_key, message, &mut OsRng)
+    let sig = RistrettoSchnorr::sign(&secret_key, message, &mut rand::rng())
         .map_err(|e| OotleWasmError::SigningFailed(e.to_string()))?;
 
     Ok(SchnorrSignatureResult {
@@ -67,7 +66,7 @@ mod tests {
 
     #[test]
     fn sign_and_verify_round_trip() {
-        let secret = RistrettoSecretKey::random(&mut OsRng);
+        let secret = RistrettoSecretKey::random(&mut rand::rng());
         let message = b"hello world";
 
         let result = schnorr_sign(secret.as_bytes(), message).unwrap();
@@ -77,7 +76,7 @@ mod tests {
 
     #[test]
     fn public_key_derivation() {
-        let secret = RistrettoSecretKey::random(&mut OsRng);
+        let secret = RistrettoSecretKey::random(&mut rand::rng());
         let expected = RistrettoPublicKey::from_secret_key(&secret);
 
         let result = public_key_from_secret_key(secret.as_bytes()).unwrap();

--- a/crates/ootle_wasm/core/src/transaction.rs
+++ b/crates/ootle_wasm/core/src/transaction.rs
@@ -60,7 +60,6 @@ pub fn add_transaction_signer_json(
 #[cfg(test)]
 mod tests {
     use ootle_byte_type::ToByteType;
-    use rand::rngs::OsRng;
     use tari_crypto::{
         keys::{PublicKey, SecretKey},
         ristretto::{RistrettoPublicKey, RistrettoSecretKey},
@@ -76,7 +75,7 @@ mod tests {
 
     #[test]
     fn seal_unsigned_transaction() {
-        let secret = RistrettoSecretKey::random(&mut OsRng);
+        let secret = RistrettoSecretKey::random(&mut rand::rng());
         let unsigned_json = serde_json::to_string(&make_unsigned_tx()).unwrap();
 
         let sealed_json = seal_transaction_json(&unsigned_json, secret.as_bytes()).unwrap();
@@ -86,8 +85,8 @@ mod tests {
 
     #[test]
     fn seal_unsealed_transaction() {
-        let seal_secret = RistrettoSecretKey::random(&mut OsRng);
-        let signer_secret = RistrettoSecretKey::random(&mut OsRng);
+        let seal_secret = RistrettoSecretKey::random(&mut rand::rng());
+        let signer_secret = RistrettoSecretKey::random(&mut rand::rng());
         let seal_pk = RistrettoPublicKey::from_secret_key(&seal_secret);
 
         // First add a signer to get an unsealed tx
@@ -103,9 +102,9 @@ mod tests {
 
     #[test]
     fn add_signer_to_unsigned_transaction() {
-        let seal_secret = RistrettoSecretKey::random(&mut OsRng);
+        let seal_secret = RistrettoSecretKey::random(&mut rand::rng());
         let seal_pk = RistrettoPublicKey::from_secret_key(&seal_secret);
-        let signer_secret = RistrettoSecretKey::random(&mut OsRng);
+        let signer_secret = RistrettoSecretKey::random(&mut rand::rng());
 
         let unsigned_json = serde_json::to_string(&make_unsigned_tx()).unwrap();
         let unsealed_json =
@@ -118,10 +117,10 @@ mod tests {
 
     #[test]
     fn add_multiple_signers() {
-        let seal_secret = RistrettoSecretKey::random(&mut OsRng);
+        let seal_secret = RistrettoSecretKey::random(&mut rand::rng());
         let seal_pk = RistrettoPublicKey::from_secret_key(&seal_secret);
-        let signer1 = RistrettoSecretKey::random(&mut OsRng);
-        let signer2 = RistrettoSecretKey::random(&mut OsRng);
+        let signer1 = RistrettoSecretKey::random(&mut rand::rng());
+        let signer2 = RistrettoSecretKey::random(&mut rand::rng());
 
         let unsigned_json = serde_json::to_string(&make_unsigned_tx()).unwrap();
 

--- a/crates/p2p/src/peer_address.rs
+++ b/crates/p2p/src/peer_address.rs
@@ -106,7 +106,7 @@ mod tests {
 
     #[test]
     fn check_conversions() {
-        let (_, pk) = RistrettoPublicKey::random_keypair(&mut rand::rngs::OsRng);
+        let (_, pk) = RistrettoPublicKey::random_keypair(&mut rand::rng());
         let peer_address = PeerAddress::try_from_public_key(&pk).unwrap();
         let peer_id = peer_address.as_peer_id();
         let peer_address2 = PeerAddress::from(peer_id);

--- a/crates/state_store_rocksdb/src/codecs/state_tree.rs
+++ b/crates/state_store_rocksdb/src/codecs/state_tree.rs
@@ -107,7 +107,7 @@ impl<'a> DbEncoder<&'a NodeKey> for NodeKeyCodec {
 mod tests {
     use std::iter;
 
-    use rand::Rng;
+    use rand::RngExt;
     use tari_state_tree::{
         JellyfishMerkleTree,
         LeafKey,
@@ -189,8 +189,6 @@ mod tests {
     }
 
     fn random_bytes<const L: usize>() -> [u8; L] {
-        let mut bytes = [0u8; L];
-        rand::thread_rng().fill(&mut bytes[..]);
-        bytes
+        rand::rng().random()
     }
 }

--- a/crates/state_store_rocksdb/tests/helpers.rs
+++ b/crates/state_store_rocksdb/tests/helpers.rs
@@ -3,7 +3,7 @@
 
 use std::{io::Write, ops::Deref};
 
-use rand::{Rng, RngCore, rngs::OsRng};
+use rand::{Rng, RngExt};
 use tari_bor::cbor;
 use tari_common_types::types::FixedHash;
 use tari_consensus_types::{BlockId, Decision, LeafBlock, PcId, ProposalCertificate, ShardGroupAccumulatedData};
@@ -75,7 +75,7 @@ pub fn create_rocksdb_with_opts(opts: DatabaseOptions) -> (RocksDbStateStore<Str
 
 pub fn create_tx_atom() -> TransactionAtom {
     let mut bytes = [0u8; 32];
-    OsRng.fill_bytes(&mut bytes);
+    rand::rng().fill_bytes(&mut bytes);
     TransactionAtom {
         id: TransactionId::new(bytes),
         decision: Decision::Commit,
@@ -93,13 +93,13 @@ pub fn create_random_substate_id() -> SubstateId {
 
 pub fn random_fixed<const SIZE: usize>() -> [u8; SIZE] {
     let mut bytes = [0u8; SIZE];
-    OsRng.fill_bytes(&mut bytes);
+    rand::rng().fill_bytes(&mut bytes);
     bytes
 }
 
 pub fn random_bytes(size: usize) -> Vec<u8> {
     let mut bytes = vec![0u8; size];
-    OsRng.fill_bytes(&mut bytes);
+    rand::rng().fill_bytes(&mut bytes);
     bytes
 }
 
@@ -213,7 +213,7 @@ pub fn random_substate_id_for_shard(shard: Shard) -> SubstateId {
     buf[..end].copy_from_slice(&seed.to_be_bytes()[..end]);
     let entity_id = EntityId::from_array(buf);
     let mut buf = [0u8; ComponentKey::LENGTH];
-    rand::thread_rng().fill_bytes(&mut buf);
+    rand::rng().fill_bytes(&mut buf);
     let component_key = ComponentKey::new(buf);
     SubstateId::Component(ComponentAddress::new(ObjectKey::new(entity_id, component_key)))
 }
@@ -284,7 +284,7 @@ pub fn create_random_block_id() -> BlockId {
 }
 
 pub fn create_random_hash() -> FixedHash {
-    let rand_bytes = OsRng.r#gen::<[u8; FixedHash::byte_size()]>();
+    let rand_bytes: [u8; FixedHash::byte_size()] = rand::rng().random();
     FixedHash::new(rand_bytes)
 }
 

--- a/crates/storage/src/consensus_models/transaction_pool.rs
+++ b/crates/storage/src/consensus_models/transaction_pool.rs
@@ -1042,9 +1042,10 @@ mod tests {
         fn simple_fuzz() {
             let mut total_fees = 0;
             let mut total_burnt = 0;
+            let mut rng = rand::rng();
             for _ in 0..1_000_000 {
-                let fee = rand::rng().random_range(100..100000u64);
-                let involved = rand::rng().random_range(1..100u64);
+                let fee = rng.random_range(100..100000u64);
+                let involved = rng.random_range(1..100u64);
                 let fee = check_calculate_leader_fee(fee, involved, 20);
                 total_fees += fee.fee * involved;
                 total_burnt += fee.exhaust_burn;

--- a/crates/storage/src/consensus_models/transaction_pool.rs
+++ b/crates/storage/src/consensus_models/transaction_pool.rs
@@ -915,7 +915,8 @@ impl IsNotFoundError for TransactionPoolError {
 
 #[cfg(test)]
 mod tests {
-    use rand::{Rng, rngs::OsRng};
+
+    use rand::RngExt;
 
     use super::*;
     use crate::consensus_models::LeaderFee;
@@ -932,6 +933,7 @@ mod tests {
     }
 
     mod calculate_leader_fee {
+
         use super::*;
 
         fn create_record_with_fee(fee: u64) -> TransactionPoolRecord {
@@ -1041,8 +1043,8 @@ mod tests {
             let mut total_fees = 0;
             let mut total_burnt = 0;
             for _ in 0..1_000_000 {
-                let fee = OsRng.gen_range(100..100000u64);
-                let involved = OsRng.gen_range(1..100u64);
+                let fee = rand::rng().random_range(100..100000u64);
+                let involved = rand::rng().random_range(1..100u64);
                 let fee = check_calculate_leader_fee(fee, involved, 20);
                 total_fees += fee.fee * involved;
                 total_burnt += fee.exhaust_burn;

--- a/crates/storage_sqlite/tests/global_db.rs
+++ b/crates/storage_sqlite/tests/global_db.rs
@@ -3,7 +3,6 @@
 
 use diesel::{Connection, SqliteConnection};
 use ootle_byte_type::ToByteType;
-use rand::rngs::OsRng;
 use tari_common_types::types::FixedHash;
 use tari_crypto::{keys::PublicKey, ristretto::RistrettoPublicKey};
 use tari_ootle_common_types::{Epoch, NumPreshards, ShardGroup, SubstateAddress, VotePower};
@@ -20,7 +19,7 @@ fn create_db() -> GlobalDb<SqliteGlobalDbAdapter<PeerAddress>> {
 }
 
 fn new_public_key() -> RistrettoPublicKey {
-    RistrettoPublicKey::random_keypair(&mut OsRng).1
+    RistrettoPublicKey::random_keypair(&mut rand::rng()).1
 }
 
 fn derived_substate_address(public_key: &RistrettoPublicKey) -> SubstateAddress {

--- a/crates/template_test_tooling/src/support/confidential.rs
+++ b/crates/template_test_tooling/src/support/confidential.rs
@@ -1,7 +1,6 @@
 //   Copyright 2023 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use rand::rngs::OsRng;
 use tari_crypto::{
     keys::SecretKey,
     ristretto::{RistrettoPublicKey, RistrettoSecretKey, pedersen::PedersenCommitment},
@@ -46,7 +45,8 @@ fn generate_confidential_proof_internal(
     RistrettoSecretKey,
     Option<RistrettoSecretKey>,
 ) {
-    let mask = RistrettoSecretKey::random(&mut OsRng);
+    let mut rng = rand::rng();
+    let mask = RistrettoSecretKey::random(&mut rng);
     let output_statement = OutputWitness {
         amount: output_amount,
         mask: mask.clone(),
@@ -56,7 +56,7 @@ fn generate_confidential_proof_internal(
         resource_view_key: view_key.clone(),
     };
 
-    let change_mask = RistrettoSecretKey::random(&mut OsRng);
+    let change_mask = RistrettoSecretKey::random(&mut rng);
     let change_statement = change.map(|amount| OutputWitness {
         amount,
         mask: change_mask.clone(),
@@ -156,13 +156,14 @@ fn generate_withdraw_proof_internal(
     revealed_output_amount: Amount,
     view_key: Option<RistrettoPublicKey>,
 ) -> ConfidentialWithdrawProofOutput {
+    let mut rng = rand::rng();
     // If the amount is zero, we omit the output UTXO, therefore the mask is zero
     let output_mask = if output_amount == 0 {
-        Default::default()
+        RistrettoSecretKey::default()
     } else {
-        RistrettoSecretKey::random(&mut OsRng)
+        RistrettoSecretKey::random(&mut rng)
     };
-    let change_mask = change_amount.map(|_| RistrettoSecretKey::random(&mut OsRng));
+    let change_mask = change_amount.map(|_| RistrettoSecretKey::random(&mut rng));
 
     let output_proof = OutputWitness {
         amount: output_amount,

--- a/crates/template_test_tooling/src/support/stealth.rs
+++ b/crates/template_test_tooling/src/support/stealth.rs
@@ -4,7 +4,6 @@
 use std::iter;
 
 use ootle_byte_type::ToByteType;
-use rand::rngs::OsRng;
 use tari_crypto::{
     keys::{PublicKey, SecretKey},
     ristretto::{RistrettoPublicKey, RistrettoSchnorr, RistrettoSecretKey},
@@ -79,7 +78,7 @@ fn generate_stealth_statement_internal(
 ) -> (StealthOutputsStatement, Vec<RistrettoSecretKey>) {
     let masks = output_amounts
         .iter()
-        .map(|_| RistrettoSecretKey::random(&mut OsRng))
+        .map(|_| RistrettoSecretKey::random(&mut rand::rng()))
         .collect::<Vec<_>>();
     let output_statements = output_amounts
         .iter()
@@ -180,7 +179,7 @@ where
         .map(Into::into)
         .filter(|os| os.value() > 0)
         .map(|spec| {
-            let output_mask = RistrettoSecretKey::random(&mut OsRng);
+            let output_mask = RistrettoSecretKey::random(&mut rand::rng());
             let statement = OutputWitness {
                 amount: spec.value(),
                 mask: output_mask.clone(),
@@ -231,7 +230,7 @@ pub fn generate_value_proof_mask_knowledge(value: Amount, mask: &RistrettoSecret
     let commitment = commit_amount(mask, value).unwrap();
     let commitment_bytes = commitment.to_byte_type();
     let message = messages::value_proof_message(&commitment_bytes, &value);
-    let sig = RistrettoSchnorr::sign(mask, message, &mut OsRng).expect("Signing cannot fail");
+    let sig = RistrettoSchnorr::sign(mask, message, &mut rand::rng()).expect("Signing cannot fail");
 
     StealthValueProof {
         value,

--- a/crates/transaction/src/transaction.rs
+++ b/crates/transaction/src/transaction.rs
@@ -428,7 +428,6 @@ impl From<Transaction> for PrunedTransaction {
 #[cfg(test)]
 mod tests {
     use ootle_byte_type::ToByteType;
-    use rand::rngs::OsRng;
     use tari_crypto::{
         keys::{PublicKey as _, SecretKey},
         ristretto::{RistrettoPublicKey, RistrettoSecretKey},
@@ -481,12 +480,12 @@ mod tests {
 
     #[test]
     fn it_correctly_signs_and_verifies() {
-        let secret = RistrettoSecretKey::random(&mut OsRng);
+        let secret = RistrettoSecretKey::random(&mut rand::rng());
         let public_key = RistrettoPublicKey::from_secret_key(&secret);
         let subject = create_transaction().build_and_seal(&secret);
         assert!(subject.verify_all_signatures());
 
-        let secret2 = RistrettoSecretKey::random(&mut OsRng);
+        let secret2 = RistrettoSecretKey::random(&mut rand::rng());
         let subject = create_transaction()
             .finish()
             .add_signer(&public_key.to_byte_type(), &secret2)

--- a/crates/transaction/src/unique.rs
+++ b/crates/transaction/src/unique.rs
@@ -23,14 +23,14 @@ impl BuildHasher for FixedState {
 
 #[cfg(test)]
 mod tests {
-    use rand::{rngs::OsRng, Rng};
+    use rand::RngExt;
     use tari_ootle_common_types::{uint::U256, SubstateAddress};
 
     use super::*;
 
     pub fn random_substate_address() -> SubstateAddress {
-        let lsb: u128 = OsRng.gen();
-        let msb: u128 = OsRng.gen();
+        let lsb: u128 = rand::rng().random();
+        let msb: u128 = rand::rng().random();
         let mut bytes = [0u8; 32];
         bytes[..16].copy_from_slice(&lsb.to_le_bytes());
         bytes[16..].copy_from_slice(&msb.to_le_bytes());

--- a/crates/transaction/src/v1/pruned.rs
+++ b/crates/transaction/src/v1/pruned.rs
@@ -321,7 +321,6 @@ impl From<TransactionV1> for PrunedTransactionV1 {
 #[cfg(test)]
 mod tests {
     use ootle_byte_type::ToByteType;
-    use rand::rngs::OsRng;
     use tari_crypto::{
         keys::{PublicKey as PublicKeyT, SecretKey},
         ristretto::{RistrettoPublicKey, RistrettoSecretKey},
@@ -353,7 +352,7 @@ mod tests {
 
     fn sealed(unsigned: UnsignedTransactionV1, sealer: &RistrettoSecretKey) -> TransactionV1 {
         let seal_signer = RistrettoPublicKey::from_secret_key(sealer).to_byte_type();
-        let extra_sk = RistrettoSecretKey::random(&mut OsRng);
+        let extra_sk = RistrettoSecretKey::random(&mut rand::rng());
         let sig = TransactionSignature::sign_v1(&extra_sk, &seal_signer, &unsigned);
         let unsealed = UnsealedTransactionV1::new(unsigned, vec![sig]);
         let seal = TransactionSealSignature::sign_v1(sealer, &unsealed);
@@ -364,7 +363,7 @@ mod tests {
     fn id_is_stable_across_pruning_with_blobs() {
         let blobs = Blobs::from_vec(vec![Blob::from(vec![1, 2, 3]), Blob::from(vec![4, 5, 6, 7, 8])]);
         let unsigned = sample_unsigned_with_blobs(blobs);
-        let sealer = RistrettoSecretKey::random(&mut OsRng);
+        let sealer = RistrettoSecretKey::random(&mut rand::rng());
         let full = sealed(unsigned, &sealer);
         let id_full = full.calculate_id();
         let pruned = PrunedTransactionV1::from(full);
@@ -375,7 +374,7 @@ mod tests {
     #[test]
     fn id_is_stable_across_pruning_without_blobs() {
         let unsigned = sample_unsigned_with_blobs(Blobs::empty());
-        let sealer = RistrettoSecretKey::random(&mut OsRng);
+        let sealer = RistrettoSecretKey::random(&mut rand::rng());
         let full = sealed(unsigned, &sealer);
         let id_full = full.calculate_id();
         let pruned = PrunedTransactionV1::from(full);
@@ -386,7 +385,7 @@ mod tests {
     fn pruned_form_verifies_signatures_without_blobs() {
         let blobs = Blobs::from_vec(vec![Blob::from(vec![10, 20, 30, 40])]);
         let unsigned = sample_unsigned_with_blobs(blobs);
-        let sealer = RistrettoSecretKey::random(&mut OsRng);
+        let sealer = RistrettoSecretKey::random(&mut rand::rng());
         let full = sealed(unsigned, &sealer);
         assert!(full.verify_all_signatures());
         let pruned = PrunedTransactionV1::from(full);
@@ -397,7 +396,7 @@ mod tests {
     fn rehydrate_succeeds_with_matching_blobs() {
         let blobs = Blobs::from_vec(vec![Blob::from(vec![1, 2, 3]), Blob::from(vec![4, 5])]);
         let unsigned = sample_unsigned_with_blobs(blobs.clone());
-        let sealer = RistrettoSecretKey::random(&mut OsRng);
+        let sealer = RistrettoSecretKey::random(&mut rand::rng());
         let full = sealed(unsigned, &sealer);
         let id = full.calculate_id();
         let pruned = PrunedTransactionV1::from(full);
@@ -410,7 +409,7 @@ mod tests {
     fn rehydrate_rejects_count_mismatch() {
         let blobs = Blobs::from_vec(vec![Blob::from(vec![1])]);
         let unsigned = sample_unsigned_with_blobs(blobs);
-        let sealer = RistrettoSecretKey::random(&mut OsRng);
+        let sealer = RistrettoSecretKey::random(&mut rand::rng());
         let full = sealed(unsigned, &sealer);
         let pruned = PrunedTransactionV1::from(full);
         let err = pruned.rehydrate(Blobs::empty()).unwrap_err();
@@ -421,7 +420,7 @@ mod tests {
     fn rehydrate_rejects_hash_mismatch() {
         let blobs = Blobs::from_vec(vec![Blob::from(vec![1, 2, 3])]);
         let unsigned = sample_unsigned_with_blobs(blobs);
-        let sealer = RistrettoSecretKey::random(&mut OsRng);
+        let sealer = RistrettoSecretKey::random(&mut rand::rng());
         let full = sealed(unsigned, &sealer);
         let pruned = PrunedTransactionV1::from(full);
         let bad = Blobs::from_vec(vec![Blob::from(vec![9, 9, 9])]);
@@ -433,7 +432,7 @@ mod tests {
     fn pruned_signature_rejects_tampered_field() {
         let blobs = Blobs::from_vec(vec![Blob::from(vec![1, 2, 3])]);
         let unsigned = sample_unsigned_with_blobs(blobs);
-        let sealer = RistrettoSecretKey::random(&mut OsRng);
+        let sealer = RistrettoSecretKey::random(&mut rand::rng());
         let full = sealed(unsigned, &sealer);
         let mut pruned = PrunedTransactionV1::from(full);
         // Tamper a field — seal verification must fail.
@@ -445,7 +444,7 @@ mod tests {
     fn pruned_signature_rejects_tampered_blob_hashes() {
         let blobs = Blobs::from_vec(vec![Blob::from(vec![1, 2, 3])]);
         let unsigned = sample_unsigned_with_blobs(blobs);
-        let sealer = RistrettoSecretKey::random(&mut OsRng);
+        let sealer = RistrettoSecretKey::random(&mut rand::rng());
         let full = sealed(unsigned, &sealer);
         let mut pruned = PrunedTransactionV1::from(full);
         // Replace the stored blob_hashes with hashes of different data.

--- a/crates/transaction/src/v1/signature.rs
+++ b/crates/transaction/src/v1/signature.rs
@@ -3,7 +3,6 @@
 
 use indexmap::IndexSet;
 use ootle_byte_type::{ConvertFromByteType, FromByteType, ToByteType};
-use rand::rngs::OsRng;
 use serde::{Deserialize, Serialize};
 use tari_crypto::{
     keys::PublicKey as PublicKeyT,
@@ -42,7 +41,7 @@ impl TransactionSealSignature {
 
         let message = Self::create_message_v1(transaction);
         Self {
-            signature: RistrettoSchnorr::sign(secret_key, message, &mut OsRng)
+            signature: RistrettoSchnorr::sign(secret_key, message, &mut rand::rng())
                 .expect("sign is infallible with Ristretto keys")
                 .to_byte_type(),
             public_key: public_key.to_byte_type(),
@@ -173,7 +172,7 @@ impl TransactionSignature {
         let message = Self::create_message_v1(seal_signer, transaction);
 
         Self {
-            signature: RistrettoSchnorr::sign(secret_key, message, &mut OsRng)
+            signature: RistrettoSchnorr::sign(secret_key, message, &mut rand::rng())
                 .expect("sign is infallible with Ristretto keys")
                 .to_byte_type(),
             public_key: public_key.to_byte_type(),
@@ -326,7 +325,7 @@ mod tests {
     use super::*;
 
     fn sample_seal_signer() -> RistrettoPublicKeyBytes {
-        RistrettoPublicKey::from_secret_key(&RistrettoSecretKey::random(&mut OsRng)).to_byte_type()
+        RistrettoPublicKey::from_secret_key(&RistrettoSecretKey::random(&mut rand::rng())).to_byte_type()
     }
 
     fn sample_unsigned() -> UnsignedTransactionV1 {
@@ -356,7 +355,7 @@ mod tests {
     }
 
     fn random_signature(tx: &UnsignedTransactionV1, seal_signer: &RistrettoPublicKeyBytes) -> TransactionSignature {
-        let sk = RistrettoSecretKey::random(&mut OsRng);
+        let sk = RistrettoSecretKey::random(&mut rand::rng());
         TransactionSignature::sign_v1(&sk, seal_signer, tx)
     }
 
@@ -473,7 +472,7 @@ mod tests {
 
     #[test]
     fn signature_is_bound_to_seal_signer_context() {
-        let signer_sk = RistrettoSecretKey::random(&mut OsRng);
+        let signer_sk = RistrettoSecretKey::random(&mut rand::rng());
         let seal_signer_pk = sample_seal_signer();
         let other_seal_signer_pk = sample_seal_signer();
         let tx = sample_unsigned();
@@ -613,7 +612,7 @@ mod tests {
 
     #[test]
     fn seal_signature_roundtrip() {
-        let sealer_sk = RistrettoSecretKey::random(&mut OsRng);
+        let sealer_sk = RistrettoSecretKey::random(&mut rand::rng());
         let seal_signer_pk: RistrettoPublicKeyBytes = RistrettoPublicKey::from_secret_key(&sealer_sk).to_byte_type();
 
         let unsigned = sample_unsigned();

--- a/crates/transaction/src/v1/transaction.rs
+++ b/crates/transaction/src/v1/transaction.rs
@@ -313,7 +313,6 @@ fn calc_blobs_weight(blobs: &crate::Blobs) -> u64 {
 #[cfg(test)]
 mod blob_validation_tests {
     use ootle_byte_type::ToByteType;
-    use rand::rngs::OsRng;
     use tari_crypto::{
         keys::{PublicKey as PublicKeyT, SecretKey},
         ristretto::{RistrettoPublicKey, RistrettoSecretKey},
@@ -336,7 +335,7 @@ mod blob_validation_tests {
             dry_run: false,
             blobs,
         };
-        let sealer = RistrettoSecretKey::random(&mut OsRng);
+        let sealer = RistrettoSecretKey::random(&mut rand::rng());
         let unsealed = UnsealedTransactionV1::new(unsigned, vec![]);
         let seal = crate::TransactionSealSignature::sign_v1(&sealer, &unsealed);
         TransactionV1::new(unsealed, seal)
@@ -428,6 +427,6 @@ mod blob_validation_tests {
     /// using a randomly-generated sealer.
     #[allow(dead_code)]
     fn pk_smoke() {
-        let _ = RistrettoPublicKey::from_secret_key(&RistrettoSecretKey::random(&mut OsRng)).to_byte_type();
+        let _ = RistrettoPublicKey::from_secret_key(&RistrettoSecretKey::random(&mut rand::rng())).to_byte_type();
     }
 }

--- a/crates/wallet/crypto/src/balance_proof.rs
+++ b/crates/wallet/crypto/src/balance_proof.rs
@@ -1,7 +1,6 @@
 //    Copyright 2025 The Tari Project
 //    SPDX-License-Identifier: BSD-3-Clause
 
-use chacha20poly1305::aead::OsRng;
 use log::warn;
 use ootle_byte_type::{ConvertFromByteType, FromByteType, ToByteType};
 use tari_crypto::{
@@ -36,7 +35,7 @@ pub(crate) fn generate_confidential_balance_proof(
         return BalanceProofSignature::zero();
     }
     let excess = RistrettoPublicKey::from_secret_key(&secret_excess);
-    let (nonce, public_nonce) = RistrettoPublicKey::random_keypair(&mut OsRng);
+    let (nonce, public_nonce) = RistrettoPublicKey::random_keypair(&mut rand::rng());
     let message =
         messages::confidential_withdraw64(&excess, &public_nonce, input_revealed_amount, output_reveal_amount);
 
@@ -56,7 +55,7 @@ pub fn generate_stealth_balance_proof_signature(
         return BalanceProofSignature::zero();
     }
     let public_excess = RistrettoPublicKey::from_secret_key(&secret_excess);
-    let (nonce, public_nonce) = RistrettoPublicKey::random_keypair(&mut OsRng);
+    let (nonce, public_nonce) = RistrettoPublicKey::random_keypair(&mut rand::rng());
     let message = messages::stealth_balance_proof64(&public_excess, &public_nonce, inputs_statement, outputs_statement);
 
     let sig = EngineSchnorrSignature::sign_raw_uniform(&secret_excess, nonce, &message).unwrap();

--- a/crates/wallet/crypto/src/confidential.rs
+++ b/crates/wallet/crypto/src/confidential.rs
@@ -136,7 +136,6 @@ pub fn create_output_statement(
 
 #[cfg(test)]
 mod tests {
-    use rand::rngs::OsRng;
     use tari_crypto::{keys::SecretKey, ristretto::RistrettoSecretKey};
     use tari_engine_types::confidential::validate_confidential_statement;
     use tari_template_lib_types::EncryptedData;
@@ -144,7 +143,7 @@ mod tests {
     use super::*;
 
     fn create_valid_proof(amount: u64, minimum_value_promise: u64) -> ConfidentialOutputStatement {
-        let mask = RistrettoSecretKey::random(&mut OsRng);
+        let mask = RistrettoSecretKey::random(&mut rand::rng());
         create_output_statement(
             Some(&OutputWitness {
                 amount,

--- a/crates/wallet/crypto/src/encrypted_data.rs
+++ b/crates/wallet/crypto/src/encrypted_data.rs
@@ -224,10 +224,10 @@ mod tests {
 
     #[test]
     fn it_encrypts_and_decrypts() {
-        let key = RistrettoSecretKey::random(&mut OsRng);
+        let key = RistrettoSecretKey::random(&mut rand::rng());
         let amount = 100;
         let commitment = get_commitment_factory().commit_value(&key, amount).to_byte_type();
-        let mask = RistrettoSecretKey::random(&mut OsRng);
+        let mask = RistrettoSecretKey::random(&mut rand::rng());
         let encrypted = encrypt_data_inner(&key, &commitment, amount, &mask, None).unwrap();
 
         let (value, msk, memo) = decrypt_inner(&key, &commitment, &encrypted, false).unwrap();
@@ -239,10 +239,10 @@ mod tests {
 
     #[test]
     fn it_encrypts_and_decrypts_with_memo() {
-        let key = RistrettoSecretKey::random(&mut OsRng);
+        let key = RistrettoSecretKey::random(&mut rand::rng());
         let amount = 100;
         let commitment = get_commitment_factory().commit_value(&key, amount).to_byte_type();
-        let mask = RistrettoSecretKey::random(&mut OsRng);
+        let mask = RistrettoSecretKey::random(&mut rand::rng());
         let memo = Memo::new_message("The quick brown fox jumps over the lazy dog").unwrap();
         let encrypted = encrypt_data_inner(&key, &commitment, amount, &mask, Some(&memo)).unwrap();
         assert!(!String::from_utf8_lossy(encrypted.as_bytes()).contains("the lazy dog"));
@@ -279,10 +279,10 @@ mod tests {
 
     #[test]
     fn it_always_returns_a_none_memo_if_skip_memo_is_true() {
-        let key = RistrettoSecretKey::random(&mut OsRng);
+        let key = RistrettoSecretKey::random(&mut rand::rng());
         let amount = 100;
         let commitment = get_commitment_factory().commit_value(&key, amount).to_byte_type();
-        let mask = RistrettoSecretKey::random(&mut OsRng);
+        let mask = RistrettoSecretKey::random(&mut rand::rng());
         let memo = Memo::new_message("The quick brown fox jumps over the lazy dog").unwrap();
         let encrypted = encrypt_data_inner(&key, &commitment, amount, &mask, Some(&memo)).unwrap();
 

--- a/crates/wallet/crypto/src/encryption.rs
+++ b/crates/wallet/crypto/src/encryption.rs
@@ -1,9 +1,8 @@
 //   Copyright 2025 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use argon2::password_hash::rand_core::RngCore;
 use chacha20poly1305::{AeadInPlace, Key, KeyInit, Nonce, Tag};
-use rand::rngs::OsRng;
+use rand::Rng;
 use subtle::ConstantTimeEq;
 use tari_crypto::tari_utilities::safe_array::SafeArray;
 use zeroize::Zeroizing;
@@ -99,7 +98,7 @@ pub fn decrypt_with_password(cipher_text: &[u8], passphrase: &[u8]) -> Result<Ze
 
 pub fn encrypt_with_password(plain_text: &[u8], passphrase: &[u8]) -> Result<Vec<u8>, CipherError> {
     let mut salt = [0u8; SALT_LENGTH];
-    OsRng.fill_bytes(salt.as_mut());
+    rand::rng().fill_bytes(salt.as_mut());
     let key = derive_keys(passphrase, salt.as_slice())?;
     let (encryption_key, mac_key) = key.split_at(ENCRYPTION_KEY_BYTES_LEN);
 

--- a/crates/wallet/crypto/src/stealth.rs
+++ b/crates/wallet/crypto/src/stealth.rs
@@ -140,7 +140,6 @@ pub fn create_outputs_statement<'a, Outputs: IntoIterator<Item = &'a StealthOutp
 
 #[cfg(test)]
 mod tests {
-    use rand::rngs::OsRng;
     use tari_crypto::{keys::SecretKey, ristretto::RistrettoSecretKey};
     use tari_engine_types::stealth::validate_stealth_outputs_statement;
     use tari_template_lib_types::{
@@ -154,7 +153,7 @@ mod tests {
     use crate::OutputWitness;
 
     fn create_valid_proof(amount: u64, minimum_value_promise: u64) -> StealthOutputsStatement {
-        let mask = RistrettoSecretKey::random(&mut OsRng);
+        let mask = RistrettoSecretKey::random(&mut rand::rng());
         create_outputs_statement(
             &[StealthOutputWitness {
                 witness: OutputWitness {

--- a/crates/wallet/crypto/src/value_lookup/io_reader_value_lookup.rs
+++ b/crates/wallet/crypto/src/value_lookup/io_reader_value_lookup.rs
@@ -114,7 +114,7 @@ impl<R: Read + Seek> ValueLookupTable for IoReaderValueLookup<'_, R> {
 mod tests {
     use std::io::Cursor;
 
-    use rand::{Rng, rngs::OsRng};
+    use rand::RngExt;
 
     use super::*;
     use crate::value_lookup::header::LOOKUP_HEADER_LEADING_BYTES;
@@ -174,7 +174,7 @@ mod tests {
         let mut reader = Cursor::new(lookup_data.as_slice());
         let mut lookup = IoReaderValueLookup::load(&mut reader).unwrap();
         for _ in 0..=1000 {
-            let v = OsRng.gen_range(0..=NUM);
+            let v = rand::rng().random_range(0..=NUM);
             let value = lookup.lookup(v).unwrap().unwrap();
             let byte = v % u64::from(u8::MAX);
             assert_eq!(value, [byte as u8; 32], "Failed at value {}", v);

--- a/crates/wallet/crypto/src/value_lookup/mmap_value_lookup.rs
+++ b/crates/wallet/crypto/src/value_lookup/mmap_value_lookup.rs
@@ -120,7 +120,7 @@ impl ValueLookupTable for MMapValueLookup {
 
 #[cfg(test)]
 mod tests {
-    use rand::{Rng, rngs::OsRng};
+    use rand::RngExt;
 
     use super::*;
 
@@ -172,8 +172,9 @@ mod tests {
         const NUM: u64 = 1000u64;
         let lookup_data = generate_lookup_data(0, NUM);
         let mut lookup = MMapValueLookup::from_buf(&lookup_data).unwrap();
+        let mut rng = rand::rng();
         for _ in 0..=1000 {
-            let v = OsRng.gen_range(0..=NUM);
+            let v = rng.random_range(0..=NUM);
             let value = lookup.lookup(v).unwrap().unwrap();
             let byte = v % u64::from(u8::MAX);
             assert_eq!(value, [byte as u8; 32], "Failed at value {}", v);

--- a/crates/wallet/crypto/src/viewable_balance_proof.rs
+++ b/crates/wallet/crypto/src/viewable_balance_proof.rs
@@ -1,7 +1,6 @@
 //    Copyright 2025 The Tari Project
 //    SPDX-License-Identifier: BSD-3-Clause
 
-use chacha20poly1305::aead::OsRng;
 use ootle_byte_type::ToByteType;
 use tari_crypto::{
     commitment::HomomorphicCommitmentFactory,
@@ -23,7 +22,8 @@ pub fn generate_elgamal_viewable_balance_proof(
     commitment: &PedersenCommitment,
     view_key: &RistrettoPublicKey,
 ) -> Result<ViewableBalanceProof, StealthProofError> {
-    let (elgamal_secret_nonce, elgamal_public_nonce) = RistrettoPublicKey::random_keypair(&mut OsRng);
+    let mut rng = rand::rng();
+    let (elgamal_secret_nonce, elgamal_public_nonce) = RistrettoPublicKey::random_keypair(&mut rng);
     let r = &elgamal_secret_nonce;
     let output_amount_as_secret = RistrettoSecretKey::from(output_amount);
 
@@ -31,9 +31,9 @@ pub fn generate_elgamal_viewable_balance_proof(
     let elgamal_encrypted = RistrettoPublicKey::from_secret_key(&output_amount_as_secret) + r * view_key;
 
     // Nonces
-    let x_v = RistrettoSecretKey::random(&mut OsRng);
-    let x_m = RistrettoSecretKey::random(&mut OsRng);
-    let x_r = RistrettoSecretKey::random(&mut OsRng);
+    let x_v = RistrettoSecretKey::random(&mut rng);
+    let x_m = RistrettoSecretKey::random(&mut rng);
+    let x_r = RistrettoSecretKey::random(&mut rng);
 
     // C' = x_m.G + x_v.H
     let c_prime = get_commitment_factory().commit(&x_m, &x_v);

--- a/crates/wallet/crypto/tests/stealth_transfer_statement.rs
+++ b/crates/wallet/crypto/tests/stealth_transfer_statement.rs
@@ -3,7 +3,6 @@
 
 use std::iter;
 
-use chacha20poly1305::aead::OsRng;
 use tari_crypto::{
     keys::{PublicKey, SecretKey},
     ristretto::{RistrettoPublicKey, RistrettoSecretKey},
@@ -128,7 +127,7 @@ mod stealth_tests {
             .iter()
             .filter(|amount| **amount > 0)
             .map(|&amount| {
-                let output_mask = RistrettoSecretKey::random(&mut OsRng);
+                let output_mask = RistrettoSecretKey::random(&mut rand::rng());
                 // For testing purposes, we use the mask as the owner key
                 let output_owner_public_key = RistrettoPublicKey::from_secret_key(&output_mask);
                 let statement = OutputWitness {

--- a/crates/wallet/crypto/tests/viewable_balance_proof.rs
+++ b/crates/wallet/crypto/tests/viewable_balance_proof.rs
@@ -3,7 +3,6 @@
 
 use std::time::Instant;
 
-use rand::rngs::OsRng;
 use tari_crypto::{
     keys::{PublicKey, SecretKey},
     ristretto::{RistrettoPublicKey, RistrettoSecretKey, pedersen::PedersenCommitment},
@@ -14,7 +13,7 @@ use tari_template_lib_types::{Amount, EncryptedData};
 use tari_utilities::ByteArray;
 
 fn create_output_statement(value: u64, view_key: &RistrettoPublicKey) -> OutputWitness {
-    let mask = RistrettoSecretKey::random(&mut OsRng);
+    let mask = RistrettoSecretKey::random(&mut rand::rng());
     OutputWitness {
         amount: value,
         mask,

--- a/crates/wallet/ootle-rs/Cargo.toml
+++ b/crates/wallet/ootle-rs/Cargo.toml
@@ -30,7 +30,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 tracing = { workspace = true }
 async-stream = { workspace = true }
-signature = "3.0.0-rc.8"
+signature = "3.0.0"
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["sync", "macros", "rt-multi-thread"] }

--- a/crates/wallet/ootle-rs/src/key_provider/local/generic_impls.rs
+++ b/crates/wallet/ootle-rs/src/key_provider/local/generic_impls.rs
@@ -5,7 +5,6 @@ use std::mem;
 
 use async_trait::async_trait;
 use ootle_byte_type::{FromByteType, ToByteType};
-use rand::thread_rng;
 use signature::hazmat::PrehashSigner;
 use tari_crypto::{
     keys::PublicKey,
@@ -157,7 +156,7 @@ async fn create_output_witness<K: OutputMaskProvider>(
 
     let crypto_api = StealthCryptoApi::new();
 
-    let (nonce_secret, public_nonce) = RistrettoPublicKey::random_keypair(&mut thread_rng());
+    let (nonce_secret, public_nonce) = RistrettoPublicKey::random_keypair(&mut rand::rng());
     let encrypted_data = crypto_api.encrypt_value_and_mask(
         amount.get(),
         &mask,

--- a/crates/wallet/ootle-rs/src/key_provider/local/private_key.rs
+++ b/crates/wallet/ootle-rs/src/key_provider/local/private_key.rs
@@ -1,7 +1,7 @@
 //   Copyright 2026 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use rand::{CryptoRng, Rng, thread_rng};
+use rand::{CryptoRng, Rng};
 
 use crate::{Network, key_provider::local::LocalKeyProvider, keys::OotleSecretKey};
 
@@ -23,7 +23,7 @@ impl LocalKeyProvider<OotleSecretKey> {
 
     /// Generate a new PrivateKeySigner with a (non-recoverable) random private key.
     pub fn random(network: Network) -> Self {
-        Self::random_with(network, &mut thread_rng())
+        Self::random_with(network, &mut rand::rng())
     }
 
     pub fn random_with<R: Rng + CryptoRng>(network: Network, rng: &mut R) -> Self {

--- a/crates/wallet/ootle-rs/src/keys/secret.rs
+++ b/crates/wallet/ootle-rs/src/keys/secret.rs
@@ -3,7 +3,6 @@
 
 use async_trait::async_trait;
 use ootle_byte_type::{FromByteType, ToByteType};
-use rand::thread_rng;
 use signature::{Keypair, hazmat::PrehashSigner};
 use tari_crypto::{
     keys::{PublicKey, SecretKey},
@@ -40,7 +39,7 @@ impl OotleSecretKey {
     }
 
     pub fn random(network: Network) -> Self {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         Self::random_with(&mut rng, network)
     }
 
@@ -75,7 +74,7 @@ impl OotleSecretKey {
 
 impl PrehashSigner<(RistrettoSchnorr, RistrettoPublicKey)> for OotleSecretKey {
     fn sign_prehash(&self, prehash: &[u8]) -> signature::Result<(RistrettoSchnorr, RistrettoPublicKey)> {
-        let signature = RistrettoSchnorr::sign(&self.account_secret, prehash, &mut rand::thread_rng())
+        let signature = RistrettoSchnorr::sign(&self.account_secret, prehash, &mut rand::rng())
             .expect("sign is infallible (challenge is the correct length)");
         let public_key = self.verifying_key();
         Ok((signature, public_key))
@@ -89,7 +88,7 @@ impl StealthKeyPrehashSigner<(RistrettoSchnorr, RistrettoPublicKey)> for OotleSe
         prehash: &[u8],
     ) -> signer::Result<(RistrettoSchnorr, RistrettoPublicKey)> {
         let secret = kdfs::owner_stealth_dh_secret(self.network(), self.account_secret(), public_nonce);
-        let signature = RistrettoSchnorr::sign(&secret, prehash, &mut thread_rng())
+        let signature = RistrettoSchnorr::sign(&secret, prehash, &mut rand::rng())
             .expect("sign is infallible (challenge is the correct length)");
         let public_key = RistrettoPublicKey::from_secret_key(&secret);
         Ok((signature, public_key))
@@ -163,6 +162,6 @@ impl OutputMaskProvider for OotleSecretKey {
     async fn next_mask(&self) -> key_provider::Result<RistrettoSecretKey> {
         // For simplicity, just generate a random mask here. Another implementation may want to derive it in some
         // deterministic way.
-        Ok(RistrettoSecretKey::random(&mut rand::thread_rng()))
+        Ok(RistrettoSecretKey::random(&mut rand::rng()))
     }
 }

--- a/crates/wallet/ootle-rs/src/signer/local_signer/private_key.rs
+++ b/crates/wallet/ootle-rs/src/signer/local_signer/private_key.rs
@@ -44,7 +44,7 @@ impl LocalSigner<OotleSecretKey> {
 
     /// Generate a new PrivateKeySigner with a (non-recoverable) random private key.
     pub fn random(network: Network) -> Self {
-        Self::random_with(network, &mut rand::thread_rng())
+        Self::random_with(network, &mut rand::rng())
     }
 
     pub fn random_with<R: Rng + CryptoRng>(network: Network, rng: &mut R) -> Self {

--- a/crates/wallet/ootle-rs/src/transaction/ephemeral_signer.rs
+++ b/crates/wallet/ootle-rs/src/transaction/ephemeral_signer.rs
@@ -23,7 +23,7 @@ impl EphemeralKeySigner {
     }
 
     pub fn random() -> Self {
-        Self::random_with(&mut rand::thread_rng())
+        Self::random_with(&mut rand::rng())
     }
 
     pub fn seal_transaction(self, transaction: UnsealedTransaction) -> Transaction {

--- a/crates/wallet/sdk/Cargo.toml
+++ b/crates/wallet/sdk/Cargo.toml
@@ -26,7 +26,6 @@ ootle_byte_type = { workspace = true }
 ootle-network = { workspace = true }
 
 anyhow = { workspace = true }
-digest = { workspace = true }
 log = { workspace = true }
 serde = { workspace = true, default-features = true }
 futures = { workspace = true }

--- a/crates/wallet/sdk/src/apis/confidential_transfer.rs
+++ b/crates/wallet/sdk/src/apis/confidential_transfer.rs
@@ -3,7 +3,6 @@
 
 use std::cmp;
 
-use digest::crypto_common::rand_core::OsRng;
 use log::*;
 use ootle_byte_type::{FromByteType, ToByteType};
 use tari_bor::{Deserialize, Serialize};
@@ -433,7 +432,7 @@ where TSpec: WalletSdkSpec
                         .to_string(),
                 })?;
 
-        let (nonce, public_nonce) = RistrettoPublicKey::random_keypair(&mut OsRng);
+        let (nonce, public_nonce) = RistrettoPublicKey::random_keypair(&mut rand::rng());
         let encrypted_data =
             self.crypto_api
                 .encrypt_value_and_mask(amount, &mask.key, dest_public_key, &nonce, memo)?;

--- a/crates/wallet/sdk/src/apis/key_manager.rs
+++ b/crates/wallet/sdk/src/apis/key_manager.rs
@@ -3,7 +3,6 @@
 
 use ootle_byte_type::FromByteType;
 use ootle_network::Network;
-use rand::rngs::OsRng;
 use tari_common_types::seeds::cipher_seed;
 use tari_crypto::{
     keys::{PublicKey as _, SecretKey},
@@ -306,7 +305,7 @@ impl<'a, TSpec: WalletSdkSpec> KeyManagerApi<'a, TSpec> {
     }
 
     pub fn create_throwaway_nonce(&self) -> RistrettoSecretKey {
-        RistrettoSecretKey::random(&mut OsRng)
+        RistrettoSecretKey::random(&mut rand::rng())
     }
 
     pub fn set_active_key<B: AsRef<str>>(&self, branch: B, index: u64) -> Result<(), KeyManagerApiError> {
@@ -400,7 +399,7 @@ impl<'a, TSpec: WalletSdkSpec> KeyManagerApi<'a, TSpec> {
         T: Signable<C>,
         T::Signature: From<SignatureOutput>,
     {
-        let signature = RistrettoSchnorr::sign(secret_key, item.to_signing_message(context), &mut OsRng)
+        let signature = RistrettoSchnorr::sign(secret_key, item.to_signing_message(context), &mut rand::rng())
             .expect("RistrettoSchnorr::sign is infallible as it internally hashes the message into canonical form");
         let public_key = RistrettoPublicKey::from_secret_key(secret_key);
         Ok(SignatureOutput { public_key, signature }.into())

--- a/crates/wallet/sdk/src/apis/password_manager.rs
+++ b/crates/wallet/sdk/src/apis/password_manager.rs
@@ -1,7 +1,7 @@
 //   Copyright 2025 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use digest::crypto_common::rand_core::{OsRng, RngCore};
+use rand::Rng;
 use ootle_network::NetworkParseError;
 use passwords::PasswordGenerator;
 use tari_crypto::tari_utilities::SafePassword;
@@ -96,7 +96,7 @@ impl<'a, TStore: WalletStore> PasswordManagerApi<'a, TStore> {
 }
 
 fn generate_password_entry_key_nonce() -> u64 {
-    OsRng.next_u64()
+    rand::rng().next_u64()
 }
 
 /// Generate a new random password.

--- a/crates/wallet/sdk/src/apis/password_manager.rs
+++ b/crates/wallet/sdk/src/apis/password_manager.rs
@@ -1,9 +1,9 @@
 //   Copyright 2025 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use rand::Rng;
 use ootle_network::NetworkParseError;
 use passwords::PasswordGenerator;
+use rand::Rng;
 use tari_crypto::tari_utilities::SafePassword;
 use tari_ootle_common_types::optional::{IsNotFoundError, Optional};
 

--- a/crates/wallet/sdk/src/apis/stealth_outputs.rs
+++ b/crates/wallet/sdk/src/apis/stealth_outputs.rs
@@ -3,7 +3,6 @@
 
 use std::collections::HashMap;
 
-use digest::crypto_common::rand_core::OsRng;
 use log::*;
 use ootle_byte_type::{FromByteType, ToByteType};
 use ootle_network::Network;
@@ -666,7 +665,7 @@ impl<'a, TSpec: WalletSdkSpec> StealthOutputsApi<'a, TSpec> {
     ) -> Result<StealthOutputWitness, StealthOutputsApiError> {
         let mask = self.key_manager_api.next_key(KeyBranch::StealthMask)?;
 
-        let (nonce_secret, public_nonce) = RistrettoPublicKey::random_keypair(&mut OsRng);
+        let (nonce_secret, public_nonce) = RistrettoPublicKey::random_keypair(&mut rand::rng());
         let encrypted_data = self.crypto_api.encrypt_value_and_mask(
             amount,
             &mask.key,

--- a/crates/wallet/sdk/src/key_managers/backend.rs
+++ b/crates/wallet/sdk/src/key_managers/backend.rs
@@ -1,7 +1,6 @@
 //   Copyright 2025 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use rand::rngs::OsRng;
 use tari_common_types::seeds::cipher_seed::CipherSeed;
 use tari_crypto::{
     keys::PublicKey,
@@ -28,7 +27,7 @@ pub trait WalletKeyStore {
         message: &M,
     ) -> Result<SignatureOutput, Self::Error> {
         let secret = self.derive_secret(key_branch, index)?;
-        let signature = RistrettoSchnorr::sign(&secret, message.to_signing_message(context), &mut OsRng)
+        let signature = RistrettoSchnorr::sign(&secret, message.to_signing_message(context), &mut rand::rng())
             .expect("RistrettoSchnorr::sign is infallible as it internally hashes the message into canonical form");
         Ok(SignatureOutput {
             signature,

--- a/crates/wallet/sdk/src/models/key.rs
+++ b/crates/wallet/sdk/src/models/key.rs
@@ -4,7 +4,6 @@
 use std::{fmt::Display, str::FromStr};
 
 use anyhow::anyhow;
-use rand::rngs::OsRng;
 use tari_bor::{Deserialize, Serialize};
 use tari_crypto::{
     keys::PublicKey as _,
@@ -177,7 +176,7 @@ impl WalletSecretKey {
 
     pub fn sign<T: Signable<C>, C>(&self, context: C, item: &T) -> RistrettoSchnorr {
         let message = item.to_signing_message(context);
-        RistrettoSchnorr::sign(&self.secret, message.as_ref(), &mut OsRng)
+        RistrettoSchnorr::sign(&self.secret, message.as_ref(), &mut rand::rng())
             .expect("message is hashed internally into canonical form, so signing is infallible")
     }
 }

--- a/crates/wallet/sdk_tests/Cargo.toml
+++ b/crates/wallet/sdk_tests/Cargo.toml
@@ -26,3 +26,4 @@ tari_indexer_client = { workspace = true, default-features = false }
 ootle_byte_type = { workspace = true }
 tempfile = { workspace = true }
 digest = { workspace = true }
+rand = { workspace = true }

--- a/crates/wallet/sdk_tests/tests/support/utils.rs
+++ b/crates/wallet/sdk_tests/tests/support/utils.rs
@@ -1,7 +1,6 @@
 //   Copyright 2025 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use digest::crypto_common::rand_core::OsRng;
 use tari_crypto::{
     keys::{PublicKey, SecretKey},
     ristretto::{RistrettoPublicKey, RistrettoSecretKey},
@@ -15,7 +14,7 @@ pub fn random_keypair() -> (RistrettoSecretKey, RistrettoPublicKey) {
 }
 
 pub fn random_key() -> RistrettoSecretKey {
-    RistrettoSecretKey::random(&mut OsRng)
+    RistrettoSecretKey::random(&mut rand::rng())
 }
 
 pub fn resource_address_from_seed(seed: u8) -> ResourceAddress {

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -48,8 +48,8 @@ ootle_byte_type = { workspace = true }
 # Minotari
 #minotari_console_wallet = { workspace = true }
 #minotari_node = { workspace = true }
-minotari_console_wallet = { git = "https://github.com/tari-project/tari.git", tag = "v5.3.0-rc.0" }
-minotari_node = { git = "https://github.com/tari-project/tari.git", tag = "v5.3.0-rc.0" }
+minotari_console_wallet = { git = "https://github.com/tari-project/tari.git", tag = "v5.3.1-pre.0" }
+minotari_node = { git = "https://github.com/tari-project/tari.git", tag = "v5.3.1-pre.0" }
 minotari_wallet = { workspace = true }
 tari_comms = { workspace = true }
 tari_comms_dht = { workspace = true }

--- a/integration_tests/src/base_node.rs
+++ b/integration_tests/src/base_node.rs
@@ -23,7 +23,6 @@
 use std::{path::PathBuf, str::FromStr, sync::Arc};
 
 use minotari_node::{BaseNodeConfig, GrpcMethod, run_base_node};
-use rand::rngs::OsRng;
 use tari_base_node_client::{BaseNodeClient, grpc::GrpcBaseNodeClient};
 use tari_common::{configuration::CommonConfig, exit_codes::ExitError};
 use tari_common_sqlite::connection::DbConnectionUrl;
@@ -67,7 +66,7 @@ pub async fn spawn_base_node(world: &mut TariWorld, bn_name: String) {
     // None => (19000, 19500), // default ports if it's the first base node to be spawned
     // };
     let base_node_address = Multiaddr::from_str(&format!("/ip4/127.0.0.1/tcp/{}", port)).unwrap();
-    let base_node_identity = NodeIdentity::random(&mut OsRng, base_node_address, PeerFeatures::COMMUNICATION_NODE);
+    let base_node_identity = NodeIdentity::random(&mut rand::rng(), base_node_address, PeerFeatures::COMMUNICATION_NODE);
     crate::cucumber_log!("Base node identity: {}", base_node_identity);
     let identity = base_node_identity.clone();
     let temp_dir = get_base_dir_for_scenario("base_node", world.current_scenario_name.as_ref().unwrap(), &bn_name);

--- a/integration_tests/src/base_node.rs
+++ b/integration_tests/src/base_node.rs
@@ -66,7 +66,8 @@ pub async fn spawn_base_node(world: &mut TariWorld, bn_name: String) {
     // None => (19000, 19500), // default ports if it's the first base node to be spawned
     // };
     let base_node_address = Multiaddr::from_str(&format!("/ip4/127.0.0.1/tcp/{}", port)).unwrap();
-    let base_node_identity = NodeIdentity::random(&mut rand::rng(), base_node_address, PeerFeatures::COMMUNICATION_NODE);
+    let base_node_identity =
+        NodeIdentity::random(&mut rand::rng(), base_node_address, PeerFeatures::COMMUNICATION_NODE);
     crate::cucumber_log!("Base node identity: {}", base_node_identity);
     let identity = base_node_identity.clone();
     let temp_dir = get_base_dir_for_scenario("base_node", world.current_scenario_name.as_ref().unwrap(), &bn_name);

--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -33,7 +33,6 @@ use http_server::MockHttpServer;
 use indexer::IndexerProcess;
 use indexmap::IndexMap;
 use miner::MinerProcess;
-use rand::rngs::OsRng;
 use tari_common::configuration::Network as L1Network;
 use tari_common_types::{
     tari_address::{TariAddress, TariAddressFeatures},
@@ -102,7 +101,7 @@ pub struct TariWorld {
 
 impl TariWorld {
     async fn init() -> Self {
-        let wallet_private_key = PrivateKey::random(&mut OsRng);
+        let wallet_private_key = PrivateKey::random(&mut rand::rng());
         let default_payment_address = TariAddress::new_single_address(
             CompressedPublicKey::from_secret_key(&wallet_private_key),
             L1Network::LocalNet,

--- a/integration_tests/tests/steps/wallet_daemon.rs
+++ b/integration_tests/tests/steps/wallet_daemon.rs
@@ -11,7 +11,7 @@ use integration_tests::{
     util::transaction_builder,
     wallet_daemon_client,
 };
-use rand::{Rng, rngs::OsRng};
+use rand::RngExt;
 use tari_crypto::tari_utilities::ByteArray;
 use tari_engine_types::commit_result::FinalizeResult;
 use tari_ootle_transaction::args;
@@ -130,7 +130,7 @@ async fn when_i_run_up_fees(
     let mut fees_total = 0;
 
     loop {
-        let payload = Bytes::from(vec![OsRng.r#gen::<u8>(); 64 * 1024]);
+        let payload = Bytes::from(vec![rand::rng().random::<u8>(); 64 * 1024]);
 
         let transaction = transaction_builder()
             .pay_fee_from_component(*account.component_address(), 100_000u64)

--- a/networking/core/src/relay_state.rs
+++ b/networking/core/src/relay_state.rs
@@ -78,7 +78,7 @@ impl RelayState {
     }
 
     pub fn select_random_relay(&mut self) {
-        let Some((peer, addrs)) = self.possible_relays.iter().choose(&mut rand::thread_rng()) else {
+        let Some((peer, addrs)) = self.possible_relays.iter().choose(&mut rand::rng()) else {
             return;
         };
         self.selected_relay = Some(RelayPeer {

--- a/utilities/traffic-sim/src/sim.rs
+++ b/utilities/traffic-sim/src/sim.rs
@@ -7,7 +7,7 @@ use std::{
     time::Duration,
 };
 
-use rand::Rng;
+use rand::RngExt;
 use reqwest::Client;
 use serde_json::json;
 use tari_indexer_client::types::{GetSubstateRequest, ListUtxosRequest};
@@ -193,12 +193,12 @@ impl TrafficSim {
             return Err(anyhow::anyhow!("Need at least 2 wallets to send transactions"));
         }
 
-        let mut rng = rand::thread_rng();
-        let sender_idx = rng.gen_range(0..self.accounts.len());
-        let mut receiver_idx = rng.gen_range(0..self.accounts.len());
+        let mut rng = rand::rng();
+        let sender_idx = rng.random_range(0..self.accounts.len());
+        let mut receiver_idx = rng.random_range(0..self.accounts.len());
 
         while receiver_idx == sender_idx {
-            receiver_idx = rng.gen_range(0..self.accounts.len());
+            receiver_idx = rng.random_range(0..self.accounts.len());
         }
 
         let sender_account = &self.accounts[sender_idx];
@@ -206,7 +206,7 @@ impl TrafficSim {
         let receiver_address = &self.accounts[receiver_idx];
         let receiver_wallet = &self.wallets[receiver_idx];
 
-        let amount_to_send = rng.gen_range(min_value..=max_value);
+        let amount_to_send = rng.random_range(min_value..=max_value);
 
         log::info!(
             "Sending {} ootle from {} to {}",
@@ -546,7 +546,7 @@ impl TrafficSim {
                 .await
             {
                 Ok(_) => {
-                    // let delay = rand::thread_rng().gen_range(1..=5);
+                    // let delay = rand::thread_rng().random_range(1..=5);
                     // sleep(Duration::from_secs(delay)).await;
                 },
                 Err(e) => {

--- a/utilities/transaction_generator/src/main.rs
+++ b/utilities/transaction_generator/src/main.rs
@@ -13,7 +13,6 @@ use std::{
 
 use anyhow::anyhow;
 use cli::Cli;
-use rand::rngs::OsRng;
 use tari_crypto::{keys::SecretKey, ristretto::RistrettoSecretKey, tari_utilities::hex::Hex};
 use tari_ootle_transaction::Network;
 use tari_transaction_manifest::ManifestValue;
@@ -89,7 +88,7 @@ fn get_transaction_builder(args: &WriteArgs) -> anyhow::Result<BoxedTransactionB
                 .map(|s| RistrettoSecretKey::from_hex(s))
                 .transpose()
                 .map_err(|_| anyhow!("Failed to parse secret"))?
-                .unwrap_or_else(|| RistrettoSecretKey::random(&mut OsRng));
+                .unwrap_or_else(|| RistrettoSecretKey::random(&mut rand::rng()));
             let mut manifest_args = parse_args(&args.manifest_args)?;
             if let Some(args_file) = &args.manifest_args_file {
                 let file = io::BufReader::new(fs::File::open(args_file)?);

--- a/utilities/transaction_generator/src/transaction_builders/free_coins.rs
+++ b/utilities/transaction_generator/src/transaction_builders/free_coins.rs
@@ -2,7 +2,6 @@
 //   SPDX-License-Identifier: BSD-3-Clause
 
 use ootle_byte_type::ToByteType;
-use rand::rngs::OsRng;
 use tari_crypto::{keys::PublicKey, ristretto::RistrettoPublicKey};
 use tari_ootle_common_types::SubstateRequirement;
 use tari_ootle_transaction::{Network, Transaction, args};
@@ -15,7 +14,7 @@ use tari_template_lib_types::constants::{
 
 pub fn builder(network: Network) -> impl Fn(u64) -> Transaction {
     move |_: u64| -> Transaction {
-        let (signer_secret_key, signer_public_key) = RistrettoPublicKey::random_keypair(&mut OsRng);
+        let (signer_secret_key, signer_public_key) = RistrettoPublicKey::random_keypair(&mut rand::rng());
         let signer_public_key = signer_public_key.to_byte_type();
 
         Transaction::builder(network.as_byte())


### PR DESCRIPTION
## Summary

Pulls in the new tari-project/rust-libp2p fork rev (`76f31bc0`), and migrates the workspace to the rand 0.10 APIs that the new fork transitively requires.

The forcing constraint is `libp2p-identity` in the new fork rev, which now declares `tari_crypto = \"0.23\"` (Schnorr-Ristretto keys). Keeping `tari_crypto` coherent across the workspace boundary (libp2p ↔ minotari ↔ ootle) requires moving the rest of the tari pins together:

- `tari_crypto`: 0.22 → 0.23
- `tari_utilities`: 0.8 → 0.10
- `tari_hashing`: 5.3.0-rc.0 → 5.3.1-pre.0
- `tari` git tag: v5.3.0-rc.0 → v5.3.1-pre.0
- `libp2p` rev: 470c4138 → 76f31bc0

`tari_crypto 0.23` moved its `rand` pin from 0.8 to 0.10, which is the bulk of the file changes. Rand 0.10 renamed/moved several APIs:

| 0.8/0.9 | 0.10 |
|---|---|
| `rand::rngs::OsRng` (zero-sized type) | `rand::rng()` (returns `ThreadRng`) — `OsRng` was renamed to `SysRng` upstream; we use the ergonomic `rng()` entry point |
| `rand::thread_rng()` | `rand::rng()` |
| `.gen()` / `.r#gen::<T>()` | `.random::<T>()` (`gen` is reserved in edition 2024) |
| `use rand::RngCore` | `use rand::Rng` (rand_core renamed `RngCore` → `Rng`) |
| `use rand::Rng` (for `random()`, `fill()`, etc.) | `use rand::RngExt` |

`crates/wallet/crypto/src/encrypted_data.rs` keeps using `aead::OsRng` from `chacha20poly1305` — that's a separate crate's RNG type, unaffected by this migration.

## Lockfile pins

Two pins keep the crypto graph compilable:

- **`blake2 = 0.11.0-rc.5`** (was rc.6). `blake2 0.11.0-rc.6` declares `digest = \"^0.11\"`, which lets cargo pick the released `digest 0.11.3`. That release pairs with `block-buffer 0.12`, but the resulting type-system combination doesn't compile (missing `NonZero` bound on `_BlockSize`). `0.11.0-rc.5` declares `digest = \"^0.11.0-rc.11\"`, which keeps cargo on the working `digest 0.11.0-rc.11` + `block-buffer 0.11` pair.
- **`digest = 0.11.0-rc.11`** to make that pin explicit and survive future re-resolves.

## Not in scope

This PR does **not** address #2091 (RUSTSEC-2026-0119, hickory-proto 0.25.2 in `libp2p-mdns`). Upstream rust-libp2p's hickory 0.26 bump is in flight at libp2p/rust-libp2p#6418 (still draft); the tari fork rev here doesn't include the hickory bump yet.

## Test plan

- [x] `cargo check --workspace` passes
- [x] `cargo check --workspace --tests --benches` passes
- [ ] Smoke test: spin up swarm, verify p2p connectivity is unaffected by the rand/tari_crypto migration
- [ ] CI green