### PR TITLE
feat(network): share peer list via rendezvous using seed peers as servers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12303,6 +12303,7 @@ dependencies = [
  "libp2p-messaging",
  "libp2p-peer-store",
  "libp2p-substream",
+ "prometheus-client",
  "thiserror 2.0.18",
 ]
 

--- a/applications/tari_indexer/docs/configuration.md
+++ b/applications/tari_indexer/docs/configuration.md
@@ -120,9 +120,6 @@ Configuration for discovering and connecting to network peers.
 
 # Require DNSSEC validation for DNS seeds (default: false)
 #dns_seeds_use_dnssec = false
-
-# Rendezvous server for peer discovery (optional)
-#rendezvous_server = "public_key::/ip4/1.2.3.4/tcp/18189"
 ```
 
 ### Network-Specific Peer Seeds

--- a/applications/tari_indexer/src/bootstrap.rs
+++ b/applications/tari_indexer/src/bootstrap.rs
@@ -24,7 +24,6 @@ use std::{collections::HashSet, fs, io, str::FromStr, sync::Arc};
 
 use anyhow::{Context, anyhow};
 use libp2p::identity;
-use log::warn;
 use ootle_byte_type::ToByteType;
 use tari_base_node_client::grpc::GrpcBaseNodeClient;
 use tari_common::configuration::bootstrap::{ApplicationType, grpc_default_port};
@@ -86,8 +85,6 @@ use crate::{
     transaction_manager::TransactionManager,
 };
 
-const LOG_TARGET: &str = "tari_indexer::bootstrap";
-
 #[allow(clippy::too_many_lines)]
 pub async fn spawn_services(
     config: &ApplicationConfig,
@@ -129,7 +126,9 @@ pub async fn spawn_services(
                     .expect("Failed to parse listener address"),
             ],
             swarm: SwarmConfig {
-                protocol_version: format!("/tari/{}/0.0.1", config.network).parse().expect("Failed to parse protocol version"),
+                protocol_version: format!("/tari/{}/0.0.1", config.network)
+                    .parse()
+                    .expect("Failed to parse protocol version"),
                 user_agent: format!("/tari/indexer/{}", env!("CARGO_PKG_VERSION")),
                 enable_mdns: config.indexer.p2p.enable_mdns,
                 enable_relay: true,
@@ -140,29 +139,10 @@ pub async fn spawn_services(
             },
             reachability_mode: config.indexer.p2p.reachability_mode.into(),
             announce: false,
-            rendezvous_namespace: format!(
-                "tari-{}",
-                config.network.to_string().to_lowercase()
-            ),
+            rendezvous_namespace: format!("tari-{}", config.network.to_string().to_lowercase()),
             ..Default::default()
         })
-        .with_seed_peers(seed_peers)
-        .then(|builder| {
-            match config.peer_seeds.rendezvous_server.as_ref() {
-                Some(server) => {
-                    let server = SeedPeer::from_str(server)
-                        .expect("Failed to parse rendezvous server seed peer");
-                    if let Some(peer_id) = server.to_peer_id() {
-                        let addr = server.address().clone();
-                        builder.with_rendezvous_server(peer_id, addr)
-                    } else{
-                        warn!(target: LOG_TARGET, "Rendezvous server peer ID is not set, skipping rendezvous server configuration");
-                        builder
-                    }
-                },
-                None => builder,
-            }
-        });
+        .with_seed_peers(seed_peers);
     #[cfg(feature = "metrics")]
     let network_builder = network_builder.with_metrics(metrics_registry);
 

--- a/applications/tari_indexer/src/cli.rs
+++ b/applications/tari_indexer/src/cli.rs
@@ -90,6 +90,7 @@ impl ConfigOverrideProvider for Cli {
         overrides.push(("network".to_string(), network.to_string()));
         overrides.push(("indexer.override_from".to_string(), network.to_string()));
         overrides.push(("epoch_oracle.override_from".to_string(), network.to_string()));
+        overrides.push(("p2p.override_from".to_string(), network.to_string()));
         overrides.push(("p2p.seeds.override_from".to_string(), network.to_string()));
 
         if let Some(ref addr) = self.api_listen_address {

--- a/applications/tari_ootle_app_utilities/config_presets/c_validator_node.toml
+++ b/applications/tari_ootle_app_utilities/config_presets/c_validator_node.toml
@@ -42,6 +42,10 @@ enable_eviction_proposal = false
 
 [validator_node.p2p]
 #enable_mdns = true
+# Run a rendezvous server on this node so other nodes can use it for peer discovery. This is the SERVER side only - the
+# rendezvous client is always active, so every node already registers with and queries its seed peers for the peer list
+# regardless of this setting. Enable this on seed/bootstrap nodes. (default: false)
+#enable_rendezvous = false
 #listener_port = 0
 #reachability_mode = "auto"
 #enable_relay = false

--- a/applications/tari_ootle_app_utilities/config_presets/d_indexer.toml
+++ b/applications/tari_ootle_app_utilities/config_presets/d_indexer.toml
@@ -29,7 +29,14 @@
 #state_scanning_interval=60
 
 [indexer.p2p]
-#transport = "tor"
+#enable_mdns = true
+# Run a rendezvous server on this node so other nodes can use it for peer discovery. This is the SERVER side only - the
+# rendezvous client is always active, so every node already registers with and queries its seed peers for the peer list
+# regardless of this setting. Enable this on seed/bootstrap nodes. (default: false)
+#enable_rendezvous = false
+#listener_port = 0
+#reachability_mode = "auto"
+#enable_relay = false
 
 
 # List of filters for events that we want to persist in the indexer database

--- a/applications/tari_ootle_app_utilities/src/p2p_config.rs
+++ b/applications/tari_ootle_app_utilities/src/p2p_config.rs
@@ -10,6 +10,7 @@ use tari_common::{SubConfigPath, configuration::StringList};
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct P2pConfig {
+    override_from: Option<String>,
     pub enable_mdns: bool,
     pub enable_rendezvous: bool,
     pub listener_port: u16,
@@ -20,12 +21,19 @@ pub struct P2pConfig {
 impl Default for P2pConfig {
     fn default() -> Self {
         Self {
+            override_from: None,
             enable_mdns: true,
             enable_rendezvous: false,
             listener_port: 0,
             reachability_mode: ReachabilityMode::default(),
             enable_relay: false,
         }
+    }
+}
+
+impl SubConfigPath for P2pConfig {
+    fn main_key_prefix() -> &'static str {
+        "p2p"
     }
 }
 

--- a/applications/tari_ootle_app_utilities/src/p2p_config.rs
+++ b/applications/tari_ootle_app_utilities/src/p2p_config.rs
@@ -76,8 +76,6 @@ pub struct PeerSeedsConfig {
     /// DNS seeds hosts. The DNS TXT records are queried from these hosts and the resulting peers added to the comms
     /// peer list.
     pub dns_seeds: StringList,
-    /// Specify a rendezvous server used for peer discovery.
-    pub rendezvous_server: Option<String>,
     // TODO
     // #[serde(
     //     deserialize_with = "deserialize_string_or_struct",

--- a/applications/tari_validator_node/src/bootstrap.rs
+++ b/applications/tari_validator_node/src/bootstrap.rs
@@ -191,29 +191,10 @@ pub async fn spawn_services(
             },
             reachability_mode: config.validator_node.p2p.reachability_mode.into(),
             announce: true,
-            rendezvous_namespace: format!(
-                "tari-{}",
-                config.network.to_string().to_lowercase()
-            ),
+            rendezvous_namespace: format!("tari-{}", config.network.to_string().to_lowercase()),
             ..Default::default()
         })
-        .with_seed_peers(seed_peers)
-        .then(|builder| {
-            match config.peer_seeds.rendezvous_server.as_ref() {
-                Some(server) => {
-                    let server = SeedPeer::from_str(server)
-                        .expect("Failed to parse rendezvous server seed peer");
-                    if let Some(peer_id) = server.to_peer_id() {
-                        let addr = server.address().clone();
-                        builder.with_rendezvous_server(peer_id, addr)
-                    } else {
-                        warn!(target: LOG_TARGET, "Rendezvous server peer ID is not set, skipping rendezvous server configuration");
-                        builder
-                    }
-                }
-                None => builder,
-            }
-        });
+        .with_seed_peers(seed_peers);
 
     #[cfg(feature = "metrics")]
     {

--- a/applications/tari_validator_node/src/cli.rs
+++ b/applications/tari_validator_node/src/cli.rs
@@ -89,6 +89,7 @@ impl ConfigOverrideProvider for Cli {
         overrides.push(("network".to_string(), network.to_string()));
         overrides.push(("validator_node.override_from".to_string(), network.to_string()));
         overrides.push(("epoch_oracle.override_from".to_string(), network.to_string()));
+        overrides.push(("p2p.override_from".to_string(), network.to_string()));
         overrides.push(("p2p.seeds.override_from".to_string(), network.to_string()));
 
         if let Some(ref json_rpc_address) = self.json_rpc_listener_address {

--- a/networking/core/src/builder.rs
+++ b/networking/core/src/builder.rs
@@ -19,7 +19,6 @@ pub struct Builder<'a, TMsg: MessageSpec> {
     messaging_mode: MessagingMode<TMsg>,
     config: crate::Config,
     seed_peers: Vec<(Option<PeerId>, Multiaddr)>,
-    rendezvous_server: Option<(PeerId, Multiaddr)>,
     #[cfg(feature = "metrics")]
     registry: Option<&'a mut libp2p::metrics::Registry>,
     #[cfg(not(feature = "metrics"))]
@@ -40,7 +39,6 @@ where
             messaging_mode: MessagingMode::Disabled,
             config: crate::Config::default(),
             seed_peers: Vec::new(),
-            rendezvous_server: None,
             #[cfg(feature = "metrics")]
             registry: None,
             #[cfg(not(feature = "metrics"))]
@@ -54,7 +52,6 @@ where
             messaging_mode: mode,
             config: self.config,
             seed_peers: self.seed_peers,
-            rendezvous_server: self.rendezvous_server,
             #[cfg(feature = "metrics")]
             registry: self.registry,
             #[cfg(not(feature = "metrics"))]
@@ -82,14 +79,6 @@ where
         self
     }
 
-    pub fn with_rendezvous_server(mut self, peer_id: PeerId, addr: Multiaddr) -> Self {
-        if !is_supported_multiaddr(&addr) {
-            panic!("Unsupported rendezvous server multi-address: {}", addr);
-        }
-        self.rendezvous_server = Some((peer_id, addr));
-        self
-    }
-
     pub fn spawn(
         self,
         shutdown_signal: ShutdownSignal,
@@ -99,7 +88,6 @@ where
             messaging_mode,
             mut config,
             seed_peers,
-            rendezvous_server,
             #[cfg(feature = "metrics")]
             registry,
             #[cfg(not(feature = "metrics"))]
@@ -135,7 +123,6 @@ where
                 .filter_map(|(peer_id, addr)| Some(((*peer_id)?, addr.clone())))
                 .collect(),
             seed_peers,
-            rendezvous_server,
             shutdown_signal,
         );
         #[cfg(feature = "metrics")]

--- a/networking/core/src/rendezvous_state.rs
+++ b/networking/core/src/rendezvous_state.rs
@@ -1,56 +1,64 @@
 //    Copyright 2025 The Tari Project
 //    SPDX-License-Identifier: BSD-3-Clause
 
+use std::collections::HashMap;
+
 use libp2p::Multiaddr;
 use tari_swarm::rendezvous::Cookie;
 
 use crate::PeerId;
 
+/// Tracks the rendezvous servers this node uses for peer discovery.
+///
+/// The rendezvous servers are assumed to be the configured seed peers (those with a known peer id). This is
+/// best-effort: a seed peer that does not run a rendezvous server simply yields failed (and harmless) register/discover
+/// attempts.
+#[derive(Debug, Default)]
 pub struct RendezvousState {
-    rendezvous_server: Option<(PeerId, RvPeerState)>,
+    servers: HashMap<PeerId, RvPeerState>,
 }
 
 #[derive(Debug, Clone)]
-pub struct RvPeerState {
+struct RvPeerState {
     address: Multiaddr,
     cookie: Option<Cookie>,
 }
 
 impl RendezvousState {
-    pub fn new(server: Option<(PeerId, Multiaddr)>) -> Self {
+    pub fn new<I: IntoIterator<Item = (PeerId, Multiaddr)>>(servers: I) -> Self {
         Self {
-            rendezvous_server: server.map(|(peer_id, addr)| {
-                (peer_id, RvPeerState {
-                    address: addr,
-                    cookie: None,
-                })
-            }),
+            servers: servers
+                .into_iter()
+                .map(|(peer_id, address)| (peer_id, RvPeerState { address, cookie: None }))
+                .collect(),
         }
     }
 
-    pub fn set_cookie(&mut self, cookie: Cookie) -> bool {
-        match self.rendezvous_server.as_mut() {
-            Some((_, state_mut)) => {
-                state_mut.cookie = Some(cookie);
+    pub fn is_empty(&self) -> bool {
+        self.servers.is_empty()
+    }
+
+    /// Returns true if the given peer is a configured rendezvous server.
+    pub fn contains(&self, peer_id: &PeerId) -> bool {
+        self.servers.contains_key(peer_id)
+    }
+
+    /// Stores the pagination cookie from a discover response for the given server. Returns false if the peer is not a
+    /// known rendezvous server.
+    pub fn set_cookie(&mut self, peer_id: &PeerId, cookie: Cookie) -> bool {
+        match self.servers.get_mut(peer_id) {
+            Some(state) => {
+                state.cookie = Some(cookie);
                 true
             },
             None => false,
         }
     }
 
-    pub fn get_peer_and_cookie(&self) -> Option<(PeerId, Option<Cookie>)> {
-        self.rendezvous_server
-            .as_ref()
-            .map(|(peer_id, state)| (*peer_id, state.cookie.clone()))
-    }
-
-    pub fn get_peer_and_address(&self) -> Option<(PeerId, Multiaddr)> {
-        self.peer_and_address().map(|(peer_id, addr)| (*peer_id, addr.clone()))
-    }
-
-    pub fn peer_and_address(&self) -> Option<(&PeerId, &Multiaddr)> {
-        self.rendezvous_server
-            .as_ref()
-            .map(|(peer_id, state)| (peer_id, &state.address))
+    /// Returns the (peer id, address, last cookie) of each configured rendezvous server.
+    pub fn servers(&self) -> impl Iterator<Item = (PeerId, Multiaddr, Option<Cookie>)> + '_ {
+        self.servers
+            .iter()
+            .map(|(peer_id, state)| (*peer_id, state.address.clone(), state.cookie.clone()))
     }
 }

--- a/networking/core/src/worker.rs
+++ b/networking/core/src/worker.rs
@@ -115,9 +115,16 @@ where
         config: crate::Config,
         known_relay_nodes: Vec<(PeerId, Multiaddr)>,
         seed_peers: Vec<(Option<PeerId>, Multiaddr)>,
-        rendezvous_server: Option<(PeerId, Multiaddr)>,
         shutdown_signal: ShutdownSignal,
     ) -> Self {
+        // Rendezvous servers are assumed to be the configured seed peers that have a known peer id. This is
+        // best-effort: seed peers that do not run a rendezvous server simply yield failed (and harmless)
+        // register/discover attempts.
+        let rendezvous_state = RendezvousState::new(
+            seed_peers
+                .iter()
+                .filter_map(|(peer_id, addr)| Some(((*peer_id)?, addr.clone()))),
+        );
         Self {
             _keypair: keypair,
             rx_request,
@@ -129,7 +136,7 @@ where
             pending_dial_requests: HashMap::new(),
             relays: RelayState::new(known_relay_nodes),
             topic_peers: HashMap::new(),
-            rendezvous_state: RendezvousState::new(rendezvous_server),
+            rendezvous_state,
             seed_peers,
             swarm,
             config,
@@ -386,24 +393,9 @@ where
 
     async fn bootstrap(&mut self) -> Result<(), NetworkingError> {
         if !self.is_initial_bootstrap_complete {
-            if let Some((peer_id, addr)) = self.rendezvous_state.get_peer_and_address() {
-                info!(target: LOG_TARGET, "🥾BOOTSTRAP: dialing rendezvous peer {peer_id} at address {addr}");
-                let opts = DialOpts::peer_id(peer_id)
-                    .addresses(vec![addr.clone()])
-                    .condition(PeerCondition::DisconnectedAndNotDialing)
-                    .extend_addresses_through_behaviour()
-                    .build();
-
-                self.swarm.dial(opts).or_else(|err| {
-                    // Peer already has pending dial or established connection - OK
-                    if matches!(&err, DialError::DialPeerConditionFalse(_)) {
-                        Ok(())
-                    } else {
-                        Err(err)
-                    }
-                })?;
-            }
-
+            // NOTE: rendezvous servers are a subset of the seed peers (those with a known peer id), so they are dialed
+            // by the loop below. Reconnection (e.g. after an idle timeout) is handled in
+            // `discover_rendezvous_peers`.
             info!(target: LOG_TARGET, "🥾 BOOTSTRAP: dialing {} seed peers", self.seed_peers.len());
             for (peer, addr) in self.seed_peers.drain(..) {
                 let opts = match peer {
@@ -464,9 +456,8 @@ where
             self.is_initial_bootstrap_complete = true;
         }
 
-        // Periodically refresh the peer list from the rendezvous server (if configured) to pick up newly-registered
-        // peers.
-        self.discover_rendezvous_peers();
+        // Periodically refresh the peer list from the rendezvous servers (if any) to pick up newly-registered peers.
+        self.discover_rendezvous_peers(None);
 
         Ok(())
     }
@@ -536,7 +527,7 @@ where
                 }
 
                 if matches!(error, DialError::NoAddresses) {
-                    self.discover_rendezvous_peers();
+                    self.discover_rendezvous_peers(None);
                 }
             },
             SwarmEvent::ExternalAddrConfirmed { address } => {
@@ -715,7 +706,7 @@ where
                     }
                 }
 
-                self.rendezvous_state.set_cookie(cookie);
+                self.rendezvous_state.set_cookie(&rendezvous_node, cookie);
             },
             RendezvousClient(rendezvous::client::Event::Registered {
                 rendezvous_node,
@@ -726,8 +717,8 @@ where
                     target: LOG_TARGET,
                     "🌐 Registered with rendezvous server {rendezvous_node} on namespace '{namespace}' (ttl={ttl}s). Discovering peers",
                 );
-                // Now that we're registered, pull the current peer list from the server.
-                self.discover_rendezvous_peers();
+                // Now that we're registered, pull the current peer list from this server.
+                self.discover_rendezvous_peers(Some(rendezvous_node));
             },
             RendezvousClient(event) => {
                 info!(target: LOG_TARGET, "ℹ️ RendezvousClient event: {:?}", event);
@@ -916,11 +907,7 @@ where
             return Ok(());
         }
 
-        if self
-            .rendezvous_state
-            .peer_and_address()
-            .is_some_and(|(p, _)| *p == peer_id)
-        {
+        if self.rendezvous_state.contains(&peer_id) {
             info!(target: LOG_TARGET, "Connected to rendezvous server {}. Registering", peer_id);
             let ns = self.get_rendezvous_namespace();
             if let Err(err) = self
@@ -1097,38 +1084,45 @@ where
         Namespace::new(self.config.rendezvous_namespace.clone()).expect("configuration error")
     }
 
-    /// Requests the peer list registered at our configured rendezvous server (if any). The discovered registrations are
-    /// handled in the [`RendezvousClient(Discovered)`] event. No-op if no rendezvous server is configured.
-    fn discover_rendezvous_peers(&mut self) {
-        let Some((rendezvous_peer_id, cookie)) = self.rendezvous_state.get_peer_and_cookie() else {
+    /// Requests the peer list registered at our rendezvous servers (the seed peers). Pass `only` to query a single
+    /// server, or `None` to query all of them. Discovered registrations are handled in the
+    /// [`RendezvousClient(Discovered)`] event. No-op if no rendezvous servers are configured.
+    ///
+    /// This is best-effort: a seed peer that does not run a rendezvous server simply yields a harmless failed request.
+    fn discover_rendezvous_peers(&mut self, only: Option<PeerId>) {
+        if self.rendezvous_state.is_empty() {
             return;
-        };
-
-        // The rendezvous server is only dialed during initial bootstrap. If that connection has since dropped (e.g.
-        // idle timeout), re-dial it so the discovery request below can be delivered.
-        if !self.active_connections.contains_key(&rendezvous_peer_id) {
-            if let Some((_, addr)) = self.rendezvous_state.get_peer_and_address() {
-                debug!(target: LOG_TARGET, "🌐 Not connected to rendezvous server {rendezvous_peer_id}. Dialing");
-                let opts = DialOpts::peer_id(rendezvous_peer_id)
+        }
+        let servers = self
+            .rendezvous_state
+            .servers()
+            .filter(|(peer_id, ..)| only.is_none_or(|o| o == *peer_id))
+            .collect::<Vec<_>>();
+        let ns = self.get_rendezvous_namespace();
+        for (peer_id, addr, cookie) in servers {
+            // Rendezvous servers are dialed at bootstrap, but if a connection has since dropped (e.g. idle timeout)
+            // re-dial it so the discovery request can be delivered.
+            if !self.active_connections.contains_key(&peer_id) {
+                debug!(target: LOG_TARGET, "🌐 Not connected to rendezvous server {peer_id}. Dialing");
+                let opts = DialOpts::peer_id(peer_id)
                     .addresses(vec![addr])
                     .condition(PeerCondition::DisconnectedAndNotDialing)
                     .extend_addresses_through_behaviour()
                     .build();
-                if let Err(err) = self.swarm.dial(opts) {
-                    if !matches!(&err, DialError::DialPeerConditionFalse(_)) {
-                        warn!(target: LOG_TARGET, "🚨 Failed to dial rendezvous server {rendezvous_peer_id}: {err}");
-                    }
+                if let Err(err) = self.swarm.dial(opts) &&
+                    !matches!(&err, DialError::DialPeerConditionFalse(_))
+                {
+                    warn!(target: LOG_TARGET, "🚨 Failed to dial rendezvous server {peer_id}: {err}");
                 }
             }
-        }
 
-        let ns = self.get_rendezvous_namespace();
-        self.swarm.behaviour_mut().rendezvous_client.discover(
-            Some(ns),
-            cookie,
-            self.config.rendezvous_peer_limit,
-            rendezvous_peer_id,
-        );
+            self.swarm.behaviour_mut().rendezvous_client.discover(
+                Some(ns.clone()),
+                cookie,
+                self.config.rendezvous_peer_limit,
+                peer_id,
+            );
+        }
     }
 }
 

--- a/networking/core/src/worker.rs
+++ b/networking/core/src/worker.rs
@@ -704,6 +704,9 @@ where
                     let addresses = registration.record.addresses();
                     debug!(target: LOG_TARGET, "🌐 Discovered peer {peer_id} with {} address(es) via rendezvous", addresses.len());
                     for address in addresses {
+                        if !is_supported_multiaddr(address) {
+                            continue;
+                        }
                         self.swarm
                             .behaviour_mut()
                             .peer_store
@@ -1100,6 +1103,25 @@ where
         let Some((rendezvous_peer_id, cookie)) = self.rendezvous_state.get_peer_and_cookie() else {
             return;
         };
+
+        // The rendezvous server is only dialed during initial bootstrap. If that connection has since dropped (e.g.
+        // idle timeout), re-dial it so the discovery request below can be delivered.
+        if !self.active_connections.contains_key(&rendezvous_peer_id) {
+            if let Some((_, addr)) = self.rendezvous_state.get_peer_and_address() {
+                debug!(target: LOG_TARGET, "🌐 Not connected to rendezvous server {rendezvous_peer_id}. Dialing");
+                let opts = DialOpts::peer_id(rendezvous_peer_id)
+                    .addresses(vec![addr])
+                    .condition(PeerCondition::DisconnectedAndNotDialing)
+                    .extend_addresses_through_behaviour()
+                    .build();
+                if let Err(err) = self.swarm.dial(opts) {
+                    if !matches!(&err, DialError::DialPeerConditionFalse(_)) {
+                        warn!(target: LOG_TARGET, "🚨 Failed to dial rendezvous server {rendezvous_peer_id}: {err}");
+                    }
+                }
+            }
+        }
+
         let ns = self.get_rendezvous_namespace();
         self.swarm.behaviour_mut().rendezvous_client.discover(
             Some(ns),

--- a/networking/core/src/worker.rs
+++ b/networking/core/src/worker.rs
@@ -464,6 +464,10 @@ where
             self.is_initial_bootstrap_complete = true;
         }
 
+        // Periodically refresh the peer list from the rendezvous server (if configured) to pick up newly-registered
+        // peers.
+        self.discover_rendezvous_peers();
+
         Ok(())
     }
 
@@ -531,16 +535,8 @@ where
                     let _ignore = waiter.send(Err(NetworkingError::OutgoingConnectionError(error.to_string())));
                 }
 
-                if matches!(error, DialError::NoAddresses) &&
-                    let Some((peer_id, cookie)) = self.rendezvous_state.get_peer_and_cookie()
-                {
-                    let ns = self.get_rendezvous_namespace();
-                    self.swarm.behaviour_mut().rendezvous_client.discover(
-                        Some(ns),
-                        cookie,
-                        self.config.rendezvous_peer_limit,
-                        peer_id,
-                    );
+                if matches!(error, DialError::NoAddresses) {
+                    self.discover_rendezvous_peers();
                 }
             },
             SwarmEvent::ExternalAddrConfirmed { address } => {
@@ -698,7 +694,37 @@ where
                     registrations.len(),
                     cookie.namespace().map(|s| format!("'{s}'")).unwrap_or_else(|| "''".to_string()),
                 );
+
+                let local_peer_id = *self.swarm.local_peer_id();
+                for registration in &registrations {
+                    let peer_id = registration.record.peer_id();
+                    if peer_id == local_peer_id {
+                        continue;
+                    }
+                    let addresses = registration.record.addresses();
+                    debug!(target: LOG_TARGET, "🌐 Discovered peer {peer_id} with {} address(es) via rendezvous", addresses.len());
+                    for address in addresses {
+                        self.swarm
+                            .behaviour_mut()
+                            .peer_store
+                            .store_mut()
+                            .add_address(&peer_id, address);
+                    }
+                }
+
                 self.rendezvous_state.set_cookie(cookie);
+            },
+            RendezvousClient(rendezvous::client::Event::Registered {
+                rendezvous_node,
+                ttl,
+                namespace,
+            }) => {
+                info!(
+                    target: LOG_TARGET,
+                    "🌐 Registered with rendezvous server {rendezvous_node} on namespace '{namespace}' (ttl={ttl}s). Discovering peers",
+                );
+                // Now that we're registered, pull the current peer list from the server.
+                self.discover_rendezvous_peers();
             },
             RendezvousClient(event) => {
                 info!(target: LOG_TARGET, "ℹ️ RendezvousClient event: {:?}", event);
@@ -1066,6 +1092,21 @@ where
     fn get_rendezvous_namespace(&self) -> Namespace {
         // Panic: namespace MUST be less than 255 characters
         Namespace::new(self.config.rendezvous_namespace.clone()).expect("configuration error")
+    }
+
+    /// Requests the peer list registered at our configured rendezvous server (if any). The discovered registrations are
+    /// handled in the [`RendezvousClient(Discovered)`] event. No-op if no rendezvous server is configured.
+    fn discover_rendezvous_peers(&mut self) {
+        let Some((rendezvous_peer_id, cookie)) = self.rendezvous_state.get_peer_and_cookie() else {
+            return;
+        };
+        let ns = self.get_rendezvous_namespace();
+        self.swarm.behaviour_mut().rendezvous_client.discover(
+            Some(ns),
+            cookie,
+            self.config.rendezvous_peer_limit,
+            rendezvous_peer_id,
+        );
     }
 }
 

--- a/networking/swarm/Cargo.toml
+++ b/networking/swarm/Cargo.toml
@@ -7,7 +7,7 @@ repository.workspace = true
 license.workspace = true
 
 [features]
-metrics = ["libp2p/metrics", "libp2p-substream/metrics", "libp2p-messaging/metrics"]
+metrics = ["libp2p/metrics", "libp2p-substream/metrics", "libp2p-messaging/metrics", "prometheus-client"]
 
 [dependencies]
 libp2p = { workspace = true, features = [
@@ -19,4 +19,5 @@ libp2p-messaging = { workspace = true, features = ["prost"] }
 libp2p-substream = { workspace = true }
 libp2p-peer-store = { workspace = true }
 
+prometheus-client = { workspace = true, optional = true }
 thiserror = { workspace = true }

--- a/networking/swarm/src/metrics.rs
+++ b/networking/swarm/src/metrics.rs
@@ -2,6 +2,8 @@
 //   SPDX-License-Identifier: BSD-3-Clause
 
 pub use libp2p::metrics::Recorder;
+use libp2p::rendezvous;
+use prometheus_client::metrics::counter::Counter;
 
 use crate::TariNodeBehaviourEvent;
 
@@ -29,9 +31,9 @@ impl<TCodec: libp2p_messaging::Codec + Send + Clone + 'static> Recorder<TariNode
             TariNodeBehaviourEvent::Identify(identify_event) => self.libp2p_metrics.record(identify_event),
             TariNodeBehaviourEvent::RelayClient(_) => {}, // Metrics not implemented for RelayClient
             TariNodeBehaviourEvent::Relay(relay_event) => self.libp2p_metrics.record(relay_event),
-            TariNodeBehaviourEvent::RendezvousServer(_) => {}, // Metrics not implemented
-            TariNodeBehaviourEvent::RendezvousClient(_) => {}, // Metrics not implemented
-            TariNodeBehaviourEvent::PeerStore(_) => {},        // No metrics for PeerStore events
+            TariNodeBehaviourEvent::RendezvousServer(event) => self.extended_metrics.record(event),
+            TariNodeBehaviourEvent::RendezvousClient(event) => self.extended_metrics.record(event),
+            TariNodeBehaviourEvent::PeerStore(_) => {}, // No metrics for PeerStore events
             TariNodeBehaviourEvent::Gossipsub(gossipsub_event) => self.libp2p_metrics.record(gossipsub_event),
             TariNodeBehaviourEvent::Messaging(messaging_event) => self.extended_metrics.record(messaging_event),
             TariNodeBehaviourEvent::Substream(substream_event) => self.extended_metrics.record(substream_event),
@@ -45,6 +47,7 @@ impl<TCodec: libp2p_messaging::Codec + Send + Clone + 'static> Recorder<TariNode
 pub struct ExtendedMetrics {
     substream: libp2p_substream::metrics::Metrics,
     messaging: libp2p_messaging::metrics::Metrics,
+    rendezvous: RendezvousMetrics,
 }
 
 impl ExtendedMetrics {
@@ -53,6 +56,7 @@ impl ExtendedMetrics {
         Self {
             substream: libp2p_substream::metrics::Metrics::new(registry),
             messaging: libp2p_messaging::metrics::Metrics::new(registry),
+            rendezvous: RendezvousMetrics::new(registry),
         }
     }
 }
@@ -66,5 +70,173 @@ impl Recorder<libp2p_substream::Event> for ExtendedMetrics {
 impl<TMsg> Recorder<libp2p_messaging::Event<TMsg>> for ExtendedMetrics {
     fn record(&self, event: &libp2p_messaging::Event<TMsg>) {
         self.messaging.record(event);
+    }
+}
+
+impl Recorder<rendezvous::client::Event> for ExtendedMetrics {
+    fn record(&self, event: &rendezvous::client::Event) {
+        self.rendezvous.record_client(event);
+    }
+}
+
+impl Recorder<rendezvous::server::Event> for ExtendedMetrics {
+    fn record(&self, event: &rendezvous::server::Event) {
+        self.rendezvous.record_server(event);
+    }
+}
+
+/// Metrics for the rendezvous client and server behaviours. libp2p does not ship metrics for rendezvous, so these are
+/// maintained here.
+struct RendezvousMetrics {
+    client_registered: Counter,
+    client_register_failed: Counter,
+    client_discovered: Counter,
+    client_discovered_peers: Counter,
+    client_discover_failed: Counter,
+    client_expired: Counter,
+    server_peer_registered: Counter,
+    server_peer_not_registered: Counter,
+    server_peer_unregistered: Counter,
+    server_registration_expired: Counter,
+    server_discover_served: Counter,
+    server_discover_not_served: Counter,
+}
+
+impl RendezvousMetrics {
+    fn new(registry: &mut libp2p::metrics::Registry) -> Self {
+        let registry = registry.sub_registry_with_prefix("rendezvous");
+
+        let client_registered = Counter::default();
+        registry.register(
+            "client_registered",
+            "Number of successful registrations with a rendezvous server",
+            client_registered.clone(),
+        );
+        let client_register_failed = Counter::default();
+        registry.register(
+            "client_register_failed",
+            "Number of failed registrations with a rendezvous server",
+            client_register_failed.clone(),
+        );
+        let client_discovered = Counter::default();
+        registry.register(
+            "client_discovered",
+            "Number of discover responses received from rendezvous servers",
+            client_discovered.clone(),
+        );
+        let client_discovered_peers = Counter::default();
+        registry.register(
+            "client_discovered_peers",
+            "Total number of peer registrations discovered via rendezvous",
+            client_discovered_peers.clone(),
+        );
+        let client_discover_failed = Counter::default();
+        registry.register(
+            "client_discover_failed",
+            "Number of failed discover requests to rendezvous servers",
+            client_discover_failed.clone(),
+        );
+        let client_expired = Counter::default();
+        registry.register(
+            "client_expired",
+            "Number of times a discovered peer's details expired",
+            client_expired.clone(),
+        );
+
+        let server_peer_registered = Counter::default();
+        registry.register(
+            "server_peer_registered",
+            "Number of peers that successfully registered with us",
+            server_peer_registered.clone(),
+        );
+        let server_peer_not_registered = Counter::default();
+        registry.register(
+            "server_peer_not_registered",
+            "Number of registrations we declined",
+            server_peer_not_registered.clone(),
+        );
+        let server_peer_unregistered = Counter::default();
+        registry.register(
+            "server_peer_unregistered",
+            "Number of peers that unregistered with us",
+            server_peer_unregistered.clone(),
+        );
+        let server_registration_expired = Counter::default();
+        registry.register(
+            "server_registration_expired",
+            "Number of registrations that expired",
+            server_registration_expired.clone(),
+        );
+        let server_discover_served = Counter::default();
+        registry.register(
+            "server_discover_served",
+            "Number of discover requests we served",
+            server_discover_served.clone(),
+        );
+        let server_discover_not_served = Counter::default();
+        registry.register(
+            "server_discover_not_served",
+            "Number of discover requests we failed to serve",
+            server_discover_not_served.clone(),
+        );
+
+        Self {
+            client_registered,
+            client_register_failed,
+            client_discovered,
+            client_discovered_peers,
+            client_discover_failed,
+            client_expired,
+            server_peer_registered,
+            server_peer_not_registered,
+            server_peer_unregistered,
+            server_registration_expired,
+            server_discover_served,
+            server_discover_not_served,
+        }
+    }
+
+    fn record_client(&self, event: &rendezvous::client::Event) {
+        match event {
+            rendezvous::client::Event::Registered { .. } => {
+                self.client_registered.inc();
+            },
+            rendezvous::client::Event::RegisterFailed { .. } => {
+                self.client_register_failed.inc();
+            },
+            rendezvous::client::Event::Discovered { registrations, .. } => {
+                self.client_discovered.inc();
+                self.client_discovered_peers.inc_by(registrations.len() as u64);
+            },
+            rendezvous::client::Event::DiscoverFailed { .. } => {
+                self.client_discover_failed.inc();
+            },
+            rendezvous::client::Event::Expired { .. } => {
+                self.client_expired.inc();
+            },
+        }
+    }
+
+    fn record_server(&self, event: &rendezvous::server::Event) {
+        match event {
+            rendezvous::server::Event::PeerRegistered { .. } => {
+                self.server_peer_registered.inc();
+            },
+            rendezvous::server::Event::PeerNotRegistered { .. } => {
+                self.server_peer_not_registered.inc();
+            },
+            rendezvous::server::Event::PeerUnregistered { .. } => {
+                self.server_peer_unregistered.inc();
+            },
+            rendezvous::server::Event::RegistrationExpired(_) => {
+                self.server_registration_expired.inc();
+            },
+            rendezvous::server::Event::DiscoverServed { .. } => {
+                self.server_discover_served.inc();
+            },
+            rendezvous::server::Event::DiscoverNotServed { .. } => {
+                self.server_discover_not_served.inc();
+            },
+        }
     }
 }


### PR DESCRIPTION
## Summary

Makes rendezvous-based peer discovery actually share the peer set, so a node no longer needs the full seed-peer list configured. The configured **seed peers are the rendezvous servers** — connect to one, register, and pull everyone else's records from it.

## Background

Rendezvous discovery was only half-wired in `networking/core/src/worker.rs`:
1. The `RendezvousClient(Discovered)` handler ignored `registrations` entirely (only the pagination cookie was kept), so discovered peers never reached the peer store.
2. `discover()` was only triggered reactively on `DialError::NoAddresses`; there was no proactive or periodic discovery.

A single rendezvous server was also a SPOF and required separate config.

## Changes

### Make discovery work
- Consume `registrations` from the `Discovered` event, adding each peer's addresses to the peer store (filtered through `is_supported_multiaddr`, skipping self).
- Trigger discovery on the `Registered` event and refresh periodically from `bootstrap()` (every `check_connections_interval`, default 2 min).
- Re-dial a rendezvous server in `discover_rendezvous_peers` if the connection has dropped (e.g. idle timeout), so periodic discovery keeps working.

### Multiple rendezvous servers = seed peers
- `RendezvousState` now tracks a **set** of servers (keyed by peer id, each with its own cookie) instead of a single server.
- Servers are derived from the configured **seed peers** that have a known peer id. **Best-effort:** a seed peer that doesn't run a rendezvous server just yields harmless failed register/discover attempts.
- `discover_rendezvous_peers(only)` can target one server or sweep all.
- Removed the now-redundant single-server plumbing: `PeerSeedsConfig.rendezvous_server`, `Builder::with_rendezvous_server`, the bootstrap `.then(...)` wiring (VN + indexer), and the separate rendezvous bootstrap dial (seed peers are already dialed).

### Rendezvous metrics
- libp2p ships no rendezvous metrics, so the `RendezvousClient`/`RendezvousServer` recorder arms were no-ops. Added `RendezvousMetrics` (client + server counters) under the `libp2p_ext.rendezvous` registry and wired both arms.
- Client: `client_registered`, `client_register_failed`, `client_discovered`, `client_discovered_peers`, `client_discover_failed`, `client_expired`.
- Server: `server_peer_registered`, `server_peer_not_registered`, `server_peer_unregistered`, `server_registration_expired`, `server_discover_served`, `server_discover_not_served`.
- `tari_swarm` gains an optional `prometheus-client` dep behind the `metrics` feature.

## Breaking change

`PeerSeedsConfig.rendezvous_server` is removed. With `#[serde(deny_unknown_fields)]`, configs that still set `rendezvous_server` will fail to parse — remove the key. To run a node as a rendezvous server, set `[p2p] enable_rendezvous = true` (unchanged); clients now use the seed peers automatically.

## Testing

- `cargo clippy` clean for the changed code (`tari_networking`, `tari_swarm` incl. `--features metrics`).
- `cargo check`/`test` pass for `tari_networking`, `tari_swarm`, `tari_validator_node`, `tari_indexer`.
- Formatted with `cargo +nightly-2025-06-25 fmt --all`.
- No integration test added (the rendezvous flow isn't currently covered by one).

## Notes

- API verified against the pinned libp2p fork (rev `e318826`): rendezvous `Discovered`/`Registration`/`PeerRecord`/`Registered`, and client/server `Event` enums.
- NAT'd nodes only register addresses the swarm has confirmed external — relay + DCUtR (already wired) covers most cases.

## Config presets

- Documented the `enable_rendezvous` p2p option in the validator node and indexer presets, clarifying it is the **server** side only — the rendezvous **client is always active**, so every node already registers with and queries its seed peers regardless of this flag. Enable it on seed/bootstrap nodes.
- Replaced the indexer `[indexer.p2p]` block's stale `#transport = "tor"` (not a `P2pConfig` field) with the real p2p options, matching the validator node preset.
