### PR TITLE
feat(walletd-ui): hide testnet faucet buttons on mainnet

### DIFF
--- a/applications/tari_walletd/web_ui/src/routes/AssetVault/NFTs/components/ClaimNftsButton.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/AssetVault/NFTs/components/ClaimNftsButton.tsx
@@ -21,6 +21,7 @@
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import { useMintTestnetFaucetNfts } from "@api/hooks/useAccounts";
+import { useWalletInfo } from "@api/hooks/useWalletInfo";
 import queryClient from "@api/queryClient";
 import Button from "@mui/material/Button";
 import { useTheme } from "@mui/material/styles";
@@ -33,9 +34,14 @@ function ClaimNftsButton() {
   const { mutate: claimTestnetFaucetNfts, isPending } = useMintTestnetFaucetNfts();
   const account = useAccountStore((state) => state.account);
   const { showError, showSuccess } = useErrorNotification();
+  const { data: walletInfo } = useWalletInfo();
   const theme = useTheme();
   const isLg = useMediaQuery(theme.breakpoints.up("md"));
   if (!account) {
+    return <></>;
+  }
+
+  if (!walletInfo || walletInfo.network === "mainnet") {
     return <></>;
   }
 

--- a/applications/tari_walletd/web_ui/src/routes/AssetVault/Tokens/components/ClaimCoinsButton.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/AssetVault/Tokens/components/ClaimCoinsButton.tsx
@@ -23,6 +23,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { useErrorNotification } from "@/contexts/ErrorNotificationContext";
 import { useAccountsCreateFreeTestCoins } from "@api/hooks/useAccounts";
+import { useWalletInfo } from "@api/hooks/useWalletInfo";
 import queryClient from "@api/queryClient";
 import CheckCircleOutlineIcon from "@mui/icons-material/CheckCircleOutline";
 import Button from "@mui/material/Button";
@@ -37,6 +38,7 @@ function ClaimCoinsButton() {
   const account = useAccountStore((s) => s.account);
   const { showError, showSuccess } = useErrorNotification();
   const [hasClaimed, setHasClaimed] = useState(false);
+  const { data: walletInfo } = useWalletInfo();
 
   const theme = useTheme();
   const isLg = useMediaQuery(theme.breakpoints.up("md"));
@@ -78,6 +80,10 @@ function ClaimCoinsButton() {
   }, [accountAddress]);
 
   if (!account || !accountAddress) {
+    return <></>;
+  }
+
+  if (!walletInfo || walletInfo.network === "mainnet") {
     return <></>;
   }
 

--- a/applications/tari_walletd/web_ui/src/services/api/hooks/useWalletInfo.ts
+++ b/applications/tari_walletd/web_ui/src/services/api/hooks/useWalletInfo.ts
@@ -27,5 +27,10 @@ export const useWalletInfo = () => {
   return useQuery({
     queryKey: ["wallet_info"],
     queryFn: () => walletGetInfo(),
+    staleTime: Infinity,
+    gcTime: Infinity,
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
   });
 };


### PR DESCRIPTION
## Summary
- Hide the Claim Testnet Funds and Claim Testnet NFTs buttons by default and only show them on non-mainnet networks, gated on the `wallet.get_info` JSON-RPC response.
- Configure `useWalletInfo` with `staleTime`/`gcTime` of `Infinity` and disable auto-refetches so the network is fetched exactly once per page load and shared (deduped) by both buttons.

## Test plan
- [x] Run wallet daemon on a testnet network, refresh the web UI: both Claim buttons appear after `wallet.get_info` resolves.
- [x] Run wallet daemon on mainnet, refresh the web UI: both Claim buttons stay hidden.
- [x] Confirm via DevTools Network tab that `wallet.get_info` is only called once on page refresh, even when both Tokens and NFTs views are visited in the same session.