### PR TITLE
ci(ootle-wasm): allow manual publish trigger and bump wasm-pack to 0.15.0

### DIFF
--- a/.github/workflows/npm_publish_ootle_wasm.yml
+++ b/.github/workflows/npm_publish_ootle_wasm.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 
 env:
-  WASM_PACK_VERSION: '0.13.1'
+  WASM_PACK_VERSION: '0.15.0'
 
 permissions:
   id-token: write

--- a/.github/workflows/npm_publish_ootle_wasm.yml
+++ b/.github/workflows/npm_publish_ootle_wasm.yml
@@ -6,6 +6,7 @@ on:
     branches: development
     paths:
       - 'crates/ootle_wasm/**'
+  workflow_dispatch:
 
 env:
   WASM_PACK_VERSION: '0.13.1'


### PR DESCRIPTION
## Summary

- Adds `workflow_dispatch:` to the `Publish ootle-wasm to npmjs` workflow. The existing path-filtered `push: development` trigger only fires when a commit touches `crates/ootle_wasm/**`, so fixes that live outside the crate (an updated `.nvmrc`, a workflow tweak, etc.) leave the workflow un-triggered and the most recent failed run can't be re-driven against the new workflow file because GitHub re-runs against the historical commit's workflow definition.
- Bumps `WASM_PACK_VERSION` from `0.13.1` to `0.15.0` (current latest on crates.io). Local rebuild against 0.15.0 produces a byte-for-byte equivalent package (1033.6 KB / 388.5 KB gzipped, identical patched `package.json`), so this is a pure version-currency bump that also silences the "newer version of wasm-pack available" advisory the older binary was printing.

## Test plan

- [ ] After merge: trigger the workflow manually from the Actions tab to publish `@tari-project/ootle-wasm@0.31.0` (the still-pending version).
- [ ] Confirm the run uses wasm-pack 0.15.0 and that the published tarball matches the previous local build's size/contents.