### PR TITLE
chore(deps): bump libp2p fork to clear hickory-dns RUSTSEC advisories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,7 +155,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -166,7 +166,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2354,7 +2354,7 @@ dependencies = [
  "lazy-regex",
  "linked-hash-map",
  "once_cell",
- "pin-project 1.1.12",
+ "pin-project 1.1.13",
  "regex",
  "sealed",
  "serde",
@@ -3372,9 +3372,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "elliptic-curve"
@@ -3421,18 +3421,6 @@ name = "endian-type"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
-
-[[package]]
-name = "enum-as-inner"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
-dependencies = [
- "heck 0.5.0",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
 
 [[package]]
 name = "enum-iterator"
@@ -3507,7 +3495,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4356,7 +4344,7 @@ dependencies = [
  "futures-channel",
  "futures-io",
  "futures-util",
- "hickory-proto 0.26.1",
+ "hickory-proto",
  "idna",
  "ipnet",
  "jni 0.22.4",
@@ -4367,32 +4355,6 @@ dependencies = [
  "tinyvec",
  "tokio",
  "tokio-rustls",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "hickory-proto"
-version = "0.25.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
-dependencies = [
- "async-trait",
- "cfg-if",
- "data-encoding",
- "enum-as-inner",
- "futures-channel",
- "futures-io",
- "futures-util",
- "idna",
- "ipnet",
- "once_cell",
- "rand 0.9.4",
- "ring",
- "socket2 0.5.10",
- "thiserror 2.0.18",
- "tinyvec",
- "tokio",
  "tracing",
  "url",
 ]
@@ -4419,27 +4381,6 @@ dependencies = [
 
 [[package]]
 name = "hickory-resolver"
-version = "0.25.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
-dependencies = [
- "cfg-if",
- "futures-util",
- "hickory-proto 0.25.2",
- "ipconfig",
- "moka",
- "once_cell",
- "parking_lot",
- "rand 0.9.4",
- "resolv-conf",
- "smallvec 1.15.1",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "hickory-resolver"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
@@ -4447,7 +4388,7 @@ dependencies = [
  "cfg-if",
  "futures-util",
  "hickory-net",
- "hickory-proto 0.26.1",
+ "hickory-proto",
  "ipconfig",
  "ipnet",
  "jni 0.22.4",
@@ -4928,11 +4869,10 @@ dependencies = [
 
 [[package]]
 name = "igd-next"
-version = "0.16.2"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "516893339c97f6011282d5825ac94fc1c7aad5cad26bdc2d0cee068c0bf97f97"
+checksum = "bac9a3c8278f43b4cd8463380f4a25653ac843e5b177e1d3eaf849cc9ba10d4d"
 dependencies = [
- "async-trait",
  "attohttpc",
  "bytes",
  "futures 0.3.31",
@@ -4941,7 +4881,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "log",
- "rand 0.9.4",
+ "rand 0.10.1",
  "tokio",
  "url",
  "xmltree",
@@ -5240,7 +5180,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5652,7 +5592,7 @@ checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 [[package]]
 name = "libp2p"
 version = "0.57.0"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a#76f31bc0ab4bd9f9f5383be6aa3fed873538e35a"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=e31882612c2e9c843a789117e460022ab7cda06b#e31882612c2e9c843a789117e460022ab7cda06b"
 dependencies = [
  "bytes",
  "either",
@@ -5667,7 +5607,7 @@ dependencies = [
  "libp2p-dns",
  "libp2p-gossipsub",
  "libp2p-identify",
- "libp2p-identity 0.2.13 (git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a)",
+ "libp2p-identity 0.2.14",
  "libp2p-mdns",
  "libp2p-metrics",
  "libp2p-noise",
@@ -5680,7 +5620,7 @@ dependencies = [
  "libp2p-upnp",
  "libp2p-yamux",
  "multiaddr 0.18.3",
- "pin-project 1.1.12",
+ "pin-project 1.1.13",
  "rw-stream-sink",
  "thiserror 2.0.18",
 ]
@@ -5688,17 +5628,17 @@ dependencies = [
 [[package]]
 name = "libp2p-allow-block-list"
 version = "0.7.0"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a#76f31bc0ab4bd9f9f5383be6aa3fed873538e35a"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=e31882612c2e9c843a789117e460022ab7cda06b#e31882612c2e9c843a789117e460022ab7cda06b"
 dependencies = [
  "libp2p-core",
- "libp2p-identity 0.2.13 (git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a)",
+ "libp2p-identity 0.2.14",
  "libp2p-swarm",
 ]
 
 [[package]]
 name = "libp2p-autonat"
 version = "0.16.0"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a#76f31bc0ab4bd9f9f5383be6aa3fed873538e35a"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=e31882612c2e9c843a789117e460022ab7cda06b#e31882612c2e9c843a789117e460022ab7cda06b"
 dependencies = [
  "asynchronous-codec",
  "either",
@@ -5706,11 +5646,11 @@ dependencies = [
  "futures-bounded 0.3.0",
  "futures-timer",
  "libp2p-core",
- "libp2p-identity 0.2.13 (git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a)",
+ "libp2p-identity 0.2.14",
  "libp2p-request-response",
  "libp2p-swarm",
- "quick-protobuf",
- "quick-protobuf-codec 0.4.0",
+ "prost 0.14.3",
+ "prost-codec",
  "rand 0.8.6",
  "rand_core 0.6.4",
  "thiserror 2.0.18",
@@ -5721,29 +5661,29 @@ dependencies = [
 [[package]]
 name = "libp2p-connection-limits"
 version = "0.7.0"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a#76f31bc0ab4bd9f9f5383be6aa3fed873538e35a"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=e31882612c2e9c843a789117e460022ab7cda06b#e31882612c2e9c843a789117e460022ab7cda06b"
 dependencies = [
  "libp2p-core",
- "libp2p-identity 0.2.13 (git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a)",
+ "libp2p-identity 0.2.14",
  "libp2p-swarm",
 ]
 
 [[package]]
 name = "libp2p-core"
 version = "0.44.0"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a#76f31bc0ab4bd9f9f5383be6aa3fed873538e35a"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=e31882612c2e9c843a789117e460022ab7cda06b#e31882612c2e9c843a789117e460022ab7cda06b"
 dependencies = [
  "either",
  "fnv",
  "futures 0.3.31",
  "futures-timer",
- "libp2p-identity 0.2.13 (git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a)",
+ "libp2p-identity 0.2.14",
  "multiaddr 0.18.3",
  "multihash",
  "multistream-select",
  "parking_lot",
- "pin-project 1.1.12",
- "quick-protobuf",
+ "pin-project 1.1.13",
+ "prost 0.14.3",
  "rand 0.8.6",
  "rw-stream-sink",
  "thiserror 2.0.18",
@@ -5755,7 +5695,7 @@ dependencies = [
 [[package]]
 name = "libp2p-dcutr"
 version = "0.15.0"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a#76f31bc0ab4bd9f9f5383be6aa3fed873538e35a"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=e31882612c2e9c843a789117e460022ab7cda06b#e31882612c2e9c843a789117e460022ab7cda06b"
 dependencies = [
  "asynchronous-codec",
  "either",
@@ -5764,10 +5704,10 @@ dependencies = [
  "futures-timer",
  "hashlink 0.11.0",
  "libp2p-core",
- "libp2p-identity 0.2.13 (git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a)",
+ "libp2p-identity 0.2.14",
  "libp2p-swarm",
- "quick-protobuf",
- "quick-protobuf-codec 0.4.0",
+ "prost 0.14.3",
+ "prost-codec",
  "thiserror 2.0.18",
  "tracing",
  "web-time",
@@ -5776,12 +5716,12 @@ dependencies = [
 [[package]]
 name = "libp2p-dns"
 version = "0.45.0"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a#76f31bc0ab4bd9f9f5383be6aa3fed873538e35a"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=e31882612c2e9c843a789117e460022ab7cda06b#e31882612c2e9c843a789117e460022ab7cda06b"
 dependencies = [
  "futures 0.3.31",
- "hickory-resolver 0.25.2",
+ "hickory-resolver",
  "libp2p-core",
- "libp2p-identity 0.2.13 (git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a)",
+ "libp2p-identity 0.2.14",
  "parking_lot",
  "smallvec 1.15.1",
  "tracing",
@@ -5790,7 +5730,7 @@ dependencies = [
 [[package]]
 name = "libp2p-gossipsub"
 version = "0.50.0"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a#76f31bc0ab4bd9f9f5383be6aa3fed873538e35a"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=e31882612c2e9c843a789117e460022ab7cda06b#e31882612c2e9c843a789117e460022ab7cda06b"
 dependencies = [
  "async-channel",
  "asynchronous-codec",
@@ -5805,11 +5745,11 @@ dependencies = [
  "hashlink 0.11.0",
  "hex_fmt",
  "libp2p-core",
- "libp2p-identity 0.2.13 (git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a)",
+ "libp2p-identity 0.2.14",
  "libp2p-swarm",
  "prometheus-client",
- "quick-protobuf",
- "quick-protobuf-codec 0.4.0",
+ "prost 0.14.3",
+ "prost-codec",
  "rand 0.8.6",
  "regex",
  "sha2 0.10.9",
@@ -5820,7 +5760,7 @@ dependencies = [
 [[package]]
 name = "libp2p-identify"
 version = "0.48.0"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a#76f31bc0ab4bd9f9f5383be6aa3fed873538e35a"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=e31882612c2e9c843a789117e460022ab7cda06b#e31882612c2e9c843a789117e460022ab7cda06b"
 dependencies = [
  "asynchronous-codec",
  "either",
@@ -5828,10 +5768,10 @@ dependencies = [
  "futures-bounded 0.3.0",
  "futures-timer",
  "libp2p-core",
- "libp2p-identity 0.2.13 (git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a)",
+ "libp2p-identity 0.2.14",
  "libp2p-swarm",
- "quick-protobuf",
- "quick-protobuf-codec 0.4.0",
+ "prost 0.14.3",
+ "prost-codec",
  "smallvec 1.15.1",
  "thiserror 2.0.18",
  "tracing",
@@ -5853,14 +5793,14 @@ dependencies = [
 
 [[package]]
 name = "libp2p-identity"
-version = "0.2.13"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a#76f31bc0ab4bd9f9f5383be6aa3fed873538e35a"
+version = "0.2.14"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=e31882612c2e9c843a789117e460022ab7cda06b#e31882612c2e9c843a789117e460022ab7cda06b"
 dependencies = [
  "bs58",
  "ed25519-dalek 3.0.0-pre.6",
  "hkdf",
  "multihash",
- "quick-protobuf",
+ "prost 0.14.3",
  "rand 0.10.1",
  "serde",
  "sha2 0.10.9",
@@ -5873,13 +5813,13 @@ dependencies = [
 [[package]]
 name = "libp2p-mdns"
 version = "0.49.0"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a#76f31bc0ab4bd9f9f5383be6aa3fed873538e35a"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=e31882612c2e9c843a789117e460022ab7cda06b#e31882612c2e9c843a789117e460022ab7cda06b"
 dependencies = [
  "futures 0.3.31",
- "hickory-proto 0.25.2",
+ "hickory-proto",
  "if-watch",
  "libp2p-core",
- "libp2p-identity 0.2.13 (git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a)",
+ "libp2p-identity 0.2.14",
  "libp2p-swarm",
  "rand 0.8.6",
  "smallvec 1.15.1",
@@ -5904,18 +5844,18 @@ dependencies = [
 [[package]]
 name = "libp2p-metrics"
 version = "0.18.0"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a#76f31bc0ab4bd9f9f5383be6aa3fed873538e35a"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=e31882612c2e9c843a789117e460022ab7cda06b#e31882612c2e9c843a789117e460022ab7cda06b"
 dependencies = [
  "futures 0.3.31",
  "libp2p-core",
  "libp2p-dcutr",
  "libp2p-gossipsub",
  "libp2p-identify",
- "libp2p-identity 0.2.13 (git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a)",
+ "libp2p-identity 0.2.14",
  "libp2p-ping",
  "libp2p-relay",
  "libp2p-swarm",
- "pin-project 1.1.12",
+ "pin-project 1.1.13",
  "prometheus-client",
  "web-time",
 ]
@@ -5923,16 +5863,16 @@ dependencies = [
 [[package]]
 name = "libp2p-noise"
 version = "0.47.0"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a#76f31bc0ab4bd9f9f5383be6aa3fed873538e35a"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=e31882612c2e9c843a789117e460022ab7cda06b#e31882612c2e9c843a789117e460022ab7cda06b"
 dependencies = [
  "asynchronous-codec",
  "bytes",
  "futures 0.3.31",
  "libp2p-core",
- "libp2p-identity 0.2.13 (git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a)",
+ "libp2p-identity 0.2.14",
  "multiaddr 0.18.3",
  "multihash",
- "quick-protobuf",
+ "prost 0.14.3",
  "rand 0.8.6",
  "snow",
  "static_assertions",
@@ -5945,7 +5885,7 @@ dependencies = [
 [[package]]
 name = "libp2p-peer-store"
 version = "0.1.0"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a#76f31bc0ab4bd9f9f5383be6aa3fed873538e35a"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=e31882612c2e9c843a789117e460022ab7cda06b#e31882612c2e9c843a789117e460022ab7cda06b"
 dependencies = [
  "hashlink 0.11.0",
  "libp2p-core",
@@ -5965,7 +5905,7 @@ dependencies = [
  "pb-rs",
  "prometheus-client",
  "quick-protobuf",
- "quick-protobuf-codec 0.3.1",
+ "quick-protobuf-codec",
  "thiserror 2.0.18",
  "tracing",
 ]
@@ -5973,12 +5913,12 @@ dependencies = [
 [[package]]
 name = "libp2p-ping"
 version = "0.48.0"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a#76f31bc0ab4bd9f9f5383be6aa3fed873538e35a"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=e31882612c2e9c843a789117e460022ab7cda06b#e31882612c2e9c843a789117e460022ab7cda06b"
 dependencies = [
  "futures 0.3.31",
  "futures-timer",
  "libp2p-core",
- "libp2p-identity 0.2.13 (git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a)",
+ "libp2p-identity 0.2.14",
  "libp2p-swarm",
  "rand 0.8.6",
  "tracing",
@@ -5988,13 +5928,13 @@ dependencies = [
 [[package]]
 name = "libp2p-quic"
 version = "0.14.0"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a#76f31bc0ab4bd9f9f5383be6aa3fed873538e35a"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=e31882612c2e9c843a789117e460022ab7cda06b#e31882612c2e9c843a789117e460022ab7cda06b"
 dependencies = [
  "futures 0.3.31",
  "futures-timer",
  "if-watch",
  "libp2p-core",
- "libp2p-identity 0.2.13 (git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a)",
+ "libp2p-identity 0.2.14",
  "libp2p-tls",
  "quinn",
  "rand 0.8.6",
@@ -6009,7 +5949,7 @@ dependencies = [
 [[package]]
 name = "libp2p-relay"
 version = "0.22.0"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a#76f31bc0ab4bd9f9f5383be6aa3fed873538e35a"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=e31882612c2e9c843a789117e460022ab7cda06b#e31882612c2e9c843a789117e460022ab7cda06b"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -6018,10 +5958,10 @@ dependencies = [
  "futures-bounded 0.3.0",
  "futures-timer",
  "libp2p-core",
- "libp2p-identity 0.2.13 (git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a)",
+ "libp2p-identity 0.2.14",
  "libp2p-swarm",
- "quick-protobuf",
- "quick-protobuf-codec 0.4.0",
+ "prost 0.14.3",
+ "prost-codec",
  "rand 0.8.6",
  "static_assertions",
  "thiserror 2.0.18",
@@ -6032,7 +5972,7 @@ dependencies = [
 [[package]]
 name = "libp2p-rendezvous"
 version = "0.18.0"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a#76f31bc0ab4bd9f9f5383be6aa3fed873538e35a"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=e31882612c2e9c843a789117e460022ab7cda06b#e31882612c2e9c843a789117e460022ab7cda06b"
 dependencies = [
  "asynchronous-codec",
  "bimap",
@@ -6040,11 +5980,11 @@ dependencies = [
  "futures-timer",
  "hashlink 0.11.0",
  "libp2p-core",
- "libp2p-identity 0.2.13 (git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a)",
+ "libp2p-identity 0.2.14",
  "libp2p-request-response",
  "libp2p-swarm",
- "quick-protobuf",
- "quick-protobuf-codec 0.4.0",
+ "prost 0.14.3",
+ "prost-codec",
  "rand 0.8.6",
  "thiserror 2.0.18",
  "tracing",
@@ -6054,12 +5994,12 @@ dependencies = [
 [[package]]
 name = "libp2p-request-response"
 version = "0.30.0"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a#76f31bc0ab4bd9f9f5383be6aa3fed873538e35a"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=e31882612c2e9c843a789117e460022ab7cda06b#e31882612c2e9c843a789117e460022ab7cda06b"
 dependencies = [
  "futures 0.3.31",
  "futures-bounded 0.3.0",
  "libp2p-core",
- "libp2p-identity 0.2.13 (git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a)",
+ "libp2p-identity 0.2.14",
  "libp2p-swarm",
  "rand 0.8.6",
  "smallvec 1.15.1",
@@ -6079,7 +6019,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm"
 version = "0.48.0"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a#76f31bc0ab4bd9f9f5383be6aa3fed873538e35a"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=e31882612c2e9c843a789117e460022ab7cda06b#e31882612c2e9c843a789117e460022ab7cda06b"
 dependencies = [
  "either",
  "fnv",
@@ -6088,7 +6028,7 @@ dependencies = [
  "getrandom 0.2.17",
  "hashlink 0.11.0",
  "libp2p-core",
- "libp2p-identity 0.2.13 (git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a)",
+ "libp2p-identity 0.2.14",
  "libp2p-swarm-derive",
  "multistream-select",
  "rand 0.8.6",
@@ -6102,7 +6042,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm-derive"
 version = "0.36.0"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a#76f31bc0ab4bd9f9f5383be6aa3fed873538e35a"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=e31882612c2e9c843a789117e460022ab7cda06b#e31882612c2e9c843a789117e460022ab7cda06b"
 dependencies = [
  "heck 0.5.0",
  "quote",
@@ -6112,7 +6052,7 @@ dependencies = [
 [[package]]
 name = "libp2p-tcp"
 version = "0.45.0"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a#76f31bc0ab4bd9f9f5383be6aa3fed873538e35a"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=e31882612c2e9c843a789117e460022ab7cda06b#e31882612c2e9c843a789117e460022ab7cda06b"
 dependencies = [
  "futures 0.3.31",
  "futures-timer",
@@ -6127,25 +6067,25 @@ dependencies = [
 [[package]]
 name = "libp2p-tls"
 version = "0.7.0"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a#76f31bc0ab4bd9f9f5383be6aa3fed873538e35a"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=e31882612c2e9c843a789117e460022ab7cda06b#e31882612c2e9c843a789117e460022ab7cda06b"
 dependencies = [
  "futures 0.3.31",
  "futures-rustls",
  "libp2p-core",
- "libp2p-identity 0.2.13 (git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a)",
+ "libp2p-identity 0.2.14",
  "rcgen 0.13.2",
  "ring",
  "rustls",
  "rustls-webpki",
  "thiserror 2.0.18",
- "x509-parser 0.17.0",
- "yasna",
+ "x509-parser 0.18.1",
+ "yasna 0.6.0",
 ]
 
 [[package]]
 name = "libp2p-upnp"
 version = "0.7.0"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a#76f31bc0ab4bd9f9f5383be6aa3fed873538e35a"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=e31882612c2e9c843a789117e460022ab7cda06b#e31882612c2e9c843a789117e460022ab7cda06b"
 dependencies = [
  "futures 0.3.31",
  "futures-timer",
@@ -6159,7 +6099,7 @@ dependencies = [
 [[package]]
 name = "libp2p-yamux"
 version = "0.48.0"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a#76f31bc0ab4bd9f9f5383be6aa3fed873538e35a"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=e31882612c2e9c843a789117e460022ab7cda06b#e31882612c2e9c843a789117e460022ab7cda06b"
 dependencies = [
  "either",
  "futures 0.3.31",
@@ -7071,7 +7011,7 @@ dependencies = [
  "arrayref",
  "byteorder",
  "data-encoding",
- "libp2p-identity 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-identity 0.2.13",
  "multibase",
  "multihash",
  "percent-encoding",
@@ -7084,13 +7024,13 @@ dependencies = [
 [[package]]
 name = "multiaddr"
 version = "0.18.3"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a#76f31bc0ab4bd9f9f5383be6aa3fed873538e35a"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=e31882612c2e9c843a789117e460022ab7cda06b#e31882612c2e9c843a789117e460022ab7cda06b"
 dependencies = [
  "arrayref",
  "byteorder",
  "bytes",
  "data-encoding",
- "libp2p-identity 0.2.13 (git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a)",
+ "libp2p-identity 0.2.14",
  "multibase",
  "multihash",
  "percent-encoding",
@@ -7136,11 +7076,11 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 [[package]]
 name = "multistream-select"
 version = "0.14.0"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a#76f31bc0ab4bd9f9f5383be6aa3fed873538e35a"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=e31882612c2e9c843a789117e460022ab7cda06b#e31882612c2e9c843a789117e460022ab7cda06b"
 dependencies = [
  "bytes",
  "futures 0.3.31",
- "pin-project 1.1.12",
+ "pin-project 1.1.13",
  "smallvec 1.15.1",
  "tracing",
  "unsigned-varint",
@@ -7403,7 +7343,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8139,7 +8079,7 @@ dependencies = [
  "aes-gcm",
  "aes-kw",
  "argon2 0.5.3",
- "base64 0.22.1",
+ "base64 0.21.7",
  "bitfields",
  "block-padding",
  "blowfish",
@@ -8220,11 +8160,11 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.12"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbf0d9e68100b3a7989b4901972f265cd542e560a3a8a724e1e20322f4d06ce9"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
- "pin-project-internal 1.1.12",
+ "pin-project-internal 1.1.13",
 ]
 
 [[package]]
@@ -8240,9 +8180,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.12"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a990e22f43e84855daf260dded30524ef4a9021cc7541c26540500a50b624389"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8596,7 +8536,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck 0.5.0",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "log",
  "multimap 0.10.1",
  "once_cell",
@@ -8616,7 +8556,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck 0.5.0",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "log",
  "multimap 0.10.1",
  "petgraph 0.8.3",
@@ -8626,6 +8566,18 @@ dependencies = [
  "regex",
  "syn 2.0.117",
  "tempfile",
+]
+
+[[package]]
+name = "prost-codec"
+version = "0.4.0"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=e31882612c2e9c843a789117e460022ab7cda06b#e31882612c2e9c843a789117e460022ab7cda06b"
+dependencies = [
+ "asynchronous-codec",
+ "bytes",
+ "prost 0.14.3",
+ "thiserror 2.0.18",
+ "unsigned-varint",
 ]
 
 [[package]]
@@ -8648,7 +8600,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -8661,7 +8613,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -8804,18 +8756,6 @@ dependencies = [
  "bytes",
  "quick-protobuf",
  "thiserror 1.0.69",
- "unsigned-varint",
-]
-
-[[package]]
-name = "quick-protobuf-codec"
-version = "0.4.0"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a#76f31bc0ab4bd9f9f5383be6aa3fed873538e35a"
-dependencies = [
- "asynchronous-codec",
- "bytes",
- "quick-protobuf",
- "thiserror 2.0.18",
  "unsigned-varint",
 ]
 
@@ -9084,7 +9024,7 @@ dependencies = [
  "pem",
  "ring",
  "time",
- "yasna",
+ "yasna 0.5.2",
 ]
 
 [[package]]
@@ -9098,7 +9038,7 @@ dependencies = [
  "rustls-pki-types",
  "time",
  "x509-parser 0.16.0",
- "yasna",
+ "yasna 0.5.2",
 ]
 
 [[package]]
@@ -9630,14 +9570,14 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.36"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -9689,7 +9629,7 @@ dependencies = [
  "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9710,7 +9650,7 @@ dependencies = [
  "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9783,10 +9723,10 @@ dependencies = [
 [[package]]
 name = "rw-stream-sink"
 version = "0.5.0"
-source = "git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a#76f31bc0ab4bd9f9f5383be6aa3fed873538e35a"
+source = "git+https://github.com/tari-project/rust-libp2p.git?rev=e31882612c2e9c843a789117e460022ab7cda06b#e31882612c2e9c843a789117e460022ab7cda06b"
 dependencies = [
  "futures 0.3.31",
- "pin-project 1.1.12",
+ "pin-project 1.1.13",
  "static_assertions",
 ]
 
@@ -10551,7 +10491,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11113,7 +11053,7 @@ dependencies = [
  "multiaddr 0.18.2",
  "nom 7.1.3",
  "once_cell",
- "pin-project 1.1.12",
+ "pin-project 1.1.13",
  "prost 0.13.5",
  "rand 0.10.1",
  "serde",
@@ -11241,7 +11181,7 @@ dependencies = [
  "fs2",
  "futures 0.3.31",
  "hex",
- "hickory-proto 0.26.1",
+ "hickory-proto",
  "integer-encoding",
  "jmt",
  "lmdb-zero",
@@ -11722,7 +11662,7 @@ dependencies = [
  "clap 3.2.25",
  "config",
  "dirs-next 2.0.0",
- "libp2p-identity 0.2.13 (git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a)",
+ "libp2p-identity 0.2.14",
  "log",
  "multiaddr 0.18.3",
  "ootle_byte_type",
@@ -11786,7 +11726,7 @@ name = "tari_ootle_p2p"
 version = "0.33.1"
 dependencies = [
  "anyhow",
- "libp2p-identity 0.2.13 (git+https://github.com/tari-project/rust-libp2p.git?rev=76f31bc0ab4bd9f9f5383be6aa3fed873538e35a)",
+ "libp2p-identity 0.2.14",
  "prost 0.14.3",
  "proto_builder",
  "rand 0.10.1",
@@ -12179,8 +12119,8 @@ source = "git+https://github.com/tari-project/tari.git?rev=d17fac8e588c98820dff1
 dependencies = [
  "anyhow",
  "futures 0.3.31",
- "hickory-proto 0.26.1",
- "hickory-resolver 0.26.1",
+ "hickory-proto",
+ "hickory-resolver",
  "log",
  "pgp",
  "prost 0.13.5",
@@ -12213,7 +12153,7 @@ dependencies = [
  "libp2p-substream",
  "log",
  "once_cell",
- "pin-project 1.1.12",
+ "pin-project 1.1.13",
  "prost 0.14.3",
  "proto_builder",
  "tari_metrics",
@@ -12855,7 +12795,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -13279,7 +13219,7 @@ dependencies = [
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
- "pin-project 1.1.12",
+ "pin-project 1.1.13",
  "prost 0.13.5",
  "socket2 0.5.10",
  "tokio",
@@ -13308,7 +13248,7 @@ dependencies = [
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
- "pin-project 1.1.12",
+ "pin-project 1.1.13",
  "prost 0.13.5",
  "rustls-native-certs",
  "socket2 0.5.10",
@@ -13358,7 +13298,7 @@ dependencies = [
  "futures-util",
  "hdrhistogram",
  "indexmap 1.9.3",
- "pin-project 1.1.12",
+ "pin-project 1.1.13",
  "pin-project-lite",
  "rand 0.8.6",
  "slab",
@@ -14627,7 +14567,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -15220,9 +15160,9 @@ dependencies = [
 
 [[package]]
 name = "x509-parser"
-version = "0.17.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4569f339c0c402346d4a75a9e39cf8dad310e287eef1ff56d4c68e5067f53460"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
 dependencies = [
  "asn1-rs 0.7.1",
  "data-encoding",
@@ -15287,7 +15227,7 @@ dependencies = [
  "log",
  "nohash-hasher",
  "parking_lot",
- "pin-project 1.1.12",
+ "pin-project 1.1.13",
  "rand 0.8.6",
  "static_assertions",
 ]
@@ -15302,7 +15242,7 @@ dependencies = [
  "log",
  "nohash-hasher",
  "parking_lot",
- "pin-project 1.1.12",
+ "pin-project 1.1.13",
  "rand 0.9.4",
  "static_assertions",
  "web-time",
@@ -15316,6 +15256,12 @@ checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
 dependencies = [
  "time",
 ]
+
+[[package]]
+name = "yasna"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282"
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -222,9 +222,9 @@ indexmap = "2.11.4"
 indoc = "1.0.6"
 lazy_static = "1.4.0"
 # Use Tari's libp2p fork that adds support for Schnorr-Ristretto
-libp2p-identity = { git = "https://github.com/tari-project/rust-libp2p.git", rev = "76f31bc0ab4bd9f9f5383be6aa3fed873538e35a" }
-libp2p = { git = "https://github.com/tari-project/rust-libp2p.git", rev = "76f31bc0ab4bd9f9f5383be6aa3fed873538e35a", default-features = false }
-libp2p-peer-store = { git = "https://github.com/tari-project/rust-libp2p.git", rev = "76f31bc0ab4bd9f9f5383be6aa3fed873538e35a", default-features = false }
+libp2p-identity = { git = "https://github.com/tari-project/rust-libp2p.git", rev = "e31882612c2e9c843a789117e460022ab7cda06b" }
+libp2p = { git = "https://github.com/tari-project/rust-libp2p.git", rev = "e31882612c2e9c843a789117e460022ab7cda06b", default-features = false }
+libp2p-peer-store = { git = "https://github.com/tari-project/rust-libp2p.git", rev = "e31882612c2e9c843a789117e460022ab7cda06b", default-features = false }
 #libp2p = "0.53.1"
 #libp2p-identity = "0.2.8"
 libsqlite3-sys = "0.30.1"
@@ -232,7 +232,7 @@ log = "0.4.20"
 log4rs = "1.3"
 mime_guess = "2.0.4"
 mini-moka = "0.10.0"
-multiaddr = { git = "https://github.com/tari-project/rust-libp2p.git", rev = "76f31bc0ab4bd9f9f5383be6aa3fed873538e35a" }
+multiaddr = { git = "https://github.com/tari-project/rust-libp2p.git", rev = "e31882612c2e9c843a789117e460022ab7cda06b" }
 #multiaddr = "0.18"
 newtype-ops = "0.1.4"
 num-integer = { version = "0.1.46", default-features = false }


### PR DESCRIPTION
## Description

Bumps the `tari-project/rust-libp2p` fork pin from `76f31bc` to `e318826` to clear the transitive hickory-dns advisories flagged by RUSTSEC.

The new rev upgrades the transitive `hickory-proto` / `hickory-resolver` crates **0.25.2 → 0.26.1**, which resolves:

- **RUSTSEC-2026-0119** (#2091) — `hickory-proto` O(n²) name-compression CPU exhaustion during message encoding (patched in ≥0.26.1)
- **RUSTSEC-2026-0118** — `hickory-proto` unbounded loop in NSEC3 closest-encloser proof validation

It also drops the `enum-as-inner` transitive dependency.

The rev additionally carries sr25519 proto field-casing compile fixes in `libp2p-identity`, which are required when the `sr25519` feature (the reason for the fork) is enabled.

## Motivation and Context

Fixes the RUSTSEC advisory tracked in #2091. The vulnerable `hickory-proto 0.25.2` was pulled in transitively via libp2p.

Closes https://github.com/tari-project/tari-ootle/issues/2091

## How Has This Been Tested?

- `cargo update -p libp2p` re-pinned the lock; old revs fully removed.
- `cargo check --workspace --all-targets --locked` passes.
- `cargo audit` no longer reports the hickory-proto advisories; `hickory-proto`/`hickory-resolver` are now 0.26.1.

## What process can a PR reviewer use to test or verify this change?

Run `cargo audit` before/after and confirm RUSTSEC-2026-0118/0119 against `hickory-proto` are gone, and that `cargo check --workspace --locked` builds.

## Breaking Changes

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other