### PR TITLE
fix(indexer): serve substates unverified when no committee member can supply a proof

### DIFF
--- a/applications/tari_indexer/src/dry_run/processor.rs
+++ b/applications/tari_indexer/src/dry_run/processor.rs
@@ -149,11 +149,14 @@ impl DryRunTransactionProcessor {
         &self,
         transaction: &Transaction,
     ) -> Result<HashMap<SubstateId, Substate>, DryRunTransactionProcessorError> {
-        let susbtates = self
+        let substates = self
             .substate_manager
             .get_substates(transaction.inputs().iter().map(|req| req.as_ref()))
             .await?;
-        Ok(susbtates)
+        Ok(substates
+            .into_iter()
+            .map(|(id, fetched)| (id, fetched.substate))
+            .collect())
     }
 
     async fn get_virtual_substates(&self) -> Result<VirtualSubstates, DryRunTransactionProcessorError> {

--- a/applications/tari_indexer/src/rest_api/handlers/resources.rs
+++ b/applications/tari_indexer/src/rest_api/handlers/resources.rs
@@ -40,7 +40,7 @@ pub async fn get_resource(
     let is_xtr = resource_address == TARI_TOKEN;
     let resource_address = SubstateId::Resource(resource_address);
 
-    let (_, substate) = context
+    let (_, fetched) = context
         .substate_manager()
         .get_substates(iter::once(SubstateRequirementRef::new(&resource_address, None)))
         .await
@@ -49,6 +49,7 @@ pub async fn get_resource(
         .next()
         .ok_or_else(|| ErrorResponse::not_found(format!("Resource {} not found", resource_address)))?;
 
+    let substate = fetched.substate;
     let version = substate.version();
     let resource = substate.into_substate_value().into_resource().ok_or_else(|| {
         ErrorResponse::general_error(format!(

--- a/applications/tari_indexer/src/rest_api/handlers/substates.rs
+++ b/applications/tari_indexer/src/rest_api/handlers/substates.rs
@@ -12,7 +12,10 @@ use tari_engine_types::substate::SubstateId;
 use tari_indexer_client::types::{GetSubstateRequest, GetSubstateResponse, GetSubstatesRequest, GetSubstatesResponse};
 use tari_ootle_common_types::SubstateRequirementRef;
 
-use crate::rest_api::{context::HandlerContext, error::ErrorResponse, handlers::HandlerResult};
+use crate::{
+    rest_api::{context::HandlerContext, error::ErrorResponse, handlers::HandlerResult},
+    substate_manager::FetchedSubstate,
+};
 
 #[utoipa::path(
     get,
@@ -55,23 +58,28 @@ pub async fn get_substate(
             .map(|a| {
                 a.into_iter()
                     .find(|(_, substate)| req.version.is_none_or(|v| substate.version() == v))
+                    .map(|(_, substate)| FetchedSubstate {
+                        substate,
+                        verified: false,
+                    })
             })
             .map_err(|e| ErrorResponse::internal_error(format!("Error getting substate: {}", e)))?
     } else {
         manager
             .get_substates(iter::once(requirement))
             .await
-            .map(|a| a.into_iter().next())
+            .map(|a| a.into_iter().next().map(|(_, fetched)| fetched))
             .map_err(|e| ErrorResponse::internal_error(format!("Error getting substate: {}", e)))?
     };
 
     match maybe_substate {
-        Some((_, substate)) => Ok(Json(GetSubstateResponse {
-            version: substate.version(),
-            substate: substate.into_substate_value(),
-            // When verification is enabled, a returned (non-cached) value was checked against the
-            // committee before being accepted; otherwise it was served unverified.
-            verified: manager.verifies_substates() && !req.local_search_only,
+        Some(fetched) => Ok(Json(GetSubstateResponse {
+            version: fetched.substate.version(),
+            substate: fetched.substate.into_substate_value(),
+            // True when this value was checked against the committee before being accepted. False
+            // for local-only lookups, when verification is disabled, or when no committee member
+            // could supply a proof yet (e.g. nothing committed since an epoch change).
+            verified: fetched.verified,
         })),
         None => Err(ErrorResponse::not_found(format!("Substate {} not found", substate_id))),
     }

--- a/applications/tari_indexer/src/substate_manager.rs
+++ b/applications/tari_indexer/src/substate_manager.rs
@@ -71,6 +71,15 @@ pub struct SubstateResponse {
     pub substate: SubstateValue,
 }
 
+/// A substate returned by a lookup together with whether it was committee-verified. `verified` is
+/// false when proof verification is disabled, or when no committee member could supply a proof yet
+/// (e.g. nothing has been committed since an epoch change).
+#[derive(Debug, Clone)]
+pub struct FetchedSubstate {
+    pub substate: Substate,
+    pub verified: bool,
+}
+
 /// Adapts the indexer's sqlite store to [`TrustedRootStore`], which the read path consults to skip
 /// commit-proof re-validation on a trusted-root hit and warms with newly-validated roots.
 #[derive(Clone)]
@@ -246,11 +255,11 @@ impl SubstateManager {
     }
 
     pub async fn get_substate(&self, req: SubstateRequirementRef<'_>) -> Result<Substate, SubstateManagerError> {
-        let substate_result = self
+        let lookup_result = self
             .cache_manager
             .get_substate(req.substate_id(), req.version())
             .await?;
-        match substate_result {
+        match lookup_result.result {
             SubstateResult::Up { substate } => Ok(*substate),
             SubstateResult::Down { version } => Err(SubstateManagerError::InputSubstateIsDown {
                 substate_id: req.substate_id().clone(),
@@ -265,7 +274,7 @@ impl SubstateManager {
     pub async fn get_substates<'a, I: IntoIterator<Item = SubstateRequirementRef<'a>>>(
         &self,
         substate_req: I,
-    ) -> Result<HashMap<SubstateId, Substate>, SubstateManagerError> {
+    ) -> Result<HashMap<SubstateId, FetchedSubstate>, SubstateManagerError> {
         let substate_req = substate_req.into_iter().collect::<HashSet<_>>();
         let mut results = HashMap::with_capacity(substate_req.len());
 
@@ -276,10 +285,11 @@ impl SubstateManager {
                 let Some(substate) = self.get_substate_from_db(req.substate_id(), Some(version)).await?
             {
                 found_in_cache.insert(*req);
-                results.insert(
-                    req.substate_id().clone(),
-                    Substate::new(substate.version, substate.substate),
-                );
+                results.insert(req.substate_id().clone(), FetchedSubstate {
+                    substate: Substate::new(substate.version, substate.substate),
+                    // Locally-stored substates were verified when ingested iff verification is on.
+                    verified: self.cache_manager.verifies_substates(),
+                });
             }
         }
 
@@ -288,19 +298,19 @@ impl SubstateManager {
             if found_in_cache.contains(&req) {
                 continue;
             }
-            let substate_result = self
+            let lookup_result = self
                 .cache_manager
                 .get_substate(req.substate_id(), req.version())
                 .await?;
-            match substate_result {
+            match lookup_result.result {
                 SubstateResult::DoesNotExist => {
                     // Skip, does not exist
                 },
                 SubstateResult::Up { substate } => {
-                    results.insert(
-                        req.substate_id().clone(),
-                        Substate::new(substate.version(), substate.into_substate_value()),
-                    );
+                    results.insert(req.substate_id().clone(), FetchedSubstate {
+                        substate: Substate::new(substate.version(), substate.into_substate_value()),
+                        verified: lookup_result.verified,
+                    });
                 },
                 SubstateResult::Down { version } => {
                     return Err(SubstateManagerError::InputSubstateIsDown {

--- a/applications/tari_indexer/src/template_manager/manager.rs
+++ b/applications/tari_indexer/src/template_manager/manager.rs
@@ -288,14 +288,12 @@ impl TemplateManager {
             });
         }
 
-        for (substate_id, substate) in fetched_templates {
-            let template =
-                substate
-                    .into_substate_value()
-                    .into_template()
-                    .ok_or(TemplateManagerError::InvariantViolation {
-                        details: format!("Expected template substate at address {}", substate_id),
-                    })?;
+        for (substate_id, fetched) in fetched_templates {
+            let template = fetched.substate.into_substate_value().into_template().ok_or(
+                TemplateManagerError::InvariantViolation {
+                    details: format!("Expected template substate at address {}", substate_id),
+                },
+            )?;
             let template_addr = substate_id
                 .as_template()
                 .expect("fetched_templates are all templates")

--- a/bindings/src/types/tari-indexer-client/IndexerGetSubstateResponse.ts
+++ b/bindings/src/types/tari-indexer-client/IndexerGetSubstateResponse.ts
@@ -6,7 +6,8 @@ export type IndexerGetSubstateResponse = {
   substate: SubstateValue;
   /**
    * True when the indexer verified this substate's value against the shard group committee (via a
-   * merkle proof). False when proofs are disabled and the value was served unverified.
+   * merkle proof). False when proofs are disabled, or when no committee member could supply a
+   * proof yet (e.g. nothing committed since an epoch change) and the value was served unverified.
    */
   verified: boolean;
 };

--- a/clients/tari_indexer_client/src/types.rs
+++ b/clients/tari_indexer_client/src/types.rs
@@ -70,7 +70,8 @@ pub struct GetSubstateResponse {
     #[cfg_attr(feature = "utoipa", schema(value_type = Object))]
     pub substate: SubstateValue,
     /// True when the indexer verified this substate's value against the shard group committee (via a
-    /// merkle proof). False when proofs are disabled and the value was served unverified.
+    /// merkle proof). False when proofs are disabled, or when no committee member could supply a
+    /// proof yet (e.g. nothing committed since an epoch change) and the value was served unverified.
     pub verified: bool,
 }
 

--- a/crates/indexer_lib/src/cached_substate_manager.rs
+++ b/crates/indexer_lib/src/cached_substate_manager.rs
@@ -332,8 +332,9 @@ where
         let f = (committee.len() - 1) / 3;
         let mut num_nexist_substate_results = 0;
         let mut last_error = None;
-        // First Up/Down response that came back without a proof. Only served if no member can prove.
-        let mut unproven_result = None;
+        // Highest-version Up/Down response that came back without a proof. Only served if no member
+        // can prove.
+        let mut unproven_result: Option<SubstateResult> = None;
         for member in committee.shuffled() {
             let vn_addr = &member.address;
             debug!(target: LOG_TARGET, "Getting substate {} from vn {}", substate_req, vn_addr);
@@ -350,9 +351,13 @@ where
                                 });
                             }
                             // The member could not prove its response (e.g. nothing committed since
-                            // the epoch started). Keep it as a fallback and try the rest of the
-                            // committee for a proven copy.
-                            if unproven_result.is_none() {
+                            // the epoch started). Keep the highest version as a fallback (a member
+                            // that is still syncing may respond with a stale copy) and try the rest
+                            // of the committee for a proven copy.
+                            if unproven_result
+                                .as_ref()
+                                .is_none_or(|r| r.version() < substate_result.version())
+                            {
                                 unproven_result = Some(substate_result);
                             }
                         },

--- a/crates/indexer_lib/src/cached_substate_manager.rs
+++ b/crates/indexer_lib/src/cached_substate_manager.rs
@@ -78,6 +78,16 @@ pub trait TrustedRootStore: std::fmt::Debug + Send + Sync + 'static {
     async fn record(&self, tip: VerifiedBlockTip) -> Result<(), IndexerError>;
 }
 
+/// Outcome of a substate lookup together with whether the value was committee-verified.
+#[derive(Debug, Clone)]
+pub struct SubstateLookupResult {
+    pub result: SubstateResult,
+    /// True when the value was proven against a committee-signed state root. False when proof
+    /// verification is disabled, the result is `DoesNotExist` (not provable), or no committee member
+    /// could supply a proof yet (e.g. nothing has been committed since an epoch change).
+    pub verified: bool,
+}
+
 #[derive(Debug, Clone)]
 pub struct CachedSubstateManager<TEpochManager, TVnClient, TSubstateCache> {
     committee_provider: TEpochManager,
@@ -153,54 +163,69 @@ where
         &self,
         substate_id: &SubstateId,
         specific_version: Option<u32>,
-    ) -> Result<SubstateResult, IndexerError> {
+    ) -> Result<SubstateLookupResult, IndexerError> {
         debug!(target: LOG_TARGET, "get_substate: {}v{}", substate_id, specific_version.display());
         let mut cached_version = None;
         // start from the latest cached version of the substate (if cached previously)
         let cache_res = self.substate_cache.read(substate_id).await?;
         if let Some(entry) = cache_res {
-            if let Some(version) = specific_version {
-                if entry.version == version {
-                    debug!(target: LOG_TARGET, "Substate cache hit for {} with version {}", entry.version, substate_id);
-                    #[cfg(feature = "metrics")]
-                    self.metrics.as_ref().inspect(|m| m.inc_cache_hits());
-                    return Ok(entry.substate_result);
-                }
-            } else {
-                let now = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH)?.as_secs();
-                if now.saturating_sub(entry.cached_at) > self.cache_ttl.as_secs() {
-                    debug!(target: LOG_TARGET, "Cached substate {} is stale. Fetching fresh copy.", substate_id);
+            // An unverified entry (e.g. written by the batch path or before verification was
+            // enabled) is never served while verification is on: refetch so it can be replaced with
+            // a proven copy.
+            if entry.verified || !self.verify_substate_proofs {
+                if let Some(version) = specific_version {
+                    if entry.version == version {
+                        debug!(target: LOG_TARGET, "Substate cache hit for {} with version {}", entry.version, substate_id);
+                        #[cfg(feature = "metrics")]
+                        self.metrics.as_ref().inspect(|m| m.inc_cache_hits());
+                        return Ok(SubstateLookupResult {
+                            result: entry.substate_result,
+                            verified: entry.verified,
+                        });
+                    }
                 } else {
-                    debug!(target: LOG_TARGET, "Substate cache hit for {} with version {}", substate_id, entry.version);
-                    #[cfg(feature = "metrics")]
-                    self.metrics.as_ref().inspect(|m| m.inc_cache_hits());
-                    return Ok(entry.substate_result.clone());
+                    let now = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH)?.as_secs();
+                    if now.saturating_sub(entry.cached_at) > self.cache_ttl.as_secs() {
+                        debug!(target: LOG_TARGET, "Cached substate {} is stale. Fetching fresh copy.", substate_id);
+                    } else {
+                        debug!(target: LOG_TARGET, "Substate cache hit for {} with version {}", substate_id, entry.version);
+                        #[cfg(feature = "metrics")]
+                        self.metrics.as_ref().inspect(|m| m.inc_cache_hits());
+                        return Ok(SubstateLookupResult {
+                            result: entry.substate_result.clone(),
+                            verified: entry.verified,
+                        });
+                    }
                 }
-            }
 
-            cached_version = Some(entry.version);
+                cached_version = Some(entry.version);
+            }
         }
         #[cfg(feature = "metrics")]
         self.metrics.as_ref().inspect(|m| m.inc_cache_misses());
 
-        let substate_result = self
+        let lookup_result = self
             .fetch_substate_from_committee(substate_id, specific_version)
             .await?;
 
-        if let Some(version) = substate_result.version() {
-            let should_update_cache = cached_version.is_none_or(|v| v < version);
+        if let Some(version) = lookup_result.result.version() {
+            // Unverified results are not cached while verification is on, so the next read retries
+            // for a proven copy instead of pinning the unverified value for the TTL.
+            let should_update_cache =
+                (lookup_result.verified || !self.verify_substate_proofs) && cached_version.is_none_or(|v| v < version);
             if should_update_cache {
                 debug!(target: LOG_TARGET, "Updating cached substate {} with version {}", substate_id, version);
                 let entry = SubstateCacheEntryRef {
                     version,
-                    substate_result: &substate_result,
+                    substate_result: &lookup_result.result,
                     cached_at: SystemTime::now().duration_since(SystemTime::UNIX_EPOCH)?.as_secs(),
+                    verified: lookup_result.verified,
                 };
                 self.substate_cache.write(substate_id, entry).await?;
             }
         }
 
-        Ok(substate_result)
+        Ok(lookup_result)
     }
 
     pub async fn get_cached_substates<'a, I: Iterator<Item = &'a SubstateId> + ExactSizeIterator>(
@@ -261,10 +286,12 @@ where
                     let substate_result = SubstateResult::Up {
                         substate: Box::new(substate.clone()),
                     };
+                    // The batch RPC does not carry proofs, so these entries are always unverified.
                     let entry = SubstateCacheEntryRef {
                         version: substate.version(),
                         substate_result: &substate_result,
                         cached_at: SystemTime::now().duration_since(SystemTime::UNIX_EPOCH)?.as_secs(),
+                        verified: false,
                     };
                     self.substate_cache.write(substate_id, entry).await?;
                 }
@@ -278,18 +305,18 @@ where
         &self,
         substate_id: &SubstateId,
         specific_version: Option<u32>,
-    ) -> Result<SubstateResult, IndexerError> {
+    ) -> Result<SubstateLookupResult, IndexerError> {
         let requirement = SubstateRequirementRef::new(substate_id, specific_version);
-        let substate_result = self.get_specific_substate_from_committee(requirement).await?;
-        debug!(target: LOG_TARGET, "Substate result for {} with version {}: {:?}", substate_id, specific_version.display(), substate_result);
-        Ok(substate_result)
+        let lookup_result = self.get_specific_substate_from_committee(requirement).await?;
+        debug!(target: LOG_TARGET, "Substate result for {} with version {}: {:?}", substate_id, specific_version.display(), lookup_result);
+        Ok(lookup_result)
     }
 
     /// Returns a specific version. If this is not found an error is returned.
     async fn get_specific_substate_from_committee(
         &self,
         substate_req: SubstateRequirementRef<'_>,
-    ) -> Result<SubstateResult, IndexerError> {
+    ) -> Result<SubstateLookupResult, IndexerError> {
         debug!(target: LOG_TARGET, "get_specific_substate_from_committee: {substate_req}");
         let epoch = self.committee_provider.current_epoch().await?;
         let committee = self
@@ -305,18 +332,36 @@ where
         let f = (committee.len() - 1) / 3;
         let mut num_nexist_substate_results = 0;
         let mut last_error = None;
+        // First Up/Down response that came back without a proof. Only served if no member can prove.
+        let mut unproven_result = None;
         for member in committee.shuffled() {
             let vn_addr = &member.address;
             debug!(target: LOG_TARGET, "Getting substate {} from vn {}", substate_req, vn_addr);
 
             match self.get_substate_from_vn(vn_addr, substate_req).await {
-                Ok(substate_result) => {
-                    debug!(target: LOG_TARGET, "Got substate result for {} from vn {}: {:?}", substate_req, vn_addr, substate_result);
+                Ok((substate_result, verified)) => {
+                    debug!(target: LOG_TARGET, "Got substate result for {} from vn {} (verified = {}): {:?}", substate_req, vn_addr, verified, substate_result);
                     match substate_result {
-                        SubstateResult::Up { .. } | SubstateResult::Down { .. } => return Ok(substate_result),
+                        SubstateResult::Up { .. } | SubstateResult::Down { .. } => {
+                            if verified || !self.verify_substate_proofs {
+                                return Ok(SubstateLookupResult {
+                                    result: substate_result,
+                                    verified,
+                                });
+                            }
+                            // The member could not prove its response (e.g. nothing committed since
+                            // the epoch started). Keep it as a fallback and try the rest of the
+                            // committee for a proven copy.
+                            if unproven_result.is_none() {
+                                unproven_result = Some(substate_result);
+                            }
+                        },
                         SubstateResult::DoesNotExist => {
                             if num_nexist_substate_results > f {
-                                return Ok(substate_result);
+                                return Ok(SubstateLookupResult {
+                                    result: substate_result,
+                                    verified: false,
+                                });
                             }
                             num_nexist_substate_results += 1;
                         },
@@ -333,6 +378,17 @@ where
             }
         }
 
+        if let Some(result) = unproven_result {
+            warn!(
+                target: LOG_TARGET,
+                "No committee member could supply a proof for {substate_req}. Returning the substate unverified.",
+            );
+            return Ok(SubstateLookupResult {
+                result,
+                verified: false,
+            });
+        }
+
         warn!(
             target: LOG_TARGET,
             "Could not get substate for shard {} from any of the validator nodes", substate_req,
@@ -341,15 +397,19 @@ where
         if let Some(e) = last_error {
             return Err(e);
         }
-        Ok(SubstateResult::DoesNotExist)
+        Ok(SubstateLookupResult {
+            result: SubstateResult::DoesNotExist,
+            verified: false,
+        })
     }
 
-    /// Gets a substate directly from querying a VN
+    /// Gets a substate directly from querying a VN. The returned flag is true if the result came
+    /// with a proof that verified against the committee.
     async fn get_substate_from_vn(
         &self,
         vn_addr: &TAddr,
         substate_requirement: SubstateRequirementRef<'_>,
-    ) -> Result<SubstateResult, IndexerError> {
+    ) -> Result<(SubstateResult, bool), IndexerError> {
         // build a client with the VN
         let mut client = self.validator_node_client_factory.create_client(vn_addr);
 
@@ -357,6 +417,7 @@ where
             return client
                 .get_substate(substate_requirement)
                 .await
+                .map(|result| (result, false))
                 .map_err(|e| IndexerError::ValidatorNodeClientError(e.to_string()));
         }
 
@@ -365,10 +426,16 @@ where
             .await
             .map_err(|e| IndexerError::ValidatorNodeClientError(e.to_string()))?;
 
-        // Verify up/down results against the committee. A missing or invalid proof disqualifies this
+        // The validator has nothing committed to anchor a proof against yet (e.g. immediately after
+        // an epoch change). Return the result unverified and let the caller decide.
+        let Some(proof) = proof else {
+            return Ok((result, false));
+        };
+
+        // Verify up/down results against the committee. An invalid proof disqualifies this
         // validator's response (fail-closed) so the caller tries another member. `DoesNotExist` is
         // not provable and is left to the existing f+1 agreement.
-        match &result {
+        let verified = match &result {
             SubstateResult::Up { substate } => {
                 self.verify_substate_proof(
                     substate_requirement.substate_id(),
@@ -377,15 +444,17 @@ where
                     proof,
                 )
                 .await?;
+                true
             },
             SubstateResult::Down { version } => {
                 self.verify_substate_proof(substate_requirement.substate_id(), *version, None, proof)
                     .await?;
+                true
             },
-            SubstateResult::DoesNotExist => {},
-        }
+            SubstateResult::DoesNotExist => false,
+        };
 
-        Ok(result)
+        Ok((result, verified))
     }
 
     async fn verify_substate_proof(
@@ -393,12 +462,8 @@ where
         substate_id: &SubstateId,
         version: u32,
         value: Option<&SubstateValue>,
-        proof: Option<SubstateProofData>,
+        proof: SubstateProofData,
     ) -> Result<(), IndexerError> {
-        let proof = proof.ok_or_else(|| IndexerError::SubstateProofVerificationFailed {
-            details: format!("validator did not return a proof for {substate_id}"),
-        })?;
-
         let commit_proof = CommittedBlockProof::from_bytes(&proof.commit_proof).map_err(|e| {
             IndexerError::SubstateProofVerificationFailed {
                 details: format!("undecodable commit proof: {e}"),

--- a/crates/indexer_lib/src/substate_cache.rs
+++ b/crates/indexer_lib/src/substate_cache.rs
@@ -38,6 +38,12 @@ pub struct SubstateCacheEntry {
     pub substate_result: SubstateResult,
     #[n(2)]
     pub cached_at: u64,
+    /// True if the value was committee-verified when it was fetched. Entries written before this
+    /// field existed decode as unverified.
+    #[n(3)]
+    #[serde(default)]
+    #[cbor(default)]
+    pub verified: bool,
 }
 
 #[derive(Debug, Serialize, Clone, Copy, minicbor::Encode, minicbor::CborLen)]
@@ -48,6 +54,8 @@ pub struct SubstateCacheEntryRef<'a> {
     pub substate_result: &'a SubstateResult,
     #[n(2)]
     pub cached_at: u64,
+    #[n(3)]
+    pub verified: bool,
 }
 
 pub trait SubstateCache: Send + Sync {

--- a/utilities/transaction_submitter/src/main.rs
+++ b/utilities/transaction_submitter/src/main.rs
@@ -393,7 +393,7 @@ impl Default for StressTestResultSummary {
 fn print_summary(summary: &StressTestResultSummary) {
     println!("Summary:");
     println!(
-        "  Success rate (fully committed): {:.2}%",
+        "  Success rate: {:.2}%",
         summary.num_committed as f64 / summary.num_transactions as f64 * 100.0
     );
     println!("  Transactions submitted: {}", summary.num_transactions);


### PR DESCRIPTION
## Description

With substate proof verification enabled, the indexer returned a 500 error (`Substate proof verification failed: validator did not return a proof for <substate_id>`) whenever validators could not yet supply a proof. Validators omit the proof when nothing has been committed beyond the current epoch's genesis (gated by `last_executed.height.is_zero()` in `attach_substate_proof` on the VN), which happens right after an epoch change, a restart into a new epoch, or while a node is syncing. The indexer's fail-closed verification disqualified every committee member's response, so a benign transient condition surfaced as a hard error.

## Changes

- A response with a **missing** proof is no longer treated as an error. It is kept as a fallback while the rest of the committee is queried for a member that can supply a proof. Only if no member can prove does the indexer serve the fallback, flagged `verified: false`. A response with an **invalid** proof still disqualifies that validator (fail-closed behaviour unchanged).
- `SubstateLookupResult` in `indexer_lib` now carries a per-result `verified` flag, which flows through `SubstateManager` into the existing `GetSubstateResponse.verified` REST field, replacing the previous blanket config-derived value. The epoch-boundary window now returns `200 + verified: false` instead of a `500`.
- Unverified results are not written to the cache, and unverified cache entries are not served while verification is enabled, so reads upgrade to verified as soon as proofs become available rather than pinning the unverified value for the full cache TTL. `SubstateCacheEntry` gained a `verified` field with `#[cbor(default)]` / `#[serde(default)]` so existing cache files decode safely as unverified. This also closes a pre-existing gap where the proofless batch path (`fetch_and_cache_substates`) populated the cache with entries that the read path implicitly treated as verified.
- TS binding comment for `IndexerGetSubstateResponse.verified` hand-synced (doc-only, no type change).

## Motivation

Validators legitimately omit proofs during the window immediately after an epoch change or restart. Treating that as a hard verification failure made the indexer unreliable at the one moment it is most likely to be queried (right after a new epoch starts). Serving an unverified-but-correct substate with a clear `verified: false` flag is strictly better than a 500 for callers that can tolerate it, while keeping the invalid-proof path fail-closed.

## Test plan

- `cargo check` clean on `tari_indexer_lib` / `tari_indexer` / `tari_indexer_client` (default features)
- All 26 tests pass: `cargo nextest r -p tari_indexer_lib -p tari_indexer`
- No new clippy warnings
- Formatted with `cargo +nightly-2025-12-05 fmt --all`