### PR TITLE
feat(template-metadata)!: extract rustdoc from public template functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11834,6 +11834,7 @@ dependencies = [
 name = "tari_ootle_template_build"
 version = "0.7.0"
 dependencies = [
+ "syn 2.0.117",
  "tari_ootle_template_metadata",
  "tempfile",
  "thiserror 2.0.18",

--- a/crates/template_build/Cargo.toml
+++ b/crates/template_build/Cargo.toml
@@ -9,6 +9,7 @@ license.workspace = true
 
 [dependencies]
 tari_ootle_template_metadata = { workspace = true, features = ["json"] }
+syn = { workspace = true, features = ["full"] }
 thiserror = { workspace = true }
 url = { workspace = true }
 

--- a/crates/template_build/src/doc_extract.rs
+++ b/crates/template_build/src/doc_extract.rs
@@ -9,12 +9,12 @@
 
 use std::{fs, path::Path};
 
-use tari_ootle_template_metadata::FunctionMetadata;
+use tari_ootle_template_metadata::FunctionDoc;
 
-/// Read the given source file and return one [`FunctionMetadata`] per public template function.
+/// Read the given source file and return one [`FunctionDoc`] per public template function.
 ///
 /// Returns an empty vec if the file contains no `#[template]` mod or no eligible public functions.
-pub fn extract_function_docs(source: &Path) -> Result<Vec<FunctionMetadata>, DocExtractError> {
+pub fn extract_function_docs(source: &Path) -> Result<Vec<FunctionDoc>, DocExtractError> {
     let content = fs::read_to_string(source).map_err(|e| DocExtractError::Io {
         path: source.to_path_buf(),
         source: e,
@@ -26,7 +26,7 @@ pub fn extract_function_docs(source: &Path) -> Result<Vec<FunctionMetadata>, Doc
     Ok(extract_from_file(&file))
 }
 
-fn extract_from_file(file: &syn::File) -> Vec<FunctionMetadata> {
+fn extract_from_file(file: &syn::File) -> Vec<FunctionDoc> {
     file.items
         .iter()
         .find_map(|item| match item {
@@ -42,7 +42,7 @@ fn has_template_attr(attrs: &[syn::Attribute]) -> bool {
         .any(|attr| attr.path().segments.last().is_some_and(|seg| seg.ident == "template"))
 }
 
-fn extract_from_mod(m: &syn::ItemMod) -> Vec<FunctionMetadata> {
+fn extract_from_mod(m: &syn::ItemMod) -> Vec<FunctionDoc> {
     let Some((_, items)) = &m.content else {
         return Vec::new();
     };
@@ -72,7 +72,7 @@ fn extract_from_mod(m: &syn::ItemMod) -> Vec<FunctionMetadata> {
             syn::ImplItem::Fn(f) if matches!(f.vis, syn::Visibility::Public(_)) => Some(f),
             _ => None,
         })
-        .map(|f| FunctionMetadata {
+        .map(|f| FunctionDoc {
             name: f.sig.ident.to_string(),
             doc: extract_doc_lines(&f.attrs),
         })
@@ -122,7 +122,7 @@ pub enum DocExtractError {
 mod tests {
     use super::*;
 
-    fn parse(src: &str) -> Vec<FunctionMetadata> {
+    fn parse(src: &str) -> Vec<FunctionDoc> {
         let file = syn::parse_file(src).unwrap();
         extract_from_file(&file)
     }

--- a/crates/template_build/src/doc_extract.rs
+++ b/crates/template_build/src/doc_extract.rs
@@ -1,0 +1,281 @@
+//   Copyright 2026 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+//! Extract rustdoc comments from public functions of a template module.
+//!
+//! Parses a Rust source file with `syn`, locates the `#[template]` `mod` block,
+//! finds its public template type, and walks `impl` blocks for that type
+//! collecting `pub fn` items together with any `///` / `#[doc = "..."]` attributes.
+
+use std::{fs, path::Path};
+
+use tari_ootle_template_metadata::FunctionMetadata;
+
+/// Read the given source file and return one [`FunctionMetadata`] per public template function.
+///
+/// Returns an empty vec if the file contains no `#[template]` mod or no eligible public functions.
+pub fn extract_function_docs(source: &Path) -> Result<Vec<FunctionMetadata>, DocExtractError> {
+    let content = fs::read_to_string(source).map_err(|e| DocExtractError::Io {
+        path: source.to_path_buf(),
+        source: e,
+    })?;
+    let file = syn::parse_file(&content).map_err(|e| DocExtractError::Parse {
+        path: source.to_path_buf(),
+        source: e,
+    })?;
+    Ok(extract_from_file(&file))
+}
+
+fn extract_from_file(file: &syn::File) -> Vec<FunctionMetadata> {
+    for item in &file.items {
+        if let syn::Item::Mod(m) = item &&
+            has_template_attr(&m.attrs)
+        {
+            return extract_from_mod(m);
+        }
+    }
+    Vec::new()
+}
+
+fn has_template_attr(attrs: &[syn::Attribute]) -> bool {
+    attrs
+        .iter()
+        .any(|attr| attr.path().segments.last().is_some_and(|seg| seg.ident == "template"))
+}
+
+fn extract_from_mod(m: &syn::ItemMod) -> Vec<FunctionMetadata> {
+    let Some((_, items)) = &m.content else {
+        return Vec::new();
+    };
+
+    // The template name is taken from the first public struct or enum (mirrors template_macros).
+    let template_name = items.iter().find_map(|item| match item {
+        syn::Item::Struct(s) if matches!(s.vis, syn::Visibility::Public(_)) => Some(s.ident.clone()),
+        syn::Item::Enum(e) if matches!(e.vis, syn::Visibility::Public(_)) => Some(e.ident.clone()),
+        _ => None,
+    });
+
+    let Some(template_name) = template_name else {
+        return Vec::new();
+    };
+
+    let mut out = Vec::new();
+    for item in items {
+        let syn::Item::Impl(impl_block) = item else {
+            continue;
+        };
+        if impl_block.trait_.is_some() {
+            continue;
+        }
+        let syn::Type::Path(self_ty) = &*impl_block.self_ty else {
+            continue;
+        };
+        if !self_ty.path.is_ident(&template_name) {
+            continue;
+        }
+
+        for impl_item in &impl_block.items {
+            let syn::ImplItem::Fn(f) = impl_item else { continue };
+            if !matches!(f.vis, syn::Visibility::Public(_)) {
+                continue;
+            }
+            out.push(FunctionMetadata {
+                name: f.sig.ident.to_string(),
+                doc: extract_doc_lines(&f.attrs),
+            });
+        }
+    }
+    out
+}
+
+fn extract_doc_lines(attrs: &[syn::Attribute]) -> String {
+    let mut lines: Vec<String> = Vec::new();
+    for attr in attrs {
+        if !attr.path().is_ident("doc") {
+            continue;
+        }
+        let syn::Meta::NameValue(nv) = &attr.meta else {
+            continue;
+        };
+        let syn::Expr::Lit(syn::ExprLit {
+            lit: syn::Lit::Str(s), ..
+        }) = &nv.value
+        else {
+            continue;
+        };
+        let raw = s.value();
+        // Rustdoc strips one leading space if present, matching `///  text` -> ` text`.
+        let trimmed = raw.strip_prefix(' ').unwrap_or(&raw);
+        lines.push(trimmed.to_string());
+    }
+    lines.join("\n")
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum DocExtractError {
+    #[error("Failed to read template source '{path}': {source}")]
+    Io {
+        path: std::path::PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("Failed to parse template source '{path}': {source}")]
+    Parse {
+        path: std::path::PathBuf,
+        #[source]
+        source: syn::Error,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(src: &str) -> Vec<FunctionMetadata> {
+        let file = syn::parse_file(src).unwrap();
+        extract_from_file(&file)
+    }
+
+    #[test]
+    fn extracts_single_function_doc() {
+        let src = r#"
+            #[template]
+            mod tpl {
+                pub struct Tpl;
+                impl Tpl {
+                    /// Mint a new token.
+                    pub fn mint() {}
+                }
+            }
+        "#;
+        let out = parse(src);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].name, "mint");
+        assert_eq!(out[0].doc, "Mint a new token.");
+    }
+
+    #[test]
+    fn joins_multi_line_doc() {
+        let src = r#"
+            #[template]
+            mod tpl {
+                pub struct Tpl;
+                impl Tpl {
+                    /// First line.
+                    /// Second line.
+                    pub fn foo() {}
+                }
+            }
+        "#;
+        let out = parse(src);
+        assert_eq!(out[0].doc, "First line.\nSecond line.");
+    }
+
+    #[test]
+    fn skips_non_public_functions() {
+        let src = r#"
+            #[template]
+            mod tpl {
+                pub struct Tpl;
+                impl Tpl {
+                    /// public
+                    pub fn pub_fn() {}
+                    /// private
+                    fn priv_fn() {}
+                }
+            }
+        "#;
+        let out = parse(src);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].name, "pub_fn");
+    }
+
+    #[test]
+    fn includes_function_with_no_doc() {
+        let src = r#"
+            #[template]
+            mod tpl {
+                pub struct Tpl;
+                impl Tpl {
+                    pub fn no_docs() {}
+                }
+            }
+        "#;
+        let out = parse(src);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].name, "no_docs");
+        assert_eq!(out[0].doc, "");
+    }
+
+    #[test]
+    fn ignores_impls_of_other_types() {
+        let src = r#"
+            #[template]
+            mod tpl {
+                pub struct Tpl;
+                pub struct Helper;
+                impl Helper {
+                    /// not a template fn
+                    pub fn other() {}
+                }
+                impl Tpl {
+                    /// is a template fn
+                    pub fn here() {}
+                }
+            }
+        "#;
+        let out = parse(src);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].name, "here");
+    }
+
+    #[test]
+    fn ignores_trait_impls() {
+        let src = r#"
+            #[template]
+            mod tpl {
+                pub struct Tpl;
+                impl Default for Tpl {
+                    fn default() -> Self { Tpl }
+                }
+                impl Tpl {
+                    /// real fn
+                    pub fn real() {}
+                }
+            }
+        "#;
+        let out = parse(src);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].name, "real");
+    }
+
+    #[test]
+    fn returns_empty_when_no_template_mod() {
+        let src = r#"
+            pub struct NotATemplate;
+            impl NotATemplate {
+                pub fn foo() {}
+            }
+        "#;
+        let out = parse(src);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn preserves_source_order() {
+        let src = r#"
+            #[template]
+            mod tpl {
+                pub struct Tpl;
+                impl Tpl {
+                    pub fn a() {}
+                    pub fn b() {}
+                    pub fn c() {}
+                }
+            }
+        "#;
+        let out = parse(src);
+        let names: Vec<_> = out.iter().map(|f| f.name.as_str()).collect();
+        assert_eq!(names, vec!["a", "b", "c"]);
+    }
+}

--- a/crates/template_build/src/doc_extract.rs
+++ b/crates/template_build/src/doc_extract.rs
@@ -27,14 +27,13 @@ pub fn extract_function_docs(source: &Path) -> Result<Vec<FunctionMetadata>, Doc
 }
 
 fn extract_from_file(file: &syn::File) -> Vec<FunctionMetadata> {
-    for item in &file.items {
-        if let syn::Item::Mod(m) = item &&
-            has_template_attr(&m.attrs)
-        {
-            return extract_from_mod(m);
-        }
-    }
-    Vec::new()
+    file.items
+        .iter()
+        .find_map(|item| match item {
+            syn::Item::Mod(m) if has_template_attr(&m.attrs) => Some(extract_from_mod(m)),
+            _ => None,
+        })
+        .unwrap_or_default()
 }
 
 fn has_template_attr(attrs: &[syn::Attribute]) -> bool {
@@ -49,43 +48,35 @@ fn extract_from_mod(m: &syn::ItemMod) -> Vec<FunctionMetadata> {
     };
 
     // The template name is taken from the first public struct or enum (mirrors template_macros).
-    let template_name = items.iter().find_map(|item| match item {
-        syn::Item::Struct(s) if matches!(s.vis, syn::Visibility::Public(_)) => Some(s.ident.clone()),
-        syn::Item::Enum(e) if matches!(e.vis, syn::Visibility::Public(_)) => Some(e.ident.clone()),
+    let Some(template_name) = items.iter().find_map(|item| match item {
+        syn::Item::Struct(s) if matches!(s.vis, syn::Visibility::Public(_)) => Some(&s.ident),
+        syn::Item::Enum(e) if matches!(e.vis, syn::Visibility::Public(_)) => Some(&e.ident),
         _ => None,
-    });
-
-    let Some(template_name) = template_name else {
+    }) else {
         return Vec::new();
     };
 
-    let mut out = Vec::new();
-    for item in items {
-        let syn::Item::Impl(impl_block) = item else {
-            continue;
-        };
-        if impl_block.trait_.is_some() {
-            continue;
-        }
-        let syn::Type::Path(self_ty) = &*impl_block.self_ty else {
-            continue;
-        };
-        if !self_ty.path.is_ident(&template_name) {
-            continue;
-        }
-
-        for impl_item in &impl_block.items {
-            let syn::ImplItem::Fn(f) = impl_item else { continue };
-            if !matches!(f.vis, syn::Visibility::Public(_)) {
-                continue;
-            }
-            out.push(FunctionMetadata {
-                name: f.sig.ident.to_string(),
-                doc: extract_doc_lines(&f.attrs),
-            });
-        }
-    }
-    out
+    items
+        .iter()
+        .filter_map(|item| match item {
+            syn::Item::Impl(impl_block)
+                if impl_block.trait_.is_none() &&
+                    matches!(&*impl_block.self_ty, syn::Type::Path(p) if p.path.is_ident(template_name)) =>
+            {
+                Some(&impl_block.items)
+            },
+            _ => None,
+        })
+        .flatten()
+        .filter_map(|impl_item| match impl_item {
+            syn::ImplItem::Fn(f) if matches!(f.vis, syn::Visibility::Public(_)) => Some(f),
+            _ => None,
+        })
+        .map(|f| FunctionMetadata {
+            name: f.sig.ident.to_string(),
+            doc: extract_doc_lines(&f.attrs),
+        })
+        .collect()
 }
 
 fn extract_doc_lines(attrs: &[syn::Attribute]) -> String {

--- a/crates/template_build/src/lib.rs
+++ b/crates/template_build/src/lib.rs
@@ -20,8 +20,14 @@
 //!     .expect("Failed to generate template metadata");
 //! ```
 
-use std::{collections::BTreeMap, path::PathBuf};
+mod doc_extract;
 
+use std::{
+    collections::BTreeMap,
+    path::{Path, PathBuf},
+};
+
+pub use doc_extract::{DocExtractError, extract_function_docs};
 pub use tari_ootle_template_metadata;
 use tari_ootle_template_metadata::{MetadataHash, TemplateMetadata, from_cargo_toml};
 use url::Url;
@@ -54,6 +60,7 @@ pub struct TemplateMetadataBuilder {
     license: Option<String>,
     logo_url: Option<String>,
     extra: Option<BTreeMap<String, String>>,
+    source_path: Option<PathBuf>,
 }
 
 impl Default for TemplateMetadataBuilder {
@@ -76,6 +83,7 @@ impl TemplateMetadataBuilder {
             license: None,
             logo_url: None,
             extra: None,
+            source_path: None,
         }
     }
 
@@ -147,6 +155,14 @@ impl TemplateMetadataBuilder {
         self
     }
 
+    /// Override the template source file used to extract function rustdoc.
+    ///
+    /// Relative paths are resolved against `CARGO_MANIFEST_DIR`. Defaults to `src/lib.rs`.
+    pub fn source_path(mut self, path: impl Into<PathBuf>) -> Self {
+        self.source_path = Some(path.into());
+        self
+    }
+
     /// Apply builder overrides to the given metadata.
     fn apply_overrides(&self, metadata: &mut TemplateMetadata) -> Result<(), TemplateBuildError> {
         if let Some(ref description) = self.description {
@@ -197,6 +213,11 @@ impl TemplateMetadataBuilder {
         let cargo_toml_path = PathBuf::from(manifest_dir).join("Cargo.toml");
         let mut metadata = from_cargo_toml(&cargo_toml_path)?;
 
+        let source_path = resolve_source_path(manifest_dir, self.source_path.as_deref());
+        if source_path.is_file() {
+            metadata.functions = extract_function_docs(&source_path)?;
+        }
+
         self.apply_overrides(&mut metadata)?;
 
         // Write CBOR
@@ -220,6 +241,9 @@ impl TemplateMetadataBuilder {
         // Emit cargo metadata
         println!("cargo::metadata=TEMPLATE_METADATA_HASH={}", hash);
         println!("cargo:rerun-if-changed=Cargo.toml");
+        if source_path.is_file() {
+            println!("cargo:rerun-if-changed={}", source_path.display());
+        }
 
         Ok(TemplateBuildOutput {
             hash,
@@ -227,6 +251,15 @@ impl TemplateMetadataBuilder {
             json_path,
             metadata,
         })
+    }
+}
+
+fn resolve_source_path(manifest_dir: &str, override_path: Option<&Path>) -> PathBuf {
+    let base = PathBuf::from(manifest_dir);
+    match override_path {
+        Some(p) if p.is_absolute() => p.to_path_buf(),
+        Some(p) => base.join(p),
+        None => base.join("src").join("lib.rs"),
     }
 }
 
@@ -240,6 +273,8 @@ pub enum TemplateBuildError {
     Metadata(#[from] tari_ootle_template_metadata::TemplateMetadataError),
     #[error("Invalid URL in field '{0}': {1}")]
     InvalidUrl(&'static str, url::ParseError),
+    #[error("Failed to extract template function docs: {0}")]
+    DocExtract(#[from] DocExtractError),
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
 }
@@ -403,6 +438,91 @@ category = "utility"
             .unwrap();
 
         assert_ne!(output_original.hash, output_overridden.hash);
+    }
+
+    #[test]
+    fn build_extracts_function_docs_from_lib_rs() {
+        let dir = tempfile::tempdir().unwrap();
+        create_test_cargo_toml(dir.path());
+        let src_dir = dir.path().join("src");
+        std::fs::create_dir_all(&src_dir).unwrap();
+        let lib_rs = r#"
+#[template]
+mod my_template {
+    pub struct My;
+    impl My {
+        /// Create a new instance.
+        pub fn new() -> Self { My }
+
+        /// Transfer to recipient.
+        /// Second line of doc.
+        pub fn transfer(&self) {}
+
+        pub fn no_doc(&self) {}
+
+        fn private(&self) {}
+    }
+}
+"#;
+        std::fs::write(src_dir.join("lib.rs"), lib_rs).unwrap();
+        let out_dir = dir.path().join("out");
+        std::fs::create_dir_all(&out_dir).unwrap();
+
+        let output = TemplateMetadataBuilder::new()
+            .build_inner(dir.path().to_str().unwrap(), out_dir.to_str().unwrap())
+            .unwrap();
+
+        let fns = &output.metadata.functions;
+        assert_eq!(fns.len(), 3);
+        assert_eq!(fns[0].name, "new");
+        assert_eq!(fns[0].doc, "Create a new instance.");
+        assert_eq!(fns[1].name, "transfer");
+        assert_eq!(fns[1].doc, "Transfer to recipient.\nSecond line of doc.");
+        assert_eq!(fns[2].name, "no_doc");
+        assert_eq!(fns[2].doc, "");
+    }
+
+    #[test]
+    fn build_without_lib_rs_leaves_functions_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        create_test_cargo_toml(dir.path());
+        let out_dir = dir.path().join("out");
+        std::fs::create_dir_all(&out_dir).unwrap();
+
+        let output = TemplateMetadataBuilder::new()
+            .build_inner(dir.path().to_str().unwrap(), out_dir.to_str().unwrap())
+            .unwrap();
+
+        assert!(output.metadata.functions.is_empty());
+    }
+
+    #[test]
+    fn source_path_override_is_honored() {
+        let dir = tempfile::tempdir().unwrap();
+        create_test_cargo_toml(dir.path());
+        let custom = dir.path().join("custom.rs");
+        let src = r#"
+#[template]
+mod tpl {
+    pub struct Tpl;
+    impl Tpl {
+        /// from custom path
+        pub fn alt() {}
+    }
+}
+"#;
+        std::fs::write(&custom, src).unwrap();
+        let out_dir = dir.path().join("out");
+        std::fs::create_dir_all(&out_dir).unwrap();
+
+        let output = TemplateMetadataBuilder::new()
+            .source_path("custom.rs")
+            .build_inner(dir.path().to_str().unwrap(), out_dir.to_str().unwrap())
+            .unwrap();
+
+        assert_eq!(output.metadata.functions.len(), 1);
+        assert_eq!(output.metadata.functions[0].name, "alt");
+        assert_eq!(output.metadata.functions[0].doc, "from custom path");
     }
 
     #[test]

--- a/crates/template_metadata/src/cargo_toml.rs
+++ b/crates/template_metadata/src/cargo_toml.rs
@@ -125,6 +125,7 @@ fn from_manifest(manifest: &Manifest) -> Result<TemplateMetadata, CargoTomlError
         license,
         logo_url,
         supersedes,
+        functions: Vec::new(),
         extra,
     })
 }

--- a/crates/template_metadata/src/lib.rs
+++ b/crates/template_metadata/src/lib.rs
@@ -15,4 +15,4 @@ mod metadata;
 
 pub use cargo_toml::{CargoTomlError, from_cargo_toml, from_cargo_toml_str};
 pub use hash::{MetadataHash, MetadataHashError, MetadataHashWriter};
-pub use metadata::{FunctionMetadata, SCHEMA_VERSION, TemplateMetadata, TemplateMetadataError};
+pub use metadata::{FunctionDoc, SCHEMA_VERSION, TemplateMetadata, TemplateMetadataError};

--- a/crates/template_metadata/src/lib.rs
+++ b/crates/template_metadata/src/lib.rs
@@ -15,4 +15,4 @@ mod metadata;
 
 pub use cargo_toml::{CargoTomlError, from_cargo_toml, from_cargo_toml_str};
 pub use hash::{MetadataHash, MetadataHashError, MetadataHashWriter};
-pub use metadata::{SCHEMA_VERSION, TemplateMetadata, TemplateMetadataError};
+pub use metadata::{FunctionMetadata, SCHEMA_VERSION, TemplateMetadata, TemplateMetadataError};

--- a/crates/template_metadata/src/metadata.rs
+++ b/crates/template_metadata/src/metadata.rs
@@ -70,9 +70,24 @@ pub struct TemplateMetadata {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[cfg_attr(feature = "ts", ts(type = "string | null"))]
     pub supersedes: Option<TemplateAddress>,
+    /// Rustdoc comments extracted from public functions of the template, keyed by source order.
     #[n(13)]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub functions: Vec<FunctionMetadata>,
+    #[n(14)]
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub extra: BTreeMap<String, String>,
+}
+
+/// Off-chain documentation for a single public template function.
+#[derive(Debug, Clone, Encode, Decode, CborLen, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export))]
+pub struct FunctionMetadata {
+    #[n(0)]
+    pub name: String,
+    #[n(1)]
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub doc: String,
 }
 
 /// minicbor adapter for `Option<Url>`. Encodes `None` as CBOR null and `Some(url)` as a text string.
@@ -172,6 +187,7 @@ impl TemplateMetadata {
             license: None,
             logo_url: None,
             supersedes: None,
+            functions: Vec::new(),
             extra: BTreeMap::new(),
         }
     }
@@ -249,6 +265,10 @@ mod tests {
             supersedes: Some(
                 TemplateAddress::from_hex("0000000000000000000000000000000000000000000000000000000000000001").unwrap(),
             ),
+            functions: vec![FunctionMetadata {
+                name: "transfer".to_string(),
+                doc: "Move funds between accounts.".to_string(),
+            }],
             extra: BTreeMap::new(),
         };
 
@@ -316,6 +336,7 @@ mod tests {
             license: None,
             logo_url: None,
             supersedes: None,
+            functions: Vec::new(),
             extra: BTreeMap::new(),
         };
 

--- a/crates/template_metadata/src/metadata.rs
+++ b/crates/template_metadata/src/metadata.rs
@@ -73,7 +73,7 @@ pub struct TemplateMetadata {
     /// Rustdoc comments extracted from public functions of the template, keyed by source order.
     #[n(13)]
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub functions: Vec<FunctionMetadata>,
+    pub functions: Vec<FunctionDoc>,
     #[n(14)]
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub extra: BTreeMap<String, String>,
@@ -82,7 +82,7 @@ pub struct TemplateMetadata {
 /// Off-chain documentation for a single public template function.
 #[derive(Debug, Clone, Encode, Decode, CborLen, Serialize, Deserialize, PartialEq, Eq)]
 #[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export))]
-pub struct FunctionMetadata {
+pub struct FunctionDoc {
     #[n(0)]
     pub name: String,
     #[n(1)]
@@ -265,7 +265,7 @@ mod tests {
             supersedes: Some(
                 TemplateAddress::from_hex("0000000000000000000000000000000000000000000000000000000000000001").unwrap(),
             ),
-            functions: vec![FunctionMetadata {
+            functions: vec![FunctionDoc {
                 name: "transfer".to_string(),
                 doc: "Move funds between accounts.".to_string(),
             }],


### PR DESCRIPTION
## Summary
- Adds a `functions: Vec<FunctionMetadata { name, doc }>` field to `TemplateMetadata` (in `tari_ootle_template_metadata`), serialized with `skip_serializing_if = \"Vec::is_empty\"` so existing CBOR blobs remain decodable.
- Wires `TemplateMetadataBuilder` (in `tari_ootle_template_build`) to parse the template's `src/lib.rs` with `syn`, locate the `#[template]` `mod`, walk the inherent impl block of the public template type, and collect each `pub fn`'s docstring (lines joined with `\n`, rustdoc's one-leading-space stripping applied).
- Defaults to `<CARGO_MANIFEST_DIR>/src/lib.rs`; `.source_path(p)` overrides the lookup. Emits an extra `cargo:rerun-if-changed=<source>` so the build picks up doc edits.

Behaviour notes
- Public functions without docs are still included with an empty `doc` string (lets tooling render a function list).
- Trait impls and impls of other types in the `#[template]` mod are ignored.
- If no `#[template]` mod is found (or the source file is absent), `functions` is left empty.
- Hash impact: this is additive; templates with public functions will now produce a different metadata hash vs. pre-this-change builds.

## Test plan
- [x] `cargo test -p tari_ootle_template_metadata -p tari_ootle_template_build` (39 tests, all pass).
- [x] `cargo build --workspace` is clean.
- [x] `cargo +nightly-2025-06-25 fmt --all`.
- [ ] Spot-check a downstream template's generated `template_metadata.json` to confirm the `functions` field renders as expected.