### PR TITLE
fix(ci): restore --no-git-checks on npm publish + keep frozen install pristine

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,15 +84,28 @@ jobs:
           node-version-file: .nvmrc
           cache: 'pnpm'
 
+      - name: install workspace dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Guard: a frozen install must not mutate tracked files. pnpm 11 appends an
+      # `allowBuilds:` scaffold to pnpm-workspace.yaml for any build-script dependency
+      # that lacks an explicit allow/deny, which silently dirties the working tree and
+      # made `pnpm publish` abort on release with ERR_PNPM_GIT_UNCLEAN. The release
+      # workflow only runs on a tag push, so this fails loudly in PR CI instead. To fix
+      # a failure here, declare the new dependency in pnpm-workspace.yaml (allowBuilds).
+      - name: assert frozen install left the tree clean
+        run: |
+          if ! git diff --exit-code; then
+            echo "::error::pnpm install modified tracked files (diff above) — declare new build-script deps in pnpm-workspace.yaml (allowBuilds)."
+            exit 1
+          fi
+
       # Builds every workspace web UI (walletd, indexer, validator node, db_inspector)
       # together with the bindings/clients they depend on, in topological order.
       # Ignored dependency build scripts (esbuild/@swc/core/@parcel/watcher) ship
-      # prebuilt binaries and aren't needed to compile the UIs; strictDepBuilds: false
-      # in pnpm-workspace.yaml keeps this frozen install green.
+      # prebuilt binaries and aren't needed to compile the UIs.
       - name: build workspace web UIs
-        run: |
-          pnpm install --frozen-lockfile
-          pnpm --recursive run build
+        run: pnpm --recursive run build
 
       # The swarm daemon web UI is a standalone npm project, not part of the pnpm workspace.
       - name: build swarm daemon web UI

--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -62,7 +62,12 @@ jobs:
           fi
 
           echo "== Publishing =="
-          pnpm publish --provenance
+          # --no-git-checks: this workflow runs on a release tag push, so the
+          # checkout lands on a detached HEAD that is not the configured
+          # publish-branch (development). pnpm's git checks (clean tree, on
+          # publish-branch, remote up to date) guard interactive publishes from
+          # a workstation, not an automated tag release, so disable them here.
+          pnpm publish --provenance --no-git-checks
 
   # Publish the Tari Wallet Daemon client to the NPM registry
   publish-wallet-daemon-client:
@@ -116,7 +121,12 @@ jobs:
           fi
 
           echo "== Publishing =="
-          pnpm publish --provenance
+          # --no-git-checks: this workflow runs on a release tag push, so the
+          # checkout lands on a detached HEAD that is not the configured
+          # publish-branch (development). pnpm's git checks (clean tree, on
+          # publish-branch, remote up to date) guard interactive publishes from
+          # a workstation, not an automated tag release, so disable them here.
+          pnpm publish --provenance --no-git-checks
 
   # Publish the Tari Indexer client to the NPM registry
   publish-indexer-client:
@@ -170,4 +180,9 @@ jobs:
           fi
 
           echo "== Publishing =="
-          pnpm publish --provenance
+          # --no-git-checks: this workflow runs on a release tag push, so the
+          # checkout lands on a detached HEAD that is not the configured
+          # publish-branch (development). pnpm's git checks (clean tree, on
+          # publish-branch, remote up to date) guard interactive publishes from
+          # a workstation, not an automated tag release, so disable them here.
+          pnpm publish --provenance --no-git-checks

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -32,4 +32,14 @@ ignoredBuiltDependencies:
 # green across CI and publish jobs without per-command --ignore-scripts workarounds.
 strictDepBuilds: false
 
+# Record an explicit allow/deny for every build-script dependency. Without this,
+# pnpm 11 treats them as "undecided" and appends an `allowBuilds:` scaffold to this
+# file on every `pnpm install` (even with --frozen-lockfile), which dirties the
+# working tree and made `pnpm publish` abort with ERR_PNPM_GIT_UNCLEAN. false = do
+# not run their build scripts (they ship prebuilt binaries).
+allowBuilds:
+  '@parcel/watcher': false
+  '@swc/core': false
+  esbuild: false
+
 publishBranch: development


### PR DESCRIPTION
## Summary

The `Publish Packages to npmjs` workflow fails on the release tag push with `ERR_PNPM_GIT_UNCLEAN` ([failing run](https://github.com/tari-project/tari-ootle/actions/runs/27692548577/job/81907108228)). Two independent regressions combine:

1. **`--no-git-checks` was dropped.** #2085 deliberately added `--no-git-checks` (+ a comment) to all three `pnpm publish` steps so releases can publish from a detached HEAD. #2074 (`ci(docker): simplify docker build pipeline`) silently removed it while rewriting `npm_publish.yml`. The job runs on a tag push, so the checkout is a detached HEAD that is **not** the configured `publishBranch: development` — pnpm's git checks (clean tree / on publish-branch / remote up to date) can never pass in CI. They exist to guard interactive publishes from a workstation, not an automated tag release.

2. **A frozen install dirties the tree.** pnpm 11's `pnpm install --frozen-lockfile` appends an `allowBuilds:` scaffold to the tracked `pnpm-workspace.yaml` for build-script deps (`@parcel/watcher`, `@swc/core`, `esbuild`) that lack an explicit allow/deny. This is the proximate cause of the unclean tree and trips the check before the detached-HEAD one.

## Changes

- **`npm_publish.yml`** — restore `--no-git-checks` (+ comment) on all three publish steps.
- **`pnpm-workspace.yaml`** — declare `allowBuilds` explicitly (`false` = don't run their build scripts; they ship prebuilt binaries) so a frozen install stops rewriting the file.
- **`ci.yml`** — split the install step out of `web_ui_build` and add an `assert frozen install left the tree clean` guard (`git diff --exit-code`). The release workflow only runs on a tag, so this catches any future install-time tree mutation in PR CI instead of at release time.

## Test plan

- [x] Reproduced `ERR_PNPM_GIT_UNCLEAN` in a clean checkout of the failing commit; isolated the cause to `pnpm install` rewriting `pnpm-workspace.yaml` (not `build-dist`, whose output is gitignored).
- [x] With the `allowBuilds` block, a clean `pnpm install --frozen-lockfile` (node_modules removed) mutates **zero** tracked files; `build-dist` still exits 0.
- [x] All three YAML files parse.
- [x] Confirmed `npm_publish_ootle_wasm.yml` uses `npm publish` (no pnpm git checks) and is unaffected.
- [ ] Re-run the release (tag push / `workflow_dispatch`) and confirm the publish step no longer errors.