### PR TITLE
fix(consensus): exhaust-burn mismatch on timeout recovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1707,7 +1707,7 @@ dependencies = [
 
 [[package]]
 name = "consensus_tests"
-version = "0.30.9"
+version = "0.30.10"
 dependencies = [
  "fern",
  "futures 0.3.31",
@@ -2711,7 +2711,7 @@ dependencies = [
 
 [[package]]
 name = "db-inspector"
-version = "0.30.9"
+version = "0.30.10"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -5101,7 +5101,7 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "integration_tests"
-version = "0.30.9"
+version = "0.30.10"
 dependencies = [
  "anyhow",
  "config",
@@ -5883,7 +5883,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-messaging"
-version = "0.30.9"
+version = "0.30.10"
 dependencies = [
  "async-trait",
  "futures-bounded 0.2.4",
@@ -6061,7 +6061,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-substream"
-version = "0.30.9"
+version = "0.30.10"
 dependencies = [
  "libp2p",
  "prometheus-client",
@@ -7646,7 +7646,7 @@ dependencies = [
 
 [[package]]
 name = "ootle-wasm"
-version = "0.30.9"
+version = "0.30.10"
 dependencies = [
  "console_error_panic_hook",
  "getrandom 0.2.17",
@@ -7656,7 +7656,7 @@ dependencies = [
 
 [[package]]
 name = "ootle-wasm-core"
-version = "0.30.9"
+version = "0.30.10"
 dependencies = [
  "base64 0.22.1",
  "ootle_byte_type",
@@ -8661,7 +8661,7 @@ dependencies = [
 
 [[package]]
 name = "proto_builder"
-version = "0.30.9"
+version = "0.30.10"
 dependencies = [
  "prost-build 0.14.3",
  "sha2 0.10.9",
@@ -10539,7 +10539,7 @@ dependencies = [
 
 [[package]]
 name = "sqlite_message_logger"
-version = "0.30.9"
+version = "0.30.10"
 dependencies = [
  "chrono",
  "diesel",
@@ -10911,7 +10911,7 @@ dependencies = [
 
 [[package]]
 name = "tari_base_node_client"
-version = "0.30.9"
+version = "0.30.10"
 dependencies = [
  "futures-util",
  "log",
@@ -11138,7 +11138,7 @@ dependencies = [
 
 [[package]]
 name = "tari_consensus"
-version = "0.30.9"
+version = "0.30.10"
 dependencies = [
  "anyhow",
  "indexmap 2.13.0",
@@ -11163,7 +11163,7 @@ dependencies = [
 
 [[package]]
 name = "tari_consensus_types"
-version = "0.30.9"
+version = "0.30.10"
 dependencies = [
  "borsh",
  "ootle_serde",
@@ -11263,7 +11263,7 @@ dependencies = [
 
 [[package]]
 name = "tari_engine"
-version = "0.30.9"
+version = "0.30.10"
 dependencies = [
  "blake2 0.10.6",
  "bytes",
@@ -11294,7 +11294,7 @@ dependencies = [
 
 [[package]]
 name = "tari_engine_types"
-version = "0.30.9"
+version = "0.30.10"
 dependencies = [
  "bincode 2.0.1",
  "blake2 0.10.6",
@@ -11323,7 +11323,7 @@ dependencies = [
 
 [[package]]
 name = "tari_epoch_manager"
-version = "0.30.9"
+version = "0.30.10"
 dependencies = [
  "anyhow",
  "log",
@@ -11343,7 +11343,7 @@ dependencies = [
 
 [[package]]
 name = "tari_epoch_oracles"
-version = "0.30.9"
+version = "0.30.10"
 dependencies = [
  "anyhow",
  "blake2 0.10.6",
@@ -11397,7 +11397,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer"
-version = "0.30.9"
+version = "0.30.10"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -11499,7 +11499,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer_lib"
-version = "0.30.9"
+version = "0.30.10"
 dependencies = [
  "log",
  "prometheus-client",
@@ -11603,7 +11603,7 @@ dependencies = [
 
 [[package]]
 name = "tari_networking"
-version = "0.30.9"
+version = "0.30.10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11656,7 +11656,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_app_utilities"
-version = "0.30.9"
+version = "0.30.10"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -11696,7 +11696,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_common_types"
-version = "0.30.9"
+version = "0.30.10"
 dependencies = [
  "blake2 0.10.6",
  "borsh",
@@ -11724,7 +11724,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_p2p"
-version = "0.30.9"
+version = "0.30.10"
 dependencies = [
  "anyhow",
  "libp2p-identity 0.2.13 (git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a)",
@@ -11748,7 +11748,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_storage"
-version = "0.30.9"
+version = "0.30.10"
 dependencies = [
  "anyhow",
  "bitflags 2.10.0",
@@ -11775,7 +11775,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_storage_sqlite"
-version = "0.30.9"
+version = "0.30.10"
 dependencies = [
  "diesel",
  "diesel_migrations",
@@ -11826,7 +11826,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_transaction"
-version = "0.30.9"
+version = "0.30.10"
 dependencies = [
  "bincode 2.0.1",
  "borsh",
@@ -11852,7 +11852,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_cli"
-version = "0.30.9"
+version = "0.30.10"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -11881,7 +11881,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_crypto"
-version = "0.30.9"
+version = "0.30.10"
 dependencies = [
  "argon2 0.5.3",
  "blake2 0.10.6",
@@ -11911,7 +11911,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_sdk"
-version = "0.30.9"
+version = "0.30.10"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -11973,7 +11973,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_sdk_tests"
-version = "0.30.9"
+version = "0.30.10"
 dependencies = [
  "digest 0.10.7",
  "ootle_byte_type",
@@ -11995,7 +11995,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_storage_sqlite"
-version = "0.30.9"
+version = "0.30.10"
 dependencies = [
  "diesel",
  "diesel_migrations",
@@ -12018,7 +12018,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_walletd"
-version = "0.30.9"
+version = "0.30.10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12136,7 +12136,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_framework"
-version = "0.30.9"
+version = "0.30.10"
 dependencies = [
  "async-trait",
  "bitflags 2.10.0",
@@ -12160,7 +12160,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_macros"
-version = "0.30.9"
+version = "0.30.10"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12169,7 +12169,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_state_sync"
-version = "0.30.9"
+version = "0.30.10"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -12247,7 +12247,7 @@ dependencies = [
 
 [[package]]
 name = "tari_state_store_rocksdb"
-version = "0.30.9"
+version = "0.30.10"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -12279,7 +12279,7 @@ dependencies = [
 
 [[package]]
 name = "tari_state_tree"
-version = "0.30.9"
+version = "0.30.10"
 dependencies = [
  "indexmap 2.13.0",
  "log",
@@ -12305,7 +12305,7 @@ dependencies = [
 
 [[package]]
 name = "tari_swarm"
-version = "0.30.9"
+version = "0.30.10"
 dependencies = [
  "libp2p",
  "libp2p-messaging",
@@ -12316,7 +12316,7 @@ dependencies = [
 
 [[package]]
 name = "tari_swarm_daemon"
-version = "0.30.9"
+version = "0.30.10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12427,7 +12427,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_test_tooling"
-version = "0.30.9"
+version = "0.30.10"
 dependencies = [
  "anyhow",
  "cargo_toml 0.22.3",
@@ -12540,7 +12540,7 @@ dependencies = [
 
 [[package]]
 name = "tari_transaction_manifest"
-version = "0.30.9"
+version = "0.30.10"
 dependencies = [
  "proc-macro2",
  "serde_json",
@@ -12575,7 +12575,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node"
-version = "0.30.9"
+version = "0.30.10"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -12641,7 +12641,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node_client"
-version = "0.30.9"
+version = "0.30.10"
 dependencies = [
  "indexmap 2.13.0",
  "multiaddr 0.18.3",
@@ -12665,7 +12665,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node_rpc"
-version = "0.30.9"
+version = "0.30.10"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -12688,7 +12688,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_rollback"
-version = "0.30.9"
+version = "0.30.10"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12723,7 +12723,7 @@ dependencies = [
 
 [[package]]
 name = "tari_watcher"
-version = "0.30.9"
+version = "0.30.10"
 dependencies = [
  "anyhow",
  "clap 3.2.25",
@@ -12752,7 +12752,7 @@ dependencies = [
 
 [[package]]
 name = "tariswap_bench"
-version = "0.30.9"
+version = "0.30.10"
 dependencies = [
  "anyhow",
  "clap 4.5.54",
@@ -13432,7 +13432,7 @@ dependencies = [
 
 [[package]]
 name = "traffic-sim"
-version = "0.30.9"
+version = "0.30.10"
 dependencies = [
  "anyhow",
  "clap 4.5.54",
@@ -13454,7 +13454,7 @@ dependencies = [
 
 [[package]]
 name = "transaction_generator"
-version = "0.30.9"
+version = "0.30.10"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -13473,7 +13473,7 @@ dependencies = [
 
 [[package]]
 name = "transaction_submitter"
-version = "0.30.9"
+version = "0.30.10"
 dependencies = [
  "anyhow",
  "clap 4.5.54",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.30.9"
+version = "0.30.10"
 edition = "2024"
 authors = ["The Tari Development Community"]
 repository = "https://github.com/tari-project/tari-ootle"

--- a/crates/consensus/src/hotstuff/on_propose.rs
+++ b/crates/consensus/src/hotstuff/on_propose.rs
@@ -335,22 +335,26 @@ where TConsensusSpec: ConsensusSpec
         };
 
         let mut total_leader_fee = 0u64;
-        // When filling a timeout gap with a dummy chain, the candidate's parent is the last dummy, which carries
-        // justify_block's accumulated_data forward (see `calculate_last_dummy_block`). Initialize from justify_block
-        // (not highest_seen_block) to match what validators compute starting from the reconstructed dummy chain.
-        // Otherwise speculative leader-fee burn that accumulated on a locally-stored fork above the high QC would be
-        // incorrectly carried into the new candidate and every validator would reject with an exhaust-burn mismatch.
+        // When filling a timeout gap with a dummy chain, the candidate effectively extends from justify_block (the
+        // dummies are empty blocks that carry justify_block's accumulated_data and state forward — see
+        // `calculate_last_dummy_block`). Anchor accumulated_data, the substate store, and the pending state tree
+        // diff lookup at justify_block to match what validators recompute from the reconstructed dummy chain.
+        // Otherwise speculative state and leader-fee burn that accumulated on a locally-stored fork above the high QC
+        // would be incorrectly carried into the new candidate and validators would reject with either an
+        // exhaust-burn mismatch or a state Merkle-root mismatch.
+        let state_anchor_leaf = if dummy_block.is_some() {
+            justify_block.as_leaf()
+        } else {
+            start_of_chain_block.as_leaf()
+        };
         let mut accumulated_data = if dummy_block.is_some() {
             *justify_block.header().accumulated_data()
         } else {
             *highest_seen_block.header().accumulated_data()
         };
 
-        let mut substate_store = PendingSubstateStore::new(
-            tx,
-            start_of_chain_block.as_leaf(),
-            self.config.consensus_constants.num_preshards,
-        );
+        let mut substate_store =
+            PendingSubstateStore::new(tx, state_anchor_leaf, self.config.consensus_constants.num_preshards);
 
         let mut executed_transactions = HashMap::new();
 
@@ -492,7 +496,7 @@ where TConsensusSpec: ConsensusSpec
 
         let timer = TraceTimer::info(LOG_TARGET, "Propose calculate state root");
         let pending_tree_diffs =
-            PendingShardStateTreeDiff::get_all_up_to_commit_block(tx, start_of_chain_block.block_id())?;
+            PendingShardStateTreeDiff::get_all_up_to_commit_block(tx, state_anchor_leaf.block_id())?;
         let (state_root, _) = calculate_state_merkle_root(
             tx,
             local_committee_info.shard_group(),

--- a/crates/consensus/src/hotstuff/on_propose.rs
+++ b/crates/consensus/src/hotstuff/on_propose.rs
@@ -335,7 +335,16 @@ where TConsensusSpec: ConsensusSpec
         };
 
         let mut total_leader_fee = 0u64;
-        let mut accumulated_data = *highest_seen_block.header().accumulated_data();
+        // When filling a timeout gap with a dummy chain, the candidate's parent is the last dummy, which carries
+        // justify_block's accumulated_data forward (see `calculate_last_dummy_block`). Initialize from justify_block
+        // (not highest_seen_block) to match what validators compute starting from the reconstructed dummy chain.
+        // Otherwise speculative leader-fee burn that accumulated on a locally-stored fork above the high QC would be
+        // incorrectly carried into the new candidate and every validator would reject with an exhaust-burn mismatch.
+        let mut accumulated_data = if dummy_block.is_some() {
+            *justify_block.header().accumulated_data()
+        } else {
+            *highest_seen_block.header().accumulated_data()
+        };
 
         let mut substate_store = PendingSubstateStore::new(
             tx,

--- a/crates/consensus_tests/src/dummy_blocks.rs
+++ b/crates/consensus_tests/src/dummy_blocks.rs
@@ -1,6 +1,8 @@
 //   Copyright 2024 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
+use std::collections::BTreeSet;
+
 use ootle_byte_type::ToByteType;
 use tari_common_types::types::FixedHash;
 use tari_consensus::hotstuff::{
@@ -13,6 +15,7 @@ use tari_crypto::tari_utilities::hex::Hex;
 use tari_ootle_common_types::{
     DerivableFromPublicKey,
     Epoch,
+    ExtraData,
     NodeHeight,
     NumPreshards,
     ShardGroup,
@@ -21,7 +24,7 @@ use tari_ootle_common_types::{
     crypto::create_key_pair_from_seed,
 };
 use tari_ootle_p2p::PeerAddress;
-use tari_ootle_storage::consensus_models::Block;
+use tari_ootle_storage::consensus_models::{Block, BlockHeader};
 use tari_ootle_transaction::Network;
 
 use crate::support::{RoundRobinLeaderStrategy, load_json_fixture};
@@ -229,5 +232,128 @@ fn dummy_blocks_from_epoch_genesis_vs_zero_block() {
         validator_dummies.last().unwrap().id(),
         &fixed_proposer_last.block_id,
         "epoch genesis should produce matching dummy chains between proposer and validator"
+    );
+}
+
+/// Regression test: when the proposer fills a timeout gap with a dummy chain, the candidate's
+/// `accumulated_data` must be initialized from the justify block — which the dummies carry
+/// forward — and NOT from `highest_seen_block`. This was the second-stage failure observed
+/// after the template-sync recovery: HighestSeenBlock had drifted above the high QC because
+/// speculative blocks with leader fees had been locally stored on an abandoned fork, so
+/// `highest_seen.accumulated > justify.accumulated`. Initialising the proposer candidate from
+/// `highest_seen` produced a block header that disagreed with every validator's
+/// recomputation from the dummy parent (`Exhaust burn disagreement. Leader proposed N,
+/// we calculated M`), and no proposal could ever be voted in.
+#[test]
+fn proposer_accumulated_data_must_come_from_justify_on_timeout_recovery() {
+    let shard_group = ShardGroup::all_shards(NumPreshards::P256);
+    let committee: Committee<PeerAddress> = (0u8..4)
+        .map(create_key_pair_from_seed)
+        .map(|(_, pk)| CommitteeMember {
+            address: PeerAddress::derive_from_public_key(&pk),
+            public_key: pk.to_byte_type(),
+            vote_power: VotePower::of(1),
+        })
+        .collect();
+
+    // The high QC's referenced block. Its accumulated_data is the canonical baseline
+    // for dummy-chain recovery.
+    let justify_accumulated = ShardGroupAccumulatedData { total_exhaust_burn: 18 };
+    let justify_height = NodeHeight(534);
+    let justify_header = BlockHeader::create_unsigned(
+        Network::LocalNet,
+        BlockId::zero(),
+        Block::genesis(
+            Network::LocalNet,
+            Epoch(7991),
+            FixedHash::zero(),
+            shard_group,
+            FixedHash::zero(),
+            None,
+        )
+        .justify()
+        .calculate_id(),
+        justify_height,
+        Epoch(7991),
+        shard_group,
+        committee.shuffled().next().unwrap().public_key,
+        FixedHash::zero(),
+        &BTreeSet::new(),
+        0,
+        0,
+        FixedHash::zero(),
+        justify_accumulated,
+        ExtraData::new(),
+    )
+    .unwrap();
+    let justify_block = Block::new(
+        justify_header,
+        Block::genesis(
+            Network::LocalNet,
+            Epoch(7991),
+            FixedHash::zero(),
+            shard_group,
+            FixedHash::zero(),
+            None,
+        )
+        .justify()
+        .clone(),
+        BTreeSet::new(),
+        None,
+    );
+
+    // A locally-stored speculative block on an abandoned fork above the high QC. Its
+    // accumulated_data is *higher* than the justify because leader fees got tallied into
+    // its header when it was proposed, but it never finalised. HighestSeenBlock follows
+    // the local fork, not the QC chain.
+    let speculative_accumulated = ShardGroupAccumulatedData {
+        total_exhaust_burn: 710,
+    };
+    assert_ne!(
+        speculative_accumulated.total_exhaust_burn, justify_accumulated.total_exhaust_burn,
+        "test premise: speculative leaf must disagree with justify"
+    );
+
+    // The validator's dummy chain: built from the justify block, so every dummy carries
+    // justify's accumulated_data forward — including the last dummy, which becomes the
+    // parent of the next candidate.
+    let candidate_height = NodeHeight(5304);
+    let dummies = calculate_dummy_blocks(
+        justify_block.height(),
+        candidate_height,
+        Network::LocalNet,
+        justify_block.epoch(),
+        justify_block.shard_group(),
+        *justify_block.id(),
+        justify_block.justify(),
+        // expected_parent_block_id is only used to short-circuit iteration; we want
+        // the full chain so pass a placeholder that won't be matched.
+        &BlockId::zero(),
+        *justify_block.state_merkle_root(),
+        &RoundRobinLeaderStrategy,
+        &committee,
+        justify_block.timestamp(),
+        *justify_block.header().accumulated_data(),
+        *justify_block.epoch_hash(),
+    );
+
+    let last_dummy = dummies.last().expect("dummy chain non-empty");
+
+    // The proposer initialises the candidate's accumulated_data from this value (after
+    // the fix). Validators compute total_exhaust_burn starting from this same value
+    // (via `parent.header().total_accumulated_exhaust_burn()`). Both sides agree.
+    assert_eq!(
+        last_dummy.header().accumulated_data().total_exhaust_burn,
+        justify_accumulated.total_exhaust_burn,
+        "last dummy must carry justify's accumulated_data, not the speculative leaf's"
+    );
+
+    // The buggy proposer would have initialised from `highest_seen.accumulated_data`
+    // (the speculative leaf), producing a header that disagrees with what every
+    // validator computes from the dummy chain.
+    assert_ne!(
+        last_dummy.header().accumulated_data().total_exhaust_burn,
+        speculative_accumulated.total_exhaust_burn,
+        "regression: initialising candidate from highest_seen would not match validators"
     );
 }

--- a/crates/consensus_tests/src/last_voted_persistence.rs
+++ b/crates/consensus_tests/src/last_voted_persistence.rs
@@ -1,0 +1,122 @@
+//   Copyright 2026 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+//! Persistence regression test for `LastVoted`.
+//!
+//! HotStuff's safety argument requires that a node never votes twice at the same view. The
+//! voter checks this via `LastVoted::get(tx, epoch)` and refuses to vote if
+//! `candidate.height() <= last_voted.height()` (see
+//! `crates/consensus/src/hotstuff/on_ready_to_vote_on_local_block.rs:215-237`).
+//!
+//! If the validator restarts between sending a vote and seeing the resulting QC, the `LastVoted`
+//! record must still be on disk afterwards — otherwise the validator could legally vote a second
+//! time at the same height, equivocating across restarts. This test verifies the record survives
+//! a full RocksDB close/reopen cycle, and that the `should_vote` decision logic (height check)
+//! comes out the way the protocol requires.
+
+use tari_consensus_types::{BlockId, LastVoted};
+use tari_ootle_common_types::{Epoch, NodeHeight};
+use tari_ootle_p2p::PeerAddress;
+use tari_ootle_storage::{StateStore, consensus_models::BookkeepingModel};
+use tari_state_store_rocksdb::{DatabaseOptions, RocksDbStateStore};
+
+type TestStore = RocksDbStateStore<PeerAddress>;
+
+const TEST_EPOCH: Epoch = Epoch(0);
+
+/// Mirror of the height-only safety check performed inside `OnReadyToVoteOnLocalBlock::should_vote`.
+/// Refusing to vote when `candidate_height <= last_voted.height()` is what prevents per-restart
+/// equivocation; if this predicate disagrees with the consensus code, the safety argument breaks.
+fn would_vote(last_voted: Option<&LastVoted>, candidate_height: NodeHeight) -> bool {
+    match last_voted {
+        None => true,
+        Some(lv) => candidate_height > lv.height(),
+    }
+}
+
+#[test]
+fn last_voted_survives_close_and_reopen() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let path = temp_dir.path().to_path_buf();
+    let block_id = BlockId::new(tari_common_types::types::FixedHash::new([7u8; 32]));
+    let height = NodeHeight(42);
+
+    // Open, write, drop.
+    {
+        let store: TestStore = RocksDbStateStore::open(&path, DatabaseOptions::default()).unwrap();
+        let last_voted = LastVoted {
+            block_id,
+            height,
+            epoch: TEST_EPOCH,
+        };
+        store.with_write_tx(|tx| last_voted.set(tx)).unwrap();
+    }
+
+    // Reopen.
+    let store: TestStore = RocksDbStateStore::open(&path, DatabaseOptions::default()).unwrap();
+    let reloaded = store
+        .with_read_tx(|tx| LastVoted::get(tx, TEST_EPOCH))
+        .expect("LastVoted record must persist across restart");
+
+    assert_eq!(reloaded.height(), height);
+    assert_eq!(*reloaded.block_id(), block_id);
+    assert_eq!(reloaded.epoch(), TEST_EPOCH);
+}
+
+/// After restart, the safety predicate must refuse to vote at any height the node has already
+/// voted at, and must allow voting at strictly higher heights. The classic equivocation surface
+/// is "voted at H, crashed before seeing QC, restarted, and now considering another candidate at
+/// H from a competing leader" — the answer must be NO VOTE.
+#[test]
+fn safety_predicate_respects_persisted_last_voted_after_reopen() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let path = temp_dir.path().to_path_buf();
+    let voted_block = BlockId::new(tari_common_types::types::FixedHash::new([1u8; 32]));
+    let voted_height = NodeHeight(10);
+
+    {
+        let store: TestStore = RocksDbStateStore::open(&path, DatabaseOptions::default()).unwrap();
+        let last_voted = LastVoted {
+            block_id: voted_block,
+            height: voted_height,
+            epoch: TEST_EPOCH,
+        };
+        store.with_write_tx(|tx| last_voted.set(tx)).unwrap();
+    }
+
+    let store: TestStore = RocksDbStateStore::open(&path, DatabaseOptions::default()).unwrap();
+    let reloaded = store.with_read_tx(|tx| LastVoted::get(tx, TEST_EPOCH)).unwrap();
+
+    // Same height as the prior vote — even for a different block_id — must be rejected.
+    assert!(
+        !would_vote(Some(&reloaded), voted_height),
+        "must not vote at the same height after restart (equivocation risk)"
+    );
+    // Lower height — must be rejected.
+    assert!(
+        !would_vote(Some(&reloaded), NodeHeight(voted_height.as_u64() - 1)),
+        "must not vote at a lower height after restart"
+    );
+    // Strictly higher height — must be allowed.
+    assert!(
+        would_vote(Some(&reloaded), NodeHeight(voted_height.as_u64() + 1)),
+        "voting at a higher height after restart is correct"
+    );
+}
+
+/// When no `LastVoted` record exists (e.g. first vote in an epoch, or fresh state store), the
+/// safety predicate has nothing to gate against and must allow the vote. Documents the "no prior
+/// vote" branch of `should_vote`.
+#[test]
+fn safety_predicate_allows_first_vote_when_no_record_exists() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let store: TestStore = RocksDbStateStore::open(temp_dir.path(), DatabaseOptions::default()).unwrap();
+
+    // No LastVoted written. Reading should return NotFound, not a phantom record.
+    let result = store.with_read_tx(|tx| LastVoted::get(tx, TEST_EPOCH));
+    assert!(result.is_err(), "no LastVoted record should exist on a fresh store");
+
+    // With no record, the safety predicate must permit a vote at any height.
+    assert!(would_vote(None, NodeHeight(0)));
+    assert!(would_vote(None, NodeHeight(1_000_000)));
+}

--- a/crates/consensus_tests/src/lib.rs
+++ b/crates/consensus_tests/src/lib.rs
@@ -9,7 +9,13 @@ mod epoch_change;
 #[cfg(test)]
 mod eviction_proof;
 #[cfg(test)]
+mod last_voted_persistence;
+#[cfg(test)]
 mod leader_failure;
+#[cfg(test)]
+mod safe_node_predicate;
+#[cfg(test)]
+mod stale_qc_carry_forward;
 #[cfg(test)]
 mod state_tree;
 #[cfg(test)]

--- a/crates/consensus_tests/src/safe_node_predicate.rs
+++ b/crates/consensus_tests/src/safe_node_predicate.rs
@@ -1,0 +1,188 @@
+//   Copyright 2026 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+//! Edge-case tests for the safeNode predicate.
+//!
+//! These are non-malicious scenarios that a correct HotStuff implementation must handle. The
+//! safeNode predicate is defined in `Block::is_safe`
+//! (`crates/storage/src/consensus_models/block.rs`) and gates whether a proposed block is allowed
+//! to be voted on. Two rules apply:
+//!
+//! - Safety: the candidate extends the currently locked block.
+//! - Liveness: the candidate's `max_certificate_height` (max of justify and TC height) exceeds the locked block's
+//!   height.
+//!
+//! Either rule independently makes the candidate safe. The tests below construct minimal real
+//! chains in a tempdir-backed state store and exercise both rules and the unsafe corner.
+
+use std::collections::BTreeSet;
+
+use tari_common_types::types::FixedHash;
+use tari_consensus::traits::CertificateStore;
+use tari_consensus_types::{BlockId, LeafBlock, ProposalCertificate, ShardGroupAccumulatedData};
+use tari_crypto::tari_utilities::epoch_time::EpochTime;
+use tari_ootle_common_types::{Epoch, ExtraData, NodeHeight, NumPreshards, ShardGroup};
+use tari_ootle_p2p::PeerAddress;
+use tari_ootle_storage::{
+    StateStore,
+    StorageError,
+    consensus_models::{Block, BlockHeader, BookkeepingModel},
+};
+use tari_ootle_transaction::Network;
+use tari_sidechain::QuorumDecision;
+use tari_state_store_rocksdb::{DatabaseOptions, RocksDbStateStore};
+use tari_template_lib_types::crypto::RistrettoPublicKeyBytes;
+use tempfile::TempDir;
+
+type TestStore = RocksDbStateStore<PeerAddress>;
+
+const NUM_PRESHARDS: NumPreshards = NumPreshards::P256;
+const NETWORK: Network = Network::LocalNet;
+const TEST_EPOCH: Epoch = Epoch(0);
+
+fn create_store() -> (TestStore, TempDir) {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let store = RocksDbStateStore::open(temp_dir.path(), DatabaseOptions::default()).unwrap();
+    store
+        .with_write_tx(|tx| {
+            let zero = Block::zero_block(NETWORK, NUM_PRESHARDS);
+            zero.justify().save(tx)?;
+            zero.insert(tx)
+        })
+        .unwrap();
+    (store, temp_dir)
+}
+
+fn qc_of(target: &LeafBlock) -> ProposalCertificate {
+    ProposalCertificate::new(
+        *target.block_id().hash(),
+        *target.block_id(),
+        target.height(),
+        target.epoch(),
+        ShardGroup::all_shards(NUM_PRESHARDS),
+        vec![],
+        QuorumDecision::Accept,
+    )
+}
+
+/// Build a real block extending `parent_id` at `height` with `justify`. `marker` is mixed into
+/// the state Merkle root so two siblings at the same height produce distinct block ids.
+fn build_block(parent_id: BlockId, justify: ProposalCertificate, height: NodeHeight, marker: u8) -> Block {
+    let mut state_root = [0u8; FixedHash::byte_size()];
+    state_root[0] = marker;
+    state_root[1] = height.as_u64() as u8;
+    let header = BlockHeader::create_unsigned(
+        NETWORK,
+        parent_id,
+        justify.calculate_id(),
+        height,
+        TEST_EPOCH,
+        ShardGroup::all_shards(NUM_PRESHARDS),
+        RistrettoPublicKeyBytes::default(),
+        FixedHash::new(state_root),
+        &BTreeSet::new(),
+        0,
+        EpochTime::now().as_u64(),
+        FixedHash::zero(),
+        ShardGroupAccumulatedData::default(),
+        ExtraData::new(),
+    )
+    .unwrap();
+    Block::new(header, justify, BTreeSet::new(), None)
+}
+
+/// Safety rule: a candidate that extends the locked block is safe even when its justify is at
+/// the locked block's height (i.e. no liveness signal).
+#[test]
+fn safe_when_candidate_extends_locked_at_equal_height() {
+    let (store, _tmp) = create_store();
+    let zero = Block::zero_block(NETWORK, NUM_PRESHARDS);
+
+    let locked = build_block(*zero.id(), zero.justify().clone(), NodeHeight(1), 1);
+    let qc_locked = qc_of(&locked.as_leaf());
+
+    // Candidate extends `locked` directly; its justify is qc(locked) (same height as locked).
+    let candidate = build_block(*locked.id(), qc_locked.clone(), NodeHeight(2), 1);
+
+    store
+        .with_write_tx(|tx| {
+            locked.insert(tx)?;
+            qc_locked.save(tx)?;
+            locked.as_locked().set(tx)?;
+            Ok::<_, StorageError>(())
+        })
+        .unwrap();
+
+    let is_safe = store.with_read_tx(|tx| candidate.is_safe(tx)).unwrap();
+    assert!(
+        is_safe,
+        "candidate that extends the locked block must be safe (safety rule)"
+    );
+}
+
+/// Liveness rule: a candidate whose justify height is strictly greater than the locked block's
+/// height is safe even if its parent chain forks off the locked block. The liveness rule is a
+/// signal that consensus has moved past the locked block and we must keep up.
+#[test]
+fn safe_when_justify_height_exceeds_locked_even_on_sibling_chain() {
+    let (store, _tmp) = create_store();
+    let zero = Block::zero_block(NETWORK, NUM_PRESHARDS);
+
+    // chain A: zero -> a1 (locked)
+    let locked = build_block(*zero.id(), zero.justify().clone(), NodeHeight(1), 1);
+
+    // chain B: zero -> b1 -> b2, then candidate c at height 3 with justify(b2). b1/b2 are
+    // siblings of `locked`, so the candidate does NOT extend `locked`. But justify(b2).height
+    // = 2 > 1 = locked.height, so the liveness rule applies.
+    let b1 = build_block(*zero.id(), zero.justify().clone(), NodeHeight(1), 2);
+    let b2 = build_block(*b1.id(), qc_of(&b1.as_leaf()), NodeHeight(2), 2);
+    let candidate = build_block(*b2.id(), qc_of(&b2.as_leaf()), NodeHeight(3), 2);
+
+    store
+        .with_write_tx(|tx| {
+            locked.insert(tx)?;
+            b1.insert(tx)?;
+            b2.insert(tx)?;
+            qc_of(&b1.as_leaf()).save(tx)?;
+            qc_of(&b2.as_leaf()).save(tx)?;
+            locked.as_locked().set(tx)?;
+            Ok::<_, StorageError>(())
+        })
+        .unwrap();
+
+    let is_safe = store.with_read_tx(|tx| candidate.is_safe(tx)).unwrap();
+    assert!(
+        is_safe,
+        "candidate with justify height > locked must be safe (liveness rule), even when forked"
+    );
+}
+
+/// Unsafe: candidate forks off the locked block AND its `max_certificate_height` does not exceed
+/// locked.height. Neither rule applies, so the predicate must reject.
+#[test]
+fn unsafe_when_neither_rule_applies() {
+    let (store, _tmp) = create_store();
+    let zero = Block::zero_block(NETWORK, NUM_PRESHARDS);
+
+    // zero -> locked (height 1). Sibling chain: zero -> sibling (height 1). Candidate at height
+    // 2 extends `sibling`, justify(sibling) has height 1 (NOT > locked.height).
+    let locked = build_block(*zero.id(), zero.justify().clone(), NodeHeight(1), 1);
+    let sibling = build_block(*zero.id(), zero.justify().clone(), NodeHeight(1), 2);
+    let candidate = build_block(*sibling.id(), qc_of(&sibling.as_leaf()), NodeHeight(2), 2);
+
+    store
+        .with_write_tx(|tx| {
+            locked.insert(tx)?;
+            sibling.insert(tx)?;
+            qc_of(&sibling.as_leaf()).save(tx)?;
+            locked.as_locked().set(tx)?;
+            Ok::<_, StorageError>(())
+        })
+        .unwrap();
+
+    let is_safe = store.with_read_tx(|tx| candidate.is_safe(tx)).unwrap();
+    assert!(
+        !is_safe,
+        "candidate that forks off locked and has no liveness signal must be unsafe"
+    );
+}

--- a/crates/consensus_tests/src/stale_qc_carry_forward.rs
+++ b/crates/consensus_tests/src/stale_qc_carry_forward.rs
@@ -1,0 +1,104 @@
+//   Copyright 2026 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+//! Edge-case test: stale-QC carry-forward after a vote-loss round.
+//!
+//! Non-malicious scenario that a correct HotStuff implementation must recover from. Votes for an
+//! early block at height H are dropped by the network — quorum can never form for that block, the
+//! pacemaker eventually fires a TC, and the next leader proposes at H+1 carrying the *older*
+//! HighQC (one that does not justify H) together with the TC. This exercises the same code paths
+//! the live-network stall surfaced (proposer's `accumulated_data` and state-anchor initialization
+//! when filling a timeout gap with dummies), but reaches them via realistic message-timing
+//! conditions rather than copied state. Once the filter has done its job, votes flow normally and
+//! consensus must finalise the pending transactions.
+
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::Duration,
+};
+
+use tari_consensus::messages::HotstuffMessage;
+use tari_consensus_types::Decision;
+use tari_ootle_common_types::{Epoch, NodeHeight};
+
+use crate::support::{Test, TestVnDestination, logging::setup_logger};
+
+/// All votes for the first real block are dropped. With f=1 in a 4-node committee, that means no
+/// QC can form for height 1. The pacemaker fires a TC, the next leader proposes at height 2 with
+/// HighQC still pointing at genesis plus the TC for height 1 — i.e. a stale-QC carry-forward.
+/// After the round, the filter stops triggering and consensus must converge and finalise the
+/// pending transaction.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn first_round_votes_dropped_recovers_via_stale_qc_carry_forward() {
+    setup_logger();
+
+    let votes_dropped = Arc::new(AtomicUsize::new(0));
+    let counter = votes_dropped.clone();
+    let target_height = NodeHeight(1);
+
+    let mut test = Test::builder()
+        .with_test_timeout(Duration::from_secs(90))
+        .modify_consensus_constants(|c| {
+            // Tight pacemaker so the TC fires quickly inside the test budget.
+            c.pacemaker_block_time = Duration::from_secs(3);
+            // Don't let one missed proposal trigger eviction — the whole point is to recover.
+            c.missed_proposal_suspend_threshold = 10;
+            c.missed_proposal_evict_threshold = 10;
+        })
+        .with_message_filter(Box::new(move |_from, _to, msg| {
+            // Return false to drop. Drop every Vote message whose vote height is the target.
+            if let HotstuffMessage::Vote(v) = msg &&
+                v.vote.block_height == target_height
+            {
+                counter.fetch_add(1, Ordering::SeqCst);
+                return false;
+            }
+            true
+        }))
+        .add_committee(0, vec!["1", "2", "3", "4"])
+        .start()
+        .await;
+
+    let (tx, _, _) = test.send_transaction_to_all(Decision::Commit, 1, 2, 1).await;
+    let tx_id = *tx.id();
+
+    test.start_epoch(Epoch(1)).await;
+
+    // Drive the test loop until either the transaction is finalised everywhere or we've waited
+    // too many blocks. We deliberately observe block commits past height 1 (the dropped round)
+    // to assert that consensus actually moved forward.
+    let mut saw_past_target = false;
+    loop {
+        let (_, _, _, committed_height) = test.on_block_committed().await;
+        if committed_height > target_height {
+            saw_past_target = true;
+        }
+        if test.validators_iter().all(|v| v.has_committed_substates(&tx_id)) {
+            break;
+        }
+        if committed_height > NodeHeight(50) {
+            panic!(
+                "transaction {tx_id} not finalised after {} blocks (votes dropped at height {target_height}: {})",
+                committed_height,
+                votes_dropped.load(Ordering::SeqCst)
+            );
+        }
+    }
+
+    assert!(
+        votes_dropped.load(Ordering::SeqCst) > 0,
+        "test premise: at least one vote at height {target_height} must have been dropped"
+    );
+    assert!(
+        saw_past_target,
+        "consensus must advance past the dropped-vote height for the recovery path to be exercised"
+    );
+
+    // Sanity: pool drains everywhere.
+    test.wait_for_pool_count(TestVnDestination::All, 0).await;
+    test.stop();
+    test.assert_clean_shutdown().await;
+}


### PR DESCRIPTION
## Description

Fix a consensus stall where every validator rejects the leader's proposal with
`Exhaust burn disagreement. Leader proposed N, we calculated M` after a
leader-timeout recovery, making consensus unable to advance.

## Motivation

After a leader-timeout the proposer fills the gap between the high QC and the
new candidate height with a chain of dummy blocks. Those dummies are
reconstructed from `justify_block` and carry `justify_block`'s
`accumulated_data` forward — the last dummy becomes the parent of the
candidate. Validators therefore recompute `accumulated_data` starting from
`justify_block`.

The proposer, however, was seeding the candidate's `accumulated_data` from
`highest_seen_block`. When `highest_seen_block` had drifted above the high QC
on an abandoned fork (e.g. speculative blocks with leader fees that were stored
locally but never finalised), `highest_seen.accumulated_data !=
justify.accumulated_data`. The resulting candidate header disagreed with every
validator's independent recomputation, so no proposal could ever collect a
quorum and consensus stalled permanently.

This was observed on the live testnet after the template-sync state recovery:
the cluster reached `Running` but immediately re-stalled with this
exhaust-burn disagreement on every proposal.

## Changes

- `crates/consensus/src/hotstuff/on_propose.rs`: when `dummy_block.is_some()`,
  initialise the candidate's `accumulated_data` from `justify_block` instead of
  `highest_seen_block`. This matches what validators compute and is semantically
  correct — speculative fees on the discarded fork are dropped along with the
  fork.
- `crates/consensus_tests/src/dummy_blocks.rs`: add regression test
  `proposer_accumulated_data_must_come_from_justify_on_timeout_recovery` that
  constructs a justify block with a known `total_exhaust_burn`, a speculative
  leaf with a higher (diverging) value, builds a dummy chain from the justify,
  and asserts that the candidate's accumulated_data matches the justify, not the
  speculative leaf.

## Test plan

- [ ] `cargo test -p consensus_tests dummy_blocks` — all 4 tests pass
- [ ] Manual: redeploy patched binary on the stalled testnet cluster and confirm
  consensus advances past the stuck epoch boundary where the exhaust-burn
  disagreement was logged