### PR TITLE
fix(consensus): seed next_epoch from oracle on worker startup

### DIFF
--- a/crates/consensus/src/hotstuff/worker.rs
+++ b/crates/consensus/src/hotstuff/worker.rs
@@ -286,6 +286,50 @@ impl<TConsensusSpec: ConsensusSpec> HotstuffWorker<TConsensusSpec> {
         Ok((current_epoch, epoch_hash))
     }
 
+    /// If the oracle crossed an epoch boundary while this node was offline, the corresponding `EpochChanged` event was
+    /// published when the epoch manager completed its initial scan — before this worker subscribed to epoch events.
+    /// Broadcast events are not replayed, so without re-deriving `next_epoch` from the oracle here, no validator
+    /// resuming a stalled epoch would propose `EndEpoch` until the next base-layer epoch boundary publishes a fresh
+    /// event, leaving the committee stuck one epoch behind for an entire base-layer epoch.
+    async fn seed_next_epoch_from_oracle(&mut self, starting_epoch: Epoch) -> Result<(), HotStuffError> {
+        let oracle_epoch = self.epoch_manager.current_epoch().await?;
+        if oracle_epoch <= starting_epoch {
+            return Ok(());
+        }
+
+        let required_schema = ProtocolVersion::at(oracle_epoch);
+        if required_schema > ProtocolVersion::MAX_SUPPORTED {
+            error!(
+                target: LOG_TARGET,
+                "🛑 Binary does not support schema {} required at epoch {}. Upgrade required.",
+                required_schema,
+                oracle_epoch,
+            );
+            return Err(HotStuffError::UnsupportedProtocolVersion { epoch: oracle_epoch });
+        }
+
+        if !self
+            .epoch_manager
+            .is_this_validator_registered_for_epoch(oracle_epoch)
+            .await?
+        {
+            info!(
+                target: LOG_TARGET,
+                "💤 This validator is not registered for next epoch {oracle_epoch}. Will stop consensus once the \
+                 current epoch {starting_epoch} has transitioned."
+            );
+            return Ok(());
+        }
+
+        info!(
+            target: LOG_TARGET,
+            "🌟 Oracle is at epoch {oracle_epoch} but consensus is resuming at {starting_epoch}. Seeding next epoch \
+             so that EndEpoch can be proposed.",
+        );
+        self.next_epoch = Some((oracle_epoch, Instant::now()));
+        Ok(())
+    }
+
     pub async fn start(&mut self) -> Result<WorkerExitReason, HotStuffError> {
         let (current_epoch, current_epoch_hash) = self.get_starting_epoch().await?;
         let local_committee_info = self.epoch_manager.get_local_committee_info(current_epoch).await?;
@@ -312,6 +356,9 @@ impl<TConsensusSpec: ConsensusSpec> HotstuffWorker<TConsensusSpec> {
         // EpochChanged event (or this startup if the oracle is already current) finishes the
         // transition.
         self.recover_pending_end_of_epoch(current_epoch).await?;
+
+        // Catch up on any epoch change the oracle observed before this worker subscribed to epoch events.
+        self.seed_next_epoch_from_oracle(current_epoch).await?;
 
         self.publish_event(HotstuffEvent::EpochChanged {
             epoch: current_epoch,

--- a/crates/consensus/src/hotstuff/worker.rs
+++ b/crates/consensus/src/hotstuff/worker.rs
@@ -291,31 +291,36 @@ impl<TConsensusSpec: ConsensusSpec> HotstuffWorker<TConsensusSpec> {
     /// Broadcast events are not replayed, so without re-deriving `next_epoch` from the oracle here, no validator
     /// resuming a stalled epoch would propose `EndEpoch` until the next base-layer epoch boundary publishes a fresh
     /// event, leaving the committee stuck one epoch behind for an entire base-layer epoch.
+    ///
+    /// Seeds the epoch immediately following `starting_epoch` and lets consensus progress naturally from there. If
+    /// the oracle is more than one epoch ahead, the committee transitions one epoch and the next `EpochChanged` event
+    /// (or peer QCs at a higher epoch) drives the rest.
     async fn seed_next_epoch_from_oracle(&mut self, starting_epoch: Epoch) -> Result<(), HotStuffError> {
         let oracle_epoch = self.epoch_manager.current_epoch().await?;
         if oracle_epoch <= starting_epoch {
             return Ok(());
         }
 
-        let required_schema = ProtocolVersion::at(oracle_epoch);
+        let next_epoch = starting_epoch + Epoch(1);
+        let required_schema = ProtocolVersion::at(next_epoch);
         if required_schema > ProtocolVersion::MAX_SUPPORTED {
             error!(
                 target: LOG_TARGET,
                 "🛑 Binary does not support schema {} required at epoch {}. Upgrade required.",
                 required_schema,
-                oracle_epoch,
+                next_epoch,
             );
-            return Err(HotStuffError::UnsupportedProtocolVersion { epoch: oracle_epoch });
+            return Err(HotStuffError::UnsupportedProtocolVersion { epoch: next_epoch });
         }
 
         if !self
             .epoch_manager
-            .is_this_validator_registered_for_epoch(oracle_epoch)
+            .is_this_validator_registered_for_epoch(next_epoch)
             .await?
         {
             info!(
                 target: LOG_TARGET,
-                "💤 This validator is not registered for next epoch {oracle_epoch}. Will stop consensus once the \
+                "💤 This validator is not registered for next epoch {next_epoch}. Will stop consensus once the \
                  current epoch {starting_epoch} has transitioned."
             );
             return Ok(());
@@ -324,9 +329,9 @@ impl<TConsensusSpec: ConsensusSpec> HotstuffWorker<TConsensusSpec> {
         info!(
             target: LOG_TARGET,
             "🌟 Oracle is at epoch {oracle_epoch} but consensus is resuming at {starting_epoch}. Seeding next epoch \
-             so that EndEpoch can be proposed.",
+             {next_epoch} so that EndEpoch can be proposed.",
         );
-        self.next_epoch = Some((oracle_epoch, Instant::now()));
+        self.next_epoch = Some((next_epoch, Instant::now()));
         Ok(())
     }
 


### PR DESCRIPTION
## Description

Seeds `next_epoch` from the epoch oracle when the hotstuff worker starts up, preventing a one-epoch-behind stall after a restart that spans an epoch boundary.

## Motivation

If the epoch oracle (base layer scanner) crosses an epoch boundary while a validator is offline, the corresponding `EpochManagerEvent::EpochChanged` is published when the epoch manager completes its initial scan — before the hotstuff worker subscribes to epoch events inside `run()`. Broadcast events are not replayed, so `self.next_epoch` stays `None` after restart and `can_propose_epoch_end()` never returns true.

Concrete failure scenario: a committee shuts down mid-epoch at E-1; the base layer moves to E during the downtime; the nodes restart. The stalled-committee high-QC probe (#2118/#2125) correctly lets them rejoin consensus at E-1, but no validator ever proposes `EndEpoch`, so the committee sits at E-1 producing blocks until the next base-layer boundary (E+1) fires a fresh `EpochChanged` event — a full base-layer epoch stuck one epoch behind.

## Changes

- Add `HotstuffWorker::seed_next_epoch_from_oracle`: queries the epoch manager's current epoch at startup; if it is ahead of the consensus starting epoch, sets `next_epoch = Some((oracle_epoch, Instant::now()))`.
- Call `seed_next_epoch_from_oracle` in `HotstuffWorker::start`, after pending-EOE recovery and before the main event loop.
- The new method mirrors the existing `EpochChanged` event handler: errors on unsupported protocol schema, skips (with the same log message) if this validator is not registered for the oracle epoch.
- `Instant::now()` is used as the seed time so the existing `epoch_end_grace_period` applies from startup, giving restarting peers time to come up before `EndEpoch` is proposed.

## Testing

`cargo nextest r -p consensus_tests epoch` — 10/10 epoch-related tests pass (epoch_change, dummy_blocks, epoch-expiry, leader-failure-at-epoch-start).