### PR TITLE
fix(validator-node): track p2p RPC server task so shutdown drops the state store

### DIFF
--- a/applications/tari_validator_node/src/bootstrap.rs
+++ b/applications/tari_validator_node/src/bootstrap.rs
@@ -361,7 +361,7 @@ pub async fn spawn_services(
     );
     handles.push(join_handle);
 
-    spawn_p2p_rpc(
+    let join_handle = spawn_p2p_rpc(
         &config,
         &mut networking,
         epoch_manager.clone(),
@@ -370,6 +370,7 @@ pub async fn spawn_services(
         consensus_handle.clone(),
     )
     .await?;
+    handles.push(join_handle);
     // Save final node identity after comms has initialized. This is required because the public_address can be
     // changed by comms during initialization when using tor.
     save_identities(&config, &keypair)?;
@@ -444,7 +445,7 @@ async fn spawn_p2p_rpc<TStateStore: StateStore + Clone + Send + Sync + 'static>(
     shard_store_store: TStateStore,
     mempool: MempoolHandle,
     consensus: ConsensusHandle,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<JoinHandle<Result<(), anyhow::Error>>> {
     let rpc_server = RpcServer::builder()
         .with_maximum_simultaneous_sessions(config.validator_node.rpc.max_simultaneous_sessions)
         .with_maximum_sessions_per_client(config.validator_node.rpc.max_sessions_per_client)
@@ -460,8 +461,12 @@ async fn spawn_p2p_rpc<TStateStore: StateStore + Clone + Send + Sync + 'static>(
     networking
         .add_protocol_notifier(rpc_server.all_protocols().iter().cloned(), notify_tx)
         .await?;
-    tokio::spawn(rpc_server.serve(notify_rx));
-    Ok(())
+    // The RPC service owns a state store clone, so this handle must be tracked in `Services::handles`:
+    // `join_all` awaiting it is what guarantees the store is dropped (and RocksDB's LOCK released) before
+    // `run_validator_node` returns. The task ends at shutdown when the networking worker exits and drops
+    // the protocol notifier sender, closing `notify_rx`.
+    let handle = tokio::spawn(async move { rpc_server.serve(notify_rx).await.map_err(anyhow::Error::from) });
+    Ok(handle)
 }
 
 pub fn create_mempool_transaction_validator<TProvider: TemplateProvider>(


### PR DESCRIPTION
## Summary

The validator's p2p RPC server was spawned with a detached `tokio::spawn` (its JoinHandle dropped), and the RPC service (`ValidatorNodeRpcServiceImpl`) owns a clone of the state store. On shutdown, `run_validator_node` could therefore return while the detached serve task still held an `Arc<TransactionDB>` clone, leaving RocksDB's LOCK file held by the process for a few scheduler ticks after the node "stopped".

This change makes `spawn_p2p_rpc` return the serve task's JoinHandle and tracks it in `Services::handles`, so `Services::join_all` awaits it — guaranteeing the RPC server's store clone is dropped before `run_validator_node` returns. This mirrors how the JSON-RPC (axum) handle is already tracked for exactly the same reason (see the comment in lib.rs added by #2065).

## Motivation

Flaky CI failure in the offline rollback cucumber test (seen on PR #2217's Test Results check, scenario "Rollback, restart, and continue producing blocks" in tests/features/offline_rollback.feature): the test shuts a VN down via `stop_and_wait` (which awaits the VN main task) and immediately re-opens the store in-process, hitting:

```
Could not connect to storage: IO error: lock hold by current process, acquire time ... acquiring thread ...: .../VN1/data/validator_node/rocksdb/LOCK: No locks available
```

`stop_and_wait`'s documented guarantee (all state store clones dropped when the main task returns) had a hole: the p2p RPC server task was never joined. The detached spawn dates back to the libp2p migration (#827); it only became observable when #2065 added the first test that re-opens a stopped VN's DB in the same process.

## Shutdown/termination

The serve task needs no shutdown signal of its own: the networking worker exits on the shutdown signal and drops the protocol-notifier sender, which closes the channel the serve loop reads from (`None => break` in `PeerRpcServer::serve`). `join_all` awaits all handles concurrently, so there is no ordering hazard.

## Out of scope

`PeerRpcServer::serve` still returns without draining in-flight session tasks (`self.tasks`), each of which holds a per-session service clone. Sessions terminate when networking drops the swarm and their substreams close, but that is the same shape of race one layer down — left as a follow-up.