### PR TITLE
fix(swarm): poll for base node identity file on startup

### DIFF
--- a/applications/tari_swarm_daemon/src/process_definitions/minotari_wallet.rs
+++ b/applications/tari_swarm_daemon/src/process_definitions/minotari_wallet.rs
@@ -43,7 +43,7 @@ impl ProcessDefinition for MinotariWallet {
 
         let mut base_node_addresses = Vec::with_capacity(base_nodes.len());
         for base_node in base_nodes {
-            let identity = base_node.get_identity()?;
+            let identity = base_node.get_identity().await?;
             debug!("Base node identity: {identity}");
             base_node_addresses.push(identity);
         }

--- a/applications/tari_swarm_daemon/src/process_manager/processes/minotari_node.rs
+++ b/applications/tari_swarm_daemon/src/process_manager/processes/minotari_node.rs
@@ -1,10 +1,11 @@
 //   Copyright 2024 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use std::fs::File;
+use std::time::Duration;
 
 use anyhow::{Context, anyhow};
 use minotari_node_grpc_client::{BaseNodeGrpcClient, grpc};
+use tokio::{fs, time::sleep};
 
 use crate::process_manager::Instance;
 
@@ -35,13 +36,30 @@ impl MinoTariNodeProcess {
         Ok(client)
     }
 
-    pub fn get_identity(&self) -> anyhow::Result<String> {
+    pub async fn get_identity(&self) -> anyhow::Result<String> {
         // We cannot call identify because we'd need to override the allowed methods via cli, and this is not
-        // supported. So we read from the base node identity file
+        // supported. So we read from the base node identity file. The node writes this file a short while after
+        // its process starts, so we poll for it rather than failing on the first miss.
         let id_file = self.instance.base_path().join("config").join("base_node_id.json");
-        let mut config =
-            File::open(&id_file).with_context(|| format!("Loading base node ID failed {}", id_file.display()))?;
-        let identity = serde_json5::from_reader::<_, serde_json::Value>(&mut config)?;
+
+        const MAX_ATTEMPTS: usize = 20;
+        const RETRY_INTERVAL: Duration = Duration::from_millis(500);
+        let contents = {
+            let mut attempt = 0;
+            loop {
+                match fs::read_to_string(&id_file).await {
+                    Ok(contents) => break contents,
+                    Err(err) if err.kind() == std::io::ErrorKind::NotFound && attempt < MAX_ATTEMPTS => {
+                        attempt += 1;
+                        sleep(RETRY_INTERVAL).await;
+                    },
+                    Err(err) => {
+                        return Err(err).with_context(|| format!("Loading base node ID failed {}", id_file.display()));
+                    },
+                }
+            }
+        };
+        let identity = serde_json5::from_str::<serde_json::Value>(&contents)?;
         let public_key = identity["public_key"]
             .as_str()
             .ok_or_else(|| anyhow!("public_key not found or not a string"))?;

--- a/applications/tari_swarm_daemon/src/process_manager/processes/minotari_node.rs
+++ b/applications/tari_swarm_daemon/src/process_manager/processes/minotari_node.rs
@@ -39,27 +39,33 @@ impl MinoTariNodeProcess {
     pub async fn get_identity(&self) -> anyhow::Result<String> {
         // We cannot call identify because we'd need to override the allowed methods via cli, and this is not
         // supported. So we read from the base node identity file. The node writes this file a short while after
-        // its process starts, so we poll for it rather than failing on the first miss.
+        // its process starts, and the write is not atomic, so we poll until the file both exists and parses
+        // rather than failing on the first miss.
         let id_file = self.instance.base_path().join("config").join("base_node_id.json");
 
         const MAX_ATTEMPTS: usize = 20;
         const RETRY_INTERVAL: Duration = Duration::from_millis(500);
-        let contents = {
-            let mut attempt = 0;
-            loop {
-                match fs::read_to_string(&id_file).await {
-                    Ok(contents) => break contents,
-                    Err(err) if err.kind() == std::io::ErrorKind::NotFound && attempt < MAX_ATTEMPTS => {
-                        attempt += 1;
-                        sleep(RETRY_INTERVAL).await;
-                    },
+        let mut attempt = 0;
+        let identity = loop {
+            attempt += 1;
+            match fs::read_to_string(&id_file).await {
+                // A non-atomic write can leave the file briefly empty or partial, so an unparseable read is
+                // treated the same as a missing one and retried.
+                Ok(contents) => match serde_json5::from_str::<serde_json::Value>(&contents) {
+                    Ok(identity) => break identity,
+                    Err(_) if attempt < MAX_ATTEMPTS => sleep(RETRY_INTERVAL).await,
                     Err(err) => {
-                        return Err(err).with_context(|| format!("Loading base node ID failed {}", id_file.display()));
+                        return Err(err).with_context(|| format!("Parsing base node ID failed {}", id_file.display()));
                     },
-                }
+                },
+                Err(err) if err.kind() == std::io::ErrorKind::NotFound && attempt < MAX_ATTEMPTS => {
+                    sleep(RETRY_INTERVAL).await;
+                },
+                Err(err) => {
+                    return Err(err).with_context(|| format!("Loading base node ID failed {}", id_file.display()));
+                },
             }
         };
-        let identity = serde_json5::from_str::<serde_json::Value>(&contents)?;
         let public_key = identity["public_key"]
             .as_str()
             .ok_or_else(|| anyhow!("public_key not found or not a string"))?;


### PR DESCRIPTION
## Problem

Swarm intermittently fails to start with:

```
Error: process manager crashed

Caused by:
    0: get_command
    1: Loading base node ID failed .../minotari-node-00/localnet/config/base_node_id.json
    2: No such file or directory (os error 2)
```

When building the `minotari_console_wallet` command, the process manager reads the base node's `base_node_id.json` (via `MinoTariNodeProcess::get_identity`) to pass the base node as a peer seed. `get_identity` opened the file exactly once and returned a hard error on `NotFound`. That error bubbles up through `get_command`, crashes the whole process manager, and the base node is then SIGKILLed via `kill_on_drop` — leaving empty stdout/stderr logs and no `localnet/` data dir, which misleadingly looks like the base node itself failed.

The base node writes its identity file early in startup (in `setup_node_identity`, before the tokio runtime / blockchain init), but the wallet command is only built ~3s after the node spawns (2s base-layer sleep + 1s `after_start_delay`). The node normally writes the file in ~1–2s, so the margin is ~1s. Under load — e.g. the first cold run right after compiling all executables — the node can exceed that window and startup fails deterministically.

## Fix

Make `get_identity` async and poll for the identity file (up to 20 × 500 ms = 10 s) using tokio async file IO instead of failing on the first miss. It retries only on `NotFound`; any other IO error still fails fast with the original context. The single caller (`MinotariWallet::get_command`) now `.await`s it.

This removes the dependency on a fragile startup-timing margin rather than just widening it.

## Testing

- `cargo build -p tari_swarm_daemon` passes.
- Reproduced the node's startup behaviour with swarm's exact launch (cwd `../tari`, non-TTY pipes): `base_node_id.json` is written ~1–2 s after spawn, confirming the tight margin. With the poll, the wallet command build now waits for the file instead of crashing the process manager.
