### PR TITLE
feat(network): use a single gossip topic for consensus and mempool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12579,7 +12579,6 @@ dependencies = [
  "config",
  "console-subscriber",
  "dashmap 5.5.3",
- "either",
  "futures 0.3.31",
  "include_dir",
  "indexmap 2.13.0",

--- a/applications/tari_validator_node/Cargo.toml
+++ b/applications/tari_validator_node/Cargo.toml
@@ -55,7 +55,6 @@ axum-jrpc = { workspace = true, features = ["anyhow_error"] }
 clap = { workspace = true, features = ["env"] }
 config = { workspace = true }
 dashmap = { workspace = true }
-either = { workspace = true }
 time = { workspace = true, features = ["formatting"] }
 lazy_static = { workspace = true }
 futures = { workspace = true }

--- a/applications/tari_validator_node/src/p2p/services/consensus_gossip/handle.rs
+++ b/applications/tari_validator_node/src/p2p/services/consensus_gossip/handle.rs
@@ -23,7 +23,6 @@
 use log::*;
 use tari_consensus::messages::HotstuffMessage;
 use tari_networking::{NetworkingHandle, NetworkingService};
-use tari_ootle_common_types::ShardGroup;
 use tari_ootle_p2p::{TariMessagingSpec, proto};
 use tari_swarm::messaging::{
     Codec,
@@ -31,7 +30,7 @@ use tari_swarm::messaging::{
 };
 
 use super::ConsensusGossipError;
-use crate::p2p::services::consensus_gossip::service::shard_group_to_topic;
+use crate::p2p::services::consensus_gossip::service::topic;
 
 const LOG_TARGET: &str = "tari::validator_node::consensus_gossip";
 
@@ -49,12 +48,8 @@ impl ConsensusGossipHandle {
         }
     }
 
-    pub async fn publish(
-        &mut self,
-        shard_group: ShardGroup,
-        message: HotstuffMessage,
-    ) -> Result<(), ConsensusGossipError> {
-        let topic = shard_group_to_topic(shard_group);
+    pub async fn publish(&mut self, message: HotstuffMessage) -> Result<(), ConsensusGossipError> {
+        let topic = topic();
 
         let message = proto::consensus::HotStuffMessage::from(&message);
         let encoded_len = message.encoded_len();

--- a/applications/tari_validator_node/src/p2p/services/consensus_gossip/service.rs
+++ b/applications/tari_validator_node/src/p2p/services/consensus_gossip/service.rs
@@ -25,7 +25,6 @@ use log::*;
 use tari_consensus::hotstuff::HotstuffEvent;
 use tari_epoch_manager::EpochManagerEvent;
 use tari_networking::{NetworkingHandle, NetworkingService};
-use tari_ootle_common_types::ShardGroup;
 use tari_ootle_p2p::{TariMessagingSpec, proto};
 use tari_swarm::messaging::{Codec, prost::ProstCodec};
 use tokio::sync::{broadcast, mpsc};
@@ -34,13 +33,16 @@ use super::ConsensusGossipError;
 
 const LOG_TARGET: &str = "tari::validator_node::consensus_gossip::service";
 
+/// All consensus gossip is published on a single network-wide topic. Using one topic (rather than a topic per shard
+/// group) keeps the gossipsub mesh stable across epoch boundaries, since validators never need to unsubscribe and
+/// resubscribe when they are shuffled into a different shard group.
 pub const TOPIC_PREFIX: &str = "consensus";
 
 #[derive(Debug)]
 pub(super) struct ConsensusGossipService {
     epoch_manager_events: broadcast::Receiver<EpochManagerEvent>,
     consensus_events: broadcast::Receiver<HotstuffEvent>,
-    is_subscribed: Option<ShardGroup>,
+    is_subscribed: bool,
     networking: NetworkingHandle<TariMessagingSpec>,
     codec: ProstCodec<proto::consensus::HotStuffMessage>,
     rx_gossip: mpsc::UnboundedReceiver<(PeerId, gossipsub::Message)>,
@@ -58,7 +60,7 @@ impl ConsensusGossipService {
         Self {
             epoch_manager_events,
             consensus_events,
-            is_subscribed: None,
+            is_subscribed: false,
             networking,
             codec: ProstCodec::default(),
             rx_gossip,
@@ -71,8 +73,10 @@ impl ConsensusGossipService {
         loop {
             tokio::select! {
                 Ok(HotstuffEvent::EpochChanged{ registered_shard_group, .. }) = self.consensus_events.recv() => {
-                    if let Some(shard_group) = registered_shard_group{
-                        self.subscribe(shard_group).await?;
+                    if registered_shard_group.is_some() {
+                        self.subscribe().await?;
+                    } else {
+                        self.unsubscribe().await?;
                     }
                 },
                 Some(msg) = self.rx_gossip.recv() => {
@@ -81,11 +85,10 @@ impl ConsensusGossipService {
                     }
                 },
                 Ok(EpochManagerEvent::EpochChanged{ registered_shard_group, .. }) = self.epoch_manager_events.recv() => {
-                    if !initial_subscription_complete
-                        && let Some(shard_group) = registered_shard_group {
-                            self.subscribe(shard_group).await?;
-                            initial_subscription_complete = true;
-                        }
+                    if !initial_subscription_complete && registered_shard_group.is_some() {
+                        self.subscribe().await?;
+                        initial_subscription_complete = true;
+                    }
                 },
                 else => {
                     info!(target: LOG_TARGET, "Consensus gossip service shutting down");
@@ -119,42 +122,28 @@ impl ConsensusGossipService {
         Ok(())
     }
 
-    async fn subscribe(&mut self, shard_group: ShardGroup) -> Result<(), ConsensusGossipError> {
-        match self.is_subscribed {
-            Some(sg) if sg == shard_group => {
-                debug!(target: LOG_TARGET, "🌬️ Consensus gossip already subscribed to messages for {shard_group}");
-                return Ok(());
-            },
-            Some(_) => {
-                self.unsubscribe().await?;
-            },
-            None => {},
+    async fn subscribe(&mut self) -> Result<(), ConsensusGossipError> {
+        if self.is_subscribed {
+            return Ok(());
         }
 
-        info!(target: LOG_TARGET, "🌬️ Consensus gossip service subscribing messages for {shard_group}");
-        let topic = shard_group_to_topic(shard_group);
-        self.networking.subscribe_topic(topic).await?;
-        self.is_subscribed = Some(shard_group);
+        info!(target: LOG_TARGET, "🌬️ Consensus gossip service subscribing to {}", topic());
+        self.networking.subscribe_topic(topic()).await?;
+        self.is_subscribed = true;
 
         Ok(())
     }
 
     async fn unsubscribe(&mut self) -> Result<(), ConsensusGossipError> {
-        if let Some(sg) = self.is_subscribed {
-            let topic = shard_group_to_topic(sg);
-            self.networking.unsubscribe_topic(topic).await?;
-            self.is_subscribed = None;
+        if self.is_subscribed {
+            self.networking.unsubscribe_topic(topic()).await?;
+            self.is_subscribed = false;
         }
 
         Ok(())
     }
 }
 
-pub(super) fn shard_group_to_topic(shard_group: ShardGroup) -> String {
-    format!(
-        "{}-{}-{}",
-        TOPIC_PREFIX,
-        shard_group.start().as_u32(),
-        shard_group.end().as_u32()
-    )
+pub(super) fn topic() -> String {
+    TOPIC_PREFIX.to_string()
 }

--- a/applications/tari_validator_node/src/p2p/services/mempool/gossip.rs
+++ b/applications/tari_validator_node/src/p2p/services/mempool/gossip.rs
@@ -1,14 +1,9 @@
 //   Copyright 2023 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use std::collections::HashSet;
-
-use either::Either;
 use libp2p::{PeerId, gossipsub};
 use log::*;
-use tari_epoch_manager::{EpochManagerReader, service::EpochManagerHandle};
 use tari_networking::{NetworkingHandle, NetworkingService};
-use tari_ootle_common_types::{Epoch, ShardGroup};
 use tari_ootle_p2p::{NewTransactionMessage, PeerAddress, TariMessage, TariMessagingSpec, proto};
 use tari_swarm::messaging::{Codec, prost::ProstCodec};
 use tokio::sync::mpsc;
@@ -17,6 +12,9 @@ use crate::p2p::services::mempool::MempoolError;
 
 const LOG_TARGET: &str = "tari::validator_node::mempool::gossip";
 
+/// All transactions are gossiped on a single network-wide topic. Using one topic (rather than a topic per shard group)
+/// keeps the gossipsub mesh stable across epoch boundaries, since validators never need to unsubscribe and resubscribe
+/// when they are shuffled into a different shard group.
 pub const TOPIC_PREFIX: &str = "transactions";
 
 #[derive(Debug)]
@@ -47,23 +45,20 @@ impl MempoolGossipCodec {
 }
 
 #[derive(Debug)]
-pub(super) struct MempoolGossip<TAddr> {
-    epoch_manager: EpochManagerHandle<TAddr>,
-    is_subscribed: Option<ShardGroup>,
+pub(super) struct MempoolGossip {
+    is_subscribed: bool,
     networking: NetworkingHandle<TariMessagingSpec>,
     rx_gossip: mpsc::UnboundedReceiver<(PeerId, gossipsub::Message)>,
     codec: MempoolGossipCodec,
 }
 
-impl MempoolGossip<PeerAddress> {
+impl MempoolGossip {
     pub fn new(
-        epoch_manager: EpochManagerHandle<PeerAddress>,
         networking: NetworkingHandle<TariMessagingSpec>,
         rx_gossip: mpsc::UnboundedReceiver<(PeerId, gossipsub::Message)>,
     ) -> Self {
         Self {
-            epoch_manager,
-            is_subscribed: None,
+            is_subscribed: false,
             networking,
             rx_gossip,
             codec: MempoolGossipCodec::new(),
@@ -85,48 +80,21 @@ impl MempoolGossip<PeerAddress> {
         }
     }
 
-    pub async fn subscribe(&mut self, shard_group: ShardGroup) -> Result<(), MempoolError> {
-        match self.is_subscribed {
-            Some(b) if b == shard_group => {
-                return Ok(());
-            },
-            Some(_) => {
-                self.unsubscribe().await?;
-            },
-            None => {},
+    pub async fn subscribe(&mut self) -> Result<(), MempoolError> {
+        if self.is_subscribed {
+            return Ok(());
         }
 
-        self.networking
-            .subscribe_topic(shard_group_to_topic(shard_group))
-            .await?;
-        self.is_subscribed = Some(shard_group);
+        self.networking.subscribe_topic(topic()).await?;
+        self.is_subscribed = true;
         Ok(())
     }
 
     pub async fn unsubscribe(&mut self) -> Result<(), MempoolError> {
-        if let Some(sg) = self.is_subscribed {
-            self.networking.unsubscribe_topic(shard_group_to_topic(sg)).await?;
-            self.is_subscribed = None;
+        if self.is_subscribed {
+            self.networking.unsubscribe_topic(topic()).await?;
+            self.is_subscribed = false;
         }
-        Ok(())
-    }
-
-    pub async fn forward_to_local_replicas(&mut self, epoch: Epoch, msg: TariMessage) -> Result<(), MempoolError> {
-        let committee = self.epoch_manager.get_local_committee_info(epoch).await?;
-
-        let topic = shard_group_to_topic(committee.shard_group());
-        debug!(
-            target: LOG_TARGET,
-            "forward_to_local_replicas: topic: {}", topic,
-        );
-
-        let msg = self
-            .codec
-            .encode(msg)
-            .await
-            .map_err(|e| MempoolError::InvalidMessage(e.into()))?;
-        self.networking.publish_gossip(topic, msg).await?;
-
         Ok(())
     }
 
@@ -134,61 +102,24 @@ impl MempoolGossip<PeerAddress> {
         self.rx_gossip.len()
     }
 
-    pub async fn forward_to_foreign_replicas(
-        &mut self,
-        epoch: Epoch,
-        msg: NewTransactionMessage,
-        exclude_shard_group: Option<ShardGroup>,
-    ) -> Result<(), MempoolError> {
-        let n = self.epoch_manager.get_num_committees(epoch).await?;
-        let committee_info = self.epoch_manager.get_local_committee_info(epoch).await?;
-        let local_shard_group = committee_info.shard_group();
-        let shard_groups = if msg.transaction.is_global() {
-            Either::Left(
-                committee_info
-                    .all_shard_groups_iter()
-                    .filter(|sg| exclude_shard_group.as_ref() != Some(sg) && sg != &local_shard_group),
-            )
-        } else {
-            let shard_groups = msg
-                .transaction
-                .involved_substate_addresses_iter()
-                .map(|s| s.to_shard_group(committee_info.num_preshards(), n))
-                .filter(|sg| exclude_shard_group.as_ref() != Some(sg) && sg != &local_shard_group)
-                .collect::<HashSet<_>>();
-            // If the only shard group involved is the excluded one.
-            if shard_groups.is_empty() {
-                return Ok(());
-            }
-            Either::Right(shard_groups.into_iter())
-        };
-
+    /// Gossip a transaction to the rest of the network. Since transactions are published on a single network-wide
+    /// topic, gossipsub delivers the transaction to every validator with one publish; replicas in the involved shard
+    /// groups pick it up directly and no per-shard-group forwarding is required.
+    pub async fn forward(&mut self, msg: NewTransactionMessage) -> Result<(), MempoolError> {
+        debug!(target: LOG_TARGET, "forward transaction on topic: {}", topic());
         let msg = self
             .codec
             .encode(msg.into())
             .await
             .map_err(|e| MempoolError::InvalidMessage(e.into()))?;
-
-        for sg in shard_groups {
-            let topic = shard_group_to_topic(sg);
-            debug!(
-                target: LOG_TARGET,
-                "forward_to_foreign_replicas: topic: {}", topic,
-            );
-            self.networking.publish_gossip(topic, msg.clone()).await?;
-        }
+        self.networking.publish_gossip(topic(), msg).await?;
 
         Ok(())
     }
 }
 
-fn shard_group_to_topic(shard_group: ShardGroup) -> String {
-    format!(
-        "{}-{}-{}",
-        TOPIC_PREFIX,
-        shard_group.start().as_u32(),
-        shard_group.end().as_u32()
-    )
+fn topic() -> String {
+    TOPIC_PREFIX.to_string()
 }
 
 pub struct IncomingMessage {

--- a/applications/tari_validator_node/src/p2p/services/mempool/service.rs
+++ b/applications/tari_validator_node/src/p2p/services/mempool/service.rs
@@ -27,7 +27,7 @@ use log::*;
 use tari_consensus::hotstuff::HotstuffEvent;
 use tari_epoch_manager::{EpochManagerReader, service::EpochManagerHandle};
 use tari_networking::NetworkingHandle;
-use tari_ootle_common_types::{ShardGroup, optional::Optional};
+use tari_ootle_common_types::optional::Optional;
 use tari_ootle_p2p::{NewTransactionMessage, PeerAddress, TariMessage, TariMessagingSpec};
 use tari_ootle_storage::{StateStore, StateStoreReadTransaction, consensus_models::TransactionRecord};
 use tari_ootle_transaction::{Transaction, TransactionId};
@@ -57,7 +57,7 @@ pub struct MempoolService<TValidator, TStateStore> {
     epoch_manager: EpochManagerHandle<PeerAddress>,
     before_execute_validator: TValidator,
     state_store: TStateStore,
-    gossip: MempoolGossip<PeerAddress>,
+    gossip: MempoolGossip,
     consensus_handle: ConsensusHandle,
     #[cfg(feature = "metrics")]
     metrics: PrometheusMempoolMetrics,
@@ -79,7 +79,7 @@ where
         #[cfg(feature = "metrics")] metrics: PrometheusMempoolMetrics,
     ) -> Self {
         Self {
-            gossip: MempoolGossip::new(epoch_manager.clone(), networking, rx_gossip),
+            gossip: MempoolGossip::new(networking, rx_gossip),
             transactions: Default::default(),
             mempool_requests,
             epoch_manager,
@@ -121,9 +121,9 @@ where
                 event = consensus_events.recv() => {
                     match event {
                         Ok(HotstuffEvent::EpochChanged { epoch, registered_shard_group})  => {
-                            if let Some(shard_group) = registered_shard_group {
-                                info!(target: LOG_TARGET, "Mempool service subscribing transaction messages for {shard_group} in {epoch}");
-                                self.gossip.subscribe(shard_group).await?;
+                            if registered_shard_group.is_some() {
+                                info!(target: LOG_TARGET, "Mempool service subscribing to transaction gossip in {epoch}");
+                                self.gossip.subscribe().await?;
                             } else {
                                 info!(target: LOG_TARGET, "Not registered for epoch {epoch}, unsubscribing from gossip if necessary");
                                 self.gossip.unsubscribe().await?;
@@ -189,7 +189,7 @@ where
             "🎱 Received NEW transaction from local: {transaction}",
         );
 
-        self.handle_new_transaction(transaction, None, self.gossip.get_num_incoming_messages())
+        self.handle_new_transaction(transaction, true, self.gossip.get_num_incoming_messages())
             .await?;
 
         Ok(())
@@ -229,19 +229,7 @@ where
             transaction
         );
 
-        let current_epoch = self.consensus_handle.current_view().get_epoch();
-        let maybe_sender_committee_info = self
-            .epoch_manager
-            .get_committee_info_by_validator_address(current_epoch, &from)
-            .await
-            .optional()?;
-
-        self.handle_new_transaction(
-            transaction,
-            maybe_sender_committee_info.map(|c| c.shard_group()),
-            num_pending,
-        )
-        .await?;
+        self.handle_new_transaction(transaction, false, num_pending).await?;
 
         Ok(())
     }
@@ -250,7 +238,7 @@ where
     async fn handle_new_transaction(
         &mut self,
         transaction: Transaction,
-        sender_shard_group: Option<ShardGroup>,
+        is_local: bool,
         num_pending: usize,
     ) -> Result<(), MempoolError> {
         #[cfg(feature = "metrics")]
@@ -276,29 +264,6 @@ where
                 .notify_new_transaction(transaction.clone(), num_pending)
                 .await
                 .map_err(|_| MempoolError::ConsensusChannelClosed)?;
-
-            // If we received the message from gossip (sender_shard_group is Some), we don't need to gossip it again on
-            // the topic (prevents Duplicate errors)
-            if sender_shard_group.is_none() {
-                // This validator is involved, we to send the transaction to local replicas
-                if let Err(e) = self
-                    .gossip
-                    .forward_to_local_replicas(
-                        current_epoch,
-                        NewTransactionMessage {
-                            transaction: transaction.clone(),
-                        }
-                        .into(),
-                    )
-                    .await
-                {
-                    warn!(
-                        target: LOG_TARGET,
-                        "⚠️ Failed to propagate transaction to local replicas: {}",
-                        e
-                    );
-                }
-            }
         } else {
             debug!(
                 target: LOG_TARGET,
@@ -306,22 +271,24 @@ where
             );
         }
 
-        debug!(
-            target: LOG_TARGET,
-            "🎱 Propagating transaction {} ({} input(s))",
-            tx_id,
-            transaction.num_inputs(),
-        );
-        if let Err(e) = self
-            .gossip
-            .forward_to_foreign_replicas(current_epoch, NewTransactionMessage { transaction }, sender_shard_group)
-            .await
-        {
-            warn!(
+        // Transactions are gossiped on a single network-wide topic, so a single publish reaches every validator
+        // (including all involved shard groups). Only the node that first introduces the transaction (received from a
+        // local client) needs to publish it; transactions received from gossip are already seen by the whole network,
+        // so re-publishing them would only produce Duplicate errors.
+        if is_local {
+            debug!(
                 target: LOG_TARGET,
-                "⚠️ Failed to propagate transaction to foreign committee: {}",
-                e
+                "🎱 Propagating transaction {} ({} input(s))",
+                tx_id,
+                transaction.num_inputs(),
             );
+            if let Err(e) = self.gossip.forward(NewTransactionMessage { transaction }).await {
+                warn!(
+                    target: LOG_TARGET,
+                    "⚠️ Failed to propagate transaction {tx_id}: {}",
+                    e
+                );
+            }
         }
 
         Ok(())

--- a/applications/tari_validator_node/src/p2p/services/messaging/outbound.rs
+++ b/applications/tari_validator_node/src/p2p/services/messaging/outbound.rs
@@ -25,7 +25,6 @@
 
 use tari_consensus::{messages::HotstuffMessage, traits::OutboundMessagingError};
 use tari_networking::{NetworkingHandle, NetworkingService};
-use tari_ootle_common_types::ShardGroup;
 use tari_ootle_p2p::{PeerAddress, TariMessagingSpec, proto};
 use tokio::sync::mpsc;
 
@@ -124,12 +123,12 @@ impl<TMsgLogger: MessageLogger + Send> tari_consensus::traits::OutboundMessaging
         Ok(())
     }
 
-    async fn broadcast<T>(&mut self, shard_group: ShardGroup, message: T) -> Result<(), OutboundMessagingError>
+    async fn broadcast<T>(&mut self, message: T) -> Result<(), OutboundMessagingError>
     where T: Into<HotstuffMessage> + Send {
         let message = message.into();
 
         self.consensus_gossip
-            .publish(shard_group, message)
+            .publish(message)
             .await
             .map_err(OutboundMessagingError::from_error)?;
 

--- a/crates/consensus/src/hotstuff/on_receive_foreign_proposal.rs
+++ b/crates/consensus/src/hotstuff/on_receive_foreign_proposal.rs
@@ -147,6 +147,18 @@ where TConsensusSpec: ConsensusSpec
             return Ok(());
         }
 
+        // The notification is gossiped on a single network-wide topic, so every validator receives it. Only fetch the
+        // foreign proposal if our shard group is in the intended audience.
+        if !message.shard_groups.contains(&local_committee_info.shard_group()) {
+            debug!(
+                target: LOG_TARGET,
+                "🌐 FOREIGN PROPOSAL: notification for block {} does not target our shard group {}. Ignoring.",
+                message.block_id,
+                local_committee_info.shard_group(),
+            );
+            return Ok(());
+        }
+
         // Check if the source is in a foreign committee
         let foreign_committee_info = self
             .epoch_manager

--- a/crates/consensus/src/hotstuff/on_receive_local_proposal.rs
+++ b/crates/consensus/src/hotstuff/on_receive_local_proposal.rs
@@ -1099,37 +1099,30 @@ async fn broadcast_foreign_proposal_if_required<TConsensusSpec: ConsensusSpec>(
     }
     info!(
         target: LOG_TARGET,
-        "🌐 FOREIGN PROPOSE: new commit block to {} foreign shard group(s). {}",
-        non_local_shard_groups.len(),
+        "🌐 FOREIGN PROPOSE: Broadcasting new commit block {} notification to {} foreign shard group(s).",
         block,
+        non_local_shard_groups.len(),
     );
 
-    for shard_group in non_local_shard_groups {
-        info!(
+    // The notification is gossiped on a single network-wide topic, so it only needs to be published once. The target
+    // shard groups are carried in the message and receivers that are not in the audience ignore it.
+    // TODO: all local VNs will broadcast this. Perhaps we can reduce this to $f+1$.
+    if let Err(err) = outbound_messaging
+        .broadcast(HotstuffMessage::ForeignProposalNotification(
+            ForeignProposalNotificationMessage {
+                block_id: *block.id(),
+                epoch: block.epoch(),
+                shard_groups: non_local_shard_groups.into_iter().collect(),
+            },
+        ))
+        .await
+    {
+        error!(
             target: LOG_TARGET,
-            "🌐 FOREIGN PROPOSE: Broadcasting commit block {} notification to shard group {}.",
-            &block,
-            shard_group,
+            "❌ Error broadcasting foreign proposal notification for block {}: {}",
+            block,
+            err
         );
-        // TODO: all local VNs will broadcast this. This message only needs to be published once. Perhaps we can reduce
-        // this to $f+1$.
-        if let Err(err) = outbound_messaging
-            .broadcast(
-                shard_group,
-                HotstuffMessage::ForeignProposalNotification(ForeignProposalNotificationMessage {
-                    block_id: *block.id(),
-                    epoch: block.epoch(),
-                }),
-            )
-            .await
-        {
-            error!(
-                target: LOG_TARGET,
-                "❌ Error broadcasting foreign proposal notification to shard group {}: {}",
-                shard_group,
-                err
-            );
-        }
     }
 
     Ok(())

--- a/crates/consensus/src/hotstuff/on_receive_local_proposal.rs
+++ b/crates/consensus/src/hotstuff/on_receive_local_proposal.rs
@@ -1107,12 +1107,16 @@ async fn broadcast_foreign_proposal_if_required<TConsensusSpec: ConsensusSpec>(
     // The notification is gossiped on a single network-wide topic, so it only needs to be published once. The target
     // shard groups are carried in the message and receivers that are not in the audience ignore it.
     // TODO: all local VNs will broadcast this. Perhaps we can reduce this to $f+1$.
+    // The shard groups are sorted so that the encoded payload is deterministic: every local VN produces identical
+    // bytes for the same block, allowing gossipsub's content-addressed message id to deduplicate the broadcasts.
+    let mut shard_groups = non_local_shard_groups.into_iter().collect::<Vec<_>>();
+    shard_groups.sort_by_key(|sg| sg.encode_as_u32());
     if let Err(err) = outbound_messaging
         .broadcast(HotstuffMessage::ForeignProposalNotification(
             ForeignProposalNotificationMessage {
                 block_id: *block.id(),
                 epoch: block.epoch(),
-                shard_groups: non_local_shard_groups.into_iter().collect(),
+                shard_groups,
             },
         ))
         .await

--- a/crates/consensus/src/messages/foreign_proposal.rs
+++ b/crates/consensus/src/messages/foreign_proposal.rs
@@ -53,14 +53,24 @@ impl Display for ForeignProposalMessage {
 pub struct ForeignProposalNotificationMessage {
     pub block_id: BlockId,
     pub epoch: Epoch,
+    /// The shard groups this notification is intended for. The notification is gossiped on a single network-wide
+    /// topic, so every validator receives it; only validators whose shard group is listed here need to fetch the
+    /// foreign proposal.
+    pub shard_groups: Vec<ShardGroup>,
 }
 
 impl Display for ForeignProposalNotificationMessage {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "ForeignProposalNotificationMessage({}, {})",
-            self.epoch, self.block_id,
+            "ForeignProposalNotificationMessage({}, {}, [{}])",
+            self.epoch,
+            self.block_id,
+            self.shard_groups
+                .iter()
+                .map(|sg| sg.to_string())
+                .collect::<Vec<_>>()
+                .join(", "),
         )
     }
 }

--- a/crates/consensus/src/traits/messaging.rs
+++ b/crates/consensus/src/traits/messaging.rs
@@ -22,7 +22,7 @@
 
 use std::future::Future;
 
-use tari_ootle_common_types::{NodeAddressable, ShardGroup};
+use tari_ootle_common_types::NodeAddressable;
 
 use crate::messages::HotstuffMessage;
 
@@ -54,16 +54,13 @@ pub trait OutboundMessaging {
         I: IntoIterator<Item = Self::Addr> + Send,
         T: Into<HotstuffMessage> + Send;
 
-    /// Broadcast/gossip a message to all nodes in a shard group. This is a best-effort broadcast and may not reach all
-    /// nodes. Since gossiped messages are sent and may be received multiple times, the message byte size should be
-    /// small e.g. <= `6KiB`. If the message is larger, consider using `multicast` instead.
-    fn broadcast<T>(
-        &mut self,
-        shard_group: ShardGroup,
-        message: T,
-    ) -> impl Future<Output = Result<(), OutboundMessagingError>> + Send
-    where
-        T: Into<HotstuffMessage> + Send;
+    /// Broadcast/gossip a message to every validator on the network-wide consensus gossip topic. This is a best-effort
+    /// broadcast and may not reach all nodes. Since gossiped messages are sent and may be received multiple times, the
+    /// message byte size should be small e.g. <= `6KiB`. If the message is larger, consider using `multicast` instead.
+    /// Messages that are only relevant to a subset of shard groups should carry that audience in their payload so
+    /// receivers can filter (see `ForeignProposalNotificationMessage`).
+    fn broadcast<T>(&mut self, message: T) -> impl Future<Output = Result<(), OutboundMessagingError>> + Send
+    where T: Into<HotstuffMessage> + Send;
 }
 
 pub trait InboundMessaging {

--- a/crates/consensus_tests/src/support/messaging_impls.rs
+++ b/crates/consensus_tests/src/support/messaging_impls.rs
@@ -5,8 +5,6 @@ use tari_consensus::{
     messages::HotstuffMessage,
     traits::{InboundMessaging, InboundMessagingError, OutboundMessaging, OutboundMessagingError},
 };
-use tari_epoch_manager::EpochManagerReader;
-use tari_ootle_common_types::ShardGroup;
 use tokio::sync::mpsc;
 
 use super::epoch_manager::TestEpochManager;
@@ -78,20 +76,16 @@ impl OutboundMessaging for TestOutboundMessaging {
         })
     }
 
-    async fn broadcast<T>(&mut self, shard_group: ShardGroup, message: T) -> Result<(), OutboundMessagingError>
+    async fn broadcast<T>(&mut self, message: T) -> Result<(), OutboundMessagingError>
     where T: Into<HotstuffMessage> + Send {
-        // TODO: technically we should use the consensus epoch here, but current tests will not trigger this bug
-        let epoch = self
+        // A broadcast is gossiped on a single network-wide topic, so it reaches every validator. Messages relevant
+        // only to a subset of shard groups carry that audience in their payload and are filtered by the receiver.
+        let peers = self
             .epoch_manager
-            .current_epoch()
+            .all_validators()
             .await
-            .map_err(|e| OutboundMessagingError::UpstreamError(e.into()))?;
-        let committee = self
-            .epoch_manager
-            .get_committee_by_shard_group(epoch, shard_group)
-            .await
-            .map_err(|e| OutboundMessagingError::UpstreamError(e.into()))?;
-        let peers = committee.address_iter().cloned();
+            .into_iter()
+            .map(|(vn, _)| vn.address);
         self.multicast(peers, message).await
     }
 }

--- a/crates/p2p/proto/consensus.proto
+++ b/crates/p2p/proto/consensus.proto
@@ -46,6 +46,7 @@ message ForeignProposalMessage {
 message ForeignProposalNotification {
   bytes block_id = 1;
   uint64 epoch = 2;
+  repeated uint32 shard_groups = 3;
 }
 
 message ForeignProposalRequest {

--- a/crates/p2p/src/conversions/consensus.rs
+++ b/crates/p2p/src/conversions/consensus.rs
@@ -279,6 +279,7 @@ impl From<&ForeignProposalNotificationMessage> for proto::consensus::ForeignProp
         Self {
             block_id: value.block_id.as_bytes().to_vec(),
             epoch: value.epoch.as_u64(),
+            shard_groups: value.shard_groups.iter().map(|sg| sg.encode_as_u32()).collect(),
         }
     }
 }
@@ -290,6 +291,14 @@ impl TryFrom<proto::consensus::ForeignProposalNotification> for ForeignProposalN
         Ok(Self {
             block_id: BlockId::try_from(value.block_id)?,
             epoch: Epoch(value.epoch),
+            shard_groups: value
+                .shard_groups
+                .into_iter()
+                .map(|sg| {
+                    ShardGroup::decode_from_u32(sg)
+                        .ok_or_else(|| anyhow!("Invalid shard group in foreign proposal notification: {sg}"))
+                })
+                .collect::<Result<_, _>>()?,
         })
     }
 }

--- a/networking/core/src/message_mode.rs
+++ b/networking/core/src/message_mode.rs
@@ -56,11 +56,14 @@ impl<TMsg: MessageSpec> MessagingMode<TMsg> {
             ..
         } = self
         {
-            let (prefix, _) = msg
+            // Topics may be a bare prefix (single global topic, e.g. "consensus") or a prefixed topic
+            // (e.g. "transactions-0-15"). Route on the prefix before the first delimiter, falling back to the
+            // whole topic when there is no delimiter.
+            let prefix = msg
                 .topic
                 .as_str()
                 .split_once(TOPIC_DELIMITER)
-                .ok_or_else(|| GossipSendError::InvalidToken(msg.topic.clone().into_string()))?;
+                .map_or_else(|| msg.topic.as_str(), |(prefix, _)| prefix);
             let tx_gossip_messages = tx_gossip_messages_by_topic
                 .get(prefix)
                 .ok_or_else(|| GossipSendError::InvalidToken(msg.topic.clone().into_string()))?;


### PR DESCRIPTION
## What
Move consensus and mempool gossip from a per-shard-group topic to a single network-wide topic.

## Why
Topics were derived from the shard-group range (`consensus-{start}-{end}`, `transactions-{start}-{end}`). When validators are shuffled into a different shard group at an epoch boundary they unsubscribe from the old topic and resubscribe to the new one. That tears down and rebuilds the gossipsub mesh; during the warm-up (mesh GRAFT + peer discovery) messages are dropped, and when many validators reshuffle at once the new topic's mesh starts sparse and lossy. A single stable topic per service removes the resubscribe churn and keeps the mesh dense across epochs.

## How
- **Single topic**: consensus gossip publishes/subscribes to `consensus`; mempool to `transactions`. `is_subscribed` becomes a bool; subscribe/unsubscribe no longer take a shard group. Validators subscribe once while registered and never resubscribe on a shard-group change.
- **Keeping traffic targeted** (every validator now receives every gossip message):
  - `ForeignProposalNotificationMessage` now carries `shard_groups` (the intended audience). A receiver only requests the full foreign proposal when its shard group is in the audience, preserving the previous targeting and avoiding every committee fetching every cross-shard proposal. The notification is published once instead of once per foreign shard group.
  - Mempool publishes a transaction once, from the node that first receives it from a local client. Transactions received from gossip are not re-published (gossipsub already floods them to all subscribers), so the cross-topic bridging (`forward_to_local_replicas` / `forward_to_foreign_replicas`) is removed.
- `OutboundMessaging::broadcast` drops its `shard_group` parameter.
- The gossip router (`networking/core/src/message_mode.rs`) routes bare-prefix topics (no `-` delimiter) using the whole topic string.

## Trade-off
Each validator now receives all consensus notifications and all mempool transactions network-wide rather than only those for its shard group. Notifications are tiny and the request path stays targeted via the audience filter, so the consensus impact is small. Mempool transaction fan-out is now global (≈N× on the bulk workload for N shard groups); this is acceptable at the current network size and should be revisited (re-sharded gossip or a content-addressed relay) before scaling the number of shard groups.

## Testing
- `cargo nextest run -p consensus_tests` — 60/60 pass, including `foreign_block_distribution`, multishard, epoch-change, and leader-failure suites.
- `cargo check --workspace` clean; `cargo nextest run -p tari_validator_node -p tari_networking` pass.
- Formatted with `cargo +nightly-2025-06-25 fmt --all`.