### PR TITLE
feat(ootle-rs): support claiming Layer 1 UTXO burns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7646,7 +7646,7 @@ dependencies = [
 
 [[package]]
 name = "ootle-rs"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/crates/wallet/ootle-rs/Cargo.toml
+++ b/crates/wallet/ootle-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ootle-rs"
-version = "0.9.0"
+version = "0.10.0"
 description = "A Rust library for interacting with the Tari Ootle network."
 edition.workspace = true
 authors.workspace = true

--- a/crates/wallet/ootle-rs/README.md
+++ b/crates/wallet/ootle-rs/README.md
@@ -15,6 +15,7 @@ experience for those transitioning from Ethereum or generic blockchain developme
 * **Alloy-like API:** Uses the familiar `Provider`, `Signer`, and `Transport` architecture found in `alloy`.
 * **Ootle Native:** First-class support for Tari Ootle
 * **Type-Safe:** Strongly typed interactions with Tari's confidential assets.
+* **Confidential & Cross-Layer:** Stealth transfers and claiming Layer 1 (minotari) burns (`claim_burn::ClaimBurn`).
 * **Async/Await:** Built on `tokio` for high-performance, non-blocking I/O.
 
 ## 📦 Installation
@@ -23,7 +24,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-ootle-rs = "0.1.0"
+ootle-rs = "0.10.0"
 ```
 
 ## 🚀 Quick Start

--- a/crates/wallet/ootle-rs/examples/README.md
+++ b/crates/wallet/ootle-rs/examples/README.md
@@ -23,6 +23,22 @@ and verify balances.
 Confidential stealth transfers with input/output commitments, encrypted memos,
 change handling, and stealth spending authorizers.
 
+### `claim_burn`
+
+Claim a Layer 1 (minotari) burn into an Ootle account.
+
+Claiming is a two-step process because the L1 burn must be addressed to a claim key
+derived from the claiming account. Run it with no arguments to print the claim public
+key (it uses a fixed, demo-only secret), burn tTARI on the L1 wallet to that key, then
+re-run with the burn proof JSON as the first argument to claim:
+
+```bash
+cargo run -p ootle-rs --example claim_burn                       # prints the claim key
+cargo run -p ootle-rs --example claim_burn -- ./burn_proof.json  # claims the burn
+```
+
+See the example file header for the full flow.
+
 ### `balance_query`
 
 Query account balances and decrypt stealth UTXO values using ElGamal view keys.

--- a/crates/wallet/ootle-rs/examples/claim_burn.rs
+++ b/crates/wallet/ootle-rs/examples/claim_burn.rs
@@ -1,0 +1,133 @@
+//   Copyright 2026 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+//! Example: claim a Layer 1 (minotari) burn into an Ootle account.
+//!
+//! Claiming a burn is a chicken-and-egg process: the L1 burn must be addressed to a *claim public
+//! key* derived from the claiming account's secret, so you must know the account before you can
+//! produce the proof. This example uses a fixed, deterministic secret so the claim key is stable
+//! across runs.
+//!
+//! WARNING: the secret is hard-coded for localnet demonstration only — anyone can derive it and
+//! claim funds burned to its claim key. Never use it for real funds.
+//!
+//! Run with no arguments to print the claim public key:
+//!
+//! ```bash
+//! cargo run -p ootle-rs --example claim_burn
+//! ```
+//!
+//! Burn tTARI on the L1 (minotari) wallet to that claim key (e.g. `create_burn_transaction` with
+//! `claim_public_key = <printed key>`). Once mined, fetch the proof (`get_burn_claim_proof`) and
+//! save it as JSON in the wallet daemon's `ClaimBurnProofContents` shape:
+//! `{ "claim_proof": { ... }, "encrypted_data": "..." }`. Then re-run with the proof file (this
+//! step requires a running indexer):
+//!
+//! ```bash
+//! cargo run -p ootle-rs --example claim_burn -- ./burn_proof.json
+//! ```
+
+use std::{env, fs};
+
+use ootle_rs::{
+    Network,
+    TransactionRequest,
+    claim_burn::{ClaimBurn, MinotariBurnClaimProof},
+    default_indexer_url,
+    key_provider::PrivateKeyProvider,
+    keys::OotleSecretKey,
+    provider::{Provider, ProviderBuilder},
+    template_types::EncryptedData,
+    wallet::{NetworkWallet, OotleWallet},
+};
+use tari_crypto::{
+    keys::{PublicKey, SecretKey},
+    ristretto::{RistrettoPublicKey, RistrettoSecretKey},
+    tari_utilities::hex::Hex,
+};
+
+/// MicroTARI revealed from the claimed funds to pay the transaction fee.
+const MAX_FEE: u64 = 2000;
+
+/// The L2 burn proof contents, as produced for the burned output. This matches the wallet daemon's
+/// `ClaimBurnProofContents` serde shape.
+#[derive(serde::Deserialize)]
+struct BurnProofFile {
+    claim_proof: MinotariBurnClaimProof,
+    encrypted_data: EncryptedData,
+}
+
+#[tokio::main]
+async fn main() {
+    // The network the funds were burned to. Change this to match your deployment.
+    let network = Network::LocalNet;
+
+    // Fixed, deterministic example keys so the claim public key is stable across runs.
+    // DO NOT use these for real funds — see the module warning.
+    let account_secret = RistrettoSecretKey::from_uniform_bytes(&[0x11u8; 64]).expect("valid scalar");
+    let view_only_secret = RistrettoSecretKey::from_uniform_bytes(&[0x22u8; 64]).expect("valid scalar");
+
+    let secret = OotleSecretKey::new(network, account_secret.clone(), view_only_secret);
+    let wallet = OotleWallet::from(PrivateKeyProvider::new(secret));
+
+    // The L1 burn must be addressed to this claim public key (the account's public key).
+    let claim_public_key = RistrettoPublicKey::from_secret_key(&account_secret);
+    println!("Account address:   {}", wallet.default_address());
+    println!("Claim public key:  {}", claim_public_key.to_hex());
+
+    let Some(proof_path) = env::args().nth(1) else {
+        println!();
+        println!("No burn proof supplied. To claim a burn:");
+        println!("  1. Burn tTARI on the L1 (minotari) wallet to the claim public key above");
+        println!("     (create_burn_transaction with claim_public_key = the key above).");
+        println!("  2. Once mined, fetch the proof (get_burn_claim_proof) and save it as JSON:");
+        println!("       {{ \"claim_proof\": {{ ... }}, \"encrypted_data\": \"...\" }}");
+        println!("  3. Re-run with the proof file:");
+        println!("       cargo run -p ootle-rs --example claim_burn -- ./burn_proof.json");
+        return;
+    };
+
+    let BurnProofFile {
+        claim_proof,
+        encrypted_data,
+    } = serde_json::from_str(&fs::read_to_string(&proof_path).expect("failed to read burn proof file"))
+        .expect("failed to parse burn proof JSON");
+
+    let mut provider = ProviderBuilder::new()
+        .wallet(wallet)
+        .connect(default_indexer_url(network))
+        .await
+        .expect("failed to connect to indexer");
+    assert_eq!(provider.network(), network);
+
+    // Build the claim transaction and the sealer that signs it with the derived stealth claim key.
+    let (unsigned_tx, sealer) = ClaimBurn::new(&provider, claim_proof, encrypted_data)
+        .with_max_fee(MAX_FEE)
+        .with_memo_message("claimed via ootle-rs")
+        .prepare()
+        .await
+        .expect("failed to prepare burn claim");
+
+    // Estimate fees with a dry run first (optional).
+    let dry_run = provider
+        .sign_and_send_dry_run_with(&sealer, unsigned_tx.clone())
+        .await
+        .expect("dry run submission failed");
+    dry_run.expect_success();
+    println!(
+        "Dry run OK. Estimated fees: {}",
+        dry_run.finalize.fee_receipt.total_fees_charged()
+    );
+
+    // Submit the claim for real.
+    let tx = TransactionRequest::default()
+        .with_transaction(unsigned_tx)
+        .build(&sealer)
+        .await
+        .expect("failed to seal claim transaction");
+
+    let pending = provider.send_transaction(tx).await.expect("failed to submit claim");
+    println!("⌛️ Claim pending... {}", pending.tx_id());
+    let outcome = pending.watch().await.expect("claim transaction failed");
+    println!("✅ Burn claimed! Outcome: {:?}", outcome);
+}

--- a/crates/wallet/ootle-rs/src/claim_burn/mod.rs
+++ b/crates/wallet/ootle-rs/src/claim_burn/mod.rs
@@ -1,0 +1,294 @@
+//   Copyright 2026 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+//! Claiming Layer 1 (minotari) burns on the Ootle network.
+//!
+//! When TARI is burned on the L1 base layer, the burn output can be claimed into an Ootle account
+//! by submitting a proof. [`ClaimBurn`] builds the claim transaction: it mints the burned funds as
+//! a confidential UTXO and immediately spends it into a stealth output owned by the claiming
+//! account (revealing a small amount to pay the fee).
+//!
+//! The L1 burn output is a stealth output addressed to the claiming account, so the transaction is
+//! sealed with a derived stealth claim key `s = H(p·R) + p` (not the account key). [`prepare`] returns
+//! that sealer alongside the unsigned transaction.
+//!
+//! [`prepare`]: ClaimBurn::prepare
+//!
+//! ```rust,ignore
+//! use ootle_rs::{
+//!     claim_burn::ClaimBurn,
+//!     provider::{Provider, WalletProvider},
+//!     TransactionRequest,
+//! };
+//!
+//! // `claim_proof` and `encrypted_data` come from the L1 (minotari) wallet's burn output.
+//! let (unsigned_tx, sealer) = ClaimBurn::new(&provider, claim_proof, encrypted_data)
+//!     .with_max_fee(1000u64)
+//!     .prepare()
+//!     .await?;
+//!
+//! let tx = TransactionRequest::default()
+//!     .with_transaction(unsigned_tx)
+//!     .build(&sealer)
+//!     .await?;
+//!
+//! provider.send_transaction(tx).await?.watch().await?;
+//! ```
+
+use std::num::NonZeroU64;
+
+use async_trait::async_trait;
+use ootle_byte_type::{FromByteType, ToByteType};
+use tari_crypto::{
+    keys::PublicKey,
+    ristretto::{RistrettoPublicKey, RistrettoSecretKey},
+};
+// Re-export the burn proof types so callers don't need to reach into `tari_ootle_common_types`.
+pub use tari_ootle_common_types::engine_types::confidential::{ClaimBurnOutputData, MinotariBurnClaimProof};
+use tari_ootle_common_types::engine_types::stealth::validate_transfer;
+use tari_ootle_transaction::{Transaction, UnsealedTransaction, UnsignedTransaction};
+use tari_ootle_wallet_crypto::{StealthCryptoApi, balance_proof::generate_stealth_balance_proof_signature, memo::Memo};
+use tari_template_lib_types::{
+    Amount,
+    EncryptedData,
+    constants::TARI_TOKEN,
+    stealth::{StealthInput, StealthInputsStatement, StealthTransferStatement},
+};
+
+use crate::{
+    Address,
+    provider::{Provider, WalletProvider},
+    signer,
+    stealth::{Output, StealthProviderError},
+    transaction::TransactionSealSigner,
+    wallet::{NetworkWallet, OotleWallet, WalletResult},
+};
+
+/// Default memo attached to the claimed funds output.
+const DEFAULT_CLAIM_MEMO: &str = "Burnt funds claimed from L1";
+
+/// Builder for claiming a Layer 1 (minotari) burn into an Ootle account.
+///
+/// See the [module documentation](crate::claim_burn) for the full flow.
+pub struct ClaimBurn<'a, P> {
+    provider: &'a P,
+    claim_proof: MinotariBurnClaimProof,
+    encrypted_data: EncryptedData,
+    max_fee: Amount,
+    recipient: Option<Address>,
+    memo: Option<Memo>,
+}
+
+impl<'a, P: Provider> ClaimBurn<'a, P> {
+    /// Create a new burn claim builder.
+    ///
+    /// `claim_proof` and `encrypted_data` are produced by the L1 (minotari) wallet for the burn
+    /// output being claimed (the wallet daemon bundles them as `ClaimBurnProofContents`).
+    pub fn new(provider: &'a P, claim_proof: MinotariBurnClaimProof, encrypted_data: EncryptedData) -> Self {
+        Self {
+            provider,
+            claim_proof,
+            encrypted_data,
+            max_fee: Amount::zero(),
+            recipient: None,
+            memo: None,
+        }
+    }
+
+    /// Set the maximum fee to pay for the claim. This amount is revealed from the claimed funds to
+    /// pay the transaction fee; any overpayment is refunded. A positive fee is required.
+    pub fn with_max_fee<A: Into<Amount>>(mut self, max_fee: A) -> Self {
+        self.max_fee = max_fee.into();
+        self
+    }
+
+    /// Claim the funds to a different address than the claiming account. Defaults to the claiming
+    /// account (the provider's default signer).
+    pub fn to_recipient(mut self, recipient: Address) -> Self {
+        self.recipient = Some(recipient);
+        self
+    }
+
+    /// Attach a custom (encrypted) memo to the claimed funds output. Defaults to a "Burnt funds
+    /// claimed from L1" message.
+    pub fn with_memo(mut self, memo: Memo) -> Self {
+        self.memo = Some(memo);
+        self
+    }
+
+    /// Convenience method to attach a text memo to the claimed funds output.
+    ///
+    /// # Panics
+    /// Panics if the message is too long to fit in a memo.
+    pub fn with_memo_message<T: Into<Box<str>>>(self, message: T) -> Self {
+        self.with_memo(Memo::new_message(message).expect("Memo message too long"))
+    }
+}
+
+impl<'a, P: WalletProvider<Wallet = OotleWallet>> ClaimBurn<'a, P> {
+    /// Build the unsigned claim transaction and the sealer that signs it with the derived stealth
+    /// claim key.
+    ///
+    /// Submit it via a [`TransactionRequest`](crate::TransactionRequest) sealed with the returned
+    /// [`BurnClaimSealer`], or estimate fees first with
+    /// [`sign_and_send_dry_run_with`](crate::provider::IndexerProvider::sign_and_send_dry_run_with).
+    pub async fn prepare(self) -> WalletResult<(UnsignedTransaction, BurnClaimSealer)> {
+        let Self {
+            provider,
+            claim_proof,
+            encrypted_data,
+            max_fee,
+            recipient,
+            memo,
+        } = self;
+
+        let network = provider.network();
+        let wallet = provider.wallet();
+        let claimant = provider.default_signer_address().clone();
+
+        // `R`, the public nonce the L1 UTXO was burnt with.
+        let sender_offset_public_key: RistrettoPublicKey = claim_proof
+            .sender_offset_public_key
+            .try_from_byte_type()
+            .map_err(|e| StealthProviderError::UnexpectedError {
+                details: format!("Invalid sender_offset_public_key in burn proof: {e}"),
+            })?;
+
+        // `s = H(p·R) + p`. The L1 ownership proof commits the burn to `s·G`, so this is the only key
+        // that can satisfy the spend condition on the minted burn UTXO. It seals the claim transaction.
+        let stealth_secret = wallet.derive_burn_claim_secret(&sender_offset_public_key).await?;
+        let stealth_claim_pk = RistrettoPublicKey::from_secret_key(&stealth_secret).to_byte_type();
+
+        if !StealthCryptoApi::new().validate_burn_claim_ownership_proof(
+            network,
+            &claim_proof.ownership_proof,
+            &claim_proof.commitment,
+            claim_proof.value,
+            &stealth_claim_pk,
+        ) {
+            return Err(StealthProviderError::BurnClaimOwnershipProofInvalid.into());
+        }
+
+        let decrypted = wallet
+            .decrypt_burn_claim_output(&encrypted_data, &claim_proof.commitment, &sender_offset_public_key)
+            .await?;
+
+        let max_fee = u64::try_from(max_fee.to_u128()).map_err(|_| StealthProviderError::UnexpectedError {
+            details: "max_fee exceeds u64::MAX".to_string(),
+        })?;
+        if max_fee == 0 {
+            return Err(StealthProviderError::UnexpectedError {
+                details: "A positive max_fee is required to claim an L1 burn".to_string(),
+            }
+            .into());
+        }
+
+        // Reveal `max_fee` to pay the fee; the remainder becomes a stealth output owned by the claimant.
+        let claimed_amount = decrypted.value();
+        let final_amount = claimed_amount.checked_sub(max_fee).filter(|amount| *amount > 0).ok_or(
+            StealthProviderError::BurnClaimFeeTooHigh {
+                claimed: claimed_amount,
+                max_fee,
+            },
+        )?;
+        let final_amount = NonZeroU64::new(final_amount).expect("final_amount checked to be positive above");
+
+        // The claimed-funds output is an ordinary stealth output to the recipient (the claimant by default).
+        let recipient = recipient.unwrap_or_else(|| claimant.clone());
+        let memo = memo.unwrap_or_else(|| Memo::new_message(DEFAULT_CLAIM_MEMO).expect("valid memo"));
+        let output = Output::new(recipient, TARI_TOKEN, final_amount).with_memo(memo);
+        let (outputs_statement, agg_output_mask) = wallet
+            .generate_outputs_statement(vec![output], Amount::from(max_fee))
+            .await?;
+
+        // The single stealth input is the burn UTXO minted by the `claim_burn` instruction. Its
+        // commitment comes from the proof and its mask from decrypting the L1 output.
+        let inputs_statement =
+            StealthInputsStatement::new(vec![StealthInput::from(claim_proof.commitment)], Amount::zero());
+        let agg_input_mask = decrypted.mask().clone();
+
+        let balance_proof = generate_stealth_balance_proof_signature(
+            &agg_input_mask,
+            &agg_output_mask,
+            &inputs_statement,
+            &outputs_statement,
+        );
+
+        let transfer = StealthTransferStatement {
+            inputs_statement,
+            outputs_statement,
+            balance_proof: Some(balance_proof),
+        };
+
+        // Sanity check the constructed transfer balances before paying any fees.
+        if let Err(err) = validate_transfer(&transfer, None) {
+            return Err(StealthProviderError::UnexpectedError {
+                details: format!("Constructed burn claim transfer is invalid: {err}"),
+            }
+            .into());
+        }
+
+        // Re-use the L1 burn output's encrypted data when minting the UTXO. The engine accepts any
+        // encrypted data here, so this is not strictly required, but it keeps the values consistent.
+        let output_data = ClaimBurnOutputData { encrypted_data };
+
+        let unsigned_tx = Transaction::builder(network)
+            .with_fee_instructions_builder(|builder| {
+                builder
+                    // Mint the burned funds as a confidential UTXO.
+                    .claim_burn(claim_proof, output_data)
+                    // Spend it into the stealth output, revealing `max_fee` for the fee.
+                    .stealth_transfer(TARI_TOKEN, transfer)
+                    .put_last_instruction_output_on_workspace("fee")
+                    .pay_fee_from_bucket("fee")
+            })
+            .build_unsigned();
+
+        Ok((unsigned_tx, BurnClaimSealer::new(stealth_secret, claimant)))
+    }
+}
+
+/// Seals a burn claim transaction with the derived stealth claim key `s`.
+///
+/// This is the only key that can satisfy the spend condition on the minted burn UTXO, so it is used
+/// instead of the wallet's account key. Implements [`TransactionSealSigner`] (for
+/// [`TransactionRequest::build`](crate::TransactionRequest::build)) and [`NetworkWallet`] (for dry-run
+/// fee estimation). A burn claim needs no additional authorizations — the seal authorizes the spend.
+#[derive(Clone)]
+pub struct BurnClaimSealer {
+    secret: RistrettoSecretKey,
+    address: Address,
+}
+
+impl BurnClaimSealer {
+    pub(crate) fn new(secret: RistrettoSecretKey, address: Address) -> Self {
+        Self { secret, address }
+    }
+}
+
+impl std::fmt::Debug for BurnClaimSealer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BurnClaimSealer")
+            .field("secret", &"<redacted>")
+            .field("address", &self.address)
+            .finish()
+    }
+}
+
+#[async_trait]
+impl TransactionSealSigner for BurnClaimSealer {
+    async fn seal_transaction(&self, transaction: UnsealedTransaction) -> signer::Result<Transaction> {
+        Ok(transaction.seal(&self.secret))
+    }
+}
+
+impl NetworkWallet for BurnClaimSealer {
+    fn default_address(&self) -> &Address {
+        &self.address
+    }
+
+    async fn sign_transaction(&self, unsigned: UnsignedTransaction) -> WalletResult<Transaction> {
+        // A burn claim carries no additional authorizations, so seal directly with the claim key.
+        Ok(unsigned.finish().seal(&self.secret))
+    }
+}

--- a/crates/wallet/ootle-rs/src/keys/secret.rs
+++ b/crates/wallet/ootle-rs/src/keys/secret.rs
@@ -10,15 +10,15 @@ use tari_crypto::{
 };
 use tari_ootle_address::{Network, OotleAddress};
 use tari_ootle_common_types::{base_layer_hashing::encrypted_data_hasher, engine_types::crypto::OutputBody};
-use tari_ootle_wallet_crypto::{DecryptedData, encrypted_data, kdfs};
-use tari_template_lib_types::crypto::PedersenCommitmentBytes;
+use tari_ootle_wallet_crypto::{DecryptedData, StealthCryptoApi, encrypted_data, kdfs};
+use tari_template_lib_types::{EncryptedData, crypto::PedersenCommitmentBytes};
 
 use crate::{
     key_provider,
     key_provider::{DiffieHellmanKdfKeyProvider, LocalKeyProvider, OutputMaskProvider},
     signer,
     signer::StealthKeyPrehashSigner,
-    stealth::{InputDecryptor, StealthProviderError, StealthResult},
+    stealth::{BurnClaimKeyProvider, InputDecryptor, StealthProviderError, StealthResult},
 };
 
 #[derive(Clone)]
@@ -145,6 +145,35 @@ where Self: DiffieHellmanKdfKeyProvider
             details: e.to_string(),
         })?;
 
+        Ok(decrypted)
+    }
+}
+
+#[async_trait]
+impl BurnClaimKeyProvider for LocalKeyProvider<OotleSecretKey> {
+    async fn derive_burn_claim_secret(
+        &self,
+        sender_offset_public_key: &RistrettoPublicKey,
+    ) -> StealthResult<RistrettoSecretKey> {
+        Ok(StealthCryptoApi::new()
+            .derive_burn_claim_stealth_secret(self.credentials().account_secret(), sender_offset_public_key))
+    }
+
+    async fn decrypt_burn_claim_output(
+        &self,
+        encrypted_data: &EncryptedData,
+        commitment: &PedersenCommitmentBytes,
+        sender_offset_public_key: &RistrettoPublicKey,
+    ) -> StealthResult<DecryptedData> {
+        // The L1 burn output's value/mask are bound to the account secret (not the view-only key), so we
+        // decrypt with the account secret. `skip_memo` because the L1 output carries no memo we need here.
+        let decrypted = StealthCryptoApi::new().decrypt_utxo_data(
+            encrypted_data,
+            commitment,
+            self.credentials().account_secret(),
+            sender_offset_public_key,
+            true,
+        )?;
         Ok(decrypted)
     }
 }

--- a/crates/wallet/ootle-rs/src/lib.rs
+++ b/crates/wallet/ootle-rs/src/lib.rs
@@ -95,6 +95,9 @@
 //! - **[`stealth`]** — confidential transfer support. [`stealth::StealthTransfer`] builds stealth transfer statements
 //!   with input/output commitments, encrypted memos, and change handling.
 //!
+//! - **[`claim_burn`]** — claim Layer 1 (minotari) burns. [`claim_burn::ClaimBurn`] mints burned funds into a
+//!   confidential UTXO and spends it into a stealth output owned by the claiming account.
+//!
 //! - **[`transaction`]** — transaction signing traits ([`transaction::TransactionSigner`],
 //!   [`transaction::TransactionSealSigner`]) and the `TransactionRequest` builder for constructing signed transactions
 //!   ready for submission.
@@ -136,6 +139,7 @@
 //!   Without this feature, values are decrypted via on-the-fly brute-force which is significantly slower.
 
 pub mod builtin_templates;
+pub mod claim_burn;
 pub mod key_provider;
 pub mod provider;
 pub mod signer;

--- a/crates/wallet/ootle-rs/src/stealth/error.rs
+++ b/crates/wallet/ootle-rs/src/stealth/error.rs
@@ -32,6 +32,10 @@ pub enum StealthProviderError {
         commitment: PedersenCommitmentBytes,
         details: String,
     },
+    #[error("L1 burn claim ownership proof validation failed")]
+    BurnClaimOwnershipProofInvalid,
+    #[error("L1 burn claim fee ({max_fee}) is greater than or equal to the claimed amount ({claimed})")]
+    BurnClaimFeeTooHigh { claimed: u64, max_fee: u64 },
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/wallet/ootle-rs/src/stealth/traits.rs
+++ b/crates/wallet/ootle-rs/src/stealth/traits.rs
@@ -5,7 +5,12 @@ use async_trait::async_trait;
 use tari_crypto::ristretto::{RistrettoPublicKey, RistrettoSecretKey};
 use tari_ootle_common_types::engine_types::crypto::OutputBody;
 use tari_ootle_wallet_crypto::DecryptedData;
-use tari_template_lib_types::{Amount, crypto::PedersenCommitmentBytes, stealth::StealthOutputsStatement};
+use tari_template_lib_types::{
+    Amount,
+    EncryptedData,
+    crypto::PedersenCommitmentBytes,
+    stealth::StealthOutputsStatement,
+};
 
 use crate::stealth::{Output, error::StealthProviderError};
 
@@ -27,6 +32,33 @@ pub trait InputDecryptor {
         commitment: &PedersenCommitmentBytes,
         input: &OutputBody,
         skip_memo: bool,
+    ) -> StealthResult<DecryptedData>;
+}
+
+/// Cryptographic operations required to claim a Layer 1 (minotari) burn.
+///
+/// Unlike a regular stealth transfer (which decrypts inputs with the view-only key), a burn claim
+/// uses the account secret directly: the L1 burn output is a stealth output addressed to the
+/// claiming account, and only the account secret can derive the key that spends the minted UTXO.
+#[async_trait]
+pub trait BurnClaimKeyProvider {
+    /// Derive the L1 burn-claim stealth secret `s = H(p·R) + p`, where `p` is the account secret and
+    /// `R` is the burn proof's `sender_offset_public_key`.
+    ///
+    /// This is the only key that satisfies the spend condition on the just-minted burn UTXO, so the
+    /// claim transaction must be sealed with it.
+    async fn derive_burn_claim_secret(
+        &self,
+        sender_offset_public_key: &RistrettoPublicKey,
+    ) -> StealthResult<RistrettoSecretKey>;
+
+    /// Decrypt the L1 burn output's encrypted value and mask using the account secret and the burn
+    /// proof's `sender_offset_public_key`.
+    async fn decrypt_burn_claim_output(
+        &self,
+        encrypted_data: &EncryptedData,
+        commitment: &PedersenCommitmentBytes,
+        sender_offset_public_key: &RistrettoPublicKey,
     ) -> StealthResult<DecryptedData>;
 }
 

--- a/crates/wallet/ootle-rs/src/wallet/ootle.rs
+++ b/crates/wallet/ootle-rs/src/wallet/ootle.rs
@@ -10,6 +10,7 @@ use tari_ootle_transaction::{IntoSigned, Transaction, TransactionSignature, Unse
 use tari_ootle_wallet_crypto::DecryptedData;
 use tari_template_lib_types::{
     Amount,
+    EncryptedData,
     crypto::{PedersenCommitmentBytes, RistrettoPublicKeyBytes},
     stealth::StealthOutputsStatement,
 };
@@ -146,6 +147,44 @@ impl OotleWallet {
             })?;
         let (statement, agg_output_mask) = signer.generate_outputs_statement(specs, revealed_output_amount).await?;
         Ok((statement, agg_output_mask))
+    }
+
+    /// Derive the L1 burn-claim stealth secret `s = H(p·R) + p` using the default key provider.
+    /// See [`crate::stealth::BurnClaimKeyProvider::derive_burn_claim_secret`].
+    pub async fn derive_burn_claim_secret(
+        &self,
+        sender_offset_public_key: &RistrettoPublicKey,
+    ) -> WalletResult<RistrettoSecretKey> {
+        let address = self.default_address();
+        let signer = self
+            .key_providers
+            .get(address)
+            .ok_or_else(|| WalletError::KeyProviderNotFound {
+                address: address.clone(),
+            })?;
+        let secret = signer.derive_burn_claim_secret(sender_offset_public_key).await?;
+        Ok(secret)
+    }
+
+    /// Decrypt an L1 burn output's value and mask using the default key provider.
+    /// See [`crate::stealth::BurnClaimKeyProvider::decrypt_burn_claim_output`].
+    pub async fn decrypt_burn_claim_output(
+        &self,
+        encrypted_data: &EncryptedData,
+        commitment: &PedersenCommitmentBytes,
+        sender_offset_public_key: &RistrettoPublicKey,
+    ) -> WalletResult<DecryptedData> {
+        let address = self.default_address();
+        let signer = self
+            .key_providers
+            .get(address)
+            .ok_or_else(|| WalletError::KeyProviderNotFound {
+                address: address.clone(),
+            })?;
+        let decrypted = signer
+            .decrypt_burn_claim_output(encrypted_data, commitment, sender_offset_public_key)
+            .await?;
+        Ok(decrypted)
     }
 
     pub fn stealth_authorizer(&self, required_signatures: SignatureRequirements) -> WalletStealthAuthorizer<'_, Self> {

--- a/crates/wallet/ootle-rs/src/wallet/traits.rs
+++ b/crates/wallet/ootle-rs/src/wallet/traits.rs
@@ -7,7 +7,7 @@ use tari_ootle_transaction::{Transaction, UnsignedTransaction};
 
 use crate::{
     Address,
-    stealth::{InputDecryptor, StealthOutputStatementFactory},
+    stealth::{BurnClaimKeyProvider, InputDecryptor, StealthOutputStatementFactory},
     transaction::{TransactionSigner, TransactionStealthKeySigner},
     wallet::WalletResult,
 };
@@ -21,12 +21,17 @@ pub trait NetworkWallet {
 }
 
 /// A key provider that can sign transactions, derive stealth keys, generate output
-/// statements, and decrypt stealth inputs. Automatically implemented for any type
-/// implementing all four constituent traits.
+/// statements, decrypt stealth inputs, and claim Layer 1 burns. Automatically implemented
+/// for any type implementing all constituent traits.
 pub trait WalletKeyProvider:
-    TransactionSigner + TransactionStealthKeySigner + StealthOutputStatementFactory + InputDecryptor
+    TransactionSigner + TransactionStealthKeySigner + StealthOutputStatementFactory + InputDecryptor + BurnClaimKeyProvider
 {
 }
 
-impl<T> WalletKeyProvider for T where T: TransactionSigner + TransactionStealthKeySigner + StealthOutputStatementFactory + InputDecryptor
-{}
+impl<T> WalletKeyProvider for T where T: TransactionSigner
+        + TransactionStealthKeySigner
+        + StealthOutputStatementFactory
+        + InputDecryptor
+        + BurnClaimKeyProvider
+{
+}


### PR DESCRIPTION
Adds L1 (minotari) burn claiming to the `ootle-rs` SDK, porting the wallet daemon's `execute_claim_burn` flow (`applications/tari_walletd/src/handlers/accounts.rs`) into a first-class builder.

## What's added

- `claim_burn::ClaimBurn` builder + `claim_burn::BurnClaimSealer`. `ClaimBurn` mints the burned funds as a confidential UTXO and spends it into a stealth output owned by the claiming account (revealing a small amount to pay the fee). The transaction is sealed with the derived stealth claim key `s = H(p·R) + p` — the only key that can satisfy the spend condition on the minted burn UTXO. `prepare()` returns `(UnsignedTransaction, BurnClaimSealer)`; the sealer implements `TransactionSealSigner` (for `TransactionRequest::build`) and `NetworkWallet` (for dry-run fee estimation), matching the stealth-transfer usage pattern.
- `BurnClaimKeyProvider` capability trait (`stealth/traits.rs`), implemented for `LocalKeyProvider<OotleSecretKey>` and exposed via `OotleWallet::{derive_burn_claim_secret, decrypt_burn_claim_output}`. Added to the `WalletKeyProvider` supertrait — only local providers implement it; the Ledger signer is not a `WalletKeyProvider` and is unaffected.
- Two `StealthProviderError` variants (`BurnClaimOwnershipProofInvalid`, `BurnClaimFeeTooHigh`).
- Runnable `examples/claim_burn.rs`, plus README / examples-README / crate-doc updates.
- Bumps `ootle-rs` `0.9.0 → 0.10.0` — a breaking minor bump per `scripts/crate_versioning.py impact ootle-rs --breaking`, because the public `WalletKeyProvider` trait gained a supertrait bound. `ootle-rs` has no in-workspace dependents, so nothing else needs republishing.

## Implementation notes

- Statement construction mirrors the in-crate `StealthTransfer::prepare` (reusing the tested `generate_outputs_statement` for the output witness) rather than re-implementing witness construction. The claimed-funds output is an ordinary stealth output to the claimant's own address.
- Burn claiming is only available for local key providers (like stealth transfers), not the Ledger signer.

## Testing

- `cargo check -p ootle-rs` (incl. `--examples` and `--features ledger`), `cargo clippy -p ootle-rs --all-targets --all-features` (clean), and `cargo test -p ootle-rs` (7 unit tests pass). End-to-end claiming needs a real L1 burn proof and is not covered by an automated test.