### PR TITLE
chore: set workspace version for tari_template_test_tooling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,7 +104,7 @@ tari_indexer_lib = { path = "crates/indexer_lib" }
 tari_rpc_state_sync = { path = "crates/rpc_state_sync" }
 tari_state_store_rocksdb = { path = "crates/state_store_rocksdb" }
 tari_state_tree = { path = "crates/state_tree" }
-tari_template_test_tooling = { path = "crates/template_test_tooling" }
+tari_template_test_tooling = { path = "crates/template_test_tooling", version = "0.31" }
 tari_transaction_manifest = { path = "crates/transaction_manifest", version = "0.31" }
 tari_validator_node_rpc = { path = "crates/validator_node_rpc" }
 sqlite_message_logger = { path = "networking/sqlite_message_logger" }


### PR DESCRIPTION
## Summary
- The `[workspace.dependencies]` entry for `tari_template_test_tooling` was missing a `version =` field, so consumers picking it up via `{ workspace = true }` (`tari_engine`, `tari_template_builtin`, `integration_tests`) would fail to publish to crates.io.
- Added `version = "0.31"` to match the crate's own package version.

## Test plan
- [ ] `cargo metadata --no-deps` resolves `tari_template_test_tooling` at `0.31.0`
- [ ] `cargo check --workspace` builds cleanly