### PR TITLE
fix(rpc): drain in-flight sessions before RPC server serve returns

### DIFF
--- a/networking/rpc_framework/src/server/mod.rs
+++ b/networking/rpc_framework/src/server/mod.rs
@@ -288,8 +288,29 @@ where
 
         debug!(
             target: LOG_TARGET,
-            "Peer RPC server is shut down because the protocol notification stream ended"
+            "Peer RPC server is shutting down because the protocol notification stream ended. Waiting for {} active \
+             session(s) to complete",
+            self.tasks.len()
         );
+
+        // Drain in-flight sessions so that returning from serve means every per-session service instance
+        // (and anything it owns, e.g. a state store handle) has been dropped. This is bounded: the
+        // notification stream only ends once networking has shut down, so each session errors out at its
+        // next substream read/write — which also closes any in-progress response stream — and handler
+        // futures are bounded by the client deadline.
+        while let Some(result) = self.tasks.next().await {
+            match result {
+                Ok(peer_id) => self.on_session_complete(&peer_id),
+                Err(err) => {
+                    error!(
+                        target: LOG_TARGET,
+                        "Session task panicked while shutting down: {}", err
+                    );
+                },
+            }
+        }
+
+        debug!(target: LOG_TARGET, "Peer RPC server is shut down");
 
         Ok(())
     }
@@ -819,5 +840,35 @@ fn err_to_log_level(err: &io::Error) -> log::Level {
         ErrorKind::WriteZero |
         ErrorKind::UnexpectedEof => log::Level::Debug,
         _ => log::Level::Error,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn serve_drains_in_flight_sessions_before_returning() {
+        let (notify_tx, notify_rx) = mpsc::unbounded_channel();
+        let (_request_tx, request_rx) = mpsc::channel(1);
+        let mut server = PeerRpcServer::new(RpcServerBuilder::new(), ProtocolServiceNotFound, notify_rx, request_rx);
+
+        // Each real session task owns a per-session service instance (and anything it captured, e.g. a state
+        // store handle). Returning from serve must guarantee those are dropped.
+        let session_resource = Arc::new(());
+        for _ in 0..3 {
+            let resource = session_resource.clone();
+            server.tasks.push(tokio::spawn(async move {
+                time::sleep(Duration::from_millis(50)).await;
+                drop(resource);
+                PeerId::random()
+            }));
+        }
+
+        // Closing the notification channel signals serve to shut down.
+        drop(notify_tx);
+        server.serve().await.unwrap();
+
+        assert_eq!(Arc::strong_count(&session_resource), 1);
     }
 }


### PR DESCRIPTION
## Summary
`PeerRpcServer::serve` returned as soon as the protocol notification stream ended, dropping its `FuturesUnordered` of session `JoinHandle`s — detaching any in-flight session tasks. Each session owns a per-session service instance (made by `MakeService`); for the validator node that includes a state store clone. So `serve` returning did not mean the server's resources were released.

This change drains the session tasks after the notification stream closes (keeping the existing `on_session_complete` bookkeeping and logging join panics), so `serve` returning now means fully quiesced: every per-session service instance has been dropped.

## Motivation
Follow-up to #2221, which made `Services::join_all` await the serve task so validator shutdown guarantees the p2p RPC server's state store clone is dropped before `run_validator_node` returns. This closes the remaining hole one layer down: a live session could still briefly hold a store clone (keeping RocksDB's LOCK file held) after the serve task itself exited. Background: the offline-rollback cucumber flake where re-opening a stopped VN's RocksDB in-process failed with "lock hold by current process".

## Why the drain is bounded (no shutdown signal needed)
The notification stream only ends once the networking worker has shut down — the worker owns both the swarm and the notifier sender and drops them together. So by the time `serve` starts draining, every substream is dead:
- a session blocked on a read gets EOF/error and exits;
- a session mid-way through a streaming response errors on its next `framed.send`, which drops the `Streaming` body's mpsc receiver and thereby stops the handler's producer (ending the stream is the built-in cancellation path);
- unary handler futures are bounded by the client deadline (`time::timeout(deadline, service_call)`).

## Testing
New unit test `serve_drains_in_flight_sessions_before_returning` pins the invariant via `Arc::strong_count`: serve must not return while a session task still holds its resources. Verified to fail without the drain. (The crate's old `test` module incl. the smoke-test harness is dead code — `mod test` is commented out in lib.rs — so the test constructs `PeerRpcServer` directly with the in-crate `ProtocolServiceNotFound` service.)