### PR TITLE
chore(publish): fix circular dev-deps and crate ordering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12430,7 +12430,6 @@ dependencies = [
  "borsh",
  "minicbor",
  "serde",
- "serde_json",
  "tari_bor",
  "tari_template_abi",
  "tari_template_lib_types",

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -41,7 +41,10 @@ default = []
 wasm-cache = ["dep:bytes", "dep:memmap2"]
 
 [dev-dependencies]
-tari_template_test_tooling = { workspace = true }
+# Path-only (no version) to break the circular dev-dep: tari_template_test_tooling
+# depends on tari_engine, so we can't list it with a published version here or
+# `cargo publish` can't resolve the manifest.
+tari_template_test_tooling = { path = "../template_test_tooling" }
 tari_transaction_manifest = { workspace = true }
 tari_ootle_transaction = { workspace = true }
 tari_template_builtin = { workspace = true, features = ["templates", "state"] }

--- a/crates/template_builtin/Cargo.toml
+++ b/crates/template_builtin/Cargo.toml
@@ -14,7 +14,10 @@ tari_template_lib_types = { workspace = true }
 minicbor = { workspace = true, default-features = false, features = ["alloc", "derive"], optional = true }
 
 [dev-dependencies]
-tari_template_test_tooling = { workspace = true }
+# Path-only (no version) to break the circular dev-dep: tari_template_test_tooling
+# depends on tari_template_builtin, so we can't list it with a published version here
+# or `cargo publish` can't resolve the manifest.
+tari_template_test_tooling = { path = "../template_test_tooling" }
 tari_engine_types = { workspace = true }
 tari_template_lib = { workspace = true }
 tari_ootle_transaction = { workspace = true }

--- a/crates/template_lib/Cargo.toml
+++ b/crates/template_lib/Cargo.toml
@@ -18,9 +18,6 @@ serde = { workspace = true, default-features = false, optional = true, features 
 ts-rs = { workspace = true, optional = true }
 borsh = { workspace = true, optional = true, features = ["derive"] }
 
-[dev-dependencies]
-serde_json = { workspace = true }
-
 [features]
 default = ["macro", "std"]
 macro = ["tari_template_macros"]

--- a/scripts/publish_crates.py
+++ b/scripts/publish_crates.py
@@ -31,12 +31,14 @@ import urllib.error
 CRATES = [
     ("tari_bor", "crates/tari_bor", 1),
     ("ootle-network", "crates/ootle_network", 1),
-    ("ootle_serde", "crates/ootle_serde", 1),
     ("tari_template_abi", "crates/template_abi", 2),
     ("tari_template_lib_types", "crates/template_lib_types", 2),
     ("ootle_byte_type", "crates/ootle_byte_type", 1),
     ("tari_template_macros", "crates/template_macros", 2),
     ("tari_template_lib", "crates/template_lib", 2),
+    # ootle_serde has a dev-dependency on tari_template_lib, so it must be
+    # published after tari_template_lib even though it's a stable/foundational crate.
+    ("ootle_serde", "crates/ootle_serde", 1),
     ("tari_ootle_template_metadata", "crates/template_metadata", 2),
     ("tari_ootle_template_build", "crates/template_build", 2),
     ("tari_engine_types", "crates/engine_types", 3),


### PR DESCRIPTION
## Summary

Fixes blockers encountered during the publish run of the Ootle crates to crates.io.

- **Reorder `ootle_serde`** in `scripts/publish_crates.py` to publish after `tari_template_lib`. `ootle_serde` has a dev-dep on `tari_template_lib`, so cargo could not resolve its manifest when uploading.
- **Path-only dev-dep on `tari_template_test_tooling`** in `crates/engine/Cargo.toml` and `crates/template_builtin/Cargo.toml`. Both ship before `tari_template_test_tooling` in the publish order, but `tari_template_test_tooling` depends on them as normal deps. Stripping the version from the dev-dep (cargo strips path-only deps from the published manifest) breaks the publish-time cycle while keeping local workspace tests working.
- **Drop unused `serde_json` dev-dep** from `tari_template_lib`.

All 27 workspace crates have been published to crates.io with these fixes applied.

## Test plan

- [x] `./scripts/publish_crates.py --execute` completes end-to-end
- [x] All 27 crates visible on crates.io at expected versions
- [ ] CI on this branch