### PR TITLE
fix(consensus): treat DOWN substate at propose time as a skippable conflict

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1708,7 +1708,7 @@ dependencies = [
 
 [[package]]
 name = "consensus_tests"
-version = "0.33.1"
+version = "0.33.2"
 dependencies = [
  "fern",
  "futures 0.3.31",
@@ -2713,7 +2713,7 @@ dependencies = [
 
 [[package]]
 name = "db-inspector"
-version = "0.33.1"
+version = "0.33.2"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -5049,7 +5049,7 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "integration_tests"
-version = "0.33.1"
+version = "0.33.2"
 dependencies = [
  "anyhow",
  "config",
@@ -5823,7 +5823,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-messaging"
-version = "0.33.1"
+version = "0.33.2"
 dependencies = [
  "async-trait",
  "futures-bounded 0.2.4",
@@ -6001,7 +6001,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-substream"
-version = "0.33.1"
+version = "0.33.2"
 dependencies = [
  "libp2p",
  "prometheus-client",
@@ -7610,7 +7610,7 @@ dependencies = [
 
 [[package]]
 name = "ootle-wasm"
-version = "0.33.1"
+version = "0.33.2"
 dependencies = [
  "console_error_panic_hook",
  "getrandom 0.2.17",
@@ -7621,7 +7621,7 @@ dependencies = [
 
 [[package]]
 name = "ootle-wasm-core"
-version = "0.33.1"
+version = "0.33.2"
 dependencies = [
  "base64 0.22.1",
  "hex",
@@ -8641,7 +8641,7 @@ dependencies = [
 
 [[package]]
 name = "proto_builder"
-version = "0.33.1"
+version = "0.33.2"
 dependencies = [
  "prost-build 0.14.3",
  "sha2 0.10.9",
@@ -10506,7 +10506,7 @@ dependencies = [
 
 [[package]]
 name = "sqlite_message_logger"
-version = "0.33.1"
+version = "0.33.2"
 dependencies = [
  "chrono",
  "diesel",
@@ -10878,7 +10878,7 @@ dependencies = [
 
 [[package]]
 name = "tari_base_node_client"
-version = "0.33.1"
+version = "0.33.2"
 dependencies = [
  "futures-util",
  "log",
@@ -11104,7 +11104,7 @@ dependencies = [
 
 [[package]]
 name = "tari_consensus"
-version = "0.33.1"
+version = "0.33.2"
 dependencies = [
  "anyhow",
  "indexmap 2.13.0",
@@ -11129,7 +11129,7 @@ dependencies = [
 
 [[package]]
 name = "tari_consensus_types"
-version = "0.33.1"
+version = "0.33.2"
 dependencies = [
  "borsh",
  "minicbor",
@@ -11231,7 +11231,7 @@ dependencies = [
 
 [[package]]
 name = "tari_engine"
-version = "0.33.1"
+version = "0.33.2"
 dependencies = [
  "blake2 0.10.6",
  "bytes",
@@ -11263,7 +11263,7 @@ dependencies = [
 
 [[package]]
 name = "tari_engine_types"
-version = "0.33.1"
+version = "0.33.2"
 dependencies = [
  "blake2 0.10.6",
  "borsh",
@@ -11292,7 +11292,7 @@ dependencies = [
 
 [[package]]
 name = "tari_epoch_manager"
-version = "0.33.1"
+version = "0.33.2"
 dependencies = [
  "anyhow",
  "log",
@@ -11312,7 +11312,7 @@ dependencies = [
 
 [[package]]
 name = "tari_epoch_oracles"
-version = "0.33.1"
+version = "0.33.2"
 dependencies = [
  "anyhow",
  "blake2 0.10.6",
@@ -11367,7 +11367,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer"
-version = "0.33.1"
+version = "0.33.2"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -11468,7 +11468,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer_lib"
-version = "0.33.1"
+version = "0.33.2"
 dependencies = [
  "log",
  "minicbor",
@@ -11581,7 +11581,7 @@ dependencies = [
 
 [[package]]
 name = "tari_networking"
-version = "0.33.1"
+version = "0.33.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11634,7 +11634,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_app_utilities"
-version = "0.33.1"
+version = "0.33.2"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -11675,7 +11675,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_common_types"
-version = "0.33.1"
+version = "0.33.2"
 dependencies = [
  "blake2 0.10.6",
  "borsh",
@@ -11704,7 +11704,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_p2p"
-version = "0.33.1"
+version = "0.33.2"
 dependencies = [
  "anyhow",
  "libp2p-identity 0.2.14",
@@ -11728,7 +11728,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_storage"
-version = "0.33.1"
+version = "0.33.2"
 dependencies = [
  "anyhow",
  "bitflags 2.10.0",
@@ -11757,7 +11757,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_storage_sqlite"
-version = "0.33.1"
+version = "0.33.2"
 dependencies = [
  "diesel",
  "diesel_migrations",
@@ -11810,7 +11810,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_transaction"
-version = "0.33.1"
+version = "0.33.2"
 dependencies = [
  "borsh",
  "hex",
@@ -11836,7 +11836,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_cli"
-version = "0.33.1"
+version = "0.33.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -11866,7 +11866,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_crypto"
-version = "0.33.1"
+version = "0.33.2"
 dependencies = [
  "argon2 0.5.3",
  "blake2 0.10.6",
@@ -11896,7 +11896,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_sdk"
-version = "0.33.1"
+version = "0.33.2"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -11958,7 +11958,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_sdk_tests"
-version = "0.33.1"
+version = "0.33.2"
 dependencies = [
  "digest 0.10.7",
  "ootle_byte_type",
@@ -11980,7 +11980,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_storage_sqlite"
-version = "0.33.1"
+version = "0.33.2"
 dependencies = [
  "diesel",
  "diesel_migrations",
@@ -12003,7 +12003,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_walletd"
-version = "0.33.1"
+version = "0.33.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12124,7 +12124,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_framework"
-version = "0.33.1"
+version = "0.33.2"
 dependencies = [
  "async-trait",
  "bitflags 2.10.0",
@@ -12148,7 +12148,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_macros"
-version = "0.33.1"
+version = "0.33.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12157,7 +12157,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_state_sync"
-version = "0.33.1"
+version = "0.33.2"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -12235,7 +12235,7 @@ dependencies = [
 
 [[package]]
 name = "tari_state_store_rocksdb"
-version = "0.33.1"
+version = "0.33.2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12267,7 +12267,7 @@ dependencies = [
 
 [[package]]
 name = "tari_state_tree"
-version = "0.33.1"
+version = "0.33.2"
 dependencies = [
  "indexmap 2.13.0",
  "log",
@@ -12295,7 +12295,7 @@ dependencies = [
 
 [[package]]
 name = "tari_swarm"
-version = "0.33.1"
+version = "0.33.2"
 dependencies = [
  "libp2p",
  "libp2p-messaging",
@@ -12306,7 +12306,7 @@ dependencies = [
 
 [[package]]
 name = "tari_swarm_daemon"
-version = "0.33.1"
+version = "0.33.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12419,7 +12419,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_test_tooling"
-version = "0.33.1"
+version = "0.33.2"
 dependencies = [
  "anyhow",
  "cargo_toml 0.22.3",
@@ -12532,7 +12532,7 @@ dependencies = [
 
 [[package]]
 name = "tari_transaction_manifest"
-version = "0.33.1"
+version = "0.33.2"
 dependencies = [
  "proc-macro2",
  "serde_json",
@@ -12567,7 +12567,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node"
-version = "0.33.1"
+version = "0.33.2"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -12633,7 +12633,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node_client"
-version = "0.33.1"
+version = "0.33.2"
 dependencies = [
  "indexmap 2.13.0",
  "multiaddr 0.18.3",
@@ -12657,7 +12657,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node_rpc"
-version = "0.33.1"
+version = "0.33.2"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -12681,7 +12681,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_rollback"
-version = "0.33.1"
+version = "0.33.2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12716,7 +12716,7 @@ dependencies = [
 
 [[package]]
 name = "tari_watcher"
-version = "0.33.1"
+version = "0.33.2"
 dependencies = [
  "anyhow",
  "clap 3.2.25",
@@ -12745,7 +12745,7 @@ dependencies = [
 
 [[package]]
 name = "tariswap_bench"
-version = "0.33.1"
+version = "0.33.2"
 dependencies = [
  "anyhow",
  "clap 4.5.54",
@@ -13425,7 +13425,7 @@ dependencies = [
 
 [[package]]
 name = "traffic-sim"
-version = "0.33.1"
+version = "0.33.2"
 dependencies = [
  "anyhow",
  "clap 4.5.54",
@@ -13447,7 +13447,7 @@ dependencies = [
 
 [[package]]
 name = "transaction_generator"
-version = "0.33.1"
+version = "0.33.2"
 dependencies = [
  "anyhow",
  "bytes",
@@ -13466,7 +13466,7 @@ dependencies = [
 
 [[package]]
 name = "transaction_submitter"
-version = "0.33.1"
+version = "0.33.2"
 dependencies = [
  "anyhow",
  "clap 4.5.54",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.33.1"
+version = "0.33.2"
 edition = "2024"
 authors = ["The Tari Development Community"]
 repository = "https://github.com/tari-project/tari-ootle"

--- a/crates/consensus/src/hotstuff/on_propose.rs
+++ b/crates/consensus/src/hotstuff/on_propose.rs
@@ -718,14 +718,15 @@ where TConsensusSpec: ConsensusSpec
                         })?;
 
                         if let Err(err) = substate_store.put_diff(diff) {
-                            error!(
+                            // A lock failure or DOWN input is an expected conflict under contention - skip the
+                            // transaction this round. Any other store error is fatal and must be propagated.
+                            let lock_err = err.ok_lock_failed()?;
+                            warn!(
                                 target: LOG_TARGET,
-                                "🔒 Failed to write to temporary state store for transaction {} for LocalOnly: {}. Skipping proposing this transaction...",
+                                "🔒 Skipping LocalOnly transaction {} while proposing due to input conflict: {}",
                                 pool_tx.id(),
-                                err,
+                                lock_err,
                             );
-                            // Only error if it is not related to lock errors
-                            let _err = err.ok_lock_failed()?;
                             return Ok(None);
                         }
                     }
@@ -928,14 +929,15 @@ where TConsensusSpec: ConsensusSpec
         })?;
         let filtered_diff = filter_diff_for_committee(local_committee_info, diff);
         if let Err(err) = substate_store.put_diff(&filtered_diff) {
-            error!(
+            // A lock failure or DOWN input is an expected conflict under contention - skip the transaction this
+            // round. Any other store error is fatal and must be propagated.
+            let lock_err = err.ok_lock_failed()?;
+            warn!(
                 target: LOG_TARGET,
-                "🔒 Failed to write to temporary state store for transaction {} for Accept: {}. Skipping proposing this transaction...",
+                "🔒 Skipping Accept transaction {} while proposing due to input conflict: {}",
                 tx_rec.id(),
-                err,
+                lock_err,
             );
-            // Only error if it is not related to lock errors
-            let _err = err.ok_lock_failed()?;
             return Ok(None);
         }
         let atom = self.get_transaction_atom_with_leader_fee(tx_rec)?;

--- a/crates/consensus/src/hotstuff/substate_store/error.rs
+++ b/crates/consensus/src/hotstuff/substate_store/error.rs
@@ -38,6 +38,10 @@ impl SubstateStoreError {
     pub fn ok_lock_failed(self) -> Result<LockFailedError, Self> {
         match self {
             SubstateStoreError::LockFailed(err) => Ok(err),
+            // A substate that is DOWN is an expected conflict (its version was already spent by an earlier
+            // transaction), not a fatal store error. Treat it as a lock failure so callers can skip or abort the
+            // transaction rather than aborting consensus.
+            SubstateStoreError::SubstateIsDown { id } => Ok(LockFailedError::SubstateIsDown { id }),
             other => Err(other),
         }
     }

--- a/crates/consensus_tests/src/substate_store.rs
+++ b/crates/consensus_tests/src/substate_store.rs
@@ -208,6 +208,19 @@ fn it_allows_requesting_the_same_lock_within_one_transaction() {
     assert_eq!(n, 2);
 }
 
+#[test]
+fn substate_is_down_is_classified_as_a_skippable_lock_failure() {
+    // A DOWN substate (e.g. surfaced by put_diff at propose time when an input version was already spent)
+    // must be classified as a recoverable lock failure. The proposer relies on ok_lock_failed() to skip such
+    // transactions instead of propagating the error, which would otherwise crash consensus.
+    let id = VersionedSubstateId::new(new_substate_id(0), 0);
+    let err = SubstateStoreError::SubstateIsDown { id };
+    assert!(matches!(
+        err.ok_lock_failed(),
+        Ok(LockFailedError::SubstateIsDown { .. })
+    ));
+}
+
 fn add_substate(store: &TestStore, seed: u8, version: u32) -> VersionedSubstateId {
     let id = new_substate_id(seed);
     let value = new_substate_value(seed);


### PR DESCRIPTION
## Summary

Fixes a HotStuff consensus crash that occurs during proposal under high write contention, and bumps the workspace version to **0.33.2**.

## The crash

While stress testing, the validator node crashed consensus with:

```
ERROR 🔒 Failed to write to temporary state store ... Substate resource_…:7150 is DOWN. Skipping proposing this transaction...
ERROR Error (on_beat): Substate store error: Substate resource_…:7150 is DOWN
ERROR HotStuff crashed: Substate store error: Substate resource_…:7150 is DOWN
TRANSITION: Running --> Failure(...) --> Sleeping
```

The log claimed it was *"Skipping proposing this transaction..."* but the error was not actually skipped — it propagated and crashed the worker.

## Root cause

When the proposer writes a transaction's diff to the temporary substate store (`put_diff`) and an input substate is already **DOWN** (its version was spent by an earlier transaction in the block/chain), `put_diff` returns the **top-level** `SubstateStoreError::SubstateIsDown`.

The propose call sites (`on_propose.rs`) handle expected conflicts via:

```rust
// Only error if it is not related to lock errors
let _err = err.ok_lock_failed()?;
return Ok(None);
```

…but `ok_lock_failed()` only unwrapped `SubstateStoreError::LockFailed(_)`. The top-level `SubstateIsDown` fell through to `Err(other)`, so `?` propagated it out of `on_propose` → `on_beat` → crashed HotStuff. This contradicts `BlockTransactionExecutorError::is_substate_down_error()`, which already treats both the top-level and the `LockFailed`-wrapped `SubstateIsDown` as the same recoverable condition.

A DOWN input at propose time is an expected conflict under contention, not a fatal error.

## Fix

- `ok_lock_failed()` now classifies `SubstateStoreError::SubstateIsDown` as a recoverable `LockFailedError::SubstateIsDown` (uses the existing conversion precedent, consistent with `is_substate_down_error()`).
- Both propose call sites now log the skip at `warn` level (the previous `error!` was misleading since the case is handled) and still propagate genuinely fatal store errors.
- Regression test asserting the classification.

## Verification

- `cargo test -p consensus_tests substate_is_down` → `1 passed`.
- `cargo check` clean at 0.33.2.

## Notes

`try_lock` only ever emits `LockFailedError::LockConflict` (wrapped), never a top-level `SubstateIsDown`, so `try_lock_all` and the existing lock-conflict tests are unaffected by the `ok_lock_failed` change.
