### PR TITLE
feat(template): stateless mode for the #[template] macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12509,7 +12509,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_macros"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "indoc",
  "proc-macro2",

--- a/crates/engine/tests/templates/confidential/utilities/src/lib.rs
+++ b/crates/engine/tests/templates/confidential/utilities/src/lib.rs
@@ -22,21 +22,19 @@
 
 use tari_template_lib::prelude::*;
 
-#[template]
-mod faucet_template {
+// A stateless utility template: it exposes only pure free functions over confidential buckets and
+// holds no component state, so invoking these functions never creates a component.
+#[template(stateless)]
+mod ConfidentialUtilities {
     use super::*;
 
-    pub struct ConfidentialUtilities;
+    /// Withdraws from a bucket and returns a new bucket containing the withdrawn funds.
+    pub fn take_from_bucket(mut bucket: Bucket, proof: ConfidentialWithdrawProof) -> Bucket {
+        bucket.take_confidential(proof)
+    }
 
-    impl ConfidentialUtilities {
-        /// Withdraws from a bucket and returns a new bucket containing the withdrawn funds.
-        pub fn take_from_bucket(mut bucket: Bucket, proof: ConfidentialWithdrawProof) -> Bucket {
-            bucket.take_confidential(proof)
-        }
-
-        /// Joins two buckets into one, returning a new bucket containing the combined value of the same resource..
-        pub fn join_buckets(mut bucket1: Bucket, bucket2: Bucket) -> Bucket {
-            bucket1.join(bucket2)
-        }
+    /// Joins two buckets into one, returning a new bucket containing the combined value of the same resource.
+    pub fn join_buckets(bucket1: Bucket, bucket2: Bucket) -> Bucket {
+        bucket1.join(bucket2)
     }
 }

--- a/crates/template_macros/Cargo.toml
+++ b/crates/template_macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_template_macros"
 description = "Tari template macro"
-version = "0.20.1"
+version = "0.20.2"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/template_macros/src/lib.rs
+++ b/crates/template_macros/src/lib.rs
@@ -35,6 +35,10 @@
 //! - `skip_cbor_derives` — suppress the default `#[derive(minicbor::Encode, minicbor::Decode, minicbor::CborLen)]`
 //!   injection on template structs/enums *and* the per-field/variant `#[n(N)]` index assignment. The author is then
 //!   responsible for providing their own derives and indices.
+//! - `stateless` — declare a component-less template. The module exposes only stateless free `pub fn` items (no
+//!   component, no state, no `&self` methods); the template name is taken from the module identifier. Methods, `->
+//!   Self` constructors and `#[migration]` functions are rejected. Useful for pure-function templates such as
+//!   spend-time scripts, resource auth-hook libraries and validation/math helpers. Composes with `skip_cbor_derives`.
 //!
 //! Field-level overrides are always honoured, regardless of the flag: if a field already
 //! carries `#[n(N)]`, `#[b(N)]`, or `#[cbor(n(N))]`, the macro will not overwrite it.
@@ -69,6 +73,14 @@
 //!         #[n(1)] beta: u32,
 //!     }
 //!     impl HandRolled { pub fn new() -> Self { Self { alpha: 0, beta: 0 } } }
+//! }
+//!
+//! // A component-less, stateless template — only free functions, no struct/state.
+//! // The template name is the module identifier (`math`).
+//! #[template(stateless)]
+//! mod math {
+//!     pub fn add(a: u32, b: u32) -> u32 { a + b }
+//!     pub fn mul(a: u32, b: u32) -> u32 { a * b }
 //! }
 //! ```
 

--- a/crates/template_macros/src/template/ast.rs
+++ b/crates/template_macros/src/template/ast.rs
@@ -22,6 +22,7 @@
 
 use std::fmt::{Debug, Formatter};
 
+use proc_macro2::Span;
 use quote::ToTokens;
 use syn::{
     Error,
@@ -32,6 +33,7 @@ use syn::{
     ImplItem,
     ImplItemFn,
     Item,
+    ItemFn,
     ItemMod,
     ItemUse,
     Result,
@@ -49,20 +51,45 @@ use syn::{
     token::Comma,
 };
 
+use crate::template::options::TemplateOptions;
+
 #[allow(dead_code)]
 pub struct TemplateAst {
     pub template_name: Ident,
     pub module_content: Vec<Item>,
     pub functions: Vec<FunctionAst>,
     pub uses: Vec<ItemUse>,
+    /// Set when the template was declared with `#[template(stateless)]`. The functions live as
+    /// free `pub fn` items in the module rather than as associated functions on a component
+    /// struct, which changes the call path the dispatcher generates.
+    pub stateless: bool,
 }
 
 impl Parse for TemplateAst {
-    #[allow(clippy::too_many_lines)]
     fn parse(input: ParseStream) -> Result<Self> {
-        // parse the "mod" block
-        let mut module: ItemMod = input.parse()?;
+        // parse the "mod" block. The `Parse` impl always uses the default (stateful) options;
+        // option-dependent parsing goes through `from_item_mod`.
+        let module: ItemMod = input.parse()?;
+        Self::from_item_mod(module, TemplateOptions::default())
+    }
+}
 
+impl TemplateAst {
+    /// Build a [`TemplateAst`] from an already-parsed module, taking the macro `options` into
+    /// account. This is the entry point used by `generate_template`, since parsing itself depends
+    /// on the `stateless` flag (which the `syn::Parse` impl has no access to).
+    pub fn from_item_mod(module: ItemMod, options: TemplateOptions) -> Result<Self> {
+        if options.stateless {
+            Self::parse_stateless(module)
+        } else {
+            Self::parse_stateful(module)
+        }
+    }
+
+    /// Parse a conventional, component-based template: the first `pub struct`/`pub enum` names the
+    /// component (and template), and its `impl` block provides the functions and methods.
+    #[allow(clippy::too_many_lines)]
+    fn parse_stateful(mut module: ItemMod) -> Result<Self> {
         // get the contents of the "mod" block
         let items = match module.content {
             Some((_, ref mut items)) => items,
@@ -186,7 +213,123 @@ impl Parse for TemplateAst {
                 .map(|(_, c)| c)
                 .ok_or_else(|| Error::new(module.ident.span(), "Template module must contain content"))?,
             uses,
+            stateless: false,
         })
+    }
+
+    /// Parse a component-less, stateless template (`#[template(stateless)]`). The template name is
+    /// the module identifier and the public API is the set of free `pub fn` items in the module —
+    /// no struct is interpreted as a component. Any struct/enum present is treated purely as a
+    /// data type (and still receives the usual CBOR derives unless `skip_cbor_derives` is set).
+    fn parse_stateless(mut module: ItemMod) -> Result<Self> {
+        let template_name = module.ident.clone();
+
+        // get the contents of the "mod" block
+        let items = match module.content {
+            Some((_, ref mut items)) => items,
+            None => return Err(Error::new(template_name.span(), "empty module")),
+        };
+
+        let mut functions = Vec::with_capacity(5);
+        let mut uses = Vec::new();
+
+        for item in items {
+            match item {
+                Item::Fn(fn_item) => {
+                    // Only public free functions form the template's public API. Anything else
+                    // (private helpers, data-type `impl` blocks, etc.) is left untouched in the
+                    // module for the author to use internally.
+                    if !matches!(fn_item.vis, Visibility::Public(_)) {
+                        continue;
+                    }
+
+                    if fn_item.attrs.iter().any(|attr| attr.path().is_ident("migration")) {
+                        return Err(Error::new(
+                            fn_item.sig.ident.span(),
+                            "stateless templates cannot have #[migration] functions",
+                        ));
+                    }
+
+                    if let Some(receiver) = fn_item.sig.receiver() {
+                        return Err(Error::new(
+                            receiver.span(),
+                            "stateless templates cannot have methods (functions with a `self` receiver)",
+                        ));
+                    }
+
+                    if let Some(span) = self_return_span(&fn_item.sig.output) {
+                        return Err(Error::new(
+                            span,
+                            "stateless templates cannot have a constructor (a function returning `Self`)",
+                        ));
+                    }
+
+                    functions.push(Self::get_function_from_fn(fn_item));
+                },
+                Item::Use(item) => {
+                    // Exclude super imports
+                    if let UseTree::Path(path) = &item.tree &&
+                        path.ident == "super"
+                    {
+                        continue;
+                    }
+                    uses.push(item.clone());
+                },
+                _ => {},
+            }
+        }
+
+        if functions.is_empty() {
+            return Err(Error::new(
+                template_name.span(),
+                "a stateless template must define at least one public function",
+            ));
+        }
+
+        Ok(Self {
+            template_name,
+            functions,
+            module_content: module
+                .content
+                .map(|(_, c)| c)
+                .ok_or_else(|| Error::new(module.ident.span(), "Template module must contain content"))?,
+            uses,
+            stateless: true,
+        })
+    }
+}
+
+/// Returns the span of a `Self` mention anywhere in a function's return type, if any. Used to
+/// reject "constructors" in stateless templates. Recurses so that wrapped forms such as
+/// `-> Self`, `-> (Self, ..)`, `-> Option<Self>`, `-> Result<Self, E>` and `-> &Self` are all
+/// caught with a clear macro error rather than a raw compiler error.
+fn self_return_span(output: &ReturnType) -> Option<Span> {
+    match output {
+        ReturnType::Default => None,
+        ReturnType::Type(_, ty) => type_self_span(ty),
+    }
+}
+
+fn type_self_span(ty: &Type) -> Option<Span> {
+    match ty {
+        Type::Path(path) => path.path.segments.iter().find_map(|segment| {
+            if segment.ident == "Self" {
+                return Some(segment.ident.span());
+            }
+            // Recurse into generic arguments (e.g. `Option<Self>`, `Result<Self, E>`).
+            match &segment.arguments {
+                syn::PathArguments::AngleBracketed(args) => args.args.iter().find_map(|arg| match arg {
+                    syn::GenericArgument::Type(inner) => type_self_span(inner),
+                    _ => None,
+                }),
+                _ => None,
+            }
+        }),
+        Type::Tuple(tuple) => tuple.elems.iter().find_map(type_self_span),
+        Type::Reference(reference) => type_self_span(&reference.elem),
+        Type::Group(group) => type_self_span(&group.elem),
+        Type::Paren(paren) => type_self_span(&paren.elem),
+        _ => None,
     }
 }
 
@@ -306,6 +449,17 @@ impl TemplateAst {
         }
     }
 
+    /// Build a [`FunctionAst`] from a free `pub fn` item (used by stateless templates). Callers
+    /// must have already rejected `self` receivers, `-> Self` returns and `#[migration]`.
+    fn get_function_from_fn(item: &ItemFn) -> FunctionAst {
+        FunctionAst {
+            name: item.sig.ident.to_string(),
+            input_types: Self::get_input_types(&item.sig.inputs),
+            output_type: Self::get_output_type_token(&item.sig.output),
+            is_migration: false,
+        }
+    }
+
     fn get_input_types(inputs: &Punctuated<FnArg, Comma>) -> Vec<TypeAst> {
         inputs
             .iter()
@@ -408,5 +562,133 @@ impl Debug for TypeAst {
                 write!(f, "Tuple {{ name: {:?}, type_tuple: {:?} }}", name, type_tuple)
             },
         }
+    }
+}
+
+#[cfg(test)]
+mod stateless_tests {
+    use std::str::FromStr;
+
+    use indoc::indoc;
+    use proc_macro2::TokenStream;
+    use syn::parse2;
+
+    use super::TemplateAst;
+    use crate::template::options::TemplateOptions;
+
+    fn parse(src: &str) -> super::Result<TemplateAst> {
+        let module = parse2::<syn::ItemMod>(TokenStream::from_str(src).unwrap()).unwrap();
+        let options = TemplateOptions {
+            stateless: true,
+            ..Default::default()
+        };
+        TemplateAst::from_item_mod(module, options)
+    }
+
+    #[test]
+    fn collects_free_functions_and_names_from_module() {
+        let ast = parse(indoc! {"
+            mod math {
+                pub fn add(a: u32, b: u32) -> u32 { a + b }
+                pub fn mul(a: u32, b: u32) -> u32 { a * b }
+            }
+        "})
+        .unwrap();
+
+        assert!(ast.stateless);
+        // The template name comes from the module identifier, not a struct.
+        assert_eq!(ast.template_name.to_string(), "math");
+        assert_eq!(ast.functions.len(), 2);
+        assert_eq!(ast.functions[0].name, "add");
+        assert_eq!(ast.functions[1].name, "mul");
+        // No function touches `self`, so none is mutable.
+        assert!(ast.functions.iter().all(|f| !f.is_mut()));
+    }
+
+    #[test]
+    fn ignores_private_helpers() {
+        let ast = parse(indoc! {"
+            mod math {
+                pub fn add(a: u32, b: u32) -> u32 { helper(a) + b }
+                fn helper(a: u32) -> u32 { a }
+            }
+        "})
+        .unwrap();
+
+        assert_eq!(ast.functions.len(), 1);
+        assert_eq!(ast.functions[0].name, "add");
+    }
+
+    #[test]
+    fn rejects_self_method() {
+        let err = parse(indoc! {"
+            mod math {
+                pub fn add(a: u32) -> u32 { a }
+                pub fn get(&self) -> u32 { 0 }
+            }
+        "})
+        .err()
+        .unwrap();
+        assert!(err.to_string().contains("cannot have methods"), "{err}");
+    }
+
+    #[test]
+    fn rejects_mut_self_method() {
+        let err = parse(indoc! {"
+            mod math {
+                pub fn set(&mut self, value: u32) { }
+            }
+        "})
+        .err()
+        .unwrap();
+        assert!(err.to_string().contains("cannot have methods"), "{err}");
+    }
+
+    #[test]
+    fn rejects_constructor_returning_self() {
+        let err = parse(indoc! {"
+            mod math {
+                pub fn new() -> Self { }
+            }
+        "})
+        .err()
+        .unwrap();
+        assert!(err.to_string().contains("constructor"), "{err}");
+    }
+
+    #[test]
+    fn rejects_constructor_returning_wrapped_self() {
+        // `Self` wrapped in generics, references or tuples is still a constructor and must be
+        // rejected with the macro error rather than a raw compiler error.
+        for ret in ["Result<Self, String>", "Option<Self>", "&Self", "(Self, u32)"] {
+            let src = format!("mod math {{ pub fn new() -> {ret} {{ }} }}");
+            let err = parse(&src).err().unwrap();
+            assert!(err.to_string().contains("constructor"), "{ret}: {err}");
+        }
+    }
+
+    #[test]
+    fn rejects_migration_function() {
+        let err = parse(indoc! {"
+            mod math {
+                #[migration]
+                pub fn migrate(a: u32) -> u32 { a }
+            }
+        "})
+        .err()
+        .unwrap();
+        assert!(err.to_string().contains("migration"), "{err}");
+    }
+
+    #[test]
+    fn requires_at_least_one_public_function() {
+        let err = parse(indoc! {"
+            mod math {
+                pub struct NotAComponent { x: u32 }
+            }
+        "})
+        .err()
+        .unwrap();
+        assert!(err.to_string().contains("at least one public function"), "{err}");
     }
 }

--- a/crates/template_macros/src/template/dispatcher.rs
+++ b/crates/template_macros/src/template/dispatcher.rs
@@ -99,11 +99,11 @@ fn get_function_idents(ast: &TemplateAst) -> Result<impl Iterator<Item = Functio
 
 fn get_function_blocks(ast: &TemplateAst) -> impl Iterator<Item = Expr> + '_ {
     ast.get_functions()
-        .map(|function| get_function_block(&ast.template_name, function))
+        .map(|function| get_function_block(&ast.template_name, function, ast.stateless))
 }
 
 #[allow(clippy::too_many_lines)]
-fn get_function_block(template_ident: &Ident, ast: &FunctionAst) -> Expr {
+fn get_function_block(template_ident: &Ident, ast: &FunctionAst, stateless: bool) -> Expr {
     let template_mod_name = format_ident!("{}_template", template_ident);
     let mut args: Vec<Expr> = vec![];
     let mut stmts = vec![];
@@ -198,8 +198,16 @@ fn get_function_block(template_ident: &Ident, ast: &FunctionAst) -> Expr {
 
     // call the user defined function in the template
     let function_ident = Ident::new(&ast.name, Span::call_site());
-    stmts.push(parse_quote! {
-        let rtn = #template_mod_name::#template_ident::#function_ident(#(#args),*);
+    stmts.push(if stateless {
+        // Stateless templates expose free functions directly in the generated module, so there is
+        // no component struct to qualify the call with.
+        parse_quote! {
+            let rtn = #template_mod_name::#function_ident(#(#args),*);
+        }
+    } else {
+        parse_quote! {
+            let rtn = #template_mod_name::#template_ident::#function_ident(#(#args),*);
+        }
     });
 
     if ast.is_migration {

--- a/crates/template_macros/src/template/mod.rs
+++ b/crates/template_macros/src/template/mod.rs
@@ -28,7 +28,7 @@ mod template_def;
 
 use proc_macro2::TokenStream;
 use quote::quote;
-use syn::{Result, parse2};
+use syn::{ItemMod, Result, parse2};
 
 use self::{
     ast::TemplateAst,
@@ -45,9 +45,14 @@ use self::{
 /// (no flags) is to inject `#[derive(minicbor::Encode, Decode, CborLen)]` and positional
 /// `#[n(N)]` tags onto every template struct/enum. Setting
 /// [`TemplateOptions::skip_cbor_derives`] suppresses both, leaving the author to write the
-/// derives and indices by hand.
+/// derives and indices by hand. Setting [`TemplateOptions::stateless`] declares a
+/// component-less template whose public API is a set of free `pub fn` items.
 pub fn generate_template(options: TemplateOptions, input: TokenStream) -> Result<TokenStream> {
-    let mut ast = parse2::<TemplateAst>(input)?;
+    // Parse to a module first so that AST construction can take `options` into account: the
+    // `stateless` flag changes how the module body is interpreted (free functions vs. a component
+    // struct/impl), which the `syn::Parse for TemplateAst` impl has no access to on its own.
+    let module = parse2::<ItemMod>(input)?;
+    let mut ast = TemplateAst::from_item_mod(module, options)?;
 
     if !options.skip_cbor_derives {
         ast::inject_cbor_derives(&mut ast.module_content)?;
@@ -68,4 +73,55 @@ pub fn generate_template(options: TemplateOptions, input: TokenStream) -> Result
     // eprintln!("output = {}", output);
 
     Ok(output)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use proc_macro2::TokenStream;
+
+    use super::{generate_template, options::TemplateOptions};
+
+    fn expand(src: &str, options: TemplateOptions) -> String {
+        generate_template(options, TokenStream::from_str(src).unwrap())
+            .unwrap()
+            .to_string()
+    }
+
+    #[test]
+    fn stateless_dispatches_to_free_functions() {
+        let out = expand(
+            "mod math { pub fn add(a: u32, b: u32) -> u32 { a + b } }",
+            TemplateOptions {
+                stateless: true,
+                ..Default::default()
+            },
+        );
+
+        assert!(out.contains("pub mod math_template"), "{out}");
+        assert!(out.contains("math_main"), "{out}");
+        // Free-function call path (`math_template :: add`), with no component struct qualifier.
+        assert!(out.contains("math_template :: add"), "{out}");
+        assert!(!out.contains("math_template :: math :: add"), "{out}");
+    }
+
+    #[test]
+    fn stateless_composes_with_skip_cbor_derives() {
+        let src = "mod math { pub struct Point { x: u32, y: u32 } pub fn sum(p: Point) -> u32 { p.x + p.y } }";
+
+        // With derives injected (default): the data struct gets the minicbor derives.
+        let with_derives = expand(src, TemplateOptions {
+            stateless: true,
+            ..Default::default()
+        });
+        assert!(with_derives.contains("minicbor :: Encode"), "{with_derives}");
+
+        // skip_cbor_derives suppresses the injection even in stateless mode.
+        let skipped = expand(src, TemplateOptions {
+            stateless: true,
+            skip_cbor_derives: true,
+        });
+        assert!(!skipped.contains("minicbor :: Encode"), "{skipped}");
+    }
 }

--- a/crates/template_macros/src/template/options.rs
+++ b/crates/template_macros/src/template/options.rs
@@ -9,6 +9,10 @@
 //!   injection. The template author becomes responsible for providing their own derives and `#[n(N)]` / `#[b(N)]` /
 //!   `#[cbor(n(N))]` numbering. Useful when the wire format needs to differ from the macro's default ordering (e.g.
 //!   preserving an existing on-disk format across a field reorder).
+//! - `stateless` — declare a component-less template whose public API is a set of free `pub fn` items rather than a
+//!   component with methods. No struct is interpreted as the component, the template name is taken from the module
+//!   identifier, and `&self`/`&mut self` methods, `-> Self` constructors and `#[migration]` functions are rejected.
+//!   Composes with `skip_cbor_derives` (e.g. `#[template(stateless, skip_cbor_derives)]`).
 
 use syn::{
     Error,
@@ -26,6 +30,11 @@ pub struct TemplateOptions {
     /// onto template structs/enums and will not auto-assign `#[n(N)]` tags to their fields or
     /// variants. The author retains full control over the CBOR wire format.
     pub skip_cbor_derives: bool,
+    /// When `true`, the module describes a component-less, stateless template. Its public API is
+    /// the set of free `pub fn` items in the module (no struct is treated as a component) and the
+    /// template name is the module identifier. Methods (`&self`/`&mut self`), `-> Self`
+    /// constructors and `#[migration]` functions are rejected during parsing.
+    pub stateless: bool,
 }
 
 impl Parse for TemplateOptions {
@@ -39,10 +48,14 @@ impl Parse for TemplateOptions {
         for flag in flags {
             match flag.to_string().as_str() {
                 "skip_cbor_derives" => options.skip_cbor_derives = true,
+                "stateless" => options.stateless = true,
                 other => {
                     return Err(Error::new(
                         flag.span(),
-                        format!("unknown `#[template]` option `{other}`. Supported options: `skip_cbor_derives`"),
+                        format!(
+                            "unknown `#[template]` option `{other}`. Supported options: `skip_cbor_derives`, \
+                             `stateless`"
+                        ),
                     ));
                 },
             }

--- a/crates/template_macros/src/template/template_def.rs
+++ b/crates/template_macros/src/template/template_def.rs
@@ -272,12 +272,26 @@ mod tests {
     use tari_template_abi::{TemplateDef, Type as ArgType};
 
     use super::generate_template_def;
-    use crate::template::ast::TemplateAst;
+    use crate::template::{ast::TemplateAst, options::TemplateOptions};
 
     fn parse_template_def(input: &str) -> TemplateDef {
         let tokens = TokenStream::from_str(input).unwrap();
         let ast = parse2::<TemplateAst>(tokens).unwrap();
-        let output = generate_template_def(&ast).unwrap();
+        decode_template_def(&ast)
+    }
+
+    fn parse_stateless_template_def(input: &str) -> TemplateDef {
+        let module = parse2::<syn::ItemMod>(TokenStream::from_str(input).unwrap()).unwrap();
+        let options = TemplateOptions {
+            stateless: true,
+            ..Default::default()
+        };
+        let ast = TemplateAst::from_item_mod(module, options).unwrap();
+        decode_template_def(&ast)
+    }
+
+    fn decode_template_def(ast: &TemplateAst) -> TemplateDef {
+        let output = generate_template_def(ast).unwrap();
 
         // The generated code is: pub static TEMPLATE_DEF: [u8; N] = [b0, b1, ...] ;
         // Extract the byte array after "= ["
@@ -518,5 +532,35 @@ mod tests {
 
         let funcs = get_functions(&def);
         assert_eq!(funcs[0].output, ArgType::Unit);
+    }
+
+    #[test]
+    fn test_stateless_template_def() {
+        let def = parse_stateless_template_def(indoc! {"
+            mod math {
+                pub fn add(a: u32, b: u32) -> u32 { a + b }
+                pub fn mul(a: u32, b: u32) -> u32 { a * b }
+            }
+        "});
+
+        // Template name is taken from the module identifier, not a struct.
+        let TemplateDef::V1(v1) = &def;
+        assert_eq!(v1.template_name, "math");
+
+        let funcs = get_functions(&def);
+        assert_eq!(funcs.len(), 2);
+
+        assert_eq!(funcs[0].name, "add");
+        assert_eq!(funcs[0].arguments.len(), 2);
+        assert_eq!(funcs[0].arguments[0].name, "a");
+        assert_eq!(funcs[0].arguments[0].arg_type, ArgType::U32);
+        assert_eq!(funcs[0].arguments[1].name, "b");
+        assert_eq!(funcs[0].arguments[1].arg_type, ArgType::U32);
+        assert_eq!(funcs[0].output, ArgType::U32);
+        // No component, so nothing is mutable.
+        assert!(!funcs[0].is_mut);
+
+        assert_eq!(funcs[1].name, "mul");
+        assert!(!funcs[1].is_mut);
     }
 }

--- a/docs/developer-docs/src/content/docs/guides/build-a-guessing-game.mdx
+++ b/docs/developer-docs/src/content/docs/guides/build-a-guessing-game.mdx
@@ -131,11 +131,11 @@ pub struct Guess {
 ```
 
 <Aside type="tip">
-  Putting the struct inside the `template` module (annotated with the `#[template]` attribute) automatically implements
-  the required `serde` traits. You can also put it outside the module, and add `#[derive(serde::Serialize,
-  serde::Deserialize)]`
-  to it to achieve the same effect. You would need to add the `serde` crate as a dependency in your `Cargo.toml` to do
-  that.
+  Putting the struct inside the `template` module (annotated with the `#[template]` attribute) automatically derives
+  the required CBOR encoding (`minicbor::Encode`, `minicbor::Decode` and `minicbor::CborLen`) and tags each field for
+  you. You can also put it outside the module and add `#[derive(minicbor::Encode, minicbor::Decode, minicbor::CborLen)]`
+  — tagging each field with `#[n(N)]` — to achieve the same effect. You would need to add the `minicbor` crate as a
+  dependency in your `Cargo.toml` to do that.
 </Aside>
 
 ## Implement a constructor

--- a/docs/developer-docs/src/content/docs/guides/template-overview.mdx
+++ b/docs/developer-docs/src/content/docs/guides/template-overview.mdx
@@ -14,6 +14,7 @@ In this guide, you will:
 - Learn about component instantiation.
 - Learn some basics: constructors, methods and functions.
 - Learn about error handling in templates.
+- Learn about component-less, stateless templates.
 
 <Aside type="tip">
   This guide provides a foundational understanding of Tari Ootle Templates.
@@ -99,9 +100,16 @@ The `#[template]` attribute macro performs several critical functions:
 The state of your component is defined by the fields within its `struct`. These fields are persisted on the blockchain.
 NOTE: that a component can also be an `enum`.
 
+<Aside type="note">
+  The **first** `pub struct` (or `pub enum`) declared in the module is the one treated as the component, and it also
+  gives the template its name. Any additional structs or enums you declare are ordinary data types — useful as method
+  arguments or return values — not components. (The exception is a <a href="#stateless-templates">stateless
+  template</a>, where no struct is interpreted as a component at all.)
+</Aside>
+
 **Important Considerations:**
 
--   **Serializable Types:** All fields in your component struct must be `serde` serializable and deserializable. The `tari_template_lib` provides various types (`Amount`, `ResourceAddress`, etc.) that are already compatible. For custom types, you may need to implement `serde::Serialize` and `serde::Deserialize`.
+-   **Encodable Types:** All fields in your component struct must be CBOR-encodable via [`minicbor`](https://docs.rs/minicbor). The `#[template]` macro automatically derives the encoding (`minicbor::Encode`, `minicbor::Decode`, `minicbor::CborLen`) — and assigns the per-field `#[n(N)]` tags — for every struct and enum declared in the template module, so you usually don't need to do anything. The `tari_template_lib` types (`Amount`, `ResourceAddress`, etc.) are already compatible. For custom types declared outside the module, derive those traits yourself. No `serde` is required.
 -   **Mutability:** To modify component state, methods must take `&mut self`.
 -   **Access:** Component state should generally be managed internally via methods. Access to component state from another template is possible (if the requisite transaction signatures are provided), but is generally discouraged.
 
@@ -176,6 +184,45 @@ impl MyComponent {
 -   **Private methods/functions (`fn`):** These are regular private functions used within your component's implementation. They cannot be called from outside the component.
 
 For more advanced topics like authorization, events, and testing, refer to the other guides.
+
+### Stateless templates
+
+Not every template needs a component. Some templates are just a library of pure functions — spend-time scripts, resource auth-hook helpers, validation or math utilities — with no state to persist and nothing to instantiate. For these, add the `stateless` flag to the macro:
+
+```rust
+use tari_template_lib::prelude::*;
+
+#[template(stateless)]
+mod math {
+    // The public API is the set of free `pub fn` items in the module.
+    pub fn add(a: u32, b: u32) -> u32 {
+        a + b
+    }
+
+    pub fn sum(values: Vec<u32>) -> u32 {
+        values.into_iter().sum()
+    }
+
+    // Private helpers are still allowed; they are not exposed.
+    fn helper(a: u32) -> u32 {
+        a + 1
+    }
+}
+```
+
+A stateless template differs from a regular one in a few ways:
+
+-   **No component struct.** The public API is the set of free `pub fn` items in the module — no struct is interpreted as a component, and there is no on-chain state.
+-   **The template name is the module identifier.** In the example above the template is named `math` (not a struct name). You invoke its functions with the `CallFunction` instruction, exactly like template functions on a regular template.
+-   **No component is ever created.** Calling a stateless function only returns its result; it never creates a component substate.
+-   **Restrictions are enforced at compile time.** Methods (`&self` / `&mut self`), `-> Self` constructors and `#[migration]` functions are rejected with a clear error, since none of those make sense without a component.
+
+You can still declare `struct`/`enum` types inside a stateless module to use as function arguments or return values — they are treated purely as data types and receive the usual CBOR derives. The `stateless` flag also composes with `skip_cbor_derives` (e.g. `#[template(stateless, skip_cbor_derives)]`) if you want to manage the wire format of those types yourself.
+
+<Aside type="note">
+  Stateless mode is an ergonomics and intent-enforcement feature: it lets you write pure-function templates without an
+  unused struct, and the compiler guarantees no state or component sneaks in.
+</Aside>
 
 ### Next Steps
 

--- a/docs/developer-docs/src/content/docs/guides/transaction-overview.mdx
+++ b/docs/developer-docs/src/content/docs/guides/transaction-overview.mdx
@@ -140,7 +140,7 @@ let transaction = Transaction::builder(network)
     .build_and_seal(&secret_key);
 ```
 
-Any type that implements `serde::Serialize` can be passed as an argument, including addresses, amounts, strings, structs, and more.
+Any CBOR-encodable type (one that implements `minicbor::Encode`) can be passed as an argument, including addresses, amounts, strings, structs, and more.
 
 ---
 


### PR DESCRIPTION
## What

Adds a `#[template(stateless)]` option to the template attribute macro so authors can write **component-less, stateless templates** — modules that expose only free `pub fn` items, with no component, no state and no `&self` methods.

This is an ergonomics + intent-enforcement feature for pure-function templates such as spend-time scripts, resource auth-hook libraries, and validation/math helpers.

```rust
#[template(stateless)]
mod math {
    pub fn add(a: u32, b: u32) -> u32 { a + b }
    pub fn sum(values: Vec<u32>) -> u32 { values.into_iter().sum() }
}
```

## How it works

It is **macro-only** — no ABI, engine, runtime or wire changes. The ABI already has no "component" concept (a constructor is just a function returning `Self`; a method is just a function with a `self` receiver), and the engine already invokes component-less functions via `CallFunction`.

When `stateless` is set, during parsing:
- the template name is taken from the **module identifier** (not a struct);
- functions are collected from free `pub fn` items (private `fn`s remain internal helpers);
- `&self`/`&mut self` methods, `-> Self` constructors and `#[migration]` functions are rejected with clear errors;
- struct/enum data types are still given the usual CBOR derives (composes with `skip_cbor_derives`).

The dispatcher emits a free-function call path (`mod_template::fn`) instead of the component-qualified path. The non-stateless path is left byte-identical.

## Tests

- **Macro unit tests** (parse-level + ABI + dispatcher/skip-composition): name derives from the module ident, all functions `is_mut == false`, and the rejection cases (`&self`, `-> Self`, `#[migration]`) error.
- **Dogfooded end-to-end**: `ConfidentialUtilities` — a pure-function utility template (a unit struct with no state, two free functions, no constructor) — is converted to `#[template(stateless)]`. Its existing confidential tests already invoke `take_from_bucket` / `join_buckets` via `CallFunction` in transaction manifests, so the stateless macro is exercised end-to-end against a real template. All 10 confidential tests pass.
- All pre-existing macro tests and engine template smoke tests (incl. builtin templates, hello_world, state, tuples, cross_template) pass — existing templates are unaffected.

## Other

- Bumps `tari_template_macros` `0.20.1 -> 0.20.2` (non-breaking patch).
- Developer docs: adds a "Stateless templates" section, notes that the first struct/enum in a module is the component, and corrects the guides to describe minicbor (CBOR) encoding instead of `serde`.