### PR TITLE
fix(consensus): reduce max commands per block from 500 to 100

### DIFF
--- a/crates/consensus/src/consensus_constants.rs
+++ b/crates/consensus/src/consensus_constants.rs
@@ -68,7 +68,7 @@ impl ConsensusConstants {
             missed_proposal_suspend_threshold: 5,
             missed_proposal_evict_threshold: 10,
             missed_proposal_recovery_threshold: 5,
-            max_number_commands_in_block: 500,
+            max_number_commands_in_block: 100,
             fee_exhaust_divisor: 20, // 1/20 = 5%
             epoch_end_spread_blocks: 10,
         }
@@ -83,7 +83,7 @@ impl ConsensusConstants {
             missed_proposal_suspend_threshold: 5,
             missed_proposal_evict_threshold: 10,
             missed_proposal_recovery_threshold: 5,
-            max_number_commands_in_block: 500,
+            max_number_commands_in_block: 100,
             fee_exhaust_divisor: 20, // 1/20 = 5%
             epoch_end_spread_blocks: 1,
         }
@@ -98,7 +98,7 @@ impl ConsensusConstants {
             missed_proposal_suspend_threshold: 5,
             missed_proposal_evict_threshold: 10,
             missed_proposal_recovery_threshold: 5,
-            max_number_commands_in_block: 500,
+            max_number_commands_in_block: 100,
             fee_exhaust_divisor: 20, // 1/20 = 5%
             epoch_end_spread_blocks: 5,
         }
@@ -113,7 +113,7 @@ impl ConsensusConstants {
             missed_proposal_suspend_threshold: 5,
             missed_proposal_evict_threshold: 10,
             missed_proposal_recovery_threshold: 5,
-            max_number_commands_in_block: 500,
+            max_number_commands_in_block: 100,
             fee_exhaust_divisor: 20, // 1/20 = 5%
             epoch_end_spread_blocks: 5,
         }


### PR DESCRIPTION
## Summary

Reduces `max_number_commands_in_block` from **500 → 100** across all networks.

## Motivation

Stress testing on slower hardware exposed a consensus liveness/recovery problem:

- Under load the leader builds blocks of up to 500 commands.
- Executing such a block (`process_valid_block`) takes **~11s** on slower CPUs — **longer than the 10s `pacemaker_block_time`**.
- When block execution exceeds the block time, the HotStuff three-chain can't complete within the window: no QC forms, the high PC stays pinned at its last value, and the chain only crawls forward via dummy-block leader timeouts.
- The pacemaker leader-timeout backoff (`delta = 2^(current_view − high_pc)`) then grows to its `MAX_DELTA` (300s) ceiling, so leader-failure rotations happen only every ~5 minutes — the node does not recover even after load subsides.

Observed in logs: `EXCESSIVE: process_valid_block took 10.82s … 11.48s` for 500-command blocks, `high_pc` frozen while `current_view` ran ahead via timeout certificates, and 5+ minute gaps between leader failures.

## Fix

A ~100-command block executes well within the block time, so QCs form again, the high PC advances, and the pacemaker delta resets to normal cadence. Both the throughput-vs-hardware mismatch and the failure-to-recover are addressed by this single knob.

`max_number_commands_in_block` is a **leader-side proposing cap** — there is no command-count rule in block validation — so the change is fork-safe (all committee members should run it for the benefit to apply, but mismatched values do not fork the chain).

## Follow-up (not in this PR)

The cap is a fixed command count; a static count that is safe on fast CPUs can still exceed the block-time budget on slow ones. A more robust long-term guard would be a time/cost-bounded proposing limit that stops adding commands once estimated execution approaches a fraction of `block_time`.
