### PR TITLE
fix(state-sync): include WASM binary in validator template sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1707,7 +1707,7 @@ dependencies = [
 
 [[package]]
 name = "consensus_tests"
-version = "0.30.5"
+version = "0.30.6"
 dependencies = [
  "fern",
  "futures 0.3.31",
@@ -2711,7 +2711,7 @@ dependencies = [
 
 [[package]]
 name = "db-inspector"
-version = "0.30.5"
+version = "0.30.6"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -5101,7 +5101,7 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "integration_tests"
-version = "0.30.5"
+version = "0.30.6"
 dependencies = [
  "anyhow",
  "config",
@@ -5883,7 +5883,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-messaging"
-version = "0.30.5"
+version = "0.30.6"
 dependencies = [
  "async-trait",
  "futures-bounded 0.2.4",
@@ -6061,7 +6061,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-substream"
-version = "0.30.5"
+version = "0.30.6"
 dependencies = [
  "libp2p",
  "prometheus-client",
@@ -7646,7 +7646,7 @@ dependencies = [
 
 [[package]]
 name = "ootle-wasm"
-version = "0.30.5"
+version = "0.30.6"
 dependencies = [
  "console_error_panic_hook",
  "getrandom 0.2.17",
@@ -7656,7 +7656,7 @@ dependencies = [
 
 [[package]]
 name = "ootle-wasm-core"
-version = "0.30.5"
+version = "0.30.6"
 dependencies = [
  "base64 0.22.1",
  "ootle_byte_type",
@@ -8661,7 +8661,7 @@ dependencies = [
 
 [[package]]
 name = "proto_builder"
-version = "0.30.5"
+version = "0.30.6"
 dependencies = [
  "prost-build 0.14.3",
  "sha2 0.10.9",
@@ -10539,7 +10539,7 @@ dependencies = [
 
 [[package]]
 name = "sqlite_message_logger"
-version = "0.30.5"
+version = "0.30.6"
 dependencies = [
  "chrono",
  "diesel",
@@ -10911,7 +10911,7 @@ dependencies = [
 
 [[package]]
 name = "tari_base_node_client"
-version = "0.30.5"
+version = "0.30.6"
 dependencies = [
  "futures-util",
  "log",
@@ -11138,7 +11138,7 @@ dependencies = [
 
 [[package]]
 name = "tari_consensus"
-version = "0.30.5"
+version = "0.30.6"
 dependencies = [
  "anyhow",
  "indexmap 2.13.0",
@@ -11163,7 +11163,7 @@ dependencies = [
 
 [[package]]
 name = "tari_consensus_types"
-version = "0.30.5"
+version = "0.30.6"
 dependencies = [
  "borsh",
  "ootle_serde",
@@ -11263,7 +11263,7 @@ dependencies = [
 
 [[package]]
 name = "tari_engine"
-version = "0.30.5"
+version = "0.30.6"
 dependencies = [
  "blake2 0.10.6",
  "bytes",
@@ -11294,7 +11294,7 @@ dependencies = [
 
 [[package]]
 name = "tari_engine_types"
-version = "0.30.5"
+version = "0.30.6"
 dependencies = [
  "bincode 2.0.1",
  "blake2 0.10.6",
@@ -11323,7 +11323,7 @@ dependencies = [
 
 [[package]]
 name = "tari_epoch_manager"
-version = "0.30.5"
+version = "0.30.6"
 dependencies = [
  "anyhow",
  "log",
@@ -11343,7 +11343,7 @@ dependencies = [
 
 [[package]]
 name = "tari_epoch_oracles"
-version = "0.30.5"
+version = "0.30.6"
 dependencies = [
  "anyhow",
  "blake2 0.10.6",
@@ -11397,7 +11397,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer"
-version = "0.30.5"
+version = "0.30.6"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -11499,7 +11499,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer_lib"
-version = "0.30.5"
+version = "0.30.6"
 dependencies = [
  "log",
  "prometheus-client",
@@ -11603,7 +11603,7 @@ dependencies = [
 
 [[package]]
 name = "tari_networking"
-version = "0.30.5"
+version = "0.30.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11656,7 +11656,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_app_utilities"
-version = "0.30.5"
+version = "0.30.6"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -11696,7 +11696,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_common_types"
-version = "0.30.5"
+version = "0.30.6"
 dependencies = [
  "blake2 0.10.6",
  "borsh",
@@ -11724,7 +11724,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_p2p"
-version = "0.30.5"
+version = "0.30.6"
 dependencies = [
  "anyhow",
  "libp2p-identity 0.2.13 (git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a)",
@@ -11748,7 +11748,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_storage"
-version = "0.30.5"
+version = "0.30.6"
 dependencies = [
  "anyhow",
  "bitflags 2.10.0",
@@ -11775,7 +11775,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_storage_sqlite"
-version = "0.30.5"
+version = "0.30.6"
 dependencies = [
  "diesel",
  "diesel_migrations",
@@ -11826,7 +11826,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_transaction"
-version = "0.30.5"
+version = "0.30.6"
 dependencies = [
  "bincode 2.0.1",
  "borsh",
@@ -11852,7 +11852,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_cli"
-version = "0.30.5"
+version = "0.30.6"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -11881,7 +11881,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_crypto"
-version = "0.30.5"
+version = "0.30.6"
 dependencies = [
  "argon2 0.5.3",
  "blake2 0.10.6",
@@ -11911,7 +11911,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_sdk"
-version = "0.30.5"
+version = "0.30.6"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -11973,7 +11973,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_sdk_tests"
-version = "0.30.5"
+version = "0.30.6"
 dependencies = [
  "digest 0.10.7",
  "ootle_byte_type",
@@ -11995,7 +11995,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_storage_sqlite"
-version = "0.30.5"
+version = "0.30.6"
 dependencies = [
  "diesel",
  "diesel_migrations",
@@ -12018,7 +12018,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_walletd"
-version = "0.30.5"
+version = "0.30.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12136,7 +12136,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_framework"
-version = "0.30.5"
+version = "0.30.6"
 dependencies = [
  "async-trait",
  "bitflags 2.10.0",
@@ -12160,7 +12160,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_macros"
-version = "0.30.5"
+version = "0.30.6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12169,7 +12169,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_state_sync"
-version = "0.30.5"
+version = "0.30.6"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -12246,7 +12246,7 @@ dependencies = [
 
 [[package]]
 name = "tari_state_store_rocksdb"
-version = "0.30.5"
+version = "0.30.6"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -12278,7 +12278,7 @@ dependencies = [
 
 [[package]]
 name = "tari_state_tree"
-version = "0.30.5"
+version = "0.30.6"
 dependencies = [
  "indexmap 2.13.0",
  "log",
@@ -12304,7 +12304,7 @@ dependencies = [
 
 [[package]]
 name = "tari_swarm"
-version = "0.30.5"
+version = "0.30.6"
 dependencies = [
  "libp2p",
  "libp2p-messaging",
@@ -12315,7 +12315,7 @@ dependencies = [
 
 [[package]]
 name = "tari_swarm_daemon"
-version = "0.30.5"
+version = "0.30.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12426,7 +12426,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_test_tooling"
-version = "0.30.5"
+version = "0.30.6"
 dependencies = [
  "anyhow",
  "cargo_toml 0.22.3",
@@ -12539,7 +12539,7 @@ dependencies = [
 
 [[package]]
 name = "tari_transaction_manifest"
-version = "0.30.5"
+version = "0.30.6"
 dependencies = [
  "proc-macro2",
  "serde_json",
@@ -12574,7 +12574,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node"
-version = "0.30.5"
+version = "0.30.6"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -12640,7 +12640,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node_client"
-version = "0.30.5"
+version = "0.30.6"
 dependencies = [
  "indexmap 2.13.0",
  "multiaddr 0.18.3",
@@ -12664,7 +12664,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node_rpc"
-version = "0.30.5"
+version = "0.30.6"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -12687,7 +12687,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_rollback"
-version = "0.30.5"
+version = "0.30.6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12722,7 +12722,7 @@ dependencies = [
 
 [[package]]
 name = "tari_watcher"
-version = "0.30.5"
+version = "0.30.6"
 dependencies = [
  "anyhow",
  "clap 3.2.25",
@@ -12751,7 +12751,7 @@ dependencies = [
 
 [[package]]
 name = "tariswap_bench"
-version = "0.30.5"
+version = "0.30.6"
 dependencies = [
  "anyhow",
  "clap 4.5.54",
@@ -13431,7 +13431,7 @@ dependencies = [
 
 [[package]]
 name = "traffic-sim"
-version = "0.30.5"
+version = "0.30.6"
 dependencies = [
  "anyhow",
  "clap 4.5.54",
@@ -13453,7 +13453,7 @@ dependencies = [
 
 [[package]]
 name = "transaction_generator"
-version = "0.30.5"
+version = "0.30.6"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -13472,7 +13472,7 @@ dependencies = [
 
 [[package]]
 name = "transaction_submitter"
-version = "0.30.5"
+version = "0.30.6"
 dependencies = [
  "anyhow",
  "clap 4.5.54",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.30.5"
+version = "0.30.6"
 edition = "2024"
 authors = ["The Tari Development Community"]
 repository = "https://github.com/tari-project/tari-ootle"

--- a/crates/rpc_state_sync/src/state_sync.rs
+++ b/crates/rpc_state_sync/src/state_sync.rs
@@ -166,9 +166,7 @@ where TConsensusSpec: ConsensusSpec<Addr = PeerAddress>
                 start_state_version,
                 shard: shard.as_u32(),
                 until_epoch: Some(checkpoint.epoch().into()),
-                value_filters: (SubstateValueFilterFlags::all_substates() |
-                    SubstateValueFilterFlags::TEMPLATE_METADATA)
-                    .bits(),
+                value_filters: SubstateValueFilterFlags::all_substates().bits(),
             })
             .await?;
 

--- a/crates/state_store_rocksdb/src/reader.rs
+++ b/crates/state_store_rocksdb/src/reader.rs
@@ -1678,7 +1678,9 @@ impl<'tx, TAddr: NodeAddressable + Serialize + DeserializeOwned + 'tx> StateStor
                             None
                         };
 
-                        let is_metadata_only = metadata_mode && substate.substate_id.is_template();
+                        let is_metadata_only = metadata_mode &&
+                            !value_filter.contains(SubstateValueFilterFlags::TEMPLATE) &&
+                            substate.substate_id.is_template();
                         let resolved_value = value_filter
                                 .contains_substate(&substate.substate_id)
                                 // filter includes substate, return full value if available (unless metadata-only for templates), otherwise return hash

--- a/crates/storage/src/consensus_models/state_transition.rs
+++ b/crates/storage/src/consensus_models/state_transition.rs
@@ -65,9 +65,10 @@ bitflags! {
         const VALIDATOR_FEE_POOL = 0x0000_0040;
         const UTXO = 0x0000_0080;
         const CLAIMED_OUTPUT_TOMBSTONE = 0x0000_0100;
-        /// Return only template metadata (name, author, hash, epoch) instead of the full WASM binary.
-        /// When set for a template substate, the sync response carries `SubstateData.template_metadata`
-        /// and `SubstateValueOrHash::Hash` (the state hash) rather than the full value.
+        /// Populate `SubstateData.template_metadata` for template substates.
+        /// On its own (without `TEMPLATE`), the response omits the WASM binary and carries
+        /// `SubstateValueOrHash::Hash` for templates. When combined with `TEMPLATE`, the full
+        /// binary is sent and the metadata field is populated alongside it.
         const TEMPLATE_METADATA = 0x0000_0200;
         /// Include all hashes for substates even if filtered out
         const ALL_HASHES = 0x1000_0000;


### PR DESCRIPTION
## Description

Validators were requesting `SubstateValueFilterFlags::all_substates() | TEMPLATE_METADATA` during state sync. The `TEMPLATE_METADATA` flag (added in #1952) causes the responder to strip the WASM binary and return only metadata + state hash for template substates. As a result, validators stored template substates with `substate_value = None`.

When a transaction later called a method on a component backed by such a template, the engine's `TemplateProvider::get_template` returned "Template substate not found". Execution failed at that instruction, producing `TransactionResult::AcceptFeeRejectRest`, which maps to `Decision::Commit` — the same decision other honest nodes produced for a normal `Accept`. The protocol could not detect the divergence at the decision-comparison step, and it surfaced as a fee disagreement (`Leader proposed X, we calculated Y`) and substate-diff mismatch on the local-only block.

This was observed in production-like logs (fee disagreement / lock-inputs-failed cascade for tx `75b1f95c…f8073d`).

## Motivation

Consensus correctness: the missing WASM binary caused validators to silently produce a different execution result from their peers, breaking agreement without triggering an explicit equivocation check.

## Changes

- **`crates/rpc_state_sync/src/state_sync.rs`** — drop `TEMPLATE_METADATA` from the validator state-sync filter so validators always receive the full WASM binary.
- **`crates/state_store_rocksdb/src/reader.rs`** — defense in depth: when a caller sets both `TEMPLATE` and `TEMPLATE_METADATA`, return the full binary *and* populate `template_metadata`, instead of silently stripping the binary. Indexers requesting `TEMPLATE_METADATA` alone keep the metadata-only behaviour.
- **`crates/storage/src/consensus_models/state_transition.rs`** — update the `TEMPLATE_METADATA` doc comment to reflect the new combined-flag semantics.
- **`Cargo.toml` / `Cargo.lock`** — bump workspace version `0.30.5` → `0.30.6`.

## Operational Note

Validators that already synced via the buggy path have template substates stored value-less in their local RocksDB. They will need to re-sync (or have the affected rows repaired) to recover. This PR fixes the bug going forward but does not automatically heal already-corrupted state.