### PR TITLE
fix(state-sync): anchor at probed epoch, not oracle's current epoch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1707,7 +1707,7 @@ dependencies = [
 
 [[package]]
 name = "consensus_tests"
-version = "0.30.10"
+version = "0.30.11"
 dependencies = [
  "fern",
  "futures 0.3.31",
@@ -2711,7 +2711,7 @@ dependencies = [
 
 [[package]]
 name = "db-inspector"
-version = "0.30.10"
+version = "0.30.11"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -5101,7 +5101,7 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "integration_tests"
-version = "0.30.10"
+version = "0.30.11"
 dependencies = [
  "anyhow",
  "config",
@@ -5883,7 +5883,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-messaging"
-version = "0.30.10"
+version = "0.30.11"
 dependencies = [
  "async-trait",
  "futures-bounded 0.2.4",
@@ -6061,7 +6061,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-substream"
-version = "0.30.10"
+version = "0.30.11"
 dependencies = [
  "libp2p",
  "prometheus-client",
@@ -7646,7 +7646,7 @@ dependencies = [
 
 [[package]]
 name = "ootle-wasm"
-version = "0.30.10"
+version = "0.30.11"
 dependencies = [
  "console_error_panic_hook",
  "getrandom 0.2.17",
@@ -7656,7 +7656,7 @@ dependencies = [
 
 [[package]]
 name = "ootle-wasm-core"
-version = "0.30.10"
+version = "0.30.11"
 dependencies = [
  "base64 0.22.1",
  "ootle_byte_type",
@@ -8661,7 +8661,7 @@ dependencies = [
 
 [[package]]
 name = "proto_builder"
-version = "0.30.10"
+version = "0.30.11"
 dependencies = [
  "prost-build 0.14.3",
  "sha2 0.10.9",
@@ -10539,7 +10539,7 @@ dependencies = [
 
 [[package]]
 name = "sqlite_message_logger"
-version = "0.30.10"
+version = "0.30.11"
 dependencies = [
  "chrono",
  "diesel",
@@ -10911,7 +10911,7 @@ dependencies = [
 
 [[package]]
 name = "tari_base_node_client"
-version = "0.30.10"
+version = "0.30.11"
 dependencies = [
  "futures-util",
  "log",
@@ -11138,7 +11138,7 @@ dependencies = [
 
 [[package]]
 name = "tari_consensus"
-version = "0.30.10"
+version = "0.30.11"
 dependencies = [
  "anyhow",
  "indexmap 2.13.0",
@@ -11163,7 +11163,7 @@ dependencies = [
 
 [[package]]
 name = "tari_consensus_types"
-version = "0.30.10"
+version = "0.30.11"
 dependencies = [
  "borsh",
  "ootle_serde",
@@ -11263,7 +11263,7 @@ dependencies = [
 
 [[package]]
 name = "tari_engine"
-version = "0.30.10"
+version = "0.30.11"
 dependencies = [
  "blake2 0.10.6",
  "bytes",
@@ -11294,7 +11294,7 @@ dependencies = [
 
 [[package]]
 name = "tari_engine_types"
-version = "0.30.10"
+version = "0.30.11"
 dependencies = [
  "bincode 2.0.1",
  "blake2 0.10.6",
@@ -11323,7 +11323,7 @@ dependencies = [
 
 [[package]]
 name = "tari_epoch_manager"
-version = "0.30.10"
+version = "0.30.11"
 dependencies = [
  "anyhow",
  "log",
@@ -11343,7 +11343,7 @@ dependencies = [
 
 [[package]]
 name = "tari_epoch_oracles"
-version = "0.30.10"
+version = "0.30.11"
 dependencies = [
  "anyhow",
  "blake2 0.10.6",
@@ -11397,7 +11397,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer"
-version = "0.30.10"
+version = "0.30.11"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -11499,7 +11499,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer_lib"
-version = "0.30.10"
+version = "0.30.11"
 dependencies = [
  "log",
  "prometheus-client",
@@ -11603,7 +11603,7 @@ dependencies = [
 
 [[package]]
 name = "tari_networking"
-version = "0.30.10"
+version = "0.30.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11656,7 +11656,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_app_utilities"
-version = "0.30.10"
+version = "0.30.11"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -11696,7 +11696,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_common_types"
-version = "0.30.10"
+version = "0.30.11"
 dependencies = [
  "blake2 0.10.6",
  "borsh",
@@ -11724,7 +11724,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_p2p"
-version = "0.30.10"
+version = "0.30.11"
 dependencies = [
  "anyhow",
  "libp2p-identity 0.2.13 (git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a)",
@@ -11748,7 +11748,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_storage"
-version = "0.30.10"
+version = "0.30.11"
 dependencies = [
  "anyhow",
  "bitflags 2.10.0",
@@ -11775,7 +11775,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_storage_sqlite"
-version = "0.30.10"
+version = "0.30.11"
 dependencies = [
  "diesel",
  "diesel_migrations",
@@ -11826,7 +11826,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_transaction"
-version = "0.30.10"
+version = "0.30.11"
 dependencies = [
  "bincode 2.0.1",
  "borsh",
@@ -11852,7 +11852,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_cli"
-version = "0.30.10"
+version = "0.30.11"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -11881,7 +11881,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_crypto"
-version = "0.30.10"
+version = "0.30.11"
 dependencies = [
  "argon2 0.5.3",
  "blake2 0.10.6",
@@ -11911,7 +11911,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_sdk"
-version = "0.30.10"
+version = "0.30.11"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -11973,7 +11973,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_sdk_tests"
-version = "0.30.10"
+version = "0.30.11"
 dependencies = [
  "digest 0.10.7",
  "ootle_byte_type",
@@ -11995,7 +11995,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_storage_sqlite"
-version = "0.30.10"
+version = "0.30.11"
 dependencies = [
  "diesel",
  "diesel_migrations",
@@ -12018,7 +12018,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_walletd"
-version = "0.30.10"
+version = "0.30.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12136,7 +12136,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_framework"
-version = "0.30.10"
+version = "0.30.11"
 dependencies = [
  "async-trait",
  "bitflags 2.10.0",
@@ -12160,7 +12160,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_macros"
-version = "0.30.10"
+version = "0.30.11"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12169,7 +12169,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_state_sync"
-version = "0.30.10"
+version = "0.30.11"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -12247,7 +12247,7 @@ dependencies = [
 
 [[package]]
 name = "tari_state_store_rocksdb"
-version = "0.30.10"
+version = "0.30.11"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -12279,7 +12279,7 @@ dependencies = [
 
 [[package]]
 name = "tari_state_tree"
-version = "0.30.10"
+version = "0.30.11"
 dependencies = [
  "indexmap 2.13.0",
  "log",
@@ -12305,7 +12305,7 @@ dependencies = [
 
 [[package]]
 name = "tari_swarm"
-version = "0.30.10"
+version = "0.30.11"
 dependencies = [
  "libp2p",
  "libp2p-messaging",
@@ -12316,7 +12316,7 @@ dependencies = [
 
 [[package]]
 name = "tari_swarm_daemon"
-version = "0.30.10"
+version = "0.30.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12427,7 +12427,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_test_tooling"
-version = "0.30.10"
+version = "0.30.11"
 dependencies = [
  "anyhow",
  "cargo_toml 0.22.3",
@@ -12540,7 +12540,7 @@ dependencies = [
 
 [[package]]
 name = "tari_transaction_manifest"
-version = "0.30.10"
+version = "0.30.11"
 dependencies = [
  "proc-macro2",
  "serde_json",
@@ -12575,7 +12575,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node"
-version = "0.30.10"
+version = "0.30.11"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -12641,7 +12641,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node_client"
-version = "0.30.10"
+version = "0.30.11"
 dependencies = [
  "indexmap 2.13.0",
  "multiaddr 0.18.3",
@@ -12665,7 +12665,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node_rpc"
-version = "0.30.10"
+version = "0.30.11"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -12688,7 +12688,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_rollback"
-version = "0.30.10"
+version = "0.30.11"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12723,7 +12723,7 @@ dependencies = [
 
 [[package]]
 name = "tari_watcher"
-version = "0.30.10"
+version = "0.30.11"
 dependencies = [
  "anyhow",
  "clap 3.2.25",
@@ -12752,7 +12752,7 @@ dependencies = [
 
 [[package]]
 name = "tariswap_bench"
-version = "0.30.10"
+version = "0.30.11"
 dependencies = [
  "anyhow",
  "clap 4.5.54",
@@ -13432,7 +13432,7 @@ dependencies = [
 
 [[package]]
 name = "traffic-sim"
-version = "0.30.10"
+version = "0.30.11"
 dependencies = [
  "anyhow",
  "clap 4.5.54",
@@ -13454,7 +13454,7 @@ dependencies = [
 
 [[package]]
 name = "transaction_generator"
-version = "0.30.10"
+version = "0.30.11"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -13473,7 +13473,7 @@ dependencies = [
 
 [[package]]
 name = "transaction_submitter"
-version = "0.30.10"
+version = "0.30.11"
 dependencies = [
  "anyhow",
  "clap 4.5.54",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.30.10"
+version = "0.30.11"
 edition = "2024"
 authors = ["The Tari Development Community"]
 repository = "https://github.com/tari-project/tari-ootle"

--- a/crates/consensus/src/hotstuff/state_machine/check_sync.rs
+++ b/crates/consensus/src/hotstuff/state_machine/check_sync.rs
@@ -39,7 +39,7 @@ where
         loop {
             match context.state_sync.check_sync().await? {
                 SyncStatus::UpToDate => return Ok(ConsensusStateEvent::Ready),
-                SyncStatus::Behind => return Ok(ConsensusStateEvent::NeedSync),
+                SyncStatus::Behind { target_epoch } => return Ok(ConsensusStateEvent::NeedSync { target_epoch }),
                 SyncStatus::Inconclusive => {
                     warn!(
                         target: LOG_TARGET,

--- a/crates/consensus/src/hotstuff/state_machine/event.rs
+++ b/crates/consensus/src/hotstuff/state_machine/event.rs
@@ -9,12 +9,23 @@ use crate::hotstuff::HotStuffError;
 
 #[derive(Debug)]
 pub enum ConsensusStateEvent {
-    RegisteredForEpoch { epoch: Epoch },
-    NotRegisteredForEpoch { epoch: Epoch },
-    NeedSync,
+    RegisteredForEpoch {
+        epoch: Epoch,
+    },
+    NotRegisteredForEpoch {
+        epoch: Epoch,
+    },
+    /// We are behind peers and need to state-sync. `target_epoch` is the epoch the caller proved
+    /// to be the highest finalised one (e.g. via stall-recovery probe). `None` means fall back to
+    /// the oracle's current epoch.
+    NeedSync {
+        target_epoch: Option<Epoch>,
+    },
     SyncComplete,
     Ready,
-    Failure { error: HotStuffError },
+    Failure {
+        error: HotStuffError,
+    },
     Resume,
     Shutdown,
 }
@@ -26,7 +37,10 @@ impl Display for ConsensusStateEvent {
         match self {
             RegisteredForEpoch { epoch } => write!(f, "Registered for epoch {}", epoch),
             NotRegisteredForEpoch { epoch } => write!(f, "Not registered for epoch {}", epoch),
-            NeedSync => write!(f, "Behind peers"),
+            NeedSync {
+                target_epoch: Some(epoch),
+            } => write!(f, "Behind peers (target epoch {})", epoch),
+            NeedSync { target_epoch: None } => write!(f, "Behind peers"),
             SyncComplete => write!(f, "Sync complete"),
             Ready => write!(f, "Ready"),
             Failure { error } => write!(f, "Failure({error})"),

--- a/crates/consensus/src/hotstuff/state_machine/running.rs
+++ b/crates/consensus/src/hotstuff/state_machine/running.rs
@@ -45,7 +45,9 @@ where TSpec: ConsensusSpec
             Err(err @ HotStuffError::FallenBehind { .. }) |
             Err(err @ HotStuffError::ProposalValidationError(ProposalValidationError::FutureEpoch { .. })) => {
                 info!(target: LOG_TARGET, "⚠️ Behind peers, starting sync ({err})");
-                Ok(ConsensusStateEvent::NeedSync)
+                // From the Running state we have no specific target — re-enter CheckSync to
+                // resolve one via the probe/oracle.
+                Ok(ConsensusStateEvent::NeedSync { target_epoch: None })
             },
             Err(err) => {
                 error!(target: LOG_TARGET, "HotStuff crashed: {}", err);

--- a/crates/consensus/src/hotstuff/state_machine/syncing.rs
+++ b/crates/consensus/src/hotstuff/state_machine/syncing.rs
@@ -3,34 +3,39 @@
 
 use std::marker::PhantomData;
 
+use tari_ootle_common_types::Epoch;
+
 use crate::{
-    hotstuff::{
-        ConsensusWorkerContext,
-        HotStuffError,
-        state_machine::{check_sync::CheckSync, event::ConsensusStateEvent},
-    },
+    hotstuff::{ConsensusWorkerContext, HotStuffError, state_machine::event::ConsensusStateEvent},
     traits::{ConsensusSpec, SyncManager},
 };
 
 #[derive(Debug)]
-pub struct Syncing<TSpec>(PhantomData<TSpec>);
+pub struct Syncing<TSpec> {
+    /// The epoch the caller proved is the highest finalised one — populated by the `NeedSync`
+    /// event that triggered the transition into this state. `None` means use the default sync
+    /// target (oracle's current epoch).
+    target_epoch: Option<Epoch>,
+    _spec: PhantomData<TSpec>,
+}
 
 impl<TSpec> Syncing<TSpec>
 where
     TSpec: ConsensusSpec,
     HotStuffError: From<<TSpec::SyncManager as SyncManager>::Error>,
 {
+    pub(super) fn new(target_epoch: Option<Epoch>) -> Self {
+        Self {
+            target_epoch,
+            _spec: PhantomData,
+        }
+    }
+
     pub(super) async fn on_enter(
         &self,
         context: &mut ConsensusWorkerContext<TSpec>,
     ) -> Result<ConsensusStateEvent, HotStuffError> {
-        context.state_sync.sync().await?;
+        context.state_sync.sync(self.target_epoch).await?;
         Ok(ConsensusStateEvent::SyncComplete)
-    }
-}
-
-impl<TSpec> From<CheckSync<TSpec>> for Syncing<TSpec> {
-    fn from(_: CheckSync<TSpec>) -> Self {
-        Self(PhantomData)
     }
 }

--- a/crates/consensus/src/hotstuff/state_machine/worker.rs
+++ b/crates/consensus/src/hotstuff/state_machine/worker.rs
@@ -15,6 +15,7 @@ use crate::{
             event::ConsensusStateEvent,
             idle::Idle,
             state::{ConsensusCurrentState, ConsensusState},
+            syncing::Syncing,
         },
     },
     traits::{ConsensusSpec, SyncManager},
@@ -87,13 +88,17 @@ where
             (ConsensusState::Idle(state), ConsensusStateEvent::RegisteredForEpoch { .. }) => {
                 ConsensusState::CheckSync(state.into())
             },
-            (ConsensusState::CheckSync(state), ConsensusStateEvent::NeedSync) => ConsensusState::Syncing(state.into()),
+            (ConsensusState::CheckSync(_), ConsensusStateEvent::NeedSync { target_epoch }) => {
+                ConsensusState::Syncing(Syncing::new(target_epoch))
+            },
             (ConsensusState::CheckSync(state), ConsensusStateEvent::Ready) => ConsensusState::Running(state.into()),
             (ConsensusState::Syncing(state), ConsensusStateEvent::SyncComplete) => {
                 ConsensusState::Running(state.into())
             },
             (ConsensusState::Sleeping, ConsensusStateEvent::Resume) => ConsensusState::Idle(Idle::new()),
-            (ConsensusState::Running(state), ConsensusStateEvent::NeedSync) => ConsensusState::CheckSync(state.into()),
+            (ConsensusState::Running(state), ConsensusStateEvent::NeedSync { .. }) => {
+                ConsensusState::CheckSync(state.into())
+            },
             (ConsensusState::Running(state), ConsensusStateEvent::NotRegisteredForEpoch { .. }) => {
                 ConsensusState::Idle(state.into())
             },

--- a/crates/consensus/src/traits/sync.rs
+++ b/crates/consensus/src/traits/sync.rs
@@ -6,7 +6,10 @@ use std::future::Future;
 pub trait SyncManager {
     type Error: std::error::Error + Send + Sync + 'static;
 
-    fn check_sync(&self) -> impl Future<Output = Result<SyncStatus, Self::Error>> + Send;
+    /// Determine whether state sync is required. Takes `&mut self` so the implementation may
+    /// record information for the subsequent [`SyncManager::sync`] call — for example, the
+    /// target epoch resolved by a stall-recovery probe.
+    fn check_sync(&mut self) -> impl Future<Output = Result<SyncStatus, Self::Error>> + Send;
 
     fn sync(&mut self) -> impl Future<Output = Result<(), Self::Error>> + Send;
 }

--- a/crates/consensus/src/traits/sync.rs
+++ b/crates/consensus/src/traits/sync.rs
@@ -3,21 +3,29 @@
 
 use std::future::Future;
 
+use tari_ootle_common_types::Epoch;
+
 pub trait SyncManager {
     type Error: std::error::Error + Send + Sync + 'static;
 
-    /// Determine whether state sync is required. Takes `&mut self` so the implementation may
-    /// record information for the subsequent [`SyncManager::sync`] call — for example, the
-    /// target epoch resolved by a stall-recovery probe.
-    fn check_sync(&mut self) -> impl Future<Output = Result<SyncStatus, Self::Error>> + Send;
+    fn check_sync(&self) -> impl Future<Output = Result<SyncStatus, Self::Error>> + Send;
 
-    fn sync(&mut self) -> impl Future<Output = Result<(), Self::Error>> + Send;
+    /// Synchronise state. `target_epoch` is the epoch the caller has resolved to be the highest
+    /// finalised epoch the network has reached (e.g. via a stall-recovery probe). `None` means
+    /// "use your usual fallback" — typically the oracle's current epoch.
+    fn sync(&mut self, target_epoch: Option<Epoch>) -> impl Future<Output = Result<(), Self::Error>> + Send;
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SyncStatus {
     UpToDate,
-    Behind,
+    /// State sync is required. `target_epoch` carries the epoch the caller proved to be the
+    /// highest finalised one (e.g. via a stall-recovery probe). `None` means the caller has no
+    /// specific target and the syncing implementation should fall back to its default — usually
+    /// the oracle's current epoch.
+    Behind {
+        target_epoch: Option<Epoch>,
+    },
     /// The sync manager could not determine whether we are behind or up to date — for example,
     /// not enough committee members responded to a recovery probe. The state machine should
     /// back off and retry [`SyncManager::check_sync`] without entering the syncing phase.

--- a/crates/consensus_tests/src/support/sync.rs
+++ b/crates/consensus_tests/src/support/sync.rs
@@ -5,6 +5,7 @@ use tari_consensus::{
     hotstuff::HotStuffError,
     traits::{SyncManager, SyncStatus},
 };
+use tari_engine_types::Epoch;
 
 #[derive(Clone)]
 pub struct AlwaysSyncedSyncManager;
@@ -16,7 +17,7 @@ impl SyncManager for AlwaysSyncedSyncManager {
         Ok(SyncStatus::UpToDate)
     }
 
-    async fn sync(&mut self) -> Result<(), Self::Error> {
+    async fn sync(&mut self, _target_epoch: Option<Epoch>) -> Result<(), Self::Error> {
         Ok(())
     }
 }

--- a/crates/rpc_state_sync/src/state_sync.rs
+++ b/crates/rpc_state_sync/src/state_sync.rs
@@ -609,8 +609,7 @@ where TConsensusSpec: ConsensusSpec<Addr = PeerAddress>
             Some(probed) => {
                 info!(
                     target: LOG_TARGET,
-                    "🛜 Sync target from caller: epoch {probed} (oracle current: {})",
-                    self.epoch_manager.current_epoch().await?,
+                    "🛜 Sync target from caller: epoch {probed}",
                 );
                 probed
             },

--- a/crates/rpc_state_sync/src/state_sync.rs
+++ b/crates/rpc_state_sync/src/state_sync.rs
@@ -66,6 +66,15 @@ pub struct RpcStateSyncClientProtocol<TConsensusSpec: ConsensusSpec> {
     valid_checkpoints: HashMap<ShardGroup, EpochCheckpoint>,
     stats: StateSyncStats,
     skip_sync: bool,
+    /// Epoch that the next `sync` call should anchor at, recorded by `check_sync` when the
+    /// stall-recovery probe sees a verified high QC at an epoch above our leaf but potentially
+    /// below the oracle's current epoch. Consumed (cleared) by `sync_inner`.
+    ///
+    /// The probed epoch is the one with a finalised checkpoint to fetch; the oracle's current
+    /// epoch may not yet have a checkpoint at all (it's just where the base layer thinks the
+    /// committee is) and anchoring sync there would reproduce the `CheckpointNotAvailable`
+    /// failure that motivated the probe in the first place.
+    next_sync_target_epoch: Option<Epoch>,
 }
 
 impl<TConsensusSpec> RpcStateSyncClientProtocol<TConsensusSpec>
@@ -85,6 +94,7 @@ where TConsensusSpec: ConsensusSpec<Addr = PeerAddress>
             valid_checkpoints: HashMap::new(),
             stats: StateSyncStats::default(),
             skip_sync: false,
+            next_sync_target_epoch: None,
         }
     }
 
@@ -603,7 +613,20 @@ where TConsensusSpec: ConsensusSpec<Addr = PeerAddress>
 
     async fn sync_inner(&mut self) -> Result<(), RpcStateSyncError> {
         let timer = Instant::now();
-        let current_epoch = self.epoch_manager.current_epoch().await?;
+        // If the stall-recovery probe recorded a target epoch in `check_sync`, anchor sync there
+        // (the highest epoch we've proven was finalised). Otherwise fall back to the oracle's
+        // current epoch — the standard "behind by an epoch boundary" path.
+        let current_epoch = match self.next_sync_target_epoch.take() {
+            Some(probed) => {
+                info!(
+                    target: LOG_TARGET,
+                    "🛜 Sync target from stall-recovery probe: epoch {probed} (oracle current: {})",
+                    self.epoch_manager.current_epoch().await?,
+                );
+                probed
+            },
+            None => self.epoch_manager.current_epoch().await?,
+        };
         let our_vn = self.epoch_manager.get_our_validator_node(current_epoch).await?;
         let local_info = self.epoch_manager.get_local_committee_info(current_epoch).await?;
         let prev_epoch_committees = match self.get_sync_committees(local_info.shard_group(), current_epoch).await {
@@ -820,7 +843,11 @@ where TConsensusSpec: ConsensusSpec<Addr = PeerAddress> + Send + Sync + 'static
 {
     type Error = RpcStateSyncError;
 
-    async fn check_sync(&self) -> Result<SyncStatus, Self::Error> {
+    async fn check_sync(&mut self) -> Result<SyncStatus, Self::Error> {
+        // Always discard any stale target recorded by a previous `check_sync`. The probed epoch
+        // is a point-in-time observation and must not survive across re-checks.
+        self.next_sync_target_epoch = None;
+
         if self.skip_sync {
             warn!(target: LOG_TARGET, "🛜 State sync is disabled (--skip-sync). Reporting as up to date without checking.");
             return Ok(SyncStatus::UpToDate);
@@ -894,6 +921,10 @@ where TConsensusSpec: ConsensusSpec<Addr = PeerAddress> + Send + Sync + 'static
                     "🛜 Peer presented verified high QC at epoch {} > our leaf {}; will state-sync.",
                     epoch, leaf.epoch(),
                 );
+                // Record the probed epoch so `sync_inner` anchors at it instead of the oracle's
+                // current epoch. The oracle may have rolled to an epoch with no checkpoint yet;
+                // the probed epoch is the most recent one we've proven was finalised.
+                self.next_sync_target_epoch = Some(epoch);
                 Ok(SyncStatus::Behind)
             },
             ProbeOutcome::QuorumAtLeaf { attested_power } => {

--- a/crates/rpc_state_sync/src/state_sync.rs
+++ b/crates/rpc_state_sync/src/state_sync.rs
@@ -66,15 +66,6 @@ pub struct RpcStateSyncClientProtocol<TConsensusSpec: ConsensusSpec> {
     valid_checkpoints: HashMap<ShardGroup, EpochCheckpoint>,
     stats: StateSyncStats,
     skip_sync: bool,
-    /// Epoch that the next `sync` call should anchor at, recorded by `check_sync` when the
-    /// stall-recovery probe sees a verified high QC at an epoch above our leaf but potentially
-    /// below the oracle's current epoch. Consumed (cleared) by `sync_inner`.
-    ///
-    /// The probed epoch is the one with a finalised checkpoint to fetch; the oracle's current
-    /// epoch may not yet have a checkpoint at all (it's just where the base layer thinks the
-    /// committee is) and anchoring sync there would reproduce the `CheckpointNotAvailable`
-    /// failure that motivated the probe in the first place.
-    next_sync_target_epoch: Option<Epoch>,
 }
 
 impl<TConsensusSpec> RpcStateSyncClientProtocol<TConsensusSpec>
@@ -94,7 +85,6 @@ where TConsensusSpec: ConsensusSpec<Addr = PeerAddress>
             valid_checkpoints: HashMap::new(),
             stats: StateSyncStats::default(),
             skip_sync: false,
-            next_sync_target_epoch: None,
         }
     }
 
@@ -611,16 +601,15 @@ where TConsensusSpec: ConsensusSpec<Addr = PeerAddress>
         })
     }
 
-    async fn sync_inner(&mut self) -> Result<(), RpcStateSyncError> {
+    async fn sync_inner(&mut self, target_epoch: Option<Epoch>) -> Result<(), RpcStateSyncError> {
         let timer = Instant::now();
-        // If the stall-recovery probe recorded a target epoch in `check_sync`, anchor sync there
-        // (the highest epoch we've proven was finalised). Otherwise fall back to the oracle's
-        // current epoch — the standard "behind by an epoch boundary" path.
-        let current_epoch = match self.next_sync_target_epoch.take() {
+        // Use the caller-provided target if any (typically the highest epoch resolved by a
+        // stall-recovery probe), otherwise fall back to the oracle's current epoch.
+        let current_epoch = match target_epoch {
             Some(probed) => {
                 info!(
                     target: LOG_TARGET,
-                    "🛜 Sync target from stall-recovery probe: epoch {probed} (oracle current: {})",
+                    "🛜 Sync target from caller: epoch {probed} (oracle current: {})",
                     self.epoch_manager.current_epoch().await?,
                 );
                 probed
@@ -713,6 +702,16 @@ where TConsensusSpec: ConsensusSpec<Addr = PeerAddress> + Send + Sync + 'static
 
         let mut counted_pks: HashSet<RistrettoPublicKeyBytes> = HashSet::new();
         let mut attested_power = VotePower::zero();
+
+        // Pre-credit our own attestation. We hold the leaf QC ourselves and by definition have no
+        // QC higher than our leaf's epoch — that's the question the probe is asking. Excluding
+        // ourselves makes the quorum unreachable on any committee where total power equals
+        // quorum threshold (e.g. 4 members with one zero-power node: total=3, threshold=3, and
+        // peer responses can never reach 3 without including us).
+        if let Some(self_member) = committee.iter().find(|m| &m.address == our_addr) {
+            counted_pks.insert(self_member.public_key);
+            attested_power += self_member.vote_power;
+        }
 
         // Iterate committee members in a randomised order so that under repeated probes we
         // sample broadly across the committee rather than always hitting the same f peers.
@@ -843,11 +842,7 @@ where TConsensusSpec: ConsensusSpec<Addr = PeerAddress> + Send + Sync + 'static
 {
     type Error = RpcStateSyncError;
 
-    async fn check_sync(&mut self) -> Result<SyncStatus, Self::Error> {
-        // Always discard any stale target recorded by a previous `check_sync`. The probed epoch
-        // is a point-in-time observation and must not survive across re-checks.
-        self.next_sync_target_epoch = None;
-
+    async fn check_sync(&self) -> Result<SyncStatus, Self::Error> {
         if self.skip_sync {
             warn!(target: LOG_TARGET, "🛜 State sync is disabled (--skip-sync). Reporting as up to date without checking.");
             return Ok(SyncStatus::UpToDate);
@@ -869,7 +864,8 @@ where TConsensusSpec: ConsensusSpec<Addr = PeerAddress> + Send + Sync + 'static
                 });
             };
             return Ok(if oracle_epoch > birthday_epoch {
-                SyncStatus::Behind
+                // Cold start: no leaf, no probe — fall back to the oracle's current epoch.
+                SyncStatus::Behind { target_epoch: None }
             } else {
                 SyncStatus::UpToDate
             });
@@ -894,7 +890,8 @@ where TConsensusSpec: ConsensusSpec<Addr = PeerAddress> + Send + Sync + 'static
                 leaf,
                 oracle_epoch,
             );
-            return Ok(SyncStatus::Behind);
+            // No probe was run on this path — fall back to the oracle's current epoch.
+            return Ok(SyncStatus::Behind { target_epoch: None });
         }
 
         // Stall-recovery probe: no checkpoint at our leaf's epoch and oracle has moved on. Ask
@@ -921,11 +918,13 @@ where TConsensusSpec: ConsensusSpec<Addr = PeerAddress> + Send + Sync + 'static
                     "🛜 Peer presented verified high QC at epoch {} > our leaf {}; will state-sync.",
                     epoch, leaf.epoch(),
                 );
-                // Record the probed epoch so `sync_inner` anchors at it instead of the oracle's
-                // current epoch. The oracle may have rolled to an epoch with no checkpoint yet;
-                // the probed epoch is the most recent one we've proven was finalised.
-                self.next_sync_target_epoch = Some(epoch);
-                Ok(SyncStatus::Behind)
+                // Anchor sync at the probed epoch — the most recent one we've proven was
+                // finalised. The oracle may have rolled past it to an epoch with no checkpoint
+                // yet; anchoring there would reproduce the `CheckpointNotAvailable` failure that
+                // motivated the probe in the first place.
+                Ok(SyncStatus::Behind {
+                    target_epoch: Some(epoch),
+                })
             },
             ProbeOutcome::QuorumAtLeaf { attested_power } => {
                 info!(
@@ -951,8 +950,8 @@ where TConsensusSpec: ConsensusSpec<Addr = PeerAddress> + Send + Sync + 'static
         }
     }
 
-    async fn sync(&mut self) -> Result<(), Self::Error> {
-        if let Err(err) = self.sync_inner().await {
+    async fn sync(&mut self, target_epoch: Option<Epoch>) -> Result<(), Self::Error> {
+        if let Err(err) = self.sync_inner(target_epoch).await {
             warn!(target: LOG_TARGET, "🛜State sync failed: {err} (stats: {})", self.stats);
             // Clear the valid checkpoints cache
             self.valid_checkpoints = HashMap::new();


### PR DESCRIPTION
## Description

Follow-up fixes to #2118 (consensus self-heal via highest-QC probe), which surfaces two bugs in the recovery path on a live cluster.

### Bug 1: Sync anchors at the oracle's current epoch, not the probed epoch

PR #2118 introduced stall-recovery in `check_sync`: when a node's leaf is behind the oracle's current epoch and no local checkpoint exists at the leaf's epoch, peers are probed for their high QCs. When a verified high QC is seen at a higher epoch B, `SyncStatus::Behind` is returned and state-sync runs.

`sync_inner` then anchored the sync at `self.epoch_manager.current_epoch()` — the oracle's view of the current epoch (call it C) — regardless of what the probe found (B). When B < C, C may not yet have a finalised checkpoint (the base layer just thinks the committee should be there), so the sync re-hits the exact `CheckpointNotAvailable` failure that motivated #2118. The probed epoch is the most recent one we've proven was finalised; it is the epoch whose checkpoint can actually be fetched.

### Bug 2: Probe never reaches quorum when total power equals quorum threshold

In `probe_high_qcs_at_leaf` we started `attested_power = 0` and excluded `our_addr` from the iteration. On any committee where total power equals quorum threshold — for example a 4-node committee with one suspended (zero-power) validator: total power = 3, `quorum_threshold = total - max_failures = 3 - 0 = 3` — the probe could never reach quorum even when every peer responded correctly. The state machine returned `Inconclusive` indefinitely and stayed in the backoff loop, surfacing as:

```
WARN  🛜 check_sync was inconclusive (peers did not reach quorum); retrying in 26s
```

We hold the leaf QC ourselves and by definition have no QC higher than our leaf — that's exactly the question the probe is asking — so our attestation counts toward the "no-higher-QC" quorum just like any other honest attester.

## Changes

### Sync target plumbed through the state-machine event

The first commit on this branch used a stash-on-the-manager approach; the second refactors it into the explicit shape:

- `SyncStatus::Behind { target_epoch: Option<Epoch> }`
- `ConsensusStateEvent::NeedSync { target_epoch: Option<Epoch> }`
- `Syncing` holds `target_epoch`, set via `Syncing::new(target)` in the worker transition matrix.
- `SyncManager::sync(&mut self, target_epoch: Option<Epoch>)`. `check_sync` stays `&self` — no per-instance state across calls.
- `sync_inner` uses the parameter when present, falls back to `oracle.current_epoch()` for the non-probe `Behind` paths (cold start, checkpoint-at-leaf).

### Probe self-attestation

In `probe_high_qcs_at_leaf`, pre-credit our own `vote_power` into `attested_power` before iterating peers. Comment in the diff explains the invariant.

## Test plan

- `cargo check -p tari_consensus -p tari_rpc_state_sync` — clean.
- Live cluster: nodes that were stuck in the `Inconclusive` backoff with VotePower(2) of VotePower(3) should now reach `QuorumAtLeaf` (attested_power becomes 1 + 2 = 3 ≥ 3) and transition to `UpToDate`, joining consensus at the existing leaf.
- For the rare case where a peer truly does hold a higher QC, sync now anchors at the probed epoch and successfully fetches its checkpoint.
