### PR TITLE
fix(consensus): reconcile transaction pool on up-to-date re-entry

### DIFF
--- a/crates/consensus/src/hotstuff/state_machine/check_sync.rs
+++ b/crates/consensus/src/hotstuff/state_machine/check_sync.rs
@@ -40,11 +40,11 @@ where
             match context.state_sync.check_sync().await? {
                 SyncStatus::UpToDate => {
                     // We're re-entering consensus already up-to-date, bypassing `Syncing` (and its
-                    // wholesale pool clear). The persisted transaction pool is not epoch-scoped, so a
-                    // transaction whose outputs are already committed can survive here across a restart
-                    // and get re-proposed in the next epoch — which can never gather a QC and wedges
-                    // consensus. Reconcile the pool against committed state (dropping records whose
-                    // outputs are already UP, keeping genuinely-pending ones) before running.
+                    // wholesale pool clear). The persisted transaction pool is not epoch-scoped, so an
+                    // already-committed transaction can survive here across a restart and get
+                    // re-proposed in the next epoch — which can never gather a QC and wedges consensus.
+                    // Reconcile the pool against committed state (dropping records whose transaction
+                    // receipt substate already exists, keeping genuinely-pending ones) before running.
                     let reconciled = context.hotstuff.reconcile_transaction_pool()?;
                     if reconciled > 0 {
                         warn!(

--- a/crates/consensus/src/hotstuff/state_machine/check_sync.rs
+++ b/crates/consensus/src/hotstuff/state_machine/check_sync.rs
@@ -38,7 +38,22 @@ where
         let mut backoff = INCONCLUSIVE_BACKOFF_INITIAL;
         loop {
             match context.state_sync.check_sync().await? {
-                SyncStatus::UpToDate => return Ok(ConsensusStateEvent::Ready),
+                SyncStatus::UpToDate => {
+                    // We're re-entering consensus already up-to-date, bypassing `Syncing` (and its
+                    // wholesale pool clear). The persisted transaction pool is not epoch-scoped, so a
+                    // transaction finalised in a previous epoch can survive here across a restart and get
+                    // re-proposed in the next epoch — which can never gather a QC and wedges consensus.
+                    // Drop any already-finalised records (keeping genuinely-pending ones) before running.
+                    let reconciled = context.hotstuff.reconcile_transaction_pool()?;
+                    if reconciled > 0 {
+                        warn!(
+                            target: LOG_TARGET,
+                            "🧹 Reconciled transaction pool on up-to-date re-entry: removed {reconciled} \
+                             already-finalised transaction(s)",
+                        );
+                    }
+                    return Ok(ConsensusStateEvent::Ready);
+                },
                 SyncStatus::Behind { target_epoch } => return Ok(ConsensusStateEvent::NeedSync { target_epoch }),
                 SyncStatus::Inconclusive => {
                     warn!(

--- a/crates/consensus/src/hotstuff/state_machine/check_sync.rs
+++ b/crates/consensus/src/hotstuff/state_machine/check_sync.rs
@@ -41,15 +41,16 @@ where
                 SyncStatus::UpToDate => {
                     // We're re-entering consensus already up-to-date, bypassing `Syncing` (and its
                     // wholesale pool clear). The persisted transaction pool is not epoch-scoped, so a
-                    // transaction finalised in a previous epoch can survive here across a restart and get
-                    // re-proposed in the next epoch — which can never gather a QC and wedges consensus.
-                    // Drop any already-finalised records (keeping genuinely-pending ones) before running.
+                    // transaction whose outputs are already committed can survive here across a restart
+                    // and get re-proposed in the next epoch — which can never gather a QC and wedges
+                    // consensus. Reconcile the pool against committed state (dropping records whose
+                    // outputs are already UP, keeping genuinely-pending ones) before running.
                     let reconciled = context.hotstuff.reconcile_transaction_pool()?;
                     if reconciled > 0 {
                         warn!(
                             target: LOG_TARGET,
                             "🧹 Reconciled transaction pool on up-to-date re-entry: removed {reconciled} \
-                             already-finalised transaction(s)",
+                             already-committed transaction(s)",
                         );
                     }
                     return Ok(ConsensusStateEvent::Ready);

--- a/crates/consensus/src/hotstuff/worker.rs
+++ b/crates/consensus/src/hotstuff/worker.rs
@@ -26,19 +26,19 @@ use tari_ootle_common_types::{
     NodeHeight,
     ProtocolVersion,
     ShardGroup,
-    VersionedSubstateIdRef,
+    VersionedSubstateId,
     displayable::Displayable,
     optional::Optional,
 };
 use tari_ootle_storage::{
     StateStore,
-    StateStoreReadTransaction,
     consensus_models::{
         Block,
         BookkeepingModel,
         EpochCheckpoint,
         ForeignProposalRecord,
         NoVoteReason,
+        SubstateRecord,
         TransactionPool,
         TransactionRecord,
     },
@@ -1051,8 +1051,8 @@ impl<TConsensusSpec: ConsensusSpec> HotstuffWorker<TConsensusSpec> {
         })
     }
 
-    /// Drop any pooled transaction whose outputs are already committed in the substate store,
-    /// returning the number removed.
+    /// Drop any pooled transaction that is already committed in the substate store, returning the
+    /// number removed.
     ///
     /// Unlike [`Self::clear_transaction_pool`] (the correct, wholesale response after a state sync
     /// rewrites the state store), this reconciles the pool against committed state and only removes
@@ -1062,34 +1062,32 @@ impl<TConsensusSpec: ConsensusSpec> HotstuffWorker<TConsensusSpec> {
     /// The persisted transaction pool is keyed by [`TransactionId`] only and is not epoch-scoped. In
     /// steady state a transaction's outputs go `UP`, its pool record is removed and it is marked
     /// finalised atomically in the same commit; but committed state applied *outside* local block-commit
-    /// (e.g. a state sync, the `#2195` case) leaves the persisted pool holding transactions whose
-    /// outputs are already `UP`. Such a record can survive across a restart that re-enters consensus
-    /// already up-to-date (i.e. without going through `Syncing`, which clears the pool). Re-proposing it
-    /// in the new epoch breaks liveness: the leader's prepare aborts with `LockInputsFailed` because the
-    /// output substate is already `UP`, replicas that removed it no-vote with `TransactionNotInPool`, no
-    /// QC forms and the pacemaker loops on `NEWVIEW` forever.
+    /// (e.g. a state sync, the `#2195` case) can leave the persisted pool holding already-committed
+    /// transactions. Such a record can survive across a restart that re-enters consensus already
+    /// up-to-date (i.e. without going through `Syncing`, which clears the pool). Re-proposing it in the
+    /// new epoch breaks liveness: the leader's prepare aborts with `LockInputsFailed` because the
+    /// output substates are already `UP`, replicas that removed it no-vote with `TransactionNotInPool`,
+    /// no QC forms and the pacemaker loops on `NEWVIEW` forever.
     ///
-    /// We detect this with exactly the condition that wedges the leader: a pooled transaction whose
-    /// output versioned substates already exist (the [`SubstateIsUp`] lock failure). Genuinely-pending
-    /// transactions have not created their outputs yet, so they are retained.
-    ///
-    /// [`SubstateIsUp`]: crate::hotstuff::substate_store::LockFailedError::SubstateIsUp
+    /// Every committed transaction creates a `TransactionReceipt` output substate (version 0) whose
+    /// address is derived from the transaction ID, so the receipt existing in the store is a precise
+    /// per-transaction commitment marker: no other transaction can create it (checking other outputs
+    /// would false-positive on address collisions with a *different* committed transaction and drop a
+    /// genuinely-pending record from only our pool). Note this detects commits whose receipt shard
+    /// belongs to the local shard group, and aborted transactions write no receipt — neither of which
+    /// produces the local output conflict that wedges the leader.
     // TODO: the transaction pool only holds pending (derived) state and should not be persisted at
     //       all — that would remove this whole class of pool-vs-state-store divergence.
     pub fn reconcile_transaction_pool(&self) -> Result<usize, HotStuffError> {
-        // Scan under a read tx so we don't hold the exclusive write lock for the per-record output
+        // Scan under a read tx so we don't hold the exclusive write lock for the per-record receipt
         // lookups. `remove_all` skips missing keys, so opening a separate write tx for the removal is
         // safe even if the pool changes in between.
         let stale_ids = self.state_store.with_read_tx(|tx| {
             let recs = self.transaction_pool.get_all(tx, usize::MAX)?;
             let mut stale_ids = Vec::new();
             for rec in &recs {
-                let outputs = rec
-                    .evidence()
-                    .iter()
-                    .flat_map(|(_, shard_evidence)| shard_evidence.outputs().iter())
-                    .map(|(substate_id, version)| VersionedSubstateIdRef::new(substate_id, *version));
-                if tx.substates_any_exist(outputs)? {
+                let receipt = VersionedSubstateId::for_tx_receipt(rec.to_receipt_id());
+                if SubstateRecord::exists(tx, receipt.as_versioned_ref())? {
                     stale_ids.push(*rec.id());
                 }
             }

--- a/crates/consensus/src/hotstuff/worker.rs
+++ b/crates/consensus/src/hotstuff/worker.rs
@@ -1049,6 +1049,37 @@ impl<TConsensusSpec: ConsensusSpec> HotstuffWorker<TConsensusSpec> {
         })
     }
 
+    /// Drop any pooled transaction that has already been finalised in the state store, returning the
+    /// number removed.
+    ///
+    /// Unlike [`Self::clear_transaction_pool`] (which is the correct, wholesale response after a state
+    /// sync rewrites the state store), this only removes records the local node itself has
+    /// already finalised — so it is safe to run on the up-to-date re-entry path, where the pool still
+    /// holds genuinely-pending transactions we must keep.
+    ///
+    /// The persisted transaction pool is keyed by [`TransactionId`] only and is not epoch-scoped, so a
+    /// transaction finalised in a previous epoch can survive in the pool across a restart that re-enters
+    /// consensus already up-to-date (i.e. without going through `Syncing`). Re-proposing such a
+    /// transaction in the new epoch breaks liveness: the rest of the committee finalised and removed it,
+    /// so the block carrying it can never gather a QC (`TransactionNotInPool`) and the pacemaker loops on
+    /// `NEWVIEW` forever. Reconciling the pool against committed state on re-entry removes those stale
+    /// records before they can be proposed.
+    // TODO: the transaction pool only holds pending (derived) state and should not be persisted at
+    //       all — that would remove this whole class of pool-vs-state-store divergence.
+    pub fn reconcile_transaction_pool(&self) -> Result<usize, HotStuffError> {
+        self.state_store.with_write_tx(|tx| {
+            let recs = self.transaction_pool.get_all(&**tx, usize::MAX)?;
+            let mut finalized_ids = Vec::new();
+            for rec in &recs {
+                if TransactionRecord::is_record_finalized(&**tx, rec.id())? {
+                    finalized_ids.push(*rec.id());
+                }
+            }
+            let removed = self.transaction_pool.remove_all(tx, &finalized_ids)?;
+            Ok::<_, HotStuffError>(removed.len())
+        })
+    }
+
     async fn propose_now(
         &mut self,
         epoch_state: &EpochState<TConsensusSpec::Addr>,

--- a/crates/consensus/src/hotstuff/worker.rs
+++ b/crates/consensus/src/hotstuff/worker.rs
@@ -26,11 +26,13 @@ use tari_ootle_common_types::{
     NodeHeight,
     ProtocolVersion,
     ShardGroup,
+    VersionedSubstateIdRef,
     displayable::Displayable,
     optional::Optional,
 };
 use tari_ootle_storage::{
     StateStore,
+    StateStoreReadTransaction,
     consensus_models::{
         Block,
         BookkeepingModel,
@@ -1049,44 +1051,57 @@ impl<TConsensusSpec: ConsensusSpec> HotstuffWorker<TConsensusSpec> {
         })
     }
 
-    /// Drop any pooled transaction that has already been finalised in the state store, returning the
-    /// number removed.
+    /// Drop any pooled transaction whose outputs are already committed in the substate store,
+    /// returning the number removed.
     ///
-    /// Unlike [`Self::clear_transaction_pool`] (which is the correct, wholesale response after a state
-    /// sync rewrites the state store), this only removes records the local node itself has
-    /// already finalised — so it is safe to run on the up-to-date re-entry path, where the pool still
-    /// holds genuinely-pending transactions we must keep.
+    /// Unlike [`Self::clear_transaction_pool`] (the correct, wholesale response after a state sync
+    /// rewrites the state store), this reconciles the pool against committed state and only removes
+    /// records that are demonstrably stale — so it is safe to run on the up-to-date re-entry path,
+    /// where the pool still holds genuinely-pending transactions we must keep.
     ///
-    /// The persisted transaction pool is keyed by [`TransactionId`] only and is not epoch-scoped, so a
-    /// transaction finalised in a previous epoch can survive in the pool across a restart that re-enters
-    /// consensus already up-to-date (i.e. without going through `Syncing`). Re-proposing such a
-    /// transaction in the new epoch breaks liveness: the rest of the committee finalised and removed it,
-    /// so the block carrying it can never gather a QC (`TransactionNotInPool`) and the pacemaker loops on
-    /// `NEWVIEW` forever. Reconciling the pool against committed state on re-entry removes those stale
-    /// records before they can be proposed.
+    /// The persisted transaction pool is keyed by [`TransactionId`] only and is not epoch-scoped. In
+    /// steady state a transaction's outputs go `UP`, its pool record is removed and it is marked
+    /// finalised atomically in the same commit; but committed state applied *outside* local block-commit
+    /// (e.g. a state sync, the `#2195` case) leaves the persisted pool holding transactions whose
+    /// outputs are already `UP`. Such a record can survive across a restart that re-enters consensus
+    /// already up-to-date (i.e. without going through `Syncing`, which clears the pool). Re-proposing it
+    /// in the new epoch breaks liveness: the leader's prepare aborts with `LockInputsFailed` because the
+    /// output substate is already `UP`, replicas that removed it no-vote with `TransactionNotInPool`, no
+    /// QC forms and the pacemaker loops on `NEWVIEW` forever.
+    ///
+    /// We detect this with exactly the condition that wedges the leader: a pooled transaction whose
+    /// output versioned substates already exist (the [`SubstateIsUp`] lock failure). Genuinely-pending
+    /// transactions have not created their outputs yet, so they are retained.
+    ///
+    /// [`SubstateIsUp`]: crate::hotstuff::substate_store::LockFailedError::SubstateIsUp
     // TODO: the transaction pool only holds pending (derived) state and should not be persisted at
     //       all — that would remove this whole class of pool-vs-state-store divergence.
     pub fn reconcile_transaction_pool(&self) -> Result<usize, HotStuffError> {
-        // Scan the pool under a read tx so we don't hold the exclusive write lock for the
-        // per-record finalized lookups. `remove_all` skips missing keys, so opening a separate
-        // write tx for the removal is safe even if the pool changes in between.
-        let finalized_ids = self.state_store.with_read_tx(|tx| {
+        // Scan under a read tx so we don't hold the exclusive write lock for the per-record output
+        // lookups. `remove_all` skips missing keys, so opening a separate write tx for the removal is
+        // safe even if the pool changes in between.
+        let stale_ids = self.state_store.with_read_tx(|tx| {
             let recs = self.transaction_pool.get_all(tx, usize::MAX)?;
-            let mut finalized_ids = Vec::new();
+            let mut stale_ids = Vec::new();
             for rec in &recs {
-                if TransactionRecord::is_record_finalized(tx, rec.id())? {
-                    finalized_ids.push(*rec.id());
+                let outputs = rec
+                    .evidence()
+                    .iter()
+                    .flat_map(|(_, shard_evidence)| shard_evidence.outputs().iter())
+                    .map(|(substate_id, version)| VersionedSubstateIdRef::new(substate_id, *version));
+                if tx.substates_any_exist(outputs)? {
+                    stale_ids.push(*rec.id());
                 }
             }
-            Ok::<_, HotStuffError>(finalized_ids)
+            Ok::<_, HotStuffError>(stale_ids)
         })?;
 
-        if finalized_ids.is_empty() {
+        if stale_ids.is_empty() {
             return Ok(0);
         }
 
         self.state_store.with_write_tx(|tx| {
-            let removed = self.transaction_pool.remove_all(tx, &finalized_ids)?;
+            let removed = self.transaction_pool.remove_all(tx, &stale_ids)?;
             Ok::<_, HotStuffError>(removed.len())
         })
     }

--- a/crates/consensus/src/hotstuff/worker.rs
+++ b/crates/consensus/src/hotstuff/worker.rs
@@ -1067,14 +1067,25 @@ impl<TConsensusSpec: ConsensusSpec> HotstuffWorker<TConsensusSpec> {
     // TODO: the transaction pool only holds pending (derived) state and should not be persisted at
     //       all — that would remove this whole class of pool-vs-state-store divergence.
     pub fn reconcile_transaction_pool(&self) -> Result<usize, HotStuffError> {
-        self.state_store.with_write_tx(|tx| {
-            let recs = self.transaction_pool.get_all(&**tx, usize::MAX)?;
+        // Scan the pool under a read tx so we don't hold the exclusive write lock for the
+        // per-record finalized lookups. `remove_all` skips missing keys, so opening a separate
+        // write tx for the removal is safe even if the pool changes in between.
+        let finalized_ids = self.state_store.with_read_tx(|tx| {
+            let recs = self.transaction_pool.get_all(tx, usize::MAX)?;
             let mut finalized_ids = Vec::new();
             for rec in &recs {
-                if TransactionRecord::is_record_finalized(&**tx, rec.id())? {
+                if TransactionRecord::is_record_finalized(tx, rec.id())? {
                     finalized_ids.push(*rec.id());
                 }
             }
+            Ok::<_, HotStuffError>(finalized_ids)
+        })?;
+
+        if finalized_ids.is_empty() {
+            return Ok(0);
+        }
+
+        self.state_store.with_write_tx(|tx| {
             let removed = self.transaction_pool.remove_all(tx, &finalized_ids)?;
             Ok::<_, HotStuffError>(removed.len())
         })


### PR DESCRIPTION
The persisted transaction pool (TransactionPoolCf) is keyed by
TransactionId only and is not epoch-scoped. The wholesale
clear_transaction_pool() is wired exclusively to the Syncing state, so a
node that re-enters consensus already up-to-date (e.g. a clean restart
routing CheckSync --Ready--&gt; Running) never reconciles its pool against
committed state.

An already-committed transaction can therefore survive in the pool across
such a restart and get re-proposed in the next epoch. The rest of the
committee already finalised and removed it, so the block carrying it can
never gather a QC (TransactionNotInPool / LockInputsFailed) and the
pacemaker loops on NEWVIEW forever, wedging consensus at the epoch
transition.

Add HotstuffWorker::reconcile_transaction_pool() and call it on the
up-to-date branch of CheckSync before transitioning to Running. It uses
the TransactionReceipt output substate as the staleness signal: every
committed transaction creates a receipt substate (version 0) at an
address derived from its transaction ID, so the receipt existing in the
committed store is a precise per-transaction commitment marker — no other
transaction can create it, so genuinely-pending transactions are never
dropped (checking generic outputs could false-positive on address
collisions with a different committed transaction). The scan runs under a
read tx, with a short write tx only when there are stale records to
remove. Unlike the wholesale clear used after a state sync, this is safe
to run on every up-to-date re-entry.

Fixes #2207