### PR TITLE
chore: bump several crates to include tari_crypto change

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1707,7 +1707,7 @@ dependencies = [
 
 [[package]]
 name = "consensus_tests"
-version = "0.30.3"
+version = "0.30.4"
 dependencies = [
  "fern",
  "futures 0.3.31",
@@ -2711,7 +2711,7 @@ dependencies = [
 
 [[package]]
 name = "db-inspector"
-version = "0.30.3"
+version = "0.30.4"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -5101,7 +5101,7 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "integration_tests"
-version = "0.30.3"
+version = "0.30.4"
 dependencies = [
  "anyhow",
  "config",
@@ -5883,7 +5883,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-messaging"
-version = "0.30.3"
+version = "0.30.4"
 dependencies = [
  "async-trait",
  "futures-bounded 0.2.4",
@@ -6061,7 +6061,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-substream"
-version = "0.30.3"
+version = "0.30.4"
 dependencies = [
  "libp2p",
  "prometheus-client",
@@ -7617,7 +7617,7 @@ dependencies = [
 
 [[package]]
 name = "ootle-rs"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7646,7 +7646,7 @@ dependencies = [
 
 [[package]]
 name = "ootle-wasm"
-version = "0.30.3"
+version = "0.30.4"
 dependencies = [
  "console_error_panic_hook",
  "getrandom 0.2.17",
@@ -7656,7 +7656,7 @@ dependencies = [
 
 [[package]]
 name = "ootle-wasm-core"
-version = "0.30.3"
+version = "0.30.4"
 dependencies = [
  "base64 0.22.1",
  "ootle_byte_type",
@@ -7673,7 +7673,7 @@ dependencies = [
 
 [[package]]
 name = "ootle_byte_type"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "tari_crypto",
  "tari_template_lib_types",
@@ -8662,7 +8662,7 @@ dependencies = [
 
 [[package]]
 name = "proto_builder"
-version = "0.30.3"
+version = "0.30.4"
 dependencies = [
  "prost-build 0.14.3",
  "sha2 0.10.9",
@@ -10540,7 +10540,7 @@ dependencies = [
 
 [[package]]
 name = "sqlite_message_logger"
-version = "0.30.3"
+version = "0.30.4"
 dependencies = [
  "chrono",
  "diesel",
@@ -10912,7 +10912,7 @@ dependencies = [
 
 [[package]]
 name = "tari_base_node_client"
-version = "0.30.3"
+version = "0.30.4"
 dependencies = [
  "futures-util",
  "log",
@@ -11139,7 +11139,7 @@ dependencies = [
 
 [[package]]
 name = "tari_consensus"
-version = "0.30.3"
+version = "0.30.4"
 dependencies = [
  "anyhow",
  "indexmap 2.13.0",
@@ -11164,7 +11164,7 @@ dependencies = [
 
 [[package]]
 name = "tari_consensus_types"
-version = "0.30.3"
+version = "0.30.4"
 dependencies = [
  "borsh",
  "ootle_serde",
@@ -11264,7 +11264,7 @@ dependencies = [
 
 [[package]]
 name = "tari_engine"
-version = "0.30.3"
+version = "0.30.4"
 dependencies = [
  "blake2 0.10.6",
  "bytes",
@@ -11295,7 +11295,7 @@ dependencies = [
 
 [[package]]
 name = "tari_engine_types"
-version = "0.30.3"
+version = "0.30.4"
 dependencies = [
  "bincode 2.0.1",
  "blake2 0.10.6",
@@ -11324,7 +11324,7 @@ dependencies = [
 
 [[package]]
 name = "tari_epoch_manager"
-version = "0.30.3"
+version = "0.30.4"
 dependencies = [
  "anyhow",
  "log",
@@ -11344,7 +11344,7 @@ dependencies = [
 
 [[package]]
 name = "tari_epoch_oracles"
-version = "0.30.3"
+version = "0.30.4"
 dependencies = [
  "anyhow",
  "blake2 0.10.6",
@@ -11398,7 +11398,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer"
-version = "0.30.3"
+version = "0.30.4"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -11471,7 +11471,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer_client"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "anyhow",
  "bounded-vec",
@@ -11500,7 +11500,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer_lib"
-version = "0.30.3"
+version = "0.30.4"
 dependencies = [
  "log",
  "prometheus-client",
@@ -11604,7 +11604,7 @@ dependencies = [
 
 [[package]]
 name = "tari_networking"
-version = "0.30.3"
+version = "0.30.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11641,7 +11641,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_address"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "bech32",
  "bincode 2.0.1",
@@ -11657,7 +11657,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_app_utilities"
-version = "0.30.3"
+version = "0.30.4"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -11697,7 +11697,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_common_types"
-version = "0.30.3"
+version = "0.30.4"
 dependencies = [
  "blake2 0.10.6",
  "borsh",
@@ -11725,7 +11725,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_p2p"
-version = "0.30.3"
+version = "0.30.4"
 dependencies = [
  "anyhow",
  "libp2p-identity 0.2.13 (git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a)",
@@ -11749,7 +11749,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_storage"
-version = "0.30.3"
+version = "0.30.4"
 dependencies = [
  "anyhow",
  "bitflags 2.10.0",
@@ -11776,7 +11776,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_storage_sqlite"
-version = "0.30.3"
+version = "0.30.4"
 dependencies = [
  "diesel",
  "diesel_migrations",
@@ -11797,7 +11797,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_template_build"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "tari_ootle_template_metadata",
  "tempfile",
@@ -11807,7 +11807,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_template_metadata"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "borsh",
  "cargo_toml 0.22.3",
@@ -11827,7 +11827,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_transaction"
-version = "0.30.3"
+version = "0.30.4"
 dependencies = [
  "bincode 2.0.1",
  "borsh",
@@ -11853,7 +11853,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_cli"
-version = "0.30.3"
+version = "0.30.4"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -11882,7 +11882,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_crypto"
-version = "0.30.3"
+version = "0.30.4"
 dependencies = [
  "argon2 0.5.3",
  "blake2 0.10.6",
@@ -11912,7 +11912,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_sdk"
-version = "0.30.3"
+version = "0.30.4"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -11974,7 +11974,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_sdk_tests"
-version = "0.30.3"
+version = "0.30.4"
 dependencies = [
  "digest 0.10.7",
  "ootle_byte_type",
@@ -11996,7 +11996,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_storage_sqlite"
-version = "0.30.3"
+version = "0.30.4"
 dependencies = [
  "diesel",
  "diesel_migrations",
@@ -12019,7 +12019,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_walletd"
-version = "0.30.3"
+version = "0.30.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12083,7 +12083,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_walletd_client"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "hex",
  "ootle_serde",
@@ -12137,7 +12137,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_framework"
-version = "0.30.3"
+version = "0.30.4"
 dependencies = [
  "async-trait",
  "bitflags 2.10.0",
@@ -12161,7 +12161,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_macros"
-version = "0.30.3"
+version = "0.30.4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12170,7 +12170,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_state_sync"
-version = "0.30.3"
+version = "0.30.4"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -12247,7 +12247,7 @@ dependencies = [
 
 [[package]]
 name = "tari_state_store_rocksdb"
-version = "0.30.3"
+version = "0.30.4"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -12279,7 +12279,7 @@ dependencies = [
 
 [[package]]
 name = "tari_state_tree"
-version = "0.30.3"
+version = "0.30.4"
 dependencies = [
  "indexmap 2.13.0",
  "log",
@@ -12305,7 +12305,7 @@ dependencies = [
 
 [[package]]
 name = "tari_swarm"
-version = "0.30.3"
+version = "0.30.4"
 dependencies = [
  "libp2p",
  "libp2p-messaging",
@@ -12316,7 +12316,7 @@ dependencies = [
 
 [[package]]
 name = "tari_swarm_daemon"
-version = "0.30.3"
+version = "0.30.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12371,7 +12371,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_builtin"
-version = "0.30.3"
+version = "0.30.4"
 dependencies = [
  "anyhow",
  "tari_engine_types",
@@ -12383,7 +12383,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_lib"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "borsh",
  "serde",
@@ -12397,7 +12397,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_lib_types"
-version = "0.25.2"
+version = "0.26.0"
 dependencies = [
  "bincode 2.0.1",
  "bnum",
@@ -12427,7 +12427,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_test_tooling"
-version = "0.30.3"
+version = "0.30.4"
 dependencies = [
  "anyhow",
  "cargo_toml 0.22.3",
@@ -12540,7 +12540,7 @@ dependencies = [
 
 [[package]]
 name = "tari_transaction_manifest"
-version = "0.30.3"
+version = "0.30.4"
 dependencies = [
  "proc-macro2",
  "serde_json",
@@ -12575,7 +12575,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node"
-version = "0.30.3"
+version = "0.30.4"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -12641,7 +12641,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node_client"
-version = "0.30.3"
+version = "0.30.4"
 dependencies = [
  "indexmap 2.13.0",
  "multiaddr 0.18.3",
@@ -12665,7 +12665,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node_rpc"
-version = "0.30.3"
+version = "0.30.4"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -12688,7 +12688,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_rollback"
-version = "0.30.3"
+version = "0.30.4"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12723,7 +12723,7 @@ dependencies = [
 
 [[package]]
 name = "tari_watcher"
-version = "0.30.3"
+version = "0.30.4"
 dependencies = [
  "anyhow",
  "clap 3.2.25",
@@ -12752,7 +12752,7 @@ dependencies = [
 
 [[package]]
 name = "tariswap_bench"
-version = "0.30.3"
+version = "0.30.4"
 dependencies = [
  "anyhow",
  "clap 4.5.54",
@@ -13432,7 +13432,7 @@ dependencies = [
 
 [[package]]
 name = "traffic-sim"
-version = "0.30.3"
+version = "0.30.4"
 dependencies = [
  "anyhow",
  "clap 4.5.54",
@@ -13454,7 +13454,7 @@ dependencies = [
 
 [[package]]
 name = "transaction_generator"
-version = "0.30.3"
+version = "0.30.4"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -13473,7 +13473,7 @@ dependencies = [
 
 [[package]]
 name = "transaction_submitter"
-version = "0.30.3"
+version = "0.30.4"
 dependencies = [
  "anyhow",
  "clap 4.5.54",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.30.3"
+version = "0.30.4"
 edition = "2024"
 authors = ["The Tari Development Community"]
 repository = "https://github.com/tari-project/tari-ootle"
@@ -88,7 +88,7 @@ tari_ootle_app_utilities = { path = "applications/tari_ootle_app_utilities" }
 
 # core crates
 tari_consensus = { path = "crates/consensus" }
-tari_ootle_address = { path = "crates/ootle_address", version = "0.4" }
+tari_ootle_address = { path = "crates/ootle_address", version = "0.5" }
 ootle-network = { path = "crates/ootle_network", version = "0.1" }
 tari_engine = { path = "crates/engine", version = "0.30" }
 tari_ootle_p2p = { path = "crates/p2p" }
@@ -128,14 +128,14 @@ tari_ootle_transaction = { path = "crates/transaction", version = "0.30" }
 
 # Template lib
 tari_ootle_template_build = { path = "crates/template_build", version = "0.5" }
-tari_ootle_template_metadata = { path = "crates/template_metadata", version = "0.5" }
+tari_ootle_template_metadata = { path = "crates/template_metadata", version = "0.6" }
 tari_template_lib = { version = "0.26", path = "crates/template_lib" }
-tari_template_lib_types = { version = "0.25", path = "crates/template_lib_types", default-features = false }
+tari_template_lib_types = { version = "0.26", path = "crates/template_lib_types", default-features = false }
 tari_template_abi = { version = "0.16", path = "crates/template_abi", default-features = false }
 tari_template_macros = { version = "0.19", path = "crates/template_macros" }
 tari_bor = { version = "0.13", path = "crates/tari_bor", default-features = false }
 
-ootle_byte_type = { path = "crates/ootle_byte_type", version = "0.6" }
+ootle_byte_type = { path = "crates/ootle_byte_type", version = "0.7" }
 ootle_serde = { path = "crates/ootle_serde", version = "0.2" }
 
 # external minotari/tari dependencies

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,7 +127,7 @@ tari_template_builtin = { path = "crates/template_builtin", version = "0.30" }
 tari_ootle_transaction = { path = "crates/transaction", version = "0.30" }
 
 # Template lib
-tari_ootle_template_build = { path = "crates/template_build", version = "0.5" }
+tari_ootle_template_build = { path = "crates/template_build", version = "0.6" }
 tari_ootle_template_metadata = { path = "crates/template_metadata", version = "0.6" }
 tari_template_lib = { version = "0.26", path = "crates/template_lib" }
 tari_template_lib_types = { version = "0.26", path = "crates/template_lib_types", default-features = false }

--- a/clients/tari_indexer_client/Cargo.toml
+++ b/clients/tari_indexer_client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_indexer_client"
 description = "Tari indexer client library"
-version = "0.30.1"
+version = "0.30.2"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/clients/wallet_daemon_client/Cargo.toml
+++ b/clients/wallet_daemon_client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_ootle_walletd_client"
 description = "Tari wallet daemon client library"
-version = "0.30.0"
+version = "0.30.1"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/ootle_address/Cargo.toml
+++ b/crates/ootle_address/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_ootle_address"
 description = "Tari Ootle address using bech32 encoding"
-version = "0.4.3"
+version = "0.5.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/ootle_byte_type/Cargo.toml
+++ b/crates/ootle_byte_type/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ootle_byte_type"
-version = "0.6.1"
+version = "0.7.0"
 description = "Conversion traits that define conversions to/from light-weight byte types"
 edition.workspace = true
 authors.workspace = true

--- a/crates/template_build/Cargo.toml
+++ b/crates/template_build/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_ootle_template_build"
 description = "Build-time metadata generation for Tari Ootle templates"
-version = "0.5.1"
+version = "0.6.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/template_builtin/Cargo.toml
+++ b/crates/template_builtin/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_template_builtin"
 description = "Tari Ootle built-in templates"
-version = "0.30.3"
+version = "0.30.4"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/template_lib/Cargo.toml
+++ b/crates/template_lib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_template_lib"
 description = "Tari template library provides abstrations that interface with the Tari validator engine"
-version = "0.26.0"
+version = "0.26.1"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/template_lib_types/Cargo.toml
+++ b/crates/template_lib_types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_template_lib_types"
-version = "0.25.2"
+version = "0.26.0"
 edition.workspace = true
 authors.workspace = true
 description = "Tari template library types"

--- a/crates/template_metadata/Cargo.toml
+++ b/crates/template_metadata/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_ootle_template_metadata"
 description = "Template metadata types, serialization, and hashing for Tari Ootle templates"
-version = "0.5.2"
+version = "0.6.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/wallet/ootle-rs/Cargo.toml
+++ b/crates/wallet/ootle-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ootle-rs"
-version = "0.6.5"
+version = "0.6.6"
 description = "A Rust library for interacting with the Tari Ootle network."
 edition.workspace = true
 authors.workspace = true


### PR DESCRIPTION
Published crates:
  - tari_template_lib_types 0.26.0
  - ootle_byte_type 0.7.0
  - tari_template_lib 0.26.1
  - tari_ootle_template_metadata 0.6.0
  - tari_ootle_template_build 0.6.0
  - tari_engine_types 0.30.4
  - tari_ootle_common_types 0.30.4
  - tari_ootle_wallet_crypto 0.30.4
  - tari_ootle_address 0.5.0
  - tari_ootle_transaction 0.30.4
  - tari_template_builtin 0.30.4
  - tari_transaction_manifest 0.30.4
  - tari_engine 0.30.4
  - tari_consensus_types 0.30.4
  - tari_indexer_client 0.30.2
  - ootle-wasm-core 0.30.4
  - ootle-wasm 0.30.4
  - tari_template_test_tooling 0.30.4
  - ootle-rs 0.6.6
  - tari_ootle_wallet_sdk 0.30.4
  - tari_ootle_wallet_storage_sqlite 0.30.4
  - tari_ootle_walletd_client 0.30.1