### PR TITLE
fix(vn): don't return internal error from get_consensus_status on startup

### DIFF
--- a/applications/tari_validator_node/src/json_rpc/handlers.rs
+++ b/applications/tari_validator_node/src/json_rpc/handlers.rs
@@ -737,14 +737,10 @@ impl JsonRpcHandlers {
             .epoch_manager
             .get_local_committee_info(epoch)
             .await
-            .map(Some)
-            .or_else(|err| {
-                if err.is_not_registered_error() {
-                    Ok(None)
-                } else {
-                    Err(internal_error(answer_id.clone())(err))
-                }
-            })?;
+            // None when the VN is not registered or the epoch is not yet established (NoEpochFound
+            // during startup); a genuine error otherwise.
+            .optional()
+            .map_err(internal_error(answer_id.clone()))?;
         let height = self.consensus.current_view().get_height();
         let state = self.consensus.get_current_state();
         let state_versions = committee_info


### PR DESCRIPTION
## Problem

`get_consensus_status` mapped only `ValidatorNodeNotRegistered` errors to a "no committee" response and surfaced every other epoch-manager error as a `-32603` internal error:

```rust
.or_else(|err| {
    if err.is_not_registered_error() {
        Ok(None)
    } else {
        Err(internal_error(answer_id.clone())(err))
    }
})?;
```

During node startup the epoch manager has not yet established the current epoch, so `consensus.current_epoch()` is `Epoch(0)` and `get_local_committee_info(Epoch(0))` returns `EpochManagerError::NoEpochFound(Epoch(0))`. That variant is **not** matched by `is_not_registered_error()`, so it leaked out as:

```
RequestFailedWithStatus { code: -32603, message: "An internal error occurred: No epoch found Epoch(0)" }
```

This intermittently failed the `a network with registered validator` cucumber step: its `wait_for_consensus_to_start` loop unwraps the RPC response and panics on the transient startup error instead of retrying. (Observed as a flaky `Transfer tokens to account that does not previously exist` failure where the scenario died on its very first step.)

## Fix

Use the existing `.optional()` combinator, which maps any `IsNotFoundError` to `None` and leaves genuine errors as errors. `EpochManagerError::is_not_found_error()` is true for **both** `ValidatorNodeNotRegistered` and `NoEpochFound`, so this preserves the previous not-registered behaviour and additionally tolerates the `NoEpochFound` startup race — without broadening to unrelated error variants.

## Follow-up (not in this PR)

Two sibling call sites in the same file (around handlers.rs:555 and :574) still branch on `is_not_registered_error()` and have the same latent `NoEpochFound`-during-startup gap. Left out to keep this change focused on the reported failure; candidates for the same `.optional()` treatment in a follow-up.