### PR TITLE
perf(epoch-oracles): speed up base layer sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11317,6 +11317,7 @@ dependencies = [
  "anyhow",
  "blake2 0.10.6",
  "log",
+ "minotari_app_grpc",
  "ootle-network",
  "ootle_serde",
  "serde",

--- a/crates/epoch_oracles/Cargo.toml
+++ b/crates/epoch_oracles/Cargo.toml
@@ -32,6 +32,8 @@ time = { workspace = true, features = ["serde", "serde-human-readable"] }
 [dev-dependencies]
 tokio = { workspace = true, features = ["time", "macros", "rt"] }
 serde_json = { workspace = true }
+# Used only by the base_layer scanner tests to build grpc ValidatorNodeChange fixtures.
+minotari_app_grpc = { workspace = true }
 
 [features]
 base_layer = [

--- a/crates/epoch_oracles/src/base_layer/header_store.rs
+++ b/crates/epoch_oracles/src/base_layer/header_store.rs
@@ -2,17 +2,13 @@
 //   SPDX-License-Identifier: BSD-3-Clause
 
 use tari_common_types::types::FixedHash;
-use tari_node_components::blocks::BlockHeader;
 use tari_ootle_common_types::{Epoch, NodeAddressable, optional::Optional};
 use tari_ootle_storage::global::{BlockHeaderModel, GlobalDb};
 use tari_ootle_storage_sqlite::global::SqliteGlobalDbAdapter;
 use tari_template_lib_types::Hash32;
 
 pub trait BaseLayerBlockHeaderStore {
-    fn add_block_headers<I: IntoIterator<Item = (Epoch, FixedHash, BlockHeader)>>(
-        &self,
-        headers: I,
-    ) -> anyhow::Result<()>;
+    fn add_block_headers<I: IntoIterator<Item = BlockHeaderModel>>(&self, headers: I) -> anyhow::Result<()>;
 
     /// Returns the stored header with the given block hash, or `None` if it is not stored. Used during
     /// reorg recovery to find the highest base-layer height whose canonical block we have already stored.
@@ -33,20 +29,11 @@ pub trait BaseLayerBlockHeaderStore {
 }
 
 impl<TAddr: NodeAddressable> BaseLayerBlockHeaderStore for GlobalDb<SqliteGlobalDbAdapter<TAddr>> {
-    fn add_block_headers<I: IntoIterator<Item = (Epoch, FixedHash, BlockHeader)>>(
-        &self,
-        headers: I,
-    ) -> anyhow::Result<()> {
+    fn add_block_headers<I: IntoIterator<Item = BlockHeaderModel>>(&self, headers: I) -> anyhow::Result<()> {
         let mut tx = self.create_transaction()?;
         let mut header_db = self.block_headers(&mut tx);
-        for (epoch, block_hash, header) in headers {
-            header_db.insert(BlockHeaderModel {
-                epoch,
-                height: header.height,
-                block_hash,
-                kernel_merkle_root: header.kernel_mr,
-                validator_node_merkle_root: header.validator_node_mr,
-            })?;
+        for header in headers {
+            header_db.insert(header)?;
         }
         tx.commit()?;
         Ok(())

--- a/crates/epoch_oracles/src/base_layer/oracle.rs
+++ b/crates/epoch_oracles/src/base_layer/oracle.rs
@@ -32,19 +32,40 @@ const LOG_TARGET: &str = "tari::ootle::epoch_oracles::base_layer_scanner";
 
 /// Maximum number of `get_validator_node_changes` requests issued concurrently after a header batch
 /// has been streamed. These per-epoch fetches are independent of one another, so they are pipelined
-/// rather than being awaited one at a time mid-stream (see `sync_blockchain`).
+/// rather than being awaited one at a time mid-stream (see `resolve_changes_and_commit`).
 const VALIDATOR_NODE_CHANGE_FETCH_CONCURRENCY: usize = 10;
 
-/// An event produced while streaming a header batch.
+/// Maximum number of epoch-boundary headers fetched concurrently in the boundary-only scan path
+/// (see `scan_epoch_boundaries`).
+const BOUNDARY_HEADER_FETCH_CONCURRENCY: usize = 16;
+
+/// Maximum number of epoch boundaries scanned per batch in the boundary-only path. Bounds memory and
+/// the number of concurrent header fetches for very long catch-ups; the remainder is picked up by
+/// the next scan round via the normal `has_more` loop.
+const MAX_BOUNDARIES_PER_BATCH: u64 = 2_000;
+
+/// An event produced while scanning a batch of base-layer blocks.
 ///
 /// `ValidatorNodeChanges` is a placeholder for an `ActiveValidatorNodeSetChanged` event whose
-/// `get_validator_node_changes` fetch is deferred until the whole header stream has been drained.
-/// Issuing that unary RPC inside the stream loop stalls the header server-stream on every epoch
-/// boundary; recording a placeholder lets us resolve all the fetches concurrently afterwards while
-/// preserving the exact position the event must occupy in the emitted order.
+/// `get_validator_node_changes` fetch is deferred until the whole batch has been scanned. Issuing
+/// that unary RPC inside the scan loop stalls it on every epoch boundary; recording a placeholder
+/// lets us resolve all the fetches concurrently afterwards while preserving the exact position the
+/// event must occupy in the emitted order.
 enum PendingScanEvent {
     Ready(EpochEvent),
     ValidatorNodeChanges { epoch: Epoch },
+}
+
+/// The in-memory result of scanning one batch of base-layer blocks, before the deferred
+/// validator-node-change fetches are resolved and the scan position is committed
+/// (see `resolve_changes_and_commit`).
+struct BatchScan {
+    scan_events: Vec<PendingScanEvent>,
+    last_validator_node_mr: Option<FixedHash>,
+    last_epoch_hash: Option<FixedHash>,
+    last_scanned_hash: Option<FixedHash>,
+    last_scanned_height: u64,
+    scan_epoch: Epoch,
 }
 
 type TaskOutput<TStore, TClient> = (
@@ -441,181 +462,20 @@ impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore, TClient: BaseNodeClie
             .await?;
         self.cached_epoch_length = Some(constants.epoch_length());
 
-        // We'll buffer 1000 headers at a time
-        // note: 10_000 is the maximum permitted by the base node gRPC service
-        let limit = 1_000.min(num_blocks);
+        // Acquire and scan this batch's blocks. The validator node needs every header (e.g. for
+        // burn-proof validation), so it streams and stores the full contiguous range. The indexer
+        // only needs epoch boundaries (and the validator-node MR sampled at them), so it fetches
+        // just the boundary headers — skipping the bulk of the range and the per-header stream cost.
+        let batch = if self.config.features.sync_headers {
+            self.scan_full_headers(&constants, start_scan_height, num_blocks)
+                .await?
+        } else {
+            self.scan_epoch_boundaries(&constants, start_scan_height, num_blocks)
+                .await?
+        };
 
-        let mut base_node_client = self.base_node_client.clone();
-        info!(
-            target: LOG_TARGET,
-            "⛓️Starting header stream from {}-{}", start_scan_height, start_scan_height + limit
-        );
-        let mut header_stream = base_node_client.stream_headers(start_scan_height, limit).await?;
-
-        if let Some(additional) = usize::try_from(limit)
-            .ok()
-            .and_then(|l| l.checked_sub(self.header_buf.capacity()))
-        {
-            self.header_buf.reserve(additional);
-        }
-
-        // ── Pass 1: drain the header stream doing ONLY in-memory work ───────────────────────────
-        // The header server-stream must not be stalled by per-epoch unary RPCs, so the only network
-        // call this loop used to make — `get_validator_node_changes` — is deferred. We record a
-        // `ValidatorNodeChanges` placeholder at the exact position its `ActiveValidatorNodeSetChanged`
-        // event must occupy, and resolve all such fetches concurrently in pass 2.
-        //
-        // Scan state evolves in locals here and is only committed to `self`/the store once the
-        // deferred fetches succeed (pass 2). This makes the batch atomic: a failed fetch leaves the
-        // persisted scan position untouched, so the whole batch is safely re-scanned next round
-        // (header inserts are idempotent). `header_buf` is cleared so a re-scan after such a failure
-        // does not accumulate the previous attempt's (unflushed) headers.
-        self.header_buf.clear();
-        let mut scan_events: Vec<PendingScanEvent> = Vec::new();
-        let mut last_validator_node_mr = self.last_scanned_validator_node_mr;
-        let mut last_epoch_hash = self.last_epoch_hash;
-        let mut last_scanned_hash = self.last_scanned_hash;
-        let mut last_scanned_height = self.last_scanned_height;
-        let mut scan_epoch = constants.height_to_epoch(start_scan_height);
-        while let Some(header) = header_stream.try_next().await? {
-            let current_epoch = constants.height_to_epoch(header.height);
-            let header_height = header.height;
-            // Note: Cant use header.hash() because it uses CURRENT_NETWORK global
-            let header_hash = hash_header(self.network, &header);
-            let current_validator_node_mr = header.validator_node_mr;
-            if self.config.features.sync_headers {
-                self.header_buf.push((current_epoch, header_hash, header));
-            }
-
-            // Record validator node MR changes BEFORE epoch changes so that new registrations are
-            // ordered ahead of the boundary's EpochChanged — assign_validators_for_epoch must see
-            // them first. This matters when the base layer updates the validator_node_mr at epoch
-            // boundary blocks.
-            if last_validator_node_mr != Some(current_validator_node_mr) {
-                debug!(
-                    target: LOG_TARGET,
-                    "⛓️ last_scanned_validator_node_mr = {} current = {}", last_validator_node_mr.display(), current_validator_node_mr
-                );
-
-                if self.config.features.sync_validator_node_changes {
-                    // Deferred: the actual fetch happens in pass 2. Here we only mark where the
-                    // resulting event belongs in the emitted order.
-                    scan_events.push(PendingScanEvent::ValidatorNodeChanges { epoch: current_epoch });
-                }
-                last_validator_node_mr = Some(current_validator_node_mr);
-            }
-
-            if header_height % constants.epoch_length() == 0 {
-                info!(
-                    target: LOG_TARGET,
-                    "🟩 New epoch block {} {} {}", current_epoch, header_height, header_hash
-                );
-                last_epoch_hash = Some(header_hash);
-
-                // TODO: we do not handle consensus constants changing during scan here for performance reasons.
-                // constants = self.base_node_client.get_consensus_constants(header_height).await?;
-
-                // Emit EpochChanged for every boundary so every (epoch, epoch_hash) pair is persisted
-                // by the epoch manager. Consensus's get_epoch_hash(epoch) lookup depends on that
-                // row being present for any epoch it may transition into — including epochs
-                // crossed during a long catch-up.
-                info!(
-                    target: LOG_TARGET,
-                    "🟩 epoch change {}->{} (height({}) hash({}))", scan_epoch, current_epoch, header_height, header_hash
-                );
-                scan_events.push(PendingScanEvent::Ready(EpochEvent::EpochChanged {
-                    epoch: current_epoch,
-                    // Set above
-                    epoch_hash: last_epoch_hash.unwrap_or_default(),
-                }));
-                scan_epoch = current_epoch;
-            }
-
-            last_scanned_hash = Some(header_hash);
-            last_scanned_height = header_height;
-        }
-        // End the header server-stream before pass 2 issues its own requests.
-        drop(header_stream);
-
-        // ── Pass 2: resolve the deferred validator-node-change fetches concurrently ─────────────
-        // Each fetch is keyed only by epoch (sidechain_id is fixed for the whole scan) and is
-        // independent of the rest, so they are pipelined with bounded concurrency instead of being
-        // awaited serially. The header stream is already drained, so nothing is stalled on them.
-        let fetch_targets: Vec<(usize, Epoch)> = scan_events
-            .iter()
-            .enumerate()
-            .filter_map(|(idx, event)| match event {
-                PendingScanEvent::ValidatorNodeChanges { epoch } => Some((idx, *epoch)),
-                PendingScanEvent::Ready(_) => None,
-            })
-            .collect();
-
-        let mut fetched_changes: HashMap<usize, Vec<ValidatorNodeChange>> = HashMap::new();
-        if !fetch_targets.is_empty() {
-            let base_client = self.base_node_client.clone();
-            let sidechain_id = self.config.sidechain_id;
-            fetched_changes = stream::iter(fetch_targets)
-                .map(move |(idx, epoch)| {
-                    let mut client = base_client.clone();
-                    async move {
-                        let node_changes = client
-                            .get_validator_node_changes(epoch, sidechain_id.as_ref())
-                            .await
-                            .map_err(BaseLayerOracleError::BaseNodeError)?;
-                        let node_changes = node_changes
-                            .into_iter()
-                            .map(TryInto::try_into)
-                            .collect::<Result<Vec<ValidatorNodeChange>, _>>()
-                            .map_err(|e| {
-                                BaseLayerOracleError::InvalidBaseNodeResponse(format!(
-                                    "Failed to convert validator node change: {}",
-                                    e
-                                ))
-                            })?;
-                        Ok::<_, BaseLayerOracleError>((idx, node_changes))
-                    }
-                })
-                .buffer_unordered(VALIDATOR_NODE_CHANGE_FETCH_CONCURRENCY)
-                .try_collect()
-                .await?;
-        }
-
-        // Replay the batch's events in stream order, splicing in each resolved validator-node-change
-        // set. A set may be empty when the MR changed because of *other* sidechains — drop those, as
-        // the inline version did.
-        for (idx, event) in scan_events.into_iter().enumerate() {
-            match event {
-                PendingScanEvent::Ready(event) => self.pending_events.push_back(event),
-                PendingScanEvent::ValidatorNodeChanges { epoch } => {
-                    if let Some(node_changes) = fetched_changes.remove(&idx) &&
-                        !node_changes.is_empty()
-                    {
-                        self.pending_events
-                            .push_back(EpochEvent::ActiveValidatorNodeSetChanged { epoch, node_changes });
-                    }
-                },
-            }
-        }
-
-        // ── Commit: persist headers and advance the scan position now the batch is complete ─────
-        // `last_scanned_tip` is set by set_last_scanned_block once the whole batch is persisted; it
-        // is intentionally not advanced earlier, so an interrupted sync re-scans rather than letting
-        // get_blockchain_progression short-circuit and silently skip the remaining headers.
-        if !self.header_buf.is_empty() {
-            self.store
-                .add_block_headers(self.header_buf.drain(..))
-                .map_err(BaseLayerOracleError::StoreError)?;
-        }
-        self.last_scanned_validator_node_mr = last_validator_node_mr;
-        self.set_last_scanned_block(
-            last_scanned_hash.unwrap_or_else(FixedHash::zero),
-            last_scanned_height,
-            tip.tip_hash,
-        )?;
-
-        if let Some(hash) = last_epoch_hash {
-            self.set_last_epoch_block(hash)?;
-        }
+        let scan_epoch = batch.scan_epoch;
+        self.resolve_changes_and_commit(batch, &tip).await?;
 
         // let scan_height = constants.epoch_to_height(scan_epoch);
         // if self.last_scanned_validator_node_mr.is_none() {
@@ -664,6 +524,316 @@ impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore, TClient: BaseNodeClie
             });
             Ok(false)
         }
+    }
+
+    /// Scans a contiguous batch of up to 1000 headers, buffering every header for storage. Used when
+    /// `sync_headers` is enabled (validator node), which needs the full header set (e.g. for
+    /// burn-proof validation).
+    ///
+    /// The single network call this loop used to make — `get_validator_node_changes` — is deferred:
+    /// a `ValidatorNodeChanges` placeholder is recorded at the exact position its
+    /// `ActiveValidatorNodeSetChanged` event must occupy, and the fetch is resolved later in
+    /// [`resolve_changes_and_commit`] so it never stalls the header server-stream.
+    #[allow(clippy::too_many_lines)]
+    async fn scan_full_headers(
+        &mut self,
+        constants: &BaseLayerConsensusConstants,
+        start_scan_height: u64,
+        num_blocks: u64,
+    ) -> Result<BatchScan, BaseLayerOracleError> {
+        // We'll buffer 1000 headers at a time
+        // note: 10_000 is the maximum permitted by the base node gRPC service
+        let limit = 1_000.min(num_blocks);
+
+        let mut base_node_client = self.base_node_client.clone();
+        info!(
+            target: LOG_TARGET,
+            "⛓️Starting header stream from {}-{}", start_scan_height, start_scan_height + limit
+        );
+        let mut header_stream = base_node_client.stream_headers(start_scan_height, limit).await?;
+
+        if let Some(additional) = usize::try_from(limit)
+            .ok()
+            .and_then(|l| l.checked_sub(self.header_buf.capacity()))
+        {
+            self.header_buf.reserve(additional);
+        }
+
+        // Scan state evolves in locals here and is only committed to `self`/the store once the
+        // deferred fetches succeed. This makes the batch atomic: a failed fetch leaves the persisted
+        // scan position untouched, so the whole batch is safely re-scanned next round (header inserts
+        // are idempotent). `header_buf` is cleared so a re-scan after such a failure does not
+        // accumulate the previous attempt's (unflushed) headers.
+        self.header_buf.clear();
+        let mut scan_events: Vec<PendingScanEvent> = Vec::new();
+        let mut last_validator_node_mr = self.last_scanned_validator_node_mr;
+        let mut last_epoch_hash = self.last_epoch_hash;
+        let mut last_scanned_hash = self.last_scanned_hash;
+        let mut last_scanned_height = self.last_scanned_height;
+        let mut scan_epoch = constants.height_to_epoch(start_scan_height);
+        while let Some(header) = header_stream.try_next().await? {
+            let current_epoch = constants.height_to_epoch(header.height);
+            let header_height = header.height;
+            // Note: Cant use header.hash() because it uses CURRENT_NETWORK global
+            let header_hash = hash_header(self.network, &header);
+            let current_validator_node_mr = header.validator_node_mr;
+            self.header_buf.push((current_epoch, header_hash, header));
+
+            // Record validator node MR changes BEFORE epoch changes so that new registrations are
+            // ordered ahead of the boundary's EpochChanged — assign_validators_for_epoch must see
+            // them first. This matters when the base layer updates the validator_node_mr at epoch
+            // boundary blocks.
+            if last_validator_node_mr != Some(current_validator_node_mr) {
+                debug!(
+                    target: LOG_TARGET,
+                    "⛓️ last_scanned_validator_node_mr = {} current = {}", last_validator_node_mr.display(), current_validator_node_mr
+                );
+
+                if self.config.features.sync_validator_node_changes {
+                    // Deferred: the actual fetch happens in resolve_changes_and_commit. Here we only
+                    // mark where the resulting event belongs in the emitted order.
+                    scan_events.push(PendingScanEvent::ValidatorNodeChanges { epoch: current_epoch });
+                }
+                last_validator_node_mr = Some(current_validator_node_mr);
+            }
+
+            if header_height % constants.epoch_length() == 0 {
+                info!(
+                    target: LOG_TARGET,
+                    "🟩 New epoch block {} {} {}", current_epoch, header_height, header_hash
+                );
+                last_epoch_hash = Some(header_hash);
+
+                // Emit EpochChanged for every boundary so every (epoch, epoch_hash) pair is persisted
+                // by the epoch manager. Consensus's get_epoch_hash(epoch) lookup depends on that
+                // row being present for any epoch it may transition into — including epochs
+                // crossed during a long catch-up.
+                info!(
+                    target: LOG_TARGET,
+                    "🟩 epoch change {}->{} (height({}) hash({}))", scan_epoch, current_epoch, header_height, header_hash
+                );
+                scan_events.push(PendingScanEvent::Ready(EpochEvent::EpochChanged {
+                    epoch: current_epoch,
+                    // Set above
+                    epoch_hash: last_epoch_hash.unwrap_or_default(),
+                }));
+                scan_epoch = current_epoch;
+            }
+
+            last_scanned_hash = Some(header_hash);
+            last_scanned_height = header_height;
+        }
+        // End the header server-stream before the deferred fetches issue their own requests.
+        drop(header_stream);
+
+        Ok(BatchScan {
+            scan_events,
+            last_validator_node_mr,
+            last_epoch_hash,
+            last_scanned_hash,
+            last_scanned_height,
+            scan_epoch,
+        })
+    }
+
+    /// Scans only the epoch-boundary headers in the next batch window, fetching them concurrently
+    /// instead of streaming every header. Used when `sync_headers` is disabled (indexer): only epoch
+    /// boundaries — and the validator-node MR sampled at them — are needed, so the non-boundary
+    /// headers (the bulk of the range, and the per-header stream-delivery cost) are never fetched.
+    ///
+    /// Relies on the base-layer invariant that `validator_node_mr` only changes at epoch-boundary
+    /// blocks, so sampling the MR at boundaries catches every validator-set change. The boundary's
+    /// epoch then drives the same deferred `get_validator_node_changes` fetch as the full path. A
+    /// trailing position-only header (the window end) advances the scan position when the window
+    /// ends mid-epoch; it carries no events and is not MR-sampled (its MR equals its epoch
+    /// boundary's, already handled).
+    async fn scan_epoch_boundaries(
+        &mut self,
+        constants: &BaseLayerConsensusConstants,
+        start_scan_height: u64,
+        num_blocks: u64,
+    ) -> Result<BatchScan, BaseLayerOracleError> {
+        let epoch_length = constants.epoch_length().max(1);
+        // Bound the window so very long catch-ups split across batches via the has_more loop.
+        let limit = MAX_BOUNDARIES_PER_BATCH.saturating_mul(epoch_length).min(num_blocks);
+        let window_end = start_scan_height + limit - 1;
+
+        // Every epoch boundary in [start_scan_height, window_end], plus window_end itself so the scan
+        // position (and its reorg-detection hash) advances to the window even when it ends mid-epoch.
+        let first_boundary = start_scan_height.div_ceil(epoch_length).saturating_mul(epoch_length);
+        let mut fetch_heights: Vec<u64> = (first_boundary..=window_end).step_by(epoch_length as usize).collect();
+        if fetch_heights.last() != Some(&window_end) {
+            fetch_heights.push(window_end);
+        }
+
+        info!(
+            target: LOG_TARGET,
+            "⛓️ Fetching {} epoch-boundary header(s) in {}-{}", fetch_heights.len(), start_scan_height, window_end
+        );
+
+        // Fetch the targeted headers concurrently; they are independent.
+        let base_client = self.base_node_client.clone();
+        let mut headers: Vec<(u64, BlockHeader)> = stream::iter(fetch_heights)
+            .map(move |height| {
+                let mut client = base_client.clone();
+                async move {
+                    let mut header_stream = client.stream_headers(height, 1).await?;
+                    let header = header_stream.try_next().await?.ok_or_else(|| {
+                        BaseLayerOracleError::InvalidBaseNodeResponse(format!(
+                            "base node returned no header at height {height}"
+                        ))
+                    })?;
+                    Ok::<_, BaseLayerOracleError>((height, header))
+                }
+            })
+            .buffer_unordered(BOUNDARY_HEADER_FETCH_CONCURRENCY)
+            .try_collect()
+            .await?;
+        headers.sort_unstable_by_key(|(height, _)| *height);
+
+        let mut scan_events: Vec<PendingScanEvent> = Vec::new();
+        let mut last_validator_node_mr = self.last_scanned_validator_node_mr;
+        let mut last_epoch_hash = self.last_epoch_hash;
+        let mut last_scanned_hash = self.last_scanned_hash;
+        let mut last_scanned_height = self.last_scanned_height;
+        let mut scan_epoch = constants.height_to_epoch(start_scan_height);
+        for (height, header) in headers {
+            let header_hash = hash_header(self.network, &header);
+
+            // Only boundary headers carry epoch changes / MR samples. A non-boundary header here is
+            // the trailing window-end marker, used solely to advance the scan position.
+            if height % epoch_length == 0 {
+                let current_epoch = constants.height_to_epoch(height);
+                let current_validator_node_mr = header.validator_node_mr;
+                if last_validator_node_mr != Some(current_validator_node_mr) {
+                    if self.config.features.sync_validator_node_changes {
+                        scan_events.push(PendingScanEvent::ValidatorNodeChanges { epoch: current_epoch });
+                    }
+                    last_validator_node_mr = Some(current_validator_node_mr);
+                }
+                last_epoch_hash = Some(header_hash);
+                info!(
+                    target: LOG_TARGET,
+                    "🟩 epoch change {}->{} (height({}) hash({}))", scan_epoch, current_epoch, height, header_hash
+                );
+                scan_events.push(PendingScanEvent::Ready(EpochEvent::EpochChanged {
+                    epoch: current_epoch,
+                    epoch_hash: header_hash,
+                }));
+                scan_epoch = current_epoch;
+            }
+
+            last_scanned_hash = Some(header_hash);
+            last_scanned_height = height;
+        }
+
+        Ok(BatchScan {
+            scan_events,
+            last_validator_node_mr,
+            last_epoch_hash,
+            last_scanned_hash,
+            last_scanned_height,
+            scan_epoch,
+        })
+    }
+
+    /// Resolves the batch's deferred validator-node-change fetches concurrently, emits the batch's
+    /// events in order, persists any buffered headers, and advances the scan position. Shared by the
+    /// full and boundary scan paths.
+    async fn resolve_changes_and_commit(
+        &mut self,
+        batch: BatchScan,
+        tip: &BaseLayerMetadata,
+    ) -> Result<(), BaseLayerOracleError> {
+        let BatchScan {
+            scan_events,
+            last_validator_node_mr,
+            last_epoch_hash,
+            last_scanned_hash,
+            last_scanned_height,
+            scan_epoch: _,
+        } = batch;
+
+        // Resolve the deferred fetches concurrently. Each is keyed only by epoch (sidechain_id is
+        // fixed for the whole scan) and is independent of the rest, so they are pipelined with
+        // bounded concurrency instead of being awaited serially.
+        let fetch_targets: Vec<(usize, Epoch)> = scan_events
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, event)| match event {
+                PendingScanEvent::ValidatorNodeChanges { epoch } => Some((idx, *epoch)),
+                PendingScanEvent::Ready(_) => None,
+            })
+            .collect();
+
+        let mut fetched_changes: HashMap<usize, Vec<ValidatorNodeChange>> = HashMap::new();
+        if !fetch_targets.is_empty() {
+            let base_client = self.base_node_client.clone();
+            let sidechain_id = self.config.sidechain_id;
+            fetched_changes = stream::iter(fetch_targets)
+                .map(move |(idx, epoch)| {
+                    let mut client = base_client.clone();
+                    async move {
+                        let node_changes = client
+                            .get_validator_node_changes(epoch, sidechain_id.as_ref())
+                            .await
+                            .map_err(BaseLayerOracleError::BaseNodeError)?;
+                        let node_changes = node_changes
+                            .into_iter()
+                            .map(TryInto::try_into)
+                            .collect::<Result<Vec<ValidatorNodeChange>, _>>()
+                            .map_err(|e| {
+                                BaseLayerOracleError::InvalidBaseNodeResponse(format!(
+                                    "Failed to convert validator node change: {}",
+                                    e
+                                ))
+                            })?;
+                        Ok::<_, BaseLayerOracleError>((idx, node_changes))
+                    }
+                })
+                .buffer_unordered(VALIDATOR_NODE_CHANGE_FETCH_CONCURRENCY)
+                .try_collect()
+                .await?;
+        }
+
+        // Replay the batch's events in order, splicing in each resolved validator-node-change set. A
+        // set may be empty when the MR changed because of *other* sidechains — drop those, as the
+        // inline version did.
+        for (idx, event) in scan_events.into_iter().enumerate() {
+            match event {
+                PendingScanEvent::Ready(event) => self.pending_events.push_back(event),
+                PendingScanEvent::ValidatorNodeChanges { epoch } => {
+                    if let Some(node_changes) = fetched_changes.remove(&idx) &&
+                        !node_changes.is_empty()
+                    {
+                        self.pending_events
+                            .push_back(EpochEvent::ActiveValidatorNodeSetChanged { epoch, node_changes });
+                    }
+                },
+            }
+        }
+
+        // Persist headers and advance the scan position now the batch is complete. `last_scanned_tip`
+        // is set by set_last_scanned_block once the whole batch is persisted; it is intentionally not
+        // advanced earlier, so an interrupted sync re-scans rather than letting
+        // get_blockchain_progression short-circuit and silently skip the remaining headers.
+        if !self.header_buf.is_empty() {
+            self.store
+                .add_block_headers(self.header_buf.drain(..))
+                .map_err(BaseLayerOracleError::StoreError)?;
+        }
+        self.last_scanned_validator_node_mr = last_validator_node_mr;
+        self.set_last_scanned_block(
+            last_scanned_hash.unwrap_or_else(FixedHash::zero),
+            last_scanned_height,
+            tip.tip_hash,
+        )?;
+
+        if let Some(hash) = last_epoch_hash {
+            self.set_last_epoch_block(hash)?;
+        }
+
+        Ok(())
     }
 
     fn set_last_scanned_block(
@@ -1399,5 +1569,127 @@ mod tests {
             store.heights().is_empty(),
             "no headers may be persisted from a failed batch"
         );
+    }
+
+    /// Indexer mode: `sync_headers` disabled, so only epoch boundaries are scanned.
+    fn make_inner_boundary_mode(
+        store: InMemoryStore,
+        client: MockBaseNode,
+        height_lag: u64,
+    ) -> BaseLayerOracleInner<InMemoryStore, MockBaseNode> {
+        let mut inner = make_inner(store, client, height_lag);
+        inner.config.features.sync_headers = false;
+        inner
+    }
+
+    /// Indexer mode that also resolves validator-node changes at the boundaries it crosses.
+    fn make_inner_boundary_mode_syncing_vn(
+        store: InMemoryStore,
+        client: MockBaseNode,
+        height_lag: u64,
+    ) -> BaseLayerOracleInner<InMemoryStore, MockBaseNode> {
+        let mut inner = make_inner_boundary_mode(store, client, height_lag);
+        inner.config.features.sync_validator_node_changes = true;
+        inner
+    }
+
+    /// Drives the scanner to the tip, collecting every emitted event (mirrors the poll loop draining
+    /// `pending_events` between scan rounds).
+    async fn run_scan_collecting_events(
+        inner: &mut BaseLayerOracleInner<InMemoryStore, MockBaseNode>,
+    ) -> Vec<EpochEvent> {
+        let mut events = Vec::new();
+        let mut has_more = false;
+        loop {
+            has_more = inner.scan_blockchain(has_more).await.unwrap();
+            events.extend(inner.pending_events.drain(..));
+            if !has_more {
+                break;
+            }
+        }
+        events
+    }
+
+    fn epoch_changes(events: &[EpochEvent]) -> Vec<(u64, FixedHash)> {
+        events
+            .iter()
+            .filter_map(|e| match e {
+                EpochEvent::EpochChanged { epoch, epoch_hash } => Some((epoch.as_u64(), *epoch_hash)),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// The boundary-only path (indexer) must emit exactly the same `EpochChanged` events — same
+    /// epochs and same boundary hashes — as the full streaming path (validator node), while storing
+    /// no headers.
+    #[tokio::test]
+    async fn boundary_scan_emits_same_epoch_changes_as_full_scan() {
+        // height_lag = 5, tip = 20 -> scans heights 1..=15, crossing boundaries at 5, 10, 15.
+        let chain = linear_chain(0..=20);
+
+        let full_store = InMemoryStore::default();
+        let mut full = make_inner(full_store.clone(), MockBaseNode::new(chain.clone()), 5);
+        let full_events = run_scan_collecting_events(&mut full).await;
+
+        let boundary_store = InMemoryStore::default();
+        let mut boundary = make_inner_boundary_mode(boundary_store.clone(), MockBaseNode::new(chain), 5);
+        let boundary_events = run_scan_collecting_events(&mut boundary).await;
+
+        // Same epoch boundaries with identical hashes.
+        assert_eq!(
+            epoch_changes(&full_events).iter().map(|(e, _)| *e).collect::<Vec<_>>(),
+            vec![1, 2, 3]
+        );
+        assert_eq!(epoch_changes(&full_events), epoch_changes(&boundary_events));
+
+        // Full mode stored every header; boundary mode stored none.
+        assert_eq!(full_store.heights(), (1..=15).collect::<Vec<_>>());
+        assert!(boundary_store.heights().is_empty());
+
+        // Both reached the lagged tip (no runaway has_more loop).
+        assert_eq!(full.last_scanned_height, 15);
+        assert_eq!(boundary.last_scanned_height, 15);
+    }
+
+    /// Boundary mode still resolves validator-node changes — deferred and concurrent — for each
+    /// boundary it crosses, ordered ahead of that epoch's `EpochChanged`.
+    #[tokio::test]
+    async fn boundary_scan_detects_validator_changes_at_boundaries() {
+        let store = InMemoryStore::default();
+        let client = MockBaseNode::new(chain_with_epoch_mr(0..=20));
+        let mut changes = HashMap::new();
+        for epoch in 1..=3u64 {
+            changes.insert(epoch, vec![vn_remove()]);
+        }
+        client.set_vn_changes(changes);
+
+        let mut inner = make_inner_boundary_mode_syncing_vn(store.clone(), client.clone(), 5);
+        let events = run_scan_collecting_events(&mut inner).await;
+
+        let ordered: Vec<(&str, u64)> = events
+            .iter()
+            .filter_map(|e| match e {
+                EpochEvent::ActiveValidatorNodeSetChanged { epoch, node_changes } => {
+                    assert!(!node_changes.is_empty());
+                    Some(("vn", epoch.as_u64()))
+                },
+                EpochEvent::EpochChanged { epoch, .. } => Some(("epoch", epoch.as_u64())),
+                _ => None,
+            })
+            .collect();
+
+        assert_eq!(ordered, vec![
+            ("vn", 1),
+            ("epoch", 1),
+            ("vn", 2),
+            ("epoch", 2),
+            ("vn", 3),
+            ("epoch", 3),
+        ]);
+        // Boundary mode samples the MR only at boundaries, so it queries the epochs it crosses
+        // (1, 2, 3) — not the pre-start epoch 0 that the full path samples at its mid-epoch start.
+        assert_eq!(client.vn_call_epochs_sorted(), vec![1, 2, 3]);
+        assert!(store.heights().is_empty());
     }
 }

--- a/crates/epoch_oracles/src/base_layer/oracle.rs
+++ b/crates/epoch_oracles/src/base_layer/oracle.rs
@@ -19,8 +19,8 @@ use tari_base_node_client::{
 };
 use tari_common_types::types::FixedHash;
 use tari_epoch_manager::epoch_event_oracle::{EpochEvent, EpochEventOracle, ValidatorNodeChange};
-use tari_node_components::blocks::BlockHeader;
 use tari_ootle_common_types::{Epoch, displayable::Displayable, optional::Optional};
+use tari_ootle_storage::global::BlockHeaderModel;
 use tokio::time;
 
 use crate::{
@@ -100,7 +100,10 @@ struct BaseLayerOracleInner<TStore, TClient> {
     base_node_client: TClient,
     has_attempted_scan: bool,
     pending_events: VecDeque<EpochEvent>,
-    header_buf: Vec<(Epoch, FixedHash, BlockHeader)>,
+    // Stores the minimal `BlockHeaderModel` (all `Copy` fields) rather than the full `BlockHeader`,
+    // so the heavy parts of a header — notably `pow.pow_data` — are dropped right after hashing
+    // instead of being held for the whole batch.
+    header_buf: Vec<BlockHeaderModel>,
     network: Network,
     /// Epoch length in base-layer blocks, cached from consensus constants on the first scan
     /// that obtains them. `None` until the first scan completes.
@@ -577,7 +580,15 @@ impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore, TClient: BaseNodeClie
             // Note: Cant use header.hash() because it uses CURRENT_NETWORK global
             let header_hash = hash_header(self.network, &header);
             let current_validator_node_mr = header.validator_node_mr;
-            self.header_buf.push((current_epoch, header_hash, header));
+            // Keep only the fields the store persists; the full `header` (incl. its pow_data blob)
+            // is dropped at the end of this iteration.
+            self.header_buf.push(BlockHeaderModel {
+                epoch: current_epoch,
+                height: header_height,
+                block_hash: header_hash,
+                kernel_merkle_root: header.kernel_mr,
+                validator_node_merkle_root: header.validator_node_mr,
+            });
 
             // Record validator node MR changes BEFORE epoch changes so that new registrations are
             // ordered ahead of the boundary's EpochChanged — assign_validators_for_epoch must see
@@ -671,9 +682,12 @@ impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore, TClient: BaseNodeClie
             "⛓️ Fetching {} epoch-boundary header(s) in {}-{}", fetch_heights.len(), start_scan_height, window_end
         );
 
-        // Fetch the targeted headers concurrently; they are independent.
+        // Fetch the targeted headers concurrently; they are independent. Each task extracts only the
+        // hash and validator-node MR the scan needs, so the full header (incl. its pow_data blob) is
+        // dropped immediately rather than collecting up to MAX_BOUNDARIES_PER_BATCH of them.
         let base_client = self.base_node_client.clone();
-        let mut headers: Vec<(u64, BlockHeader)> = stream::iter(fetch_heights)
+        let network = self.network;
+        let mut samples: Vec<(u64, FixedHash, FixedHash)> = stream::iter(fetch_heights)
             .map(move |height| {
                 let mut client = base_client.clone();
                 async move {
@@ -683,13 +697,14 @@ impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore, TClient: BaseNodeClie
                             "base node returned no header at height {height}"
                         ))
                     })?;
-                    Ok::<_, BaseLayerOracleError>((height, header))
+                    let header_hash = hash_header(network, &header);
+                    Ok::<_, BaseLayerOracleError>((height, header_hash, header.validator_node_mr))
                 }
             })
             .buffer_unordered(BOUNDARY_HEADER_FETCH_CONCURRENCY)
             .try_collect()
             .await?;
-        headers.sort_unstable_by_key(|(height, _)| *height);
+        samples.sort_unstable_by_key(|(height, _, _)| *height);
 
         let mut scan_events: Vec<PendingScanEvent> = Vec::new();
         let mut last_validator_node_mr = self.last_scanned_validator_node_mr;
@@ -697,19 +712,16 @@ impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore, TClient: BaseNodeClie
         let mut last_scanned_hash = self.last_scanned_hash;
         let mut last_scanned_height = self.last_scanned_height;
         let mut scan_epoch = constants.height_to_epoch(start_scan_height);
-        for (height, header) in headers {
-            let header_hash = hash_header(self.network, &header);
-
-            // Only boundary headers carry epoch changes / MR samples. A non-boundary header here is
+        for (height, header_hash, validator_node_mr) in samples {
+            // Only boundary headers carry epoch changes / MR samples. A non-boundary sample here is
             // the trailing window-end marker, used solely to advance the scan position.
             if height % epoch_length == 0 {
                 let current_epoch = constants.height_to_epoch(height);
-                let current_validator_node_mr = header.validator_node_mr;
-                if last_validator_node_mr != Some(current_validator_node_mr) {
+                if last_validator_node_mr != Some(validator_node_mr) {
                     if self.config.features.sync_validator_node_changes {
                         scan_events.push(PendingScanEvent::ValidatorNodeChanges { epoch: current_epoch });
                     }
-                    last_validator_node_mr = Some(current_validator_node_mr);
+                    last_validator_node_mr = Some(validator_node_mr);
                 }
                 last_epoch_hash = Some(header_hash);
                 info!(
@@ -1109,23 +1121,17 @@ mod tests {
     }
 
     impl BaseLayerBlockHeaderStore for InMemoryStore {
-        fn add_block_headers<I: IntoIterator<Item = (Epoch, FixedHash, BlockHeader)>>(
-            &self,
-            headers: I,
-        ) -> anyhow::Result<()> {
+        fn add_block_headers<I: IntoIterator<Item = BlockHeaderModel>>(&self, headers: I) -> anyhow::Result<()> {
             let mut stored = self.headers.lock().unwrap();
-            for (epoch, block_hash, header) in headers {
+            for header in headers {
                 // Mirror the SQL on_conflict(block_hash, epoch).do_nothing() idempotency.
-                if stored.iter().any(|m| m.block_hash == block_hash && m.epoch == epoch) {
+                if stored
+                    .iter()
+                    .any(|m| m.block_hash == header.block_hash && m.epoch == header.epoch)
+                {
                     continue;
                 }
-                stored.push(BlockHeaderModel {
-                    epoch,
-                    height: header.height,
-                    block_hash,
-                    kernel_merkle_root: header.kernel_mr,
-                    validator_node_merkle_root: header.validator_node_mr,
-                });
+                stored.push(header);
             }
             Ok(())
         }

--- a/crates/epoch_oracles/src/base_layer/oracle.rs
+++ b/crates/epoch_oracles/src/base_layer/oracle.rs
@@ -2,7 +2,7 @@
 //   SPDX-License-Identifier: BSD-3-Clause
 
 use std::{
-    collections::VecDeque,
+    collections::{HashMap, VecDeque},
     future::{Future, poll_fn},
     pin::Pin,
     task::{Context, Poll},
@@ -13,12 +13,12 @@ use ootle_network::Network;
 use tari_base_node_client::{
     BaseNodeClient,
     BaseNodeClientError,
-    futures_util::TryStreamExt,
+    futures_util::{StreamExt, TryStreamExt, stream},
     grpc::GrpcBaseNodeClient,
     types::{BaseLayerConsensusConstants, BaseLayerMetadata},
 };
 use tari_common_types::types::FixedHash;
-use tari_epoch_manager::epoch_event_oracle::{EpochEvent, EpochEventOracle};
+use tari_epoch_manager::epoch_event_oracle::{EpochEvent, EpochEventOracle, ValidatorNodeChange};
 use tari_node_components::blocks::BlockHeader;
 use tari_ootle_common_types::{Epoch, displayable::Displayable, optional::Optional};
 use tokio::time;
@@ -29,6 +29,23 @@ use crate::{
 };
 
 const LOG_TARGET: &str = "tari::ootle::epoch_oracles::base_layer_scanner";
+
+/// Maximum number of `get_validator_node_changes` requests issued concurrently after a header batch
+/// has been streamed. These per-epoch fetches are independent of one another, so they are pipelined
+/// rather than being awaited one at a time mid-stream (see `sync_blockchain`).
+const VALIDATOR_NODE_CHANGE_FETCH_CONCURRENCY: usize = 10;
+
+/// An event produced while streaming a header batch.
+///
+/// `ValidatorNodeChanges` is a placeholder for an `ActiveValidatorNodeSetChanged` event whose
+/// `get_validator_node_changes` fetch is deferred until the whole header stream has been drained.
+/// Issuing that unary RPC inside the stream loop stalls the header server-stream on every epoch
+/// boundary; recording a placeholder lets us resolve all the fetches concurrently afterwards while
+/// preserving the exact position the event must occupy in the emitted order.
+enum PendingScanEvent {
+    Ready(EpochEvent),
+    ValidatorNodeChanges { epoch: Epoch },
+}
 
 type TaskOutput<TStore, TClient> = (
     Result<bool, BaseLayerOracleError>,
@@ -433,7 +450,7 @@ impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore, TClient: BaseNodeClie
             target: LOG_TARGET,
             "⛓️Starting header stream from {}-{}", start_scan_height, start_scan_height + limit
         );
-        let mut stream = base_node_client.stream_headers(start_scan_height, limit).await?;
+        let mut header_stream = base_node_client.stream_headers(start_scan_height, limit).await?;
 
         if let Some(additional) = usize::try_from(limit)
             .ok()
@@ -442,8 +459,25 @@ impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore, TClient: BaseNodeClie
             self.header_buf.reserve(additional);
         }
 
+        // ── Pass 1: drain the header stream doing ONLY in-memory work ───────────────────────────
+        // The header server-stream must not be stalled by per-epoch unary RPCs, so the only network
+        // call this loop used to make — `get_validator_node_changes` — is deferred. We record a
+        // `ValidatorNodeChanges` placeholder at the exact position its `ActiveValidatorNodeSetChanged`
+        // event must occupy, and resolve all such fetches concurrently in pass 2.
+        //
+        // Scan state evolves in locals here and is only committed to `self`/the store once the
+        // deferred fetches succeed (pass 2). This makes the batch atomic: a failed fetch leaves the
+        // persisted scan position untouched, so the whole batch is safely re-scanned next round
+        // (header inserts are idempotent). `header_buf` is cleared so a re-scan after such a failure
+        // does not accumulate the previous attempt's (unflushed) headers.
+        self.header_buf.clear();
+        let mut scan_events: Vec<PendingScanEvent> = Vec::new();
+        let mut last_validator_node_mr = self.last_scanned_validator_node_mr;
+        let mut last_epoch_hash = self.last_epoch_hash;
+        let mut last_scanned_hash = self.last_scanned_hash;
+        let mut last_scanned_height = self.last_scanned_height;
         let mut scan_epoch = constants.height_to_epoch(start_scan_height);
-        while let Some(header) = stream.try_next().await? {
+        while let Some(header) = header_stream.try_next().await? {
             let current_epoch = constants.height_to_epoch(header.height);
             let header_height = header.height;
             // Note: Cant use header.hash() because it uses CURRENT_NETWORK global
@@ -453,42 +487,22 @@ impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore, TClient: BaseNodeClie
                 self.header_buf.push((current_epoch, header_hash, header));
             }
 
-            // Check validator node MR changes BEFORE epoch changes so that new registrations
-            // are processed before assign_validators_for_epoch runs. This matters when the base
-            // layer updates the validator_node_mr at epoch boundary blocks.
-            if self.last_scanned_validator_node_mr != Some(current_validator_node_mr) {
+            // Record validator node MR changes BEFORE epoch changes so that new registrations are
+            // ordered ahead of the boundary's EpochChanged — assign_validators_for_epoch must see
+            // them first. This matters when the base layer updates the validator_node_mr at epoch
+            // boundary blocks.
+            if last_validator_node_mr != Some(current_validator_node_mr) {
                 debug!(
                     target: LOG_TARGET,
-                    "⛓️ last_scanned_validator_node_mr = {} current = {}", self.last_scanned_validator_node_mr.display(), current_validator_node_mr
+                    "⛓️ last_scanned_validator_node_mr = {} current = {}", last_validator_node_mr.display(), current_validator_node_mr
                 );
 
                 if self.config.features.sync_validator_node_changes {
-                    let node_changes = self
-                        .base_node_client
-                        .get_validator_node_changes(current_epoch, self.config.sidechain_id.as_ref())
-                        .await
-                        .map_err(BaseLayerOracleError::BaseNodeError)?;
-                    let node_changes = node_changes
-                        .into_iter()
-                        .map(TryInto::try_into)
-                        .collect::<Result<Vec<_>, _>>()
-                        .map_err(|e| {
-                            BaseLayerOracleError::InvalidBaseNodeResponse(format!(
-                                "Failed to convert validator node change: {}",
-                                e
-                            ))
-                        })?;
-
-                    // This maybe empty if the MR changed as a result of other side chain IDs
-                    if !node_changes.is_empty() {
-                        self.pending_events
-                            .push_back(EpochEvent::ActiveValidatorNodeSetChanged {
-                                epoch: current_epoch,
-                                node_changes,
-                            });
-                    }
+                    // Deferred: the actual fetch happens in pass 2. Here we only mark where the
+                    // resulting event belongs in the emitted order.
+                    scan_events.push(PendingScanEvent::ValidatorNodeChanges { epoch: current_epoch });
                 }
-                self.last_scanned_validator_node_mr = Some(current_validator_node_mr);
+                last_validator_node_mr = Some(current_validator_node_mr);
             }
 
             if header_height % constants.epoch_length() == 0 {
@@ -496,7 +510,7 @@ impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore, TClient: BaseNodeClie
                     target: LOG_TARGET,
                     "🟩 New epoch block {} {} {}", current_epoch, header_height, header_hash
                 );
-                self.last_epoch_hash = Some(header_hash);
+                last_epoch_hash = Some(header_hash);
 
                 // TODO: we do not handle consensus constants changing during scan here for performance reasons.
                 // constants = self.base_node_client.get_consensus_constants(header_height).await?;
@@ -509,36 +523,97 @@ impl<TStore: EpochOracleStore + BaseLayerBlockHeaderStore, TClient: BaseNodeClie
                     target: LOG_TARGET,
                     "🟩 epoch change {}->{} (height({}) hash({}))", scan_epoch, current_epoch, header_height, header_hash
                 );
-                self.pending_events.push_back(EpochEvent::EpochChanged {
+                scan_events.push(PendingScanEvent::Ready(EpochEvent::EpochChanged {
                     epoch: current_epoch,
                     // Set above
-                    epoch_hash: self.last_epoch_hash.unwrap_or_default(),
-                });
+                    epoch_hash: last_epoch_hash.unwrap_or_default(),
+                }));
                 scan_epoch = current_epoch;
             }
 
-            // Track incremental progress of hash/height so a mid-loop failure can resume from the
-            // last processed header. `last_scanned_tip` is intentionally NOT updated here — it
-            // represents the un-lagged tip we've fully caught up to, and is set only by
-            // set_last_scanned_block below once the whole batch has been persisted. Otherwise an
-            // interrupted sync would cause get_blockchain_progression to short-circuit on the next
-            // round and silently skip the remaining headers.
-            self.last_scanned_hash = Some(header_hash);
-            self.last_scanned_height = header_height;
+            last_scanned_hash = Some(header_hash);
+            last_scanned_height = header_height;
+        }
+        // End the header server-stream before pass 2 issues its own requests.
+        drop(header_stream);
+
+        // ── Pass 2: resolve the deferred validator-node-change fetches concurrently ─────────────
+        // Each fetch is keyed only by epoch (sidechain_id is fixed for the whole scan) and is
+        // independent of the rest, so they are pipelined with bounded concurrency instead of being
+        // awaited serially. The header stream is already drained, so nothing is stalled on them.
+        let fetch_targets: Vec<(usize, Epoch)> = scan_events
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, event)| match event {
+                PendingScanEvent::ValidatorNodeChanges { epoch } => Some((idx, *epoch)),
+                PendingScanEvent::Ready(_) => None,
+            })
+            .collect();
+
+        let mut fetched_changes: HashMap<usize, Vec<ValidatorNodeChange>> = HashMap::new();
+        if !fetch_targets.is_empty() {
+            let base_client = self.base_node_client.clone();
+            let sidechain_id = self.config.sidechain_id;
+            fetched_changes = stream::iter(fetch_targets)
+                .map(move |(idx, epoch)| {
+                    let mut client = base_client.clone();
+                    async move {
+                        let node_changes = client
+                            .get_validator_node_changes(epoch, sidechain_id.as_ref())
+                            .await
+                            .map_err(BaseLayerOracleError::BaseNodeError)?;
+                        let node_changes = node_changes
+                            .into_iter()
+                            .map(TryInto::try_into)
+                            .collect::<Result<Vec<ValidatorNodeChange>, _>>()
+                            .map_err(|e| {
+                                BaseLayerOracleError::InvalidBaseNodeResponse(format!(
+                                    "Failed to convert validator node change: {}",
+                                    e
+                                ))
+                            })?;
+                        Ok::<_, BaseLayerOracleError>((idx, node_changes))
+                    }
+                })
+                .buffer_unordered(VALIDATOR_NODE_CHANGE_FETCH_CONCURRENCY)
+                .try_collect()
+                .await?;
         }
 
+        // Replay the batch's events in stream order, splicing in each resolved validator-node-change
+        // set. A set may be empty when the MR changed because of *other* sidechains — drop those, as
+        // the inline version did.
+        for (idx, event) in scan_events.into_iter().enumerate() {
+            match event {
+                PendingScanEvent::Ready(event) => self.pending_events.push_back(event),
+                PendingScanEvent::ValidatorNodeChanges { epoch } => {
+                    if let Some(node_changes) = fetched_changes.remove(&idx) &&
+                        !node_changes.is_empty()
+                    {
+                        self.pending_events
+                            .push_back(EpochEvent::ActiveValidatorNodeSetChanged { epoch, node_changes });
+                    }
+                },
+            }
+        }
+
+        // ── Commit: persist headers and advance the scan position now the batch is complete ─────
+        // `last_scanned_tip` is set by set_last_scanned_block once the whole batch is persisted; it
+        // is intentionally not advanced earlier, so an interrupted sync re-scans rather than letting
+        // get_blockchain_progression short-circuit and silently skip the remaining headers.
         if !self.header_buf.is_empty() {
             self.store
                 .add_block_headers(self.header_buf.drain(..))
                 .map_err(BaseLayerOracleError::StoreError)?;
         }
+        self.last_scanned_validator_node_mr = last_validator_node_mr;
         self.set_last_scanned_block(
-            self.last_scanned_hash.unwrap_or_else(FixedHash::zero),
-            self.last_scanned_height,
+            last_scanned_hash.unwrap_or_else(FixedHash::zero),
+            last_scanned_height,
             tip.tip_hash,
         )?;
 
-        if let Some(hash) = self.last_epoch_hash {
+        if let Some(hash) = last_epoch_hash {
             self.set_last_epoch_block(hash)?;
         }
 
@@ -801,6 +876,7 @@ mod tests {
         types::{BaseLayerConsensusConstants, BaseLayerMetadata, BaseLayerValidatorNode, SideChainUtxos},
     };
     use tari_common_types::types::FixedHash;
+    use tari_epoch_manager::epoch_event_oracle::EpochEvent;
     use tari_node_components::blocks::BlockHeader;
     use tari_ootle_common_types::Epoch;
     use tari_ootle_storage::global::BlockHeaderModel;
@@ -922,17 +998,41 @@ mod tests {
     #[derive(Clone)]
     struct MockBaseNode {
         chain: Arc<Mutex<Vec<BlockHeader>>>,
+        /// Validator-node changes served per epoch by `get_validator_node_changes`. Empty by default.
+        vn_changes: Arc<Mutex<HashMap<u64, Vec<ValidatorNodeChange>>>>,
+        /// Epochs `get_validator_node_changes` was called with. The deferred fetches run concurrently,
+        /// so the recorded order is non-deterministic — assert against the sorted set.
+        vn_calls: Arc<Mutex<Vec<u64>>>,
+        /// When true, `get_validator_node_changes` returns an error instead of data.
+        vn_fail: Arc<Mutex<bool>>,
     }
 
     impl MockBaseNode {
         fn new(chain: Vec<BlockHeader>) -> Self {
             Self {
                 chain: Arc::new(Mutex::new(chain)),
+                vn_changes: Arc::new(Mutex::new(HashMap::new())),
+                vn_calls: Arc::new(Mutex::new(Vec::new())),
+                vn_fail: Arc::new(Mutex::new(false)),
             }
         }
 
         fn set_chain(&self, chain: Vec<BlockHeader>) {
             *self.chain.lock().unwrap() = chain;
+        }
+
+        fn set_vn_changes(&self, changes: HashMap<u64, Vec<ValidatorNodeChange>>) {
+            *self.vn_changes.lock().unwrap() = changes;
+        }
+
+        fn fail_vn_changes(&self) {
+            *self.vn_fail.lock().unwrap() = true;
+        }
+
+        fn vn_call_epochs_sorted(&self) -> Vec<u64> {
+            let mut calls = self.vn_calls.lock().unwrap().clone();
+            calls.sort_unstable();
+            calls
         }
     }
 
@@ -956,10 +1056,23 @@ mod tests {
 
         async fn get_validator_node_changes(
             &mut self,
-            _epoch: Epoch,
+            epoch: Epoch,
             _sidechain_id: Option<&RistrettoPublicKeyBytes>,
         ) -> Result<Vec<ValidatorNodeChange>, BaseNodeClientError> {
-            Ok(Vec::new())
+            self.vn_calls.lock().unwrap().push(epoch.as_u64());
+            if *self.vn_fail.lock().unwrap() {
+                return Err(BaseNodeClientError::GrpcStatus {
+                    code: tonic::Code::Internal,
+                    message: "injected validator node change failure".to_string(),
+                });
+            }
+            Ok(self
+                .vn_changes
+                .lock()
+                .unwrap()
+                .get(&epoch.as_u64())
+                .cloned()
+                .unwrap_or_default())
         }
 
         async fn get_validator_nodes(
@@ -1164,5 +1277,127 @@ mod tests {
         assert!(store.heights().is_empty());
         assert_eq!(inner.last_scanned_height, 0);
         assert_eq!(inner.last_scanned_hash, None);
+    }
+
+    fn make_inner_syncing_vn_changes(
+        store: InMemoryStore,
+        client: MockBaseNode,
+        height_lag: u64,
+    ) -> BaseLayerOracleInner<InMemoryStore, MockBaseNode> {
+        let mut inner = make_inner(store, client, height_lag);
+        inner.config.features.sync_validator_node_changes = true;
+        inner
+    }
+
+    /// Linear chain whose `validator_node_mr` is a function of the epoch, so the MR changes exactly
+    /// at each epoch boundary — the trigger for a deferred `get_validator_node_changes` fetch.
+    fn chain_with_epoch_mr(heights: std::ops::RangeInclusive<u64>) -> Vec<BlockHeader> {
+        heights
+            .map(|h| {
+                let mut header = make_header(h, h);
+                header.validator_node_mr = FixedHash::from([(h / EPOCH_LENGTH) as u8; 32]);
+                header
+            })
+            .collect()
+    }
+
+    /// A minimal, convertible grpc validator-node-change (a Remove with a valid 32-byte key).
+    fn vn_remove() -> ValidatorNodeChange {
+        use minotari_app_grpc::tari_rpc;
+        tari_rpc::ValidatorNodeChange {
+            change: Some(tari_rpc::validator_node_change::Change::Remove(
+                tari_rpc::ValidatorNodeChangeRemove {
+                    public_key: vec![0u8; 32],
+                },
+            )),
+        }
+    }
+
+    /// The deferred fetches (pass 2) must still produce `ActiveValidatorNodeSetChanged` events in the
+    /// same stream order as the inline version did — each one immediately ahead of its epoch's
+    /// `EpochChanged`, with empty change sets dropped.
+    #[tokio::test]
+    async fn validator_node_changes_are_emitted_in_order_before_each_epoch_change() {
+        // height_lag = 5, tip = 20 -> lagged tip = 15. One batch scans heights 1..=15, crossing epoch
+        // boundaries at heights 5, 10, 15 (epochs 1, 2, 3). The MR also changes at height 1 (epoch 0).
+        let store = InMemoryStore::default();
+        let client = MockBaseNode::new(chain_with_epoch_mr(0..=20));
+        // Serve changes for epochs 1..=3; epoch 0 is intentionally left empty to exercise the path
+        // where the MR changed (because of other sidechains) but our change set is empty -> dropped.
+        let mut changes = HashMap::new();
+        for epoch in 1..=3u64 {
+            changes.insert(epoch, vec![vn_remove()]);
+        }
+        client.set_vn_changes(changes);
+
+        let mut inner = make_inner_syncing_vn_changes(store, client.clone(), 5);
+
+        // The whole range fits in a single batch (15 < the 1000-header batch limit).
+        inner.scan_blockchain(false).await.unwrap();
+
+        let ordered: Vec<(&str, u64)> = inner
+            .pending_events
+            .iter()
+            .filter_map(|e| match e {
+                EpochEvent::ActiveValidatorNodeSetChanged { epoch, node_changes } => {
+                    assert!(
+                        !node_changes.is_empty(),
+                        "empty change sets must be dropped, not emitted"
+                    );
+                    Some(("vn", epoch.as_u64()))
+                },
+                EpochEvent::EpochChanged { epoch, .. } => Some(("epoch", epoch.as_u64())),
+                _ => None,
+            })
+            .collect();
+
+        assert_eq!(
+            ordered,
+            vec![
+                ("vn", 1),
+                ("epoch", 1),
+                ("vn", 2),
+                ("epoch", 2),
+                ("vn", 3),
+                ("epoch", 3),
+            ],
+            "each ActiveValidatorNodeSetChanged must immediately precede its epoch's EpochChanged"
+        );
+
+        // Every MR change (epochs 0,1,2,3) triggered exactly one fetch — including epoch 0, whose
+        // empty result was dropped above.
+        assert_eq!(client.vn_call_epochs_sorted(), vec![0, 1, 2, 3]);
+    }
+
+    /// A failed deferred fetch must abort the batch atomically: because the fetch now happens after
+    /// the whole header stream is drained, the scan position must not be advanced (and no events may
+    /// leak), so the entire batch is safely re-scanned on the next round.
+    #[tokio::test]
+    async fn failed_validator_node_change_fetch_leaves_scan_position_unadvanced() {
+        let store = InMemoryStore::default();
+        let client = MockBaseNode::new(chain_with_epoch_mr(0..=20));
+        client.fail_vn_changes();
+        let mut inner = make_inner_syncing_vn_changes(store.clone(), client.clone(), 5);
+
+        let result = inner.scan_blockchain(false).await;
+        assert!(
+            result.is_err(),
+            "a failed validator-node-change fetch must fail the scan"
+        );
+
+        assert_eq!(
+            inner.last_scanned_height, 0,
+            "scan position must not advance on failure"
+        );
+        assert_eq!(inner.last_scanned_hash, None);
+        assert!(inner.last_scanned_validator_node_mr.is_none());
+        assert!(
+            inner.pending_events.is_empty(),
+            "no events may leak from a failed batch"
+        );
+        assert!(
+            store.heights().is_empty(),
+            "no headers may be persisted from a failed batch"
+        );
     }
 }


### PR DESCRIPTION
Speeds up the epoch manager's base-layer sync. Two independent commits.

## 1. Defer & parallelize validator-node-change fetches

The scanner issued a blocking `get_validator_node_changes` RPC **inside the header scan loop**, firing whenever `validator_node_mr` changed (i.e. at every epoch boundary on a churning validator set). Each call stalled the header server-stream on a full round-trip, serializing catch-up against base-node latency.

The fetch is keyed only by `epoch` (the `sidechain_id` is fixed for the scan), so it never depended on the streamed header. The scan now:

- records a placeholder at the position each `ActiveValidatorNodeSetChanged` event must occupy, and
- resolves all deferred fetches **concurrently** (bounded) after the batch is scanned, then replays events in order.

**Correctness:** ordering preserved (`ActiveValidatorNodeSetChanged{E}` before `EpochChanged{E}`), empty change-sets dropped, and the batch is now **atomic** — scan state is committed only after the fetches succeed, so a failed fetch re-scans the whole batch rather than skipping un-fetched epochs (header inserts are idempotent).

## 2. Boundary-only scan when `sync_headers` is disabled

The scanner is shared: the **validator node** needs every header (burn-proof validation, `sync_headers = true`), but the **indexer** only needs epoch boundaries (`sync_headers = false`). Both streamed the full contiguous range. On a remote/Cloudflare-proxied base node the per-header stream-delivery cost dominates the indexer's initial sync (~20ms/header) — streaming ~11k headers to consume ~140.

Now the per-batch scan branches on `sync_headers`:

- `scan_full_headers` (validator node): the existing contiguous stream, **unchanged** — every header buffered and stored.
- `scan_epoch_boundaries` (indexer): fetches only the epoch-boundary headers in the window (plus a trailing position-only header), concurrently, and skips the rest.

Shared pass-2 + commit is extracted into `resolve_changes_and_commit`, so both paths emit identical events and bookkeeping.

**Assumption:** `validator_node_mr` only changes at epoch-boundary blocks, so sampling the MR at boundaries catches every validator-set change. Boundary mode queries `get_validator_node_changes` for the epochs it crosses; unlike the full path it does not sample the pre-start epoch on a mid-epoch fresh start (full initial-set download remains a separate concern). The boundary path is gated entirely behind `!sync_headers`, so the validator node's behavior is unchanged.

## Tests

- Event ordering/completeness and failure atomicity for the deferred-fetch path.
- Boundary scan emits the same `EpochChanged` events (epochs + hashes) as the full scan while storing no headers, and still resolves validator-node changes at the boundaries it crosses.

Adds `minotari_app_grpc` as a dev-dependency (test fixtures only).