### PR TITLE
fix(indexer): treat read-only genesis substates as verified by definition

### DIFF
--- a/crates/indexer_lib/Cargo.toml
+++ b/crates/indexer_lib/Cargo.toml
@@ -13,6 +13,7 @@ tari_ootle_common_types = { workspace = true }
 tari_ootle_storage = { workspace = true }
 tari_epoch_manager = { workspace = true }
 tari_engine_types = { workspace = true }
+tari_template_lib_types = { workspace = true }
 tari_validator_node_rpc = { workspace = true }
 
 async-trait = { workspace = true }

--- a/crates/indexer_lib/src/cached_substate_manager.rs
+++ b/crates/indexer_lib/src/cached_substate_manager.rs
@@ -47,6 +47,7 @@ use tari_ootle_storage::{
     verify_substate_value_proof,
     verify_substate_value_proof_against_root,
 };
+use tari_template_lib_types::constants::{PUBLIC_IDENTITY_RESOURCE_ADDRESS, STEALTH_TARI_RESOURCE_ADDRESS};
 use tari_validator_node_rpc::client::{
     SubstateProofData,
     SubstateResult,
@@ -426,14 +427,22 @@ where
                 .map_err(|e| IndexerError::ValidatorNodeClientError(e.to_string()));
         }
 
-        // Read-only substates (the TARI resource, the public identity resource) are protocol
-        // constants bootstrapped directly into the substate store at genesis. They are never
-        // written to the shard state tree, so no inclusion proof can be produced for them and
-        // verification would always fail with a leaf-key mismatch. Their value is fixed by the
-        // protocol, so they are verified by definition: fetch without a proof and treat as verified.
+        // The TARI resource and the public identity resource are immutable protocol constants
+        // bootstrapped directly into the substate store at genesis. They are never written to the
+        // shard state tree, so no inclusion proof can be produced for them and verification would
+        // always fail with a leaf-key mismatch. Their value is fixed by the protocol, so they are
+        // verified by definition: fetch without a proof and treat as verified.
+        //
+        // This is deliberately restricted to these two genesis addresses. Other read-only substates
+        // (templates, transaction receipts, claimed output tombstones) are created during
+        // transaction execution and *are* committed to the state tree, so they must still be proven.
+        //
         // TODO: commit genesis substates to the state tree so they can be cryptographically verified
         //       like any other substate (changes the genesis state root, so deferred).
-        if substate_requirement.substate_id().is_read_only() {
+        let resource_address = substate_requirement.substate_id().as_resource_address();
+        if resource_address == Some(STEALTH_TARI_RESOURCE_ADDRESS) ||
+            resource_address == Some(PUBLIC_IDENTITY_RESOURCE_ADDRESS)
+        {
             return client
                 .get_substate(substate_requirement)
                 .await

--- a/crates/indexer_lib/src/cached_substate_manager.rs
+++ b/crates/indexer_lib/src/cached_substate_manager.rs
@@ -426,6 +426,21 @@ where
                 .map_err(|e| IndexerError::ValidatorNodeClientError(e.to_string()));
         }
 
+        // Read-only substates (the TARI resource, the public identity resource) are protocol
+        // constants bootstrapped directly into the substate store at genesis. They are never
+        // written to the shard state tree, so no inclusion proof can be produced for them and
+        // verification would always fail with a leaf-key mismatch. Their value is fixed by the
+        // protocol, so they are verified by definition: fetch without a proof and treat as verified.
+        // TODO: commit genesis substates to the state tree so they can be cryptographically verified
+        //       like any other substate (changes the genesis state root, so deferred).
+        if substate_requirement.substate_id().is_read_only() {
+            return client
+                .get_substate(substate_requirement)
+                .await
+                .map(|result| (result, true))
+                .map_err(|e| IndexerError::ValidatorNodeClientError(e.to_string()));
+        }
+
         let (result, proof) = client
             .get_substate_with_proof(substate_requirement)
             .await


### PR DESCRIPTION
## Problem

Verified reads of read-only genesis substates fail. For example `GET /resources/tari` on the indexer returns:

```
Error getting resource: Indexer error: Substate proof verification failed:
substate value proof invalid: substate-leaf-in-shard-root proof is invalid:
Keys do not match. Key in proof: fb0e2158...  Expected key: fb0a7bac...
```

## Root cause

Read-only genesis substates — the **TARI resource** and the **public identity resource** — are bootstrapped directly into the substate store (`genesis_state.rs`, and likewise by node migrations in `migrations/common.rs`) via `SubstateRecord::commit_batch` → `substates_commit_batch`, which writes **only** the substate store column families, **never the per-shard JMT**. The genesis block (`create_genesis_block_if_required`) merely *reads* the resulting (empty) state root.

Consequently no inclusion proof can be produced for these substates:

- VN side: `generate_substate_proof` calls `tree.get_proof(version, (tari, 0))`. Since `(tari, 0)` is absent from the JMT, the terminal leaf belongs to some other committed substate (key `fb0e…`).
- Indexer side: `verify_inclusion` computes the expected leaf key `fb0a… = jmt_node_hash((tari, 0))`, which mismatches → **"Keys do not match."**

Because every committee member produces the same unprovable proof, each hits the error arm in `get_specific_substate_from_committee` and the read **fails closed** rather than degrading to unverified.

(Aside on why this set is precise: consensus-committed substates always get `created.at_state_version >= 1` because the JMT version starts at `unwrap_or(0) + 1`; only genesis/migration direct writes use `0` and bypass the tree.)

## Fix

Read-only substates are immutable protocol constants, so they are **verified by definition**. The indexer short-circuits them in `get_substate_from_vn`: fetch without a proof and return the result as verified. This is an indexer-only change with no wire/proto/public-API changes (non-breaking).

```rust
if substate_requirement.substate_id().is_read_only() {
    return client
        .get_substate(substate_requirement)
        .await
        .map(|result| (result, true))
        .map_err(|e| IndexerError::ValidatorNodeClientError(e.to_string()));
}
```

## Scope / follow-up

- Covers the user-facing breakage (read-only protocol constants: TARI + public identity).
- Not covered by this narrow workaround: non-read-only genesis substates (testnet faucet component/vault/resources at v0) and migration-created substates that are never mutated. These are transient (faucets move into the JMT on first use) or edge cases.
- **Proper fix (deferred):** commit genesis + migration substates to the state tree so they are cryptographically verified like any other substate. That changes the genesis state root (consensus-breaking), so it's left as a separate tracked change.

## Residual gap

Until the proper fix lands, the value for these substates comes from a single committee member and isn't cross-checked against the known genesis value, so a malicious member could serve forged metadata/access-rules for them. Acceptable for these immutable pre-launch constants; the JMT fix restores cryptographic verification.