### PR TITLE
test(consensus): fix flaky stale_qc_carry_forward dummy-event race

### DIFF
--- a/crates/consensus_tests/src/stale_qc_carry_forward.rs
+++ b/crates/consensus_tests/src/stale_qc_carry_forward.rs
@@ -88,8 +88,8 @@ async fn first_round_votes_dropped_recovers_via_stale_qc_carry_forward() {
                 .get_validator(&address)
                 .state_store()
                 .with_read_tx(|tx| Block::get(tx, &block_id))
-                .map(|b| b.is_dummy())
-                .unwrap_or(false);
+                .expect("block from BlockCommitted event must exist in the validator's store")
+                .is_dummy();
             if !is_dummy {
                 saw_past_target = true;
             }

--- a/crates/consensus_tests/src/stale_qc_carry_forward.rs
+++ b/crates/consensus_tests/src/stale_qc_carry_forward.rs
@@ -23,6 +23,7 @@ use std::{
 use tari_consensus::messages::HotstuffMessage;
 use tari_consensus_types::Decision;
 use tari_ootle_common_types::{Epoch, NodeHeight};
+use tari_ootle_storage::{StateStore, consensus_models::Block};
 
 use crate::support::{Test, TestVnDestination, logging::setup_logger};
 
@@ -67,16 +68,33 @@ async fn first_round_votes_dropped_recovers_via_stale_qc_carry_forward() {
 
     test.start_epoch(Epoch(1)).await;
 
-    // Drive the test loop until either the transaction is finalised everywhere or we've waited
-    // too many blocks. We deliberately observe block commits past height 1 (the dropped round)
-    // to assert that consensus actually moved forward.
+    // Drive the test loop until the transaction is finalised everywhere AND we've witnessed a
+    // real (non-dummy) block commit past the dropped-vote height — that's the only proof the
+    // recovery path actually carried forward, not just the dummy filler the chain-commit
+    // cascade walks back to.
+    //
+    // Why both conditions: the cascade emits a `BlockCommitted` event for the dummy at
+    // target_height (height matches but it's a filler) before the event for the real recovery
+    // block at target_height+1. Both publishes happen inside the same storage write
+    // transaction, so substates become visible roughly together across the committee. Without
+    // the dummy filter, `has_committed_substates` can return true for everyone while the loop
+    // has only consumed the dummy events, leaving `saw_past_target` false even though recovery
+    // succeeded.
     let mut saw_past_target = false;
     loop {
-        let (_, _, _, committed_height) = test.on_block_committed().await;
+        let (address, block_id, _, committed_height) = test.on_block_committed().await;
         if committed_height > target_height {
-            saw_past_target = true;
+            let is_dummy = test
+                .get_validator(&address)
+                .state_store()
+                .with_read_tx(|tx| Block::get(tx, &block_id))
+                .map(|b| b.is_dummy())
+                .unwrap_or(false);
+            if !is_dummy {
+                saw_past_target = true;
+            }
         }
-        if test.validators_iter().all(|v| v.has_committed_substates(&tx_id)) {
+        if saw_past_target && test.validators_iter().all(|v| v.has_committed_substates(&tx_id)) {
             break;
         }
         if committed_height > NodeHeight(50) {


### PR DESCRIPTION
## Summary

`first_round_votes_dropped_recovers_via_stale_qc_carry_forward` is flaky
under CI load (e.g. [run 26226530090](https://github.com/tari-project/tari-ootle/actions/runs/26226530090/job/77175036126?pr=2145)) and panics with:

> consensus must advance past the dropped-vote height for the recovery path to be exercised

### Root cause

When the test recovers from the dropped-vote round, the 3-chain commit cascade
in `on_commit_block_recurse` (`crates/consensus/src/traits/block_store.rs`)
walks back from the real recovery block to the **dummy filler** at
`target_height` and commits it first. Each `on_commit` call publishes a
`HotstuffEvent::BlockCommitted`, so every validator emits, in order:

1. `BlockCommitted { height: target_height }` — the dummy
2. `BlockCommitted { height: target_height + 1 }` — the real recovery block

Both publishes happen inside the same storage write transaction, so once that
transaction commits, **all** of a validator's substate writes (including the
tx outputs from the real block) are visible at once.

The harness's `on_block_committed` races per-validator channels with
`FuturesUnordered`. Under fast/synchronous timing — exactly what an idle CI
runner produces — the test can pull a dummy event first while every validator's
storage transaction has already committed. `saw_past_target` stays `false`
(because dummy height equals target), `has_committed_substates` returns true
for all four validators, the loop exits, and the final assertion panics even
though recovery actually succeeded.

### Fix

Look the committed block up in the emitting validator's state store and only
treat **non-dummy** commits past `target_height` as progress. Also require
`saw_past_target` before breaking the loop, so we cannot exit on a
dummy-only observation.

This is a test-only change — no consensus or harness behaviour is altered.

## Test plan

- [x] Pre-fix: 30 local runs of `stale_qc_carry_forward` (didn't repro
      locally, flake is CI-timing-sensitive)
- [x] Post-fix: 30 local runs — all pass
- [x] `cargo build -p consensus_tests --tests` clean