### PR TITLE
fix(indexer): honour p2p.enable_relay config instead of hard-coding relay on

### DIFF
--- a/applications/tari_indexer/src/bootstrap.rs
+++ b/applications/tari_indexer/src/bootstrap.rs
@@ -131,7 +131,7 @@ pub async fn spawn_services(
                     .expect("Failed to parse protocol version"),
                 user_agent: format!("/tari/indexer/{}", env!("CARGO_PKG_VERSION")),
                 enable_mdns: config.indexer.p2p.enable_mdns,
-                enable_relay: true,
+                enable_relay: config.indexer.p2p.enable_relay,
                 relay_circuit_limits: RelayCircuitLimits::high(),
                 relay_reservation_limits: RelayReservationLimits::high(),
                 rendezvous_server_enabled: config.indexer.p2p.enable_rendezvous,


### PR DESCRIPTION
## Description

The indexer unconditionally enabled the libp2p relay server, ignoring the `indexer.p2p.enable_relay` config value (which defaults to `false`, and is documented as disabled in the `d_indexer.toml` preset). This forced every indexer into the relay-server role regardless of operator intent.

## Motivation

On live testnet, having relay forcibly enabled exposed indexers to a remote panic in the forked libp2p relay behaviour (`assert_eq!(*status, Reservation::Active)` at `protocols/relay/src/behaviour.rs:719`). This assert fires when a peer requests a circuit to a peer that is connected to the relay but holds no active reservation, crashing the node during normal operation. The crash was observed consistently on dry-run submissions.

## Changes

- `applications/tari_indexer/src/bootstrap.rs`: pass `config.indexer.p2p.enable_relay` instead of the hard-coded `true`, making the indexer behave consistently with validator nodes.

The underlying libp2p relay bug will be addressed separately.

**Note for operators:** indexers that are intended to act as relay servers must now explicitly opt in with `indexer.p2p.enable_relay = true` in their config.