### PR TITLE
fix(swarm): send correct get_stdout RPC param struct from web UI

### DIFF
--- a/applications/tari_swarm_daemon/webui/src/routes/Main.tsx
+++ b/applications/tari_swarm_daemon/webui/src/routes/Main.tsx
@@ -466,12 +466,12 @@ export default function Main() {
         Object.keys(resp.nodes).map((index) => {
           jsonRpc("get_logs", { instance_type: "TariWalletDaemon", index: Number(index) })
             .then((resp) => {
-              setLogs((state: any) => ({ ...state, [`dan ${index}`]: resp }));
+              setLogs((state: any) => ({ ...state, [`wallet ${index}`]: resp }));
             })
             .catch((error) => console.log(error));
           jsonRpc("get_stdout", { instance_type: "TariWalletDaemon", index: Number(index) })
             .then((resp) => {
-              setStdoutLogs((state: any) => ({ ...state, [`dan ${index}`]: resp }));
+              setStdoutLogs((state: any) => ({ ...state, [`wallet ${index}`]: resp }));
             })
             .catch((error) => console.log(error));
         });

--- a/applications/tari_swarm_daemon/webui/src/routes/Main.tsx
+++ b/applications/tari_swarm_daemon/webui/src/routes/Main.tsx
@@ -450,7 +450,7 @@ export default function Main() {
               setLogs((state: any) => ({ ...state, [`vn ${index}`]: resp }));
             })
             .catch((error) => console.log(error));
-          jsonRpc("get_stdout", `vn ${index}`)
+          jsonRpc("get_stdout", { instance_type: "TariValidatorNode", index: Number(index) })
             .then((resp) => {
               setStdoutLogs((state: any) => ({ ...state, [`vn ${index}`]: resp }));
             })
@@ -469,7 +469,7 @@ export default function Main() {
               setLogs((state: any) => ({ ...state, [`dan ${index}`]: resp }));
             })
             .catch((error) => console.log(error));
-          jsonRpc("get_stdout", `dan ${index}`)
+          jsonRpc("get_stdout", { instance_type: "TariWalletDaemon", index: Number(index) })
             .then((resp) => {
               setStdoutLogs((state: any) => ({ ...state, [`dan ${index}`]: resp }));
             })
@@ -488,7 +488,7 @@ export default function Main() {
               setLogs((state: any) => ({ ...state, [`indexer ${index}`]: resp }));
             })
             .catch((error) => console.log(error));
-          jsonRpc("get_stdout", `indexer ${index}`)
+          jsonRpc("get_stdout", { instance_type: "TariIndexer", index: Number(index) })
             .then((resp) => {
               setStdoutLogs((state: any) => ({ ...state, [`indexer ${index}`]: resp }));
             })


### PR DESCRIPTION
## Description

The swarm daemon web UI was passing a bare string to `get_stdout` for the validator node, wallet daemon, and indexer instances (e.g. `"vn 0"`, `"dan 0"`, `"indexer 0"`). The server handler deserializes params into `ListLogFilesRequest` (`{ instance_type, index }`), so these calls produced server-side errors:

```
WARN 🌐 JSON-RPC params error: Invalid params: invalid type: string "indexer 0", expected struct ListLogFilesRequest
```

## Motivation

The stdout log panel was silently broken for VN, wallet daemon, and indexer instances. The `MinoTari*` `get_stdout` calls already used the correct struct shape; this aligns the remaining three.

## Changes

- `get_stdout` for validator node: `"vn ${index}"` → `{ instance_type: "TariValidatorNode", index: Number(index) }`
- `get_stdout` for wallet daemon: `"dan ${index}"` → `{ instance_type: "TariWalletDaemon", index: Number(index) }`
- `get_stdout` for indexer: `"indexer ${index}"` → `{ instance_type: "TariIndexer", index: Number(index) }`

Variant names verified against the `InstanceType` enum in `applications/tari_swarm_daemon/src/config.rs`.