### PR TITLE
docs(ledger): add descriptions, READMEs and rustdocs to ledger crates for publishing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7598,6 +7598,7 @@ dependencies = [
  "futures 0.3.31",
  "indexmap 2.13.0",
  "ootle_byte_type",
+ "ootle_ledger_client",
  "ootle_ledger_common",
  "rand 0.10.1",
  "serde",
@@ -7606,7 +7607,6 @@ dependencies = [
  "tari_bor",
  "tari_crypto",
  "tari_indexer_client",
- "tari_ledger_client",
  "tari_ootle_address",
  "tari_ootle_common_types",
  "tari_ootle_template_metadata",
@@ -7657,6 +7657,30 @@ version = "0.8.0"
 dependencies = [
  "tari_crypto",
  "tari_template_lib_types",
+]
+
+[[package]]
+name = "ootle_ledger_client"
+version = "0.1.1"
+dependencies = [
+ "blake2 0.10.6",
+ "borsh",
+ "curve25519-dalek 4.1.3",
+ "hex",
+ "indexmap 2.13.0",
+ "ledger-transport",
+ "ledger-transport-hid",
+ "ootle-network",
+ "ootle_ledger_common",
+ "rand 0.10.1",
+ "reqwest 0.13.2",
+ "serde",
+ "tari_crypto",
+ "tari_ootle_transaction",
+ "tari_ootle_wallet_crypto",
+ "tari_template_lib_types",
+ "thiserror 2.0.18",
+ "tokio",
 ]
 
 [[package]]
@@ -11508,30 +11532,6 @@ dependencies = [
  "tari_crypto",
  "tari_hashing",
  "thiserror 2.0.18",
-]
-
-[[package]]
-name = "tari_ledger_client"
-version = "0.1.1"
-dependencies = [
- "blake2 0.10.6",
- "borsh",
- "curve25519-dalek 4.1.3",
- "hex",
- "indexmap 2.13.0",
- "ledger-transport",
- "ledger-transport-hid",
- "ootle-network",
- "ootle_ledger_common",
- "rand 0.10.1",
- "reqwest 0.13.2",
- "serde",
- "tari_crypto",
- "tari_ootle_transaction",
- "tari_ootle_wallet_crypto",
- "tari_template_lib_types",
- "thiserror 2.0.18",
- "tokio",
 ]
 
 [[package]]

--- a/crates/wallet/ledger/client/Cargo.toml
+++ b/crates/wallet/ledger/client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
-name = "tari_ledger_client"
+name = "ootle_ledger_client"
 version = "0.1.1"
-description = "A client for interacting with Ootle Ledger wallet app."
+description = "Host client for the Tari Ootle Ledger app: on-device key derivation and transaction signing over any APDU transport"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true
@@ -17,7 +17,7 @@ thiserror = { workspace = true }
 
 # Speculos transport
 reqwest = { workspace = true, features = ["json"], optional = true }
-serde = { workspace = true, optional = true }
+serde = { workspace = true, features = ["derive"], optional = true }
 hex = { workspace = true, optional = true }
 borsh = { workspace = true, default-features = false }
 
@@ -36,3 +36,6 @@ indexmap = { workspace = true }
 [features]
 speculos-transport = ["serde", "reqwest", "hex"]
 hid-transport = ["dep:ledger-transport-hid"]
+
+[package.metadata.docs.rs]
+all-features = true

--- a/crates/wallet/ledger/client/README.md
+++ b/crates/wallet/ledger/client/README.md
@@ -1,0 +1,70 @@
+# `ootle_ledger_client`
+
+## Overview
+
+`ootle_ledger_client` is the host-side client for the Tari Ootle Ledger app. `LedgerClient` wraps
+any [`ledger_transport::Exchange`](https://docs.rs/ledger-transport) APDU transport and exposes
+the app's instruction set:
+
+- app name and version queries,
+- on-device key derivation (`get_public_key`) — secrets never leave the device,
+- streamed transaction signing (`sign_transaction`) for both authorization ("add signer") and
+  seal signatures, with optional stealth key derivation for confidential transfers.
+
+The wire format is defined in
+[`ootle_ledger_common`](https://crates.io/crates/ootle_ledger_common), which the device app also
+depends on, so host and device share a single protocol definition. Higher-level signers (e.g.
+`ootle-rs`'s ledger signer) build on this crate.
+
+## Transports
+
+Transports are feature-gated; enable the one you need:
+
+| Feature               | Provides                                                          |
+|-----------------------|-------------------------------------------------------------------|
+| `hid-transport`       | `LedgerHidClient` — native USB HID for physical devices           |
+| `speculos-transport`  | `SpeculosTransport` — drives the [Speculos] emulator's REST API   |
+
+Any other `Exchange` implementation (e.g. TCP, Bluetooth) works too — pass it to
+`LedgerClient::new`.
+
+[Speculos]: https://github.com/LedgerHQ/speculos
+
+## Usage
+
+```rust,no_run
+use ootle_ledger_client::{LedgerClient, speculos_transport::SpeculosTransport};
+use ootle_ledger_common::arg_types::KeyType;
+
+# async fn example() -> Result<(), Box<dyn std::error::Error>> {
+// Any `Exchange` transport works; Speculos shown here.
+let client = LedgerClient::new(SpeculosTransport::new());
+
+let version = client.get_app_version().await?;
+let public_key = client.get_public_key(0, 0, KeyType::Account).await?;
+# Ok(())
+# }
+```
+
+Signing streams the canonical transaction preimage fields to the device, which recomputes the
+signing message and Schnorr challenge itself before showing the user review — see
+`LedgerClient::sign_transaction` and the protocol description in `ootle_ledger_common`.
+
+## Testing
+
+- `tests/signing_recipe.rs` is a host reference implementation of the on-device signing recipe,
+  proving it produces signatures that verify under `tari_ootle_transaction` / `tari_crypto` —
+  no device required.
+- The `#[ignore]`d integration tests exercise the real exchange against Speculos running the
+  Ootle app:
+
+  ```sh
+  cargo test -p ootle_ledger_client --features speculos-transport -- --ignored
+  ```
+
+  The Speculos URL defaults to `http://localhost:5000` and can be overridden with `SPECULOS_URL`.
+
+## Documentation
+
+Detailed documentation is available at
+[docs.rs/ootle_ledger_client](https://docs.rs/ootle_ledger_client).

--- a/crates/wallet/ledger/client/src/client.rs
+++ b/crates/wallet/ledger/client/src/client.rs
@@ -21,6 +21,7 @@ use tari_template_lib_types::crypto::RistrettoPublicKeyBytes;
 
 use crate::{decode::DecodeAnswer, error::LedgerClientError};
 
+/// Result of a [`LedgerClient`] operation; `E` is the transport's error type.
 pub type LedgerClientResult<T, E> = Result<T, LedgerClientError<E>>;
 
 const CLA: u8 = 0x80;
@@ -31,15 +32,19 @@ const MAX_CHUNK: usize = 250;
 /// One field of the canonical signing preimage to stream: its wire tag and borsh bytes.
 pub type SegmentRef<'a> = (SigningField, &'a [u8]);
 
+/// Client for the Ootle Ledger app, generic over the APDU transport `T`.
 pub struct LedgerClient<T> {
     inner: T,
 }
 
 impl<T: Exchange> LedgerClient<T> {
+    /// Wrap an APDU transport. The transport is assumed to be connected to a device (or emulator)
+    /// with the Ootle app open.
     pub fn new(inner: T) -> Self {
         Self { inner }
     }
 
+    /// Return the running app's version string, e.g. `"0.1.0"`.
     pub async fn get_app_version(&self) -> LedgerClientResult<String, T::Error> {
         let command = APDUCommand {
             cla: CLA,
@@ -53,6 +58,7 @@ impl<T: Exchange> LedgerClient<T> {
         answer.decode()
     }
 
+    /// Return the running app's name, e.g. `"Tari Ootle"`.
     pub async fn get_app_name(&self) -> LedgerClientResult<String, T::Error> {
         let command = APDUCommand {
             cla: CLA,
@@ -66,6 +72,8 @@ impl<T: Exchange> LedgerClient<T> {
         answer.decode()
     }
 
+    /// Derive a key on-device from the `(account, index, key_type)` BIP-32 path parameters and
+    /// return its public key. The secret never leaves the device.
     pub async fn get_public_key(
         &self,
         account: u64,

--- a/crates/wallet/ledger/client/src/decode.rs
+++ b/crates/wallet/ledger/client/src/decode.rs
@@ -8,6 +8,7 @@ use ledger_transport::APDUAnswer;
 
 use crate::LedgerClientError;
 
+/// Decode an APDU answer's data field as a borsh-encoded value.
 pub trait DecodeAnswer<Out> {
     fn decode<E>(&self) -> Result<Out, LedgerClientError<E>>
     where Self: Sized;

--- a/crates/wallet/ledger/client/src/error.rs
+++ b/crates/wallet/ledger/client/src/error.rs
@@ -4,16 +4,23 @@
 use ledger_transport::APDUErrorCode;
 use ootle_ledger_common::OotleStatusWord;
 
+/// Error returned by `LedgerClient` operations; `E` is the transport's error type.
 #[derive(Debug, thiserror::Error)]
 pub enum LedgerClientError<E> {
+    /// The underlying APDU transport failed (USB HID, Speculos HTTP, etc.).
     #[error("Ledger transport error: {0}")]
     Transport(#[from] E),
+    /// The device replied OK but the response body failed to decode.
     #[error("Invalid response from ledger: {details}")]
     InvalidResponse { details: String },
+    /// The device returned a standard (ISO 7816 / Ledger SDK) error status word.
     #[error("Ledger returned APDU error code: {code}")]
     APDUError { code: APDUErrorCode },
+    /// The device returned a status word that is neither a standard APDU code nor an
+    /// [`OotleStatusWord`].
     #[error("Ledger returned unknown APDU error code: {code}")]
     APDUOtherCodeError { code: u16 },
+    /// The Ootle app returned an app-specific error, e.g. the user rejected the transaction.
     #[error("Ledger returned application error code: {code:?}")]
     AppError { code: OotleStatusWord },
 }

--- a/crates/wallet/ledger/client/src/lib.rs
+++ b/crates/wallet/ledger/client/src/lib.rs
@@ -1,6 +1,20 @@
 //   Copyright 2026 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
+//! Host-side client for the Tari Ootle Ledger app.
+//!
+//! [`LedgerClient`] wraps any [`ledger_transport::Exchange`] transport and exposes the app's
+//! instruction set: app name/version queries, on-device key derivation, and streamed transaction
+//! signing (authorization and seal signatures, with optional stealth key derivation). The wire
+//! format — instructions, status words, and request/response bodies — comes from
+//! `ootle_ledger_common`, which the device app also depends on, so both sides share a single
+//! protocol definition.
+//!
+//! Transports are feature-gated:
+//! - `hid-transport` — `LedgerHidClient`, native USB HID for physical devices.
+//! - `speculos-transport` — `SpeculosTransport`, which drives the [Speculos](https://github.com/LedgerHQ/speculos)
+//!   emulator's REST API; used by the integration tests.
+
 mod client;
 mod error;
 #[cfg(feature = "hid-transport")]

--- a/crates/wallet/ledger/client/src/speculos_transport.rs
+++ b/crates/wallet/ledger/client/src/speculos_transport.rs
@@ -1,11 +1,15 @@
 //   Copyright 2026 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
+//! APDU transport for the [Speculos](https://github.com/LedgerHQ/speculos) Ledger emulator.
+
 use std::ops::Deref;
 
 use ledger_transport::{APDUAnswer, APDUCommand, Exchange, async_trait};
 use serde::{Deserialize, Serialize};
 
+/// [`Exchange`] implementation that sends APDUs to a running Speculos emulator over its REST API,
+/// so the full client/app exchange can be exercised without a physical device.
 #[derive(Debug, Default)]
 pub struct SpeculosTransport {
     inner: reqwest::Client,

--- a/crates/wallet/ledger/common/Cargo.toml
+++ b/crates/wallet/ledger/common/Cargo.toml
@@ -1,8 +1,10 @@
 [package]
 name = "ootle_ledger_common"
 version = "0.1.0"
+description = "Shared APDU protocol types for the Tari Ootle Ledger app and its host client"
 edition = "2024"
 authors = ["Tari Development Community"]
+repository = "https://github.com/tari-project/tari-ootle"
 license = "BSD-3-Clause"
 
 [dependencies]

--- a/crates/wallet/ledger/common/README.md
+++ b/crates/wallet/ledger/common/README.md
@@ -1,0 +1,47 @@
+# `ootle_ledger_common`
+
+## Overview
+
+`ootle_ledger_common` defines the APDU protocol spoken between the Tari Ootle Ledger device app
+and a host client ([`ootle_ledger_client`](https://crates.io/crates/ootle_ledger_client)). Both
+sides depend on this crate so the wire format — instruction set, status words, request/response
+bodies, and the framing of the streamed `SignTransaction` exchange — is defined exactly once.
+
+The crate is `no_std` by default so it can build inside the Ledger embedded app; hosts enable the
+`std` feature. Request/response bodies are [borsh](https://crates.io/crates/borsh)-encoded.
+
+## Protocol summary
+
+All commands use APDU class byte `0x80`.
+
+| Instruction       | Code   | Request body          | Response                  |
+|-------------------|--------|-----------------------|---------------------------|
+| `GetVersion`      | `0x01` | —                     | App version (UTF-8)       |
+| `GetAppName`      | `0x02` | —                     | App name (UTF-8)          |
+| `GetPublicKey`    | `0x03` | `GetPublicKeyRequest` | `GetPublicKeyResponse`    |
+| `SignTransaction` | `0x04` | Streamed (see below)  | `SignTransactionResponse` |
+
+### `SignTransaction` streaming
+
+A signing exchange streams the canonical transaction signing preimage to the device as a sequence
+of frames, distinguished by `P2` (`FrameKind`):
+
+1. one `Header` frame carrying a `SignTransactionHeader` (key-derivation path, signing mode, and
+   optional stealth nonce),
+2. one `Segment` frame per preimage field (`SigningField`, tagged in the low 7 bits of `P1`), in
+   chain order, each possibly split across multiple APDUs with the high bit of `P1` marking the
+   field's last chunk,
+3. one `Finalize` frame, which triggers the user review on-device and, on approval, returns the
+   public key and Schnorr signature.
+
+The device recomputes the transaction message digest and Schnorr challenge itself from the
+streamed bytes using the domain-separation constants in the `signing` module, so a compromised
+host cannot substitute a different message than the one the user reviews.
+
+Errors are reported as app-specific status words (`OotleStatusWord`) offset into the `0xB0xx`
+range.
+
+## Documentation
+
+Detailed documentation is available at
+[docs.rs/ootle_ledger_common](https://docs.rs/ootle_ledger_common).

--- a/crates/wallet/ledger/common/src/arg_types.rs
+++ b/crates/wallet/ledger/common/src/arg_types.rs
@@ -1,8 +1,15 @@
 //   Copyright 2026 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
+//! Borsh-encoded APDU request/response bodies and the framing of the streamed `SignTransaction`
+//! exchange.
+
 use borsh::{BorshDeserialize, BorshSerialize};
 
+/// Key-derivation branch for [`GetPublicKeyRequest`] and [`SignTransactionHeader`].
+///
+/// Mirrors `tari_ootle_wallet_sdk::models::KeyBranch` variant-for-variant so host and device
+/// derive the same keys.
 #[repr(u64)]
 #[derive(Clone, Copy, BorshSerialize, BorshDeserialize)]
 #[borsh(use_discriminant = true)]
@@ -26,11 +33,13 @@ pub enum KeyType {
 }
 
 impl KeyType {
+    /// The branch's borsh discriminant, used as the derivation-path component.
     pub fn as_u64(&self) -> u64 {
         *self as u64
     }
 }
 
+/// Body of a `GetPublicKey` request: the derivation path of the key to return.
 #[derive(BorshSerialize, BorshDeserialize)]
 pub struct GetPublicKeyRequest {
     pub account: u64,
@@ -38,6 +47,7 @@ pub struct GetPublicKeyRequest {
     pub key_type: KeyType,
 }
 
+/// Response to `GetPublicKey`: the compressed Ristretto public key for the requested path.
 #[derive(BorshSerialize, BorshDeserialize)]
 pub struct GetPublicKeyResponse {
     pub public_key: [u8; 32],
@@ -110,6 +120,7 @@ pub enum SigningField {
 }
 
 impl SigningField {
+    /// The field tag carried in the low 7 bits of `P1` on `Segment` frames.
     pub fn as_tag(self) -> u8 {
         self as u8
     }

--- a/crates/wallet/ledger/common/src/lib.rs
+++ b/crates/wallet/ledger/common/src/lib.rs
@@ -1,6 +1,20 @@
 //   Copyright 2026 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
+//! Shared definitions of the APDU protocol spoken between the Tari Ootle Ledger device app and a
+//! host client (`ootle_ledger_client`).
+//!
+//! Both sides depend on this crate so the wire format is defined exactly once:
+//!
+//! - [`Instruction`] — the APDU instruction set (sent under class byte `0x80`).
+//! - [`OotleStatusWord`] — app-specific error status words returned by the device.
+//! - [`arg_types`] — borsh-encoded request/response bodies and the framing of the streamed `SignTransaction` exchange.
+//! - [`signing`] — domain-separation constants the device uses to recompute the transaction signing message and Schnorr
+//!   challenge.
+//!
+//! The crate is `no_std` by default so it can build inside the Ledger embedded app; the host
+//! enables the `std` feature.
+
 #![cfg_attr(not(feature = "std"), no_std)]
 
 pub mod arg_types;
@@ -37,13 +51,19 @@ pub mod signing {
 }
 
 /// APDU instruction set for the Ootle Ledger app.
-/// Byte values must match what `tari-ledger-client` sends (CLA = 0x80).
+/// Byte values must match what `ootle_ledger_client` sends (CLA = 0x80).
 #[repr(u8)]
 #[derive(Debug)]
 pub enum Instruction {
+    /// Return the app version (`CARGO_PKG_VERSION`) as UTF-8 bytes.
     GetVersion = 0x01,
+    /// Return the app name as UTF-8 bytes.
     GetAppName = 0x02,
+    /// Derive and return a public key. Body: [`arg_types::GetPublicKeyRequest`], response:
+    /// [`arg_types::GetPublicKeyResponse`].
     GetPublicKey = 0x03,
+    /// Sign a transaction, streamed as a sequence of frames (see [`arg_types::FrameKind`]).
+    /// Concludes with the user review on-device and an [`arg_types::SignTransactionResponse`].
     SignTransaction = 0x04,
 }
 
@@ -62,12 +82,19 @@ impl TryFrom<u8> for Instruction {
     }
 }
 
-/// Ledger application status words.
+/// App-specific error status words returned in the APDU status bytes (`SW1SW2`).
+///
+/// On the wire these are offset by [`OOTLE_STATUS_BASE`] (see [`Self::to_status`]) to keep them
+/// out of the ISO 7816 / Ledger SDK status ranges. A successful exchange returns the standard
+/// `0x9000` instead.
 #[repr(u16)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum OotleStatusWord {
+    /// The request body could not be decoded, or the APDU parameters were invalid.
     BadRequest = 0x01,
+    /// The device failed to encode the response body.
     EncodeResponseFail = 0x02,
+    /// Deriving the requested key on-device failed.
     KeyDeriveFail = 0x03,
     /// A streamed `SignTransaction` chunk arrived out of order or in an unexpected state.
     SignStreamError = 0x04,
@@ -77,9 +104,12 @@ pub enum OotleStatusWord {
     UserRejected = 0x06,
 }
 
+/// Base offset for [`OotleStatusWord`] values on the wire, keeping app-specific errors clear of
+/// the ISO 7816 and Ledger SDK status word ranges.
 pub const OOTLE_STATUS_BASE: u16 = 0xB000;
 
 impl OotleStatusWord {
+    /// The 16-bit status word as sent on the wire: [`OOTLE_STATUS_BASE`] plus the error code.
     pub fn to_status(self) -> u16 {
         OOTLE_STATUS_BASE | self as u16
     }

--- a/crates/wallet/ootle-rs/Cargo.toml
+++ b/crates/wallet/ootle-rs/Cargo.toml
@@ -21,7 +21,7 @@ tari_ootle_address = { workspace = true }
 tari_template_builtin = { workspace = true }
 
 # Ledger hardware-wallet signer (feature-gated).
-tari_ledger_client = { path = "../ledger/client", version = "0.1.1", optional = true }
+ootle_ledger_client = { path = "../ledger/client", version = "0.1.1", optional = true }
 ootle_ledger_common = { workspace = true, optional = true }
 
 async-trait = { workspace = true }
@@ -44,4 +44,4 @@ tracing = { workspace = true, features = ["log-always"] }
 [features]
 default = []
 mmap-value-lookup = ["tari_ootle_wallet_crypto/mmap-value-lookup"]
-ledger = ["dep:tari_ledger_client", "dep:ootle_ledger_common"]
+ledger = ["dep:ootle_ledger_client", "dep:ootle_ledger_common"]

--- a/crates/wallet/ootle-rs/src/signer/ledger.rs
+++ b/crates/wallet/ootle-rs/src/signer/ledger.rs
@@ -17,9 +17,9 @@
 //! identical to the public path.
 
 use async_trait::async_trait;
+use ootle_ledger_client::{Exchange, LedgerClient, LedgerClientError};
 use ootle_ledger_common::arg_types::{KeyType, SignMode, SigningField};
 use tari_crypto::{ristretto::RistrettoPublicKey, tari_utilities::ByteArray};
-use tari_ledger_client::{Exchange, LedgerClient, LedgerClientError};
 use tari_ootle_address::OotleAddress;
 use tari_ootle_transaction::{
     IntoSigned,

--- a/scripts/publish_crates.py
+++ b/scripts/publish_crates.py
@@ -56,6 +56,8 @@ CRATES = [
     ("ootle-wasm-core", "crates/ootle_wasm/core", 3),
     ("ootle-wasm", "crates/ootle_wasm/wasm", 3),
     ("tari_template_test_tooling", "crates/template_test_tooling", 3),
+    ("ootle_ledger_common", "crates/wallet/ledger/common", 4),
+    ("ootle_ledger_client", "crates/wallet/ledger/client", 4),
     ("ootle-rs", "crates/wallet/ootle-rs", 4),
     ("tari_ootle_wallet_sdk", "crates/wallet/sdk", 4),
     ("tari_ootle_wallet_storage_sqlite", "crates/wallet/storage_sqlite", 4),


### PR DESCRIPTION
## Description

Prepares `ootle_ledger_common` and `ootle_ledger_client` for publishing to crates.io by adding package metadata, READMEs, rustdocs, and registering both crates in the publish script.

## Motivation

Neither crate had the metadata or documentation required for a crates.io publish. The `ootle_ledger_client` crate was also renamed from `tari_ledger_client` on this branch, and had a latent build bug with the `speculos-transport` feature.

## Changes

**`ootle_ledger_common`** (`crates/wallet/ledger/common`):
- `Cargo.toml`: added `description` and `repository` fields
- New `README.md`: overview, APDU instruction table (CLA 0x80), SignTransaction streaming protocol walkthrough, status word range
- Rustdocs: crate-level overview in `lib.rs`; docs for all previously undocumented items (`Instruction` variants, `OotleStatusWord` variants, `OOTLE_STATUS_BASE`, `to_status`, `arg_types` module, `KeyType` enum, `as_u64`, `as_tag`, `GetPublicKeyRequest`/`Response`)
- Updated stale `tari-ledger-client` doc reference to `ootle_ledger_client`

**`ootle_ledger_client`** (`crates/wallet/ledger/client`):
- `Cargo.toml`: improved `description`; added `[package.metadata.docs.rs] all-features = true` so feature-gated transports appear on docs.rs
- New `README.md`: overview, transports/feature-flag table, usage example, testing section (signing_recipe.rs host reference test + Speculos integration tests)
- Rustdocs: crate-level overview; docs for `LedgerClient`, `new`, `get_app_version`, `get_app_name`, `get_public_key`, `LedgerClientResult`, all `LedgerClientError` variants, `SpeculosTransport` (+ module doc), `DecodeAnswer`
- Bug fix: `speculos-transport` feature enabled `serde` without `serde/derive` (workspace serde is `default-features = false`), so the lib failed to build standalone with that feature. The optional serde dep now enables `derive` itself.

**`scripts/publish_crates.py`**: both ledger crates added to the publish list