### PR TITLE
fix(p2p): always obey enable_relay config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1707,7 +1707,7 @@ dependencies = [
 
 [[package]]
 name = "consensus_tests"
-version = "0.30.11"
+version = "0.30.12"
 dependencies = [
  "fern",
  "futures 0.3.31",
@@ -2711,7 +2711,7 @@ dependencies = [
 
 [[package]]
 name = "db-inspector"
-version = "0.30.11"
+version = "0.30.12"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -5101,7 +5101,7 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "integration_tests"
-version = "0.30.11"
+version = "0.30.12"
 dependencies = [
  "anyhow",
  "config",
@@ -5883,7 +5883,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-messaging"
-version = "0.30.11"
+version = "0.30.12"
 dependencies = [
  "async-trait",
  "futures-bounded 0.2.4",
@@ -6061,7 +6061,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-substream"
-version = "0.30.11"
+version = "0.30.12"
 dependencies = [
  "libp2p",
  "prometheus-client",
@@ -7646,7 +7646,7 @@ dependencies = [
 
 [[package]]
 name = "ootle-wasm"
-version = "0.30.11"
+version = "0.30.12"
 dependencies = [
  "console_error_panic_hook",
  "getrandom 0.2.17",
@@ -7656,7 +7656,7 @@ dependencies = [
 
 [[package]]
 name = "ootle-wasm-core"
-version = "0.30.11"
+version = "0.30.12"
 dependencies = [
  "base64 0.22.1",
  "ootle_byte_type",
@@ -8661,7 +8661,7 @@ dependencies = [
 
 [[package]]
 name = "proto_builder"
-version = "0.30.11"
+version = "0.30.12"
 dependencies = [
  "prost-build 0.14.3",
  "sha2 0.10.9",
@@ -10539,7 +10539,7 @@ dependencies = [
 
 [[package]]
 name = "sqlite_message_logger"
-version = "0.30.11"
+version = "0.30.12"
 dependencies = [
  "chrono",
  "diesel",
@@ -10911,7 +10911,7 @@ dependencies = [
 
 [[package]]
 name = "tari_base_node_client"
-version = "0.30.11"
+version = "0.30.12"
 dependencies = [
  "futures-util",
  "log",
@@ -11138,7 +11138,7 @@ dependencies = [
 
 [[package]]
 name = "tari_consensus"
-version = "0.30.11"
+version = "0.30.12"
 dependencies = [
  "anyhow",
  "indexmap 2.13.0",
@@ -11163,7 +11163,7 @@ dependencies = [
 
 [[package]]
 name = "tari_consensus_types"
-version = "0.30.11"
+version = "0.30.12"
 dependencies = [
  "borsh",
  "ootle_serde",
@@ -11263,7 +11263,7 @@ dependencies = [
 
 [[package]]
 name = "tari_engine"
-version = "0.30.11"
+version = "0.30.12"
 dependencies = [
  "blake2 0.10.6",
  "bytes",
@@ -11294,7 +11294,7 @@ dependencies = [
 
 [[package]]
 name = "tari_engine_types"
-version = "0.30.11"
+version = "0.30.12"
 dependencies = [
  "bincode 2.0.1",
  "blake2 0.10.6",
@@ -11323,7 +11323,7 @@ dependencies = [
 
 [[package]]
 name = "tari_epoch_manager"
-version = "0.30.11"
+version = "0.30.12"
 dependencies = [
  "anyhow",
  "log",
@@ -11343,7 +11343,7 @@ dependencies = [
 
 [[package]]
 name = "tari_epoch_oracles"
-version = "0.30.11"
+version = "0.30.12"
 dependencies = [
  "anyhow",
  "blake2 0.10.6",
@@ -11397,7 +11397,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer"
-version = "0.30.11"
+version = "0.30.12"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -11499,7 +11499,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer_lib"
-version = "0.30.11"
+version = "0.30.12"
 dependencies = [
  "log",
  "prometheus-client",
@@ -11603,7 +11603,7 @@ dependencies = [
 
 [[package]]
 name = "tari_networking"
-version = "0.30.11"
+version = "0.30.12"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11656,7 +11656,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_app_utilities"
-version = "0.30.11"
+version = "0.30.12"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -11696,7 +11696,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_common_types"
-version = "0.30.11"
+version = "0.30.12"
 dependencies = [
  "blake2 0.10.6",
  "borsh",
@@ -11724,7 +11724,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_p2p"
-version = "0.30.11"
+version = "0.30.12"
 dependencies = [
  "anyhow",
  "libp2p-identity 0.2.13 (git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a)",
@@ -11748,7 +11748,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_storage"
-version = "0.30.11"
+version = "0.30.12"
 dependencies = [
  "anyhow",
  "bitflags 2.10.0",
@@ -11775,7 +11775,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_storage_sqlite"
-version = "0.30.11"
+version = "0.30.12"
 dependencies = [
  "diesel",
  "diesel_migrations",
@@ -11826,7 +11826,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_transaction"
-version = "0.30.11"
+version = "0.30.12"
 dependencies = [
  "bincode 2.0.1",
  "borsh",
@@ -11852,7 +11852,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_cli"
-version = "0.30.11"
+version = "0.30.12"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -11881,7 +11881,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_crypto"
-version = "0.30.11"
+version = "0.30.12"
 dependencies = [
  "argon2 0.5.3",
  "blake2 0.10.6",
@@ -11911,7 +11911,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_sdk"
-version = "0.30.11"
+version = "0.30.12"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -11973,7 +11973,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_sdk_tests"
-version = "0.30.11"
+version = "0.30.12"
 dependencies = [
  "digest 0.10.7",
  "ootle_byte_type",
@@ -11995,7 +11995,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_storage_sqlite"
-version = "0.30.11"
+version = "0.30.12"
 dependencies = [
  "diesel",
  "diesel_migrations",
@@ -12018,7 +12018,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_walletd"
-version = "0.30.11"
+version = "0.30.12"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12136,7 +12136,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_framework"
-version = "0.30.11"
+version = "0.30.12"
 dependencies = [
  "async-trait",
  "bitflags 2.10.0",
@@ -12160,7 +12160,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_macros"
-version = "0.30.11"
+version = "0.30.12"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12169,7 +12169,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_state_sync"
-version = "0.30.11"
+version = "0.30.12"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -12247,7 +12247,7 @@ dependencies = [
 
 [[package]]
 name = "tari_state_store_rocksdb"
-version = "0.30.11"
+version = "0.30.12"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -12279,7 +12279,7 @@ dependencies = [
 
 [[package]]
 name = "tari_state_tree"
-version = "0.30.11"
+version = "0.30.12"
 dependencies = [
  "indexmap 2.13.0",
  "log",
@@ -12305,7 +12305,7 @@ dependencies = [
 
 [[package]]
 name = "tari_swarm"
-version = "0.30.11"
+version = "0.30.12"
 dependencies = [
  "libp2p",
  "libp2p-messaging",
@@ -12316,7 +12316,7 @@ dependencies = [
 
 [[package]]
 name = "tari_swarm_daemon"
-version = "0.30.11"
+version = "0.30.12"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12427,7 +12427,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_test_tooling"
-version = "0.30.11"
+version = "0.30.12"
 dependencies = [
  "anyhow",
  "cargo_toml 0.22.3",
@@ -12540,7 +12540,7 @@ dependencies = [
 
 [[package]]
 name = "tari_transaction_manifest"
-version = "0.30.11"
+version = "0.30.12"
 dependencies = [
  "proc-macro2",
  "serde_json",
@@ -12575,7 +12575,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node"
-version = "0.30.11"
+version = "0.30.12"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -12641,7 +12641,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node_client"
-version = "0.30.11"
+version = "0.30.12"
 dependencies = [
  "indexmap 2.13.0",
  "multiaddr 0.18.3",
@@ -12665,7 +12665,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node_rpc"
-version = "0.30.11"
+version = "0.30.12"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -12688,7 +12688,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_rollback"
-version = "0.30.11"
+version = "0.30.12"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12723,7 +12723,7 @@ dependencies = [
 
 [[package]]
 name = "tari_watcher"
-version = "0.30.11"
+version = "0.30.12"
 dependencies = [
  "anyhow",
  "clap 3.2.25",
@@ -12752,7 +12752,7 @@ dependencies = [
 
 [[package]]
 name = "tariswap_bench"
-version = "0.30.11"
+version = "0.30.12"
 dependencies = [
  "anyhow",
  "clap 4.5.54",
@@ -13432,7 +13432,7 @@ dependencies = [
 
 [[package]]
 name = "traffic-sim"
-version = "0.30.11"
+version = "0.30.12"
 dependencies = [
  "anyhow",
  "clap 4.5.54",
@@ -13454,7 +13454,7 @@ dependencies = [
 
 [[package]]
 name = "transaction_generator"
-version = "0.30.11"
+version = "0.30.12"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -13473,7 +13473,7 @@ dependencies = [
 
 [[package]]
 name = "transaction_submitter"
-version = "0.30.11"
+version = "0.30.12"
 dependencies = [
  "anyhow",
  "clap 4.5.54",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.30.11"
+version = "0.30.12"
 edition = "2024"
 authors = ["The Tari Development Community"]
 repository = "https://github.com/tari-project/tari-ootle"

--- a/networking/core/src/builder.rs
+++ b/networking/core/src/builder.rs
@@ -112,7 +112,6 @@ where
             }
         }
 
-        config.swarm.enable_relay = config.swarm.enable_relay || !config.reachability_mode.is_private();
         config.swarm.enable_messaging = messaging_mode.is_enabled();
         let swarm = tari_swarm::create_swarm::<ProstCodec<TMsg::Message>>(
             identity.clone(),


### PR DESCRIPTION
Description
---
fix(p2p): always obey enable_relay config

Motivation and Context
---
Relay could (and by default would) be enabled even if enable_relay == false if reachability was set private.

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify