### PR TITLE
feat(wallet): stealth-address claim key for L1 burn claims

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11718,6 +11718,7 @@ dependencies = [
  "anyhow",
  "bincode 2.0.1",
  "blake2 0.10.6",
+ "bounded-vec",
  "clap 3.2.25",
  "config",
  "dirs-next 2.0.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6669,7 +6669,7 @@ dependencies = [
 [[package]]
 name = "minotari_app_grpc"
 version = "5.4.0-pre.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1#20172bdaf1b4c4a96048ebdadb4f289f6f32d3c0"
+source = "git+https://github.com/tari-project/tari.git?rev=d17fac8e588c98820dff1250c4e00752545a6aed#d17fac8e588c98820dff1250c4e00752545a6aed"
 dependencies = [
  "argon2 0.6.0-rc.8",
  "base64 0.22.1",
@@ -6700,7 +6700,7 @@ dependencies = [
 [[package]]
 name = "minotari_app_utilities"
 version = "5.4.0-pre.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1#20172bdaf1b4c4a96048ebdadb4f289f6f32d3c0"
+source = "git+https://github.com/tari-project/tari.git?rev=d17fac8e588c98820dff1250c4e00752545a6aed#d17fac8e588c98820dff1250c4e00752545a6aed"
 dependencies = [
  "clap 4.5.54",
  "dialoguer 0.10.4",
@@ -6723,7 +6723,7 @@ dependencies = [
 [[package]]
 name = "minotari_console_wallet"
 version = "5.4.0-pre.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1#20172bdaf1b4c4a96048ebdadb4f289f6f32d3c0"
+source = "git+https://github.com/tari-project/tari.git?rev=d17fac8e588c98820dff1250c4e00752545a6aed#d17fac8e588c98820dff1250c4e00752545a6aed"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6759,7 +6759,7 @@ dependencies = [
  "tari_core",
  "tari_crypto",
  "tari_features",
- "tari_hashing 5.4.0-pre.1 (git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1)",
+ "tari_hashing 5.4.0-pre.1 (git+https://github.com/tari-project/tari.git?rev=d17fac8e588c98820dff1250c4e00752545a6aed)",
  "tari_p2p",
  "tari_script",
  "tari_shutdown",
@@ -6779,7 +6779,7 @@ dependencies = [
 [[package]]
 name = "minotari_ledger_wallet_common"
 version = "5.4.0-pre.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1#20172bdaf1b4c4a96048ebdadb4f289f6f32d3c0"
+source = "git+https://github.com/tari-project/tari.git?rev=d17fac8e588c98820dff1250c4e00752545a6aed#d17fac8e588c98820dff1250c4e00752545a6aed"
 dependencies = [
  "borsh",
  "bs58",
@@ -6789,7 +6789,7 @@ dependencies = [
 [[package]]
 name = "minotari_ledger_wallet_comms"
 version = "5.4.0-pre.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1#20172bdaf1b4c4a96048ebdadb4f289f6f32d3c0"
+source = "git+https://github.com/tari-project/tari.git?rev=d17fac8e588c98820dff1250c4e00752545a6aed#d17fac8e588c98820dff1250c4e00752545a6aed"
 dependencies = [
  "borsh",
  "dialoguer 0.11.0",
@@ -6811,7 +6811,7 @@ dependencies = [
 [[package]]
 name = "minotari_node"
 version = "5.4.0-pre.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1#20172bdaf1b4c4a96048ebdadb4f289f6f32d3c0"
+source = "git+https://github.com/tari-project/tari.git?rev=d17fac8e588c98820dff1250c4e00752545a6aed#d17fac8e588c98820dff1250c4e00752545a6aed"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6870,7 +6870,7 @@ dependencies = [
 [[package]]
 name = "minotari_node_grpc_client"
 version = "5.4.0-pre.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1#20172bdaf1b4c4a96048ebdadb4f289f6f32d3c0"
+source = "git+https://github.com/tari-project/tari.git?rev=d17fac8e588c98820dff1250c4e00752545a6aed#d17fac8e588c98820dff1250c4e00752545a6aed"
 dependencies = [
  "minotari_app_grpc",
 ]
@@ -6878,7 +6878,7 @@ dependencies = [
 [[package]]
 name = "minotari_node_wallet_client"
 version = "5.4.0-pre.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1#20172bdaf1b4c4a96048ebdadb4f289f6f32d3c0"
+source = "git+https://github.com/tari-project/tari.git?rev=d17fac8e588c98820dff1250c4e00752545a6aed#d17fac8e588c98820dff1250c4e00752545a6aed"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6896,7 +6896,7 @@ dependencies = [
 [[package]]
 name = "minotari_wallet"
 version = "5.4.0-pre.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1#20172bdaf1b4c4a96048ebdadb4f289f6f32d3c0"
+source = "git+https://github.com/tari-project/tari.git?rev=d17fac8e588c98820dff1250c4e00752545a6aed#d17fac8e588c98820dff1250c4e00752545a6aed"
 dependencies = [
  "anyhow",
  "argon2 0.6.0-rc.8",
@@ -6932,7 +6932,7 @@ dependencies = [
  "tari_comms",
  "tari_comms_dht",
  "tari_crypto",
- "tari_hashing 5.4.0-pre.1 (git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1)",
+ "tari_hashing 5.4.0-pre.1 (git+https://github.com/tari-project/tari.git?rev=d17fac8e588c98820dff1250c4e00752545a6aed)",
  "tari_max_size",
  "tari_p2p",
  "tari_script",
@@ -6954,7 +6954,7 @@ dependencies = [
 [[package]]
 name = "minotari_wallet_grpc_client"
 version = "5.4.0-pre.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1#20172bdaf1b4c4a96048ebdadb4f289f6f32d3c0"
+source = "git+https://github.com/tari-project/tari.git?rev=d17fac8e588c98820dff1250c4e00752545a6aed#d17fac8e588c98820dff1250c4e00752545a6aed"
 dependencies = [
  "minotari_app_grpc",
  "tari_common",
@@ -11013,7 +11013,7 @@ dependencies = [
 [[package]]
 name = "tari_common"
 version = "5.4.0-pre.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1#20172bdaf1b4c4a96048ebdadb4f289f6f32d3c0"
+source = "git+https://github.com/tari-project/tari.git?rev=d17fac8e588c98820dff1250c4e00752545a6aed#d17fac8e588c98820dff1250c4e00752545a6aed"
 dependencies = [
  "anyhow",
  "cargo_toml 0.20.5",
@@ -11039,7 +11039,7 @@ dependencies = [
 [[package]]
 name = "tari_common_sqlite"
 version = "5.4.0-pre.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1#20172bdaf1b4c4a96048ebdadb4f289f6f32d3c0"
+source = "git+https://github.com/tari-project/tari.git?rev=d17fac8e588c98820dff1250c4e00752545a6aed#d17fac8e588c98820dff1250c4e00752545a6aed"
 dependencies = [
  "diesel",
  "diesel_migrations",
@@ -11056,7 +11056,7 @@ dependencies = [
 [[package]]
 name = "tari_common_types"
 version = "5.4.0-pre.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1#20172bdaf1b4c4a96048ebdadb4f289f6f32d3c0"
+source = "git+https://github.com/tari-project/tari.git?rev=d17fac8e588c98820dff1250c4e00752545a6aed#d17fac8e588c98820dff1250c4e00752545a6aed"
 dependencies = [
  "argon2 0.6.0-rc.8",
  "base64 0.22.1",
@@ -11082,7 +11082,7 @@ dependencies = [
  "subtle",
  "tari_common",
  "tari_crypto",
- "tari_hashing 5.4.0-pre.1 (git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1)",
+ "tari_hashing 5.4.0-pre.1 (git+https://github.com/tari-project/tari.git?rev=d17fac8e588c98820dff1250c4e00752545a6aed)",
  "tari_max_size",
  "tari_utilities",
  "thiserror 2.0.18",
@@ -11093,7 +11093,7 @@ dependencies = [
 [[package]]
 name = "tari_comms"
 version = "5.4.0-pre.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1#20172bdaf1b4c4a96048ebdadb4f289f6f32d3c0"
+source = "git+https://github.com/tari-project/tari.git?rev=d17fac8e588c98820dff1250c4e00752545a6aed#d17fac8e588c98820dff1250c4e00752545a6aed"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11140,7 +11140,7 @@ dependencies = [
 [[package]]
 name = "tari_comms_dht"
 version = "5.4.0-pre.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1#20172bdaf1b4c4a96048ebdadb4f289f6f32d3c0"
+source = "git+https://github.com/tari-project/tari.git?rev=d17fac8e588c98820dff1250c4e00752545a6aed#d17fac8e588c98820dff1250c4e00752545a6aed"
 dependencies = [
  "anyhow",
  "bitflags 2.10.0",
@@ -11174,7 +11174,7 @@ dependencies = [
 [[package]]
 name = "tari_comms_rpc_macros"
 version = "5.4.0-pre.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1#20172bdaf1b4c4a96048ebdadb4f289f6f32d3c0"
+source = "git+https://github.com/tari-project/tari.git?rev=d17fac8e588c98820dff1250c4e00752545a6aed#d17fac8e588c98820dff1250c4e00752545a6aed"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11228,7 +11228,7 @@ dependencies = [
 [[package]]
 name = "tari_core"
 version = "5.4.0-pre.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1#20172bdaf1b4c4a96048ebdadb4f289f6f32d3c0"
+source = "git+https://github.com/tari-project/tari.git?rev=d17fac8e588c98820dff1250c4e00752545a6aed#d17fac8e588c98820dff1250c4e00752545a6aed"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11267,7 +11267,7 @@ dependencies = [
  "tari_comms_rpc_macros",
  "tari_crypto",
  "tari_features",
- "tari_hashing 5.4.0-pre.1 (git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1)",
+ "tari_hashing 5.4.0-pre.1 (git+https://github.com/tari-project/tari.git?rev=d17fac8e588c98820dff1250c4e00752545a6aed)",
  "tari_max_size",
  "tari_mmr",
  "tari_node_components",
@@ -11419,7 +11419,7 @@ dependencies = [
 [[package]]
 name = "tari_features"
 version = "5.4.0-pre.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1#20172bdaf1b4c4a96048ebdadb4f289f6f32d3c0"
+source = "git+https://github.com/tari-project/tari.git?rev=d17fac8e588c98820dff1250c4e00752545a6aed#d17fac8e588c98820dff1250c4e00752545a6aed"
 
 [[package]]
 name = "tari_hashing"
@@ -11436,7 +11436,7 @@ dependencies = [
 [[package]]
 name = "tari_hashing"
 version = "5.4.0-pre.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1#20172bdaf1b4c4a96048ebdadb4f289f6f32d3c0"
+source = "git+https://github.com/tari-project/tari.git?rev=d17fac8e588c98820dff1250c4e00752545a6aed#d17fac8e588c98820dff1250c4e00752545a6aed"
 dependencies = [
  "blake2 0.10.6",
  "borsh",
@@ -11563,14 +11563,14 @@ dependencies = [
 [[package]]
 name = "tari_jellyfish"
 version = "5.4.0-pre.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1#20172bdaf1b4c4a96048ebdadb4f289f6f32d3c0"
+source = "git+https://github.com/tari-project/tari.git?rev=d17fac8e588c98820dff1250c4e00752545a6aed#d17fac8e588c98820dff1250c4e00752545a6aed"
 dependencies = [
  "borsh",
  "digest 0.10.7",
  "indexmap 2.13.0",
  "serde",
  "tari_crypto",
- "tari_hashing 5.4.0-pre.1 (git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1)",
+ "tari_hashing 5.4.0-pre.1 (git+https://github.com/tari-project/tari.git?rev=d17fac8e588c98820dff1250c4e00752545a6aed)",
  "thiserror 2.0.18",
 ]
 
@@ -11601,7 +11601,7 @@ dependencies = [
 [[package]]
 name = "tari_libtor"
 version = "5.4.0-pre.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1#20172bdaf1b4c4a96048ebdadb4f289f6f32d3c0"
+source = "git+https://github.com/tari-project/tari.git?rev=d17fac8e588c98820dff1250c4e00752545a6aed#d17fac8e588c98820dff1250c4e00752545a6aed"
 dependencies = [
  "derivative",
  "libtor",
@@ -11615,7 +11615,7 @@ dependencies = [
 [[package]]
 name = "tari_max_size"
 version = "5.4.0-pre.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1#20172bdaf1b4c4a96048ebdadb4f289f6f32d3c0"
+source = "git+https://github.com/tari-project/tari.git?rev=d17fac8e588c98820dff1250c4e00752545a6aed#d17fac8e588c98820dff1250c4e00752545a6aed"
 dependencies = [
  "borsh",
  "serde",
@@ -11638,7 +11638,7 @@ dependencies = [
 [[package]]
 name = "tari_metrics"
 version = "5.4.0-pre.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1#20172bdaf1b4c4a96048ebdadb4f289f6f32d3c0"
+source = "git+https://github.com/tari-project/tari.git?rev=d17fac8e588c98820dff1250c4e00752545a6aed#d17fac8e588c98820dff1250c4e00752545a6aed"
 dependencies = [
  "once_cell",
  "prometheus",
@@ -11648,7 +11648,7 @@ dependencies = [
 [[package]]
 name = "tari_mmr"
 version = "5.4.0-pre.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1#20172bdaf1b4c4a96048ebdadb4f289f6f32d3c0"
+source = "git+https://github.com/tari-project/tari.git?rev=d17fac8e588c98820dff1250c4e00752545a6aed#d17fac8e588c98820dff1250c4e00752545a6aed"
 dependencies = [
  "borsh",
  "digest 0.10.7",
@@ -11678,7 +11678,7 @@ dependencies = [
 [[package]]
 name = "tari_node_components"
 version = "5.4.0-pre.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1#20172bdaf1b4c4a96048ebdadb4f289f6f32d3c0"
+source = "git+https://github.com/tari-project/tari.git?rev=d17fac8e588c98820dff1250c4e00752545a6aed#d17fac8e588c98820dff1250c4e00752545a6aed"
 dependencies = [
  "blake2 0.10.6",
  "borsh",
@@ -11689,7 +11689,7 @@ dependencies = [
  "primitive-types",
  "serde",
  "tari_common_types",
- "tari_hashing 5.4.0-pre.1 (git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1)",
+ "tari_hashing 5.4.0-pre.1 (git+https://github.com/tari-project/tari.git?rev=d17fac8e588c98820dff1250c4e00752545a6aed)",
  "tari_transaction_components",
  "tari_utilities",
  "thiserror 2.0.18",
@@ -12175,7 +12175,7 @@ dependencies = [
 [[package]]
 name = "tari_p2p"
 version = "5.4.0-pre.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1#20172bdaf1b4c4a96048ebdadb4f289f6f32d3c0"
+source = "git+https://github.com/tari-project/tari.git?rev=d17fac8e588c98820dff1250c4e00752545a6aed#d17fac8e588c98820dff1250c4e00752545a6aed"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -12257,7 +12257,7 @@ dependencies = [
 [[package]]
 name = "tari_script"
 version = "5.4.0-pre.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1#20172bdaf1b4c4a96048ebdadb4f289f6f32d3c0"
+source = "git+https://github.com/tari-project/tari.git?rev=d17fac8e588c98820dff1250c4e00752545a6aed#d17fac8e588c98820dff1250c4e00752545a6aed"
 dependencies = [
  "blake2 0.10.6",
  "borsh",
@@ -12275,7 +12275,7 @@ dependencies = [
 [[package]]
 name = "tari_service_framework"
 version = "5.4.0-pre.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1#20172bdaf1b4c4a96048ebdadb4f289f6f32d3c0"
+source = "git+https://github.com/tari-project/tari.git?rev=d17fac8e588c98820dff1250c4e00752545a6aed#d17fac8e588c98820dff1250c4e00752545a6aed"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12290,7 +12290,7 @@ dependencies = [
 [[package]]
 name = "tari_shutdown"
 version = "5.4.0-pre.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1#20172bdaf1b4c4a96048ebdadb4f289f6f32d3c0"
+source = "git+https://github.com/tari-project/tari.git?rev=d17fac8e588c98820dff1250c4e00752545a6aed#d17fac8e588c98820dff1250c4e00752545a6aed"
 dependencies = [
  "futures 0.3.31",
 ]
@@ -12298,7 +12298,7 @@ dependencies = [
 [[package]]
 name = "tari_sidechain"
 version = "5.4.0-pre.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1#20172bdaf1b4c4a96048ebdadb4f289f6f32d3c0"
+source = "git+https://github.com/tari-project/tari.git?rev=d17fac8e588c98820dff1250c4e00752545a6aed#d17fac8e588c98820dff1250c4e00752545a6aed"
 dependencies = [
  "borsh",
  "hex",
@@ -12306,7 +12306,7 @@ dependencies = [
  "serde",
  "tari_common_types",
  "tari_crypto",
- "tari_hashing 5.4.0-pre.1 (git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1)",
+ "tari_hashing 5.4.0-pre.1 (git+https://github.com/tari-project/tari.git?rev=d17fac8e588c98820dff1250c4e00752545a6aed)",
  "tari_jellyfish",
  "tari_utilities",
  "thiserror 2.0.18",
@@ -12363,7 +12363,7 @@ dependencies = [
 [[package]]
 name = "tari_storage"
 version = "5.4.0-pre.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1#20172bdaf1b4c4a96048ebdadb4f289f6f32d3c0"
+source = "git+https://github.com/tari-project/tari.git?rev=d17fac8e588c98820dff1250c4e00752545a6aed#d17fac8e588c98820dff1250c4e00752545a6aed"
 dependencies = [
  "bincode 1.3.3",
  "lmdb-zero",
@@ -12521,7 +12521,7 @@ dependencies = [
 [[package]]
 name = "tari_test_utils"
 version = "5.4.0-pre.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1#20172bdaf1b4c4a96048ebdadb4f289f6f32d3c0"
+source = "git+https://github.com/tari-project/tari.git?rev=d17fac8e588c98820dff1250c4e00752545a6aed#d17fac8e588c98820dff1250c4e00752545a6aed"
 dependencies = [
  "futures 0.3.31",
  "rand 0.10.1",
@@ -12533,7 +12533,7 @@ dependencies = [
 [[package]]
 name = "tari_transaction_components"
 version = "5.4.0-pre.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1#20172bdaf1b4c4a96048ebdadb4f289f6f32d3c0"
+source = "git+https://github.com/tari-project/tari.git?rev=d17fac8e588c98820dff1250c4e00752545a6aed#d17fac8e588c98820dff1250c4e00752545a6aed"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -12565,7 +12565,7 @@ dependencies = [
  "tari_common",
  "tari_common_types",
  "tari_crypto",
- "tari_hashing 5.4.0-pre.1 (git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1)",
+ "tari_hashing 5.4.0-pre.1 (git+https://github.com/tari-project/tari.git?rev=d17fac8e588c98820dff1250c4e00752545a6aed)",
  "tari_max_size",
  "tari_script",
  "tari_sidechain",
@@ -12579,7 +12579,7 @@ dependencies = [
 [[package]]
 name = "tari_transaction_key_manager"
 version = "5.4.0-pre.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1#20172bdaf1b4c4a96048ebdadb4f289f6f32d3c0"
+source = "git+https://github.com/tari-project/tari.git?rev=d17fac8e588c98820dff1250c4e00752545a6aed#d17fac8e588c98820dff1250c4e00752545a6aed"
 dependencies = [
  "async-trait",
  "blake2 0.10.6",
@@ -12599,7 +12599,7 @@ dependencies = [
  "tari_common_sqlite",
  "tari_common_types",
  "tari_crypto",
- "tari_hashing 5.4.0-pre.1 (git+https://github.com/tari-project/tari.git?tag=v5.4.0-pre.1)",
+ "tari_hashing 5.4.0-pre.1 (git+https://github.com/tari-project/tari.git?rev=d17fac8e588c98820dff1250c4e00752545a6aed)",
  "tari_script",
  "tari_service_framework",
  "tari_transaction_components",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,34 +138,35 @@ tari_bor = { version = "0.14", path = "crates/tari_bor", default-features = fals
 ootle_byte_type = { path = "crates/ootle_byte_type", version = "0.8" }
 ootle_serde = { path = "crates/ootle_serde", version = "0.3" }
 
-# external minotari/tari dependencies (pinned to the v5.4.0-pre.1 release tag)
-minotari_app_grpc = { git = "https://github.com/tari-project/tari.git", tag = "v5.4.0-pre.1" }
-minotari_app_utilities = { git = "https://github.com/tari-project/tari.git", tag = "v5.4.0-pre.1" }
-minotari_node_grpc_client = { git = "https://github.com/tari-project/tari.git", tag = "v5.4.0-pre.1" }
-minotari_wallet_grpc_client = { git = "https://github.com/tari-project/tari.git", tag = "v5.4.0-pre.1" }
-tari_common = { git = "https://github.com/tari-project/tari.git", tag = "v5.4.0-pre.1", version = "5.4.0-pre.1" }
-tari_common_sqlite = { git = "https://github.com/tari-project/tari.git", tag = "v5.4.0-pre.1", version = "5.4.0-pre.1" }
-tari_common_types = { git = "https://github.com/tari-project/tari.git", tag = "v5.4.0-pre.1", version = "5.4.0-pre.1" }
-tari_jellyfish = { git = "https://github.com/tari-project/tari.git", tag = "v5.4.0-pre.1", version = "5.4.0-pre.1" }
-tari_metrics = { git = "https://github.com/tari-project/tari.git", tag = "v5.4.0-pre.1" }
-tari_mmr = { git = "https://github.com/tari-project/tari.git", tag = "v5.4.0-pre.1", version = "5.4.0-pre.1" }
-tari_node_components = { git = "https://github.com/tari-project/tari.git", tag = "v5.4.0-pre.1" }
-tari_shutdown = { git = "https://github.com/tari-project/tari.git", tag = "v5.4.0-pre.1" }
-tari_sidechain = { git = "https://github.com/tari-project/tari.git", tag = "v5.4.0-pre.1", version = "5.4.0-pre.1" }
-tari_transaction_components = { git = "https://github.com/tari-project/tari.git", tag = "v5.4.0-pre.1" }
-minotari_console_wallet = { git = "https://github.com/tari-project/tari.git", tag = "v5.4.0-pre.1" }
-minotari_node = { git = "https://github.com/tari-project/tari.git", tag = "v5.4.0-pre.1" }
-minotari_wallet = { git = "https://github.com/tari-project/tari.git", tag = "v5.4.0-pre.1" }
-tari_comms = { git = "https://github.com/tari-project/tari.git", tag = "v5.4.0-pre.1" }
-tari_comms_dht = { git = "https://github.com/tari-project/tari.git", tag = "v5.4.0-pre.1" }
-tari_p2p = { git = "https://github.com/tari-project/tari.git", tag = "v5.4.0-pre.1" }
+# external minotari/tari dependencies (pinned to a post-v5.4.0-pre.1 commit carrying the L1 burn
+# stealth-claim fixes — bump back to a release tag once one cuts on top of this commit)
+minotari_app_grpc = { git = "https://github.com/tari-project/tari.git", rev = "d17fac8e588c98820dff1250c4e00752545a6aed" }
+minotari_app_utilities = { git = "https://github.com/tari-project/tari.git", rev = "d17fac8e588c98820dff1250c4e00752545a6aed" }
+minotari_node_grpc_client = { git = "https://github.com/tari-project/tari.git", rev = "d17fac8e588c98820dff1250c4e00752545a6aed" }
+minotari_wallet_grpc_client = { git = "https://github.com/tari-project/tari.git", rev = "d17fac8e588c98820dff1250c4e00752545a6aed" }
+tari_common = { git = "https://github.com/tari-project/tari.git", rev = "d17fac8e588c98820dff1250c4e00752545a6aed", version = "5.4.0-pre.1" }
+tari_common_sqlite = { git = "https://github.com/tari-project/tari.git", rev = "d17fac8e588c98820dff1250c4e00752545a6aed", version = "5.4.0-pre.1" }
+tari_common_types = { git = "https://github.com/tari-project/tari.git", rev = "d17fac8e588c98820dff1250c4e00752545a6aed", version = "5.4.0-pre.1" }
+tari_jellyfish = { git = "https://github.com/tari-project/tari.git", rev = "d17fac8e588c98820dff1250c4e00752545a6aed", version = "5.4.0-pre.1" }
+tari_metrics = { git = "https://github.com/tari-project/tari.git", rev = "d17fac8e588c98820dff1250c4e00752545a6aed" }
+tari_mmr = { git = "https://github.com/tari-project/tari.git", rev = "d17fac8e588c98820dff1250c4e00752545a6aed", version = "5.4.0-pre.1" }
+tari_node_components = { git = "https://github.com/tari-project/tari.git", rev = "d17fac8e588c98820dff1250c4e00752545a6aed" }
+tari_shutdown = { git = "https://github.com/tari-project/tari.git", rev = "d17fac8e588c98820dff1250c4e00752545a6aed" }
+tari_sidechain = { git = "https://github.com/tari-project/tari.git", rev = "d17fac8e588c98820dff1250c4e00752545a6aed", version = "5.4.0-pre.1" }
+tari_transaction_components = { git = "https://github.com/tari-project/tari.git", rev = "d17fac8e588c98820dff1250c4e00752545a6aed" }
+minotari_console_wallet = { git = "https://github.com/tari-project/tari.git", rev = "d17fac8e588c98820dff1250c4e00752545a6aed" }
+minotari_node = { git = "https://github.com/tari-project/tari.git", rev = "d17fac8e588c98820dff1250c4e00752545a6aed" }
+minotari_wallet = { git = "https://github.com/tari-project/tari.git", rev = "d17fac8e588c98820dff1250c4e00752545a6aed" }
+tari_comms = { git = "https://github.com/tari-project/tari.git", rev = "d17fac8e588c98820dff1250c4e00752545a6aed" }
+tari_comms_dht = { git = "https://github.com/tari-project/tari.git", rev = "d17fac8e588c98820dff1250c4e00752545a6aed" }
+tari_p2p = { git = "https://github.com/tari-project/tari.git", rev = "d17fac8e588c98820dff1250c4e00752545a6aed" }
 
 tari_crypto = "0.23"
 tari_utilities = "0.10"
 tari_hashing = "5.4.0-pre.1"
 
 ## Ledger
-minotari_ledger_wallet_common = { git = "https://github.com/tari-project/tari.git", tag = "v5.4.0-pre.1" }
+minotari_ledger_wallet_common = { git = "https://github.com/tari-project/tari.git", rev = "d17fac8e588c98820dff1250c4e00752545a6aed" }
 ootle_ledger_common = { path = "crates/wallet/ledger/common", version = "0.1.0" }
 
 # networking crates

--- a/applications/tari_ootle_app_utilities/Cargo.toml
+++ b/applications/tari_ootle_app_utilities/Cargo.toml
@@ -43,6 +43,9 @@ url = { workspace = true, features = ["serde"] }
 toml = { workspace = true }
 config = { workspace = true }
 
+[dev-dependencies]
+bounded-vec = { workspace = true }
+
 [features]
 p2p = ["tari_networking", "tari_ootle_p2p", "libp2p-identity", "multiaddr"]
 epoch_oracle = ["tari_epoch_oracles"]

--- a/applications/tari_ootle_app_utilities/src/claim_burn_proof_verifier.rs
+++ b/applications/tari_ootle_app_utilities/src/claim_burn_proof_verifier.rs
@@ -209,21 +209,25 @@ impl ClaimProofVerifier for KnowledgeProofVerifier {
     fn verify_claim_proof(
         &self,
         _epoch: Epoch,
-        claimant: &RistrettoPublicKeyBytes,
+        _claimant: &RistrettoPublicKeyBytes,
         claim: &MinotariBurnClaimProof,
     ) -> Result<(), String> {
         let MinotariBurnClaimProof {
             commitment,
             ownership_proof: proof_of_knowledge,
             value,
+            stealth_claim_public_key,
             ..
         } = claim;
 
+        // The L1 ownership-proof signature is bound to `C` (the stealth claim public key) carried
+        // in the proof, not to the L2 account's public key. The L2 caller's `_claimant` is unused
+        // here for that reason — kept on the trait to satisfy the runtime contract.
         // NOTE: .as_bytes() used because the tari_crypto borsh implementations serialize fixed length bytes as variable
         // length bytes of size 32
         let message = ownership_proof_hasher64(self.network)
             .chain(&commitment.as_bytes())
-            .chain(&claimant.as_bytes())
+            .chain(&stealth_claim_public_key.as_bytes())
             .finalize();
 
         let commitment = PedersenCommitment::convert_from_byte_type(commitment).map_err(|e| {
@@ -246,5 +250,98 @@ impl ClaimProofVerifier for KnowledgeProofVerifier {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ootle_byte_type::ToByteType;
+    use tari_crypto::{
+        commitment::HomomorphicCommitmentFactory,
+        keys::{PublicKey as _, SecretKey as _},
+        ristretto::{RistrettoPublicKey, RistrettoSchnorr, RistrettoSecretKey},
+    };
+    use tari_engine::traits::ClaimProofVerifier;
+    use tari_engine_types::{
+        confidential::{AbridgedTransactionKernel, EncodedMerkleProof, MinotariBurnClaimProof},
+        crypto::get_commitment_factory,
+    };
+    use tari_ootle_common_types::{Epoch, base_layer_hashing::ownership_proof_hasher64};
+    use tari_ootle_transaction::Network;
+    use tari_template_lib::types::crypto::{PedersenCommitmentBytes, RistrettoPublicKeyBytes, SchnorrSignatureBytes};
+
+    use super::KnowledgeProofVerifier;
+
+    /// Mints a `MinotariBurnClaimProof` with a valid `ownership_proof` Schnorr signature bound to
+    /// `stealth_claim_pk` (the key the proof commits to in `H(commitment ‖ stealth_claim_pk)`).
+    fn build_proof(network: Network, value: u64, stealth_claim_pk: RistrettoPublicKeyBytes) -> MinotariBurnClaimProof {
+        let mask = RistrettoSecretKey::random(&mut rand::rng());
+        let commitment = get_commitment_factory().commit_value(&mask, value);
+        let commitment_bytes = commitment.to_byte_type();
+
+        let message = ownership_proof_hasher64(network)
+            .chain(&commitment_bytes.as_bytes())
+            .chain(&stealth_claim_pk.as_bytes())
+            .finalize();
+        let signature = RistrettoSchnorr::sign(&mask, &message[..], &mut rand::rng()).expect("sign with random nonce");
+
+        // Dummy merkle proof / kernel — KnowledgeProofVerifier doesn't read them.
+        let encoded_merkle_proof = EncodedMerkleProof {
+            block_hash: Default::default(),
+            encoded_merkle_proof: bounded_vec::BoundedVec::<u8, 1, 4096>::from_vec(vec![0]).expect("valid bounded vec"),
+            leaf_index: 0,
+        };
+        let kernel = AbridgedTransactionKernel {
+            version: 0,
+            fee: 0,
+            lock_height: 0,
+            excess: PedersenCommitmentBytes::zero(),
+            excess_sig: SchnorrSignatureBytes::zero(),
+        };
+
+        MinotariBurnClaimProof {
+            burn_public_key: RistrettoPublicKeyBytes::zero(),
+            commitment: commitment_bytes,
+            ownership_proof: signature.to_byte_type(),
+            encoded_merkle_proof,
+            kernel,
+            value,
+            sender_offset_public_key: RistrettoPublicKeyBytes::zero(),
+            stealth_claim_public_key: stealth_claim_pk,
+        }
+    }
+
+    #[test]
+    fn verifies_against_stealth_claim_public_key_from_proof() {
+        let network = Network::LocalNet;
+        // C is the stealth claim public key — the verifier reads it directly from the proof,
+        // ignoring the caller-supplied claimant. For this test it doesn't have to be derived from
+        // any specific account.
+        let (_c_sec, c_pub) = RistrettoPublicKey::random_keypair(&mut rand::rng());
+        let (_account_sec, account_pub) = RistrettoPublicKey::random_keypair(&mut rand::rng());
+
+        let proof = build_proof(network, 2_000, c_pub.to_byte_type());
+        let verifier = KnowledgeProofVerifier::new(network);
+
+        // Passing the account pubkey here mirrors what the runtime does today; it must be ignored.
+        verifier
+            .verify_claim_proof(Epoch(0), &account_pub.to_byte_type(), &proof)
+            .expect("proof should verify against the C carried in it");
+    }
+
+    #[test]
+    fn rejects_signature_bound_to_wrong_key() {
+        let network = Network::LocalNet;
+        let (_c_sec, c_pub) = RistrettoPublicKey::random_keypair(&mut rand::rng());
+        let (_other_sec, other_pub) = RistrettoPublicKey::random_keypair(&mut rand::rng());
+        let (_account_sec, account_pub) = RistrettoPublicKey::random_keypair(&mut rand::rng());
+
+        // Sign against `other_pub` but advertise the proof as binding to `c_pub`.
+        let mut proof = build_proof(network, 3_000, other_pub.to_byte_type());
+        proof.stealth_claim_public_key = c_pub.to_byte_type();
+
+        let verifier = KnowledgeProofVerifier::new(network);
+        let result = verifier.verify_claim_proof(Epoch(0), &account_pub.to_byte_type(), &proof);
+        assert!(result.is_err(), "expected verification to reject mismatched binding");
     }
 }

--- a/applications/tari_ootle_app_utilities/src/claim_burn_proof_verifier.rs
+++ b/applications/tari_ootle_app_utilities/src/claim_burn_proof_verifier.rs
@@ -209,25 +209,24 @@ impl ClaimProofVerifier for KnowledgeProofVerifier {
     fn verify_claim_proof(
         &self,
         _epoch: Epoch,
-        _claimant: &RistrettoPublicKeyBytes,
+        claimant: &RistrettoPublicKeyBytes,
         claim: &MinotariBurnClaimProof,
     ) -> Result<(), String> {
         let MinotariBurnClaimProof {
             commitment,
             ownership_proof: proof_of_knowledge,
             value,
-            stealth_claim_public_key,
             ..
         } = claim;
 
-        // The L1 ownership-proof signature is bound to `C` (the stealth claim public key) carried
-        // in the proof, not to the L2 account's public key. The L2 caller's `_claimant` is unused
-        // here for that reason — kept on the trait to satisfy the runtime contract.
+        // `claimant` is the stealth claim public key `C = H(r·P)·G + P`. The runtime supplies it
+        // via `seal_signer_public_key`: the L2 wallet signs the claim transaction with
+        // `s = H(R·p) + p`, so the transaction's seal-signer pubkey is `s·G = C`.
         // NOTE: .as_bytes() used because the tari_crypto borsh implementations serialize fixed length bytes as variable
         // length bytes of size 32
         let message = ownership_proof_hasher64(self.network)
             .chain(&commitment.as_bytes())
-            .chain(&stealth_claim_public_key.as_bytes())
+            .chain(&claimant.as_bytes())
             .finalize();
 
         let commitment = PedersenCommitment::convert_from_byte_type(commitment).map_err(|e| {
@@ -272,16 +271,16 @@ mod tests {
 
     use super::KnowledgeProofVerifier;
 
-    /// Mints a `MinotariBurnClaimProof` with a valid `ownership_proof` Schnorr signature bound to
-    /// `stealth_claim_pk` (the key the proof commits to in `H(commitment ‖ stealth_claim_pk)`).
-    fn build_proof(network: Network, value: u64, stealth_claim_pk: RistrettoPublicKeyBytes) -> MinotariBurnClaimProof {
+    /// Mints a `MinotariBurnClaimProof` whose `ownership_proof` Schnorr signature is bound to
+    /// `claimant_pk` (the key the message commits to in `H(commitment ‖ claimant_pk)`).
+    fn build_proof(network: Network, value: u64, claimant_pk: RistrettoPublicKeyBytes) -> MinotariBurnClaimProof {
         let mask = RistrettoSecretKey::random(&mut rand::rng());
         let commitment = get_commitment_factory().commit_value(&mask, value);
         let commitment_bytes = commitment.to_byte_type();
 
         let message = ownership_proof_hasher64(network)
             .chain(&commitment_bytes.as_bytes())
-            .chain(&stealth_claim_pk.as_bytes())
+            .chain(&claimant_pk.as_bytes())
             .finalize();
         let signature = RistrettoSchnorr::sign(&mask, &message[..], &mut rand::rng()).expect("sign with random nonce");
 
@@ -307,41 +306,35 @@ mod tests {
             kernel,
             value,
             sender_offset_public_key: RistrettoPublicKeyBytes::zero(),
-            stealth_claim_public_key: stealth_claim_pk,
         }
     }
 
     #[test]
-    fn verifies_against_stealth_claim_public_key_from_proof() {
+    fn verifies_against_caller_supplied_claimant() {
         let network = Network::LocalNet;
-        // C is the stealth claim public key — the verifier reads it directly from the proof,
-        // ignoring the caller-supplied claimant. For this test it doesn't have to be derived from
-        // any specific account.
+        // The runtime feeds the transaction's seal-signer pubkey as the claimant. For stealth
+        // claims the wallet signs with `s = H(R·p) + p`, so this is `C = s·G`.
         let (_c_sec, c_pub) = RistrettoPublicKey::random_keypair(&mut rand::rng());
-        let (_account_sec, account_pub) = RistrettoPublicKey::random_keypair(&mut rand::rng());
 
         let proof = build_proof(network, 2_000, c_pub.to_byte_type());
         let verifier = KnowledgeProofVerifier::new(network);
 
-        // Passing the account pubkey here mirrors what the runtime does today; it must be ignored.
         verifier
-            .verify_claim_proof(Epoch(0), &account_pub.to_byte_type(), &proof)
-            .expect("proof should verify against the C carried in it");
+            .verify_claim_proof(Epoch(0), &c_pub.to_byte_type(), &proof)
+            .expect("proof should verify against the seal signer C");
     }
 
     #[test]
-    fn rejects_signature_bound_to_wrong_key() {
+    fn rejects_when_claimant_does_not_match_signed_binding() {
         let network = Network::LocalNet;
         let (_c_sec, c_pub) = RistrettoPublicKey::random_keypair(&mut rand::rng());
-        let (_other_sec, other_pub) = RistrettoPublicKey::random_keypair(&mut rand::rng());
-        let (_account_sec, account_pub) = RistrettoPublicKey::random_keypair(&mut rand::rng());
+        let (_wrong_sec, wrong_pub) = RistrettoPublicKey::random_keypair(&mut rand::rng());
 
-        // Sign against `other_pub` but advertise the proof as binding to `c_pub`.
-        let mut proof = build_proof(network, 3_000, other_pub.to_byte_type());
-        proof.stealth_claim_public_key = c_pub.to_byte_type();
+        // Signed against c_pub but the runtime passes wrong_pub.
+        let proof = build_proof(network, 3_000, c_pub.to_byte_type());
 
         let verifier = KnowledgeProofVerifier::new(network);
-        let result = verifier.verify_claim_proof(Epoch(0), &account_pub.to_byte_type(), &proof);
-        assert!(result.is_err(), "expected verification to reject mismatched binding");
+        let result = verifier.verify_claim_proof(Epoch(0), &wrong_pub.to_byte_type(), &proof);
+        assert!(result.is_err(), "expected verification to reject mismatched claimant");
     }
 }

--- a/applications/tari_walletd/src/handlers/accounts.rs
+++ b/applications/tari_walletd/src/handlers/accounts.rs
@@ -513,16 +513,16 @@ pub(crate) async fn execute_claim_burn(
     let network = sdk.config_api().get_network()?;
     // We derive secrets directly here because claim burn is a unique case, making it difficult to use the higher
     // level stealth output api that takes care of keys but assumes that this is a regular transfer.
-    let claim_key_id = account_owner_key_id;
-    let claim_key = sdk.key_manager_api().get_key(claim_key_id)?;
-    let claim_public_key = claim_key.to_public_key().to_byte_type();
+    let account_owner_key = sdk.key_manager_api().get_key(account_owner_key_id)?;
 
+    // The L1 ownership proof binds the commitment to the stealth claim public key `C` carried in
+    // the proof — not to the L2 account pubkey `P` — so we validate against `C`.
     if !sdk.stealth_crypto_api().validate_burn_claim_ownership_proof(
         network,
         &claim_proof.ownership_proof,
         &claim_proof.commitment,
         claim_proof.value,
-        &claim_public_key,
+        &claim_proof.stealth_claim_public_key,
     ) {
         return Err(invalid_params(
             "claim_proof.ownership_proof",
@@ -532,18 +532,10 @@ pub(crate) async fn execute_claim_burn(
 
     info!(
         target: LOG_TARGET,
-        "ℹ️ Signing claim burn with key {}. NOTE: This must be the same as the claiming key (owner_nonce_key_index) used in the burn transaction for this to succeed.",
-        claim_public_key
+        "ℹ️ Signing claim burn for account {} (stealth claim pk on proof: {})",
+        account_owner_key.to_public_key().to_byte_type(),
+        claim_proof.stealth_claim_public_key,
     );
-
-    if claim_proof.burn_public_key != claim_public_key {
-        warn!(
-            target: LOG_TARGET,
-            "⚠️ The provided reciprocal claim public key ({}) does not match the derived claim public key ({}). The claim will likely fail.",
-            claim_proof.burn_public_key,
-            claim_public_key
-        );
-    }
 
     // Get the sender_offset_public_key and use it to create a DH with the claim_nonce_key
     let sender_offset_pub_key: RistrettoPublicKey = claim_proof
@@ -554,7 +546,7 @@ pub(crate) async fn execute_claim_burn(
     let decrypted = sdk.stealth_crypto_api().decrypt_utxo_data(
         &claimed_encrypted_data,
         &claim_proof.commitment,
-        claim_key.secret(),
+        account_owner_key.secret(),
         &sender_offset_pub_key,
         true,
     )?;
@@ -639,8 +631,14 @@ pub(crate) async fn execute_claim_burn(
         .with_dry_run(is_dry_run)
         .finish();
 
-    // Add the required spend signature to the transaction
-    let transaction = sdk.signer_api().sign(*claim_key.key_id(), transaction)?;
+    // Spend secret is `s = H(R·p) + p`. The L1 ownership proof commits the burn to `s·G` (= C),
+    // so this is the only key that can spend the just-minted UTXO.
+    let stealth_secret = sdk.stealth_crypto_api().derive_stealth_owner_secret(
+        network,
+        account_owner_key.secret(),
+        &sender_offset_pub_key,
+    );
+    let transaction = sdk.signer_api().sign_with_explicit_key(&stealth_secret, transaction)?;
 
     if is_dry_run {
         let transaction_id = transaction.calculate_id();

--- a/applications/tari_walletd/src/handlers/accounts.rs
+++ b/applications/tari_walletd/src/handlers/accounts.rs
@@ -1,7 +1,7 @@
 //   Copyright 2023 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use std::{collections::HashSet, fs, iter, path::Path, time::Duration};
+use std::{collections::HashSet, iter, path::Path, time::Duration};
 
 use anyhow::{Context, anyhow};
 use axum_extra::headers::authorization::Bearer;
@@ -106,6 +106,7 @@ use crate::handlers::{
         invalid_request,
         not_found,
         transaction_rejected,
+        validate_burn_proof_file_name,
         wait_for_result,
         wait_for_result_and_account,
     },
@@ -473,7 +474,7 @@ pub async fn handle_claim_burn(
     let proof_dir = context.config().get_burn_proof_dir(network);
     let proof_contents = resolve_claim_proof(&proof_dir, claim_proof).await.map_err(|e| {
         error!(target: LOG_TARGET, "Error resolving claim proof: {}", e);
-        invalid_request(format!("Could not resolve claim proof. {e} Is the file name correct?"))
+        invalid_request(format!("Could not resolve claim proof: {e}"))
     })?;
 
     execute_claim_burn(
@@ -524,11 +525,9 @@ pub(crate) async fn execute_claim_burn(
     // Stealth spend secret `s = H(R·p) + p`. The L1 ownership proof commits the burn to `C = s·G`,
     // so this is the only key that can sign the claim transaction and satisfy the spend condition
     // on the just-minted burn UTXO.
-    let stealth_secret = sdk.stealth_crypto_api().derive_stealth_owner_secret(
-        network,
-        account_owner_key.secret(),
-        &sender_offset_pub_key,
-    );
+    let stealth_secret = sdk
+        .stealth_crypto_api()
+        .derive_burn_claim_stealth_secret(account_owner_key.secret(), &sender_offset_pub_key);
     let stealth_claim_pk = RistrettoPublicKey::from_secret_key(&stealth_secret).to_byte_type();
 
     if !sdk.stealth_crypto_api().validate_burn_claim_ownership_proof(
@@ -664,6 +663,10 @@ pub(crate) async fn execute_claim_burn(
     })
 }
 
+/// Burn proofs are small fixed-size JSON. Cap reads at 1 MiB so a caller can't point us
+/// at `/dev/zero` (or a huge attacker-planted file) and exhaust memory.
+const MAX_BURN_PROOF_BYTES: u64 = 1 << 20;
+
 async fn resolve_claim_proof<P: AsRef<Path>>(
     base_path: P,
     proof: ClaimBurnProof,
@@ -671,10 +674,18 @@ async fn resolve_claim_proof<P: AsRef<Path>>(
     match proof {
         ClaimBurnProof::Contents(contents) => Ok(*contents),
         ClaimBurnProof::FromFile { file_name } => {
-            let file_name = base_path.as_ref().join(file_name);
-            let mut file = fs::File::open(&file_name)
-                .with_context(|| format!("Failed to open claim proof file: {}", file_name.display()))?;
-            let proof = serde_json::from_reader(&mut file)?;
+            validate_burn_proof_file_name(&file_name)?;
+            let path = base_path.as_ref().join(&file_name);
+            let metadata = tokio::fs::metadata(&path)
+                .await
+                .map_err(|_| anyhow!("Burn proof file not found: {file_name}"))?;
+            if metadata.len() > MAX_BURN_PROOF_BYTES {
+                return Err(anyhow!("Burn proof file too large: {file_name}"));
+            }
+            let bytes = tokio::fs::read(&path)
+                .await
+                .map_err(|_| anyhow!("Burn proof file not found: {file_name}"))?;
+            let proof = serde_json::from_slice(&bytes).map_err(|_| anyhow!("Invalid burn proof file: {file_name}"))?;
             complete_burn_proof_to_contents(proof)
         },
     }

--- a/applications/tari_walletd/src/handlers/accounts.rs
+++ b/applications/tari_walletd/src/handlers/accounts.rs
@@ -515,14 +515,28 @@ pub(crate) async fn execute_claim_burn(
     // level stealth output api that takes care of keys but assumes that this is a regular transfer.
     let account_owner_key = sdk.key_manager_api().get_key(account_owner_key_id)?;
 
-    // The L1 ownership proof binds the commitment to the stealth claim public key `C` carried in
-    // the proof — not to the L2 account pubkey `P` — so we validate against `C`.
+    // Get the sender_offset_public_key (R) and use it to create a DH with the account owner key
+    let sender_offset_pub_key: RistrettoPublicKey = claim_proof
+        .sender_offset_public_key
+        .try_from_byte_type()
+        .map_err(|e| invalid_params("claim_proof.sender_offset_public_key", Some(e)))?;
+
+    // Stealth spend secret `s = H(R·p) + p`. The L1 ownership proof commits the burn to `C = s·G`,
+    // so this is the only key that can sign the claim transaction and satisfy the spend condition
+    // on the just-minted burn UTXO.
+    let stealth_secret = sdk.stealth_crypto_api().derive_stealth_owner_secret(
+        network,
+        account_owner_key.secret(),
+        &sender_offset_pub_key,
+    );
+    let stealth_claim_pk = RistrettoPublicKey::from_secret_key(&stealth_secret).to_byte_type();
+
     if !sdk.stealth_crypto_api().validate_burn_claim_ownership_proof(
         network,
         &claim_proof.ownership_proof,
         &claim_proof.commitment,
         claim_proof.value,
-        &claim_proof.stealth_claim_public_key,
+        &stealth_claim_pk,
     ) {
         return Err(invalid_params(
             "claim_proof.ownership_proof",
@@ -532,16 +546,10 @@ pub(crate) async fn execute_claim_burn(
 
     info!(
         target: LOG_TARGET,
-        "ℹ️ Signing claim burn for account {} (stealth claim pk on proof: {})",
+        "ℹ️ Signing claim burn for account {} (stealth claim pk: {})",
         account_owner_key.to_public_key().to_byte_type(),
-        claim_proof.stealth_claim_public_key,
+        stealth_claim_pk,
     );
-
-    // Get the sender_offset_public_key and use it to create a DH with the claim_nonce_key
-    let sender_offset_pub_key: RistrettoPublicKey = claim_proof
-        .sender_offset_public_key
-        .try_from_byte_type()
-        .map_err(|e| invalid_params("claim_proof.sender_offset_public_key", Some(e)))?;
 
     let decrypted = sdk.stealth_crypto_api().decrypt_utxo_data(
         &claimed_encrypted_data,
@@ -631,13 +639,6 @@ pub(crate) async fn execute_claim_burn(
         .with_dry_run(is_dry_run)
         .finish();
 
-    // Spend secret is `s = H(R·p) + p`. The L1 ownership proof commits the burn to `s·G` (= C),
-    // so this is the only key that can spend the just-minted UTXO.
-    let stealth_secret = sdk.stealth_crypto_api().derive_stealth_owner_secret(
-        network,
-        account_owner_key.secret(),
-        &sender_offset_pub_key,
-    );
     let transaction = sdk.signer_api().sign_with_explicit_key(&stealth_secret, transaction)?;
 
     if is_dry_run {

--- a/applications/tari_walletd/src/handlers/burn_proofs.rs
+++ b/applications/tari_walletd/src/handlers/burn_proofs.rs
@@ -1,8 +1,6 @@
 //   Copyright 2023 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use std::path::Path;
-
 use anyhow::anyhow;
 use axum_extra::headers::authorization::Bearer;
 use log::*;
@@ -18,7 +16,10 @@ use tari_ootle_walletd_client::{
 };
 use tari_sidechain::CompleteClaimBurnProof;
 
-use super::{context::HandlerContext, helpers::complete_burn_proof_to_contents};
+use super::{
+    context::HandlerContext,
+    helpers::{complete_burn_proof_to_contents, validate_burn_proof_file_name},
+};
 
 const LOG_TARGET: &str = "tari::ootle::wallet_daemon::handlers::burn_proofs";
 
@@ -117,11 +118,7 @@ pub async fn handle_get(
     context.authorize(token, &[Permission::BurnProofs(ReadOnly::Read)])?;
     let dir = context.config().get_burn_proof_dir(context.wallet_sdk().network());
 
-    // Prevent path traversal
-    let file_name = Path::new(&req.file_name);
-    if file_name.components().count() != 1 || req.file_name.contains("..") {
-        return Err(anyhow!("Invalid file name"));
-    }
+    validate_burn_proof_file_name(&req.file_name)?;
 
     let path = dir.join(&req.file_name);
     let bytes = tokio::fs::read(&path).await.map_err(|e| {

--- a/applications/tari_walletd/src/handlers/helpers.rs
+++ b/applications/tari_walletd/src/handlers/helpers.rs
@@ -240,7 +240,6 @@ pub(crate) fn complete_burn_proof_to_contents(proof: CompleteClaimBurnProof) -> 
             },
             value: proof.claim_proof.value,
             sender_offset_public_key: proof.claim_proof.sender_offset_public_key.to_byte_type(),
-            stealth_claim_public_key: proof.claim_proof.stealth_claim_public_key.to_byte_type(),
         },
         encrypted_data,
     })

--- a/applications/tari_walletd/src/handlers/helpers.rs
+++ b/applications/tari_walletd/src/handlers/helpers.rs
@@ -240,6 +240,7 @@ pub(crate) fn complete_burn_proof_to_contents(proof: CompleteClaimBurnProof) -> 
             },
             value: proof.claim_proof.value,
             sender_offset_public_key: proof.claim_proof.sender_offset_public_key.to_byte_type(),
+            stealth_claim_public_key: proof.claim_proof.stealth_claim_public_key.to_byte_type(),
         },
         encrypted_data,
     })

--- a/applications/tari_walletd/src/handlers/helpers.rs
+++ b/applications/tari_walletd/src/handlers/helpers.rs
@@ -1,7 +1,7 @@
 //   Copyright 2023 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use std::{collections::HashSet, fmt::Display};
+use std::{collections::HashSet, fmt::Display, path::Path};
 
 use anyhow::anyhow;
 use ootle_byte_type::ToByteType;
@@ -202,6 +202,16 @@ pub(super) fn faucet_already_claimed() -> anyhow::Error {
 
 pub(super) fn general_error<T: Display>(details: T) -> anyhow::Error {
     application_error(ApplicationErrorCode::GeneralError, details)
+}
+
+/// Reject anything that isn't a single, non-`..` path component, so caller-supplied
+/// names cannot escape the burn-proof directory via `Path::join`.
+pub(crate) fn validate_burn_proof_file_name(file_name: &str) -> anyhow::Result<()> {
+    let p = Path::new(file_name);
+    if p.components().count() != 1 || file_name.contains("..") {
+        return Err(anyhow!("Invalid file name"));
+    }
+    Ok(())
 }
 
 /// Converts a `CompleteClaimBurnProof` (the L1 burn proof file format) into the

--- a/applications/tari_walletd/src/services/claim_burn_monitor.rs
+++ b/applications/tari_walletd/src/services/claim_burn_monitor.rs
@@ -10,6 +10,8 @@ use tari_ootle_wallet_sdk_services::notify::Notify;
 use tari_shutdown::ShutdownSignal;
 use tokio::sync::broadcast;
 
+use crate::handlers::helpers::validate_burn_proof_file_name;
+
 const LOG_TARGET: &str = "tari::ootle::wallet_daemon::claim_burn_monitor";
 
 /// Monitors wallet events to move burn proof files to the "claimed" directory
@@ -117,6 +119,13 @@ impl ClaimBurnMonitor {
     }
 
     async fn mark_as_claimed(&self, file_name: &str) {
+        if let Err(e) = validate_burn_proof_file_name(file_name) {
+            warn!(
+                target: LOG_TARGET,
+                "Refusing to move burn proof with unsafe file name {file_name}: {e}"
+            );
+            return;
+        }
         let claimed_dir = self.burn_proof_dir.join("claimed");
         if let Err(e) = tokio::fs::create_dir_all(&claimed_dir).await {
             warn!(

--- a/crates/engine_types/src/confidential/claim.rs
+++ b/crates/engine_types/src/confidential/claim.rs
@@ -38,12 +38,6 @@ pub struct MinotariBurnClaimProof {
     pub value: u64,
     #[n(6)]
     pub sender_offset_public_key: RistrettoPublicKeyBytes,
-    /// Stealth claim public key `C = H(r·P)·G + P`. The L1 burn proof's `ownership_proof` Schnorr
-    /// signature binds the commitment to `C`, and the L2 wallet spends the claim with the matching
-    /// stealth secret `s = H(R·p) + p`. `P` (the L2 account public key) never appears on chain or
-    /// in this proof.
-    #[n(7)]
-    pub stealth_claim_public_key: RistrettoPublicKeyBytes,
 }
 
 impl Display for MinotariBurnClaimProof {
@@ -51,14 +45,13 @@ impl Display for MinotariBurnClaimProof {
         write!(
             f,
             "MinotariBurnClaimProof (burn_public_key: {}, commitment: {}, ownership_proof: {}, encoded_merkle_proof: \
-             {} bytes, kernel: {}, value: {}, stealth_claim_public_key: {})",
+             {} bytes, kernel: {}, value: {})",
             self.burn_public_key,
             self.commitment,
             self.ownership_proof,
             self.encoded_merkle_proof.encoded_merkle_proof.len(),
             self.kernel.excess_sig,
             self.value,
-            self.stealth_claim_public_key,
         )
     }
 }

--- a/crates/engine_types/src/confidential/claim.rs
+++ b/crates/engine_types/src/confidential/claim.rs
@@ -38,6 +38,12 @@ pub struct MinotariBurnClaimProof {
     pub value: u64,
     #[n(6)]
     pub sender_offset_public_key: RistrettoPublicKeyBytes,
+    /// Stealth claim public key `C = H(r·P)·G + P`. The L1 burn proof's `ownership_proof` Schnorr
+    /// signature binds the commitment to `C`, and the L2 wallet spends the claim with the matching
+    /// stealth secret `s = H(R·p) + p`. `P` (the L2 account public key) never appears on chain or
+    /// in this proof.
+    #[n(7)]
+    pub stealth_claim_public_key: RistrettoPublicKeyBytes,
 }
 
 impl Display for MinotariBurnClaimProof {
@@ -45,13 +51,14 @@ impl Display for MinotariBurnClaimProof {
         write!(
             f,
             "MinotariBurnClaimProof (burn_public_key: {}, commitment: {}, ownership_proof: {}, encoded_merkle_proof: \
-             {} bytes, kernel: {}, value: {})",
+             {} bytes, kernel: {}, value: {}, stealth_claim_public_key: {})",
             self.burn_public_key,
             self.commitment,
             self.ownership_proof,
             self.encoded_merkle_proof.encoded_merkle_proof.len(),
             self.kernel.excess_sig,
-            self.value
+            self.value,
+            self.stealth_claim_public_key,
         )
     }
 }

--- a/crates/wallet/crypto/src/api.rs
+++ b/crates/wallet/crypto/src/api.rs
@@ -108,6 +108,17 @@ impl StealthCryptoApi {
         kdfs::owner_stealth_dh_secret(network, secret_key, public_nonce)
     }
 
+    /// Derive `s = H(p·R) + p` using L1's exact `stealth_address` hash domain. Use only on L1
+    /// burn-claim paths where the L1 wallet signed the ownership proof against the matching
+    /// stealth address `C = s·G`.
+    pub fn derive_burn_claim_stealth_secret(
+        &self,
+        account_secret: &RistrettoSecretKey,
+        sender_offset_public_key: &RistrettoPublicKey,
+    ) -> RistrettoSecretKey {
+        kdfs::burn_claim_stealth_secret(account_secret, sender_offset_public_key)
+    }
+
     pub fn encrypt_value_and_mask(
         &self,
         amount: u64,

--- a/crates/wallet/crypto/src/api.rs
+++ b/crates/wallet/crypto/src/api.rs
@@ -148,19 +148,21 @@ impl StealthCryptoApi {
         Ok(decrypted)
     }
 
+    /// `claimant_pk` is the stealth claim public key `C = H(r·P)·G + P` carried in the L1 burn
+    /// proof — the key the `ownership_proof` Schnorr signature commits to.
     pub fn validate_burn_claim_ownership_proof(
         &self,
         network: Network,
         ownership_proof: &SchnorrSignatureBytes,
         commitment: &PedersenCommitmentBytes,
         value: u64,
-        account_owner_pk: &RistrettoPublicKeyBytes,
+        claimant_pk: &RistrettoPublicKeyBytes,
     ) -> bool {
         // NOTE: .as_bytes() used because the tari_crypto borsh implementations serialize fixed length bytes as variable
         // length bytes of size 32
         let message = ownership_proof_hasher64(network)
             .chain(&commitment.as_bytes())
-            .chain(&account_owner_pk.as_bytes())
+            .chain(&claimant_pk.as_bytes())
             .finalize();
 
         let Ok(commitment) = PedersenCommitment::convert_from_byte_type(commitment) else {

--- a/crates/wallet/crypto/src/kdfs.rs
+++ b/crates/wallet/crypto/src/kdfs.rs
@@ -68,6 +68,26 @@ pub fn owner_stealth_dh_secret(
     c + private_key
 }
 
+/// L1-compatible derivation of the stealth claim secret `s = H(p·R) + p` for an L1 burn claim.
+///
+/// `H` mirrors the L1 wallet's `diffie_hellman_stealth_domain_hasher`:
+/// `WalletHasher::new_with_label("stealth_address")` over the raw 32-byte compressed DH product.
+/// This MUST stay byte-identical to the L1 derivation — see
+/// `tari/base_layer/transaction_components/src/transaction_components/one_sided.rs` and
+/// `key_manager/manager.rs::compute_stealth_claim_public_key`.
+pub fn burn_claim_stealth_secret(
+    account_secret: &RistrettoSecretKey,
+    sender_offset_public_key: &RistrettoPublicKey,
+) -> RistrettoSecretKey {
+    let shared_secret = dh(sender_offset_public_key, account_secret);
+    let hash = tari_hashing::WalletHasher::new_with_label("stealth_address")
+        .chain(shared_secret.as_bytes())
+        .finalize();
+    let scalar = RistrettoSecretKey::from_uniform_bytes(hash.as_ref())
+        .expect("Blake2b<U64> produces 64 bytes which is valid uniform input");
+    scalar + account_secret
+}
+
 fn stealth_owner_dh(
     network: Network,
     public_key: &RistrettoPublicKey,


### PR DESCRIPTION
## Summary
L2 half of the stealth burn-claim work tracked in #1890. Pairs with [tari-project/tari#7861](https://github.com/tari-project/tari/pull/7861) (L1).

* `MinotariBurnClaimProof` carries a required `stealth_claim_public_key` field — the stealth address `C = H(r·P)·G + P` the L1 burn proof's `ownership_proof` Schnorr signature commits to. The L2 account pubkey `P` no longer appears in the proof.
* `KnowledgeProofVerifier::verify_claim_proof` binds the ownership proof to `C` from the proof (ignoring the runtime-supplied claimant). The runtime call site at `crates/engine/src/runtime/impl.rs::claim_burn` is unchanged.
* `execute_claim_burn` (in `applications/tari_walletd/src/handlers/accounts.rs`) validates the ownership proof against `C`, derives the spend secret `s = H(R·p) + p` via the existing `derive_stealth_owner_secret` helper, and signs the claim transaction via `SignerApi::sign_with_explicit_key` rather than going through the key manager's key-id path.
* `StealthCryptoApi::validate_burn_claim_ownership_proof`'s pubkey parameter renamed to `claimant_pk` to reflect that the caller now always supplies `C`.

## Coupling / build status
This PR depends on the matching L1 wire-shape change in tari#7861. Specifically `tari_sidechain::BurnClaimProof` needs the `stealth_claim_public_key` field added so `complete_burn_proof_to_contents` (in `handlers/helpers.rs`) can thread it through. Until that lands, `tari_ootle_walletd` won't compile against pinned tari (`v5.4.0-pre.1`). Other crates touched by this PR (`tari_engine_types`, `tari_ootle_app_utilities`, `tari_ootle_wallet_crypto`) build clean.

No on-L2 consensus / runtime changes. No support for the pre-stealth proof shape — Ootle is pre-launch and the migration is total.

Closes #1890.

## Test plan
- [x] cargo test -p tari_ootle_app_utilities claim_burn — happy path + rejection of mismatched binding key.
- [x] End-to-end claim_burn flow once tari#7861's sidechain field lands.
- [x] Verify that the swarm-daemon claim-burn handoff in process_manager/processes/minotari_wallet.rs continues to round-trip once the sidechain proto carries the stealth field.