### PR TITLE
fix(consensus): escalate to state sync on validated future-epoch QC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1707,7 +1707,7 @@ dependencies = [
 
 [[package]]
 name = "consensus_tests"
-version = "0.30.4"
+version = "0.30.5"
 dependencies = [
  "fern",
  "futures 0.3.31",
@@ -2711,7 +2711,7 @@ dependencies = [
 
 [[package]]
 name = "db-inspector"
-version = "0.30.4"
+version = "0.30.5"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -5101,7 +5101,7 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "integration_tests"
-version = "0.30.4"
+version = "0.30.5"
 dependencies = [
  "anyhow",
  "config",
@@ -5883,7 +5883,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-messaging"
-version = "0.30.4"
+version = "0.30.5"
 dependencies = [
  "async-trait",
  "futures-bounded 0.2.4",
@@ -6061,7 +6061,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-substream"
-version = "0.30.4"
+version = "0.30.5"
 dependencies = [
  "libp2p",
  "prometheus-client",
@@ -7646,7 +7646,7 @@ dependencies = [
 
 [[package]]
 name = "ootle-wasm"
-version = "0.30.4"
+version = "0.30.5"
 dependencies = [
  "console_error_panic_hook",
  "getrandom 0.2.17",
@@ -7656,7 +7656,7 @@ dependencies = [
 
 [[package]]
 name = "ootle-wasm-core"
-version = "0.30.4"
+version = "0.30.5"
 dependencies = [
  "base64 0.22.1",
  "ootle_byte_type",
@@ -8661,7 +8661,7 @@ dependencies = [
 
 [[package]]
 name = "proto_builder"
-version = "0.30.4"
+version = "0.30.5"
 dependencies = [
  "prost-build 0.14.3",
  "sha2 0.10.9",
@@ -10539,7 +10539,7 @@ dependencies = [
 
 [[package]]
 name = "sqlite_message_logger"
-version = "0.30.4"
+version = "0.30.5"
 dependencies = [
  "chrono",
  "diesel",
@@ -10911,7 +10911,7 @@ dependencies = [
 
 [[package]]
 name = "tari_base_node_client"
-version = "0.30.4"
+version = "0.30.5"
 dependencies = [
  "futures-util",
  "log",
@@ -11138,7 +11138,7 @@ dependencies = [
 
 [[package]]
 name = "tari_consensus"
-version = "0.30.4"
+version = "0.30.5"
 dependencies = [
  "anyhow",
  "indexmap 2.13.0",
@@ -11163,7 +11163,7 @@ dependencies = [
 
 [[package]]
 name = "tari_consensus_types"
-version = "0.30.4"
+version = "0.30.5"
 dependencies = [
  "borsh",
  "ootle_serde",
@@ -11263,7 +11263,7 @@ dependencies = [
 
 [[package]]
 name = "tari_engine"
-version = "0.30.4"
+version = "0.30.5"
 dependencies = [
  "blake2 0.10.6",
  "bytes",
@@ -11294,7 +11294,7 @@ dependencies = [
 
 [[package]]
 name = "tari_engine_types"
-version = "0.30.4"
+version = "0.30.5"
 dependencies = [
  "bincode 2.0.1",
  "blake2 0.10.6",
@@ -11323,7 +11323,7 @@ dependencies = [
 
 [[package]]
 name = "tari_epoch_manager"
-version = "0.30.4"
+version = "0.30.5"
 dependencies = [
  "anyhow",
  "log",
@@ -11343,7 +11343,7 @@ dependencies = [
 
 [[package]]
 name = "tari_epoch_oracles"
-version = "0.30.4"
+version = "0.30.5"
 dependencies = [
  "anyhow",
  "blake2 0.10.6",
@@ -11397,7 +11397,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer"
-version = "0.30.4"
+version = "0.30.5"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -11499,7 +11499,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer_lib"
-version = "0.30.4"
+version = "0.30.5"
 dependencies = [
  "log",
  "prometheus-client",
@@ -11603,7 +11603,7 @@ dependencies = [
 
 [[package]]
 name = "tari_networking"
-version = "0.30.4"
+version = "0.30.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11656,7 +11656,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_app_utilities"
-version = "0.30.4"
+version = "0.30.5"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -11696,7 +11696,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_common_types"
-version = "0.30.4"
+version = "0.30.5"
 dependencies = [
  "blake2 0.10.6",
  "borsh",
@@ -11724,7 +11724,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_p2p"
-version = "0.30.4"
+version = "0.30.5"
 dependencies = [
  "anyhow",
  "libp2p-identity 0.2.13 (git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a)",
@@ -11748,7 +11748,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_storage"
-version = "0.30.4"
+version = "0.30.5"
 dependencies = [
  "anyhow",
  "bitflags 2.10.0",
@@ -11775,7 +11775,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_storage_sqlite"
-version = "0.30.4"
+version = "0.30.5"
 dependencies = [
  "diesel",
  "diesel_migrations",
@@ -11826,7 +11826,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_transaction"
-version = "0.30.4"
+version = "0.30.5"
 dependencies = [
  "bincode 2.0.1",
  "borsh",
@@ -11852,7 +11852,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_cli"
-version = "0.30.4"
+version = "0.30.5"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -11881,7 +11881,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_crypto"
-version = "0.30.4"
+version = "0.30.5"
 dependencies = [
  "argon2 0.5.3",
  "blake2 0.10.6",
@@ -11911,7 +11911,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_sdk"
-version = "0.30.4"
+version = "0.30.5"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -11973,7 +11973,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_sdk_tests"
-version = "0.30.4"
+version = "0.30.5"
 dependencies = [
  "digest 0.10.7",
  "ootle_byte_type",
@@ -11995,7 +11995,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_storage_sqlite"
-version = "0.30.4"
+version = "0.30.5"
 dependencies = [
  "diesel",
  "diesel_migrations",
@@ -12018,7 +12018,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_walletd"
-version = "0.30.4"
+version = "0.30.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12136,7 +12136,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_framework"
-version = "0.30.4"
+version = "0.30.5"
 dependencies = [
  "async-trait",
  "bitflags 2.10.0",
@@ -12160,7 +12160,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_macros"
-version = "0.30.4"
+version = "0.30.5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12169,7 +12169,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_state_sync"
-version = "0.30.4"
+version = "0.30.5"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -12246,7 +12246,7 @@ dependencies = [
 
 [[package]]
 name = "tari_state_store_rocksdb"
-version = "0.30.4"
+version = "0.30.5"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -12278,7 +12278,7 @@ dependencies = [
 
 [[package]]
 name = "tari_state_tree"
-version = "0.30.4"
+version = "0.30.5"
 dependencies = [
  "indexmap 2.13.0",
  "log",
@@ -12304,7 +12304,7 @@ dependencies = [
 
 [[package]]
 name = "tari_swarm"
-version = "0.30.4"
+version = "0.30.5"
 dependencies = [
  "libp2p",
  "libp2p-messaging",
@@ -12315,7 +12315,7 @@ dependencies = [
 
 [[package]]
 name = "tari_swarm_daemon"
-version = "0.30.4"
+version = "0.30.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12426,7 +12426,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_test_tooling"
-version = "0.30.4"
+version = "0.30.5"
 dependencies = [
  "anyhow",
  "cargo_toml 0.22.3",
@@ -12539,7 +12539,7 @@ dependencies = [
 
 [[package]]
 name = "tari_transaction_manifest"
-version = "0.30.4"
+version = "0.30.5"
 dependencies = [
  "proc-macro2",
  "serde_json",
@@ -12574,7 +12574,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node"
-version = "0.30.4"
+version = "0.30.5"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -12640,7 +12640,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node_client"
-version = "0.30.4"
+version = "0.30.5"
 dependencies = [
  "indexmap 2.13.0",
  "multiaddr 0.18.3",
@@ -12664,7 +12664,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node_rpc"
-version = "0.30.4"
+version = "0.30.5"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -12687,7 +12687,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_rollback"
-version = "0.30.4"
+version = "0.30.5"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12722,7 +12722,7 @@ dependencies = [
 
 [[package]]
 name = "tari_watcher"
-version = "0.30.4"
+version = "0.30.5"
 dependencies = [
  "anyhow",
  "clap 3.2.25",
@@ -12751,7 +12751,7 @@ dependencies = [
 
 [[package]]
 name = "tariswap_bench"
-version = "0.30.4"
+version = "0.30.5"
 dependencies = [
  "anyhow",
  "clap 4.5.54",
@@ -13431,7 +13431,7 @@ dependencies = [
 
 [[package]]
 name = "traffic-sim"
-version = "0.30.4"
+version = "0.30.5"
 dependencies = [
  "anyhow",
  "clap 4.5.54",
@@ -13453,7 +13453,7 @@ dependencies = [
 
 [[package]]
 name = "transaction_generator"
-version = "0.30.4"
+version = "0.30.5"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -13472,7 +13472,7 @@ dependencies = [
 
 [[package]]
 name = "transaction_submitter"
-version = "0.30.4"
+version = "0.30.5"
 dependencies = [
  "anyhow",
  "clap 4.5.54",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.30.4"
+version = "0.30.5"
 edition = "2024"
 authors = ["The Tari Development Community"]
 repository = "https://github.com/tari-project/tari-ootle"

--- a/crates/consensus/src/hotstuff/on_inbound_message.rs
+++ b/crates/consensus/src/hotstuff/on_inbound_message.rs
@@ -203,8 +203,8 @@ impl<TConsensusSpec: ConsensusSpec> MessageBuffer<TConsensusSpec> {
     /// Returns `None` when:
     /// - the message carries no embedded QC (e.g. `Vote`);
     /// - the QC's epoch is not strictly ahead of `current_epoch` (nothing to prove);
-    /// - the local oracle has not yet observed the QC's epoch (we can't verify, so we fall back to buffering or discard
-    ///   — peers will keep resending and the oracle will eventually catch up);
+    /// - the local oracle has not yet observed the QC's epoch or assigned its committee (both surface as `NoEpochFound`
+    ///   and are caught by `.optional()`) — buffer and re-probe on the next future-epoch message;
     /// - the QC is empty / justifies the zero block (no signatures to verify, so unforgeability doesn't hold — must not
     ///   promote on this);
     /// - signature verification fails (likely spam or a malicious peer trying to wedge us into sync mode — drop
@@ -226,17 +226,21 @@ impl<TConsensusSpec: ConsensusSpec> MessageBuffer<TConsensusSpec> {
         // Did the local oracle observe `qc_epoch`? If not, we cannot fetch the committee or
         // verify the signatures; buffer and try again on the next incoming future-epoch
         // message (peers keep proposing in the new epoch, so this retries naturally).
-        match self.epoch_manager.get_epoch_hash(qc_epoch).await.optional()? {
-            Some(_) => {},
-            None => return Ok(None),
+        if self.epoch_manager.get_epoch_hash(qc_epoch).await.optional()?.is_none() {
+            return Ok(None);
         }
 
-        let committee = self
+        // `get_committee_by_shard_group` surfaces an unassigned committee as `NoEpochFound`
+        // (see `epoch_manager.rs:get_committee_for_shard_group`), so `.optional()` covers both
+        // the "oracle hasn't observed the epoch" and "committee not yet assigned for this
+        // shard group" cases. Returning `Ok(None)` here keeps the buffer / discard fall-through
+        // intact and avoids any reliance on cached empty committees.
+        let Some(committee) = self
             .epoch_manager
             .get_committee_by_shard_group(qc_epoch, qc.shard_group())
             .await
-            .optional()?;
-        let Some(committee) = committee else {
+            .optional()?
+        else {
             return Ok(None);
         };
 

--- a/crates/consensus/src/hotstuff/on_inbound_message.rs
+++ b/crates/consensus/src/hotstuff/on_inbound_message.rs
@@ -4,13 +4,15 @@
 use std::collections::{BTreeMap, VecDeque};
 
 use log::*;
-use tari_consensus_types::Vote;
-use tari_ootle_common_types::{Epoch, NodeHeight};
+use tari_consensus_types::{ProposalCertificate, Vote};
+use tari_epoch_manager::EpochManagerReader;
+use tari_ootle_common_types::{Epoch, NodeHeight, optional::Optional};
 
 use crate::{
     hotstuff::error::HotStuffError,
     messages::HotstuffMessage,
     traits::{ConsensusSpec, InboundMessaging, hooks::ConsensusHooks},
+    validations::check_quorum_certificate_signatures,
 };
 
 const LOG_TARGET: &str = "tari::ootle::consensus::hotstuff::inbound_messages";
@@ -23,9 +25,14 @@ pub struct OnInboundMessage<TConsensusSpec: ConsensusSpec> {
 }
 
 impl<TConsensusSpec: ConsensusSpec> OnInboundMessage<TConsensusSpec> {
-    pub fn new(inbound_messaging: TConsensusSpec::InboundMessaging, hooks: TConsensusSpec::Hooks) -> Self {
+    pub fn new(
+        inbound_messaging: TConsensusSpec::InboundMessaging,
+        epoch_manager: TConsensusSpec::EpochManager,
+        signer_service: TConsensusSpec::SignerService,
+        hooks: TConsensusSpec::Hooks,
+    ) -> Self {
         Self {
-            message_buffer: MessageBuffer::new(inbound_messaging),
+            message_buffer: MessageBuffer::new(inbound_messaging, epoch_manager, signer_service),
             hooks,
         }
     }
@@ -70,13 +77,21 @@ type EpochAndHeight = (Epoch, NodeHeight);
 pub struct MessageBuffer<TConsensusSpec: ConsensusSpec> {
     buffer: BTreeMap<EpochAndHeight, VecDeque<(TConsensusSpec::Addr, HotstuffMessage)>>,
     inbound_messaging: TConsensusSpec::InboundMessaging,
+    epoch_manager: TConsensusSpec::EpochManager,
+    signer_service: TConsensusSpec::SignerService,
 }
 
 impl<TConsensusSpec: ConsensusSpec> MessageBuffer<TConsensusSpec> {
-    pub fn new(inbound_messaging: TConsensusSpec::InboundMessaging) -> Self {
+    pub fn new(
+        inbound_messaging: TConsensusSpec::InboundMessaging,
+        epoch_manager: TConsensusSpec::EpochManager,
+        signer_service: TConsensusSpec::SignerService,
+    ) -> Self {
         Self {
             buffer: BTreeMap::new(),
             inbound_messaging,
+            epoch_manager,
+            signer_service,
         }
     }
 
@@ -134,7 +149,16 @@ impl<TConsensusSpec: ConsensusSpec> MessageBuffer<TConsensusSpec> {
                     info!(target: LOG_TARGET, "🗑️ Discard message {} is for previous view {}/{}. Current view {}/{}", msg, epoch, height, current_epoch, current_height);
                 },
                 MessageRelativeView::Future { epoch, height } => {
-                    // Buffer message for future epoch/height
+                    // Before buffering: if this message embeds a 2f+1 QC for an epoch ahead of us,
+                    // the network has rolled over without our committing the EOE locally — we
+                    // can't recover via block-level catch-up (peers won't serve us cross-epoch),
+                    // so escalate to state sync.
+                    if epoch > current_epoch &&
+                        let Some(reason) = self.probe_future_epoch_qc(&msg, current_epoch).await?
+                    {
+                        return Err(HotStuffError::NeedsSync { reason });
+                    }
+
                     if msg.proposal().is_some() {
                         info!(target: LOG_TARGET, "🔮 Proposal {msg} is for future view {height} (Current view: {current_epoch}, {current_height})");
                     } else {
@@ -165,6 +189,75 @@ impl<TConsensusSpec: ConsensusSpec> MessageBuffer<TConsensusSpec> {
         self.buffer.clear();
     }
 
+    /// Returns `Some(reason)` if `msg` carries a 2f+1-signed QC for an epoch strictly ahead of
+    /// `current_epoch`, validated against that epoch's committee. The presence of such a QC is
+    /// unforgeable proof that the network has run consensus past the local view — so we need to
+    /// state-sync rather than continue waiting on peers who have moved on.
+    ///
+    /// Returns `None` when:
+    /// - the message carries no embedded QC (e.g. `Vote`);
+    /// - the QC's epoch is not strictly ahead of `current_epoch` (nothing to prove);
+    /// - the local oracle has not yet observed the QC's epoch (we can't verify, so we fall back to buffering — peers
+    ///   will keep resending);
+    /// - the QC is empty / justifies the zero block (no signatures to verify, so unforgeability doesn't hold — must not
+    ///   promote on this);
+    /// - signature verification fails (likely spam or a malicious peer trying to wedge us into sync mode — drop
+    ///   silently and buffer normally).
+    async fn probe_future_epoch_qc(
+        &self,
+        msg: &HotstuffMessage,
+        current_epoch: Epoch,
+    ) -> Result<Option<String>, HotStuffError> {
+        let Some(qc) = extract_embedded_qc(msg) else {
+            return Ok(None);
+        };
+
+        let qc_epoch = qc.epoch();
+        if qc_epoch <= current_epoch || qc.justifies_zero_block() {
+            return Ok(None);
+        }
+
+        // Did the local oracle observe `qc_epoch`? If not, we cannot fetch the committee or
+        // verify the signatures; buffer and try again on the next incoming future-epoch
+        // message (peers keep proposing in the new epoch, so this retries naturally).
+        match self.epoch_manager.get_epoch_hash(qc_epoch).await.optional()? {
+            Some(_) => {},
+            None => return Ok(None),
+        }
+
+        let committee = self
+            .epoch_manager
+            .get_committee_by_shard_group(qc_epoch, qc.shard_group())
+            .await
+            .optional()?;
+        let Some(committee) = committee else {
+            return Ok(None);
+        };
+
+        match check_quorum_certificate_signatures::<TConsensusSpec>(qc.into(), &committee, &self.signer_service) {
+            Ok(()) => {
+                let reason = format!(
+                    "Received valid 2f+1 QC for {} ({} signatures) while consensus view is still in {}: network \
+                     rolled over without us — escalating to state sync.",
+                    qc_epoch,
+                    qc.signatures().len(),
+                    current_epoch,
+                );
+                warn!(target: LOG_TARGET, "🚨 {reason}");
+                Ok(Some(reason))
+            },
+            Err(err) => {
+                // Unverifiable QC — either a forgery from a current-epoch peer or a transient
+                // committee mismatch. Don't escalate; drop silently and buffer the message.
+                debug!(
+                    target: LOG_TARGET,
+                    "Ignoring future-epoch QC for {qc_epoch}: signature check failed ({err})"
+                );
+                Ok(None)
+            },
+        }
+    }
+
     fn push_to_buffer(&mut self, epoch: Epoch, height: NodeHeight, from: TConsensusSpec::Addr, msg: HotstuffMessage) {
         const MAX_BUFFERED_MESSAGES_PER_VIEW: usize = 1000;
         const MAX_BUFFERED_VIEWS: usize = 100_000;
@@ -193,6 +286,21 @@ impl<TConsensusSpec: ConsensusSpec> MessageBuffer<TConsensusSpec> {
             return;
         }
         messages_mut.push_back((from, msg));
+    }
+}
+
+/// Extracts a 2f+1 QC from a HotstuffMessage when one is embedded. Used by the future-epoch
+/// probe to gate the `NeedsSync` escalation on cryptographic evidence rather than wall-clock
+/// heuristics.
+///
+/// Only `Proposal` (via its block's `justify`) and `NewView` (via `high_pc`) carry QCs. `Vote`
+/// is a single-validator signature and cannot prove anything about a 2f+1 quorum, so it must
+/// not be used as evidence.
+fn extract_embedded_qc(msg: &HotstuffMessage) -> Option<&ProposalCertificate> {
+    match msg {
+        HotstuffMessage::Proposal(p) => Some(p.block.justify()),
+        HotstuffMessage::NewView(nv) => Some(&nv.high_pc),
+        _ => None,
     }
 }
 

--- a/crates/consensus/src/hotstuff/on_inbound_message.rs
+++ b/crates/consensus/src/hotstuff/on_inbound_message.rs
@@ -127,6 +127,17 @@ impl<TConsensusSpec: ConsensusSpec> MessageBuffer<TConsensusSpec> {
         while let Some(result) = self.inbound_messaging.next_message().await {
             let (from, msg) = result?;
 
+            // Probe BEFORE the discard gate so a validator that has fallen many epochs behind
+            // (e.g., long network partition) can still escalate to state sync when *any*
+            // future-epoch message it receives carries a QC that validates against an
+            // oracle-observed committee. The probe is the only safe trigger for cross-epoch
+            // recovery — block-level catch-up cannot rescue a node from cross-epoch lag.
+            if msg.epoch() > current_epoch &&
+                let Some(reason) = self.probe_future_epoch_qc(&msg, current_epoch).await?
+            {
+                return Err(HotStuffError::NeedsSync { reason });
+            }
+
             // If the message is for two epochs or more ahead or behind, discard it.
             if msg.epoch() > current_epoch + Epoch(1) ||
                 current_epoch.checked_sub(Epoch(1)).is_some_and(|e| msg.epoch() < e)
@@ -149,16 +160,6 @@ impl<TConsensusSpec: ConsensusSpec> MessageBuffer<TConsensusSpec> {
                     info!(target: LOG_TARGET, "🗑️ Discard message {} is for previous view {}/{}. Current view {}/{}", msg, epoch, height, current_epoch, current_height);
                 },
                 MessageRelativeView::Future { epoch, height } => {
-                    // Before buffering: if this message embeds a 2f+1 QC for an epoch ahead of us,
-                    // the network has rolled over without our committing the EOE locally — we
-                    // can't recover via block-level catch-up (peers won't serve us cross-epoch),
-                    // so escalate to state sync.
-                    if epoch > current_epoch &&
-                        let Some(reason) = self.probe_future_epoch_qc(&msg, current_epoch).await?
-                    {
-                        return Err(HotStuffError::NeedsSync { reason });
-                    }
-
                     if msg.proposal().is_some() {
                         info!(target: LOG_TARGET, "🔮 Proposal {msg} is for future view {height} (Current view: {current_epoch}, {current_height})");
                     } else {
@@ -194,11 +195,16 @@ impl<TConsensusSpec: ConsensusSpec> MessageBuffer<TConsensusSpec> {
     /// unforgeable proof that the network has run consensus past the local view — so we need to
     /// state-sync rather than continue waiting on peers who have moved on.
     ///
+    /// The probe handles arbitrary epoch deltas: a validator that has fallen multiple epochs
+    /// behind (e.g. long network partition) still escalates correctly the first time any peer
+    /// delivers a future-epoch message whose QC validates against an oracle-observed committee.
+    /// The trust gate is the oracle + committee signatures, not the epoch delta.
+    ///
     /// Returns `None` when:
     /// - the message carries no embedded QC (e.g. `Vote`);
     /// - the QC's epoch is not strictly ahead of `current_epoch` (nothing to prove);
-    /// - the local oracle has not yet observed the QC's epoch (we can't verify, so we fall back to buffering — peers
-    ///   will keep resending);
+    /// - the local oracle has not yet observed the QC's epoch (we can't verify, so we fall back to buffering or discard
+    ///   — peers will keep resending and the oracle will eventually catch up);
     /// - the QC is empty / justifies the zero block (no signatures to verify, so unforgeability doesn't hold — must not
     ///   promote on this);
     /// - signature verification fails (likely spam or a malicious peer trying to wedge us into sync mode — drop

--- a/crates/consensus/src/hotstuff/worker.rs
+++ b/crates/consensus/src/hotstuff/worker.rs
@@ -163,7 +163,12 @@ impl<TConsensusSpec: ConsensusSpec> HotstuffWorker<TConsensusSpec> {
             rx_new_transactions,
             rx_missing_transactions,
 
-            on_inbound_message: OnInboundMessage::new(inbound_messaging, hooks.clone()),
+            on_inbound_message: OnInboundMessage::new(
+                inbound_messaging,
+                epoch_manager.clone(),
+                signing_service.clone(),
+                hooks.clone(),
+            ),
             on_message_validate: OnMessageValidate::new(
                 config.clone(),
                 state_store.clone(),

--- a/crates/consensus_tests/src/epoch_change.rs
+++ b/crates/consensus_tests/src/epoch_change.rs
@@ -434,3 +434,106 @@ async fn epoch_change_no_vote_wedge_escalates_on_future_qc() {
         "escalation reason should reference the next-epoch QC; got: {outcome}"
     );
 }
+
+/// Companion to [`epoch_change_no_vote_wedge_escalates_on_future_qc`]: verifies the probe
+/// also escalates when the validator has fallen **multiple** epochs behind (e.g., a long
+/// network partition).
+///
+/// Without the lifted gate, `MessageBuffer::next` discards any message whose epoch is more
+/// than one ahead of `current_epoch` *before* the probe runs — so a validator stuck on
+/// Epoch(1) while peers reach Epoch(3) would silently drop every Epoch(3) message and
+/// remain wedged. The fix runs the probe before the discard, so the first authenticated
+/// future-epoch QC trips `NeedsSync` regardless of the epoch delta.
+///
+/// Test flow:
+/// 1. Run four validators through Epoch(1).
+/// 2. Take validator "1" offline and cap its `current_epoch()` at Epoch(1).
+/// 3. Drive the honest three through Epoch(1) → Epoch(2) → Epoch(3).
+/// 4. Bring validator "1" back online and clear the cap.
+/// 5. Assert that the probe fires on an Epoch(3) message — proving the multi-epoch path works end-to-end.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn epoch_change_multi_epoch_lag_escalates_on_future_qc() {
+    setup_logger();
+    let mut test = Test::builder()
+        .modify_config(|cfg| {
+            cfg.epoch_end_grace_period = Duration::from_millis(10);
+        })
+        .modify_consensus_constants(|c| {
+            c.pacemaker_block_time = Duration::from_secs(1);
+        })
+        .with_test_timeout(Duration::from_secs(90))
+        .add_committee(0, vec!["1", "2", "3", "4"])
+        .start()
+        .await;
+
+    let lagging_addr = TestAddress::new("1");
+
+    test.start_epoch(Epoch(1)).await;
+
+    for _ in 0..2 {
+        test.send_transaction_to_all(Decision::Commit, 1, 1, 1).await;
+    }
+
+    // Lag and remove validator "1" before peers cross any epoch boundaries.
+    test.get_validator(&lagging_addr)
+        .epoch_manager
+        .set_oracle_current_epoch_cap(Epoch(1));
+    test.network().go_offline(lagging_addr.clone()).await;
+
+    // First boundary: Epoch(1) → Epoch(2). The honest three commit and roll over.
+    test.start_epoch(Epoch(2)).await;
+    for _ in 0..3 {
+        test.send_transaction_to_all(Decision::Commit, 1, 1, 1).await;
+    }
+    wait_for_validators_at_epoch(&mut test, &lagging_addr, Epoch(2), Duration::from_secs(45)).await;
+
+    // Second boundary: Epoch(2) → Epoch(3). Now validator "1" is *two* epochs behind, which
+    // is what the pre-fix discard logic would have masked entirely.
+    test.start_epoch(Epoch(3)).await;
+    for _ in 0..3 {
+        test.send_transaction_to_all(Decision::Commit, 1, 1, 1).await;
+    }
+    wait_for_validators_at_epoch(&mut test, &lagging_addr, Epoch(3), Duration::from_secs(45)).await;
+
+    let lagged = test.get_validator(&lagging_addr);
+    assert_eq!(
+        lagged._current_view.get_epoch(),
+        Epoch(1),
+        "lagged validator's view must remain on Epoch(1) before recovery"
+    );
+
+    log::info!("✅ multi-epoch wedge reproduced: peers in Epoch(3), {lagging_addr} on Epoch(1)");
+
+    let mut events = lagged.events.resubscribe();
+
+    // Oracle catches up + network rejoins. From now on, the honest validators' Epoch(3)
+    // messages reach validator "1". Each carries a 2f+1 QC over Epoch(3) — which would
+    // have been discarded outright before the gate was lifted (3 > 1 + 1).
+    lagged.epoch_manager.clear_oracle_current_epoch_cap();
+    test.network().go_online(&lagging_addr).await;
+
+    for _ in 0..3 {
+        test.send_transaction_to_all(Decision::Commit, 1, 1, 1).await;
+    }
+
+    let outcome = tokio::time::timeout(Duration::from_secs(20), async {
+        loop {
+            match events.recv().await {
+                Ok(HotstuffEvent::Failure { message }) if message.contains("Received valid 2f+1 QC") => {
+                    return message;
+                },
+                Ok(_) => continue,
+                Err(broadcast::error::RecvError::Lagged(_)) => continue,
+                Err(broadcast::error::RecvError::Closed) => panic!("validator event channel closed"),
+            }
+        }
+    })
+    .await
+    .expect("Timed out waiting for QC-based NeedsSync escalation");
+
+    log::info!("✅ probe fired across multi-epoch gap: {outcome}");
+    assert!(
+        outcome.contains("Epoch(3)"),
+        "escalation reason should reference the Epoch(3) QC across the multi-epoch gap; got: {outcome}"
+    );
+}

--- a/crates/consensus_tests/src/epoch_change.rs
+++ b/crates/consensus_tests/src/epoch_change.rs
@@ -3,7 +3,7 @@
 
 use std::time::{Duration, Instant};
 
-use tari_consensus::hotstuff::HotStuffError;
+use tari_consensus::hotstuff::{HotStuffError, HotstuffEvent};
 use tari_consensus_types::{Decision, LeafBlock};
 use tari_ootle_common_types::{Epoch, NodeHeight, optional::Optional};
 use tari_ootle_storage::{
@@ -11,6 +11,7 @@ use tari_ootle_storage::{
     StateStoreReadTransaction,
     consensus_models::{Block, BookkeepingModel},
 };
+use tokio::sync::broadcast;
 
 use crate::support::{Test, TestAddress, logging::setup_logger};
 
@@ -289,5 +290,147 @@ async fn wait_for_single_validator_at_epoch(test: &mut Test, addr: &TestAddress,
     panic!(
         "Timed out waiting for {addr} to reach {epoch} (currently on {})",
         test.get_validator(addr)._current_view.get_epoch()
+    );
+}
+
+/// Reproduces the second variant of the epoch-change wedge described in the
+/// `consensus-epoch-change-eoe-no-vote-wedge` investigation. PR #2104 fixed the case where a
+/// validator manages to vote on the EOE but its oracle is lagging when
+/// `process_end_of_epoch` looks up the next epoch's hash. This test covers the *other* entry
+/// point: a validator whose oracle is lagging at vote-time, so it no-votes the EOE with
+/// `NoVoteReason::NotEndOfEpoch`. Peers form quorum without it, commit, and roll over.
+///
+/// In production this wedges the validator permanently — its leaf stays in the old epoch,
+/// catch-up sync fails because peers' leaves are now in the next epoch and refuse cross-epoch
+/// requests, and the oracle catching up has no code path to retry the missed transition.
+///
+/// The fix gates a `NeedsSync` escalation on **cryptographic evidence**, not on wall-clock
+/// heuristics: in `MessageBuffer::next`, any future-epoch Proposal/NewView whose embedded
+/// 2f+1 QC validates against the future epoch's committee proves the network has rolled
+/// over. The lagged validator escalates to `CheckSync` → `Syncing`, which in production
+/// downloads the epoch checkpoint and resumes on the new epoch's genesis.
+///
+/// Test flow:
+/// 1. Four validators, single committee. Start Epoch(1) and exchange a few transactions.
+/// 2. Take validator "1" *network-offline* and cap its `current_epoch()` at Epoch(1). Taking it offline keeps it out of
+///    the leader rotation as far as peers are concerned — the other three time-out validator "1"'s leadership slot and
+///    form a TC, so the chain progresses without it. Capping `current_epoch()` ensures that *if* it ever did receive
+///    the EOE proposal it would no-vote (the production failure mode).
+/// 3. Trigger Epoch(2). The three honest validators commit the EOE and run `process_end_of_epoch` to advance to
+///    Epoch(2). They keep proposing blocks in Epoch(2), each carrying a 2f+1 QC over Epoch(2).
+/// 4. Bring validator "1" back online and clear the oracle cap (modeling a node whose network rejoined and whose
+///    base-layer scanner caught up). The next Epoch(2) Proposal that the network delivers to it goes through
+///    `MessageBuffer::next`, where the probe verifies the embedded QC against the Epoch(2) committee and raises
+///    `HotStuffError::NeedsSync`.
+/// 5. We assert on the resulting `HotstuffEvent::Failure` event — its message identifies the QC-based reason. No
+///    time-based sleeps: the assertion fires deterministically when an authenticated Epoch(2) QC reaches the validator.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn epoch_change_no_vote_wedge_escalates_on_future_qc() {
+    setup_logger();
+    let mut test = Test::builder()
+        .modify_config(|cfg| {
+            cfg.epoch_end_grace_period = Duration::from_millis(10);
+        })
+        .modify_consensus_constants(|c| {
+            // Short pacemaker so the honest validators time-out validator "1"'s leadership
+            // slot quickly and form a TC to skip past it.
+            c.pacemaker_block_time = Duration::from_secs(1);
+        })
+        .with_test_timeout(Duration::from_secs(60))
+        // 4 validators so 3 honest yes-votes are enough for quorum without the lagged one.
+        .add_committee(0, vec!["1", "2", "3", "4"])
+        .start()
+        .await;
+
+    let lagging_addr = TestAddress::new("1");
+
+    test.start_epoch(Epoch(1)).await;
+
+    // A few transactions to advance the chain in Epoch(1) before the boundary.
+    for _ in 0..3 {
+        test.send_transaction_to_all(Decision::Commit, 1, 1, 1).await;
+    }
+
+    // Cap validator "1"'s view of `current_epoch()`. Unlike `set_oracle_visible_epoch` (which
+    // only caps `get_epoch_hash`), this makes the vote-time check
+    // `em_epoch > current_epoch` fail for this validator — reproducing the no-vote path.
+    test.get_validator(&lagging_addr)
+        .epoch_manager
+        .set_oracle_current_epoch_cap(Epoch(1));
+
+    // Take validator "1" offline so the network delivers no messages to/from it. This stops
+    // its (now-wedged) view from blocking leader rotation on the honest committee — peers
+    // time out validator "1"'s slot, gather a TC, and the next leader takes over.
+    test.network().go_offline(lagging_addr.clone()).await;
+
+    // Trigger the epoch change. The shared `inner.current_epoch` moves to Epoch(2) and
+    // `EpochChanged(2)` is broadcast (via tokio, not the test network — so even the offline
+    // validator receives it). The three honest validators commit the EOE and advance.
+    test.start_epoch(Epoch(2)).await;
+
+    for _ in 0..3 {
+        test.send_transaction_to_all(Decision::Commit, 1, 1, 1).await;
+    }
+
+    // The three honest validators advance to Epoch(2); the lagged one (offline + capped)
+    // cannot make progress and remains on Epoch(1).
+    wait_for_validators_at_epoch(&mut test, &lagging_addr, Epoch(2), Duration::from_secs(45)).await;
+
+    let lagged = test.get_validator(&lagging_addr);
+    assert_eq!(
+        lagged._current_view.get_epoch(),
+        Epoch(1),
+        "lagged validator's view must remain on Epoch(1) before recovery"
+    );
+    let leaf_at_2 = lagged
+        .state_store
+        .with_read_tx(|tx| LeafBlock::get(tx, Epoch(2)))
+        .optional()
+        .unwrap();
+    assert!(
+        leaf_at_2.is_none(),
+        "lagged validator must NOT have a leaf in Epoch(2) before recovery; got {leaf_at_2:?}"
+    );
+
+    log::info!("✅ wedge reproduced: validator {lagging_addr} stuck on Epoch(1) while peers committed Epoch(2)");
+
+    // Subscribe to validator "1"'s event stream BEFORE clearing the oracle cap and going
+    // online, so we don't miss the Failure event the worker publishes when it raises
+    // `HotStuffError::NeedsSync`.
+    let mut events = lagged.events.resubscribe();
+
+    // Oracle catches up, and the network rejoins. From now on, the honest validators'
+    // Epoch(2) proposals reach validator "1" — each carries an authenticated 2f+1 QC over
+    // Epoch(2). The first one trips the probe in `MessageBuffer::next`.
+    lagged.epoch_manager.clear_oracle_current_epoch_cap();
+    test.network().go_online(&lagging_addr).await;
+
+    // Honest validators keep producing proposals in Epoch(2); send more transactions to
+    // drive them.
+    for _ in 0..3 {
+        test.send_transaction_to_all(Decision::Commit, 1, 1, 1).await;
+    }
+
+    // Wait for the Failure event whose message identifies the QC-based escalation. This is
+    // deterministic — fires on the first authenticated Epoch(2) QC that arrives.
+    let outcome = tokio::time::timeout(Duration::from_secs(20), async {
+        loop {
+            match events.recv().await {
+                Ok(HotstuffEvent::Failure { message }) if message.contains("Received valid 2f+1 QC") => {
+                    return message;
+                },
+                Ok(_) => continue,
+                Err(broadcast::error::RecvError::Lagged(_)) => continue,
+                Err(broadcast::error::RecvError::Closed) => panic!("validator event channel closed"),
+            }
+        }
+    })
+    .await
+    .expect("Timed out waiting for QC-based NeedsSync escalation");
+
+    log::info!("✅ probe fired: {outcome}");
+    assert!(
+        outcome.contains("Epoch(2)"),
+        "escalation reason should reference the next-epoch QC; got: {outcome}"
     );
 }

--- a/crates/consensus_tests/src/support/epoch_manager.rs
+++ b/crates/consensus_tests/src/support/epoch_manager.rs
@@ -44,6 +44,11 @@ pub struct TestEpochManager {
     /// while the cheap `Clone` impl shares it with downstream consumers — the worker, outbound
     /// messaging, etc. — for the same validator.
     oracle_visible_epoch: Arc<StdMutex<Option<Epoch>>>,
+    /// Caps the value returned by `current_epoch()` for this validator. When `Some(cap)`,
+    /// `current_epoch().await` returns `min(state.current_epoch, cap)`. Unlike
+    /// `oracle_visible_epoch`, this *does* lag the vote-time `em_epoch > current_epoch`
+    /// check — used to reproduce the wedge where a validator no-votes the EOE block.
+    oracle_current_epoch_cap: Arc<StdMutex<Option<Epoch>>>,
 }
 
 impl TestEpochManager {
@@ -54,6 +59,7 @@ impl TestEpochManager {
             tx_epoch_events,
             current_epoch: Epoch(1),
             oracle_visible_epoch: Arc::new(StdMutex::new(None)),
+            oracle_current_epoch_cap: Arc::new(StdMutex::new(None)),
         }
     }
 
@@ -77,6 +83,24 @@ impl TestEpochManager {
 
     fn oracle_visible_epoch(&self) -> Option<Epoch> {
         *self.oracle_visible_epoch.lock().unwrap()
+    }
+
+    /// Cap the value returned by `current_epoch()` for this validator. After this,
+    /// `current_epoch().await` returns `min(state.current_epoch, cap)`. Used by the
+    /// EOE-no-vote wedge test: lagging this value makes the vote-time check
+    /// `em_epoch > current_epoch` fail on this validator while peers (which read the
+    /// shared `inner.current_epoch`) vote yes and commit the EOE without us.
+    pub fn set_oracle_current_epoch_cap(&self, epoch: Epoch) {
+        *self.oracle_current_epoch_cap.lock().unwrap() = Some(epoch);
+    }
+
+    /// Remove the `current_epoch()` cap for this validator.
+    pub fn clear_oracle_current_epoch_cap(&self) {
+        *self.oracle_current_epoch_cap.lock().unwrap() = None;
+    }
+
+    fn oracle_current_epoch_cap(&self) -> Option<Epoch> {
+        *self.oracle_current_epoch_cap.lock().unwrap()
     }
 
     pub async fn set_current_epoch(&mut self, current_epoch: Epoch, shard_group: ShardGroup) -> &Self {
@@ -110,6 +134,7 @@ impl TestEpochManager {
         // Each validator gets its own lag state — sibling clones (worker, outbound, etc.) for
         // this same validator share via the cheap `Clone` impl.
         copy.oracle_visible_epoch = Arc::new(StdMutex::new(None));
+        copy.oracle_current_epoch_cap = Arc::new(StdMutex::new(None));
         if let Some(our_validator_node) = self.our_validator_node.clone() {
             copy.our_validator_node = Some(ValidatorNode {
                 address,
@@ -247,7 +272,11 @@ impl EpochManagerReader for TestEpochManager {
     }
 
     async fn current_epoch(&self) -> Result<Epoch, EpochManagerError> {
-        Ok(self.inner.lock().await.current_epoch)
+        let actual = self.inner.lock().await.current_epoch;
+        if let Some(cap) = self.oracle_current_epoch_cap() {
+            return Ok(std::cmp::min(actual, cap));
+        }
+        Ok(actual)
     }
 
     async fn get_current_epoch_hash(&self) -> Result<FixedHash, EpochManagerError> {

--- a/crates/epoch_manager/src/error.rs
+++ b/crates/epoch_manager/src/error.rs
@@ -54,7 +54,7 @@ impl EpochManagerError {
 impl IsNotFoundError for EpochManagerError {
     fn is_not_found_error(&self) -> bool {
         match self {
-            Self::ValidatorNodeNotRegistered { .. } => true,
+            Self::ValidatorNodeNotRegistered { .. } | Self::NoEpochFound(_) => true,
             Self::StorageError(err) => err.is_not_found_error(),
             _ => false,
         }

--- a/crates/epoch_manager/src/service/epoch_manager.rs
+++ b/crates/epoch_manager/src/service/epoch_manager.rs
@@ -428,9 +428,18 @@ where TSpec: EpochManagerSpec
     ) -> Result<Committee<TSpec::Addr>, EpochManagerError> {
         let mut tx = self.global_db.create_transaction()?;
         let mut validator_node_db = self.global_db.validator_nodes(&mut tx);
-        let committees =
+        let committee =
             validator_node_db.get_committee_for_shard_group(epoch, shard_group, limit.unwrap_or(usize::MAX))?;
-        Ok(committees)
+        // An empty committee means no validators have been assigned for `(epoch, shard_group)`
+        // — either the epoch is not yet known to the local oracle, or validator assignment is
+        // pending. Surfacing this as `NoEpochFound` (rather than the previous `Ok(empty)`)
+        // lets `.optional()` callers handle the missing-data case, prevents the shared
+        // `committee_cache` from caching a poisoned 0-of-0 quorum result, and surfaces a
+        // loud error to any caller that previously silently relied on an empty committee.
+        if committee.is_empty() {
+            return Err(EpochManagerError::NoEpochFound(epoch));
+        }
+        Ok(committee)
     }
 
     pub(crate) fn get_committees_overlapping_shard_group(


### PR DESCRIPTION
## Summary

- Detects when a validator has fallen behind by an epoch — using a cryptographically verified 2f+1 QC for a future epoch as the trigger — and escalates to state sync.
- Closes the no-vote variant of the epoch-change wedge: a validator whose oracle lags at EOE vote-time no-votes the EOE block with `NotEndOfEpoch`, peers commit it without us, and there is currently no recovery path (peers won't serve cross-epoch catch-up).
- Companion to #2104, which handles the case where the validator successfully voted on the EOE but trips inside `process_end_of_epoch`.

## The bug

Production logs (`~/Litterbox/logs3`, 2026-05-09 18:06:23) showed a validator stuck on `Epoch(7886)/NodeHeight(307)` for ~21 hours after a single oracle-lag at EOE vote-time:

1. Local oracle lagged on Epoch(N+1) when the EOE block at Epoch(N)/NodeHeight(307) arrived.
2. The vote-time check in \`on_receive_local_proposal.rs:302\` (\`em_epoch > current_epoch || is_within_epoch_end_spread(...)\`) failed.
3. Validator no-voted with \`NoVoteReason::NotEndOfEpoch\`; \`local_decision = None\` so the pacemaker did not enter the next view.
4. The other validators reached quorum without us and committed the EOE.
5. Catch-up sync from us repeatedly failed: \`on_catch_up_sync_request.rs:60\` refuses cross-epoch requests (the peers' leaves are now in Epoch(N+1)), so they silently ignore us.
6. The oracle eventually caught up, but no code path retried — \`on_epoch_manager_event\`'s post-#2104 hook only fires when \`pending_end_of_epoch\` is set, which only happens if we reached \`process_end_of_epoch\`.

## The fix

In \`MessageBuffer::next\`, before buffering a future-epoch \`Proposal\` or \`NewView\`:

- If the embedded QC's epoch is strictly ahead of our consensus view, look up that epoch's committee via the local oracle.
- If the oracle hasn't observed the epoch yet → buffer as before (we can't verify; peers keep resending).
- If observed → run \`check_quorum_certificate_signatures\` against that committee.
  - **Valid 2f+1 signatures**: return \`HotStuffError::NeedsSync\`. The state machine routes through \`CheckSync → Syncing\`, downloading the \`EpochCheckpoint\` and resuming on the new epoch's genesis.
  - **Invalid signatures**: drop silently. A forged QC must never trigger sync mode — that would be a free DoS vector.
- \`Vote\` messages carry only a single-validator signature and are explicitly excluded.

A valid 2f+1 QC for Epoch(N+1) is unforgeable proof that the network has run consensus past the local view. That's the trust boundary — no wall-clock heuristics, no relying on leader-failure counts that could be caused by network partitions or other issues.

### Why this composes with #2104

- \`pending_end_of_epoch\` (the resume path #2104 added) still runs first when applicable. If we have the EOE block committed locally and just need the oracle to catch up, the resume handles it without bouncing through sync.
- The new probe only fires when we receive an authenticated QC for an epoch ahead of our view. By that point peers have moved on and we genuinely need a checkpoint, not a deferred resume.

## Test plan

- [x] New \`epoch_change_no_vote_wedge_escalates_on_future_qc\` consensus test deterministically reproduces the wedge: validator 1 no-votes the EOE; the other three commit Epoch(2) without it; on receiving an authenticated Epoch(2) Proposal, validator 1 emits a \`HotstuffEvent::Failure\` whose message identifies the QC-based escalation.
  - Stable across 5 consecutive runs (15–20s each).
  - Fails reliably without the fix (times out waiting for the escalation event).
- [x] \`cargo test -p consensus_tests\` — 49/49 pass (48 pre-existing + 1 new).
- [x] \`cargo +nightly-2025-06-25 fmt --all\` clean.
- [ ] Devnet/soak run to confirm no behavior regression on clean epoch transitions (the existing \`single_shard_epoch_change\`, \`multishard_epoch_change\`, and \`epoch_change_with_lagging_oracle\` tests pass, so clean rollovers are covered).

## Files

- \`crates/consensus/src/hotstuff/on_inbound_message.rs\` — \`probe_future_epoch_qc\` + plumbing (epoch_manager + signer_service into \`MessageBuffer\`).
- \`crates/consensus/src/hotstuff/worker.rs\` — pass the new dependencies to \`OnInboundMessage::new\`.
- \`crates/consensus_tests/src/support/epoch_manager.rs\` — per-validator \`oracle_current_epoch_cap\` to reproduce the no-vote condition (the existing \`oracle_visible_epoch\` intentionally does not cap \`current_epoch()\` per #2104's contract).
- \`crates/consensus_tests/src/epoch_change.rs\` — regression test.