### PR TITLE
fix(epoch-oracles): self-heal base layer headers on reorg

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11393,7 +11393,6 @@ dependencies = [
  "anyhow",
  "blake2 0.10.6",
  "log",
- "minotari_app_grpc",
  "ootle-network",
  "ootle_serde",
  "serde",
@@ -11412,7 +11411,6 @@ dependencies = [
  "thiserror 2.0.18",
  "time",
  "tokio",
- "tonic 0.13.1",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11406,6 +11406,7 @@ dependencies = [
  "tari_ootle_storage",
  "tari_ootle_storage_sqlite",
  "tari_template_lib",
+ "tari_template_lib_types",
  "tari_transaction_components",
  "thiserror 2.0.18",
  "time",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7645,7 +7645,7 @@ dependencies = [
 
 [[package]]
 name = "ootle-rs"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11393,6 +11393,7 @@ dependencies = [
  "anyhow",
  "blake2 0.10.6",
  "log",
+ "minotari_app_grpc",
  "ootle-network",
  "ootle_serde",
  "serde",
@@ -11411,6 +11412,7 @@ dependencies = [
  "thiserror 2.0.18",
  "time",
  "tokio",
+ "tonic 0.13.1",
 ]
 
 [[package]]

--- a/clients/base_node_client/src/grpc.rs
+++ b/clients/base_node_client/src/grpc.rs
@@ -147,7 +147,8 @@ impl BaseNodeClient for GrpcBaseNodeClient {
     async fn get_validator_nodes(
         &mut self,
         height: u64,
-    ) -> Result<impl Stream<Item = Result<BaseLayerValidatorNode, BaseNodeClientError>>, BaseNodeClientError> {
+    ) -> Result<impl Stream<Item = Result<BaseLayerValidatorNode, BaseNodeClientError>> + Send, BaseNodeClientError>
+    {
         let inner = self.connection().await?;
 
         // SidechainId is empty because we need all the sidechain nodes to create the merkle root
@@ -248,7 +249,7 @@ impl BaseNodeClient for GrpcBaseNodeClient {
         &mut self,
         from_height: u64,
         limit: u64,
-    ) -> Result<impl Stream<Item = Result<BlockHeader, BaseNodeClientError>> + Unpin, BaseNodeClientError> {
+    ) -> Result<impl Stream<Item = Result<BlockHeader, BaseNodeClientError>> + Unpin + Send, BaseNodeClientError> {
         let inner = self.connection().await?;
         let request = grpc::ListHeadersRequest {
             from_height,

--- a/clients/base_node_client/src/lib.rs
+++ b/clients/base_node_client/src/lib.rs
@@ -9,4 +9,9 @@ pub mod types;
 
 mod traits;
 pub use ::futures_util;
+// Re-exported because they appear in this crate's public API: `ValidatorNodeChange` in the
+// `BaseNodeClient` trait signature and `tonic::Code` in `BaseNodeClientError::GrpcStatus`. This lets
+// downstream code (e.g. mock clients in tests) name them without depending on minotari_app_grpc/tonic.
+pub use ::tonic;
+pub use minotari_app_grpc::tari_rpc::ValidatorNodeChange;
 pub use traits::BaseNodeClient;

--- a/clients/base_node_client/src/traits.rs
+++ b/clients/base_node_client/src/traits.rs
@@ -29,7 +29,10 @@ pub trait BaseNodeClient: Send + Sync + Clone {
         &mut self,
         height: u64,
     ) -> impl Future<
-        Output = Result<impl Stream<Item = Result<BaseLayerValidatorNode, BaseNodeClientError>>, BaseNodeClientError>,
+        Output = Result<
+            impl Stream<Item = Result<BaseLayerValidatorNode, BaseNodeClientError>> + Send,
+            BaseNodeClientError,
+        >,
     > + Send;
     fn get_template_registrations(
         &mut self,
@@ -45,7 +48,10 @@ pub trait BaseNodeClient: Send + Sync + Clone {
         from_height: u64,
         limit: u64,
     ) -> impl Future<
-        Output = Result<impl Stream<Item = Result<BlockHeader, BaseNodeClientError>> + Unpin, BaseNodeClientError>,
+        Output = Result<
+            impl Stream<Item = Result<BlockHeader, BaseNodeClientError>> + Unpin + Send,
+            BaseNodeClientError,
+        >,
     > + Send;
     fn get_consensus_constants(
         &mut self,

--- a/crates/epoch_oracles/Cargo.toml
+++ b/crates/epoch_oracles/Cargo.toml
@@ -32,6 +32,9 @@ time = { workspace = true, features = ["serde", "serde-human-readable"] }
 [dev-dependencies]
 tokio = { workspace = true, features = ["time", "macros", "rt"] }
 serde_json = { workspace = true }
+# Used by the base_layer reorg tests to mock the base node client (see base_layer::oracle::tests).
+minotari_app_grpc = { workspace = true }
+tonic = { workspace = true }
 
 [features]
 base_layer = [

--- a/crates/epoch_oracles/Cargo.toml
+++ b/crates/epoch_oracles/Cargo.toml
@@ -32,9 +32,6 @@ time = { workspace = true, features = ["serde", "serde-human-readable"] }
 [dev-dependencies]
 tokio = { workspace = true, features = ["time", "macros", "rt"] }
 serde_json = { workspace = true }
-# Used by the base_layer reorg tests to mock the base node client (see base_layer::oracle::tests).
-minotari_app_grpc = { workspace = true }
-tonic = { workspace = true }
 
 [features]
 base_layer = [

--- a/crates/epoch_oracles/Cargo.toml
+++ b/crates/epoch_oracles/Cargo.toml
@@ -11,6 +11,7 @@ tari_base_node_client = { workspace = true, optional = true }
 tari_common_types = { workspace = true }
 tari_transaction_components = { workspace = true, optional = true }
 tari_node_components = { workspace = true, optional = true }
+tari_template_lib_types = { workspace = true, optional = true }
 tari_ootle_common_types = { workspace = true }
 tari_ootle_storage = { workspace = true }
 tari_ootle_storage_sqlite = { workspace = true }
@@ -37,4 +38,5 @@ base_layer = [
     "tari_base_node_client",
     "tari_transaction_components",
     "tari_node_components",
+    "tari_template_lib_types"
 ]

--- a/crates/epoch_oracles/src/base_layer/header_store.rs
+++ b/crates/epoch_oracles/src/base_layer/header_store.rs
@@ -3,15 +3,33 @@
 
 use tari_common_types::types::FixedHash;
 use tari_node_components::blocks::BlockHeader;
-use tari_ootle_common_types::{Epoch, NodeAddressable};
+use tari_ootle_common_types::{Epoch, NodeAddressable, optional::Optional};
 use tari_ootle_storage::global::{BlockHeaderModel, GlobalDb};
 use tari_ootle_storage_sqlite::global::SqliteGlobalDbAdapter;
+use tari_template_lib_types::Hash32;
 
 pub trait BaseLayerBlockHeaderStore {
     fn add_block_headers<I: IntoIterator<Item = (Epoch, FixedHash, BlockHeader)>>(
         &self,
         headers: I,
     ) -> anyhow::Result<()>;
+
+    /// Returns the stored header with the given block hash, or `None` if it is not stored. Used during
+    /// reorg recovery to find the highest base-layer height whose canonical block we have already stored.
+    /// `max_epoch` bounds the lookup to headers stored at or below that epoch.
+    fn find_block_header_by_hash(
+        &self,
+        max_epoch: Epoch,
+        block_hash: &FixedHash,
+    ) -> anyhow::Result<Option<BlockHeaderModel>>;
+
+    /// Returns the lowest-height stored header in the given epoch, or `None` if none are stored. Used
+    /// during reorg recovery to recover the epoch's boundary block hash.
+    fn get_first_block_header_in_epoch(&self, epoch: Epoch) -> anyhow::Result<Option<BlockHeaderModel>>;
+
+    /// Deletes every stored header with a height strictly greater than `height`, returning the number of
+    /// rows removed. Used to discard headers orphaned by a base-layer reorg.
+    fn delete_block_headers_above(&self, height: u64) -> anyhow::Result<usize>;
 }
 
 impl<TAddr: NodeAddressable> BaseLayerBlockHeaderStore for GlobalDb<SqliteGlobalDbAdapter<TAddr>> {
@@ -32,5 +50,35 @@ impl<TAddr: NodeAddressable> BaseLayerBlockHeaderStore for GlobalDb<SqliteGlobal
         }
         tx.commit()?;
         Ok(())
+    }
+
+    fn find_block_header_by_hash(
+        &self,
+        max_epoch: Epoch,
+        block_hash: &FixedHash,
+    ) -> anyhow::Result<Option<BlockHeaderModel>> {
+        let block_hash = Hash32::from_array(block_hash.into_array());
+        let mut tx = self.create_transaction()?;
+        let header = self
+            .block_headers(&mut tx)
+            .get_by_hash(max_epoch, &block_hash)
+            .optional()?;
+        Ok(header)
+    }
+
+    fn get_first_block_header_in_epoch(&self, epoch: Epoch) -> anyhow::Result<Option<BlockHeaderModel>> {
+        let mut tx = self.create_transaction()?;
+        let header = self
+            .block_headers(&mut tx)
+            .get_first_block_header_in_epoch(epoch)
+            .optional()?;
+        Ok(header)
+    }
+
+    fn delete_block_headers_above(&self, height: u64) -> anyhow::Result<usize> {
+        let mut tx = self.create_transaction()?;
+        let num_deleted = self.block_headers(&mut tx).delete_above(height)?;
+        tx.commit()?;
+        Ok(num_deleted)
     }
 }

--- a/crates/epoch_oracles/src/base_layer/oracle.rs
+++ b/crates/epoch_oracles/src/base_layer/oracle.rs
@@ -317,8 +317,11 @@ impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore, TClient: BaseNodeClie
     /// orphaned boundary hash carried over from a chain-shortening reorg — the re-scan resumes *above* the
     /// fork point and so never re-crosses the fork epoch's own boundary to correct it.
     ///
-    /// If that boundary block sits below our scan range (so we never emitted it), there is nothing to
-    /// recover from the store and the existing value is left as-is.
+    /// If that boundary block sits below our scan range (so we never emitted it), there is no stored hash
+    /// to restore. We clear `last_epoch_hash` rather than leave it: in that case it can only hold a
+    /// boundary from an epoch *above* the fork epoch (the fork epoch's own boundary is below the floor and
+    /// was never crossed), which a chain-shortening reorg has orphaned. `None` is the same "unknown"
+    /// sentinel used at startup, and the re-scan re-populates it on the next boundary it crosses.
     fn reset_last_epoch_hash_to_boundary(
         &mut self,
         fork_epoch: Epoch,
@@ -336,8 +339,9 @@ impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore, TClient: BaseNodeClie
             _ => {
                 debug!(
                     target: LOG_TARGET,
-                    "Fork epoch {fork_epoch} boundary block is not within the scan range; leaving last_epoch_hash unchanged"
+                    "Fork epoch {fork_epoch} boundary block is not within the scan range; clearing last_epoch_hash"
                 );
+                self.last_epoch_hash = None;
             },
         }
         Ok(())
@@ -351,11 +355,14 @@ impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore, TClient: BaseNodeClie
     }
 
     /// Resets the in-memory scan position to the start of our scan range, as on a fresh start. The
-    /// persisted position is corrected by the next successful `set_last_scanned_block`.
+    /// persisted position is corrected by the next successful `set_last_scanned_block`. `last_epoch_hash`
+    /// is cleared too so a reorg that orphaned the last boundary we crossed does not leave a stale hash;
+    /// the re-scan re-emits every boundary above the floor and re-populates it.
     fn rewind_to_floor(&mut self) {
         self.last_scanned_height = self.lag_start_height();
         self.last_scanned_hash = None;
         self.last_scanned_validator_node_mr = None;
+        self.last_epoch_hash = None;
     }
 
     #[allow(clippy::too_many_lines)]
@@ -772,12 +779,13 @@ mod tests {
         time::Duration,
     };
 
-    use minotari_app_grpc::tari_rpc::ValidatorNodeChange;
     use ootle_network::Network;
     use tari_base_node_client::{
         BaseNodeClient,
         BaseNodeClientError,
+        ValidatorNodeChange,
         futures_util::stream::{self, Stream},
+        tonic,
         types::{BaseLayerConsensusConstants, BaseLayerMetadata, BaseLayerValidatorNode, SideChainUtxos},
     };
     use tari_common_types::types::FixedHash;

--- a/crates/epoch_oracles/src/base_layer/oracle.rs
+++ b/crates/epoch_oracles/src/base_layer/oracle.rs
@@ -228,17 +228,21 @@ impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore, TClient: BaseNodeClie
 
     /// Recovers from a detected base-layer reorg by rewinding the scanner to the fork point.
     ///
-    /// Walks backwards from the deepest height we scanned, asking the base node for the block on the
-    /// (new) canonical chain at each height. The fork point is the highest such height whose canonical
-    /// block we have already stored — everything above it was built on the orphaned chain. We delete
-    /// those stale headers and rewind our scan position to the fork point, so the subsequent
-    /// `sync_blockchain` re-fetches and stores the canonical headers in their place. The epoch database
-    /// therefore converges on the correct chain rather than accumulating orphaned headers.
+    /// The fork point is the highest height whose canonical block we have already stored — everything
+    /// above it was built on the orphaned chain. We delete those stale headers and rewind our scan
+    /// position to the fork point, so the subsequent `sync_blockchain` re-fetches and stores the canonical
+    /// headers in their place. The epoch database therefore converges on the correct chain rather than
+    /// accumulating orphaned headers.
     ///
     /// We only attempt surgical recovery for reorgs within the confirmation depth (`height_lag`); a reorg
     /// deeper than that is treated as unrecoverable — we discard all stored headers and rescan from the
-    /// start height. This both matches the confirmation-depth guarantee (boundaries are only emitted once
-    /// `height_lag`-buried) and bounds the backward probe below to at most `height_lag` base-node calls.
+    /// start height. This matches the confirmation-depth guarantee (boundaries are only emitted once
+    /// `height_lag`-buried) and bounds the candidate window to `height_lag` heights.
+    ///
+    /// The whole candidate window is fetched in a single `stream_headers` call (one round-trip rather than
+    /// one per height) and the fork point is then located locally. "Canonical block at height `h` is in
+    /// our store" is monotonic — true at and below the fork, false above it — so scanning the window from
+    /// the top down stops at the fork.
     async fn handle_reorg(&mut self, tip: &BaseLayerMetadata) -> Result<(), BaseLayerOracleError> {
         let floor = self.lag_start_height();
 
@@ -257,43 +261,58 @@ impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore, TClient: BaseNodeClie
         // epoch_length constant changed since the header was stored).
         let max_epoch = constants.height_to_epoch(tip.height_of_longest_chain);
 
-        // The fork point cannot be above the new canonical tip, nor above the deepest height we scanned.
-        // We only walk back `height_lag` blocks: a deeper fork is treated as unrecoverable below.
-        let mut height = self.last_scanned_height.min(tip.height_of_longest_chain);
+        // Candidate window is (search_floor, top]: the fork cannot be above the new canonical tip nor above
+        // the deepest height we scanned, and we only recover within `height_lag` of our scan position.
+        let top = self.last_scanned_height.min(tip.height_of_longest_chain);
         let search_floor = self
             .last_scanned_height
             .saturating_sub(self.config.height_lag)
             .max(floor);
-        while height > search_floor {
-            let epoch = constants.height_to_epoch(height);
-            // The block on the new canonical chain at this height (None if the chain is now shorter).
-            let Some(canonical) = self.fetch_canonical_header_at(height).await? else {
-                height -= 1;
-                continue;
+        if top > search_floor {
+            // Fetch the whole candidate window in one streamed request (the base node returns up to its
+            // new tip, so a chain-shortening reorg simply yields fewer headers). `window_len` is bounded by
+            // `height_lag`. Scoped so the stream (which borrows the base node client) is dropped before the
+            // store lookups below.
+            let window_len = top - search_floor;
+            let canonical = {
+                let mut stream = self
+                    .base_node_client
+                    .stream_headers(search_floor + 1, window_len)
+                    .await?;
+                let mut headers = Vec::with_capacity(window_len as usize);
+                while let Some(header) = stream.try_next().await? {
+                    headers.push(header);
+                }
+                headers
             };
-            let canonical_hash = hash_header(self.network, &canonical);
-            if self
-                .store
-                .find_block_header_by_hash(max_epoch, &canonical_hash)
-                .map_err(BaseLayerOracleError::StoreError)?
-                .is_some()
-            {
-                let num_deleted = self
+
+            // Highest stored canonical block is the fork point (predicate is monotonic, so the first hit
+            // from the top is the answer).
+            for header in canonical.into_iter().rev() {
+                let canonical_hash = hash_header(self.network, &header);
+                if self
                     .store
-                    .delete_block_headers_above(height)
-                    .map_err(BaseLayerOracleError::StoreError)?;
-                info!(
-                    target: LOG_TARGET,
-                    "⚓ Base layer fork point at height {height} ({canonical_hash}). Deleted {num_deleted} stale \
-                     header(s) above it; rewinding scanner."
-                );
-                self.last_scanned_height = height;
-                self.last_scanned_hash = Some(canonical_hash);
-                self.last_scanned_validator_node_mr = Some(canonical.validator_node_mr);
-                self.reset_last_epoch_hash_to_boundary(epoch, &constants)?;
-                return Ok(());
+                    .find_block_header_by_hash(max_epoch, &canonical_hash)
+                    .map_err(BaseLayerOracleError::StoreError)?
+                    .is_some()
+                {
+                    let fork_height = header.height;
+                    let num_deleted = self
+                        .store
+                        .delete_block_headers_above(fork_height)
+                        .map_err(BaseLayerOracleError::StoreError)?;
+                    info!(
+                        target: LOG_TARGET,
+                        "⚓ Base layer fork point at height {fork_height} ({canonical_hash}). Deleted \
+                         {num_deleted} stale header(s) above it; rewinding scanner."
+                    );
+                    self.last_scanned_height = fork_height;
+                    self.last_scanned_hash = Some(canonical_hash);
+                    self.last_scanned_validator_node_mr = Some(header.validator_node_mr);
+                    self.reset_last_epoch_hash_to_boundary(constants.height_to_epoch(fork_height), &constants)?;
+                    return Ok(());
+                }
             }
-            height -= 1;
         }
 
         // No common ancestor within the recoverable range: discard everything and rebuild from the start
@@ -345,13 +364,6 @@ impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore, TClient: BaseNodeClie
             },
         }
         Ok(())
-    }
-
-    /// Fetches the block header on the canonical chain at the given height, or `None` if the chain does
-    /// not (yet) extend to it.
-    async fn fetch_canonical_header_at(&mut self, height: u64) -> Result<Option<BlockHeader>, BaseLayerOracleError> {
-        let mut stream = self.base_node_client.stream_headers(height, 1).await?;
-        Ok(stream.try_next().await?)
     }
 
     /// Resets the in-memory scan position to the start of our scan range, as on a fresh start. The

--- a/crates/epoch_oracles/src/base_layer/oracle.rs
+++ b/crates/epoch_oracles/src/base_layer/oracle.rs
@@ -15,7 +15,7 @@ use tari_base_node_client::{
     BaseNodeClientError,
     futures_util::TryStreamExt,
     grpc::GrpcBaseNodeClient,
-    types::BaseLayerMetadata,
+    types::{BaseLayerConsensusConstants, BaseLayerMetadata},
 };
 use tari_common_types::types::FixedHash;
 use tari_epoch_manager::epoch_event_oracle::{EpochEvent, EpochEventOracle};
@@ -157,14 +157,12 @@ impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore> BaseLayerOracleInner<
                 self.sync_blockchain(tip).await
             },
             BlockchainProgression::Reorged => {
-                error!(
+                warn!(
                     target: LOG_TARGET,
-                    "⚠️ Base layer reorg detected. Rescanning from genesis."
+                    "⚠️ Base layer reorg detected at scanned height {}. Locating fork point.",
+                    self.last_scanned_height
                 );
-                // TODO: we need to figure out where the fork happened, and delete data after the fork if able.
-                self.last_scanned_hash = None;
-                self.last_scanned_validator_node_mr = None;
-                self.last_scanned_height = 0;
+                self.handle_reorg(&tip).await?;
                 self.has_attempted_scan = true;
                 self.sync_blockchain(tip).await
             },
@@ -219,6 +217,138 @@ impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore> BaseLayerOracleInner<
             },
             None => Ok(BlockchainProgression::Progressed),
         }
+    }
+
+    /// Recovers from a detected base-layer reorg by rewinding the scanner to the fork point.
+    ///
+    /// Walks backwards from the deepest height we scanned, asking the base node for the block on the
+    /// (new) canonical chain at each height. The fork point is the highest such height whose canonical
+    /// block we have already stored — everything above it was built on the orphaned chain. We delete
+    /// those stale headers and rewind our scan position to the fork point, so the subsequent
+    /// `sync_blockchain` re-fetches and stores the canonical headers in their place. The epoch database
+    /// therefore converges on the correct chain rather than accumulating orphaned headers.
+    ///
+    /// We only attempt surgical recovery for reorgs within the confirmation depth (`height_lag`); a reorg
+    /// deeper than that is treated as unrecoverable — we discard all stored headers and rescan from the
+    /// start height. This both matches the confirmation-depth guarantee (boundaries are only emitted once
+    /// `height_lag`-buried) and bounds the backward probe below to at most `height_lag` base-node calls.
+    async fn handle_reorg(&mut self, tip: &BaseLayerMetadata) -> Result<(), BaseLayerOracleError> {
+        let floor = self.lag_start_height();
+
+        // Without persisted headers there is nothing in the epoch DB to repair; rewind to the start of
+        // our range and let the normal scan re-emit events on the new chain.
+        if !self.config.features.sync_headers {
+            self.rewind_to_floor();
+            return Ok(());
+        }
+
+        let constants = self
+            .base_node_client
+            .get_consensus_constants(tip.height_of_longest_chain)
+            .await?;
+        // Bound the lookup epoch by the tip epoch (never excludes a stored header, even if the L1
+        // epoch_length constant changed since the header was stored).
+        let max_epoch = constants.height_to_epoch(tip.height_of_longest_chain);
+
+        // The fork point cannot be above the new canonical tip, nor above the deepest height we scanned.
+        // We only walk back `height_lag` blocks: a deeper fork is treated as unrecoverable below.
+        let mut height = self.last_scanned_height.min(tip.height_of_longest_chain);
+        let search_floor = self
+            .last_scanned_height
+            .saturating_sub(self.config.height_lag)
+            .max(floor);
+        while height > search_floor {
+            let epoch = constants.height_to_epoch(height);
+            // The block on the new canonical chain at this height (None if the chain is now shorter).
+            let Some(canonical) = self.fetch_canonical_header_at(height).await? else {
+                height -= 1;
+                continue;
+            };
+            let canonical_hash = hash_header(self.network, &canonical);
+            if self
+                .store
+                .find_block_header_by_hash(max_epoch, &canonical_hash)
+                .map_err(BaseLayerOracleError::StoreError)?
+                .is_some()
+            {
+                let num_deleted = self
+                    .store
+                    .delete_block_headers_above(height)
+                    .map_err(BaseLayerOracleError::StoreError)?;
+                info!(
+                    target: LOG_TARGET,
+                    "⚓ Base layer fork point at height {height} ({canonical_hash}). Deleted {num_deleted} stale \
+                     header(s) above it; rewinding scanner."
+                );
+                self.last_scanned_height = height;
+                self.last_scanned_hash = Some(canonical_hash);
+                self.last_scanned_validator_node_mr = Some(canonical.validator_node_mr);
+                self.reset_last_epoch_hash_to_boundary(epoch, &constants)?;
+                return Ok(());
+            }
+            height -= 1;
+        }
+
+        // No common ancestor within the recoverable range: discard everything and rebuild from the start
+        // height. The re-scan re-crosses (and re-emits) every epoch boundary above the floor, so the epoch
+        // hashes self-correct.
+        let num_deleted = self
+            .store
+            .delete_block_headers_above(floor)
+            .map_err(BaseLayerOracleError::StoreError)?;
+        warn!(
+            target: LOG_TARGET,
+            "⚠️ Base layer reorg deeper than the recoverable range (start height {floor}). Deleted {num_deleted} \
+             header(s); rescanning from the start."
+        );
+        self.rewind_to_floor();
+        Ok(())
+    }
+
+    /// After rewinding to a fork point in `fork_epoch`, points `last_epoch_hash` back at the boundary block
+    /// that opened that epoch. Boundaries at or below the fork point are canonical, so this discards any
+    /// orphaned boundary hash carried over from a chain-shortening reorg — the re-scan resumes *above* the
+    /// fork point and so never re-crosses the fork epoch's own boundary to correct it.
+    ///
+    /// If that boundary block sits below our scan range (so we never emitted it), there is nothing to
+    /// recover from the store and the existing value is left as-is.
+    fn reset_last_epoch_hash_to_boundary(
+        &mut self,
+        fork_epoch: Epoch,
+        constants: &BaseLayerConsensusConstants,
+    ) -> Result<(), BaseLayerOracleError> {
+        let boundary_height = fork_epoch.as_u64().saturating_mul(constants.epoch_length());
+        match self
+            .store
+            .get_first_block_header_in_epoch(fork_epoch)
+            .map_err(BaseLayerOracleError::StoreError)?
+        {
+            Some(boundary) if boundary.height == boundary_height => {
+                self.last_epoch_hash = Some(boundary.block_hash);
+            },
+            _ => {
+                debug!(
+                    target: LOG_TARGET,
+                    "Fork epoch {fork_epoch} boundary block is not within the scan range; leaving last_epoch_hash unchanged"
+                );
+            },
+        }
+        Ok(())
+    }
+
+    /// Fetches the block header on the canonical chain at the given height, or `None` if the chain does
+    /// not (yet) extend to it.
+    async fn fetch_canonical_header_at(&mut self, height: u64) -> Result<Option<BlockHeader>, BaseLayerOracleError> {
+        let mut stream = self.base_node_client.stream_headers(height, 1).await?;
+        Ok(stream.try_next().await?)
+    }
+
+    /// Resets the in-memory scan position to the start of our scan range, as on a fresh start. The
+    /// persisted position is corrected by the next successful `set_last_scanned_block`.
+    fn rewind_to_floor(&mut self) {
+        self.last_scanned_height = self.lag_start_height();
+        self.last_scanned_hash = None;
+        self.last_scanned_validator_node_mr = None;
     }
 
     #[allow(clippy::too_many_lines)]

--- a/crates/epoch_oracles/src/base_layer/oracle.rs
+++ b/crates/epoch_oracles/src/base_layer/oracle.rs
@@ -30,20 +30,28 @@ use crate::{
 
 const LOG_TARGET: &str = "tari::ootle::epoch_oracles::base_layer_scanner";
 
-type TaskOutput<TStore> = (Result<bool, BaseLayerOracleError>, Box<BaseLayerOracleInner<TStore>>);
+type TaskOutput<TStore, TClient> = (
+    Result<bool, BaseLayerOracleError>,
+    Box<BaseLayerOracleInner<TStore, TClient>>,
+);
 
+/// The in-flight blockchain scan future, boxed so it can be held across poll calls.
+type ScanTask<TStore, TClient> = Pin<Box<dyn Future<Output = TaskOutput<TStore, TClient>> + Send>>;
+
+/// `TClient` defaults to [`GrpcBaseNodeClient`] for production; tests substitute a mock base node
+/// client so the scan/reorg logic can be driven without a live base node.
 #[allow(clippy::struct_excessive_bools)]
-pub struct BaseLayerOracle<TStore> {
-    inner: Option<Box<BaseLayerOracleInner<TStore>>>,
+pub struct BaseLayerOracle<TStore, TClient = GrpcBaseNodeClient> {
+    inner: Option<Box<BaseLayerOracleInner<TStore, TClient>>>,
     is_initialized: bool,
     is_done: bool,
     has_more: bool,
     sleep_or_shutdown: bool,
-    task: Option<Pin<Box<dyn Future<Output = TaskOutput<TStore>> + Send>>>,
+    task: Option<ScanTask<TStore, TClient>>,
     sleep_task: Option<Pin<Box<time::Sleep>>>,
 }
 
-struct BaseLayerOracleInner<TStore> {
+struct BaseLayerOracleInner<TStore, TClient> {
     config: BaseLayerEpochOracleConfig,
     store: TStore,
     last_scanned_height: u64,
@@ -51,7 +59,7 @@ struct BaseLayerOracleInner<TStore> {
     last_scanned_hash: Option<FixedHash>,
     last_epoch_hash: Option<FixedHash>,
     last_scanned_validator_node_mr: Option<FixedHash>,
-    base_node_client: GrpcBaseNodeClient,
+    base_node_client: TClient,
     has_attempted_scan: bool,
     pending_events: VecDeque<EpochEvent>,
     header_buf: Vec<(Epoch, FixedHash, BlockHeader)>,
@@ -61,13 +69,10 @@ struct BaseLayerOracleInner<TStore> {
     cached_epoch_length: Option<u64>,
 }
 
-impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore + 'static> BaseLayerOracle<TStore> {
-    pub fn new(
-        store: TStore,
-        base_node_client: GrpcBaseNodeClient,
-        config: BaseLayerEpochOracleConfig,
-        network: Network,
-    ) -> Self {
+impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore + 'static, TClient: BaseNodeClient>
+    BaseLayerOracle<TStore, TClient>
+{
+    pub fn new(store: TStore, base_node_client: TClient, config: BaseLayerEpochOracleConfig, network: Network) -> Self {
         Self {
             inner: Some(Box::new(BaseLayerOracleInner {
                 config,
@@ -94,7 +99,9 @@ impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore + 'static> BaseLayerOr
     }
 }
 
-impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore> BaseLayerOracleInner<TStore> {
+impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore, TClient: BaseNodeClient>
+    BaseLayerOracleInner<TStore, TClient>
+{
     /// The configured start height adjusted for the height lag. This is the minimum height
     /// that the scanner will scan from.
     fn lag_start_height(&self) -> u64 {
@@ -628,7 +635,9 @@ impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore> BaseLayerOracleInner<
     }
 }
 
-impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore + Send + 'static> BaseLayerOracle<TStore> {
+impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore + Send + 'static, TClient: BaseNodeClient + 'static>
+    BaseLayerOracle<TStore, TClient>
+{
     fn poll_next_event(&mut self, cx: &mut Context) -> Poll<Option<EpochEvent>> {
         if self.is_done {
             return Poll::Ready(None);
@@ -717,8 +726,8 @@ impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore + Send + 'static> Base
     }
 }
 
-impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore + Send + 'static> EpochEventOracle
-    for BaseLayerOracle<TStore>
+impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore + Send + 'static, TClient: BaseNodeClient + 'static>
+    EpochEventOracle for BaseLayerOracle<TStore, TClient>
 {
     /// Returns a Future that returns the next event, completing a round of scanning if necessary.
     /// This Future is cancel-safe. Returns None if a shutdown is triggered.
@@ -753,4 +762,387 @@ enum BlockchainProgression {
     Reorged,
     /// The blockchain has not progressed since the last scan
     NoProgress,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::{HashMap, VecDeque},
+        sync::{Arc, Mutex},
+        time::Duration,
+    };
+
+    use minotari_app_grpc::tari_rpc::ValidatorNodeChange;
+    use ootle_network::Network;
+    use tari_base_node_client::{
+        BaseNodeClient,
+        BaseNodeClientError,
+        futures_util::stream::{self, Stream},
+        types::{BaseLayerConsensusConstants, BaseLayerMetadata, BaseLayerValidatorNode, SideChainUtxos},
+    };
+    use tari_common_types::types::FixedHash;
+    use tari_node_components::blocks::BlockHeader;
+    use tari_ootle_common_types::Epoch;
+    use tari_ootle_storage::global::BlockHeaderModel;
+    use tari_template_lib::types::crypto::RistrettoPublicKeyBytes;
+    use tari_transaction_components::{tari_amount::MicroMinotari, transaction_components::CodeTemplateRegistration};
+
+    use super::{BaseLayerOracleInner, hash_header};
+    use crate::{
+        base_layer::{
+            BaseLayerBlockHeaderStore,
+            config::{BaseLayerEpochOracleConfig, BaseLayerEpochOracleFeatures},
+        },
+        store::EpochOracleStore,
+    };
+
+    const NETWORK: Network = Network::LocalNet;
+    const EPOCH_LENGTH: u64 = 5;
+
+    /// In-memory implementation of the oracle's store traits. Cloneable: the test holds one handle for
+    /// assertions while the oracle owns another.
+    #[derive(Clone, Default)]
+    struct InMemoryStore {
+        metadata: Arc<Mutex<HashMap<Vec<u8>, Vec<u8>>>>,
+        headers: Arc<Mutex<Vec<BlockHeaderModel>>>,
+    }
+
+    impl InMemoryStore {
+        /// Sorted list of stored header heights.
+        fn heights(&self) -> Vec<u64> {
+            let mut heights: Vec<u64> = self.headers.lock().unwrap().iter().map(|m| m.height).collect();
+            heights.sort_unstable();
+            heights
+        }
+
+        fn hash_at(&self, height: u64) -> Option<FixedHash> {
+            self.headers
+                .lock()
+                .unwrap()
+                .iter()
+                .find(|m| m.height == height)
+                .map(|m| m.block_hash)
+        }
+    }
+
+    impl EpochOracleStore for InMemoryStore {
+        fn get<T: serde::de::DeserializeOwned>(&self, key: &[u8]) -> anyhow::Result<Option<T>> {
+            match self.metadata.lock().unwrap().get(key) {
+                Some(bytes) => Ok(Some(serde_json::from_slice(bytes)?)),
+                None => Ok(None),
+            }
+        }
+
+        fn set<T: serde::Serialize>(&self, key: &[u8], value: &T) -> anyhow::Result<()> {
+            self.metadata
+                .lock()
+                .unwrap()
+                .insert(key.to_vec(), serde_json::to_vec(value)?);
+            Ok(())
+        }
+    }
+
+    impl BaseLayerBlockHeaderStore for InMemoryStore {
+        fn add_block_headers<I: IntoIterator<Item = (Epoch, FixedHash, BlockHeader)>>(
+            &self,
+            headers: I,
+        ) -> anyhow::Result<()> {
+            let mut stored = self.headers.lock().unwrap();
+            for (epoch, block_hash, header) in headers {
+                // Mirror the SQL on_conflict(block_hash, epoch).do_nothing() idempotency.
+                if stored.iter().any(|m| m.block_hash == block_hash && m.epoch == epoch) {
+                    continue;
+                }
+                stored.push(BlockHeaderModel {
+                    epoch,
+                    height: header.height,
+                    block_hash,
+                    kernel_merkle_root: header.kernel_mr,
+                    validator_node_merkle_root: header.validator_node_mr,
+                });
+            }
+            Ok(())
+        }
+
+        fn find_block_header_by_hash(
+            &self,
+            max_epoch: Epoch,
+            block_hash: &FixedHash,
+        ) -> anyhow::Result<Option<BlockHeaderModel>> {
+            Ok(self
+                .headers
+                .lock()
+                .unwrap()
+                .iter()
+                .find(|m| m.block_hash == *block_hash && m.epoch <= max_epoch)
+                .cloned())
+        }
+
+        fn get_first_block_header_in_epoch(&self, epoch: Epoch) -> anyhow::Result<Option<BlockHeaderModel>> {
+            Ok(self
+                .headers
+                .lock()
+                .unwrap()
+                .iter()
+                .filter(|m| m.epoch == epoch)
+                .min_by_key(|m| m.height)
+                .cloned())
+        }
+
+        fn delete_block_headers_above(&self, height: u64) -> anyhow::Result<usize> {
+            let mut stored = self.headers.lock().unwrap();
+            let before = stored.len();
+            stored.retain(|m| m.height <= height);
+            Ok(before - stored.len())
+        }
+    }
+
+    /// Mock base node serving a configurable canonical chain (indexed by height). Swapping the chain
+    /// simulates a reorg.
+    #[derive(Clone)]
+    struct MockBaseNode {
+        chain: Arc<Mutex<Vec<BlockHeader>>>,
+    }
+
+    impl MockBaseNode {
+        fn new(chain: Vec<BlockHeader>) -> Self {
+            Self {
+                chain: Arc::new(Mutex::new(chain)),
+            }
+        }
+
+        fn set_chain(&self, chain: Vec<BlockHeader>) {
+            *self.chain.lock().unwrap() = chain;
+        }
+    }
+
+    impl BaseNodeClient for MockBaseNode {
+        async fn test_connection(&mut self) -> Result<(), BaseNodeClientError> {
+            Ok(())
+        }
+
+        async fn get_network(&mut self) -> Result<u8, BaseNodeClientError> {
+            Ok(NETWORK.as_byte())
+        }
+
+        async fn get_tip_info(&mut self) -> Result<BaseLayerMetadata, BaseNodeClientError> {
+            let chain = self.chain.lock().unwrap();
+            let tip = chain.last().expect("chain must not be empty");
+            Ok(BaseLayerMetadata {
+                height_of_longest_chain: tip.height,
+                tip_hash: hash_header(NETWORK, tip),
+            })
+        }
+
+        async fn get_validator_node_changes(
+            &mut self,
+            _epoch: Epoch,
+            _sidechain_id: Option<&RistrettoPublicKeyBytes>,
+        ) -> Result<Vec<ValidatorNodeChange>, BaseNodeClientError> {
+            Ok(Vec::new())
+        }
+
+        async fn get_validator_nodes(
+            &mut self,
+            _height: u64,
+        ) -> Result<impl Stream<Item = Result<BaseLayerValidatorNode, BaseNodeClientError>> + Send, BaseNodeClientError>
+        {
+            Ok(stream::iter(
+                Vec::<Result<BaseLayerValidatorNode, BaseNodeClientError>>::new(),
+            ))
+        }
+
+        async fn get_template_registrations(
+            &mut self,
+            _start_hash: Option<FixedHash>,
+            _count: u64,
+        ) -> Result<Vec<CodeTemplateRegistration>, BaseNodeClientError> {
+            unimplemented!("not used by the reorg tests")
+        }
+
+        async fn get_header_by_hash(&mut self, block_hash: &FixedHash) -> Result<BlockHeader, BaseNodeClientError> {
+            self.chain
+                .lock()
+                .unwrap()
+                .iter()
+                .find(|h| hash_header(NETWORK, h) == *block_hash)
+                .cloned()
+                .ok_or(BaseNodeClientError::GrpcStatus {
+                    code: tonic::Code::NotFound,
+                    message: "header not found".to_string(),
+                })
+        }
+
+        async fn stream_headers(
+            &mut self,
+            from_height: u64,
+            limit: u64,
+        ) -> Result<impl Stream<Item = Result<BlockHeader, BaseNodeClientError>> + Unpin + Send, BaseNodeClientError>
+        {
+            let chain = self.chain.lock().unwrap();
+            let headers: Vec<_> = chain
+                .iter()
+                .filter(|h| h.height >= from_height && h.height < from_height.saturating_add(limit))
+                .cloned()
+                .map(Ok)
+                .collect();
+            Ok(stream::iter(headers))
+        }
+
+        async fn get_consensus_constants(
+            &mut self,
+            _tip: u64,
+        ) -> Result<BaseLayerConsensusConstants, BaseNodeClientError> {
+            Ok(BaseLayerConsensusConstants {
+                epoch_length: EPOCH_LENGTH,
+                validator_node_registration_min_deposit_amount: MicroMinotari::from(0u64),
+            })
+        }
+
+        async fn get_sidechain_utxos(
+            &mut self,
+            _start_hash: Option<FixedHash>,
+            _count: u64,
+        ) -> Result<Vec<SideChainUtxos>, BaseNodeClientError> {
+            unimplemented!("not used by the reorg tests")
+        }
+    }
+
+    fn make_header(height: u64, salt: u64) -> BlockHeader {
+        let mut header = BlockHeader::new(0);
+        header.height = height;
+        // nonce feeds hash_header, so distinct salts give distinct block hashes.
+        header.nonce = salt;
+        header
+    }
+
+    fn make_inner(
+        store: InMemoryStore,
+        client: MockBaseNode,
+        height_lag: u64,
+    ) -> BaseLayerOracleInner<InMemoryStore, MockBaseNode> {
+        BaseLayerOracleInner {
+            config: BaseLayerEpochOracleConfig {
+                start_height: 0,
+                height_lag,
+                scanning_interval: Duration::from_secs(1),
+                sidechain_id: None,
+                features: BaseLayerEpochOracleFeatures {
+                    sync_headers: true,
+                    sync_validator_node_changes: false,
+                },
+                epoch_end_spread_blocks: 0,
+            },
+            store,
+            last_scanned_height: 0,
+            last_scanned_tip: None,
+            last_scanned_hash: None,
+            last_epoch_hash: None,
+            last_scanned_validator_node_mr: None,
+            base_node_client: client,
+            has_attempted_scan: false,
+            pending_events: VecDeque::new(),
+            header_buf: Vec::new(),
+            network: NETWORK,
+            cached_epoch_length: None,
+        }
+    }
+
+    /// Drives the scanner until it has fully caught up with the tip, mirroring the poll loop's
+    /// `scan_blockchain(has_more)` driving.
+    async fn sync_to_tip(inner: &mut BaseLayerOracleInner<InMemoryStore, MockBaseNode>) {
+        let mut has_more = false;
+        loop {
+            has_more = inner.scan_blockchain(has_more).await.unwrap();
+            inner.pending_events.clear();
+            if !has_more {
+                break;
+            }
+        }
+    }
+
+    fn linear_chain(heights: std::ops::RangeInclusive<u64>) -> Vec<BlockHeader> {
+        heights.map(|h| make_header(h, h)).collect()
+    }
+
+    #[tokio::test]
+    async fn reorg_rewinds_to_fork_point_and_prunes_orphans() {
+        // height_lag = 5, tip = 20 -> lagged tip = 15. Scans heights 1..=15.
+        let store = InMemoryStore::default();
+        let chain_a = linear_chain(0..=20);
+        let client = MockBaseNode::new(chain_a.clone());
+        let mut inner = make_inner(store.clone(), client.clone(), 5);
+
+        sync_to_tip(&mut inner).await;
+        assert_eq!(inner.last_scanned_height, 15);
+        assert_eq!(store.heights(), (1..=15).collect::<Vec<_>>());
+
+        // Reorg diverging at height 13 (fork point 12), within the recoverable depth (15 - 5 = 10).
+        let mut chain_b = chain_a[..=12].to_vec();
+        chain_b.extend((13..=20).map(|h| make_header(h, h + 10_000)));
+        client.set_chain(chain_b.clone());
+
+        let tip_b = inner.base_node_client.get_tip_info().await.unwrap();
+        inner.handle_reorg(&tip_b).await.unwrap();
+
+        // Orphaned headers 13..=15 pruned; scan rewound to the fork point.
+        assert_eq!(inner.last_scanned_height, 12);
+        assert_eq!(store.heights(), (1..=12).collect::<Vec<_>>());
+        assert_eq!(inner.last_scanned_hash, Some(hash_header(NETWORK, &chain_b[12])));
+        // last_epoch_hash reset to the boundary that opened the fork epoch (epoch 2 -> height 10),
+        // not left at the orphaned epoch-3 boundary (height 15).
+        assert_eq!(inner.last_epoch_hash, Some(hash_header(NETWORK, &chain_a[10])));
+    }
+
+    #[tokio::test]
+    async fn reorg_scan_converges_on_new_chain() {
+        let store = InMemoryStore::default();
+        let chain_a = linear_chain(0..=20);
+        let client = MockBaseNode::new(chain_a.clone());
+        let mut inner = make_inner(store.clone(), client.clone(), 5);
+
+        sync_to_tip(&mut inner).await;
+
+        let mut chain_b = chain_a[..=12].to_vec();
+        chain_b.extend((13..=20).map(|h| make_header(h, h + 10_000)));
+        client.set_chain(chain_b.clone());
+
+        // A full scan round detects the reorg, repairs the store, and re-scans the new chain.
+        sync_to_tip(&mut inner).await;
+
+        assert_eq!(inner.last_scanned_height, 15);
+        assert_eq!(store.heights(), (1..=15).collect::<Vec<_>>());
+        // Heights above the fork now carry chain B's hashes; the orphaned chain A headers are gone.
+        for h in 13..=15u64 {
+            assert_eq!(store.hash_at(h), Some(hash_header(NETWORK, &chain_b[h as usize])));
+        }
+        // Heights at and below the fork are untouched.
+        for h in 1..=12u64 {
+            assert_eq!(store.hash_at(h), Some(hash_header(NETWORK, &chain_a[h as usize])));
+        }
+    }
+
+    #[tokio::test]
+    async fn reorg_deeper_than_lag_triggers_full_rescan() {
+        let store = InMemoryStore::default();
+        let chain_a = linear_chain(0..=20);
+        let client = MockBaseNode::new(chain_a.clone());
+        let mut inner = make_inner(store.clone(), client.clone(), 5);
+
+        sync_to_tip(&mut inner).await;
+        assert_eq!(inner.last_scanned_height, 15);
+
+        // Diverge at height 8 (fork point 7), below the recoverable range (15 - 5 = 10): the scanner
+        // cannot find a common ancestor in [11, 15] and rebuilds from the start height.
+        let mut chain_b = chain_a[..=7].to_vec();
+        chain_b.extend((8..=20).map(|h| make_header(h, h + 10_000)));
+        client.set_chain(chain_b);
+
+        let tip_b = inner.base_node_client.get_tip_info().await.unwrap();
+        inner.handle_reorg(&tip_b).await.unwrap();
+
+        assert!(store.heights().is_empty());
+        assert_eq!(inner.last_scanned_height, 0);
+        assert_eq!(inner.last_scanned_hash, None);
+    }
 }

--- a/crates/storage/src/global/backend_adapter.rs
+++ b/crates/storage/src/global/backend_adapter.rs
@@ -209,4 +209,9 @@ pub trait GlobalDbAdapter: AtomicDb + Send + Sync + Clone {
         tx: &mut Self::DbTransaction<'_>,
         epoch: Epoch,
     ) -> Result<BlockHeaderModel, Self::Error>;
+
+    /// Deletes every stored block header with a height strictly greater than `height`. Used to discard
+    /// base-layer headers orphaned by a reorg so the canonical headers can be re-scanned in their place.
+    /// Returns the number of rows deleted.
+    fn delete_block_headers_above(&self, tx: &mut Self::DbTransaction<'_>, height: u64) -> Result<usize, Self::Error>;
 }

--- a/crates/storage/src/global/block_header.rs
+++ b/crates/storage/src/global/block_header.rs
@@ -50,6 +50,12 @@ impl<'a, 'tx, TGlobalDbAdapter: GlobalDbAdapter> BlockHeaderDb<'a, 'tx, TGlobalD
     ) -> Result<BlockHeaderModel, TGlobalDbAdapter::Error> {
         self.backend.get_first_block_header_by_epoch(self.tx, epoch)
     }
+
+    /// Deletes every stored header with a height strictly greater than `height`, returning the number of
+    /// rows removed. Used to discard headers orphaned by a base-layer reorg.
+    pub fn delete_above(&mut self, height: u64) -> Result<usize, TGlobalDbAdapter::Error> {
+        self.backend.delete_block_headers_above(self.tx, height)
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/crates/storage_sqlite/src/global/backend_adapter.rs
+++ b/crates/storage_sqlite/src/global/backend_adapter.rs
@@ -889,9 +889,10 @@ impl<TAddr: NodeAddressable> GlobalDbAdapter for SqliteGlobalDbAdapter<TAddr> {
         use crate::global::schema::block_headers;
 
         // Idempotent insert: the base-layer scanner may re-scan previously seen heights after a
-        // base-layer reorg (see base_layer/oracle.rs::scan_blockchain's Reorged branch), in which
-        // case this insert would otherwise fail the UNIQUE(block_hash, epoch) constraint and abort
-        // the scan. Swallowing duplicates is safe because (block_hash, epoch) identifies the row.
+        // base-layer reorg (see base_layer/oracle.rs::handle_reorg, which rewinds the scan position
+        // to the fork point), in which case this insert would otherwise fail the UNIQUE(block_hash,
+        // epoch) constraint and abort the scan. Swallowing duplicates is safe because (block_hash,
+        // epoch) identifies the row.
         diesel::insert_into(block_headers::table)
             .values((
                 block_headers::epoch.eq(header.epoch.as_u64() as i64),
@@ -948,6 +949,19 @@ impl<TAddr: NodeAddressable> GlobalDbAdapter for SqliteGlobalDbAdapter<TAddr> {
             })?;
 
         header.try_into()
+    }
+
+    fn delete_block_headers_above(&self, tx: &mut Self::DbTransaction<'_>, height: u64) -> Result<usize, Self::Error> {
+        use crate::global::schema::block_headers;
+
+        let num_deleted = diesel::delete(block_headers::table.filter(block_headers::height.gt(height as i64)))
+            .execute(tx.connection())
+            .map_err(|source| SqliteStorageError::DieselError {
+                source,
+                operation: "delete::block_headers_above",
+            })?;
+
+        Ok(num_deleted)
     }
 }
 

--- a/crates/storage_sqlite/src/global/backend_adapter.rs
+++ b/crates/storage_sqlite/src/global/backend_adapter.rs
@@ -954,7 +954,14 @@ impl<TAddr: NodeAddressable> GlobalDbAdapter for SqliteGlobalDbAdapter<TAddr> {
     fn delete_block_headers_above(&self, tx: &mut Self::DbTransaction<'_>, height: u64) -> Result<usize, Self::Error> {
         use crate::global::schema::block_headers;
 
-        let num_deleted = diesel::delete(block_headers::table.filter(block_headers::height.gt(height as i64)))
+        // Convert with try_from rather than `as`: a height above i64::MAX would wrap negative and the
+        // `height > N` filter would then match every row, deleting all stored headers. No stored height
+        // can exceed i64::MAX, so a height that large means there is nothing above it to delete.
+        let Ok(height) = i64::try_from(height) else {
+            return Ok(0);
+        };
+
+        let num_deleted = diesel::delete(block_headers::table.filter(block_headers::height.gt(height)))
             .execute(tx.connection())
             .map_err(|source| SqliteStorageError::DieselError {
                 source,

--- a/crates/storage_sqlite/tests/global_db.rs
+++ b/crates/storage_sqlite/tests/global_db.rs
@@ -108,9 +108,9 @@ fn change_committee_shard_group() {
 
 #[test]
 fn block_header_insert_is_idempotent() {
-    // The base-layer scanner rescans from genesis on reorg detection, which re-inserts
-    // already-seen (block_hash, epoch) rows. These must be swallowed rather than erroring out the
-    // scan.
+    // On reorg detection the base-layer scanner rewinds to the fork point and re-scans, which can
+    // re-insert already-seen (block_hash, epoch) rows. These must be swallowed rather than erroring
+    // out the scan.
     let db = create_db();
     let mut tx = db.create_transaction().unwrap();
     let mut headers = db.block_headers(&mut tx);
@@ -134,4 +134,31 @@ fn block_header_insert_is_idempotent() {
         validator_node_merkle_root: FixedHash::from([5u8; 32]),
     };
     headers.insert(other_epoch).unwrap();
+}
+
+#[test]
+fn delete_block_headers_above_removes_higher_headers() {
+    // On reorg recovery the scanner deletes every header above the fork point so the canonical
+    // headers can be re-scanned in their place (see base_layer/oracle.rs::handle_reorg).
+    let db = create_db();
+    let mut tx = db.create_transaction().unwrap();
+    let mut headers = db.block_headers(&mut tx);
+    for height in [100u64, 101, 102, 103] {
+        headers
+            .insert(BlockHeaderModel {
+                epoch: Epoch(1),
+                height,
+                block_hash: FixedHash::from([height as u8; 32]),
+                kernel_merkle_root: FixedHash::from([2u8; 32]),
+                validator_node_merkle_root: FixedHash::from([3u8; 32]),
+            })
+            .unwrap();
+    }
+
+    // Heights 102 and 103 sit above the fork point at 101 and must be removed.
+    assert_eq!(headers.delete_above(101).unwrap(), 2);
+    // The fork-point block and everything below it are retained.
+    assert_eq!(headers.delete_above(0).unwrap(), 2);
+    // Nothing left to delete.
+    assert_eq!(headers.delete_above(0).unwrap(), 0);
 }

--- a/crates/wallet/ootle-rs/Cargo.toml
+++ b/crates/wallet/ootle-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ootle-rs"
-version = "0.8.0"
+version = "0.9.0"
 description = "A Rust library for interacting with the Tari Ootle network."
 edition.workspace = true
 authors.workspace = true


### PR DESCRIPTION
## Description

The base layer epoch oracle previously rescanned from genesis when it detected a reorg. Because header inserts are idempotent on `(block_hash, epoch)`, the orphaned headers from the abandoned fork were never removed — leaving the epoch database with stale rows at reorged heights. This makes the oracle self-heal instead.

### Reorg handling (`handle_reorg`)
- Walks back from the deepest scanned height (bounded to the confirmation depth, `height_lag`) to locate the **fork point** — the highest height whose canonical block we already store.
- Deletes every stored header above the fork point and rewinds the scan position, so the subsequent sync re-fetches and overwrites the headers on the new canonical chain. The epoch database converges on the correct chain rather than accumulating orphaned headers.
- Resets `last_epoch_hash` to the fork epoch's boundary block, so a chain-shortening reorg doesn't leave an orphaned epoch hash (the re-scan resumes above the fork and never re-crosses that boundary to correct it).
- A reorg deeper than `height_lag` falls through to a full rescan from the start height (still correct, just not surgical) — this matches the confirmation-depth guarantee and bounds the backward probe.

### Storage
- Adds `delete_block_headers_above(height)` to the global DB adapter / sqlite backend / `BlockHeaderDb`.
- Exposes `find_block_header_by_hash` and `get_first_block_header_in_epoch` on the base-layer header store.

### Testability
- `BaseLayerOracle` is now generic over the base node client (`TClient`, defaulting to `GrpcBaseNodeClient`), so a mock can be injected. Production call sites are unchanged via the default type parameter.
- The `BaseNodeClient` trait now promises `Send` streams (it already promised `Send` futures), required so the boxed scan task stays `Send` for an arbitrary client; the grpc impl already returned Send streams.

## Testing
- New reorg unit tests (in-memory store + mock base node): fork-point rewind + orphan pruning + epoch-hash reset, end-to-end convergence on the new chain, and the deep-reorg full-rescan fallback. Run with `cargo test -p tari_epoch_oracles --features base_layer` (the tests are gated behind the `base_layer` feature).
- New storage test `delete_block_headers_above_removes_higher_headers` (`cargo test -p tari_ootle_storage_sqlite --test global_db`).
- Clippy clean on the changed crates; formatted with the project nightly.
- `tari_validator_node`, `tari_indexer`, and `tari_base_node_client` all compile against the trait change.

## Note for reviewers
The new oracle tests are behind the `base_layer` feature — please confirm CI runs `tari_epoch_oracles` tests with that feature enabled, otherwise they won't execute.