### PR TITLE
ci: pin pnpm 11.6.0 centrally and fix frozen-lockfile config mismatch

### DIFF
--- a/.github/workflows/build_binaries.yml
+++ b/.github/workflows/build_binaries.yml
@@ -225,9 +225,8 @@ jobs:
           rustup target add ${{ matrix.builds.target }}
 
       - name: Install Dependencies - Node
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
-          version: 10
           run_install: true
 
       - name: Set environment variables - Nix

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,9 +76,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: install pnpm
-        uses: pnpm/action-setup@078e9d416474b29c0c387560859308974f7e9c53 # v6.0.1
-        with:
-          version: 10.28.0
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: setup node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -88,15 +86,12 @@ jobs:
 
       # Builds every workspace web UI (walletd, indexer, validator node, db_inspector)
       # together with the bindings/clients they depend on, in topological order.
-      # --no-frozen-lockfile: this is a build check, not a lockfile-integrity gate,
-      #   and the committed lockfile's pnpm "overrides" representation otherwise
-      #   trips pnpm's frozen check under CI.
       # --ignore-scripts: dependency build scripts (esbuild/@swc/core/@parcel/watcher)
       #   ship prebuilt binaries and are not needed to compile the UIs; without this,
-      #   pnpm 10 fails CI installs with ERR_PNPM_IGNORED_BUILDS.
+      #   pnpm fails CI installs with ERR_PNPM_IGNORED_BUILDS.
       - name: build workspace web UIs
         run: |
-          pnpm install --no-frozen-lockfile --ignore-scripts
+          pnpm install --frozen-lockfile --ignore-scripts
           pnpm --recursive run build
 
       # The swarm daemon web UI is a standalone npm project, not part of the pnpm workspace.

--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -28,9 +28,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install pnpm
-        uses: pnpm/action-setup@078e9d416474b29c0c387560859308974f7e9c53 # v6.0.1
-        with:
-          package_json_file: bindings/package.json
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
       - name: Use Node.js from .nvmrc
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -81,9 +79,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install pnpm
-        uses: pnpm/action-setup@078e9d416474b29c0c387560859308974f7e9c53 # v6.0.1
-        with:
-          package_json_file: clients/javascript/wallet_daemon_client/package.json
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
       - name: Use Node.js from .nvmrc
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -137,9 +133,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install pnpm
-        uses: pnpm/action-setup@078e9d416474b29c0c387560859308974f7e9c53 # v6.0.1
-        with:
-          package_json_file: clients/javascript/indexer_client/package.json
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
       - name: Use Node.js from .nvmrc
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:

--- a/applications/theming/package.json
+++ b/applications/theming/package.json
@@ -27,7 +27,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "packageManager": "pnpm@10.28.0",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [

--- a/bindings/package.json
+++ b/bindings/package.json
@@ -30,7 +30,6 @@
   ],
   "author": "",
   "license": "ISC",
-  "packageManager": "pnpm@10.28.0",
   "dependencies": {
     "bech32": "^2.0.0"
   },

--- a/clients/javascript/indexer_client/package.json
+++ b/clients/javascript/indexer_client/package.json
@@ -26,7 +26,6 @@
   ],
   "author": "",
   "license": "ISC",
-  "packageManager": "pnpm@10.28.0",
   "dependencies": {
     "@tari-project/ootle-ts-bindings": "workspace:^"
   },

--- a/clients/javascript/wallet_daemon_client/package.json
+++ b/clients/javascript/wallet_daemon_client/package.json
@@ -27,7 +27,6 @@
   ],
   "author": "",
   "license": "ISC",
-  "packageManager": "pnpm@10.28.0",
   "dependencies": {
     "@tari-project/ootle-ts-bindings": "workspace:^"
   },

--- a/package.json
+++ b/package.json
@@ -1,16 +1,8 @@
 {
+  "packageManager": "pnpm@11.6.0",
   "dependencies": {
     "@tari-project/ootle-ts-bindings": "link:bindings",
     "@tari-project/ootle-web-ui-theming": "link:applications/theming",
     "@tari-project/wallet_jrpc_client": "link:clients/javascript/wallet_daemon_client"
-  },
-  "pnpm": {
-    "overrides": {
-      "vite@<8.0.8": ">=8.0.8",
-      "picomatch@<4.0.4": ">=4.0.4",
-      "defu@<=6.1.4": ">=6.1.5",
-      "brace-expansion@>=5.0.0 <5.0.5": ">=5.0.5",
-      "yaml@<1.10.3": ">=1.10.3"
-    }
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,6 +7,13 @@ packages:
   - applications/tari_validator_node/web_ui
   - utilities/db_inspector/web_ui
 
+overrides:
+  vite@<8.0.8: '>=8.0.8'
+  picomatch@<4.0.4: '>=4.0.4'
+  defu@<=6.1.4: '>=6.1.5'
+  brace-expansion@>=5.0.0 <5.0.5: '>=5.0.5'
+  yaml@<1.10.3: '>=1.10.3'
+
 catalog:
   '@types/node': ^25.3.5
   typescript: ^5.9.3


### PR DESCRIPTION
## Description

The \"Publish Packages to npmjs\" workflow failed on tag v0.34.0 with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` during `pnpm install --frozen-lockfile`. This PR fixes the root cause and removes the workarounds that were papering over it.

## Motivation

The repo was pinned to `pnpm/action-setup@v6.0.1`, which has a bug where its bootstrap binary shadows the requested pnpm version on PATH (fixed in v6.0.2: \"pnpm self-update binary shadowed by bootstrap on PATH\"). As a result, CI jobs were actually running pnpm 11 regardless of the `version:` or `package_json_file:` pins. pnpm 11 no longer reads `pnpm.overrides` from `package.json` — it expects them in `pnpm-workspace.yaml` — so its computed overrides were empty while the lockfile recorded them, causing the frozen-lockfile check to fail. This same mismatch was also why the `web_ui_build` job previously required `--no-frozen-lockfile`.

## Changes

- Add `"packageManager": "pnpm@11.6.0"` to the root `package.json` as the single central pnpm version source; `pnpm/action-setup` reads this by default. Remove the per-package `packageManager` fields from `bindings/`, `theming/`, and both JS clients, and remove the per-workflow `version:`/`package_json_file:` overrides.
- Move `overrides` from `package.json` (`pnpm.overrides`) to `pnpm-workspace.yaml` (pnpm 11's settings home). The lockfile required no regeneration — pnpm 11.6.0 considers it current with the new layout.
- Bump `pnpm/action-setup` to v6.0.8 (SHA-pinned: `0e279bb959325dab635dd2c09392533439d90093`) in `ci.yml`, `npm_publish.yml`, and `build_binaries.yml`.
- Restore `--frozen-lockfile` in the `web_ui_build` job now that the underlying cause is resolved.

## Verification

In a clean worktree with these changes, `CI=true pnpm@11.6.0 install --frozen-lockfile --ignore-scripts` passes from `bindings/` (matching the publish job). `pnpm --recursive run build` (all web UIs) and `pnpm run build-dist` in `bindings/` both succeed under pnpm 11.6.0.