### PR TITLE
fix(template_lib_types): decode Amount and PrecisionAmount from CBOR strings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12417,7 +12417,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_lib_types"
-version = "0.27.1"
+version = "0.27.2"
 dependencies = [
  "bnum",
  "borsh",

--- a/crates/template_lib_types/Cargo.toml
+++ b/crates/template_lib_types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_template_lib_types"
-version = "0.27.1"
+version = "0.27.2"
 edition.workspace = true
 authors.workspace = true
 description = "Tari template library types"

--- a/crates/template_lib_types/src/amount/amount.rs
+++ b/crates/template_lib_types/src/amount/amount.rs
@@ -60,6 +60,14 @@ impl<'b, C> minicbor::Decode<'b, C> for Amount {
                 let v = d.i64()?;
                 Amount::try_from(v).map_err(|e| minicbor::decode::Error::message(format!("Amount: {}", e)))
             },
+            Type::String | Type::StringIndef => {
+                let mut s = String::new();
+                for chunk in d.str_iter()? {
+                    s.push_str(chunk?);
+                }
+                s.parse::<Amount>()
+                    .map_err(|e| minicbor::decode::Error::message(format!("Amount: invalid string '{}': {}", s, e)))
+            },
             other => Err(minicbor::decode::Error::message(format!(
                 "Amount: unexpected CBOR datatype {:?}",
                 other
@@ -673,6 +681,16 @@ mod tests {
         let encoded = tari_bor::encode(&a).unwrap();
         let decoded = tari_bor::decode::<Amount>(&encoded).unwrap();
         assert_eq!(a, decoded);
+    }
+
+    #[test]
+    fn can_decode_cbor_string() {
+        let encoded = tari_bor::encode(&"100000000000000000000000000").unwrap();
+        let decoded = tari_bor::decode::<Amount>(&encoded).unwrap();
+        assert_eq!(decoded, Amount::new(100000000000000000000000000));
+
+        let encoded = tari_bor::encode(&"not a number").unwrap();
+        tari_bor::decode::<Amount>(&encoded).unwrap_err();
     }
 
     #[test]

--- a/crates/template_lib_types/src/amount/amount.rs
+++ b/crates/template_lib_types/src/amount/amount.rs
@@ -60,7 +60,12 @@ impl<'b, C> minicbor::Decode<'b, C> for Amount {
                 let v = d.i64()?;
                 Amount::try_from(v).map_err(|e| minicbor::decode::Error::message(format!("Amount: {}", e)))
             },
-            Type::String | Type::StringIndef => {
+            Type::String => {
+                let s = d.str()?;
+                s.parse::<Amount>()
+                    .map_err(|e| minicbor::decode::Error::message(format!("Amount: invalid string '{}': {}", s, e)))
+            },
+            Type::StringIndef => {
                 let mut s = String::new();
                 for chunk in d.str_iter()? {
                     s.push_str(chunk?);

--- a/crates/template_lib_types/src/precision/amount.rs
+++ b/crates/template_lib_types/src/precision/amount.rs
@@ -78,7 +78,13 @@ impl<'b, C> minicbor::Decode<'b, C> for PrecisionAmount {
                 let v = d.i64()?;
                 Ok(PrecisionAmount::from(v))
             },
-            Type::String | Type::StringIndef => {
+            Type::String => {
+                let s = d.str()?;
+                s.parse::<PrecisionAmount>().map_err(|e| {
+                    minicbor::decode::Error::message(format!("PrecisionAmount: invalid string '{}': {}", s, e))
+                })
+            },
+            Type::StringIndef => {
                 let mut s = String::new();
                 for chunk in d.str_iter()? {
                     s.push_str(chunk?);

--- a/crates/template_lib_types/src/precision/amount.rs
+++ b/crates/template_lib_types/src/precision/amount.rs
@@ -78,6 +78,15 @@ impl<'b, C> minicbor::Decode<'b, C> for PrecisionAmount {
                 let v = d.i64()?;
                 Ok(PrecisionAmount::from(v))
             },
+            Type::String | Type::StringIndef => {
+                let mut s = String::new();
+                for chunk in d.str_iter()? {
+                    s.push_str(chunk?);
+                }
+                s.parse::<PrecisionAmount>().map_err(|e| {
+                    minicbor::decode::Error::message(format!("PrecisionAmount: invalid string '{}': {}", s, e))
+                })
+            },
             other => Err(minicbor::decode::Error::message(format!(
                 "PrecisionAmount: unexpected CBOR datatype {:?}",
                 other
@@ -643,6 +652,16 @@ mod tests {
     use serde_json::json;
 
     use super::{PrecisionAmount as Amount, *};
+
+    #[test]
+    fn can_decode_cbor_string() {
+        let encoded = tari_bor::encode(&"-100000000000000000000000000").unwrap();
+        let decoded = tari_bor::decode::<Amount>(&encoded).unwrap();
+        assert_eq!(decoded, "-100000000000000000000000000".parse::<Amount>().unwrap());
+
+        let encoded = tari_bor::encode(&"not a number").unwrap();
+        tari_bor::decode::<Amount>(&encoded).unwrap_err();
+    }
 
     #[test]
     fn basic_arithmetic() {


### PR DESCRIPTION
## Description

`Amount` is wire-encoded as a two-element `[lo, hi]` u64 array in CBOR. Its minicbor `Decode` impl accepted arrays and native CBOR integers, but not CBOR strings. `PrecisionAmount` had the same gap.

This matters because native CBOR integers are capped at 64 bits, so amounts larger than `u64::MAX` cannot be represented as raw CBOR integers. Transaction manifests that pass large amount literals (e.g. `100000000000000000000000000`) as string arguments hit:

```
Amount: unexpected CBOR datatype String
```

Both `Amount` and `PrecisionAmount` already implement `FromStr`, and the serde/JSON path already accepts strings. This fix makes the minicbor path consistent with that behaviour.

## Motivation

Templates with functions taking `Amount` parameters were unreachable from manifests for values above `u64::MAX`. The unsuffixed manifest integer literal parses as `i64`; u128-suffixed literals fail to serialise as `tari_bor::Value::Integer` beyond `u64::MAX`; the only working path is passing the value as a quoted string — which was rejected by the decoder.

## Changes

- `Amount` minicbor `Decode`: accept `String`/`StringIndef` tokens, parse via `FromStr` (`u128`); emit a clear error for non-numeric strings. Added test `can_decode_cbor_string`.
- `PrecisionAmount` minicbor `Decode`: same, parsing via `I192`/`FromStr`, supporting negatives. Added test `can_decode_cbor_string`.
- `tari_template_lib_types` version bumped `0.27.1 → 0.27.2` (patch; workspace pin is `^0.27` so no dependents need updating).
- `Cargo.lock` updated for the version bump.