### PR TITLE
feat(wallet)!: claim validator fees to stealth UTXO by default

### DIFF
--- a/applications/tari_wallet_cli/src/command/validator.rs
+++ b/applications/tari_wallet_cli/src/command/validator.rs
@@ -29,6 +29,10 @@ pub struct ClaimFeesArgs {
     pub max_fee: Option<u32>,
     #[clap(long)]
     pub dry_run: bool,
+    /// Deposit the claim into the account's revealed vault. By default, the claim is sent to a stealth UTXO addressed
+    /// to the account's own owner key.
+    #[clap(long)]
+    pub revealed: bool,
 }
 
 fn parse_shard(s: &str) -> Result<Shard, String> {
@@ -84,6 +88,7 @@ pub async fn handle_claim_validator_fees(
         shard,
         max_fee,
         dry_run,
+        revealed,
     } = args;
 
     println!("Submitting claim validator fees transaction...");
@@ -97,6 +102,7 @@ pub async fn handle_claim_validator_fees(
             max_fee: max_fee.map(Into::into).unwrap_or(1500),
             shards: vec![shard],
             dry_run,
+            output_to_revealed: revealed,
         })
         .await?;
 

--- a/applications/tari_walletd/src/handlers/validator.rs
+++ b/applications/tari_walletd/src/handlers/validator.rs
@@ -1,16 +1,18 @@
 //   Copyright 2023 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use std::collections::HashMap;
+use std::{collections::HashMap, iter};
 
 use anyhow::anyhow;
 use axum_extra::headers::authorization::Bearer;
 use either::Either;
 use log::*;
 use ootle_byte_type::ToByteType;
+use tari_crypto::{keys::PublicKey as _, ristretto::RistrettoPublicKey};
 use tari_engine_types::substate::SubstateId;
 use tari_ootle_common_types::{SubstateAddress, SubstateRequirement, derive_fee_pool_address};
 use tari_ootle_transaction::args;
+use tari_ootle_wallet_crypto::{OutputWitness, StealthInputWitness, StealthOutputWitness, memo::Memo};
 use tari_ootle_wallet_sdk::models::{KeyBranch, KeyId};
 use tari_ootle_walletd_client::{
     permissions::JrpcPermission,
@@ -22,6 +24,11 @@ use tari_ootle_walletd_client::{
         GetValidatorFeesRequest,
         GetValidatorFeesResponse,
     },
+};
+use tari_template_lib_types::{
+    ValidatorFeePoolAddress,
+    constants::{STEALTH_TARI_RESOURCE_ADDRESS, TARI_TOKEN},
+    stealth::{SpendCondition, StealthTransferStatement},
 };
 
 use crate::{
@@ -125,24 +132,27 @@ pub async fn handle_claim_validator_fees(
         None => *account.address.account_public_key(),
     };
 
-    let fee_pool_addresses = req
+    let fee_pool_addresses: Vec<ValidatorFeePoolAddress> = req
         .shards
-        .into_iter()
-        .map(|shard| derive_fee_pool_address(&claim_public_key, NUM_PRESHARDS, shard));
+        .iter()
+        .map(|shard| derive_fee_pool_address(&claim_public_key, NUM_PRESHARDS, *shard))
+        .collect();
 
     // build the transaction
     let max_fee = req.max_fee.max(1);
+    let account_public_key = *account.address.account_public_key();
 
-    let unsigned_transaction = context
-        .transaction_builder()
-        .with_dry_run(req.dry_run)
-        .with_fee_instructions_builder(|builder| {
+    let builder = context.transaction_builder().with_dry_run(req.dry_run);
+
+    let builder = if req.output_to_revealed {
+        builder.with_fee_instructions_builder(|builder| {
             builder
-                .create_account(*account.address.account_public_key())
+                .create_account(account_public_key)
                 .then(|builder| {
                     let mut bucket_names = vec![];
                     fee_pool_addresses
-                        .clone()
+                        .iter()
+                        .copied()
                         .enumerate()
                         .fold(builder, |builder, (i, address)| {
                             bucket_names.push(format!("b{}", i));
@@ -162,16 +172,39 @@ pub async fn handle_claim_validator_fees(
                 })
                 .call_method(account_component_address, "pay_fee", args![max_fee])
         })
+    } else {
+        let stealth_outputs =
+            build_self_stealth_statements(&sdk, &account, account_key_id, &fee_pool_addresses).await?;
+        builder.with_fee_instructions_builder(move |builder| {
+            builder
+                .create_account(account_public_key)
+                .then(|builder| {
+                    stealth_outputs
+                        .into_iter()
+                        .enumerate()
+                        .fold(builder, |builder, (i, (address, statement))| {
+                            let bucket = format!("b{}", i);
+                            builder
+                                .claim_validator_fees(address)
+                                .put_last_instruction_output_on_workspace(bucket.clone())
+                                .stealth_transfer_with_input_bucket(TARI_TOKEN, statement, bucket)
+                        })
+                })
+                .call_method(account_component_address, "pay_fee", args![max_fee])
+        })
+    };
+
+    let unsigned_transaction = builder
         .with_inputs(inputs.into_iter().map(|input| input.into_unversioned()))
-        .with_inputs(fee_pool_addresses.map(SubstateRequirement::unversioned))
+        .with_inputs(fee_pool_addresses.iter().copied().map(SubstateRequirement::unversioned))
         .map(|builder| {
             if let Some(index) = req.claim_key_index {
-                if claim_public_key == *account.address.account_public_key() {
+                if claim_public_key == account_public_key {
                     Ok(builder.finish())
                 } else {
                     // If the claim key is different from the account secret, we need to sign with both
                     sdk.signer_api()
-                        .with_context(account.address.account_public_key())
+                        .with_context(&account_public_key)
                         .sign(KeyId::derived(KeyBranch::Account, index), builder.finish())
                 }
             } else {
@@ -224,4 +257,94 @@ pub async fn handle_claim_validator_fees(
         fee: finalized.final_fee,
         result: finalized.finalize,
     })
+}
+
+/// Fetches each fee pool's current amount and builds a per-shard [`StealthTransferStatement`] that converts the claimed
+/// revealed amount into a stealth UTXO addressed to the account's own owner key. Each statement consumes the full
+/// claimed bucket as revealed input and produces a single stealth output of the same amount (no revealed output).
+async fn build_self_stealth_statements(
+    sdk: &crate::WalletSdk,
+    account: &tari_ootle_wallet_sdk::models::AccountWithAddress,
+    account_owner_key_id: tari_ootle_wallet_sdk::models::KeyId,
+    fee_pool_addresses: &[ValidatorFeePoolAddress],
+) -> Result<Vec<(ValidatorFeePoolAddress, StealthTransferStatement)>, anyhow::Error> {
+    let network = sdk.config_api().get_network()?;
+    let account_owner = sdk.key_manager_api().get_public_key(account_owner_key_id)?;
+    let view_only = sdk.key_manager_api().get_public_key(account.view_only_key_id())?;
+
+    let substate_ids: Vec<SubstateId> = fee_pool_addresses.iter().copied().map(SubstateId::from).collect();
+    let mut amounts: HashMap<ValidatorFeePoolAddress, u64> = HashMap::with_capacity(substate_ids.len());
+    const CHUNK_SIZE: usize = 20;
+    for chunk in substate_ids.chunks(CHUNK_SIZE) {
+        let substates = sdk.substate_api().get_substates_from_network(chunk.to_vec()).await?;
+        for (id, substate) in substates {
+            let Some(addr) = id.as_validator_fee_pool_address() else {
+                continue;
+            };
+            let Some(amount) = substate.substate_value().as_validator_fee_pool().map(|p| p.amount()) else {
+                continue;
+            };
+            amounts.insert(addr, amount);
+        }
+    }
+
+    let memo = Memo::new_message("Validator fees claimed to stealth").expect("valid memo");
+
+    fee_pool_addresses
+        .iter()
+        .copied()
+        .map(|address| {
+            let amount = amounts.get(&address).copied().unwrap_or(0);
+            if amount == 0 {
+                return Err(invalid_params(
+                    "shards",
+                    Some(format!("Fee pool {address} is empty or could not be fetched")),
+                ));
+            }
+
+            let mask = sdk.key_manager_api().next_key(KeyBranch::StealthMask)?;
+            let (nonce, output_public_nonce) = RistrettoPublicKey::random_keypair(&mut rand::rng());
+
+            let encrypted_data = sdk.stealth_crypto_api().encrypt_value_and_mask(
+                amount,
+                &mask.key,
+                view_only.public_key(),
+                &nonce,
+                Some(&memo),
+            )?;
+
+            let tag = sdk.stealth_crypto_api().derive_stealth_output_tag(
+                network,
+                &nonce,
+                view_only.public_key(),
+                &STEALTH_TARI_RESOURCE_ADDRESS,
+            );
+
+            let stealth_owner_public_key =
+                sdk.stealth_crypto_api()
+                    .derive_stealth_owner_public_key(network, account_owner.public_key(), &nonce);
+
+            let output_witness = StealthOutputWitness {
+                witness: OutputWitness {
+                    amount,
+                    mask: mask.key,
+                    sender_public_nonce: output_public_nonce,
+                    minimum_value_promise: 0,
+                    encrypted_data,
+                    resource_view_key: None,
+                },
+                spend_condition: SpendCondition::Signed(stealth_owner_public_key.to_byte_type()),
+                tag,
+            };
+
+            let statement = sdk.stealth_crypto_api().generate_transfer_statement(
+                iter::empty::<StealthInputWitness>(),
+                amount,
+                iter::once(&output_witness),
+                0u64,
+            )?;
+
+            Ok((address, statement))
+        })
+        .collect()
 }

--- a/applications/tari_walletd/src/handlers/validator.rs
+++ b/applications/tari_walletd/src/handlers/validator.rs
@@ -145,57 +145,54 @@ pub async fn handle_claim_validator_fees(
     let builder = context.transaction_builder().with_dry_run(req.dry_run);
 
     let builder = if req.output_to_revealed {
-        builder.with_fee_instructions_builder(|builder| {
-            builder
-                .create_account(account_public_key)
-                .then(|builder| {
-                    let mut bucket_names = vec![];
-                    fee_pool_addresses
-                        .iter()
-                        .copied()
-                        .enumerate()
-                        .fold(builder, |builder, (i, address)| {
-                            bucket_names.push(format!("b{}", i));
-                            builder
-                                .claim_validator_fees(address)
-                                .put_last_instruction_output_on_workspace(bucket_names.last().unwrap())
-                        })
-                        .then(|builder| {
-                            // TODO: improve this - suggest: the workspace implicitly collect all returned resources
-                            // (buckets) and we should create buckets by taking from the
-                            // workspace. Then we could collect all buckets and
-                            // deposit once. Greatly reducing gas for this (and a lot of other) transactions.
-                            bucket_names.into_iter().fold(builder, |builder, bucket| {
-                                builder.call_method(account_component_address, "deposit", args![Workspace(bucket)])
+        builder
+            .with_fee_instructions_builder(|builder| {
+                builder
+                    .create_account(account_public_key)
+                    .then(|builder| {
+                        let mut bucket_names = vec![];
+                        fee_pool_addresses
+                            .iter()
+                            .copied()
+                            .enumerate()
+                            .fold(builder, |builder, (i, address)| {
+                                bucket_names.push(format!("b{}", i));
+                                builder
+                                    .claim_validator_fees(address)
+                                    .put_last_instruction_output_on_workspace(bucket_names.last().unwrap())
                             })
-                        })
-                })
-                .call_method(account_component_address, "pay_fee", args![max_fee])
-        })
+                            .then(|builder| {
+                                // TODO: improve this - suggest: the workspace implicitly collect all returned resources
+                                // (buckets) and we should create buckets by taking from the
+                                // workspace. Then we could collect all buckets and
+                                // deposit once. Greatly reducing gas for this (and a lot of other) transactions.
+                                bucket_names.into_iter().fold(builder, |builder, bucket| {
+                                    builder.call_method(account_component_address, "deposit", args![Workspace(bucket)])
+                                })
+                            })
+                    })
+                    .call_method(account_component_address, "pay_fee", args![max_fee])
+            })
+            .with_inputs(inputs.into_iter().map(|input| input.into_unversioned()))
     } else {
-        let stealth_outputs =
-            build_self_stealth_statements(&sdk, &account, account_key_id, &fee_pool_addresses).await?;
+        let plan = build_self_stealth_plan(&sdk, &account, account_key_id, &fee_pool_addresses, max_fee).await?;
         builder.with_fee_instructions_builder(move |builder| {
-            builder
-                .create_account(account_public_key)
-                .then(|builder| {
-                    stealth_outputs
-                        .into_iter()
-                        .enumerate()
-                        .fold(builder, |builder, (i, (address, statement))| {
-                            let bucket = format!("b{}", i);
-                            builder
-                                .claim_validator_fees(address)
-                                .put_last_instruction_output_on_workspace(bucket.clone())
-                                .stealth_transfer_with_input_bucket(TARI_TOKEN, statement, bucket)
-                        })
-                })
-                .call_method(account_component_address, "pay_fee", args![max_fee])
+            let mut builder = builder;
+            for (i, (address, statement)) in plan.statements.into_iter().enumerate() {
+                let bucket = format!("b{}", i);
+                builder = builder
+                    .claim_validator_fees(address)
+                    .put_last_instruction_output_on_workspace(bucket.clone())
+                    .stealth_transfer_with_input_bucket(TARI_TOKEN, statement, bucket);
+                if i == plan.fee_carrier_idx {
+                    builder = builder.put_last_instruction_output_on_workspace("fee");
+                }
+            }
+            builder.pay_fee_from_bucket("fee")
         })
     };
 
     let unsigned_transaction = builder
-        .with_inputs(inputs.into_iter().map(|input| input.into_unversioned()))
         .with_inputs(fee_pool_addresses.iter().copied().map(SubstateRequirement::unversioned))
         .map(|builder| {
             if let Some(index) = req.claim_key_index {
@@ -259,15 +256,24 @@ pub async fn handle_claim_validator_fees(
     })
 }
 
-/// Fetches each fee pool's current amount and builds a per-shard [`StealthTransferStatement`] that converts the claimed
-/// revealed amount into a stealth UTXO addressed to the account's own owner key. Each statement consumes the full
-/// claimed bucket as revealed input and produces a single stealth output of the same amount (no revealed output).
-async fn build_self_stealth_statements(
+struct StealthClaimPlan {
+    statements: Vec<(ValidatorFeePoolAddress, StealthTransferStatement)>,
+    /// Index of the pool whose stealth_transfer carves out `max_fee` as a revealed-output bucket to pay the network
+    /// fee. All other pools carve out 0.
+    fee_carrier_idx: usize,
+}
+
+/// Fetches each fee pool's current amount and builds a per-shard [`StealthTransferStatement`] that converts the
+/// claimed revealed amount into a stealth UTXO addressed to the account's own owner key. The pool with the largest
+/// amount additionally carves `max_fee` as a revealed-output bucket which the caller pays the network fee from — so
+/// no funds need to come from the user's account.
+async fn build_self_stealth_plan(
     sdk: &crate::WalletSdk,
     account: &tari_ootle_wallet_sdk::models::AccountWithAddress,
     account_owner_key_id: tari_ootle_wallet_sdk::models::KeyId,
     fee_pool_addresses: &[ValidatorFeePoolAddress],
-) -> Result<Vec<(ValidatorFeePoolAddress, StealthTransferStatement)>, anyhow::Error> {
+    max_fee: u64,
+) -> Result<StealthClaimPlan, anyhow::Error> {
     let network = sdk.config_api().get_network()?;
     let account_owner = sdk.key_manager_api().get_public_key(account_owner_key_id)?;
     let view_only = sdk.key_manager_api().get_public_key(account.view_only_key_id())?;
@@ -288,12 +294,30 @@ async fn build_self_stealth_statements(
         }
     }
 
+    let (fee_carrier_idx, fee_carrier_amount) = fee_pool_addresses
+        .iter()
+        .enumerate()
+        .map(|(i, addr)| (i, amounts.get(addr).copied().unwrap_or(0)))
+        .max_by_key(|(_, amount)| *amount)
+        .ok_or_else(|| invalid_params("shards", Some("no fee pool addresses to claim")))?;
+
+    if fee_carrier_amount < max_fee {
+        return Err(invalid_params(
+            "max_fee",
+            Some(format!(
+                "max_fee ({max_fee}) exceeds the largest claimable fee pool amount ({fee_carrier_amount}); reduce \
+                 max_fee or include shards with larger balances"
+            )),
+        ));
+    }
+
     let memo = Memo::new_message("Validator fees claimed to stealth").expect("valid memo");
 
-    fee_pool_addresses
+    let statements = fee_pool_addresses
         .iter()
         .copied()
-        .map(|address| {
+        .enumerate()
+        .map(|(i, address)| {
             let amount = amounts.get(&address).copied().unwrap_or(0);
             if amount == 0 {
                 return Err(invalid_params(
@@ -302,11 +326,14 @@ async fn build_self_stealth_statements(
                 ));
             }
 
+            let revealed_output = if i == fee_carrier_idx { max_fee } else { 0 };
+            let stealth_amount = amount - revealed_output;
+
             let mask = sdk.key_manager_api().next_key(KeyBranch::StealthMask)?;
             let (nonce, output_public_nonce) = RistrettoPublicKey::random_keypair(&mut rand::rng());
 
             let encrypted_data = sdk.stealth_crypto_api().encrypt_value_and_mask(
-                amount,
+                stealth_amount,
                 &mask.key,
                 view_only.public_key(),
                 &nonce,
@@ -326,7 +353,7 @@ async fn build_self_stealth_statements(
 
             let output_witness = StealthOutputWitness {
                 witness: OutputWitness {
-                    amount,
+                    amount: stealth_amount,
                     mask: mask.key,
                     sender_public_nonce: output_public_nonce,
                     minimum_value_promise: 0,
@@ -341,10 +368,15 @@ async fn build_self_stealth_statements(
                 iter::empty::<StealthInputWitness>(),
                 amount,
                 iter::once(&output_witness),
-                0u64,
+                revealed_output,
             )?;
 
             Ok((address, statement))
         })
-        .collect()
+        .collect::<Result<Vec<_>, _>>()?;
+
+    Ok(StealthClaimPlan {
+        statements,
+        fee_carrier_idx,
+    })
 }

--- a/applications/tari_walletd/src/handlers/validator.rs
+++ b/applications/tari_walletd/src/handlers/validator.rs
@@ -108,7 +108,7 @@ pub async fn handle_get_validator_fees(
 pub async fn handle_claim_validator_fees(
     context: &HandlerContext,
     token: Option<&Bearer>,
-    req: ClaimValidatorFeesRequest,
+    mut req: ClaimValidatorFeesRequest,
 ) -> Result<ClaimValidatorFeesResponse, anyhow::Error> {
     let sdk = context.wallet_sdk().clone();
     context.check_auth(token, &[JrpcPermission::Admin])?;
@@ -132,11 +132,13 @@ pub async fn handle_claim_validator_fees(
         None => *account.address.account_public_key(),
     };
 
-    let fee_pool_addresses: Vec<ValidatorFeePoolAddress> = req
+    req.shards.sort();
+    req.shards.dedup();
+    let fee_pool_addresses = req
         .shards
         .iter()
         .map(|shard| derive_fee_pool_address(&claim_public_key, NUM_PRESHARDS, *shard))
-        .collect();
+        .collect::<Vec<_>>();
 
     // build the transaction
     let max_fee = req.max_fee.max(1);

--- a/applications/tari_walletd/web_ui/src/routes/AssetVault/Components/ClaimFees.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/AssetVault/Components/ClaimFees.tsx
@@ -23,9 +23,10 @@
 import PopupTitle from "@/components/PopupTitle";
 import { useAccountsList } from "@api/hooks/useAccounts";
 import { useKeysList } from "@api/hooks/useKeys";
-import { FormControl, InputLabel, MenuItem, Select, SelectChangeEvent } from "@mui/material";
+import { FormControl, FormControlLabel, InputLabel, MenuItem, Select, SelectChangeEvent, Typography } from "@mui/material";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
+import CheckBox from "@mui/material/Checkbox";
 import Dialog from "@mui/material/Dialog";
 import DialogContent from "@mui/material/DialogContent";
 import { useTheme } from "@mui/material/styles";
@@ -50,13 +51,15 @@ interface FormState {
   fee: string;
   shards: Array<number>;
   keyIndex: number | null;
+  outputToRevealed: boolean;
 }
 
-const INITIAL_VALUES = {
+const INITIAL_VALUES: FormState = {
   account: null,
   fee: "",
   shards: [],
   keyIndex: null,
+  outputToRevealed: false,
 };
 
 const INITIAL_VALIDITY = {
@@ -140,6 +143,7 @@ export default function ClaimFees() {
       max_fee: isFeeSet ? BigInt(formState.fee) : 1n,
       shards: formState.shards,
       dry_run: !isFeeSet,
+      output_to_revealed: formState.outputToRevealed,
     })
       .then((resp) => {
         if ("Accept" in resp.result.result) {
@@ -282,6 +286,24 @@ export default function ClaimFees() {
               style={{ flexGrow: 1 }}
               disabled={disabled}
             />
+
+            <FormControlLabel
+              control={
+                <CheckBox
+                  name="outputToRevealed"
+                  checked={formState.outputToRevealed}
+                  onChange={(e) => setFormState({ ...formState, outputToRevealed: e.target.checked })}
+                  disabled={disabled}
+                />
+              }
+              label="Claim to revealed funds"
+            />
+            {formState.outputToRevealed ? (
+              <Typography color="warning.main">
+                ⚠️ Warning: Revealed funds are visible on the blockchain and can be viewed by anyone. By default, fees
+                are claimed into a stealth UTXO that is private to your wallet.
+              </Typography>
+            ) : null}
 
             <Box
               className="flex-container"

--- a/bindings/src/types/wallet-types/ClaimValidatorFeesRequest.ts
+++ b/bindings/src/types/wallet-types/ClaimValidatorFeesRequest.ts
@@ -8,4 +8,9 @@ export type ClaimValidatorFeesRequest = {
   max_fee: bigint;
   shards: Array<Shard>;
   dry_run: boolean;
+  /**
+   * If true, claim into the account's revealed vault. If false (default), claim into a per-shard stealth UTXO
+   * addressed to the account's own owner key.
+   */
+  output_to_revealed: boolean;
 };

--- a/clients/wallet_daemon_client/src/types.rs
+++ b/clients/wallet_daemon_client/src/types.rs
@@ -920,6 +920,10 @@ pub struct ClaimValidatorFeesRequest {
     pub max_fee: u64,
     pub shards: Vec<Shard>,
     pub dry_run: bool,
+    /// If true, claim into the account's revealed vault. If false (default), claim into a per-shard stealth UTXO
+    /// addressed to the account's own owner key.
+    #[serde(default)]
+    pub output_to_revealed: bool,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/integration_tests/src/wallet_daemon_client.rs
+++ b/integration_tests/src/wallet_daemon_client.rs
@@ -95,6 +95,7 @@ pub async fn claim_fees(
                 .start(),
         ],
         dry_run,
+        output_to_revealed: true,
     };
 
     client.claim_validator_fees(request).await


### PR DESCRIPTION
## Summary

- Adds `output_to_revealed: bool` (default `false`) to `ClaimValidatorFeesRequest` so fee claims land in a stealth UTXO by default rather than the account's revealed vault.
- The new stealth path fetches each fee pool's current amount, then builds one `StealthTransferStatement` per shard using the same `encrypt_value_and_mask` / `derive_stealth_output_tag` / `derive_stealth_owner_public_key` primitives as the burn/claim flow. Fee payment continues from the account's existing revealed balance.
- Surfaces the option across walletd handler, wallet CLI (`--revealed` flag), web UI (checkbox with warning), TypeScript bindings (regenerated), and the integration-test helper (hardcoded to `true` to keep testing the legacy path).

## Breaking change

`output_to_revealed` defaults to `false`. Callers that previously relied on the implicit revealed-deposit behavior must now explicitly pass `output_to_revealed: true`. Given Ootle is pre-launch this is acceptable.

## Test plan

- [ ] Run workspace nextest sweep (excluding integration tests): `cargo nextest r -E "not package(integration_tests)" --no-fail-fast`
- [ ] Start a local walletd against a live validator and claim fees with `output_to_revealed` omitted (or `false`) — verify the resulting transaction contains a `StealthTransfer` instruction and that the wallet scanner picks up the stealth UTXO without the account's revealed balance increasing.
- [ ] Repeat the claim with `output_to_revealed: true` (or `--revealed` CLI flag) — verify behavior is byte-equivalent to the prior revealed-deposit path (bucket deposited to account vault, no stealth output).
- [ ] Confirm TypeScript binding `ClaimValidatorFeesRequest` compiles cleanly (`tsc --noEmit` in `bindings/`).

> Note: end-to-end smoke against a live validator has not been run by the author (no local validator setup). Please cover items 2–3 during review.