### PR TITLE
fix(consensus): only reuse cached executions from ancestor blocks

### DIFF
--- a/crates/engine_types/src/commit_result.rs
+++ b/crates/engine_types/src/commit_result.rs
@@ -265,11 +265,7 @@ impl FinalizeResult {
         self.any_accept()
             .into_iter()
             .flat_map(|diff| diff.up_iter())
-            .filter_map(|(id, s)| {
-                s.substate_value()
-                    .as_resource()
-                    .and_then(|r| id.as_resource_address().map(|a| (a, r)))
-            })
+            .filter_map(|(id, s)| id.as_resource_address().zip(s.substate_value().as_resource()))
     }
 }
 

--- a/crates/state_store_rocksdb/src/reader.rs
+++ b/crates/state_store_rocksdb/src/reader.rs
@@ -652,28 +652,31 @@ impl<'tx, TAddr: NodeAddressable + Serialize + DeserializeOwned + 'tx> StateStor
             return Ok(exec);
         }
 
-        let block_ids = self.get_pending_chain_until(from_block.block_id())?;
-        debug!(
-            target: LOG_TARGET,
-            "{OPERATION}: No execution found for {transaction_id} in pending chain ({} blocks)",
-            block_ids.len(),
-        );
-
+        // Collect every execution recorded for this transaction.
         let query = self.db().cf(block_transaction_execution::ByTransactionIdQuery)?;
-        let iter = query.query_prefix_range_key_iterator(Ordering::default(), transaction_id);
-        let mut max_height_key = None;
-        for result in iter {
-            let (tx_id, block_id, height) = result?;
 
-            if max_height_key
-                .as_ref()
-                .is_none_or(|(_, block_id, current_height)| *current_height < height && block_ids.contains(block_id))
-            {
-                max_height_key = Some((tx_id, block_id, height));
+        // An execution may only be reused if it was recorded on an ancestor of `from_block`. This is determined with
+        // index lookups only - no blocks are loaded:
+        //  - a block on `from_block`'s pending chain is an uncommitted ancestor, so reusable;
+        //  - a block no longer in the pending-chain index has been committed, and because the committed chain is final
+        //    and linear every committed block is an ancestor, so reusable;
+        //  - a block still in the pending-chain index but not on `from_block`'s chain is an uncommitted
+        //    orphan/abandoned branch (e.g. left over across a restart) and must NOT be reused - its execution is pinned
+        //    to already-spent input versions.
+        let pending_chain = self.get_pending_chain_until(from_block.block_id())?;
+        let pending_index = self.db().cf(chain::PendingChainIndex)?;
+
+        let mut best: Option<(TransactionId, BlockId, NodeHeight)> = None;
+        let candidates = query.query_prefix_range_key_iterator(Ordering::default(), transaction_id);
+        for res in candidates {
+            let (tx_id, block_id, height) = res?;
+            let is_ancestor = pending_chain.contains(&block_id) || !pending_index.exists(&block_id, OPERATION)?;
+            if is_ancestor && best.as_ref().is_none_or(|(_, _, h)| *h < height) {
+                best = Some((tx_id, block_id, height));
             }
         }
 
-        if let Some((tx_id, block_id, height)) = max_height_key {
+        if let Some((tx_id, block_id, height)) = best {
             debug!(
                 target: LOG_TARGET,
                 "{OPERATION}: Found execution for {transaction_id} in {block_id} {height}",

--- a/crates/state_store_rocksdb/tests/transactions.rs
+++ b/crates/state_store_rocksdb/tests/transactions.rs
@@ -284,6 +284,7 @@ mod transaction_execution_operations {
         );
         tx.block_transaction_executions_insert_or_ignore(&exec1).unwrap();
 
+        // A committed ancestor of the queried block - its execution is still reusable (e.g. multishard accept).
         let committed_block = chain[6].clone();
         // insert transaction executions
         let exec2 = BlockTransactionExecution::new(
@@ -335,6 +336,74 @@ mod transaction_execution_operations {
         // block_transaction_executions_lock_any_for_block
         tx.block_transaction_executions_lock_any_for_block(&not_committed_block.as_leaf())
             .unwrap();
+
+        tx.rollback().unwrap();
+    }
+
+    #[test]
+    fn it_excludes_orphan_block_executions_rocksdb() {
+        let (db, _tmp) = create_rocksdb();
+        it_excludes_orphan_block_executions(db);
+    }
+
+    // Regression: an execution recorded on a block that is NOT part of the queried block's pending chain (e.g. an
+    // abandoned/orphan branch left over across a restart) must never be returned, otherwise a stale execution pinned
+    // to already-spent input versions can be reused.
+    fn it_excludes_orphan_block_executions(db: impl StateStore) {
+        use tari_ootle_storage::StorageError;
+
+        use crate::helpers::create_block_with_qc;
+
+        let mut tx = db.create_write_tx().unwrap();
+
+        let tx1 = TransactionRecord::new(
+            Transaction::builder_localnet()
+                .add_instruction(Instruction::DropAllProofsInWorkspace)
+                .add_input(SubstateRequirement::new(create_random_substate_id(), Some(0)))
+                .build_and_seal(&PrivateKey::default()),
+        );
+        tx.transactions_insert(&tx1).unwrap();
+
+        let chain = create_chain(10);
+        commit_chain(&mut tx, &chain);
+        let leaf = chain.last().unwrap().as_leaf();
+
+        // Fork off an in-chain block: this block is not on `leaf`'s parent chain, so it is an orphan w.r.t. `leaf`.
+        let orphan_block = create_block_with_qc(&chain[5].as_leaf());
+        orphan_block.insert(&mut tx).unwrap();
+
+        // The transaction's only execution lives on the orphan block.
+        let exec = BlockTransactionExecution::new(
+            orphan_block.as_leaf(),
+            *tx1.id(),
+            ExecuteResult {
+                finalize: FinalizeResult::new(
+                    Hash32::default(),
+                    vec![],
+                    vec![],
+                    TransactionResult::Accept(SubstateDiff::new()),
+                    FeeReceiptBuilder {
+                        total_fee_payment: 0,
+                        total_fees_paid: 0,
+                        total_fee_overcharge: 0,
+                        cost_breakdown: FeeBreakdown::default(),
+                    }
+                    .build(),
+                ),
+                execution_time: Duration::from_secs(1),
+                execute_epoch: None,
+            },
+            vec![],
+            vec![],
+        );
+        assert!(tx.block_transaction_executions_insert_or_ignore(&exec).unwrap());
+
+        // It must not be returned for the canonical chain leaf - it belongs to an abandoned branch.
+        let res = tx.block_transaction_executions_get_pending_for_block(tx1.id(), &leaf);
+        assert!(
+            matches!(res, Err(StorageError::NotFound { .. })),
+            "orphan-branch execution must not be reused, got {res:?}"
+        );
 
         tx.rollback().unwrap();
     }


### PR DESCRIPTION
## Summary

Fixes the root cause behind the `Substate … is DOWN` consensus crash seen under stress after a restart: the proposer could reuse a **stale cached transaction execution** from a block that is not an ancestor of the block being proposed.

## Root cause

`block_transaction_executions_get_pending_for_block` (`state_store_rocksdb/src/reader.rs`) returns a transaction's previously-recorded execution so it can be reused at prepare/accept time. Its chain-walk fallback filtered candidates incorrectly:

```rust
if max_height_key
    .as_ref()
    .is_none_or(|(_, block_id, current_height)|        // block_id shadows the loop variable
        *current_height < height && block_ids.contains(block_id))
{ ... }
```

- The `block_ids.contains(block_id)` check tested the **already-tracked max's** block, not the candidate (variable shadowing).
- When `max_height_key` is `None`, `is_none_or` short-circuits to `true`, so the **first record seen is accepted unconditionally**, bypassing the filter.

So an execution recorded on a block that is **not an ancestor of `from_block`** (an abandoned/orphan branch) could be returned.

## Why it surfaced after the restart

When the chain isn't committing, a backlog of uncommitted pending blocks builds up, each with persisted `BlockTransactionExecution` records pinned to specific input versions. After a restart and re-sequencing of those transactions, the broken filter could hand back a stale execution pinned to an already-spent input version (`resource_…@7150`). Applying that diff then hit a DOWN substate at `put_diff` — the crash addressed defensively in #2179. This PR removes the reason a stale execution is selected.

## Fix

Reuse an execution only if it was recorded on an **ancestor** of `from_block`, determined with **pending-chain index lookups only — no blocks are loaded**:

- on `from_block`'s pending chain → uncommitted ancestor → reusable;
- absent from the pending-chain index → committed, and since the committed chain is final and linear it is an ancestor → reusable;
- present in the index but off `from_block`'s chain → uncommitted orphan/abandoned branch → **not** reusable.

**Committed ancestors must stay reusable.** A multishard transaction is prepared in an earlier block (which may since have committed) and its execution is reused at accept time. An earlier attempt that scoped to only the *uncommitted* pending chain broke that path with `accept_transaction: … execution is missing` (caught by `consensus_tests::multi_shard_single_transaction` / `multishard_output_conflict_abort`).

The consensus caller treats a missing execution as `None` and re-executes against current state — the correct recovery.

## Also included

- `engine_types/commit_result.rs`: small `FinalizeResult` resource-filter simplification (using `zip`). Unrelated cleanup riding along.

## Tests

- New regression test `it_excludes_orphan_block_executions`: an execution on an orphan branch is never returned for the canonical chain leaf (`NotFound`).
- `transaction_execution_operations` confirms a **committed ancestor's** execution is still reused.
- `cargo test -p tari_state_store_rocksdb --test transactions` → 4 passed.
- `cargo test -p consensus_tests` → 60 passed (incl. the two multishard tests).

## Relationship to #2179

Complementary. #2179 stops a DOWN substate from crashing consensus (defense in depth); this fixes why a stale execution was reused at all.
