### PR TITLE
fix(consensus): recover from consensus liveness loss after node/epoch recovery

### DIFF
--- a/crates/consensus/src/hotstuff/on_receive_local_proposal.rs
+++ b/crates/consensus/src/hotstuff/on_receive_local_proposal.rs
@@ -162,12 +162,37 @@ impl<TConsensusSpec: ConsensusSpec> OnReceiveLocalProposalHandler<TConsensusSpec
             foreign_proposals,
         } = msg;
 
-        let maybe_valid_block = self.store.with_read_tx(|tx| {
+        // Idempotent view advancement for already-processed blocks.
+        //
+        // Normally a block we have already stored is a no-op: the validate/process path below is
+        // skipped, and so is the `enter_view` it would have performed. That is correct in steady
+        // state, but it is unsafe after a non-monotonic catch-up view reset
+        // (`request_catch_up_sync`), which can move the pacemaker view *below* a block we have
+        // already stored. In that state every re-delivery of the bridging block (via catch-up or
+        // gossip) is deduplicated here without advancing the view, so the view can never climb back
+        // to the stored tip: the node buffers all higher proposals as "future" and re-requests
+        // catch-up forever. Making the re-entry idempotent — advancing to the view the stored block
+        // justifies — lets the node recover. `enter_view` is monotonic, so this never rewinds.
+        let already_processed = self.store.with_read_tx(|tx| {
             if Block::record_exists(tx, block.id())? {
-                info!(target: LOG_TARGET, "🧊 Block {} has already been processed", block);
-                return Ok(None);
+                Ok::<_, HotStuffError>(Some(Block::get(tx, block.id())?))
+            } else {
+                Ok(None)
             }
+        })?;
+        if let Some(existing) = already_processed {
+            info!(target: LOG_TARGET, "🧊 Block {} has already been processed", existing);
+            let justify_height = existing.justify().height();
+            let view_height = existing
+                .timeout_certificate()
+                .map_or(justify_height, |tc| tc.height().max(justify_height));
+            self.pacemaker
+                .enter_view(existing.epoch(), view_height, justify_height)
+                .await?;
+            return Ok(None);
+        }
 
+        let maybe_valid_block = self.store.with_read_tx(|tx| {
             self.validate_block(
                 tx,
                 epoch_state.epoch(),

--- a/crates/consensus/src/hotstuff/state_machine/syncing.rs
+++ b/crates/consensus/src/hotstuff/state_machine/syncing.rs
@@ -3,12 +3,15 @@
 
 use std::marker::PhantomData;
 
+use log::*;
 use tari_ootle_common_types::Epoch;
 
 use crate::{
     hotstuff::{ConsensusWorkerContext, HotStuffError, state_machine::event::ConsensusStateEvent},
     traits::{ConsensusSpec, SyncManager},
 };
+
+const LOG_TARGET: &str = "tari::ootle::consensus::sm::syncing";
 
 #[derive(Debug)]
 pub struct Syncing<TSpec> {
@@ -36,6 +39,17 @@ where
         context: &mut ConsensusWorkerContext<TSpec>,
     ) -> Result<ConsensusStateEvent, HotStuffError> {
         context.state_sync.sync(self.target_epoch).await?;
+
+        // State sync only rewrites the state store, not the consensus transaction pool. Drop any pool
+        // records so that on re-entering consensus we don't re-propose transactions the freshly-synced
+        // state has already finalised (the rest of the committee removed them on commit, so they can
+        // never gather a QC again — this wedges the network). Genuinely-pending transactions return via
+        // mempool gossip.
+        let cleared = context.hotstuff.clear_transaction_pool()?;
+        if cleared > 0 {
+            info!(target: LOG_TARGET, "🧹 Cleared {cleared} transaction(s) from the pool after state sync");
+        }
+
         Ok(ConsensusStateEvent::SyncComplete)
     }
 }

--- a/crates/consensus/src/hotstuff/worker.rs
+++ b/crates/consensus/src/hotstuff/worker.rs
@@ -1030,6 +1030,29 @@ impl<TConsensusSpec: ConsensusSpec> HotstuffWorker<TConsensusSpec> {
         Ok(())
     }
 
+    /// Remove all records from the transaction pool, returning the number removed.
+    ///
+    /// Called after a state sync. State sync only rewrites the state store, not the (persisted)
+    /// consensus transaction pool, so the pool can be left holding transactions the freshly-synced
+    /// state has already finalised. Re-proposing such a transaction breaks liveness: the rest of the
+    /// committee finalised and removed it, so it can never gather a QC again and every block carrying
+    /// it is rejected (`TransactionNotInPool`). Clearing lets the node rebuild its pool from fresh
+    /// mempool/consensus activity against the synced state.
+    // TODO: the transaction pool only holds pending (derived) state and should not be persisted at
+    //       all — that would remove this whole class of pool-vs-state-store divergence.
+    pub fn clear_transaction_pool(&self) -> Result<usize, HotStuffError> {
+        self.state_store.with_write_tx(|tx| {
+            let ids = self
+                .transaction_pool
+                .get_all(&**tx, usize::MAX)?
+                .iter()
+                .map(|rec| *rec.id())
+                .collect::<Vec<_>>();
+            let removed = self.transaction_pool.remove_all(tx, &ids)?;
+            Ok::<_, HotStuffError>(removed.len())
+        })
+    }
+
     async fn propose_now(
         &mut self,
         epoch_state: &EpochState<TConsensusSpec::Addr>,
@@ -1063,17 +1086,23 @@ impl<TConsensusSpec: ConsensusSpec> HotstuffWorker<TConsensusSpec> {
             return Ok(());
         }
 
-        // We use the highest seen block - specifically to handle the case where a block is proposed and locally
-        // accepted, however, for whatever reason, a new certificate could not be created for it. We still use
-        // it at the parent for this block, subsequent certificates will justify it.
+        // The parent of the next block must be a block every honest node provably shares: either the
+        // HighQC's justified block, or a deterministic dummy chain extending it. Building directly on
+        // `highest_block` is correct ONLY when it *is* the HighQC (the steady-state case): a block can
+        // be locally accepted without a certificate forming for it, and we still build on it so a
+        // subsequent QC justifies it. But when the highest seen block sits *above* the HighQC
+        // (`leaf > HighPC` — accepted locally yet never certified), we must NOT extend it on a recovery
+        // proposal. Validators reconstruct the post-timeout chain from the HighQC carried in our
+        // proposal and would reject a real parent at the gap height as "does not extend justify",
+        // forking the committee. So on a timeout (or a height gap) we anchor on the HighQC and fill the
+        // gap with dummy blocks instead — exactly what validators recompute.
         let highest_block = self
             .state_store
             .with_read_tx(|tx| HighestSeenBlock::get(tx, epoch_state.epoch()))?;
 
-        // If there are timeout "gaps", we need to fill them in with dummy blocks
         let mut dummy_block = None;
         let mut propose_high_tc = None;
-        if next_height > highest_block.height + NodeHeight(1) {
+        if is_timeout || next_height > highest_block.height + NodeHeight(1) {
             let (high_qc, high_tc, justify_block) = self.state_store.with_read_tx(|tx| {
                 let high_qc = HighPc::get(tx, epoch_state.epoch())?;
                 let high_qc = ProposalCertificate::get(tx, high_qc.epoch(), high_qc.id())?;
@@ -1087,40 +1116,36 @@ impl<TConsensusSpec: ConsensusSpec> HotstuffWorker<TConsensusSpec> {
 
             propose_high_tc = high_tc;
 
-            info!(
-                target: LOG_TARGET,
-                "⚠️ Leader Failure: Next height is {next_height} but the highest block is {highest_block}. Proposing with dummy blocks to fill the gap.",
-            );
+            // Fill [justify_block.height + 1, next_height - 1] with dummy blocks anchored on the HighQC,
+            // so our parent matches what every validator deterministically recomputes from the QC. When
+            // next_height == justify_block.height + 1 there is no gap: the parent is the HighQC block
+            // itself, which in that case is also the highest seen block, so on_propose's fallback to
+            // highest_block is correct.
+            if next_height > justify_block.height() + NodeHeight(1) {
+                info!(
+                    target: LOG_TARGET,
+                    "⚠️ Leader Failure: proposing at {next_height} anchored on HighQC (height {}); highest seen is {highest_block}. Filling the gap with dummy blocks.",
+                    justify_block.height(),
+                );
 
-            if let Some(dummy) = calculate_last_dummy_block(
-                justify_block.height(),
-                next_height,
-                self.config.network,
-                epoch_state.epoch(),
-                justify_block.shard_group(),
-                *justify_block.id(),
-                &high_qc,
-                *justify_block.state_merkle_root(),
-                &self.leader_strategy,
-                epoch_state.local_committee(),
-                justify_block.timestamp(),
-                *justify_block.header().accumulated_data(),
-                *justify_block.epoch_hash(),
-            ) {
-                dummy_block = Some(dummy);
+                if let Some(dummy) = calculate_last_dummy_block(
+                    justify_block.height(),
+                    next_height,
+                    self.config.network,
+                    epoch_state.epoch(),
+                    justify_block.shard_group(),
+                    *justify_block.id(),
+                    &high_qc,
+                    *justify_block.state_merkle_root(),
+                    &self.leader_strategy,
+                    epoch_state.local_committee(),
+                    justify_block.timestamp(),
+                    *justify_block.header().accumulated_data(),
+                    *justify_block.epoch_hash(),
+                ) {
+                    dummy_block = Some(dummy);
+                }
             }
-        } else if is_timeout {
-            // If this is a timeout (without dummies because the highest block is the parent), we need to propose with
-            // the highest timeout certificate
-            let high_tc = self.state_store.with_read_tx(|tx| {
-                let high_tc = HighTc::get(tx, epoch_state.epoch()).optional()?;
-                high_tc
-                    .map(|tc| TimeoutCertificate::get(tx, tc.epoch(), tc.id()))
-                    .transpose()
-            })?;
-            propose_high_tc = high_tc;
-        } else {
-            // Nothing to do
         }
 
         if propose_epoch_end {

--- a/crates/consensus_tests/src/catch_up_rewind.rs
+++ b/crates/consensus_tests/src/catch_up_rewind.rs
@@ -1,0 +1,247 @@
+//   Copyright 2026 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+//! Regression test: catch-up view-rewind deadlock.
+//!
+//! A node can hold a **stored** block above its highest certified block (`HighestSeenBlock >
+//! HighPC`) — this is the normal consequence of a timeout gap: after votes for a height are lost,
+//! the next leader proposes a recovery block carrying the older HighQC plus a TC, so every node
+//! stores that block (and the dummy fillers beneath it) while its HighPC stays back at the last
+//! certified height.
+//!
+//! When such a node then suffers three consecutive leader failures, `request_catch_up_sync`
+//! rewinds the pacemaker view *down* to the HighPC height — i.e. **below blocks it has already
+//! stored**. Catch-up re-delivers those blocks as ordinary `Proposal` messages, but the receiver
+//! dedups them (`record_exists` -> "already processed") and returns without advancing the view.
+//! The view can therefore never climb back to the stored tip: every higher proposal is buffered as
+//! "future", every catch-up round re-rewinds to the same height, and the node is wedged forever
+//! while the rest of the committee runs on.
+//!
+//! Reproduction: let the target fully catch up, induce a single timeout gap right at its tip so it
+//! stores a recovery block above its HighPC, freeze it there (partition) until it suffers the
+//! rewind, then restore connectivity. Recovery is asserted on the target's HighPC climbing back to
+//! the network tip — not merely on the batch committing, since those transactions finalise before
+//! the freeze and a wedged node would still report them committed while its HighPC stays pinned at
+//! the rewind height forever. Without the fix the target wedges exactly so; with it, it re-joins.
+
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering},
+    },
+    time::Duration,
+};
+
+use tari_consensus::messages::HotstuffMessage;
+use tari_consensus_types::{Decision, HighPc, HighestSeenBlock};
+use tari_ootle_common_types::{Epoch, NodeHeight};
+use tari_ootle_storage::{StateStore, consensus_models::BookkeepingModel};
+
+use crate::support::{Test, TestAddress, TestVnDestination, logging::setup_logger};
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn catch_up_rewind_below_leaf_recovers() {
+    setup_logger();
+
+    let votes_dropped = Arc::new(AtomicUsize::new(0));
+    // First height of the three-height vote-drop window that manufactures one timeout gap. 0 until
+    // the loop arms it (once the target is fully caught up).
+    let gap_at = Arc::new(AtomicU64::new(0));
+    // Set by the filter when it has delivered the gap's recovery block to the target and partitioned
+    // it; the target now holds a stored tip above its HighPC.
+    let frozen = Arc::new(AtomicBool::new(false));
+    // While true, every message to the target is dropped, forcing the leader-failure → catch-up →
+    // view-rewind cascade.
+    let partition = Arc::new(AtomicBool::new(false));
+
+    let target = TestAddress::new("2");
+
+    let votes_dropped_f = votes_dropped.clone();
+    let gap_at_f = gap_at.clone();
+    let frozen_f = frozen.clone();
+    let partition_f = partition.clone();
+    let target_f = target.clone();
+
+    let mut test = Test::builder()
+        .with_test_timeout(Duration::from_secs(240))
+        .modify_consensus_constants(|c| {
+            // Tight pacemaker so the three leader failures (and the rewind) happen quickly.
+            c.pacemaker_block_time = Duration::from_secs(2);
+            // The whole point is recovery — never evict the isolated node for missed proposals.
+            c.missed_proposal_suspend_threshold = 50;
+            c.missed_proposal_evict_threshold = 50;
+        })
+        .modify_config(|config| {
+            config.enable_eviction_proposal = false;
+        })
+        .with_message_filter(Box::new(move |_from, to, msg| {
+            let gap = gap_at_f.load(Ordering::SeqCst);
+
+            // (1) Manufacture a single timeout gap at the armed height (drop a small window of
+            // consecutive heights so the gap reliably forms).
+            if gap != 0 &&
+                let HotstuffMessage::Vote(v) = msg
+            {
+                let h = v.vote.block_height.as_u64();
+                if h >= gap && h <= gap + 6 {
+                    votes_dropped_f.fetch_add(1, Ordering::SeqCst);
+                    return false;
+                }
+            }
+
+            if *to != target_f {
+                return true;
+            }
+
+            // Already partitioned: drop everything to the target.
+            if partition_f.load(Ordering::SeqCst) {
+                return false;
+            }
+
+            // (2) Freeze the target on the gap's recovery block: a proposal carrying a TC whose
+            // justify sits more than one height below it (a dummy gap). The target is caught up, so
+            // it applies the block immediately — leaving a stored tip above its HighPC — and we
+            // partition it there.
+            if gap != 0 &&
+                !frozen_f.load(Ordering::SeqCst) &&
+                let HotstuffMessage::Proposal(p) = msg &&
+                p.block.timeout_certificate().is_some() &&
+                p.block.justify().height() + NodeHeight(1) < p.block.height()
+            {
+                frozen_f.store(true, Ordering::SeqCst);
+                partition_f.store(true, Ordering::SeqCst);
+                return true;
+            }
+
+            true
+        }))
+        .add_committee(0, vec!["1", "2", "3", "4"])
+        .start()
+        .await;
+
+    // A batch of transactions the committee must finalise. The online quorum (3 of 4) will commit
+    // them while the target is isolated; the target must catch up and commit them too.
+    let mut tx_ids = Vec::new();
+    for _ in 0..5 {
+        let (tx, _, _) = test.send_transaction_to_all(Decision::Commit, 1, 2, 1).await;
+        tx_ids.push(*tx.id());
+    }
+
+    test.start_epoch(Epoch(1)).await;
+
+    enum Phase {
+        Warmup,
+        Armed,
+        Frozen { froze_at: NodeHeight },
+        Lifted,
+    }
+    let mut phase = Phase::Warmup;
+    // Highest height committed anywhere in the committee. `on_block_committed` fires per-node, so a
+    // single event's height can dip (e.g. the target committing an early block as it recovers); we
+    // track the running max for the network's true progress.
+    let mut network_max = NodeHeight::zero();
+    loop {
+        let (_, _, _, committed_height) = test.on_block_committed().await;
+        network_max = network_max.max(committed_height);
+
+        let seen = target_highest_seen(&test, &target);
+        let high_pc = target_high_pc(&test, &target);
+
+        match &phase {
+            // Wait for the chain to get going and the target to be fully caught up, then arm a gap a
+            // couple of heights ahead — right at the target's tip, where it can apply the recovery
+            // block immediately.
+            Phase::Warmup => {
+                if network_max >= NodeHeight(8) && high_pc + NodeHeight(3) >= network_max {
+                    let arm = network_max + NodeHeight(2);
+                    gap_at.store(arm.as_u64(), Ordering::SeqCst);
+                    log::info!("🎯 Arming timeout gap at height {arm} (target caught up at HighPC {high_pc})");
+                    phase = Phase::Armed;
+                }
+            },
+            // The filter froze & partitioned the target on the recovery block; confirm it holds a
+            // stored tip above its HighPC.
+            Phase::Armed => {
+                if frozen.load(Ordering::SeqCst) && seen >= high_pc + NodeHeight(2) {
+                    log::info!(
+                        "❄️ Froze {target} on gap tip: HighestSeen {seen} >= HighPC {high_pc} + 2 (network height \
+                         {network_max})"
+                    );
+                    phase = Phase::Frozen { froze_at: network_max };
+                }
+            },
+            // Give the partitioned target time for three leader failures + the catch-up rewind, then
+            // restore connectivity and require it to re-join. The window must be long enough for the
+            // target to hit its *third* consecutive leader timeout, which is what triggers the
+            // `request_catch_up_sync` view-rewind.
+            Phase::Frozen { froze_at } => {
+                if network_max >= *froze_at + NodeHeight(18) {
+                    assert!(
+                        seen > high_pc,
+                        "test premise: frozen target should hold a stored tip ({seen}) above HighPC ({high_pc})"
+                    );
+                    log::info!(
+                        "🔌 Restoring {target} at network height {network_max} (HighestSeen {seen}, HighPC {high_pc})"
+                    );
+                    partition.store(false, Ordering::SeqCst);
+                    phase = Phase::Lifted;
+                }
+            },
+            // Success requires *genuine* recovery: the target's HighPC must climb back up to the
+            // network tip. (Checking only that the batch is committed is not enough — those
+            // transactions are finalised early, before the freeze, so a wedged target would still
+            // report them committed.) A node stuck in the catch-up rewind keeps its HighPC pinned at
+            // the rewind height forever, so this is exactly what the bug breaks.
+            Phase::Lifted => {
+                let committed = tx_ids
+                    .iter()
+                    .all(|id| test.get_validator(&target).has_committed_substates(id));
+                if committed && high_pc + NodeHeight(4) >= network_max {
+                    log::info!("✅ {target} recovered: HighPC {high_pc} caught up to network height {network_max}");
+                    break;
+                }
+            },
+        }
+
+        if network_max > NodeHeight(70) {
+            let reached = match phase {
+                Phase::Warmup => "Warmup (never armed)",
+                Phase::Armed => "Armed (gap never froze the target)",
+                Phase::Frozen { .. } => "Frozen (never lifted)",
+                Phase::Lifted => "Lifted (restored but stayed wedged — HighPC pinned at the rewind height)",
+            };
+            panic!(
+                "{target} failed to re-join consensus after connectivity was restored (network height {network_max}, \
+                 target HighestSeen {seen}, target HighPC {high_pc}, phase {reached}, votes_dropped={}). This is the \
+                 catch-up view-rewind deadlock.",
+                votes_dropped.load(Ordering::SeqCst),
+            );
+        }
+    }
+
+    assert!(
+        votes_dropped.load(Ordering::SeqCst) > 0,
+        "test premise: votes at the gap height must have been dropped"
+    );
+
+    // Everyone — including the recovered target — finalises the batch.
+    test.wait_for_pool_count(TestVnDestination::All, 0).await;
+    test.stop();
+    test.assert_clean_shutdown().await;
+}
+
+fn target_high_pc(test: &Test, target: &TestAddress) -> NodeHeight {
+    test.get_validator(target)
+        .state_store()
+        .with_read_tx(|tx| HighPc::get(tx, Epoch(1)))
+        .map(|h| h.height())
+        .unwrap_or_else(|_| NodeHeight::zero())
+}
+
+fn target_highest_seen(test: &Test, target: &TestAddress) -> NodeHeight {
+    test.get_validator(target)
+        .state_store()
+        .with_read_tx(|tx| HighestSeenBlock::get(tx, Epoch(1)))
+        .map(|h| h.height())
+        .unwrap_or_else(|_| NodeHeight::zero())
+}

--- a/crates/consensus_tests/src/catch_up_rewind.rs
+++ b/crates/consensus_tests/src/catch_up_rewind.rs
@@ -39,6 +39,7 @@ use tari_ootle_storage::{StateStore, consensus_models::BookkeepingModel};
 
 use crate::support::{Test, TestAddress, TestVnDestination, logging::setup_logger};
 
+#[expect(clippy::too_many_lines)]
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn catch_up_rewind_below_leaf_recovers() {
     setup_logger();

--- a/crates/consensus_tests/src/catch_up_rewind.rs
+++ b/crates/consensus_tests/src/catch_up_rewind.rs
@@ -235,7 +235,7 @@ fn target_high_pc(test: &Test, target: &TestAddress) -> NodeHeight {
         .state_store()
         .with_read_tx(|tx| HighPc::get(tx, Epoch(1)))
         .map(|h| h.height())
-        .unwrap_or_else(|_| NodeHeight::zero())
+        .expect("Failed to retrieve HighPc from state store")
 }
 
 fn target_highest_seen(test: &Test, target: &TestAddress) -> NodeHeight {
@@ -243,5 +243,5 @@ fn target_highest_seen(test: &Test, target: &TestAddress) -> NodeHeight {
         .state_store()
         .with_read_tx(|tx| HighestSeenBlock::get(tx, Epoch(1)))
         .map(|h| h.height())
-        .unwrap_or_else(|_| NodeHeight::zero())
+        .expect("Failed to retrieve HighestSeenBlock from state store")
 }

--- a/crates/consensus_tests/src/dummy_blocks.rs
+++ b/crates/consensus_tests/src/dummy_blocks.rs
@@ -357,3 +357,126 @@ fn proposer_accumulated_data_must_come_from_justify_on_timeout_recovery() {
         "regression: initialising candidate from highest_seen would not match validators"
     );
 }
+
+/// Regression test for the proposer-side of the leader-failure recovery fork (defect B).
+///
+/// After a timeout, the next leader's proposal must extend a block the whole committee
+/// deterministically agrees on: the HighQC's justified block, or a dummy chain extending it.
+/// Validators reconstruct exactly that chain from the HighQC carried in the candidate
+/// (`calculate_dummy_blocks_from_justify`) and require the candidate's parent to equal the last
+/// dummy. When the leader's `HighestSeenBlock` is an *uncertified* real block sitting above the
+/// HighQC (`leaf > HighPC` — accepted locally but never QC'd, e.g. a re-proposed
+/// already-committed transaction whose votes the rest of the committee withholds), the proposer
+/// must NOT extend that real block. Its id differs from the dummy every validator recomputes, so
+/// the proposal is rejected as `CandidateBlockDoesNotExtendJustify` and the committee forks on
+/// every timeout round. The fix anchors the proposer on the HighQC (via `justify_block.height()`),
+/// so its parent matches the validators' reconstruction.
+#[test]
+fn proposer_must_anchor_recovery_on_justify_not_uncertified_leaf() {
+    let shard_group = ShardGroup::all_shards(NumPreshards::P256);
+    let epoch = Epoch(8516);
+    let committee: Committee<PeerAddress> = (0u8..4)
+        .map(create_key_pair_from_seed)
+        .map(|(_, pk)| CommitteeMember {
+            address: PeerAddress::derive_from_public_key(&pk),
+            public_key: pk.to_byte_type(),
+            vote_power: VotePower::of(1),
+        })
+        .collect();
+
+    let genesis = Block::genesis(
+        Network::LocalNet,
+        epoch,
+        FixedHash::zero(),
+        shard_group,
+        FixedHash::zero(),
+        None,
+    );
+
+    let make_block = |parent, height, timestamp| {
+        let header = BlockHeader::create_unsigned(
+            Network::LocalNet,
+            parent,
+            genesis.justify().calculate_id(),
+            height,
+            epoch,
+            shard_group,
+            committee.shuffled().next().unwrap().public_key,
+            FixedHash::zero(),
+            &BTreeSet::new(),
+            0,
+            timestamp,
+            FixedHash::zero(),
+            ShardGroupAccumulatedData::default(),
+            ExtraData::new(),
+        )
+        .unwrap();
+        Block::new(header, genesis.justify().clone(), BTreeSet::new(), None)
+    };
+
+    // The HighQC's justified block (HighPC), at height H.
+    let high_qc_height = NodeHeight(162);
+    let justify_block = make_block(*genesis.id(), high_qc_height, 0);
+    let gap_height = high_qc_height + NodeHeight(1);
+    // After a timeout at H+1, the leader proposes the recovery block at H+2 (one dummy to fill).
+    let candidate_height = high_qc_height + NodeHeight(2);
+
+    // The dummy chain every validator reconstructs from the HighQC. The last dummy (at H+1) is the
+    // parent the candidate must extend.
+    let validator_dummies = calculate_dummy_blocks(
+        justify_block.height(),
+        candidate_height,
+        Network::LocalNet,
+        epoch,
+        shard_group,
+        *justify_block.id(),
+        justify_block.justify(),
+        &BlockId::zero(), // no early short-circuit; we want the full chain
+        *justify_block.state_merkle_root(),
+        &RoundRobinLeaderStrategy,
+        &committee,
+        justify_block.timestamp(),
+        *justify_block.header().accumulated_data(),
+        *justify_block.epoch_hash(),
+    );
+    let expected_parent = validator_dummies.last().expect("a dummy block fills the H+1 gap");
+    assert_eq!(expected_parent.height(), gap_height);
+    assert!(expected_parent.is_dummy());
+
+    // The fix: the proposer anchors on the HighQC, producing the same last dummy as the validator.
+    let fixed_parent = calculate_last_dummy_block(
+        justify_block.height(),
+        candidate_height,
+        Network::LocalNet,
+        epoch,
+        shard_group,
+        *justify_block.id(),
+        justify_block.justify(),
+        *justify_block.state_merkle_root(),
+        &RoundRobinLeaderStrategy,
+        &committee,
+        justify_block.timestamp(),
+        *justify_block.header().accumulated_data(),
+        *justify_block.epoch_hash(),
+    )
+    .expect("a dummy block fills the H+1 gap");
+    assert_eq!(
+        fixed_parent.block_id(),
+        expected_parent.id(),
+        "fixed proposer (HighQC-anchored) parent must match the validator reconstruction"
+    );
+
+    // The buggy proposer extended its HighestSeenBlock instead: a block stored at the gap height that
+    // was accepted locally but never gathered a QC (in production, the signed re-proposal of an
+    // already-committed transaction). It is a distinct block from the reconstructed dummy.
+    let uncertified_leaf = make_block(*justify_block.id(), gap_height, 1);
+    assert_eq!(uncertified_leaf.height(), expected_parent.height());
+
+    // Defect B: that real leaf is NOT the dummy validators expect at the gap height, so extending it
+    // is rejected as `CandidateBlockDoesNotExtendJustify`, forking the committee on every timeout.
+    assert_ne!(
+        uncertified_leaf.id(),
+        expected_parent.id(),
+        "uncertified leaf diverges from the validators' reconstructed dummy — extending it forks the committee"
+    );
+}

--- a/crates/consensus_tests/src/lib.rs
+++ b/crates/consensus_tests/src/lib.rs
@@ -1,6 +1,8 @@
 //   Copyright 2023 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 #[cfg(test)]
+mod catch_up_rewind;
+#[cfg(test)]
 mod consensus;
 #[cfg(test)]
 mod dummy_blocks;


### PR DESCRIPTION
## Description

Fixes a set of related consensus liveness bugs where a validator that fails and later recovers (via catch-up and/or state sync across an epoch change) could wedge the **whole committee** — block production limps forward on dummy/timeout blocks but no transaction ever finalises.

The incident that motivated this: a validator failed, recovered into a new epoch, and began perpetually re-proposing a transaction that the rest of the committee had already committed. Every such block was rejected, and the timeout-recovery path then forked the committee, so the network produced empty blocks indefinitely without committing anything.

## Root causes & fixes

**1. Catch-up view-rewind deadlock** (`2229d8fad`, from prior work on this branch)
A node holding a stored block above its high QC (`leaf > HighPC`, the normal result of a timeout gap) that then suffers three leader failures rewinds its pacemaker view *below* blocks it has already stored. Catch-up re-delivers those blocks, the receiver dedups them ("already processed") and never advances, so the view can never climb back to the leaf and the node is wedged forever. Recovery now re-joins instead of deadlocking.

**2. Stale transaction pool after state sync**
State sync only rewrites the **state store**, not the consensus **transaction pool**. A recovered node could keep pool entries for transactions the synced state has already finalised and re-propose them indefinitely. Because the rest of the committee finalised and removed those transactions, they can never gather a QC again (`TransactionNotInPool`) and every block carrying them is rejected. The transaction pool is now cleared when state sync completes; genuinely-pending transactions return via mempool gossip.

**3. Leader-failure recovery fork (proposer anchored on the wrong block)**
On a timeout, the proposer anchored the recovery block on its highest-seen block. When that block is uncertified and above the high QC (`leaf > HighPC`), validators deterministically reconstruct a dummy chain from the high QC and reject the proposer's real parent as `CandidateBlockDoesNotExtendJustify`, forking the committee on every timeout round. The proposer now anchors recovery on the high QC, so its parent matches the validators' reconstruction. This is the same `leaf > HighPC` condition as (1), in the proposer path.

## Tests

- New deterministic regression test `proposer_must_anchor_recovery_on_justify_not_uncertified_leaf` (proposer-anchor fix).
- New `catch_up_rewind_below_leaf_recovers` integration test (rewind deadlock).
- Existing `dummy_blocks`, `leader_failure`, and `catch_up_rewind` suites pass; full `consensus_tests` suite green (62 passed, 0 failed).

## Notes

- The pool clear is the pragmatic fix; the transaction pool only holds pending (derived) state and ideally should not be persisted at all — a follow-up (`TODO` noted in `clear_transaction_pool`) can remove the persisted pool entirely and delete this class of pool-vs-state-store divergence.