### PR TITLE
feat(wallet)!: migrate OS keyring to keyring-core v1 with per-platform stores

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,6 +176,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
+name = "apple-native-keyring-store"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7be2f067ccd8d4b4d4a66ddafe0f32a5dff31732f32dbff85fefc40929b1f72"
+dependencies = [
+ "keyring-core",
+ "log",
+ "security-framework 3.7.0",
+]
+
+[[package]]
 name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -874,7 +885,7 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -938,9 +949,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 dependencies = [
  "serde_core",
 ]
@@ -2232,7 +2243,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "crossterm_winapi",
  "filedescriptor",
  "futures-core",
@@ -2762,8 +2773,26 @@ version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "708b509edf7889e53d7efb0ffadd994cc6c2345ccb62f55cfd6b0682165e4fa6"
 dependencies = [
+ "aes",
+ "block-padding",
+ "cbc",
  "dbus",
+ "fastrand",
+ "hkdf",
+ "num",
+ "once_cell",
+ "sha2 0.10.9",
  "zeroize",
+]
+
+[[package]]
+name = "dbus-secret-service-keyring-store"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21d8f54da401bb5eb2a4d873ac4b359f4a599df2ca8634bb5b8c045e5ee78757"
+dependencies = [
+ "dbus-secret-service",
+ "keyring-core",
 ]
 
 [[package]]
@@ -4037,7 +4066,7 @@ version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "libc",
  "libgit2-sys",
  "log",
@@ -4080,7 +4109,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "ignore",
  "walkdir",
 ]
@@ -4914,7 +4943,7 @@ dependencies = [
  "byteorder",
  "color_quant",
  "num-iter",
- "num-rational",
+ "num-rational 0.3.2",
  "num-traits",
 ]
 
@@ -5017,7 +5046,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "inotify-sys",
  "libc",
 ]
@@ -5408,18 +5437,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "keyring"
-version = "3.6.3"
+name = "keyring-core"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+checksum = "fb1e621458ca9c51aa110bd0339d4751a056b9576bf1253aee1aa560dda0fc9d"
 dependencies = [
- "byteorder",
- "dbus-secret-service",
  "log",
- "security-framework 2.11.1",
- "security-framework 3.5.1",
- "windows-sys 0.60.2",
- "zeroize",
 ]
 
 [[package]]
@@ -6109,7 +6132,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "libc",
  "redox_syscall 0.7.0",
 ]
@@ -7139,7 +7162,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e23bebbf3e157c402c4d5ee113233e5e0610cc27453b2f07eefce649c7365dcc"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "byteorder",
  "derive_builder 0.20.2",
  "getset",
@@ -7177,7 +7200,7 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ce3636fa715e988114552619582b530481fd5ef176a1e5c1bf024077c2c9445"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "libc",
  "log",
  "netlink-packet-core",
@@ -7257,7 +7280,7 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "cfg-if",
  "cfg_aliases 0.1.1",
  "libc",
@@ -7269,7 +7292,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "cfg-if",
  "cfg_aliases 0.2.1",
  "libc",
@@ -7323,7 +7346,7 @@ version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "fsevent-sys",
  "inotify",
  "kqueue",
@@ -7351,6 +7374,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational 0.4.2",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7375,6 +7412,15 @@ dependencies = [
  "serde",
  "smallvec 1.15.1",
  "zeroize",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -7457,6 +7503,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12ac428b1cb17fce6f731001d307d351ec70a6d202fc2e60f7d4c5e42d8f4f07"
 dependencies = [
  "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
  "num-integer",
  "num-traits",
 ]
@@ -7714,7 +7771,7 @@ version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -8744,7 +8801,7 @@ version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57206b407293d2bcd3af849ce869d52068623f19e1b5ff8e8778e3309439682b"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "memchr",
  "unicase",
 ]
@@ -9075,7 +9132,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -9084,7 +9141,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f3fe0889e69e2ae9e41f4d6c4c0181701d00e4697b356fb1f74173a5e0ee27"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -9378,7 +9435,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
 dependencies = [
  "base64 0.21.7",
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "serde",
  "serde_derive",
 ]
@@ -9581,7 +9638,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -9594,7 +9651,7 @@ version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
@@ -9626,7 +9683,7 @@ dependencies = [
  "openssl-probe 0.2.0",
  "rustls-pki-types",
  "schannel",
- "security-framework 3.5.1",
+ "security-framework 3.7.0",
 ]
 
 [[package]]
@@ -9654,7 +9711,7 @@ dependencies = [
  "rustls-native-certs",
  "rustls-platform-verifier-android",
  "rustls-webpki",
- "security-framework 3.5.1",
+ "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
  "windows-sys 0.61.2",
@@ -9675,7 +9732,7 @@ dependencies = [
  "rustls-native-certs",
  "rustls-platform-verifier-android",
  "rustls-webpki",
- "security-framework 3.5.1",
+ "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
  "windows-sys 0.61.2",
@@ -9872,7 +9929,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
@@ -9881,11 +9938,11 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "3.5.1"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -9894,9 +9951,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.15.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -10837,7 +10894,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -10848,7 +10905,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -11019,7 +11076,7 @@ checksum = "0524755e1907db61bd3cfe1cd54910580f5bedfa0c5ea63f82ef93366231970e"
 dependencies = [
  "argon2 0.6.0-rc.8",
  "base64 0.22.1",
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "blake2 0.10.6",
  "borsh",
  "bs58",
@@ -11057,7 +11114,7 @@ checksum = "1355b0ccb870b33e0590b751a2beacbf7e5854f45bccf63a1b91cc25faf7d005"
 dependencies = [
  "anyhow",
  "async-trait",
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "blake2 0.10.6",
  "bytes",
  "chrono",
@@ -11104,7 +11161,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8ddb3219c0dc390089d3277ac949b40b6581d603809ec18775b1c99157fb107"
 dependencies = [
  "anyhow",
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "blake2 0.10.6",
  "chacha20 0.7.3",
  "chacha20poly1305",
@@ -11751,7 +11808,7 @@ name = "tari_ootle_storage"
 version = "0.33.5"
 dependencies = [
  "anyhow",
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "borsh",
  "indexmap 2.13.0",
  "log",
@@ -11920,7 +11977,7 @@ version = "0.33.3"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
- "keyring",
+ "keyring-core",
  "log",
  "ootle-network",
  "ootle_byte_type",
@@ -12027,6 +12084,7 @@ name = "tari_ootle_walletd"
 version = "0.33.5"
 dependencies = [
  "anyhow",
+ "apple-native-keyring-store",
  "async-trait",
  "axum 0.8.8",
  "axum-extra",
@@ -12036,6 +12094,7 @@ dependencies = [
  "clap 3.2.25",
  "config",
  "dashmap 5.5.3",
+ "dbus-secret-service-keyring-store",
  "dirs-next 2.0.0",
  "either",
  "futures 0.3.31",
@@ -12044,6 +12103,7 @@ dependencies = [
  "include_dir",
  "indexmap 2.13.0",
  "jsonwebtoken",
+ "keyring-core",
  "libsqlite3-sys",
  "log",
  "log4rs",
@@ -12086,6 +12146,7 @@ dependencies = [
  "wasm-opt",
  "webauthn-rs",
  "webrtc",
+ "windows-native-keyring-store",
  "zeroize",
 ]
 
@@ -12149,7 +12210,7 @@ name = "tari_rpc_framework"
 version = "0.33.5"
 dependencies = [
  "async-trait",
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "bytes",
  "futures 0.3.31",
  "libp2p",
@@ -12488,7 +12549,7 @@ checksum = "ae152524d25cea59fbda93725e41111c6eab88393080626e0cfec62c856e7d0e"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "blake2 0.10.6",
  "borsh",
  "bytes",
@@ -13357,7 +13418,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "bytes",
  "futures-core",
  "futures-util",
@@ -14244,7 +14305,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "hashbrown 0.15.5",
  "indexmap 2.13.0",
  "semver",
@@ -14681,6 +14742,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-native-keyring-store"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "063426e76fdec7438d56bb777f67e318a84a25c707b07e575cb8b78e10c028f8"
+dependencies = [
+ "byteorder",
+ "keyring-core",
+ "regex",
+ "windows-sys 0.61.2",
+ "zeroize",
+]
+
+[[package]]
 name = "windows-numerics"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15114,7 +15188,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "indexmap 2.13.0",
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -221,6 +221,11 @@ humantime-serde = "1.1.1"
 include_dir = "0.7.2"
 indexmap = "2.11.4"
 indoc = "1.0.6"
+# OS keyring: the wallet SDK talks to keyring-core; binaries install a platform store at startup
+keyring-core = "1.0"
+apple-native-keyring-store = "1.0"
+dbus-secret-service-keyring-store = "1.0"
+windows-native-keyring-store = "1.1"
 lazy_static = "1.4.0"
 # Use Tari's libp2p fork that adds support for Schnorr-Ristretto
 libp2p-identity = { git = "https://github.com/tari-project/rust-libp2p.git", rev = "e31882612c2e9c843a789117e460022ab7cda06b" }

--- a/applications/tari_walletd/Cargo.toml
+++ b/applications/tari_walletd/Cargo.toml
@@ -50,6 +50,7 @@ futures = { workspace = true }
 include_dir = { workspace = true, optional = true }
 indexmap = { workspace = true }
 jsonwebtoken = { workspace = true, features = ["aws_lc_rs"] }
+keyring-core = { workspace = true }
 libsqlite3-sys = { workspace = true, features = ["bundled"] }
 log = { workspace = true }
 log4rs = { workspace = true, features = [
@@ -81,6 +82,15 @@ tempfile.workspace = true
 sha2 = { workspace = true }
 time = { workspace = true }
 zeroize = { workspace = true, features = ["derive"] }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+apple-native-keyring-store = { workspace = true, features = ["keychain"] }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+dbus-secret-service-keyring-store = { workspace = true, features = ["crypto-rust"] }
+
+[target.'cfg(target_os = "windows")'.dependencies]
+windows-native-keyring-store = { workspace = true }
 
 [dev-dependencies]
 tari_utilities = { workspace = true }

--- a/applications/tari_walletd/src/lib.rs
+++ b/applications/tari_walletd/src/lib.rs
@@ -201,6 +201,19 @@ pub async fn run_tari_ootle_walletd(
     Ok(())
 }
 
+/// Installs the OS-native credential store that the wallet SDK uses to hold the cipher seed password.
+/// Must be called before the SDK touches the keyring. Not needed when `override_keyring_password` is set.
+/// On platforms without a supported store, keyring access fails with a clear error advising `--password`.
+pub fn init_os_keyring_store() -> anyhow::Result<()> {
+    #[cfg(target_os = "macos")]
+    keyring_core::set_default_store(apple_native_keyring_store::keychain::Store::new()?);
+    #[cfg(target_os = "linux")]
+    keyring_core::set_default_store(dbus_secret_service_keyring_store::Store::new()?);
+    #[cfg(target_os = "windows")]
+    keyring_core::set_default_store(windows_native_keyring_store::Store::new()?);
+    Ok(())
+}
+
 pub fn init_wallet_store(config: &ApplicationConfig) -> anyhow::Result<SqliteWalletStore> {
     let store = SqliteWalletStore::try_open(config.to_data_dir().join("wallet.sqlite"))?;
     store.run_migrations()?;

--- a/applications/tari_walletd/src/lib.rs
+++ b/applications/tari_walletd/src/lib.rs
@@ -203,15 +203,38 @@ pub async fn run_tari_ootle_walletd(
 
 /// Installs the OS-native credential store that the wallet SDK uses to hold the cipher seed password.
 /// Must be called before the SDK touches the keyring. Not needed when `override_keyring_password` is set.
-/// On platforms without a supported store, keyring access fails with a clear error advising `--password`.
-pub fn init_os_keyring_store() -> anyhow::Result<()> {
-    #[cfg(target_os = "macos")]
-    keyring_core::set_default_store(apple_native_keyring_store::keychain::Store::new()?);
-    #[cfg(target_os = "linux")]
-    keyring_core::set_default_store(dbus_secret_service_keyring_store::Store::new()?);
-    #[cfg(target_os = "windows")]
-    keyring_core::set_default_store(windows_native_keyring_store::Store::new()?);
-    Ok(())
+/// If no store can be installed (e.g. no DBus Secret Service on a headless host), a warning is logged and
+/// any later keyring access fails with a clear error advising `--password`.
+pub fn init_os_keyring_store() {
+    let result: keyring_core::Result<std::sync::Arc<keyring_core::CredentialStore>> = {
+        #[cfg(target_os = "macos")]
+        {
+            apple_native_keyring_store::keychain::Store::new().map(|s| s as _)
+        }
+        #[cfg(target_os = "linux")]
+        {
+            dbus_secret_service_keyring_store::Store::new().map(|s| s as _)
+        }
+        #[cfg(target_os = "windows")]
+        {
+            windows_native_keyring_store::Store::new().map(|s| s as _)
+        }
+        #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+        {
+            Err(keyring_core::Error::NotSupportedByStore(
+                "no OS keyring store is available on this platform".to_string(),
+            ))
+        }
+    };
+
+    match result {
+        Ok(store) => keyring_core::set_default_store(store),
+        Err(err) => warn!(
+            target: LOG_TARGET,
+            "⚠️ OS keyring store is unavailable: {err}. The wallet cannot store or retrieve the cipher seed \
+             password; use the `--password` option to provide one.",
+        ),
+    }
 }
 
 pub fn init_wallet_store(config: &ApplicationConfig) -> anyhow::Result<SqliteWalletStore> {

--- a/applications/tari_walletd/src/main.rs
+++ b/applications/tari_walletd/src/main.rs
@@ -64,7 +64,7 @@ async fn main() -> Result<(), anyhow::Error> {
     }
 
     if config.ootle_wallet_daemon.override_keyring_password.is_none() {
-        init_os_keyring_store()?;
+        init_os_keyring_store();
     }
 
     match &cli.command {

--- a/applications/tari_walletd/src/main.rs
+++ b/applications/tari_walletd/src/main.rs
@@ -33,6 +33,7 @@ use tari_ootle_wallet_sdk::{cipher_seed::CipherSeedRestore, models::KeyBranch};
 use tari_ootle_walletd::{
     cli::{Cli, Subcommand},
     config::ApplicationConfig,
+    init_os_keyring_store,
     init_wallet_store,
     initialize_wallet_sdk,
     run_tari_ootle_walletd,
@@ -60,6 +61,10 @@ async fn main() -> Result<(), anyhow::Error> {
     config.ootle_wallet_daemon.network = cli.network();
     if let Some(password) = cli.override_keyring_password.take() {
         config.ootle_wallet_daemon.override_keyring_password = Some(password);
+    }
+
+    if config.ootle_wallet_daemon.override_keyring_password.is_none() {
+        init_os_keyring_store()?;
     }
 
     match &cli.command {

--- a/crates/wallet/sdk/Cargo.toml
+++ b/crates/wallet/sdk/Cargo.toml
@@ -33,7 +33,7 @@ time = { workspace = true, features = ["serde", "serde-human-readable"] }
 thiserror = { workspace = true }
 ts-rs = { workspace = true, optional = true }
 webauthn-rs = { workspace = true }
-keyring = { version = "3.6.3", features = ["apple-native", "windows-native", "sync-secret-service"] }
+keyring-core = { workspace = true }
 rand = { workspace = true }
 passwords = "3.1.16"
 zeroize = { workspace = true, features = ["serde", "simd"] }

--- a/crates/wallet/sdk/src/apis/password_manager.rs
+++ b/crates/wallet/sdk/src/apis/password_manager.rs
@@ -78,16 +78,19 @@ impl<'a, TStore: WalletStore> PasswordManagerApi<'a, TStore> {
         Ok(SafePassword::from(str_password))
     }
 
-    fn get_cipher_seed_password_keyring_entry(&self, key: &str) -> Result<keyring::Entry, PasswordManagerApiError> {
-        let result = keyring::Entry::new(KEYRING_ENTRIES_SERVICE, key);
+    fn get_cipher_seed_password_keyring_entry(
+        &self,
+        key: &str,
+    ) -> Result<keyring_core::Entry, PasswordManagerApiError> {
+        let result = keyring_core::Entry::new(KEYRING_ENTRIES_SERVICE, key);
 
         match result {
             Ok(entry) => Ok(entry),
-            Err(keyring::Error::NoEntry) => {
-                // NoEntry maps to various errors in the keyring codebase, including AccessDenied, keyExpired etc.
-                // Entry::new says that it will only return an error if the service/user are invalid but there may be
-                // more errors possible e.g. AccessDenied. In any case we provide a better error than NoEntry for this
-                // case. We dont want IsNotFoundError to be true for this case.
+            // NoDefaultStore means the binary did not install a credential store before using the SDK
+            // (see e.g. tari_ootle_walletd::init_os_keyring_store). NoEntry from Entry::new can mask other
+            // access errors. Both mean "the keyring is unusable", not "the password is not set", so we must
+            // not let IsNotFoundError be true for them.
+            Err(keyring_core::Error::NoEntry | keyring_core::Error::NoDefaultStore) => {
                 Err(PasswordManagerApiError::FailedToAccessKeyRing)
             },
             Err(err) => Err(err.into()),
@@ -123,7 +126,7 @@ pub enum PasswordManagerApiError {
     #[error("Config API error: {0}")]
     ConfigApiError(#[from] ConfigApiError),
     #[error("OS Keyring error: {0}")]
-    KeyRing(#[from] keyring::Error),
+    KeyRing(#[from] keyring_core::Error),
     #[error("Failed to generate password for cipher seed: {0}")]
     PasswordGeneration(String),
     #[error(
@@ -137,6 +140,6 @@ pub enum PasswordManagerApiError {
 
 impl IsNotFoundError for PasswordManagerApiError {
     fn is_not_found_error(&self) -> bool {
-        matches!(self, Self::KeyRing(e) if matches!(e, keyring::Error::NoEntry))
+        matches!(self, Self::KeyRing(e) if matches!(e, keyring_core::Error::NoEntry))
     }
 }


### PR DESCRIPTION
## Description

Replaces the `keyring` v3 dependency in `tari_ootle_wallet_sdk` with `keyring-core` 1.0, following the keyring v4 architecture: libraries use only the core `Entry` API; the application installs a platform credential store at startup.

## Changes

- `tari_ootle_walletd` gains `init_os_keyring_store()` which installs the OS-native store at startup:
  - macOS: login keychain via `apple-native-keyring-store`
  - Linux: dbus Secret Service via `dbus-secret-service-keyring-store` with pure-Rust session crypto
  - Windows: credential manager via `windows-native-keyring-store`
- `init_os_keyring_store()` is called from `main()` for all subcommands, and skipped when `override_keyring_password` is set — so integration tests, sdk_tests, swarm and the tariswap bench never touch a real keyring (no dbus needed in CI; CI's `libdbus-1-dev` already covers the Linux build, same as v3's `sync-secret-service`).
- Error mapping: `Entry::new` failing with `NoEntry`/`NoDefaultStore` maps to the existing `FailedToAccessKeyRing` error advising `--password`; `IsNotFoundError` semantics unchanged.
- Backward compatible with existing stored wallet passwords on all three platforms (verified against v3 store sources: same macOS service/account generic password, same Linux service/username attributes, same Windows `user.service` target name).
- Marked breaking (`!`) because `PasswordManagerApiError::KeyRing` now wraps `keyring_core::Error`.

## Motivation

`keyring` v3 is legacy. The v4 store-split architecture lets us later add an opt-in macOS Data Protection keychain store with Touch ID (user-presence) gating for bundled/provisioned wallet builds, without changing the SDK's `Entry` call sites.

## Testing

- `cargo check` + `cargo lints clippy` clean
- 43/43 tests pass across `tari_ootle_wallet_sdk`, `sdk_tests` and `walletd`
- Formatted with `cargo +nightly-2025-12-05 fmt --all`