### PR TITLE
fix(state-store): tolerate missing commit block in transaction_pool_get_all

### DIFF
--- a/crates/consensus/src/hotstuff/worker.rs
+++ b/crates/consensus/src/hotstuff/worker.rs
@@ -1042,13 +1042,9 @@ impl<TConsensusSpec: ConsensusSpec> HotstuffWorker<TConsensusSpec> {
     //       all — that would remove this whole class of pool-vs-state-store divergence.
     pub fn clear_transaction_pool(&self) -> Result<usize, HotStuffError> {
         self.state_store.with_write_tx(|tx| {
-            let ids = self
-                .transaction_pool
-                .get_all(&**tx, usize::MAX)?
-                .iter()
-                .map(|rec| *rec.id())
-                .collect::<Vec<_>>();
-            let removed = self.transaction_pool.remove_all(tx, &ids)?;
+            let recs = self.transaction_pool.get_all(&**tx, usize::MAX)?;
+            let ids = recs.iter().map(|rec| rec.id());
+            let removed = self.transaction_pool.remove_all(tx, ids)?;
             Ok::<_, HotStuffError>(removed.len())
         })
     }

--- a/crates/state_store_rocksdb/src/reader.rs
+++ b/crates/state_store_rocksdb/src/reader.rs
@@ -1205,19 +1205,22 @@ impl<'tx, TAddr: NodeAddressable + Serialize + DeserializeOwned + 'tx> StateStor
     }
 
     fn transaction_pool_get_all(&self, limit: usize) -> Result<Vec<TransactionPoolRecord>, StorageError> {
-        // TODO: Only used in tests
         const OPERATION: &str = "transaction_pool_get_all";
         let cf = self.db().cf(TransactionPoolCf)?;
 
-        let commit_block = self.get_commit_block()?;
-        let pending_chain = self.get_pending_chain_ordered(&commit_block.block_id)?;
-        let query = self.db().cf(transaction_pool_state_update::ByBlockIdQuery)?;
+        // A freshly state-synced node that has not yet entered consensus will not have a commit block (or pending
+        // chain) yet. Therefore, there are then no block-scoped pool updates to overlay — return the base
+        // records as-is rather than failing with NotFound.
         let mut updates = HashMap::new();
-        for block_id in pending_chain.into_iter().rev() {
-            let iter = query.query_prefix_range_iterator(Ordering::default(), &block_id);
-            for result in iter {
-                let ((_, tx_id), update) = result?;
-                updates.insert(tx_id, update);
+        if let Some(commit_block) = self.get_commit_block().optional()? {
+            let pending_chain = self.get_pending_chain_ordered(&commit_block.block_id)?;
+            let query = self.db().cf(transaction_pool_state_update::ByBlockIdQuery)?;
+            for block_id in pending_chain.into_iter().rev() {
+                let iter = query.query_prefix_range_iterator(Ordering::default(), &block_id);
+                for result in iter {
+                    let ((_, tx_id), update) = result?;
+                    updates.insert(tx_id, update);
+                }
             }
         }
 


### PR DESCRIPTION
## Description

Fixes the intermittent `@state_sync` cucumber scenario **"New validator node registers and syncs"** (the `Then the validator node VN2 has started epoch 4` step times out).

## Root cause

This is a real RocksDB state-store bug, not test flakiness.

A validator joining via state sync (VN2) gets stuck in the consensus `Syncing` state forever and never joins consensus:

1. VN2 activates correctly at the target epoch.
2. `CheckSync` routes it into `Syncing`. State sync itself **completes successfully** (often a no-op — the previous-epoch checkpoint reports no state changes).
3. Immediately after, `Syncing::on_enter` calls `clear_transaction_pool()` → `transaction_pool.get_all()` → RocksDB `transaction_pool_get_all`, which unconditionally calls `get_commit_block()`.
4. A freshly state-synced node has rewritten its state store but **has not yet entered consensus, so no `CommitBlock` has been written** (that happens when it creates its epoch genesis block, *after* `SyncComplete`). The read fails with `NotFound` (`Transaction pool error: Storage error: Not found: get_commit_block`).
5. `Syncing` fails on every retry → the node never reaches `SyncComplete`, never creates its genesis block, never participates. In a small committee this stalls the whole epoch (the remaining members hit escalating leader timeouts), and the cucumber step times out after ~27 minutes.

It is intermittent because it only triggers when `CheckSync` routes the joining node through `Syncing` *before* it has entered consensus for the new epoch. When timing lets it enter consensus directly, the genesis/commit block is written first and `clear_transaction_pool` succeeds.

## Fix

`transaction_pool_get_all` now treats a missing commit block as "no pending chain to overlay" and returns the base pool records instead of erroring. `clear_transaction_pool` then succeeds, `SyncComplete` fires, and the node creates its genesis (commit) block on entering consensus and participates normally.

The other two `get_commit_block()` call sites were audited and are safe — they are only reachable during active consensus (proposal conflict resolution) or after a `PendingChainIndex` existence guard, where the commit block is guaranteed to exist. `clear_transaction_pool` (via `syncing.rs`) is the only pre-consensus caller.

## How this has been tested

- `cargo check -p tari_state_store_rocksdb`
- Root cause was traced end-to-end from the CI cucumber per-node log artifacts (state-sync success immediately followed by the `get_commit_block` NotFound, and the consequent `Syncing → Sleeping → Idle → CheckSync → Syncing` loop).

Suggested follow-up: a `transaction_pool_get_all` unit test against a store with no `CommitBlock` row asserting it returns records rather than `NotFound`, and an e2e run of `cargo test --release --test cucumber -p integration_tests -- --tags "@state_sync"`.

## Breaking Changes

- [x] None