### PR TITLE
fix(consensus): defer end-of-epoch processing when local oracle lags

### DIFF
--- a/crates/consensus/src/hotstuff/on_receive_local_proposal.rs
+++ b/crates/consensus/src/hotstuff/on_receive_local_proposal.rs
@@ -5,6 +5,7 @@ use std::{collections::HashSet, time::Duration};
 
 use log::*;
 use ootle_byte_type::ToByteType;
+use tari_common_types::types::FixedHash;
 use tari_consensus_types::{
     Decision,
     HighPc,
@@ -16,7 +17,7 @@ use tari_consensus_types::{
     TimeoutVoteMessage,
     ValidatorSignatureBytes,
 };
-use tari_epoch_manager::EpochManagerReader;
+use tari_epoch_manager::{EpochManagerError, EpochManagerReader};
 use tari_ootle_common_types::{
     Epoch,
     NodeHeight,
@@ -77,6 +78,17 @@ pub struct OnReceiveLocalProposalHandler<TConsensusSpec: ConsensusSpec> {
     on_receive_foreign_proposal: OnReceiveForeignProposalHandler<TConsensusSpec>,
     tx_events: broadcast::WeakSender<HotstuffEvent>,
     hooks: TConsensusSpec::Hooks,
+    /// EOE block whose `next_epoch` could not be looked up locally (oracle is lagging).
+    /// We commit the EOE on disk (peers attest with 2f+1) but defer next-genesis creation
+    /// until the local oracle observes the new epoch.
+    pending_end_of_epoch: Option<PendingEndOfEpoch>,
+}
+
+#[derive(Debug, Clone)]
+struct PendingEndOfEpoch {
+    eoe_block: Block,
+    commit_qc: ProposalCertificate,
+    next_genesis_state_merkle_root: FixedHash,
 }
 
 impl<TConsensusSpec: ConsensusSpec> OnReceiveLocalProposalHandler<TConsensusSpec> {
@@ -122,6 +134,7 @@ impl<TConsensusSpec: ConsensusSpec> OnReceiveLocalProposalHandler<TConsensusSpec
                 transaction_manager,
             ),
             change_set: None,
+            pending_end_of_epoch: None,
         }
     }
 
@@ -433,7 +446,13 @@ impl<TConsensusSpec: ConsensusSpec> OnReceiveLocalProposalHandler<TConsensusSpec
 
         // THere should only be one committed block with end of epoch
         if let Some(eoe_block) = block_decision.take_end_of_epoch_block() {
-            self.process_end_of_epoch(eoe_block, valid_block).await?;
+            // The QC of the block we're processing is the QC that committed the EOE via the
+            // 3-chain rule. Use it as the commit proof and the tip's state merkle root as the
+            // genesis state.
+            let commit_qc = valid_block.justify().clone();
+            let next_genesis_state_merkle_root = *valid_block.block().state_merkle_root();
+            self.process_end_of_epoch(eoe_block, commit_qc, next_genesis_state_merkle_root)
+                .await?;
         }
 
         self.propose_foreign_proposals(local_committee_info, block_decision.commit_blocks);
@@ -449,18 +468,38 @@ impl<TConsensusSpec: ConsensusSpec> OnReceiveLocalProposalHandler<TConsensusSpec
     async fn process_end_of_epoch(
         &mut self,
         eoe_block: Block,
-        valid_tip_block: ValidBlock,
+        commit_qc: ProposalCertificate,
+        next_genesis_state_merkle_root: FixedHash,
     ) -> Result<(), HotStuffError> {
         let _timer = TraceTimer::debug(LOG_TARGET, "process-end-of-epoch");
         let prev_epoch = eoe_block.epoch();
         let next_epoch = prev_epoch + Epoch(1);
 
+        // Pre-flight: confirm the local oracle has observed `next_epoch`. If not, the EOE has been
+        // committed (peers attest with 2f+1) but we cannot stamp a deterministic genesis yet.
+        // Defer until the oracle catches up; `try_resume_pending_end_of_epoch` will retry from
+        // `on_epoch_manager_event` or worker startup.
+        let epoch_hash = match self.epoch_manager.get_epoch_hash(next_epoch).await {
+            Ok(hash) => hash,
+            Err(EpochManagerError::NoEpochFound(_)) => {
+                warn!(
+                    target: LOG_TARGET,
+                    "⏳ EOE block {} committed but local oracle has not observed {next_epoch}. \
+                     Deferring next-epoch genesis until oracle catches up.",
+                    eoe_block.id()
+                );
+                self.pending_end_of_epoch = Some(PendingEndOfEpoch {
+                    eoe_block,
+                    commit_qc,
+                    next_genesis_state_merkle_root,
+                });
+                return Ok(());
+            },
+            Err(err) => return Err(err.into()),
+        };
+
         // We're registered for the next epoch. Checkpoint and create a new genesis block.
         let num_committees = self.epoch_manager.get_num_committees(next_epoch).await?;
-        // Must look up the hash for `next_epoch` specifically. The oracle's "current" hash can
-        // race ahead when the base-layer scanner catches up across multiple epoch boundaries,
-        // which would stamp a later epoch's hash into this genesis block and wedge consensus.
-        let epoch_hash = self.epoch_manager.get_epoch_hash(next_epoch).await?;
         // Now that EndEpoch has committed and we're about to stamp `epoch_hash` into the genesis
         // block for `next_epoch`, prevent the oracle from later rewriting this epoch's stored hash
         // if a base-layer reorg surfaces a different view.
@@ -475,9 +514,8 @@ impl<TConsensusSpec: ConsensusSpec> OnReceiveLocalProposalHandler<TConsensusSpec
         let sidechain_id = self.config.sidechain_id;
         task::spawn_blocking(move || {
             store.with_write_tx(|tx| {
-                let tip_qc = valid_tip_block.justify();
                 // Generate checkpoint
-                let checkpoint = generate_epoch_checkpoint(&**tx, &eoe_block, tip_qc)?;
+                let checkpoint = generate_epoch_checkpoint(&**tx, &eoe_block, &commit_qc)?;
                 // Technically not needed, but this will make it clear for debugging purposes if the checkpoint is
                 // invalid To validate the entire proof requires the quorum threshold and the committee,
                 // so we'll just skip it
@@ -513,7 +551,7 @@ impl<TConsensusSpec: ConsensusSpec> OnReceiveLocalProposalHandler<TConsensusSpec
                         next_epoch,
                         epoch_hash,
                         next_shard_group,
-                        *valid_tip_block.block().state_merkle_root(),
+                        next_genesis_state_merkle_root,
                         sidechain_id,
                     );
                     info!(target: LOG_TARGET, "⭐️ Creating new genesis block {genesis}");
@@ -551,6 +589,49 @@ impl<TConsensusSpec: ConsensusSpec> OnReceiveLocalProposalHandler<TConsensusSpec
             // Exit consensus and transition to idle
             Err(HotStuffError::NotRegisteredForCurrentEpoch { epoch: next_epoch })
         }
+    }
+
+    /// Seed pending state from disk so a worker that restarts after a deferred EOE can resume
+    /// once the local oracle catches up. `commit_qc` must be the QC that committed `eoe_block`
+    /// (typically `eoe_block.get_commit_qc(tx)`); `next_genesis_state_merkle_root` is the state
+    /// root to stamp into the next epoch's genesis (the EOE's own root suffices when no state
+    /// changes follow it).
+    pub fn set_pending_end_of_epoch(
+        &mut self,
+        eoe_block: Block,
+        commit_qc: ProposalCertificate,
+        next_genesis_state_merkle_root: FixedHash,
+    ) {
+        self.pending_end_of_epoch = Some(PendingEndOfEpoch {
+            eoe_block,
+            commit_qc,
+            next_genesis_state_merkle_root,
+        });
+    }
+
+    pub fn has_pending_end_of_epoch(&self) -> bool {
+        self.pending_end_of_epoch.is_some()
+    }
+
+    /// Retry deferred end-of-epoch processing. Called by the worker when the local oracle
+    /// observes the new epoch (via `EpochManagerEvent::EpochChanged`). If the oracle is still
+    /// not ready, `process_end_of_epoch` will re-defer.
+    pub async fn try_resume_pending_end_of_epoch(&mut self) -> Result<bool, HotStuffError> {
+        let Some(pending) = self.pending_end_of_epoch.take() else {
+            return Ok(false);
+        };
+        info!(
+            target: LOG_TARGET,
+            "▶️ Resuming deferred end-of-epoch processing for EOE block {}",
+            pending.eoe_block.id()
+        );
+        self.process_end_of_epoch(
+            pending.eoe_block,
+            pending.commit_qc,
+            pending.next_genesis_state_merkle_root,
+        )
+        .await?;
+        Ok(true)
     }
 
     fn publish_event(&self, event: HotstuffEvent) {

--- a/crates/consensus/src/hotstuff/worker.rs
+++ b/crates/consensus/src/hotstuff/worker.rs
@@ -299,6 +299,13 @@ impl<TConsensusSpec: ConsensusSpec> HotstuffWorker<TConsensusSpec> {
 
         info!(target: LOG_TARGET, "🚀 Pacemaker started at epoch {}, height: {}", current_epoch, current_height);
 
+        // Recovery: if the previous run crashed inside `process_end_of_epoch` (e.g. NoEpochFound
+        // because the local oracle was lagging), the EOE block is committed on disk but no
+        // checkpoint was written. Detect that here and seed the deferred-EOE state so the next
+        // EpochChanged event (or this startup if the oracle is already current) finishes the
+        // transition.
+        self.recover_pending_end_of_epoch(current_epoch).await?;
+
         self.publish_event(HotstuffEvent::EpochChanged {
             epoch: current_epoch,
             registered_shard_group: Some(local_committee_info.shard_group()),
@@ -631,6 +638,56 @@ impl<TConsensusSpec: ConsensusSpec> HotstuffWorker<TConsensusSpec> {
         Ok(is_any_block_unparked)
     }
 
+    /// Detects an EOE block that was committed but whose next-epoch processing did not finish
+    /// (most likely the previous run crashed inside `process_end_of_epoch` while looking up an
+    /// epoch the local oracle had not yet observed). When found, seeds the deferred-EOE state on
+    /// the local-proposal handler and immediately attempts to resume; if the oracle is still
+    /// behind, the resume will re-defer and `on_epoch_manager_event` will retry later.
+    async fn recover_pending_end_of_epoch(&mut self, current_epoch: Epoch) -> Result<(), HotStuffError> {
+        let pending = self.state_store.with_read_tx(|tx| {
+            // A successful end-of-epoch transition writes a checkpoint for `current_epoch`.
+            // If the latest checkpoint covers this epoch (or later), the previous run finished
+            // cleanly and there is nothing to recover.
+            if let Some(last) = EpochCheckpoint::get_last_checkpoint(tx).optional()? &&
+                last.epoch() >= current_epoch
+            {
+                return Ok::<_, HotStuffError>(None);
+            }
+
+            // Walk back from the leaf looking for a committed EOE block in `current_epoch`.
+            let leaf = LeafBlock::get(tx, current_epoch)?;
+            if leaf.is_genesis() {
+                return Ok(None);
+            }
+            let mut block = Block::get(tx, leaf.block_id())?;
+            loop {
+                if block.is_epoch_end() && block.is_committed() {
+                    let commit_qc = block.get_commit_qc(tx)?;
+                    let state_root = *block.state_merkle_root();
+                    return Ok(Some((block, commit_qc, state_root)));
+                }
+                if block.height().is_zero() || block.parent().is_zero() {
+                    return Ok(None);
+                }
+                block = block.get_parent(tx)?;
+            }
+        })?;
+
+        if let Some((eoe_block, commit_qc, state_root)) = pending {
+            info!(
+                target: LOG_TARGET,
+                "🔄 Detected unprocessed EOE block {} on startup. Seeding deferred end-of-epoch state.",
+                eoe_block.id()
+            );
+            self.on_receive_local_proposal
+                .set_pending_end_of_epoch(eoe_block, commit_qc, state_root);
+            // Attempt to complete immediately. If the oracle is still behind, this will re-defer
+            // and a later EpochChanged event will retry.
+            let _ = self.on_receive_local_proposal.try_resume_pending_end_of_epoch().await?;
+        }
+        Ok(())
+    }
+
     async fn on_epoch_manager_event(&mut self, event: EpochManagerEvent) -> Result<(), HotStuffError> {
         match event {
             EpochManagerEvent::EpochChanged {
@@ -669,6 +726,19 @@ impl<TConsensusSpec: ConsensusSpec> HotstuffWorker<TConsensusSpec> {
                     "🌟 This validator is registered for epoch {}.", epoch
                 );
                 self.next_epoch = Some((epoch, activated_at));
+
+                // Oracle just observed `epoch`. If we previously deferred end-of-epoch
+                // processing because the oracle was lagging, retry now that the data is
+                // available.
+                if self.on_receive_local_proposal.has_pending_end_of_epoch() &&
+                    let Err(err) = self.on_receive_local_proposal.try_resume_pending_end_of_epoch().await
+                {
+                    error!(
+                        target: LOG_TARGET,
+                        "Failed to resume deferred end-of-epoch processing for {epoch}: {err}"
+                    );
+                    return Err(err);
+                }
             },
         }
 

--- a/crates/consensus_tests/src/epoch_change.rs
+++ b/crates/consensus_tests/src/epoch_change.rs
@@ -1,14 +1,18 @@
 //   Copyright 2026 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use tari_consensus::hotstuff::HotStuffError;
-use tari_consensus_types::Decision;
-use tari_ootle_common_types::{Epoch, NodeHeight};
-use tari_ootle_storage::{StateStore, StateStoreReadTransaction};
+use tari_consensus_types::{Decision, LeafBlock};
+use tari_ootle_common_types::{Epoch, NodeHeight, optional::Optional};
+use tari_ootle_storage::{
+    StateStore,
+    StateStoreReadTransaction,
+    consensus_models::{Block, BookkeepingModel},
+};
 
-use crate::support::{Test, logging::setup_logger};
+use crate::support::{Test, TestAddress, logging::setup_logger};
 
 async fn epoch_change(mut test: Test) {
     test.start_epoch(Epoch(1)).await;
@@ -104,4 +108,186 @@ async fn multishard_epoch_change() {
         .await;
 
     epoch_change(test).await;
+}
+
+/// Reproduces the wedge described in `consensus-epoch-change-race-cond`:
+///
+/// One validator's base-layer oracle is still behind when consensus commits the EndEpoch
+/// block. `process_end_of_epoch` then asks the local epoch manager for `next_epoch`'s hash to
+/// stamp into the new genesis; the lookup fails with `NoEpochFound`. Before the fix, that error
+/// killed the worker and left the node permanently stuck on the old epoch — even after the
+/// oracle eventually caught up, no code path retried the deferred work. After the fix, the
+/// work is parked in `pending_end_of_epoch`, the worker keeps running, and the next
+/// `EpochChanged` event (or the next worker startup) retries the transition.
+///
+/// The test:
+///   1. Runs four validators in a single committee.
+///   2. Caps validator "1"'s oracle at `Epoch(1)` so `get_epoch_hash(Epoch(2))` returns `NoEpochFound`. (The cap
+///      intentionally does NOT override `current_epoch()` — the vote-time check uses that, and we want the chain to
+///      commit the EOE on every node so `process_end_of_epoch` actually runs and trips the failure mode.)
+///   3. Drives an epoch change to `Epoch(2)`. All four nodes vote on the EOE, the chain commits it via 3-chain, and
+///      `process_end_of_epoch` runs on each. Three succeed and advance to Epoch(2); validator "1" defers instead of
+///      crashing.
+///   4. Asserts the other three have advanced to `Epoch(2)` while validator "1"'s pacemaker is still on `Epoch(1)` with
+///      a committed EOE block in its chain.
+///   5. Clears the lag and refires `EpochChanged(2)` (modeling the oracle catching up).
+///   6. Asserts validator "1" then advances to `Epoch(2)`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn epoch_change_with_lagging_oracle() {
+    setup_logger();
+    let mut test = Test::builder()
+        .modify_config(|cfg| {
+            cfg.epoch_end_grace_period = Duration::from_millis(10);
+        })
+        .modify_consensus_constants(|c| {
+            c.pacemaker_block_time = Duration::from_secs(2);
+        })
+        .with_test_timeout(Duration::from_secs(60))
+        // 4 validators so 3 honest votes-yes is enough for quorum without the lagged one.
+        .add_committee(0, vec!["1", "2", "3", "4"])
+        .start()
+        .await;
+
+    let lagging_addr = TestAddress::new("1");
+
+    test.start_epoch(Epoch(1)).await;
+
+    // A few transactions to get the chain moving in epoch 1.
+    for _ in 0..3 {
+        test.send_transaction_to_all(Decision::Commit, 1, 1, 1).await;
+    }
+
+    // Cap the lagged validator's oracle BEFORE the epoch transition. After this,
+    // `get_epoch_hash(Epoch(2))` returns `NoEpochFound` for this validator only.
+    test.get_validator(&lagging_addr)
+        .epoch_manager
+        .set_oracle_visible_epoch(Epoch(1));
+
+    // Trigger the epoch change. All four workers receive `EpochChanged(2)` and set
+    // `next_epoch`. Voting on the EOE block goes through normally (we deliberately do
+    // not cap `current_epoch()` so the lagged node still votes Yes), so quorum is
+    // reached and the chain commits the EOE on every node via the 3-chain rule. This
+    // is exactly the state the production bug ends up in once a lagged node catches
+    // up via sync — the EOE is committed locally, but `process_end_of_epoch` then
+    // tries to look up `next_epoch`'s hash and fails.
+    test.start_epoch(Epoch(2)).await;
+
+    // Drive the chain so the EOE 3-chain commits and the non-lagged validators run
+    // process_end_of_epoch successfully (creating the next epoch's genesis and advancing
+    // their pacemakers to Epoch(2)). Sending more transactions keeps the leaders proposing.
+    for _ in 0..3 {
+        test.send_transaction_to_all(Decision::Commit, 1, 1, 1).await;
+    }
+
+    // Wait until the three non-lagged validators have advanced to Epoch(2). Don't include
+    // the lagged validator — under the fix it stays on Epoch(1) until the oracle catches up.
+    wait_for_validators_at_epoch(&mut test, &lagging_addr, Epoch(2), Duration::from_secs(30)).await;
+
+    // Confirm the bug condition is reproduced on the lagged validator:
+    //   (a) its pacemaker is still on Epoch(1)
+    //   (b) the EOE block is committed in its chain (process_end_of_epoch was reached)
+    //   (c) it has no leaf in Epoch(2) (next genesis was deferred)
+    let lagged = test.get_validator(&lagging_addr);
+    assert_eq!(
+        lagged._current_view.get_epoch(),
+        Epoch(1),
+        "lagged validator's pacemaker must remain on Epoch(1) before recovery"
+    );
+
+    let has_committed_eoe = lagged
+        .state_store
+        .with_read_tx(|tx| chain_has_committed_epoch_end(tx, Epoch(1)))
+        .unwrap();
+    assert!(
+        has_committed_eoe,
+        "lagged validator should have committed the EOE block via 3-chain (process_end_of_epoch must have run and \
+         deferred)"
+    );
+
+    let leaf_at_2 = lagged
+        .state_store
+        .with_read_tx(|tx| LeafBlock::get(tx, Epoch(2)))
+        .optional()
+        .unwrap();
+    assert!(
+        leaf_at_2.is_none(),
+        "lagged validator must NOT have a leaf in Epoch(2) before the oracle catches up; got {leaf_at_2:?}"
+    );
+
+    log::info!("✅ bug condition reproduced: lagged validator stuck at Epoch(1) with committed EOE");
+
+    // Now simulate the oracle catching up: clear the lag and re-publish `EpochChanged(2)`.
+    // The worker's `on_epoch_manager_event` sees `has_pending_end_of_epoch` and calls
+    // `try_resume_pending_end_of_epoch`, which re-runs `process_end_of_epoch`. With the
+    // oracle now current, `get_epoch_hash(Epoch(2))` succeeds, the next genesis is created
+    // and the pacemaker advances.
+    let lagged_sg = lagged.shard_group;
+    lagged.epoch_manager.clear_oracle_lag();
+    test.get_validator_mut(&lagging_addr)
+        .epoch_manager
+        .set_current_epoch(Epoch(2), lagged_sg)
+        .await;
+
+    // Assert recovery: the lagged validator now reaches Epoch(2).
+    wait_for_single_validator_at_epoch(&mut test, &lagging_addr, Epoch(2), Duration::from_secs(15)).await;
+
+    log::info!("✅ recovery confirmed: lagged validator advanced to Epoch(2) after oracle caught up");
+
+    test.stop();
+    test.assert_clean_shutdown().await;
+}
+
+/// Walks the chain from the leaf of `epoch` looking for a committed `EndEpoch` block.
+fn chain_has_committed_epoch_end<TTx: StateStoreReadTransaction>(
+    tx: &TTx,
+    epoch: Epoch,
+) -> Result<bool, HotStuffError> {
+    let leaf = LeafBlock::get(tx, epoch)?;
+    if leaf.is_genesis() {
+        return Ok(false);
+    }
+    let mut block = Block::get(tx, leaf.block_id())?;
+    loop {
+        if block.is_epoch_end() && block.is_committed() {
+            return Ok(true);
+        }
+        if block.height().is_zero() || block.parent().is_zero() {
+            return Ok(false);
+        }
+        block = block.get_parent(tx)?;
+    }
+}
+
+/// Waits until every validator EXCEPT `excluded` reaches `epoch` on its pacemaker.
+async fn wait_for_validators_at_epoch(test: &mut Test, excluded: &TestAddress, epoch: Epoch, timeout: Duration) {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        // Drain block events so receiver buffers don't overflow.
+        let _unused = tokio::time::timeout(Duration::from_millis(100), test.on_block_committed()).await;
+
+        let all_advanced = test
+            .validators_iter()
+            .filter(|v| v.address != *excluded)
+            .all(|v| v._current_view.get_epoch() >= epoch);
+        if all_advanced {
+            return;
+        }
+    }
+    panic!("Timed out waiting for non-excluded validators to reach {epoch}");
+}
+
+/// Waits until `addr`'s pacemaker reaches `epoch`.
+async fn wait_for_single_validator_at_epoch(test: &mut Test, addr: &TestAddress, epoch: Epoch, timeout: Duration) {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        let _unused = tokio::time::timeout(Duration::from_millis(100), test.on_block_committed()).await;
+
+        if test.get_validator(addr)._current_view.get_epoch() >= epoch {
+            return;
+        }
+    }
+    panic!(
+        "Timed out waiting for {addr} to reach {epoch} (currently on {})",
+        test.get_validator(addr)._current_view.get_epoch()
+    );
 }

--- a/crates/consensus_tests/src/support/epoch_manager.rs
+++ b/crates/consensus_tests/src/support/epoch_manager.rs
@@ -3,7 +3,7 @@
 
 use std::{
     collections::{HashMap, HashSet},
-    sync::Arc,
+    sync::{Arc, Mutex as StdMutex},
     time::Instant,
 };
 
@@ -38,6 +38,12 @@ pub struct TestEpochManager {
     our_validator_node: Option<ValidatorNode<TestAddress>>,
     tx_epoch_events: broadcast::Sender<EpochManagerEvent>,
     current_epoch: Epoch,
+    /// Simulates a lagged base-layer oracle for this validator. When `Some(cap)`,
+    /// `get_epoch_hash(e)` returns `NoEpochFound(e)` for `e > cap`.
+    /// A fresh `Arc` is allocated by `clone_for` (so each validator has independent lag state),
+    /// while the cheap `Clone` impl shares it with downstream consumers — the worker, outbound
+    /// messaging, etc. — for the same validator.
+    oracle_visible_epoch: Arc<StdMutex<Option<Epoch>>>,
 }
 
 impl TestEpochManager {
@@ -47,7 +53,30 @@ impl TestEpochManager {
             our_validator_node: None,
             tx_epoch_events,
             current_epoch: Epoch(1),
+            oracle_visible_epoch: Arc::new(StdMutex::new(None)),
         }
+    }
+
+    /// Cap this validator's oracle view to `epoch`. After this, `get_epoch_hash(e)` returns
+    /// `NoEpochFound` for `e > epoch`. Mirrors a real validator whose base-layer scanner has
+    /// not yet observed the new epoch.
+    ///
+    /// NB: the cap intentionally does *not* override `current_epoch()` — that lets the worker
+    /// vote on the EOE block normally (so the chain progresses to a 3-chain commit on every
+    /// node) while still tripping `process_end_of_epoch` when it tries to look up the next
+    /// epoch's base-layer hash. That is exactly the failure mode the production bug exhibits
+    /// once a node catches up via sync.
+    pub fn set_oracle_visible_epoch(&self, epoch: Epoch) {
+        *self.oracle_visible_epoch.lock().unwrap() = Some(epoch);
+    }
+
+    /// Remove the oracle lag for this validator.
+    pub fn clear_oracle_lag(&self) {
+        *self.oracle_visible_epoch.lock().unwrap() = None;
+    }
+
+    fn oracle_visible_epoch(&self) -> Option<Epoch> {
+        *self.oracle_visible_epoch.lock().unwrap()
     }
 
     pub async fn set_current_epoch(&mut self, current_epoch: Epoch, shard_group: ShardGroup) -> &Self {
@@ -78,6 +107,9 @@ impl TestEpochManager {
         fee_claim_pk: RistrettoPublicKeyBytes,
     ) -> Self {
         let mut copy = self.clone();
+        // Each validator gets its own lag state — sibling clones (worker, outbound, etc.) for
+        // this same validator share via the cheap `Clone` impl.
+        copy.oracle_visible_epoch = Arc::new(StdMutex::new(None));
         if let Some(our_validator_node) = self.our_validator_node.clone() {
             copy.our_validator_node = Some(ValidatorNode {
                 address,
@@ -222,7 +254,12 @@ impl EpochManagerReader for TestEpochManager {
         Ok(self.inner.lock().await.last_epoch_hash)
     }
 
-    async fn get_epoch_hash(&self, _epoch: Epoch) -> Result<FixedHash, EpochManagerError> {
+    async fn get_epoch_hash(&self, epoch: Epoch) -> Result<FixedHash, EpochManagerError> {
+        if let Some(cap) = self.oracle_visible_epoch() &&
+            epoch > cap
+        {
+            return Err(EpochManagerError::NoEpochFound(epoch));
+        }
         Ok(self.inner.lock().await.last_epoch_hash)
     }
 


### PR DESCRIPTION
## Summary

Fixes a wedge where a validator whose base-layer scanner is behind at an epoch boundary crashes inside `process_end_of_epoch` and stays stuck on the old epoch — even after the oracle eventually catches up.

### The bug

When the EOE block 3-chain commits on a node whose local oracle has not yet observed `next_epoch`, `process_end_of_epoch` calls `epoch_manager.get_epoch_hash(next_epoch)` and gets `NoEpochFound`. Before this PR:

1. The error bubbles up; the worker errors out (`HotStuff crashed: Epoch manager error: No epoch found Epoch(N+1)`).
2. The EOE block stays committed on disk but no checkpoint was written and `pacemaker.set_epoch` was never called.
3. State machine transitions `Running → Sleeping → Idle → CheckSync → Running` and resumes at `prev_epoch` / leaf height. There is no code path that re-enters `process_end_of_epoch` for an already-committed block.
4. The oracle eventually emits `EpochChanged(N+1)`. `on_epoch_manager_event` records it as `next_epoch` but does nothing else. The pacemaker stays on `prev_epoch` forever — the node sends NEWVIEWs to peers that have moved on.

Observed in `~/Litterbox/logs3` at `08:57:39` (crash) → `08:57:44` (resume at `Epoch(7808)/NodeHeight(3924)` with EOE committed) → `08:58:50` (oracle catches up; nothing happens) → `10:06:07` (still wedged).

### The fix

Pre-flight `get_epoch_hash(next_epoch)` in `process_end_of_epoch`. On `NoEpochFound`, park the work — `eoe_block`, `commit_qc`, next-genesis state merkle root — in `pending_end_of_epoch` and return `Ok(())` instead of crashing. Two retry triggers:

- **`on_epoch_manager_event` (`EpochChanged` branch)**: when the oracle catches up and `has_pending_end_of_epoch()` is true, call `try_resume_pending_end_of_epoch` which re-runs `process_end_of_epoch`. With the oracle now current, `get_epoch_hash` succeeds, the genesis is created, and the pacemaker advances.
- **Worker startup**: walk back from `current_epoch`'s leaf looking for a committed EOE block whose checkpoint is missing. If found, seed the deferred state and try to resume immediately. Handles the restart-after-crash case for nodes that hit this bug before the fix shipped.

`process_end_of_epoch` was refactored to take `commit_qc` and `next_genesis_state_merkle_root` directly (was: a full `ValidBlock`) so retry paths can rebuild the inputs without the original `valid_tip_block` — startup recovery uses `Block::get_commit_qc` + the EOE's own state root.

### Why deferring is safe

The genesis block for `next_epoch` is deterministic over `(network, next_epoch, epoch_hash, next_shard_group, state_merkle_root, sidechain_id)`. Creating it seconds or minutes later (when the oracle has the data) produces the same block all peers agreed on. Other nodes' QC-attestation of the EOE doesn't help here — the EOE block's own `epoch_hash` field is the *previous* epoch's hash, not the next one — so the only correct path is to wait for the local oracle.

## Test plan

Adds `epoch_change_with_lagging_oracle` consensus test that reproduces the bug and exercises the recovery path.

- [x] `cargo test -p consensus_tests` — 48/48 pass
- [x] Without the fix (`git stash` of the consensus changes), the new test fails with the production symptom: `HotStuff crashed: Epoch manager error: No epoch found Epoch(2)`
- [x] With the fix, the test logs `⏳ EOE block ... Deferring next-epoch genesis until oracle catches up` → `✅ bug condition reproduced` → `▶️ Resuming deferred end-of-epoch processing` → `✅ recovery confirmed`
- [x] `cargo check --workspace` clean
- [ ] Soak/devnet run to confirm no behavior regression on clean epoch transitions

The test infra change is a per-validator `oracle_visible_epoch` cap on `TestEpochManager` — fresh `Arc` per validator (in `clone_for`), shared with the worker/outbound clones for the same validator. Caps `get_epoch_hash` only (not `current_epoch`) so the chain still commits the EOE on the lagged node, putting `process_end_of_epoch` in exactly the failing position.