### PR TITLE
fix(consensus): surface epoch-hash divergence and unblock hash self-heal

### DIFF
--- a/crates/consensus/src/hotstuff/worker.rs
+++ b/crates/consensus/src/hotstuff/worker.rs
@@ -1281,6 +1281,34 @@ impl<TConsensusSpec: ConsensusSpec> HotstuffWorker<TConsensusSpec> {
                 justify_block,
                 ..
             }) => (justify_block.epoch(), justify_block.height()),
+            HotStuffError::ProposalValidationError(ProposalValidationError::InvalidEpochHash {
+                epoch,
+                local_epoch_hash,
+                invalid_epoch_hash,
+                ..
+            }) => {
+                // A locked epoch hash can no longer be corrected by the oracle (see
+                // EpochManager::lock_epoch), so a persistent mismatch against peers means this node
+                // committed a different base-layer boundary block than the rest of the committee —
+                // almost always a base-layer reorg deeper than `base_layer_confirmations` straddling
+                // the epoch boundary. Consensus cannot recover from this automatically yet (epoch
+                // state rollback + resync is a follow-up), so raise a single loud alarm per distinct
+                // divergence rather than swallowing one warning per rejected proposal.
+                let divergence = (*epoch, *local_epoch_hash, *invalid_epoch_hash);
+                if self.worker_state.last_epoch_hash_alarm != Some(divergence) {
+                    self.worker_state.last_epoch_hash_alarm = Some(divergence);
+                    error!(
+                        target: LOG_TARGET,
+                        "🚨 Epoch hash divergence at {epoch}: this node committed {local_epoch_hash} but peers are \
+                         proposing against {invalid_epoch_hash}. Consensus is stalled on this node. It can only \
+                         recover once the rest of the committee reaches quorum on the other hash and advances past \
+                         this epoch (a higher-epoch QC then triggers state sync); if the committee is split with no \
+                         quorum, manual recovery is required. Likely cause: a base-layer reorg deeper than the \
+                         confirmation depth at the epoch boundary."
+                    );
+                }
+                return Ok(());
+            },
             HotStuffError::ProposalValidationError(err) => {
                 warn!(
                     target: LOG_TARGET,
@@ -1431,6 +1459,9 @@ struct WorkerState<TAddr> {
     /// to request more.
     pub catch_up: Option<CatchUp<TAddr>>,
     pub has_processed_first_block: bool,
+    /// Last (epoch, local_hash, remote_hash) we raised an epoch-hash divergence alarm for, used to
+    /// emit a single loud alarm per distinct divergence instead of once per rejected proposal.
+    pub last_epoch_hash_alarm: Option<(Epoch, FixedHash, FixedHash)>,
 }
 
 impl<TAddr> WorkerState<TAddr> {
@@ -1444,6 +1475,7 @@ impl<TAddr> Default for WorkerState<TAddr> {
         Self {
             catch_up: None,
             has_processed_first_block: false,
+            last_epoch_hash_alarm: None,
         }
     }
 }

--- a/crates/storage/src/global/backend_adapter.rs
+++ b/crates/storage/src/global/backend_adapter.rs
@@ -175,6 +175,9 @@ pub trait GlobalDbAdapter: AtomicDb + Send + Sync + Clone {
         epoch: Epoch,
     ) -> Result<HashMap<ShardGroup, Committee<Self::Addr>>, Self::Error>;
 
+    /// Upserts the epoch hash for `epoch`. Overwrites an existing row so the epoch manager can apply
+    /// an oracle hash correction for an epoch it has already persisted (only done while the epoch is
+    /// unlocked; locked epochs are guarded in `EpochManagerService::activate_epoch`).
     fn insert_epoch(
         &self,
         tx: &mut Self::DbTransaction<'_>,

--- a/crates/storage_sqlite/src/global/backend_adapter.rs
+++ b/crates/storage_sqlite/src/global/backend_adapter.rs
@@ -822,11 +822,19 @@ impl<TAddr: NodeAddressable> GlobalDbAdapter for SqliteGlobalDbAdapter<TAddr> {
     ) -> Result<(), Self::Error> {
         use crate::global::schema::epochs;
 
+        // Upsert: the base-layer scanner re-emits EpochChanged for an epoch it has already persisted
+        // when a reorg near the epoch boundary surfaces a different boundary-block hash. The epoch
+        // manager only forwards such a correction while the epoch is still unlocked (see
+        // EpochManagerService::activate_epoch), so overwriting the stored hash here is the intended
+        // self-heal. A plain INSERT would hit the UNIQUE(epoch) constraint and abort the correction.
         diesel::insert_into(epochs::table)
             .values((
                 epochs::epoch.eq(epoch.as_u64() as i64),
                 epochs::epoch_hash.eq(epoch_hash.as_slice()),
             ))
+            .on_conflict(epochs::epoch)
+            .do_update()
+            .set(epochs::epoch_hash.eq(epoch_hash.as_slice()))
             .execute(tx.connection())
             .map_err(|source| SqliteStorageError::DieselError {
                 source,


### PR DESCRIPTION
## Problem

A base-layer reorg deeper than `base_layer_confirmations` that straddles an epoch boundary can leave a validator committed on a different epoch hash (the L1 boundary-block hash) than the rest of its committee. From then on the node rejects **every** peer proposal with `InvalidEpochHash` and consensus on that node wedges indefinitely.

This was observed on Esmeralda: the base-layer scanner saw two competing blocks at the same epoch-boundary height (height `657600`, epoch `8220`), and the committee split across the two hashes — `QC=NodeHeight(0)`, only timeout certificates, no progress.

## Changes

**`storage` / `storage_sqlite`: `insert_epoch` is now an upsert.**
The pre-lock self-heal in `EpochManagerService::activate_epoch` is meant to correct the stored epoch hash for an already-persisted, still-**unlocked** epoch (e.g. a reorg near the boundary surfaced a corrected hash before consensus committed against it). The previous plain `INSERT` hit the `UNIQUE(epoch)` constraint and silently aborted the correction. Locked epochs remain guarded in `activate_epoch`, so a hash consensus has already committed against is never rewritten — the anti-double-burn invariant is unchanged.

**`consensus`: throttled alarm on epoch-hash divergence.**
`InvalidEpochHash` against the current epoch was swallowed as a per-proposal `WARN` (thousands of identical lines, no signal that the node was wedged). It now raises a single `ERROR`-level alarm per distinct `(epoch, local_hash, remote_hash)` divergence, and the message states the recovery conditions: the node recovers via state sync once the rest of the committee reaches quorum on the other hash and advances past the epoch (a higher-epoch QC then triggers `CheckSync`); if the committee is split with no quorum, manual recovery is required.

## Scope / follow-ups

This PR is the groundwork: it makes the stored hash correctable and makes the wedge observable. It does **not** add automatic recovery for a node that has already committed a divergent genesis (state-sync kick on persistent divergence, or epoch-state rollback) — that is a follow-up, and is also not testable in the `consensus_tests` harness today since it stubs the sync manager (`AlwaysSyncedSyncManager`).

## Testing

- `cargo check` + `cargo clippy` clean on the three touched crates (no new warnings).
- Existing `epoch_change` suite unaffected.