### PR TITLE
feat(walletd): add scoped API keys for agent auth (#1957)

### DIFF
--- a/applications/tari_wallet_cli/src/command/auth.rs
+++ b/applications/tari_wallet_cli/src/command/auth.rs
@@ -25,7 +25,16 @@ use tari_ootle_common_types::displayable::Displayable;
 use tari_ootle_walletd_client::{
     WalletDaemonClient,
     permissions::JrpcPermission,
-    types::{AuthCredentials, AuthListSessionsRequest, AuthLoginRequest, AuthRevokeTokenRequest},
+    types::{
+        AuthApiKeyCredentials,
+        AuthCreateApiKeyRequest,
+        AuthListApiKeysRequest,
+        AuthListSessionsRequest,
+        AuthLoginRequest,
+        AuthRevokeApiKeyRequest,
+        AuthRevokeTokenRequest,
+        AuthCredentials,
+    },
 };
 
 #[derive(Debug, Subcommand, Clone)]
@@ -33,6 +42,16 @@ pub enum AuthSubcommand {
     Request(RequestArgs),
     Revoke(RevokeArgs),
     List,
+    #[command(subcommand)]
+    ApiKey(ApiKeySubcommand),
+}
+
+#[derive(Debug, Subcommand, Clone)]
+pub enum ApiKeySubcommand {
+    Create(CreateApiKeyArgs),
+    List,
+    Revoke(RevokeApiKeyArgs),
+    Authenticate(AuthenticateApiKeyArgs),
 }
 
 #[derive(Debug, Args, Clone)]
@@ -43,6 +62,27 @@ pub struct RequestArgs {
 #[derive(Debug, Args, Clone)]
 pub struct RevokeArgs {
     permission_token_id: String,
+}
+
+#[derive(Debug, Args, Clone)]
+pub struct CreateApiKeyArgs {
+    #[clap(long)]
+    name: String,
+    #[clap(long)]
+    allow_admin: bool,
+    permissions: Vec<JrpcPermission>,
+}
+
+#[derive(Debug, Args, Clone)]
+pub struct RevokeApiKeyArgs {
+    id: String,
+}
+
+#[derive(Debug, Args, Clone)]
+pub struct AuthenticateApiKeyArgs {
+    #[clap(long)]
+    api_key: String,
+    permissions: Vec<JrpcPermission>,
 }
 
 impl AuthSubcommand {
@@ -76,6 +116,43 @@ impl AuthSubcommand {
                 for session in &resp.sessions {
                     println!("Id {} name {}", session.id, session.permissions.display());
                 }
+            },
+            ApiKey(subcommand) => match subcommand {
+                ApiKeySubcommand::Create(args) => {
+                    let resp = client
+                        .auth_create_api_key(AuthCreateApiKeyRequest {
+                            name: args.name,
+                            permissions: args.permissions,
+                            allow_admin: args.allow_admin,
+                        })
+                        .await?;
+                    println!("API key id: {}", resp.id);
+                    println!("API key: {}", resp.api_key);
+                },
+                ApiKeySubcommand::List => {
+                    let resp = client.auth_list_api_keys(AuthListApiKeysRequest {}).await?;
+                    for key in &resp.api_keys {
+                        println!(
+                            "Id {} name {} permissions {}",
+                            key.id,
+                            key.name,
+                            key.permissions.display()
+                        );
+                    }
+                },
+                ApiKeySubcommand::Revoke(args) => {
+                    client.auth_revoke_api_key(AuthRevokeApiKeyRequest { id: args.id }).await?;
+                    println!("API key revoked!");
+                },
+                ApiKeySubcommand::Authenticate(args) => {
+                    let resp = client
+                        .auth_request(AuthLoginRequest {
+                            permissions: args.permissions,
+                            credentials: AuthCredentials::ApiKey(AuthApiKeyCredentials { api_key: args.api_key }),
+                        })
+                        .await?;
+                    println!("{}", resp.token);
+                },
             },
         }
         Ok(())

--- a/applications/tari_walletd/src/handlers/auth/handlers.rs
+++ b/applications/tari_walletd/src/handlers/auth/handlers.rs
@@ -4,20 +4,34 @@
 //   Copyright 2023 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
+use std::time::{SystemTime, UNIX_EPOCH};
+
 use axum_extra::{extract::CookieJar, headers::authorization::Bearer};
 use axum_jrpc::JsonRpcResponse;
-use tari_ootle_wallet_sdk::models::AuthLoginRequestEvent;
+use rand::RngCore;
+use sha2::{Digest, Sha256};
+use tari_ootle_wallet_sdk::{
+    models::{AuthLoginRequestEvent, NewApiKeyModel},
+    storage::{WalletStore, WalletStoreReader, WalletStoreWriter},
+};
 use tari_ootle_walletd_client::{
-    permissions::JrpcPermission,
+    permissions::{JrpcPermission, JrpcPermissions},
     types::{
+        AuthApiKeyInfo,
+        AuthCreateApiKeyRequest,
+        AuthCreateApiKeyResponse,
         AuthGetMethodRequest,
         AuthGetMethodResponse,
+        AuthListApiKeysRequest,
+        AuthListApiKeysResponse,
         AuthListSessionsRequest,
         AuthListSessionsResponse,
         AuthLoginRequest,
         AuthLoginResponse,
         AuthMethod,
         AuthRefreshRequest,
+        AuthRevokeApiKeyRequest,
+        AuthRevokeApiKeyResponse,
         AuthRevokeTokenRequest,
         AuthRevokeTokenResponse,
         AuthSessionInfo,
@@ -37,6 +51,12 @@ pub async fn handle_login_request(
     request: (axum_jrpc::Id, AuthLoginRequest),
 ) -> Result<(CookieJar, JsonRpcResponse), anyhow::Error> {
     let (answer_id, request) = request;
+    if request.credentials.as_api_key().is_some() {
+        let response = login_with_api_key(context, request).await?;
+        context.notifier().notify(AuthLoginRequestEvent);
+        return Ok((CookieJar::new(), JsonRpcResponse::success(answer_id, response)));
+    }
+
     context.authenticator().authenticate(&request.credentials).await?;
     let jwt = context.jwt_api();
     let claims = jwt.generate_auth_claims(request.permissions.into())?;
@@ -93,6 +113,84 @@ pub async fn handle_revoke(
     Ok(AuthRevokeTokenResponse {})
 }
 
+pub async fn handle_create_api_key(
+    context: &HandlerContext,
+    token: Option<&Bearer>,
+    request: AuthCreateApiKeyRequest,
+) -> Result<AuthCreateApiKeyResponse, anyhow::Error> {
+    context.check_auth(token, &[JrpcPermission::Admin])?;
+    if request.name.trim().is_empty() {
+        anyhow::bail!("API key name is required");
+    }
+    if request.permissions.is_empty() {
+        anyhow::bail!("At least one permission is required");
+    }
+    if request.permissions.contains(&JrpcPermission::Admin) && !request.allow_admin {
+        anyhow::bail!("Granting Admin to an API key requires explicit confirmation");
+    }
+
+    let id = uuid::Uuid::new_v4().to_string();
+    let secret = generate_api_key_secret();
+    let api_key = format!("twda_{}_{}", id, secret);
+    let key_hash = hash_api_key(&api_key);
+    let permissions = request.permissions.iter().map(ToString::to_string).collect::<Vec<_>>();
+
+    context.wallet_sdk().store().with_write_tx(|tx| {
+        tx.api_keys_insert(NewApiKeyModel {
+            id: id.clone(),
+            name: request.name.trim().to_string(),
+            key_hash: key_hash.to_vec(),
+            permissions,
+        })
+    })?;
+
+    let created_at = unix_timestamp_secs()?;
+    Ok(AuthCreateApiKeyResponse {
+        id,
+        name: request.name.trim().to_string(),
+        api_key,
+        permissions: request.permissions,
+        created_at,
+    })
+}
+
+pub async fn handle_list_api_keys(
+    context: &HandlerContext,
+    token: Option<&Bearer>,
+    _request: AuthListApiKeysRequest,
+) -> Result<AuthListApiKeysResponse, anyhow::Error> {
+    context.check_auth(token, &[JrpcPermission::Admin])?;
+    let api_keys = context
+        .wallet_sdk()
+        .store()
+        .with_read_tx(|tx| tx.api_keys_list_active())?
+        .into_iter()
+        .map(|api_key| {
+            Ok(AuthApiKeyInfo {
+                id: api_key.id,
+                name: api_key.name,
+                permissions: parse_permissions(api_key.permissions)?,
+                created_at: api_key.created_at,
+                last_used_at: api_key.last_used_at,
+            })
+        })
+        .collect::<Result<Vec<_>, anyhow::Error>>()?;
+    Ok(AuthListApiKeysResponse { api_keys })
+}
+
+pub async fn handle_revoke_api_key(
+    context: &HandlerContext,
+    token: Option<&Bearer>,
+    request: AuthRevokeApiKeyRequest,
+) -> Result<AuthRevokeApiKeyResponse, anyhow::Error> {
+    context.check_auth(token, &[JrpcPermission::Admin])?;
+    context
+        .wallet_sdk()
+        .store()
+        .with_write_tx(|tx| tx.api_keys_revoke(&request.id))?;
+    Ok(AuthRevokeApiKeyResponse {})
+}
+
 pub async fn handle_list_sessions(
     context: &HandlerContext,
     token: Option<&Bearer>,
@@ -125,4 +223,76 @@ pub async fn handle_get_auth_method(
             WalletDaemonAuth::WebAuthn => AuthMethod::Webauthn,
         },
     })
+}
+
+async fn login_with_api_key(
+    context: &HandlerContext,
+    request: AuthLoginRequest,
+) -> Result<AuthLoginResponse, anyhow::Error> {
+    let credentials = request
+        .credentials
+        .as_api_key()
+        .ok_or_else(|| unauthorized("API key credentials are required"))?;
+    let api_key_id = parse_api_key_id(&credentials.api_key)?;
+    let api_key = context
+        .wallet_sdk()
+        .store()
+        .with_read_tx(|tx| tx.api_keys_get_active(api_key_id))?;
+    let supplied_hash = hash_api_key(&credentials.api_key);
+    if !hashes_equal(&supplied_hash, &api_key.key_hash) {
+        return Err(unauthorized("Invalid API key"));
+    }
+
+    let stored_permissions = JrpcPermissions::try_from(api_key.permissions.as_slice())?;
+    let requested_permissions = JrpcPermissions::from(request.permissions);
+    if !stored_permissions.has_permission(&JrpcPermission::Admin) && !requested_permissions.is_subset_of(&stored_permissions) {
+        return Err(unauthorized("API key does not grant all requested permissions"));
+    }
+
+    context
+        .wallet_sdk()
+        .store()
+        .with_write_tx(|tx| tx.api_keys_touch_last_used(&api_key.id))?;
+
+    let jwt = context.jwt_api();
+    let mut claims = jwt.generate_auth_claims(requested_permissions)?;
+    claims.api_key_id = Some(api_key.id);
+    let token = jwt.grant(&claims)?;
+    Ok(AuthLoginResponse { token })
+}
+
+fn parse_permissions(permissions: Vec<String>) -> Result<Vec<JrpcPermission>, anyhow::Error> {
+    permissions
+        .iter()
+        .map(|permission| permission.parse().map_err(Into::into))
+        .collect()
+}
+
+fn parse_api_key_id(api_key: &str) -> Result<&str, anyhow::Error> {
+    let mut parts = api_key.splitn(3, '_');
+    match (parts.next(), parts.next(), parts.next()) {
+        (Some("twda"), Some(id), Some(secret)) if !id.is_empty() && !secret.is_empty() => Ok(id),
+        _ => Err(unauthorized("Invalid API key format")),
+    }
+}
+
+fn generate_api_key_secret() -> String {
+    let mut secret = [0u8; 32];
+    rand::thread_rng().fill_bytes(&mut secret);
+    hex::encode(secret)
+}
+
+fn hash_api_key(api_key: &str) -> [u8; 32] {
+    let digest = Sha256::digest(api_key.as_bytes());
+    let mut bytes = [0u8; 32];
+    bytes.copy_from_slice(&digest);
+    bytes
+}
+
+fn hashes_equal(left: &[u8], right: &[u8]) -> bool {
+    left.len() == right.len() && left.iter().zip(right).fold(0u8, |acc, (a, b)| acc | (a ^ b)) == 0
+}
+
+fn unix_timestamp_secs() -> Result<u64, anyhow::Error> {
+    Ok(SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs())
 }

--- a/applications/tari_walletd/src/handlers/auth/jwt.rs
+++ b/applications/tari_walletd/src/handlers/auth/jwt.rs
@@ -33,10 +33,11 @@ impl<'a> JwtApi<'a> {
         Ok(Claims {
             permissions,
             exp: exp.as_secs(),
+            api_key_id: None,
         })
     }
 
-    fn decode_jwt(&self, token: &str) -> Result<TokenData<Claims>, JwtApiError> {
+    pub fn decode_jwt(&self, token: &str) -> Result<TokenData<Claims>, JwtApiError> {
         let token_data = jsonwebtoken::decode::<Claims>(
             token,
             &DecodingKey::from_secret(self.jwt_secret_key.reveal()),
@@ -55,10 +56,13 @@ impl<'a> JwtApi<'a> {
         Ok(permissions_token.into())
     }
 
-    pub fn check_auth(&self, token: Option<&Bearer>, req_permissions: &[JrpcPermission]) -> Result<(), JwtApiError> {
+    pub fn decode_bearer(&self, token: Option<&Bearer>) -> Result<Claims, JwtApiError> {
         let token = token.ok_or(JwtApiError::AccessDeniedNoBearerToken)?;
-        let token_data = self.decode_jwt(token.token())?;
-        let token_permissions = &token_data.claims.permissions;
+        Ok(self.decode_jwt(token.token())?.claims)
+    }
+
+    pub fn check_claims_auth(&self, claims: &Claims, req_permissions: &[JrpcPermission]) -> Result<(), JwtApiError> {
+        let token_permissions = &claims.permissions;
         if token_permissions.has_permission(&JrpcPermission::Admin) {
             return Ok(());
         }
@@ -70,6 +74,11 @@ impl<'a> JwtApi<'a> {
             }
         }
         Ok(())
+    }
+
+    pub fn check_auth(&self, token: Option<&Bearer>, req_permissions: &[JrpcPermission]) -> Result<(), JwtApiError> {
+        let claims = self.decode_bearer(token)?;
+        self.check_claims_auth(&claims, req_permissions)
     }
 }
 

--- a/applications/tari_walletd/src/handlers/context.rs
+++ b/applications/tari_walletd/src/handlers/context.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 
 use axum_extra::headers::authorization::Bearer;
 use tari_ootle_transaction::{Transaction, TransactionBuilder};
-use tari_ootle_wallet_sdk::models::WalletEvent;
+use tari_ootle_wallet_sdk::{models::WalletEvent, storage::{WalletStore, WalletStoreReader}};
 use tari_ootle_wallet_sdk_services::{
     account_monitor::AccountMonitorHandle,
     notify::Notify,
@@ -73,7 +73,14 @@ impl HandlerContext {
     }
 
     pub fn check_auth(&self, token: Option<&Bearer>, permissions: &[JrpcPermission]) -> Result<(), JwtApiError> {
-        self.jwt_api().check_auth(token, permissions)
+        let jwt = self.jwt_api();
+        let claims = jwt.decode_bearer(token)?;
+        if let Some(api_key_id) = &claims.api_key_id {
+            self.wallet_sdk
+                .store()
+                .with_read_tx(|tx| tx.api_keys_get_active(api_key_id))?;
+        }
+        jwt.check_claims_auth(&claims, permissions)
     }
 
     pub fn jwt_api(&self) -> JwtApi<'_> {

--- a/applications/tari_walletd/src/server.rs
+++ b/applications/tari_walletd/src/server.rs
@@ -92,7 +92,11 @@ async fn handler(
 ) -> Response {
     let token = authorization_header.map(|auth| auth.0.0);
     info!(target: LOG_TARGET, "🌐 JSON-RPC request: {}", value.method);
-    debug!(target: LOG_TARGET, "🌐 JSON-RPC request: {:?}", value);
+    if value.method == "auth.request" || value.method == "auth.api_key_create" {
+        debug!(target: LOG_TARGET, "🌐 JSON-RPC request: {} <credentials redacted>", value.method);
+    } else {
+        debug!(target: LOG_TARGET, "🌐 JSON-RPC request: {:?}", value);
+    }
     match value.method.as_str().split_once('.') {
         Some(("auth", method)) => match method {
             "request" => call_handler_any_response(context, value, token, auth::handle_login_request).await,
@@ -108,6 +112,9 @@ async fn handler(
             },
             "revoke" => call_handler(context, value, token, auth::handle_revoke).await,
             "list_sessions" => call_handler(context, value, token, auth::handle_list_sessions).await,
+            "api_key_create" => call_handler(context, value, token, auth::handle_create_api_key).await,
+            "api_key_list" => call_handler(context, value, token, auth::handle_list_api_keys).await,
+            "api_key_revoke" => call_handler(context, value, token, auth::handle_revoke_api_key).await,
             "method" => call_handler(context, value, token, auth::handle_get_auth_method).await,
             _ => value.method_not_found(&value.method).into_response(),
         },

--- a/applications/tari_walletd/src/services/refresh_token_store.rs
+++ b/applications/tari_walletd/src/services/refresh_token_store.rs
@@ -58,7 +58,11 @@ impl RefreshTokenStore {
         let mut write = self.tokens.write().await;
         clear_expired_tokens(&mut write);
         let data = RefreshTokenData {
-            claims: Claims { permissions, exp },
+            claims: Claims {
+                permissions,
+                exp,
+                api_key_id: None,
+            },
             expires_at: Instant::now() + self.expiry,
         };
 

--- a/applications/tari_walletd/web_ui/src/routes/Wallet/Components/AccessTokens.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/Wallet/Components/AccessTokens.tsx
@@ -20,15 +20,24 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import { useAuthRevokeToken, useGetAllTokens } from "@api/hooks/useTokens";
+import {
+  useAuthRevokeToken,
+  useCreateApiKey,
+  useGetAllTokens,
+  useListApiKeys,
+  useRevokeApiKey,
+} from "@api/hooks/useTokens";
 import FetchStatusCheck from "@components/FetchStatusCheck";
 import { AccordionIconButton, CodeBlock, DataTableCell } from "@components/StyledComponents";
 import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
 import KeyboardArrowUpIcon from "@mui/icons-material/KeyboardArrowUp";
 import {
   Fade,
+  Checkbox,
+  FormControlLabel,
   List,
   ListItem,
+  Stack,
   Table,
   TableBody,
   TableCell,
@@ -36,6 +45,8 @@ import {
   TableHead,
   TablePagination,
   TableRow,
+  TextField,
+  Typography,
 } from "@mui/material";
 import Button from "@mui/material/Button";
 import Collapse from "@mui/material/Collapse";
@@ -54,6 +65,18 @@ import type {
 import { jrpcPermissionToString } from "@tari-project/ootle-ts-bindings";
 import { useState } from "react";
 import { IoCloseCircleOutline } from "react-icons/io5";
+
+const API_KEY_PERMISSIONS: JrpcPermission[] = [
+  "AccountInfo",
+  "AccountList",
+  "SubstatesRead",
+  "TemplatesRead",
+  "KeyList",
+  "TransactionGet",
+  "TransactionSend",
+  "GetNft",
+  "Admin",
+];
 
 function AlertDialog({ fn }: any) {
   const [open, setOpen] = useState(false);
@@ -191,8 +214,10 @@ export default function AccessTokens() {
   return (
     <FetchStatusCheck isLoading={isLoading} isError={isError} errorMessage={error?.message || "Error fetching data"}>
       <Fade in={!isLoading && !isError}>
-        <TableContainer>
-          <Table>
+        <Stack spacing={3}>
+          <ApiKeysSection />
+          <TableContainer>
+            <Table>
             <TableHead>
               <TableRow>
                 <TableCell>ID</TableCell>
@@ -218,20 +243,134 @@ export default function AccessTokens() {
                 </TableRow>
               )}
             </TableBody>
-          </Table>
-          {data?.sessions && (
-            <TablePagination
-              rowsPerPageOptions={[10, 25, 50]}
-              component="div"
-              count={data.sessions.length}
-              rowsPerPage={rowsPerPage}
-              page={page}
-              onPageChange={handleChangePage}
-              onRowsPerPageChange={handleChangeRowsPerPage}
-            />
-          )}
-        </TableContainer>
+            </Table>
+            {data?.sessions && (
+              <TablePagination
+                rowsPerPageOptions={[10, 25, 50]}
+                component="div"
+                count={data.sessions.length}
+                rowsPerPage={rowsPerPage}
+                page={page}
+                onPageChange={handleChangePage}
+                onRowsPerPageChange={handleChangeRowsPerPage}
+              />
+            )}
+          </TableContainer>
+        </Stack>
       </Fade>
     </FetchStatusCheck>
   );
+}
+
+function ApiKeysSection() {
+  const { data } = useListApiKeys();
+  const createApiKey = useCreateApiKey();
+  const revokeApiKey = useRevokeApiKey();
+  const [name, setName] = useState("");
+  const [selectedPermissions, setSelectedPermissions] = useState<JrpcPermission[]>(["AccountInfo"]);
+  const [createdApiKey, setCreatedApiKey] = useState<string | null>(null);
+
+  const togglePermission = (permission: JrpcPermission) => {
+    setSelectedPermissions((current) =>
+      current.includes(permission) ? current.filter((item) => item !== permission) : [...current, permission],
+    );
+  };
+
+  const create = () => {
+    createApiKey.mutate(
+      {
+        name,
+        permissions: selectedPermissions,
+        allow_admin: selectedPermissions.includes("Admin"),
+      },
+      {
+        onSuccess: (response) => {
+          setCreatedApiKey(response.api_key);
+          setName("");
+          setSelectedPermissions(["AccountInfo"]);
+        },
+      },
+    );
+  };
+
+  return (
+    <Stack spacing={2} sx={{ mb: 4 }}>
+      <Typography variant="h6">API Keys</Typography>
+      <Stack direction={{ xs: "column", md: "row" }} spacing={2} alignItems={{ xs: "stretch", md: "flex-start" }}>
+        <TextField label="Name" value={name} onChange={(event) => setName(event.target.value)} size="small" />
+        <Stack direction="row" flexWrap="wrap" gap={1}>
+          {API_KEY_PERMISSIONS.map((permission) => (
+            <FormControlLabel
+              key={jrpcPermissionToString(permission)}
+              control={
+                <Checkbox
+                  checked={selectedPermissions.includes(permission)}
+                  onChange={() => togglePermission(permission)}
+                  size="small"
+                />
+              }
+              label={jrpcPermissionToString(permission)}
+            />
+          ))}
+        </Stack>
+        <Button
+          variant="contained"
+          onClick={create}
+          disabled={!name.trim() || selectedPermissions.length === 0 || createApiKey.isPending}
+        >
+          Create
+        </Button>
+      </Stack>
+      {createdApiKey && (
+        <CodeBlock>
+          <Stack spacing={1}>
+            <Typography variant="body2">New API key</Typography>
+            <Typography variant="body2">{createdApiKey}</Typography>
+            <Button variant="outlined" onClick={() => setCreatedApiKey(null)}>
+              Dismiss
+            </Button>
+          </Stack>
+        </CodeBlock>
+      )}
+      <TableContainer>
+        <Table>
+          <TableHead>
+            <TableRow>
+              <TableCell>Name</TableCell>
+              <TableCell>ID</TableCell>
+              <TableCell>Created</TableCell>
+              <TableCell>Last Used</TableCell>
+              <TableCell>Permissions</TableCell>
+              <TableCell width="100" align="center">
+                Revoke
+              </TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {data?.api_keys.map((apiKey) => (
+              <TableRow key={apiKey.id}>
+                <DataTableCell>{apiKey.name}</DataTableCell>
+                <DataTableCell>{apiKey.id}</DataTableCell>
+                <DataTableCell>{formatTimestamp(apiKey.created_at)}</DataTableCell>
+                <DataTableCell>{apiKey.last_used_at ? formatTimestamp(apiKey.last_used_at) : ""}</DataTableCell>
+                <DataTableCell>
+                  {apiKey.permissions.map((permission: JrpcPermission) => jrpcPermissionToString(permission)).join(", ")}
+                </DataTableCell>
+                <DataTableCell sx={{ textAlign: "center" }}>
+                  <IconButton onClick={() => revokeApiKey.mutate(apiKey.id)} color="primary">
+                    <IoCloseCircleOutline />
+                  </IconButton>
+                </DataTableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+    </Stack>
+  );
+}
+
+function formatTimestamp(timestamp: number) {
+  const date = new Date(Number(timestamp) * 1000);
+  return `${date.toISOString().slice(0, 10)} ${date.toISOString().slice(11, 16)}`;
 }

--- a/applications/tari_walletd/web_ui/src/services/api/hooks/useTokens.tsx
+++ b/applications/tari_walletd/web_ui/src/services/api/hooks/useTokens.tsx
@@ -23,14 +23,45 @@
 import { ApiError } from "@api/helpers/types";
 import queryClient from "@api/queryClient";
 import { useMutation, useQuery } from "@tanstack/react-query";
-import type { RefreshTokenHash } from "@tari-project/ootle-ts-bindings";
-import { authGetAllJwt, authRevoke } from "@utils/json_rpc";
+import type { AuthCreateApiKeyRequest, RefreshTokenHash } from "@tari-project/ootle-ts-bindings";
+import { authCreateApiKey, authGetAllJwt, authListApiKeys, authRevoke, authRevokeApiKey } from "@utils/json_rpc";
 
 export const useGetAllTokens = () => {
   return useQuery({
     queryKey: ["jwts_list"],
     queryFn: () => {
       return authGetAllJwt({});
+    },
+  });
+};
+
+export const useCreateApiKey = () => {
+  return useMutation({
+    mutationFn: (request: AuthCreateApiKeyRequest) => authCreateApiKey(request),
+    onError: (error: ApiError) => {
+      console.error(error);
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ["api_keys_list"] });
+    },
+  });
+};
+
+export const useListApiKeys = () => {
+  return useQuery({
+    queryKey: ["api_keys_list"],
+    queryFn: () => authListApiKeys({}),
+  });
+};
+
+export const useRevokeApiKey = () => {
+  return useMutation({
+    mutationFn: (id: string) => authRevokeApiKey({ id }),
+    onError: (error: ApiError) => {
+      console.error(error);
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ["api_keys_list"] });
     },
   });
 };

--- a/applications/tari_walletd/web_ui/src/utils/json_rpc.ts
+++ b/applications/tari_walletd/web_ui/src/utils/json_rpc.ts
@@ -41,9 +41,15 @@ import type {
   AccountsRenameResponse,
   AccountsTransferRequest,
   AccountsTransferResponse,
+  AuthCreateApiKeyRequest,
+  AuthCreateApiKeyResponse,
   AuthGetMethodResponse,
+  AuthListApiKeysRequest,
+  AuthListApiKeysResponse,
   AuthListSessionsRequest,
   AuthListSessionsResponse,
+  AuthRevokeApiKeyRequest,
+  AuthRevokeApiKeyResponse,
   AuthRevokeTokenRequest,
   AuthRevokeTokenResponse,
   BurnProofsGetRequest,
@@ -188,6 +194,12 @@ export const authRevoke = (request: AuthRevokeTokenRequest): Promise<AuthRevokeT
   client().then((c) => c.authRevoke(request));
 export const authGetAllJwt = (request: AuthListSessionsRequest): Promise<AuthListSessionsResponse> =>
   client().then((c) => c.authListSessions(request));
+export const authCreateApiKey = (request: AuthCreateApiKeyRequest): Promise<AuthCreateApiKeyResponse> =>
+  client().then((c) => c.authCreateApiKey(request));
+export const authListApiKeys = (request: AuthListApiKeysRequest): Promise<AuthListApiKeysResponse> =>
+  client().then((c) => c.authListApiKeys(request));
+export const authRevokeApiKey = (request: AuthRevokeApiKeyRequest): Promise<AuthRevokeApiKeyResponse> =>
+  client().then((c) => c.authRevokeApiKey(request));
 
 // indexer
 export const indexerGetNetworkInfo = (indexerUrl: string) =>

--- a/clients/javascript/wallet_daemon_client/README.md
+++ b/clients/javascript/wallet_daemon_client/README.md
@@ -3,3 +3,19 @@
 ## Overview
 
 Client library for interacting with the Tari Ootle Wallet Daemon via JSON-RPC. 
+
+## Agent API Keys
+
+Admin clients can create, list, and revoke permission-scoped API keys:
+
+```ts
+const created = await client.authCreateApiKey({
+  name: "codex-agent",
+  permissions: ["AccountInfo", "TransactionGet"],
+  allow_admin: false,
+});
+
+await client.authenticateWithApiKey(["AccountInfo"], created.api_key);
+```
+
+The API key is shown once at creation; the wallet daemon persists only its hash.

--- a/clients/javascript/wallet_daemon_client/src/index.ts
+++ b/clients/javascript/wallet_daemon_client/src/index.ts
@@ -24,12 +24,19 @@ import type {
   AccountsRenameResponse,
   AccountsTransferRequest,
   AccountsTransferResponse,
+  AuthApiKeyCredentials,
   AuthCredentials,
+  AuthCreateApiKeyRequest,
+  AuthCreateApiKeyResponse,
   AuthListSessionsRequest,
   AuthListSessionsResponse,
+  AuthListApiKeysRequest,
+  AuthListApiKeysResponse,
   AuthGetMethodResponse,
   AuthLoginRequest,
   AuthLoginResponse,
+  AuthRevokeApiKeyRequest,
+  AuthRevokeApiKeyResponse,
   AuthRevokeTokenRequest,
   AuthRevokeTokenResponse,
   BurnProofsGetRequest,
@@ -175,6 +182,18 @@ export class WalletDaemonClient<T extends RpcTransport = FetchRpcTransport> {
     return this.sendRequest("auth.list_sessions", params);
   }
 
+  public authCreateApiKey(params: AuthCreateApiKeyRequest): Promise<AuthCreateApiKeyResponse> {
+    return this.sendRequest("auth.api_key_create", params);
+  }
+
+  public authListApiKeys(params: AuthListApiKeysRequest): Promise<AuthListApiKeysResponse> {
+    return this.sendRequest("auth.api_key_list", params);
+  }
+
+  public authRevokeApiKey(params: AuthRevokeApiKeyRequest): Promise<AuthRevokeApiKeyResponse> {
+    return this.sendRequest("auth.api_key_revoke", params);
+  }
+
   public async authRequest(permissions: JrpcPermission[], credentials: AuthCredentials): Promise<string> {
     let request: AuthLoginRequest = {
       permissions: permissions,
@@ -182,6 +201,13 @@ export class WalletDaemonClient<T extends RpcTransport = FetchRpcTransport> {
     };
     let resp = await this.sendRequest<AuthLoginResponse>("auth.request", request);
     return resp.token;
+  }
+
+  public async authenticateWithApiKey(permissions: JrpcPermission[], apiKey: string): Promise<string> {
+    let credentials: AuthApiKeyCredentials = { api_key: apiKey };
+    const token = await this.authRequest(permissions, { ApiKey: credentials });
+    this.setToken(token);
+    return token;
   }
 
   public authRevoke(params: AuthRevokeTokenRequest): Promise<AuthRevokeTokenResponse> {

--- a/clients/wallet_daemon_client/README.md
+++ b/clients/wallet_daemon_client/README.md
@@ -23,6 +23,18 @@ let auth_resp = client.auth_request(AuthLoginRequest {
 }).await?;
 client.set_auth_token(auth_resp.token);
 
+// Create a permission-scoped API key for a non-interactive agent.
+let created = client.auth_create_api_key(AuthCreateApiKeyRequest {
+    name: "codex-agent".to_string(),
+    permissions: vec![JrpcPermission::AccountInfo, JrpcPermission::TransactionGet],
+    allow_admin: false,
+}).await?;
+
+// Authenticate later with the long-lived API key to receive a short-lived scoped JWT.
+client
+    .authenticate_with_api_key(vec![JrpcPermission::AccountInfo], created.api_key.to_string())
+    .await?;
+
 // Create an account
 let resp = client.create_account(AccountsCreateRequest {
     account_name: Some("my-account".to_string()),

--- a/clients/wallet_daemon_client/src/lib.rs
+++ b/clients/wallet_daemon_client/src/lib.rs
@@ -90,6 +90,9 @@ use crate::{
         AccountsListResponse,
         AccountsRenameRequest,
         AccountsRenameResponse,
+        AuthApiKeyCredentials,
+        AuthCreateApiKeyRequest,
+        AuthCreateApiKeyResponse,
         AddressBookAddRequest,
         AddressBookAddResponse,
         AddressBookDeleteRequest,
@@ -104,8 +107,12 @@ use crate::{
         AuthGetMethodResponse,
         AuthListSessionsRequest,
         AuthListSessionsResponse,
+        AuthListApiKeysRequest,
+        AuthListApiKeysResponse,
         AuthRevokeTokenRequest,
         AuthRevokeTokenResponse,
+        AuthRevokeApiKeyRequest,
+        AuthRevokeApiKeyResponse,
         BurnProofsGetRequest,
         BurnProofsGetResponse,
         BurnProofsListRequest,
@@ -598,6 +605,46 @@ impl WalletDaemonClient {
         req: T,
     ) -> Result<AuthListSessionsResponse, WalletDaemonClientError> {
         self.send_request("auth.list_sessions", req.borrow()).await
+    }
+
+    /// Creates a long-lived API key. Requires Admin authentication.
+    pub async fn auth_create_api_key<T: Borrow<AuthCreateApiKeyRequest>>(
+        &mut self,
+        req: T,
+    ) -> Result<AuthCreateApiKeyResponse, WalletDaemonClientError> {
+        self.send_request("auth.api_key_create", req.borrow()).await
+    }
+
+    /// Lists active API keys. Requires Admin authentication.
+    pub async fn auth_list_api_keys<T: Borrow<AuthListApiKeysRequest>>(
+        &mut self,
+        req: T,
+    ) -> Result<AuthListApiKeysResponse, WalletDaemonClientError> {
+        self.send_request("auth.api_key_list", req.borrow()).await
+    }
+
+    /// Revokes an active API key immediately. Requires Admin authentication.
+    pub async fn auth_revoke_api_key<T: Borrow<AuthRevokeApiKeyRequest>>(
+        &mut self,
+        req: T,
+    ) -> Result<AuthRevokeApiKeyResponse, WalletDaemonClientError> {
+        self.send_request("auth.api_key_revoke", req.borrow()).await
+    }
+
+    /// Authenticates using a long-lived API key and stores the returned scoped JWT on this client.
+    pub async fn authenticate_with_api_key(
+        &mut self,
+        permissions: Vec<crate::permissions::JrpcPermission>,
+        api_key: String,
+    ) -> Result<EncodedJwtString, WalletDaemonClientError> {
+        let response = self
+            .auth_request(AuthLoginRequest {
+                permissions,
+                credentials: crate::types::AuthCredentials::ApiKey(AuthApiKeyCredentials { api_key }),
+            })
+            .await?;
+        self.set_auth_token(response.token.clone());
+        Ok(response.token)
     }
 
     /// Initiates a WebRTC signalling session with the wallet daemon.

--- a/clients/wallet_daemon_client/src/permissions.rs
+++ b/clients/wallet_daemon_client/src/permissions.rs
@@ -53,7 +53,9 @@ impl FromStr for JrpcPermission {
             Some(("TransactionSend", addr)) => Ok(JrpcPermission::TransactionSend(Some(
                 SubstateId::from_str(addr).map_err(|e| InvalidJrpcPermissionsFormat(e.to_string()))?,
             ))),
-            Some(("AddressBook", perm)) => Ok(JrpcPermission::AddressBook(perm.parse()?)),
+            Some(("AddressBook", perm)) => Ok(JrpcPermission::AddressBook(
+                perm.trim_matches(|c| c == '(' || c == ')').parse()?,
+            )),
             Some(_) => Err(InvalidJrpcPermissionsFormat(s.to_string())),
             None => match s {
                 "AccountInfo" => Ok(JrpcPermission::AccountInfo),
@@ -91,7 +93,7 @@ impl Display for JrpcPermission {
             JrpcPermission::Admin => write!(f, "Admin"),
             JrpcPermission::SubstatesRead => write!(f, "SubstatesRead"),
             JrpcPermission::TemplatesRead => write!(f, "TemplatesRead"),
-            JrpcPermission::AddressBook(perm) => write!(f, "AddressBook({})", perm),
+            JrpcPermission::AddressBook(perm) => write!(f, "AddressBook_{}", perm),
         }
     }
 }
@@ -124,6 +126,18 @@ impl JrpcPermissions {
 
     pub fn has_permission(&self, permission: &JrpcPermission) -> bool {
         self.0.contains(permission)
+    }
+
+    pub fn is_subset_of(&self, other: &Self) -> bool {
+        self.0.is_subset(&other.0)
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &JrpcPermission> {
+        self.0.iter()
+    }
+
+    pub fn to_vec(&self) -> Vec<JrpcPermission> {
+        self.0.iter().cloned().collect()
     }
 
     pub fn into_vec(self) -> Vec<JrpcPermission> {
@@ -160,6 +174,8 @@ impl FromIterator<JrpcPermission> for JrpcPermissions {
 pub struct Claims {
     pub permissions: JrpcPermissions,
     pub exp: u64,
+    #[serde(default)]
+    pub api_key_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, Hash, Eq, PartialEq)]
@@ -194,5 +210,29 @@ impl Display for AddressBookPermission {
             AddressBookPermission::Update => write!(f, "update"),
             AddressBookPermission::Delete => write!(f, "delete"),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{AddressBookPermission, JrpcPermission, JrpcPermissions};
+
+    #[test]
+    fn permissions_subset_requires_every_requested_permission() {
+        let granted = JrpcPermissions::from(vec![JrpcPermission::AccountInfo, JrpcPermission::TransactionGet]);
+        let allowed = JrpcPermissions::from(vec![JrpcPermission::AccountInfo]);
+        let denied = JrpcPermissions::from(vec![JrpcPermission::AccountInfo, JrpcPermission::TransactionSend(None)]);
+
+        assert!(allowed.is_subset_of(&granted));
+        assert!(!denied.is_subset_of(&granted));
+    }
+
+    #[test]
+    fn address_book_permission_round_trips_from_display() {
+        let permission = JrpcPermission::AddressBook(AddressBookPermission::Read);
+        let encoded = permission.to_string();
+        let decoded = encoded.parse::<JrpcPermission>().unwrap();
+
+        assert_eq!(decoded, permission);
     }
 }

--- a/clients/wallet_daemon_client/src/types.rs
+++ b/clients/wallet_daemon_client/src/types.rs
@@ -753,6 +753,8 @@ pub enum AuthCredentials {
     None,
     /// Credentials for WebAuthN auth mode. Contains the request from the client to finish the auth.
     WebAuthN(Box<WebauthnFinishAuthRequest>),
+    /// Long-lived API key credentials for agent authentication.
+    ApiKey(AuthApiKeyCredentials),
 }
 
 impl AuthCredentials {
@@ -769,6 +771,13 @@ impl AuthCredentials {
             _ => None,
         }
     }
+
+    pub fn as_api_key(&self) -> Option<&AuthApiKeyCredentials> {
+        match self {
+            Self::ApiKey(req) => Some(req),
+            _ => None,
+        }
+    }
 }
 
 /// Represents a JWT token. The token is zeroized from memory on drop.
@@ -780,6 +789,60 @@ pub struct AuthLoginResponse {
     #[cfg_attr(feature = "ts", ts(type = "string"))]
     pub token: EncodedJwtString,
 }
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export, export_to = "wallet-types/"))]
+pub struct AuthApiKeyCredentials {
+    pub api_key: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export, export_to = "wallet-types/"))]
+pub struct AuthCreateApiKeyRequest {
+    pub name: String,
+    pub permissions: Vec<JrpcPermission>,
+    pub allow_admin: bool,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export, export_to = "wallet-types/"))]
+pub struct AuthCreateApiKeyResponse {
+    pub id: String,
+    pub name: String,
+    pub api_key: String,
+    pub permissions: Vec<JrpcPermission>,
+    pub created_at: u64,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export, export_to = "wallet-types/"))]
+pub struct AuthListApiKeysRequest {}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export, export_to = "wallet-types/"))]
+pub struct AuthListApiKeysResponse {
+    pub api_keys: Vec<AuthApiKeyInfo>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export, export_to = "wallet-types/"))]
+pub struct AuthApiKeyInfo {
+    pub id: String,
+    pub name: String,
+    pub permissions: Vec<JrpcPermission>,
+    pub created_at: u64,
+    pub last_used_at: Option<u64>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export, export_to = "wallet-types/"))]
+pub struct AuthRevokeApiKeyRequest {
+    pub id: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export, export_to = "wallet-types/"))]
+pub struct AuthRevokeApiKeyResponse {}
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export, export_to = "wallet-types/"))]

--- a/crates/wallet/sdk/src/models/api_key.rs
+++ b/crates/wallet/sdk/src/models/api_key.rs
@@ -1,0 +1,21 @@
+// Copyright 2026 The Tari Project
+// SPDX-License-Identifier: BSD-3-Clause
+
+#[derive(Debug, Clone)]
+pub struct ApiKeyModel {
+    pub id: String,
+    pub name: String,
+    pub key_hash: Vec<u8>,
+    pub permissions: Vec<String>,
+    pub created_at: u64,
+    pub last_used_at: Option<u64>,
+    pub revoked_at: Option<u64>,
+}
+
+#[derive(Debug, Clone)]
+pub struct NewApiKeyModel {
+    pub id: String,
+    pub name: String,
+    pub key_hash: Vec<u8>,
+    pub permissions: Vec<String>,
+}

--- a/crates/wallet/sdk/src/models/mod.rs
+++ b/crates/wallet/sdk/src/models/mod.rs
@@ -3,6 +3,7 @@
 
 mod account;
 mod address_book_entry;
+mod api_key;
 mod authored_template;
 mod confidential_output;
 mod config;
@@ -22,6 +23,7 @@ mod webauthn_registration;
 
 pub use account::*;
 pub use address_book_entry::*;
+pub use api_key::*;
 pub use authored_template::*;
 pub use confidential_output::*;
 pub use config::Config;

--- a/crates/wallet/sdk/src/storage/reader.rs
+++ b/crates/wallet/sdk/src/storage/reader.rs
@@ -21,6 +21,7 @@ use crate::{
     models::{
         Account,
         AddressBookEntry,
+        ApiKeyModel,
         AuthoredTemplateModel,
         ConfidentialOutputModel,
         Config,
@@ -207,6 +208,11 @@ pub trait WalletStoreReader {
     // Webauthn registration
     fn webauthn_is_user_registered(&mut self, username: &str) -> Result<bool, WalletStorageError>;
     fn webauthn_reg_fetch_passkeys(&mut self, username: String) -> Result<Vec<Passkey>, WalletStorageError>;
+
+    // API keys
+    fn api_keys_get(&mut self, id: &str) -> Result<ApiKeyModel, WalletStorageError>;
+    fn api_keys_get_active(&mut self, id: &str) -> Result<ApiKeyModel, WalletStorageError>;
+    fn api_keys_list_active(&mut self) -> Result<Vec<ApiKeyModel>, WalletStorageError>;
 
     // Authored templates
     fn authored_templates_exists_by_address(&mut self, address: &TemplateAddress) -> Result<bool, WalletStorageError>;

--- a/crates/wallet/sdk/src/storage/writer.rs
+++ b/crates/wallet/sdk/src/storage/writer.rs
@@ -31,6 +31,7 @@ use crate::{
         ImportedKeyId,
         KeyId,
         KeyType,
+        NewApiKeyModel,
         NewAccountData,
         NonFungibleToken,
         OutputStatus,
@@ -205,6 +206,11 @@ pub trait WalletStoreWriter: CommittableStore {
 
     // Webauthn registrations
     fn webauthn_reg_insert(&mut self, username: String, passkey: Passkey) -> Result<(), WalletStorageError>;
+
+    // API keys
+    fn api_keys_insert(&mut self, api_key: NewApiKeyModel) -> Result<(), WalletStorageError>;
+    fn api_keys_touch_last_used(&mut self, id: &str) -> Result<(), WalletStorageError>;
+    fn api_keys_revoke(&mut self, id: &str) -> Result<(), WalletStorageError>;
 
     // Authored templates
     fn authored_templates_insert(&mut self, model: AuthoredTemplateModel) -> Result<(), WalletStorageError>;

--- a/crates/wallet/storage_sqlite/migrations/2026-05-06-000001_wallet_api_keys/down.sql
+++ b/crates/wallet/storage_sqlite/migrations/2026-05-06-000001_wallet_api_keys/down.sql
@@ -1,0 +1,3 @@
+DROP INDEX wallet_api_keys_active_idx;
+DROP INDEX wallet_api_keys_key_hash_idx;
+DROP TABLE wallet_api_keys;

--- a/crates/wallet/storage_sqlite/migrations/2026-05-06-000001_wallet_api_keys/up.sql
+++ b/crates/wallet/storage_sqlite/migrations/2026-05-06-000001_wallet_api_keys/up.sql
@@ -1,0 +1,14 @@
+CREATE TABLE wallet_api_keys
+(
+    id           TEXT      NOT NULL PRIMARY KEY,
+    name         TEXT      NOT NULL,
+    key_hash     BLOB      NOT NULL,
+    permissions  BLOB      NOT NULL,
+    last_used_at TIMESTAMP NULL,
+    revoked_at   TIMESTAMP NULL,
+    created_at   TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at   TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE UNIQUE INDEX wallet_api_keys_key_hash_idx ON wallet_api_keys (key_hash);
+CREATE INDEX wallet_api_keys_active_idx ON wallet_api_keys (revoked_at);

--- a/crates/wallet/storage_sqlite/src/models/api_key.rs
+++ b/crates/wallet/storage_sqlite/src/models/api_key.rs
@@ -1,0 +1,42 @@
+// Copyright 2026 The Tari Project
+// SPDX-License-Identifier: BSD-3-Clause
+
+use tari_ootle_wallet_sdk::models::ApiKeyModel;
+use time::PrimitiveDateTime;
+
+use crate::schema::wallet_api_keys;
+
+#[derive(Debug, Clone, Queryable, Identifiable, Selectable)]
+#[diesel(table_name = wallet_api_keys)]
+#[diesel(primary_key(id))]
+pub struct ApiKey {
+    pub id: String,
+    pub name: String,
+    pub key_hash: Vec<u8>,
+    pub permissions: Vec<u8>,
+    pub last_used_at: Option<PrimitiveDateTime>,
+    pub revoked_at: Option<PrimitiveDateTime>,
+    pub created_at: PrimitiveDateTime,
+    pub updated_at: PrimitiveDateTime,
+}
+
+impl TryFrom<ApiKey> for ApiKeyModel {
+    type Error = serde_json::Error;
+
+    fn try_from(value: ApiKey) -> Result<Self, Self::Error> {
+        let permissions = serde_json::from_slice(&value.permissions)?;
+        Ok(Self {
+            id: value.id,
+            name: value.name,
+            key_hash: value.key_hash,
+            permissions,
+            created_at: primitive_datetime_to_secs(value.created_at),
+            last_used_at: value.last_used_at.map(primitive_datetime_to_secs),
+            revoked_at: value.revoked_at.map(primitive_datetime_to_secs),
+        })
+    }
+}
+
+fn primitive_datetime_to_secs(value: PrimitiveDateTime) -> u64 {
+    value.assume_utc().unix_timestamp().max(0) as u64
+}

--- a/crates/wallet/storage_sqlite/src/models/mod.rs
+++ b/crates/wallet/storage_sqlite/src/models/mod.rs
@@ -3,6 +3,7 @@
 
 mod account;
 mod address_book_entry;
+mod api_key;
 
 mod config;
 
@@ -23,6 +24,7 @@ mod webauthn_registrations;
 
 pub use account::*;
 pub use address_book_entry::*;
+pub use api_key::*;
 pub use authored_template::*;
 pub use confidential_output::*;
 pub use config::*;

--- a/crates/wallet/storage_sqlite/src/reader.rs
+++ b/crates/wallet/storage_sqlite/src/reader.rs
@@ -29,6 +29,7 @@ use tari_ootle_wallet_sdk::{
     models::{
         Account,
         AddressBookEntry,
+        ApiKeyModel,
         AuthoredTemplateModel,
         ConfidentialOutputModel,
         Config,
@@ -62,7 +63,7 @@ use webauthn_rs::prelude::Passkey;
 
 use crate::{
     models,
-    models::{AuthoredTemplate, WebauthnRegistrationPasskey},
+    models::{ApiKey, AuthoredTemplate, WebauthnRegistrationPasskey},
     schema::accounts,
     serialization::{deserialize_hex_try_from, deserialize_json, serialize_hex},
 };
@@ -1393,6 +1394,76 @@ impl WalletStoreReader for ReadTransaction<'_> {
                 Err(_) => None,
             })
             .collect::<Vec<Passkey>>())
+    }
+
+    fn api_keys_get(&mut self, id: &str) -> Result<ApiKeyModel, WalletStorageError> {
+        const OPERATION: &str = "api_keys_get";
+        use crate::schema::wallet_api_keys;
+
+        wallet_api_keys::table
+            .filter(wallet_api_keys::id.eq(id))
+            .select(ApiKey::as_select())
+            .first::<ApiKey>(self.connection())
+            .optional()
+            .map_err(|e| WalletStorageError::general(OPERATION, e))?
+            .ok_or_else(|| WalletStorageError::NotFound {
+                operation: OPERATION,
+                entity: "wallet_api_key".to_string(),
+                key: id.to_string(),
+            })
+            .and_then(|model| {
+                ApiKeyModel::try_from(model).map_err(|e| WalletStorageError::DecodingError {
+                    operation: OPERATION,
+                    item: "wallet_api_keys.permissions",
+                    details: e.to_string(),
+                })
+            })
+    }
+
+    fn api_keys_get_active(&mut self, id: &str) -> Result<ApiKeyModel, WalletStorageError> {
+        const OPERATION: &str = "api_keys_get_active";
+        use crate::schema::wallet_api_keys;
+
+        wallet_api_keys::table
+            .filter(wallet_api_keys::id.eq(id))
+            .filter(wallet_api_keys::revoked_at.is_null())
+            .select(ApiKey::as_select())
+            .first::<ApiKey>(self.connection())
+            .optional()
+            .map_err(|e| WalletStorageError::general(OPERATION, e))?
+            .ok_or_else(|| WalletStorageError::NotFound {
+                operation: OPERATION,
+                entity: "active_wallet_api_key".to_string(),
+                key: id.to_string(),
+            })
+            .and_then(|model| {
+                ApiKeyModel::try_from(model).map_err(|e| WalletStorageError::DecodingError {
+                    operation: OPERATION,
+                    item: "wallet_api_keys.permissions",
+                    details: e.to_string(),
+                })
+            })
+    }
+
+    fn api_keys_list_active(&mut self) -> Result<Vec<ApiKeyModel>, WalletStorageError> {
+        const OPERATION: &str = "api_keys_list_active";
+        use crate::schema::wallet_api_keys;
+
+        wallet_api_keys::table
+            .filter(wallet_api_keys::revoked_at.is_null())
+            .select(ApiKey::as_select())
+            .order(wallet_api_keys::created_at.desc())
+            .load::<ApiKey>(self.connection())
+            .map_err(|e| WalletStorageError::general(OPERATION, e))?
+            .into_iter()
+            .map(|model| {
+                ApiKeyModel::try_from(model).map_err(|e| WalletStorageError::DecodingError {
+                    operation: OPERATION,
+                    item: "wallet_api_keys.permissions",
+                    details: e.to_string(),
+                })
+            })
+            .collect()
     }
 
     fn authored_templates_exists_by_address(&mut self, address: &TemplateAddress) -> Result<bool, WalletStorageError> {

--- a/crates/wallet/storage_sqlite/src/schema.rs
+++ b/crates/wallet/storage_sqlite/src/schema.rs
@@ -235,6 +235,19 @@ diesel::table! {
 }
 
 diesel::table! {
+    wallet_api_keys (id) {
+        id -> Text,
+        name -> Text,
+        key_hash -> Binary,
+        permissions -> Binary,
+        last_used_at -> Nullable<Timestamp>,
+        revoked_at -> Nullable<Timestamp>,
+        created_at -> Timestamp,
+        updated_at -> Timestamp,
+    }
+}
+
+diesel::table! {
     wallet_events (id) {
         id -> Nullable<Integer>,
         account_id -> Nullable<Integer>,
@@ -305,6 +318,7 @@ diesel::allow_tables_to_appear_in_same_query!(
     utxo_process_queue,
     vault_locks,
     vaults,
+    wallet_api_keys,
     wallet_events,
     webauthn_registration_passkeys,
     webauthn_registrations,

--- a/crates/wallet/storage_sqlite/src/writer.rs
+++ b/crates/wallet/storage_sqlite/src/writer.rs
@@ -45,6 +45,7 @@ use tari_ootle_wallet_sdk::{
         ImportedKeyId,
         KeyId,
         KeyType,
+        NewApiKeyModel,
         NewAccountData,
         NonFungibleToken,
         OutputStatus,
@@ -1551,6 +1552,71 @@ impl WalletStoreWriter for WriteTransaction<'_> {
             ))
             .execute(self.connection())
             .map_err(|e| WalletStorageError::general("webauthn_reg_passkeys_insert", e))?;
+
+        Ok(())
+    }
+
+    fn api_keys_insert(&mut self, api_key: NewApiKeyModel) -> Result<(), WalletStorageError> {
+        const OPERATION: &str = "api_keys_insert";
+        use crate::schema::wallet_api_keys;
+
+        let permissions = serde_json::to_vec(&api_key.permissions).map_err(|e| WalletStorageError::DecodingError {
+            operation: OPERATION,
+            item: "api_key.permissions",
+            details: e.to_string(),
+        })?;
+
+        diesel::insert_into(wallet_api_keys::table)
+            .values((
+                wallet_api_keys::id.eq(api_key.id),
+                wallet_api_keys::name.eq(api_key.name),
+                wallet_api_keys::key_hash.eq(api_key.key_hash),
+                wallet_api_keys::permissions.eq(permissions),
+            ))
+            .execute(self.connection())
+            .map_err(|e| WalletStorageError::general(OPERATION, e))?;
+
+        Ok(())
+    }
+
+    fn api_keys_touch_last_used(&mut self, id: &str) -> Result<(), WalletStorageError> {
+        const OPERATION: &str = "api_keys_touch_last_used";
+        use crate::schema::wallet_api_keys;
+
+        diesel::update(wallet_api_keys::table.filter(wallet_api_keys::id.eq(id)))
+            .set((
+                wallet_api_keys::last_used_at.eq(diesel::dsl::now),
+                wallet_api_keys::updated_at.eq(diesel::dsl::now),
+            ))
+            .execute(self.connection())
+            .map_err(|e| WalletStorageError::general(OPERATION, e))?;
+
+        Ok(())
+    }
+
+    fn api_keys_revoke(&mut self, id: &str) -> Result<(), WalletStorageError> {
+        const OPERATION: &str = "api_keys_revoke";
+        use crate::schema::wallet_api_keys;
+
+        let affected = diesel::update(
+            wallet_api_keys::table
+                .filter(wallet_api_keys::id.eq(id))
+                .filter(wallet_api_keys::revoked_at.is_null()),
+        )
+        .set((
+            wallet_api_keys::revoked_at.eq(diesel::dsl::now),
+            wallet_api_keys::updated_at.eq(diesel::dsl::now),
+        ))
+        .execute(self.connection())
+        .map_err(|e| WalletStorageError::general(OPERATION, e))?;
+
+        if affected == 0 {
+            return Err(WalletStorageError::NotFound {
+                operation: OPERATION,
+                entity: "active_wallet_api_key".to_string(),
+                key: id.to_string(),
+            });
+        }
 
         Ok(())
     }

--- a/crates/wallet/storage_sqlite/tests/api_keys.rs
+++ b/crates/wallet/storage_sqlite/tests/api_keys.rs
@@ -1,0 +1,38 @@
+// Copyright 2026 The Tari Project
+// SPDX-License-Identifier: BSD-3-Clause
+
+use tari_ootle_wallet_sdk::{
+    models::NewApiKeyModel,
+    storage::{CommittableStore, WalletStoreReader, WalletStoreWriter, WriteableWalletStore},
+};
+use tari_ootle_wallet_storage_sqlite::SqliteWalletStore;
+
+#[test]
+fn api_keys_can_be_created_listed_touched_and_revoked() {
+    let db = SqliteWalletStore::try_open(":memory:").unwrap();
+    db.run_migrations().unwrap();
+    let mut tx = db.create_write_tx().unwrap();
+
+    tx.api_keys_insert(NewApiKeyModel {
+        id: "key-1".to_string(),
+        name: "agent".to_string(),
+        key_hash: vec![1; 32],
+        permissions: vec!["AccountInfo".to_string(), "TransactionGet".to_string()],
+    })
+    .unwrap();
+
+    let key = tx.api_keys_get_active("key-1").unwrap();
+    assert_eq!(key.name, "agent");
+    assert_eq!(key.permissions, vec!["AccountInfo", "TransactionGet"]);
+    assert!(key.last_used_at.is_none());
+
+    tx.api_keys_touch_last_used("key-1").unwrap();
+    assert!(tx.api_keys_get_active("key-1").unwrap().last_used_at.is_some());
+    assert_eq!(tx.api_keys_list_active().unwrap().len(), 1);
+
+    tx.api_keys_revoke("key-1").unwrap();
+    assert!(tx.api_keys_get_active("key-1").is_err());
+    assert_eq!(tx.api_keys_list_active().unwrap().len(), 0);
+
+    tx.commit().unwrap();
+}

--- a/docs/skills/claude-code/tari-manifest/references/wallet-daemon-api.md
+++ b/docs/skills/claude-code/tari-manifest/references/wallet-daemon-api.md
@@ -28,7 +28,7 @@ WebAuthn requires a browser-based passkey interaction (biometric, hardware key, 
 4. **Login:** `auth.request` with `{"permissions": [...], "credentials": {"WebAuthN": <response>}}`
 5. **Use token:** Same as above
 
-**For agents:** Ask the user to authenticate via the wallet daemon web UI and provide the JWT token. Once received, use it in `Authorization: Bearer <token>` headers. If the token expires, ask the user for a fresh one.
+**For agents:** Ask an Admin user to create a permission-scoped API key in the wallet UI or with `tari_wallet_cli auth api-key create`. Use the API key with `auth.request` credentials `{"ApiKey":{"api_key":"..."}}` to receive a short-lived JWT scoped to the key. If the JWT expires, repeat `auth.request` with the same API key.
 
 ### JWT Token Details
 
@@ -83,9 +83,39 @@ Authenticate and receive a JWT token.
 
 For WebAuthn: `"credentials": {"WebAuthN": <WebauthnFinishAuthRequest>}`
 
+For API keys: `"credentials": {"ApiKey": {"api_key": "twda_<id>_<secret>"}}`
+
 **Response:** `{"result":{"token":"eyJ..."}}`
 
 Also sets an HttpOnly `r-tkn` cookie for refresh.
+
+### auth.api_key_create
+
+Create a named API key. Requires `Admin` permission. The API key is returned only in this response; the wallet stores only its hash.
+
+**Request:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 4,
+  "method": "auth.api_key_create",
+  "params": {
+    "name": "codex-agent",
+    "permissions": ["AccountInfo", "TransactionGet"],
+    "allow_admin": false
+  }
+}
+```
+
+Set `allow_admin` to `true` only when `permissions` includes `Admin`.
+
+### auth.api_key_list
+
+List active API keys. Requires `Admin` permission. Returns each key's `id`, `name`, `permissions`, `created_at`, and `last_used_at`.
+
+### auth.api_key_revoke
+
+Revoke an active API key by id. Requires `Admin` permission. Revocation is immediate for new and existing JWT checks.
 
 ### auth.refresh
 


### PR DESCRIPTION
Description
---
Adds Admin-managed, permission-scoped API keys for wallet daemon agent authentication. Raw API keys are returned only at creation, only hashes are persisted, and API-key-backed JWTs include the key id so revocation is checked immediately during auth checks.

Bounty issue: https://github.com/tari-project/tari-ootle/issues/1957

Motivation and Context
---
The wallet daemon currently requires WebAuthn or a manually copied short-lived token, which does not work well for AI agents. This extends the existing JSON-RPC permission/JWT model instead of adding a separate auth path.

Implemented:
- persistent wallet API key storage with create/list/revoke and timestamps
- auth.request API-key credential exchange for scoped JWTs
- Admin-only management endpoints and explicit Admin grant confirmation
- Rust wallet daemon client methods and authenticate-with-key helper
- JavaScript wallet daemon client methods and authenticateWithApiKey helper
- wallet CLI auth api-key create/list/revoke/authenticate commands
- wallet UI API key creation/list/revoke surface under access tokens
- docs for agent setup flow and API endpoints

How Has This Been Tested?
---
- git diff --cached --check
- Added storage coverage for create/list/touch/revoke API-key persistence.
- Added permission subset and AddressBook permission round-trip tests.

Local limitations: cargo/rustup are not installed in this Windows shell, so I could not run cargo +nightly-2025-06-25 fmt --all or cargo test locally. pnpm is present, but repo dependencies are not installed, so local prettier/tsc also could not run.

What process can a PR reviewer use to test or verify this change?
---
- cargo +nightly-2025-06-25 fmt --all
- cargo test -p tari_ootle_wallet_storage_sqlite api_keys_can_be_created_listed_touched_and_revoked
- cargo test -p tari_ootle_walletd_client permissions_subset_requires_every_requested_permission address_book_permission_round_trips_from_display
- cargo check -p tari_ootle_walletd -p tari_ootle_walletd_client -p tari_wallet_cli -p tari_ootle_wallet_storage_sqlite
- Generate TS bindings, then run the wallet web UI/client TypeScript build.
- Manual JSON-RPC smoke flow: authenticate as Admin, call auth.api_key_create, call auth.request with {ApiKey:{api_key:...}}, verify in-scope request succeeds, out-of-scope request fails, auth.api_key_revoke invalidates the key-backed JWT.

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify