### PR TITLE
feat(walletd)!: default authentication to webauthn

### DIFF
--- a/applications/tari_ootle_app_utilities/config_presets/e_wallet_daemon.toml
+++ b/applications/tari_ootle_app_utilities/config_presets/e_wallet_daemon.toml
@@ -15,6 +15,7 @@
 # Indexer API url (default: http://127.0.0.1:18200)
 # indexer_api_url = "http://127.0.0.1:18200"
 [esmeralda.ootle_wallet_daemon]
+# Authentication method: "webauthn" (default) or "none" (dangerous: any local program can spend funds)
 #authentication = "webauthn"
 # Indexer API url for Esme.
 indexer_api_url = "https://ootle-indexer-a.tari.com/"

--- a/applications/tari_walletd/src/config.rs
+++ b/applications/tari_walletd/src/config.rs
@@ -174,8 +174,8 @@ pub struct WebAuthnConfig {
 #[derive(Debug, Serialize, Deserialize, Clone, Copy, Default)]
 #[serde(rename_all = "lowercase")]
 pub enum WalletDaemonAuth {
-    #[default]
     None,
+    #[default]
     WebAuthn,
 }
 

--- a/docs/skills/claude-code/tari-manifest/references/wallet-daemon-api.md
+++ b/docs/skills/claude-code/tari-manifest/references/wallet-daemon-api.md
@@ -8,8 +8,8 @@ The wallet daemon exposes a JSON-RPC 2.0 API. All requests are POST to the endpo
 
 The daemon supports two authentication modes configured via `WalletDaemonAuth`:
 
-- **`none`** (default) - Anonymous authentication. Any client can obtain a JWT by sending `"credentials": "None"`.
-- **`webauthn`** - WebAuthn/passkey-based authentication. Requires a registered passkey to authenticate.
+- **`none`** - Anonymous authentication. Any client can obtain a JWT by sending `"credentials": "None"`.
+- **`webauthn`** (default) - WebAuthn/passkey-based authentication. Requires a registered passkey to authenticate.
 
 ### Authentication Flow (auth.method = "none")
 


### PR DESCRIPTION
## Description

Changes the `WalletDaemonAuth` default from `none` to `webauthn`.

Running with `authentication = none` leaves the wallet spendable by any local program (or anyone who can reach the JSON-RPC port). The daemon already emits a loud warning when `none` is active — secure-by-default is the right posture, and WebAuthn is already fully integrated.

## Changes

- `applications/tari_walletd/src/config.rs`: change `WalletDaemonAuth` default impl from `None` to `WebAuthn`
- `e_wallet_daemon.toml` config preset: update comment to reflect the new default
- `docs/skills/claude-code/tari-manifest/references/wallet-daemon-api.md`: update skill reference doc to reflect `webauthn` as the default

## Notes

- **No extra configuration needed for the default setup.** WebAuthn works out of the box: `rp_id` defaults to `"localhost"` and `rp_origin` is derived from the JSON-RPC port when unset.
- **Local tooling is unaffected.** `tari_swarm_daemon` passes `-pootle_wallet_daemon.authentication=none` explicitly (its own default), and integration tests set `WalletDaemonAuth::None` directly.
- **Breaking change.** Existing deployments that relied on the implicit `none` default must now set `authentication = none` explicitly in their config (or register a passkey).

## Testing

- `cargo check` clean
- Formatted with `cargo +nightly-2025-12-05 fmt --all`