### PR TITLE
feat(ootle_wasm): add stealth crypto primitives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7656,6 +7656,7 @@ version = "0.30.13"
 dependencies = [
  "console_error_panic_hook",
  "getrandom 0.2.17",
+ "getrandom 0.4.2",
  "ootle-wasm-core",
  "wasm-bindgen",
 ]
@@ -7665,14 +7666,18 @@ name = "ootle-wasm-core"
 version = "0.30.13"
 dependencies = [
  "base64 0.22.1",
+ "hex",
+ "ootle-network",
  "ootle_byte_type",
  "rand 0.10.1",
  "serde",
  "serde_json",
  "tari_bor",
  "tari_crypto",
+ "tari_engine_types",
  "tari_ootle_address",
  "tari_ootle_transaction",
+ "tari_ootle_wallet_crypto",
  "tari_template_lib_types",
  "thiserror 2.0.18",
 ]

--- a/crates/ootle_wasm/core/Cargo.toml
+++ b/crates/ootle_wasm/core/Cargo.toml
@@ -10,16 +10,20 @@ license.workspace = true
 [dependencies]
 tari_ootle_transaction = { workspace = true }
 tari_ootle_address = { workspace = true }
+tari_ootle_wallet_crypto = { workspace = true, features = ["serde"] }
+tari_engine_types = { workspace = true }
 tari_crypto = { workspace = true, features = ["borsh"] }
 tari_bor = { workspace = true }
 tari_template_lib_types = { workspace = true, features = ["std"] }
 ootle_byte_type = { workspace = true, features = ["crypto"] }
+ootle-network = { workspace = true }
 
 rand = { workspace = true }
-serde = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 base64 = { workspace = true }
+hex = { workspace = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }

--- a/crates/ootle_wasm/core/src/error.rs
+++ b/crates/ootle_wasm/core/src/error.rs
@@ -19,4 +19,20 @@ pub enum OotleWasmError {
     InvalidPayRef(usize),
     #[error("Invalid address: {0}")]
     InvalidAddress(String),
+    #[error("Invalid hex: {0}")]
+    InvalidHex(#[from] hex::FromHexError),
+    #[error("Invalid commitment: {0}")]
+    InvalidCommitment(String),
+    #[error("Invalid encrypted data: {0}")]
+    InvalidEncryptedData(String),
+    #[error("Invalid byte length for {field}: expected {expected}, got {got}")]
+    InvalidByteLength {
+        field: &'static str,
+        expected: usize,
+        got: usize,
+    },
+    #[error("Stealth crypto error: {0}")]
+    Stealth(String),
+    #[error("Stealth transfer validation failed: {0}")]
+    StealthValidation(String),
 }

--- a/crates/ootle_wasm/core/src/keys.rs
+++ b/crates/ootle_wasm/core/src/keys.rs
@@ -1,0 +1,31 @@
+//   Copyright 2026 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+//! Shared byte-parsing helpers for the WASM ABI boundary.
+//!
+//! The WASM exports accept fixed-size scalars and public keys as raw byte slices for performance, and
+//! variable-length values (hex strings, JSON blobs) as `&str`. These helpers centralise the conversion
+//! and validation logic so the individual modules only deal with strongly-typed values.
+
+use tari_crypto::{
+    ristretto::{RistrettoPublicKey, RistrettoSecretKey},
+    tari_utilities::ByteArray,
+};
+use tari_template_lib_types::crypto::PedersenCommitmentBytes;
+
+use crate::error::OotleWasmError;
+
+/// Parse a Ristretto secret key (32-byte canonical scalar) from raw bytes.
+pub(crate) fn secret_key_from_bytes(bytes: &[u8]) -> Result<RistrettoSecretKey, OotleWasmError> {
+    RistrettoSecretKey::from_canonical_bytes(bytes).map_err(|e| OotleWasmError::InvalidSecretKey(e.to_string()))
+}
+
+/// Parse a Ristretto public key (32-byte canonical curve point) from raw bytes.
+pub(crate) fn public_key_from_bytes(bytes: &[u8]) -> Result<RistrettoPublicKey, OotleWasmError> {
+    RistrettoPublicKey::from_canonical_bytes(bytes).map_err(|e| OotleWasmError::InvalidPublicKey(e.to_string()))
+}
+
+/// Parse a Pedersen commitment (32-byte byte type) from raw bytes.
+pub(crate) fn commitment_bytes_from_bytes(bytes: &[u8]) -> Result<PedersenCommitmentBytes, OotleWasmError> {
+    PedersenCommitmentBytes::from_bytes(bytes).map_err(|e| OotleWasmError::InvalidCommitment(e.to_string()))
+}

--- a/crates/ootle_wasm/core/src/lib.rs
+++ b/crates/ootle_wasm/core/src/lib.rs
@@ -5,5 +5,7 @@ pub mod address;
 pub mod bor;
 pub mod error;
 pub mod hash;
+pub mod keys;
 pub mod sign;
+pub mod stealth;
 pub mod transaction;

--- a/crates/ootle_wasm/core/src/stealth/balance_proof.rs
+++ b/crates/ootle_wasm/core/src/stealth/balance_proof.rs
@@ -1,0 +1,170 @@
+//   Copyright 2026 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+//! Balance proof signature generation and validation.
+
+use tari_ootle_wallet_crypto::balance_proof::{
+    generate_stealth_balance_proof_signature as crypto_generate,
+    validate_balance_proof_signature as crypto_validate,
+};
+use tari_template_lib_types::{
+    crypto::{BalanceProofSignature, RistrettoPublicKeyBytes, Scalar32Bytes, SchnorrSignatureBytes},
+    stealth::{StealthInputsStatement, StealthOutputsStatement},
+};
+
+use crate::{error::OotleWasmError, keys::secret_key_from_bytes, sign::SchnorrSignatureResult};
+
+/// Generate the Schnorr signature that proves
+/// `∑ input_commitments + revealed_input ≡ ∑ output_commitments + revealed_output`.
+///
+/// `inputs_statement_json` and `outputs_statement_json` are the serialized wire-format statements. The
+/// returned `(public_nonce, signature)` pair may be all-zeros for revealed-only transfers; in that case
+/// callers normally omit the proof from the transfer entirely.
+pub fn generate_stealth_balance_proof_signature(
+    aggregated_input_mask: &[u8],
+    aggregated_output_mask: &[u8],
+    inputs_statement_json: &str,
+    outputs_statement_json: &str,
+) -> Result<SchnorrSignatureResult, OotleWasmError> {
+    let agg_input_mask = secret_key_from_bytes(aggregated_input_mask)?;
+    let agg_output_mask = secret_key_from_bytes(aggregated_output_mask)?;
+    let inputs_statement: StealthInputsStatement = serde_json::from_str(inputs_statement_json)?;
+    let outputs_statement: StealthOutputsStatement = serde_json::from_str(outputs_statement_json)?;
+
+    let sig = crypto_generate(&agg_input_mask, &agg_output_mask, &inputs_statement, &outputs_statement);
+
+    Ok(SchnorrSignatureResult {
+        public_nonce: sig.public_nonce().as_bytes().to_vec(),
+        signature: sig.signature().as_bytes().to_vec(),
+    })
+}
+
+/// Verify a balance-proof signature against its inputs and outputs statements. Returns `false` on
+/// malformed inputs or on an invalid signature; the engine performs the authoritative check at submission.
+pub fn validate_balance_proof_signature(
+    public_nonce: &[u8],
+    signature: &[u8],
+    inputs_statement_json: &str,
+    outputs_statement_json: &str,
+) -> Result<bool, OotleWasmError> {
+    let public_nonce =
+        RistrettoPublicKeyBytes::from_bytes(public_nonce).map_err(|e| OotleWasmError::InvalidByteLength {
+            field: "public_nonce",
+            expected: RistrettoPublicKeyBytes::length(),
+            got: e.actual_size(),
+        })?;
+    let signature_scalar = Scalar32Bytes::from_bytes(signature).map_err(|e| OotleWasmError::InvalidByteLength {
+        field: "signature",
+        expected: Scalar32Bytes::length(),
+        got: e.actual_size(),
+    })?;
+    let sig_bytes: BalanceProofSignature = SchnorrSignatureBytes::new(public_nonce, signature_scalar);
+    let inputs_statement: StealthInputsStatement = serde_json::from_str(inputs_statement_json)?;
+    let outputs_statement: StealthOutputsStatement = serde_json::from_str(outputs_statement_json)?;
+
+    Ok(crypto_validate(&sig_bytes, &inputs_statement, &outputs_statement))
+}
+
+#[cfg(test)]
+mod tests {
+    use ootle_byte_type::ToByteType;
+    use tari_crypto::{
+        keys::{PublicKey, SecretKey},
+        ristretto::{RistrettoPublicKey, RistrettoSecretKey},
+        tari_utilities::ByteArray,
+    };
+    use tari_ootle_wallet_crypto::{
+        MaskAndValue,
+        OutputWitness,
+        StealthInputWitness,
+        StealthOutputWitness,
+        stealth::create_transfer_statement,
+    };
+    use tari_template_lib_types::{
+        Amount,
+        EncryptedData,
+        crypto::UtxoTag,
+        stealth::{SpendCondition, StealthTransferStatement},
+    };
+
+    use super::*;
+
+    fn build_simple_transfer() -> (RistrettoSecretKey, RistrettoSecretKey, StealthTransferStatement) {
+        let mut rng = rand::rng();
+        let input_mask = RistrettoSecretKey::random(&mut rng);
+        let output_mask = RistrettoSecretKey::random(&mut rng);
+        let owner_pk = RistrettoPublicKey::from_secret_key(&output_mask);
+
+        let inputs = vec![StealthInputWitness {
+            mask_and_value: MaskAndValue::new(2000, input_mask.clone()),
+        }];
+        let outputs = vec![StealthOutputWitness {
+            witness: OutputWitness {
+                amount: 2000,
+                mask: output_mask.clone(),
+                sender_public_nonce: owner_pk.clone(),
+                minimum_value_promise: 0,
+                encrypted_data: EncryptedData::try_from(vec![0; EncryptedData::min_size()]).unwrap(),
+                resource_view_key: None,
+            },
+            spend_condition: SpendCondition::Signed(owner_pk.to_byte_type()),
+            tag: UtxoTag::new(0),
+        }];
+        let transfer = create_transfer_statement(inputs, Amount::zero(), outputs.iter(), Amount::zero()).unwrap();
+        (input_mask, output_mask, transfer)
+    }
+
+    #[test]
+    fn generated_signature_validates() {
+        let (input_mask, output_mask, transfer) = build_simple_transfer();
+        let inputs_json = serde_json::to_string(&transfer.inputs_statement).unwrap();
+        let outputs_json = serde_json::to_string(&transfer.outputs_statement).unwrap();
+
+        let sig = generate_stealth_balance_proof_signature(
+            input_mask.as_bytes(),
+            output_mask.as_bytes(),
+            &inputs_json,
+            &outputs_json,
+        )
+        .unwrap();
+
+        let valid =
+            validate_balance_proof_signature(&sig.public_nonce, &sig.signature, &inputs_json, &outputs_json).unwrap();
+        assert!(valid);
+    }
+
+    #[test]
+    fn existing_signature_validates() {
+        let (_, _, transfer) = build_simple_transfer();
+        let inputs_json = serde_json::to_string(&transfer.inputs_statement).unwrap();
+        let outputs_json = serde_json::to_string(&transfer.outputs_statement).unwrap();
+        let proof = transfer.balance_proof.unwrap();
+
+        let valid = validate_balance_proof_signature(
+            proof.public_nonce().as_bytes(),
+            proof.signature().as_bytes(),
+            &inputs_json,
+            &outputs_json,
+        )
+        .unwrap();
+        assert!(valid);
+    }
+
+    #[test]
+    fn validate_returns_false_for_zero_signature() {
+        let (_, _, transfer) = build_simple_transfer();
+        let inputs_json = serde_json::to_string(&transfer.inputs_statement).unwrap();
+        let outputs_json = serde_json::to_string(&transfer.outputs_statement).unwrap();
+        let valid = validate_balance_proof_signature(&[0u8; 32], &[0u8; 32], &inputs_json, &outputs_json).unwrap();
+        assert!(!valid);
+    }
+
+    #[test]
+    fn validate_rejects_wrong_signature_length() {
+        let (_, _, transfer) = build_simple_transfer();
+        let inputs_json = serde_json::to_string(&transfer.inputs_statement).unwrap();
+        let outputs_json = serde_json::to_string(&transfer.outputs_statement).unwrap();
+        let err = validate_balance_proof_signature(&[0u8; 31], &[0u8; 32], &inputs_json, &outputs_json).unwrap_err();
+        assert!(matches!(err, OotleWasmError::InvalidByteLength { .. }));
+    }
+}

--- a/crates/ootle_wasm/core/src/stealth/balance_proof.rs
+++ b/crates/ootle_wasm/core/src/stealth/balance_proof.rs
@@ -95,10 +95,10 @@ mod tests {
         let output_mask = RistrettoSecretKey::random(&mut rng);
         let owner_pk = RistrettoPublicKey::from_secret_key(&output_mask);
 
-        let inputs = vec![StealthInputWitness {
+        let inputs = [StealthInputWitness {
             mask_and_value: MaskAndValue::new(2000, input_mask.clone()),
         }];
-        let outputs = vec![StealthOutputWitness {
+        let outputs = [StealthOutputWitness {
             witness: OutputWitness {
                 amount: 2000,
                 mask: output_mask.clone(),

--- a/crates/ootle_wasm/core/src/stealth/encrypted_data.rs
+++ b/crates/ootle_wasm/core/src/stealth/encrypted_data.rs
@@ -51,7 +51,7 @@ pub fn unblind_output(
     let decrypted = crypto_unblind_output(&commitment, &encrypted_data, &encryption_key, skip_memo)
         .map_err(|e| OotleWasmError::Stealth(e.to_string()))?;
 
-    let memo_json = decrypted.memo().map(|m| serde_json::to_string(m)).transpose()?;
+    let memo_json = decrypted.memo().map(serde_json::to_string).transpose()?;
 
     Ok(DecryptedOutputResult {
         mask: decrypted.mask().as_bytes().to_vec(),

--- a/crates/ootle_wasm/core/src/stealth/encrypted_data.rs
+++ b/crates/ootle_wasm/core/src/stealth/encrypted_data.rs
@@ -1,0 +1,135 @@
+//   Copyright 2026 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+//! Decrypting inbound stealth UTXOs.
+
+use tari_crypto::tari_utilities::ByteArray;
+use tari_ootle_wallet_crypto::encrypted_data::unblind_output as crypto_unblind_output;
+use tari_template_lib_types::EncryptedData;
+
+use crate::{
+    error::OotleWasmError,
+    keys::{commitment_bytes_from_bytes, secret_key_from_bytes},
+};
+
+/// Result of decrypting and verifying an inbound stealth UTXO payload.
+#[derive(Debug, Clone)]
+pub struct DecryptedOutputResult {
+    /// The 32-byte commitment mask scalar.
+    pub mask: Vec<u8>,
+    /// The plaintext value (microtari).
+    pub value: u64,
+    /// JSON-encoded `Memo` (one of `U256`/`Message`/`Bytes`/`PayRefAndBytes`) or `None` if the encrypted
+    /// payload carried no memo, or if the caller passed `skip_memo`.
+    pub memo_json: Option<String>,
+}
+
+/// Decrypt an inbound stealth UTXO's `encrypted_data` blob and verify that the recovered (mask, value)
+/// pair commits to the same Pedersen commitment.
+///
+/// `encrypted_data_bytes` is the raw encrypted blob (between [`EncryptedData::min_size`] and
+/// [`EncryptedData::max_size`] bytes, including AEAD tag, nonce and ciphertext).
+///
+/// Returns `Err` on AEAD failure or a commitment mismatch — both indicate the payload was not produced
+/// for this view key.
+pub fn unblind_output(
+    output_commitment: &[u8],
+    encrypted_data_bytes: &[u8],
+    encryption_key: &[u8],
+    skip_memo: bool,
+) -> Result<DecryptedOutputResult, OotleWasmError> {
+    let commitment = commitment_bytes_from_bytes(output_commitment)?;
+    let encrypted_data = EncryptedData::try_from(encrypted_data_bytes.to_vec()).map_err(|len| {
+        OotleWasmError::InvalidEncryptedData(format!(
+            "invalid length {len}; expected [{}, {}] bytes",
+            EncryptedData::min_size(),
+            EncryptedData::max_size()
+        ))
+    })?;
+    let encryption_key = secret_key_from_bytes(encryption_key)?;
+
+    let decrypted = crypto_unblind_output(&commitment, &encrypted_data, &encryption_key, skip_memo)
+        .map_err(|e| OotleWasmError::Stealth(e.to_string()))?;
+
+    let memo_json = decrypted.memo().map(|m| serde_json::to_string(m)).transpose()?;
+
+    Ok(DecryptedOutputResult {
+        mask: decrypted.mask().as_bytes().to_vec(),
+        value: decrypted.value(),
+        memo_json,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use ootle_byte_type::ToByteType;
+    use tari_crypto::{commitment::HomomorphicCommitmentFactory, keys::SecretKey, ristretto::RistrettoSecretKey};
+    use tari_engine_types::crypto::get_commitment_factory;
+    use tari_ootle_wallet_crypto::{encrypted_data::encrypt_data, memo::Memo};
+
+    use super::*;
+
+    #[test]
+    fn unblind_round_trip_without_memo() {
+        let encryption_key = RistrettoSecretKey::random(&mut rand::rng());
+        let mask = RistrettoSecretKey::random(&mut rand::rng());
+        let amount = 42u64;
+        let commitment = get_commitment_factory().commit_value(&mask, amount).to_byte_type();
+        let encrypted = encrypt_data(amount, &mask, &encryption_key, None).unwrap();
+
+        let result = unblind_output(
+            commitment.as_bytes(),
+            encrypted.as_bytes(),
+            encryption_key.as_bytes(),
+            false,
+        )
+        .unwrap();
+        assert_eq!(result.value, amount);
+        assert_eq!(result.mask, mask.as_bytes());
+        assert!(result.memo_json.is_none());
+    }
+
+    #[test]
+    fn unblind_round_trip_with_memo() {
+        let encryption_key = RistrettoSecretKey::random(&mut rand::rng());
+        let mask = RistrettoSecretKey::random(&mut rand::rng());
+        let amount = 7u64;
+        let commitment = get_commitment_factory().commit_value(&mask, amount).to_byte_type();
+        let memo = Memo::new_message("hi").unwrap();
+        let encrypted = encrypt_data(amount, &mask, &encryption_key, Some(&memo)).unwrap();
+
+        let result = unblind_output(
+            commitment.as_bytes(),
+            encrypted.as_bytes(),
+            encryption_key.as_bytes(),
+            false,
+        )
+        .unwrap();
+        let memo_json = result.memo_json.expect("memo should be decoded");
+        let decoded: Memo = serde_json::from_str(&memo_json).unwrap();
+        assert_eq!(decoded, memo);
+
+        // skip_memo discards the memo even if present
+        let result = unblind_output(
+            commitment.as_bytes(),
+            encrypted.as_bytes(),
+            encryption_key.as_bytes(),
+            true,
+        )
+        .unwrap();
+        assert!(result.memo_json.is_none());
+    }
+
+    #[test]
+    fn unblind_rejects_wrong_key() {
+        let encryption_key = RistrettoSecretKey::random(&mut rand::rng());
+        let other_key = RistrettoSecretKey::random(&mut rand::rng());
+        let mask = RistrettoSecretKey::random(&mut rand::rng());
+        let amount = 1u64;
+        let commitment = get_commitment_factory().commit_value(&mask, amount).to_byte_type();
+        let encrypted = encrypt_data(amount, &mask, &encryption_key, None).unwrap();
+
+        let err = unblind_output(commitment.as_bytes(), encrypted.as_bytes(), other_key.as_bytes(), false).unwrap_err();
+        assert!(matches!(err, OotleWasmError::Stealth(_)));
+    }
+}

--- a/crates/ootle_wasm/core/src/stealth/inputs.rs
+++ b/crates/ootle_wasm/core/src/stealth/inputs.rs
@@ -8,13 +8,17 @@
 //! so Python (or any other client) can assemble a `StealthInputsStatement` from raw commitment bytes
 //! without hand-crafting JSON.
 
+use tari_crypto::{ristretto::RistrettoSecretKey, tari_utilities::ByteArray};
 use tari_template_lib_types::{
     Amount,
     crypto::PedersenCommitmentBytes,
     stealth::{StealthInput, StealthInputsStatement},
 };
 
-use crate::{error::OotleWasmError, keys::commitment_bytes_from_bytes};
+use crate::{
+    error::OotleWasmError,
+    keys::{commitment_bytes_from_bytes, secret_key_from_bytes},
+};
 
 /// Build a `StealthInputsStatement` JSON from a list of raw 32-byte input commitments and a revealed
 /// amount.
@@ -48,8 +52,36 @@ pub fn build_stealth_inputs_statement(
     Ok(serde_json::to_string(&statement)?)
 }
 
+/// Aggregate the commitment masks of stealth inputs into a single 32-byte Ristretto scalar.
+///
+/// `masks_concat` is the concatenated bytes of the input masks (32 bytes per mask, so the input
+/// length must be a multiple of 32). Pass an empty slice to obtain the zero scalar.
+///
+/// Returns the sum as 32 bytes, suitable as the `aggregated_input_mask` argument to
+/// [`crate::stealth::balance_proof::generate_stealth_balance_proof_signature`]. The output side of
+/// the balance proof is aggregated automatically by
+/// [`crate::stealth::outputs::generate_stealth_outputs_statement`].
+pub fn aggregate_input_masks(masks_concat: &[u8]) -> Result<Vec<u8>, OotleWasmError> {
+    const SCALAR_LEN: usize = 32;
+    if !masks_concat.len().is_multiple_of(SCALAR_LEN) {
+        return Err(OotleWasmError::InvalidByteLength {
+            field: "masks_concat",
+            expected: SCALAR_LEN,
+            got: masks_concat.len(),
+        });
+    }
+
+    let mut acc = RistrettoSecretKey::default();
+    for chunk in masks_concat.chunks_exact(SCALAR_LEN) {
+        acc = acc + secret_key_from_bytes(chunk)?;
+    }
+    Ok(acc.as_bytes().to_vec())
+}
+
 #[cfg(test)]
 mod tests {
+    use tari_crypto::keys::SecretKey;
+
     use super::*;
 
     #[test]
@@ -74,5 +106,40 @@ mod tests {
     fn rejects_non_multiple_of_32() {
         let err = build_stealth_inputs_statement(&[0u8; 33], 0).unwrap_err();
         assert!(matches!(err, OotleWasmError::InvalidByteLength { .. }));
+    }
+
+    #[test]
+    fn aggregate_empty_returns_zero_scalar() {
+        let result = aggregate_input_masks(&[]).unwrap();
+        assert_eq!(result, vec![0u8; 32]);
+    }
+
+    #[test]
+    fn aggregate_single_mask_returns_itself() {
+        let mask = RistrettoSecretKey::random(&mut rand::rng());
+        let result = aggregate_input_masks(mask.as_bytes()).unwrap();
+        assert_eq!(result, mask.as_bytes().to_vec());
+    }
+
+    #[test]
+    fn aggregate_two_masks_matches_native_addition() {
+        let mut rng = rand::rng();
+        let a = RistrettoSecretKey::random(&mut rng);
+        let b = RistrettoSecretKey::random(&mut rng);
+        let mut concat = a.as_bytes().to_vec();
+        concat.extend_from_slice(b.as_bytes());
+
+        let sum = aggregate_input_masks(&concat).unwrap();
+        let expected = (a + b).as_bytes().to_vec();
+        assert_eq!(sum, expected);
+    }
+
+    #[test]
+    fn aggregate_rejects_non_multiple_of_32() {
+        let err = aggregate_input_masks(&[0u8; 33]).unwrap_err();
+        assert!(matches!(err, OotleWasmError::InvalidByteLength {
+            field: "masks_concat",
+            ..
+        }));
     }
 }

--- a/crates/ootle_wasm/core/src/stealth/inputs.rs
+++ b/crates/ootle_wasm/core/src/stealth/inputs.rs
@@ -1,0 +1,78 @@
+//   Copyright 2026 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+//! Building the input side of a stealth transfer.
+//!
+//! The inputs statement is structurally trivial — `(commitments[], revealed_amount)` — but its on-wire
+//! JSON layout is not something callers should have to know about. This module exposes a small builder
+//! so Python (or any other client) can assemble a `StealthInputsStatement` from raw commitment bytes
+//! without hand-crafting JSON.
+
+use tari_template_lib_types::{
+    Amount,
+    crypto::PedersenCommitmentBytes,
+    stealth::{StealthInput, StealthInputsStatement},
+};
+
+use crate::{error::OotleWasmError, keys::commitment_bytes_from_bytes};
+
+/// Build a `StealthInputsStatement` JSON from a list of raw 32-byte input commitments and a revealed
+/// amount.
+///
+/// `input_commitments` is the concatenated bytes of all input commitments (32 bytes per commitment, so
+/// the input length must be a multiple of 32). Pass an empty slice to build a revealed-only statement.
+pub fn build_stealth_inputs_statement(
+    input_commitments: &[u8],
+    revealed_amount_microtari: u64,
+) -> Result<String, OotleWasmError> {
+    if !input_commitments
+        .len()
+        .is_multiple_of(PedersenCommitmentBytes::length())
+    {
+        return Err(OotleWasmError::InvalidByteLength {
+            field: "input_commitments",
+            expected: PedersenCommitmentBytes::length(),
+            got: input_commitments.len(),
+        });
+    }
+
+    let inputs = input_commitments
+        .chunks_exact(PedersenCommitmentBytes::length())
+        .map(|chunk| commitment_bytes_from_bytes(chunk).map(StealthInput::new))
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let statement = StealthInputsStatement {
+        inputs,
+        revealed_amount: Amount::from_u64(revealed_amount_microtari),
+    };
+    Ok(serde_json::to_string(&statement)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_revealed_only_statement() {
+        let json = build_stealth_inputs_statement(&[], 1000).unwrap();
+        let stmt: StealthInputsStatement = serde_json::from_str(&json).unwrap();
+        assert!(stmt.inputs.is_empty());
+        assert_eq!(stmt.revealed_amount, Amount::from_u64(1000));
+    }
+
+    #[test]
+    fn build_statement_with_two_inputs() {
+        let commitments: Vec<u8> = (0..64).map(|i| i as u8).collect();
+        let json = build_stealth_inputs_statement(&commitments, 0).unwrap();
+        let stmt: StealthInputsStatement = serde_json::from_str(&json).unwrap();
+        assert_eq!(stmt.inputs.len(), 2);
+        assert_eq!(stmt.inputs[0].commitment.as_bytes(), &commitments[..32]);
+        assert_eq!(stmt.inputs[1].commitment.as_bytes(), &commitments[32..]);
+    }
+
+    #[test]
+    fn rejects_non_multiple_of_32() {
+        let err = build_stealth_inputs_statement(&[0u8; 33], 0).unwrap_err();
+        assert!(matches!(err, OotleWasmError::InvalidByteLength { .. }));
+    }
+}

--- a/crates/ootle_wasm/core/src/stealth/kdfs.rs
+++ b/crates/ootle_wasm/core/src/stealth/kdfs.rs
@@ -1,0 +1,91 @@
+//   Copyright 2026 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+//! Key-derivation primitives for stealth transfers.
+
+use ootle_network::Network;
+use tari_crypto::tari_utilities::ByteArray;
+use tari_ootle_wallet_crypto::kdfs::{encrypted_data_dh_kdf_aead, owner_stealth_dh_secret};
+
+use crate::{
+    error::OotleWasmError,
+    keys::{public_key_from_bytes, secret_key_from_bytes},
+};
+
+/// Derive the recipient's stealth spending scalar `c + k`, where `c = H(network || k.G * r)`.
+///
+/// The receiver runs this over each candidate UTXO with their account secret key and the sender-provided
+/// public nonce to produce the one-time secret that controls the stealth output.
+pub fn stealth_dh_secret(network_byte: u8, private_key: &[u8], public_nonce: &[u8]) -> Result<Vec<u8>, OotleWasmError> {
+    let network = Network::try_from(network_byte).map_err(|e| OotleWasmError::InvalidNetwork(e.to_string()))?;
+    let private = secret_key_from_bytes(private_key)?;
+    let nonce = public_key_from_bytes(public_nonce)?;
+    let stealth = owner_stealth_dh_secret(network, &private, &nonce);
+    Ok(stealth.as_bytes().to_vec())
+}
+
+/// Derive the AEAD encryption key from a Diffie-Hellman shared secret: `H(DH(s, P))`.
+///
+/// Sender derives it with `(sender_secret_nonce, recipient_view_pub)`, receiver derives the same key with
+/// `(recipient_view_secret, sender_public_nonce)`.
+pub fn encrypted_data_dh_kdf(private_key: &[u8], public_key: &[u8]) -> Result<Vec<u8>, OotleWasmError> {
+    let private = secret_key_from_bytes(private_key)?;
+    let public = public_key_from_bytes(public_key)?;
+    Ok(encrypted_data_dh_kdf_aead(&private, &public).as_bytes().to_vec())
+}
+
+#[cfg(test)]
+mod tests {
+    use tari_crypto::{
+        keys::{PublicKey, SecretKey},
+        ristretto::{RistrettoPublicKey, RistrettoSecretKey},
+    };
+
+    use super::*;
+
+    #[test]
+    fn stealth_dh_secret_matches_native_impl() {
+        let network = Network::LocalNet;
+        let secret = RistrettoSecretKey::random(&mut rand::rng());
+        let (nonce_sk, nonce_pk) = RistrettoPublicKey::random_keypair(&mut rand::rng());
+
+        let ours = stealth_dh_secret(network.as_byte(), secret.as_bytes(), nonce_pk.as_bytes()).unwrap();
+        let expected = owner_stealth_dh_secret(network, &secret, &nonce_pk);
+        assert_eq!(ours, expected.as_bytes().to_vec());
+
+        // Sanity check the corresponding stealth public key matches the sender-side derivation.
+        let stealth_secret = secret_key_from_bytes(&ours).unwrap();
+        let derived_pk = RistrettoPublicKey::from_secret_key(&stealth_secret);
+        let sender_side =
+            tari_ootle_wallet_crypto::kdfs::owner_stealth_dh_stealth_address(network, &nonce_pk, &nonce_sk);
+        // The receiver-side DH uses (secret_key, public_nonce); to match we need owner_pubkey and secret_nonce.
+        // Just verify the round-trip identity via the receiver's secret key derivation.
+        let owner_side = tari_ootle_wallet_crypto::kdfs::owner_stealth_dh_stealth_address(
+            network,
+            &RistrettoPublicKey::from_secret_key(&secret),
+            &nonce_sk,
+        );
+        assert_eq!(derived_pk, owner_side);
+        // sender_side uses different params and should not match (sanity check that we didn't get a no-op).
+        assert_ne!(sender_side, owner_side);
+    }
+
+    #[test]
+    fn stealth_dh_secret_rejects_invalid_network() {
+        let secret = RistrettoSecretKey::random(&mut rand::rng());
+        let pk = RistrettoPublicKey::from_secret_key(&secret);
+        let err = stealth_dh_secret(0xFF, secret.as_bytes(), pk.as_bytes()).unwrap_err();
+        assert!(matches!(err, OotleWasmError::InvalidNetwork(_)));
+    }
+
+    #[test]
+    fn encrypted_data_dh_kdf_round_trips() {
+        let (alice_sk, alice_pk) = RistrettoPublicKey::random_keypair(&mut rand::rng());
+        let (bob_sk, bob_pk) = RistrettoPublicKey::random_keypair(&mut rand::rng());
+
+        let from_alice = encrypted_data_dh_kdf(alice_sk.as_bytes(), bob_pk.as_bytes()).unwrap();
+        let from_bob = encrypted_data_dh_kdf(bob_sk.as_bytes(), alice_pk.as_bytes()).unwrap();
+        assert_eq!(from_alice, from_bob);
+        assert_eq!(from_alice.len(), 32);
+    }
+}

--- a/crates/ootle_wasm/core/src/stealth/mod.rs
+++ b/crates/ootle_wasm/core/src/stealth/mod.rs
@@ -1,0 +1,18 @@
+//   Copyright 2026 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+//! Pure-Rust stealth crypto primitives exposed to WASM.
+//!
+//! Each submodule wraps a slice of the daemon-side stealth flow so wallets can build stealth transfers
+//! entirely client-side. The thin `#[wasm_bindgen]` bindings live in the sibling `ootle-wasm` crate.
+
+pub mod balance_proof;
+pub mod encrypted_data;
+pub mod inputs;
+pub mod kdfs;
+pub mod outputs;
+mod types;
+pub mod validate;
+pub mod viewable_balance;
+
+pub use types::{InputWitness, StealthInputWitnessJson, StealthOutputWitnessJson};

--- a/crates/ootle_wasm/core/src/stealth/outputs.rs
+++ b/crates/ootle_wasm/core/src/stealth/outputs.rs
@@ -1,0 +1,146 @@
+//   Copyright 2026 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+//! Building the output side of a stealth transfer: per-output commitments + encrypted data, optional
+//! ElGamal view-key proofs, and the aggregated bulletproof range proof.
+
+use tari_crypto::{ristretto::RistrettoSecretKey, tari_utilities::ByteArray};
+use tari_ootle_wallet_crypto::{
+    bullet_proof::generate_extended_bullet_proof as crypto_generate_extended_bullet_proof,
+    stealth::create_outputs_statement,
+};
+use tari_template_lib_types::{Amount, crypto::RangeProofBytes};
+
+use crate::{
+    error::OotleWasmError,
+    stealth::types::{OutputWitnessJson, StealthOutputWitnessJson},
+};
+
+/// Result of [`generate_stealth_outputs_statement`]: the wire-ready statement plus the aggregated mask the
+/// sender retains for the balance proof.
+#[derive(Debug, Clone)]
+pub struct StealthOutputsResult {
+    /// Serialized `StealthOutputsStatement` (containing outputs, revealed amount, and aggregated range
+    /// proof).
+    pub statement_json: String,
+    /// Sum of all witness masks as a 32-byte Ristretto scalar. Feed this into
+    /// [`crate::stealth::balance_proof::generate_stealth_balance_proof_signature`] as the aggregated
+    /// output mask.
+    pub aggregated_output_mask: Vec<u8>,
+}
+
+/// Generate the output half of a stealth transfer.
+///
+/// `witnesses_json` is a JSON array of [`StealthOutputWitnessJson`]; `revealed_output_amount_microtari` is
+/// the plaintext revealed amount (in microtari, fits a `u64`). Output witnesses that contain a
+/// `resource_view_key` automatically receive an ElGamal viewable-balance proof.
+pub fn generate_stealth_outputs_statement(
+    witnesses_json: &str,
+    revealed_output_amount_microtari: u64,
+) -> Result<StealthOutputsResult, OotleWasmError> {
+    use tari_ootle_wallet_crypto::StealthOutputWitness;
+
+    let witnesses: Vec<StealthOutputWitnessJson> = serde_json::from_str(witnesses_json)?;
+    let witnesses: Vec<StealthOutputWitness> = witnesses
+        .into_iter()
+        .map(StealthOutputWitness::try_from)
+        .collect::<Result<Vec<_>, OotleWasmError>>()?;
+
+    let aggregated_output_mask = witnesses
+        .iter()
+        .map(|w| &w.witness.mask)
+        .fold(RistrettoSecretKey::default(), |acc, mask| acc + mask);
+
+    let statement = create_outputs_statement(witnesses.iter(), Amount::from_u64(revealed_output_amount_microtari))
+        .map_err(|e| OotleWasmError::Stealth(e.to_string()))?;
+
+    Ok(StealthOutputsResult {
+        statement_json: serde_json::to_string(&statement)?,
+        aggregated_output_mask: aggregated_output_mask.as_bytes().to_vec(),
+    })
+}
+
+/// Generate an extended bulletproof that aggregates range proofs for the supplied output witnesses.
+///
+/// Exposed independently of [`generate_stealth_outputs_statement`] for testing and audit. The Python
+/// transfer flow uses the bundled variant.
+///
+/// `witnesses_json` is a JSON array of [`OutputWitnessJson`]. Returns the raw `RangeProofBytes` (may be
+/// empty for an empty input array).
+pub fn generate_extended_bullet_proof(witnesses_json: &str) -> Result<Vec<u8>, OotleWasmError> {
+    let witnesses: Vec<OutputWitnessJson> = serde_json::from_str(witnesses_json)?;
+    let witnesses = witnesses
+        .into_iter()
+        .map(OutputWitnessJson::try_into_witness)
+        .collect::<Result<Vec<_>, OotleWasmError>>()?;
+
+    let proof: RangeProofBytes =
+        crypto_generate_extended_bullet_proof(witnesses.iter()).map_err(|e| OotleWasmError::Stealth(e.to_string()))?;
+    Ok(proof.into_vec())
+}
+
+#[cfg(test)]
+mod tests {
+    use ootle_byte_type::ToByteType;
+    use tari_crypto::{
+        keys::{PublicKey, SecretKey},
+        ristretto::{RistrettoPublicKey, RistrettoSecretKey},
+    };
+    use tari_engine_types::stealth::validate_stealth_outputs_statement;
+    use tari_template_lib_types::{EncryptedData, stealth::StealthOutputsStatement};
+
+    use super::*;
+
+    fn make_witness_json(amount: u64) -> String {
+        let mask = RistrettoSecretKey::random(&mut rand::rng());
+        let nonce = RistrettoPublicKey::from_secret_key(&mask);
+        let spend_pk: tari_template_lib_types::crypto::RistrettoPublicKeyBytes = nonce.to_byte_type();
+        format!(
+            r#"[{{"witness":{{"amount":{},"mask":"{}","sender_public_nonce":"{}","minimum_value_promise":0,"encrypted_data":"{}"}},"spend_condition":{{"Signed":"{}"}},"tag":0}}]"#,
+            amount,
+            hex::encode(mask.as_bytes()),
+            hex::encode(nonce.as_bytes()),
+            hex::encode(vec![0u8; EncryptedData::min_size()]),
+            hex::encode(spend_pk.as_bytes()),
+        )
+    }
+
+    #[test]
+    fn generate_outputs_produces_valid_statement() {
+        let witnesses = make_witness_json(1000);
+        let result = generate_stealth_outputs_statement(&witnesses, 0).unwrap();
+        let stmt: StealthOutputsStatement = serde_json::from_str(&result.statement_json).unwrap();
+        validate_stealth_outputs_statement(&stmt, None).unwrap();
+        assert_eq!(result.aggregated_output_mask.len(), 32);
+    }
+
+    #[test]
+    fn generate_outputs_with_empty_array() {
+        let result = generate_stealth_outputs_statement("[]", 100).unwrap();
+        let stmt: StealthOutputsStatement = serde_json::from_str(&result.statement_json).unwrap();
+        assert!(stmt.outputs.is_empty());
+        assert!(stmt.agg_range_proof.is_empty());
+        assert_eq!(result.aggregated_output_mask, vec![0u8; 32]);
+    }
+
+    #[test]
+    fn generate_extended_bullet_proof_empty() {
+        let proof = generate_extended_bullet_proof("[]").unwrap();
+        assert!(proof.is_empty());
+    }
+
+    #[test]
+    fn generate_extended_bullet_proof_non_empty() {
+        // Flat OutputWitnessJson (no spend_condition / tag wrapper).
+        let mask = RistrettoSecretKey::random(&mut rand::rng());
+        let nonce = RistrettoPublicKey::from_secret_key(&mask);
+        let witness_json = format!(
+            r#"[{{"amount":50,"mask":"{}","sender_public_nonce":"{}","minimum_value_promise":0,"encrypted_data":"{}"}}]"#,
+            hex::encode(mask.as_bytes()),
+            hex::encode(nonce.as_bytes()),
+            hex::encode(vec![0u8; EncryptedData::min_size()]),
+        );
+        let proof = generate_extended_bullet_proof(&witness_json).unwrap();
+        assert!(!proof.is_empty());
+    }
+}

--- a/crates/ootle_wasm/core/src/stealth/types.rs
+++ b/crates/ootle_wasm/core/src/stealth/types.rs
@@ -1,0 +1,142 @@
+//   Copyright 2026 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+//! JSON wrapper types for stealth witnesses.
+//!
+//! The internal `OutputWitness`, `StealthOutputWitness` and `StealthInputWitness` types in
+//! `tari_ootle_wallet_crypto` are intentionally not `Serialize`/`Deserialize`. These mirror types provide a
+//! stable JSON shape for the WASM ABI and convert into the internal types via [`Into`].
+//!
+//! All 32-byte values (masks, public keys) are hex-encoded strings; `encrypted_data` follows the standard
+//! `EncryptedData` hex encoding; `spend_condition` and `tag` are the same shapes used by the wallet daemon
+//! RPC layer.
+
+use serde::Deserialize;
+use tari_crypto::ristretto::{RistrettoPublicKey, RistrettoSecretKey};
+use tari_ootle_wallet_crypto::{MaskAndValue, OutputWitness, StealthInputWitness, StealthOutputWitness};
+use tari_template_lib_types::{EncryptedData, crypto::UtxoTag, stealth::SpendCondition};
+
+use crate::{
+    error::OotleWasmError,
+    keys::{public_key_from_bytes, secret_key_from_bytes},
+};
+
+/// Unblinded data for a single stealth output (sender side).
+#[derive(Debug, Clone, Deserialize)]
+pub struct OutputWitnessJson {
+    pub amount: u64,
+    /// Hex-encoded 32-byte Ristretto scalar.
+    pub mask: String,
+    /// Hex-encoded 32-byte Ristretto public key.
+    pub sender_public_nonce: String,
+    #[serde(default)]
+    pub minimum_value_promise: u64,
+    pub encrypted_data: EncryptedData,
+    /// Optional hex-encoded 32-byte Ristretto public key for the resource view-key holder.
+    #[serde(default)]
+    pub resource_view_key: Option<String>,
+}
+
+impl OutputWitnessJson {
+    pub(crate) fn try_into_witness(self) -> Result<OutputWitness, OotleWasmError> {
+        let mask = decode_secret_key(&self.mask, "mask")?;
+        let sender_public_nonce = decode_public_key(&self.sender_public_nonce, "sender_public_nonce")?;
+        let resource_view_key = self
+            .resource_view_key
+            .as_deref()
+            .map(|h| decode_public_key(h, "resource_view_key"))
+            .transpose()?;
+        Ok(OutputWitness {
+            amount: self.amount,
+            mask,
+            sender_public_nonce,
+            minimum_value_promise: self.minimum_value_promise,
+            encrypted_data: self.encrypted_data,
+            resource_view_key,
+        })
+    }
+}
+
+/// A full stealth output witness: the unblinded data plus the spend condition and UTXO tag attached to it.
+#[derive(Debug, Clone, Deserialize)]
+pub struct StealthOutputWitnessJson {
+    pub witness: OutputWitnessJson,
+    pub spend_condition: SpendCondition,
+    pub tag: UtxoTag,
+}
+
+impl TryFrom<StealthOutputWitnessJson> for StealthOutputWitness {
+    type Error = OotleWasmError;
+
+    fn try_from(value: StealthOutputWitnessJson) -> Result<Self, Self::Error> {
+        Ok(StealthOutputWitness {
+            witness: value.witness.try_into_witness()?,
+            spend_condition: value.spend_condition,
+            tag: value.tag,
+        })
+    }
+}
+
+/// An input being spent: the plaintext value and the commitment mask used to bind it. Once decrypted, the
+/// receiver has both halves and can construct this directly.
+#[derive(Debug, Clone, Deserialize)]
+pub struct InputWitness {
+    pub value: u64,
+    /// Hex-encoded 32-byte Ristretto scalar.
+    pub mask: String,
+}
+
+/// A stealth input being spent (currently just the unblinded commitment opening).
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+pub enum StealthInputWitnessJson {
+    /// Object form: `{ "mask_and_value": { "value": 100, "mask": "..." } }`.
+    Wrapped { mask_and_value: InputWitness },
+    /// Flat form: `{ "value": 100, "mask": "..." }`.
+    Flat(InputWitness),
+}
+
+impl StealthInputWitnessJson {
+    fn into_inner(self) -> InputWitness {
+        match self {
+            Self::Wrapped { mask_and_value } => mask_and_value,
+            Self::Flat(w) => w,
+        }
+    }
+}
+
+impl TryFrom<StealthInputWitnessJson> for StealthInputWitness {
+    type Error = OotleWasmError;
+
+    fn try_from(value: StealthInputWitnessJson) -> Result<Self, Self::Error> {
+        let inner = value.into_inner();
+        let mask = decode_secret_key(&inner.mask, "mask")?;
+        Ok(StealthInputWitness {
+            mask_and_value: MaskAndValue::new(inner.value, mask),
+        })
+    }
+}
+
+pub(crate) fn decode_secret_key(hex_str: &str, field: &'static str) -> Result<RistrettoSecretKey, OotleWasmError> {
+    let bytes = decode_fixed_hex::<32>(hex_str, field)?;
+    secret_key_from_bytes(&bytes)
+}
+
+pub(crate) fn decode_public_key(hex_str: &str, field: &'static str) -> Result<RistrettoPublicKey, OotleWasmError> {
+    let bytes = decode_fixed_hex::<32>(hex_str, field)?;
+    public_key_from_bytes(&bytes)
+}
+
+fn decode_fixed_hex<const N: usize>(hex_str: &str, field: &'static str) -> Result<[u8; N], OotleWasmError> {
+    let bytes = hex::decode(hex_str)?;
+    if bytes.len() != N {
+        return Err(OotleWasmError::InvalidByteLength {
+            field,
+            expected: N,
+            got: bytes.len(),
+        });
+    }
+    let mut out = [0u8; N];
+    out.copy_from_slice(&bytes);
+    Ok(out)
+}

--- a/crates/ootle_wasm/core/src/stealth/types.rs
+++ b/crates/ootle_wasm/core/src/stealth/types.rs
@@ -128,15 +128,14 @@ pub(crate) fn decode_public_key(hex_str: &str, field: &'static str) -> Result<Ri
 }
 
 fn decode_fixed_hex<const N: usize>(hex_str: &str, field: &'static str) -> Result<[u8; N], OotleWasmError> {
-    let bytes = hex::decode(hex_str)?;
-    if bytes.len() != N {
+    if hex_str.len() != N * 2 {
         return Err(OotleWasmError::InvalidByteLength {
             field,
             expected: N,
-            got: bytes.len(),
+            got: hex_str.len() / 2,
         });
     }
     let mut out = [0u8; N];
-    out.copy_from_slice(&bytes);
+    hex::decode_to_slice(hex_str, &mut out)?;
     Ok(out)
 }

--- a/crates/ootle_wasm/core/src/stealth/validate.rs
+++ b/crates/ootle_wasm/core/src/stealth/validate.rs
@@ -51,10 +51,10 @@ mod tests {
         let output_mask = RistrettoSecretKey::random(&mut rng);
         let owner_pk = RistrettoPublicKey::from_secret_key(&output_mask);
 
-        let inputs = vec![StealthInputWitness {
+        let inputs = [StealthInputWitness {
             mask_and_value: MaskAndValue::new(500, input_mask),
         }];
-        let outputs = vec![StealthOutputWitness {
+        let outputs = [StealthOutputWitness {
             witness: OutputWitness {
                 amount: 500,
                 mask: output_mask,

--- a/crates/ootle_wasm/core/src/stealth/validate.rs
+++ b/crates/ootle_wasm/core/src/stealth/validate.rs
@@ -1,0 +1,82 @@
+//   Copyright 2026 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+//! Pre-flight validation for a full `StealthTransferStatement` envelope.
+
+use tari_engine_types::stealth::validate_transfer as crypto_validate_transfer;
+use tari_template_lib_types::stealth::StealthTransferStatement;
+
+use crate::{error::OotleWasmError, keys::public_key_from_bytes};
+
+/// Run the same validation the engine performs on a `StealthTransferStatement`: structural sanity,
+/// commitment well-formedness, range and balance-proof verification.
+///
+/// `view_key` (optional) is the resource view-key public key — required when the resource has a viewable
+/// balance enabled. Pass `None` for resources without a view key.
+///
+/// Returns `Ok(())` on a valid statement, or an error describing the validation failure.
+pub fn validate_stealth_transfer(transfer_json: &str, view_key: Option<&[u8]>) -> Result<(), OotleWasmError> {
+    let transfer: StealthTransferStatement = serde_json::from_str(transfer_json)?;
+    let view_key = view_key.map(public_key_from_bytes).transpose()?;
+
+    crypto_validate_transfer(&transfer, view_key.as_ref())
+        .map_err(|e| OotleWasmError::StealthValidation(e.to_string()))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::iter;
+
+    use ootle_byte_type::ToByteType;
+    use tari_crypto::{
+        keys::{PublicKey, SecretKey},
+        ristretto::{RistrettoPublicKey, RistrettoSecretKey},
+    };
+    use tari_ootle_wallet_crypto::{
+        MaskAndValue,
+        OutputWitness,
+        StealthInputWitness,
+        StealthOutputWitness,
+        stealth::create_transfer_statement,
+    };
+    use tari_template_lib_types::{Amount, EncryptedData, crypto::UtxoTag, stealth::SpendCondition};
+
+    use super::*;
+
+    #[test]
+    fn validates_a_well_formed_transfer() {
+        let mut rng = rand::rng();
+        let input_mask = RistrettoSecretKey::random(&mut rng);
+        let output_mask = RistrettoSecretKey::random(&mut rng);
+        let owner_pk = RistrettoPublicKey::from_secret_key(&output_mask);
+
+        let inputs = vec![StealthInputWitness {
+            mask_and_value: MaskAndValue::new(500, input_mask),
+        }];
+        let outputs = vec![StealthOutputWitness {
+            witness: OutputWitness {
+                amount: 500,
+                mask: output_mask,
+                sender_public_nonce: owner_pk.clone(),
+                minimum_value_promise: 0,
+                encrypted_data: EncryptedData::try_from(vec![0; EncryptedData::min_size()]).unwrap(),
+                resource_view_key: None,
+            },
+            spend_condition: SpendCondition::Signed(owner_pk.to_byte_type()),
+            tag: UtxoTag::new(0),
+        }];
+        let transfer = create_transfer_statement(inputs, Amount::zero(), outputs.iter(), Amount::zero()).unwrap();
+        let json = serde_json::to_string(&transfer).unwrap();
+
+        validate_stealth_transfer(&json, None).unwrap();
+    }
+
+    #[test]
+    fn rejects_a_noop_transfer() {
+        let transfer = create_transfer_statement(iter::empty(), Amount::zero(), iter::empty(), Amount::zero()).unwrap();
+        let json = serde_json::to_string(&transfer).unwrap();
+        let err = validate_stealth_transfer(&json, None).unwrap_err();
+        assert!(matches!(err, OotleWasmError::StealthValidation(_)));
+    }
+}

--- a/crates/ootle_wasm/core/src/stealth/viewable_balance.rs
+++ b/crates/ootle_wasm/core/src/stealth/viewable_balance.rs
@@ -1,0 +1,156 @@
+//   Copyright 2026 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+//! ElGamal viewable-balance proof generation and decryption.
+
+use ootle_byte_type::ConvertFromByteType;
+use tari_crypto::ristretto::pedersen::PedersenCommitment;
+use tari_engine_types::crypto::{ValueLookupTable, validate_elgamal_verifiable_balance_proof};
+use tari_ootle_wallet_crypto::{
+    GenerateValueLookup,
+    viewable_balance_proof::generate_elgamal_viewable_balance_proof as crypto_generate,
+};
+use tari_template_lib_types::stealth::ViewableBalanceProof;
+
+use crate::{
+    error::OotleWasmError,
+    keys::{commitment_bytes_from_bytes, public_key_from_bytes, secret_key_from_bytes},
+};
+
+/// Generate an ElGamal viewable-balance proof that the supplied `amount` is the value bound by the given
+/// Pedersen `commitment`, encrypted to the resource view-key holder.
+///
+/// `mask` is the 32-byte commitment mask, `commitment` is the 32-byte Pedersen commitment, and
+/// `view_public_key` is the resource's view public key.
+///
+/// Returns the JSON-encoded `ViewableBalanceProof`.
+pub fn generate_elgamal_viewable_balance_proof(
+    mask: &[u8],
+    amount: u64,
+    commitment: &[u8],
+    view_public_key: &[u8],
+) -> Result<String, OotleWasmError> {
+    let mask = secret_key_from_bytes(mask)?;
+    let commitment_bytes = commitment_bytes_from_bytes(commitment)?;
+    let commitment = PedersenCommitment::convert_from_byte_type(&commitment_bytes)
+        .map_err(|e| OotleWasmError::InvalidCommitment(e.to_string()))?;
+    let view_key = public_key_from_bytes(view_public_key)?;
+
+    let proof =
+        crypto_generate(&mask, amount, &commitment, &view_key).map_err(|e| OotleWasmError::Stealth(e.to_string()))?;
+    Ok(serde_json::to_string(&proof)?)
+}
+
+/// Brute-force decrypt an ElGamal viewable-balance proof to recover the bound value.
+///
+/// The decryptor checks each value in `[min_value, max_value]` (inclusive). Returns `None` if no
+/// candidate value matches. This uses an on-the-fly value lookup; for large ranges callers should keep
+/// the range tight to bound the work performed.
+///
+/// `commitment` is the Pedersen commitment the proof is bound to (the same commitment from the UTXO).
+///
+/// Both `view_public_key` and `view_secret_key` are required: the public key is used to re-verify the
+/// ZK proof (rejecting tampered proofs before decrypting), the secret key is used for the actual ElGamal
+/// decryption (`v.G = E - p.R`).
+pub fn decrypt_elgamal_viewable_balance(
+    proof_json: &str,
+    commitment: &[u8],
+    view_public_key: &[u8],
+    view_secret_key: &[u8],
+    min_value: u64,
+    max_value: u64,
+) -> Result<Option<u64>, OotleWasmError> {
+    if max_value < min_value {
+        return Err(OotleWasmError::Stealth(format!(
+            "max_value ({max_value}) must be >= min_value ({min_value})"
+        )));
+    }
+
+    let proof: ViewableBalanceProof = serde_json::from_str(proof_json)?;
+    let commitment_bytes = commitment_bytes_from_bytes(commitment)?;
+    let commitment = PedersenCommitment::convert_from_byte_type(&commitment_bytes)
+        .map_err(|e| OotleWasmError::InvalidCommitment(e.to_string()))?;
+    let view_pk = public_key_from_bytes(view_public_key)?;
+    let view_sk = secret_key_from_bytes(view_secret_key)?;
+
+    let verifiable = validate_elgamal_verifiable_balance_proof(&commitment, Some(&view_pk), Some(&proof))
+        .map_err(|e| OotleWasmError::Stealth(e.to_string()))?
+        .ok_or_else(|| OotleWasmError::Stealth("ElGamal proof returned no verifiable balance".to_string()))?;
+
+    // GenerateValueLookup computes `v.G` on-the-fly — no precomputed file is required, which means this
+    // works in any sandbox (including WASM with no filesystem access).
+    let mut lookup: GenerateValueLookup = GenerateValueLookup;
+    let result: Result<Option<u64>, <GenerateValueLookup as ValueLookupTable>::Error> =
+        verifiable.brute_force_balance(&view_sk, min_value..=max_value, &mut lookup);
+    let value = result.map_err(|e| OotleWasmError::Stealth(format!("Value lookup failed: {e}")))?;
+    Ok(value)
+}
+
+#[cfg(test)]
+mod tests {
+    use ootle_byte_type::ToByteType;
+    use tari_crypto::{
+        commitment::HomomorphicCommitmentFactory,
+        keys::{PublicKey, SecretKey},
+        ristretto::{RistrettoPublicKey, RistrettoSecretKey},
+        tari_utilities::ByteArray,
+    };
+    use tari_engine_types::crypto::get_commitment_factory;
+
+    use super::*;
+
+    fn build_proof(
+        amount: u64,
+    ) -> (
+        RistrettoSecretKey,
+        RistrettoPublicKey,
+        RistrettoSecretKey,
+        Vec<u8>,
+        String,
+    ) {
+        let mut rng = rand::rng();
+        let mask = RistrettoSecretKey::random(&mut rng);
+        let (view_sk, view_pk) = RistrettoPublicKey::random_keypair(&mut rng);
+        let commitment = get_commitment_factory().commit_value(&mask, amount);
+        let commitment_bytes = commitment.to_byte_type();
+        let proof_json = generate_elgamal_viewable_balance_proof(
+            mask.as_bytes(),
+            amount,
+            commitment_bytes.as_bytes(),
+            view_pk.as_bytes(),
+        )
+        .unwrap();
+        (mask, view_pk, view_sk, commitment_bytes.as_bytes().to_vec(), proof_json)
+    }
+
+    #[test]
+    fn round_trip_with_view_key_holder() {
+        let amount = 42u64;
+        let (_mask, view_pk, view_sk, commitment, proof_json) = build_proof(amount);
+
+        let decoded =
+            decrypt_elgamal_viewable_balance(&proof_json, &commitment, view_pk.as_bytes(), view_sk.as_bytes(), 0, 100)
+                .unwrap();
+        assert_eq!(decoded, Some(amount));
+    }
+
+    #[test]
+    fn returns_none_when_value_is_outside_range() {
+        let amount = 200u64;
+        let (_mask, view_pk, view_sk, commitment, proof_json) = build_proof(amount);
+
+        let decoded =
+            decrypt_elgamal_viewable_balance(&proof_json, &commitment, view_pk.as_bytes(), view_sk.as_bytes(), 0, 100)
+                .unwrap();
+        assert_eq!(decoded, None);
+    }
+
+    #[test]
+    fn rejects_inverted_range() {
+        let (_mask, view_pk, view_sk, commitment, proof_json) = build_proof(0);
+        let err =
+            decrypt_elgamal_viewable_balance(&proof_json, &commitment, view_pk.as_bytes(), view_sk.as_bytes(), 10, 5)
+                .unwrap_err();
+        assert!(matches!(err, OotleWasmError::Stealth(_)));
+    }
+}

--- a/crates/ootle_wasm/core/src/transaction.rs
+++ b/crates/ootle_wasm/core/src/transaction.rs
@@ -2,10 +2,9 @@
 //   SPDX-License-Identifier: BSD-3-Clause
 
 use serde::Deserialize;
-use tari_crypto::{ristretto::RistrettoSecretKey, tari_utilities::ByteArray};
 use tari_ootle_transaction::{UnsealedTransactionV1, UnsignedTransactionV1};
 
-use crate::{error::OotleWasmError, hash::public_key_bytes_from_bytes};
+use crate::{error::OotleWasmError, hash::public_key_bytes_from_bytes, keys::secret_key_from_bytes};
 
 /// An unsigned or unsealed transaction parsed from JSON.
 #[derive(Deserialize)]
@@ -26,10 +25,6 @@ impl TransactionInput {
 
 fn parse_transaction_json(tx_json: &str) -> Result<TransactionInput, OotleWasmError> {
     serde_json::from_str(tx_json).map_err(Into::into)
-}
-
-fn secret_key_from_bytes(bytes: &[u8]) -> Result<RistrettoSecretKey, OotleWasmError> {
-    RistrettoSecretKey::from_canonical_bytes(bytes).map_err(|e| OotleWasmError::InvalidSecretKey(e.to_string()))
 }
 
 /// Seal a transaction (accepts unsigned or unsealed JSON) with the seal signer's secret key.

--- a/crates/ootle_wasm/wasm/Cargo.toml
+++ b/crates/ootle_wasm/wasm/Cargo.toml
@@ -15,7 +15,10 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 ootle-wasm-core = { path = "../core", version = "0.30" }
 wasm-bindgen = "0.2"
+# getrandom is pulled in transitively via `rand` and `tari_bulletproofs_plus`. The wasm32-unknown-unknown
+# target requires explicit feature opt-in for both major versions used in the graph.
 getrandom = { version = "0.2", features = ["js"] }
+getrandom_v04 = { package = "getrandom", version = "0.4", features = ["wasm_js"] }
 
 [features]
 default = []
@@ -27,8 +30,9 @@ optional = true
 
 [package.metadata.cargo-machete]
 ignored = [
-    # getrandom does not need to be imported in code
+    # getrandom is only needed to enable the js/wasm_js feature transitively
     "getrandom",
+    "getrandom_v04",
 ]
 
 

--- a/crates/ootle_wasm/wasm/src/lib.rs
+++ b/crates/ootle_wasm/wasm/src/lib.rs
@@ -17,11 +17,34 @@ pub struct KeypairResult {
     pub public_key: Vec<u8>,
 }
 
-/// Result of a Schnorr signature operation (raw bytes).
+/// Result of a Schnorr signature operation (raw bytes). Also used for balance proof signatures, which
+/// share the `(public_nonce, signature)` shape.
 #[wasm_bindgen(getter_with_clone)]
 pub struct SchnorrSignatureResult {
     pub public_nonce: Vec<u8>,
     pub signature: Vec<u8>,
+}
+
+/// Result of generating a stealth outputs statement.
+#[wasm_bindgen(getter_with_clone)]
+pub struct StealthOutputsResult {
+    /// JSON-serialized `StealthOutputsStatement` (the wire-format payload).
+    pub statement_json: String,
+    /// Sum of all witness masks, suitable for use as the `aggregated_output_mask` argument to
+    /// `generateStealthBalanceProofSignature`.
+    pub aggregated_output_mask: Vec<u8>,
+}
+
+/// Decrypted contents of an inbound stealth UTXO.
+#[wasm_bindgen(getter_with_clone)]
+pub struct DecryptedOutputResult {
+    /// The 32-byte commitment mask scalar.
+    pub mask: Vec<u8>,
+    /// The plaintext value (u64).
+    pub value: u64,
+    /// JSON-encoded `Memo` (variants: `U256` / `Message` / `Bytes` / `PayRefAndBytes`), or `null` if
+    /// the payload carried no memo or `skipMemo` was set.
+    pub memo_json: Option<String>,
 }
 
 /// A pair of Ootle secret keys (owner + view).
@@ -176,4 +199,232 @@ pub fn parse_ootle_address(address: &str) -> Result<ParsedOotleAddress, JsError>
         network: result.network,
         memo: result.memo,
     })
+}
+
+// ---------------------------------------------------------------------------
+// Stealth crypto primitives
+// ---------------------------------------------------------------------------
+
+/// Generate the output side of a stealth transfer: per-output Pedersen commitments and encrypted data,
+/// optional ElGamal viewable-balance proofs (for outputs with a `resource_view_key`), and an aggregated
+/// bulletproof range proof.
+///
+/// `witnesses_json` is a JSON array of stealth output witnesses. Each entry has the shape:
+/// ```text
+/// {
+///   "witness": {
+///     "amount": <u64>,
+///     "mask": <hex 32 bytes>,
+///     "sender_public_nonce": <hex 32 bytes>,
+///     "minimum_value_promise": <u64>,
+///     "encrypted_data": <hex variable-length>,
+///     "resource_view_key": <hex 32 bytes | null>
+///   },
+///   "spend_condition": <SpendCondition>,
+///   "tag": <u32>
+/// }
+/// ```
+///
+/// Returns the serialized statement plus the aggregated output mask, which the sender feeds to
+/// `generateStealthBalanceProofSignature` together with the aggregated input mask.
+#[wasm_bindgen(js_name = "generateStealthOutputsStatement")]
+pub fn generate_stealth_outputs_statement(
+    witnesses_json: &str,
+    revealed_output_amount_microtari: u64,
+) -> Result<StealthOutputsResult, JsError> {
+    let result = ootle_wasm_core::stealth::outputs::generate_stealth_outputs_statement(
+        witnesses_json,
+        revealed_output_amount_microtari,
+    )
+    .map_err(|e| JsError::new(&e.to_string()))?;
+    Ok(StealthOutputsResult {
+        statement_json: result.statement_json,
+        aggregated_output_mask: result.aggregated_output_mask,
+    })
+}
+
+/// Build a `StealthInputsStatement` JSON from raw input commitments and a revealed amount.
+///
+/// `input_commitments` is the concatenated bytes of all 32-byte commitments (so the length must be a
+/// multiple of 32). Pass an empty array for a revealed-only statement.
+///
+/// This is a convenience helper so callers don't need to hand-craft the wire JSON; the result is used
+/// as the `inputs_statement_json` argument to `generateStealthBalanceProofSignature` and friends.
+#[wasm_bindgen(js_name = "buildStealthInputsStatement")]
+pub fn build_stealth_inputs_statement(
+    input_commitments: &[u8],
+    revealed_amount_microtari: u64,
+) -> Result<String, JsError> {
+    ootle_wasm_core::stealth::inputs::build_stealth_inputs_statement(input_commitments, revealed_amount_microtari)
+        .map_err(|e| JsError::new(&e.to_string()))
+}
+
+/// Generate an extended bulletproof aggregating range proofs for a set of output witnesses, proving
+/// each amount is in `[minimum_value_promise, 2^64)`. The number of witnesses is padded to the next
+/// power of two internally.
+///
+/// `witnesses_json` is a JSON array of "flat" output witnesses (the `witness` field shape from
+/// [`generate_stealth_outputs_statement`] — without the surrounding `spend_condition` / `tag`).
+///
+/// Returns the raw range proof bytes (may be empty if the input array is empty).
+#[wasm_bindgen(js_name = "generateExtendedBulletProof")]
+pub fn generate_extended_bullet_proof(witnesses_json: &str) -> Result<Vec<u8>, JsError> {
+    ootle_wasm_core::stealth::outputs::generate_extended_bullet_proof(witnesses_json)
+        .map_err(|e| JsError::new(&e.to_string()))
+}
+
+/// Sign the balance proof for a stealth transfer.
+///
+/// `aggregated_input_mask` and `aggregated_output_mask` are the 32-byte sums of all input / output
+/// commitment masks respectively. Returns a `(public_nonce, signature)` pair (each 32 bytes); the pair
+/// may be all-zeros for revealed-only transfers — callers normally omit the balance proof in that case.
+#[wasm_bindgen(js_name = "generateStealthBalanceProofSignature")]
+pub fn generate_stealth_balance_proof_signature(
+    aggregated_input_mask: &[u8],
+    aggregated_output_mask: &[u8],
+    inputs_statement_json: &str,
+    outputs_statement_json: &str,
+) -> Result<SchnorrSignatureResult, JsError> {
+    let result = ootle_wasm_core::stealth::balance_proof::generate_stealth_balance_proof_signature(
+        aggregated_input_mask,
+        aggregated_output_mask,
+        inputs_statement_json,
+        outputs_statement_json,
+    )
+    .map_err(|e| JsError::new(&e.to_string()))?;
+    Ok(SchnorrSignatureResult {
+        public_nonce: result.public_nonce,
+        signature: result.signature,
+    })
+}
+
+/// Pre-flight check that a balance proof signature is cryptographically valid for the given input /
+/// output statements. Returns `false` on a malformed proof or invalid signature; the engine performs
+/// the authoritative check at submission.
+#[wasm_bindgen(js_name = "validateBalanceProofSignature")]
+pub fn validate_balance_proof_signature(
+    public_nonce: &[u8],
+    signature: &[u8],
+    inputs_statement_json: &str,
+    outputs_statement_json: &str,
+) -> Result<bool, JsError> {
+    ootle_wasm_core::stealth::balance_proof::validate_balance_proof_signature(
+        public_nonce,
+        signature,
+        inputs_statement_json,
+        outputs_statement_json,
+    )
+    .map_err(|e| JsError::new(&e.to_string()))
+}
+
+/// Run the same validation the engine performs on a complete `StealthTransferStatement` envelope:
+/// structural sanity, commitment well-formedness, range and balance-proof verification.
+///
+/// `view_key` is the 32-byte resource view public key, required for resources with a viewable balance
+/// and rejected otherwise. Pass `null` for resources without a view key.
+///
+/// Throws on a validation failure; returns successfully on a valid statement.
+#[wasm_bindgen(js_name = "validateStealthTransfer")]
+pub fn validate_stealth_transfer(transfer_json: &str, view_key: Option<Vec<u8>>) -> Result<(), JsError> {
+    ootle_wasm_core::stealth::validate::validate_stealth_transfer(transfer_json, view_key.as_deref())
+        .map_err(|e| JsError::new(&e.to_string()))
+}
+
+/// Decrypt and verify the AEAD payload of an inbound stealth UTXO.
+///
+/// `output_commitment` is the 32-byte Pedersen commitment; `encrypted_data` is the variable-length
+/// XChaCha20Poly1305-encrypted blob; `encryption_key` is the 32-byte AEAD key derived via
+/// `encryptedDataDhKdfAead`. Setting `skip_memo` to `true` returns no memo even if the payload carries
+/// one (useful when only the value / mask are needed).
+///
+/// Throws on AEAD failure or on a commitment mismatch — either indicates the payload was not produced
+/// for this view key.
+#[wasm_bindgen(js_name = "unblindOutput")]
+pub fn unblind_output(
+    output_commitment: &[u8],
+    encrypted_data: &[u8],
+    encryption_key: &[u8],
+    skip_memo: bool,
+) -> Result<DecryptedOutputResult, JsError> {
+    let result = ootle_wasm_core::stealth::encrypted_data::unblind_output(
+        output_commitment,
+        encrypted_data,
+        encryption_key,
+        skip_memo,
+    )
+    .map_err(|e| JsError::new(&e.to_string()))?;
+    Ok(DecryptedOutputResult {
+        mask: result.mask,
+        value: result.value,
+        memo_json: result.memo_json,
+    })
+}
+
+/// Derive the recipient's stealth spending scalar `c + k`, where `c = H(network || k.G * r)`. The
+/// receiver runs this with their account secret key (`private_key`) and the sender-provided public
+/// nonce to obtain the one-time secret that controls the stealth output.
+///
+/// `network` is the network byte (0x00 = MainNet, 0x10 = LocalNet, 0x26 = Esmeralda, ...).
+#[wasm_bindgen(js_name = "stealthDhSecret")]
+pub fn stealth_dh_secret(network: u8, private_key: &[u8], public_nonce: &[u8]) -> Result<Vec<u8>, JsError> {
+    ootle_wasm_core::stealth::kdfs::stealth_dh_secret(network, private_key, public_nonce)
+        .map_err(|e| JsError::new(&e.to_string()))
+}
+
+/// Derive the AEAD encryption key for `encrypted_data` from a Diffie-Hellman shared secret: `H(DH(s, P))`.
+/// Sender derives it with `(sender_secret_nonce, recipient_view_pub)`; receiver derives the same key
+/// with `(recipient_view_secret, sender_public_nonce)`.
+#[wasm_bindgen(js_name = "encryptedDataDhKdfAead")]
+pub fn encrypted_data_dh_kdf_aead(private_key: &[u8], public_key: &[u8]) -> Result<Vec<u8>, JsError> {
+    ootle_wasm_core::stealth::kdfs::encrypted_data_dh_kdf(private_key, public_key)
+        .map_err(|e| JsError::new(&e.to_string()))
+}
+
+/// Generate an ElGamal viewable-balance proof: a zero-knowledge proof that `amount` is the value bound
+/// by `commitment`, encrypted to the resource view-key holder.
+///
+/// Returns the JSON-encoded `ViewableBalanceProof` (8 × 32-byte fields).
+#[wasm_bindgen(js_name = "generateElgamalViewableBalanceProof")]
+pub fn generate_elgamal_viewable_balance_proof(
+    mask: &[u8],
+    amount: u64,
+    commitment: &[u8],
+    view_public_key: &[u8],
+) -> Result<String, JsError> {
+    ootle_wasm_core::stealth::viewable_balance::generate_elgamal_viewable_balance_proof(
+        mask,
+        amount,
+        commitment,
+        view_public_key,
+    )
+    .map_err(|e| JsError::new(&e.to_string()))
+}
+
+/// Brute-force decrypt an ElGamal viewable-balance proof to recover the bound value.
+///
+/// Tries each value in `[min_value, max_value]` (inclusive). Returns `null` (via `Option`) if no
+/// candidate matches. Uses an on-the-fly value lookup — there is no precomputed table dependency, so
+/// callers should keep the range tight (large ranges produce proportional CPU cost).
+///
+/// `commitment` is the Pedersen commitment the proof is bound to. Both the view public key and the
+/// view secret key are required: the public key is used to re-verify the ZK proof (rejecting tampered
+/// proofs before decrypting), the secret key performs the ElGamal decryption itself.
+#[wasm_bindgen(js_name = "decryptElgamalViewableBalance")]
+pub fn decrypt_elgamal_viewable_balance(
+    proof_json: &str,
+    commitment: &[u8],
+    view_public_key: &[u8],
+    view_secret_key: &[u8],
+    min_value: u64,
+    max_value: u64,
+) -> Result<Option<u64>, JsError> {
+    ootle_wasm_core::stealth::viewable_balance::decrypt_elgamal_viewable_balance(
+        proof_json,
+        commitment,
+        view_public_key,
+        view_secret_key,
+        min_value,
+        max_value,
+    )
+    .map_err(|e| JsError::new(&e.to_string()))
 }

--- a/crates/ootle_wasm/wasm/src/lib.rs
+++ b/crates/ootle_wasm/wasm/src/lib.rs
@@ -259,6 +259,19 @@ pub fn build_stealth_inputs_statement(
         .map_err(|e| JsError::new(&e.to_string()))
 }
 
+/// Aggregate the commitment masks of stealth inputs into a single 32-byte Ristretto scalar.
+///
+/// `masks_concat` is the concatenated bytes of all input masks (32 bytes per mask, so the input
+/// length must be a multiple of 32). Pass an empty array to obtain the zero scalar.
+///
+/// Returns the sum as 32 bytes, suitable as the `aggregated_input_mask` argument to
+/// `generateStealthBalanceProofSignature`. The output side of the same balance proof is aggregated
+/// automatically by `generateStealthOutputsStatement` (returned as `aggregated_output_mask`).
+#[wasm_bindgen(js_name = "aggregateInputMasks")]
+pub fn aggregate_input_masks(masks_concat: &[u8]) -> Result<Vec<u8>, JsError> {
+    ootle_wasm_core::stealth::inputs::aggregate_input_masks(masks_concat).map_err(|e| JsError::new(&e.to_string()))
+}
+
 /// Generate an extended bulletproof aggregating range proofs for a set of output witnesses, proving
 /// each amount is in `[minimum_value_promise, 2^64)`. The number of witnesses is padded to the next
 /// power of two internally.


### PR DESCRIPTION
Description
---

Adds WASM bindings for the full stealth-transfer crypto surface — output statement generation (with range proofs + viewable-balance proofs), balance proof signing/validation, inbound UTXO decryption, DH key derivation, ElGamal
  view-key decryption, and a transfer validator. Also fixes the pre-existing `wasm-pack` build break by enabling `getrandom`'s `wasm_js` feature for the v0.4 line pulled in transitively.

Motivation and Context
---

The Python Ootle client currently relies on the wallet daemon to perform stealth crypto operations. To enable a daemon-less client, the WASM library needs to expose the same primitives directly. This PR closes the gap and unblocks single-input stealth transfers end-to-end from Python.

How Has This Been Tested?
---

  - 42 unit tests in `ootle-wasm-core` covering round-trips, validation against the engine, error paths, and edge cases (empty arrays, wrong keys, out-of-range values).
  - `wasm-pack build --release` produces a working 1.1 MB WASM package (408 KB gzipped) with all 12 new exports surfaced in the generated TypeScript bindings.

What process can a PR reviewer use to test or verify this change?
---

  1. `cargo test -p ootle-wasm-core` — runs the test suite.
  2. `cd crates/ootle_wasm && ./build.sh bundler release` — produces the npm package; check `pkg/ootle_wasm.d.ts` for the new exports.
  3. Optionally publish a local build and run the Python client's stealth-transfer flow against an Ootle network.

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify