### PR TITLE
refactor(transaction): make serde an optional feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7659,7 +7659,7 @@ dependencies = [
 
 [[package]]
 name = "ootle-rs"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1725,7 +1725,7 @@ dependencies = [
 
 [[package]]
 name = "consensus_tests"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "fern",
  "futures 0.3.31",
@@ -2735,7 +2735,7 @@ dependencies = [
 
 [[package]]
 name = "db-inspector"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -5090,7 +5090,7 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "integration_tests"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "anyhow",
  "config",
@@ -5858,7 +5858,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-messaging"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "async-trait",
  "futures-bounded 0.2.4",
@@ -6036,7 +6036,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-substream"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "libp2p",
  "prometheus-client",
@@ -7690,7 +7690,7 @@ dependencies = [
 
 [[package]]
 name = "ootle-wasm"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "console_error_panic_hook",
  "getrandom 0.2.17",
@@ -7701,7 +7701,7 @@ dependencies = [
 
 [[package]]
 name = "ootle-wasm-core"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "base64 0.22.1",
  "hex",
@@ -8745,7 +8745,7 @@ dependencies = [
 
 [[package]]
 name = "proto_builder"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "prost-build 0.14.3",
  "sha2 0.10.9",
@@ -10610,7 +10610,7 @@ dependencies = [
 
 [[package]]
 name = "sqlite_message_logger"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "chrono",
  "diesel",
@@ -10982,7 +10982,7 @@ dependencies = [
 
 [[package]]
 name = "tari_base_node_client"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "futures-util",
  "log",
@@ -11214,7 +11214,7 @@ dependencies = [
 
 [[package]]
 name = "tari_consensus"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "anyhow",
  "indexmap 2.13.0",
@@ -11239,7 +11239,7 @@ dependencies = [
 
 [[package]]
 name = "tari_consensus_types"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "borsh",
  "minicbor",
@@ -11342,7 +11342,7 @@ dependencies = [
 
 [[package]]
 name = "tari_engine"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "blake2 0.10.6",
  "bytes",
@@ -11374,7 +11374,7 @@ dependencies = [
 
 [[package]]
 name = "tari_engine_types"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "blake2 0.10.6",
  "borsh",
@@ -11403,7 +11403,7 @@ dependencies = [
 
 [[package]]
 name = "tari_epoch_manager"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "anyhow",
  "log",
@@ -11423,7 +11423,7 @@ dependencies = [
 
 [[package]]
 name = "tari_epoch_oracles"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "anyhow",
  "blake2 0.10.6",
@@ -11469,7 +11469,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -11572,7 +11572,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer_lib"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "async-trait",
  "log",
@@ -11670,7 +11670,7 @@ dependencies = [
 
 [[package]]
 name = "tari_networking"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11724,7 +11724,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_app_utilities"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -11765,7 +11765,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_common_types"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "blake2 0.10.6",
  "borsh",
@@ -11794,7 +11794,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_p2p"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "anyhow",
  "libp2p-identity 0.2.14",
@@ -11818,7 +11818,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_storage"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "anyhow",
  "bitflags 2.13.0",
@@ -11847,7 +11847,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_storage_sqlite"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "diesel",
  "diesel_migrations",
@@ -11900,7 +11900,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_transaction"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "borsh",
  "hex",
@@ -11926,7 +11926,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_cli"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -12048,7 +12048,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_sdk_tests"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "digest 0.10.7",
  "ootle_byte_type",
@@ -12094,7 +12094,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_walletd"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "anyhow",
  "apple-native-keyring-store",
@@ -12220,7 +12220,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_framework"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "async-trait",
  "bitflags 2.13.0",
@@ -12244,7 +12244,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_macros"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12253,7 +12253,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_state_sync"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -12335,7 +12335,7 @@ dependencies = [
 
 [[package]]
 name = "tari_state_store_rocksdb"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12367,7 +12367,7 @@ dependencies = [
 
 [[package]]
 name = "tari_state_tree"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "indexmap 2.13.0",
  "log",
@@ -12396,7 +12396,7 @@ dependencies = [
 
 [[package]]
 name = "tari_swarm"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "libp2p",
  "libp2p-messaging",
@@ -12408,7 +12408,7 @@ dependencies = [
 
 [[package]]
 name = "tari_swarm_daemon"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12521,7 +12521,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_test_tooling"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "anyhow",
  "cargo_toml 0.22.3",
@@ -12637,7 +12637,7 @@ dependencies = [
 
 [[package]]
 name = "tari_transaction_manifest"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "proc-macro2",
  "serde_json",
@@ -12672,7 +12672,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -12737,7 +12737,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node_client"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "indexmap 2.13.0",
  "multiaddr 0.18.3",
@@ -12761,7 +12761,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node_rpc"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -12785,7 +12785,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_rollback"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12820,7 +12820,7 @@ dependencies = [
 
 [[package]]
 name = "tari_watcher"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "anyhow",
  "clap 3.2.25",
@@ -12849,7 +12849,7 @@ dependencies = [
 
 [[package]]
 name = "tariswap_bench"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "anyhow",
  "clap 4.5.54",
@@ -13541,7 +13541,7 @@ dependencies = [
 
 [[package]]
 name = "traffic-sim"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "anyhow",
  "clap 4.5.54",
@@ -13563,7 +13563,7 @@ dependencies = [
 
 [[package]]
 name = "transaction_generator"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -13584,7 +13584,7 @@ dependencies = [
 
 [[package]]
 name = "transaction_submitter"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "anyhow",
  "clap 4.5.54",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.34.0"
+version = "0.34.1"
 edition = "2024"
 authors = ["The Tari Development Community"]
 repository = "https://github.com/tari-project/tari-ootle"

--- a/clients/tari_indexer_client/Cargo.toml
+++ b/clients/tari_indexer_client/Cargo.toml
@@ -11,7 +11,7 @@ license.workspace = true
 tari_ootle_common_types = { workspace = true }
 tari_engine_types = { workspace = true }
 tari_ootle_template_metadata = { workspace = true }
-tari_ootle_transaction = { workspace = true }
+tari_ootle_transaction = { workspace = true, features = ["serde"] }
 tari_template_abi = { workspace = true }
 tari_template_lib_types = { workspace = true }
 tari_consensus_types = { workspace = true }

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -17,7 +17,7 @@ tari_template_abi = { workspace = true, features = ["std", "func-hasher"] }
 tari_template_builtin = { workspace = true }
 tari_template_lib = { workspace = true }
 tari_utilities = { workspace = true }
-tari_ootle_transaction = { workspace = true }
+tari_ootle_transaction = { workspace = true, features = ["serde"] }
 ootle_byte_type = { workspace = true }
 
 blake2 = { workspace = true }
@@ -46,7 +46,7 @@ wasm-cache = ["dep:bytes", "dep:memmap2"]
 # `cargo publish` can't resolve the manifest.
 tari_template_test_tooling = { path = "../template_test_tooling" }
 tari_transaction_manifest = { workspace = true }
-tari_ootle_transaction = { workspace = true }
+tari_ootle_transaction = { workspace = true, features = ["serde"] }
 tari_template_builtin = { workspace = true, features = ["templates", "state"] }
 
 criterion = { version = "0.8.1", features = ["html_reports"] }

--- a/crates/ootle_wasm/core/Cargo.toml
+++ b/crates/ootle_wasm/core/Cargo.toml
@@ -8,7 +8,7 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-tari_ootle_transaction = { workspace = true }
+tari_ootle_transaction = { workspace = true, features = ["serde"] }
 tari_ootle_address = { workspace = true }
 tari_ootle_wallet_crypto = { workspace = true, features = ["serde"] }
 tari_engine_types = { workspace = true }

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -17,7 +17,7 @@ tari_consensus_types = { workspace = true }
 
 # Shard store deps
 tari_engine_types = { workspace = true }
-tari_ootle_transaction = { workspace = true }
+tari_ootle_transaction = { workspace = true, features = ["serde"] }
 tari_bor = { workspace = true, default-features = true, features = ["std", "indexmap", "serde"] }
 minicbor = { workspace = true, default-features = false, features = ["alloc", "derive"] }
 ootle_serde = { workspace = true, features = ["cbor"] }

--- a/crates/transaction/Cargo.toml
+++ b/crates/transaction/Cargo.toml
@@ -12,19 +12,19 @@ tari_engine_types = { workspace = true }
 tari_ootle_common_types = { workspace = true }
 tari_ootle_template_metadata = { workspace = true, features = ["borsh"] }
 tari_crypto = { workspace = true, features = ["borsh"] }
-tari_template_lib_types = { workspace = true, features = ["std", "serde"] }
+tari_template_lib_types = { workspace = true, features = ["std"] }
 tari_bor = { workspace = true, features = ["std", "indexmap"] }
 minicbor = { workspace = true, default-features = false, features = ["alloc", "derive"] }
 tari_hashing = { workspace = true }
-ootle_serde = { workspace = true, features = ["base64"] }
+ootle_serde = { workspace = true, features = ["base64"], optional = true }
 ootle_byte_type = { workspace = true, features = ["crypto"] }
 ootle-network = { workspace = true }
 
 borsh = { workspace = true }
 log = { workspace = true }
 rand = { workspace = true }
-indexmap = { workspace = true, features = ["serde"] }
-serde = { workspace = true, default-features = true }
+indexmap = { workspace = true }
+serde = { workspace = true, default-features = true, features = ["derive"], optional = true }
 ts-rs = { workspace = true, optional = true }
 hex = { workspace = true }
 thiserror = { workspace = true }
@@ -33,4 +33,5 @@ thiserror = { workspace = true }
 serde_json = { workspace = true }
 
 [features]
+serde = ["dep:serde", "dep:ootle_serde", "tari_bor/serde", "tari_template_lib_types/serde", "indexmap/serde"]
 ts = ["ts-rs", "tari_engine_types/ts", "tari_ootle_common_types/ts", "tari_template_lib_types/ts", "tari_bor/ts"]

--- a/crates/transaction/Cargo.toml
+++ b/crates/transaction/Cargo.toml
@@ -34,4 +34,4 @@ serde_json = { workspace = true }
 
 [features]
 serde = ["dep:serde", "dep:ootle_serde", "tari_bor/serde", "tari_template_lib_types/serde", "indexmap/serde"]
-ts = ["ts-rs", "tari_engine_types/ts", "tari_ootle_common_types/ts", "tari_template_lib_types/ts", "tari_bor/ts"]
+ts = ["ts-rs", "serde", "tari_engine_types/ts", "tari_ootle_common_types/ts", "tari_template_lib_types/ts", "tari_bor/ts"]

--- a/crates/transaction/src/args.rs
+++ b/crates/transaction/src/args.rs
@@ -3,7 +3,6 @@
 
 use std::fmt;
 
-use serde::{Deserialize, Serialize};
 use tari_bor::encode;
 use tari_template_lib_types::bytes::Bytes;
 
@@ -18,13 +17,12 @@ pub type WorkspaceId = u16;
     PartialEq,
     Eq,
     Hash,
-    Serialize,
-    Deserialize,
     borsh::BorshSerialize,
     minicbor::Encode,
     minicbor::Decode,
     minicbor::CborLen,
 )]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export))]
 pub struct WorkspaceOffsetId {
     #[n(0)]
@@ -82,17 +80,8 @@ impl fmt::Display for WorkspaceOffsetId {
 
 /// Represents an argument that can be passed to a transaction instruction. Either a literal value or a reference to a
 /// item on the runtime's workspace, or a reference to a transaction blob by index.
-#[derive(
-    Debug,
-    Clone,
-    PartialEq,
-    Serialize,
-    Deserialize,
-    borsh::BorshSerialize,
-    minicbor::Encode,
-    minicbor::Decode,
-    minicbor::CborLen,
-)]
+#[derive(Debug, Clone, PartialEq, borsh::BorshSerialize, minicbor::Encode, minicbor::Decode, minicbor::CborLen)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export))]
 pub enum InstructionArg {
     /// The argument is in the transaction execution's workspace, which means it is the result of a previous
@@ -103,9 +92,12 @@ pub enum InstructionArg {
     #[n(1)]
     Literal(
         #[n(0)]
-        #[serde(
-            serialize_with = "ootle_serde::hex::serialize",
-            deserialize_with = "ootle_serde::hex::deserialize_from_vec"
+        #[cfg_attr(
+            feature = "serde",
+            serde(
+                serialize_with = "ootle_serde::hex::serialize",
+                deserialize_with = "ootle_serde::hex::deserialize_from_vec"
+            )
         )]
         #[cfg_attr(feature = "ts", ts(type = "string"))]
         Bytes,
@@ -128,7 +120,7 @@ impl InstructionArg {
         Self::Literal(bytes.into())
     }
 
-    pub fn from_type<T: Serialize + tari_bor::Encode<()>>(val: &T) -> Result<Self, tari_bor::BorError> {
+    pub fn from_type<T: tari_bor::Encode<()>>(val: &T) -> Result<Self, tari_bor::BorError> {
         Ok(Self::raw_literal_bytes(encode(val)?))
     }
 
@@ -326,6 +318,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "serde")]
     #[test]
     fn decode_encode_json() {
         let arg = InstructionArg::workspace(1, Some(2));

--- a/crates/transaction/src/blobs.rs
+++ b/crates/transaction/src/blobs.rs
@@ -3,7 +3,6 @@
 
 use std::ops::Deref;
 
-use serde::{Deserialize, Serialize};
 use tari_engine_types::hashing::{EngineHashDomainLabel, hasher32};
 use tari_template_lib_types::{Hash32, MaxBytes, bytes::Bytes};
 
@@ -34,20 +33,21 @@ pub struct BlobIndexOverflow {
     PartialEq,
     Eq,
     Hash,
-    Serialize,
-    Deserialize,
     borsh::BorshSerialize,
     minicbor::Encode,
     minicbor::Decode,
     minicbor::CborLen,
 )]
-#[serde(transparent)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize), serde(transparent))]
 #[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export, type = "string"))]
 pub struct Blob(
     #[n(0)]
-    #[serde(
-        serialize_with = "ootle_serde::base64::serialize",
-        deserialize_with = "ootle_serde::base64::deserialize"
+    #[cfg_attr(
+        feature = "serde",
+        serde(
+            serialize_with = "ootle_serde::base64::serialize",
+            deserialize_with = "ootle_serde::base64::deserialize"
+        )
     )]
     Bytes,
 );
@@ -120,18 +120,9 @@ pub fn hash_blob(blob: &Blob) -> Hash32 {
 /// Ordered collection of `Blob`s carried by a transaction. Index 0 corresponds to the first
 /// blob, etc. Instructions and arguments reference blobs by `BlobIndex` into this list.
 #[derive(
-    Debug,
-    Clone,
-    Default,
-    PartialEq,
-    Eq,
-    Serialize,
-    Deserialize,
-    borsh::BorshSerialize,
-    minicbor::Encode,
-    minicbor::Decode,
-    minicbor::CborLen,
+    Debug, Clone, Default, PartialEq, Eq, borsh::BorshSerialize, minicbor::Encode, minicbor::Decode, minicbor::CborLen,
 )]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export))]
 pub struct Blobs(#[n(0)] Vec<Blob>);
 
@@ -192,19 +183,9 @@ impl Blobs {
 /// hashing real blobs or arrived via deserialization of bytes previously written by this
 /// crate's storage layer (and is bound by a signature, so tampering is detectable).
 #[derive(
-    Debug,
-    Clone,
-    Default,
-    PartialEq,
-    Eq,
-    Serialize,
-    Deserialize,
-    borsh::BorshSerialize,
-    minicbor::Encode,
-    minicbor::Decode,
-    minicbor::CborLen,
+    Debug, Clone, Default, PartialEq, Eq, borsh::BorshSerialize, minicbor::Encode, minicbor::Decode, minicbor::CborLen,
 )]
-#[serde(transparent)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize), serde(transparent))]
 #[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export))]
 pub struct BlobHashes(#[n(0)] Vec<Hash32>);
 
@@ -305,6 +286,7 @@ mod tests {
         assert_eq!(buf.len(), 4 + 32);
     }
 
+    #[cfg(feature = "serde")]
     #[test]
     fn blob_serde_json_roundtrip() {
         let blob = Blob::from(vec![1, 2, 3, 4]);
@@ -313,6 +295,7 @@ mod tests {
         assert_eq!(blob, decoded);
     }
 
+    #[cfg(feature = "serde")]
     #[test]
     fn blobs_serde_json_roundtrip() {
         let blobs = Blobs::from_vec(vec![Blob::from(vec![1]), Blob::from(vec![2, 3])]);

--- a/crates/transaction/src/builder/named_args.rs
+++ b/crates/transaction/src/builder/named_args.rs
@@ -3,7 +3,6 @@
 
 use std::error::Error;
 
-use serde::Serialize;
 use tari_bor::encode;
 
 pub type BuilderWorkspaceKey = String;
@@ -34,7 +33,7 @@ impl NamedArg {
         Ok(Self::Literal(encode(&value)?))
     }
 
-    pub fn from_type<T: Serialize + tari_bor::Encode<()>>(val: &T) -> Result<Self, tari_bor::BorError> {
+    pub fn from_type<T: tari_bor::Encode<()>>(val: &T) -> Result<Self, tari_bor::BorError> {
         Ok(Self::Literal(encode(val)?))
     }
 
@@ -57,7 +56,7 @@ impl NamedArg {
 /// Trait for converting a value into a [`NamedArg`] for use in template method calls.
 ///
 /// This enables macro-generated template methods to accept either:
-/// - Concrete values (any `T: Serialize`, CBOR-encoded into `NamedArg::Literal`)
+/// - Concrete values (any `T: tari_bor::Encode`, CBOR-encoded into `NamedArg::Literal`)
 /// - Workspace references (`NamedArg::Workspace`, created via `workspace!("key")`)
 pub trait IntoArg {
     fn into_arg(self) -> NamedArg;
@@ -69,7 +68,7 @@ impl IntoArg for NamedArg {
     }
 }
 
-impl<T: Serialize + tari_bor::Encode<()>> IntoArg for T {
+impl<T: tari_bor::Encode<()>> IntoArg for T {
     /// Converts a serializable type to a `NamedArg::Literal` by CBOR-encoding it.
     ///
     /// ## Panics
@@ -169,7 +168,7 @@ macro_rules! __args_inner {
 /// // Workspace arguments are resolved at runtime.
 /// let args = args![Workspace("foo"), 42, "bar"];
 ///
-/// // Any data type that implements `serde::Serialize` can be used as a literal argument.
+/// // Any data type that implements `tari_bor::Encode` can be used as a literal argument.
 /// let args = args![MyStruct { field1: 42, field2: "hello".to_string() }];
 /// ```
 ///

--- a/crates/transaction/src/envelope.rs
+++ b/crates/transaction/src/envelope.rs
@@ -3,23 +3,13 @@
 
 use crate::Transaction;
 
-#[derive(
-    Debug,
-    Clone,
-    minicbor::Encode,
-    minicbor::Decode,
-    minicbor::CborLen,
-    serde::Serialize,
-    serde::Deserialize,
-    PartialEq,
-    Eq,
-)]
+#[derive(Debug, Clone, minicbor::Encode, minicbor::Decode, minicbor::CborLen, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize), serde(transparent))]
 #[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export, type = "string"))]
-#[serde(transparent)]
 pub struct TransactionEnvelope(
     #[n(0)]
     #[cbor(with = "minicbor::bytes")]
-    #[serde(with = "ootle_serde::base64")]
+    #[cfg_attr(feature = "serde", serde(with = "ootle_serde::base64"))]
     pub Box<[u8]>,
 );
 

--- a/crates/transaction/src/transaction.rs
+++ b/crates/transaction/src/transaction.rs
@@ -5,7 +5,6 @@ use std::{collections::HashSet, fmt::Display};
 
 use indexmap::IndexSet;
 use ootle_network::Network;
-use serde::{Deserialize, Serialize};
 use tari_engine_types::{
     confidential::MinotariBurnClaimProof,
     indexed_value::IndexedValueError,
@@ -36,9 +35,8 @@ use crate::{
     weight::TransactionWeight,
 };
 
-#[derive(
-    Debug, Clone, Serialize, Deserialize, borsh::BorshSerialize, minicbor::Encode, minicbor::Decode, minicbor::CborLen,
-)]
+#[derive(Debug, Clone, borsh::BorshSerialize, minicbor::Encode, minicbor::Decode, minicbor::CborLen)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export))]
 pub enum Transaction {
     #[n(0)]
@@ -334,9 +332,8 @@ impl Display for Transaction {
 ///
 /// Constructed only via `From<Transaction>` (which derives commitments from the full blobs and
 /// drops the payloads) or via deserialization of bytes previously written by the storage layer.
-#[derive(
-    Debug, Clone, Serialize, Deserialize, borsh::BorshSerialize, minicbor::Encode, minicbor::Decode, minicbor::CborLen,
-)]
+#[derive(Debug, Clone, borsh::BorshSerialize, minicbor::Encode, minicbor::Decode, minicbor::CborLen)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export))]
 pub enum PrunedTransaction {
     #[n(0)]

--- a/crates/transaction/src/transaction_id.rs
+++ b/crates/transaction/src/transaction_id.rs
@@ -7,7 +7,6 @@ use std::{
 };
 
 use borsh::BorshSerialize;
-use serde::{Deserialize, Serialize};
 use tari_ootle_common_types::{SubstateAddress, ToSubstateAddress};
 use tari_template_lib_types::{
     Hash32,
@@ -25,20 +24,18 @@ use tari_template_lib_types::{
     PartialOrd,
     Ord,
     Hash,
-    Deserialize,
-    Serialize,
     Default,
     BorshSerialize,
     minicbor::Encode,
     minicbor::Decode,
     minicbor::CborLen,
 )]
-#[serde(transparent)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize), serde(transparent))]
 #[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export))]
 pub struct TransactionId(
     #[n(0)]
     #[cbor(with = "minicbor::bytes")]
-    #[serde(with = "ootle_serde::hex")]
+    #[cfg_attr(feature = "serde", serde(with = "ootle_serde::hex"))]
     #[cfg_attr(feature = "ts", ts(type = "string"))]
     [u8; 32],
 );

--- a/crates/transaction/src/unsealed.rs
+++ b/crates/transaction/src/unsealed.rs
@@ -1,15 +1,13 @@
 //   Copyright 2026 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use tari_bor::{Deserialize, Serialize};
 use tari_crypto::ristretto::RistrettoSecretKey;
 use tari_template_lib_types::crypto::RistrettoPublicKeyBytes;
 
 use crate::{IntoSigned, Signable, Transaction, TransactionSealSignature, TransactionSignature, UnsealedTransactionV1};
 
-#[derive(
-    Debug, Clone, Serialize, Deserialize, borsh::BorshSerialize, minicbor::Encode, minicbor::Decode, minicbor::CborLen,
-)]
+#[derive(Debug, Clone, borsh::BorshSerialize, minicbor::Encode, minicbor::Decode, minicbor::CborLen)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export))]
 pub enum UnsealedTransaction {
     #[n(0)]

--- a/crates/transaction/src/unsigned_transaction.rs
+++ b/crates/transaction/src/unsigned_transaction.rs
@@ -4,7 +4,6 @@
 use std::collections::HashSet;
 
 use indexmap::IndexSet;
-use serde::{Deserialize, Serialize};
 use tari_crypto::ristretto::RistrettoSecretKey;
 use tari_engine_types::{indexed_value::IndexedValueError, substate::SubstateId};
 use tari_ootle_common_types::{Epoch, SubstateRequirement};
@@ -23,7 +22,8 @@ use crate::{
     unsealed::UnsealedTransaction,
 };
 
-#[derive(Debug, Clone, Serialize, Deserialize, minicbor::Encode, minicbor::Decode, minicbor::CborLen)]
+#[derive(Debug, Clone, minicbor::Encode, minicbor::Decode, minicbor::CborLen)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export))]
 pub enum UnsignedTransaction {
     #[n(0)]

--- a/crates/transaction/src/v1/assertion.rs
+++ b/crates/transaction/src/v1/assertion.rs
@@ -3,27 +3,17 @@
 
 use std::fmt::Display;
 
-use serde::{Deserialize, Serialize};
 use tari_ootle_common_types::displayable::Displayable;
 use tari_template_lib_types::{Amount, MaxVec, NonFungibleId, ResourceAddress};
 
 pub type NftAssertVec = MaxVec<32, NonFungibleId>;
 
-#[derive(
-    Debug,
-    Clone,
-    Deserialize,
-    Serialize,
-    PartialEq,
-    borsh::BorshSerialize,
-    minicbor::Encode,
-    minicbor::Decode,
-    minicbor::CborLen,
-)]
+#[derive(Debug, Clone, PartialEq, borsh::BorshSerialize, minicbor::Encode, minicbor::Decode, minicbor::CborLen)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export))]
 pub enum Assertion {
     #[n(0)]
-    #[serde(rename = "BktAmt")]
+    #[cfg_attr(feature = "serde", serde(rename = "BktAmt"))]
     BucketAmount {
         #[n(0)]
         resource_address: ResourceAddress,
@@ -33,10 +23,10 @@ pub enum Assertion {
         amount: Amount,
     },
     #[n(1)]
-    #[serde(rename = "NtNil")]
+    #[cfg_attr(feature = "serde", serde(rename = "NtNil"))]
     IsNotNull,
     #[n(2)]
-    #[serde(rename = "BktCtnNft")]
+    #[cfg_attr(feature = "serde", serde(rename = "BktCtnNft"))]
     BucketContainsNonFungibles {
         #[n(0)]
         resource_address: ResourceAddress,
@@ -76,17 +66,8 @@ impl Display for Assertion {
     }
 }
 
-#[derive(
-    Debug,
-    Clone,
-    Deserialize,
-    Serialize,
-    PartialEq,
-    borsh::BorshSerialize,
-    minicbor::Encode,
-    minicbor::Decode,
-    minicbor::CborLen,
-)]
+#[derive(Debug, Clone, PartialEq, borsh::BorshSerialize, minicbor::Encode, minicbor::Decode, minicbor::CborLen)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export))]
 pub enum CheckOrd {
     #[n(0)]
@@ -126,17 +107,8 @@ impl Display for CheckOrd {
     }
 }
 
-#[derive(
-    Debug,
-    Clone,
-    Deserialize,
-    Serialize,
-    PartialEq,
-    borsh::BorshSerialize,
-    minicbor::Encode,
-    minicbor::Decode,
-    minicbor::CborLen,
-)]
+#[derive(Debug, Clone, PartialEq, borsh::BorshSerialize, minicbor::Encode, minicbor::Decode, minicbor::CborLen)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export))]
 pub enum NftCheck {
     #[n(0)]

--- a/crates/transaction/src/v1/component_reference.rs
+++ b/crates/transaction/src/v1/component_reference.rs
@@ -3,23 +3,13 @@
 
 use std::fmt::{Display, Formatter};
 
-use tari_bor::{Deserialize, Serialize};
 use tari_template_lib_types::ComponentAddress;
 
 use crate::args::WorkspaceId;
 
 /// A reference to a component, either by its address or by a workspace ID.
-#[derive(
-    Debug,
-    Clone,
-    Deserialize,
-    Serialize,
-    PartialEq,
-    borsh::BorshSerialize,
-    minicbor::Encode,
-    minicbor::Decode,
-    minicbor::CborLen,
-)]
+#[derive(Debug, Clone, PartialEq, borsh::BorshSerialize, minicbor::Encode, minicbor::Decode, minicbor::CborLen)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export))]
 pub enum ComponentReference {
     #[n(0)]

--- a/crates/transaction/src/v1/instruction.rs
+++ b/crates/transaction/src/v1/instruction.rs
@@ -3,7 +3,6 @@
 
 use std::fmt::{Display, Formatter};
 
-use serde::{Deserialize, Serialize};
 use tari_engine_types::{
     confidential::{ClaimBurnOutputData, MinotariBurnClaimProof},
     limits,
@@ -32,17 +31,8 @@ use crate::{
     args::{InstructionArg, WorkspaceId, WorkspaceOffsetId},
 };
 
-#[derive(
-    Debug,
-    Clone,
-    Deserialize,
-    Serialize,
-    PartialEq,
-    borsh::BorshSerialize,
-    minicbor::Encode,
-    minicbor::Decode,
-    minicbor::CborLen,
-)]
+#[derive(Debug, Clone, PartialEq, borsh::BorshSerialize, minicbor::Encode, minicbor::Decode, minicbor::CborLen)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export))]
 pub enum Instruction {
     #[n(0)]
@@ -127,7 +117,7 @@ pub enum Instruction {
         binary: BlobIndex,
         /// Optional multihash of off-chain CBOR metadata
         #[n(1)]
-        #[serde(default)]
+        #[cfg_attr(feature = "serde", serde(default))]
         #[cbor(default)]
         #[cfg_attr(feature = "ts", ts(type = "string | null"))]
         metadata_hash: Option<MetadataHash>,
@@ -507,17 +497,8 @@ fn collect_arg_blob_ids(args: &[InstructionArg], out: &mut Vec<BlobIndex>) {
     }
 }
 
-#[derive(
-    Debug,
-    Clone,
-    Deserialize,
-    Serialize,
-    PartialEq,
-    borsh::BorshSerialize,
-    minicbor::Encode,
-    minicbor::Decode,
-    minicbor::CborLen,
-)]
+#[derive(Debug, Clone, PartialEq, borsh::BorshSerialize, minicbor::Encode, minicbor::Decode, minicbor::CborLen)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export))]
 pub struct MigrateFunction {
     #[n(0)]
@@ -548,6 +529,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "serde")]
     #[test]
     fn decode_encode_json() {
         let instruction = make_sample();

--- a/crates/transaction/src/v1/pruned.rs
+++ b/crates/transaction/src/v1/pruned.rs
@@ -12,7 +12,6 @@
 
 use indexmap::IndexSet;
 use log::*;
-use serde::{Deserialize, Serialize};
 use tari_engine_types::hashing::{EngineHashDomainLabel, hasher32};
 use tari_ootle_common_types::{Epoch, SubstateRequirement};
 use tari_template_lib_types::crypto::RistrettoPublicKeyBytes;
@@ -36,9 +35,8 @@ const LOG_TARGET: &str = "tari::ootle::transaction::pruned";
 ///
 /// All non-blob fields are preserved verbatim so the field projection used in the signing /
 /// id digest is byte-identical to the full form.
-#[derive(
-    Debug, Clone, Serialize, Deserialize, borsh::BorshSerialize, minicbor::Encode, minicbor::Decode, minicbor::CborLen,
-)]
+#[derive(Debug, Clone, borsh::BorshSerialize, minicbor::Encode, minicbor::Decode, minicbor::CborLen)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export))]
 pub struct PrunedUnsignedTransactionV1 {
     #[n(0)]
@@ -66,7 +64,7 @@ pub struct PrunedUnsignedTransactionV1 {
     /// blob sizes without downloading payloads. May be empty when deserialised from older
     /// archives that didn't record sizes.
     #[n(9)]
-    #[serde(default)]
+    #[cfg_attr(feature = "serde", serde(default))]
     #[cbor(default)]
     #[borsh(skip)]
     pub blob_sizes: Vec<u32>,
@@ -114,9 +112,8 @@ impl From<UnsignedTransactionV1> for PrunedUnsignedTransactionV1 {
 }
 
 /// Mirror of `UnsealedTransactionV1` for the pruned form.
-#[derive(
-    Debug, Clone, Serialize, Deserialize, borsh::BorshSerialize, minicbor::Encode, minicbor::Decode, minicbor::CborLen,
-)]
+#[derive(Debug, Clone, borsh::BorshSerialize, minicbor::Encode, minicbor::Decode, minicbor::CborLen)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export))]
 pub struct PrunedUnsealedTransactionV1 {
     #[n(0)]
@@ -186,9 +183,8 @@ impl From<UnsealedTransactionV1> for PrunedUnsealedTransactionV1 {
 /// Constructed only via `From<TransactionV1>` (which derives blob commitments from the full
 /// blobs and drops the payloads) or via deserialization of bytes previously written by the
 /// storage layer.
-#[derive(
-    Debug, Clone, Serialize, Deserialize, borsh::BorshSerialize, minicbor::Encode, minicbor::Decode, minicbor::CborLen,
-)]
+#[derive(Debug, Clone, borsh::BorshSerialize, minicbor::Encode, minicbor::Decode, minicbor::CborLen)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export))]
 pub struct PrunedTransactionV1 {
     #[n(0)]

--- a/crates/transaction/src/v1/resource_address_ref.rs
+++ b/crates/transaction/src/v1/resource_address_ref.rs
@@ -3,22 +3,12 @@
 
 use std::fmt::{Display, Formatter};
 
-use tari_bor::{Deserialize, Serialize};
 use tari_template_lib_types::ResourceAddress;
 
 use crate::args::{WorkspaceId, WorkspaceOffsetId};
 
-#[derive(
-    Debug,
-    Clone,
-    Deserialize,
-    Serialize,
-    PartialEq,
-    borsh::BorshSerialize,
-    minicbor::Encode,
-    minicbor::Decode,
-    minicbor::CborLen,
-)]
+#[derive(Debug, Clone, PartialEq, borsh::BorshSerialize, minicbor::Encode, minicbor::Decode, minicbor::CborLen)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export))]
 pub enum ResourceAddressRef {
     #[n(0)]

--- a/crates/transaction/src/v1/signature.rs
+++ b/crates/transaction/src/v1/signature.rs
@@ -3,7 +3,6 @@
 
 use indexmap::IndexSet;
 use ootle_byte_type::{ConvertFromByteType, FromByteType, ToByteType};
-use serde::{Deserialize, Serialize};
 use tari_crypto::{
     keys::PublicKey as PublicKeyT,
     ristretto::{RistrettoPublicKey, RistrettoSchnorr, RistrettoSecretKey},
@@ -65,18 +64,8 @@ fn preimage_segment<T: borsh::BorshSerialize + ?Sized>(field: PreimageField, val
     }
 }
 
-#[derive(
-    Debug,
-    Clone,
-    Serialize,
-    Deserialize,
-    Eq,
-    PartialEq,
-    borsh::BorshSerialize,
-    minicbor::Encode,
-    minicbor::Decode,
-    minicbor::CborLen,
-)]
+#[derive(Debug, Clone, Eq, PartialEq, borsh::BorshSerialize, minicbor::Encode, minicbor::Decode, minicbor::CborLen)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export))]
 pub struct TransactionSealSignature {
     #[n(0)]
@@ -222,18 +211,8 @@ impl From<SignatureOutput> for TransactionSealSignature {
     }
 }
 
-#[derive(
-    Debug,
-    Clone,
-    Serialize,
-    Deserialize,
-    Eq,
-    PartialEq,
-    borsh::BorshSerialize,
-    minicbor::Encode,
-    minicbor::Decode,
-    minicbor::CborLen,
-)]
+#[derive(Debug, Clone, Eq, PartialEq, borsh::BorshSerialize, minicbor::Encode, minicbor::Decode, minicbor::CborLen)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export))]
 pub struct TransactionSignature {
     #[n(0)]

--- a/crates/transaction/src/v1/transaction.rs
+++ b/crates/transaction/src/v1/transaction.rs
@@ -5,7 +5,6 @@ use std::{collections::HashSet, fmt::Display, iter};
 
 use indexmap::IndexSet;
 use log::*;
-use serde::{Deserialize, Serialize};
 use tari_engine_types::{
     hashing::{EngineHashDomainLabel, hash_template_code, hasher32},
     indexed_value::IndexedValueError,
@@ -30,9 +29,8 @@ const LOG_TARGET: &str = "tari::ootle::transaction::transaction";
 
 static XTR_REQUIREMENT: SubstateRequirement = SubstateRequirement::new(SubstateId::Resource(TARI_TOKEN), None);
 
-#[derive(
-    Debug, Clone, Serialize, Deserialize, borsh::BorshSerialize, minicbor::Encode, minicbor::Decode, minicbor::CborLen,
-)]
+#[derive(Debug, Clone, borsh::BorshSerialize, minicbor::Encode, minicbor::Decode, minicbor::CborLen)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export))]
 pub struct TransactionV1 {
     #[n(0)]

--- a/crates/transaction/src/v1/types.rs
+++ b/crates/transaction/src/v1/types.rs
@@ -1,22 +1,11 @@
 //   Copyright 2025 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use tari_bor::{Deserialize, Serialize};
-
 /// Possible allocatable address types
 #[derive(
-    Debug,
-    Clone,
-    Copy,
-    Deserialize,
-    Serialize,
-    PartialEq,
-    Eq,
-    borsh::BorshSerialize,
-    minicbor::Encode,
-    minicbor::Decode,
-    minicbor::CborLen,
+    Debug, Clone, Copy, PartialEq, Eq, borsh::BorshSerialize, minicbor::Encode, minicbor::Decode, minicbor::CborLen,
 )]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export))]
 pub enum AllocatableAddressType {
     #[n(0)]

--- a/crates/transaction/src/v1/unsealed.rs
+++ b/crates/transaction/src/v1/unsealed.rs
@@ -4,7 +4,6 @@
 use std::collections::HashSet;
 
 use indexmap::IndexSet;
-use serde::{Deserialize, Serialize};
 use tari_crypto::ristretto::RistrettoSecretKey;
 use tari_engine_types::{indexed_value::IndexedValueError, substate::SubstateId};
 use tari_ootle_common_types::{Epoch, SubstateRequirement};
@@ -22,9 +21,8 @@ use crate::{
 
 const LOG_TARGET: &str = "tari::ootle::transaction::transaction";
 
-#[derive(
-    Debug, Clone, Serialize, Deserialize, borsh::BorshSerialize, minicbor::Encode, minicbor::Decode, minicbor::CborLen,
-)]
+#[derive(Debug, Clone, borsh::BorshSerialize, minicbor::Encode, minicbor::Decode, minicbor::CborLen)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export))]
 pub struct UnsealedTransactionV1 {
     #[n(0)]

--- a/crates/transaction/src/v1/unsigned.rs
+++ b/crates/transaction/src/v1/unsigned.rs
@@ -4,7 +4,6 @@
 use std::collections::HashSet;
 
 use indexmap::IndexSet;
-use serde::{Deserialize, Serialize};
 use tari_engine_types::{
     indexed_value::{IndexedValue, IndexedValueError},
     substate::SubstateId,
@@ -14,9 +13,8 @@ use tari_template_lib_types::{ComponentAddress, UtxoAddress, crypto::RistrettoPu
 
 use crate::{Blobs, ComponentReference, Instruction, ResourceAddressRef, Signable, TransactionSignature};
 
-#[derive(
-    Debug, Clone, Serialize, Deserialize, borsh::BorshSerialize, minicbor::Encode, minicbor::Decode, minicbor::CborLen,
-)]
+#[derive(Debug, Clone, borsh::BorshSerialize, minicbor::Encode, minicbor::Decode, minicbor::CborLen)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export))]
 pub struct UnsignedTransactionV1 {
     #[n(0)]
@@ -44,7 +42,7 @@ pub struct UnsignedTransactionV1 {
     /// raw blob bytes are excluded so that storage layers can drop them without affecting
     /// signature verifiability or transaction id.
     #[n(8)]
-    #[serde(default)]
+    #[cfg_attr(feature = "serde", serde(default))]
     #[cbor(default)]
     pub blobs: Blobs,
 }

--- a/crates/wallet/ootle-rs/Cargo.toml
+++ b/crates/wallet/ootle-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ootle-rs"
-version = "0.10.0"
+version = "0.10.1"
 description = "A Rust library for interacting with the Tari Ootle network."
 edition.workspace = true
 authors.workspace = true


### PR DESCRIPTION
## Description

Makes `serde` an opt-in feature of the `tari_ootle_transaction` crate, continuing the minicbor migration where serde is feature-gated on all CBOR-encoded crates. Without the `serde` feature enabled the crate has no serde dependency at all, keeping binary sizes and compile times smaller for consumers that only need CBOR.

## Motivation

The minicbor migration gates serde on every CBOR-encoded crate so that non-serde consumers do not pull in the dependency. `tari_ootle_transaction` is the next crate in line.

Enabling the feature remains backwards-compatible — existing dependents simply add `features = ["serde"]` — so this is a patch bump (0.34.0 -> 0.34.1).

## Changes

- `crates/transaction/Cargo.toml`: `serde` and `ootle_serde` marked `optional = true`; new `serde` feature activates them together with `tari_bor/serde`, `tari_template_lib_types/serde`, and `indexmap/serde`.
- All transaction source files: `#[derive(Serialize, Deserialize)]` split into `#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]`; all `#[serde(...)]` attributes wrapped in `#[cfg_attr(feature = "serde", ...)]`.
- Removed the `Serialize` trait bound from `InstructionArg::from_type` and the `IntoArg for T` blanket impl — args are CBOR-encoded, not serde.
- The 4 `serde_json` JSON round-trip unit tests gated behind `#[cfg(feature = "serde")]` (42 tests run by default, 46 with `--features serde`).
- Direct dependents that need serde on transaction types (`tari_engine`, `tari_ootle_storage`, `tari_indexer_client`, `ootle-wasm-core`) opt in with `features = ["serde"]`.
- Workspace version bumped 0.34.0 -> 0.34.1.