### PR TITLE
feat(consensus)!: ratify next-epoch hash via the EndEpoch command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1719,7 +1719,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tari_bor",
- "tari_common_types 5.4.0-pre.0",
+ "tari_common_types",
  "tari_consensus",
  "tari_consensus_types",
  "tari_crypto",
@@ -1731,8 +1731,8 @@ dependencies = [
  "tari_ootle_p2p",
  "tari_ootle_storage",
  "tari_ootle_transaction",
- "tari_shutdown 5.4.0-pre.0",
- "tari_sidechain 5.4.0-pre.0",
+ "tari_shutdown",
+ "tari_sidechain",
  "tari_state_store_rocksdb",
  "tari_state_tree",
  "tari_template_lib_types",
@@ -2724,7 +2724,7 @@ dependencies = [
  "mime_guess",
  "serde",
  "serde_json",
- "tari_jellyfish 5.4.0-pre.0",
+ "tari_jellyfish",
  "tari_ootle_common_types",
  "tari_ootle_p2p",
  "tari_ootle_storage",
@@ -5118,12 +5118,12 @@ dependencies = [
  "libp2p",
  "log",
  "log4rs",
- "minotari_app_grpc 5.4.0-pre.0",
- "minotari_app_utilities 5.4.0-pre.0",
+ "minotari_app_grpc",
+ "minotari_app_utilities",
  "minotari_console_wallet",
  "minotari_node",
  "minotari_node_grpc_client",
- "minotari_wallet 5.4.0-pre.0",
+ "minotari_wallet",
  "multiaddr 0.18.3",
  "notify",
  "ootle_byte_type",
@@ -5134,11 +5134,11 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "tari_base_node_client",
- "tari_common 5.4.0-pre.0",
- "tari_common_sqlite 5.4.0-pre.0",
- "tari_common_types 5.4.0-pre.0",
- "tari_comms 5.4.0-pre.0",
- "tari_comms_dht 5.4.0-pre.0",
+ "tari_common",
+ "tari_common_sqlite",
+ "tari_common_types",
+ "tari_comms",
+ "tari_comms_dht",
  "tari_consensus",
  "tari_crypto",
  "tari_engine",
@@ -5153,14 +5153,14 @@ dependencies = [
  "tari_ootle_wallet_sdk",
  "tari_ootle_walletd",
  "tari_ootle_walletd_client",
- "tari_p2p 5.4.0-pre.0",
- "tari_shutdown 5.4.0-pre.0",
- "tari_sidechain 5.4.0-pre.0",
+ "tari_p2p",
+ "tari_shutdown",
+ "tari_sidechain",
  "tari_state_store_rocksdb",
  "tari_template_builtin",
  "tari_template_lib_types",
  "tari_template_test_tooling",
- "tari_transaction_components 5.4.0-pre.0",
+ "tari_transaction_components",
  "tari_transaction_manifest",
  "tari_validator_node",
  "tari_validator_node_client",
@@ -6667,37 +6667,6 @@ dependencies = [
 
 [[package]]
 name = "minotari_app_grpc"
-version = "5.3.1-pre.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0#1f94bc8fdc909072a295ece3ace0f98bf1b2c3cc"
-dependencies = [
- "argon2 0.6.0-rc.8",
- "base64 0.22.1",
- "borsh",
- "log",
- "prost 0.13.5",
- "rand 0.10.1",
- "rcgen 0.12.1",
- "subtle",
- "tari_common_types 5.3.1-pre.0",
- "tari_comms 5.3.1-pre.0",
- "tari_core 5.3.1-pre.0",
- "tari_crypto",
- "tari_features 5.3.1-pre.0",
- "tari_max_size 5.3.1-pre.0",
- "tari_node_components 5.3.1-pre.0",
- "tari_script 5.3.1-pre.0",
- "tari_sidechain 5.3.1-pre.0",
- "tari_transaction_components 5.3.1-pre.0",
- "tari_utilities",
- "thiserror 2.0.18",
- "tokio",
- "tonic 0.13.1",
- "tonic-build",
- "zeroize",
-]
-
-[[package]]
-name = "minotari_app_grpc"
 version = "5.4.0-pre.0"
 source = "git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef#941dd8592993629bbb1d2cc9f0dca51689a4bfef"
 dependencies = [
@@ -6709,45 +6678,22 @@ dependencies = [
  "rand 0.10.1",
  "rcgen 0.12.1",
  "subtle",
- "tari_common_types 5.4.0-pre.0",
- "tari_comms 5.4.0-pre.0",
- "tari_core 5.4.0-pre.0",
+ "tari_common_types",
+ "tari_comms",
+ "tari_core",
  "tari_crypto",
- "tari_features 5.4.0-pre.0",
- "tari_max_size 5.4.0-pre.0",
- "tari_node_components 5.4.0-pre.0",
- "tari_script 5.4.0-pre.0",
- "tari_sidechain 5.4.0-pre.0",
- "tari_transaction_components 5.4.0-pre.0",
+ "tari_features",
+ "tari_max_size",
+ "tari_node_components",
+ "tari_script",
+ "tari_sidechain",
+ "tari_transaction_components",
  "tari_utilities",
  "thiserror 2.0.18",
  "tokio",
  "tonic 0.13.1",
  "tonic-build",
  "zeroize",
-]
-
-[[package]]
-name = "minotari_app_utilities"
-version = "5.3.1-pre.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0#1f94bc8fdc909072a295ece3ace0f98bf1b2c3cc"
-dependencies = [
- "clap 4.5.54",
- "dialoguer 0.10.4",
- "futures 0.3.31",
- "json5",
- "log",
- "rand 0.10.1",
- "serde",
- "tari_common 5.3.1-pre.0",
- "tari_common_types 5.3.1-pre.0",
- "tari_comms 5.3.1-pre.0",
- "tari_features 5.3.1-pre.0",
- "tari_p2p 5.3.1-pre.0",
- "tari_utilities",
- "thiserror 2.0.18",
- "tokio",
- "tonic 0.13.1",
 ]
 
 [[package]]
@@ -6762,11 +6708,11 @@ dependencies = [
  "log",
  "rand 0.10.1",
  "serde",
- "tari_common 5.4.0-pre.0",
- "tari_common_types 5.4.0-pre.0",
- "tari_comms 5.4.0-pre.0",
- "tari_features 5.4.0-pre.0",
- "tari_p2p 5.4.0-pre.0",
+ "tari_common",
+ "tari_common_types",
+ "tari_comms",
+ "tari_features",
+ "tari_p2p",
  "tari_utilities",
  "thiserror 2.0.18",
  "tokio",
@@ -6775,8 +6721,8 @@ dependencies = [
 
 [[package]]
 name = "minotari_console_wallet"
-version = "5.3.1-pre.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0#1f94bc8fdc909072a295ece3ace0f98bf1b2c3cc"
+version = "5.4.0-pre.0"
+source = "git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef#941dd8592993629bbb1d2cc9f0dca51689a4bfef"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6791,12 +6737,12 @@ dependencies = [
  "futures 0.3.31",
  "log",
  "log4rs",
- "minotari_app_grpc 5.3.1-pre.0",
- "minotari_app_utilities 5.3.1-pre.0",
- "minotari_ledger_wallet_common 5.3.1-pre.0",
+ "minotari_app_grpc",
+ "minotari_app_utilities",
+ "minotari_ledger_wallet_common",
  "minotari_ledger_wallet_comms",
- "minotari_node_wallet_client 5.3.1-pre.0",
- "minotari_wallet 5.3.1-pre.0",
+ "minotari_node_wallet_client",
+ "minotari_wallet",
  "qrcode",
  "rand 0.10.1",
  "regex",
@@ -6806,19 +6752,19 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "strum 0.22.0",
- "tari_common 5.3.1-pre.0",
- "tari_common_types 5.3.1-pre.0",
- "tari_comms 5.3.1-pre.0",
- "tari_core 5.3.1-pre.0",
+ "tari_common",
+ "tari_common_types",
+ "tari_comms",
+ "tari_core",
  "tari_crypto",
- "tari_features 5.3.1-pre.0",
- "tari_hashing 5.3.1-pre.0",
- "tari_p2p 5.3.1-pre.0",
- "tari_script 5.3.1-pre.0",
- "tari_shutdown 5.3.1-pre.0",
- "tari_sidechain 5.3.1-pre.0",
- "tari_transaction_components 5.3.1-pre.0",
- "tari_transaction_key_manager 5.3.1-pre.0",
+ "tari_features",
+ "tari_hashing 5.4.0-pre.0 (git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef)",
+ "tari_p2p",
+ "tari_script",
+ "tari_shutdown",
+ "tari_sidechain",
+ "tari_transaction_components",
+ "tari_transaction_key_manager",
  "tari_utilities",
  "thiserror 2.0.18",
  "tokio",
@@ -6827,15 +6773,6 @@ dependencies = [
  "unicode-width 0.1.14",
  "url",
  "zxcvbn",
-]
-
-[[package]]
-name = "minotari_ledger_wallet_common"
-version = "5.3.1-pre.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0#1f94bc8fdc909072a295ece3ace0f98bf1b2c3cc"
-dependencies = [
- "bs58",
- "serde",
 ]
 
 [[package]]
@@ -6850,30 +6787,30 @@ dependencies = [
 
 [[package]]
 name = "minotari_ledger_wallet_comms"
-version = "5.3.1-pre.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0#1f94bc8fdc909072a295ece3ace0f98bf1b2c3cc"
+version = "5.4.0-pre.0"
+source = "git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef#941dd8592993629bbb1d2cc9f0dca51689a4bfef"
 dependencies = [
  "borsh",
  "dialoguer 0.11.0",
  "ledger-transport",
  "ledger-transport-hid",
  "log",
- "minotari_ledger_wallet_common 5.3.1-pre.0",
+ "minotari_ledger_wallet_common",
  "rand 0.10.1",
  "semver",
  "serde",
- "tari_common 5.3.1-pre.0",
- "tari_common_types 5.3.1-pre.0",
+ "tari_common",
+ "tari_common_types",
  "tari_crypto",
- "tari_script 5.3.1-pre.0",
+ "tari_script",
  "tari_utilities",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "minotari_node"
-version = "5.3.1-pre.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0#1f94bc8fdc909072a295ece3ace0f98bf1b2c3cc"
+version = "5.4.0-pre.0"
+source = "git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef#941dd8592993629bbb1d2cc9f0dca51689a4bfef"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6897,8 +6834,8 @@ dependencies = [
  "hyper-util",
  "log",
  "log4rs",
- "minotari_app_grpc 5.3.1-pre.0",
- "minotari_app_utilities 5.3.1-pre.0",
+ "minotari_app_grpc",
+ "minotari_app_utilities",
  "nom 7.1.3",
  "qrcode",
  "rustyline",
@@ -6906,19 +6843,19 @@ dependencies = [
  "serde",
  "serde_json",
  "strum 0.22.0",
- "tari_common 5.3.1-pre.0",
- "tari_common_types 5.3.1-pre.0",
- "tari_comms 5.3.1-pre.0",
- "tari_comms_dht 5.3.1-pre.0",
- "tari_core 5.3.1-pre.0",
- "tari_features 5.3.1-pre.0",
+ "tari_common",
+ "tari_common_types",
+ "tari_comms",
+ "tari_comms_dht",
+ "tari_core",
+ "tari_features",
  "tari_libtor",
- "tari_node_components 5.3.1-pre.0",
- "tari_p2p 5.3.1-pre.0",
- "tari_service_framework 5.3.1-pre.0",
- "tari_shutdown 5.3.1-pre.0",
- "tari_storage 5.3.1-pre.0",
- "tari_transaction_components 5.3.1-pre.0",
+ "tari_node_components",
+ "tari_p2p",
+ "tari_service_framework",
+ "tari_shutdown",
+ "tari_storage",
+ "tari_transaction_components",
  "tari_utilities",
  "thiserror 2.0.18",
  "tokio",
@@ -6934,25 +6871,7 @@ name = "minotari_node_grpc_client"
 version = "5.4.0-pre.0"
 source = "git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef#941dd8592993629bbb1d2cc9f0dca51689a4bfef"
 dependencies = [
- "minotari_app_grpc 5.4.0-pre.0",
-]
-
-[[package]]
-name = "minotari_node_wallet_client"
-version = "5.3.1-pre.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0#1f94bc8fdc909072a295ece3ace0f98bf1b2c3cc"
-dependencies = [
- "anyhow",
- "async-trait",
- "log",
- "reqwest 0.12.28",
- "serde",
- "serde_json",
- "tari_shutdown 5.3.1-pre.0",
- "tari_transaction_components 5.3.1-pre.0",
- "tari_utilities",
- "tokio",
- "url",
+ "minotari_app_grpc",
 ]
 
 [[package]]
@@ -6966,69 +6885,11 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
- "tari_shutdown 5.4.0-pre.0",
- "tari_transaction_components 5.4.0-pre.0",
+ "tari_shutdown",
+ "tari_transaction_components",
  "tari_utilities",
  "tokio",
  "url",
-]
-
-[[package]]
-name = "minotari_wallet"
-version = "5.3.1-pre.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0#1f94bc8fdc909072a295ece3ace0f98bf1b2c3cc"
-dependencies = [
- "anyhow",
- "argon2 0.6.0-rc.8",
- "async-trait",
- "bincode 1.3.3",
- "blake2 0.10.6",
- "borsh",
- "chacha20poly1305",
- "chrono",
- "derivative",
- "diesel",
- "diesel_migrations",
- "digest 0.10.7",
- "dirs-next 1.0.2",
- "fs2",
- "futures 0.3.31",
- "itertools 0.10.5",
- "libsqlite3-sys",
- "log",
- "minotari_ledger_wallet_common 5.3.1-pre.0",
- "minotari_node_wallet_client 5.3.1-pre.0",
- "phc",
- "prost 0.13.5",
- "rand 0.10.1",
- "serde",
- "serde_json",
- "sha2 0.10.9",
- "strum 0.22.0",
- "strum_macros 0.22.0",
- "tari_common 5.3.1-pre.0",
- "tari_common_sqlite 5.3.1-pre.0",
- "tari_common_types 5.3.1-pre.0",
- "tari_comms 5.3.1-pre.0",
- "tari_comms_dht 5.3.1-pre.0",
- "tari_crypto",
- "tari_hashing 5.3.1-pre.0",
- "tari_max_size 5.3.1-pre.0",
- "tari_p2p 5.3.1-pre.0",
- "tari_script 5.3.1-pre.0",
- "tari_service_framework 5.3.1-pre.0",
- "tari_shutdown 5.3.1-pre.0",
- "tari_sidechain 5.3.1-pre.0",
- "tari_transaction_components 5.3.1-pre.0",
- "tari_transaction_key_manager 5.3.1-pre.0",
- "tari_utilities",
- "tempfile",
- "thiserror 2.0.18",
- "tokio",
- "tower 0.4.13",
- "url",
- "uuid",
- "zeroize",
 ]
 
 [[package]]
@@ -7054,8 +6915,8 @@ dependencies = [
  "itertools 0.10.5",
  "libsqlite3-sys",
  "log",
- "minotari_ledger_wallet_common 5.4.0-pre.0",
- "minotari_node_wallet_client 5.4.0-pre.0",
+ "minotari_ledger_wallet_common",
+ "minotari_node_wallet_client",
  "phc",
  "prost 0.13.5",
  "rand 0.10.1",
@@ -7064,21 +6925,21 @@ dependencies = [
  "sha2 0.10.9",
  "strum 0.22.0",
  "strum_macros 0.22.0",
- "tari_common 5.4.0-pre.0",
- "tari_common_sqlite 5.4.0-pre.0",
- "tari_common_types 5.4.0-pre.0",
- "tari_comms 5.4.0-pre.0",
- "tari_comms_dht 5.4.0-pre.0",
+ "tari_common",
+ "tari_common_sqlite",
+ "tari_common_types",
+ "tari_comms",
+ "tari_comms_dht",
  "tari_crypto",
  "tari_hashing 5.4.0-pre.0 (git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef)",
- "tari_max_size 5.4.0-pre.0",
- "tari_p2p 5.4.0-pre.0",
- "tari_script 5.4.0-pre.0",
- "tari_service_framework 5.4.0-pre.0",
- "tari_shutdown 5.4.0-pre.0",
- "tari_sidechain 5.4.0-pre.0",
- "tari_transaction_components 5.4.0-pre.0",
- "tari_transaction_key_manager 5.4.0-pre.0",
+ "tari_max_size",
+ "tari_p2p",
+ "tari_script",
+ "tari_service_framework",
+ "tari_shutdown",
+ "tari_sidechain",
+ "tari_transaction_components",
+ "tari_transaction_key_manager",
  "tari_utilities",
  "tempfile",
  "thiserror 2.0.18",
@@ -7094,9 +6955,9 @@ name = "minotari_wallet_grpc_client"
 version = "5.4.0-pre.0"
 source = "git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef#941dd8592993629bbb1d2cc9f0dca51689a4bfef"
 dependencies = [
- "minotari_app_grpc 5.4.0-pre.0",
- "tari_common 5.4.0-pre.0",
- "tari_common_types 5.4.0-pre.0",
+ "minotari_app_grpc",
+ "tari_common",
+ "tari_common_types",
  "thiserror 2.0.18",
  "tonic 0.13.1",
 ]
@@ -9553,12 +9414,13 @@ dependencies = [
 
 [[package]]
 name = "rpassword"
-version = "5.0.1"
+version = "7.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffc936cf8a7ea60c58f030fd36a612a48f440610214dc54bc36431f9ea0c3efb"
+checksum = "835a57a69104632d64deb0df2e09a69945cd7a6eab4070fc9b1d7e50cf6c3edc"
 dependencies = [
  "libc",
- "winapi",
+ "rtoolbox",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9608,6 +9470,16 @@ dependencies = [
  "nix 0.30.1",
  "thiserror 1.0.69",
  "tokio",
+]
+
+[[package]]
+name = "rtoolbox"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50a0e551c1e27e1731aba276dbeaeac73f53c7cd34d1bda485d02bd1e0f36844"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11086,14 +10958,14 @@ version = "0.33.0"
 dependencies = [
  "futures-util",
  "log",
- "minotari_app_grpc 5.4.0-pre.0",
+ "minotari_app_grpc",
  "minotari_node_grpc_client",
  "serde",
- "tari_common_types 5.4.0-pre.0",
- "tari_node_components 5.4.0-pre.0",
+ "tari_common_types",
+ "tari_node_components",
  "tari_ootle_common_types",
  "tari_template_lib",
- "tari_transaction_components 5.4.0-pre.0",
+ "tari_transaction_components",
  "tari_utilities",
  "thiserror 2.0.18",
  "tonic 0.13.1",
@@ -11137,32 +11009,6 @@ dependencies = [
 
 [[package]]
 name = "tari_common"
-version = "5.3.1-pre.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0#1f94bc8fdc909072a295ece3ace0f98bf1b2c3cc"
-dependencies = [
- "anyhow",
- "cargo_toml 0.20.5",
- "config",
- "dirs-next 1.0.2",
- "git2",
- "log",
- "log4rs",
- "multiaddr 0.18.2",
- "path-clean",
- "prost-build 0.11.9",
- "serde",
- "serde_json",
- "serde_yaml",
- "sha2 0.10.9",
- "structopt",
- "tari_features 5.3.1-pre.0",
- "tempfile",
- "thiserror 2.0.18",
- "toml 0.5.11",
-]
-
-[[package]]
-name = "tari_common"
 version = "5.4.0-pre.0"
 source = "git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef#941dd8592993629bbb1d2cc9f0dca51689a4bfef"
 dependencies = [
@@ -11181,27 +11027,10 @@ dependencies = [
  "serde_yaml",
  "sha2 0.10.9",
  "structopt",
- "tari_features 5.4.0-pre.0",
+ "tari_features",
  "tempfile",
  "thiserror 2.0.18",
  "toml 0.5.11",
-]
-
-[[package]]
-name = "tari_common_sqlite"
-version = "5.3.1-pre.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0#1f94bc8fdc909072a295ece3ace0f98bf1b2c3cc"
-dependencies = [
- "diesel",
- "diesel_migrations",
- "lazy_static",
- "log",
- "rand 0.10.1",
- "serde",
- "serde_json",
- "tari_utilities",
- "thiserror 2.0.18",
- "tokio",
 ]
 
 [[package]]
@@ -11219,43 +11048,6 @@ dependencies = [
  "tari_utilities",
  "thiserror 2.0.18",
  "tokio",
-]
-
-[[package]]
-name = "tari_common_types"
-version = "5.3.1-pre.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0#1f94bc8fdc909072a295ece3ace0f98bf1b2c3cc"
-dependencies = [
- "argon2 0.6.0-rc.8",
- "base64 0.22.1",
- "bitflags 2.10.0",
- "blake2 0.10.6",
- "borsh",
- "bs58",
- "chacha20 0.7.3",
- "chacha20poly1305",
- "crc32fast",
- "digest 0.10.7",
- "getrandom 0.2.17",
- "getrandom 0.4.2",
- "js-sys",
- "newtype-ops",
- "once_cell",
- "primitive-types",
- "rand 0.10.1",
- "serde",
- "serde_json",
- "strum 0.22.0",
- "strum_macros 0.22.0",
- "subtle",
- "tari_common 5.3.1-pre.0",
- "tari_crypto",
- "tari_hashing 5.3.1-pre.0",
- "tari_max_size 5.3.1-pre.0",
- "tari_utilities",
- "thiserror 2.0.18",
- "utoipa",
- "zeroize",
 ]
 
 [[package]]
@@ -11285,10 +11077,10 @@ dependencies = [
  "strum 0.22.0",
  "strum_macros 0.22.0",
  "subtle",
- "tari_common 5.4.0-pre.0",
+ "tari_common",
  "tari_crypto",
  "tari_hashing 5.4.0-pre.0 (git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef)",
- "tari_max_size 5.4.0-pre.0",
+ "tari_max_size",
  "tari_utilities",
  "thiserror 2.0.18",
  "utoipa",
@@ -11297,53 +11089,6 @@ dependencies = [
 
 [[package]]
 name = "tari_comms"
-version = "5.3.1-pre.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0#1f94bc8fdc909072a295ece3ace0f98bf1b2c3cc"
-dependencies = [
- "anyhow",
- "async-trait",
- "bitflags 2.10.0",
- "blake2 0.10.6",
- "bytes",
- "chrono",
- "cidr",
- "data-encoding",
- "derivative",
- "diesel",
- "diesel_migrations",
- "digest 0.10.7",
- "futures 0.3.31",
- "local-ip-address",
- "log",
- "multiaddr 0.18.2",
- "nom 7.1.3",
- "once_cell",
- "pin-project 1.1.12",
- "prost 0.13.5",
- "rand 0.10.1",
- "serde",
- "serde_derive",
- "serde_json",
- "sha3",
- "snow",
- "tari_common 5.3.1-pre.0",
- "tari_common_sqlite 5.3.1-pre.0",
- "tari_crypto",
- "tari_shutdown 5.3.1-pre.0",
- "tari_storage 5.3.1-pre.0",
- "tari_utilities",
- "thiserror 2.0.18",
- "tokio",
- "tokio-stream",
- "tokio-util 0.6.10",
- "tower 0.4.13",
- "tracing",
- "yamux 0.13.10",
- "zeroize",
-]
-
-[[package]]
-name = "tari_comms"
 version = "5.4.0-pre.0"
 source = "git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef#941dd8592993629bbb1d2cc9f0dca51689a4bfef"
 dependencies = [
@@ -11373,11 +11118,11 @@ dependencies = [
  "serde_json",
  "sha3",
  "snow",
- "tari_common 5.4.0-pre.0",
- "tari_common_sqlite 5.4.0-pre.0",
+ "tari_common",
+ "tari_common_sqlite",
  "tari_crypto",
- "tari_shutdown 5.4.0-pre.0",
- "tari_storage 5.4.0-pre.0",
+ "tari_shutdown",
+ "tari_storage",
  "tari_utilities",
  "thiserror 2.0.18",
  "tokio",
@@ -11386,40 +11131,6 @@ dependencies = [
  "tower 0.4.13",
  "tracing",
  "yamux 0.13.10",
- "zeroize",
-]
-
-[[package]]
-name = "tari_comms_dht"
-version = "5.3.1-pre.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0#1f94bc8fdc909072a295ece3ace0f98bf1b2c3cc"
-dependencies = [
- "anyhow",
- "bitflags 2.10.0",
- "blake2 0.10.6",
- "chacha20 0.7.3",
- "chacha20poly1305",
- "chrono",
- "diesel",
- "diesel_migrations",
- "digest 0.10.7",
- "futures 0.3.31",
- "futures-util",
- "log",
- "pin-project 0.4.30",
- "prost 0.13.5",
- "rand 0.10.1",
- "serde",
- "tari_common 5.3.1-pre.0",
- "tari_common_sqlite 5.3.1-pre.0",
- "tari_comms 5.3.1-pre.0",
- "tari_comms_rpc_macros 5.3.1-pre.0",
- "tari_crypto",
- "tari_shutdown 5.3.1-pre.0",
- "tari_utilities",
- "thiserror 2.0.18",
- "tokio",
- "tower 0.4.13",
  "zeroize",
 ]
 
@@ -11444,27 +11155,17 @@ dependencies = [
  "prost 0.13.5",
  "rand 0.10.1",
  "serde",
- "tari_common 5.4.0-pre.0",
- "tari_common_sqlite 5.4.0-pre.0",
- "tari_comms 5.4.0-pre.0",
- "tari_comms_rpc_macros 5.4.0-pre.0",
+ "tari_common",
+ "tari_common_sqlite",
+ "tari_comms",
+ "tari_comms_rpc_macros",
  "tari_crypto",
- "tari_shutdown 5.4.0-pre.0",
+ "tari_shutdown",
  "tari_utilities",
  "thiserror 2.0.18",
  "tokio",
  "tower 0.4.13",
  "zeroize",
-]
-
-[[package]]
-name = "tari_comms_rpc_macros"
-version = "5.3.1-pre.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0#1f94bc8fdc909072a295ece3ace0f98bf1b2c3cc"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -11486,7 +11187,7 @@ dependencies = [
  "log",
  "ootle_byte_type",
  "serde",
- "tari_common_types 5.4.0-pre.0",
+ "tari_common_types",
  "tari_consensus_types",
  "tari_crypto",
  "tari_engine_types",
@@ -11494,8 +11195,8 @@ dependencies = [
  "tari_ootle_common_types",
  "tari_ootle_storage",
  "tari_ootle_transaction",
- "tari_shutdown 5.4.0-pre.0",
- "tari_sidechain 5.4.0-pre.0",
+ "tari_shutdown",
+ "tari_sidechain",
  "tari_state_tree",
  "tari_template_lib_types",
  "thiserror 2.0.18",
@@ -11511,75 +11212,14 @@ dependencies = [
  "ootle_serde",
  "serde",
  "tari_bor",
- "tari_common_types 5.4.0-pre.0",
+ "tari_common_types",
  "tari_crypto",
  "tari_engine_types",
  "tari_hashing 5.4.0-pre.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tari_ootle_common_types",
- "tari_sidechain 5.4.0-pre.0",
+ "tari_sidechain",
  "tari_template_lib",
  "ts-rs",
-]
-
-[[package]]
-name = "tari_core"
-version = "5.3.1-pre.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0#1f94bc8fdc909072a295ece3ace0f98bf1b2c3cc"
-dependencies = [
- "anyhow",
- "async-trait",
- "bincode 1.3.3",
- "blake2 0.10.6",
- "borsh",
- "chrono",
- "digest 0.10.7",
- "dirs-next 1.0.2",
- "fs2",
- "futures 0.3.31",
- "hex",
- "hickory-proto 0.26.1",
- "integer-encoding",
- "jmt",
- "lmdb-zero",
- "log",
- "monero",
- "once_cell",
- "primitive-types",
- "prost 0.13.5",
- "rand 0.10.1",
- "randomx-rs",
- "serde",
- "serde_json",
- "serde_valid",
- "sha2 0.10.9",
- "sha3",
- "strum_macros 0.22.0",
- "tari-tiny-keccak",
- "tari_common 5.3.1-pre.0",
- "tari_common_sqlite 5.3.1-pre.0",
- "tari_common_types 5.3.1-pre.0",
- "tari_comms 5.3.1-pre.0",
- "tari_comms_dht 5.3.1-pre.0",
- "tari_comms_rpc_macros 5.3.1-pre.0",
- "tari_crypto",
- "tari_features 5.3.1-pre.0",
- "tari_hashing 5.3.1-pre.0",
- "tari_max_size 5.3.1-pre.0",
- "tari_mmr 5.3.1-pre.0",
- "tari_node_components 5.3.1-pre.0",
- "tari_p2p 5.3.1-pre.0",
- "tari_script 5.3.1-pre.0",
- "tari_service_framework 5.3.1-pre.0",
- "tari_shutdown 5.3.1-pre.0",
- "tari_sidechain 5.3.1-pre.0",
- "tari_storage 5.3.1-pre.0",
- "tari_test_utils 5.3.1-pre.0",
- "tari_transaction_components 5.3.1-pre.0",
- "tari_utilities",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
- "url",
 ]
 
 [[package]]
@@ -11616,26 +11256,26 @@ dependencies = [
  "sha3",
  "strum_macros 0.22.0",
  "tari-tiny-keccak",
- "tari_common 5.4.0-pre.0",
- "tari_common_sqlite 5.4.0-pre.0",
- "tari_common_types 5.4.0-pre.0",
- "tari_comms 5.4.0-pre.0",
- "tari_comms_dht 5.4.0-pre.0",
- "tari_comms_rpc_macros 5.4.0-pre.0",
+ "tari_common",
+ "tari_common_sqlite",
+ "tari_common_types",
+ "tari_comms",
+ "tari_comms_dht",
+ "tari_comms_rpc_macros",
  "tari_crypto",
- "tari_features 5.4.0-pre.0",
+ "tari_features",
  "tari_hashing 5.4.0-pre.0 (git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef)",
- "tari_max_size 5.4.0-pre.0",
- "tari_mmr 5.4.0-pre.0",
- "tari_node_components 5.4.0-pre.0",
- "tari_p2p 5.4.0-pre.0",
- "tari_script 5.4.0-pre.0",
- "tari_service_framework 5.4.0-pre.0",
- "tari_shutdown 5.4.0-pre.0",
- "tari_sidechain 5.4.0-pre.0",
- "tari_storage 5.4.0-pre.0",
- "tari_test_utils 5.4.0-pre.0",
- "tari_transaction_components 5.4.0-pre.0",
+ "tari_max_size",
+ "tari_mmr",
+ "tari_node_components",
+ "tari_p2p",
+ "tari_script",
+ "tari_service_framework",
+ "tari_shutdown",
+ "tari_sidechain",
+ "tari_storage",
+ "tari_test_utils",
+ "tari_transaction_components",
  "tari_utilities",
  "thiserror 2.0.18",
  "tokio",
@@ -11732,15 +11372,15 @@ version = "0.33.0"
 dependencies = [
  "anyhow",
  "log",
- "minotari_app_grpc 5.4.0-pre.0",
+ "minotari_app_grpc",
  "ootle_byte_type",
  "serde",
- "tari_common_types 5.4.0-pre.0",
+ "tari_common_types",
  "tari_ootle_common_types",
  "tari_ootle_storage",
  "tari_ootle_storage_sqlite",
- "tari_shutdown 5.4.0-pre.0",
- "tari_sidechain 5.4.0-pre.0",
+ "tari_shutdown",
+ "tari_sidechain",
  "tari_template_lib_types",
  "thiserror 2.0.18",
  "tokio",
@@ -11758,15 +11398,15 @@ dependencies = [
  "serde",
  "serde_json",
  "tari_base_node_client",
- "tari_common_types 5.4.0-pre.0",
+ "tari_common_types",
  "tari_epoch_manager",
  "tari_hashing 5.4.0-pre.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tari_node_components 5.4.0-pre.0",
+ "tari_node_components",
  "tari_ootle_common_types",
  "tari_ootle_storage",
  "tari_ootle_storage_sqlite",
  "tari_template_lib",
- "tari_transaction_components 5.4.0-pre.0",
+ "tari_transaction_components",
  "thiserror 2.0.18",
  "time",
  "tokio",
@@ -11774,24 +11414,8 @@ dependencies = [
 
 [[package]]
 name = "tari_features"
-version = "5.3.1-pre.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0#1f94bc8fdc909072a295ece3ace0f98bf1b2c3cc"
-
-[[package]]
-name = "tari_features"
 version = "5.4.0-pre.0"
 source = "git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef#941dd8592993629bbb1d2cc9f0dca51689a4bfef"
-
-[[package]]
-name = "tari_hashing"
-version = "5.3.1-pre.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0#1f94bc8fdc909072a295ece3ace0f98bf1b2c3cc"
-dependencies = [
- "blake2 0.10.6",
- "borsh",
- "digest 0.10.7",
- "tari_crypto",
-]
 
 [[package]]
 name = "tari_hashing"
@@ -11853,7 +11477,7 @@ dependencies = [
  "serde_with",
  "tari_base_node_client",
  "tari_bor",
- "tari_common 5.4.0-pre.0",
+ "tari_common",
  "tari_consensus",
  "tari_crypto",
  "tari_engine",
@@ -11871,7 +11495,7 @@ dependencies = [
  "tari_ootle_template_metadata",
  "tari_ootle_transaction",
  "tari_rpc_framework",
- "tari_shutdown 5.4.0-pre.0",
+ "tari_shutdown",
  "tari_template_builtin",
  "tari_template_lib_types",
  "tari_validator_node_rpc",
@@ -11934,20 +11558,6 @@ dependencies = [
 
 [[package]]
 name = "tari_jellyfish"
-version = "5.3.1-pre.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0#1f94bc8fdc909072a295ece3ace0f98bf1b2c3cc"
-dependencies = [
- "borsh",
- "digest 0.10.7",
- "indexmap 2.13.0",
- "serde",
- "tari_crypto",
- "tari_hashing 5.3.1-pre.0",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "tari_jellyfish"
 version = "5.4.0-pre.0"
 source = "git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef#941dd8592993629bbb1d2cc9f0dca51689a4bfef"
 dependencies = [
@@ -11978,27 +11588,16 @@ dependencies = [
 
 [[package]]
 name = "tari_libtor"
-version = "5.3.1-pre.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0#1f94bc8fdc909072a295ece3ace0f98bf1b2c3cc"
+version = "5.4.0-pre.0"
+source = "git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef#941dd8592993629bbb1d2cc9f0dca51689a4bfef"
 dependencies = [
  "derivative",
  "libtor",
  "log",
  "rand 0.10.1",
- "tari_common 5.3.1-pre.0",
- "tari_p2p 5.3.1-pre.0",
+ "tari_common",
+ "tari_p2p",
  "tor-hash-passwd",
-]
-
-[[package]]
-name = "tari_max_size"
-version = "5.3.1-pre.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0#1f94bc8fdc909072a295ece3ace0f98bf1b2c3cc"
-dependencies = [
- "borsh",
- "serde",
- "tari_utilities",
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -12036,19 +11635,6 @@ dependencies = [
 
 [[package]]
 name = "tari_mmr"
-version = "5.3.1-pre.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0#1f94bc8fdc909072a295ece3ace0f98bf1b2c3cc"
-dependencies = [
- "borsh",
- "digest 0.10.7",
- "serde",
- "tari_crypto",
- "tari_utilities",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "tari_mmr"
 version = "5.4.0-pre.0"
 source = "git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef#941dd8592993629bbb1d2cc9f0dca51689a4bfef"
 dependencies = [
@@ -12071,30 +11657,10 @@ dependencies = [
  "prometheus-client",
  "rand 0.10.1",
  "tari_rpc_framework",
- "tari_shutdown 5.4.0-pre.0",
+ "tari_shutdown",
  "tari_swarm",
  "thiserror 2.0.18",
  "tokio",
-]
-
-[[package]]
-name = "tari_node_components"
-version = "5.3.1-pre.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0#1f94bc8fdc909072a295ece3ace0f98bf1b2c3cc"
-dependencies = [
- "blake2 0.10.6",
- "borsh",
- "chrono",
- "digest 0.10.7",
- "getrandom 0.2.17",
- "js-sys",
- "primitive-types",
- "serde",
- "tari_common_types 5.3.1-pre.0",
- "tari_hashing 5.3.1-pre.0",
- "tari_transaction_components 5.3.1-pre.0",
- "tari_utilities",
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -12110,9 +11676,9 @@ dependencies = [
  "js-sys",
  "primitive-types",
  "serde",
- "tari_common_types 5.4.0-pre.0",
+ "tari_common_types",
  "tari_hashing 5.4.0-pre.0 (git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef)",
- "tari_transaction_components 5.4.0-pre.0",
+ "tari_transaction_components",
  "tari_utilities",
  "thiserror 2.0.18",
 ]
@@ -12152,21 +11718,21 @@ dependencies = [
  "serde",
  "serde_json5",
  "tari_bor",
- "tari_common 5.4.0-pre.0",
- "tari_common_types 5.4.0-pre.0",
+ "tari_common",
+ "tari_common_types",
  "tari_crypto",
  "tari_engine",
  "tari_engine_types",
  "tari_epoch_oracles",
  "tari_hashing 5.4.0-pre.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tari_mmr 5.4.0-pre.0",
+ "tari_mmr",
  "tari_networking",
  "tari_ootle_common_types",
  "tari_ootle_p2p",
  "tari_ootle_storage",
  "tari_ootle_transaction",
  "tari_template_lib",
- "tari_transaction_components 5.4.0-pre.0",
+ "tari_transaction_components",
  "thiserror 2.0.18",
  "tokio",
  "toml 0.9.11+spec-1.1.0",
@@ -12217,7 +11783,7 @@ dependencies = [
  "tari_consensus_types",
  "tari_crypto",
  "tari_engine_types",
- "tari_jellyfish 5.4.0-pre.0",
+ "tari_jellyfish",
  "tari_networking",
  "tari_ootle_common_types",
  "tari_ootle_storage",
@@ -12240,13 +11806,13 @@ dependencies = [
  "rand 0.10.1",
  "serde",
  "tari_bor",
- "tari_common_types 5.4.0-pre.0",
+ "tari_common_types",
  "tari_consensus_types",
  "tari_crypto",
  "tari_engine_types",
  "tari_ootle_common_types",
  "tari_ootle_transaction",
- "tari_sidechain 5.4.0-pre.0",
+ "tari_sidechain",
  "tari_state_tree",
  "tari_template_lib",
  "tari_template_lib_types",
@@ -12266,7 +11832,7 @@ dependencies = [
  "rand 0.10.1",
  "serde",
  "serde_json",
- "tari_common_types 5.4.0-pre.0",
+ "tari_common_types",
  "tari_crypto",
  "tari_ootle_common_types",
  "tari_ootle_p2p",
@@ -12409,7 +11975,7 @@ dependencies = [
  "rand 0.10.1",
  "serde",
  "tari_bor",
- "tari_common_types 5.4.0-pre.0",
+ "tari_common_types",
  "tari_consensus_types",
  "tari_crypto",
  "tari_engine_types",
@@ -12446,7 +12012,7 @@ dependencies = [
  "tari_ootle_common_types",
  "tari_ootle_transaction",
  "tari_ootle_wallet_sdk",
- "tari_shutdown 5.4.0-pre.0",
+ "tari_shutdown",
  "tari_template_abi",
  "tari_template_builtin",
  "tari_template_lib_types",
@@ -12474,7 +12040,7 @@ dependencies = [
  "tari_ootle_wallet_storage_sqlite",
  "tari_template_abi",
  "tari_template_lib",
- "tari_transaction_components 5.4.0-pre.0",
+ "tari_transaction_components",
  "tempfile",
 ]
 
@@ -12534,8 +12100,8 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "tari_common 5.4.0-pre.0",
- "tari_common_types 5.4.0-pre.0",
+ "tari_common",
+ "tari_common_types",
  "tari_crypto",
  "tari_engine",
  "tari_engine_types",
@@ -12549,8 +12115,8 @@ dependencies = [
  "tari_ootle_wallet_sdk_services",
  "tari_ootle_wallet_storage_sqlite",
  "tari_ootle_walletd_client",
- "tari_shutdown 5.4.0-pre.0",
- "tari_sidechain 5.4.0-pre.0",
+ "tari_shutdown",
+ "tari_sidechain",
  "tari_template_builtin",
  "tari_template_lib_types",
  "tari_transaction_manifest",
@@ -12595,35 +12161,6 @@ dependencies = [
 
 [[package]]
 name = "tari_p2p"
-version = "5.3.1-pre.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0#1f94bc8fdc909072a295ece3ace0f98bf1b2c3cc"
-dependencies = [
- "anyhow",
- "futures 0.3.31",
- "hickory-proto 0.26.1",
- "hickory-resolver 0.26.1",
- "log",
- "pgp",
- "prost 0.13.5",
- "rand 0.10.1",
- "reqwest 0.12.28",
- "semver",
- "serde",
- "tari_common 5.3.1-pre.0",
- "tari_common_sqlite 5.3.1-pre.0",
- "tari_comms 5.3.1-pre.0",
- "tari_comms_dht 5.3.1-pre.0",
- "tari_service_framework 5.3.1-pre.0",
- "tari_shutdown 5.3.1-pre.0",
- "tari_utilities",
- "thiserror 2.0.18",
- "tokio",
- "tokio-stream",
- "tower 0.4.13",
-]
-
-[[package]]
-name = "tari_p2p"
 version = "5.4.0-pre.0"
 source = "git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef#941dd8592993629bbb1d2cc9f0dca51689a4bfef"
 dependencies = [
@@ -12638,12 +12175,12 @@ dependencies = [
  "reqwest 0.12.28",
  "semver",
  "serde",
- "tari_common 5.4.0-pre.0",
- "tari_common_sqlite 5.4.0-pre.0",
- "tari_comms 5.4.0-pre.0",
- "tari_comms_dht 5.4.0-pre.0",
- "tari_service_framework 5.4.0-pre.0",
- "tari_shutdown 5.4.0-pre.0",
+ "tari_common",
+ "tari_common_sqlite",
+ "tari_comms",
+ "tari_comms_dht",
+ "tari_service_framework",
+ "tari_shutdown",
  "tari_utilities",
  "thiserror 2.0.18",
  "tokio",
@@ -12667,7 +12204,7 @@ dependencies = [
  "prost 0.14.3",
  "proto_builder",
  "tari_metrics",
- "tari_shutdown 5.4.0-pre.0",
+ "tari_shutdown",
  "thiserror 2.0.18",
  "tokio",
  "tokio-util 0.7.18",
@@ -12706,24 +12243,6 @@ dependencies = [
 
 [[package]]
 name = "tari_script"
-version = "5.3.1-pre.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0#1f94bc8fdc909072a295ece3ace0f98bf1b2c3cc"
-dependencies = [
- "blake2 0.10.6",
- "borsh",
- "digest 0.10.7",
- "integer-encoding",
- "serde",
- "sha2 0.10.9",
- "sha3",
- "tari_crypto",
- "tari_max_size 5.3.1-pre.0",
- "tari_utilities",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "tari_script"
 version = "5.4.0-pre.0"
 source = "git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef#941dd8592993629bbb1d2cc9f0dca51689a4bfef"
 dependencies = [
@@ -12735,24 +12254,9 @@ dependencies = [
  "sha2 0.10.9",
  "sha3",
  "tari_crypto",
- "tari_max_size 5.4.0-pre.0",
+ "tari_max_size",
  "tari_utilities",
  "thiserror 2.0.18",
-]
-
-[[package]]
-name = "tari_service_framework"
-version = "5.3.1-pre.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0#1f94bc8fdc909072a295ece3ace0f98bf1b2c3cc"
-dependencies = [
- "anyhow",
- "async-trait",
- "futures 0.3.31",
- "log",
- "tari_shutdown 5.3.1-pre.0",
- "thiserror 2.0.18",
- "tokio",
- "tower-service",
 ]
 
 [[package]]
@@ -12764,18 +12268,10 @@ dependencies = [
  "async-trait",
  "futures 0.3.31",
  "log",
- "tari_shutdown 5.4.0-pre.0",
+ "tari_shutdown",
  "thiserror 2.0.18",
  "tokio",
  "tower-service",
-]
-
-[[package]]
-name = "tari_shutdown"
-version = "5.3.1-pre.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0#1f94bc8fdc909072a295ece3ace0f98bf1b2c3cc"
-dependencies = [
- "futures 0.3.31",
 ]
 
 [[package]]
@@ -12788,23 +12284,6 @@ dependencies = [
 
 [[package]]
 name = "tari_sidechain"
-version = "5.3.1-pre.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0#1f94bc8fdc909072a295ece3ace0f98bf1b2c3cc"
-dependencies = [
- "borsh",
- "hex",
- "log",
- "serde",
- "tari_common_types 5.3.1-pre.0",
- "tari_crypto",
- "tari_hashing 5.3.1-pre.0",
- "tari_jellyfish 5.3.1-pre.0",
- "tari_utilities",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "tari_sidechain"
 version = "5.4.0-pre.0"
 source = "git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef#941dd8592993629bbb1d2cc9f0dca51689a4bfef"
 dependencies = [
@@ -12812,10 +12291,10 @@ dependencies = [
  "hex",
  "log",
  "serde",
- "tari_common_types 5.4.0-pre.0",
+ "tari_common_types",
  "tari_crypto",
  "tari_hashing 5.4.0-pre.0 (git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef)",
- "tari_jellyfish 5.4.0-pre.0",
+ "tari_jellyfish",
  "tari_utilities",
  "thiserror 2.0.18",
 ]
@@ -12836,13 +12315,13 @@ dependencies = [
  "smallvec 2.0.0-alpha.12",
  "strum_macros 0.27.2",
  "tari_bor",
- "tari_common_types 5.4.0-pre.0",
+ "tari_common_types",
  "tari_consensus_types",
  "tari_engine_types",
  "tari_ootle_common_types",
  "tari_ootle_storage",
  "tari_ootle_transaction",
- "tari_sidechain 5.4.0-pre.0",
+ "tari_sidechain",
  "tari_state_tree",
  "tari_template_lib",
  "tari_template_lib_types",
@@ -12862,21 +12341,9 @@ dependencies = [
  "serde",
  "tari_bor",
  "tari_engine_types",
- "tari_jellyfish 5.4.0-pre.0",
+ "tari_jellyfish",
  "tari_ootle_common_types",
  "tari_template_lib_types",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "tari_storage"
-version = "5.3.1-pre.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0#1f94bc8fdc909072a295ece3ace0f98bf1b2c3cc"
-dependencies = [
- "bincode 1.3.3",
- "lmdb-zero",
- "log",
- "serde",
  "thiserror 2.0.18",
 ]
 
@@ -12928,16 +12395,16 @@ dependencies = [
  "serde_json",
  "serde_json5",
  "slug",
- "tari_common_types 5.4.0-pre.0",
+ "tari_common_types",
  "tari_crypto",
  "tari_ootle_app_utilities",
  "tari_ootle_common_types",
  "tari_ootle_wallet_sdk",
  "tari_ootle_walletd_client",
- "tari_shutdown 5.4.0-pre.0",
- "tari_sidechain 5.4.0-pre.0",
+ "tari_shutdown",
+ "tari_sidechain",
  "tari_template_lib_types",
- "tari_transaction_components 5.4.0-pre.0",
+ "tari_transaction_components",
  "tari_validator_node_client",
  "thiserror 2.0.18",
  "tokio",
@@ -13040,32 +12507,20 @@ dependencies = [
 
 [[package]]
 name = "tari_test_utils"
-version = "5.3.1-pre.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0#1f94bc8fdc909072a295ece3ace0f98bf1b2c3cc"
-dependencies = [
- "futures 0.3.31",
- "rand 0.10.1",
- "tari_shutdown 5.3.1-pre.0",
- "tempfile",
- "tokio",
-]
-
-[[package]]
-name = "tari_test_utils"
 version = "5.4.0-pre.0"
 source = "git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef#941dd8592993629bbb1d2cc9f0dca51689a4bfef"
 dependencies = [
  "futures 0.3.31",
  "rand 0.10.1",
- "tari_shutdown 5.4.0-pre.0",
+ "tari_shutdown",
  "tempfile",
  "tokio",
 ]
 
 [[package]]
 name = "tari_transaction_components"
-version = "5.3.1-pre.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0#1f94bc8fdc909072a295ece3ace0f98bf1b2c3cc"
+version = "5.4.0-pre.0"
+source = "git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef#941dd8592993629bbb1d2cc9f0dca51689a4bfef"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -13080,7 +12535,7 @@ dependencies = [
  "digest 0.10.7",
  "integer-encoding",
  "log",
- "minotari_ledger_wallet_common 5.3.1-pre.0",
+ "minotari_ledger_wallet_common",
  "minotari_ledger_wallet_comms",
  "newtype-ops",
  "num-derive 0.4.2",
@@ -13094,95 +12549,17 @@ dependencies = [
  "serde_repr",
  "serde_valid",
  "strum_macros 0.22.0",
- "tari_common 5.3.1-pre.0",
- "tari_common_types 5.3.1-pre.0",
- "tari_crypto",
- "tari_hashing 5.3.1-pre.0",
- "tari_max_size 5.3.1-pre.0",
- "tari_script 5.3.1-pre.0",
- "tari_sidechain 5.3.1-pre.0",
- "tari_utilities",
- "thiserror 2.0.18",
- "utoipa",
- "uuid",
- "zeroize",
-]
-
-[[package]]
-name = "tari_transaction_components"
-version = "5.4.0-pre.0"
-source = "git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef#941dd8592993629bbb1d2cc9f0dca51689a4bfef"
-dependencies = [
- "anyhow",
- "base64 0.22.1",
- "bitflags 2.10.0",
- "blake2 0.10.6",
- "borsh",
- "bytes",
- "chacha20poly1305",
- "chrono",
- "decimal-rs",
- "derivative",
- "digest 0.10.7",
- "integer-encoding",
- "log",
- "minotari_ledger_wallet_common 5.4.0-pre.0",
- "newtype-ops",
- "num-derive 0.4.2",
- "num-format",
- "num-traits",
- "primitive-types",
- "rand 0.10.1",
- "semver",
- "serde",
- "serde_json",
- "serde_repr",
- "serde_valid",
- "strum_macros 0.22.0",
- "tari_common 5.4.0-pre.0",
- "tari_common_types 5.4.0-pre.0",
+ "tari_common",
+ "tari_common_types",
  "tari_crypto",
  "tari_hashing 5.4.0-pre.0 (git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef)",
- "tari_max_size 5.4.0-pre.0",
- "tari_script 5.4.0-pre.0",
- "tari_sidechain 5.4.0-pre.0",
+ "tari_max_size",
+ "tari_script",
+ "tari_sidechain",
  "tari_utilities",
  "thiserror 2.0.18",
  "utoipa",
  "uuid",
- "zeroize",
-]
-
-[[package]]
-name = "tari_transaction_key_manager"
-version = "5.3.1-pre.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0#1f94bc8fdc909072a295ece3ace0f98bf1b2c3cc"
-dependencies = [
- "async-trait",
- "blake2 0.10.6",
- "chacha20poly1305",
- "chrono",
- "derivative",
- "diesel",
- "diesel_migrations",
- "digest 0.10.7",
- "futures 0.3.31",
- "log",
- "minotari_ledger_wallet_common 5.3.1-pre.0",
- "rand 0.10.1",
- "serde",
- "strum 0.22.0",
- "strum_macros 0.22.0",
- "tari_common_sqlite 5.3.1-pre.0",
- "tari_common_types 5.3.1-pre.0",
- "tari_crypto",
- "tari_hashing 5.3.1-pre.0",
- "tari_script 5.3.1-pre.0",
- "tari_service_framework 5.3.1-pre.0",
- "tari_transaction_components 5.3.1-pre.0",
- "tari_utilities",
- "thiserror 2.0.18",
- "tokio",
  "zeroize",
 ]
 
@@ -13201,18 +12578,18 @@ dependencies = [
  "digest 0.10.7",
  "futures 0.3.31",
  "log",
- "minotari_ledger_wallet_common 5.4.0-pre.0",
+ "minotari_ledger_wallet_common",
  "rand 0.10.1",
  "serde",
  "strum 0.22.0",
  "strum_macros 0.22.0",
- "tari_common_sqlite 5.4.0-pre.0",
- "tari_common_types 5.4.0-pre.0",
+ "tari_common_sqlite",
+ "tari_common_types",
  "tari_crypto",
  "tari_hashing 5.4.0-pre.0 (git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef)",
- "tari_script 5.4.0-pre.0",
- "tari_service_framework 5.4.0-pre.0",
- "tari_transaction_components 5.4.0-pre.0",
+ "tari_script",
+ "tari_service_framework",
+ "tari_transaction_components",
  "tari_utilities",
  "thiserror 2.0.18",
  "tokio",
@@ -13286,8 +12663,8 @@ dependencies = [
  "std-semaphore",
  "tari_base_node_client",
  "tari_bor",
- "tari_common 5.4.0-pre.0",
- "tari_common_types 5.4.0-pre.0",
+ "tari_common",
+ "tari_common_types",
  "tari_consensus",
  "tari_consensus_types",
  "tari_crypto",
@@ -13304,13 +12681,13 @@ dependencies = [
  "tari_ootle_transaction",
  "tari_rpc_framework",
  "tari_rpc_state_sync",
- "tari_shutdown 5.4.0-pre.0",
+ "tari_shutdown",
  "tari_state_store_rocksdb",
  "tari_state_tree",
  "tari_swarm",
  "tari_template_builtin",
  "tari_template_lib",
- "tari_transaction_components 5.4.0-pre.0",
+ "tari_transaction_components",
  "tari_validator_node_client",
  "tari_validator_node_rpc",
  "thiserror 2.0.18",
@@ -13330,14 +12707,14 @@ dependencies = [
  "serde",
  "serde_json",
  "tari_base_node_client",
- "tari_common_types 5.4.0-pre.0",
+ "tari_common_types",
  "tari_consensus_types",
  "tari_engine_types",
  "tari_ootle_common_types",
  "tari_ootle_p2p",
  "tari_ootle_storage",
  "tari_ootle_transaction",
- "tari_sidechain 5.4.0-pre.0",
+ "tari_sidechain",
  "tari_template_abi",
  "tari_template_lib_types",
  "thiserror 2.0.18",
@@ -13412,7 +12789,7 @@ dependencies = [
  "fern",
  "humantime",
  "log",
- "minotari_app_grpc 5.4.0-pre.0",
+ "minotari_app_grpc",
  "minotari_node_grpc_client",
  "minotari_wallet_grpc_client",
  "ootle-network",
@@ -13422,10 +12799,10 @@ dependencies = [
  "serde_json5",
  "tari_crypto",
  "tari_ootle_common_types",
- "tari_shutdown 5.4.0-pre.0",
- "tari_sidechain 5.4.0-pre.0",
+ "tari_shutdown",
+ "tari_sidechain",
  "tari_template_lib_types",
- "tari_transaction_components 5.4.0-pre.0",
+ "tari_transaction_components",
  "tokio",
  "toml 0.8.23",
  "tonic 0.13.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1707,7 +1707,7 @@ dependencies = [
 
 [[package]]
 name = "consensus_tests"
-version = "0.32.2"
+version = "0.33.0"
 dependencies = [
  "fern",
  "futures 0.3.31",
@@ -2711,7 +2711,7 @@ dependencies = [
 
 [[package]]
 name = "db-inspector"
-version = "0.32.2"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -5107,7 +5107,7 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "integration_tests"
-version = "0.32.2"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "config",
@@ -5889,7 +5889,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-messaging"
-version = "0.32.2"
+version = "0.33.0"
 dependencies = [
  "async-trait",
  "futures-bounded 0.2.4",
@@ -6067,7 +6067,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-substream"
-version = "0.32.2"
+version = "0.33.0"
 dependencies = [
  "libp2p",
  "prometheus-client",
@@ -7813,7 +7813,7 @@ dependencies = [
 
 [[package]]
 name = "ootle-wasm"
-version = "0.32.2"
+version = "0.33.0"
 dependencies = [
  "console_error_panic_hook",
  "getrandom 0.2.17",
@@ -7824,7 +7824,7 @@ dependencies = [
 
 [[package]]
 name = "ootle-wasm-core"
-version = "0.32.2"
+version = "0.33.0"
 dependencies = [
  "base64 0.22.1",
  "hex",
@@ -8832,7 +8832,7 @@ dependencies = [
 
 [[package]]
 name = "proto_builder"
-version = "0.32.2"
+version = "0.33.0"
 dependencies = [
  "prost-build 0.14.3",
  "sha2 0.10.9",
@@ -10710,7 +10710,7 @@ dependencies = [
 
 [[package]]
 name = "sqlite_message_logger"
-version = "0.32.2"
+version = "0.33.0"
 dependencies = [
  "chrono",
  "diesel",
@@ -11082,7 +11082,7 @@ dependencies = [
 
 [[package]]
 name = "tari_base_node_client"
-version = "0.32.2"
+version = "0.33.0"
 dependencies = [
  "futures-util",
  "log",
@@ -11479,7 +11479,7 @@ dependencies = [
 
 [[package]]
 name = "tari_consensus"
-version = "0.32.2"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "indexmap 2.13.0",
@@ -11504,7 +11504,7 @@ dependencies = [
 
 [[package]]
 name = "tari_consensus_types"
-version = "0.32.2"
+version = "0.33.0"
 dependencies = [
  "borsh",
  "minicbor",
@@ -11667,7 +11667,7 @@ dependencies = [
 
 [[package]]
 name = "tari_engine"
-version = "0.32.2"
+version = "0.33.0"
 dependencies = [
  "blake2 0.10.6",
  "bytes",
@@ -11699,7 +11699,7 @@ dependencies = [
 
 [[package]]
 name = "tari_engine_types"
-version = "0.32.2"
+version = "0.33.0"
 dependencies = [
  "blake2 0.10.6",
  "borsh",
@@ -11728,7 +11728,7 @@ dependencies = [
 
 [[package]]
 name = "tari_epoch_manager"
-version = "0.32.2"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "log",
@@ -11748,7 +11748,7 @@ dependencies = [
 
 [[package]]
 name = "tari_epoch_oracles"
-version = "0.32.2"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "blake2 0.10.6",
@@ -11818,7 +11818,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer"
-version = "0.32.2"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -11919,7 +11919,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer_lib"
-version = "0.32.2"
+version = "0.33.0"
 dependencies = [
  "log",
  "minicbor",
@@ -12062,7 +12062,7 @@ dependencies = [
 
 [[package]]
 name = "tari_networking"
-version = "0.32.2"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12135,7 +12135,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_app_utilities"
-version = "0.32.2"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -12175,7 +12175,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_common_types"
-version = "0.32.2"
+version = "0.33.0"
 dependencies = [
  "blake2 0.10.6",
  "borsh",
@@ -12204,7 +12204,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_p2p"
-version = "0.32.2"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "libp2p-identity 0.2.13 (git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a)",
@@ -12228,7 +12228,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_storage"
-version = "0.32.2"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "bitflags 2.10.0",
@@ -12257,7 +12257,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_storage_sqlite"
-version = "0.32.2"
+version = "0.33.0"
 dependencies = [
  "diesel",
  "diesel_migrations",
@@ -12310,7 +12310,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_transaction"
-version = "0.32.2"
+version = "0.33.0"
 dependencies = [
  "borsh",
  "hex",
@@ -12336,7 +12336,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_cli"
-version = "0.32.2"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -12366,7 +12366,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_crypto"
-version = "0.32.2"
+version = "0.33.0"
 dependencies = [
  "argon2 0.5.3",
  "blake2 0.10.6",
@@ -12396,7 +12396,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_sdk"
-version = "0.32.2"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -12458,7 +12458,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_sdk_tests"
-version = "0.32.2"
+version = "0.33.0"
 dependencies = [
  "digest 0.10.7",
  "ootle_byte_type",
@@ -12480,7 +12480,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_storage_sqlite"
-version = "0.32.2"
+version = "0.33.0"
 dependencies = [
  "diesel",
  "diesel_migrations",
@@ -12503,7 +12503,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_walletd"
-version = "0.32.2"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12653,7 +12653,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_framework"
-version = "0.32.2"
+version = "0.33.0"
 dependencies = [
  "async-trait",
  "bitflags 2.10.0",
@@ -12677,7 +12677,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_macros"
-version = "0.32.2"
+version = "0.33.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12686,7 +12686,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_state_sync"
-version = "0.32.2"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -12822,7 +12822,7 @@ dependencies = [
 
 [[package]]
 name = "tari_state_store_rocksdb"
-version = "0.32.2"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12854,7 +12854,7 @@ dependencies = [
 
 [[package]]
 name = "tari_state_tree"
-version = "0.32.2"
+version = "0.33.0"
 dependencies = [
  "indexmap 2.13.0",
  "log",
@@ -12894,7 +12894,7 @@ dependencies = [
 
 [[package]]
 name = "tari_swarm"
-version = "0.32.2"
+version = "0.33.0"
 dependencies = [
  "libp2p",
  "libp2p-messaging",
@@ -12905,7 +12905,7 @@ dependencies = [
 
 [[package]]
 name = "tari_swarm_daemon"
-version = "0.32.2"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -13018,7 +13018,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_test_tooling"
-version = "0.32.2"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "cargo_toml 0.22.3",
@@ -13221,7 +13221,7 @@ dependencies = [
 
 [[package]]
 name = "tari_transaction_manifest"
-version = "0.32.2"
+version = "0.33.0"
 dependencies = [
  "proc-macro2",
  "serde_json",
@@ -13256,7 +13256,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node"
-version = "0.32.2"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -13322,7 +13322,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node_client"
-version = "0.32.2"
+version = "0.33.0"
 dependencies = [
  "indexmap 2.13.0",
  "multiaddr 0.18.3",
@@ -13346,7 +13346,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node_rpc"
-version = "0.32.2"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -13370,7 +13370,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_rollback"
-version = "0.32.2"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -13405,7 +13405,7 @@ dependencies = [
 
 [[package]]
 name = "tari_watcher"
-version = "0.32.2"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "clap 3.2.25",
@@ -13434,7 +13434,7 @@ dependencies = [
 
 [[package]]
 name = "tariswap_bench"
-version = "0.32.2"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "clap 4.5.54",
@@ -14114,7 +14114,7 @@ dependencies = [
 
 [[package]]
 name = "traffic-sim"
-version = "0.32.2"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "clap 4.5.54",
@@ -14136,7 +14136,7 @@ dependencies = [
 
 [[package]]
 name = "transaction_generator"
-version = "0.32.2"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -14155,7 +14155,7 @@ dependencies = [
 
 [[package]]
 name = "transaction_submitter"
-version = "0.32.2"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "clap 4.5.54",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1719,7 +1719,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tari_bor",
- "tari_common_types",
+ "tari_common_types 5.4.0-pre.0",
  "tari_consensus",
  "tari_consensus_types",
  "tari_crypto",
@@ -1731,8 +1731,8 @@ dependencies = [
  "tari_ootle_p2p",
  "tari_ootle_storage",
  "tari_ootle_transaction",
- "tari_shutdown",
- "tari_sidechain",
+ "tari_shutdown 5.4.0-pre.0",
+ "tari_sidechain 5.4.0-pre.0",
  "tari_state_store_rocksdb",
  "tari_state_tree",
  "tari_template_lib_types",
@@ -2706,7 +2706,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2724,7 +2724,7 @@ dependencies = [
  "mime_guess",
  "serde",
  "serde_json",
- "tari_jellyfish",
+ "tari_jellyfish 5.4.0-pre.0",
  "tari_ootle_common_types",
  "tari_ootle_p2p",
  "tari_ootle_storage",
@@ -4439,9 +4439,9 @@ dependencies = [
 
 [[package]]
 name = "hickory-resolver"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a10bd64d950b4d38ca21e25c8ae230712e4955fb8290cfcb29a5e5dc6017e544"
+checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -5118,12 +5118,12 @@ dependencies = [
  "libp2p",
  "log",
  "log4rs",
- "minotari_app_grpc",
- "minotari_app_utilities",
+ "minotari_app_grpc 5.4.0-pre.0",
+ "minotari_app_utilities 5.4.0-pre.0",
  "minotari_console_wallet",
  "minotari_node",
  "minotari_node_grpc_client",
- "minotari_wallet",
+ "minotari_wallet 5.4.0-pre.0",
  "multiaddr 0.18.3",
  "notify",
  "ootle_byte_type",
@@ -5134,11 +5134,11 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "tari_base_node_client",
- "tari_common",
- "tari_common_sqlite",
- "tari_common_types",
- "tari_comms",
- "tari_comms_dht",
+ "tari_common 5.4.0-pre.0",
+ "tari_common_sqlite 5.4.0-pre.0",
+ "tari_common_types 5.4.0-pre.0",
+ "tari_comms 5.4.0-pre.0",
+ "tari_comms_dht 5.4.0-pre.0",
  "tari_consensus",
  "tari_crypto",
  "tari_engine",
@@ -5153,14 +5153,14 @@ dependencies = [
  "tari_ootle_wallet_sdk",
  "tari_ootle_walletd",
  "tari_ootle_walletd_client",
- "tari_p2p",
- "tari_shutdown",
- "tari_sidechain",
+ "tari_p2p 5.4.0-pre.0",
+ "tari_shutdown 5.4.0-pre.0",
+ "tari_sidechain 5.4.0-pre.0",
  "tari_state_store_rocksdb",
  "tari_template_builtin",
  "tari_template_lib_types",
  "tari_template_test_tooling",
- "tari_transaction_components",
+ "tari_transaction_components 5.4.0-pre.0",
  "tari_transaction_manifest",
  "tari_validator_node",
  "tari_validator_node_client",
@@ -6678,16 +6678,47 @@ dependencies = [
  "rand 0.10.1",
  "rcgen 0.12.1",
  "subtle",
- "tari_common_types",
- "tari_comms",
- "tari_core",
+ "tari_common_types 5.3.1-pre.0",
+ "tari_comms 5.3.1-pre.0",
+ "tari_core 5.3.1-pre.0",
  "tari_crypto",
- "tari_features",
- "tari_max_size",
- "tari_node_components",
- "tari_script",
- "tari_sidechain",
- "tari_transaction_components",
+ "tari_features 5.3.1-pre.0",
+ "tari_max_size 5.3.1-pre.0",
+ "tari_node_components 5.3.1-pre.0",
+ "tari_script 5.3.1-pre.0",
+ "tari_sidechain 5.3.1-pre.0",
+ "tari_transaction_components 5.3.1-pre.0",
+ "tari_utilities",
+ "thiserror 2.0.18",
+ "tokio",
+ "tonic 0.13.1",
+ "tonic-build",
+ "zeroize",
+]
+
+[[package]]
+name = "minotari_app_grpc"
+version = "5.4.0-pre.0"
+source = "git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef#941dd8592993629bbb1d2cc9f0dca51689a4bfef"
+dependencies = [
+ "argon2 0.6.0-rc.8",
+ "base64 0.22.1",
+ "borsh",
+ "log",
+ "prost 0.13.5",
+ "rand 0.10.1",
+ "rcgen 0.12.1",
+ "subtle",
+ "tari_common_types 5.4.0-pre.0",
+ "tari_comms 5.4.0-pre.0",
+ "tari_core 5.4.0-pre.0",
+ "tari_crypto",
+ "tari_features 5.4.0-pre.0",
+ "tari_max_size 5.4.0-pre.0",
+ "tari_node_components 5.4.0-pre.0",
+ "tari_script 5.4.0-pre.0",
+ "tari_sidechain 5.4.0-pre.0",
+ "tari_transaction_components 5.4.0-pre.0",
  "tari_utilities",
  "thiserror 2.0.18",
  "tokio",
@@ -6708,11 +6739,34 @@ dependencies = [
  "log",
  "rand 0.10.1",
  "serde",
- "tari_common",
- "tari_common_types",
- "tari_comms",
- "tari_features",
- "tari_p2p",
+ "tari_common 5.3.1-pre.0",
+ "tari_common_types 5.3.1-pre.0",
+ "tari_comms 5.3.1-pre.0",
+ "tari_features 5.3.1-pre.0",
+ "tari_p2p 5.3.1-pre.0",
+ "tari_utilities",
+ "thiserror 2.0.18",
+ "tokio",
+ "tonic 0.13.1",
+]
+
+[[package]]
+name = "minotari_app_utilities"
+version = "5.4.0-pre.0"
+source = "git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef#941dd8592993629bbb1d2cc9f0dca51689a4bfef"
+dependencies = [
+ "clap 4.5.54",
+ "dialoguer 0.10.4",
+ "futures 0.3.31",
+ "json5",
+ "log",
+ "rand 0.10.1",
+ "serde",
+ "tari_common 5.4.0-pre.0",
+ "tari_common_types 5.4.0-pre.0",
+ "tari_comms 5.4.0-pre.0",
+ "tari_features 5.4.0-pre.0",
+ "tari_p2p 5.4.0-pre.0",
  "tari_utilities",
  "thiserror 2.0.18",
  "tokio",
@@ -6737,12 +6791,12 @@ dependencies = [
  "futures 0.3.31",
  "log",
  "log4rs",
- "minotari_app_grpc",
- "minotari_app_utilities",
- "minotari_ledger_wallet_common",
+ "minotari_app_grpc 5.3.1-pre.0",
+ "minotari_app_utilities 5.3.1-pre.0",
+ "minotari_ledger_wallet_common 5.3.1-pre.0",
  "minotari_ledger_wallet_comms",
- "minotari_node_wallet_client",
- "minotari_wallet",
+ "minotari_node_wallet_client 5.3.1-pre.0",
+ "minotari_wallet 5.3.1-pre.0",
  "qrcode",
  "rand 0.10.1",
  "regex",
@@ -6752,19 +6806,19 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "strum 0.22.0",
- "tari_common",
- "tari_common_types",
- "tari_comms",
- "tari_core",
+ "tari_common 5.3.1-pre.0",
+ "tari_common_types 5.3.1-pre.0",
+ "tari_comms 5.3.1-pre.0",
+ "tari_core 5.3.1-pre.0",
  "tari_crypto",
- "tari_features",
- "tari_hashing 5.3.1-pre.0 (git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0)",
- "tari_p2p",
- "tari_script",
- "tari_shutdown",
- "tari_sidechain",
- "tari_transaction_components",
- "tari_transaction_key_manager",
+ "tari_features 5.3.1-pre.0",
+ "tari_hashing 5.3.1-pre.0",
+ "tari_p2p 5.3.1-pre.0",
+ "tari_script 5.3.1-pre.0",
+ "tari_shutdown 5.3.1-pre.0",
+ "tari_sidechain 5.3.1-pre.0",
+ "tari_transaction_components 5.3.1-pre.0",
+ "tari_transaction_key_manager 5.3.1-pre.0",
  "tari_utilities",
  "thiserror 2.0.18",
  "tokio",
@@ -6785,6 +6839,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "minotari_ledger_wallet_common"
+version = "5.4.0-pre.0"
+source = "git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef#941dd8592993629bbb1d2cc9f0dca51689a4bfef"
+dependencies = [
+ "borsh",
+ "bs58",
+ "serde",
+]
+
+[[package]]
 name = "minotari_ledger_wallet_comms"
 version = "5.3.1-pre.0"
 source = "git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0#1f94bc8fdc909072a295ece3ace0f98bf1b2c3cc"
@@ -6794,14 +6858,14 @@ dependencies = [
  "ledger-transport",
  "ledger-transport-hid",
  "log",
- "minotari_ledger_wallet_common",
+ "minotari_ledger_wallet_common 5.3.1-pre.0",
  "rand 0.10.1",
  "semver",
  "serde",
- "tari_common",
- "tari_common_types",
+ "tari_common 5.3.1-pre.0",
+ "tari_common_types 5.3.1-pre.0",
  "tari_crypto",
- "tari_script",
+ "tari_script 5.3.1-pre.0",
  "tari_utilities",
  "thiserror 2.0.18",
 ]
@@ -6833,8 +6897,8 @@ dependencies = [
  "hyper-util",
  "log",
  "log4rs",
- "minotari_app_grpc",
- "minotari_app_utilities",
+ "minotari_app_grpc 5.3.1-pre.0",
+ "minotari_app_utilities 5.3.1-pre.0",
  "nom 7.1.3",
  "qrcode",
  "rustyline",
@@ -6842,19 +6906,19 @@ dependencies = [
  "serde",
  "serde_json",
  "strum 0.22.0",
- "tari_common",
- "tari_common_types",
- "tari_comms",
- "tari_comms_dht",
- "tari_core",
- "tari_features",
+ "tari_common 5.3.1-pre.0",
+ "tari_common_types 5.3.1-pre.0",
+ "tari_comms 5.3.1-pre.0",
+ "tari_comms_dht 5.3.1-pre.0",
+ "tari_core 5.3.1-pre.0",
+ "tari_features 5.3.1-pre.0",
  "tari_libtor",
- "tari_node_components",
- "tari_p2p",
- "tari_service_framework",
- "tari_shutdown",
- "tari_storage",
- "tari_transaction_components",
+ "tari_node_components 5.3.1-pre.0",
+ "tari_p2p 5.3.1-pre.0",
+ "tari_service_framework 5.3.1-pre.0",
+ "tari_shutdown 5.3.1-pre.0",
+ "tari_storage 5.3.1-pre.0",
+ "tari_transaction_components 5.3.1-pre.0",
  "tari_utilities",
  "thiserror 2.0.18",
  "tokio",
@@ -6867,10 +6931,10 @@ dependencies = [
 
 [[package]]
 name = "minotari_node_grpc_client"
-version = "5.3.1-pre.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0#1f94bc8fdc909072a295ece3ace0f98bf1b2c3cc"
+version = "5.4.0-pre.0"
+source = "git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef#941dd8592993629bbb1d2cc9f0dca51689a4bfef"
 dependencies = [
- "minotari_app_grpc",
+ "minotari_app_grpc 5.4.0-pre.0",
 ]
 
 [[package]]
@@ -6884,8 +6948,26 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
- "tari_shutdown",
- "tari_transaction_components",
+ "tari_shutdown 5.3.1-pre.0",
+ "tari_transaction_components 5.3.1-pre.0",
+ "tari_utilities",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "minotari_node_wallet_client"
+version = "5.4.0-pre.0"
+source = "git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef#941dd8592993629bbb1d2cc9f0dca51689a4bfef"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "log",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "tari_shutdown 5.4.0-pre.0",
+ "tari_transaction_components 5.4.0-pre.0",
  "tari_utilities",
  "tokio",
  "url",
@@ -6914,8 +6996,8 @@ dependencies = [
  "itertools 0.10.5",
  "libsqlite3-sys",
  "log",
- "minotari_ledger_wallet_common",
- "minotari_node_wallet_client",
+ "minotari_ledger_wallet_common 5.3.1-pre.0",
+ "minotari_node_wallet_client 5.3.1-pre.0",
  "phc",
  "prost 0.13.5",
  "rand 0.10.1",
@@ -6924,21 +7006,79 @@ dependencies = [
  "sha2 0.10.9",
  "strum 0.22.0",
  "strum_macros 0.22.0",
- "tari_common",
- "tari_common_sqlite",
- "tari_common_types",
- "tari_comms",
- "tari_comms_dht",
+ "tari_common 5.3.1-pre.0",
+ "tari_common_sqlite 5.3.1-pre.0",
+ "tari_common_types 5.3.1-pre.0",
+ "tari_comms 5.3.1-pre.0",
+ "tari_comms_dht 5.3.1-pre.0",
  "tari_crypto",
- "tari_hashing 5.3.1-pre.0 (git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0)",
- "tari_max_size",
- "tari_p2p",
- "tari_script",
- "tari_service_framework",
- "tari_shutdown",
- "tari_sidechain",
- "tari_transaction_components",
- "tari_transaction_key_manager",
+ "tari_hashing 5.3.1-pre.0",
+ "tari_max_size 5.3.1-pre.0",
+ "tari_p2p 5.3.1-pre.0",
+ "tari_script 5.3.1-pre.0",
+ "tari_service_framework 5.3.1-pre.0",
+ "tari_shutdown 5.3.1-pre.0",
+ "tari_sidechain 5.3.1-pre.0",
+ "tari_transaction_components 5.3.1-pre.0",
+ "tari_transaction_key_manager 5.3.1-pre.0",
+ "tari_utilities",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tower 0.4.13",
+ "url",
+ "uuid",
+ "zeroize",
+]
+
+[[package]]
+name = "minotari_wallet"
+version = "5.4.0-pre.0"
+source = "git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef#941dd8592993629bbb1d2cc9f0dca51689a4bfef"
+dependencies = [
+ "anyhow",
+ "argon2 0.6.0-rc.8",
+ "async-trait",
+ "bincode 1.3.3",
+ "blake2 0.10.6",
+ "borsh",
+ "chacha20poly1305",
+ "chrono",
+ "derivative",
+ "diesel",
+ "diesel_migrations",
+ "digest 0.10.7",
+ "dirs-next 1.0.2",
+ "fs2",
+ "futures 0.3.31",
+ "itertools 0.10.5",
+ "libsqlite3-sys",
+ "log",
+ "minotari_ledger_wallet_common 5.4.0-pre.0",
+ "minotari_node_wallet_client 5.4.0-pre.0",
+ "phc",
+ "prost 0.13.5",
+ "rand 0.10.1",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "strum 0.22.0",
+ "strum_macros 0.22.0",
+ "tari_common 5.4.0-pre.0",
+ "tari_common_sqlite 5.4.0-pre.0",
+ "tari_common_types 5.4.0-pre.0",
+ "tari_comms 5.4.0-pre.0",
+ "tari_comms_dht 5.4.0-pre.0",
+ "tari_crypto",
+ "tari_hashing 5.4.0-pre.0 (git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef)",
+ "tari_max_size 5.4.0-pre.0",
+ "tari_p2p 5.4.0-pre.0",
+ "tari_script 5.4.0-pre.0",
+ "tari_service_framework 5.4.0-pre.0",
+ "tari_shutdown 5.4.0-pre.0",
+ "tari_sidechain 5.4.0-pre.0",
+ "tari_transaction_components 5.4.0-pre.0",
+ "tari_transaction_key_manager 5.4.0-pre.0",
  "tari_utilities",
  "tempfile",
  "thiserror 2.0.18",
@@ -6951,12 +7091,12 @@ dependencies = [
 
 [[package]]
 name = "minotari_wallet_grpc_client"
-version = "5.3.1-pre.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0#1f94bc8fdc909072a295ece3ace0f98bf1b2c3cc"
+version = "5.4.0-pre.0"
+source = "git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef#941dd8592993629bbb1d2cc9f0dca51689a4bfef"
 dependencies = [
- "minotari_app_grpc",
- "tari_common",
- "tari_common_types",
+ "minotari_app_grpc 5.4.0-pre.0",
+ "tari_common 5.4.0-pre.0",
+ "tari_common_types 5.4.0-pre.0",
  "thiserror 2.0.18",
  "tonic 0.13.1",
 ]
@@ -10946,14 +11086,14 @@ version = "0.32.2"
 dependencies = [
  "futures-util",
  "log",
- "minotari_app_grpc",
+ "minotari_app_grpc 5.4.0-pre.0",
  "minotari_node_grpc_client",
  "serde",
- "tari_common_types",
- "tari_node_components",
+ "tari_common_types 5.4.0-pre.0",
+ "tari_node_components 5.4.0-pre.0",
  "tari_ootle_common_types",
  "tari_template_lib",
- "tari_transaction_components",
+ "tari_transaction_components 5.4.0-pre.0",
  "tari_utilities",
  "thiserror 2.0.18",
  "tonic 0.13.1",
@@ -11015,7 +11155,33 @@ dependencies = [
  "serde_yaml",
  "sha2 0.10.9",
  "structopt",
- "tari_features",
+ "tari_features 5.3.1-pre.0",
+ "tempfile",
+ "thiserror 2.0.18",
+ "toml 0.5.11",
+]
+
+[[package]]
+name = "tari_common"
+version = "5.4.0-pre.0"
+source = "git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef#941dd8592993629bbb1d2cc9f0dca51689a4bfef"
+dependencies = [
+ "anyhow",
+ "cargo_toml 0.20.5",
+ "config",
+ "dirs-next 1.0.2",
+ "git2",
+ "log",
+ "log4rs",
+ "multiaddr 0.18.2",
+ "path-clean",
+ "prost-build 0.11.9",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "sha2 0.10.9",
+ "structopt",
+ "tari_features 5.4.0-pre.0",
  "tempfile",
  "thiserror 2.0.18",
  "toml 0.5.11",
@@ -11025,6 +11191,23 @@ dependencies = [
 name = "tari_common_sqlite"
 version = "5.3.1-pre.0"
 source = "git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0#1f94bc8fdc909072a295ece3ace0f98bf1b2c3cc"
+dependencies = [
+ "diesel",
+ "diesel_migrations",
+ "lazy_static",
+ "log",
+ "rand 0.10.1",
+ "serde",
+ "serde_json",
+ "tari_utilities",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
+name = "tari_common_sqlite"
+version = "5.4.0-pre.0"
+source = "git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef#941dd8592993629bbb1d2cc9f0dca51689a4bfef"
 dependencies = [
  "diesel",
  "diesel_migrations",
@@ -11065,10 +11248,47 @@ dependencies = [
  "strum 0.22.0",
  "strum_macros 0.22.0",
  "subtle",
- "tari_common",
+ "tari_common 5.3.1-pre.0",
  "tari_crypto",
- "tari_hashing 5.3.1-pre.0 (git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0)",
- "tari_max_size",
+ "tari_hashing 5.3.1-pre.0",
+ "tari_max_size 5.3.1-pre.0",
+ "tari_utilities",
+ "thiserror 2.0.18",
+ "utoipa",
+ "zeroize",
+]
+
+[[package]]
+name = "tari_common_types"
+version = "5.4.0-pre.0"
+source = "git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef#941dd8592993629bbb1d2cc9f0dca51689a4bfef"
+dependencies = [
+ "argon2 0.6.0-rc.8",
+ "base64 0.22.1",
+ "bitflags 2.10.0",
+ "blake2 0.10.6",
+ "borsh",
+ "bs58",
+ "chacha20 0.7.3",
+ "chacha20poly1305",
+ "crc32fast",
+ "digest 0.10.7",
+ "getrandom 0.2.17",
+ "getrandom 0.4.2",
+ "js-sys",
+ "newtype-ops",
+ "once_cell",
+ "primitive-types",
+ "rand 0.10.1",
+ "serde",
+ "serde_json",
+ "strum 0.22.0",
+ "strum_macros 0.22.0",
+ "subtle",
+ "tari_common 5.4.0-pre.0",
+ "tari_crypto",
+ "tari_hashing 5.4.0-pre.0 (git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef)",
+ "tari_max_size 5.4.0-pre.0",
  "tari_utilities",
  "thiserror 2.0.18",
  "utoipa",
@@ -11106,11 +11326,58 @@ dependencies = [
  "serde_json",
  "sha3",
  "snow",
- "tari_common",
- "tari_common_sqlite",
+ "tari_common 5.3.1-pre.0",
+ "tari_common_sqlite 5.3.1-pre.0",
  "tari_crypto",
- "tari_shutdown",
- "tari_storage",
+ "tari_shutdown 5.3.1-pre.0",
+ "tari_storage 5.3.1-pre.0",
+ "tari_utilities",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tokio-util 0.6.10",
+ "tower 0.4.13",
+ "tracing",
+ "yamux 0.13.10",
+ "zeroize",
+]
+
+[[package]]
+name = "tari_comms"
+version = "5.4.0-pre.0"
+source = "git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef#941dd8592993629bbb1d2cc9f0dca51689a4bfef"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bitflags 2.10.0",
+ "blake2 0.10.6",
+ "bytes",
+ "chrono",
+ "cidr",
+ "data-encoding",
+ "derivative",
+ "diesel",
+ "diesel_migrations",
+ "digest 0.10.7",
+ "futures 0.3.31",
+ "local-ip-address",
+ "log",
+ "multiaddr 0.18.2",
+ "nom 7.1.3",
+ "once_cell",
+ "pin-project 1.1.12",
+ "prost 0.13.5",
+ "rand 0.10.1",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "sha3",
+ "snow",
+ "tari_common 5.4.0-pre.0",
+ "tari_common_sqlite 5.4.0-pre.0",
+ "tari_crypto",
+ "tari_shutdown 5.4.0-pre.0",
+ "tari_storage 5.4.0-pre.0",
  "tari_utilities",
  "thiserror 2.0.18",
  "tokio",
@@ -11143,12 +11410,46 @@ dependencies = [
  "prost 0.13.5",
  "rand 0.10.1",
  "serde",
- "tari_common",
- "tari_common_sqlite",
- "tari_comms",
- "tari_comms_rpc_macros",
+ "tari_common 5.3.1-pre.0",
+ "tari_common_sqlite 5.3.1-pre.0",
+ "tari_comms 5.3.1-pre.0",
+ "tari_comms_rpc_macros 5.3.1-pre.0",
  "tari_crypto",
- "tari_shutdown",
+ "tari_shutdown 5.3.1-pre.0",
+ "tari_utilities",
+ "thiserror 2.0.18",
+ "tokio",
+ "tower 0.4.13",
+ "zeroize",
+]
+
+[[package]]
+name = "tari_comms_dht"
+version = "5.4.0-pre.0"
+source = "git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef#941dd8592993629bbb1d2cc9f0dca51689a4bfef"
+dependencies = [
+ "anyhow",
+ "bitflags 2.10.0",
+ "blake2 0.10.6",
+ "chacha20 0.7.3",
+ "chacha20poly1305",
+ "chrono",
+ "diesel",
+ "diesel_migrations",
+ "digest 0.10.7",
+ "futures 0.3.31",
+ "futures-util",
+ "log",
+ "pin-project 0.4.30",
+ "prost 0.13.5",
+ "rand 0.10.1",
+ "serde",
+ "tari_common 5.4.0-pre.0",
+ "tari_common_sqlite 5.4.0-pre.0",
+ "tari_comms 5.4.0-pre.0",
+ "tari_comms_rpc_macros 5.4.0-pre.0",
+ "tari_crypto",
+ "tari_shutdown 5.4.0-pre.0",
  "tari_utilities",
  "thiserror 2.0.18",
  "tokio",
@@ -11167,6 +11468,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tari_comms_rpc_macros"
+version = "5.4.0-pre.0"
+source = "git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef#941dd8592993629bbb1d2cc9f0dca51689a4bfef"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "tari_consensus"
 version = "0.32.2"
 dependencies = [
@@ -11175,7 +11486,7 @@ dependencies = [
  "log",
  "ootle_byte_type",
  "serde",
- "tari_common_types",
+ "tari_common_types 5.4.0-pre.0",
  "tari_consensus_types",
  "tari_crypto",
  "tari_engine_types",
@@ -11183,8 +11494,8 @@ dependencies = [
  "tari_ootle_common_types",
  "tari_ootle_storage",
  "tari_ootle_transaction",
- "tari_shutdown",
- "tari_sidechain",
+ "tari_shutdown 5.4.0-pre.0",
+ "tari_sidechain 5.4.0-pre.0",
  "tari_state_tree",
  "tari_template_lib_types",
  "thiserror 2.0.18",
@@ -11200,12 +11511,12 @@ dependencies = [
  "ootle_serde",
  "serde",
  "tari_bor",
- "tari_common_types",
+ "tari_common_types 5.4.0-pre.0",
  "tari_crypto",
  "tari_engine_types",
- "tari_hashing 5.3.1-pre.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tari_hashing 5.4.0-pre.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tari_ootle_common_types",
- "tari_sidechain",
+ "tari_sidechain 5.4.0-pre.0",
  "tari_template_lib",
  "ts-rs",
 ]
@@ -11244,26 +11555,87 @@ dependencies = [
  "sha3",
  "strum_macros 0.22.0",
  "tari-tiny-keccak",
- "tari_common",
- "tari_common_sqlite",
- "tari_common_types",
- "tari_comms",
- "tari_comms_dht",
- "tari_comms_rpc_macros",
+ "tari_common 5.3.1-pre.0",
+ "tari_common_sqlite 5.3.1-pre.0",
+ "tari_common_types 5.3.1-pre.0",
+ "tari_comms 5.3.1-pre.0",
+ "tari_comms_dht 5.3.1-pre.0",
+ "tari_comms_rpc_macros 5.3.1-pre.0",
  "tari_crypto",
- "tari_features",
- "tari_hashing 5.3.1-pre.0 (git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0)",
- "tari_max_size",
- "tari_mmr",
- "tari_node_components",
- "tari_p2p",
- "tari_script",
- "tari_service_framework",
- "tari_shutdown",
- "tari_sidechain",
- "tari_storage",
- "tari_test_utils",
- "tari_transaction_components",
+ "tari_features 5.3.1-pre.0",
+ "tari_hashing 5.3.1-pre.0",
+ "tari_max_size 5.3.1-pre.0",
+ "tari_mmr 5.3.1-pre.0",
+ "tari_node_components 5.3.1-pre.0",
+ "tari_p2p 5.3.1-pre.0",
+ "tari_script 5.3.1-pre.0",
+ "tari_service_framework 5.3.1-pre.0",
+ "tari_shutdown 5.3.1-pre.0",
+ "tari_sidechain 5.3.1-pre.0",
+ "tari_storage 5.3.1-pre.0",
+ "tari_test_utils 5.3.1-pre.0",
+ "tari_transaction_components 5.3.1-pre.0",
+ "tari_utilities",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "tari_core"
+version = "5.4.0-pre.0"
+source = "git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef#941dd8592993629bbb1d2cc9f0dca51689a4bfef"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bincode 1.3.3",
+ "blake2 0.10.6",
+ "borsh",
+ "chrono",
+ "digest 0.10.7",
+ "dirs-next 1.0.2",
+ "fs2",
+ "futures 0.3.31",
+ "hex",
+ "hickory-proto 0.26.1",
+ "integer-encoding",
+ "jmt",
+ "lmdb-zero",
+ "log",
+ "monero",
+ "once_cell",
+ "primitive-types",
+ "prost 0.13.5",
+ "rand 0.10.1",
+ "randomx-rs",
+ "serde",
+ "serde_json",
+ "serde_valid",
+ "sha2 0.10.9",
+ "sha3",
+ "strum_macros 0.22.0",
+ "tari-tiny-keccak",
+ "tari_common 5.4.0-pre.0",
+ "tari_common_sqlite 5.4.0-pre.0",
+ "tari_common_types 5.4.0-pre.0",
+ "tari_comms 5.4.0-pre.0",
+ "tari_comms_dht 5.4.0-pre.0",
+ "tari_comms_rpc_macros 5.4.0-pre.0",
+ "tari_crypto",
+ "tari_features 5.4.0-pre.0",
+ "tari_hashing 5.4.0-pre.0 (git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef)",
+ "tari_max_size 5.4.0-pre.0",
+ "tari_mmr 5.4.0-pre.0",
+ "tari_node_components 5.4.0-pre.0",
+ "tari_p2p 5.4.0-pre.0",
+ "tari_script 5.4.0-pre.0",
+ "tari_service_framework 5.4.0-pre.0",
+ "tari_shutdown 5.4.0-pre.0",
+ "tari_sidechain 5.4.0-pre.0",
+ "tari_storage 5.4.0-pre.0",
+ "tari_test_utils 5.4.0-pre.0",
+ "tari_transaction_components 5.4.0-pre.0",
  "tari_utilities",
  "thiserror 2.0.18",
  "tokio",
@@ -11346,7 +11718,7 @@ dependencies = [
  "serde_json",
  "tari_bor",
  "tari_crypto",
- "tari_hashing 5.3.1-pre.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tari_hashing 5.4.0-pre.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tari_ootle_template_metadata",
  "tari_template_abi",
  "tari_template_lib",
@@ -11360,15 +11732,15 @@ version = "0.32.2"
 dependencies = [
  "anyhow",
  "log",
- "minotari_app_grpc",
+ "minotari_app_grpc 5.4.0-pre.0",
  "ootle_byte_type",
  "serde",
- "tari_common_types",
+ "tari_common_types 5.4.0-pre.0",
  "tari_ootle_common_types",
  "tari_ootle_storage",
  "tari_ootle_storage_sqlite",
- "tari_shutdown",
- "tari_sidechain",
+ "tari_shutdown 5.4.0-pre.0",
+ "tari_sidechain 5.4.0-pre.0",
  "tari_template_lib_types",
  "thiserror 2.0.18",
  "tokio",
@@ -11386,15 +11758,15 @@ dependencies = [
  "serde",
  "serde_json",
  "tari_base_node_client",
- "tari_common_types",
+ "tari_common_types 5.4.0-pre.0",
  "tari_epoch_manager",
- "tari_hashing 5.3.1-pre.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tari_node_components",
+ "tari_hashing 5.4.0-pre.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tari_node_components 5.4.0-pre.0",
  "tari_ootle_common_types",
  "tari_ootle_storage",
  "tari_ootle_storage_sqlite",
  "tari_template_lib",
- "tari_transaction_components",
+ "tari_transaction_components 5.4.0-pre.0",
  "thiserror 2.0.18",
  "time",
  "tokio",
@@ -11406,10 +11778,14 @@ version = "5.3.1-pre.0"
 source = "git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0#1f94bc8fdc909072a295ece3ace0f98bf1b2c3cc"
 
 [[package]]
+name = "tari_features"
+version = "5.4.0-pre.0"
+source = "git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef#941dd8592993629bbb1d2cc9f0dca51689a4bfef"
+
+[[package]]
 name = "tari_hashing"
 version = "5.3.1-pre.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60bca3ce500ae7dde4fe774a0ce56a34c2630a4ebf5fc380c0cbe4d9a2ef1775"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0#1f94bc8fdc909072a295ece3ace0f98bf1b2c3cc"
 dependencies = [
  "blake2 0.10.6",
  "borsh",
@@ -11419,8 +11795,20 @@ dependencies = [
 
 [[package]]
 name = "tari_hashing"
-version = "5.3.1-pre.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0#1f94bc8fdc909072a295ece3ace0f98bf1b2c3cc"
+version = "5.4.0-pre.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00d8b3083ccdca440840e08cde7de9e4e483926802d6600f000bfc69a5f395e1"
+dependencies = [
+ "blake2 0.10.6",
+ "borsh",
+ "digest 0.10.7",
+ "tari_crypto",
+]
+
+[[package]]
+name = "tari_hashing"
+version = "5.4.0-pre.0"
+source = "git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef#941dd8592993629bbb1d2cc9f0dca51689a4bfef"
 dependencies = [
  "blake2 0.10.6",
  "borsh",
@@ -11465,7 +11853,7 @@ dependencies = [
  "serde_with",
  "tari_base_node_client",
  "tari_bor",
- "tari_common",
+ "tari_common 5.4.0-pre.0",
  "tari_consensus",
  "tari_crypto",
  "tari_engine",
@@ -11483,7 +11871,7 @@ dependencies = [
  "tari_ootle_template_metadata",
  "tari_ootle_transaction",
  "tari_rpc_framework",
- "tari_shutdown",
+ "tari_shutdown 5.4.0-pre.0",
  "tari_template_builtin",
  "tari_template_lib_types",
  "tari_validator_node_rpc",
@@ -11554,7 +11942,21 @@ dependencies = [
  "indexmap 2.13.0",
  "serde",
  "tari_crypto",
- "tari_hashing 5.3.1-pre.0 (git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0)",
+ "tari_hashing 5.3.1-pre.0",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "tari_jellyfish"
+version = "5.4.0-pre.0"
+source = "git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef#941dd8592993629bbb1d2cc9f0dca51689a4bfef"
+dependencies = [
+ "borsh",
+ "digest 0.10.7",
+ "indexmap 2.13.0",
+ "serde",
+ "tari_crypto",
+ "tari_hashing 5.4.0-pre.0 (git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef)",
  "thiserror 2.0.18",
 ]
 
@@ -11583,8 +11985,8 @@ dependencies = [
  "libtor",
  "log",
  "rand 0.10.1",
- "tari_common",
- "tari_p2p",
+ "tari_common 5.3.1-pre.0",
+ "tari_p2p 5.3.1-pre.0",
  "tor-hash-passwd",
 ]
 
@@ -11592,6 +11994,17 @@ dependencies = [
 name = "tari_max_size"
 version = "5.3.1-pre.0"
 source = "git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0#1f94bc8fdc909072a295ece3ace0f98bf1b2c3cc"
+dependencies = [
+ "borsh",
+ "serde",
+ "tari_utilities",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "tari_max_size"
+version = "5.4.0-pre.0"
+source = "git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef#941dd8592993629bbb1d2cc9f0dca51689a4bfef"
 dependencies = [
  "borsh",
  "serde",
@@ -11613,8 +12026,8 @@ dependencies = [
 
 [[package]]
 name = "tari_metrics"
-version = "5.3.1-pre.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0#1f94bc8fdc909072a295ece3ace0f98bf1b2c3cc"
+version = "5.4.0-pre.0"
+source = "git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef#941dd8592993629bbb1d2cc9f0dca51689a4bfef"
 dependencies = [
  "once_cell",
  "prometheus",
@@ -11635,6 +12048,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tari_mmr"
+version = "5.4.0-pre.0"
+source = "git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef#941dd8592993629bbb1d2cc9f0dca51689a4bfef"
+dependencies = [
+ "borsh",
+ "digest 0.10.7",
+ "serde",
+ "tari_crypto",
+ "tari_utilities",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "tari_networking"
 version = "0.32.2"
 dependencies = [
@@ -11645,7 +12071,7 @@ dependencies = [
  "prometheus-client",
  "rand 0.10.1",
  "tari_rpc_framework",
- "tari_shutdown",
+ "tari_shutdown 5.4.0-pre.0",
  "tari_swarm",
  "thiserror 2.0.18",
  "tokio",
@@ -11664,9 +12090,29 @@ dependencies = [
  "js-sys",
  "primitive-types",
  "serde",
- "tari_common_types",
- "tari_hashing 5.3.1-pre.0 (git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0)",
- "tari_transaction_components",
+ "tari_common_types 5.3.1-pre.0",
+ "tari_hashing 5.3.1-pre.0",
+ "tari_transaction_components 5.3.1-pre.0",
+ "tari_utilities",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "tari_node_components"
+version = "5.4.0-pre.0"
+source = "git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef#941dd8592993629bbb1d2cc9f0dca51689a4bfef"
+dependencies = [
+ "blake2 0.10.6",
+ "borsh",
+ "chrono",
+ "digest 0.10.7",
+ "getrandom 0.2.17",
+ "js-sys",
+ "primitive-types",
+ "serde",
+ "tari_common_types 5.4.0-pre.0",
+ "tari_hashing 5.4.0-pre.0 (git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef)",
+ "tari_transaction_components 5.4.0-pre.0",
  "tari_utilities",
  "thiserror 2.0.18",
 ]
@@ -11706,21 +12152,21 @@ dependencies = [
  "serde",
  "serde_json5",
  "tari_bor",
- "tari_common",
- "tari_common_types",
+ "tari_common 5.4.0-pre.0",
+ "tari_common_types 5.4.0-pre.0",
  "tari_crypto",
  "tari_engine",
  "tari_engine_types",
  "tari_epoch_oracles",
- "tari_hashing 5.3.1-pre.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tari_mmr",
+ "tari_hashing 5.4.0-pre.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tari_mmr 5.4.0-pre.0",
  "tari_networking",
  "tari_ootle_common_types",
  "tari_ootle_p2p",
  "tari_ootle_storage",
  "tari_ootle_transaction",
  "tari_template_lib",
- "tari_transaction_components",
+ "tari_transaction_components 5.4.0-pre.0",
  "thiserror 2.0.18",
  "tokio",
  "toml 0.9.11+spec-1.1.0",
@@ -11749,7 +12195,7 @@ dependencies = [
  "tari_bor",
  "tari_crypto",
  "tari_engine_types",
- "tari_hashing 5.3.1-pre.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tari_hashing 5.4.0-pre.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tari_ootle_template_metadata",
  "tari_template_lib_types",
  "thiserror 2.0.18",
@@ -11771,7 +12217,7 @@ dependencies = [
  "tari_consensus_types",
  "tari_crypto",
  "tari_engine_types",
- "tari_jellyfish",
+ "tari_jellyfish 5.4.0-pre.0",
  "tari_networking",
  "tari_ootle_common_types",
  "tari_ootle_storage",
@@ -11794,13 +12240,13 @@ dependencies = [
  "rand 0.10.1",
  "serde",
  "tari_bor",
- "tari_common_types",
+ "tari_common_types 5.4.0-pre.0",
  "tari_consensus_types",
  "tari_crypto",
  "tari_engine_types",
  "tari_ootle_common_types",
  "tari_ootle_transaction",
- "tari_sidechain",
+ "tari_sidechain 5.4.0-pre.0",
  "tari_state_tree",
  "tari_template_lib",
  "tari_template_lib_types",
@@ -11820,7 +12266,7 @@ dependencies = [
  "rand 0.10.1",
  "serde",
  "serde_json",
- "tari_common_types",
+ "tari_common_types 5.4.0-pre.0",
  "tari_crypto",
  "tari_ootle_common_types",
  "tari_ootle_p2p",
@@ -11880,7 +12326,7 @@ dependencies = [
  "tari_bor",
  "tari_crypto",
  "tari_engine_types",
- "tari_hashing 5.3.1-pre.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tari_hashing 5.4.0-pre.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tari_ootle_common_types",
  "tari_ootle_template_metadata",
  "tari_template_lib_types",
@@ -11939,7 +12385,7 @@ dependencies = [
  "tari_bor",
  "tari_crypto",
  "tari_engine_types",
- "tari_hashing 5.3.1-pre.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tari_hashing 5.4.0-pre.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tari_ootle_common_types",
  "tari_template_lib_types",
  "tari_utilities",
@@ -11963,7 +12409,7 @@ dependencies = [
  "rand 0.10.1",
  "serde",
  "tari_bor",
- "tari_common_types",
+ "tari_common_types 5.4.0-pre.0",
  "tari_consensus_types",
  "tari_crypto",
  "tari_engine_types",
@@ -12000,7 +12446,7 @@ dependencies = [
  "tari_ootle_common_types",
  "tari_ootle_transaction",
  "tari_ootle_wallet_sdk",
- "tari_shutdown",
+ "tari_shutdown 5.4.0-pre.0",
  "tari_template_abi",
  "tari_template_builtin",
  "tari_template_lib_types",
@@ -12028,7 +12474,7 @@ dependencies = [
  "tari_ootle_wallet_storage_sqlite",
  "tari_template_abi",
  "tari_template_lib",
- "tari_transaction_components",
+ "tari_transaction_components 5.4.0-pre.0",
  "tempfile",
 ]
 
@@ -12088,8 +12534,8 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "tari_common",
- "tari_common_types",
+ "tari_common 5.4.0-pre.0",
+ "tari_common_types 5.4.0-pre.0",
  "tari_crypto",
  "tari_engine",
  "tari_engine_types",
@@ -12103,8 +12549,8 @@ dependencies = [
  "tari_ootle_wallet_sdk_services",
  "tari_ootle_wallet_storage_sqlite",
  "tari_ootle_walletd_client",
- "tari_shutdown",
- "tari_sidechain",
+ "tari_shutdown 5.4.0-pre.0",
+ "tari_sidechain 5.4.0-pre.0",
  "tari_template_builtin",
  "tari_template_lib_types",
  "tari_transaction_manifest",
@@ -12155,7 +12601,7 @@ dependencies = [
  "anyhow",
  "futures 0.3.31",
  "hickory-proto 0.26.1",
- "hickory-resolver 0.26.0",
+ "hickory-resolver 0.26.1",
  "log",
  "pgp",
  "prost 0.13.5",
@@ -12163,12 +12609,41 @@ dependencies = [
  "reqwest 0.12.28",
  "semver",
  "serde",
- "tari_common",
- "tari_common_sqlite",
- "tari_comms",
- "tari_comms_dht",
- "tari_service_framework",
- "tari_shutdown",
+ "tari_common 5.3.1-pre.0",
+ "tari_common_sqlite 5.3.1-pre.0",
+ "tari_comms 5.3.1-pre.0",
+ "tari_comms_dht 5.3.1-pre.0",
+ "tari_service_framework 5.3.1-pre.0",
+ "tari_shutdown 5.3.1-pre.0",
+ "tari_utilities",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tower 0.4.13",
+]
+
+[[package]]
+name = "tari_p2p"
+version = "5.4.0-pre.0"
+source = "git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef#941dd8592993629bbb1d2cc9f0dca51689a4bfef"
+dependencies = [
+ "anyhow",
+ "futures 0.3.31",
+ "hickory-proto 0.26.1",
+ "hickory-resolver 0.26.1",
+ "log",
+ "pgp",
+ "prost 0.13.5",
+ "rand 0.10.1",
+ "reqwest 0.12.28",
+ "semver",
+ "serde",
+ "tari_common 5.4.0-pre.0",
+ "tari_common_sqlite 5.4.0-pre.0",
+ "tari_comms 5.4.0-pre.0",
+ "tari_comms_dht 5.4.0-pre.0",
+ "tari_service_framework 5.4.0-pre.0",
+ "tari_shutdown 5.4.0-pre.0",
  "tari_utilities",
  "thiserror 2.0.18",
  "tokio",
@@ -12192,7 +12667,7 @@ dependencies = [
  "prost 0.14.3",
  "proto_builder",
  "tari_metrics",
- "tari_shutdown",
+ "tari_shutdown 5.4.0-pre.0",
  "thiserror 2.0.18",
  "tokio",
  "tokio-util 0.7.18",
@@ -12242,7 +12717,25 @@ dependencies = [
  "sha2 0.10.9",
  "sha3",
  "tari_crypto",
- "tari_max_size",
+ "tari_max_size 5.3.1-pre.0",
+ "tari_utilities",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "tari_script"
+version = "5.4.0-pre.0"
+source = "git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef#941dd8592993629bbb1d2cc9f0dca51689a4bfef"
+dependencies = [
+ "blake2 0.10.6",
+ "borsh",
+ "digest 0.10.7",
+ "integer-encoding",
+ "serde",
+ "sha2 0.10.9",
+ "sha3",
+ "tari_crypto",
+ "tari_max_size 5.4.0-pre.0",
  "tari_utilities",
  "thiserror 2.0.18",
 ]
@@ -12256,7 +12749,22 @@ dependencies = [
  "async-trait",
  "futures 0.3.31",
  "log",
- "tari_shutdown",
+ "tari_shutdown 5.3.1-pre.0",
+ "thiserror 2.0.18",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
+name = "tari_service_framework"
+version = "5.4.0-pre.0"
+source = "git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef#941dd8592993629bbb1d2cc9f0dca51689a4bfef"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "futures 0.3.31",
+ "log",
+ "tari_shutdown 5.4.0-pre.0",
  "thiserror 2.0.18",
  "tokio",
  "tower-service",
@@ -12271,6 +12779,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "tari_shutdown"
+version = "5.4.0-pre.0"
+source = "git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef#941dd8592993629bbb1d2cc9f0dca51689a4bfef"
+dependencies = [
+ "futures 0.3.31",
+]
+
+[[package]]
 name = "tari_sidechain"
 version = "5.3.1-pre.0"
 source = "git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0#1f94bc8fdc909072a295ece3ace0f98bf1b2c3cc"
@@ -12279,10 +12795,27 @@ dependencies = [
  "hex",
  "log",
  "serde",
- "tari_common_types",
+ "tari_common_types 5.3.1-pre.0",
  "tari_crypto",
- "tari_hashing 5.3.1-pre.0 (git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0)",
- "tari_jellyfish",
+ "tari_hashing 5.3.1-pre.0",
+ "tari_jellyfish 5.3.1-pre.0",
+ "tari_utilities",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "tari_sidechain"
+version = "5.4.0-pre.0"
+source = "git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef#941dd8592993629bbb1d2cc9f0dca51689a4bfef"
+dependencies = [
+ "borsh",
+ "hex",
+ "log",
+ "serde",
+ "tari_common_types 5.4.0-pre.0",
+ "tari_crypto",
+ "tari_hashing 5.4.0-pre.0 (git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef)",
+ "tari_jellyfish 5.4.0-pre.0",
  "tari_utilities",
  "thiserror 2.0.18",
 ]
@@ -12303,13 +12836,13 @@ dependencies = [
  "smallvec 2.0.0-alpha.12",
  "strum_macros 0.27.2",
  "tari_bor",
- "tari_common_types",
+ "tari_common_types 5.4.0-pre.0",
  "tari_consensus_types",
  "tari_engine_types",
  "tari_ootle_common_types",
  "tari_ootle_storage",
  "tari_ootle_transaction",
- "tari_sidechain",
+ "tari_sidechain 5.4.0-pre.0",
  "tari_state_tree",
  "tari_template_lib",
  "tari_template_lib_types",
@@ -12329,7 +12862,7 @@ dependencies = [
  "serde",
  "tari_bor",
  "tari_engine_types",
- "tari_jellyfish",
+ "tari_jellyfish 5.4.0-pre.0",
  "tari_ootle_common_types",
  "tari_template_lib_types",
  "thiserror 2.0.18",
@@ -12339,6 +12872,18 @@ dependencies = [
 name = "tari_storage"
 version = "5.3.1-pre.0"
 source = "git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0#1f94bc8fdc909072a295ece3ace0f98bf1b2c3cc"
+dependencies = [
+ "bincode 1.3.3",
+ "lmdb-zero",
+ "log",
+ "serde",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "tari_storage"
+version = "5.4.0-pre.0"
+source = "git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef#941dd8592993629bbb1d2cc9f0dca51689a4bfef"
 dependencies = [
  "bincode 1.3.3",
  "lmdb-zero",
@@ -12383,16 +12928,16 @@ dependencies = [
  "serde_json",
  "serde_json5",
  "slug",
- "tari_common_types",
+ "tari_common_types 5.4.0-pre.0",
  "tari_crypto",
  "tari_ootle_app_utilities",
  "tari_ootle_common_types",
  "tari_ootle_wallet_sdk",
  "tari_ootle_walletd_client",
- "tari_shutdown",
- "tari_sidechain",
+ "tari_shutdown 5.4.0-pre.0",
+ "tari_sidechain 5.4.0-pre.0",
  "tari_template_lib_types",
- "tari_transaction_components",
+ "tari_transaction_components 5.4.0-pre.0",
  "tari_validator_node_client",
  "thiserror 2.0.18",
  "tokio",
@@ -12500,7 +13045,19 @@ source = "git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0#1f94bc8f
 dependencies = [
  "futures 0.3.31",
  "rand 0.10.1",
- "tari_shutdown",
+ "tari_shutdown 5.3.1-pre.0",
+ "tempfile",
+ "tokio",
+]
+
+[[package]]
+name = "tari_test_utils"
+version = "5.4.0-pre.0"
+source = "git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef#941dd8592993629bbb1d2cc9f0dca51689a4bfef"
+dependencies = [
+ "futures 0.3.31",
+ "rand 0.10.1",
+ "tari_shutdown 5.4.0-pre.0",
  "tempfile",
  "tokio",
 ]
@@ -12523,7 +13080,7 @@ dependencies = [
  "digest 0.10.7",
  "integer-encoding",
  "log",
- "minotari_ledger_wallet_common",
+ "minotari_ledger_wallet_common 5.3.1-pre.0",
  "minotari_ledger_wallet_comms",
  "newtype-ops",
  "num-derive 0.4.2",
@@ -12537,13 +13094,58 @@ dependencies = [
  "serde_repr",
  "serde_valid",
  "strum_macros 0.22.0",
- "tari_common",
- "tari_common_types",
+ "tari_common 5.3.1-pre.0",
+ "tari_common_types 5.3.1-pre.0",
  "tari_crypto",
- "tari_hashing 5.3.1-pre.0 (git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0)",
- "tari_max_size",
- "tari_script",
- "tari_sidechain",
+ "tari_hashing 5.3.1-pre.0",
+ "tari_max_size 5.3.1-pre.0",
+ "tari_script 5.3.1-pre.0",
+ "tari_sidechain 5.3.1-pre.0",
+ "tari_utilities",
+ "thiserror 2.0.18",
+ "utoipa",
+ "uuid",
+ "zeroize",
+]
+
+[[package]]
+name = "tari_transaction_components"
+version = "5.4.0-pre.0"
+source = "git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef#941dd8592993629bbb1d2cc9f0dca51689a4bfef"
+dependencies = [
+ "anyhow",
+ "base64 0.22.1",
+ "bitflags 2.10.0",
+ "blake2 0.10.6",
+ "borsh",
+ "bytes",
+ "chacha20poly1305",
+ "chrono",
+ "decimal-rs",
+ "derivative",
+ "digest 0.10.7",
+ "integer-encoding",
+ "log",
+ "minotari_ledger_wallet_common 5.4.0-pre.0",
+ "newtype-ops",
+ "num-derive 0.4.2",
+ "num-format",
+ "num-traits",
+ "primitive-types",
+ "rand 0.10.1",
+ "semver",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "serde_valid",
+ "strum_macros 0.22.0",
+ "tari_common 5.4.0-pre.0",
+ "tari_common_types 5.4.0-pre.0",
+ "tari_crypto",
+ "tari_hashing 5.4.0-pre.0 (git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef)",
+ "tari_max_size 5.4.0-pre.0",
+ "tari_script 5.4.0-pre.0",
+ "tari_sidechain 5.4.0-pre.0",
  "tari_utilities",
  "thiserror 2.0.18",
  "utoipa",
@@ -12566,18 +13168,51 @@ dependencies = [
  "digest 0.10.7",
  "futures 0.3.31",
  "log",
- "minotari_ledger_wallet_common",
+ "minotari_ledger_wallet_common 5.3.1-pre.0",
  "rand 0.10.1",
  "serde",
  "strum 0.22.0",
  "strum_macros 0.22.0",
- "tari_common_sqlite",
- "tari_common_types",
+ "tari_common_sqlite 5.3.1-pre.0",
+ "tari_common_types 5.3.1-pre.0",
  "tari_crypto",
- "tari_hashing 5.3.1-pre.0 (git+https://github.com/tari-project/tari.git?tag=v5.3.1-pre.0)",
- "tari_script",
- "tari_service_framework",
- "tari_transaction_components",
+ "tari_hashing 5.3.1-pre.0",
+ "tari_script 5.3.1-pre.0",
+ "tari_service_framework 5.3.1-pre.0",
+ "tari_transaction_components 5.3.1-pre.0",
+ "tari_utilities",
+ "thiserror 2.0.18",
+ "tokio",
+ "zeroize",
+]
+
+[[package]]
+name = "tari_transaction_key_manager"
+version = "5.4.0-pre.0"
+source = "git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef#941dd8592993629bbb1d2cc9f0dca51689a4bfef"
+dependencies = [
+ "async-trait",
+ "blake2 0.10.6",
+ "chacha20poly1305",
+ "chrono",
+ "derivative",
+ "diesel",
+ "diesel_migrations",
+ "digest 0.10.7",
+ "futures 0.3.31",
+ "log",
+ "minotari_ledger_wallet_common 5.4.0-pre.0",
+ "rand 0.10.1",
+ "serde",
+ "strum 0.22.0",
+ "strum_macros 0.22.0",
+ "tari_common_sqlite 5.4.0-pre.0",
+ "tari_common_types 5.4.0-pre.0",
+ "tari_crypto",
+ "tari_hashing 5.4.0-pre.0 (git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef)",
+ "tari_script 5.4.0-pre.0",
+ "tari_service_framework 5.4.0-pre.0",
+ "tari_transaction_components 5.4.0-pre.0",
  "tari_utilities",
  "thiserror 2.0.18",
  "tokio",
@@ -12651,8 +13286,8 @@ dependencies = [
  "std-semaphore",
  "tari_base_node_client",
  "tari_bor",
- "tari_common",
- "tari_common_types",
+ "tari_common 5.4.0-pre.0",
+ "tari_common_types 5.4.0-pre.0",
  "tari_consensus",
  "tari_consensus_types",
  "tari_crypto",
@@ -12669,13 +13304,13 @@ dependencies = [
  "tari_ootle_transaction",
  "tari_rpc_framework",
  "tari_rpc_state_sync",
- "tari_shutdown",
+ "tari_shutdown 5.4.0-pre.0",
  "tari_state_store_rocksdb",
  "tari_state_tree",
  "tari_swarm",
  "tari_template_builtin",
  "tari_template_lib",
- "tari_transaction_components",
+ "tari_transaction_components 5.4.0-pre.0",
  "tari_validator_node_client",
  "tari_validator_node_rpc",
  "thiserror 2.0.18",
@@ -12695,14 +13330,14 @@ dependencies = [
  "serde",
  "serde_json",
  "tari_base_node_client",
- "tari_common_types",
+ "tari_common_types 5.4.0-pre.0",
  "tari_consensus_types",
  "tari_engine_types",
  "tari_ootle_common_types",
  "tari_ootle_p2p",
  "tari_ootle_storage",
  "tari_ootle_transaction",
- "tari_sidechain",
+ "tari_sidechain 5.4.0-pre.0",
  "tari_template_abi",
  "tari_template_lib_types",
  "thiserror 2.0.18",
@@ -12777,7 +13412,7 @@ dependencies = [
  "fern",
  "humantime",
  "log",
- "minotari_app_grpc",
+ "minotari_app_grpc 5.4.0-pre.0",
  "minotari_node_grpc_client",
  "minotari_wallet_grpc_client",
  "ootle-network",
@@ -12787,10 +13422,10 @@ dependencies = [
  "serde_json5",
  "tari_crypto",
  "tari_ootle_common_types",
- "tari_shutdown",
- "tari_sidechain",
+ "tari_shutdown 5.4.0-pre.0",
+ "tari_sidechain 5.4.0-pre.0",
  "tari_template_lib_types",
- "tari_transaction_components",
+ "tari_transaction_components 5.4.0-pre.0",
  "tokio",
  "toml 0.8.23",
  "tonic 0.13.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,33 +139,33 @@ ootle_byte_type = { path = "crates/ootle_byte_type", version = "0.8" }
 ootle_serde = { path = "crates/ootle_serde", version = "0.3" }
 
 # external minotari/tari dependencies
-minotari_app_grpc = { git = "https://github.com/tari-project/tari.git", tag = "v5.3.1-pre.0" }
-minotari_app_utilities = { git = "https://github.com/tari-project/tari.git", tag = "v5.3.1-pre.0" }
-minotari_node_grpc_client = { git = "https://github.com/tari-project/tari.git", tag = "v5.3.1-pre.0" }
-minotari_wallet_grpc_client = { git = "https://github.com/tari-project/tari.git", tag = "v5.3.1-pre.0" }
-tari_common = { git = "https://github.com/tari-project/tari.git", tag = "v5.3.1-pre.0", version = "5.3.1-pre.0" }
-tari_common_sqlite = { git = "https://github.com/tari-project/tari.git", tag = "v5.3.1-pre.0", version = "5.3.1-pre.0" }
-tari_common_types = { git = "https://github.com/tari-project/tari.git", tag = "v5.3.1-pre.0", version = "5.3.1-pre.0" }
-tari_jellyfish = { git = "https://github.com/tari-project/tari.git", tag = "v5.3.1-pre.0", version = "5.3.1-pre.0" }
-tari_metrics = { git = "https://github.com/tari-project/tari.git", tag = "v5.3.1-pre.0" }
-tari_mmr = { git = "https://github.com/tari-project/tari.git", tag = "v5.3.1-pre.0", version = "5.3.1-pre.0" }
-tari_node_components = { git = "https://github.com/tari-project/tari.git", tag = "v5.3.1-pre.0" }
-tari_shutdown = { git = "https://github.com/tari-project/tari.git", tag = "v5.3.1-pre.0" }
-tari_sidechain = { git = "https://github.com/tari-project/tari.git", tag = "v5.3.1-pre.0", version = "5.3.1-pre.0" }
-tari_transaction_components = { git = "https://github.com/tari-project/tari.git", tag = "v5.3.1-pre.0" }
-minotari_console_wallet = { git = "https://github.com/tari-project/tari.git", tag = "v5.3.1-pre.0" }
-minotari_node = { git = "https://github.com/tari-project/tari.git", tag = "v5.3.1-pre.0" }
-minotari_wallet = { git = "https://github.com/tari-project/tari.git", tag = "v5.3.1-pre.0" }
-tari_comms = { git = "https://github.com/tari-project/tari.git", tag = "v5.3.1-pre.0" }
-tari_comms_dht = { git = "https://github.com/tari-project/tari.git", tag = "v5.3.1-pre.0" }
-tari_p2p = { git = "https://github.com/tari-project/tari.git", tag = "v5.3.1-pre.0" }
+minotari_app_grpc = { git = "https://github.com/tari-project/tari.git", rev = "941dd8592993629bbb1d2cc9f0dca51689a4bfef" }
+minotari_app_utilities = { git = "https://github.com/tari-project/tari.git", rev = "941dd8592993629bbb1d2cc9f0dca51689a4bfef" }
+minotari_node_grpc_client = { git = "https://github.com/tari-project/tari.git", rev = "941dd8592993629bbb1d2cc9f0dca51689a4bfef" }
+minotari_wallet_grpc_client = { git = "https://github.com/tari-project/tari.git", rev = "941dd8592993629bbb1d2cc9f0dca51689a4bfef" }
+tari_common = { git = "https://github.com/tari-project/tari.git", rev = "941dd8592993629bbb1d2cc9f0dca51689a4bfef", version = "5.4.0-pre.0" }
+tari_common_sqlite = { git = "https://github.com/tari-project/tari.git", rev = "941dd8592993629bbb1d2cc9f0dca51689a4bfef", version = "5.4.0-pre.0" }
+tari_common_types = { git = "https://github.com/tari-project/tari.git", rev = "941dd8592993629bbb1d2cc9f0dca51689a4bfef", version = "5.4.0-pre.0" }
+tari_jellyfish = { git = "https://github.com/tari-project/tari.git", rev = "941dd8592993629bbb1d2cc9f0dca51689a4bfef", version = "5.4.0-pre.0" }
+tari_metrics = { git = "https://github.com/tari-project/tari.git", rev = "941dd8592993629bbb1d2cc9f0dca51689a4bfef" }
+tari_mmr = { git = "https://github.com/tari-project/tari.git", rev = "941dd8592993629bbb1d2cc9f0dca51689a4bfef", version = "5.4.0-pre.0" }
+tari_node_components = { git = "https://github.com/tari-project/tari.git", rev = "941dd8592993629bbb1d2cc9f0dca51689a4bfef" }
+tari_shutdown = { git = "https://github.com/tari-project/tari.git", rev = "941dd8592993629bbb1d2cc9f0dca51689a4bfef" }
+tari_sidechain = { git = "https://github.com/tari-project/tari.git", rev = "941dd8592993629bbb1d2cc9f0dca51689a4bfef", version = "5.4.0-pre.0" }
+tari_transaction_components = { git = "https://github.com/tari-project/tari.git", rev = "941dd8592993629bbb1d2cc9f0dca51689a4bfef" }
+minotari_console_wallet = { git = "https://github.com/tari-project/tari.git", rev = "941dd8592993629bbb1d2cc9f0dca51689a4bfef" }
+minotari_node = { git = "https://github.com/tari-project/tari.git", rev = "941dd8592993629bbb1d2cc9f0dca51689a4bfef" }
+minotari_wallet = { git = "https://github.com/tari-project/tari.git", rev = "941dd8592993629bbb1d2cc9f0dca51689a4bfef" }
+tari_comms = { git = "https://github.com/tari-project/tari.git", rev = "941dd8592993629bbb1d2cc9f0dca51689a4bfef" }
+tari_comms_dht = { git = "https://github.com/tari-project/tari.git", rev = "941dd8592993629bbb1d2cc9f0dca51689a4bfef" }
+tari_p2p = { git = "https://github.com/tari-project/tari.git", rev = "941dd8592993629bbb1d2cc9f0dca51689a4bfef" }
 
 tari_crypto = "0.23"
 tari_utilities = "0.10"
-tari_hashing = "5.3.1-pre.0"
+tari_hashing = "5.4.0-pre.0"
 
 ## Ledger
-minotari_ledger_wallet_common = { git = "https://github.com/tari-project/tari.git", tag = "v5.3.1-pre.0" }
+minotari_ledger_wallet_common = { git = "https://github.com/tari-project/tari.git", rev = "941dd8592993629bbb1d2cc9f0dca51689a4bfef" }
 ootle_ledger_common = { path = "crates/wallet/ledger/common", version = "0.1.0" }
 
 # networking crates

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.32.2"
+version = "0.33.0"
 edition = "2024"
 authors = ["The Tari Development Community"]
 repository = "https://github.com/tari-project/tari-ootle"
@@ -90,22 +90,22 @@ tari_ootle_app_utilities = { path = "applications/tari_ootle_app_utilities" }
 tari_consensus = { path = "crates/consensus" }
 tari_ootle_address = { path = "crates/ootle_address", version = "0.6" }
 ootle-network = { path = "crates/ootle_network", version = "0.2" }
-tari_engine = { path = "crates/engine", version = "0.32" }
+tari_engine = { path = "crates/engine", version = "0.33" }
 tari_ootle_p2p = { path = "crates/p2p" }
 tari_ootle_storage = { path = "crates/storage" }
 tari_ootle_storage_sqlite = { path = "crates/storage_sqlite" }
-tari_ootle_wallet_crypto = { path = "crates/wallet/crypto", version = "0.32" }
-tari_ootle_wallet_sdk = { path = "crates/wallet/sdk", version = "0.32" }
+tari_ootle_wallet_crypto = { path = "crates/wallet/crypto", version = "0.33" }
+tari_ootle_wallet_sdk = { path = "crates/wallet/sdk", version = "0.33" }
 tari_ootle_wallet_sdk_services = { path = "crates/wallet/sdk_services" }
-tari_ootle_wallet_storage_sqlite = { path = "crates/wallet/storage_sqlite", version = "0.32" }
+tari_ootle_wallet_storage_sqlite = { path = "crates/wallet/storage_sqlite", version = "0.33" }
 tari_epoch_manager = { path = "crates/epoch_manager" }
 tari_epoch_oracles = { path = "crates/epoch_oracles" }
 tari_indexer_lib = { path = "crates/indexer_lib" }
 tari_rpc_state_sync = { path = "crates/rpc_state_sync" }
 tari_state_store_rocksdb = { path = "crates/state_store_rocksdb" }
 tari_state_tree = { path = "crates/state_tree" }
-tari_template_test_tooling = { path = "crates/template_test_tooling", version = "0.32" }
-tari_transaction_manifest = { path = "crates/transaction_manifest", version = "0.32" }
+tari_template_test_tooling = { path = "crates/template_test_tooling", version = "0.33" }
+tari_transaction_manifest = { path = "crates/transaction_manifest", version = "0.33" }
 tari_validator_node_rpc = { path = "crates/validator_node_rpc" }
 sqlite_message_logger = { path = "networking/sqlite_message_logger" }
 tari_base_node_client = { path = "clients/base_node_client" }
@@ -115,16 +115,16 @@ tari_rpc_framework = { path = "networking/rpc_framework" }
 tari_rpc_macros = { path = "networking/rpc_macros" }
 tari_swarm = { path = "networking/swarm" }
 tari_validator_node_client = { path = "clients/validator_node_client" }
-tari_validator_rollback = { path = "utilities/validator_rollback", version = "0.32" }
+tari_validator_rollback = { path = "utilities/validator_rollback", version = "0.33" }
 tari_ootle_walletd_client = { path = "clients/wallet_daemon_client", version = "0.32" }
 transaction_generator = { path = "utilities/transaction_generator" }
 
 # Dependency crates on crates.io (update versions here as well when updating the workspace version)
-tari_consensus_types = { path = "crates/consensus_types", version = "0.32" }
-tari_ootle_common_types = { path = "crates/common_types", version = "0.32" }
-tari_engine_types = { path = "crates/engine_types", version = "0.32" }
+tari_consensus_types = { path = "crates/consensus_types", version = "0.33" }
+tari_ootle_common_types = { path = "crates/common_types", version = "0.33" }
+tari_engine_types = { path = "crates/engine_types", version = "0.33" }
 tari_template_builtin = { path = "crates/template_builtin", version = "0.32" }
-tari_ootle_transaction = { path = "crates/transaction", version = "0.32" }
+tari_ootle_transaction = { path = "crates/transaction", version = "0.33" }
 
 # Template lib
 tari_ootle_template_build = { path = "crates/template_build", version = "0.7" }

--- a/crates/consensus/src/hotstuff/commit_proofs.rs
+++ b/crates/consensus/src/hotstuff/commit_proofs.rs
@@ -86,9 +86,25 @@ pub fn generate_end_of_epoch_commit_proof<TTx: StateStoreReadTransaction>(
         )));
     }
 
+    // The single command is the EndEpoch command; its atom carries the next epoch's hash. Rebuild the
+    // proof command from it so its hash matches the committed block's command merkle root.
+    let end_epoch_atom = committed_block
+        .commands()
+        .iter()
+        .find_map(|cmd| cmd.end_epoch())
+        .ok_or_else(|| {
+            HotStuffError::InvariantError(format!(
+                "End-of-epoch block {committed_block} does not contain an EndEpoch command"
+            ))
+        })?;
+
     let proof = generate_block_commit_proof(tx, commit_qc, committed_block)?;
     let inclusion_proof = committed_block.compute_command_inclusion_proof(0)?;
-    let command_commit_proof = CommandCommitProof::new(EndOfEpochCommand, proof, inclusion_proof);
+    let command_commit_proof = CommandCommitProof::new(
+        EndOfEpochCommand::new(*end_epoch_atom.next_epoch_hash()),
+        proof,
+        inclusion_proof,
+    );
     Ok(command_commit_proof)
 }
 

--- a/crates/consensus/src/hotstuff/foreign_proposal_processor.rs
+++ b/crates/consensus/src/hotstuff/foreign_proposal_processor.rs
@@ -551,7 +551,7 @@ pub fn process_foreign_block<TStore: StateStore>(
                 proposed_block_change_set.set_next_transaction_update(tx_rec)?;
             },
             // Should never receive this
-            Command::EndEpoch => {
+            Command::EndEpoch(_) => {
                 warn!(
                     target: LOG_TARGET,
                     "❓️ NEVER HAPPEN: Foreign proposal received {} contains an EndEpoch command. This is invalid behaviour but continuing anyway.",

--- a/crates/consensus/src/hotstuff/on_propose.rs
+++ b/crates/consensus/src/hotstuff/on_propose.rs
@@ -9,6 +9,7 @@ use std::{
 
 use log::*;
 use ootle_byte_type::ToByteType;
+use tari_common_types::types::FixedHash;
 use tari_consensus_types::{Decision, HighPc, HighestSeenBlock, LeafBlock, ProposalCertificate, TimeoutCertificate};
 use tari_crypto::tari_utilities::epoch_time::EpochTime;
 use tari_engine_types::commit_result::RejectReason;
@@ -29,6 +30,7 @@ use tari_ootle_storage::{
         BlockTransactionExecution,
         BookkeepingModel,
         Command,
+        EndEpochAtom,
         EvictNodeAtom,
         ForeignProposal,
         ForeignProposalRecord,
@@ -136,6 +138,27 @@ where TConsensusSpec: ConsensusSpec
         let local_committee = epoch_state.local_committee();
         let _timer = TraceTimer::info(LOG_TARGET, "OnPropose");
 
+        // The EndEpoch command commits the committee to the *next* epoch's boundary hash. Only propose
+        // it once our (lagged, reorg-stable) oracle has actually observed that epoch — otherwise we have
+        // no hash to commit to and would be locking a value the committee hasn't ratified. If the oracle
+        // hasn't crossed the boundary yet, defer the EOE proposal; a later round proposes it once the
+        // boundary block is scanned.
+        let next_epoch_hash = if propose_epoch_end {
+            let next_epoch = epoch + Epoch(1);
+            match self.epoch_manager.get_epoch_hash(next_epoch).await.optional()? {
+                Some(hash) => Some(hash),
+                None => {
+                    info!(
+                        target: LOG_TARGET,
+                        "⏳ Not proposing EndEpoch for {epoch}: oracle has not yet observed the boundary block for {next_epoch}"
+                    );
+                    None
+                },
+            }
+        } else {
+            None
+        };
+
         let on_propose = self.clone();
 
         let (next_block, foreign_proposals) = task::spawn_blocking(move || {
@@ -152,7 +175,7 @@ where TConsensusSpec: ConsensusSpec
                     &local_committee_info,
                     &local_claim_public_key,
                     propose_high_tc,
-                    propose_epoch_end,
+                    next_epoch_hash,
                 )?;
 
                 let NextBlock {
@@ -317,7 +340,8 @@ where TConsensusSpec: ConsensusSpec
         local_committee_info: &CommitteeInfo,
         local_claim_public_key_bytes: &RistrettoPublicKeyBytes,
         propose_high_tc: Option<TimeoutCertificate>,
-        can_propose_epoch_end: bool,
+        // `Some(hash)` if we are proposing an end-of-epoch block; carries the next epoch's boundary hash.
+        end_epoch_hash: Option<FixedHash>,
     ) -> Result<NextBlock, HotStuffError> {
         let high_qc_id = high_qc_certificate.calculate_id();
         let justify_block = Block::get_justified_block(tx, &high_qc_certificate, epoch)?;
@@ -326,7 +350,7 @@ where TConsensusSpec: ConsensusSpec
         let highest_seen_block = Block::get(tx, highest_seen_block.block_id())?;
         let is_end_of_epoch_in_chain = highest_seen_block.is_epoch_end_proposed_in_chain(tx)?;
 
-        let should_not_propose_commands = is_end_of_epoch_in_chain || can_propose_epoch_end || {
+        let should_not_propose_commands = is_end_of_epoch_in_chain || end_epoch_hash.is_some() || {
             // TODO: prevent proposers from proposing transactions after an epoch end command is in the justified
             // pending chain, regardless of whether we see the end of epoch or not (race condition).
             // If the last justified/parent block is an epoch end block, we dont propose commands since the block will
@@ -367,8 +391,8 @@ where TConsensusSpec: ConsensusSpec
 
         let mut commands = if is_end_of_epoch_in_chain {
             BTreeSet::from_iter([])
-        } else if can_propose_epoch_end {
-            BTreeSet::from_iter([Command::EndEpoch])
+        } else if let Some(next_epoch_hash) = end_epoch_hash {
+            BTreeSet::from_iter([Command::EndEpoch(EndEpochAtom::new(next_epoch_hash))])
         } else {
             BTreeSet::from_iter(
                 batch

--- a/crates/consensus/src/hotstuff/on_ready_to_vote_on_local_block.rs
+++ b/crates/consensus/src/hotstuff/on_ready_to_vote_on_local_block.rs
@@ -4,6 +4,7 @@
 use std::num::NonZeroU64;
 
 use log::*;
+use tari_common_types::types::FixedHash;
 use tari_consensus_types::{Decision, LastVoted, LeafBlock, PcId};
 use tari_crypto::ristretto::RistrettoPublicKey;
 use tari_engine_types::commit_result::{AbortReason, RejectReason};
@@ -105,6 +106,10 @@ where TConsensusSpec: ConsensusSpec
         local_committee_info: &CommitteeInfo,
         proposer_claim_public_key_bytes: &RistrettoPublicKeyBytes,
         mut can_propose_epoch_end: bool,
+        // The local oracle's view of the next epoch's boundary hash, if it has observed it. Used to
+        // ratify the hash carried in an EndEpoch command before voting. `None` means our oracle has
+        // not yet crossed the boundary, so we cannot ratify and must abstain.
+        expected_next_epoch_hash: Option<FixedHash>,
         change_set: &mut ProposedBlockChangeSet,
     ) -> Result<BlockDecision, HotStuffError> {
         let _timer =
@@ -176,6 +181,7 @@ where TConsensusSpec: ConsensusSpec
                 local_committee_info,
                 proposer_claim_public_key_bytes,
                 can_propose_epoch_end,
+                expected_next_epoch_hash,
                 change_set,
             )?;
         } else {
@@ -245,6 +251,7 @@ where TConsensusSpec: ConsensusSpec
         local_committee_info: &CommitteeInfo,
         proposer_claim_public_key_bytes: &RistrettoPublicKeyBytes,
         can_propose_epoch_end: bool,
+        expected_next_epoch_hash: Option<FixedHash>,
         proposed_block_change_set: &mut ProposedBlockChangeSet,
     ) -> Result<(), HotStuffError> {
         // Store used for transactions that have inputs without specific versions.
@@ -382,7 +389,7 @@ where TConsensusSpec: ConsensusSpec
                     );
                     proposed_block_change_set.add_evict_node(atom.public_key);
                 },
-                Command::EndEpoch => {
+                Command::EndEpoch(atom) => {
                     if !can_propose_epoch_end {
                         warn!(
                             target: LOG_TARGET,
@@ -400,6 +407,38 @@ where TConsensusSpec: ConsensusSpec
                         );
                         proposed_block_change_set.set_no_vote(NoVoteReason::EndOfEpochWithOtherCommands);
                         return Ok(());
+                    }
+
+                    // Ratify the next epoch's hash against our own (lagged, reorg-stable) oracle. Voting
+                    // for the EOE block is how the committee agrees on the next epoch's boundary hash;
+                    // by gating on the LOCAL oracle (not on the majority signal that may have set
+                    // can_propose_epoch_end above), a node never lends quorum to a hash it has not
+                    // itself observed. If our oracle has not crossed the boundary, abstain until it has.
+                    match expected_next_epoch_hash {
+                        Some(local) if local == *atom.next_epoch_hash() => {},
+                        Some(local) => {
+                            warn!(
+                                target: LOG_TARGET,
+                                "❌ NO VOTE: EndEpoch in block {} proposes next-epoch hash {} but our oracle has {}",
+                                block.id(),
+                                atom.next_epoch_hash(),
+                                local,
+                            );
+                            proposed_block_change_set.set_no_vote(NoVoteReason::EndOfEpochHashMismatch {
+                                local,
+                                proposed: *atom.next_epoch_hash(),
+                            });
+                            return Ok(());
+                        },
+                        None => {
+                            warn!(
+                                target: LOG_TARGET,
+                                "❌ NO VOTE: EndEpoch in block {} but our oracle has not yet observed the next epoch boundary block",
+                                block.id(),
+                            );
+                            proposed_block_change_set.set_no_vote(NoVoteReason::EndOfEpochHashNotObserved);
+                            return Ok(());
+                        },
                     }
 
                     continue;

--- a/crates/consensus/src/hotstuff/on_receive_local_proposal.rs
+++ b/crates/consensus/src/hotstuff/on_receive_local_proposal.rs
@@ -17,7 +17,7 @@ use tari_consensus_types::{
     TimeoutVoteMessage,
     ValidatorSignatureBytes,
 };
-use tari_epoch_manager::{EpochManagerError, EpochManagerReader};
+use tari_epoch_manager::EpochManagerReader;
 use tari_ootle_common_types::{
     Epoch,
     NodeHeight,
@@ -303,6 +303,18 @@ impl<TConsensusSpec: ConsensusSpec> OnReceiveLocalProposalHandler<TConsensusSpec
             em_epoch > current_epoch || self.epoch_manager.is_within_epoch_end_spread(current_epoch).await?;
         let is_epoch_end = valid_block.block().is_epoch_end();
 
+        // Our own oracle's view of the next epoch's boundary hash, used by the voter to ratify the hash
+        // carried in an EndEpoch command. `None` if our oracle has not yet observed the next epoch — in
+        // which case the voter abstains rather than lending quorum to an unratified hash.
+        let expected_next_epoch_hash = if is_epoch_end {
+            self.epoch_manager
+                .get_epoch_hash(current_epoch + Epoch(1))
+                .await
+                .optional()?
+        } else {
+            None
+        };
+
         let mut on_ready_to_vote_on_local_block = self.on_ready_to_vote_on_local_block.clone();
 
         // Reusing the change set allocated memory (pointers in the Vec types are passed onto the thread stack).
@@ -325,6 +337,7 @@ impl<TConsensusSpec: ConsensusSpec> OnReceiveLocalProposalHandler<TConsensusSpec
                     &local_committee_info,
                     &proposer_claim_public_key_bytes,
                     can_propose_epoch_end,
+                    expected_next_epoch_hash,
                     &mut change_set,
                 )?;
 
@@ -465,6 +478,7 @@ impl<TConsensusSpec: ConsensusSpec> OnReceiveLocalProposalHandler<TConsensusSpec
         Ok(block_decision.no_vote_reason)
     }
 
+    #[expect(clippy::too_many_lines)]
     async fn process_end_of_epoch(
         &mut self,
         eoe_block: Block,
@@ -475,28 +489,46 @@ impl<TConsensusSpec: ConsensusSpec> OnReceiveLocalProposalHandler<TConsensusSpec
         let prev_epoch = eoe_block.epoch();
         let next_epoch = prev_epoch + Epoch(1);
 
-        // Pre-flight: confirm the local oracle has observed `next_epoch`. If not, the EOE has been
-        // committed (peers attest with 2f+1) but we cannot stamp a deterministic genesis yet.
-        // Defer until the oracle catches up; `try_resume_pending_end_of_epoch` will retry from
-        // `on_epoch_manager_event` or worker startup.
-        let epoch_hash = match self.epoch_manager.get_epoch_hash(next_epoch).await {
-            Ok(hash) => hash,
-            Err(EpochManagerError::NoEpochFound(_)) => {
-                warn!(
-                    target: LOG_TARGET,
-                    "⏳ EOE block {} committed but local oracle has not observed {next_epoch}. \
-                     Deferring next-epoch genesis until oracle catches up.",
+        // The next epoch's boundary hash is taken from the committed EndEpoch command, NOT re-derived
+        // from our local oracle. Because the EOE block only commits with 2f+1 votes and voters ratify
+        // this hash against their own oracle (see the EndEpoch arm in on_ready_to_vote), the value here
+        // is quorum-agreed. A node that diverged on the boundary block (e.g. a base-layer reorg deeper
+        // than the confirmation depth) therefore adopts the committee's hash instead of wedging on its
+        // own. `lock_epoch(next_epoch)` below thus locks a hash the committee has agreed on.
+        let epoch_hash = match eoe_block.commands().iter().find_map(|c| c.end_epoch()) {
+            Some(atom) => *atom.next_epoch_hash(),
+            None => {
+                return Err(HotStuffError::InvariantError(format!(
+                    "EOE block {} does not contain an EndEpoch command",
                     eoe_block.id()
-                );
-                self.pending_end_of_epoch = Some(PendingEndOfEpoch {
-                    eoe_block,
-                    commit_qc,
-                    next_genesis_state_merkle_root,
-                });
-                return Ok(());
+                )));
             },
-            Err(err) => return Err(err.into()),
         };
+
+        // We still need the local oracle to have observed `next_epoch` to assign its committee /
+        // validator set. If it has not yet (rare, given the base-layer scan lag keeps the boundary
+        // block buried), defer; `try_resume_pending_end_of_epoch` retries from `on_epoch_manager_event`
+        // or worker startup.
+        if self
+            .epoch_manager
+            .get_epoch_hash(next_epoch)
+            .await
+            .optional()?
+            .is_none()
+        {
+            warn!(
+                target: LOG_TARGET,
+                "⏳ EOE block {} committed but local oracle has not observed {next_epoch}. \
+                 Deferring next-epoch genesis until oracle catches up.",
+                eoe_block.id()
+            );
+            self.pending_end_of_epoch = Some(PendingEndOfEpoch {
+                eoe_block,
+                commit_qc,
+                next_genesis_state_merkle_root,
+            });
+            return Ok(());
+        }
 
         // We're registered for the next epoch. Checkpoint and create a new genesis block.
         let num_committees = self.epoch_manager.get_num_committees(next_epoch).await?;

--- a/crates/consensus_tests/src/epoch_change.rs
+++ b/crates/consensus_tests/src/epoch_change.rs
@@ -3,6 +3,7 @@
 
 use std::time::{Duration, Instant};
 
+use tari_common_types::types::FixedHash;
 use tari_consensus::hotstuff::{HotStuffError, HotstuffEvent};
 use tari_consensus_types::{Decision, LeafBlock};
 use tari_ootle_common_types::{Epoch, NodeHeight, optional::Optional};
@@ -111,30 +112,29 @@ async fn multishard_epoch_change() {
     epoch_change(test).await;
 }
 
-/// Reproduces the wedge described in `consensus-epoch-change-race-cond`:
+/// A validator whose base-layer oracle has not yet observed the next epoch's boundary block must
+/// **not** vote for the EndEpoch block — it cannot ratify a next-epoch hash it has never seen.
 ///
-/// One validator's base-layer oracle is still behind when consensus commits the EndEpoch
-/// block. `process_end_of_epoch` then asks the local epoch manager for `next_epoch`'s hash to
-/// stamp into the new genesis; the lookup fails with `NoEpochFound`. Before the fix, that error
-/// killed the worker and left the node permanently stuck on the old epoch — even after the
-/// oracle eventually caught up, no code path retried the deferred work. After the fix, the
-/// work is parked in `pending_end_of_epoch`, the worker keeps running, and the next
-/// `EpochChanged` event (or the next worker startup) retries the transition.
+/// This is the safety half of carrying the next epoch's hash in the EndEpoch command: voting is how
+/// the committee ratifies that hash, so a node that votes without having observed the boundary block
+/// would be lending quorum to a value it cannot verify. Combined with a base-layer reorg that splits
+/// the committee, a permissive vote here could push a non-canonical hash to quorum and lock it — the
+/// very wedge we are preventing. So the voter no-votes with `NoVoteReason::EndOfEpochHashNotObserved`
+/// and waits until its (lagged, reorg-stable) oracle catches up.
 ///
 /// The test:
 ///   1. Runs four validators in a single committee.
-///   2. Caps validator "1"'s oracle at `Epoch(1)` so `get_epoch_hash(Epoch(2))` returns `NoEpochFound`. (The cap
-///      intentionally does NOT override `current_epoch()` — the vote-time check uses that, and we want the chain to
-///      commit the EOE on every node so `process_end_of_epoch` actually runs and trips the failure mode.)
-///   3. Drives an epoch change to `Epoch(2)`. All four nodes vote on the EOE, the chain commits it via 3-chain, and
-///      `process_end_of_epoch` runs on each. Three succeed and advance to Epoch(2); validator "1" defers instead of
-///      crashing.
-///   4. Asserts the other three have advanced to `Epoch(2)` while validator "1"'s pacemaker is still on `Epoch(1)` with
-///      a committed EOE block in its chain.
-///   5. Clears the lag and refires `EpochChanged(2)` (modeling the oracle catching up).
-///   6. Asserts validator "1" then advances to `Epoch(2)`.
+///   2. Caps validator "1"'s oracle at `Epoch(1)` so `get_epoch_hash(Epoch(2))` returns `NoEpochFound` for it only.
+///   3. Drives an epoch change to `Epoch(2)`. The three observers ratify and commit the EOE (3 = quorum) and advance;
+///      validator "1" no-votes the EOE (it has no Epoch(2) hash to check against).
+///   4. Asserts the three observers reached `Epoch(2)` while validator "1" stayed on `Epoch(1)` with no leaf in
+///      `Epoch(2)` — i.e. it never lent quorum to, or locked, an unobserved hash.
+///
+/// (A lagged node recovers in production via state sync once it sees an authenticated future-epoch
+/// QC — see `epoch_change_no_vote_wedge_escalates_on_future_qc`. End-to-end self-healing after a
+/// committee split is covered by `epoch_change_hash_divergence_self_heals`.)
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn epoch_change_with_lagging_oracle() {
+async fn epoch_change_unobserved_next_hash_is_not_voted() {
     setup_logger();
     let mut test = Test::builder()
         .modify_config(|cfg| {
@@ -144,7 +144,7 @@ async fn epoch_change_with_lagging_oracle() {
             c.pacemaker_block_time = Duration::from_secs(2);
         })
         .with_test_timeout(Duration::from_secs(60))
-        // 4 validators so 3 honest votes-yes is enough for quorum without the lagged one.
+        // 4 validators so the 3 observers reach quorum without the lagged one.
         .add_committee(0, vec!["1", "2", "3", "4"])
         .start()
         .await;
@@ -159,80 +159,62 @@ async fn epoch_change_with_lagging_oracle() {
     }
 
     // Cap the lagged validator's oracle BEFORE the epoch transition. After this,
-    // `get_epoch_hash(Epoch(2))` returns `NoEpochFound` for this validator only.
+    // `get_epoch_hash(Epoch(2))` returns `NoEpochFound` for this validator only, so at vote time it
+    // has no next-epoch hash to ratify the EndEpoch command against.
     test.get_validator(&lagging_addr)
         .epoch_manager
         .set_oracle_visible_epoch(Epoch(1));
 
-    // Trigger the epoch change. All four workers receive `EpochChanged(2)` and set
-    // `next_epoch`. Voting on the EOE block goes through normally (we deliberately do
-    // not cap `current_epoch()` so the lagged node still votes Yes), so quorum is
-    // reached and the chain commits the EOE on every node via the 3-chain rule. This
-    // is exactly the state the production bug ends up in once a lagged node catches
-    // up via sync — the EOE is committed locally, but `process_end_of_epoch` then
-    // tries to look up `next_epoch`'s hash and fails.
+    // Trigger the epoch change. All four workers receive `EpochChanged(2)`. The three observers
+    // ratify the EOE's next-epoch hash against their oracle and vote; validator "1" no-votes with
+    // `EndOfEpochHashNotObserved`. Three votes is quorum, so the EOE still commits and the observers
+    // advance — without the lagged node's vote.
     test.start_epoch(Epoch(2)).await;
 
-    // Drive the chain so the EOE 3-chain commits and the non-lagged validators run
-    // process_end_of_epoch successfully (creating the next epoch's genesis and advancing
-    // their pacemakers to Epoch(2)). Sending more transactions keeps the leaders proposing.
+    // Keep the leaders proposing so the EOE 3-chain commits on the observers.
     for _ in 0..3 {
         test.send_transaction_to_all(Decision::Commit, 1, 1, 1).await;
     }
 
-    // Wait until the three non-lagged validators have advanced to Epoch(2). Don't include
-    // the lagged validator — under the fix it stays on Epoch(1) until the oracle catches up.
+    // The three observers advance to Epoch(2); the lagged one is excluded.
     wait_for_validators_at_epoch(&mut test, &lagging_addr, Epoch(2), Duration::from_secs(30)).await;
 
-    // Confirm the bug condition is reproduced on the lagged validator:
+    // The lagged validator must NOT have advanced or locked an unobserved hash:
     //   (a) its pacemaker is still on Epoch(1)
-    //   (b) the EOE block is committed in its chain (process_end_of_epoch was reached)
-    //   (c) it has no leaf in Epoch(2) (next genesis was deferred)
+    //   (b) it has no leaf in Epoch(2) (it never created the next genesis)
     let lagged = test.get_validator(&lagging_addr);
     assert_eq!(
         lagged._current_view.get_epoch(),
         Epoch(1),
-        "lagged validator's pacemaker must remain on Epoch(1) before recovery"
+        "lagged validator must remain on Epoch(1): it cannot ratify an unobserved next-epoch hash"
     );
 
     let has_committed_eoe = lagged
         .state_store
         .with_read_tx(|tx| chain_has_committed_epoch_end(tx, Epoch(1)))
         .unwrap();
-    assert!(
-        has_committed_eoe,
-        "lagged validator should have committed the EOE block via 3-chain (process_end_of_epoch must have run and \
-         deferred)"
-    );
 
     let leaf_at_2 = lagged
         .state_store
         .with_read_tx(|tx| LeafBlock::get(tx, Epoch(2)))
         .optional()
         .unwrap();
+    log::info!(
+        "🔬 lagged state: epoch={:?} committed_eoe={} leaf_at_2={:?}",
+        lagged._current_view.get_epoch(),
+        has_committed_eoe,
+        leaf_at_2
+    );
     assert!(
         leaf_at_2.is_none(),
-        "lagged validator must NOT have a leaf in Epoch(2) before the oracle catches up; got {leaf_at_2:?}"
+        "lagged validator must NOT have a leaf in Epoch(2): it no-voted the EOE and never transitioned; got \
+         {leaf_at_2:?}"
     );
 
-    log::info!("✅ bug condition reproduced: lagged validator stuck at Epoch(1) with committed EOE");
-
-    // Now simulate the oracle catching up: clear the lag and re-publish `EpochChanged(2)`.
-    // The worker's `on_epoch_manager_event` sees `has_pending_end_of_epoch` and calls
-    // `try_resume_pending_end_of_epoch`, which re-runs `process_end_of_epoch`. With the
-    // oracle now current, `get_epoch_hash(Epoch(2))` succeeds, the next genesis is created
-    // and the pacemaker advances.
-    let lagged_sg = lagged.shard_group;
-    lagged.epoch_manager.clear_oracle_lag();
-    test.get_validator_mut(&lagging_addr)
-        .epoch_manager
-        .set_current_epoch(Epoch(2), lagged_sg)
-        .await;
-
-    // Assert recovery: the lagged validator now reaches Epoch(2).
-    wait_for_single_validator_at_epoch(&mut test, &lagging_addr, Epoch(2), Duration::from_secs(15)).await;
-
-    log::info!("✅ recovery confirmed: lagged validator advanced to Epoch(2) after oracle caught up");
+    log::info!(
+        "✅ gate held: validator with an unobserved next-epoch hash no-voted the EOE; the observers reached quorum \
+         without it"
+    );
 
     test.stop();
     test.assert_clean_shutdown().await;
@@ -277,20 +259,17 @@ async fn wait_for_validators_at_epoch(test: &mut Test, excluded: &TestAddress, e
     panic!("Timed out waiting for non-excluded validators to reach {epoch}");
 }
 
-/// Waits until `addr`'s pacemaker reaches `epoch`.
-async fn wait_for_single_validator_at_epoch(test: &mut Test, addr: &TestAddress, epoch: Epoch, timeout: Duration) {
+/// Waits until *every* validator's pacemaker reaches `epoch`.
+async fn wait_for_all_validators_at_epoch(test: &mut Test, epoch: Epoch, timeout: Duration) {
     let deadline = Instant::now() + timeout;
     while Instant::now() < deadline {
         let _unused = tokio::time::timeout(Duration::from_millis(100), test.on_block_committed()).await;
 
-        if test.get_validator(addr)._current_view.get_epoch() >= epoch {
+        if test.validators_iter().all(|v| v._current_view.get_epoch() >= epoch) {
             return;
         }
     }
-    panic!(
-        "Timed out waiting for {addr} to reach {epoch} (currently on {})",
-        test.get_validator(addr)._current_view.get_epoch()
-    );
+    panic!("Timed out waiting for all validators to reach {epoch}");
 }
 
 /// Reproduces the second variant of the epoch-change wedge described in the
@@ -536,4 +515,151 @@ async fn epoch_change_multi_epoch_lag_escalates_on_future_qc() {
         outcome.contains("Epoch(3)"),
         "escalation reason should reference the Epoch(3) QC across the multi-epoch gap; got: {outcome}"
     );
+}
+
+/// Reproduces the base-layer-reorg committee split from the incident logs and shows the committee
+/// self-heals once oracles re-converge — the property the EndEpoch-hash-in-command change buys us.
+///
+/// Production scenario: a base-layer reorg deeper than the confirmation depth straddled an epoch
+/// boundary, so 2/4 validators' oracles reported boundary hash A for the next epoch and the other
+/// 2 reported hash B. Before the fix, each node stamped and *locked* its own hash into the next
+/// epoch's genesis, the committee split into two irreconcilable halves, and every cross-half
+/// proposal was rejected with `InvalidEpochHash` — a permanent wedge with no quorum on either hash.
+///
+/// With the next epoch's hash carried in the `EndEpoch` command and ratified at vote time against
+/// each voter's own oracle, the divergence can no longer be locked: an EOE proposed with hash A
+/// only collects the two A-votes (and B only the two B-votes), so neither reaches the 3-vote
+/// quorum. The transition simply stalls — no node advances or locks. Once the base layer settles
+/// and every oracle re-converges on the canonical boundary block, the EOE is ratified by all four,
+/// commits, and the committee advances together. No manual recovery, no permanent wedge.
+///
+/// Test flow:
+/// 1. Four validators, single committee. Run a few transactions in Epoch(1).
+/// 2. Split the committee's oracle view of Epoch(2)'s hash: "1"/"2" see hash A, "3"/"4" see hash B.
+/// 3. Trigger Epoch(2). Assert the stall: every validator stays on Epoch(1) with no leaf in Epoch(2) (neither hash can
+///    muster quorum, so nothing commits or locks).
+/// 4. Re-converge every oracle on hash B (the base layer settles on the surviving chain).
+/// 5. Assert recovery: all four validators commit the EOE and advance to Epoch(2).
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn epoch_change_hash_divergence_self_heals() {
+    setup_logger();
+    let mut test = Test::builder()
+        .modify_config(|cfg| {
+            cfg.epoch_end_grace_period = Duration::from_millis(10);
+        })
+        .modify_consensus_constants(|c| {
+            c.pacemaker_block_time = Duration::from_secs(1);
+        })
+        .with_test_timeout(Duration::from_secs(120))
+        // 4 validators: quorum is 3, so a 2/2 hash split can never reach it.
+        .add_committee(0, vec!["1", "2", "3", "4"])
+        .start()
+        .await;
+
+    // Two distinct, non-default boundary hashes standing in for the two sides of the reorg.
+    let hash_a = FixedHash::from([0x0a; 32]);
+    let hash_b = FixedHash::from([0x0b; 32]);
+
+    test.start_epoch(Epoch(1)).await;
+
+    // Move the chain in Epoch(1) and let it settle before the boundary.
+    for _ in 0..3 {
+        test.send_transaction_to_all(Decision::Commit, 1, 1, 1).await;
+    }
+    let deadline = Instant::now() + Duration::from_secs(30);
+    while !test.is_all_submitted_transactions_finalized() {
+        if Instant::now() > deadline {
+            panic!("Epoch(1) transactions did not finalize");
+        }
+        let _unused = tokio::time::timeout(Duration::from_millis(500), test.on_block_committed()).await;
+    }
+
+    // Split the committee's oracle view of Epoch(2)'s boundary hash BEFORE the transition, so the
+    // EOE proposer and voters read divergent next-epoch hashes — exactly the reorg-at-boundary state.
+    for addr in ["1", "2"] {
+        test.get_validator(&TestAddress::new(addr))
+            .epoch_manager
+            .set_oracle_epoch_hash(hash_a);
+    }
+    for addr in ["3", "4"] {
+        test.get_validator(&TestAddress::new(addr))
+            .epoch_manager
+            .set_oracle_epoch_hash(hash_b);
+    }
+
+    // Trigger the transition. Every worker sees em_epoch == Epoch(2) and starts proposing EndEpoch,
+    // but each EOE carries the proposer's hash and is ratified against each voter's oracle: A gets
+    // only the two A-votes, B only the two B-votes — never the 3 needed for quorum.
+    test.start_epoch(Epoch(2)).await;
+
+    // Let the chain repeatedly attempt (and fail to commit) the EOE. No transactions needed — the
+    // pacemaker proposes the EOE on its own once past the boundary.
+    let drain_until = Instant::now() + Duration::from_secs(12);
+    while Instant::now() < drain_until {
+        let _unused = tokio::time::timeout(Duration::from_millis(200), test.on_block_committed()).await;
+    }
+
+    // Assert the stall: because neither hash reached quorum, no node committed the EOE, advanced, or
+    // locked Epoch(2). This is the key property — a divergent hash can no longer be locked unilaterally.
+    for vn in test.validators_iter() {
+        assert_eq!(
+            vn._current_view.get_epoch(),
+            Epoch(1),
+            "validator {} must remain on Epoch(1) while the committee is split on the epoch hash",
+            vn.address
+        );
+        let leaf_at_2 = vn
+            .state_store
+            .with_read_tx(|tx| LeafBlock::get(tx, Epoch(2)))
+            .optional()
+            .unwrap();
+        assert!(
+            leaf_at_2.is_none(),
+            "validator {} must NOT have a leaf in Epoch(2) during the split; got {leaf_at_2:?}",
+            vn.address
+        );
+    }
+    log::info!(
+        "✅ split reproduced: committee divided on the Epoch(2) hash, EOE cannot reach quorum, no node advanced or \
+         locked"
+    );
+
+    // The base layer settles: every oracle re-converges on the canonical surviving boundary block.
+    for addr in ["1", "2", "3", "4"] {
+        test.get_validator(&TestAddress::new(addr))
+            .epoch_manager
+            .set_oracle_epoch_hash(hash_b);
+    }
+
+    // With agreement restored, the next EOE (carrying hash B) is ratified by all four, commits via
+    // the 3-chain, and the committee rolls over to Epoch(2) together.
+    wait_for_all_validators_at_epoch(&mut test, Epoch(2), Duration::from_secs(45)).await;
+
+    // And every validator must have stamped the *ratified* hash (hash_b) into its Epoch(2) genesis —
+    // including the former-A minority ("1"/"2"), which adopts the committee's hash from the committed
+    // EndEpoch command rather than its own earlier (diverged) view. All blocks in an epoch inherit the
+    // genesis epoch_hash, so reading the leaf is sufficient.
+    for vn in test.validators_iter() {
+        let epoch_hash = vn
+            .state_store
+            .with_read_tx(|tx| {
+                let leaf = LeafBlock::get(tx, Epoch(2))?;
+                let block = Block::get(tx, leaf.block_id())?;
+                Ok::<_, HotStuffError>(*block.epoch_hash())
+            })
+            .unwrap();
+        assert_eq!(
+            epoch_hash, hash_b,
+            "validator {} must have stamped the ratified hash_b into Epoch(2), got {epoch_hash}",
+            vn.address
+        );
+    }
+
+    log::info!(
+        "✅ self-heal confirmed: after oracles re-converged on the canonical hash, the committee committed the EOE \
+         and advanced to Epoch(2) with epoch_hash=hash_b on every validator"
+    );
+
+    test.stop();
+    test.assert_clean_shutdown().await;
 }

--- a/crates/consensus_tests/src/support/epoch_manager.rs
+++ b/crates/consensus_tests/src/support/epoch_manager.rs
@@ -49,6 +49,12 @@ pub struct TestEpochManager {
     /// `oracle_visible_epoch`, this *does* lag the vote-time `em_epoch > current_epoch`
     /// check — used to reproduce the wedge where a validator no-votes the EOE block.
     oracle_current_epoch_cap: Arc<StdMutex<Option<Epoch>>>,
+    /// Overrides the boundary hash this validator's oracle reports from `get_epoch_hash`. When
+    /// `Some(hash)`, simulates a base-layer reorg that left this node on a different epoch-boundary
+    /// block than its peers (the committee-split scenario). `None` = report the shared
+    /// `last_epoch_hash`. Like the lag fields, a fresh `Arc` is allocated per validator by
+    /// `clone_for`.
+    oracle_epoch_hash_override: Arc<StdMutex<Option<FixedHash>>>,
 }
 
 impl TestEpochManager {
@@ -60,6 +66,7 @@ impl TestEpochManager {
             current_epoch: Epoch(1),
             oracle_visible_epoch: Arc::new(StdMutex::new(None)),
             oracle_current_epoch_cap: Arc::new(StdMutex::new(None)),
+            oracle_epoch_hash_override: Arc::new(StdMutex::new(None)),
         }
     }
 
@@ -74,11 +81,6 @@ impl TestEpochManager {
     /// once a node catches up via sync.
     pub fn set_oracle_visible_epoch(&self, epoch: Epoch) {
         *self.oracle_visible_epoch.lock().unwrap() = Some(epoch);
-    }
-
-    /// Remove the oracle lag for this validator.
-    pub fn clear_oracle_lag(&self) {
-        *self.oracle_visible_epoch.lock().unwrap() = None;
     }
 
     fn oracle_visible_epoch(&self) -> Option<Epoch> {
@@ -101,6 +103,18 @@ impl TestEpochManager {
 
     fn oracle_current_epoch_cap(&self) -> Option<Epoch> {
         *self.oracle_current_epoch_cap.lock().unwrap()
+    }
+
+    /// Override the boundary hash this validator's oracle reports from `get_epoch_hash`, for every
+    /// epoch. Used to model a base-layer reorg that splits the committee across two boundary-block
+    /// hashes: set different overrides on different validators and they will disagree on the next
+    /// epoch's hash, just like the production divergence.
+    pub fn set_oracle_epoch_hash(&self, hash: FixedHash) {
+        *self.oracle_epoch_hash_override.lock().unwrap() = Some(hash);
+    }
+
+    fn oracle_epoch_hash_override(&self) -> Option<FixedHash> {
+        *self.oracle_epoch_hash_override.lock().unwrap()
     }
 
     pub async fn set_current_epoch(&mut self, current_epoch: Epoch, shard_group: ShardGroup) -> &Self {
@@ -135,6 +149,7 @@ impl TestEpochManager {
         // this same validator share via the cheap `Clone` impl.
         copy.oracle_visible_epoch = Arc::new(StdMutex::new(None));
         copy.oracle_current_epoch_cap = Arc::new(StdMutex::new(None));
+        copy.oracle_epoch_hash_override = Arc::new(StdMutex::new(None));
         if let Some(our_validator_node) = self.our_validator_node.clone() {
             copy.our_validator_node = Some(ValidatorNode {
                 address,
@@ -288,6 +303,9 @@ impl EpochManagerReader for TestEpochManager {
             epoch > cap
         {
             return Err(EpochManagerError::NoEpochFound(epoch));
+        }
+        if let Some(hash) = self.oracle_epoch_hash_override() {
+            return Ok(hash);
         }
         Ok(self.inner.lock().await.last_epoch_hash)
     }

--- a/crates/ootle_wasm/wasm/Cargo.toml
+++ b/crates/ootle_wasm/wasm/Cargo.toml
@@ -13,7 +13,7 @@ readme = "../NPM_README.md"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-ootle-wasm-core = { path = "../core", version = "0.32" }
+ootle-wasm-core = { path = "../core", version = "0.33" }
 wasm-bindgen = "0.2"
 # getrandom is pulled in transitively via `rand` and `tari_bulletproofs_plus`. The wasm32-unknown-unknown
 # target requires explicit feature opt-in for both major versions used in the graph.

--- a/crates/p2p/proto/consensus.proto
+++ b/crates/p2p/proto/consensus.proto
@@ -119,8 +119,12 @@ message Command {
 
     ForeignProposalAtom foreign_proposal = 6;
     EvictNodeAtom evict_node = 8;
-    bool end_epoch = 9;
+    EndEpochAtom end_epoch = 9;
   }
+}
+
+message EndEpochAtom {
+  bytes next_epoch_hash = 1;
 }
 
 message ForeignProposalAtom {

--- a/crates/p2p/src/conversions/consensus.rs
+++ b/crates/p2p/src/conversions/consensus.rs
@@ -67,6 +67,7 @@ use tari_ootle_storage::{
     consensus_models,
     consensus_models::{
         Command,
+        EndEpochAtom,
         EvictNodeAtom,
         Evidence,
         ForeignProposal,
@@ -637,7 +638,7 @@ impl From<&Command> for proto::consensus::Command {
                 proto::consensus::command::Command::ForeignProposal(foreign_proposal.into())
             },
             Command::EvictNode(atom) => proto::consensus::command::Command::EvictNode(atom.into()),
-            Command::EndEpoch => proto::consensus::command::Command::EndEpoch(true),
+            Command::EndEpoch(atom) => proto::consensus::command::Command::EndEpoch(atom.into()),
         };
 
         Self { command: Some(command) }
@@ -659,7 +660,7 @@ impl TryFrom<proto::consensus::Command> for Command {
                 Command::ForeignProposal(foreign_proposal.try_into()?)
             },
             proto::consensus::command::Command::EvictNode(atom) => Command::EvictNode(atom.try_into()?),
-            proto::consensus::command::Command::EndEpoch(_) => Command::EndEpoch,
+            proto::consensus::command::Command::EndEpoch(atom) => Command::EndEpoch(atom.try_into()?),
         })
     }
 }
@@ -761,6 +762,30 @@ impl TryFrom<proto::consensus::EvictNodeAtom> for EvictNodeAtom {
                 .as_slice()
                 .try_into()
                 .map_err(|e| anyhow!("EvictNodeAtom failed to decode public key: {e}"))?,
+        })
+    }
+}
+
+// -------------------------------- EndEpochAtom -------------------------------- //
+
+impl From<&EndEpochAtom> for proto::consensus::EndEpochAtom {
+    fn from(value: &EndEpochAtom) -> Self {
+        Self {
+            next_epoch_hash: value.next_epoch_hash.as_slice().to_vec(),
+        }
+    }
+}
+
+impl TryFrom<proto::consensus::EndEpochAtom> for EndEpochAtom {
+    type Error = anyhow::Error;
+
+    fn try_from(value: proto::consensus::EndEpochAtom) -> Result<Self, Self::Error> {
+        Ok(Self {
+            next_epoch_hash: value
+                .next_epoch_hash
+                .as_slice()
+                .try_into()
+                .map_err(|e| anyhow!("EndEpochAtom failed to decode next_epoch_hash: {e}"))?,
         })
     }
 }

--- a/crates/state_store_rocksdb/tests/misc.rs
+++ b/crates/state_store_rocksdb/tests/misc.rs
@@ -5,6 +5,7 @@ pub mod helpers;
 
 use helpers::{assert_eq_debug, create_rocksdb};
 use indexmap::IndexMap;
+use tari_common_types::types::FixedHash;
 use tari_consensus_types::{
     BlockId,
     HighPc,
@@ -191,7 +192,11 @@ fn miscellaneous_rocksdb() {
         },
         proof_elements: vec![],
     };
-    let proof = CommandCommitProof::new(EndOfEpochCommand, commit_proof, inclusion_proof);
+    let proof = CommandCommitProof::new(
+        EndOfEpochCommand::new(FixedHash::default()),
+        commit_proof,
+        inclusion_proof,
+    );
     let epoch_checkpoint = EpochCheckpoint::new(proof, shard_summary);
 
     tx.epoch_checkpoint_save(&epoch_checkpoint).unwrap();

--- a/crates/storage/src/consensus_models/command.rs
+++ b/crates/storage/src/consensus_models/command.rs
@@ -112,7 +112,7 @@ pub enum Command {
     #[n(6)]
     EvictNode(#[n(0)] EvictNodeAtom),
     #[n(7)]
-    EndEpoch,
+    EndEpoch(#[n(0)] EndEpochAtom),
 }
 
 /// Defines the order in which commands should be processed in a block. "Smallest" comes first and "largest" comes last.
@@ -133,7 +133,7 @@ impl Command {
             Command::AllAccept(tx) |
             Command::SomeAccept(tx) |
             Command::LocalOnly(tx) => Some(tx),
-            Command::ForeignProposal(_) | Command::EvictNode(_) | Command::EndEpoch => None,
+            Command::ForeignProposal(_) | Command::EvictNode(_) | Command::EndEpoch(_) => None,
         }
     }
 
@@ -149,7 +149,7 @@ impl Command {
                 CommandOrdering::ForeignProposal(foreign_proposal.shard_group, &foreign_proposal.block_id)
             },
             Command::EvictNode(_) => CommandOrdering::EvictNode,
-            Command::EndEpoch => CommandOrdering::EndEpoch,
+            Command::EndEpoch(_) => CommandOrdering::EndEpoch,
         }
     }
 
@@ -192,6 +192,13 @@ impl Command {
         }
     }
 
+    pub fn end_epoch(&self) -> Option<&EndEpochAtom> {
+        match self {
+            Command::EndEpoch(atom) => Some(atom),
+            _ => None,
+        }
+    }
+
     pub fn all_accept(&self) -> Option<&TransactionAtom> {
         match self {
             Command::AllAccept(tx) => Some(tx),
@@ -230,7 +237,7 @@ impl Command {
     }
 
     pub fn is_epoch_end(&self) -> bool {
-        matches!(self, Command::EndEpoch)
+        matches!(self, Command::EndEpoch(_))
     }
 
     pub fn is_local_prepare(&self) -> bool {
@@ -264,7 +271,7 @@ impl Display for Command {
             Command::SomeAccept(tx) => write!(f, "SomeAccept({}, {})", tx.id, tx.decision),
             Command::ForeignProposal(fp) => write!(f, "ForeignProposal {}", fp.block_id),
             Command::EvictNode(atom) => write!(f, "EvictNode({atom})"),
-            Command::EndEpoch => write!(f, "EndEpoch"),
+            Command::EndEpoch(atom) => write!(f, "EndEpoch({atom})"),
         }
     }
 }
@@ -305,6 +312,55 @@ impl Display for EvictNodeAtom {
     }
 }
 
+/// The atom committed by an [`Command::EndEpoch`] command.
+///
+/// Carries the base-layer boundary-block hash of the *next* epoch. Because the hash is part of the
+/// command, it is committed in the block's command merkle root and ratified by the quorum that
+/// commits the end-of-epoch block: a validator only votes for the EOE block if `next_epoch_hash`
+/// matches its own (lagged, reorg-stable) oracle view. This prevents a node from unilaterally
+/// locking an epoch hash the committee never agreed on — the failure mode that wedges consensus when
+/// a base-layer reorg deeper than the confirmation depth straddles an epoch boundary.
+///
+/// The Borsh layout (a single 32-byte hash) is identical to [`tari_sidechain::EndEpochAtom`] so the
+/// layer-2 `command_hasher` output matches what L1 recomputes during checkpoint inclusion-proof
+/// verification.
+#[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export))]
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    BorshSerialize,
+    minicbor::Encode,
+    minicbor::Decode,
+    minicbor::CborLen,
+)]
+pub struct EndEpochAtom {
+    #[cfg_attr(feature = "ts", ts(type = "string"))]
+    #[serde(with = "ootle_serde::hex")]
+    #[n(0)]
+    #[cbor(with = "tari_bor::adapters::serde_bridge")]
+    pub next_epoch_hash: FixedHash,
+}
+
+impl EndEpochAtom {
+    pub fn new(next_epoch_hash: FixedHash) -> Self {
+        Self { next_epoch_hash }
+    }
+
+    pub fn next_epoch_hash(&self) -> &FixedHash {
+        &self.next_epoch_hash
+    }
+}
+
+impl Display for EndEpochAtom {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "next_epoch_hash={}", self.next_epoch_hash)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeSet;
@@ -327,7 +383,7 @@ mod tests {
         assert!(CommandOrdering::TransactionId(&tx_id) < CommandOrdering::EndEpoch);
         let mut set = BTreeSet::new();
         let cmds = [
-            Command::EndEpoch,
+            Command::EndEpoch(EndEpochAtom::new(FixedHash::zero())),
             Command::AllAccept(TransactionAtom {
                 id: TransactionId::new([1; 32]),
                 decision: Decision::Commit,

--- a/crates/storage/src/consensus_models/epoch_checkpoint.rs
+++ b/crates/storage/src/consensus_models/epoch_checkpoint.rs
@@ -250,10 +250,26 @@ fn convert_sidechain_shard_group_to_shard_group(
 #[derive(
     Debug, Clone, PartialEq, Eq, Deserialize, Serialize, BorshSerialize, BorshDeserialize, Encode, Decode, CborLen,
 )]
-pub struct EndOfEpochCommand;
+pub struct EndOfEpochCommand {
+    #[n(0)]
+    #[cbor(with = "tari_bor::adapters::serde_bridge")]
+    next_epoch_hash: FixedHash,
+}
+
+impl EndOfEpochCommand {
+    pub fn new(next_epoch_hash: FixedHash) -> Self {
+        Self { next_epoch_hash }
+    }
+
+    pub fn next_epoch_hash(&self) -> &FixedHash {
+        &self.next_epoch_hash
+    }
+}
 
 impl ToCommand for EndOfEpochCommand {
     fn to_command(&self) -> tari_sidechain::Command {
-        tari_sidechain::Command::EndEpoch
+        // Must match the dan-side `Command::EndEpoch(EndEpochAtom)` byte-for-byte so the command hash
+        // (and thus the inclusion proof against the committed block's command merkle root) verifies.
+        tari_sidechain::Command::EndEpoch(tari_sidechain::EndEpochAtom::new(self.next_epoch_hash))
     }
 }

--- a/crates/storage/src/consensus_models/no_vote.rs
+++ b/crates/storage/src/consensus_models/no_vote.rs
@@ -1,6 +1,7 @@
 //   Copyright 2024 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
+use tari_common_types::types::FixedHash;
 use tari_consensus_types::{BlockId, Decision};
 use tari_ootle_common_types::ShardGroup;
 use tari_ootle_transaction::TransactionId;
@@ -77,6 +78,12 @@ pub enum NoVoteReason {
     NotEndOfEpoch,
     #[error("The node is not at the end of the epoch and other commands are present")]
     EndOfEpochWithOtherCommands,
+    #[error("End-of-epoch next-epoch hash mismatch. Local oracle: {local}, proposed: {proposed}")]
+    EndOfEpochHashMismatch { local: FixedHash, proposed: FixedHash },
+    #[error(
+        "End-of-epoch next-epoch hash cannot be ratified: local oracle has not observed the next epoch boundary block"
+    )]
+    EndOfEpochHashNotObserved,
     #[error("The state Merkle root does not match")]
     StateMerkleRootMismatch,
     #[error("The command Merkle root does not match")]
@@ -130,6 +137,8 @@ impl NoVoteReason {
             Self::ForeignProposalProcessingFailed => "ForeignProposalProcessingFailed",
             Self::NotEndOfEpoch => "NotEndOfEpoch",
             Self::EndOfEpochWithOtherCommands => "EndOfEpochWithOtherCommands",
+            Self::EndOfEpochHashMismatch { .. } => "EndOfEpochHashMismatch",
+            Self::EndOfEpochHashNotObserved => "EndOfEpochHashNotObserved",
             Self::TotalLeaderFeeDisagreement => "TotalLeaderFeeDisagreement",
             Self::StateMerkleRootMismatch => "StateMerkleRootMismatch",
             Self::CommandMerkleRootMismatch => "CommandMerkleRootMismatch",

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -46,10 +46,8 @@ tari_ootle_wallet_sdk = { workspace = true }
 ootle_byte_type = { workspace = true }
 
 # Minotari
-#minotari_console_wallet = { workspace = true }
-#minotari_node = { workspace = true }
-minotari_console_wallet = { git = "https://github.com/tari-project/tari.git", tag = "v5.3.1-pre.0" }
-minotari_node = { git = "https://github.com/tari-project/tari.git", tag = "v5.3.1-pre.0" }
+minotari_console_wallet = { workspace = true }
+minotari_node = { workspace = true }
 minotari_wallet = { workspace = true }
 tari_comms = { workspace = true }
 tari_comms_dht = { workspace = true }


### PR DESCRIPTION
## Summary

Makes the next epoch's base-layer boundary hash a **consensus-agreed** value carried in the `EndEpoch` command, instead of one each validator derives from its own oracle and locks unilaterally.

The proposer fills `EndEpochAtom { next_epoch_hash }` from its oracle; voters **ratify** it against their own (lagged, reorg-stable) oracle and no-vote on mismatch or non-observation; `process_end_of_epoch` stamps the next genesis from the *committed* command's hash. Because the EOE only commits with 2f+1 ratifying the hash, **a validator can no longer lock an epoch hash the committee never agreed on.**

## Motivation

From the dev-net incident: a base-layer reorg deeper than `base_layer_confirmations` straddled an epoch boundary, so 2/4 validators saw boundary hash A and 2/4 saw hash B. Each node stamped and locked its own hash, the committee split into two irreconcilable halves, and every cross-half proposal was rejected with `InvalidEpochHash` — a permanent wedge.

With the hash ratified at vote time, that divergence can no longer be locked: an EOE proposed with A only collects the two A-votes (B only the two B-votes), so neither reaches quorum. The transition **stalls** — no node advances or locks. Once the base layer settles and oracles re-converge, the EOE is ratified by all four, commits, and the committee advances together. No manual recovery.

## Changes

- **storage**: `Command::EndEpoch(EndEpochAtom)`; `EndOfEpochCommand` carries the hash; new `NoVoteReason::{EndOfEpochHashMismatch, EndOfEpochHashNotObserved}`. Borsh layout byte-identical to `tari_sidechain::EndEpochAtom` so the command-merkle root and L1 inclusion-proof verification are unaffected.
- **consensus**: proposer fills the atom (defers the EOE if its oracle hasn't observed the boundary); voter ratifies against its own oracle; `process_end_of_epoch` consumes the committed command's hash, so `lock_epoch` is now quorum-backed.
- **p2p**: `EndEpochAtom` proto message + conversions.
- **tests**: `epoch_change_hash_divergence_self_heals` reproduces the 2/4 split, asserts stall → re-converge → advance, and verifies every validator stamps the ratified `hash_b` into Epoch(2). Adds a per-validator `set_oracle_epoch_hash` test hook.

## Behavioral change worth reviewer attention

A validator whose oracle hasn't observed the next epoch now **no-votes** the EOE (`EndOfEpochHashNotObserved`) rather than voting and deferring genesis creation — a permissive vote there could lend quorum to an unverifiable hash. The old `epoch_change_with_lagging_oracle` test is repurposed to `epoch_change_unobserved_next_hash_is_not_voted`; such a node recovers via state sync (covered by `epoch_change_no_vote_wedge_escalates_on_future_qc`).

## ⚠️ Breaking: EpochCheckpoint schema change

This changes the `EpochCheckpoint` CBOR schema (`EndOfEpochCommand` gains the hash). Existing nodes must **reset their EpochCheckpoints store (or resync)** on upgrade or they'll hit a minicbor decode error. Acceptable pre-launch.

## Dependency

Depends on tari-project/tari#7856 (now **merged**). The tari deps are pinned to `tari-project/tari@941dd85` for now; swap to a published tari release tag once one carrying `EndEpochAtom` is cut.

## Testing

Full `consensus_tests` suite passes (59 tests). Builds against the merged tari commit.
