### PR TITLE
fix(consensus): reset pacemaker height when entering a new epoch

### DIFF
--- a/crates/consensus/src/hotstuff/current_view.rs
+++ b/crates/consensus/src/hotstuff/current_view.rs
@@ -30,19 +30,22 @@ impl CurrentView {
         self.height.load(atomic::Ordering::SeqCst).into()
     }
 
-    /// Updates the height and epoch if they are greater than the current values.
+    /// Updates the view if (epoch, height) is lexicographically greater than the current view. Heights restart from
+    /// zero each epoch, so entering a later epoch must always take the new height, even when it is lower than the
+    /// current one.
     pub(crate) fn enter(&self, epoch: Epoch, height: NodeHeight) -> bool {
         let current_epoch = self.get_epoch();
-        let mut is_updated = false;
-        if epoch > current_epoch {
-            is_updated = true;
-            self.epoch.store(epoch.as_u64(), atomic::Ordering::SeqCst);
-        }
         let current_height = self.get_height();
-        if height > current_height {
-            is_updated = true;
+        let is_updated = if epoch > current_epoch {
+            self.epoch.store(epoch.as_u64(), atomic::Ordering::SeqCst);
             self.height.store(height.as_u64(), atomic::Ordering::SeqCst);
-        }
+            true
+        } else if epoch == current_epoch && height > current_height {
+            self.height.store(height.as_u64(), atomic::Ordering::SeqCst);
+            true
+        } else {
+            false
+        };
 
         if is_updated {
             info!(target: LOG_TARGET, "🧿 PACEMAKER: View updated from {current_epoch}/{current_height} to {self}");
@@ -67,5 +70,43 @@ impl CurrentView {
 impl Display for CurrentView {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}/{}", self.get_epoch(), self.get_height())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_enters_a_later_epoch_at_a_lower_height() {
+        let view = CurrentView::new();
+        assert!(view.enter(Epoch(8601), NodeHeight(11378)));
+
+        assert!(view.enter(Epoch(8602), NodeHeight(0)));
+        assert_eq!(view.get_epoch(), Epoch(8602));
+        assert_eq!(view.get_height(), NodeHeight(0));
+    }
+
+    #[test]
+    fn it_only_moves_forward_within_an_epoch() {
+        let view = CurrentView::new();
+        assert!(view.enter(Epoch(1), NodeHeight(10)));
+
+        assert!(!view.enter(Epoch(1), NodeHeight(10)));
+        assert!(!view.enter(Epoch(1), NodeHeight(9)));
+        assert_eq!(view.get_height(), NodeHeight(10));
+
+        assert!(view.enter(Epoch(1), NodeHeight(11)));
+        assert_eq!(view.get_height(), NodeHeight(11));
+    }
+
+    #[test]
+    fn it_never_enters_an_earlier_view() {
+        let view = CurrentView::new();
+        assert!(view.enter(Epoch(2), NodeHeight(5)));
+
+        assert!(!view.enter(Epoch(1), NodeHeight(100)));
+        assert_eq!(view.get_epoch(), Epoch(2));
+        assert_eq!(view.get_height(), NodeHeight(5));
     }
 }


### PR DESCRIPTION
## Description

`CurrentView::enter()` compared epoch and height independently and monotonically. Entering a later epoch at height 0 left the stored height unchanged when `0 < current_height`, because the height guard `height > current_height` failed. Heights restart from zero each epoch, so this comparison is only valid within a single epoch.

## Motivation

Validators that missed an epoch rollover (the network committed an EndEpoch block without them) escalated to state sync and restarted the consensus worker. On restart, `PaceMakerHandle::start` calls `enter(next_epoch, NodeHeight(0))`. The epoch advanced but the height remained at the pre-sync value (e.g. `NodeHeight(11378)`). From there:

- Every incoming proposal was discarded as "for previous view".
- A `NEXTSYNCVIEW` leader-failure fired every ~32 s, permanently.
- The only unconditional view reset (`set_epoch`) runs when the node *itself* commits an EndEpoch block — which it could never do.
- Every subsequent epoch rollover went through the same sync path and re-inherited the stale height.

Observed on a testnet validator wedged at height 11378 for 21 epochs (8602–8623) over 3 days, spamming `NEWVIEW` at heights 11380+ each timeout.

## Changes

- `CurrentView::enter()` is now lexicographic on `(epoch, height)`: entering a later epoch stores both epoch **and** height unconditionally (height may decrease); within the same epoch the height still only moves forward; an earlier epoch is never entered.
- Three unit tests added: epoch-rollover at a lower height (the regression), same-epoch monotonicity, and earlier-epoch rejection.