### PR TITLE
feat(indexer)!: add explicit rejected state for mempool-rejected transactions

### DIFF
--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -1,12 +1,13 @@
 ---
-# Publishing all NPM packages to the npm registry when the version number changes
+# Publishing all NPM packages to the npm registry when a version tag is pushed.
+# Packages whose local version already matches the registry are skipped.
 # See https://github.com/marketplace/actions/npm-publish for more information
 name: Publish Packages to npmjs
 
 on:
-  release:
-    types:
-      - published
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]*"
   # Allows you to run this workflow manually from the Actions tab on GitHub.
   workflow_dispatch:
 

--- a/applications/tari_indexer/src/network_client.rs
+++ b/applications/tari_indexer/src/network_client.rs
@@ -11,6 +11,7 @@ use log::{info, warn};
 use tari_epoch_manager::{EpochManagerError, EpochManagerReader};
 use tari_ootle_common_types::{NodeAddressable, NumPreshards, ShardGroup, SubstateAddress, displayable::Displayable};
 use tari_ootle_transaction::{Transaction, TransactionId};
+use tari_rpc_framework::RpcStatusCode;
 use tari_validator_node_rpc::{
     ValidatorNodeRpcClientError,
     client::{ValidatorNodeClientFactory, ValidatorNodeRpcClient},
@@ -215,4 +216,25 @@ pub enum NetworkClientError {
     },
     #[error("No committee at present. Try again later")]
     NoCommitteeMembers,
+}
+
+impl NetworkClientError {
+    /// Returns the rejection details when every involved validator failed and the last failure was a
+    /// BAD_REQUEST, i.e. the transaction was explicitly rejected as invalid (e.g. by mempool
+    /// validation) rather than failing for transient reasons.
+    pub fn validation_rejection_details(&self) -> Option<&str> {
+        let NetworkClientError::AllValidatorsFailed {
+            last_error: Some(rpc_err),
+            ..
+        } = self
+        else {
+            return None;
+        };
+        let status = rpc_err.status()?;
+        if status.as_status_code() == RpcStatusCode::BadRequest {
+            Some(status.details())
+        } else {
+            None
+        }
+    }
 }

--- a/applications/tari_indexer/src/rest_api/handlers/transactions.rs
+++ b/applications/tari_indexer/src/rest_api/handlers/transactions.rs
@@ -11,7 +11,6 @@ use log::*;
 use tari_indexer_client::types::{
     GetTransactionResponse,
     GetTransactionResultResponse,
-    IndexerTransactionFinalizedResult,
     ListRecentTransactionsRequest,
     ListRecentTransactionsResponse,
     QueryTransactionEventsRequest,
@@ -23,7 +22,6 @@ use tari_indexer_client::types::{
 use tari_ootle_common_types::{displayable::Displayable, optional::Optional};
 use tari_ootle_transaction::TransactionId;
 use tari_rpc_framework::RpcStatusCode;
-use tari_validator_node_rpc::client::TransactionResultStatus;
 
 use crate::{
     network_client::NetworkClientError,
@@ -225,22 +223,7 @@ pub async fn get_transaction_result(
         .map_err(ErrorResponse::anyhow)?
         .ok_or_else(|| ErrorResponse::not_found(format!("Transaction {transaction_id} not found")))?;
 
-    let resp = match result {
-        TransactionResultStatus::Pending => GetTransactionResultResponse {
-            result: IndexerTransactionFinalizedResult::Pending,
-        },
-        TransactionResultStatus::Finalized(finalized) => GetTransactionResultResponse {
-            result: IndexerTransactionFinalizedResult::Finalized {
-                final_decision: finalized.final_decision,
-                execution_result: finalized.execute_result.map(Box::new),
-                execution_time: finalized.execution_time,
-                finalized_time: finalized.finalized_time,
-                abort_details: finalized.abort_details,
-            },
-        },
-    };
-
-    Ok(Json(GetTransactionResultResponse { result: resp.result }))
+    Ok(Json(GetTransactionResultResponse { result }))
 }
 
 #[utoipa::path(

--- a/applications/tari_indexer/src/storage_sqlite/migrations/2026-06-11-000001_transaction_rejections/down.sql
+++ b/applications/tari_indexer/src/storage_sqlite/migrations/2026-06-11-000001_transaction_rejections/down.sql
@@ -1,0 +1,4 @@
+alter table transactions
+    drop column rejected_reason;
+alter table transactions
+    drop column rejected_at;

--- a/applications/tari_indexer/src/storage_sqlite/migrations/2026-06-11-000001_transaction_rejections/up.sql
+++ b/applications/tari_indexer/src/storage_sqlite/migrations/2026-06-11-000001_transaction_rejections/up.sql
@@ -1,0 +1,4 @@
+alter table transactions
+    add column rejected_reason text null;
+alter table transactions
+    add column rejected_at timestamp null;

--- a/applications/tari_indexer/src/storage_sqlite/reader.rs
+++ b/applications/tari_indexer/src/storage_sqlite/reader.rs
@@ -463,6 +463,7 @@ impl IndexerStoreReadTransaction for SqliteStoreReadTransaction<'_> {
             .select((
                 transactions::body,
                 transactions::created_at,
+                transactions::rejected_reason,
                 (
                     transaction_receipts::outcome,
                     transaction_receipts::total_fees_paid,
@@ -483,7 +484,12 @@ impl IndexerStoreReadTransaction for SqliteStoreReadTransaction<'_> {
                 reason: format!("list_recent_transactions: {}", e),
             })
             .and_then(
-                |(body, created_at, receipt): (String, PrimitiveDateTime, ReceiptSummaryRow)| {
+                |(body, created_at, rejected_reason, receipt): (
+                    String,
+                    PrimitiveDateTime,
+                    Option<String>,
+                    ReceiptSummaryRow,
+                )| {
                     let full: Transaction = deserialize_json(&body)?;
                     let transaction_id = full.calculate_id();
                     Ok(TransactionEntry {
@@ -491,6 +497,7 @@ impl IndexerStoreReadTransaction for SqliteStoreReadTransaction<'_> {
                         created_at,
                         transaction: full.into(),
                         summary: receipt.map(map_receipt_summary).transpose()?,
+                        rejected_reason,
                     })
                 },
             )
@@ -506,6 +513,7 @@ impl IndexerStoreReadTransaction for SqliteStoreReadTransaction<'_> {
             .select((
                 transactions::body,
                 transactions::created_at,
+                transactions::rejected_reason,
                 (
                     transaction_receipts::outcome,
                     transaction_receipts::total_fees_paid,
@@ -514,13 +522,13 @@ impl IndexerStoreReadTransaction for SqliteStoreReadTransaction<'_> {
                     .nullable(),
             ))
             .filter(transactions::transaction_id.eq(serialize_hex(transaction_id)))
-            .first::<(String, PrimitiveDateTime, ReceiptSummaryRow)>(self.connection())
+            .first::<(String, PrimitiveDateTime, Option<String>, ReceiptSummaryRow)>(self.connection())
             .optional()
             .map_err(|e| StorageError::QueryError {
                 reason: format!("get_transaction: {e}"),
             })?;
 
-        row.map(|(body, created_at, receipt)| {
+        row.map(|(body, created_at, rejected_reason, receipt)| {
             let full: Transaction = deserialize_json(&body)?;
             Ok(TransactionEntry {
                 // The row was looked up by this id, so it matches full.calculate_id() without recomputing it.
@@ -528,9 +536,28 @@ impl IndexerStoreReadTransaction for SqliteStoreReadTransaction<'_> {
                 created_at,
                 transaction: full.into(),
                 summary: receipt.map(map_receipt_summary).transpose()?,
+                rejected_reason,
             })
         })
         .transpose()
+    }
+
+    fn get_transaction_rejection(
+        &mut self,
+        transaction_id: TransactionId,
+    ) -> Result<Option<(String, PrimitiveDateTime)>, StorageError> {
+        use crate::storage_sqlite::schema::transactions;
+
+        let row = transactions::table
+            .select((transactions::rejected_reason, transactions::rejected_at))
+            .filter(transactions::transaction_id.eq(serialize_hex(transaction_id)))
+            .first::<(Option<String>, Option<PrimitiveDateTime>)>(self.connection())
+            .optional()
+            .map_err(|e| StorageError::QueryError {
+                reason: format!("get_transaction_rejection: {e}"),
+            })?;
+
+        Ok(row.and_then(|(reason, rejected_at)| reason.zip(rejected_at)))
     }
 
     fn list_transaction_receipts(

--- a/applications/tari_indexer/src/storage_sqlite/schema.rs
+++ b/applications/tari_indexer/src/storage_sqlite/schema.rs
@@ -93,6 +93,8 @@ diesel::table! {
         transaction_id -> Text,
         body -> Text,
         created_at -> Timestamp,
+        rejected_reason -> Nullable<Text>,
+        rejected_at -> Nullable<Timestamp>,
     }
 }
 

--- a/applications/tari_indexer/src/storage_sqlite/writer.rs
+++ b/applications/tari_indexer/src/storage_sqlite/writer.rs
@@ -18,6 +18,7 @@ use tari_ootle_common_types::{Epoch, StateVersion, shard::Shard, substate_type::
 use tari_ootle_storage::{
     StorageError,
     consensus_models::{EpochCheckpoint, SubstateData, SubstateUpdateProof},
+    time::PrimitiveDateTime,
 };
 use tari_ootle_storage_sqlite::SqliteTransaction;
 use tari_ootle_transaction::{Transaction, TransactionId};
@@ -321,6 +322,41 @@ impl IndexerStoreWriteTransaction for SqliteStoreWriteTransaction<'_> {
             .execute(self.connection())
             .map_err(|e| StorageError::QueryError {
                 reason: format!("insert_transaction: {e}"),
+            })?;
+
+        Ok(())
+    }
+
+    fn set_transaction_rejected(&mut self, transaction_id: TransactionId, reason: &str) -> Result<(), StorageError> {
+        use crate::storage_sqlite::schema::transactions;
+
+        diesel::update(transactions::table)
+            .filter(transactions::transaction_id.eq(serialize_hex(transaction_id)))
+            .set((
+                transactions::rejected_reason.eq(reason),
+                transactions::rejected_at.eq(diesel::dsl::now),
+            ))
+            .execute(self.connection())
+            .map_err(|e| StorageError::QueryError {
+                reason: format!("set_transaction_rejected: {e}"),
+            })?;
+
+        Ok(())
+    }
+
+    fn clear_transaction_rejection(&mut self, transaction_id: TransactionId) -> Result<(), StorageError> {
+        use crate::storage_sqlite::schema::transactions;
+
+        diesel::update(transactions::table)
+            .filter(transactions::transaction_id.eq(serialize_hex(transaction_id)))
+            .filter(transactions::rejected_reason.is_not_null())
+            .set((
+                transactions::rejected_reason.eq(None::<String>),
+                transactions::rejected_at.eq(None::<PrimitiveDateTime>),
+            ))
+            .execute(self.connection())
+            .map_err(|e| StorageError::QueryError {
+                reason: format!("clear_transaction_rejection: {e}"),
             })?;
 
         Ok(())

--- a/applications/tari_indexer/src/store.rs
+++ b/applications/tari_indexer/src/store.rs
@@ -30,6 +30,7 @@ use tari_ootle_storage::{
     Ordering,
     StorageError,
     consensus_models::{EpochCheckpoint, SubstateData, SubstateUpdateProof},
+    time::PrimitiveDateTime,
 };
 use tari_ootle_transaction::{Transaction, TransactionId};
 use tari_template_lib_types::{
@@ -134,6 +135,13 @@ pub trait IndexerStoreReadTransaction {
     /// Fetch a single transaction (with its instructions) by ID. Returns `None` if the transaction
     /// was not submitted through this indexer.
     fn get_transaction(&mut self, transaction_id: TransactionId) -> Result<Option<TransactionEntry>, StorageError>;
+
+    /// Fetch the mempool rejection reason and time for a transaction submitted through this indexer.
+    /// Returns `None` if the transaction is unknown or was not rejected.
+    fn get_transaction_rejection(
+        &mut self,
+        transaction_id: TransactionId,
+    ) -> Result<Option<(String, PrimitiveDateTime)>, StorageError>;
 
     // -------------------------------- Transaction Receipts -------------------------------- //
     fn list_transaction_receipts(
@@ -255,6 +263,10 @@ pub trait IndexerStoreWriteTransaction {
         event_filters: &[EventFilter],
     ) -> Result<Vec<InsertedEvent>, StorageError>;
     fn insert_or_ignore_transaction(&mut self, transaction: &Transaction) -> Result<(), StorageError>;
+    /// Mark a stored transaction as rejected by mempool validation, recording the reason.
+    fn set_transaction_rejected(&mut self, transaction_id: TransactionId, reason: &str) -> Result<(), StorageError>;
+    /// Clear a previous rejection, e.g. when the same transaction is later resubmitted successfully.
+    fn clear_transaction_rejection(&mut self, transaction_id: TransactionId) -> Result<(), StorageError>;
     fn insert_or_ignore_epoch_checkpoint(&mut self, epoch_checkpoint: &EpochCheckpoint) -> Result<(), StorageError>;
     fn upsert_template_catalogue(
         &mut self,

--- a/applications/tari_indexer/src/transaction_manager/mod.rs
+++ b/applications/tari_indexer/src/transaction_manager/mod.rs
@@ -23,7 +23,7 @@
 pub(crate) mod error;
 
 use tari_epoch_manager::EpochManagerReader;
-use tari_indexer_client::types::TransactionEntry;
+use tari_indexer_client::types::{IndexerTransactionFinalizedResult, TransactionEntry};
 use tari_ootle_common_types::{NodeAddressable, ToSubstateAddress, optional::Optional};
 use tari_ootle_transaction::{Transaction, TransactionId};
 use tari_validator_node_rpc::client::{TransactionResultStatus, ValidatorNodeClientFactory, ValidatorNodeRpcClient};
@@ -52,11 +52,12 @@ where
     }
 
     pub async fn submit_transaction(&self, transaction: Transaction) -> Result<TransactionId, TransactionManagerError> {
+        let transaction_id = transaction.calculate_id();
         if !transaction.verify_all_signatures() {
             // DEV note: If signatures are invalid here, this is probably an issue
             // with the JSON decoding (crates/engine_types/src/argument_parser.rs)
             return Err(TransactionManagerError::InvalidTransaction {
-                transaction_id: transaction.calculate_id(),
+                transaction_id,
                 details: "Transaction has one or more invalid signature(s)".to_string(),
             });
         }
@@ -64,16 +65,47 @@ where
         self.store
             .with_write_tx(move |tx| tx.insert_or_ignore_transaction(&transaction_for_db))
             .await?;
-        let id = self.network_client.submit_transaction(transaction).await?;
-        Ok(id)
+        match self.network_client.submit_transaction(transaction).await {
+            Ok(id) => {
+                // A previously rejected transaction may be accepted on resubmission (e.g. after a
+                // missing template is published), so a stale rejection must not shadow it.
+                self.store
+                    .with_write_tx(move |tx| tx.clear_transaction_rejection(id))
+                    .await?;
+                Ok(id)
+            },
+            Err(err) => {
+                if let Some(details) = err.validation_rejection_details() {
+                    let details = details.to_string();
+                    self.store
+                        .with_write_tx(move |tx| tx.set_transaction_rejected(transaction_id, &details))
+                        .await?;
+                }
+                Err(err.into())
+            },
+        }
     }
 
     pub async fn get_transaction_result(
         &self,
         transaction_id: TransactionId,
-    ) -> Result<TransactionResultStatus, TransactionManagerError> {
+    ) -> Result<IndexerTransactionFinalizedResult, TransactionManagerError> {
+        // A transaction rejected by mempool validation is never sequenced, so the network would
+        // report it as pending forever. Report the locally recorded rejection instead.
+        let rejection = self
+            .store
+            .with_read_tx(move |tx| tx.get_transaction_rejection(transaction_id))
+            .await?;
+        if let Some((details, rejected_at)) = rejection {
+            return Ok(IndexerTransactionFinalizedResult::Rejected {
+                details,
+                rejected_time: rejected_at,
+            });
+        }
+
         let transaction_substate_address = transaction_id.to_substate_address();
-        self.network_client
+        let result = self
+            .network_client
             .try_single_with_committee(transaction_substate_address, |mut client| async move {
                 client.get_finalized_transaction_result(transaction_id).await.optional()
             })
@@ -81,7 +113,18 @@ where
             .ok_or_else(|| TransactionManagerError::NotFound {
                 entity: "Transaction result",
                 key: transaction_id.to_string(),
-            })
+            })?;
+
+        Ok(match result {
+            TransactionResultStatus::Pending => IndexerTransactionFinalizedResult::Pending,
+            TransactionResultStatus::Finalized(finalized) => IndexerTransactionFinalizedResult::Finalized {
+                final_decision: finalized.final_decision,
+                execution_result: finalized.execute_result.map(Box::new),
+                execution_time: finalized.execution_time,
+                finalized_time: finalized.finalized_time,
+                abort_details: finalized.abort_details,
+            },
+        })
     }
 
     pub async fn list_recent_transactions(

--- a/bindings/package.json
+++ b/bindings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tari-project/ootle-ts-bindings",
-  "version": "1.38.0",
+  "version": "1.39.0",
   "private": false,
   "publishConfig": {
     "access": "public"

--- a/bindings/src/types/tari-indexer-client/IndexerTransactionFinalizedResult.ts
+++ b/bindings/src/types/tari-indexer-client/IndexerTransactionFinalizedResult.ts
@@ -12,4 +12,10 @@ export type IndexerTransactionFinalizedResult =
         finalized_time: string;
         abort_details: string | null;
       };
+    }
+  | {
+      Rejected: {
+        details: string;
+        rejected_time: string;
+      };
     };

--- a/bindings/src/types/tari-indexer-client/TransactionEntry.ts
+++ b/bindings/src/types/tari-indexer-client/TransactionEntry.ts
@@ -16,4 +16,9 @@ export type TransactionEntry = {
    * indexed yet (pending or aborted).
    */
   summary: TransactionResultSummary | null;
+  /**
+   * Reason the transaction was rejected by mempool validation when it was submitted through
+   * this indexer. None if the transaction was not rejected at submission.
+   */
+  rejected_reason: string | null;
 };

--- a/clients/tari_indexer_client/src/types.rs
+++ b/clients/tari_indexer_client/src/types.rs
@@ -370,6 +370,9 @@ pub struct TransactionEntry {
     /// Result summary from the locally indexed transaction receipt. None when no receipt has been
     /// indexed yet (pending or aborted).
     pub summary: Option<TransactionResultSummary>,
+    /// Reason the transaction was rejected by mempool validation when it was submitted through
+    /// this indexer. None if the transaction was not rejected at submission.
+    pub rejected_reason: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -398,6 +401,13 @@ pub enum IndexerTransactionFinalizedResult {
         #[cfg_attr(feature = "ts", ts(type = "string"))]
         finalized_time: PrimitiveDateTime,
         abort_details: Option<String>,
+    },
+    /// The transaction was rejected by mempool validation when it was submitted through this
+    /// indexer and was never sequenced by the network.
+    Rejected {
+        details: String,
+        #[cfg_attr(feature = "ts", ts(type = "string"))]
+        rejected_time: PrimitiveDateTime,
     },
 }
 

--- a/crates/wallet/ootle-rs/src/provider/tx_watcher.rs
+++ b/crates/wallet/ootle-rs/src/provider/tx_watcher.rs
@@ -21,7 +21,7 @@ use tari_indexer_client::{
 };
 use tari_ootle_common_types::{
     engine_types::{
-        commit_result::TransactionResult,
+        commit_result::{ExecuteResult, TransactionResult},
         transaction_receipt::{DiffSummary, FinalizeOutcome, TransactionReceipt},
     },
     optional::Optional,
@@ -295,24 +295,7 @@ impl PendingTransaction {
                         execution_result,
                         abort_details,
                         ..
-                    })) => {
-                        if let Some(result) = execution_result {
-                            return match result.finalize.result {
-                                TransactionResult::Accept(_) => Ok(TransactionOutcome::Commit),
-                                TransactionResult::AcceptFeeRejectRest(_, reason) => {
-                                    Ok(TransactionOutcome::OnlyFeeCommit(reason))
-                                },
-                                TransactionResult::Reject(reason) => Ok(TransactionOutcome::Reject(reason)),
-                            };
-                        }
-
-                        // Any commit case would have been handled above, so this is a rejection
-                        let reason = abort_details.unwrap_or_else(|| "Unknown".to_string());
-                        Err(PendingTransactionError::TransactionRejected {
-                            tx_id: self.tx_id,
-                            reason,
-                        })
-                    },
+                    })) => self.outcome_from_finalized(execution_result, abort_details),
                     Ok(Some(IndexerTransactionFinalizedResult::Rejected { details, .. })) => {
                         Err(PendingTransactionError::TransactionRejected {
                             tx_id: self.tx_id,
@@ -340,24 +323,7 @@ impl PendingTransaction {
                         execution_result,
                         abort_details,
                         ..
-                    })) => {
-                        if let Some(result) = execution_result {
-                            return match result.finalize.result {
-                                TransactionResult::Accept(_) => Ok(TransactionOutcome::Commit),
-                                TransactionResult::AcceptFeeRejectRest(_, reason) => {
-                                    Ok(TransactionOutcome::OnlyFeeCommit(reason))
-                                },
-                                TransactionResult::Reject(reason) => Ok(TransactionOutcome::Reject(reason)),
-                            };
-                        }
-
-                        // Any commit case would have been handled above, so this is a rejection
-                        let reason = abort_details.unwrap_or_else(|| "Unknown".to_string());
-                        Err(PendingTransactionError::TransactionRejected {
-                            tx_id: self.tx_id,
-                            reason,
-                        })
-                    },
+                    })) => self.outcome_from_finalized(execution_result, abort_details),
                     Ok(Some(IndexerTransactionFinalizedResult::Rejected { details, .. })) => {
                         Err(PendingTransactionError::TransactionRejected {
                             tx_id: self.tx_id,
@@ -376,6 +342,27 @@ impl PendingTransaction {
             },
             Err(e) => Err(e),
         }
+    }
+
+    fn outcome_from_finalized(
+        &self,
+        execution_result: Option<Box<ExecuteResult>>,
+        abort_details: Option<String>,
+    ) -> Result<TransactionOutcome, PendingTransactionError> {
+        if let Some(result) = execution_result {
+            return match result.finalize.result {
+                TransactionResult::Accept(_) => Ok(TransactionOutcome::Commit),
+                TransactionResult::AcceptFeeRejectRest(_, reason) => Ok(TransactionOutcome::OnlyFeeCommit(reason)),
+                TransactionResult::Reject(reason) => Ok(TransactionOutcome::Reject(reason)),
+            };
+        }
+
+        // Any commit case would have been handled above, so this is a rejection
+        let reason = abort_details.unwrap_or_else(|| "Unknown".to_string());
+        Err(PendingTransactionError::TransactionRejected {
+            tx_id: self.tx_id,
+            reason,
+        })
     }
 
     async fn try_get_transaction_result(

--- a/crates/wallet/ootle-rs/src/provider/tx_watcher.rs
+++ b/crates/wallet/ootle-rs/src/provider/tx_watcher.rs
@@ -313,6 +313,12 @@ impl PendingTransaction {
                             reason,
                         })
                     },
+                    Ok(Some(IndexerTransactionFinalizedResult::Rejected { details, .. })) => {
+                        Err(PendingTransactionError::TransactionRejected {
+                            tx_id: self.tx_id,
+                            reason: details,
+                        })
+                    },
                     Ok(None) => {
                         tracing::error!("Transaction result not found after fee reject: {}", self.tx_id);
                         Err(PendingTransactionError::Timeout { tx_id: self.tx_id })
@@ -350,6 +356,12 @@ impl PendingTransaction {
                         Err(PendingTransactionError::TransactionRejected {
                             tx_id: self.tx_id,
                             reason,
+                        })
+                    },
+                    Ok(Some(IndexerTransactionFinalizedResult::Rejected { details, .. })) => {
+                        Err(PendingTransactionError::TransactionRejected {
+                            tx_id: self.tx_id,
+                            reason: details,
                         })
                     },
                     Ok(None) => {
@@ -400,64 +412,72 @@ impl PendingTransaction {
         if let Some(receipt) = self.try_get_transaction_receipt().await? {
             return Ok(receipt);
         }
-        if let Some(IndexerTransactionFinalizedResult::Finalized {
-            final_decision,
-            abort_details,
-            execution_result,
-            ..
-        }) = self.try_get_transaction_result().await?
-        {
-            if final_decision.is_abort() {
-                let reason = execution_result
-                    .as_ref()
-                    .and_then(|res| res.finalize.result.any_reject())
-                    .map(|reject| reject.to_string())
-                    .or(abort_details)
-                    .unwrap_or_else(|| "Unknown".to_string());
+        match self.try_get_transaction_result().await? {
+            Some(IndexerTransactionFinalizedResult::Rejected { details, .. }) => {
                 return Err(PendingTransactionError::TransactionRejected {
                     tx_id: self.tx_id,
-                    reason,
+                    reason: details,
                 });
-            }
-            if final_decision.is_commit() {
-                // Transaction committed but receipt not found. This is a due to a race condition where the indexer may
-                // not have indexed the receipt yet.
-                //
-                // TODO: improvements to the indexer may be needed to fully resolve this.
-                tracing::warn!("Transaction committed but receipt not found for tx_id: {}", self.tx_id);
-                let execute_epoch = execution_result
-                    .as_ref()
-                    .and_then(|res| res.execute_epoch)
-                    .unwrap_or_default();
-                return Ok(TransactionReceipt {
-                    outcome: FinalizeOutcome::Commit,
-                    diff_summary: execution_result
+            },
+            Some(IndexerTransactionFinalizedResult::Pending) | None => {},
+            Some(IndexerTransactionFinalizedResult::Finalized {
+                final_decision,
+                abort_details,
+                execution_result,
+                ..
+            }) => {
+                if final_decision.is_abort() {
+                    let reason = execution_result
                         .as_ref()
-                        .and_then(|res| res.finalize.any_accept())
-                        .map(|diff| DiffSummary::from_diff(diff, execute_epoch))
-                        .unwrap_or_default(),
-                    fee_withdrawals: execution_result
+                        .and_then(|res| res.finalize.result.any_reject())
+                        .map(|reject| reject.to_string())
+                        .or(abort_details)
+                        .unwrap_or_else(|| "Unknown".to_string());
+                    return Err(PendingTransactionError::TransactionRejected {
+                        tx_id: self.tx_id,
+                        reason,
+                    });
+                }
+                if final_decision.is_commit() {
+                    // Transaction committed but receipt not found. This is a due to a race condition where the indexer
+                    // may not have indexed the receipt yet.
+                    //
+                    // TODO: improvements to the indexer may be needed to fully resolve this.
+                    tracing::warn!("Transaction committed but receipt not found for tx_id: {}", self.tx_id);
+                    let execute_epoch = execution_result
                         .as_ref()
-                        .and_then(|res| res.finalize.any_accept())
-                        .map(|diff| diff.validator_fee_withdrawals().to_vec().into_boxed_slice())
-                        .unwrap_or_default(),
-                    events: execution_result
-                        .as_ref()
-                        .map(|res| res.finalize.events.clone().into_boxed_slice())
-                        .unwrap_or_default(),
-                    logs: execution_result
-                        .as_ref()
-                        .map(|res| res.finalize.logs.clone().into_boxed_slice())
-                        .unwrap_or_default(),
-                    fee_receipt: execution_result
-                        .as_ref()
-                        .map(|res| res.finalize.fee_receipt.clone())
-                        .unwrap_or_default(),
-                    epoch: execute_epoch,
-                });
+                        .and_then(|res| res.execute_epoch)
+                        .unwrap_or_default();
+                    return Ok(TransactionReceipt {
+                        outcome: FinalizeOutcome::Commit,
+                        diff_summary: execution_result
+                            .as_ref()
+                            .and_then(|res| res.finalize.any_accept())
+                            .map(|diff| DiffSummary::from_diff(diff, execute_epoch))
+                            .unwrap_or_default(),
+                        fee_withdrawals: execution_result
+                            .as_ref()
+                            .and_then(|res| res.finalize.any_accept())
+                            .map(|diff| diff.validator_fee_withdrawals().to_vec().into_boxed_slice())
+                            .unwrap_or_default(),
+                        events: execution_result
+                            .as_ref()
+                            .map(|res| res.finalize.events.clone().into_boxed_slice())
+                            .unwrap_or_default(),
+                        logs: execution_result
+                            .as_ref()
+                            .map(|res| res.finalize.logs.clone().into_boxed_slice())
+                            .unwrap_or_default(),
+                        fee_receipt: execution_result
+                            .as_ref()
+                            .map(|res| res.finalize.fee_receipt.clone())
+                            .unwrap_or_default(),
+                        epoch: execute_epoch,
+                    });
 
-                // return Err(PendingTransactionError::ReceiptNotFound { tx_id: self.tx_id });
-            }
+                    // return Err(PendingTransactionError::ReceiptNotFound { tx_id: self.tx_id });
+                }
+            },
         }
 
         let _outcome = self.watch().await?;

--- a/crates/wallet/sdk/src/apis/transaction.rs
+++ b/crates/wallet/sdk/src/apis/transaction.rs
@@ -144,6 +144,18 @@ where
                         details: "Pending execution result returned from dry run".to_string(),
                     });
                 },
+                TransactionFinalizedResult::Rejected { details, .. } => {
+                    self.store.with_write_tx(|tx| {
+                        tx.transactions_update(
+                            WalletTransactionUpdate::new(tx_id)
+                                .with_new_status(TransactionStatus::DryRunFailed)
+                                .with_invalid_reason(details),
+                        )
+                    })?;
+                    return Err(TransactionApiError::InvalidTransactionQueryResponse {
+                        details: format!("Transaction rejected by dry run: {details}"),
+                    });
+                },
                 TransactionFinalizedResult::Finalized {
                     execution_result,
                     finalized_time,
@@ -222,6 +234,21 @@ where
 
         match resp.result {
             TransactionFinalizedResult::Pending => Ok(None),
+            TransactionFinalizedResult::Rejected { details, rejected_time } => {
+                let transaction = self.store.with_write_tx(|tx| {
+                    tx.transactions_update(
+                        WalletTransactionUpdate::new(transaction_id)
+                            .with_new_status(TransactionStatus::InvalidTransaction)
+                            .with_invalid_reason(&details)
+                            .with_finalized_time(rejected_time),
+                    )?;
+                    self.release_all_locks_for_transaction_internal(tx, transaction_id)?;
+                    let transaction = tx.transactions_get(transaction_id)?;
+                    Ok::<_, TransactionApiError>(transaction)
+                })?;
+
+                Ok(Some(transaction))
+            },
             TransactionFinalizedResult::Finalized {
                 final_decision,
                 execution_result,

--- a/crates/wallet/sdk/src/network.rs
+++ b/crates/wallet/sdk/src/network.rs
@@ -120,6 +120,11 @@ pub enum TransactionFinalizedResult {
         finalized_time: PrimitiveDateTime,
         abort_details: Option<String>,
     },
+    /// The transaction was rejected by mempool validation at submission and was never sequenced.
+    Rejected {
+        details: String,
+        rejected_time: PrimitiveDateTime,
+    },
 }
 
 impl TransactionFinalizedResult {
@@ -127,6 +132,7 @@ impl TransactionFinalizedResult {
         match self {
             TransactionFinalizedResult::Pending => None,
             TransactionFinalizedResult::Finalized { execution_result, .. } => execution_result.map(|r| *r),
+            TransactionFinalizedResult::Rejected { .. } => None,
         }
     }
 }

--- a/crates/wallet/sdk_services/src/indexer_rest_api.rs
+++ b/crates/wallet/sdk_services/src/indexer_rest_api.rs
@@ -419,6 +419,9 @@ fn convert_indexer_result_to_wallet_result(result: IndexerTransactionFinalizedRe
             finalized_time,
             abort_details,
         },
+        IndexerTransactionFinalizedResult::Rejected { details, rejected_time } => {
+            TransactionFinalizedResult::Rejected { details, rejected_time }
+        },
     }
 }
 

--- a/utilities/transaction_submitter/src/main.rs
+++ b/utilities/transaction_submitter/src/main.rs
@@ -256,6 +256,24 @@ async fn fetch_result_summary(
                         })) => {
                             sleep(Duration::from_secs(1)).await;
                         },
+                        Ok(Some(GetTransactionResultResponse {
+                            result: IndexerTransactionFinalizedResult::Rejected { details, .. },
+                        })) => {
+                            println!(
+                                "Transaction {} rejected by mempool validation: {}",
+                                transaction_id, details
+                            );
+                            results_tx
+                                .send(TxFinalized {
+                                    outcome: Outcome::Rejected,
+                                    num_up_substates: 0,
+                                    num_down_substates: 0,
+                                    execution_time: Duration::from_secs(0),
+                                })
+                                .await
+                                .unwrap();
+                            break;
+                        },
                         Ok(None) => {
                             println!(
                                 "[{}] Result not found for transaction {}. The indexer may not have seen it yet. \


### PR DESCRIPTION
## Description

A transaction that fails mempool validation (e.g. referenced template does not exist) is rejected synchronously by every validator's `submit_transaction` RPC, but the validator never persists the rejection and the indexer stores the transaction before submitting. `get_transaction_result` then asks the network, which reports `Pending` forever, so explicitly-rejected transactions sit as pending in the indexer indefinitely.

This PR records the rejection locally in the indexer when all involved validator committees reject the submission with a `BAD_REQUEST` RPC status, and surfaces it as a new `Rejected` variant throughout the stack.

## Changes

- **Indexer DB migration**: adds nullable `rejected_reason`/`rejected_at` columns to the `transactions` table.
- **`TransactionManager::submit_transaction`**: records the rejection reason when all involved validator committees reject the submission with `BAD_REQUEST` (`NetworkClientError::validation_rejection_details`). Transient/transport failures are not recorded. A successful resubmission (e.g. after the missing template is published) clears a previously recorded rejection.
- **New `IndexerTransactionFinalizedResult::Rejected { details, rejected_time }` variant**: `get_transaction_result` short-circuits with the locally recorded rejection before querying the network; the `Pending`/`Finalized` conversion moved from the REST handler into the manager.
- **`TransactionEntry`** (recent transactions list / get transaction): now includes `rejected_reason`.
- **Wallet SDK**: new `TransactionFinalizedResult::Rejected` variant; `check_and_store_finalized_transaction` maps it to the existing `TransactionStatus::InvalidTransaction` with the rejection reason and releases output locks; dry-run path treats it as `DryRunFailed`. `ootle-rs` tx watcher surfaces it as `PendingTransactionError::TransactionRejected`. `transaction_submitter` utility counts it as a Rejected outcome.
- **TS bindings**: hand-updated committed bindings (`IndexerTransactionFinalizedResult`, `TransactionEntry`) and bumped `@tari-project/ootle-ts-bindings` to `1.39.0`.
- **CI**: the npm publish workflow now triggers on `v[0-9]+.[0-9]+.[0-9]*` tag pushes (same pattern as the binaries build) instead of GitHub release publication; per-package version-vs-registry checks still skip already-published versions.

## Out of scope

A transaction rejected by remote validators after gossip (i.e. not via this indexer's submission) still has no network-side rejection record. That would require persisting rejections on the validator node and extending the RPC result proto.

## Verification

- Full workspace `cargo check` clean.
- `cargo nextest` on affected crates: 54 tests passed.
- ts-rs export diff verified against hand-edited bindings.
- All web UIs typecheck against the rebuilt bindings.