### PR TITLE
ci(release): publish linux-x86_64 binary to draft release early

### DIFF
--- a/.github/workflows/build_binaries.yml
+++ b/.github/workflows/build_binaries.yml
@@ -101,6 +101,8 @@ jobs:
     name: Building ${{ matrix.builds.name }} on ${{ matrix.builds.runs-on }}
     needs: matrix-prep
     continue-on-error: ${{ startsWith(github.ref, 'refs/tags/') || matrix.builds.best_effort || false }}
+    permissions:
+      contents: write
     outputs:
       TARI_VERSION: ${{ steps.set-tari-vars.outputs.TARI_VERSION }}
       VSHA_SHORT: ${{ steps.set-tari-vars.outputs.VSHA_SHORT }}
@@ -735,6 +737,24 @@ jobs:
         with:
           name: tari_ootle_walletd-${{ env.TARI_VERSION }}-${{ env.VSHA_SHORT }}-${{ matrix.builds.name }}
           path: "${{ github.workspace }}${{ env.TS_DIST }}/tari_ootle_walletd-${{ env.TARI_VERSION }}-${{ env.VSHA_SHORT }}-${{ matrix.builds.name }}${{ env.TS_EXT }}*"
+
+      - name: Publish linux-x86_64 binary to draft release early
+        if: ${{ startsWith(github.ref, 'refs/tags/v') && matrix.builds.name == 'linux-x86_64' }}
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: |
+            ${{ github.workspace }}${{ env.TS_DIST }}/${{ env.BINFILE }}.zip
+            ${{ github.workspace }}${{ env.TS_DIST }}/${{ env.BINFILE }}.zip.sha256
+            ${{ github.workspace }}${{ env.TS_DIST }}/tari_ootle_walletd-${{ env.TARI_VERSION }}-${{ env.VSHA_SHORT }}-${{ matrix.builds.name }}${{ env.TS_EXT }}
+            ${{ github.workspace }}${{ env.TS_DIST }}/tari_ootle_walletd-${{ env.TARI_VERSION }}-${{ env.VSHA_SHORT }}-${{ matrix.builds.name }}${{ env.TS_EXT }}.sha256
+          token: ${{ secrets.GITHUB_TOKEN }}
+          prerelease: true
+          draft: true
+          allowUpdates: true
+          updateOnlyUnreleased: true
+          replacesArtifacts: true
+          omitBodyDuringUpdate: true
+          omitNameDuringUpdate: true
 
   macOS-universal-assemble:
     name: macOS universal assemble


### PR DESCRIPTION
## Summary

- Adds a step to the matrix `builds` job that uploads the `linux-x86_64` archive (`tari_ootle-*-linux-x86_64.zip` + `.sha256`) and the standalone `tari_ootle_walletd-*-linux-x86_64` binary to the draft release as soon as that target finishes, instead of waiting for the full matrix and the macOS-universal assemble job.
- The step is gated on `startsWith(github.ref, 'refs/tags/v') && matrix.builds.name == 'linux-x86_64'`, uses `ncipollo/release-action@v1` with `allowUpdates: true` / `updateOnlyUnreleased: true` / `replacesArtifacts: true`, so it creates the draft release on first run and updates it on subsequent uploads. The existing `create-release` job is unchanged and harmlessly replaces the same files in place when it runs, plus continues to produce the aggregated `sha256-unsigned.txt`.
- Grants `contents: write` to the `builds` job so the new step can call the releases API; the top-level workflow permission stays at `contents: read`.

## Motivation

The release matrix takes a long time to complete end-to-end (Windows and macOS-arm64 in particular). The most-needed binary is `linux-x86_64`, so making it available on the draft release as soon as it builds avoids blocking on slower targets.

## Test plan

- [ ] Push a `vX.Y.Z` tag and confirm the draft release is created with the `linux-x86_64` artifacts shortly after that matrix entry finishes.
- [ ] Confirm the existing `create-release` job still runs at the end of the matrix and uploads the remaining targets + the aggregated `sha256-unsigned.txt` without errors.
- [ ] Confirm the workflow still works for non-tag triggers (scheduled / `build-bins-*` branches) — the new step's `if` skips it cleanly.