### PR TITLE
ci: disable pnpm strictDepBuilds to fix ERR_PNPM_IGNORED_BUILDS in publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,12 +86,12 @@ jobs:
 
       # Builds every workspace web UI (walletd, indexer, validator node, db_inspector)
       # together with the bindings/clients they depend on, in topological order.
-      # --ignore-scripts: dependency build scripts (esbuild/@swc/core/@parcel/watcher)
-      #   ship prebuilt binaries and are not needed to compile the UIs; without this,
-      #   pnpm fails CI installs with ERR_PNPM_IGNORED_BUILDS.
+      # Ignored dependency build scripts (esbuild/@swc/core/@parcel/watcher) ship
+      # prebuilt binaries and aren't needed to compile the UIs; strictDepBuilds: false
+      # in pnpm-workspace.yaml keeps this frozen install green.
       - name: build workspace web UIs
         run: |
-          pnpm install --frozen-lockfile --ignore-scripts
+          pnpm install --frozen-lockfile
           pnpm --recursive run build
 
       # The swarm daemon web UI is a standalone npm project, not part of the pnpm workspace.

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -25,4 +25,11 @@ ignoredBuiltDependencies:
   - esbuild
   - msw
 
+# These dependencies ship prebuilt binaries, so their build scripts are intentionally
+# ignored (above) and not needed to compile the bindings, clients or web UIs. pnpm 11
+# otherwise hard-fails any install that leaves build scripts unrun with
+# ERR_PNPM_IGNORED_BUILDS; disabling the strict gate keeps `pnpm install --frozen-lockfile`
+# green across CI and publish jobs without per-command --ignore-scripts workarounds.
+strictDepBuilds: false
+
 publishBranch: development


### PR DESCRIPTION
## Description

Follow-up to #2235. After that PR fixed the frozen-lockfile config mismatch, the re-tagged v0.34.0 publish run (run 27534389621) hit the next pnpm 11 gate: `ERR_PNPM_IGNORED_BUILDS — Ignored build scripts: @parcel/watcher, @swc/core, esbuild` during `pnpm install --frozen-lockfile`.

## Motivation

pnpm 11 introduced `strictDepBuilds`, which hard-fails any install that leaves dependency build scripts unrun. This fires even when those packages are listed in `ignoredBuiltDependencies` — that list silences the warning but does not satisfy the strict gate. The three publish jobs in `npm_publish.yml` run a bare `pnpm install --frozen-lockfile` and therefore trip it. The `web_ui_build` CI job had only been dodging it via a per-command `--ignore-scripts` flag.

## Changes

- `pnpm-workspace.yaml`: set `strictDepBuilds: false` with an explanatory comment. These dependencies (`esbuild`, `@swc/core`, `@parcel/watcher`) ship prebuilt binaries; their build scripts are not needed to compile the bindings, clients, or web UIs.
- `.github/workflows/ci.yml`: drop the now-redundant `--ignore-scripts` flag from the `web_ui_build` install step and update the comment, so every install across CI and publish uses the identical bare `pnpm install --frozen-lockfile` command.

The publish jobs in `npm_publish.yml` need no changes — they already use the bare frozen install that will now pass.