### PR TITLE
fix(consensus): import catch-up blocks via a dedicated message, drop non-monotonic view rewind

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1708,7 +1708,7 @@ dependencies = [
 
 [[package]]
 name = "consensus_tests"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "fern",
  "futures 0.3.31",
@@ -2713,7 +2713,7 @@ dependencies = [
 
 [[package]]
 name = "db-inspector"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -5049,7 +5049,7 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "integration_tests"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "anyhow",
  "config",
@@ -5823,7 +5823,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-messaging"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "async-trait",
  "futures-bounded 0.2.4",
@@ -6001,7 +6001,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-substream"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "libp2p",
  "prometheus-client",
@@ -7610,7 +7610,7 @@ dependencies = [
 
 [[package]]
 name = "ootle-wasm"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "console_error_panic_hook",
  "getrandom 0.2.17",
@@ -7621,7 +7621,7 @@ dependencies = [
 
 [[package]]
 name = "ootle-wasm-core"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "base64 0.22.1",
  "hex",
@@ -8641,7 +8641,7 @@ dependencies = [
 
 [[package]]
 name = "proto_builder"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "prost-build 0.14.3",
  "sha2 0.10.9",
@@ -10506,7 +10506,7 @@ dependencies = [
 
 [[package]]
 name = "sqlite_message_logger"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "chrono",
  "diesel",
@@ -10878,7 +10878,7 @@ dependencies = [
 
 [[package]]
 name = "tari_base_node_client"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "futures-util",
  "log",
@@ -11104,7 +11104,7 @@ dependencies = [
 
 [[package]]
 name = "tari_consensus"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "anyhow",
  "indexmap 2.13.0",
@@ -11129,7 +11129,7 @@ dependencies = [
 
 [[package]]
 name = "tari_consensus_types"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "borsh",
  "minicbor",
@@ -11231,7 +11231,7 @@ dependencies = [
 
 [[package]]
 name = "tari_engine"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "blake2 0.10.6",
  "bytes",
@@ -11263,7 +11263,7 @@ dependencies = [
 
 [[package]]
 name = "tari_engine_types"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "blake2 0.10.6",
  "borsh",
@@ -11292,7 +11292,7 @@ dependencies = [
 
 [[package]]
 name = "tari_epoch_manager"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "anyhow",
  "log",
@@ -11312,7 +11312,7 @@ dependencies = [
 
 [[package]]
 name = "tari_epoch_oracles"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "anyhow",
  "blake2 0.10.6",
@@ -11368,7 +11368,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -11469,7 +11469,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer_lib"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "log",
  "minicbor",
@@ -11582,7 +11582,7 @@ dependencies = [
 
 [[package]]
 name = "tari_networking"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11635,7 +11635,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_app_utilities"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -11676,7 +11676,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_common_types"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "blake2 0.10.6",
  "borsh",
@@ -11705,7 +11705,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_p2p"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "anyhow",
  "libp2p-identity 0.2.14",
@@ -11729,7 +11729,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_storage"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "anyhow",
  "bitflags 2.10.0",
@@ -11758,7 +11758,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_storage_sqlite"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "diesel",
  "diesel_migrations",
@@ -11811,7 +11811,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_transaction"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "borsh",
  "hex",
@@ -11837,7 +11837,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_cli"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -11959,7 +11959,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_sdk_tests"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "digest 0.10.7",
  "ootle_byte_type",
@@ -12005,7 +12005,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_walletd"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12126,7 +12126,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_framework"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "async-trait",
  "bitflags 2.10.0",
@@ -12150,7 +12150,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_macros"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12159,7 +12159,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_state_sync"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -12237,7 +12237,7 @@ dependencies = [
 
 [[package]]
 name = "tari_state_store_rocksdb"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12269,7 +12269,7 @@ dependencies = [
 
 [[package]]
 name = "tari_state_tree"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "indexmap 2.13.0",
  "log",
@@ -12297,7 +12297,7 @@ dependencies = [
 
 [[package]]
 name = "tari_swarm"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "libp2p",
  "libp2p-messaging",
@@ -12309,7 +12309,7 @@ dependencies = [
 
 [[package]]
 name = "tari_swarm_daemon"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12422,7 +12422,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_test_tooling"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "anyhow",
  "cargo_toml 0.22.3",
@@ -12535,7 +12535,7 @@ dependencies = [
 
 [[package]]
 name = "tari_transaction_manifest"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "proc-macro2",
  "serde_json",
@@ -12570,7 +12570,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -12635,7 +12635,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node_client"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "indexmap 2.13.0",
  "multiaddr 0.18.3",
@@ -12659,7 +12659,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node_rpc"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -12683,7 +12683,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_rollback"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12718,7 +12718,7 @@ dependencies = [
 
 [[package]]
 name = "tari_watcher"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "anyhow",
  "clap 3.2.25",
@@ -12747,7 +12747,7 @@ dependencies = [
 
 [[package]]
 name = "tariswap_bench"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "anyhow",
  "clap 4.5.54",
@@ -13427,7 +13427,7 @@ dependencies = [
 
 [[package]]
 name = "traffic-sim"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "anyhow",
  "clap 4.5.54",
@@ -13449,7 +13449,7 @@ dependencies = [
 
 [[package]]
 name = "transaction_generator"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "anyhow",
  "bytes",
@@ -13468,7 +13468,7 @@ dependencies = [
 
 [[package]]
 name = "transaction_submitter"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "anyhow",
  "clap 4.5.54",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.33.2"
+version = "0.33.3"
 edition = "2024"
 authors = ["The Tari Development Community"]
 repository = "https://github.com/tari-project/tari-ootle"

--- a/crates/consensus/src/hotstuff/on_catch_up_sync.rs
+++ b/crates/consensus/src/hotstuff/on_catch_up_sync.rs
@@ -42,10 +42,6 @@ impl<TConsensusSpec: ConsensusSpec> OnCatchUpSync<TConsensusSpec> {
             NodeHeight(1)
         };
 
-        // Reset leader timeout to previous height since we're behind and need to process catch up blocks. This is the
-        // only case where the view is non-monotonic.
-        self.pacemaker.reset_view(epoch, block_height, block_height).await?;
-
         info!(
             target: LOG_TARGET,
             "⏰ Catch up required from block {}/{} from {} (current view: {})",

--- a/crates/consensus/src/hotstuff/on_catch_up_sync_request.rs
+++ b/crates/consensus/src/hotstuff/on_catch_up_sync_request.rs
@@ -162,7 +162,7 @@ impl<TConsensusSpec: ConsensusSpec> OnSyncRequest<TConsensusSpec> {
                     if let Err(err) = outbound_messaging
                         .send(
                             from.clone(),
-                            HotstuffMessage::new_proposal(ProposalMessage {
+                            HotstuffMessage::new_catch_up_sync_response(ProposalMessage {
                                 block,
                                 foreign_proposals: foreign_proposals.into_iter().map(|p| p.into_proposal()).collect(),
                             }),

--- a/crates/consensus/src/hotstuff/on_inbound_message.rs
+++ b/crates/consensus/src/hotstuff/on_inbound_message.rs
@@ -490,5 +490,11 @@ fn msg_relative_view(
             }
             MessageRelativeView::Current
         },
+        // Catch-up responses are an ordered block import, not live consensus. They are deliberately
+        // exempt from the view filter: a node behind on blocks must ingest them regardless of where
+        // its current view sits (above OR below the imported heights). Ordering is preserved by the
+        // sender (FIFO, height order) and the request/response loop, and each imported block advances
+        // the view monotonically, so they are never buffered or dropped here.
+        HotstuffMessage::CatchUpSyncResponse(_) => MessageRelativeView::Current,
     }
 }

--- a/crates/consensus/src/hotstuff/on_message_validate.rs
+++ b/crates/consensus/src/hotstuff/on_message_validate.rs
@@ -96,6 +96,17 @@ impl<TConsensusSpec: ConsensusSpec> OnMessageValidate<TConsensusSpec> {
                 }
                 self.process_local_proposal(current_height, from, epoch_state, *msg)
             },
+            HotstuffMessage::CatchUpSyncResponse(msg) => {
+                if !epoch_state.local_committee().contains(&from) {
+                    warn!(
+                        target: LOG_TARGET,
+                        "❌ Received catch-up response from non-committee member {}. Discarding message.",
+                        from
+                    );
+                    return Ok(MessageValidationResult::Discard);
+                }
+                self.process_catch_up_response(from, epoch_state, *msg)
+            },
             HotstuffMessage::ForeignProposal(proposal) => {
                 self.process_foreign_proposal(epoch_state, from, proposal).await
             },
@@ -185,6 +196,55 @@ impl<TConsensusSpec: ConsensusSpec> OnMessageValidate<TConsensusSpec> {
         }
 
         self.handle_missing_transactions_local_block(from, epoch_state.local_committee_info(), proposal)
+    }
+
+    /// Validate a block delivered via catch-up sync. This is an ordered block import, so — unlike
+    /// [`Self::process_local_proposal`] — it is intentionally NOT gated on the current view height:
+    /// a node whose view has advanced beyond its stored blocks must still ingest the gap. Stateless
+    /// validation and missing-transaction parking are identical to the live-proposal path.
+    fn process_catch_up_response(
+        &mut self,
+        from: TConsensusSpec::Addr,
+        epoch_state: &EpochState<TConsensusSpec::Addr>,
+        proposal: ProposalMessage,
+    ) -> Result<MessageValidationResult<TConsensusSpec::Addr>, HotStuffError> {
+        info!(
+            target: LOG_TARGET,
+            "🌐 new unvalidated CATCH-UP block {} from {}",
+            proposal.block,
+            from,
+        );
+
+        if let Err(err) = self.check_local_proposal(&proposal.block, epoch_state) {
+            return Ok(MessageValidationResult::Invalid {
+                from,
+                message: HotstuffMessage::new_catch_up_sync_response(proposal),
+                err,
+            });
+        }
+
+        let missing_tx_ids = self.store.with_write_tx(|tx| {
+            self.check_for_missing_transactions(tx, epoch_state.local_committee_info(), &proposal)
+        })?;
+
+        if missing_tx_ids.is_empty() {
+            return Ok(MessageValidationResult::Ready {
+                from,
+                message: HotstuffMessage::new_catch_up_sync_response(proposal),
+            });
+        }
+
+        self.publish_event(HotstuffEvent::ProposedBlockParked {
+            block: proposal.block.as_leaf(),
+            num_missing_txs: missing_tx_ids.len(),
+            num_awaiting_txs: 0,
+        });
+
+        Ok(MessageValidationResult::ParkedProposal {
+            block_id: *proposal.block.id(),
+            epoch: proposal.block.epoch(),
+            missing_txs: missing_tx_ids,
+        })
     }
 
     pub fn update_parked_blocks<'a, I: IntoIterator<Item = &'a TransactionId> + ExactSizeIterator>(

--- a/crates/consensus/src/hotstuff/pacemaker_handle.rs
+++ b/crates/consensus/src/hotstuff/pacemaker_handle.rs
@@ -153,19 +153,6 @@ impl PaceMakerHandle {
             .map_err(|e| HotStuffError::PacemakerChannelDropped { details: e.to_string() })
     }
 
-    /// Reset the leader timeout and set the view. In general, should not be used. This is used to reverse the view when
-    /// catching up (TODO: confirm is this is correct or if there is another way).
-    pub async fn reset_view(
-        &self,
-        epoch: Epoch,
-        last_seen_height: NodeHeight,
-        high_pc_height: NodeHeight,
-    ) -> Result<(), HotStuffError> {
-        // Update current height here to prevent possibility of race conditions
-        self.current_view.reset(epoch, last_seen_height);
-        self.reset(high_pc_height).await
-    }
-
     /// Reset the leader timeout. This should be called when an end of epoch proposal has been committed.
     pub async fn set_epoch(&self, epoch: Epoch) -> Result<(), HotStuffError> {
         self.current_view.reset(epoch, NodeHeight::zero());

--- a/crates/consensus/src/hotstuff/worker.rs
+++ b/crates/consensus/src/hotstuff/worker.rs
@@ -1226,6 +1226,13 @@ impl<TConsensusSpec: ConsensusSpec> HotstuffWorker<TConsensusSpec> {
                 self.on_sync_request.handle(from, epoch_state.epoch(), msg);
                 Ok(())
             },
+            // Catch-up blocks reach here already past the view filter (see `msg_relative_view`) and
+            // are processed by the same block-import path as live proposals; `on_proposal_message`
+            // also drives the catch-up re-request loop.
+            HotstuffMessage::CatchUpSyncResponse(msg) => log_err(
+                "on_receive_catch_up_sync_response",
+                self.on_proposal_message(epoch_state, current_height, *msg).await,
+            ),
         }
     }
 

--- a/crates/consensus/src/messages/message.rs
+++ b/crates/consensus/src/messages/message.rs
@@ -38,11 +38,19 @@ pub enum HotstuffMessage {
     MissingTransactionsResponse(MissingTransactionsResponse),
     /// Request to send blocks from a given height
     CatchUpSyncRequest(CatchUpRequestMessage),
+    /// A block delivered in response to a catch-up sync request. Unlike a [`HotstuffMessage::Proposal`],
+    /// this is an ordered block import: it is not subject to the live-consensus view filter and is
+    /// processed regardless of the current view.
+    CatchUpSyncResponse(Box<ProposalMessage>),
 }
 
 impl HotstuffMessage {
     pub fn new_proposal(message: ProposalMessage) -> Self {
         Self::Proposal(Box::new(message))
+    }
+
+    pub fn new_catch_up_sync_response(message: ProposalMessage) -> Self {
+        Self::CatchUpSyncResponse(Box::new(message))
     }
 
     pub fn new_newview(message: NewViewMessage) -> Self {
@@ -60,6 +68,7 @@ impl HotstuffMessage {
             Self::MissingTransactionsRequest(_) => "MissingTransactionsRequest",
             Self::MissingTransactionsResponse(_) => "MissingTransactionsResponse",
             Self::CatchUpSyncRequest(_) => "CatchUpSyncRequest",
+            Self::CatchUpSyncResponse(_) => "CatchUpSyncResponse",
         }
     }
 
@@ -74,6 +83,7 @@ impl HotstuffMessage {
             Self::MissingTransactionsRequest(msg) => msg.epoch,
             Self::MissingTransactionsResponse(msg) => msg.epoch,
             Self::CatchUpSyncRequest(msg) => msg.epoch,
+            Self::CatchUpSyncResponse(msg) => msg.block.epoch(),
         }
     }
 
@@ -143,6 +153,17 @@ impl Display for HotstuffMessage {
                 msg.epoch
             ),
             Self::CatchUpSyncRequest(msg) => write!(f, "SyncRequest({}/{})", msg.epoch, msg.block_height),
+            Self::CatchUpSyncResponse(msg) => {
+                write!(
+                    f,
+                    "CatchUpSyncResponse(Epoch={},Height={},QC={},TC={},#foreign={})",
+                    msg.block.epoch(),
+                    msg.block.height(),
+                    msg.block.justify().height(),
+                    msg.block.timeout_certificate().display(),
+                    msg.foreign_proposals.len()
+                )
+            },
         }
     }
 }

--- a/crates/p2p/proto/consensus.proto
+++ b/crates/p2p/proto/consensus.proto
@@ -19,6 +19,7 @@ message HotStuffMessage {
     MissingTransactionsRequest request_missing_transactions = 7;
     MissingTransactionsResponse requested_transaction = 8;
     SyncRequest sync_request = 9;
+    ProposalMessage catch_up_sync_response = 10;
   }
 }
 

--- a/crates/p2p/src/conversions/consensus.rs
+++ b/crates/p2p/src/conversions/consensus.rs
@@ -112,6 +112,9 @@ impl From<&HotstuffMessage> for proto::consensus::HotStuffMessage {
             HotstuffMessage::CatchUpSyncRequest(msg) => {
                 proto::consensus::hot_stuff_message::Message::SyncRequest(msg.into())
             },
+            HotstuffMessage::CatchUpSyncResponse(msg) => {
+                proto::consensus::hot_stuff_message::Message::CatchUpSyncResponse((&**msg).into())
+            },
         };
         Self { message: Some(message) }
     }
@@ -145,6 +148,9 @@ impl TryFrom<proto::consensus::HotStuffMessage> for HotstuffMessage {
             },
             proto::consensus::hot_stuff_message::Message::SyncRequest(msg) => {
                 HotstuffMessage::CatchUpSyncRequest(msg.try_into()?)
+            },
+            proto::consensus::hot_stuff_message::Message::CatchUpSyncResponse(msg) => {
+                HotstuffMessage::new_catch_up_sync_response(msg.try_into()?)
             },
         })
     }


### PR DESCRIPTION
## Description

Catch-up sync re-delivered gap blocks as ordinary `Proposal` messages, forcing them through the live-consensus view filter (`msg_relative_view` plus the `height < current` discard) and the `record_exists` dedup. To make those blocks pass the filter, `request_catch_up_sync` rewound the pacemaker view **down to HighPC** — the only non-monotonic view change in consensus. That rewind could move the view *below* blocks the node had already stored and wedge it in a catch-up loop: HighPC pinned, every higher proposal buffered as "future", the same rewind repeated each round.

This conflates a **bulk ordered block import** (which may re-deliver blocks we already have) with **live consensus message processing** (view-filtered, dedup-gated). This PR separates the two so the rewind is no longer needed, then removes it.

## What changed

- New `HotstuffMessage::CatchUpSyncResponse` carrying a single block; the catch-up server sends these instead of `Proposal` messages.
- The response **bypasses the view filter** (`msg_relative_view` → `Current`) and the `height < current` discard (a dedicated `process_catch_up_response` that still validates and parks on missing transactions), so a node behind on blocks ingests the gap regardless of its current view.
- Dispatch reuses `on_receive_local_proposal`, so catch-up blocks are validated, parked on missing transactions, processed, and **advance the view monotonically** via `enter_view`. The view ends at the import tip and never rewinds.
- The non-monotonic `PaceMakerHandle::reset_view` (its only caller was `request_catch_up_sync`) is removed.

Ordering is preserved by the sender (FIFO per peer, height order) and the existing request/response loop; each imported block advances the view, so responses are never buffered or dropped.

## Relationship to prior work

- Builds on #2195, which made view-entry idempotent on the `record_exists` path (the symptom-level fix). That safety net is **kept** and is still exercised when catch-up re-delivers already-stored blocks during recovery.
- Keeps #1813's case working: a node whose view is *ahead* of its stored blocks no longer drops catch-up blocks as "Past", because catch-up responses are not view-filtered.

## Testing

- `catch_up_rewind_below_leaf_recovers` regression test passes (recovery now proceeds via the new `CatchUpSyncResponse` import path; the frozen node's HighPC climbs back to the network tip).
- Full `consensus_tests --lib` suite: **62 passed, 0 failed**.
- `cargo build -p tari_consensus -p tari_ootle_p2p` and `cargo check -p tari_validator_node` clean.