### PR TITLE
feat(consensus): budget blocks by transaction weight instead of command count

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1708,7 +1708,7 @@ dependencies = [
 
 [[package]]
 name = "consensus_tests"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "fern",
  "futures 0.3.31",
@@ -2713,7 +2713,7 @@ dependencies = [
 
 [[package]]
 name = "db-inspector"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -5049,7 +5049,7 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "integration_tests"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "anyhow",
  "config",
@@ -5823,7 +5823,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-messaging"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "async-trait",
  "futures-bounded 0.2.4",
@@ -6001,7 +6001,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-substream"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "libp2p",
  "prometheus-client",
@@ -7610,7 +7610,7 @@ dependencies = [
 
 [[package]]
 name = "ootle-wasm"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "console_error_panic_hook",
  "getrandom 0.2.17",
@@ -7621,7 +7621,7 @@ dependencies = [
 
 [[package]]
 name = "ootle-wasm-core"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "base64 0.22.1",
  "hex",
@@ -8641,7 +8641,7 @@ dependencies = [
 
 [[package]]
 name = "proto_builder"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "prost-build 0.14.3",
  "sha2 0.10.9",
@@ -10506,7 +10506,7 @@ dependencies = [
 
 [[package]]
 name = "sqlite_message_logger"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "chrono",
  "diesel",
@@ -10878,7 +10878,7 @@ dependencies = [
 
 [[package]]
 name = "tari_base_node_client"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "futures-util",
  "log",
@@ -11104,7 +11104,7 @@ dependencies = [
 
 [[package]]
 name = "tari_consensus"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "anyhow",
  "indexmap 2.13.0",
@@ -11129,7 +11129,7 @@ dependencies = [
 
 [[package]]
 name = "tari_consensus_types"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "borsh",
  "minicbor",
@@ -11231,7 +11231,7 @@ dependencies = [
 
 [[package]]
 name = "tari_engine"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "blake2 0.10.6",
  "bytes",
@@ -11263,7 +11263,7 @@ dependencies = [
 
 [[package]]
 name = "tari_engine_types"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "blake2 0.10.6",
  "borsh",
@@ -11292,7 +11292,7 @@ dependencies = [
 
 [[package]]
 name = "tari_epoch_manager"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "anyhow",
  "log",
@@ -11312,7 +11312,7 @@ dependencies = [
 
 [[package]]
 name = "tari_epoch_oracles"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "anyhow",
  "blake2 0.10.6",
@@ -11367,7 +11367,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -11468,7 +11468,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer_lib"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "log",
  "minicbor",
@@ -11581,7 +11581,7 @@ dependencies = [
 
 [[package]]
 name = "tari_networking"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11634,7 +11634,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_app_utilities"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -11675,7 +11675,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_common_types"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "blake2 0.10.6",
  "borsh",
@@ -11704,7 +11704,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_p2p"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "anyhow",
  "libp2p-identity 0.2.14",
@@ -11728,7 +11728,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_storage"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "anyhow",
  "bitflags 2.10.0",
@@ -11757,7 +11757,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_storage_sqlite"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "diesel",
  "diesel_migrations",
@@ -11810,7 +11810,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_transaction"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "borsh",
  "hex",
@@ -11836,7 +11836,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_cli"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -11866,7 +11866,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_crypto"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "argon2 0.5.3",
  "blake2 0.10.6",
@@ -11896,7 +11896,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_sdk"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -11958,7 +11958,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_sdk_tests"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "digest 0.10.7",
  "ootle_byte_type",
@@ -11980,7 +11980,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_storage_sqlite"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "diesel",
  "diesel_migrations",
@@ -12003,7 +12003,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_walletd"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12124,7 +12124,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_framework"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "async-trait",
  "bitflags 2.10.0",
@@ -12148,7 +12148,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_macros"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12157,7 +12157,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_state_sync"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -12235,7 +12235,7 @@ dependencies = [
 
 [[package]]
 name = "tari_state_store_rocksdb"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12267,7 +12267,7 @@ dependencies = [
 
 [[package]]
 name = "tari_state_tree"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "indexmap 2.13.0",
  "log",
@@ -12295,7 +12295,7 @@ dependencies = [
 
 [[package]]
 name = "tari_swarm"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "libp2p",
  "libp2p-messaging",
@@ -12306,7 +12306,7 @@ dependencies = [
 
 [[package]]
 name = "tari_swarm_daemon"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12419,7 +12419,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_test_tooling"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "anyhow",
  "cargo_toml 0.22.3",
@@ -12532,7 +12532,7 @@ dependencies = [
 
 [[package]]
 name = "tari_transaction_manifest"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "proc-macro2",
  "serde_json",
@@ -12567,7 +12567,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -12633,7 +12633,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node_client"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "indexmap 2.13.0",
  "multiaddr 0.18.3",
@@ -12657,7 +12657,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node_rpc"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -12681,7 +12681,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_rollback"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12716,7 +12716,7 @@ dependencies = [
 
 [[package]]
 name = "tari_watcher"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "anyhow",
  "clap 3.2.25",
@@ -12745,7 +12745,7 @@ dependencies = [
 
 [[package]]
 name = "tariswap_bench"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "anyhow",
  "clap 4.5.54",
@@ -13425,7 +13425,7 @@ dependencies = [
 
 [[package]]
 name = "traffic-sim"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "anyhow",
  "clap 4.5.54",
@@ -13447,7 +13447,7 @@ dependencies = [
 
 [[package]]
 name = "transaction_generator"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "anyhow",
  "bytes",
@@ -13466,7 +13466,7 @@ dependencies = [
 
 [[package]]
 name = "transaction_submitter"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "anyhow",
  "clap 4.5.54",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.33.2"
+version = "0.33.3"
 edition = "2024"
 authors = ["The Tari Development Community"]
 repository = "https://github.com/tari-project/tari-ootle"

--- a/crates/consensus/src/consensus_constants.rs
+++ b/crates/consensus/src/consensus_constants.rs
@@ -46,8 +46,16 @@ pub struct ConsensusConstants {
     /// `missed_proposal_recovery_threshold`) is decremented for each block that they participate (vote) in. Once
     /// this reaches zero, the node is considered stable and out of suspension.
     pub missed_proposal_recovery_threshold: u64,
-    /// The maximum number of commands that a block may contain.
-    pub max_number_commands_in_block: usize,
+    /// The maximum total weight of commands a leader will pack into a single block. This is a budget
+    /// of transaction weight (see `Transaction::calculate_transaction_weight`) rather than a flat
+    /// command count, so heavy transactions consume more of a block than light ones. This is a local
+    /// proposing heuristic only — it is not validated when receiving/voting on a block, so it carries
+    /// no fork risk and nodes may run different values.
+    pub max_block_weight: u64,
+    /// A hard upper bound on the number of commands in a block, independent of weight. Bounds the
+    /// on-the-wire/`BTreeSet` overhead so a flood of near-zero-weight commands cannot bloat a block.
+    /// Like `max_block_weight`, this is a propose-time heuristic and is not validated on receive.
+    pub max_commands_in_block: usize,
     /// The value that fees are divided by to determine the amount of fees to burn. 0 means no fees are burned.
     pub fee_exhaust_divisor: u64,
     /// Number of base-layer blocks of leeway a voter is allowed when accepting `EndEpoch` proposals.
@@ -68,7 +76,16 @@ impl ConsensusConstants {
             missed_proposal_suspend_threshold: 5,
             missed_proposal_evict_threshold: 10,
             missed_proposal_recovery_threshold: 5,
-            max_number_commands_in_block: 100,
+            // Calibrated against 2-core hardware (Esmeralda class), where ~500 LocalOnly stress
+            // transactions (~62 weight each, ~31k weight) executed in ~11.5s — i.e. ~2.7k weight/s.
+            // A 10000 budget (~160 of those commands) therefore projects to ~3.7s of propose-time
+            // execution, comfortably within the 10s block time and under the 5s execution circuit
+            // breaker, while heavier transactions naturally consume more of the budget. The breaker in
+            // on_propose is the backstop for outliers the static weight under-estimates. NOTE:
+            // propose-time execution is sequential, so more cores does not raise this proportionally —
+            // calibrate to single-core throughput.
+            max_block_weight: 10_000,
+            max_commands_in_block: 1000,
             fee_exhaust_divisor: 20, // 1/20 = 5%
             epoch_end_spread_blocks: 10,
         }
@@ -83,7 +100,16 @@ impl ConsensusConstants {
             missed_proposal_suspend_threshold: 5,
             missed_proposal_evict_threshold: 10,
             missed_proposal_recovery_threshold: 5,
-            max_number_commands_in_block: 100,
+            // Calibrated against 2-core hardware (Esmeralda class), where ~500 LocalOnly stress
+            // transactions (~62 weight each, ~31k weight) executed in ~11.5s — i.e. ~2.7k weight/s.
+            // A 10000 budget (~160 of those commands) therefore projects to ~3.7s of propose-time
+            // execution, comfortably within the 10s block time and under the 5s execution circuit
+            // breaker, while heavier transactions naturally consume more of the budget. The breaker in
+            // on_propose is the backstop for outliers the static weight under-estimates. NOTE:
+            // propose-time execution is sequential, so more cores does not raise this proportionally —
+            // calibrate to single-core throughput.
+            max_block_weight: 10_000,
+            max_commands_in_block: 1000,
             fee_exhaust_divisor: 20, // 1/20 = 5%
             epoch_end_spread_blocks: 1,
         }
@@ -98,7 +124,16 @@ impl ConsensusConstants {
             missed_proposal_suspend_threshold: 5,
             missed_proposal_evict_threshold: 10,
             missed_proposal_recovery_threshold: 5,
-            max_number_commands_in_block: 100,
+            // Calibrated against 2-core hardware (Esmeralda class), where ~500 LocalOnly stress
+            // transactions (~62 weight each, ~31k weight) executed in ~11.5s — i.e. ~2.7k weight/s.
+            // A 10000 budget (~160 of those commands) therefore projects to ~3.7s of propose-time
+            // execution, comfortably within the 10s block time and under the 5s execution circuit
+            // breaker, while heavier transactions naturally consume more of the budget. The breaker in
+            // on_propose is the backstop for outliers the static weight under-estimates. NOTE:
+            // propose-time execution is sequential, so more cores does not raise this proportionally —
+            // calibrate to single-core throughput.
+            max_block_weight: 10_000,
+            max_commands_in_block: 1000,
             fee_exhaust_divisor: 20, // 1/20 = 5%
             epoch_end_spread_blocks: 5,
         }
@@ -113,7 +148,16 @@ impl ConsensusConstants {
             missed_proposal_suspend_threshold: 5,
             missed_proposal_evict_threshold: 10,
             missed_proposal_recovery_threshold: 5,
-            max_number_commands_in_block: 100,
+            // Calibrated against 2-core hardware (Esmeralda class), where ~500 LocalOnly stress
+            // transactions (~62 weight each, ~31k weight) executed in ~11.5s — i.e. ~2.7k weight/s.
+            // A 10000 budget (~160 of those commands) therefore projects to ~3.7s of propose-time
+            // execution, comfortably within the 10s block time and under the 5s execution circuit
+            // breaker, while heavier transactions naturally consume more of the budget. The breaker in
+            // on_propose is the backstop for outliers the static weight under-estimates. NOTE:
+            // propose-time execution is sequential, so more cores does not raise this proportionally —
+            // calibrate to single-core throughput.
+            max_block_weight: 10_000,
+            max_commands_in_block: 1000,
             fee_exhaust_divisor: 20, // 1/20 = 5%
             epoch_end_spread_blocks: 5,
         }

--- a/crates/consensus/src/consensus_constants.rs
+++ b/crates/consensus/src/consensus_constants.rs
@@ -56,6 +56,14 @@ pub struct ConsensusConstants {
     /// on-the-wire/`BTreeSet` overhead so a flood of near-zero-weight commands cannot bloat a block.
     /// Like `max_block_weight`, this is a propose-time heuristic and is not validated on receive.
     pub max_commands_in_block: usize,
+    /// The maximum total transaction execution weight a block may contain to be considered valid. Unlike
+    /// `max_block_weight` (a local proposing heuristic) this IS enforced when receiving/voting on a block:
+    /// a block whose transaction execution weight exceeds this — and that contains more than one
+    /// transaction command — is rejected (no-vote). It bounds how long a replica can be made to spend
+    /// executing a block, preventing a misbehaving leader from pushing replicas past the block time.
+    /// Set above `max_block_weight` so honest proposals are never rejected. CONSENSUS RULE: must be
+    /// uniform network-wide, otherwise nodes diverge on block validity.
+    pub max_block_validation_weight: u64,
     /// The value that fees are divided by to determine the amount of fees to burn. 0 means no fees are burned.
     pub fee_exhaust_divisor: u64,
     /// Number of base-layer blocks of leeway a voter is allowed when accepting `EndEpoch` proposals.
@@ -86,6 +94,10 @@ impl ConsensusConstants {
             // calibrate to single-core throughput.
             max_block_weight: 10_000,
             max_commands_in_block: 1000,
+            // 1.5x the proposal budget: honest blocks (<= max_block_weight) are never rejected, while a
+            // full validation-weight block projects to ~5.5s of execution on 2-core hardware — well
+            // within the 10s block time. Rejects the ~31k-weight/500-command overload that broke things.
+            max_block_validation_weight: 15_000,
             fee_exhaust_divisor: 20, // 1/20 = 5%
             epoch_end_spread_blocks: 10,
         }
@@ -110,6 +122,10 @@ impl ConsensusConstants {
             // calibrate to single-core throughput.
             max_block_weight: 10_000,
             max_commands_in_block: 1000,
+            // 1.5x the proposal budget: honest blocks (<= max_block_weight) are never rejected, while a
+            // full validation-weight block projects to ~5.5s of execution on 2-core hardware — well
+            // within the 10s block time. Rejects the ~31k-weight/500-command overload that broke things.
+            max_block_validation_weight: 15_000,
             fee_exhaust_divisor: 20, // 1/20 = 5%
             epoch_end_spread_blocks: 1,
         }
@@ -134,6 +150,10 @@ impl ConsensusConstants {
             // calibrate to single-core throughput.
             max_block_weight: 10_000,
             max_commands_in_block: 1000,
+            // 1.5x the proposal budget: honest blocks (<= max_block_weight) are never rejected, while a
+            // full validation-weight block projects to ~5.5s of execution on 2-core hardware — well
+            // within the 10s block time. Rejects the ~31k-weight/500-command overload that broke things.
+            max_block_validation_weight: 15_000,
             fee_exhaust_divisor: 20, // 1/20 = 5%
             epoch_end_spread_blocks: 5,
         }
@@ -158,6 +178,10 @@ impl ConsensusConstants {
             // calibrate to single-core throughput.
             max_block_weight: 10_000,
             max_commands_in_block: 1000,
+            // 1.5x the proposal budget: honest blocks (<= max_block_weight) are never rejected, while a
+            // full validation-weight block projects to ~5.5s of execution on 2-core hardware — well
+            // within the 10s block time. Rejects the ~31k-weight/500-command overload that broke things.
+            max_block_validation_weight: 15_000,
             fee_exhaust_divisor: 20, // 1/20 = 5%
             epoch_end_spread_blocks: 5,
         }

--- a/crates/consensus/src/hotstuff/block_change_set.rs
+++ b/crates/consensus/src/hotstuff/block_change_set.rs
@@ -471,6 +471,7 @@ impl ProposedBlockChangeSet {
                 pool_rec.is_ready(),
                 pool_rec.is_global(),
                 pool_rec.max_epoch(),
+                pool_rec.transaction_weight(),
             )?;
         }
 

--- a/crates/consensus/src/hotstuff/on_propose.rs
+++ b/crates/consensus/src/hotstuff/on_propose.rs
@@ -5,6 +5,7 @@ use std::{
     collections::{BTreeSet, HashMap},
     fmt::Display,
     num::NonZeroU64,
+    time::Instant,
 };
 
 use log::*;
@@ -458,12 +459,41 @@ where TConsensusSpec: ConsensusSpec
         );
 
         // batch is empty for is_empty, is_epoch_end and is_epoch_start blocks
-        let timer = TraceTimer::info(LOG_TARGET, "Generating commands").with_iterations(batch.transactions.len());
+        let batch_size = batch.transactions.len();
+        let timer = TraceTimer::info(LOG_TARGET, "Generating commands").with_iterations(batch_size);
         let mut lock_conflicts = TransactionLockConflicts::new();
-        for mut transaction in batch.transactions {
+        // Local proposing heuristic (not a consensus rule, so no fork risk): stop executing transactions
+        // once roughly half the block time has been spent, so that a batch of heavy transactions cannot
+        // push proposing past the block time. The static weight budget bounds block size; this bounds the
+        // actual execution latency that the static estimate cannot perfectly predict. Deferred
+        // transactions remain in the pool and are proposed in a later block.
+        let propose_exec_deadline = self.config.consensus_constants.pacemaker_block_time / 2;
+        let propose_started_at = Instant::now();
+        // Accumulated to log observed execution throughput (weight/s) for calibrating `max_block_weight`
+        // against the block time. See the calibration log emitted after the loop.
+        let mut executed_weight = 0u64;
+        let mut num_executed = 0usize;
+        for (idx, mut transaction) in batch.transactions.into_iter().enumerate() {
+            // Always attempt at least the first transaction before honouring the deadline so we make
+            // progress even when a single transaction is slow to execute.
+            if idx > 0 && propose_started_at.elapsed() >= propose_exec_deadline {
+                warn!(
+                    target: LOG_TARGET,
+                    "⏱️ PROPOSE: execution soft deadline ({:.1?}) reached after {} of {} transaction(s); deferring {} to a later block",
+                    propose_exec_deadline,
+                    idx,
+                    batch_size,
+                    batch_size - idx,
+                );
+                break;
+            }
             // Apply the transaction updates (if any) that occurred as a result of the justified block.
             // This allows us to propose evidence in the next block that relates to transactions in the justified block.
             change_set.apply_transaction_update(&mut transaction);
+            // Capture before the record is moved. The processing work below (incl. execution) is incurred
+            // whether or not a command is produced, so accumulate for every processed transaction.
+            executed_weight += transaction.proposal_weight();
+            num_executed += 1;
             if let Some(command) = self.transaction_pool_record_to_command(
                 &start_of_chain_block.as_leaf(),
                 // This locked epoch is used to set the transaction LockedEpoch if necessary
@@ -499,6 +529,28 @@ where TConsensusSpec: ConsensusSpec
             }
         }
         timer.done();
+
+        // Calibration signal: observed propose-time execution throughput and the time a full
+        // `max_block_weight` block would take at that rate. Use this (from real traffic, at debug level)
+        // to tune `max_block_weight` so a full block executes well within the block time.
+        let exec_elapsed = propose_started_at.elapsed();
+        let exec_secs = exec_elapsed.as_secs_f64();
+        if executed_weight > 0 && exec_secs > 0.0 {
+            let weight_per_sec = executed_weight as f64 / exec_secs;
+            let projected_full_block_secs = self.config.consensus_constants.max_block_weight as f64 / weight_per_sec;
+            debug!(
+                target: LOG_TARGET,
+                "📊 PROPOSE calibration: executed {} command(s) / {} weight in {:.2?} (~{:.0} weight/s); a full \
+                 max_block_weight={} block projects to ~{:.2}s of execution (block_time={:.0?})",
+                num_executed,
+                executed_weight,
+                exec_elapsed,
+                weight_per_sec,
+                self.config.consensus_constants.max_block_weight,
+                projected_full_block_secs,
+                self.config.consensus_constants.pacemaker_block_time,
+            );
+        }
 
         debug!(
             target: LOG_TARGET,
@@ -571,15 +623,21 @@ where TConsensusSpec: ConsensusSpec
         start_of_chain_block: HighestSeenBlock,
     ) -> Result<ProposalBatch, HotStuffError> {
         let _timer = TraceTimer::debug(LOG_TARGET, "fetch_next_proposal_batch");
-        // Foreign proposals are weighted by 10x. Each foreign proposal can contain max_number_commands_in_block*inputs
-        // substate pledges. TODO: this is a loosey goosey upper bound. We need to evaluate this, find an acceptable
-        // upper bound or perhaps re-design how foreign proposals work
-        const FP_WEIGHT_MULTIPLIER: usize = 10;
-        let foreign_proposals = ForeignProposalRecord::get_all_new(
-            tx,
-            start_of_chain_block.block_id(),
-            self.config.consensus_constants.max_number_commands_in_block / FP_WEIGHT_MULTIPLIER,
-        )?;
+        // A block is budgeted by total command weight (`max_block_weight`), not a flat command count.
+        // Foreign proposals and evict nodes consume part of that budget before local transactions fill the
+        // rest. A foreign proposal is weighted by the substate pledges it carries (the dominant processing
+        // cost when applying it at propose time), on the same scale as transaction input weight, rather
+        // than a flat 10x multiplier.
+        const MAX_FOREIGN_PROPOSALS_PER_BLOCK: usize = 10;
+        const FP_BASE_WEIGHT: u64 = 50;
+        const FP_PLEDGE_WEIGHT: u64 = 15;
+        const EVICT_NODE_WEIGHT: u64 = 50;
+
+        let max_block_weight = self.config.consensus_constants.max_block_weight;
+        let max_commands = self.config.consensus_constants.max_commands_in_block;
+
+        let foreign_proposals =
+            ForeignProposalRecord::get_all_new(tx, start_of_chain_block.block_id(), MAX_FOREIGN_PROPOSALS_PER_BLOCK)?;
 
         if !foreign_proposals.is_empty() {
             debug!(
@@ -589,22 +647,24 @@ where TConsensusSpec: ConsensusSpec
             );
         }
 
-        let mut remaining_block_size = subtract_block_size_checked(
-            Some(self.config.consensus_constants.max_number_commands_in_block),
-            foreign_proposals.len() * FP_WEIGHT_MULTIPLIER,
-        );
+        let foreign_proposal_weight: u64 = foreign_proposals
+            .iter()
+            .map(|fp| FP_BASE_WEIGHT + fp.block_pledge().len() as u64 * FP_PLEDGE_WEIGHT)
+            .sum();
 
-        let evict_nodes = remaining_block_size
+        let mut remaining_weight = subtract_weight_checked(Some(max_block_weight), foreign_proposal_weight);
+
+        let evict_nodes = remaining_weight
             // Disable eviction proposals if not enabled in config
             .filter(|_| self.config.enable_eviction_proposal)
-            .map(|max| {
+            .map(|remaining| {
                 let num_evicted =
                     ValidatorConsensusStats::count_number_evicted_nodes(tx, start_of_chain_block.epoch())?;
                 // TODO: technically, we should not evict more than 1/3 of the voting power, not the number of nodes
                 // (but this is currently the same thing)
                 let max_allowed_to_evict = u64::from(local_committee_info.max_failure_shard_group_members())
                     .saturating_sub(num_evicted)
-                    .min(max as u64);
+                    .min(remaining / EVICT_NODE_WEIGHT);
                 ValidatorConsensusStats::get_nodes_to_evict(
                     tx,
                     start_of_chain_block.block_id(),
@@ -623,12 +683,21 @@ where TConsensusSpec: ConsensusSpec
             )
         }
 
-        remaining_block_size = subtract_block_size_checked(remaining_block_size, evict_nodes.len());
+        remaining_weight = subtract_weight_checked(remaining_weight, evict_nodes.len() as u64 * EVICT_NODE_WEIGHT);
 
-        let transactions = remaining_block_size
-            .map(|size| {
-                self.transaction_pool
-                    .get_batch_for_next_block(tx, size, start_of_chain_block.block_id())
+        // Bound the transaction count so the total command count (foreign proposals + evict + transactions)
+        // stays under the hard command cap regardless of how light the transactions are.
+        let max_tx_count = max_commands.saturating_sub(foreign_proposals.len() + evict_nodes.len());
+
+        let transactions = remaining_weight
+            .filter(|_| max_tx_count > 0)
+            .map(|weight_budget| {
+                self.transaction_pool.get_batch_for_next_block(
+                    tx,
+                    weight_budget,
+                    max_tx_count,
+                    start_of_chain_block.block_id(),
+                )
             })
             .transpose()?
             .unwrap_or_default();
@@ -1022,8 +1091,33 @@ impl Display for ProposalBatch {
     }
 }
 
-fn subtract_block_size_checked(remaining_block_size: Option<usize>, by: usize) -> Option<usize> {
-    remaining_block_size
-        .and_then(|sz| sz.checked_sub(by))
-        .filter(|sz| *sz > 0)
+/// Subtract `by` from the remaining block weight budget, returning `None` once the budget is
+/// exhausted (i.e. drops to zero or would underflow). Mirrors the previous count-based helper but
+/// operates on the weight budget.
+fn subtract_weight_checked(remaining_weight: Option<u64>, by: u64) -> Option<u64> {
+    remaining_weight.and_then(|w| w.checked_sub(by)).filter(|w| *w > 0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    mod subtract_weight_checked {
+        use super::*;
+
+        #[test]
+        fn it_subtracts_within_budget() {
+            assert_eq!(subtract_weight_checked(Some(100), 40), Some(60));
+        }
+
+        #[test]
+        fn it_returns_none_when_exhausted_or_underflowing() {
+            // Reaching exactly zero exhausts the budget.
+            assert_eq!(subtract_weight_checked(Some(100), 100), None);
+            // Underflow (subtracting more than remaining) also exhausts it.
+            assert_eq!(subtract_weight_checked(Some(40), 100), None);
+            // Once None, it stays None.
+            assert_eq!(subtract_weight_checked(None, 1), None);
+        }
+    }
 }

--- a/crates/consensus/src/hotstuff/on_ready_to_vote_on_local_block.rs
+++ b/crates/consensus/src/hotstuff/on_ready_to_vote_on_local_block.rs
@@ -254,6 +254,38 @@ where TConsensusSpec: ConsensusSpec
         expected_next_epoch_hash: Option<FixedHash>,
         proposed_block_change_set: &mut ProposedBlockChangeSet,
     ) -> Result<(), HotStuffError> {
+        // Reject (no-vote) a block whose total transaction execution weight exceeds the network cap,
+        // before executing any of its commands. This bounds how long a replica can be made to spend
+        // executing a single block, so a misbehaving leader cannot push replicas past the block time by
+        // packing more than the propose-time budget. A block with a single transaction command is exempt
+        // so an individually-heavy transaction stays committable (its static weight also over-estimates
+        // its execution). CONSENSUS RULE: `max_block_validation_weight` must be uniform network-wide.
+        let max_validation_weight = self.config.consensus_constants.max_block_validation_weight;
+        let mut block_execution_weight = 0u64;
+        let mut num_transaction_commands = 0usize;
+        for cmd in block.commands() {
+            let Some(atom) = cmd.transaction() else {
+                continue;
+            };
+            num_transaction_commands += 1;
+            let weight = atom
+                .get_transaction(tx)?
+                .transaction()
+                .calculate_transaction_weight()
+                .as_u64();
+            block_execution_weight =
+                block_execution_weight.saturating_add(weight.saturating_mul(cmd.execution_weight_percent()) / 100);
+        }
+        if exceeds_block_validation_weight(block_execution_weight, num_transaction_commands, max_validation_weight) {
+            let reason = NoVoteReason::BlockWeightExceeded {
+                total_weight: block_execution_weight,
+                max_weight: max_validation_weight,
+            };
+            warn!(target: LOG_TARGET, "❌ NO VOTE: {reason}");
+            proposed_block_change_set.set_no_vote(reason);
+            return Ok(());
+        }
+
         // Store used for transactions that have inputs without specific versions.
         // It lives through the entire block so multiple transactions can be sequenced together in the same block
         let mut substate_store =
@@ -1694,5 +1726,47 @@ where TConsensusSpec: ConsensusSpec
         block.clear_leader_failure_count(tx)?;
 
         Ok(finalized_transactions)
+    }
+}
+
+/// Consensus rule: a block is rejected (no-vote) when its total transaction execution weight exceeds
+/// `max_validation_weight`, EXCEPT when it carries at most one transaction command. The single-command
+/// exemption preserves liveness: an individually-heavy transaction must remain committable (and the
+/// static weight over-estimates its real execution). This bounds the work a leader can force replicas to
+/// do per block. Must be evaluated identically on every node — keep it a pure function of these inputs.
+fn exceeds_block_validation_weight(
+    block_execution_weight: u64,
+    num_transaction_commands: usize,
+    max_validation_weight: u64,
+) -> bool {
+    num_transaction_commands > 1 && block_execution_weight > max_validation_weight
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    mod exceeds_block_validation_weight {
+        use super::*;
+
+        #[test]
+        fn within_budget_is_allowed() {
+            assert!(!exceeds_block_validation_weight(10_000, 50, 15_000));
+            // Exactly at the cap is allowed.
+            assert!(!exceeds_block_validation_weight(15_000, 50, 15_000));
+        }
+
+        #[test]
+        fn over_budget_with_multiple_commands_is_rejected() {
+            assert!(exceeds_block_validation_weight(15_001, 2, 15_000));
+            assert!(exceeds_block_validation_weight(31_000, 500, 15_000));
+        }
+
+        #[test]
+        fn single_heavy_transaction_is_always_allowed() {
+            // A single transaction heavier than the whole cap must stay committable (liveness).
+            assert!(!exceeds_block_validation_weight(1_000_000, 1, 15_000));
+            assert!(!exceeds_block_validation_weight(0, 0, 15_000));
+        }
     }
 }

--- a/crates/consensus/src/hotstuff/on_receive_new_transaction.rs
+++ b/crates/consensus/src/hotstuff/on_receive_new_transaction.rs
@@ -205,6 +205,7 @@ where TConsensusSpec: ConsensusSpec
             is_ready,
             transaction.transaction().is_global(),
             transaction.transaction().max_epoch(),
+            transaction.transaction().calculate_transaction_weight().as_u64(),
         )?;
         Ok(())
     }

--- a/crates/consensus_tests/src/support/harness.rs
+++ b/crates/consensus_tests/src/support/harness.rs
@@ -668,6 +668,9 @@ impl TestBuilder {
                     // count-limited (as before) unless a test specifically exercises the weight budget.
                     max_block_weight: 1_000_000,
                     max_commands_in_block: 500,
+                    // Effectively disable the validation-time weight cap by default; tests that exercise
+                    // it set a low value explicitly.
+                    max_block_validation_weight: u64::MAX,
                     fee_exhaust_divisor: 20,
                     epoch_end_spread_blocks: 0,
                 },

--- a/crates/consensus_tests/src/support/harness.rs
+++ b/crates/consensus_tests/src/support/harness.rs
@@ -664,7 +664,10 @@ impl TestBuilder {
                     missed_proposal_suspend_threshold: 5,
                     missed_proposal_evict_threshold: 10,
                     missed_proposal_recovery_threshold: 5,
-                    max_number_commands_in_block: 500,
+                    // Keep the weight budget effectively unbounded in tests so behaviour stays
+                    // count-limited (as before) unless a test specifically exercises the weight budget.
+                    max_block_weight: 1_000_000,
+                    max_commands_in_block: 500,
                     fee_exhaust_divisor: 20,
                     epoch_end_spread_blocks: 0,
                 },

--- a/crates/state_store_rocksdb/src/reader.rs
+++ b/crates/state_store_rocksdb/src/reader.rs
@@ -1239,7 +1239,8 @@ impl<'tx, TAddr: NodeAddressable + Serialize + DeserializeOwned + 'tx> StateStor
 
     fn transaction_pool_get_many_ready(
         &self,
-        max_txs: usize,
+        weight_budget: u64,
+        max_count: usize,
         block_id: &BlockId,
     ) -> Result<Vec<TransactionPoolRecord>, StorageError> {
         const OPERATION: &str = "transaction_pool_get_many_ready";
@@ -1272,6 +1273,7 @@ impl<'tx, TAddr: NodeAddressable + Serialize + DeserializeOwned + 'tx> StateStor
         }
 
         let mut transactions = Vec::new();
+        let mut accumulated_weight = 0u64;
         let iter = cf.value_iterator(Ordering::default(), OPERATION);
 
         for result in iter {
@@ -1287,9 +1289,16 @@ impl<'tx, TAddr: NodeAddressable + Serialize + DeserializeOwned + 'tx> StateStor
                 update.merge_into(&mut tx);
             }
             if tx.is_ready() {
+                // Always include at least one ready record so a transaction heavier than the whole
+                // budget still makes progress, then stop once the budget or count cap is reached.
+                let next_weight = accumulated_weight.saturating_add(tx.proposal_weight());
+                if !transactions.is_empty() && next_weight > weight_budget {
+                    break;
+                }
+                accumulated_weight = next_weight;
                 transactions.push(tx);
 
-                if transactions.len() >= max_txs {
+                if transactions.len() >= max_count {
                     break;
                 }
             }

--- a/crates/state_store_rocksdb/src/writer.rs
+++ b/crates/state_store_rocksdb/src/writer.rs
@@ -816,6 +816,7 @@ impl<'tx, TAddr: NodeAddressable + 'tx> StateStoreWriteTransaction for RocksDbSt
         is_ready: bool,
         is_global: bool,
         max_epoch: Option<Epoch>,
+        transaction_weight: u64,
     ) -> Result<(), StorageError> {
         let value = TransactionPoolRecord::load(
             tx_id,
@@ -833,6 +834,7 @@ impl<'tx, TAddr: NodeAddressable + 'tx> StateStoreWriteTransaction for RocksDbSt
             None,
             time::OffsetDateTime::now_utc(),
             None,
+            transaction_weight,
         );
 
         self.db()

--- a/crates/state_store_rocksdb/tests/transactions.rs
+++ b/crates/state_store_rocksdb/tests/transactions.rs
@@ -86,11 +86,11 @@ mod confirm_all_transitions {
         block1.as_locked().set(&mut tx).unwrap();
         block1.as_leaf().set(&mut tx).unwrap();
 
-        tx.transaction_pool_insert_new(atom1.id, atom1.decision, &Evidence::empty(), true, false, None)
+        tx.transaction_pool_insert_new(atom1.id, atom1.decision, &Evidence::empty(), true, false, None, 0)
             .unwrap();
-        tx.transaction_pool_insert_new(atom2.id, atom2.decision, &Evidence::empty(), true, false, None)
+        tx.transaction_pool_insert_new(atom2.id, atom2.decision, &Evidence::empty(), true, false, None, 0)
             .unwrap();
-        tx.transaction_pool_insert_new(atom3.id, atom3.decision, &Evidence::empty(), true, false, None)
+        tx.transaction_pool_insert_new(atom3.id, atom3.decision, &Evidence::empty(), true, false, None, 0)
             .unwrap();
         let block_id = *block1.id();
         let transactions = tx.transaction_pool_get_all(1000).unwrap();
@@ -118,7 +118,7 @@ mod confirm_all_transitions {
         tx.transaction_pool_add_pending_update(&block1.as_leaf(), &TransactionPoolStatusUpdate::new(tx_3, true))
             .unwrap();
 
-        let rec = tx.transaction_pool_get_many_ready(10, &block_id).unwrap();
+        let rec = tx.transaction_pool_get_many_ready(u64::MAX, 10, &block_id).unwrap();
         assert_eq!(rec.len(), 3);
 
         let rec = tx.transaction_pool_get_for_blocks(&block_id, &atom1.id).unwrap();
@@ -319,7 +319,7 @@ mod transaction_execution_operations {
         assert_eq_debug(&res, &exec1);
 
         // transactions_finalize_all
-        tx.transaction_pool_insert_new(*tx1.id(), Decision::Commit, &Evidence::empty(), true, false, None)
+        tx.transaction_pool_insert_new(*tx1.id(), Decision::Commit, &Evidence::empty(), true, false, None, 0)
             .unwrap();
         let transactions = tx.transaction_pool_get_all(1000).unwrap();
         assert_eq!(transactions.len(), 1);
@@ -406,5 +406,99 @@ mod transaction_execution_operations {
         );
 
         tx.rollback().unwrap();
+    }
+}
+
+mod get_many_ready_weight_budget {
+    use tari_consensus_types::BlockId;
+    use tari_ootle_transaction::Network;
+    use tari_template_lib_types::crypto::SchnorrSignatureBytes;
+
+    use super::*;
+    use crate::helpers::num_preshards;
+
+    /// Insert `weights.len()` ready (New stage) transactions with the given static weights and return
+    /// the block id to query against.
+    fn setup_ready_pool(db: &impl StateStore, weights: &[u64]) -> BlockId {
+        let mut tx = db.create_write_tx().unwrap();
+        let network = Network::LocalNet;
+        let zero_block = Block::zero_block(network, num_preshards());
+        zero_block.insert(&mut tx).unwrap();
+        tx.proposal_certificates_save(zero_block.justify()).unwrap();
+        tx.blocks_set_qcs(zero_block.id(), Some(&PcId::zero()), Some(&PcId::zero()))
+            .unwrap();
+        let shard_group = zero_block.shard_group();
+
+        let atoms: Vec<_> = weights.iter().map(|_| create_tx_atom()).collect();
+        let block1 = Block::create(
+            network,
+            *zero_block.id(),
+            zero_block.justify().clone(),
+            None,
+            NodeHeight(1),
+            Epoch(0),
+            shard_group,
+            Default::default(),
+            // Need at least one command so the block causes a state change and is queryable.
+            [Command::LocalPrepare(atoms[0].clone())].into_iter().collect(),
+            Default::default(),
+            Default::default(),
+            SchnorrSignatureBytes::zero(),
+            EpochTime::now().as_u64(),
+            FixedHash::zero(),
+            ShardGroupAccumulatedData::default(),
+            ExtraData::default(),
+        )
+        .unwrap();
+        block1.insert(&mut tx).unwrap();
+        block1.as_locked().set(&mut tx).unwrap();
+        block1.as_leaf().set(&mut tx).unwrap();
+
+        for (atom, weight) in atoms.iter().zip(weights) {
+            tx.transaction_pool_insert_new(atom.id, atom.decision, &Evidence::empty(), true, false, None, *weight)
+                .unwrap();
+        }
+        let block_id = *block1.id();
+        tx.commit().unwrap();
+        block_id
+    }
+
+    #[test]
+    fn it_stops_when_weight_budget_exhausted_rocksdb() {
+        let (db, _tmp) = create_rocksdb();
+        // Three New-stage transactions, each weight 100 (proposal_weight == 100 at New stage).
+        let block_id = setup_ready_pool(&db, &[100, 100, 100]);
+        let tx = db.create_read_tx().unwrap();
+
+        // Budget for 2 (100 + 100 = 200 <= 250; the third would push to 300 > 250).
+        let recs = tx.transaction_pool_get_many_ready(250, 10, &block_id).unwrap();
+        assert_eq!(recs.len(), 2);
+
+        // Generous budget fits all three.
+        let recs = tx.transaction_pool_get_many_ready(u64::MAX, 10, &block_id).unwrap();
+        assert_eq!(recs.len(), 3);
+    }
+
+    #[test]
+    fn it_always_returns_at_least_one_rocksdb() {
+        let (db, _tmp) = create_rocksdb();
+        // A single transaction heavier than the whole budget must still be returned so consensus
+        // makes progress.
+        let block_id = setup_ready_pool(&db, &[1000, 1000]);
+        let tx = db.create_read_tx().unwrap();
+
+        let recs = tx.transaction_pool_get_many_ready(10, 10, &block_id).unwrap();
+        assert_eq!(recs.len(), 1);
+    }
+
+    #[test]
+    fn it_respects_the_hard_count_cap_rocksdb() {
+        let (db, _tmp) = create_rocksdb();
+        let block_id = setup_ready_pool(&db, &[1, 1, 1, 1]);
+        let tx = db.create_read_tx().unwrap();
+
+        // Weight is effectively unbounded but the count cap limits the batch.
+        let recs = tx.transaction_pool_get_many_ready(u64::MAX, 2, &block_id).unwrap();
+        assert_eq!(recs.len(), 2);
     }
 }

--- a/crates/storage/src/consensus_models/command.rs
+++ b/crates/storage/src/consensus_models/command.rs
@@ -137,6 +137,20 @@ impl Command {
         }
     }
 
+    /// The percentage of a transaction's static weight that proposing/processing this command costs,
+    /// reflecting whether the command executes the transaction. Phases that execute (or carry the
+    /// transaction's full footprint) cost 100%; finalisation phases reuse a prior execution and only
+    /// apply its diff, so they are discounted. Mirrors [`TransactionPoolStage::proposal_weight_percent`]
+    /// keyed on the command rather than the pool stage, so a block's execution weight is computable
+    /// deterministically from its commands alone. Non-transaction commands contribute 0.
+    pub fn execution_weight_percent(&self) -> u64 {
+        match self {
+            Command::LocalOnly(_) | Command::LocalPrepare(_) | Command::LocalAccept(_) => 100,
+            Command::AllAccept(_) | Command::SomeAccept(_) => 35,
+            Command::ForeignProposal(_) | Command::EvictNode(_) | Command::EndEpoch(_) => 0,
+        }
+    }
+
     fn as_ordering(&self) -> CommandOrdering<'_> {
         match self {
             Command::LocalPrepare(tx) |
@@ -412,5 +426,36 @@ mod tests {
             let next = iter.next().unwrap();
             assert_eq!(next, exp);
         }
+    }
+
+    #[test]
+    fn execution_weight_percent() {
+        let atom = || TransactionAtom {
+            id: TransactionId::default(),
+            decision: Decision::Commit,
+            evidence: Evidence::default(),
+            transaction_fee: 0,
+            leader_fee: None,
+        };
+        // Executing phases charge the full transaction weight.
+        assert_eq!(Command::LocalOnly(atom()).execution_weight_percent(), 100);
+        assert_eq!(Command::LocalPrepare(atom()).execution_weight_percent(), 100);
+        assert_eq!(Command::LocalAccept(atom()).execution_weight_percent(), 100);
+        // Finalisation phases reuse a prior execution and are discounted.
+        assert_eq!(Command::AllAccept(atom()).execution_weight_percent(), 35);
+        assert_eq!(Command::SomeAccept(atom()).execution_weight_percent(), 35);
+        // Non-transaction commands carry no transaction execution weight.
+        assert_eq!(
+            Command::ForeignProposal(ForeignProposalAtom {
+                block_id: BlockId::zero(),
+                shard_group: ShardGroup::new(0, 64),
+            })
+            .execution_weight_percent(),
+            0
+        );
+        assert_eq!(
+            Command::EndEpoch(EndEpochAtom::new(FixedHash::zero())).execution_weight_percent(),
+            0
+        );
     }
 }

--- a/crates/storage/src/consensus_models/no_vote.rs
+++ b/crates/storage/src/consensus_models/no_vote.rs
@@ -100,6 +100,8 @@ pub enum NoVoteReason {
     NotAllInputsOutputsAccepted,
     #[error("Invalid evidence")]
     InvalidEvidence { reason: InvalidEvidenceReason },
+    #[error("Block transaction execution weight {total_weight} exceeds the maximum {max_weight}")]
+    BlockWeightExceeded { total_weight: u64, max_weight: u64 },
 }
 
 #[derive(Debug, Clone, thiserror::Error)]
@@ -148,6 +150,7 @@ impl NoVoteReason {
             Self::CannotEvictNodeBelowQuorumThreshold => "CannotSuspendNodeBelowQuorumThreshold",
             Self::NotAllInputsOutputsAccepted => "NotAllInputsOutputsAccepted",
             Self::InvalidEvidence { .. } => "InvalidEvidence",
+            Self::BlockWeightExceeded { .. } => "BlockWeightExceeded",
         }
     }
 }

--- a/crates/storage/src/consensus_models/transaction_pool.rs
+++ b/crates/storage/src/consensus_models/transaction_pool.rs
@@ -65,6 +65,7 @@ impl<TStateStore: StateStore> TransactionPool<TStateStore> {
         Ok(exists)
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn insert_new(
         &self,
         tx: &mut TStateStore::WriteTransaction<'_>,
@@ -74,8 +75,17 @@ impl<TStateStore: StateStore> TransactionPool<TStateStore> {
         is_ready: bool,
         is_global: bool,
         max_epoch: Option<Epoch>,
+        transaction_weight: u64,
     ) -> Result<(), TransactionPoolError> {
-        tx.transaction_pool_insert_new(tx_id, decision, initial_evidence, is_ready, is_global, max_epoch)?;
+        tx.transaction_pool_insert_new(
+            tx_id,
+            decision,
+            initial_evidence,
+            is_ready,
+            is_global,
+            max_epoch,
+            transaction_weight,
+        )?;
         Ok(())
     }
 
@@ -94,6 +104,7 @@ impl<TStateStore: StateStore> TransactionPool<TStateStore> {
                 is_ready,
                 transaction.transaction().is_global(),
                 transaction.transaction().max_epoch(),
+                transaction.transaction().calculate_transaction_weight().as_u64(),
             )?;
         }
         Ok(())
@@ -108,16 +119,22 @@ impl<TStateStore: StateStore> TransactionPool<TStateStore> {
         Ok(recs)
     }
 
+    /// Fetch ready transactions for the next block, bounded by a weight budget and a hard command
+    /// count cap. Records are accumulated in order until either their cumulative
+    /// [`TransactionPoolRecord::proposal_weight`] would exceed `weight_budget` or `max_count` records
+    /// have been collected. At least one ready record is always returned (if any exist) so that a
+    /// single transaction heavier than the whole budget still makes progress.
     pub fn get_batch_for_next_block(
         &self,
         tx: &TStateStore::ReadTransaction<'_>,
-        max: usize,
+        weight_budget: u64,
+        max_count: usize,
         block_id: &BlockId,
     ) -> Result<Vec<TransactionPoolRecord>, TransactionPoolError> {
-        if max == 0 {
+        if weight_budget == 0 || max_count == 0 {
             return Ok(Vec::new());
         }
-        let recs = tx.transaction_pool_get_many_ready(max, block_id)?;
+        let recs = tx.transaction_pool_get_many_ready(weight_budget, max_count, block_id)?;
         Ok(recs)
     }
 
@@ -291,6 +308,26 @@ impl TransactionPoolStage {
     pub fn is_finalising(&self) -> bool {
         self.is_local_only() || self.is_all_accepted() || self.is_some_accepted()
     }
+
+    /// Heuristic cost (as a percentage of the transaction's static weight) of proposing the next
+    /// command for a record at this stage. Phases that execute the transaction and/or carry its full
+    /// footprint cost full weight; finalisation phases reuse an already-computed execution and only
+    /// carry a small atom, so they are discounted. Used purely as a local block-packing heuristic.
+    pub fn proposal_weight_percent(&self) -> u64 {
+        match self {
+            // Prepare phase. May execute (LocalOnly / output-only) or only resolve+pledge local inputs,
+            // but the command carries the transaction's full footprint either way. Charged in full.
+            TransactionPoolStage::New => 100,
+            // Accept phase: executes the transaction with all gathered pledges.
+            TransactionPoolStage::LocalPrepared => 100,
+            // Finalisation phases: reuse the prior execution and apply its diff (or abort). No
+            // re-execution and only a compact atom is proposed.
+            TransactionPoolStage::LocalAccepted |
+            TransactionPoolStage::AllAccepted |
+            TransactionPoolStage::SomeAccepted |
+            TransactionPoolStage::LocalOnly => 35,
+        }
+    }
 }
 
 impl Display for TransactionPoolStage {
@@ -392,6 +429,13 @@ pub struct TransactionPoolRecord {
     last_updated: time::OffsetDateTime,
     #[n(14)]
     last_updated_in_block: Option<BlockId>,
+    /// Static transaction weight (`Transaction::calculate_transaction_weight`), cached here so block
+    /// proposal can budget by weight without loading the full transaction body. Computed once when the
+    /// record is created.
+    #[serde(default)]
+    #[cbor(default)]
+    #[n(15)]
+    transaction_weight: u64,
 }
 
 impl TransactionPoolRecord {
@@ -412,6 +456,7 @@ impl TransactionPoolRecord {
             locked_epoch: None,
             last_updated: time::OffsetDateTime::now_utc(),
             last_updated_in_block: None,
+            transaction_weight: transaction.calculate_transaction_weight().as_u64(),
         }
     }
 
@@ -431,6 +476,7 @@ impl TransactionPoolRecord {
         locked_epoch: Option<LockedEpoch>,
         last_updated: time::OffsetDateTime,
         last_updated_in_block: Option<BlockId>,
+        transaction_weight: u64,
     ) -> Self {
         Self {
             transaction_id: id,
@@ -448,6 +494,7 @@ impl TransactionPoolRecord {
             locked_epoch,
             last_updated,
             last_updated_in_block,
+            transaction_weight,
         }
     }
 
@@ -537,6 +584,20 @@ impl TransactionPoolRecord {
 
     pub fn stage(&self) -> TransactionPoolStage {
         self.stage
+    }
+
+    /// The cached static transaction weight (see `Transaction::calculate_transaction_weight`).
+    pub fn transaction_weight(&self) -> u64 {
+        self.transaction_weight
+    }
+
+    /// The weight this record contributes to a block when proposing its next command. It is the static
+    /// transaction weight scaled by the per-phase cost of the next command (see
+    /// [`TransactionPoolStage::proposal_weight_percent`]). Always at least 1 so every command consumes
+    /// some of the block weight budget. This is a local proposing heuristic, not a consensus rule.
+    pub fn proposal_weight(&self) -> u64 {
+        let percent = self.current_stage().proposal_weight_percent();
+        self.transaction_weight.saturating_mul(percent).div_ceil(100).max(1)
     }
 
     pub fn leader_fee(&self) -> Option<&LeaderFee> {
@@ -968,6 +1029,69 @@ mod tests {
         }
     }
 
+    mod proposal_weight {
+        use super::*;
+
+        fn record_with_weight_and_stage(weight: u64, stage: TransactionPoolStage) -> TransactionPoolRecord {
+            TransactionPoolRecord {
+                transaction_id: TransactionId::new([0; 32]),
+                original_decision: Decision::Commit,
+                evidence: Default::default(),
+                transaction_fee: 0,
+                leader_fee: None,
+                stage,
+                is_global: false,
+                pending_stage: None,
+                local_decision: None,
+                remote_decision: None,
+                is_ready: true,
+                max_epoch: None,
+                locked_epoch: None,
+                last_updated: time::OffsetDateTime::now_utc(),
+                last_updated_in_block: None,
+                transaction_weight: weight,
+            }
+        }
+
+        #[test]
+        fn executing_phases_cost_full_weight() {
+            assert_eq!(TransactionPoolStage::New.proposal_weight_percent(), 100);
+            assert_eq!(TransactionPoolStage::LocalPrepared.proposal_weight_percent(), 100);
+
+            let rec = record_with_weight_and_stage(200, TransactionPoolStage::New);
+            assert_eq!(rec.proposal_weight(), 200);
+        }
+
+        #[test]
+        fn finalisation_phases_are_discounted() {
+            // Finalisation phases reuse a prior execution and carry only a compact atom.
+            for stage in [
+                TransactionPoolStage::LocalAccepted,
+                TransactionPoolStage::AllAccepted,
+                TransactionPoolStage::SomeAccepted,
+                TransactionPoolStage::LocalOnly,
+            ] {
+                assert!(
+                    stage.proposal_weight_percent() < 100,
+                    "{stage} should be discounted relative to an executing phase"
+                );
+                let rec = record_with_weight_and_stage(200, stage);
+                assert!(
+                    rec.proposal_weight() < 200,
+                    "{stage} proposal weight should be discounted"
+                );
+            }
+        }
+
+        #[test]
+        fn proposal_weight_is_at_least_one() {
+            // A zero-weight (e.g. legacy/empty) record still consumes some budget so the count cap
+            // is the only thing bounding it, never an unbounded fill.
+            let rec = record_with_weight_and_stage(0, TransactionPoolStage::New);
+            assert_eq!(rec.proposal_weight(), 1);
+        }
+    }
+
     mod calculate_leader_fee {
 
         use super::*;
@@ -989,6 +1113,7 @@ mod tests {
                 locked_epoch: None,
                 last_updated: time::OffsetDateTime::now_utc(),
                 last_updated_in_block: None,
+                transaction_weight: 0,
             }
         }
 

--- a/crates/storage/src/consensus_models/transaction_pool.rs
+++ b/crates/storage/src/consensus_models/transaction_pool.rs
@@ -65,7 +65,6 @@ impl<TStateStore: StateStore> TransactionPool<TStateStore> {
         Ok(exists)
     }
 
-    #[allow(clippy::too_many_arguments)]
     pub fn insert_new(
         &self,
         tx: &mut TStateStore::WriteTransaction<'_>,

--- a/crates/storage/src/state_store/mod.rs
+++ b/crates/storage/src/state_store/mod.rs
@@ -244,7 +244,8 @@ pub trait StateStoreReadTransaction: Sized {
     fn transaction_pool_get_all(&self, limit: usize) -> Result<Vec<TransactionPoolRecord>, StorageError>;
     fn transaction_pool_get_many_ready(
         &self,
-        max_txs: usize,
+        weight_budget: u64,
+        max_count: usize,
         block_id: &BlockId,
     ) -> Result<Vec<TransactionPoolRecord>, StorageError>;
     fn transaction_pool_has_pending_state_updates(&self, block_id: &BlockId) -> Result<bool, StorageError>;
@@ -466,6 +467,7 @@ pub trait StateStoreWriteTransaction {
         is_ready: bool,
         is_global: bool,
         max_epoch: Option<Epoch>,
+        transaction_weight: u64,
     ) -> Result<(), StorageError>;
     fn transaction_pool_add_pending_update(
         &mut self,


### PR DESCRIPTION
## Summary

Block proposal previously capped a block at a flat command count, treating every command as equal weight. This replaces that with a **weight budget** (each transaction contributes its existing `calculate_transaction_weight`, phase-discounted), and adds a **validation-time weight cap** so a misbehaving leader cannot make replicas execute past the block time.

The change has two parts with different fork-risk profiles — see below.

---

## Part 1 — Propose-time weight budget (fork-safe, local heuristic)

`max_number_commands_in_block` → `max_block_weight` (weight budget) + `max_commands_in_block` (hard count cap for wire/`BTreeSet` overhead).

- `TransactionPoolRecord` caches the static transaction weight; the batch query accumulates weight until the budget/count cap is hit, **always returning ≥1** so a transaction heavier than the budget still makes progress.
- Per-phase weighting (`TransactionPoolStage::proposal_weight_percent`): executing phases full weight; finalisation phases (`Accept` onwards) discounted (reuse a prior execution, carry only a compact atom).
- Foreign proposals weighted by the substate pledges they carry, not a flat `10x`.
- **Execution-time circuit breaker** (`block_time / 2`): the leader stops executing once the soft deadline is hit, deferring the rest. Bounds actual propose latency the static weight can't predict.
- A debug `📊 PROPOSE calibration` log reports observed weight/s + projected full-budget execution time for tuning from real traffic.

This is a **local proposing heuristic** — command count/weight is not validated on receive — so **no fork risk**.

**Calibration:** `max_block_weight = 10000`, calibrated against 2-core (Esmeralda-class) hardware where ~500 LocalOnly stress txs (~62 weight each) executed in ~11.5s ⇒ ~2.7k weight/s; a full 10000-weight block (~160 commands) projects to ~3.7s, within the 10s block time. (Propose-time execution is sequential, so core count does not raise this proportionally — calibrate to single-core throughput.)

## Part 2 — Validation-time weight cap (consensus-affecting voting rule)

The propose-time budget + breaker only protect the **proposer**. A replica replaying a received block re-executes every command with **no bound** — so a misbehaving/buggy leader could push replicas past the block time (this is what broke things at 500 commands / ~11.5s).

Added a rule: when **voting**, a node no-votes a received block whose total transaction execution weight exceeds `max_block_validation_weight`, **unless it carries a single transaction command** (so an individually-heavy transaction stays committable; static weight over-estimates its real execution anyway).

- `max_block_validation_weight = 15000` (1.5× the proposal budget → ~5.5s on 2-core, well within 10s). Honest blocks (≤10000) are never rejected; rejects the ~31k-weight/500-command overload.
- Computed **before executing any command** (in `decide_what_to_vote`), so an oversized block is rejected without paying its execution cost. Transactions are guaranteed present (blocks are parked until all their transactions arrive), so the weight is deterministic across honest nodes.
- `Command::execution_weight_percent` keys the phase factor on the command variant (not the pool stage) so block weight is computable from the block alone.

⚠️ **Consensus-affecting, but enforced at vote time only** (in `decide_what_to_vote`), **not on block acceptance/commit**. A node that no-votes an over-weight block still follows and executes it if it later reaches a QC (the commit path does not re-check weight). Therefore:
- Non-uniform caps do **not** fork committed state — there is no safety divergence.
- The rejection is only **effective** when honest nodes vote consistently: if a quorum votes a bad block through it commits and everyone executes it (no-voters included), and split votes cause liveness wobble (stalls / view changes).
- So `max_block_validation_weight` **should be uniform network-wide and rolled out together** — for effectiveness + liveness, not for safety. (Pre-launch, so acceptable.) Putting the check on acceptance instead would make it a hard validity rule that genuinely could fork a minority off the chain — the vote-only design is the safer choice.

**Scope (v1):** the cap counts transaction commands only; foreign proposals / evict / end-epoch are excluded (lighter). Each FP's *size* becomes transitively bounded once every committee enforces this cap on its own blocks — but the *number* of FPs per block is not bounded here, so FP-stuffing remains an unaddressed vector for a follow-up.

## Versioning
Workspace patch bump 0.33.2 → 0.33.3.

## Tests
- Unit: `proposal_weight` / phase factor; `subtract_weight_checked`; `Command::execution_weight_percent`; `exceeds_block_validation_weight` (incl. the single-transaction exemption).
- RocksDB reader: weight-budget selection (stops at budget, ≥1 guard, count cap).
- Integration: full `consensus_tests` suite (60 tests) green with the validation pre-pass active across single-shard/multishard/epoch-change/eviction scenarios — confirms it runs on every block and never false-rejects honest blocks. Verified the proposal budget + calibration log on a live local swarm node.

A rejection-triggering integration test is intentionally omitted: forcing a leader to propose an over-cap block makes every replica no-vote → consensus stalls by design → the test would hang. The rejection logic is unit-tested instead.