### PR TITLE
chore: bump workspace version to 0.34.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1714,7 +1714,7 @@ dependencies = [
 
 [[package]]
 name = "consensus_tests"
-version = "0.33.5"
+version = "0.34.0"
 dependencies = [
  "fern",
  "futures 0.3.31",
@@ -2724,7 +2724,7 @@ dependencies = [
 
 [[package]]
 name = "db-inspector"
-version = "0.33.5"
+version = "0.34.0"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -5061,7 +5061,7 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "integration_tests"
-version = "0.33.5"
+version = "0.34.0"
 dependencies = [
  "anyhow",
  "config",
@@ -5835,7 +5835,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-messaging"
-version = "0.33.5"
+version = "0.34.0"
 dependencies = [
  "async-trait",
  "futures-bounded 0.2.4",
@@ -6013,7 +6013,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-substream"
-version = "0.33.5"
+version = "0.34.0"
 dependencies = [
  "libp2p",
  "prometheus-client",
@@ -7633,7 +7633,7 @@ dependencies = [
 
 [[package]]
 name = "ootle-wasm"
-version = "0.33.5"
+version = "0.34.0"
 dependencies = [
  "console_error_panic_hook",
  "getrandom 0.2.17",
@@ -7644,7 +7644,7 @@ dependencies = [
 
 [[package]]
 name = "ootle-wasm-core"
-version = "0.33.5"
+version = "0.34.0"
 dependencies = [
  "base64 0.22.1",
  "hex",
@@ -8688,7 +8688,7 @@ dependencies = [
 
 [[package]]
 name = "proto_builder"
-version = "0.33.5"
+version = "0.34.0"
 dependencies = [
  "prost-build 0.14.3",
  "sha2 0.10.9",
@@ -10553,7 +10553,7 @@ dependencies = [
 
 [[package]]
 name = "sqlite_message_logger"
-version = "0.33.5"
+version = "0.34.0"
 dependencies = [
  "chrono",
  "diesel",
@@ -10925,7 +10925,7 @@ dependencies = [
 
 [[package]]
 name = "tari_base_node_client"
-version = "0.33.5"
+version = "0.34.0"
 dependencies = [
  "futures-util",
  "log",
@@ -11157,7 +11157,7 @@ dependencies = [
 
 [[package]]
 name = "tari_consensus"
-version = "0.33.5"
+version = "0.34.0"
 dependencies = [
  "anyhow",
  "indexmap 2.13.0",
@@ -11182,7 +11182,7 @@ dependencies = [
 
 [[package]]
 name = "tari_consensus_types"
-version = "0.33.5"
+version = "0.34.0"
 dependencies = [
  "borsh",
  "minicbor",
@@ -11285,7 +11285,7 @@ dependencies = [
 
 [[package]]
 name = "tari_engine"
-version = "0.33.5"
+version = "0.34.0"
 dependencies = [
  "blake2 0.10.6",
  "bytes",
@@ -11317,7 +11317,7 @@ dependencies = [
 
 [[package]]
 name = "tari_engine_types"
-version = "0.33.5"
+version = "0.34.0"
 dependencies = [
  "blake2 0.10.6",
  "borsh",
@@ -11346,7 +11346,7 @@ dependencies = [
 
 [[package]]
 name = "tari_epoch_manager"
-version = "0.33.5"
+version = "0.34.0"
 dependencies = [
  "anyhow",
  "log",
@@ -11366,7 +11366,7 @@ dependencies = [
 
 [[package]]
 name = "tari_epoch_oracles"
-version = "0.33.5"
+version = "0.34.0"
 dependencies = [
  "anyhow",
  "blake2 0.10.6",
@@ -11412,7 +11412,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer"
-version = "0.33.5"
+version = "0.34.0"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -11515,7 +11515,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer_lib"
-version = "0.33.5"
+version = "0.34.0"
 dependencies = [
  "async-trait",
  "log",
@@ -11612,7 +11612,7 @@ dependencies = [
 
 [[package]]
 name = "tari_networking"
-version = "0.33.5"
+version = "0.34.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11666,7 +11666,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_app_utilities"
-version = "0.33.5"
+version = "0.34.0"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -11707,7 +11707,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_common_types"
-version = "0.33.5"
+version = "0.34.0"
 dependencies = [
  "blake2 0.10.6",
  "borsh",
@@ -11736,7 +11736,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_p2p"
-version = "0.33.5"
+version = "0.34.0"
 dependencies = [
  "anyhow",
  "libp2p-identity 0.2.14",
@@ -11760,7 +11760,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_storage"
-version = "0.33.5"
+version = "0.34.0"
 dependencies = [
  "anyhow",
  "bitflags 2.10.0",
@@ -11789,7 +11789,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_storage_sqlite"
-version = "0.33.5"
+version = "0.34.0"
 dependencies = [
  "diesel",
  "diesel_migrations",
@@ -11842,7 +11842,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_transaction"
-version = "0.33.5"
+version = "0.34.0"
 dependencies = [
  "borsh",
  "hex",
@@ -11868,7 +11868,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_cli"
-version = "0.33.5"
+version = "0.34.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -11990,7 +11990,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_sdk_tests"
-version = "0.33.5"
+version = "0.34.0"
 dependencies = [
  "digest 0.10.7",
  "ootle_byte_type",
@@ -12036,7 +12036,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_walletd"
-version = "0.33.5"
+version = "0.34.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12158,7 +12158,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_framework"
-version = "0.33.5"
+version = "0.34.0"
 dependencies = [
  "async-trait",
  "bitflags 2.10.0",
@@ -12182,7 +12182,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_macros"
-version = "0.33.5"
+version = "0.34.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12191,7 +12191,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_state_sync"
-version = "0.33.5"
+version = "0.34.0"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -12273,7 +12273,7 @@ dependencies = [
 
 [[package]]
 name = "tari_state_store_rocksdb"
-version = "0.33.5"
+version = "0.34.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12305,7 +12305,7 @@ dependencies = [
 
 [[package]]
 name = "tari_state_tree"
-version = "0.33.5"
+version = "0.34.0"
 dependencies = [
  "indexmap 2.13.0",
  "log",
@@ -12334,7 +12334,7 @@ dependencies = [
 
 [[package]]
 name = "tari_swarm"
-version = "0.33.5"
+version = "0.34.0"
 dependencies = [
  "libp2p",
  "libp2p-messaging",
@@ -12346,7 +12346,7 @@ dependencies = [
 
 [[package]]
 name = "tari_swarm_daemon"
-version = "0.33.5"
+version = "0.34.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12459,7 +12459,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_test_tooling"
-version = "0.33.5"
+version = "0.34.0"
 dependencies = [
  "anyhow",
  "cargo_toml 0.22.3",
@@ -12575,7 +12575,7 @@ dependencies = [
 
 [[package]]
 name = "tari_transaction_manifest"
-version = "0.33.5"
+version = "0.34.0"
 dependencies = [
  "proc-macro2",
  "serde_json",
@@ -12610,7 +12610,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node"
-version = "0.33.5"
+version = "0.34.0"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -12675,7 +12675,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node_client"
-version = "0.33.5"
+version = "0.34.0"
 dependencies = [
  "indexmap 2.13.0",
  "multiaddr 0.18.3",
@@ -12699,7 +12699,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node_rpc"
-version = "0.33.5"
+version = "0.34.0"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -12723,7 +12723,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_rollback"
-version = "0.33.5"
+version = "0.34.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12758,7 +12758,7 @@ dependencies = [
 
 [[package]]
 name = "tari_watcher"
-version = "0.33.5"
+version = "0.34.0"
 dependencies = [
  "anyhow",
  "clap 3.2.25",
@@ -12787,7 +12787,7 @@ dependencies = [
 
 [[package]]
 name = "tariswap_bench"
-version = "0.33.5"
+version = "0.34.0"
 dependencies = [
  "anyhow",
  "clap 4.5.54",
@@ -13479,7 +13479,7 @@ dependencies = [
 
 [[package]]
 name = "traffic-sim"
-version = "0.33.5"
+version = "0.34.0"
 dependencies = [
  "anyhow",
  "clap 4.5.54",
@@ -13501,7 +13501,7 @@ dependencies = [
 
 [[package]]
 name = "transaction_generator"
-version = "0.33.5"
+version = "0.34.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -13522,7 +13522,7 @@ dependencies = [
 
 [[package]]
 name = "transaction_submitter"
-version = "0.33.5"
+version = "0.34.0"
 dependencies = [
  "anyhow",
  "clap 4.5.54",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.33.5"
+version = "0.34.0"
 edition = "2024"
 authors = ["The Tari Development Community"]
 repository = "https://github.com/tari-project/tari-ootle"
@@ -95,7 +95,7 @@ tari_ootle_app_utilities = { path = "applications/tari_ootle_app_utilities" }
 tari_consensus = { path = "crates/consensus" }
 tari_ootle_address = { path = "crates/ootle_address", version = "0.6" }
 ootle-network = { path = "crates/ootle_network", version = "0.2" }
-tari_engine = { path = "crates/engine", version = "0.33" }
+tari_engine = { path = "crates/engine", version = "0.34" }
 tari_ootle_p2p = { path = "crates/p2p" }
 tari_ootle_storage = { path = "crates/storage" }
 tari_ootle_storage_sqlite = { path = "crates/storage_sqlite" }
@@ -109,8 +109,8 @@ tari_indexer_lib = { path = "crates/indexer_lib" }
 tari_rpc_state_sync = { path = "crates/rpc_state_sync" }
 tari_state_store_rocksdb = { path = "crates/state_store_rocksdb" }
 tari_state_tree = { path = "crates/state_tree" }
-tari_template_test_tooling = { path = "crates/template_test_tooling", version = "0.33" }
-tari_transaction_manifest = { path = "crates/transaction_manifest", version = "0.33" }
+tari_template_test_tooling = { path = "crates/template_test_tooling", version = "0.34" }
+tari_transaction_manifest = { path = "crates/transaction_manifest", version = "0.34" }
 tari_validator_node_rpc = { path = "crates/validator_node_rpc" }
 sqlite_message_logger = { path = "networking/sqlite_message_logger" }
 tari_base_node_client = { path = "clients/base_node_client" }
@@ -120,16 +120,16 @@ tari_rpc_framework = { path = "networking/rpc_framework" }
 tari_rpc_macros = { path = "networking/rpc_macros" }
 tari_swarm = { path = "networking/swarm" }
 tari_validator_node_client = { path = "clients/validator_node_client" }
-tari_validator_rollback = { path = "utilities/validator_rollback", version = "0.33" }
+tari_validator_rollback = { path = "utilities/validator_rollback", version = "0.34" }
 tari_ootle_walletd_client = { path = "clients/wallet_daemon_client", version = "0.33" }
 transaction_generator = { path = "utilities/transaction_generator" }
 
 # Dependency crates on crates.io (update versions here as well when updating the workspace version)
-tari_consensus_types = { path = "crates/consensus_types", version = "0.33" }
-tari_ootle_common_types = { path = "crates/common_types", version = "0.33" }
-tari_engine_types = { path = "crates/engine_types", version = "0.33" }
+tari_consensus_types = { path = "crates/consensus_types", version = "0.34" }
+tari_ootle_common_types = { path = "crates/common_types", version = "0.34" }
+tari_engine_types = { path = "crates/engine_types", version = "0.34" }
 tari_template_builtin = { path = "crates/template_builtin", version = "0.32" }
-tari_ootle_transaction = { path = "crates/transaction", version = "0.33" }
+tari_ootle_transaction = { path = "crates/transaction", version = "0.34" }
 
 # Template lib
 tari_ootle_template_build = { path = "crates/template_build", version = "0.7" }

--- a/crates/ootle_wasm/wasm/Cargo.toml
+++ b/crates/ootle_wasm/wasm/Cargo.toml
@@ -13,7 +13,7 @@ readme = "../NPM_README.md"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-ootle-wasm-core = { path = "../core", version = "0.33" }
+ootle-wasm-core = { path = "../core", version = "0.34" }
 wasm-bindgen = "0.2"
 # getrandom is pulled in transitively via `rand` and `tari_bulletproofs_plus`. The wasm32-unknown-unknown
 # target requires explicit feature opt-in for both major versions used in the graph.


### PR DESCRIPTION
## Description

Bumps `workspace.package.version` from 0.33.5 to 0.34.0.

## Changes

- `workspace.package.version`: 0.33.5 → 0.34.0
- Workspace-dependency pins updated from `"0.33"` to `"0.34"` for the workspace-version-inheriting crates: `tari_engine`, `tari_template_test_tooling`, `tari_transaction_manifest`, `tari_validator_rollback`, `tari_consensus_types`, `tari_ootle_common_types`, `tari_engine_types`, `tari_ootle_transaction`
- `crates/ootle_wasm/wasm/Cargo.toml`: `ootle-wasm-core` pin `"0.33"` → `"0.34"`
- `Cargo.lock` refreshed
- Wallet-tier crates (`tari_ootle_wallet_crypto`, `tari_ootle_wallet_sdk`, `tari_ootle_wallet_storage_sqlite`, `tari_ootle_walletd_client`) are independently versioned and intentionally keep their `"0.33"` pins