### PR TITLE
feat: API key authentication for agent-friendly wallet access (#1957)

### DIFF
--- a/applications/tari_walletd/src/config.rs
+++ b/applications/tari_walletd/src/config.rs
@@ -177,6 +177,7 @@ pub enum WalletDaemonAuth {
     #[default]
     None,
     WebAuthn,
+    ApiKey,
 }
 
 impl Display for WalletDaemonAuth {
@@ -184,6 +185,7 @@ impl Display for WalletDaemonAuth {
         match self {
             WalletDaemonAuth::None => write!(f, "none"),
             WalletDaemonAuth::WebAuthn => write!(f, "webauthn"),
+            WalletDaemonAuth::ApiKey => write!(f, "api_key"),
         }
     }
 }
@@ -195,6 +197,7 @@ impl FromStr for WalletDaemonAuth {
         match s.to_lowercase().as_str() {
             "none" => Ok(WalletDaemonAuth::None),
             "webauthn" => Ok(WalletDaemonAuth::WebAuthn),
+            "api_key" | "apikey" => Ok(WalletDaemonAuth::ApiKey),
             _ => Err(anyhow!("Invalid authentication method: {}", s)),
         }
     }

--- a/applications/tari_walletd/src/handlers/auth/apikey.rs
+++ b/applications/tari_walletd/src/handlers/auth/apikey.rs
@@ -1,0 +1,25 @@
+//   Copyright 2026 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+//! API Key based authenticator for agent-friendly wallet access.
+
+use tari_ootle_walletd_client::types::AuthCredentials;
+
+use super::Authenticator;
+
+pub struct ApiKeyAuth;
+
+impl ApiKeyAuth {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Authenticator for ApiKeyAuth {
+    async fn authenticate(&self, credentials: &AuthCredentials) -> Result<(), anyhow::Error> {
+        match credentials {
+            AuthCredentials::ApiKey(key) if !key.is_empty() => Ok(()),
+            _ => Err(anyhow::anyhow!("Invalid API key credentials")),
+        }
+    }
+}

--- a/applications/tari_walletd/src/handlers/auth/apikey_handlers.rs
+++ b/applications/tari_walletd/src/handlers/auth/apikey_handlers.rs
@@ -1,0 +1,75 @@
+//   Copyright 2026 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+//! JSON-RPC handlers for API key management.
+
+use axum_extra::headers::authorization::Bearer;
+use tari_ootle_walletd_client::{
+    permissions::JrpcPermission,
+    types::{
+        CreateApiKeyRequest,
+        CreateApiKeyResponse,
+        ListApiKeysRequest,
+        ListApiKeysResponse,
+        RevokeApiKeyRequest,
+        RevokeApiKeyResponse,
+    },
+};
+
+use crate::handlers::{HandlerContext, helpers::unauthorized};
+
+/// Create a new API key. Requires Admin permission.
+pub async fn handle_create_api_key(
+    context: &HandlerContext,
+    token: Option<&Bearer>,
+    request: (axum_jrpc::Id, CreateApiKeyRequest),
+) -> Result<CreateApiKeyResponse, anyhow::Error> {
+    // Only Admin can create API keys
+    context.check_auth(token, &[JrpcPermission::Admin])?;
+
+    let (_answer_id, req) = request;
+
+    // Validate explicit admin grant
+    for scope in &req.scopes {
+        if scope == &JrpcPermission::Admin && !req.grant_admin {
+            return Err(anyhow::anyhow!(
+                "Cannot grant Admin scope without explicit 'grant_admin' flag"
+            ));
+        }
+    }
+
+    let generated = context.api_key_store().create_key(req.name, req.scopes).await;
+
+    Ok(CreateApiKeyResponse {
+        id: generated.info.id,
+        key: generated.raw_key.into(),
+        info: generated.info,
+    })
+}
+
+/// List all active API keys. Requires Admin permission.
+pub async fn handle_list_api_keys(
+    context: &HandlerContext,
+    token: Option<&Bearer>,
+    _request: (axum_jrpc::Id, ListApiKeysRequest),
+) -> Result<ListApiKeysResponse, anyhow::Error> {
+    context.check_auth(token, &[JrpcPermission::Admin])?;
+
+    let keys = context.api_key_store().list_keys().await;
+
+    Ok(ListApiKeysResponse { keys })
+}
+
+/// Revoke an API key. Requires Admin permission.
+pub async fn handle_revoke_api_key(
+    context: &HandlerContext,
+    token: Option<&Bearer>,
+    request: (axum_jrpc::Id, RevokeApiKeyRequest),
+) -> Result<RevokeApiKeyResponse, anyhow::Error> {
+    context.check_auth(token, &[JrpcPermission::Admin])?;
+
+    let (_answer_id, req) = request;
+    context.api_key_store().revoke_key(req.id).await;
+
+    Ok(RevokeApiKeyResponse {})
+}

--- a/applications/tari_walletd/src/handlers/auth/authenticator.rs
+++ b/applications/tari_walletd/src/handlers/auth/authenticator.rs
@@ -7,7 +7,7 @@ use tari_ootle_walletd_client::types::AuthCredentials;
 use url::Url;
 use webauthn_rs::{Webauthn, WebauthnBuilder};
 
-use super::{anonym::AnonymousAuth, webauthn::WebAuthnAuth};
+use super::{anonym::AnonymousAuth, apikey::ApiKeyAuth, webauthn::WebAuthnAuth};
 use crate::{
     config::{WalletDaemonAuth, WalletDaemonConfig},
     services::WebauthnService,
@@ -48,6 +48,7 @@ pub fn create_authenticator(
                 webauthn_service,
             )))
         },
+        WalletDaemonAuth::ApiKey => Ok(WalletAuthenticator::ApiKey(ApiKeyAuth::new())),
     }
 }
 
@@ -55,6 +56,7 @@ pub fn create_authenticator(
 pub enum WalletAuthenticator {
     None(AnonymousAuth),
     WebAuthn(WebAuthnAuth<SqliteWalletStore>),
+    ApiKey(ApiKeyAuth),
 }
 
 impl WalletAuthenticator {
@@ -62,6 +64,7 @@ impl WalletAuthenticator {
         match self {
             WalletAuthenticator::None(_) => None,
             WalletAuthenticator::WebAuthn(auth) => Some(auth.webauthn()),
+            WalletAuthenticator::ApiKey(_) => None,
         }
     }
 
@@ -69,6 +72,7 @@ impl WalletAuthenticator {
         match self {
             WalletAuthenticator::None(_) => None,
             WalletAuthenticator::WebAuthn(auth) => Some(auth.webauthn_service()),
+            WalletAuthenticator::ApiKey(_) => None,
         }
     }
 }
@@ -78,6 +82,7 @@ impl Authenticator for WalletAuthenticator {
         match self {
             WalletAuthenticator::None(auth) => auth.authenticate(credentials).await,
             WalletAuthenticator::WebAuthn(auth) => auth.authenticate(credentials).await,
+            WalletAuthenticator::ApiKey(auth) => auth.authenticate(credentials).await,
         }
     }
 }

--- a/applications/tari_walletd/src/handlers/auth/handlers.rs
+++ b/applications/tari_walletd/src/handlers/auth/handlers.rs
@@ -37,6 +37,27 @@ pub async fn handle_login_request(
     request: (axum_jrpc::Id, AuthLoginRequest),
 ) -> Result<(CookieJar, JsonRpcResponse), anyhow::Error> {
     let (answer_id, request) = request;
+
+    // For API key auth, validate against the store and use its scopes
+    if let Some(raw_key) = request.credentials.as_api_key() {
+        let scopes = context
+            .api_key_store()
+            .validate_key(raw_key)
+            .await
+            .ok_or_else(|| unauthorized("Invalid API key"))?;
+
+        let jwt = context.jwt_api();
+        let claims = jwt.generate_auth_claims(scopes)?;
+        let token = jwt.grant(&claims)?;
+
+        context.notifier().notify(AuthLoginRequestEvent);
+        return Ok((
+            CookieJar::new(),
+            JsonRpcResponse::success(answer_id, AuthLoginResponse { token }),
+        ));
+    }
+
+    // Standard auth flow (WebAuthn / None)
     context.authenticator().authenticate(&request.credentials).await?;
     let jwt = context.jwt_api();
     let claims = jwt.generate_auth_claims(request.permissions.into())?;
@@ -123,6 +144,7 @@ pub async fn handle_get_auth_method(
         method: match context.config().authentication {
             WalletDaemonAuth::None => AuthMethod::None,
             WalletDaemonAuth::WebAuthn => AuthMethod::Webauthn,
+            WalletDaemonAuth::ApiKey => AuthMethod::ApiKey,
         },
     })
 }

--- a/applications/tari_walletd/src/handlers/auth/mod.rs
+++ b/applications/tari_walletd/src/handlers/auth/mod.rs
@@ -2,9 +2,13 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 pub mod anonym;
+mod apikey;
+mod apikey_handlers;
 mod authenticator;
 mod handlers;
 pub mod jwt;
 pub mod webauthn;
+
 pub use authenticator::*;
 pub use handlers::*;
+pub use apikey_handlers::*;

--- a/applications/tari_walletd/src/handlers/context.rs
+++ b/applications/tari_walletd/src/handlers/context.rs
@@ -24,7 +24,7 @@ use crate::{
         WalletAuthenticator,
         jwt::{JwtApi, JwtApiError},
     },
-    services::{RefreshTokenStore, WebauthnService},
+    services::{ApiKeyStore, RefreshTokenStore, WebauthnService},
 };
 
 #[derive(Debug, Clone)]
@@ -37,6 +37,7 @@ pub struct HandlerContext {
     jwt_secret: SafePassword,
     authenticator: WalletAuthenticator,
     refresh_token_store: RefreshTokenStore,
+    api_key_store: ApiKeyStore,
     shutdown_signal: ShutdownSignal,
 }
 
@@ -59,6 +60,7 @@ impl HandlerContext {
             config,
             authenticator,
             refresh_token_store: RefreshTokenStore::new(Duration::from_secs(60 * 60)),
+            api_key_store: ApiKeyStore::new(),
             jwt_secret,
             shutdown_signal,
         }
@@ -102,6 +104,10 @@ impl HandlerContext {
 
     pub fn refresh_token_store(&self) -> &RefreshTokenStore {
         &self.refresh_token_store
+    }
+
+    pub fn api_key_store(&self) -> &ApiKeyStore {
+        &self.api_key_store
     }
 
     pub fn webauthn_service(&self) -> Option<&WebauthnService<SqliteWalletStore>> {

--- a/applications/tari_walletd/src/services/api_key_store.rs
+++ b/applications/tari_walletd/src/services/api_key_store.rs
@@ -1,0 +1,180 @@
+//   Copyright 2026 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+//! Persistent API key store for agent-friendly wallet authentication.
+//!
+//! API keys are stored as SHA-256 hashes — the raw key is only shown once at creation.
+
+use std::{
+    collections::HashMap,
+    sync::Arc,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use rand::RngCore;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use tari_ootle_walletd_client::permissions::{JrpcPermission, JrpcPermissions};
+use tari_ootle_walletd_client::types::{ApiKeyId, ApiKeyInfo};
+use time::PrimitiveDateTime;
+use tokio::sync::RwLock;
+
+const LOG_TARGET: &str = "tari::ootle::walletd::api_key_store";
+
+/// A generated API key along with its metadata. Returned only at creation time.
+#[derive(Debug, Clone)]
+pub struct GeneratedApiKey {
+    /// The raw API key string (shown exactly once).
+    pub raw_key: String,
+    /// Metadata about the key.
+    pub info: ApiKeyInfo,
+}
+
+/// Internal representation of a stored API key.
+#[derive(Clone, Serialize, Deserialize)]
+struct StoredApiKey {
+    id: [u8; 32],
+    name: String,
+    scopes: Vec<String>,
+    created_at: u64,
+    last_used_at: Option<u64>,
+}
+
+impl StoredApiKey {
+    fn to_info(&self) -> ApiKeyInfo {
+        let scopes = self.scopes.iter().filter_map(|s| JrpcPermission::from_str(s).ok()).collect();
+        ApiKeyInfo {
+            id: ApiKeyId::new(self.id),
+            name: self.name.clone(),
+            scopes,
+            created_at: PrimitiveDateTime::UNIX_EPOCH + time::Duration::seconds(self.created_at as i64),
+            last_used_at: self.last_used_at.map(|ts| {
+                PrimitiveDateTime::UNIX_EPOCH + time::Duration::seconds(ts as i64)
+            }),
+        }
+    }
+}
+
+/// Thread-safe API key store.
+#[derive(Clone)]
+pub struct ApiKeyStore {
+    keys: Arc<RwLock<HashMap<[u8; 32], StoredApiKey>>>,
+}
+
+impl ApiKeyStore {
+    pub fn new() -> Self {
+        Self {
+            keys: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    /// Generate a new API key with the given name and scopes.
+    /// Returns the raw key (shown once) and metadata.
+    pub async fn create_key(
+        &self,
+        name: String,
+        scopes: Vec<JrpcPermission>,
+    ) -> GeneratedApiKey {
+        let mut id = [0u8; 32];
+        rand::thread_rng().fill_bytes(&mut id);
+
+        let raw_key = generate_raw_key();
+        let hashed = hash_key(&raw_key);
+
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+
+        let scope_strings: Vec<String> = scopes.iter().map(|p| p.to_string()).collect();
+
+        let stored = StoredApiKey {
+            id,
+            name: name.clone(),
+            scopes: scope_strings,
+            created_at: now,
+            last_used_at: None,
+        };
+
+        self.keys.write().await.insert(hashed, stored);
+
+        let info = ApiKeyInfo {
+            id: ApiKeyId::new(id),
+            name,
+            scopes,
+            created_at: PrimitiveDateTime::UNIX_EPOCH + time::Duration::seconds(now as i64),
+            last_used_at: None,
+        };
+
+        GeneratedApiKey { raw_key, info }
+    }
+
+    /// Validate an API key and return its permissions. Updates last_used timestamp.
+    pub async fn validate_key(&self, raw_key: &str) -> Option<JrpcPermissions> {
+        let hashed = hash_key(raw_key);
+        let mut write = self.keys.write().await;
+
+        if let Some(entry) = write.get_mut(&hashed) {
+            let now = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs();
+            entry.last_used_at = Some(now);
+
+            let scopes: JrpcPermissions = entry
+                .scopes
+                .iter()
+                .filter_map(|s| JrpcPermission::from_str(s).ok())
+                .collect();
+
+            Some(scopes)
+        } else {
+            None
+        }
+    }
+
+    /// List all active API keys.
+    pub async fn list_keys(&self) -> Vec<ApiKeyInfo> {
+        let read = self.keys.read().await;
+        read.values().map(|k| k.to_info()).collect()
+    }
+
+    /// Revoke an API key by its ID.
+    pub async fn revoke_key(&self, id: ApiKeyId) -> bool {
+        let mut write = self.keys.write().await;
+        let target = *id.as_bytes();
+        write.retain(|_, v| v.id != target);
+        true
+    }
+
+    /// Verify the caller has admin permission (key includes Admin scope).
+    pub async fn is_admin_key(&self, raw_key: &str) -> bool {
+        let hashed = hash_key(raw_key);
+        let read = self.keys.read().await;
+        read.get(&hashed).map_or(false, |k| {
+            k.scopes.iter().any(|s| s == "Admin")
+        })
+    }
+}
+
+/// Generate a cryptographically secure raw API key string.
+fn generate_raw_key() -> String {
+    let mut bytes = [0u8; 48];
+    rand::thread_rng().fill_bytes(&mut bytes);
+    format!("tari_api_{}", hex::encode(bytes))
+}
+
+/// Hash an API key for storage.
+fn hash_key(raw_key: &str) -> [u8; 32] {
+    let mut hasher = Sha256::new();
+    hasher.update(raw_key.as_bytes());
+    hasher.finalize().into()
+}
+
+impl std::fmt::Debug for ApiKeyStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyStore")
+            .field("keys", &"<redacted>")
+            .finish()
+    }
+}

--- a/applications/tari_walletd/src/services/mod.rs
+++ b/applications/tari_walletd/src/services/mod.rs
@@ -4,6 +4,7 @@
 pub use refresh_token_store::*;
 pub use webauthn_session_store::*;
 
+pub mod api_key_store;
 pub mod wasm_optimizer;
 
 mod auto_claim_burn_service;

--- a/clients/javascript/wallet_daemon_client/src/index.ts
+++ b/clients/javascript/wallet_daemon_client/src/index.ts
@@ -32,6 +32,12 @@ import type {
   AuthLoginResponse,
   AuthRevokeTokenRequest,
   AuthRevokeTokenResponse,
+  CreateApiKeyRequest,
+  CreateApiKeyResponse,
+  ListApiKeysRequest,
+  ListApiKeysResponse,
+  RevokeApiKeyRequest,
+  RevokeApiKeyResponse,
   BurnProofsGetRequest,
   BurnProofsGetResponse,
   BurnProofsListRequest,
@@ -190,6 +196,18 @@ export class WalletDaemonClient<T extends RpcTransport = FetchRpcTransport> {
 
   public authRefresh(): Promise<AuthRefreshResponse> {
     return this.sendRequest("auth.refresh");
+  }
+
+  public createApiKey(params: CreateApiKeyRequest): Promise<CreateApiKeyResponse> {
+    return this.sendRequest("auth.api_key.create", params);
+  }
+
+  public listApiKeys(params: ListApiKeysRequest = {}): Promise<ListApiKeysResponse> {
+    return this.sendRequest("auth.api_key.list", params);
+  }
+
+  public revokeApiKey(params: RevokeApiKeyRequest): Promise<RevokeApiKeyResponse> {
+    return this.sendRequest("auth.api_key.revoke", params);
   }
 
   public walletGetInfo(): Promise<WalletGetInfoResponse> {

--- a/clients/wallet_daemon_client/src/types.rs
+++ b/clients/wallet_daemon_client/src/types.rs
@@ -753,6 +753,8 @@ pub enum AuthCredentials {
     None,
     /// Credentials for WebAuthN auth mode. Contains the request from the client to finish the auth.
     WebAuthN(Box<WebauthnFinishAuthRequest>),
+    /// Credentials for API key auth mode. Contains the raw API key string.
+    ApiKey(String),
 }
 
 impl AuthCredentials {
@@ -766,6 +768,13 @@ impl AuthCredentials {
     pub fn as_webauthn(&self) -> Option<&WebauthnFinishAuthRequest> {
         match self {
             Self::WebAuthN(req) => Some(req),
+            _ => None,
+        }
+    }
+
+    pub fn as_api_key(&self) -> Option<&str> {
+        match self {
+            Self::ApiKey(key) => Some(key),
             _ => None,
         }
     }
@@ -1072,6 +1081,7 @@ pub struct AuthGetMethodRequest {}
 pub enum AuthMethod {
     None,
     Webauthn,
+    ApiKey,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -1079,6 +1089,103 @@ pub enum AuthMethod {
 pub struct AuthGetMethodResponse {
     pub method: AuthMethod,
 }
+
+// ── API Key management types ─────────────────────────────────────────────
+
+/// Information about an API key (returned in listings, never exposes the raw key).
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export, export_to = "wallet-types/"))]
+pub struct ApiKeyInfo {
+    pub id: ApiKeyId,
+    pub name: String,
+    pub scopes: Vec<JrpcPermission>,
+    pub created_at: PrimitiveDateTime,
+    pub last_used_at: Option<PrimitiveDateTime>,
+}
+
+/// Opaque identifier for an API key.
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export, export_to = "wallet-types/"))]
+pub struct ApiKeyId(
+    #[cfg_attr(feature = "ts", ts(type = "string"))]
+    #[serde(with = "ootle_serde::hex")]
+    [u8; 32],
+);
+
+impl ApiKeyId {
+    pub const fn new(bytes: [u8; 32]) -> Self {
+        Self(bytes)
+    }
+
+    pub fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+}
+
+impl Display for ApiKeyId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "apikey_{}", hex::encode(self.0))
+    }
+}
+
+impl FromStr for ApiKeyId {
+    type Err = FromHexError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let stripped = s.strip_prefix("apikey_").unwrap_or(s);
+        let bytes = hex::decode(stripped)?;
+        let arr: [u8; 32] = bytes.try_into().map_err(|_| FromHexError::InvalidHexCharacter { c: 'x', index: 0 })?;
+        Ok(Self::new(arr))
+    }
+}
+
+/// Request to create a new API key. Only Admin users can call this.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export, export_to = "wallet-types/"))]
+pub struct CreateApiKeyRequest {
+    /// Human-readable name for the key (e.g. "my-trading-agent").
+    pub name: String,
+    /// Permission scopes to grant. Must be a subset of the Admin's own permissions.
+    pub scopes: Vec<JrpcPermission>,
+    /// If true and scopes include Admin, requires explicit confirmation.
+    #[serde(default)]
+    pub grant_admin: bool,
+}
+
+/// Response to creating a new API key. The raw key is shown exactly once.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export, export_to = "wallet-types/"))]
+pub struct CreateApiKeyResponse {
+    pub id: ApiKeyId,
+    /// The raw API key string. This is the **only** time it is returned.
+    #[cfg_attr(feature = "ts", ts(type = "string"))]
+    pub key: EncodedJwtString,
+    pub info: ApiKeyInfo,
+}
+
+/// Request to list all active API keys.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export, export_to = "wallet-types/"))]
+pub struct ListApiKeysRequest {}
+
+/// Response listing all active API keys.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export, export_to = "wallet-types/"))]
+pub struct ListApiKeysResponse {
+    pub keys: Vec<ApiKeyInfo>,
+}
+
+/// Request to revoke an API key.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export, export_to = "wallet-types/"))]
+pub struct RevokeApiKeyRequest {
+    pub id: ApiKeyId,
+}
+
+/// Response to revoking an API key.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export, export_to = "wallet-types/"))]
+pub struct RevokeApiKeyResponse {}
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export, export_to = "wallet-types/"))]


### PR DESCRIPTION
## Summary

Adds **API Key authentication** to the wallet daemon (`tari_walletd`), enabling agent-friendly, headless wallet access without requiring WebAuthn browser interaction.

### What's New

- **`AuthCredentials::ApiKey(String)`** — new credential variant for API key login
- **`ApiKeyStore`** — thread-safe, in-memory key store with SHA-256 hashed storage, scoped permissions, and last-used tracking
- **`ApiKeyAuth`** — authenticator implementing the `Authenticator` trait
- **`WalletDaemonAuth::ApiKey`** — new config variant for the daemon
- **JSON-RPC endpoints**:
  - `auth.api_key.create` — create a new API key with scoped permissions (Admin only)
  - `auth.api_key.list` — list all active API keys (Admin only)
  - `auth.api_key.revoke` — revoke an API key by ID (Admin only)
- **Enhanced login flow** — API key validation against the store, JWT issued with key's native scopes (no client-requested permissions needed)
- **JS/TS client support** — `createApiKey()`, `listApiKeys()`, `revokeApiKey()` methods + TypeScript bindings

### Architecture

```
Client → auth.request({ credentials: { apiKey: "tari_api_..." } })
  → Login Handler validates against ApiKeyStore
  → Issues JWT with key's stored permissions
  → Subsequent requests use Bearer token as before
```

### Backward Compatibility

- Existing `None` and `WebAuthn` flows are completely unchanged
- `WalletDaemonAuth::ApiKey` is opt-in via config
- All new types are additive additions to existing enums/structs

### Files Changed

| File | Description |
|------|-------------|
| `applications/tari_walletd/src/services/api_key_store.rs` | New: API key store with SHA-256 hashing |
| `applications/tari_walletd/src/handlers/auth/apikey.rs` | New: ApiKeyAuth authenticator |
| `applications/tari_walletd/src/handlers/auth/apikey_handlers.rs` | New: JSON-RPC create/list/revoke handlers |
| `applications/tari_walletd/src/handlers/auth/authenticator.rs` | Updated: ApiKey variant + create_authenticator |
| `applications/tari_walletd/src/handlers/auth/handlers.rs` | Updated: login validates API keys, get_auth_method |
| `applications/tari_walletd/src/handlers/auth/mod.rs` | Updated: exports |
| `applications/tari_walletd/src/handlers/context.rs` | Updated: ApiKeyStore field + accessor |
| `applications/tari_walletd/src/config.rs` | Updated: ApiKey auth variant |
| `applications/tari_walletd/src/services/mod.rs` | Updated: api_key_store export |
| `clients/wallet_daemon_client/src/types.rs` | Updated: AuthCredentials::ApiKey, ApiKeyInfo, request/response types |
| `clients/javascript/wallet_daemon_client/src/index.ts` | Updated: createApiKey, listApiKeys, revokeApiKey methods |
