### PR TITLE
refactor(consensus): avoid double validation of tx signatures

### DIFF
--- a/applications/tari_validator_node/src/bootstrap.rs
+++ b/applications/tari_validator_node/src/bootstrap.rs
@@ -78,7 +78,6 @@ use tari_ootle_transaction_validation::{
     TransactionValidationError,
     TransactionWeightValidator,
     Validator,
-    WithContext,
 };
 use tari_rpc_framework::RpcServer;
 use tari_shutdown::ShutdownSignal;
@@ -102,7 +101,7 @@ use crate::{
         self,
         ConsensusHandle,
         TariBlockTransactionExecutor,
-        ValidationContext,
+        TariBlockTransactionValidator,
         spec::ValidatorTemplateProvider,
     },
     file_l1_submitter::FileLayerOneSubmitter,
@@ -316,9 +315,10 @@ pub async fn spawn_services(
             global_db.clone(),
         )),
     );
-    let transaction_executor = TariBlockTransactionExecutor::new(
-        transaction_processor,
-        create_consensus_transaction_validator(config.network, template_provider.clone()).boxed(),
+    let transaction_executor = TariBlockTransactionExecutor::new(transaction_processor);
+    let transaction_validator = TariBlockTransactionValidator::new(
+        create_mempool_transaction_validator(config.network, template_provider.clone()).boxed(),
+        EpochRangeValidator::new().boxed(),
     );
 
     #[cfg(feature = "metrics")]
@@ -344,6 +344,7 @@ pub async fn spawn_services(
         metrics,
         shutdown.clone(),
         transaction_executor,
+        transaction_validator,
         tx_hotstuff_events,
         consensus_constants.clone(),
     )
@@ -482,15 +483,6 @@ pub fn create_mempool_transaction_validator<TProvider: TemplateProvider>(
         .and_then(TransactionWeightValidator::new(max_transaction_weight))
         .and_then(TransactionSignatureValidator)
         .and_then(TemplateExistsValidator::new(template_manager))
-}
-
-pub fn create_consensus_transaction_validator<TProvider: TemplateProvider>(
-    network: Network,
-    template_manager: TProvider,
-) -> impl Validator<Transaction, Context = ValidationContext, Error = TransactionValidationError> {
-    WithContext::<ValidationContext, _, _>::new()
-        .map_context(|_| (), create_mempool_transaction_validator(network, template_manager))
-        .map_context(|c| c.current_epoch, EpochRangeValidator::new())
 }
 
 async fn create_base_layer_client(

--- a/applications/tari_validator_node/src/consensus/block_transaction_executor.rs
+++ b/applications/tari_validator_node/src/consensus/block_transaction_executor.rs
@@ -1,7 +1,7 @@
 //   Copyright 2024 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use std::{collections::HashMap, sync::Arc};
+use std::collections::HashMap;
 
 use log::info;
 use tari_consensus::traits::{BlockTransactionExecutor, BlockTransactionExecutorError};
@@ -15,31 +15,23 @@ use tari_engine_types::{
     virtual_substate::{VirtualSubstate, VirtualSubstateId, VirtualSubstates},
 };
 use tari_ootle_app_utilities::transaction_executor::TransactionExecutor;
-use tari_ootle_common_types::{Epoch, SubstateRequirement, VersionedSubstateId};
+use tari_ootle_common_types::{SubstateRequirement, VersionedSubstateId};
 use tari_ootle_storage::{
     StateStore,
-    StateStoreReadTransaction,
     consensus_models::{LockedEpoch, TransactionExecution, VersionedSubstateIdLockIntent},
 };
 use tari_ootle_transaction::Transaction;
-use tari_ootle_transaction_validation::{TransactionValidationError, Validator};
 
 const LOG_TARGET: &str = "tari::ootle::consensus::hotstuff::block_transaction_executor";
 
-#[derive(Debug)]
-pub struct TariBlockTransactionExecutor<TExecutor, TValidator> {
+#[derive(Debug, Clone)]
+pub struct TariBlockTransactionExecutor<TExecutor> {
     executor: TExecutor,
-    validator: Arc<TValidator>,
 }
 
-impl<TExecutor: TransactionExecutor<ReadOnlyMemoryStateStore>, TValidator>
-    TariBlockTransactionExecutor<TExecutor, TValidator>
-{
-    pub fn new(executor: TExecutor, validator: TValidator) -> Self {
-        Self {
-            executor,
-            validator: Arc::new(validator),
-        }
+impl<TExecutor: TransactionExecutor<ReadOnlyMemoryStateStore>> TariBlockTransactionExecutor<TExecutor> {
+    pub fn new(executor: TExecutor) -> Self {
+        Self { executor }
     }
 
     fn add_substates_to_memory_db<'a, I: IntoIterator<Item = (&'a SubstateRequirement, &'a Substate)>>(
@@ -56,25 +48,11 @@ impl<TExecutor: TransactionExecutor<ReadOnlyMemoryStateStore>, TValidator>
     }
 }
 
-impl<TExecutor, TStateStore, TValidator> BlockTransactionExecutor<TStateStore>
-    for TariBlockTransactionExecutor<TExecutor, TValidator>
+impl<TExecutor, TStateStore> BlockTransactionExecutor<TStateStore> for TariBlockTransactionExecutor<TExecutor>
 where
     TStateStore: StateStore,
     TExecutor: TransactionExecutor<ReadOnlyMemoryStateStore>,
-    for<'a> TValidator: Validator<Transaction, Context = ValidationContext, Error = TransactionValidationError>,
 {
-    fn validate<TTx: StateStoreReadTransaction>(
-        &self,
-        _tx: &TTx,
-        current_epoch: Epoch,
-        transaction: &Transaction,
-    ) -> Result<(), BlockTransactionExecutorError> {
-        self.validator
-            .validate(&ValidationContext { current_epoch }, transaction)
-            // TODO: see if we can avoid the err as string
-            .map_err(|e| BlockTransactionExecutorError::TransactionValidationError(e.to_string()))
-    }
-
     fn execute(
         &self,
         transaction: &Transaction,
@@ -133,16 +111,4 @@ where
         info!(target: LOG_TARGET, "Transaction {} executed in {:.2?}. {}", id, exec.result().execution_time, exec.result().finalize.result);
         Ok(exec)
     }
-}
-
-impl<TExecutor: Clone, TValidator> Clone for TariBlockTransactionExecutor<TExecutor, TValidator> {
-    fn clone(&self) -> Self {
-        Self {
-            executor: self.executor.clone(),
-            validator: self.validator.clone(),
-        }
-    }
-}
-pub struct ValidationContext {
-    pub current_epoch: Epoch,
 }

--- a/applications/tari_validator_node/src/consensus/block_transaction_validator.rs
+++ b/applications/tari_validator_node/src/consensus/block_transaction_validator.rs
@@ -1,0 +1,49 @@
+//   Copyright 2024 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+use std::sync::Arc;
+
+use tari_consensus::traits::BlockTransactionValidator;
+use tari_ootle_common_types::Epoch;
+use tari_ootle_transaction::Transaction;
+use tari_ootle_transaction_validation::{BoxedValidator, TransactionValidationError, Validator};
+
+/// Validators whose checks depend only on the transaction itself. These are immutable over a transaction's
+/// lifetime (signature, network, weight, template existence, ...) and need only be run once.
+pub type StructuralTransactionValidator = BoxedValidator<(), Transaction, TransactionValidationError>;
+
+/// Validators whose checks depend on the current epoch, which advances while a transaction waits to be
+/// sequenced, so they must be re-run at sequencing time.
+pub type EpochTransactionValidator = BoxedValidator<Epoch, Transaction, TransactionValidationError>;
+
+/// Splits transaction validation into its structural (content-only) and epoch-dependent parts so that consensus
+/// can re-run only what is necessary: peer-requested transactions are validated in full, while mempool-originated
+/// transactions — already structurally validated on ingress — are only re-checked against the current epoch.
+#[derive(Clone)]
+pub struct TariBlockTransactionValidator {
+    structural: Arc<StructuralTransactionValidator>,
+    epoch: Arc<EpochTransactionValidator>,
+}
+
+impl TariBlockTransactionValidator {
+    pub fn new(structural: StructuralTransactionValidator, epoch: EpochTransactionValidator) -> Self {
+        Self {
+            structural: Arc::new(structural),
+            epoch: Arc::new(epoch),
+        }
+    }
+}
+
+impl BlockTransactionValidator for TariBlockTransactionValidator {
+    type Error = TransactionValidationError;
+
+    fn validate_full(&self, current_epoch: Epoch, transaction: &Transaction) -> Result<(), Self::Error> {
+        self.structural.validate(&(), transaction)?;
+        self.epoch.validate(&current_epoch, transaction)?;
+        Ok(())
+    }
+
+    fn validate_epoch(&self, current_epoch: Epoch, transaction: &Transaction) -> Result<(), Self::Error> {
+        self.epoch.validate(&current_epoch, transaction)
+    }
+}

--- a/applications/tari_validator_node/src/consensus/mod.rs
+++ b/applications/tari_validator_node/src/consensus/mod.rs
@@ -9,8 +9,7 @@ use tari_consensus::{
 };
 use tari_epoch_manager::service::EpochManagerHandle;
 use tari_ootle_storage::consensus_models::TransactionPool;
-use tari_ootle_transaction::{Network, Transaction};
-use tari_ootle_transaction_validation::{BoxedValidator, TransactionValidationError};
+use tari_ootle_transaction::Network;
 use tari_rpc_state_sync::RpcStateSyncClientProtocol;
 use tari_shutdown::ShutdownSignal;
 use tari_validator_node_rpc::client::TariValidatorNodeRpcClientFactory;
@@ -26,6 +25,7 @@ use crate::{
 };
 
 mod block_transaction_executor;
+mod block_transaction_validator;
 mod handle;
 mod leader_selection;
 #[cfg(feature = "metrics")]
@@ -34,6 +34,7 @@ mod signer_service;
 pub mod spec;
 
 pub use block_transaction_executor::*;
+pub use block_transaction_validator::*;
 pub use handle::*;
 pub use signer_service::*;
 use tari_consensus::{consensus_constants::ConsensusConstants, hotstuff::HotstuffEvent};
@@ -45,8 +46,6 @@ use crate::{
     consensus::spec::{ValidatorNodeStateStore, ValidatorTransactionProcessor},
     p2p::NopLogger,
 };
-
-pub type ConsensusTransactionValidator = BoxedValidator<ValidationContext, Transaction, TransactionValidationError>;
 
 pub async fn spawn(
     network: Network,
@@ -61,7 +60,8 @@ pub async fn spawn(
     client_factory: TariValidatorNodeRpcClientFactory,
     hooks: <TariConsensusSpec as ConsensusSpec>::Hooks,
     shutdown_signal: ShutdownSignal,
-    transaction_executor: TariBlockTransactionExecutor<ValidatorTransactionProcessor, ConsensusTransactionValidator>,
+    transaction_executor: TariBlockTransactionExecutor<ValidatorTransactionProcessor>,
+    transaction_validator: TariBlockTransactionValidator,
     tx_hotstuff_events: broadcast::Sender<HotstuffEvent>,
     consensus_constants: ConsensusConstants,
 ) -> (JoinHandle<Result<(), anyhow::Error>>, ConsensusHandle) {
@@ -96,6 +96,7 @@ pub async fn spawn(
         signing_service.clone(),
         transaction_pool,
         transaction_executor,
+        transaction_validator,
         tx_hotstuff_events.clone(),
         hooks,
         shutdown_signal.clone(),

--- a/applications/tari_validator_node/src/consensus/spec.rs
+++ b/applications/tari_validator_node/src/consensus/spec.rs
@@ -12,8 +12,8 @@ use tari_rpc_state_sync::RpcStateSyncClientProtocol;
 use crate::consensus::metrics::PrometheusConsensusMetrics;
 use crate::{
     consensus::{
-        ConsensusTransactionValidator,
         TariBlockTransactionExecutor,
+        TariBlockTransactionValidator,
         leader_selection::RoundRobinLeaderStrategy,
         signer_service::TariSignatureService,
         // template_metadata_hooks::TemplateMetadataHooks,
@@ -46,6 +46,6 @@ impl ConsensusSpec for TariConsensusSpec {
     type SignerService = TariSignatureService;
     type StateStore = ValidatorNodeStateStore;
     type SyncManager = RpcStateSyncClientProtocol<Self>;
-    type TransactionExecutor =
-        TariBlockTransactionExecutor<ValidatorTransactionProcessor, ConsensusTransactionValidator>;
+    type TransactionExecutor = TariBlockTransactionExecutor<ValidatorTransactionProcessor>;
+    type TransactionValidator = TariBlockTransactionValidator;
 }

--- a/crates/consensus/src/hotstuff/on_receive_new_transaction.rs
+++ b/crates/consensus/src/hotstuff/on_receive_new_transaction.rs
@@ -15,15 +15,23 @@ use crate::{
     hotstuff::error::HotStuffError,
     messages::MissingTransactionsResponse,
     tracing::TraceTimer,
-    traits::{BlockTransactionExecutor, ConsensusSpec},
+    traits::{BlockTransactionValidator, ConsensusSpec},
 };
 
 const LOG_TARGET: &str = "tari::ootle::consensus::hotstuff::on_receive_new_transaction";
 
+/// Where a transaction entered consensus from, which determines how much validation it still requires.
+enum TransactionSource {
+    /// Received from our own mempool, where it has already passed full validation.
+    OwnMempool,
+    /// Requested from a peer as a missing transaction; not yet validated locally.
+    Requested,
+}
+
 pub struct OnReceiveNewTransaction<TConsensusSpec: ConsensusSpec> {
     store: TConsensusSpec::StateStore,
     transaction_pool: TransactionPool<TConsensusSpec::StateStore>,
-    executor: TConsensusSpec::TransactionExecutor,
+    validator: TConsensusSpec::TransactionValidator,
     tx_missing_transactions: mpsc::UnboundedSender<Vec<TransactionId>>,
 }
 
@@ -33,13 +41,13 @@ where TConsensusSpec: ConsensusSpec
     pub fn new(
         store: TConsensusSpec::StateStore,
         transaction_pool: TransactionPool<TConsensusSpec::StateStore>,
-        executor: TConsensusSpec::TransactionExecutor,
+        validator: TConsensusSpec::TransactionValidator,
         tx_missing_transactions: mpsc::UnboundedSender<Vec<TransactionId>>,
     ) -> Self {
         Self {
             store,
             transaction_pool,
-            executor,
+            validator,
             tx_missing_transactions,
         }
     }
@@ -58,9 +66,13 @@ where TConsensusSpec: ConsensusSpec
             let mut batch = Vec::with_capacity(recs.len());
             debug!(target: LOG_TARGET, "Processing {} requested transactions", recs.len());
             for transaction in recs {
-                if let Some(validate_data) =
-                    self.validate_new_transaction(tx, current_epoch, transaction, local_committee_info)?
-                {
+                if let Some(validate_data) = self.validate_new_transaction(
+                    tx,
+                    current_epoch,
+                    transaction,
+                    local_committee_info,
+                    TransactionSource::Requested,
+                )? {
                     debug!(
                         target: LOG_TARGET,
                         "Transaction {} must sequence: {}.",
@@ -101,8 +113,13 @@ where TConsensusSpec: ConsensusSpec
         local_committee_info: &CommitteeInfo,
     ) -> Result<Option<TransactionRecord>, HotStuffError> {
         self.store.with_write_tx(|tx| {
-            let Some(validate_data) =
-                self.validate_new_transaction(tx, current_epoch, transaction, local_committee_info)?
+            let Some(validate_data) = self.validate_new_transaction(
+                tx,
+                current_epoch,
+                transaction,
+                local_committee_info,
+                TransactionSource::OwnMempool,
+            )?
             else {
                 return Ok(None);
             };
@@ -132,6 +149,7 @@ where TConsensusSpec: ConsensusSpec
         current_epoch: Epoch,
         rec: TransactionRecord,
         local_committee_info: &CommitteeInfo,
+        source: TransactionSource,
     ) -> Result<Option<NewTransactionValidation>, HotStuffError> {
         if self.transaction_pool.exists(&**tx, rec.id())? {
             return Ok(None);
@@ -146,12 +164,18 @@ where TConsensusSpec: ConsensusSpec
             return Ok(None);
         }
 
-        let result = self.executor.validate(&**tx, current_epoch, rec.transaction());
+        // Mempool-originated transactions have already passed full validation; their structural properties are
+        // immutable, so only the epoch-dependent rules are re-checked. Peer-requested transactions have not been
+        // validated locally and are validated in full.
+        let result = match source {
+            TransactionSource::OwnMempool => self.validator.validate_epoch(current_epoch, rec.transaction()),
+            TransactionSource::Requested => self.validator.validate_full(current_epoch, rec.transaction()),
+        };
 
         if let Err(err) = result {
             warn!(
                 target: LOG_TARGET,
-                "Transaction {} received from validator (missing transactions) failed validation and will be ignored: {}", rec.id(), err
+                "Transaction {} failed validation and will be ignored: {}", rec.id(), err
             );
             return Ok(None);
         }

--- a/crates/consensus/src/hotstuff/worker.rs
+++ b/crates/consensus/src/hotstuff/worker.rs
@@ -146,6 +146,7 @@ impl<TConsensusSpec: ConsensusSpec> HotstuffWorker<TConsensusSpec> {
         signing_service: TConsensusSpec::SignerService,
         transaction_pool: TransactionPool<TConsensusSpec::StateStore>,
         transaction_executor: TConsensusSpec::TransactionExecutor,
+        transaction_validator: TConsensusSpec::TransactionValidator,
         tx_events: broadcast::Sender<HotstuffEvent>,
         hooks: TConsensusSpec::Hooks,
         shutdown: ShutdownSignal,
@@ -228,7 +229,7 @@ impl<TConsensusSpec: ConsensusSpec> HotstuffWorker<TConsensusSpec> {
             on_receive_new_transaction: OnReceiveNewTransaction::new(
                 state_store.clone(),
                 transaction_pool.clone(),
-                transaction_executor.clone(),
+                transaction_validator,
                 tx_missing_transactions,
             ),
             on_propose: OnPropose::new(

--- a/crates/consensus/src/traits/mod.rs
+++ b/crates/consensus/src/traits/mod.rs
@@ -11,6 +11,7 @@ mod substate_store;
 mod sync;
 mod tasks;
 mod transaction_executor;
+mod transaction_validator;
 
 pub use block_store::*;
 pub use certificate::*;
@@ -24,6 +25,7 @@ use tari_ootle_common_types::DerivableFromPublicKey;
 use tari_ootle_storage::StateStore;
 pub(crate) use tasks::*;
 pub use transaction_executor::*;
+pub use transaction_validator::*;
 
 use crate::traits::hooks::ConsensusHooks;
 
@@ -36,6 +38,7 @@ pub trait ConsensusSpec: Send + Sync + Clone + 'static {
     type SignerService: ValidatorSignatureVerifierService + ValidatorSignerService + Send + Sync + Clone + 'static;
     type SyncManager: SyncManager + Send + Sync + 'static;
     type TransactionExecutor: BlockTransactionExecutor<Self::StateStore> + Send + Sync + Clone + 'static;
+    type TransactionValidator: BlockTransactionValidator + Send + Sync + Clone + 'static;
     type InboundMessaging: InboundMessaging<Addr = Self::Addr> + Send + Sync + 'static;
     type OutboundMessaging: OutboundMessaging<Addr = Self::Addr> + Clone + Send + Sync + 'static;
     type Hooks: ConsensusHooks + Clone + Send + Sync + 'static;

--- a/crates/consensus/src/traits/transaction_executor.rs
+++ b/crates/consensus/src/traits/transaction_executor.rs
@@ -4,10 +4,9 @@
 use std::collections::HashMap;
 
 use tari_engine_types::substate::Substate;
-use tari_ootle_common_types::{Epoch, SubstateRequirement, optional::IsNotFoundError};
+use tari_ootle_common_types::{SubstateRequirement, optional::IsNotFoundError};
 use tari_ootle_storage::{
     StateStore,
-    StateStoreReadTransaction,
     StorageError,
     consensus_models::{LockedEpoch, TransactionExecution, TransactionPoolError},
 };
@@ -25,8 +24,6 @@ pub enum BlockTransactionExecutorError {
     StateStoreError(String),
     #[error("Substate store error: {0}")]
     SubstateStoreError(#[from] SubstateStoreError),
-    #[error("Transaction validation error: {0}")]
-    TransactionValidationError(String),
     #[error("Transaction pool error: {0}")]
     TransactionPoolError(#[from] TransactionPoolError),
     #[error("BUG: Invariant error: {0}")]
@@ -55,13 +52,6 @@ impl IsNotFoundError for BlockTransactionExecutorError {
 }
 
 pub trait BlockTransactionExecutor<TStateStore: StateStore> {
-    fn validate<TTx: StateStoreReadTransaction>(
-        &self,
-        tx: &TTx,
-        current_epoch: Epoch,
-        transaction: &Transaction,
-    ) -> Result<(), BlockTransactionExecutorError>;
-
     fn execute(
         &self,
         transaction: &Transaction,

--- a/crates/consensus/src/traits/transaction_validator.rs
+++ b/crates/consensus/src/traits/transaction_validator.rs
@@ -1,0 +1,26 @@
+//   Copyright 2024 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+use tari_ootle_common_types::Epoch;
+use tari_ootle_transaction::Transaction;
+
+/// Validates transactions before they are admitted to the transaction pool.
+///
+/// Validation is intentionally separate from [`super::BlockTransactionExecutor`]: it is a pure function of the
+/// transaction and the current epoch, with no dependency on execution or substate state. The two entry points
+/// reflect how much validation a transaction still requires:
+///
+/// * [`validate_full`](BlockTransactionValidator::validate_full) — the transaction comes from an untrusted source (e.g.
+///   requested from a peer) and has not yet been validated locally, so it must be validated in full.
+/// * [`validate_epoch`](BlockTransactionValidator::validate_epoch) — the transaction has already passed full validation
+///   locally (e.g. via the mempool). Its structural properties are immutable, so only the epoch/time-dependent rules —
+///   which can change while the transaction waits to be sequenced — are re-checked.
+pub trait BlockTransactionValidator {
+    type Error: std::error::Error + Send + Sync + 'static;
+
+    /// Fully validate a transaction from an untrusted source.
+    fn validate_full(&self, current_epoch: Epoch, transaction: &Transaction) -> Result<(), Self::Error>;
+
+    /// Re-validate only the epoch/time-dependent rules of an already fully-validated transaction.
+    fn validate_epoch(&self, current_epoch: Epoch, transaction: &Transaction) -> Result<(), Self::Error>;
+}

--- a/crates/consensus_tests/src/support/spec.rs
+++ b/crates/consensus_tests/src/support/spec.rs
@@ -29,4 +29,5 @@ impl ConsensusSpec for TestConsensusSpec {
     type StateStore = TestStore;
     type SyncManager = AlwaysSyncedSyncManager;
     type TransactionExecutor = TestBlockTransactionProcessor;
+    type TransactionValidator = TestBlockTransactionProcessor;
 }

--- a/crates/consensus_tests/src/support/transaction_executor.rs
+++ b/crates/consensus_tests/src/support/transaction_executor.rs
@@ -7,7 +7,7 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use tari_consensus::traits::{BlockTransactionExecutor, BlockTransactionExecutorError};
+use tari_consensus::traits::{BlockTransactionExecutor, BlockTransactionExecutorError, BlockTransactionValidator};
 use tari_engine::state_store::{StateWriter, memory::MemoryStateStore, new_memory_store};
 use tari_engine_types::substate::{Substate, SubstateId};
 use tari_ootle_common_types::{
@@ -20,7 +20,6 @@ use tari_ootle_common_types::{
 };
 use tari_ootle_storage::{
     StateStore,
-    StateStoreReadTransaction,
     consensus_models::{LockedEpoch, TransactionExecution, VersionedSubstateIdLockIntent},
 };
 use tari_ootle_transaction::{Transaction, TransactionId};
@@ -66,16 +65,19 @@ impl TestBlockTransactionProcessor {
     }
 }
 
-impl<TStateStore: StateStore> BlockTransactionExecutor<TStateStore> for TestBlockTransactionProcessor {
-    fn validate<TTx: StateStoreReadTransaction>(
-        &self,
-        _tx: &TTx,
-        _current_epoch: Epoch,
-        _transaction: &Transaction,
-    ) -> Result<(), BlockTransactionExecutorError> {
+impl BlockTransactionValidator for TestBlockTransactionProcessor {
+    type Error = BlockTransactionExecutorError;
+
+    fn validate_full(&self, _current_epoch: Epoch, _transaction: &Transaction) -> Result<(), Self::Error> {
         Ok(())
     }
 
+    fn validate_epoch(&self, _current_epoch: Epoch, _transaction: &Transaction) -> Result<(), Self::Error> {
+        Ok(())
+    }
+}
+
+impl<TStateStore: StateStore> BlockTransactionExecutor<TStateStore> for TestBlockTransactionProcessor {
     #[allow(clippy::too_many_lines)]
     fn execute(
         &self,

--- a/crates/consensus_tests/src/support/validator/builder.rs
+++ b/crates/consensus_tests/src/support/validator/builder.rs
@@ -185,6 +185,7 @@ impl ValidatorBuilder {
             signing_service,
             transaction_pool,
             transaction_executor.clone(),
+            transaction_executor.clone(),
             tx_events.clone(),
             NoopHooks,
             shutdown_signal.clone(),


### PR DESCRIPTION
## Motivation

On a validator node, transaction signatures (and every other structural check) were verified **twice** for the normal path. `validate` was a method on `BlockTransactionExecutor`, and the consensus validation chain (`create_consensus_transaction_validator`) wrapped the *entire* mempool chain via `map_context`. So a mempool-originated transaction was:

1. fully validated at mempool ingress (`TransactionSignatureValidator` et al.), then
2. fully validated **again** when sequenced into consensus (`OnReceiveNewTransaction::try_sequence_transaction` → `executor.validate`).

`TariBlockTransactionExecutor::validate` didn't even use the executor's state (its `_tx` arg was ignored) — validation is a pure function of `(epoch, transaction)`, so it never belonged on the executor.

## Change

- **Executor is execute-only.** `BlockTransactionExecutor` loses `validate`; `TariBlockTransactionExecutor` drops its validator field and generic.
- **Validation is its own concern:** a new `BlockTransactionValidator` trait, injected via `ConsensusSpec::TransactionValidator` (mirroring how the executor is injected).
- Validation is split into its two orthogonal parts:
  - **structural / content-only** (network, dry-run, basic, weight, **signature**, template-exists): immutable over a transaction's lifetime → run once.
  - **epoch / time-dependent** (epoch range): the current epoch advances while a transaction waits in the pool → must be re-checked at sequencing time.
- The handler selects scope by **provenance** (no skip-flags leaking into the validator chain):
  - peer-requested **missing** transactions never passed local validation → validated **in full**.
  - mempool-originated transactions were already fully validated on ingress → only the **epoch** rules are re-checked when sequenced.

Net result: structural checks, including signature verification, now run **exactly once** per transaction per node on every path. `create_consensus_transaction_validator`, `ConsensusTransactionValidator`, and the `ValidationContext`/`WithContext` plumbing are removed.

## Safety

Skipping structural re-validation on the mempool→consensus path is sound only if everything delivered via `ConsensusHandle::notify_new_transaction` has already passed mempool validation. Audited: `notify_new_transaction` has a single caller (`MempoolService::handle_new_transaction`), reached only after `before_execute_validator.validate()` succeeds, and the channel sender is private to `ConsensusHandle`. The invariant holds.

## Testing

- `cargo check` clean for `tari_consensus`, `tari_validator_node`, `consensus_tests`.
- `cargo nextest run -p consensus_tests`: **62/62 pass**, including `node_requests_missing_transaction_from_local_leader` (full-validation peer path), `single_transaction*` (mempool→sequence epoch-only path), and `single_transaction_epoch_expired` (epoch validator on the sequence path).
