### PR TITLE
fix(epoch_manager): resolve current epoch hash inside the service to avoid startup race

### DIFF
--- a/crates/epoch_manager/src/service/epoch_manager_service.rs
+++ b/crates/epoch_manager/src/service/epoch_manager_service.rs
@@ -379,6 +379,9 @@ impl<TSpec: EpochManagerSpec> EpochManagerService<TSpec> {
             EpochManagerRequest::GetEpochHash { epoch, reply } => {
                 handle(reply, self.inner.get_epoch_hash(epoch), context)
             },
+            EpochManagerRequest::GetCurrentEpochHash { reply } => {
+                handle(reply, Ok(self.inner.current_epoch_hash()), context)
+            },
             EpochManagerRequest::GetValidatorNodeByPublicKey {
                 epoch,
                 public_key,

--- a/crates/epoch_manager/src/service/handle.rs
+++ b/crates/epoch_manager/src/service/handle.rs
@@ -279,10 +279,13 @@ impl<TAddr: NodeAddressable> EpochManagerReader for EpochManagerHandle<TAddr> {
     }
 
     async fn get_current_epoch_hash(&self) -> Result<FixedHash, EpochManagerError> {
-        let epoch = self.get_current_epoch();
+        // Resolve the current epoch inside the service rather than reading the shared atomic here.
+        // Reading the epoch and then requesting its hash is racy: the service may advance the
+        // epoch in between, and the previously-current epoch may have no persisted row (epoch 0 on
+        // a fresh chain never does), turning a "current hash" read into a spurious NoEpochFound.
         let (tx, rx) = oneshot::channel();
         self.tx_request
-            .send(EpochManagerRequest::GetEpochHash { epoch, reply: tx })
+            .send(EpochManagerRequest::GetCurrentEpochHash { reply: tx })
             .await
             .map_err(|_| EpochManagerError::SendError)?;
 

--- a/crates/epoch_manager/src/service/types.rs
+++ b/crates/epoch_manager/src/service/types.rs
@@ -32,6 +32,9 @@ pub enum EpochManagerRequest<TAddr> {
         epoch: Epoch,
         reply: Reply<FixedHash>,
     },
+    GetCurrentEpochHash {
+        reply: Reply<FixedHash>,
+    },
     GetValidatorNodeByPublicKey {
         epoch: Epoch,
         public_key: RistrettoPublicKeyBytes,


### PR DESCRIPTION
Description
---

Adds an `EpochManagerRequest::GetCurrentEpochHash` request and uses it in `EpochManagerHandle::get_current_epoch_hash`, so the service answers from its own `current_epoch_hash` state instead of the handle reading the shared `current_epoch` atomic and then requesting that epoch's hash in a second step.

Motivation and Context
---

`get_current_epoch_hash` was racy: the handle read the `current_epoch` atomic (e.g. `Epoch(0)` shortly after the initial base-layer scan on a fresh chain), then queued `GetEpochHash { epoch: 0 }`. If the service processed an `EpochChanged` event before that request, the epoch was no longer current, so `get_epoch_hash` fell through to a DB lookup — and epoch 0 never gets a persisted row (rows are only inserted by `activate_epoch` on an epoch change), producing a spurious `NoEpochFound(Epoch(0))`.

This surfaced as a flaky CI failure in the cucumber `Given a network with registered validator VN and wallet daemon WALLET_D` setup step: the `get_epoch_manager_stats` JSON-RPC handler maps the error to `-32603 "An internal error occurred: No epoch found Epoch(0)"`, and the registration poll loop in `assert_vn_is_registered` unwraps the client result. The poll runs exactly while the VN scanner crosses the 0→1 epoch boundary, so the race window lands right when the test hammers the endpoint. Seen on multiple PRs, e.g. https://github.com/tari-project/tari-ootle/pull/2216/checks?check_run_id=80808721333 (scenarios `indexer.feature:83` and `wallet_daemon.feature:54`, both failing with the same error).

How Has This Been Tested?
---

`cargo check -p tari_epoch_manager` and existing test suites; the race itself is timing-dependent and was only observable in CI cucumber runs.

What process can a PR reviewer use to test or verify this change?
---

Run the cucumber integration tests; the flaky `NoEpochFound(Epoch(0))` error should no longer appear. The logic change is small enough to verify by inspection: `get_current_epoch_hash` now sends a single `GetCurrentEpochHash` request whose handler reads `self.inner.current_epoch_hash()` atomically with respect to epoch transitions.

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify