### PR TITLE
feat(validator-node): add epoch manager, oracle, and consensus epoch metrics

### DIFF
--- a/applications/tari_validator_node/src/bootstrap.rs
+++ b/applications/tari_validator_node/src/bootstrap.rs
@@ -79,6 +79,8 @@ use tokio::{
 
 #[cfg(feature = "metrics")]
 use crate::consensus::metrics::PrometheusConsensusMetrics;
+#[cfg(feature = "metrics")]
+use crate::epoch_metrics::{EpochManagerCollector, MeteredEpochOracle, PrometheusEpochOracleMetrics};
 use crate::{
     ApplicationConfig,
     ValidatorNodeEpochManagerSpec,
@@ -244,8 +246,19 @@ pub async fn spawn_services(
         num_preshards: consensus_constants.num_preshards,
     };
 
-    // Epoch event scanner
+    // All Tari-side metrics live under the `tari` sub-registry. Sub-registries from this
+    // point on (consensus, mempool, epoch_oracle, epoch_manager) are derived from it.
+    #[cfg(feature = "metrics")]
+    let tari_metrics_registry = metrics_registry.sub_registry_with_prefix("tari");
+
+    // Epoch event scanner. When metrics are enabled, wrap the oracle so every event it
+    // produces is counted on its way into the epoch manager.
     let epoch_event_oracle = create_epoch_oracle(&config, global_db.clone(), &consensus_constants).await?;
+    #[cfg(feature = "metrics")]
+    let epoch_event_oracle = MeteredEpochOracle::new(
+        epoch_event_oracle,
+        PrometheusEpochOracleMetrics::register(tari_metrics_registry),
+    );
 
     let layer_one_transaction_submitter = FileLayerOneSubmitter::new(config.get_layer_one_transaction_base_path());
 
@@ -261,6 +274,12 @@ pub async fn spawn_services(
         );
 
     handles.push(epoch_manager_join_handle);
+
+    // Register the epoch manager's current-epoch collector now that we have a handle. The
+    // collector reads the handle's atomic on every scrape, so it always reflects whatever
+    // the epoch manager currently believes the epoch to be.
+    #[cfg(feature = "metrics")]
+    EpochManagerCollector::new(epoch_manager.clone()).register(tari_metrics_registry);
 
     let validator_node_client_factory = TariValidatorNodeRpcClientFactory::new(networking.clone());
 
@@ -316,8 +335,6 @@ pub async fn spawn_services(
         create_consensus_transaction_validator(config.network, template_provider.clone()).boxed(),
     );
 
-    #[cfg(feature = "metrics")]
-    let tari_metrics_registry = metrics_registry.sub_registry_with_prefix("tari");
     #[cfg(feature = "metrics")]
     let metrics = PrometheusConsensusMetrics::register(tari_metrics_registry);
     #[cfg(not(feature = "metrics"))]

--- a/applications/tari_validator_node/src/consensus/metrics.rs
+++ b/applications/tari_validator_node/src/consensus/metrics.rs
@@ -21,6 +21,10 @@ pub struct PrometheusConsensusMetrics {
     blocks_committed: Counter,
     blocks_validation_failed: Counter,
     commit_height: UnsignedGauge,
+    /// Epoch of the most recently committed local block. Tracks consensus' view of the
+    /// active epoch, which can lag the epoch manager's view across an epoch boundary
+    /// until the first block of the new epoch is committed.
+    current_epoch: UnsignedGauge,
 
     commands_count: UnsignedGauge,
     published_templates_count: Counter,
@@ -50,6 +54,11 @@ impl PrometheusConsensusMetrics {
             commit_height: UnsignedGauge::default().register_at(
                 "commit_height",
                 "Current block commit height",
+                registry,
+            ),
+            current_epoch: UnsignedGauge::default().register_at(
+                "current_epoch",
+                "Epoch of the most recently committed local block",
                 registry,
             ),
             commands_count: UnsignedGauge::default().register_at("num_commands", "Number of commands added", registry),
@@ -107,6 +116,7 @@ impl ConsensusHooks for PrometheusConsensusMetrics {
     fn on_local_block_committed(&mut self, block: &ValidBlock) {
         self.blocks_committed.inc();
         self.commit_height.set(block.block().height().as_u64());
+        self.current_epoch.set(block.block().epoch().as_u64());
         self.commands_count.inc_by(block.block().commands().len() as u64);
     }
 

--- a/applications/tari_validator_node/src/epoch_metrics.rs
+++ b/applications/tari_validator_node/src/epoch_metrics.rs
@@ -12,7 +12,7 @@
 //! [`MeteredEpochOracle`], which counts the events it forwards and tracks the highest
 //! epoch ever seen across all event variants.
 
-use std::{fmt, future::Future};
+use std::fmt;
 
 use prometheus_client::{
     collector::Collector,
@@ -43,7 +43,7 @@ pub struct PrometheusEpochOracleMetrics {
     /// liveness signal — a stuck oracle stops bumping this even if the validator node is
     /// otherwise healthy.
     last_event_epoch: UnsignedGauge,
-    errors: Counter,
+    errors_total: Counter,
     epoch_changed_total: Counter,
     active_validator_set_changed_total: Counter,
     new_validator_registered_total: Counter,
@@ -60,8 +60,8 @@ impl PrometheusEpochOracleMetrics {
                 "Highest epoch observed across all events emitted by the epoch oracle",
                 registry,
             ),
-            errors: Counter::default().register_at(
-                "errors",
+            errors_total: Counter::default().register_at(
+                "errors_total",
                 "Number of Error events emitted by the epoch oracle",
                 registry,
             ),
@@ -96,7 +96,7 @@ impl PrometheusEpochOracleMetrics {
     fn record(&self, event: &EpochEvent) {
         match event {
             EpochEvent::Error(_) => {
-                self.errors.inc();
+                self.errors_total.inc();
             },
             EpochEvent::ActiveValidatorNodeSetChanged { epoch, .. } => {
                 self.active_validator_set_changed_total.inc();
@@ -140,14 +140,12 @@ impl<O> MeteredEpochOracle<O> {
 }
 
 impl<O: EpochEventOracle + Send> EpochEventOracle for MeteredEpochOracle<O> {
-    fn next_epoch_event(&mut self) -> impl Future<Output = Option<EpochEvent>> + Send {
-        async {
-            let event = self.inner.next_epoch_event().await;
-            if let Some(ref e) = event {
-                self.metrics.record(e);
-            }
-            event
+    async fn next_epoch_event(&mut self) -> Option<EpochEvent> {
+        let event = self.inner.next_epoch_event().await;
+        if let Some(ref e) = event {
+            self.metrics.record(e);
         }
+        event
     }
 
     fn is_within_epoch_end_spread(&self, current_epoch: Epoch) -> bool {

--- a/applications/tari_validator_node/src/epoch_metrics.rs
+++ b/applications/tari_validator_node/src/epoch_metrics.rs
@@ -1,0 +1,201 @@
+//   Copyright 2025 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+//! Prometheus instrumentation for the epoch manager and the epoch event oracle.
+//!
+//! The epoch manager exposes its current epoch via an [`Arc<AtomicU64>`] on its handle,
+//! so [`EpochManagerCollector`] reads it on each scrape rather than maintaining a separate
+//! gauge — the metric is always exactly in sync with the source of truth and there is no
+//! background task to spawn.
+//!
+//! The epoch oracle is observed by wrapping the [`EpochEventOracle`] implementation with
+//! [`MeteredEpochOracle`], which counts the events it forwards and tracks the highest
+//! epoch ever seen across all event variants.
+
+use std::{fmt, future::Future};
+
+use prometheus_client::{
+    collector::Collector,
+    encoding::{DescriptorEncoder, EncodeMetric},
+    metrics::{
+        counter::Counter,
+        gauge::{ConstGauge, Gauge},
+    },
+    registry::Registry,
+};
+use tari_epoch_manager::{
+    epoch_event_oracle::{EpochEvent, EpochEventOracle},
+    service::EpochManagerHandle,
+};
+use tari_ootle_common_types::Epoch;
+use tari_ootle_p2p::PeerAddress;
+
+use crate::metrics::CollectorRegister;
+
+type UnsignedGauge = Gauge<u64, std::sync::atomic::AtomicU64>;
+
+// === Epoch oracle metrics ===
+
+/// Counters/gauges for every event variant produced by an [`EpochEventOracle`].
+#[derive(Debug, Clone)]
+pub struct PrometheusEpochOracleMetrics {
+    /// Highest epoch observed across all event variants the oracle has emitted. Useful as a
+    /// liveness signal — a stuck oracle stops bumping this even if the validator node is
+    /// otherwise healthy.
+    last_event_epoch: UnsignedGauge,
+    errors: Counter,
+    epoch_changed_total: Counter,
+    active_validator_set_changed_total: Counter,
+    new_validator_registered_total: Counter,
+    new_validator_exit_total: Counter,
+    done_for_now_total: Counter,
+}
+
+impl PrometheusEpochOracleMetrics {
+    pub fn register(registry: &mut Registry) -> Self {
+        let registry = registry.sub_registry_with_prefix("epoch_oracle");
+        Self {
+            last_event_epoch: UnsignedGauge::default().register_at(
+                "last_event_epoch",
+                "Highest epoch observed across all events emitted by the epoch oracle",
+                registry,
+            ),
+            errors: Counter::default().register_at(
+                "errors",
+                "Number of Error events emitted by the epoch oracle",
+                registry,
+            ),
+            epoch_changed_total: Counter::default().register_at(
+                "epoch_changed_total",
+                "Number of EpochChanged events emitted by the epoch oracle",
+                registry,
+            ),
+            active_validator_set_changed_total: Counter::default().register_at(
+                "active_validator_set_changed_total",
+                "Number of ActiveValidatorNodeSetChanged events emitted by the epoch oracle",
+                registry,
+            ),
+            new_validator_registered_total: Counter::default().register_at(
+                "new_validator_registered_total",
+                "Number of NewValidatorRegistered events emitted by the epoch oracle",
+                registry,
+            ),
+            new_validator_exit_total: Counter::default().register_at(
+                "new_validator_exit_total",
+                "Number of NewValidatorNodeExit events emitted by the epoch oracle",
+                registry,
+            ),
+            done_for_now_total: Counter::default().register_at(
+                "done_for_now_total",
+                "Number of DoneForNow events emitted by the epoch oracle",
+                registry,
+            ),
+        }
+    }
+
+    fn record(&self, event: &EpochEvent) {
+        match event {
+            EpochEvent::Error(_) => {
+                self.errors.inc();
+            },
+            EpochEvent::ActiveValidatorNodeSetChanged { epoch, .. } => {
+                self.active_validator_set_changed_total.inc();
+                self.last_event_epoch.set(epoch.as_u64());
+            },
+            EpochEvent::NewValidatorRegistered { epoch, .. } => {
+                self.new_validator_registered_total.inc();
+                self.last_event_epoch.set(epoch.as_u64());
+            },
+            EpochEvent::NewValidatorNodeExit { epoch, .. } => {
+                self.new_validator_exit_total.inc();
+                self.last_event_epoch.set(epoch.as_u64());
+            },
+            EpochEvent::EpochChanged { epoch, .. } => {
+                self.epoch_changed_total.inc();
+                self.last_event_epoch.set(epoch.as_u64());
+            },
+            EpochEvent::DoneForNow { epoch, .. } => {
+                self.done_for_now_total.inc();
+                self.last_event_epoch.set(epoch.as_u64());
+            },
+        }
+    }
+}
+
+// === MeteredEpochOracle wrapper ===
+
+/// [`EpochEventOracle`] decorator that records every event flowing into the epoch manager.
+///
+/// Wraps any oracle implementation transparently — the epoch manager sees the same event
+/// stream it would otherwise have received.
+pub struct MeteredEpochOracle<O> {
+    inner: O,
+    metrics: PrometheusEpochOracleMetrics,
+}
+
+impl<O> MeteredEpochOracle<O> {
+    pub fn new(inner: O, metrics: PrometheusEpochOracleMetrics) -> Self {
+        Self { inner, metrics }
+    }
+}
+
+impl<O: EpochEventOracle + Send> EpochEventOracle for MeteredEpochOracle<O> {
+    fn next_epoch_event(&mut self) -> impl Future<Output = Option<EpochEvent>> + Send {
+        async {
+            let event = self.inner.next_epoch_event().await;
+            if let Some(ref e) = event {
+                self.metrics.record(e);
+            }
+            event
+        }
+    }
+
+    fn is_within_epoch_end_spread(&self, current_epoch: Epoch) -> bool {
+        self.inner.is_within_epoch_end_spread(current_epoch)
+    }
+}
+
+// === Epoch manager current-epoch collector ===
+
+/// Read-on-scrape collector that emits the epoch manager's current epoch.
+///
+/// The handle's `Arc<AtomicU64>` is the authoritative current-epoch value inside the
+/// node, so we read it directly during encoding — no background task, no risk of the
+/// metric drifting from the manager's state.
+pub struct EpochManagerCollector {
+    handle: EpochManagerHandle<PeerAddress>,
+}
+
+impl EpochManagerCollector {
+    pub fn new(handle: EpochManagerHandle<PeerAddress>) -> Self {
+        Self { handle }
+    }
+
+    /// Registers the collector under the `epoch_manager` sub-registry; the resulting
+    /// metric name on the wire is `epoch_manager_current_epoch`.
+    pub fn register(self, registry: &mut Registry) {
+        let registry = registry.sub_registry_with_prefix("epoch_manager");
+        registry.register_collector(Box::new(self));
+    }
+}
+
+impl fmt::Debug for EpochManagerCollector {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("EpochManagerCollector").finish_non_exhaustive()
+    }
+}
+
+impl Collector for EpochManagerCollector {
+    fn encode(&self, mut encoder: DescriptorEncoder) -> Result<(), fmt::Error> {
+        let epoch = self.handle.get_current_epoch().as_u64();
+        let gauge = ConstGauge::<u64>::new(epoch);
+        let metric_encoder = encoder.encode_descriptor(
+            "current_epoch",
+            "Current epoch as tracked by the epoch manager",
+            None,
+            gauge.metric_type(),
+        )?;
+        gauge.encode(metric_encoder)?;
+        Ok(())
+    }
+}

--- a/applications/tari_validator_node/src/lib.rs
+++ b/applications/tari_validator_node/src/lib.rs
@@ -25,6 +25,8 @@ mod bootstrap;
 mod cmap_semaphore;
 mod config;
 pub mod consensus;
+#[cfg(feature = "metrics")]
+mod epoch_metrics;
 mod event_subscription;
 mod file_l1_submitter;
 mod genesis_state;
@@ -228,7 +230,13 @@ pub struct ValidatorNodeEpochManagerSpec;
 
 impl EpochManagerSpec for ValidatorNodeEpochManagerSpec {
     type Addr = PeerAddress;
+    // When metrics are enabled, the oracle is wrapped by MeteredEpochOracle so it records every
+    // event it forwards to the epoch manager. When disabled, the raw oracle is used directly.
+    #[cfg(not(feature = "metrics"))]
     type EpochEventOracle = EpochOracle<GlobalDb<SqliteGlobalDbAdapter<PeerAddress>>>;
+    #[cfg(feature = "metrics")]
+    type EpochEventOracle =
+        crate::epoch_metrics::MeteredEpochOracle<EpochOracle<GlobalDb<SqliteGlobalDbAdapter<PeerAddress>>>>;
     type LayerOneSubmitter = FileLayerOneSubmitter;
 }
 


### PR DESCRIPTION
## Description

Before this change, `/_metrics` on the validator node exposed nothing about the current epoch or epoch oracle activity, making it difficult to diagnose epoch-boundary issues from Prometheus dashboards. This PR adds three new metric subsystems, all feature-gated behind the existing `metrics` feature flag.

## Motivation

Epoch-boundary bugs (stuck committees, missed validator set rotations) are hard to spot without observability on what epoch the node believes it is in and how often epoch events are flowing through the oracle pipeline.

## New metrics

**Consensus subsystem** (`applications/tari_validator_node/src/consensus/metrics.rs`)
- `tari_consensus_current_epoch` — gauge, updated on every local block commit via the existing `on_local_block_committed` hook.

**Epoch manager** (`applications/tari_validator_node/src/epoch_metrics.rs`)
- `tari_epoch_manager_current_epoch` — gauge emitted by a `Collector` that reads the manager's `Arc<AtomicU64>` on each Prometheus scrape. Always in sync with the source of truth; no background task or event listener needed.

**Epoch oracle** (`applications/tari_validator_node/src/epoch_metrics.rs`)
- `tari_epoch_oracle_epoch_changed_total`
- `tari_epoch_oracle_active_validator_set_changed_total`
- `tari_epoch_oracle_new_validator_registered_total`
- `tari_epoch_oracle_new_validator_exit_total`
- `tari_epoch_oracle_done_for_now_total`
- `tari_epoch_oracle_errors_total`
- `tari_epoch_oracle_last_event_epoch` — gauge tracking the highest epoch seen across all oracle events (liveness signal).

## Design notes

- **`EpochManagerCollector`** implements `prometheus_client::collector::Collector` and emits a `ConstGauge` on each scrape by reading the existing `Arc<AtomicU64>` directly, avoiding any mirroring overhead.
- **`MeteredEpochOracle<O>`** is a thin decorator over the `EpochEventOracle` trait. It forwards `next_epoch_event()` and records each event before returning it, keeping the prometheus dependency out of the `tari_epoch_oracles` and `tari_epoch_manager` crates entirely.
- **`ValidatorNodeEpochManagerSpec::EpochEventOracle`** is feature-gated so non-metrics builds use the raw `EpochOracle<…>` type directly with zero overhead.

## Verification

- `cargo check -p tari_validator_node --features metrics` — clean
- `cargo check -p tari_validator_node --no-default-features` — clean
- `cargo +nightly-2025-06-25 fmt --all` — applied