### PR TITLE
fix(indexer-ui): show rejected transactions instead of perpetual pending

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14343,7 +14343,7 @@ version = "0.245.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f08c9adee0428b7bddf3890fc27e015ac4b761cc608c822667102b8bfd6995e"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -14352,7 +14352,7 @@ version = "0.246.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71cde4757396defafd25417cfb36aa3161027d06d865b0c24baaae229aac005d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "indexmap 2.13.0",
  "semver",
 ]

--- a/applications/tari_indexer/web_ui/src/api/hooks/useTransactions.tsx
+++ b/applications/tari_indexer/web_ui/src/api/hooks/useTransactions.tsx
@@ -28,9 +28,12 @@ import {
   getTransactionResult,
 } from "../../utils/api";
 
-// A finalized result is `{ Finalized: {...} }`; a pending one is the string "Pending".
-const isFinalizedResult = (data: IndexerGetTransactionResultResponse | undefined): boolean =>
-  data?.result != null && typeof data.result === "object" && "Finalized" in data.result;
+// A settled result is `{ Finalized: {...} }` or `{ Rejected: {...} }`; a pending one is the
+// string "Pending". Both settled states are terminal.
+const isSettledResult = (data: IndexerGetTransactionResultResponse | undefined): boolean =>
+  data?.result != null &&
+  typeof data.result === "object" &&
+  ("Finalized" in data.result || "Rejected" in data.result);
 
 interface UseListRecentTransactionsProps {
   last_id: string | null;
@@ -55,10 +58,10 @@ export const useGetTransactionResult = (transaction_id: string) => {
     queryKey: ["transaction_result", transaction_id],
     queryFn: () => getTransactionResult({ transaction_id }),
     enabled: !!transaction_id,
-    // Once a transaction is finalized (Accept/Abort) its result is immutable, so treat it as
-    // permanently fresh — React Query then never auto-refetches it (no polling, window-focus or
-    // remount refresh). Pending results keep the default so they still update.
-    staleTime: (query) => (isFinalizedResult(query.state.data) ? Infinity : 0),
+    // Once a transaction is finalized (Accept/Abort) or rejected its result is immutable, so treat
+    // it as permanently fresh — React Query then never auto-refetches it (no polling, window-focus
+    // or remount refresh). Pending results keep the default so they still update.
+    staleTime: (query) => (isSettledResult(query.state.data) ? Infinity : 0),
   });
 };
 

--- a/applications/tari_indexer/web_ui/src/routes/RecentTransactions/components/RecentTransactions.tsx
+++ b/applications/tari_indexer/web_ui/src/routes/RecentTransactions/components/RecentTransactions.tsx
@@ -49,7 +49,7 @@ import TimeChip from "./TimeChip";
 type ExtendedTransactionEntry = TransactionEntry & { id: string; show?: boolean };
 
 function TransactionRow({ entry }: { entry: ExtendedTransactionEntry }) {
-  const { transaction_id, created_at, summary } = entry;
+  const { transaction_id, created_at, summary, rejected_reason } = entry;
   const theme = useTheme();
   const isSm = useMediaQuery(theme.breakpoints.down("sm"));
   const shortLen = isSm ? 4 : 8;
@@ -74,6 +74,8 @@ function TransactionRow({ entry }: { entry: ExtendedTransactionEntry }) {
       <DataTableCell>
         {summary ? (
           <StatusChip status="Commit" feeOnly={summary.outcome === "FeeIntentCommit"} showTitle={true} />
+        ) : rejected_reason ? (
+          <Chip label="Rejected" color="error" size="small" variant="outlined" title={rejected_reason} />
         ) : (
           <Chip label="Pending" color="warning" size="small" variant="outlined" />
         )}

--- a/applications/tari_indexer/web_ui/src/routes/RecentTransactions/components/RecentTransactions.tsx
+++ b/applications/tari_indexer/web_ui/src/routes/RecentTransactions/components/RecentTransactions.tsx
@@ -74,7 +74,7 @@ function TransactionRow({ entry }: { entry: ExtendedTransactionEntry }) {
       <DataTableCell>
         {summary ? (
           <StatusChip status="Commit" feeOnly={summary.outcome === "FeeIntentCommit"} showTitle={true} />
-        ) : rejected_reason ? (
+        ) : rejected_reason != null ? (
           <Chip label="Rejected" color="error" size="small" variant="outlined" title={rejected_reason} />
         ) : (
           <Chip label="Pending" color="warning" size="small" variant="outlined" />

--- a/applications/tari_indexer/web_ui/src/routes/Transaction/components/Result.tsx
+++ b/applications/tari_indexer/web_ui/src/routes/Transaction/components/Result.tsx
@@ -66,6 +66,9 @@ import SubstatesContent from "./SubstatesContent";
 const isFinalized = (result: any): result is { Finalized: any } =>
   typeof result === "object" && result !== null && "Finalized" in result;
 
+const isRejected = (result: any): result is { Rejected: { details: string; rejected_time: string } } =>
+  typeof result === "object" && result !== null && "Rejected" in result;
+
 const isAcceptResult = (result: any): result is { Accept: any } =>
   result && typeof result === "object" && "Accept" in result;
 
@@ -122,6 +125,8 @@ function Result({ transaction_id }: IndexerGetTransactionResultRequest) {
     data?.result && isFinalized(data.result)
       ? data.result.Finalized.execution_result?.finalize?.result
       : undefined;
+
+  const rejected = data?.result && isRejected(data.result) ? data.result.Rejected : undefined;
 
   const handleChange = (panel: string) => (_event: React.SyntheticEvent, isExpanded: boolean) => {
     setExpandedPanels((prev) =>
@@ -381,9 +386,25 @@ function Result({ transaction_id }: IndexerGetTransactionResultRequest) {
                   <TableRow>
                     <TableCell>Status</TableCell>
                     <DataTableCell>
-                      <Chip label="Pending" color="warning" variant="filled" />
+                      {rejected ? (
+                        <Chip label="Rejected" color="error" variant="filled" />
+                      ) : (
+                        <Chip label="Pending" color="warning" variant="filled" />
+                      )}
                     </DataTableCell>
                   </TableRow>
+                  {rejected && (
+                    <>
+                      <TableRow>
+                        <TableCell>Rejection Reason</TableCell>
+                        <DataTableCell>{rejected.details}</DataTableCell>
+                      </TableRow>
+                      <TableRow>
+                        <TableCell>Rejected Time</TableCell>
+                        <DataTableCell>{rejected.rejected_time}</DataTableCell>
+                      </TableRow>
+                    </>
+                  )}
                 </TableBody>
               </Table>
             </TableContainer>


### PR DESCRIPTION
## Description

The indexer REST API (`GET /transactions/:id/result`) returns `{"Rejected": {...}}` for transactions rejected during mempool validation. The indexer web UI only recognised the `Finalized` variant, so rejected transactions showed as \"Pending\" forever and React Query never stopped polling.

## Changes

- **`routes/Transaction/components/Result.tsx`** — added an `isRejected` guard; the result page now shows a \"Rejected\" chip with the rejection reason and rejected time instead of a hardcoded \"Pending\" chip.
- **`api/hooks/useTransactions.tsx`** — `isFinalizedResult` renamed to `isSettledResult` and now treats `Rejected` as terminal, so `staleTime: Infinity` applies and polling stops.
- **`routes/RecentTransactions/components/RecentTransactions.tsx`** — rows with a `rejected_reason` now show a \"Rejected\" chip (reason in tooltip) instead of \"Pending\".
- **`Cargo.lock`** — bitflags 2.10.0 → 2.13.0 lockfile refresh.

TypeScript typecheck (`npx tsc --noEmit`) passes in the `web_ui` directory.