### PR TITLE
fix(state-store): overlay pending updates from the leaf block in transaction_pool_get_all

### DIFF
--- a/crates/state_store_rocksdb/src/reader.rs
+++ b/crates/state_store_rocksdb/src/reader.rs
@@ -1208,13 +1208,14 @@ impl<'tx, TAddr: NodeAddressable + Serialize + DeserializeOwned + 'tx> StateStor
         const OPERATION: &str = "transaction_pool_get_all";
         let cf = self.db().cf(TransactionPoolCf)?;
 
-        // A freshly state-synced node that has not yet entered consensus will not have a commit block (or pending
-        // chain) yet. Therefore, there are then no block-scoped pool updates to overlay — return the base
-        // records as-is rather than failing with NotFound.
+        // Overlay each record's latest pending update by walking the pending chain back from the leaf block, so
+        // callers see its effective state at the tip. With no leaf block yet (e.g. freshly state-synced, before
+        // joining consensus) there is no pending chain and nothing to overlay.
         let mut updates = HashMap::new();
-        if let Some(commit_block) = self.get_commit_block().optional()? {
-            let pending_chain = self.get_pending_chain_ordered(&commit_block.block_id)?;
+        if let Some(leaf_block) = self.leaf_block_get_any().optional()? {
+            let pending_chain = self.get_pending_chain_ordered(leaf_block.block_id())?;
             let query = self.db().cf(transaction_pool_state_update::ByBlockIdQuery)?;
+            // Oldest first so the tip's update wins per transaction.
             for block_id in pending_chain.into_iter().rev() {
                 let iter = query.query_prefix_range_iterator(Ordering::default(), &block_id);
                 for result in iter {

--- a/crates/state_store_rocksdb/tests/transactions.rs
+++ b/crates/state_store_rocksdb/tests/transactions.rs
@@ -145,6 +145,74 @@ mod confirm_all_transitions {
 
         tx.rollback().unwrap();
     }
+
+    #[test]
+    fn transaction_pool_get_all_overlays_pending_update_rocksdb() {
+        let (db, _tmp) = create_rocksdb();
+        transaction_pool_get_all_overlays_pending_update(db);
+    }
+
+    // Regression: get_all must return each record's effective state, i.e. with the pending update from the
+    // chain at the leaf block overlaid, not the bare committed record.
+    fn transaction_pool_get_all_overlays_pending_update(db: impl StateStore) {
+        let mut tx = db.create_write_tx().unwrap();
+
+        let atom1 = create_tx_atom();
+
+        let network = Network::LocalNet;
+        let zero_block = Block::zero_block(network, num_preshards());
+        zero_block.insert(&mut tx).unwrap();
+        tx.proposal_certificates_save(zero_block.justify()).unwrap();
+        tx.blocks_set_qcs(zero_block.id(), Some(&PcId::zero()), Some(&PcId::zero()))
+            .unwrap();
+
+        let shard_group = zero_block.shard_group();
+
+        let block1 = Block::create(
+            network,
+            *zero_block.id(),
+            zero_block.justify().clone(),
+            None,
+            NodeHeight(1),
+            Epoch(0),
+            shard_group,
+            Default::default(),
+            [Command::LocalPrepare(atom1.clone())].into_iter().collect(),
+            Default::default(),
+            Default::default(),
+            SchnorrSignatureBytes::zero(),
+            EpochTime::now().as_u64(),
+            FixedHash::zero(),
+            ShardGroupAccumulatedData::default(),
+            ExtraData::default(),
+        )
+        .unwrap();
+        block1.insert(&mut tx).unwrap();
+        block1.as_locked().set(&mut tx).unwrap();
+        block1.as_leaf().set(&mut tx).unwrap();
+
+        tx.transaction_pool_insert_new(atom1.id, atom1.decision, &Evidence::empty(), true, false, None, 0)
+            .unwrap();
+
+        // Base record has no pending update yet.
+        let base = tx.transaction_pool_get_all(1000).unwrap();
+        let base_rec = base.iter().find(|r| *r.id() == atom1.id).unwrap().clone();
+        assert!(base_rec.pending_stage().is_none());
+
+        // Record a pending transition for the transaction in block1, which is on the chain at the leaf.
+        let mut updated = base_rec;
+        updated
+            .set_next_stage_and_readiness(TransactionPoolStage::LocalPrepared, shard_group)
+            .unwrap();
+        tx.transaction_pool_add_pending_update(&block1.as_leaf(), &TransactionPoolStatusUpdate::new(updated, true))
+            .unwrap();
+
+        let overlaid = tx.transaction_pool_get_all(1000).unwrap();
+        let rec = overlaid.iter().find(|r| *r.id() == atom1.id).unwrap();
+        assert_eq!(rec.pending_stage(), Some(TransactionPoolStage::LocalPrepared));
+
+        tx.rollback().unwrap();
+    }
 }
 
 mod transaction_operations {


### PR DESCRIPTION
## Description

Follow-up to #2203. `transaction_pool_get_all` is meant to return each pooled transaction's **effective state at the chain tip** — the last-committed (base) record with the latest *pending* per-block update overlaid. It never did.

It anchored the pending-chain walk at the **commit block**:

```rust
let pending_chain = self.get_pending_chain_ordered(&commit_block.block_id)?;
```

But a block is removed from the `PendingChainIndex` the moment it commits (`writer.rs:351-354`), and `get_pending_chain_ordered` returns empty for any `end_block` not in that index (`reader.rs:226`). So the walk always returned an empty chain, the `updates` map stayed empty, and `merge_into` was never called — the overlay was dead code and callers got the bare committed records.

## Fix

Anchor the walk at the **leaf block** (which *is* in the pending chain), so the latest pending update along the current chain is overlaid. A node with no leaf block yet (e.g. freshly state-synced, before joining consensus) has no pending chain and returns the base records unchanged — preserving the NotFound-tolerance added in #2203.

## Impact

No behavioural change for the only non-test caller, `clear_transaction_pool`, which reads just `id()` to remove all records. The fix matters for the test-helper / effective-state use of `transaction_pool_get_all`, which was silently returning stale records.

## Tests

Adds `transaction_pool_get_all_overlays_pending_update` — no existing test exercised the overlay, which is how this stayed hidden. Verified it **fails on the old commit-block anchor** (`left: None, right: Some(LocalPrepared)`) and **passes** with the leaf-block anchor. Full `transactions` suite green.

This was raised by an automated reviewer on #2203; confirmed it was a pre-existing latent bug independent of that PR's state-sync fix.

## Breaking Changes

- [x] None