### PR TITLE
fix(template-abi): declare "env" wasm import module for engine host functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12429,7 +12429,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_abi"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "hashbrown 0.13.2",
  "minicbor",

--- a/crates/template_abi/Cargo.toml
+++ b/crates/template_abi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_template_abi"
 description = "Defines the low-level Tari engine ABI for WASM targets"
-version = "0.17.0"
+version = "0.17.1"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/template_abi/src/abi/wasm.rs
+++ b/crates/template_abi/src/abi/wasm.rs
@@ -20,6 +20,12 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+// As of Rust 1.96, the `wasm32-unknown-unknown` target no longer passes `--allow-undefined` to the linker, so
+// undefined symbols are hard linker errors instead of being implicitly turned into imports. These functions are
+// resolved at runtime by the engine host, which provides them under the "env" module (see the wasmer `imports!`
+// wiring in the engine crate), so we declare that import module explicitly.
+// https://blog.rust-lang.org/2026/04/04/changes-to-webassembly-targets-and-handling-undefined-symbols/
+#[link(wasm_import_module = "env")]
 unsafe extern "C" {
     pub fn tari_engine(op: i32, input_ptr: *const u8, input_len: usize) -> *mut u8;
     pub fn tari_debug(input_ptr: *const u8, input_len: usize);


### PR DESCRIPTION
## Description

Rust 1.96 removed the implicit `--allow-undefined` linker flag for the `wasm32-unknown-unknown` target. Undefined symbols are now hard linker errors instead of being silently turned into wasm imports, breaking all template builds with errors like:

```
rust-lld: error: undefined symbol: tari_engine
rust-lld: error: undefined symbol: on_panic
```

## Motivation

The engine host registers the `tari_engine`, `tari_debug`, and `on_panic` host functions under the `"env"` import module (via wasmer's `imports!` macro in `crates/engine/src/wasm/module.rs`). Previously the linker silently manufactured wasm imports for them; now it requires the import module to be explicitly declared on the Rust side.

This is the migration path recommended in the [Rust 1.96 release notes](https://blog.rust-lang.org/2026/04/04/changes-to-webassembly-targets-and-handling-undefined-symbols/).

## Changes

- Add `#[link(wasm_import_module = "env")]` to the `extern "C"` block in `crates/template_abi/src/abi/wasm.rs` that declares the three engine host functions
- The attribute is `#[cfg(target_arch = "wasm32")]`-gated so host (non-wasm) builds are unaffected

## Verification

All four builtin templates (`account`, `nft_faucet`, `faucet`, `liquidity_pool`) build cleanly to `wasm32-unknown-unknown --release` with this change. The fix is compatible with both old and new toolchains.