### PR TITLE
chore(deps): pin tari/minotari L1 deps to v5.4.0-pre.1 git tag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6668,8 +6668,8 @@ dependencies = [
 
 [[package]]
 name = "minotari_app_grpc"
-version = "5.4.0-pre.0"
-source = "git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef#941dd8592993629bbb1d2cc9f0dca51689a4bfef"
+version = "5.4.0-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1#20172bdaf1b4c4a96048ebdadb4f289f6f32d3c0"
 dependencies = [
  "argon2 0.6.0-rc.8",
  "base64 0.22.1",
@@ -6699,8 +6699,8 @@ dependencies = [
 
 [[package]]
 name = "minotari_app_utilities"
-version = "5.4.0-pre.0"
-source = "git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef#941dd8592993629bbb1d2cc9f0dca51689a4bfef"
+version = "5.4.0-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1#20172bdaf1b4c4a96048ebdadb4f289f6f32d3c0"
 dependencies = [
  "clap 4.5.54",
  "dialoguer 0.10.4",
@@ -6722,8 +6722,8 @@ dependencies = [
 
 [[package]]
 name = "minotari_console_wallet"
-version = "5.4.0-pre.0"
-source = "git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef#941dd8592993629bbb1d2cc9f0dca51689a4bfef"
+version = "5.4.0-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1#20172bdaf1b4c4a96048ebdadb4f289f6f32d3c0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6759,7 +6759,7 @@ dependencies = [
  "tari_core",
  "tari_crypto",
  "tari_features",
- "tari_hashing 5.4.0-pre.0 (git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef)",
+ "tari_hashing 5.4.0-pre.1 (git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1)",
  "tari_p2p",
  "tari_script",
  "tari_shutdown",
@@ -6778,8 +6778,8 @@ dependencies = [
 
 [[package]]
 name = "minotari_ledger_wallet_common"
-version = "5.4.0-pre.0"
-source = "git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef#941dd8592993629bbb1d2cc9f0dca51689a4bfef"
+version = "5.4.0-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1#20172bdaf1b4c4a96048ebdadb4f289f6f32d3c0"
 dependencies = [
  "borsh",
  "bs58",
@@ -6788,8 +6788,8 @@ dependencies = [
 
 [[package]]
 name = "minotari_ledger_wallet_comms"
-version = "5.4.0-pre.0"
-source = "git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef#941dd8592993629bbb1d2cc9f0dca51689a4bfef"
+version = "5.4.0-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1#20172bdaf1b4c4a96048ebdadb4f289f6f32d3c0"
 dependencies = [
  "borsh",
  "dialoguer 0.11.0",
@@ -6810,8 +6810,8 @@ dependencies = [
 
 [[package]]
 name = "minotari_node"
-version = "5.4.0-pre.0"
-source = "git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef#941dd8592993629bbb1d2cc9f0dca51689a4bfef"
+version = "5.4.0-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1#20172bdaf1b4c4a96048ebdadb4f289f6f32d3c0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6869,16 +6869,16 @@ dependencies = [
 
 [[package]]
 name = "minotari_node_grpc_client"
-version = "5.4.0-pre.0"
-source = "git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef#941dd8592993629bbb1d2cc9f0dca51689a4bfef"
+version = "5.4.0-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1#20172bdaf1b4c4a96048ebdadb4f289f6f32d3c0"
 dependencies = [
  "minotari_app_grpc",
 ]
 
 [[package]]
 name = "minotari_node_wallet_client"
-version = "5.4.0-pre.0"
-source = "git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef#941dd8592993629bbb1d2cc9f0dca51689a4bfef"
+version = "5.4.0-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1#20172bdaf1b4c4a96048ebdadb4f289f6f32d3c0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6895,8 +6895,8 @@ dependencies = [
 
 [[package]]
 name = "minotari_wallet"
-version = "5.4.0-pre.0"
-source = "git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef#941dd8592993629bbb1d2cc9f0dca51689a4bfef"
+version = "5.4.0-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1#20172bdaf1b4c4a96048ebdadb4f289f6f32d3c0"
 dependencies = [
  "anyhow",
  "argon2 0.6.0-rc.8",
@@ -6932,7 +6932,7 @@ dependencies = [
  "tari_comms",
  "tari_comms_dht",
  "tari_crypto",
- "tari_hashing 5.4.0-pre.0 (git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef)",
+ "tari_hashing 5.4.0-pre.1 (git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1)",
  "tari_max_size",
  "tari_p2p",
  "tari_script",
@@ -6953,8 +6953,8 @@ dependencies = [
 
 [[package]]
 name = "minotari_wallet_grpc_client"
-version = "5.4.0-pre.0"
-source = "git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef#941dd8592993629bbb1d2cc9f0dca51689a4bfef"
+version = "5.4.0-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1#20172bdaf1b4c4a96048ebdadb4f289f6f32d3c0"
 dependencies = [
  "minotari_app_grpc",
  "tari_common",
@@ -11012,8 +11012,8 @@ dependencies = [
 
 [[package]]
 name = "tari_common"
-version = "5.4.0-pre.0"
-source = "git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef#941dd8592993629bbb1d2cc9f0dca51689a4bfef"
+version = "5.4.0-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1#20172bdaf1b4c4a96048ebdadb4f289f6f32d3c0"
 dependencies = [
  "anyhow",
  "cargo_toml 0.20.5",
@@ -11038,8 +11038,8 @@ dependencies = [
 
 [[package]]
 name = "tari_common_sqlite"
-version = "5.4.0-pre.0"
-source = "git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef#941dd8592993629bbb1d2cc9f0dca51689a4bfef"
+version = "5.4.0-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1#20172bdaf1b4c4a96048ebdadb4f289f6f32d3c0"
 dependencies = [
  "diesel",
  "diesel_migrations",
@@ -11055,8 +11055,8 @@ dependencies = [
 
 [[package]]
 name = "tari_common_types"
-version = "5.4.0-pre.0"
-source = "git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef#941dd8592993629bbb1d2cc9f0dca51689a4bfef"
+version = "5.4.0-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1#20172bdaf1b4c4a96048ebdadb4f289f6f32d3c0"
 dependencies = [
  "argon2 0.6.0-rc.8",
  "base64 0.22.1",
@@ -11082,7 +11082,7 @@ dependencies = [
  "subtle",
  "tari_common",
  "tari_crypto",
- "tari_hashing 5.4.0-pre.0 (git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef)",
+ "tari_hashing 5.4.0-pre.1 (git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1)",
  "tari_max_size",
  "tari_utilities",
  "thiserror 2.0.18",
@@ -11092,8 +11092,8 @@ dependencies = [
 
 [[package]]
 name = "tari_comms"
-version = "5.4.0-pre.0"
-source = "git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef#941dd8592993629bbb1d2cc9f0dca51689a4bfef"
+version = "5.4.0-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1#20172bdaf1b4c4a96048ebdadb4f289f6f32d3c0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11139,8 +11139,8 @@ dependencies = [
 
 [[package]]
 name = "tari_comms_dht"
-version = "5.4.0-pre.0"
-source = "git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef#941dd8592993629bbb1d2cc9f0dca51689a4bfef"
+version = "5.4.0-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1#20172bdaf1b4c4a96048ebdadb4f289f6f32d3c0"
 dependencies = [
  "anyhow",
  "bitflags 2.10.0",
@@ -11173,8 +11173,8 @@ dependencies = [
 
 [[package]]
 name = "tari_comms_rpc_macros"
-version = "5.4.0-pre.0"
-source = "git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef#941dd8592993629bbb1d2cc9f0dca51689a4bfef"
+version = "5.4.0-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1#20172bdaf1b4c4a96048ebdadb4f289f6f32d3c0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11218,7 +11218,7 @@ dependencies = [
  "tari_common_types",
  "tari_crypto",
  "tari_engine_types",
- "tari_hashing 5.4.0-pre.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tari_hashing 5.4.0-pre.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tari_ootle_common_types",
  "tari_sidechain",
  "tari_template_lib",
@@ -11227,8 +11227,8 @@ dependencies = [
 
 [[package]]
 name = "tari_core"
-version = "5.4.0-pre.0"
-source = "git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef#941dd8592993629bbb1d2cc9f0dca51689a4bfef"
+version = "5.4.0-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1#20172bdaf1b4c4a96048ebdadb4f289f6f32d3c0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11267,7 +11267,7 @@ dependencies = [
  "tari_comms_rpc_macros",
  "tari_crypto",
  "tari_features",
- "tari_hashing 5.4.0-pre.0 (git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef)",
+ "tari_hashing 5.4.0-pre.1 (git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1)",
  "tari_max_size",
  "tari_mmr",
  "tari_node_components",
@@ -11361,7 +11361,7 @@ dependencies = [
  "serde_json",
  "tari_bor",
  "tari_crypto",
- "tari_hashing 5.4.0-pre.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tari_hashing 5.4.0-pre.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tari_ootle_template_metadata",
  "tari_template_abi",
  "tari_template_lib",
@@ -11403,7 +11403,7 @@ dependencies = [
  "tari_base_node_client",
  "tari_common_types",
  "tari_epoch_manager",
- "tari_hashing 5.4.0-pre.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tari_hashing 5.4.0-pre.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tari_node_components",
  "tari_ootle_common_types",
  "tari_ootle_storage",
@@ -11418,14 +11418,14 @@ dependencies = [
 
 [[package]]
 name = "tari_features"
-version = "5.4.0-pre.0"
-source = "git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef#941dd8592993629bbb1d2cc9f0dca51689a4bfef"
+version = "5.4.0-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1#20172bdaf1b4c4a96048ebdadb4f289f6f32d3c0"
 
 [[package]]
 name = "tari_hashing"
-version = "5.4.0-pre.0"
+version = "5.4.0-pre.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00d8b3083ccdca440840e08cde7de9e4e483926802d6600f000bfc69a5f395e1"
+checksum = "8502889186caf458239f712c1efc20ac1ea80227ecc3c756b4c9937b20ec5277"
 dependencies = [
  "blake2 0.10.6",
  "borsh",
@@ -11435,8 +11435,8 @@ dependencies = [
 
 [[package]]
 name = "tari_hashing"
-version = "5.4.0-pre.0"
-source = "git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef#941dd8592993629bbb1d2cc9f0dca51689a4bfef"
+version = "5.4.0-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1#20172bdaf1b4c4a96048ebdadb4f289f6f32d3c0"
 dependencies = [
  "blake2 0.10.6",
  "borsh",
@@ -11562,15 +11562,15 @@ dependencies = [
 
 [[package]]
 name = "tari_jellyfish"
-version = "5.4.0-pre.0"
-source = "git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef#941dd8592993629bbb1d2cc9f0dca51689a4bfef"
+version = "5.4.0-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1#20172bdaf1b4c4a96048ebdadb4f289f6f32d3c0"
 dependencies = [
  "borsh",
  "digest 0.10.7",
  "indexmap 2.13.0",
  "serde",
  "tari_crypto",
- "tari_hashing 5.4.0-pre.0 (git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef)",
+ "tari_hashing 5.4.0-pre.1 (git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1)",
  "thiserror 2.0.18",
 ]
 
@@ -11600,8 +11600,8 @@ dependencies = [
 
 [[package]]
 name = "tari_libtor"
-version = "5.4.0-pre.0"
-source = "git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef#941dd8592993629bbb1d2cc9f0dca51689a4bfef"
+version = "5.4.0-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1#20172bdaf1b4c4a96048ebdadb4f289f6f32d3c0"
 dependencies = [
  "derivative",
  "libtor",
@@ -11614,8 +11614,8 @@ dependencies = [
 
 [[package]]
 name = "tari_max_size"
-version = "5.4.0-pre.0"
-source = "git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef#941dd8592993629bbb1d2cc9f0dca51689a4bfef"
+version = "5.4.0-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1#20172bdaf1b4c4a96048ebdadb4f289f6f32d3c0"
 dependencies = [
  "borsh",
  "serde",
@@ -11637,8 +11637,8 @@ dependencies = [
 
 [[package]]
 name = "tari_metrics"
-version = "5.4.0-pre.0"
-source = "git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef#941dd8592993629bbb1d2cc9f0dca51689a4bfef"
+version = "5.4.0-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1#20172bdaf1b4c4a96048ebdadb4f289f6f32d3c0"
 dependencies = [
  "once_cell",
  "prometheus",
@@ -11647,8 +11647,8 @@ dependencies = [
 
 [[package]]
 name = "tari_mmr"
-version = "5.4.0-pre.0"
-source = "git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef#941dd8592993629bbb1d2cc9f0dca51689a4bfef"
+version = "5.4.0-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1#20172bdaf1b4c4a96048ebdadb4f289f6f32d3c0"
 dependencies = [
  "borsh",
  "digest 0.10.7",
@@ -11677,8 +11677,8 @@ dependencies = [
 
 [[package]]
 name = "tari_node_components"
-version = "5.4.0-pre.0"
-source = "git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef#941dd8592993629bbb1d2cc9f0dca51689a4bfef"
+version = "5.4.0-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1#20172bdaf1b4c4a96048ebdadb4f289f6f32d3c0"
 dependencies = [
  "blake2 0.10.6",
  "borsh",
@@ -11689,7 +11689,7 @@ dependencies = [
  "primitive-types",
  "serde",
  "tari_common_types",
- "tari_hashing 5.4.0-pre.0 (git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef)",
+ "tari_hashing 5.4.0-pre.1 (git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1)",
  "tari_transaction_components",
  "tari_utilities",
  "thiserror 2.0.18",
@@ -11736,7 +11736,7 @@ dependencies = [
  "tari_engine",
  "tari_engine_types",
  "tari_epoch_oracles",
- "tari_hashing 5.4.0-pre.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tari_hashing 5.4.0-pre.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tari_mmr",
  "tari_networking",
  "tari_ootle_common_types",
@@ -11773,7 +11773,7 @@ dependencies = [
  "tari_bor",
  "tari_crypto",
  "tari_engine_types",
- "tari_hashing 5.4.0-pre.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tari_hashing 5.4.0-pre.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tari_ootle_template_metadata",
  "tari_template_lib_types",
  "thiserror 2.0.18",
@@ -11904,7 +11904,7 @@ dependencies = [
  "tari_bor",
  "tari_crypto",
  "tari_engine_types",
- "tari_hashing 5.4.0-pre.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tari_hashing 5.4.0-pre.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tari_ootle_common_types",
  "tari_ootle_template_metadata",
  "tari_template_lib_types",
@@ -11963,7 +11963,7 @@ dependencies = [
  "tari_bor",
  "tari_crypto",
  "tari_engine_types",
- "tari_hashing 5.4.0-pre.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tari_hashing 5.4.0-pre.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tari_ootle_common_types",
  "tari_template_lib_types",
  "tari_utilities",
@@ -12173,8 +12173,8 @@ dependencies = [
 
 [[package]]
 name = "tari_p2p"
-version = "5.4.0-pre.0"
-source = "git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef#941dd8592993629bbb1d2cc9f0dca51689a4bfef"
+version = "5.4.0-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1#20172bdaf1b4c4a96048ebdadb4f289f6f32d3c0"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -12255,8 +12255,8 @@ dependencies = [
 
 [[package]]
 name = "tari_script"
-version = "5.4.0-pre.0"
-source = "git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef#941dd8592993629bbb1d2cc9f0dca51689a4bfef"
+version = "5.4.0-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1#20172bdaf1b4c4a96048ebdadb4f289f6f32d3c0"
 dependencies = [
  "blake2 0.10.6",
  "borsh",
@@ -12273,8 +12273,8 @@ dependencies = [
 
 [[package]]
 name = "tari_service_framework"
-version = "5.4.0-pre.0"
-source = "git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef#941dd8592993629bbb1d2cc9f0dca51689a4bfef"
+version = "5.4.0-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1#20172bdaf1b4c4a96048ebdadb4f289f6f32d3c0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12288,16 +12288,16 @@ dependencies = [
 
 [[package]]
 name = "tari_shutdown"
-version = "5.4.0-pre.0"
-source = "git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef#941dd8592993629bbb1d2cc9f0dca51689a4bfef"
+version = "5.4.0-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1#20172bdaf1b4c4a96048ebdadb4f289f6f32d3c0"
 dependencies = [
  "futures 0.3.31",
 ]
 
 [[package]]
 name = "tari_sidechain"
-version = "5.4.0-pre.0"
-source = "git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef#941dd8592993629bbb1d2cc9f0dca51689a4bfef"
+version = "5.4.0-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1#20172bdaf1b4c4a96048ebdadb4f289f6f32d3c0"
 dependencies = [
  "borsh",
  "hex",
@@ -12305,7 +12305,7 @@ dependencies = [
  "serde",
  "tari_common_types",
  "tari_crypto",
- "tari_hashing 5.4.0-pre.0 (git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef)",
+ "tari_hashing 5.4.0-pre.1 (git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1)",
  "tari_jellyfish",
  "tari_utilities",
  "thiserror 2.0.18",
@@ -12361,8 +12361,8 @@ dependencies = [
 
 [[package]]
 name = "tari_storage"
-version = "5.4.0-pre.0"
-source = "git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef#941dd8592993629bbb1d2cc9f0dca51689a4bfef"
+version = "5.4.0-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1#20172bdaf1b4c4a96048ebdadb4f289f6f32d3c0"
 dependencies = [
  "bincode 1.3.3",
  "lmdb-zero",
@@ -12519,8 +12519,8 @@ dependencies = [
 
 [[package]]
 name = "tari_test_utils"
-version = "5.4.0-pre.0"
-source = "git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef#941dd8592993629bbb1d2cc9f0dca51689a4bfef"
+version = "5.4.0-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1#20172bdaf1b4c4a96048ebdadb4f289f6f32d3c0"
 dependencies = [
  "futures 0.3.31",
  "rand 0.10.1",
@@ -12531,8 +12531,8 @@ dependencies = [
 
 [[package]]
 name = "tari_transaction_components"
-version = "5.4.0-pre.0"
-source = "git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef#941dd8592993629bbb1d2cc9f0dca51689a4bfef"
+version = "5.4.0-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1#20172bdaf1b4c4a96048ebdadb4f289f6f32d3c0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -12564,7 +12564,7 @@ dependencies = [
  "tari_common",
  "tari_common_types",
  "tari_crypto",
- "tari_hashing 5.4.0-pre.0 (git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef)",
+ "tari_hashing 5.4.0-pre.1 (git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1)",
  "tari_max_size",
  "tari_script",
  "tari_sidechain",
@@ -12577,8 +12577,8 @@ dependencies = [
 
 [[package]]
 name = "tari_transaction_key_manager"
-version = "5.4.0-pre.0"
-source = "git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef#941dd8592993629bbb1d2cc9f0dca51689a4bfef"
+version = "5.4.0-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1#20172bdaf1b4c4a96048ebdadb4f289f6f32d3c0"
 dependencies = [
  "async-trait",
  "blake2 0.10.6",
@@ -12598,7 +12598,7 @@ dependencies = [
  "tari_common_sqlite",
  "tari_common_types",
  "tari_crypto",
- "tari_hashing 5.4.0-pre.0 (git+https://github.com/tari-project/tari.git?rev=941dd8592993629bbb1d2cc9f0dca51689a4bfef)",
+ "tari_hashing 5.4.0-pre.1 (git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1)",
  "tari_script",
  "tari_service_framework",
  "tari_transaction_components",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,34 +138,34 @@ tari_bor = { version = "0.14", path = "crates/tari_bor", default-features = fals
 ootle_byte_type = { path = "crates/ootle_byte_type", version = "0.8" }
 ootle_serde = { path = "crates/ootle_serde", version = "0.3" }
 
-# external minotari/tari dependencies
-minotari_app_grpc = { git = "https://github.com/tari-project/tari.git", rev = "941dd8592993629bbb1d2cc9f0dca51689a4bfef" }
-minotari_app_utilities = { git = "https://github.com/tari-project/tari.git", rev = "941dd8592993629bbb1d2cc9f0dca51689a4bfef" }
-minotari_node_grpc_client = { git = "https://github.com/tari-project/tari.git", rev = "941dd8592993629bbb1d2cc9f0dca51689a4bfef" }
-minotari_wallet_grpc_client = { git = "https://github.com/tari-project/tari.git", rev = "941dd8592993629bbb1d2cc9f0dca51689a4bfef" }
-tari_common = { git = "https://github.com/tari-project/tari.git", rev = "941dd8592993629bbb1d2cc9f0dca51689a4bfef", version = "5.4.0-pre.0" }
-tari_common_sqlite = { git = "https://github.com/tari-project/tari.git", rev = "941dd8592993629bbb1d2cc9f0dca51689a4bfef", version = "5.4.0-pre.0" }
-tari_common_types = { git = "https://github.com/tari-project/tari.git", rev = "941dd8592993629bbb1d2cc9f0dca51689a4bfef", version = "5.4.0-pre.0" }
-tari_jellyfish = { git = "https://github.com/tari-project/tari.git", rev = "941dd8592993629bbb1d2cc9f0dca51689a4bfef", version = "5.4.0-pre.0" }
-tari_metrics = { git = "https://github.com/tari-project/tari.git", rev = "941dd8592993629bbb1d2cc9f0dca51689a4bfef" }
-tari_mmr = { git = "https://github.com/tari-project/tari.git", rev = "941dd8592993629bbb1d2cc9f0dca51689a4bfef", version = "5.4.0-pre.0" }
-tari_node_components = { git = "https://github.com/tari-project/tari.git", rev = "941dd8592993629bbb1d2cc9f0dca51689a4bfef" }
-tari_shutdown = { git = "https://github.com/tari-project/tari.git", rev = "941dd8592993629bbb1d2cc9f0dca51689a4bfef" }
-tari_sidechain = { git = "https://github.com/tari-project/tari.git", rev = "941dd8592993629bbb1d2cc9f0dca51689a4bfef", version = "5.4.0-pre.0" }
-tari_transaction_components = { git = "https://github.com/tari-project/tari.git", rev = "941dd8592993629bbb1d2cc9f0dca51689a4bfef" }
-minotari_console_wallet = { git = "https://github.com/tari-project/tari.git", rev = "941dd8592993629bbb1d2cc9f0dca51689a4bfef" }
-minotari_node = { git = "https://github.com/tari-project/tari.git", rev = "941dd8592993629bbb1d2cc9f0dca51689a4bfef" }
-minotari_wallet = { git = "https://github.com/tari-project/tari.git", rev = "941dd8592993629bbb1d2cc9f0dca51689a4bfef" }
-tari_comms = { git = "https://github.com/tari-project/tari.git", rev = "941dd8592993629bbb1d2cc9f0dca51689a4bfef" }
-tari_comms_dht = { git = "https://github.com/tari-project/tari.git", rev = "941dd8592993629bbb1d2cc9f0dca51689a4bfef" }
-tari_p2p = { git = "https://github.com/tari-project/tari.git", rev = "941dd8592993629bbb1d2cc9f0dca51689a4bfef" }
+# external minotari/tari dependencies (pinned to the v5.4.0-pre.1 release tag)
+minotari_app_grpc = { git = "https://github.com/tari-project/tari.git", tag = "v5.4.0-pre.1" }
+minotari_app_utilities = { git = "https://github.com/tari-project/tari.git", tag = "v5.4.0-pre.1" }
+minotari_node_grpc_client = { git = "https://github.com/tari-project/tari.git", tag = "v5.4.0-pre.1" }
+minotari_wallet_grpc_client = { git = "https://github.com/tari-project/tari.git", tag = "v5.4.0-pre.1" }
+tari_common = { git = "https://github.com/tari-project/tari.git", tag = "v5.4.0-pre.1", version = "5.4.0-pre.1" }
+tari_common_sqlite = { git = "https://github.com/tari-project/tari.git", tag = "v5.4.0-pre.1", version = "5.4.0-pre.1" }
+tari_common_types = { git = "https://github.com/tari-project/tari.git", tag = "v5.4.0-pre.1", version = "5.4.0-pre.1" }
+tari_jellyfish = { git = "https://github.com/tari-project/tari.git", tag = "v5.4.0-pre.1", version = "5.4.0-pre.1" }
+tari_metrics = { git = "https://github.com/tari-project/tari.git", tag = "v5.4.0-pre.1" }
+tari_mmr = { git = "https://github.com/tari-project/tari.git", tag = "v5.4.0-pre.1", version = "5.4.0-pre.1" }
+tari_node_components = { git = "https://github.com/tari-project/tari.git", tag = "v5.4.0-pre.1" }
+tari_shutdown = { git = "https://github.com/tari-project/tari.git", tag = "v5.4.0-pre.1" }
+tari_sidechain = { git = "https://github.com/tari-project/tari.git", tag = "v5.4.0-pre.1", version = "5.4.0-pre.1" }
+tari_transaction_components = { git = "https://github.com/tari-project/tari.git", tag = "v5.4.0-pre.1" }
+minotari_console_wallet = { git = "https://github.com/tari-project/tari.git", tag = "v5.4.0-pre.1" }
+minotari_node = { git = "https://github.com/tari-project/tari.git", tag = "v5.4.0-pre.1" }
+minotari_wallet = { git = "https://github.com/tari-project/tari.git", tag = "v5.4.0-pre.1" }
+tari_comms = { git = "https://github.com/tari-project/tari.git", tag = "v5.4.0-pre.1" }
+tari_comms_dht = { git = "https://github.com/tari-project/tari.git", tag = "v5.4.0-pre.1" }
+tari_p2p = { git = "https://github.com/tari-project/tari.git", tag = "v5.4.0-pre.1" }
 
 tari_crypto = "0.23"
 tari_utilities = "0.10"
-tari_hashing = "5.4.0-pre.0"
+tari_hashing = "5.4.0-pre.1"
 
 ## Ledger
-minotari_ledger_wallet_common = { git = "https://github.com/tari-project/tari.git", rev = "941dd8592993629bbb1d2cc9f0dca51689a4bfef" }
+minotari_ledger_wallet_common = { git = "https://github.com/tari-project/tari.git", tag = "v5.4.0-pre.1" }
 ootle_ledger_common = { path = "crates/wallet/ledger/common", version = "0.1.0" }
 
 # networking crates
@@ -327,7 +327,7 @@ opt-level = 1
 ## Make a copy of this code, uncomment and replace account and my-branch with the name of your fork and the branch you want to temporarily use
 #[patch."https://github.com/tari-project/tari.git"]
 #minotari_app_grpc = { git = "https://github.com/account/tari.git", branch = "my-branch" }
-#minotari_wallet_grpc_client= { git = "https://github.com/account/tari.git", branch = "my-branch" }
+#minotari_wallet_grpc_client = { git = "https://github.com/account/tari.git", branch = "my-branch" }
 #minotari_node_grpc_client = { git = "https://github.com/account/tari.git", branch = "my-branch" }
 #tari_common = { git = "https://github.com/account/tari.git", branch = "my-branch" }
 #tari_common_types = { git = "https://github.com/account/tari.git", branch = "my-branch" }


### PR DESCRIPTION
## Description

Updates every external `tari` / `minotari` dependency from the floating git rev (`941dd8592993629bbb1d2cc9f0dca51689a4bfef`) to the `v5.4.0-pre.1` release tag, and bumps the matching version metadata to `5.4.0-pre.1`.

## Motivation

L1 was tagged `v5.4.0-pre.1`. A tag pin is auditable, reproducible, and ties the dependency set to a named release rather than an arbitrary commit on `development`.

## What changed

- All 21 `git = "…/tari.git", rev = "941dd859…"` entries → `git = "…/tari.git", tag = "v5.4.0-pre.1"`.
- `version` fields on `tari_common`, `tari_common_sqlite`, `tari_common_types`, `tari_jellyfish`, `tari_mmr`, `tari_sidechain` bumped from `5.4.0-pre.0` → `5.4.0-pre.1`.
- `tari_hashing` (crates.io) bumped `5.4.0-pre.0` → `5.4.0-pre.1`.
- `tari_crypto = "0.23"` and `tari_utilities = "0.10"` unchanged.
- `Cargo.lock` regenerated; single git source resolves to the tagged commit.
- `cargo check --workspace --all-targets` passes (0 errors).

## Why not crates.io

The 5.4.0-pre.1 L1 crates are published on crates.io, but `tari_common`'s build helper (`StaticApplicationInfo::get_version_number`) reads `[workspace.package].version` from the Cargo manifest it finds by walking up for a `.git` directory. cargo strips `[workspace.package]` on publish, so when a registry consumer's build script runs, the generated `APP_VERSION_NUMBER` is empty and `minotari_node::bootstrap.rs:152` panics at runtime with *"empty string, expected a semver version"*. Upstream fix tracked separately; this PR pins the tag in the meantime.
