### PR TITLE
fix(transaction): price inline literal args into weight + add max transaction weight mempool guard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1725,7 +1725,7 @@ dependencies = [
 
 [[package]]
 name = "consensus_tests"
-version = "0.34.1"
+version = "0.34.2"
 dependencies = [
  "fern",
  "futures 0.3.31",
@@ -2735,7 +2735,7 @@ dependencies = [
 
 [[package]]
 name = "db-inspector"
-version = "0.34.1"
+version = "0.34.2"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -5090,7 +5090,7 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "integration_tests"
-version = "0.34.1"
+version = "0.34.2"
 dependencies = [
  "anyhow",
  "config",
@@ -5858,7 +5858,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-messaging"
-version = "0.34.1"
+version = "0.34.2"
 dependencies = [
  "async-trait",
  "futures-bounded 0.2.4",
@@ -6036,7 +6036,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-substream"
-version = "0.34.1"
+version = "0.34.2"
 dependencies = [
  "libp2p",
  "prometheus-client",
@@ -7690,7 +7690,7 @@ dependencies = [
 
 [[package]]
 name = "ootle-wasm"
-version = "0.34.1"
+version = "0.34.2"
 dependencies = [
  "console_error_panic_hook",
  "getrandom 0.2.17",
@@ -7701,7 +7701,7 @@ dependencies = [
 
 [[package]]
 name = "ootle-wasm-core"
-version = "0.34.1"
+version = "0.34.2"
 dependencies = [
  "base64 0.22.1",
  "hex",
@@ -8745,7 +8745,7 @@ dependencies = [
 
 [[package]]
 name = "proto_builder"
-version = "0.34.1"
+version = "0.34.2"
 dependencies = [
  "prost-build 0.14.3",
  "sha2 0.10.9",
@@ -10610,7 +10610,7 @@ dependencies = [
 
 [[package]]
 name = "sqlite_message_logger"
-version = "0.34.1"
+version = "0.34.2"
 dependencies = [
  "chrono",
  "diesel",
@@ -10982,7 +10982,7 @@ dependencies = [
 
 [[package]]
 name = "tari_base_node_client"
-version = "0.34.1"
+version = "0.34.2"
 dependencies = [
  "futures-util",
  "log",
@@ -11214,7 +11214,7 @@ dependencies = [
 
 [[package]]
 name = "tari_consensus"
-version = "0.34.1"
+version = "0.34.2"
 dependencies = [
  "anyhow",
  "indexmap 2.13.0",
@@ -11239,7 +11239,7 @@ dependencies = [
 
 [[package]]
 name = "tari_consensus_types"
-version = "0.34.1"
+version = "0.34.2"
 dependencies = [
  "borsh",
  "minicbor",
@@ -11342,7 +11342,7 @@ dependencies = [
 
 [[package]]
 name = "tari_engine"
-version = "0.34.1"
+version = "0.34.2"
 dependencies = [
  "blake2 0.10.6",
  "bytes",
@@ -11374,7 +11374,7 @@ dependencies = [
 
 [[package]]
 name = "tari_engine_types"
-version = "0.34.1"
+version = "0.34.2"
 dependencies = [
  "blake2 0.10.6",
  "borsh",
@@ -11403,7 +11403,7 @@ dependencies = [
 
 [[package]]
 name = "tari_epoch_manager"
-version = "0.34.1"
+version = "0.34.2"
 dependencies = [
  "anyhow",
  "log",
@@ -11423,7 +11423,7 @@ dependencies = [
 
 [[package]]
 name = "tari_epoch_oracles"
-version = "0.34.1"
+version = "0.34.2"
 dependencies = [
  "anyhow",
  "blake2 0.10.6",
@@ -11469,7 +11469,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer"
-version = "0.34.1"
+version = "0.34.2"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -11572,7 +11572,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer_lib"
-version = "0.34.1"
+version = "0.34.2"
 dependencies = [
  "async-trait",
  "log",
@@ -11670,7 +11670,7 @@ dependencies = [
 
 [[package]]
 name = "tari_networking"
-version = "0.34.1"
+version = "0.34.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11724,7 +11724,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_app_utilities"
-version = "0.34.1"
+version = "0.34.2"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -11765,7 +11765,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_common_types"
-version = "0.34.1"
+version = "0.34.2"
 dependencies = [
  "blake2 0.10.6",
  "borsh",
@@ -11794,7 +11794,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_p2p"
-version = "0.34.1"
+version = "0.34.2"
 dependencies = [
  "anyhow",
  "libp2p-identity 0.2.14",
@@ -11818,7 +11818,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_storage"
-version = "0.34.1"
+version = "0.34.2"
 dependencies = [
  "anyhow",
  "bitflags 2.13.0",
@@ -11847,7 +11847,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_storage_sqlite"
-version = "0.34.1"
+version = "0.34.2"
 dependencies = [
  "diesel",
  "diesel_migrations",
@@ -11900,7 +11900,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_transaction"
-version = "0.34.1"
+version = "0.34.2"
 dependencies = [
  "borsh",
  "hex",
@@ -11926,7 +11926,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_cli"
-version = "0.34.1"
+version = "0.34.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -12048,7 +12048,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_sdk_tests"
-version = "0.34.1"
+version = "0.34.2"
 dependencies = [
  "digest 0.10.7",
  "ootle_byte_type",
@@ -12094,7 +12094,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_walletd"
-version = "0.34.1"
+version = "0.34.2"
 dependencies = [
  "anyhow",
  "apple-native-keyring-store",
@@ -12220,7 +12220,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_framework"
-version = "0.34.1"
+version = "0.34.2"
 dependencies = [
  "async-trait",
  "bitflags 2.13.0",
@@ -12244,7 +12244,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_macros"
-version = "0.34.1"
+version = "0.34.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12253,7 +12253,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_state_sync"
-version = "0.34.1"
+version = "0.34.2"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -12335,7 +12335,7 @@ dependencies = [
 
 [[package]]
 name = "tari_state_store_rocksdb"
-version = "0.34.1"
+version = "0.34.2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12367,7 +12367,7 @@ dependencies = [
 
 [[package]]
 name = "tari_state_tree"
-version = "0.34.1"
+version = "0.34.2"
 dependencies = [
  "indexmap 2.13.0",
  "log",
@@ -12396,7 +12396,7 @@ dependencies = [
 
 [[package]]
 name = "tari_swarm"
-version = "0.34.1"
+version = "0.34.2"
 dependencies = [
  "libp2p",
  "libp2p-messaging",
@@ -12408,7 +12408,7 @@ dependencies = [
 
 [[package]]
 name = "tari_swarm_daemon"
-version = "0.34.1"
+version = "0.34.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12521,7 +12521,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_test_tooling"
-version = "0.34.1"
+version = "0.34.2"
 dependencies = [
  "anyhow",
  "cargo_toml 0.22.3",
@@ -12637,7 +12637,7 @@ dependencies = [
 
 [[package]]
 name = "tari_transaction_manifest"
-version = "0.34.1"
+version = "0.34.2"
 dependencies = [
  "proc-macro2",
  "serde_json",
@@ -12672,7 +12672,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node"
-version = "0.34.1"
+version = "0.34.2"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -12737,7 +12737,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node_client"
-version = "0.34.1"
+version = "0.34.2"
 dependencies = [
  "indexmap 2.13.0",
  "multiaddr 0.18.3",
@@ -12761,7 +12761,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node_rpc"
-version = "0.34.1"
+version = "0.34.2"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -12785,7 +12785,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_rollback"
-version = "0.34.1"
+version = "0.34.2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12820,7 +12820,7 @@ dependencies = [
 
 [[package]]
 name = "tari_watcher"
-version = "0.34.1"
+version = "0.34.2"
 dependencies = [
  "anyhow",
  "clap 3.2.25",
@@ -12849,7 +12849,7 @@ dependencies = [
 
 [[package]]
 name = "tariswap_bench"
-version = "0.34.1"
+version = "0.34.2"
 dependencies = [
  "anyhow",
  "clap 4.5.54",
@@ -13541,7 +13541,7 @@ dependencies = [
 
 [[package]]
 name = "traffic-sim"
-version = "0.34.1"
+version = "0.34.2"
 dependencies = [
  "anyhow",
  "clap 4.5.54",
@@ -13563,7 +13563,7 @@ dependencies = [
 
 [[package]]
 name = "transaction_generator"
-version = "0.34.1"
+version = "0.34.2"
 dependencies = [
  "anyhow",
  "bytes",
@@ -13584,7 +13584,7 @@ dependencies = [
 
 [[package]]
 name = "transaction_submitter"
-version = "0.34.1"
+version = "0.34.2"
 dependencies = [
  "anyhow",
  "clap 4.5.54",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.34.1"
+version = "0.34.2"
 edition = "2024"
 authors = ["The Tari Development Community"]
 repository = "https://github.com/tari-project/tari-ootle"

--- a/applications/tari_validator_node/src/bootstrap.rs
+++ b/applications/tari_validator_node/src/bootstrap.rs
@@ -113,6 +113,7 @@ use crate::{
         TransactionNetworkValidator,
         TransactionSignatureValidator,
         TransactionValidationError,
+        TransactionWeightValidator,
         WithContext,
     },
     validator::Validator,
@@ -473,9 +474,12 @@ pub fn create_mempool_transaction_validator<TProvider: TemplateProvider>(
     network: Network,
     template_manager: TProvider,
 ) -> impl Validator<Transaction, Context = (), Error = TransactionValidationError> {
+    let max_transaction_weight = ConsensusConstants::from(network).max_transaction_weight;
     TransactionNetworkValidator::new(network)
         .and_then(TransactionDryRunValidator)
         .and_then(BasicValidations::new())
+        // Cheap structural check — reject over-weight transactions before verifying signatures.
+        .and_then(TransactionWeightValidator::new(max_transaction_weight))
         .and_then(TransactionSignatureValidator)
         .and_then(TemplateExistsValidator::new(template_manager))
 }

--- a/applications/tari_validator_node/src/transaction_validators/error.rs
+++ b/applications/tari_validator_node/src/transaction_validators/error.rs
@@ -48,4 +48,10 @@ pub enum TransactionValidationError {
     ContainsPayFeeInstruction { transaction_id: TransactionId },
     #[error("Dry run transactions are not allowed")]
     DryRunNotAllowed,
+    #[error("Transaction {transaction_id} weight {weight} exceeds the maximum allowed weight {max_weight}")]
+    TransactionExceedsMaxWeight {
+        transaction_id: TransactionId,
+        weight: u64,
+        max_weight: u64,
+    },
 }

--- a/applications/tari_validator_node/src/transaction_validators/mod.rs
+++ b/applications/tari_validator_node/src/transaction_validators/mod.rs
@@ -6,6 +6,7 @@ mod epoch_range;
 mod network;
 mod signature;
 mod template_exists;
+mod weight;
 
 mod dry_run;
 
@@ -15,6 +16,7 @@ pub use epoch_range::*;
 pub use network::*;
 pub use signature::*;
 pub use template_exists::*;
+pub use weight::*;
 
 mod error;
 mod with_context;

--- a/applications/tari_validator_node/src/transaction_validators/weight.rs
+++ b/applications/tari_validator_node/src/transaction_validators/weight.rs
@@ -1,0 +1,120 @@
+// Copyright 2025 The Tari Project
+// SPDX-License-Identifier: BSD-3-Clause
+
+use log::warn;
+use tari_ootle_transaction::Transaction;
+
+use crate::{transaction_validators::TransactionValidationError, validator::Validator};
+
+const LOG_TARGET: &str = "tari::ootle::mempool::validators::weight";
+
+/// Rejects transactions whose [`Transaction::calculate_transaction_weight`] exceeds `max_weight`.
+///
+/// This bounds the size/IO/execution cost of a single transaction at ingress, before it is gossiped,
+/// stored and executed, so one transaction cannot carry a disproportionate payload (e.g. multi-MiB
+/// inline arguments or a flood of cheap instructions) into the network. `max_weight` comes from
+/// `ConsensusConstants::max_transaction_weight` and is set above the heaviest legitimate transaction
+/// (a max-size template publish) so honest transactions are never rejected.
+#[derive(Debug, Clone)]
+pub struct TransactionWeightValidator {
+    max_weight: u64,
+}
+
+impl TransactionWeightValidator {
+    pub fn new(max_weight: u64) -> Self {
+        Self { max_weight }
+    }
+}
+
+impl Validator<Transaction> for TransactionWeightValidator {
+    type Context = ();
+    type Error = TransactionValidationError;
+
+    fn validate(&self, _context: &(), transaction: &Transaction) -> Result<(), Self::Error> {
+        let weight = transaction.calculate_transaction_weight().as_u64();
+        if weight > self.max_weight {
+            let transaction_id = transaction.calculate_id();
+            warn!(
+                target: LOG_TARGET,
+                "TransactionWeightValidator - FAIL: {transaction_id} weight {weight} exceeds maximum {}",
+                self.max_weight
+            );
+            return Err(TransactionValidationError::TransactionExceedsMaxWeight {
+                transaction_id,
+                weight,
+                max_weight: self.max_weight,
+            });
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use indexmap::IndexSet;
+    use tari_ootle_transaction::{
+        Instruction,
+        Network,
+        Transaction,
+        TransactionSealSignature,
+        TransactionSignature,
+        UnsealedTransactionV1,
+        UnsignedTransactionV1,
+        args::InstructionArg,
+    };
+    use tari_template_lib::types::{
+        FunctionName,
+        TemplateAddress,
+        crypto::{RistrettoPublicKeyBytes, SchnorrSignatureBytes},
+    };
+
+    use super::*;
+
+    fn tx_with_literal_arg(arg_len: usize) -> Transaction {
+        let instructions = vec![Instruction::CallFunction {
+            address: TemplateAddress::from_array([0; 32]),
+            function: FunctionName::try_from("f").unwrap(),
+            args: vec![InstructionArg::raw_literal_bytes(vec![0u8; arg_len])],
+        }];
+        Transaction::new(
+            UnsealedTransactionV1::new(
+                UnsignedTransactionV1::new(
+                    Network::LocalNet.as_byte(),
+                    vec![],
+                    instructions,
+                    IndexSet::new(),
+                    None,
+                    None,
+                    false,
+                ),
+                vec![TransactionSignature::new(
+                    RistrettoPublicKeyBytes::zero(),
+                    SchnorrSignatureBytes::zero(),
+                )],
+            )
+            .into(),
+            TransactionSealSignature::new(RistrettoPublicKeyBytes::zero(), SchnorrSignatureBytes::zero()),
+        )
+    }
+
+    #[test]
+    fn accepts_transaction_within_weight_limit() {
+        let validator = TransactionWeightValidator::new(1000);
+        // A small literal arg keeps the weight well under the limit.
+        let tx = tx_with_literal_arg(30);
+        assert!(validator.validate(&(), &tx).is_ok());
+    }
+
+    #[test]
+    fn rejects_transaction_exceeding_weight_limit() {
+        let validator = TransactionWeightValidator::new(1000);
+        // A large inline literal argument pushes the weight past the limit.
+        let tx = tx_with_literal_arg(6000);
+        let err = validator.validate(&(), &tx).unwrap_err();
+        assert!(matches!(err, TransactionValidationError::TransactionExceedsMaxWeight {
+            max_weight: 1000,
+            ..
+        }));
+    }
+}

--- a/crates/consensus/src/consensus_constants.rs
+++ b/crates/consensus/src/consensus_constants.rs
@@ -64,6 +64,14 @@ pub struct ConsensusConstants {
     /// Set above `max_block_weight` so honest proposals are never rejected. CONSENSUS RULE: must be
     /// uniform network-wide, otherwise nodes diverge on block validity.
     pub max_block_validation_weight: u64,
+    /// The maximum weight (see `Transaction::calculate_transaction_weight`) a single transaction may
+    /// have to be admitted. Unlike the block-level budgets this bounds an *individual* transaction,
+    /// stopping one transaction from carrying a disproportionate amount of size/IO/execution work
+    /// (e.g. multi-MiB inline arguments or a flood of cheap instructions) into the network before it
+    /// is gossiped, stored and executed. Must sit above the heaviest legitimate transaction — a
+    /// max-size template publish (`limits::ENGINE_LIMITS.max_template_binary_size_bytes`) — so honest
+    /// transactions are never rejected. Enforced at RPC submit / mempool admission, not in consensus.
+    pub max_transaction_weight: u64,
     /// The maximum total WASM metering points a leader will pack into a single block, summed from each
     /// transaction's actual metered execution (`ExecuteResult::wasm_execution_points`). Transaction weight is
     /// size/IO-based and blind to execution cost, so a low-weight compute-heavy transaction evades the weight
@@ -114,6 +122,10 @@ impl ConsensusConstants {
             // full validation-weight block projects to ~5.5s of execution on 2-core hardware — well
             // within the 10s block time. Rejects the ~31k-weight/500-command overload that broke things.
             max_block_validation_weight: 15_000,
+            // Admits the heaviest legitimate transaction — a 1.5 MiB template publish is ~524k weight
+            // (binary bytes / 3) — with ~2x headroom, while bounding any single transaction's
+            // size/execution cost at ingress. A mempool admission bound, not a consensus rule.
+            max_transaction_weight: 1_000_000,
             // ~45 max-compute transactions (100M points each, ~33ms on ~3GHz x86) — ~1.5s of serial WASM
             // execution with ~3x headroom for slower validator hardware. Provisional pending re-measurement
             // of the metering costs on x86-class hardware.
@@ -149,6 +161,10 @@ impl ConsensusConstants {
             // full validation-weight block projects to ~5.5s of execution on 2-core hardware — well
             // within the 10s block time. Rejects the ~31k-weight/500-command overload that broke things.
             max_block_validation_weight: 15_000,
+            // Admits the heaviest legitimate transaction — a 1.5 MiB template publish is ~524k weight
+            // (binary bytes / 3) — with ~2x headroom, while bounding any single transaction's
+            // size/execution cost at ingress. A mempool admission bound, not a consensus rule.
+            max_transaction_weight: 1_000_000,
             // ~45 max-compute transactions (100M points each, ~33ms on ~3GHz x86) — ~1.5s of serial WASM
             // execution with ~3x headroom for slower validator hardware. Provisional pending re-measurement
             // of the metering costs on x86-class hardware.
@@ -184,6 +200,10 @@ impl ConsensusConstants {
             // full validation-weight block projects to ~5.5s of execution on 2-core hardware — well
             // within the 10s block time. Rejects the ~31k-weight/500-command overload that broke things.
             max_block_validation_weight: 15_000,
+            // Admits the heaviest legitimate transaction — a 1.5 MiB template publish is ~524k weight
+            // (binary bytes / 3) — with ~2x headroom, while bounding any single transaction's
+            // size/execution cost at ingress. A mempool admission bound, not a consensus rule.
+            max_transaction_weight: 1_000_000,
             // ~45 max-compute transactions (100M points each, ~33ms on ~3GHz x86) — ~1.5s of serial WASM
             // execution with ~3x headroom for slower validator hardware. Provisional pending re-measurement
             // of the metering costs on x86-class hardware.
@@ -219,6 +239,10 @@ impl ConsensusConstants {
             // full validation-weight block projects to ~5.5s of execution on 2-core hardware — well
             // within the 10s block time. Rejects the ~31k-weight/500-command overload that broke things.
             max_block_validation_weight: 15_000,
+            // Admits the heaviest legitimate transaction — a 1.5 MiB template publish is ~524k weight
+            // (binary bytes / 3) — with ~2x headroom, while bounding any single transaction's
+            // size/execution cost at ingress. A mempool admission bound, not a consensus rule.
+            max_transaction_weight: 1_000_000,
             // ~45 max-compute transactions (100M points each, ~33ms on ~3GHz x86) — ~1.5s of serial WASM
             // execution with ~3x headroom for slower validator hardware. Provisional pending re-measurement
             // of the metering costs on x86-class hardware.
@@ -251,7 +275,7 @@ impl From<Network> for ConsensusConstants {
 
 #[cfg(test)]
 mod tests {
-    use tari_engine_types::limits::MAX_WASM_POINTS_PER_TRANSACTION;
+    use tari_engine_types::limits::{ENGINE_LIMITS, MAX_WASM_POINTS_PER_TRANSACTION};
 
     use super::*;
 
@@ -269,6 +293,27 @@ mod tests {
             assert!(
                 constants.max_block_validation_wasm_points >=
                     constants.max_block_wasm_points + MAX_WASM_POINTS_PER_TRANSACTION
+            );
+        }
+    }
+
+    #[test]
+    fn max_transaction_weight_admits_max_template_publish() {
+        // A max-size template publish carries the binary as a blob, weighing roughly
+        // (binary bytes / 3) (see `calc_blobs_weight`). The per-transaction cap must stay above this
+        // so honest template publishes are never rejected at ingress.
+        let max_template_publish_weight = ENGINE_LIMITS.max_template_binary_size_bytes as u64 / 3;
+        for constants in [
+            ConsensusConstants::mainnet(),
+            ConsensusConstants::devnet(7),
+            ConsensusConstants::esmeralda(),
+            ConsensusConstants::testnet(),
+        ] {
+            assert!(
+                constants.max_transaction_weight > max_template_publish_weight,
+                "max_transaction_weight ({}) must exceed a max-size template publish (~{})",
+                constants.max_transaction_weight,
+                max_template_publish_weight,
             );
         }
     }

--- a/crates/consensus_tests/src/support/harness.rs
+++ b/crates/consensus_tests/src/support/harness.rs
@@ -674,6 +674,8 @@ impl TestBuilder {
                     // Effectively disable the validation-time weight cap by default; tests that exercise
                     // it set a low value explicitly.
                     max_block_validation_weight: u64::MAX,
+                    // Per-transaction mempool weight cap; effectively unbounded in tests.
+                    max_transaction_weight: u64::MAX,
                     // Network-default wasm budgets. Fabricated executions consume
                     // TEST_WASM_EXECUTION_POINTS each, sized so normal test transactions can never
                     // hit the budget (asserted in `start`). Tests exercising excessive computation

--- a/crates/transaction/src/v1/transaction.rs
+++ b/crates/transaction/src/v1/transaction.rs
@@ -290,17 +290,29 @@ fn calc_args_weight(args: &[InstructionArg]) -> u64 {
     // Workspace and blob refs are cheap — just an index. Blob payloads are charged at the
     // transaction level by `calc_blobs_weight`, so we don't double-count them here.
     const NON_LITERAL_WEIGHT: u64 = 1;
-    // Inline literal args carry their bytes directly in the instruction, so price them by size
-    // (consistent with blob/log byte costing) with a floor so any non-empty arg costs at least as
-    // much as a cheap ref.
+    // Inline literal args carry their bytes directly in the instruction, so price them by size,
+    // consistent with blob/log byte costing.
     const LITERAL_BYTE_DIVISOR: u64 = 3;
-    args.iter()
-        .map(|a| {
-            a.as_literal_bytes().map_or(NON_LITERAL_WEIGHT, |b| {
-                (b.len() as u64 / LITERAL_BYTE_DIVISOR).max(NON_LITERAL_WEIGHT)
-            })
-        })
-        .sum()
+
+    // Accumulate the raw literal bytes and apply the divisor once across the whole instruction.
+    // Dividing per-argument would let a large literal be split into many small ones so each share
+    // rounds down, evading the weight (and hence the fee). Each literal still costs at least
+    // `NON_LITERAL_WEIGHT`, so a flood of tiny args can never be cheaper than the same bytes in one.
+    let mut total_literal_bytes = 0u64;
+    let mut num_literals = 0u64;
+    let mut num_non_literals = 0u64;
+    for arg in args {
+        match arg.as_literal_bytes() {
+            Some(bytes) => {
+                total_literal_bytes += bytes.len() as u64;
+                num_literals += 1;
+            },
+            None => num_non_literals += 1,
+        }
+    }
+
+    let literal_weight = (total_literal_bytes / LITERAL_BYTE_DIVISOR).max(num_literals * NON_LITERAL_WEIGHT);
+    literal_weight + num_non_literals * NON_LITERAL_WEIGHT
 }
 
 /// Per-blob byte weight. Each blob's payload contributes its bytes (divided by the binary
@@ -445,6 +457,26 @@ mod blob_validation_tests {
         assert!(
             large.calculate_transaction_weight() > small.calculate_transaction_weight(),
             "larger literal argument payload must produce larger transaction weight",
+        );
+    }
+
+    #[test]
+    fn splitting_literal_args_does_not_reduce_weight() {
+        // A payload split across many small literal args must not weigh less than the same bytes in
+        // a single arg — otherwise an attacker could chunk a literal to round each share down and
+        // evade weight/fee pricing.
+        const TOTAL: usize = 3000;
+        const CHUNK: usize = 5;
+        let single = build_with_blobs(vec![], vec![call_function(vec![InstructionArg::raw_literal_bytes(
+            vec![0u8; TOTAL],
+        )])]);
+        let split_args = (0..TOTAL / CHUNK)
+            .map(|_| InstructionArg::raw_literal_bytes(vec![0u8; CHUNK]))
+            .collect();
+        let split = build_with_blobs(vec![], vec![call_function(split_args)]);
+        assert!(
+            split.calculate_transaction_weight() >= single.calculate_transaction_weight(),
+            "splitting a literal arg into smaller chunks must not reduce transaction weight",
         );
     }
 

--- a/crates/transaction/src/v1/transaction.rs
+++ b/crates/transaction/src/v1/transaction.rs
@@ -287,13 +287,18 @@ fn calc_stealth_statement_weight(statement: &StealthTransferStatement) -> u64 {
 }
 
 fn calc_args_weight(args: &[InstructionArg]) -> u64 {
-    const NON_LITERAL_WEIGHT: u64 = 1; // Default weight for workspace and blob refs (cheap, just an index)
-    // Blob payloads are charged at the transaction level by `calc_blobs_weight`, so we don't
-    // double-count them here.
+    // Workspace and blob refs are cheap — just an index. Blob payloads are charged at the
+    // transaction level by `calc_blobs_weight`, so we don't double-count them here.
+    const NON_LITERAL_WEIGHT: u64 = 1;
+    // Inline literal args carry their bytes directly in the instruction, so price them by size
+    // (consistent with blob/log byte costing) with a floor so any non-empty arg costs at least as
+    // much as a cheap ref.
+    const LITERAL_BYTE_DIVISOR: u64 = 3;
     args.iter()
         .map(|a| {
-            a.as_literal_bytes()
-                .map_or(NON_LITERAL_WEIGHT, |b| b.len().min(1) as u64)
+            a.as_literal_bytes().map_or(NON_LITERAL_WEIGHT, |b| {
+                (b.len() as u64 / LITERAL_BYTE_DIVISOR).max(NON_LITERAL_WEIGHT)
+            })
         })
         .sum()
 }
@@ -423,6 +428,23 @@ mod blob_validation_tests {
         assert!(
             large.calculate_transaction_weight() > small.calculate_transaction_weight(),
             "larger blob payload must produce larger transaction weight",
+        );
+    }
+
+    #[test]
+    fn literal_arg_size_contributes_to_transaction_weight() {
+        // Same instruction shape, differing only in the byte size of an inline literal argument →
+        // the larger argument must produce a larger weight. Guards against under-pricing inline
+        // args, which would otherwise let multi-KiB payloads ride along at near-zero weight/fee.
+        let small = build_with_blobs(vec![], vec![call_function(vec![InstructionArg::raw_literal_bytes(
+            vec![0u8; 30],
+        )])]);
+        let large = build_with_blobs(vec![], vec![call_function(vec![InstructionArg::raw_literal_bytes(
+            vec![0u8; 3000],
+        )])]);
+        assert!(
+            large.calculate_transaction_weight() > small.calculate_transaction_weight(),
+            "larger literal argument payload must produce larger transaction weight",
         );
     }
 


### PR DESCRIPTION
## Summary

Closes a transaction-weight under-pricing gap and adds a per-transaction weight bound at mempool ingress.

- **Weight pricing fix.** `calc_args_weight` capped each inline literal argument's weight contribution at `1` (`b.len().min(1)`), so a multi-MiB `InstructionArg::Literal` cost essentially nothing in transaction weight or fees. Inline literals are now priced by size (`len / 3`, floored at 1), consistent with how blobs and log messages are already costed.
- **Per-transaction weight cap.** Adds `ConsensusConstants::max_transaction_weight` (`1_000_000`) and a `TransactionWeightValidator` wired into the mempool validation chain (before signature verification). It rejects transactions whose `calculate_transaction_weight()` exceeds the cap, before they are gossiped, stored, or executed. The cap sits above the heaviest legitimate transaction — a max-size (1.5 MiB) template publish is ~524k weight — so honest transactions are never rejected.

## Why

Previously, large inline literal arguments were not meaningfully priced and no per-transaction weight/size gate existed at mempool admission. A low-cost transaction could therefore carry multi-MiB payloads (or a flood of cheap instructions) that get propagated and executed across a committee.

## Tests

- `literal_arg_size_contributes_to_transaction_weight` (added; red → green)
- `max_transaction_weight_admits_max_template_publish` invariant (guards the cap against future regressions below template-publish needs)
- `TransactionWeightValidator` accept/reject unit tests
- Existing transaction (43) and validator-node validator (7) tests pass

## Versioning

Non-breaking patch: workspace `0.34.1 → 0.34.2` (tier-3 core cohort; caret pins auto-pick-up).

## Follow-up

The mempool validators live in the `tari_validator_node` binary crate, so the indexer (which today only verifies signatures before fanning out to committees) can't reuse them. A follow-up will extract them into a shared library crate and have the indexer run the structural validations (network/basic/weight/signature) before forwarding. Tracked separately.