### PR TITLE
fix(template): correct liquidity pool ratio math, redemption and change handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12464,7 +12464,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_builtin"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "anyhow",
  "minicbor",

--- a/applications/tari_indexer/src/substate_manager.rs
+++ b/applications/tari_indexer/src/substate_manager.rs
@@ -400,7 +400,7 @@ pub enum SubstateManagerError {
     IndexerError(#[from] IndexerError),
     #[error("Storage error: {0}")]
     StorageError(#[from] StorageError),
-    #[error("Input substate {substate_id}v{version} is down")]
+    #[error("Input substate {substate_id} (v{version}) is down")]
     InputSubstateIsDown { substate_id: SubstateId, version: u32 },
     #[error("Input substate {substate_id} does not exist")]
     InputSubstateDoesNotExist { substate_id: SubstateId },

--- a/applications/tari_walletd/src/handlers/swap_pools.rs
+++ b/applications/tari_walletd/src/handlers/swap_pools.rs
@@ -3,8 +3,8 @@
 
 use axum_extra::headers::authorization::Bearer;
 use log::warn;
-use tari_engine_types::{component::Component, indexed_value::IndexedWellKnownTypes, substate::SubstateId};
-use tari_ootle_wallet_sdk::network::WalletNetworkInterface;
+use tari_engine_types::substate::SubstateId;
+use tari_ootle_wallet_sdk::{apis::swap_pool, network::WalletNetworkInterface};
 use tari_ootle_walletd_client::{
     permissions::{Permission, ReadOnly},
     types::{
@@ -16,101 +16,11 @@ use tari_ootle_walletd_client::{
     },
 };
 use tari_template_builtin::LIQUIDITY_POOL_TEMPLATE_ADDRESS;
-use tari_template_lib_types::{Amount, ComponentAddress, ResourceAddress, constants::TARI_TOKEN};
+use tari_template_lib_types::ComponentAddress;
 
 use crate::handlers::HandlerContext;
 
 const LOG_TARGET: &str = "tari::ootle::wallet_daemon::handlers::swap_pools";
-
-/// Calculate the input amount of a non-TARI token needed for a constant-product swap
-/// to yield at least `desired_output` of TARI. Returns `None` if the pool lacks liquidity.
-///
-/// Includes a 5% slippage margin and uses ceiling division to avoid integer truncation issues.
-fn calculate_swap_input(desired_output: Amount, reserve_in: Amount, reserve_out: Amount) -> Option<Amount> {
-    if reserve_out <= desired_output {
-        return None;
-    }
-    // ceil(desired_output * reserve_in * 105 / ((reserve_out - desired_output) * 100))
-    let numerator = desired_output
-        .to_u128()
-        .checked_mul(reserve_in.to_u128())?
-        .checked_mul(105)?;
-    let denominator = reserve_out.checked_sub(desired_output)?.to_u128().checked_mul(100)?;
-    // Ceiling division: (a + b - 1) / b
-    let result = numerator.checked_add(denominator - 1)? / denominator;
-    Some(Amount::new(result))
-}
-
-/// Given the pool vault balances, determine which side is TARI and calculate the
-/// required swap input amount for the given `desired_tari_output`.
-fn calculate_swap_input_for_pool(
-    resource_a: &ResourceAddress,
-    balance_a: Amount,
-    resource_b: &ResourceAddress,
-    balance_b: Amount,
-    desired_tari_output: Amount,
-) -> Result<Amount, anyhow::Error> {
-    let (reserve_in, reserve_out) = if *resource_a == TARI_TOKEN {
-        // resource_b is non-TARI (input), resource_a is TARI (output)
-        (balance_b, balance_a)
-    } else if *resource_b == TARI_TOKEN {
-        // resource_a is non-TARI (input), resource_b is TARI (output)
-        (balance_a, balance_b)
-    } else {
-        return Err(anyhow::anyhow!("Neither pool resource is TARI"));
-    };
-
-    calculate_swap_input(desired_tari_output, reserve_in, reserve_out)
-        .ok_or_else(|| anyhow::anyhow!("Pool does not have enough TARI liquidity for the desired output"))
-}
-
-/// Fetches vault balances for a validated liquidity pool component.
-async fn get_pool_vault_info(
-    context: &HandlerContext,
-    component: &Component,
-) -> Result<(ResourceAddress, Amount, ResourceAddress, Amount), anyhow::Error> {
-    let sdk = context.wallet_sdk().clone();
-
-    let indexed = IndexedWellKnownTypes::from_value(component.state())?;
-    let vault_ids = indexed.vault_ids();
-
-    if vault_ids.len() < 2 {
-        return Err(anyhow::anyhow!(
-            "Expected at least 2 vaults in the liquidity pool component, found {}",
-            vault_ids.len()
-        ));
-    }
-
-    let vault_substate_ids: Vec<SubstateId> = vault_ids.iter().take(2).map(|id| SubstateId::Vault(*id)).collect();
-
-    let vault_substates = sdk
-        .get_network_interface()
-        .get_substates(vault_substate_ids.clone())
-        .await?;
-
-    let vault_a_substate = vault_substates
-        .get(&vault_substate_ids[0])
-        .ok_or_else(|| anyhow::anyhow!("Vault A substate not found"))?;
-    let vault_b_substate = vault_substates
-        .get(&vault_substate_ids[1])
-        .ok_or_else(|| anyhow::anyhow!("Vault B substate not found"))?;
-
-    let vault_a = vault_a_substate
-        .substate_value()
-        .vault()
-        .ok_or_else(|| anyhow::anyhow!("Vault A substate is not a vault"))?;
-    let vault_b = vault_b_substate
-        .substate_value()
-        .vault()
-        .ok_or_else(|| anyhow::anyhow!("Vault B substate is not a vault"))?;
-
-    Ok((
-        *vault_a.resource_address(),
-        vault_a.balance(),
-        *vault_b.resource_address(),
-        vault_b.balance(),
-    ))
-}
 
 pub async fn handle_get_exchange_rate(
     context: &HandlerContext,
@@ -120,41 +30,28 @@ pub async fn handle_get_exchange_rate(
     let sdk = context.wallet_sdk().clone();
     context.authorize(token, &[Permission::SwapPools(ReadOnly::Read)])?;
 
-    let result = sdk
-        .get_network_interface()
-        .query_substate(&SubstateId::Component(req.pool_address), None, false)
-        .await?;
-
-    let component = result
-        .substate
-        .into_component()
-        .ok_or_else(|| anyhow::anyhow!("Substate is not a component"))?;
-
-    if *component.template_address() != LIQUIDITY_POOL_TEMPLATE_ADDRESS {
-        return Err(anyhow::anyhow!(
-            "Component is not a liquidity pool (template: {})",
-            component.template_address()
-        ));
-    }
-
-    let (resource_a, balance_a, resource_b, balance_b) = get_pool_vault_info(context, &component).await?;
+    let substate_api = sdk.substate_api();
+    let reserves = swap_pool::get_pool_reserves(&substate_api, req.pool_address).await?;
 
     let swap_input_amount = match req.desired_tari_output {
-        Some(desired) => Some(calculate_swap_input_for_pool(
-            &resource_a,
-            balance_a,
-            &resource_b,
-            balance_b,
-            desired,
-        )?),
+        Some(desired) => {
+            let (_non_tari_resource, reserve_in, reserve_out) = reserves
+                .tari_swap_reserves()
+                .ok_or_else(|| anyhow::anyhow!("Neither pool resource is TARI"))?;
+            Some(
+                swap_pool::calculate_swap_input(desired, reserve_in, reserve_out).ok_or_else(|| {
+                    anyhow::anyhow!("Pool does not have enough TARI liquidity for the desired output")
+                })?,
+            )
+        },
         None => None,
     };
 
     Ok(SwapPoolGetExchangeRateResponse {
-        resource_a,
-        balance_a,
-        resource_b,
-        balance_b,
+        resource_a: reserves.resource_a,
+        balance_a: reserves.balance_a,
+        resource_b: reserves.resource_b,
+        balance_b: reserves.balance_b,
         swap_input_amount,
     })
 }
@@ -227,23 +124,14 @@ async fn fetch_pool_info(
 ) -> Result<SwapPoolInfo, anyhow::Error> {
     let sdk = context.wallet_sdk().clone();
 
-    let result = sdk
-        .get_network_interface()
-        .query_substate(&SubstateId::Component(pool_address), None, false)
-        .await?;
-
-    let component = result
-        .substate
-        .into_component()
-        .ok_or_else(|| anyhow::anyhow!("Substate is not a component"))?;
-
-    let (resource_a, balance_a, resource_b, balance_b) = get_pool_vault_info(context, &component).await?;
+    let substate_api = sdk.substate_api();
+    let reserves = swap_pool::get_pool_reserves(&substate_api, pool_address).await?;
 
     Ok(SwapPoolInfo {
         pool_address,
-        resource_a,
-        balance_a,
-        resource_b,
-        balance_b,
+        resource_a: reserves.resource_a,
+        balance_a: reserves.balance_a,
+        resource_b: reserves.resource_b,
+        balance_b: reserves.balance_b,
     })
 }

--- a/crates/indexer_lib/src/cached_substate_manager.rs
+++ b/crates/indexer_lib/src/cached_substate_manager.rs
@@ -186,8 +186,19 @@ where
                     }
                 } else {
                     let now = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH)?.as_secs();
-                    if now.saturating_sub(entry.cached_at) > self.cache_ttl.as_secs() {
+                    let is_stale = now.saturating_sub(entry.cached_at) > self.cache_ttl.as_secs();
+                    // A cached `Down` result means the substate has advanced past `entry.version`. An
+                    // unversioned lookup asks for the *latest* version, so a `Down` entry can never
+                    // satisfy it: refetch from the committee (which always returns the latest Up for an
+                    // unversioned request) to discover the new version. Serving the stale `Down`
+                    // surfaces as a spurious "input substate is down" error — e.g. dry-running a
+                    // transaction whose unversioned inputs include a frequently-updated substate such as
+                    // a swap pool reserve.
+                    let is_down = matches!(entry.substate_result, SubstateResult::Down { .. });
+                    if is_stale {
                         debug!(target: LOG_TARGET, "Cached substate {} is stale. Fetching fresh copy.", substate_id);
+                    } else if is_down {
+                        debug!(target: LOG_TARGET, "Cached substate {} is down at v{}. Fetching latest version.", substate_id, entry.version);
                     } else {
                         debug!(target: LOG_TARGET, "Substate cache hit for {} with version {}", substate_id, entry.version);
                         #[cfg(feature = "metrics")]

--- a/crates/template_builtin/Cargo.toml
+++ b/crates/template_builtin/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_template_builtin"
 description = "Tari Ootle built-in templates"
-version = "0.32.0"
+version = "0.32.1"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/template_builtin/templates/liquidity_pool/src/lib.rs
+++ b/crates/template_builtin/templates/liquidity_pool/src/lib.rs
@@ -138,31 +138,22 @@ mod template {
                 reserve_a.is_positive(),
                 reserve_b.is_positive(),
             ) {
-                // Reserve pools are empty, mint initial lp tokens
-                (false, false, false) => {
-                    // initial liquidity provision, mint lp tokens equal to the geometric mean  `sqrt(c_1 * c_2)` of the
-                    // contributions
-
-                    (
-                        // TODO: possible lost of precision even with 192 bit integer
-                        a_amount
-                            .checked_mul(b_amount)
-                            .and_then(|c1_c2| c1_c2.checked_sqrt())
-                            .expect(OVERFLOW_MSG),
-                        a_amount,
-                        b_amount,
-                    )
-                },
+                // No LP tokens exist yet: this is the initial liquidity provision. Reserves may already be non-zero
+                // if the owner pre-seeded a vault via `protected_add_liquidity` (e.g. to bootstrap a pool in stages),
+                // in which case we mint on top of them. With no LP outstanding there is no existing price to
+                // preserve, so the first provider sets it: take the full contribution and mint LP equal to the
+                // geometric mean of the resulting total reserves, `sqrt((reserve_a + a) * (reserve_b + b))`. This
+                // reduces to `sqrt(a * b)` for a fresh, empty pool.
                 (false, _, _) => {
-                    // No LP tokens exist but reserves are non-zero. The only way to reach this is the owner seeding a
-                    // vault via `protected_add_liquidity` without minting LP; the normal flow keeps reserves and LP
-                    // supply in lockstep. Minting here would credit the contributor for reserves they did not provide,
-                    // so reject it. The owner can drain the orphaned reserves via `protected_remove_liquidity` to
-                    // return the pool to an empty state, after which contributions can bootstrap it normally.
-                    panic!(
-                        "Pool has reserves but no LP supply; owner must drain via protected_remove_liquidity before \
-                         contributions can resume"
-                    );
+                    let total_a = reserve_a.checked_add(a_amount).expect(OVERFLOW_MSG);
+                    let total_b = reserve_b.checked_add(b_amount).expect(OVERFLOW_MSG);
+                    // TODO: possible loss of precision even with 192 bit integer
+                    let mint = total_a
+                        .checked_mul(total_b)
+                        .and_then(|product| product.checked_sqrt())
+                        .expect(OVERFLOW_MSG);
+
+                    (mint, a_amount, b_amount)
                 },
                 (true, true, true) => {
                     // Normal case: existing LP supply and non-zero reserves

--- a/crates/template_builtin/templates/liquidity_pool/src/lib.rs
+++ b/crates/template_builtin/templates/liquidity_pool/src/lib.rs
@@ -102,7 +102,12 @@ mod template {
             .create()
         }
 
-        pub fn contribute(&mut self, mut bucket_a: Bucket, mut bucket_b: Bucket) -> Bucket {
+        /// Contributes liquidity to the pool, minting LP tokens in return.
+        ///
+        /// To preserve the reserve ratio the pool only takes the matching portion of one of the input buckets, so the
+        /// remainder of the other is returned to the caller as change. Returns `(lp_tokens, change_a, change_b)` where
+        /// `change_a`/`change_b` correspond to `bucket_a`/`bucket_b` and may be empty.
+        pub fn contribute(&mut self, mut bucket_a: Bucket, mut bucket_b: Bucket) -> (Bucket, Bucket, Bucket) {
             // Potentially saves binary space
             const OVERFLOW_MSG: &str = "Overflow when calculating LP token mint amount";
 
@@ -149,38 +154,33 @@ mod template {
                     )
                 },
                 (false, _, _) => {
-                    // No LP tokens currently exist but reserves are non-zero
-                    // Calculate the geometric mean of the ratios of the contributions to the reserves
-                    // i.e. sqrt(c_1 + r_1) * sqrt(c_2 + r_2)
-
-                    // TODO: lost of precision
-                    let mint = a_amount
-                        .checked_add(reserve_a)
-                        .and_then(|c1_r1| c1_r1.checked_sqrt())
-                        .and_then(|sqrt_c1_r1| {
-                            b_amount
-                                .checked_add(reserve_b)
-                                .and_then(|c2_r2| c2_r2.checked_sqrt())
-                                .and_then(|sqrt_c2_r2| sqrt_c1_r1.checked_mul(sqrt_c2_r2))
-                        })
-                        .expect(OVERFLOW_MSG);
-
-                    (mint, a_amount, b_amount)
+                    // No LP tokens exist but reserves are non-zero. The only way to reach this is the owner seeding a
+                    // vault via `protected_add_liquidity` without minting LP; the normal flow keeps reserves and LP
+                    // supply in lockstep. Minting here would credit the contributor for reserves they did not provide,
+                    // so reject it. The owner can drain the orphaned reserves via `protected_remove_liquidity` to
+                    // return the pool to an empty state, after which contributions can bootstrap it normally.
+                    panic!(
+                        "Pool has reserves but no LP supply; owner must drain via protected_remove_liquidity before \
+                         contributions can resume"
+                    );
                 },
                 (true, true, true) => {
                     // Normal case: existing LP supply and non-zero reserves
                     // calculate the amount each contribution can be contributed to keep the ratio of the reserves the
                     // same
 
+                    // Multiply before dividing: `PrecisionAmount` is a 192-bit *integer*, so dividing first
+                    // truncates the ratio to zero whenever a contribution is smaller than its reserve. The wide
+                    // intermediate holds the product without overflow.
                     let required_contribution_a = a_amount
-                        .checked_div(reserve_a)
-                        .and_then(|r| r.checked_mul(reserve_b))
+                        .checked_mul(reserve_b)
+                        .and_then(|num| num.checked_div(reserve_a))
                         .map(|b_required| (a_amount, b_required))
                         .expect(OVERFLOW_MSG);
 
                     let required_contribution_b = b_amount
-                        .checked_div(reserve_b)
-                        .and_then(|r| r.checked_mul(reserve_a))
+                        .checked_mul(reserve_a)
+                        .and_then(|num| num.checked_div(reserve_b))
                         .map(|a_required| (a_required, b_amount))
                         .expect(OVERFLOW_MSG);
 
@@ -190,8 +190,8 @@ mod template {
                         .filter(|(c_a, c_b)| *c_a <= a_amount && *c_b <= b_amount)
                         .map(|(c_a, c_b)| {
                             let mint = c_a
-                                .checked_div(reserve_a)
-                                .and_then(|r| r.checked_mul(lp_supply))
+                                .checked_mul(lp_supply)
+                                .and_then(|num| num.checked_div(reserve_a))
                                 .expect(OVERFLOW_MSG);
                             (mint, c_a, c_b)
                         })
@@ -209,6 +209,13 @@ mod template {
             let lp_mint_amount = Amount::try_from(lp_mint_amount).expect("LP mint amount conversion failed");
             let a_contribution = Amount::try_from(a_contribution).expect("A contribution conversion failed");
             let b_contribution = Amount::try_from(b_contribution).expect("B contribution conversion failed");
+
+            // Reject dust contributions that round down to a zero contribution or zero mint, rather than failing
+            // later with an opaque `Bucket::take` assertion.
+            assert!(
+                a_contribution.is_positive() && b_contribution.is_positive() && lp_mint_amount.is_positive(),
+                "Contribution too small relative to pool reserves to mint any LP tokens"
+            );
 
             // mint and return the new lp tokens
             let mint_lp_tokens = self.lp_resource.mint_fungible(lp_mint_amount);
@@ -228,7 +235,9 @@ mod template {
                 "contributed_b" => b_contribution.to_string(),
             ]);
 
-            mint_lp_tokens
+            // Return the LP tokens plus the unused remainder of each input bucket as change. `bucket_a`/`bucket_b`
+            // now hold only what was not contributed; one is usually empty, which is harmless to return.
+            (mint_lp_tokens, bucket_a, bucket_b)
         }
 
         pub fn redeem(&mut self, lp_bucket: Bucket) -> (Bucket, Bucket) {
@@ -246,6 +255,13 @@ mod template {
             let lp_total_supply = self.lp_total_supply();
 
             let (a_amount, b_amount) = self.calculate_redemption_amounts(lp_total_supply, redeem_amount);
+
+            // A redemption so small it rounds down to zero of either reserve would otherwise abort with an opaque
+            // withdraw error (or, worse, return nothing). Reject it up front before burning the LP tokens.
+            assert!(
+                a_amount.is_positive() && b_amount.is_positive(),
+                "Redemption amount too small to withdraw any tokens from the pool"
+            );
 
             // withdraw the redeemed amounts from the pool
             let a_bucket = self.vault_a.withdraw(a_amount);
@@ -314,12 +330,22 @@ mod template {
 
             // Simple constant product formula without fees
             // Δy = y.Δx / (X + Δx)
-            let output_amount = input_amount
-                .checked_mul(output_reserve)
+            // Computed in 192-bit precision to avoid overflow in the `y·Δx` product for large reserves.
+            let dx = input_amount.into_precision_amount();
+            let output_amount = dx
+                .checked_mul(output_reserve.into_precision_amount())
                 .and_then(|num| {
-                    num.checked_div(input_reserve.checked_add(input_amount).expect("Overflow in swap calc"))
+                    input_reserve
+                        .into_precision_amount()
+                        .checked_add(dx)
+                        .and_then(|denom| num.checked_div(denom))
                 })
                 .expect("Overflow in swap calculation");
+            let output_amount = Amount::try_from(output_amount).expect("swap output conversion failed");
+
+            // A swap input too small to move any of the output reserve would otherwise abort with an opaque
+            // withdraw error. Reject it with a clear message.
+            assert!(output_amount.is_positive(), "Swap input too small to yield any output");
 
             // Perform the swap
             self.get_pool_vault(input_pool).deposit(input_bucket);
@@ -349,21 +375,34 @@ mod template {
         }
 
         fn calculate_redemption_amounts(&self, lp_total_supply: Amount, lp_redeem_amount: Amount) -> (Amount, Amount) {
-            // get the pool reserve
-            let a_reserve = self.vault_a.balance();
-            let b_reserve = self.vault_b.balance();
+            assert!(
+                lp_total_supply.is_positive(),
+                "Cannot redeem from a pool with no LP supply"
+            );
 
-            // calculate the amounts owed to the user based on provided LP tokens
-            let lp_ratio = lp_redeem_amount.checked_div(lp_total_supply).expect("Div zero");
-            let a_amount_owed = lp_ratio
+            // get the pool reserve. Compute in 192-bit precision and multiply before dividing: dividing the LP ratio
+            // first truncates it to zero for any partial redemption (since these are integers), and the wide
+            // intermediate avoids overflow in `lp_redeem_amount * reserve`.
+            let a_reserve = self.vault_a.balance().into_precision_amount();
+            let b_reserve = self.vault_b.balance().into_precision_amount();
+            let lp_total_supply = lp_total_supply.into_precision_amount();
+            let lp_redeem_amount = lp_redeem_amount.into_precision_amount();
+
+            // amount_owed = lp_redeem_amount * reserve / lp_total_supply (rounded down in favour of the pool)
+            let a_amount_owed = lp_redeem_amount
                 .checked_mul(a_reserve)
+                .and_then(|num| num.checked_div(lp_total_supply))
                 .expect("Amount overflow when calculating redemption value for resource A");
 
-            let b_amount_owed = lp_ratio
+            let b_amount_owed = lp_redeem_amount
                 .checked_mul(b_reserve)
+                .and_then(|num| num.checked_div(lp_total_supply))
                 .expect("Amount overflow when calculating redemption value for resource B");
 
-            (a_amount_owed, b_amount_owed)
+            (
+                Amount::try_from(a_amount_owed).expect("redemption amount A conversion failed"),
+                Amount::try_from(b_amount_owed).expect("redemption amount B conversion failed"),
+            )
         }
 
         pub fn get_pool_balances(&self) -> (Amount, Amount) {

--- a/crates/template_builtin/tests/liquidity_pool.rs
+++ b/crates/template_builtin/tests/liquidity_pool.rs
@@ -229,6 +229,90 @@ fn second_contribution_and_partial_redeem() {
 }
 
 #[test]
+fn bootstrap_contribution_after_seeding_reserve() {
+    // Regression test for the `(false, _, _)` branch: the owner seeds one reserve via the owner-only
+    // `protected_add_liquidity` (which mints no LP), then bootstraps the pool with a full `contribute`. With no LP
+    // outstanding the first contribution must succeed and set the price over the combined reserves, not be rejected.
+    let mut test = TemplateTest::new(CRATE_PATH, TEMPLATE_PATHS);
+    let template_address = test.get_template_address(TEMPLATE_NAME);
+
+    let (faucet_component, faucet_resource) = create_test_faucet_component(&mut test, 1_000_000_000_000u64);
+    let (user1, user1_proof, user1_secret) = test.create_funded_account();
+
+    // ACT 1: create the pool owned by user1 (so user1 can call the owner-gated protected_* methods). With
+    // `OwnerRule::OwnedBySigner` the owner is the seal signer, i.e. user1.
+    test.execute_expect_success(
+        Transaction::builder_localnet()
+            .allocate_component_address("pool")
+            .call_function(template_address, "create", args![
+                OwnerRule::OwnedBySigner,
+                AccessRule::AllowAll,
+                TARI_TOKEN,
+                faucet_resource,
+                metadata!["name" => "TARI-Stablecoin Liquidity Pool"],
+                Workspace("pool"),
+            ])
+            .build_and_seal(&user1_secret),
+        vec![user1_proof.clone()],
+    );
+
+    let store = test.read_only_state_store();
+    let (pool_addr, _) = store
+        .get_components_by_template_address(template_address)
+        .unwrap()
+        .pop()
+        .unwrap();
+
+    // ACT 2: owner seeds 1000 TARI into reserve A via protected_add_liquidity (no LP minted).
+    test.execute_expect_success(
+        Transaction::builder_localnet()
+            .call_method(user1, "withdraw", args![TARI_TOKEN, 1000])
+            .put_last_instruction_output_on_workspace("seed_a")
+            .call_method(pool_addr, "protected_add_liquidity", args![Workspace("seed_a")])
+            .build_and_seal(&user1_secret),
+        vec![user1_proof.clone()],
+    );
+
+    // ACT 3: bootstrap with a full contribution of 500 TARI + 2000 stablecoin. Total reserves become
+    // (1000 + 500, 0 + 2000) = (1500, 2000) and LP minted = floor(sqrt(1500 * 2000)) = 1732.
+    test.execute_expect_success(
+        Transaction::builder_localnet()
+            .call_method(faucet_component, "take_free_coins_custom", args![2000])
+            .put_last_instruction_output_on_workspace("faucet_coins")
+            .call_method(user1, "withdraw", args![TARI_TOKEN, 500])
+            .put_last_instruction_output_on_workspace("xtr_coins")
+            .call_method(pool_addr, "contribute", args![
+                Workspace("xtr_coins"),
+                Workspace("faucet_coins")
+            ])
+            .put_last_instruction_output_on_workspace("contribution")
+            .call_method(user1, "deposit", args![Workspace("contribution.0")])
+            .call_method(user1, "deposit", args![Workspace("contribution.1")])
+            .call_method(user1, "deposit", args![Workspace("contribution.2")])
+            .build_and_seal(&user1_secret),
+        vec![user1_proof.clone()],
+    );
+
+    let store = test.read_only_state_store();
+    let pool_body = store.get_component(pool_addr).unwrap();
+    let indexed = pool_body.body.to_indexed_well_known_types().unwrap();
+    let vaults = indexed
+        .vault_ids()
+        .iter()
+        .map(|id| store.get_vault(id).unwrap())
+        .map(|v| (*v.resource_address(), v))
+        .collect::<HashMap<_, _>>();
+    assert_eq!(vaults.get(&TARI_TOKEN).unwrap().balance(), 1500);
+    assert_eq!(vaults.get(&faucet_resource).unwrap().balance(), 2000);
+
+    let lp_resx = indexed.resource_addresses().first().copied().unwrap();
+    let user_account = store.get_account(user1).unwrap();
+    let lp_vault = user_account.get_vault_by_resource(&lp_resx).unwrap();
+    let lp_balance = store.get_vault(&lp_vault.vault_id()).unwrap().balance();
+    assert_eq!(lp_balance, 1732);
+}
+
+#[test]
 fn basic_constant_product_swap() {
     // Setup
     let mut test = TemplateTest::new(CRATE_PATH, TEMPLATE_PATHS);

--- a/crates/template_builtin/tests/liquidity_pool.rs
+++ b/crates/template_builtin/tests/liquidity_pool.rs
@@ -44,8 +44,10 @@ fn initial_contribution_and_redeem() {
                 Workspace("xtr_coins"),
                 Workspace("faucet_coins")
             ])
-            .put_last_instruction_output_on_workspace("pool_units")
-            .call_method(user1, "deposit", args![Workspace("pool_units")])
+            .put_last_instruction_output_on_workspace("contribution")
+            .call_method(user1, "deposit", args![Workspace("contribution.0")])
+            .call_method(user1, "deposit", args![Workspace("contribution.1")])
+            .call_method(user1, "deposit", args![Workspace("contribution.2")])
             .finish()
             .add_signer(&test.to_public_key_bytes(), &user1_secret)
             .seal(test.secret_key()),
@@ -104,6 +106,129 @@ fn initial_contribution_and_redeem() {
 }
 
 #[test]
+fn second_contribution_and_partial_redeem() {
+    // Regression test for the `(true, true, true)` contribute branch and partial redemption, neither of which were
+    // previously covered. A non-proportional second contribution exercises (a) the ratio math that must not truncate
+    // to zero and (b) the change bucket returned for the over-supplied resource. The partial redeem exercises the
+    // proportional-payout math that must not truncate to zero either.
+    let mut test = TemplateTest::new(CRATE_PATH, TEMPLATE_PATHS);
+    let template_address = test.get_template_address(TEMPLATE_NAME);
+
+    let (faucet_component, faucet_resource) = create_test_faucet_component(&mut test, 1_000_000_000_000u64);
+    let (user1, _user1_proof, user1_secret) = test.create_funded_account();
+
+    // ACT 1: create the pool with an initial 1000 TARI : 4000 stablecoin contribution (ratio 1:4, LP minted = 2000).
+    test.execute_expect_success(
+        Transaction::builder_localnet()
+            .allocate_component_address("pool")
+            .call_function(template_address, "create", args![
+                OwnerRule::OwnedBySigner,
+                AccessRule::AllowAll,
+                TARI_TOKEN,
+                faucet_resource,
+                metadata!["name" => "TARI-Stablecoin Liquidity Pool"],
+                Workspace("pool"),
+            ])
+            .call_method(faucet_component, "take_free_coins_custom", args![4000])
+            .put_last_instruction_output_on_workspace("faucet_coins")
+            .call_method(user1, "withdraw", args![TARI_TOKEN, 1000])
+            .put_last_instruction_output_on_workspace("xtr_coins")
+            .call_method("pool", "contribute", args![
+                Workspace("xtr_coins"),
+                Workspace("faucet_coins")
+            ])
+            .put_last_instruction_output_on_workspace("contribution")
+            .call_method(user1, "deposit", args![Workspace("contribution.0")])
+            .call_method(user1, "deposit", args![Workspace("contribution.1")])
+            .call_method(user1, "deposit", args![Workspace("contribution.2")])
+            .finish()
+            .add_signer(&test.to_public_key_bytes(), &user1_secret)
+            .seal(test.secret_key()),
+        vec![],
+    );
+
+    let store = test.read_only_state_store();
+    let (pool_addr, pool_body) = store
+        .get_components_by_template_address(template_address)
+        .unwrap()
+        .pop()
+        .unwrap();
+    let indexed = pool_body.body.to_indexed_well_known_types().unwrap();
+    let lp_resx = indexed.resource_addresses().first().copied().unwrap();
+
+    // ACT 2: a deliberately non-proportional second contribution: 500 TARI but 4000 stablecoin. At the 1:4 reserve
+    // ratio only 2000 stablecoin is needed to match the 500 TARI, so 2000 stablecoin must be returned as change.
+    test.execute_expect_success(
+        Transaction::builder_localnet()
+            .call_method(faucet_component, "take_free_coins_custom", args![4000])
+            .put_last_instruction_output_on_workspace("faucet_coins")
+            .call_method(user1, "withdraw", args![TARI_TOKEN, 500])
+            .put_last_instruction_output_on_workspace("xtr_coins")
+            .call_method(pool_addr, "contribute", args![
+                Workspace("xtr_coins"),
+                Workspace("faucet_coins")
+            ])
+            .put_last_instruction_output_on_workspace("contribution")
+            // change_a (TARI) is empty, change_b (stablecoin) must hold the unused 2000.
+            .assert_bucket_contains_at_least("contribution.2", faucet_resource, 2000u64)
+            .call_method(user1, "deposit", args![Workspace("contribution.0")])
+            .call_method(user1, "deposit", args![Workspace("contribution.1")])
+            .call_method(user1, "deposit", args![Workspace("contribution.2")])
+            .finish()
+            .seal(&user1_secret),
+        vec![],
+    );
+
+    // Reserves must keep the 1:4 ratio: a = 1000 + 500 = 1500, b = 4000 + 2000 = 6000.
+    let store = test.read_only_state_store();
+    let pool_body = store.get_component(pool_addr).unwrap();
+    let indexed = pool_body.body.to_indexed_well_known_types().unwrap();
+    let vaults = indexed
+        .vault_ids()
+        .iter()
+        .map(|id| store.get_vault(id).unwrap())
+        .map(|v| (*v.resource_address(), v))
+        .collect::<HashMap<_, _>>();
+    assert_eq!(vaults.get(&TARI_TOKEN).unwrap().balance(), 1500);
+    assert_eq!(vaults.get(&faucet_resource).unwrap().balance(), 6000);
+
+    // The user should now hold LP = 2000 (initial) + 1000 (second) = 3000.
+    let user_account = store.get_account(user1).unwrap();
+    let lp_vault = user_account.get_vault_by_resource(&lp_resx).unwrap();
+    let lp_balance = store.get_vault(&lp_vault.vault_id()).unwrap().balance();
+    assert_eq!(lp_balance, 3000);
+
+    // ACT 3: redeem HALF the LP (1500 of 3000). Proportional payout = 750 TARI and 3000 stablecoin.
+    test.execute_expect_success(
+        Transaction::builder_localnet()
+            .call_method(user1, "withdraw", args![lp_resx, 1500])
+            .put_last_instruction_output_on_workspace("redeem_lp")
+            .call_method(pool_addr, "redeem", args![Workspace("redeem_lp")])
+            .put_last_instruction_output_on_workspace("redeemed")
+            .assert_bucket_contains_at_least("redeemed.0", TARI_TOKEN, 750u64)
+            .assert_bucket_contains_at_least("redeemed.1", faucet_resource, 3000u64)
+            .call_method(user1, "deposit", args![Workspace("redeemed.0")])
+            .call_method(user1, "deposit", args![Workspace("redeemed.1")])
+            .finish()
+            .seal(&user1_secret),
+        vec![],
+    );
+
+    // Half the reserves should remain in the pool: a = 750, b = 3000.
+    let store = test.read_only_state_store();
+    let pool_body = store.get_component(pool_addr).unwrap();
+    let indexed = pool_body.body.to_indexed_well_known_types().unwrap();
+    let vaults = indexed
+        .vault_ids()
+        .iter()
+        .map(|id| store.get_vault(id).unwrap())
+        .map(|v| (*v.resource_address(), v))
+        .collect::<HashMap<_, _>>();
+    assert_eq!(vaults.get(&TARI_TOKEN).unwrap().balance(), 750);
+    assert_eq!(vaults.get(&faucet_resource).unwrap().balance(), 3000);
+}
+
+#[test]
 fn basic_constant_product_swap() {
     // Setup
     let mut test = TemplateTest::new(CRATE_PATH, TEMPLATE_PATHS);
@@ -139,8 +264,10 @@ fn basic_constant_product_swap() {
                 Workspace("xtr_coins"),
                 Workspace("faucet_coins")
             ])
-            .put_last_instruction_output_on_workspace("pool_units")
-            .call_method(user1, "deposit", args![Workspace("pool_units")])
+            .put_last_instruction_output_on_workspace("contribution")
+            .call_method(user1, "deposit", args![Workspace("contribution.0")])
+            .call_method(user1, "deposit", args![Workspace("contribution.1")])
+            .call_method(user1, "deposit", args![Workspace("contribution.2")])
             // Give user some stablecoin for later
             .call_method(faucet_component, "take_free_coins_custom", args![
                 1_000_000

--- a/crates/wallet/sdk/src/apis/mod.rs
+++ b/crates/wallet/sdk/src/apis/mod.rs
@@ -17,6 +17,7 @@ pub mod signer;
 pub mod stealth_outputs;
 pub mod stealth_transfer;
 pub mod substate;
+pub mod swap_pool;
 pub mod template;
 pub mod transaction;
 pub mod viewable_balance;

--- a/crates/wallet/sdk/src/apis/stealth_transfer/api.rs
+++ b/crates/wallet/sdk/src/apis/stealth_transfer/api.rs
@@ -42,6 +42,7 @@ use crate::{
         locks::LocksApi,
         stealth_outputs::{StealthOutputsApi, StealthOutputsApiError, TransferStatementParams},
         substate::{SubstatesApi, ValidatorScanResult},
+        swap_pool,
     },
     models::{
         AccountWithAddress,
@@ -297,7 +298,7 @@ impl<'a, TSpec: WalletSdkSpec> StealthTransferApi<'a, TSpec> {
     pub async fn transfer(
         &self,
         owner_account: AccountWithAddress,
-        params: StealthTransferParams,
+        mut params: StealthTransferParams,
     ) -> Result<(WalletLockDropGuard<'a, TSpec::Store>, StealthTransferOutput), StealthTransferApiError> {
         let network = self.config_api.get_network()?;
         params.validate(network)?;
@@ -346,6 +347,36 @@ impl<'a, TSpec: WalletSdkSpec> StealthTransferApi<'a, TSpec> {
         } else {
             Default::default()
         };
+
+        // When paying the fee with a swap but no (positive) input amount was supplied, derive how much of the input
+        // resource must be swapped to yield at least `min_xtr_output_amount` of TARI from the pool's current reserves.
+        // The amounts are in different tokens (and exchange rates), so we cannot simply fall back to `max_fee` here.
+        let derive_swap = params
+            .fee_params
+            .pay_fee_with_swap
+            .as_ref()
+            .filter(|swap| !swap.input_amount.is_positive())
+            .map(|swap| (swap.pool_address, swap.input_resource, swap.min_xtr_output_amount));
+        if let Some((pool_address, input_resource, min_xtr_output_amount)) = derive_swap {
+            let derived_input = swap_pool::derive_swap_input_for_tari_output(
+                &self.substate_api,
+                pool_address,
+                input_resource,
+                min_xtr_output_amount,
+            )
+            .await?;
+            info!(
+                target: LOG_TARGET,
+                "Derived swap input amount {} of {} to yield >= {} TARI from pool {}",
+                derived_input, input_resource, min_xtr_output_amount, pool_address
+            );
+            params
+                .fee_params
+                .pay_fee_with_swap
+                .as_mut()
+                .expect("pay_fee_with_swap is Some")
+                .input_amount = derived_input;
+        }
 
         // Generate outputs
         let resource_view_key = resource

--- a/crates/wallet/sdk/src/apis/stealth_transfer/error.rs
+++ b/crates/wallet/sdk/src/apis/stealth_transfer/error.rs
@@ -13,6 +13,7 @@ use crate::{
         locks::LocksApiError,
         stealth_outputs::StealthOutputsApiError,
         substate::SubstateApiError,
+        swap_pool::SwapPoolApiError,
     },
     storage::WalletStorageError,
 };
@@ -53,6 +54,8 @@ pub enum StealthTransferApiError {
     InvariantViolation { details: String },
     #[error("Locks API error: {0}")]
     LocksApiError(#[from] LocksApiError),
+    #[error("Swap pool error: {0}")]
+    SwapPoolApi(#[from] SwapPoolApiError),
 }
 
 impl IsNotFoundError for StealthTransferApiError {

--- a/crates/wallet/sdk/src/apis/substate.rs
+++ b/crates/wallet/sdk/src/apis/substate.rs
@@ -215,6 +215,19 @@ where
             }
         }
 
+        // `get_dependent_substates` and the parent fetches above carry the version from the wallet's
+        // local store / network scan, ignoring the `unversioned` request. When the caller asked for
+        // unversioned dependencies, normalise the whole set: a locally-cached version can be stale
+        // (e.g. a swap pool reserve advances on every swap), and pinning it makes the indexer reject the
+        // input as "down" once the chain moves past it. `SubstateRequirement` hashes by id only, so
+        // collapsing to unversioned cannot introduce duplicates.
+        if unversioned {
+            return Ok(substate_ids
+                .into_iter()
+                .map(SubstateRequirement::into_unversioned)
+                .collect());
+        }
+
         Ok(substate_ids)
     }
 

--- a/crates/wallet/sdk/src/apis/swap_pool.rs
+++ b/crates/wallet/sdk/src/apis/swap_pool.rs
@@ -1,0 +1,293 @@
+//   Copyright 2025 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+use tari_engine_types::{
+    indexed_value::{IndexedValueError, IndexedWellKnownTypes},
+    substate::SubstateId,
+};
+use tari_ootle_common_types::optional::IsNotFoundError;
+use tari_template_builtin::LIQUIDITY_POOL_TEMPLATE_ADDRESS;
+use tari_template_lib::types::{Amount, ComponentAddress, ResourceAddress, TemplateAddress, constants::TARI_TOKEN};
+
+use crate::{
+    apis::substate::{SubstateApiError, SubstatesApi},
+    network::WalletNetworkInterface,
+    storage::WalletStore,
+};
+
+/// Slippage margin (percent) applied when deriving a swap input amount, to account for the pool reserves moving
+/// between the time the input is computed and the time the swap executes on-chain.
+const SLIPPAGE_MARGIN_PERCENT: u128 = 5;
+
+#[derive(Debug, thiserror::Error)]
+pub enum SwapPoolApiError {
+    #[error("Substate API error: {0}")]
+    SubstateApi(#[from] SubstateApiError),
+    #[error("Indexed value error: {0}")]
+    IndexedValue(#[from] IndexedValueError),
+    #[error("Substate {pool_address} is not a component")]
+    NotAComponent { pool_address: ComponentAddress },
+    #[error("Component {pool_address} is not a liquidity pool (template: {template_address})")]
+    NotALiquidityPool {
+        pool_address: ComponentAddress,
+        template_address: TemplateAddress,
+    },
+    #[error("Expected at least 2 vaults in liquidity pool component, found {found}")]
+    InsufficientVaults { found: usize },
+    #[error("Vault substate {vault} not found")]
+    VaultNotFound { vault: SubstateId },
+    #[error("Substate {vault} is not a vault")]
+    NotAVault { vault: SubstateId },
+    #[error("Neither resource in pool {pool_address} is TARI")]
+    NeitherResourceIsTari { pool_address: ComponentAddress },
+    #[error(
+        "Swap input resource {input_resource} is not the non-TARI side of pool {pool_address} (expected \
+         {expected_resource})"
+    )]
+    InputResourceMismatch {
+        pool_address: ComponentAddress,
+        input_resource: ResourceAddress,
+        expected_resource: ResourceAddress,
+    },
+    #[error("Pool {pool_address} does not have enough TARI liquidity for the desired output of {desired_output}")]
+    InsufficientPoolLiquidity {
+        pool_address: ComponentAddress,
+        desired_output: Amount,
+    },
+    #[error("Desired TARI output must be positive")]
+    NonPositiveDesiredOutput,
+}
+
+/// The resolved reserves of a two-resource liquidity pool.
+#[derive(Debug, Clone)]
+pub struct PoolReserves {
+    pub resource_a: ResourceAddress,
+    pub balance_a: Amount,
+    pub resource_b: ResourceAddress,
+    pub balance_b: Amount,
+}
+
+impl PoolReserves {
+    /// Identifies the TARI side of the pool and returns `(non_tari_resource, reserve_in, reserve_out)` where
+    /// `reserve_in` is the non-TARI (input) reserve and `reserve_out` is the TARI (output) reserve. Returns `None` if
+    /// neither resource is TARI.
+    pub fn tari_swap_reserves(&self) -> Option<(ResourceAddress, Amount, Amount)> {
+        if self.resource_a == TARI_TOKEN {
+            Some((self.resource_b, self.balance_b, self.balance_a))
+        } else if self.resource_b == TARI_TOKEN {
+            Some((self.resource_a, self.balance_a, self.balance_b))
+        } else {
+            None
+        }
+    }
+}
+
+/// Calculate the input amount of a non-TARI token needed for a constant-product swap to yield at least
+/// `desired_output` of the output token. Returns `None` if the pool lacks enough output liquidity.
+///
+/// Includes a [`SLIPPAGE_MARGIN_PERCENT`] slippage margin and uses ceiling division to avoid integer truncation.
+pub fn calculate_swap_input(desired_output: Amount, reserve_in: Amount, reserve_out: Amount) -> Option<Amount> {
+    if reserve_out <= desired_output {
+        return None;
+    }
+    // ceil(desired_output * reserve_in * (100 + margin) / ((reserve_out - desired_output) * 100))
+    let numerator = desired_output
+        .to_u128()
+        .checked_mul(reserve_in.to_u128())?
+        .checked_mul(100 + SLIPPAGE_MARGIN_PERCENT)?;
+    let denominator = reserve_out.checked_sub(desired_output)?.to_u128().checked_mul(100)?;
+    // Ceiling division: (a + b - 1) / b
+    let result = numerator.checked_add(denominator - 1)? / denominator;
+    Some(Amount::new(result))
+}
+
+/// Fetches and resolves the vault reserves of a liquidity pool component from the network.
+pub async fn get_pool_reserves<TStore, TNetworkInterface>(
+    substate_api: &SubstatesApi<'_, TStore, TNetworkInterface>,
+    pool_address: ComponentAddress,
+) -> Result<PoolReserves, SwapPoolApiError>
+where
+    TStore: WalletStore,
+    TNetworkInterface: WalletNetworkInterface,
+    TNetworkInterface::Error: IsNotFoundError,
+{
+    let scan = substate_api
+        .fetch_substate_from_network(&SubstateId::Component(pool_address), None)
+        .await?;
+
+    let component = scan
+        .substate
+        .component()
+        .ok_or(SwapPoolApiError::NotAComponent { pool_address })?;
+
+    if *component.template_address() != LIQUIDITY_POOL_TEMPLATE_ADDRESS {
+        return Err(SwapPoolApiError::NotALiquidityPool {
+            pool_address,
+            template_address: *component.template_address(),
+        });
+    }
+
+    let indexed = IndexedWellKnownTypes::from_value(component.state())?;
+    let vault_ids = indexed.vault_ids();
+    if vault_ids.len() < 2 {
+        return Err(SwapPoolApiError::InsufficientVaults { found: vault_ids.len() });
+    }
+
+    let vault_substate_ids: Vec<SubstateId> = vault_ids.iter().take(2).map(|id| SubstateId::Vault(*id)).collect();
+    let vault_substates = substate_api
+        .get_substates_from_network(vault_substate_ids.clone())
+        .await?;
+
+    let mut reserves = Vec::with_capacity(2);
+    for id in &vault_substate_ids {
+        let vault = vault_substates
+            .get(id)
+            .ok_or_else(|| SwapPoolApiError::VaultNotFound { vault: id.clone() })?
+            .substate_value()
+            .vault()
+            .ok_or_else(|| SwapPoolApiError::NotAVault { vault: id.clone() })?;
+        reserves.push((*vault.resource_address(), vault.balance()));
+    }
+
+    let (resource_a, balance_a) = reserves[0];
+    let (resource_b, balance_b) = reserves[1];
+    Ok(PoolReserves {
+        resource_a,
+        balance_a,
+        resource_b,
+        balance_b,
+    })
+}
+
+/// Derives the amount of `input_resource` that must be swapped through `pool_address` to yield at least
+/// `desired_tari_output` of TARI, using the pool's current reserves. This is what a caller would otherwise have to
+/// compute up-front via [`get_pool_reserves`] + [`calculate_swap_input`].
+pub async fn derive_swap_input_for_tari_output<TStore, TNetworkInterface>(
+    substate_api: &SubstatesApi<'_, TStore, TNetworkInterface>,
+    pool_address: ComponentAddress,
+    input_resource: ResourceAddress,
+    desired_tari_output: Amount,
+) -> Result<Amount, SwapPoolApiError>
+where
+    TStore: WalletStore,
+    TNetworkInterface: WalletNetworkInterface,
+    TNetworkInterface::Error: IsNotFoundError,
+{
+    if !desired_tari_output.is_positive() {
+        return Err(SwapPoolApiError::NonPositiveDesiredOutput);
+    }
+
+    let reserves = get_pool_reserves(substate_api, pool_address).await?;
+    let (non_tari_resource, reserve_in, reserve_out) = reserves
+        .tari_swap_reserves()
+        .ok_or(SwapPoolApiError::NeitherResourceIsTari { pool_address })?;
+
+    if input_resource != non_tari_resource {
+        return Err(SwapPoolApiError::InputResourceMismatch {
+            pool_address,
+            input_resource,
+            expected_resource: non_tari_resource,
+        });
+    }
+
+    calculate_swap_input(desired_tari_output, reserve_in, reserve_out).ok_or(
+        SwapPoolApiError::InsufficientPoolLiquidity {
+            pool_address,
+            desired_output: desired_tari_output,
+        },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use tari_template_lib::types::ObjectKey;
+
+    use super::*;
+
+    fn amt(v: u128) -> Amount {
+        Amount::new(v)
+    }
+
+    /// The constant-product output for a given input, matching the on-chain pool: `Δy = y·Δx / (x + Δx)` (floored).
+    fn constant_product_output(input: Amount, reserve_in: Amount, reserve_out: Amount) -> u128 {
+        let dx = input.to_u128();
+        dx * reserve_out.to_u128() / (reserve_in.to_u128() + dx)
+    }
+
+    fn non_tari_resource() -> ResourceAddress {
+        ResourceAddress::new(ObjectKey::from_array([7u8; ObjectKey::LENGTH]))
+    }
+
+    #[test]
+    fn returns_none_when_pool_cannot_cover_desired_output() {
+        // reserve_out equal to or below the desired output can never yield it
+        assert!(calculate_swap_input(amt(1000), amt(1000), amt(1000)).is_none());
+        assert!(calculate_swap_input(amt(1500), amt(1000), amt(1000)).is_none());
+    }
+
+    #[test]
+    fn derived_input_yields_at_least_desired_output() {
+        let desired = amt(1500);
+        let reserve_in = amt(1_000_000);
+        let reserve_out = amt(2_000_000);
+
+        let input = calculate_swap_input(desired, reserve_in, reserve_out).unwrap();
+        assert!(input.is_positive());
+
+        // The pool's own constant-product math on this input must clear the desired output (with margin to spare).
+        let output = constant_product_output(input, reserve_in, reserve_out);
+        assert!(
+            output >= desired.to_u128(),
+            "swap of {input} should yield >= {desired}, got {output}"
+        );
+    }
+
+    #[test]
+    fn applies_slippage_margin_over_the_exact_input() {
+        // Symmetric reserves: exact input for 100 out is ceil(100*1000/900) = 112; with the 5% margin we expect more.
+        let reserve_in = amt(1000);
+        let reserve_out = amt(1000);
+        let desired = amt(100);
+
+        let input = calculate_swap_input(desired, reserve_in, reserve_out).unwrap();
+        // ceil(100 * 1000 * 105 / (900 * 100)) = ceil(10_500_000 / 90_000) = 117
+        assert_eq!(input, amt(117));
+    }
+
+    #[test]
+    fn tari_swap_reserves_identifies_the_tari_side() {
+        let other = non_tari_resource();
+
+        // TARI on side A: input reserve is the non-TARI (B) balance, output reserve is the TARI (A) balance
+        let reserves = PoolReserves {
+            resource_a: TARI_TOKEN,
+            balance_a: amt(500),
+            resource_b: other,
+            balance_b: amt(300),
+        };
+        assert_eq!(reserves.tari_swap_reserves(), Some((other, amt(300), amt(500))));
+
+        // TARI on side B
+        let reserves = PoolReserves {
+            resource_a: other,
+            balance_a: amt(300),
+            resource_b: TARI_TOKEN,
+            balance_b: amt(500),
+        };
+        assert_eq!(reserves.tari_swap_reserves(), Some((other, amt(300), amt(500))));
+    }
+
+    #[test]
+    fn tari_swap_reserves_none_when_no_tari_side() {
+        // Both keys must differ from TARI_TOKEN, which is ObjectKey([1u8; LENGTH]).
+        let a = ResourceAddress::new(ObjectKey::from_array([3u8; ObjectKey::LENGTH]));
+        let b = ResourceAddress::new(ObjectKey::from_array([4u8; ObjectKey::LENGTH]));
+        let reserves = PoolReserves {
+            resource_a: a,
+            balance_a: amt(300),
+            resource_b: b,
+            balance_b: amt(500),
+        };
+        assert_eq!(reserves.tari_swap_reserves(), None);
+    }
+}


### PR DESCRIPTION
## Summary
Fixes several correctness bugs in the builtin two-resource liquidity pool template (`crates/template_builtin/templates/liquidity_pool`), found while debugging a `bucket.take` "amount must be positive" assertion failure on `contribute`. The existing tests only ever exercised the initial contribution and a full (100%) redemption, so the buggy code paths were uncovered.

## Bugs fixed
1. **`contribute` ratio/mint truncation (`true,true,true` branch).** The ratio and LP-mint math divided before multiplying; since `PrecisionAmount` is a 192-bit integer (no fixed-point scaling), `amount / reserve` floored to `0` whenever a contribution was smaller than its reserve, producing a zero contribution → `bucket.take(0)` abort. Reordered to multiply-before-divide (the 192-bit width exists precisely to hold the intermediate product); added a dust guard.
2. **`redeem` truncation + overflow.** `calculate_redemption_amounts` computed `lp_redeem_amount / lp_total_supply` first → floored to `0` for any partial redemption, so partial redeems returned nothing and aborted on `withdraw(0)`. Now multiply-before-divide in 192-bit precision (also avoids `u128` overflow); added a dust guard.
3. **`contribute` dropped change → abort.** To keep the reserve ratio the pool only takes the matching portion of one input bucket; the unused remainder of the other was dropped at scope exit → `BucketNotEmpty` abort for any non-proportional contribution. Now returned to the caller as change. **BREAKING ABI CHANGE:** `contribute` now returns `(Bucket, Bucket, Bucket)` = `(lp_tokens, change_a, change_b)` instead of `Bucket`. Manifests must destructure and deposit all three buckets (the change buckets may be empty, which is harmless to deposit).
4. **`swap` overflow + opaque dust failure.** `swap_constant_product` computed `input_amount * output_reserve` in plain `u128`, risking overflow on large pools, and aborted opaquely on a dust input. Now computed in 192-bit precision with a clear zero-output guard.
5. **`(false, _, _)` zero-LP-supply contribution.** When LP supply is zero but a reserve was pre-seeded by the owner via the owner-only `protected_add_liquidity` (e.g. bootstrapping a pool in stages), the previous code's ratio math broke down. This is now handled as a proper initial liquidity provision: with no LP outstanding there is no price to preserve, so the full contribution is taken and LP is minted as the geometric mean of the resulting total reserves, `sqrt((reserve_a + a) * (reserve_b + b))` (which reduces to `sqrt(a * b)` for a fresh, empty pool). This unifies the two zero-supply arms and removes the precision loss of the old two-sqrt formula.

## Tests
- Updated both existing tests for the new `contribute` signature (deposit `.0`/`.1`/`.2`).
- Added `second_contribution_and_partial_redeem` covering the previously-untested non-proportional second contribution (asserts the change bucket is returned and reserves keep their ratio) and a partial (half-supply) redemption.
- Added `bootstrap_contribution_after_seeding_reserve` covering seed-a-reserve-then-bootstrap: the owner seeds one reserve via `protected_add_liquidity` and then bootstraps the pool with a full `contribute`.

## Note for reviewers / deployers
These are builtin-template changes — they only take effect once the template wasm is rebuilt into the engine and validators are restarted. Any client manifests calling `contribute` must be updated for the new tuple return type.