### PR TITLE
fix(template_lib_types): prevent panic on non-ASCII hex input

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12403,7 +12403,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_lib"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "borsh",
  "minicbor",
@@ -12417,7 +12417,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_lib_types"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "bnum",
  "borsh",

--- a/crates/template_lib/Cargo.toml
+++ b/crates/template_lib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_template_lib"
 description = "Tari template library provides abstrations that interface with the Tari validator engine"
-version = "0.27.0"
+version = "0.27.1"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/template_lib_types/Cargo.toml
+++ b/crates/template_lib_types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_template_lib_types"
-version = "0.27.0"
+version = "0.27.1"
 edition.workspace = true
 authors.workspace = true
 description = "Tari template library types"

--- a/crates/template_lib_types/src/hex.rs
+++ b/crates/template_lib_types/src/hex.rs
@@ -6,28 +6,38 @@ use tari_template_abi::rust::{fmt, prelude::*};
 use crate::KeyParseError;
 
 pub fn fixed_bytes_from_hex<const L: usize>(s: &str) -> Result<[u8; L], KeyParseError> {
+    let s = s.as_bytes();
     if s.len() != L * 2 {
         return Err(KeyParseError);
     }
 
     let mut bytes = [0u8; L];
-    for (i, h) in bytes.iter_mut().enumerate() {
-        *h = u8::from_str_radix(&s[2 * i..2 * (i + 1)], 16).map_err(|_| KeyParseError)?;
+    for (byte, chunk) in bytes.iter_mut().zip(s.chunks_exact(2)) {
+        *byte = (hex_digit(chunk[0])? << 4) | hex_digit(chunk[1])?;
     }
     Ok(bytes)
 }
 
 pub fn bytes_from_hex(s: &str) -> Result<Vec<u8>, KeyParseError> {
+    let s = s.as_bytes();
     if !s.len().is_multiple_of(2) {
         return Err(KeyParseError);
     }
 
     let mut bytes = Vec::with_capacity(s.len() / 2);
-    for i in (0..s.len()).step_by(2) {
-        let byte = u8::from_str_radix(&s[i..i + 2], 16).map_err(|_| KeyParseError)?;
-        bytes.push(byte);
+    for chunk in s.chunks_exact(2) {
+        bytes.push((hex_digit(chunk[0])? << 4) | hex_digit(chunk[1])?);
     }
     Ok(bytes)
+}
+
+fn hex_digit(b: u8) -> Result<u8, KeyParseError> {
+    match b {
+        b'0'..=b'9' => Ok(b - b'0'),
+        b'a'..=b'f' => Ok(b - b'a' + 10),
+        b'A'..=b'F' => Ok(b - b'A' + 10),
+        _ => Err(KeyParseError),
+    }
 }
 
 pub fn bytes_to_hex<T: AsRef<[u8]>>(bytes: T) -> String {
@@ -52,5 +62,43 @@ mod tests {
         let bytes = [0xde, 0xad, 0xbe, 0xef];
         let hex = bytes_to_hex(bytes);
         assert_eq!(hex, "deadbeef");
+    }
+
+    #[test]
+    fn it_decodes_valid_hex() {
+        assert_eq!(fixed_bytes_from_hex::<4>("deadbeef").unwrap(), [0xde, 0xad, 0xbe, 0xef]);
+        assert_eq!(fixed_bytes_from_hex::<4>("DEADBEEF").unwrap(), [0xde, 0xad, 0xbe, 0xef]);
+        assert_eq!(bytes_from_hex("deadbeef").unwrap(), vec![0xde, 0xad, 0xbe, 0xef]);
+    }
+
+    #[test]
+    fn it_rejects_wrong_length() {
+        assert!(fixed_bytes_from_hex::<4>("deadbe").is_err());
+        assert!(fixed_bytes_from_hex::<4>("deadbeef00").is_err());
+        assert!(bytes_from_hex("abc").is_err());
+    }
+
+    #[test]
+    fn it_rejects_non_hex_without_panicking() {
+        assert!(fixed_bytes_from_hex::<2>("zzzz").is_err());
+        assert!(bytes_from_hex("gg").is_err());
+        // A leading '+' is valid for u8::from_str_radix but is not a valid hex byte.
+        assert!(bytes_from_hex("+a").is_err());
+    }
+
+    #[test]
+    fn it_rejects_multibyte_utf8_without_panicking() {
+        // Regression: the length guard counts bytes, so a multibyte char positioned to
+        // straddle a 2-byte chunk boundary used to slice mid-codepoint and panic.
+        // `é` (2 bytes) at byte offset 1 makes byte index 2 a non-char-boundary.
+        let mut s = String::from("a");
+        s.push('é');
+        s.push_str(&"a".repeat(61));
+        assert_eq!(s.len(), 64);
+        assert!(fixed_bytes_from_hex::<32>(&s).is_err());
+
+        // 4-byte emoji with even byte-length passes the parity guard in bytes_from_hex.
+        assert!(bytes_from_hex("😀").is_err());
+        assert!(bytes_from_hex(&"😀".repeat(16)).is_err());
     }
 }


### PR DESCRIPTION
## Problem

`fixed_bytes_from_hex` / `bytes_from_hex` (`crates/template_lib_types/src/hex.rs`) validated **byte** length (`s.len()`), then byte-sliced the `&str` (`&s[2*i..2*(i+1)]`). A multibyte UTF-8 character positioned to straddle a 2-byte chunk boundary slices mid-codepoint, which **panics**:

```
byte index 2 is not a char boundary; it is inside '😀'
```

With `panic = 'abort'` in release this is an uncatchable process crash.

### Reachability (remote DoS)

The input is attacker-controlled and reaches the sink from the wallet daemon's `submit_manifest` JSON-RPC endpoint:

```
submit_manifest variables (HashMap<String,String>)
  -> ManifestValue::from_str
  -> SubstateId::from_str
  -> {Component,Resource,Vault,NonFungible,...}Address::from_hex
  -> fixed_bytes_from_hex   // panic
```

A variable string such as `nft_<emoji + 59×'a'>_u32_1` (64-byte hex segment with one multibyte char) crashes the parsing path. This shared sink underlies **every** `from_hex` branch of every address type.

## Fix

Decode over `s.as_bytes()` with a nibble lookup (`hex_digit`) instead of slicing the `&str`. There is no `&str` byte-indexing left, so the panic is **structurally impossible** rather than guarded by a precondition.

Behaviour is unchanged for all valid input (upper/lower hex, same length rules). The only intentional tightening: a leading `+` — which `u8::from_str_radix(_, 16)` accepted but is never a valid hex byte — is now rejected.

## Tests

Added regression coverage (all passing under `--all-features`):

- valid decode (lower + upper case)
- wrong-length rejection
- non-hex rejection (incl. the `+` case)
- **`it_rejects_multibyte_utf8_without_panicking`** — `"a" + "é" + 61×"a"` (64 bytes, `é` straddling a chunk boundary) and a 4-byte emoji; both panicked before this change and now return `Err`.

## Versioning

Patch-bumped `tari_template_lib_types` and `tari_template_lib` (0.27.0 → 0.27.1) to ship the fix. Other dependents auto-pick-up via `^0.y` constraints.

## Related

Found during a fuzz-target audit. Broader fuzzing follow-up (covering CBOR decode recursion and unbounded allocation sinks as well) is tracked in #2209; the `substate_id_from_str` harness proposed there is the regression guard for this class across all address types.
