### PR TITLE
feat(ootle-wasm): add createStealthOutputWitness for WASM stealth sends

### DIFF
--- a/crates/ootle_wasm/core/src/stealth/mod.rs
+++ b/crates/ootle_wasm/core/src/stealth/mod.rs
@@ -15,4 +15,4 @@ mod types;
 pub mod validate;
 pub mod viewable_balance;
 
-pub use types::{InputWitness, StealthInputWitnessJson, StealthOutputWitnessJson};
+pub use types::{InputWitness, OutputWitnessJson, StealthInputWitnessJson, StealthOutputWitnessJson};

--- a/crates/ootle_wasm/core/src/stealth/outputs.rs
+++ b/crates/ootle_wasm/core/src/stealth/outputs.rs
@@ -4,15 +4,29 @@
 //! Building the output side of a stealth transfer: per-output commitments + encrypted data, optional
 //! ElGamal view-key proofs, and the aggregated bulletproof range proof.
 
-use tari_crypto::{ristretto::RistrettoSecretKey, tari_utilities::ByteArray};
+use std::str::FromStr;
+
+use ootle_byte_type::ToByteType;
+use ootle_network::Network;
+use tari_crypto::{
+    keys::{PublicKey, SecretKey},
+    ristretto::{RistrettoPublicKey, RistrettoSecretKey},
+    tari_utilities::ByteArray,
+};
 use tari_ootle_wallet_crypto::{
+    OutputWitness,
+    StealthCryptoApi,
+    StealthOutputWitness,
     bullet_proof::generate_extended_bullet_proof as crypto_generate_extended_bullet_proof,
+    memo::Memo,
+    pay_to::PayTo,
     stealth::create_outputs_statement,
 };
-use tari_template_lib_types::{Amount, crypto::RangeProofBytes};
+use tari_template_lib_types::{Amount, ResourceAddress, crypto::RangeProofBytes, stealth::SpendCondition};
 
 use crate::{
     error::OotleWasmError,
+    keys::public_key_from_bytes,
     stealth::types::{OutputWitnessJson, StealthOutputWitnessJson},
 };
 
@@ -58,6 +72,100 @@ pub fn generate_stealth_outputs_statement(
         statement_json: serde_json::to_string(&statement)?,
         aggregated_output_mask: aggregated_output_mask.as_bytes().to_vec(),
     })
+}
+
+/// Inputs to [`create_stealth_output_witness`].
+///
+/// All keys are raw 32-byte slices; `resource_address` is the bech-style `resource_<hex>` string. The
+/// commitment mask and ephemeral nonce are generated internally, so this struct carries only the
+/// caller-controlled parameters.
+pub struct CreateStealthOutputWitnessParams<'a> {
+    /// Network byte (0x00 = MainNet, 0x10 = LocalNet, 0x26 = Esmeralda, ...).
+    pub network: u8,
+    /// Recipient's long-term account public key (used to derive the one-time stealth spend key).
+    pub destination_account_public_key: &'a [u8],
+    /// Recipient's view-only public key (used for the AEAD key and the UTXO scanning tag).
+    pub destination_view_public_key: &'a [u8],
+    /// Output value in microtari.
+    pub amount: u64,
+    /// The resource this output belongs to, as a `resource_<hex>` string.
+    pub resource_address: &'a str,
+    /// View public key of the resource view-key holder, if the resource has a viewable balance.
+    pub resource_view_key: Option<&'a [u8]>,
+    /// Optional JSON-encoded [`Memo`] to embed in the encrypted payload.
+    pub memo_json: Option<&'a str>,
+    /// Optional JSON-encoded [`PayTo`]: `"StealthPublicKey"` (the default when `None`) or
+    /// `{"AccessRule": <AccessRule>}`.
+    pub pay_to_json: Option<&'a str>,
+    /// Minimum value the range proof commits to (must be `<= amount`). Use `0` unless you have a reason
+    /// to reveal a lower bound.
+    pub minimum_value_promise: u64,
+}
+
+/// Build a single stealth output witness entirely client-side, mirroring the wallet daemon's
+/// `StealthOutputsApi::create_output_witness`.
+///
+/// Generates a fresh random commitment mask and ephemeral nonce, AEAD-encrypts the value+mask to the
+/// recipient, derives the spend condition and the UTXO scanning tag, and returns one
+/// [`StealthOutputWitnessJson`] serialized to a JSON string. Collect one such witness per output (including
+/// change) into a JSON array and feed it to [`generate_stealth_outputs_statement`].
+///
+/// The mask is random rather than HD-derived: recipients (including the sender, for change) always recover
+/// `value` and `mask` by decrypting `encrypted_data`, so determinism is not required.
+pub fn create_stealth_output_witness(params: CreateStealthOutputWitnessParams<'_>) -> Result<String, OotleWasmError> {
+    let network = Network::try_from(params.network).map_err(|e| OotleWasmError::InvalidNetwork(e.to_string()))?;
+    let account_key = public_key_from_bytes(params.destination_account_public_key)?;
+    let view_key = public_key_from_bytes(params.destination_view_public_key)?;
+    let resource_address = ResourceAddress::from_str(params.resource_address)
+        .map_err(|e| OotleWasmError::InvalidAddress(e.to_string()))?;
+    let resource_view_key = params.resource_view_key.map(public_key_from_bytes).transpose()?;
+    let memo: Option<Memo> = params.memo_json.map(serde_json::from_str).transpose()?;
+    let pay_to: PayTo = params
+        .pay_to_json
+        .map(serde_json::from_str)
+        .transpose()?
+        .unwrap_or_default();
+
+    // Fail fast with a clear message rather than a cryptic range-proof error later, at statement time.
+    if params.minimum_value_promise > params.amount {
+        return Err(OotleWasmError::Stealth(format!(
+            "minimum_value_promise ({}) must be <= amount ({})",
+            params.minimum_value_promise, params.amount
+        )));
+    }
+
+    let mask = RistrettoSecretKey::random(&mut rand::rng());
+    let (nonce_secret, public_nonce) = RistrettoPublicKey::random_keypair(&mut rand::rng());
+
+    let crypto = StealthCryptoApi::new();
+    let encrypted_data = crypto
+        .encrypt_value_and_mask(params.amount, &mask, &view_key, &nonce_secret, memo.as_ref())
+        .map_err(|e| OotleWasmError::Stealth(e.to_string()))?;
+
+    let spend_condition = match pay_to {
+        PayTo::StealthPublicKey => {
+            let owner_public_key = crypto.derive_stealth_owner_public_key(network, &account_key, &nonce_secret);
+            SpendCondition::Signed(owner_public_key.to_byte_type())
+        },
+        PayTo::AccessRule(access_rule) => SpendCondition::AccessRule(access_rule),
+    };
+
+    let tag = crypto.derive_stealth_output_tag(network, &nonce_secret, &view_key, &resource_address);
+
+    let witness = StealthOutputWitness {
+        witness: OutputWitness {
+            amount: params.amount,
+            mask,
+            sender_public_nonce: public_nonce,
+            minimum_value_promise: params.minimum_value_promise,
+            encrypted_data,
+            resource_view_key,
+        },
+        spend_condition,
+        tag,
+    };
+
+    Ok(serde_json::to_string(&StealthOutputWitnessJson::from(&witness))?)
 }
 
 /// Generate an extended bulletproof that aggregates range proofs for the supplied output witnesses.
@@ -142,5 +250,218 @@ mod tests {
         );
         let proof = generate_extended_bullet_proof(&witness_json).unwrap();
         assert!(!proof.is_empty());
+    }
+
+    fn tari_resource() -> String {
+        tari_template_lib_types::constants::STEALTH_TARI_RESOURCE_ADDRESS.to_string()
+    }
+
+    fn random_public_key() -> RistrettoPublicKey {
+        RistrettoPublicKey::random_keypair(&mut rand::rng()).1
+    }
+
+    #[test]
+    fn created_witness_produces_valid_outputs_statement() {
+        let account_pk = random_public_key();
+        let view_pk = random_public_key();
+        let resource = tari_resource();
+
+        let json = create_stealth_output_witness(CreateStealthOutputWitnessParams {
+            network: Network::LocalNet.as_byte(),
+            destination_account_public_key: account_pk.as_bytes(),
+            destination_view_public_key: view_pk.as_bytes(),
+            amount: 1000,
+            resource_address: &resource,
+            resource_view_key: None,
+            memo_json: None,
+            pay_to_json: None,
+            minimum_value_promise: 0,
+        })
+        .unwrap();
+
+        let result = generate_stealth_outputs_statement(&format!("[{json}]"), 0).unwrap();
+        let stmt: StealthOutputsStatement = serde_json::from_str(&result.statement_json).unwrap();
+        validate_stealth_outputs_statement(&stmt, None).unwrap();
+        assert_eq!(stmt.outputs.len(), 1);
+        // The default pay_to produces a one-time stealth spend key.
+        assert!(matches!(stmt.outputs[0].spend_condition, SpendCondition::Signed(_)));
+    }
+
+    #[test]
+    fn created_witness_is_spendable_and_decryptable() {
+        use tari_crypto::commitment::HomomorphicCommitmentFactory;
+        use tari_engine_types::crypto::get_commitment_factory;
+
+        let network = Network::LocalNet;
+        let (account_sk, account_pk) = RistrettoPublicKey::random_keypair(&mut rand::rng());
+        let (view_sk, view_pk) = RistrettoPublicKey::random_keypair(&mut rand::rng());
+        let amount = 12_345u64;
+        let resource = tari_resource();
+
+        let json = create_stealth_output_witness(CreateStealthOutputWitnessParams {
+            network: network.as_byte(),
+            destination_account_public_key: account_pk.as_bytes(),
+            destination_view_public_key: view_pk.as_bytes(),
+            amount,
+            resource_address: &resource,
+            resource_view_key: None,
+            memo_json: None,
+            pay_to_json: None,
+            minimum_value_promise: 0,
+        })
+        .unwrap();
+
+        let witness: StealthOutputWitness = serde_json::from_str::<StealthOutputWitnessJson>(&json)
+            .unwrap()
+            .try_into()
+            .unwrap();
+
+        // The recipient recomputes the AEAD key from (view_secret, sender_public_nonce) and decrypts the
+        // value + mask back out, confirming the output is addressed to them.
+        let commitment = get_commitment_factory()
+            .commit_value(&witness.witness.mask, amount)
+            .to_byte_type();
+        let encryption_key = crate::stealth::kdfs::encrypted_data_dh_kdf(
+            view_sk.as_bytes(),
+            witness.witness.sender_public_nonce.as_bytes(),
+        )
+        .unwrap();
+        let decrypted = crate::stealth::encrypted_data::unblind_output(
+            commitment.as_bytes(),
+            witness.witness.encrypted_data.as_bytes(),
+            &encryption_key,
+            false,
+        )
+        .unwrap();
+        assert_eq!(decrypted.value, amount);
+        assert_eq!(decrypted.mask, witness.witness.mask.as_bytes().to_vec());
+
+        // The recipient's one-time spend secret matches the spend condition's public key, so the output
+        // is actually spendable.
+        let stealth_secret_bytes = crate::stealth::kdfs::stealth_dh_secret(
+            network.as_byte(),
+            account_sk.as_bytes(),
+            witness.witness.sender_public_nonce.as_bytes(),
+        )
+        .unwrap();
+        let stealth_secret = RistrettoSecretKey::from_canonical_bytes(&stealth_secret_bytes).unwrap();
+        let derived_pub = RistrettoPublicKey::from_secret_key(&stealth_secret);
+        let SpendCondition::Signed(expected) = witness.spend_condition else {
+            panic!("expected a Signed spend condition");
+        };
+        assert_eq!(derived_pub.to_byte_type(), expected);
+    }
+
+    #[test]
+    fn created_witness_with_access_rule() {
+        let account_pk = random_public_key();
+        let view_pk = random_public_key();
+        let resource = tari_resource();
+
+        let json = create_stealth_output_witness(CreateStealthOutputWitnessParams {
+            network: Network::LocalNet.as_byte(),
+            destination_account_public_key: account_pk.as_bytes(),
+            destination_view_public_key: view_pk.as_bytes(),
+            amount: 500,
+            resource_address: &resource,
+            resource_view_key: None,
+            memo_json: None,
+            pay_to_json: Some(r#"{"AccessRule":"AllowAll"}"#),
+            minimum_value_promise: 0,
+        })
+        .unwrap();
+
+        let witness: StealthOutputWitnessJson = serde_json::from_str(&json).unwrap();
+        assert!(matches!(witness.spend_condition, SpendCondition::AccessRule(_)));
+
+        let result = generate_stealth_outputs_statement(&format!("[{json}]"), 0).unwrap();
+        let stmt: StealthOutputsStatement = serde_json::from_str(&result.statement_json).unwrap();
+        validate_stealth_outputs_statement(&stmt, None).unwrap();
+    }
+
+    #[test]
+    fn created_witness_with_memo_round_trips() {
+        use tari_crypto::commitment::HomomorphicCommitmentFactory;
+        use tari_engine_types::crypto::get_commitment_factory;
+
+        let (_, account_pk) = RistrettoPublicKey::random_keypair(&mut rand::rng());
+        let (view_sk, view_pk) = RistrettoPublicKey::random_keypair(&mut rand::rng());
+        let amount = 777u64;
+        let resource = tari_resource();
+
+        let json = create_stealth_output_witness(CreateStealthOutputWitnessParams {
+            network: Network::LocalNet.as_byte(),
+            destination_account_public_key: account_pk.as_bytes(),
+            destination_view_public_key: view_pk.as_bytes(),
+            amount,
+            resource_address: &resource,
+            resource_view_key: None,
+            memo_json: Some(r#"{"Message":"gm"}"#),
+            pay_to_json: None,
+            minimum_value_promise: 0,
+        })
+        .unwrap();
+
+        let witness: StealthOutputWitness = serde_json::from_str::<StealthOutputWitnessJson>(&json)
+            .unwrap()
+            .try_into()
+            .unwrap();
+        let commitment = get_commitment_factory()
+            .commit_value(&witness.witness.mask, amount)
+            .to_byte_type();
+        let encryption_key = crate::stealth::kdfs::encrypted_data_dh_kdf(
+            view_sk.as_bytes(),
+            witness.witness.sender_public_nonce.as_bytes(),
+        )
+        .unwrap();
+        let decrypted = crate::stealth::encrypted_data::unblind_output(
+            commitment.as_bytes(),
+            witness.witness.encrypted_data.as_bytes(),
+            &encryption_key,
+            false,
+        )
+        .unwrap();
+        assert_eq!(decrypted.memo_json.as_deref(), Some(r#"{"Message":"gm"}"#));
+    }
+
+    #[test]
+    fn create_witness_rejects_invalid_resource_address() {
+        let account_pk = random_public_key();
+        let view_pk = random_public_key();
+
+        let err = create_stealth_output_witness(CreateStealthOutputWitnessParams {
+            network: Network::LocalNet.as_byte(),
+            destination_account_public_key: account_pk.as_bytes(),
+            destination_view_public_key: view_pk.as_bytes(),
+            amount: 1,
+            resource_address: "not-a-resource",
+            resource_view_key: None,
+            memo_json: None,
+            pay_to_json: None,
+            minimum_value_promise: 0,
+        })
+        .unwrap_err();
+        assert!(matches!(err, OotleWasmError::InvalidAddress(_)));
+    }
+
+    #[test]
+    fn create_witness_rejects_minimum_value_promise_above_amount() {
+        let account_pk = random_public_key();
+        let view_pk = random_public_key();
+        let resource = tari_resource();
+
+        let err = create_stealth_output_witness(CreateStealthOutputWitnessParams {
+            network: Network::LocalNet.as_byte(),
+            destination_account_public_key: account_pk.as_bytes(),
+            destination_view_public_key: view_pk.as_bytes(),
+            amount: 100,
+            resource_address: &resource,
+            resource_view_key: None,
+            memo_json: None,
+            pay_to_json: None,
+            minimum_value_promise: 101,
+        })
+        .unwrap_err();
+        assert!(matches!(err, OotleWasmError::Stealth(_)));
     }
 }

--- a/crates/ootle_wasm/core/src/stealth/types.rs
+++ b/crates/ootle_wasm/core/src/stealth/types.rs
@@ -11,8 +11,11 @@
 //! `EncryptedData` hex encoding; `spend_condition` and `tag` are the same shapes used by the wallet daemon
 //! RPC layer.
 
-use serde::Deserialize;
-use tari_crypto::ristretto::{RistrettoPublicKey, RistrettoSecretKey};
+use serde::{Deserialize, Serialize};
+use tari_crypto::{
+    ristretto::{RistrettoPublicKey, RistrettoSecretKey},
+    tari_utilities::ByteArray,
+};
 use tari_ootle_wallet_crypto::{MaskAndValue, OutputWitness, StealthInputWitness, StealthOutputWitness};
 use tari_template_lib_types::{EncryptedData, crypto::UtxoTag, stealth::SpendCondition};
 
@@ -22,7 +25,7 @@ use crate::{
 };
 
 /// Unblinded data for a single stealth output (sender side).
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OutputWitnessJson {
     pub amount: u64,
     /// Hex-encoded 32-byte Ristretto scalar.
@@ -57,12 +60,45 @@ impl OutputWitnessJson {
     }
 }
 
+impl From<&OutputWitness> for OutputWitnessJson {
+    fn from(witness: &OutputWitness) -> Self {
+        // Destructured so adding a field to `OutputWitness` is a compile error here, keeping this in
+        // lock-step with the inverse `try_into_witness`.
+        let OutputWitness {
+            amount,
+            mask,
+            sender_public_nonce,
+            minimum_value_promise,
+            encrypted_data,
+            resource_view_key,
+        } = witness;
+        Self {
+            amount: *amount,
+            mask: hex::encode(mask.as_bytes()),
+            sender_public_nonce: hex::encode(sender_public_nonce.as_bytes()),
+            minimum_value_promise: *minimum_value_promise,
+            encrypted_data: encrypted_data.clone(),
+            resource_view_key: resource_view_key.as_ref().map(|k| hex::encode(k.as_bytes())),
+        }
+    }
+}
+
 /// A full stealth output witness: the unblinded data plus the spend condition and UTXO tag attached to it.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StealthOutputWitnessJson {
     pub witness: OutputWitnessJson,
     pub spend_condition: SpendCondition,
     pub tag: UtxoTag,
+}
+
+impl From<&StealthOutputWitness> for StealthOutputWitnessJson {
+    fn from(witness: &StealthOutputWitness) -> Self {
+        Self {
+            witness: OutputWitnessJson::from(&witness.witness),
+            spend_condition: witness.spend_condition.clone(),
+            tag: witness.tag,
+        }
+    }
 }
 
 impl TryFrom<StealthOutputWitnessJson> for StealthOutputWitness {

--- a/crates/ootle_wasm/wasm/Cargo.toml
+++ b/crates/ootle_wasm/wasm/Cargo.toml
@@ -17,6 +17,11 @@ ootle-wasm-core = { path = "../core", version = "0.31" }
 wasm-bindgen = "0.2"
 # getrandom is pulled in transitively via `rand` and `tari_bulletproofs_plus`. The wasm32-unknown-unknown
 # target requires explicit feature opt-in for both major versions used in the graph.
+#
+# 0.2 stays in the graph transitively (aead 0.5 -> rand_core 0.6) and must keep its `js` feature or it
+# fails to compile for wasm32. No runtime path calls it though — all randomness routes through 0.4 — so
+# its JS env-detection backend is dead-code-eliminated and contributes zero host imports to the blob.
+# Keep this dep: dropping it breaks the build; reintroducing a 0.2 RNG call re-bloats the import surface.
 getrandom = { version = "0.2", features = ["js"] }
 getrandom_v04 = { package = "getrandom", version = "0.4", features = ["wasm_js"] }
 

--- a/crates/ootle_wasm/wasm/src/lib.rs
+++ b/crates/ootle_wasm/wasm/src/lib.rs
@@ -243,6 +243,68 @@ pub fn generate_stealth_outputs_statement(
     })
 }
 
+/// Build a single stealth output witness entirely client-side (sender side), mirroring the wallet
+/// daemon's `create_output_witness`.
+///
+/// A fresh commitment mask and ephemeral nonce are generated internally; the recipient recovers the
+/// value and mask by decrypting `encrypted_data`. Returns one witness as a JSON string with the shape:
+/// ```text
+/// {
+///   "witness": {
+///     "amount": <u64>,
+///     "mask": <hex 32 bytes>,
+///     "sender_public_nonce": <hex 32 bytes>,
+///     "minimum_value_promise": <u64>,
+///     "encrypted_data": <hex variable-length>,
+///     "resource_view_key": <hex 32 bytes | null>
+///   },
+///   "spend_condition": <SpendCondition>,
+///   "tag": <u32>
+/// }
+/// ```
+/// Collect one witness per output (including change) into a JSON array and pass it to
+/// `generateStealthOutputsStatement`.
+///
+/// - `network` is the network byte (0x00 = MainNet, 0x10 = LocalNet, 0x26 = Esmeralda, ...).
+/// - `destination_account_public_key` / `destination_view_public_key` are the recipient's 32-byte keys.
+/// - `resource_address` is the `resource_<hex>` string of the resource being sent.
+/// - `resource_view_key` is the resource view-key holder's 32-byte public key, or `null` for resources without a
+///   viewable balance (when set, the output receives an ElGamal proof at statement time).
+/// - `memo_json` is an optional JSON-encoded `Memo` to embed in the encrypted payload.
+/// - `pay_to_json` is an optional JSON-encoded `PayTo`: `"StealthPublicKey"` (the default when `null`, producing a
+///   one-time stealth spend key) or `{"AccessRule": <AccessRule>}`.
+/// - `minimum_value_promise` is the range-proof lower bound and must be `<= amount` (use `0` normally).
+// `#[wasm_bindgen]` exports must take primitive/JS-marshalled arguments, so the params cannot be passed
+// as a struct here — they are repacked into `CreateStealthOutputWitnessParams` for the core call.
+#[wasm_bindgen(js_name = "createStealthOutputWitness")]
+#[allow(clippy::too_many_arguments)]
+pub fn create_stealth_output_witness(
+    network: u8,
+    destination_account_public_key: &[u8],
+    destination_view_public_key: &[u8],
+    amount: u64,
+    resource_address: &str,
+    resource_view_key: Option<Vec<u8>>,
+    memo_json: Option<String>,
+    pay_to_json: Option<String>,
+    minimum_value_promise: u64,
+) -> Result<String, JsError> {
+    ootle_wasm_core::stealth::outputs::create_stealth_output_witness(
+        ootle_wasm_core::stealth::outputs::CreateStealthOutputWitnessParams {
+            network,
+            destination_account_public_key,
+            destination_view_public_key,
+            amount,
+            resource_address,
+            resource_view_key: resource_view_key.as_deref(),
+            memo_json: memo_json.as_deref(),
+            pay_to_json: pay_to_json.as_deref(),
+            minimum_value_promise,
+        },
+    )
+    .map_err(|e| JsError::new(&e.to_string()))
+}
+
 /// Build a `StealthInputsStatement` JSON from raw input commitments and a revealed amount.
 ///
 /// `input_commitments` is the concatenated bytes of all 32-byte commitments (so the length must be a

--- a/crates/wallet/crypto/src/encrypted_data.rs
+++ b/crates/wallet/crypto/src/encrypted_data.rs
@@ -3,18 +3,18 @@
 
 use blake2::Blake2b;
 use chacha20poly1305::{
-    AeadCore,
     AeadInPlace,
     KeyInit,
     Tag,
     XChaCha20Poly1305,
     XNonce,
     aead,
-    aead::{OsRng, generic_array::GenericArray},
+    aead::generic_array::GenericArray,
     consts::U32,
 };
 use digest::FixedOutput;
 use ootle_byte_type::ToByteType;
+use rand::Rng;
 use tari_crypto::{
     commitment::HomomorphicCommitmentFactory,
     hashing::DomainSeparatedHasher,
@@ -106,8 +106,13 @@ fn encrypt_data_inner(
             .expect("invariant violation: nonce length is less than payload_offset")
     }
 
-    // Produce a secure random nonce and the AEAD
-    let nonce = XChaCha20Poly1305::generate_nonce(&mut OsRng);
+    // Produce a secure random nonce and the AEAD. The nonce is drawn via `rand` (backed by getrandom
+    // 0.4) rather than aead's `OsRng` (rand_core 0.6 -> getrandom 0.2). Both are CSPRNGs, but routing
+    // through `rand` keeps wasm32 builds on a single getrandom backend instead of dragging in
+    // getrandom 0.2's JS env-detection import shim. See crates/ootle_wasm.
+    let mut nonce_bytes = [0u8; EncryptedData::SIZE_NONCE];
+    rand::rng().fill_bytes(&mut nonce_bytes);
+    let nonce = XNonce::from_slice(&nonce_bytes);
     let aead_key = inner_encrypted_data_kdf_aead(encryption_key, commitment);
     let cipher = XChaCha20Poly1305::new(GenericArray::from_slice(aead_key.reveal()));
 
@@ -138,10 +143,10 @@ fn encrypt_data_inner(
     }
 
     // Encrypt in place
-    match cipher.encrypt_in_place_detached(&nonce, ENCRYPTED_DATA_TAG, payload_mut) {
+    match cipher.encrypt_in_place_detached(nonce, ENCRYPTED_DATA_TAG, payload_mut) {
         Ok(tag) => {
             tag_slice_mut(&mut bytes).copy_from_slice(&tag);
-            nonce_slice_mut(&mut bytes).copy_from_slice(&nonce);
+            nonce_slice_mut(&mut bytes).copy_from_slice(&nonce_bytes);
 
             Ok(EncryptedData::try_from(bytes).expect("bytes length <= EncryptedData::max_size()"))
         },


### PR DESCRIPTION
Description
---

Adds a single new WASM function, `createStealthOutputWitness`, that lets a wallet build a stealth payment output entirely in the browser/client. This is the last missing piece needed to *send* stealth (private) transactions from WASM
  — everything for receiving and verifying them was already in place.

Motivation and Context
---

The team building stealth transactions on top of the WASM package could fully receive and verify private payments, but had no way to construct the outgoing output on the sender side. This change fills that gap so the complete send
  flow now works client-side, without needing the Rust wallet backend.

How Has This Been Tested?
---

  - Added automated tests covering the new function end-to-end, confirming each created output is valid, can be decrypted by the intended recipient, and is actually spendable by them.
  - Verified it compiles for the real WASM target and passes the project's linting and formatting checks.

What process can a PR reviewer use to test or verify this change?
---

  - Run the package tests: `cargo test -p ootle-wasm-core`
  - Build for WASM: `cargo build -p ootle-wasm --target wasm32-unknown-unknown`

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify