### PR TITLE
fix(stealth): bound per-transaction stealth-transfer work to prevent leader-stall DoS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11988,6 +11988,7 @@ dependencies = [
  "anyhow",
  "indexmap 2.13.0",
  "log",
+ "tari_engine_types",
  "tari_networking",
  "tari_ootle_common_types",
  "tari_ootle_storage",

--- a/applications/tari_validator_node/src/bootstrap.rs
+++ b/applications/tari_validator_node/src/bootstrap.rs
@@ -71,6 +71,7 @@ use tari_ootle_transaction::{Network, Transaction};
 use tari_ootle_transaction_validation::{
     BasicValidations,
     EpochRangeValidator,
+    StealthTransactionLimitsValidator,
     TemplateExistsValidator,
     TransactionDryRunValidator,
     TransactionNetworkValidator,
@@ -481,6 +482,9 @@ pub fn create_mempool_transaction_validator<TProvider: TemplateProvider>(
         .and_then(BasicValidations::new())
         // Cheap structural check — reject over-weight transactions before verifying signatures.
         .and_then(TransactionWeightValidator::new(max_transaction_weight))
+        // Reject transactions whose aggregate stealth-transfer work exceeds the per-transaction caps before
+        // verifying signatures or executing.
+        .and_then(StealthTransactionLimitsValidator::new())
         .and_then(TransactionSignatureValidator)
         .and_then(TemplateExistsValidator::new(template_manager))
 }

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -57,3 +57,7 @@ tempfile = { workspace = true }
 [[bench]]
 name = "benchmarks"
 harness = false
+
+[[bench]]
+name = "stealth_cost"
+harness = false

--- a/crates/engine/benches/stealth_cost.rs
+++ b/crates/engine/benches/stealth_cost.rs
@@ -1,0 +1,77 @@
+//   Copyright 2026 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+//! Measures the native crypto cost of verifying a single stealth transfer (`validate_transfer`) as a function of the
+//! number of inputs and outputs, with and without a resource view key (ElGamal viewable-balance proofs). Used to
+//! calibrate the per-transaction stealth caps and the transaction-weight pricing for stealth transfers.
+
+use std::hint::black_box;
+
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use tari_crypto::{
+    keys::PublicKey,
+    ristretto::{RistrettoPublicKey, RistrettoSecretKey},
+};
+use tari_engine_types::stealth::validate_transfer;
+use tari_template_lib::types::stealth::StealthTransferStatement;
+use tari_template_test_tooling::{
+    support::stealth::{generate_mint_statement, generate_transfer_data},
+    wallet_crypto::MaskAndValue,
+};
+
+fn view_key() -> RistrettoPublicKey {
+    RistrettoPublicKey::from_secret_key(&RistrettoSecretKey::from(7u64))
+}
+
+/// A transfer of `n` stealth outputs and no stealth inputs (a revealed-funded mint). Exercises the aggregated
+/// bulletproof over `n` outputs plus, with a view key, `n` ElGamal proofs.
+fn outputs_statement(n: usize, with_view_key: bool) -> (StealthTransferStatement, Option<RistrettoPublicKey>) {
+    let vk = with_view_key.then(view_key);
+    let data = generate_mint_statement(vec![1_000u64; n], 0u64, vk.as_ref());
+    (data.statement, vk)
+}
+
+/// A transfer spending `n` stealth inputs into a single output. Exercises the per-input commitment aggregation
+/// (point decompress + add) plus one bulletproof and one balance proof.
+fn inputs_statement(n: usize) -> StealthTransferStatement {
+    let inputs = (0..n)
+        .map(|i| MaskAndValue {
+            mask: RistrettoSecretKey::from(i as u64 + 1),
+            value: 1,
+        })
+        .collect::<Vec<_>>();
+    generate_transfer_data(inputs, 0u64, vec![n as u64], 0u64).statement
+}
+
+fn bench(c: &mut Criterion) {
+    let mut g = c.benchmark_group("stealth_validate_transfer");
+
+    // Output scaling, no view key.
+    for n in [1usize, 2, 4, 8] {
+        let (stmt, vk) = outputs_statement(n, false);
+        g.bench_with_input(BenchmarkId::new("outputs", n), &n, |b, _| {
+            b.iter(|| black_box(validate_transfer(black_box(&stmt), vk.as_ref())).unwrap())
+        });
+    }
+
+    // Output scaling, with view key (adds one ElGamal viewable-balance proof per output).
+    for n in [1usize, 2, 4, 8] {
+        let (stmt, vk) = outputs_statement(n, true);
+        g.bench_with_input(BenchmarkId::new("outputs_viewkey", n), &n, |b, _| {
+            b.iter(|| black_box(validate_transfer(black_box(&stmt), vk.as_ref())).unwrap())
+        });
+    }
+
+    // Input scaling, single output, no view key.
+    for n in [1usize, 10, 100, 1000] {
+        let stmt = inputs_statement(n);
+        g.bench_with_input(BenchmarkId::new("inputs", n), &n, |b, _| {
+            b.iter(|| black_box(validate_transfer(black_box(&stmt), None)).unwrap())
+        });
+    }
+
+    g.finish();
+}
+
+criterion_group!(benches, bench);
+criterion_main!(benches);

--- a/crates/engine/src/runtime/error.rs
+++ b/crates/engine/src/runtime/error.rs
@@ -393,6 +393,12 @@ pub enum ArgumentValidationError {
     MaxStealthOutputsExceeded { max_outputs: usize, actual_outputs: usize },
     #[error("Maximum number of stealth inputs exceeded: max {max_inputs}, got {actual_inputs}")]
     MaxStealthInputsExceeded { max_inputs: usize, actual_inputs: usize },
+    #[error("Maximum number of stealth transfers per transaction exceeded: max {max_transfers}")]
+    MaxStealthTransfersPerTransactionExceeded { max_transfers: usize },
+    #[error("Maximum total stealth outputs per transaction exceeded: max {max_outputs}, got at least {actual_outputs}")]
+    MaxStealthOutputsPerTransactionExceeded { max_outputs: usize, actual_outputs: usize },
+    #[error("Maximum total stealth inputs per transaction exceeded: max {max_inputs}, got at least {actual_inputs}")]
+    MaxStealthInputsPerTransactionExceeded { max_inputs: usize, actual_inputs: usize },
     #[error("Too many arguments provided. Got {got}, max is {max}")]
     TooManyArguments { got: usize, max: usize },
     #[error("Blob index {index} out of bounds (transaction has {count} blob(s))")]

--- a/crates/engine/src/runtime/validation.rs
+++ b/crates/engine/src/runtime/validation.rs
@@ -32,3 +32,134 @@ pub(crate) fn check_stealth_outputs_limits(
     }
     Ok(())
 }
+
+/// Running per-transaction tally of stealth-transfer work. Bounds the aggregate native verification cost a single
+/// transaction can incur across all its `StealthTransfer` instructions, so one transaction cannot stall the proposing
+/// leader. See [`StealthLimits`] and [`tari_engine_types::limits::STEALTH_LIMITS`].
+#[derive(Debug, Clone, Default)]
+pub(crate) struct StealthTransactionTotals {
+    transfers: usize,
+    inputs: usize,
+    outputs: usize,
+}
+
+impl StealthTransactionTotals {
+    /// Accounts one more stealth transfer against the per-transaction caps. Returns an error — which aborts the
+    /// transaction before the transfer's (expensive) crypto runs — if any cap would be exceeded. Totals only advance
+    /// when the transfer is admitted, so the work actually performed never exceeds the caps.
+    pub fn account_transfer(
+        &mut self,
+        limits: &StealthLimits,
+        statement: &StealthTransferStatement,
+    ) -> Result<(), ArgumentValidationError> {
+        let transfers = self.transfers + 1;
+        if transfers > limits.max_transfers_per_transaction {
+            return Err(ArgumentValidationError::MaxStealthTransfersPerTransactionExceeded {
+                max_transfers: limits.max_transfers_per_transaction,
+            });
+        }
+        let inputs = self.inputs + statement.inputs_statement.inputs.len();
+        if inputs > limits.max_total_inputs_per_transaction {
+            return Err(ArgumentValidationError::MaxStealthInputsPerTransactionExceeded {
+                max_inputs: limits.max_total_inputs_per_transaction,
+                actual_inputs: inputs,
+            });
+        }
+        let outputs = self.outputs + statement.outputs_statement.outputs.len();
+        if outputs > limits.max_total_outputs_per_transaction {
+            return Err(ArgumentValidationError::MaxStealthOutputsPerTransactionExceeded {
+                max_outputs: limits.max_total_outputs_per_transaction,
+                actual_outputs: outputs,
+            });
+        }
+        self.transfers = transfers;
+        self.inputs = inputs;
+        self.outputs = outputs;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tari_template_lib::types::{
+        Amount,
+        EncryptedData,
+        crypto::{PedersenCommitmentBytes, RistrettoPublicKeyBytes, UtxoTag},
+        stealth::{SpendCondition, StealthInput, StealthUnspentOutput, UnspentOutput},
+    };
+
+    use super::*;
+
+    const LIMITS: StealthLimits = StealthLimits {
+        max_inputs: 1000,
+        max_outputs: 8,
+        max_transfers_per_transaction: 2,
+        max_total_inputs_per_transaction: 3,
+        max_total_outputs_per_transaction: 2,
+    };
+
+    fn dummy_commitment() -> PedersenCommitmentBytes {
+        PedersenCommitmentBytes::from_bytes(&[0u8; 32]).unwrap()
+    }
+
+    fn dummy_output() -> StealthUnspentOutput {
+        StealthUnspentOutput {
+            output: UnspentOutput {
+                commitment: dummy_commitment(),
+                sender_public_nonce: RistrettoPublicKeyBytes::zero(),
+                encrypted_data: EncryptedData::try_from(vec![0u8; EncryptedData::min_size()]).unwrap(),
+                minimum_value_promise: 0,
+                viewable_balance_proof: None,
+            },
+            spend_condition: SpendCondition::Signed(RistrettoPublicKeyBytes::zero()),
+            tag: UtxoTag::new(0),
+        }
+    }
+
+    /// A stealth transfer statement with the given input/output counts; only the counts matter to the accumulator.
+    fn statement(n_inputs: usize, n_outputs: usize) -> StealthTransferStatement {
+        let mut stmt = StealthTransferStatement::revealed_only(Amount::new(1), Amount::new(1));
+        stmt.inputs_statement.inputs = (0..n_inputs).map(|_| StealthInput::new(dummy_commitment())).collect();
+        stmt.outputs_statement.outputs = (0..n_outputs).map(|_| dummy_output()).collect();
+        stmt
+    }
+
+    #[test]
+    fn admits_a_transfer_sitting_on_every_cap() {
+        let mut totals = StealthTransactionTotals::default();
+        totals.account_transfer(&LIMITS, &statement(3, 2)).unwrap();
+    }
+
+    #[test]
+    fn rejects_the_transfer_that_exceeds_the_transfer_cap() {
+        let mut totals = StealthTransactionTotals::default();
+        totals.account_transfer(&LIMITS, &statement(0, 0)).unwrap();
+        totals.account_transfer(&LIMITS, &statement(0, 0)).unwrap();
+        let err = totals.account_transfer(&LIMITS, &statement(0, 0)).unwrap_err();
+        assert!(matches!(
+            err,
+            ArgumentValidationError::MaxStealthTransfersPerTransactionExceeded { max_transfers: 2 }
+        ));
+    }
+
+    #[test]
+    fn sums_inputs_and_outputs_across_transfers() {
+        let mut totals = StealthTransactionTotals::default();
+        totals.account_transfer(&LIMITS, &statement(2, 1)).unwrap();
+        let err = totals.account_transfer(&LIMITS, &statement(2, 0)).unwrap_err();
+        assert!(matches!(
+            err,
+            ArgumentValidationError::MaxStealthInputsPerTransactionExceeded { max_inputs: 3, .. }
+        ));
+    }
+
+    #[test]
+    fn a_rejected_transfer_does_not_consume_budget() {
+        let mut totals = StealthTransactionTotals::default();
+        totals.account_transfer(&LIMITS, &statement(2, 0)).unwrap();
+        // Rejected: 2 + 2 = 4 > 3 inputs. Must not advance the running totals.
+        totals.account_transfer(&LIMITS, &statement(2, 0)).unwrap_err();
+        // A 1-input transfer still fits (2 + 1 = 3).
+        totals.account_transfer(&LIMITS, &statement(1, 0)).unwrap();
+    }
+}

--- a/crates/engine/src/runtime/working_state.rs
+++ b/crates/engine/src/runtime/working_state.rs
@@ -76,7 +76,7 @@ use crate::{
         scope::{CallFrame, CallScope},
         state_store::WorkingStateStore,
         tracker_auth::Authorization,
-        validation::check_stealth_transfer_limits,
+        validation::{StealthTransactionTotals, check_stealth_transfer_limits},
     },
     state_store::StateReader,
 };
@@ -112,6 +112,9 @@ pub(super) struct WorkingState<TStore> {
     /// the validator pays the cold compile/deserialise cost at most once per template per process,
     /// so charging it on every entry over-bills the user.
     loaded_template_charges: HashSet<TemplateAddress>,
+    /// Running tally of stealth-transfer work across this transaction, bounding the aggregate native verification cost
+    /// any one transaction can incur (see `limits::STEALTH_LIMITS`).
+    stealth_totals: StealthTransactionTotals,
 }
 
 impl<TStore: StateReader> WorkingState<TStore> {
@@ -143,6 +146,7 @@ impl<TStore: StateReader> WorkingState<TStore> {
             fee_state: FeeState::new(),
             loaded_template_charges: HashSet::new(),
             object_ids: ObjectIds::new(limits::ENGINE_LIMITS.max_substate_outputs),
+            stealth_totals: StealthTransactionTotals::default(),
         }
     }
 
@@ -1695,6 +1699,10 @@ impl<TStore: StateReader> WorkingState<TStore> {
         revealed_funds_bucket_id: Option<BucketId>,
     ) -> Result<Option<ResourceContainer>, RuntimeError> {
         check_stealth_transfer_limits(&limits::STEALTH_LIMITS, &statement)?;
+        // Bound the aggregate stealth work across the whole transaction before doing this transfer's crypto, so a
+        // single transaction cannot stack enough native verification to stall the proposing leader.
+        self.stealth_totals
+            .account_transfer(&limits::STEALTH_LIMITS, &statement)?;
         let resource_address = self.resolve_resource_address_ref(resource_address)?;
 
         let resource_lock = self.read_lock_substate(SubstateId::Resource(resource_address))?;

--- a/crates/engine_types/src/limits.rs
+++ b/crates/engine_types/src/limits.rs
@@ -68,11 +68,27 @@ pub const MAX_DIVISIBILITY: u8 = 18;
 pub const MAX_TOKEN_SYMBOL_LEN: usize = 10;
 
 pub struct StealthLimits {
+    /// Maximum stealth inputs in a single transfer statement.
     pub max_inputs: usize,
+    /// Maximum stealth outputs in a single transfer statement.
     pub max_outputs: usize,
+    /// Maximum number of stealth transfers across a whole transaction.
+    pub max_transfers_per_transaction: usize,
+    /// Maximum total stealth inputs across a whole transaction.
+    pub max_total_inputs_per_transaction: usize,
+    /// Maximum total stealth outputs across a whole transaction.
+    pub max_total_outputs_per_transaction: usize,
 }
 
+/// Verifying a stealth transfer is native, unmetered work dominated by the per-output bulletproof range proof and
+/// ElGamal viewable-balance proof (~1ms per output on x86-class hardware). The per-transfer limits bound one statement;
+/// the per-transaction limits bound the aggregate so a single transaction cannot stack enough stealth verification to
+/// exceed the block execution budget and stall the proposing leader. The per-transaction caps are a consensus-relevant
+/// execution rule enforced uniformly during execution, not just a mempool heuristic.
 pub const STEALTH_LIMITS: StealthLimits = StealthLimits {
     max_inputs: 1000,
     max_outputs: 8,
+    max_transfers_per_transaction: 64,
+    max_total_inputs_per_transaction: 1024,
+    max_total_outputs_per_transaction: 256,
 };

--- a/crates/transaction/src/v1/transaction.rs
+++ b/crates/transaction/src/v1/transaction.rs
@@ -297,9 +297,18 @@ fn calc_stealth_statement_weight(statement: &StealthTransferStatement) -> u64 {
         .map(|o| tari_bor::encoded_len(&o.spend_condition).unwrap_or(0) as u64)
         .sum();
 
-    // TODO: weight inputs and outputs accordingly - currently outputs cost 2x inputs
-    100 + statement.inputs_statement.inputs.len() as u64 +
-        (statement.outputs_statement.outputs.len() as u64 * 2) +
+    // Fixed cost of a transfer (resource lock, balance-proof verification, basic validation).
+    const WEIGHT_PER_TRANSFER: u64 = 100;
+    // An input contributes a commitment aggregation and a substate lookup — cheap relative to an output.
+    const WEIGHT_PER_INPUT: u64 = 1;
+    // Each output is verified natively via an aggregated bulletproof range proof plus an ElGamal viewable-balance
+    // proof (~1ms/output on x86-class hardware) — the dominant cost of a transfer. Priced well above an input so the
+    // per-transaction and per-block weight budgets bound this unmetered native verification work.
+    const WEIGHT_PER_OUTPUT: u64 = 8;
+
+    WEIGHT_PER_TRANSFER +
+        statement.inputs_statement.inputs.len() as u64 * WEIGHT_PER_INPUT +
+        statement.outputs_statement.outputs.len() as u64 * WEIGHT_PER_OUTPUT +
         spend_condition_bytes / SPEND_CONDITION_BYTE_DIVISOR
 }
 

--- a/crates/transaction_validation/Cargo.toml
+++ b/crates/transaction_validation/Cargo.toml
@@ -11,6 +11,7 @@ license.workspace = true
 tari_ootle_common_types = { workspace = true }
 tari_ootle_storage = { workspace = true }
 tari_ootle_transaction = { workspace = true }
+tari_engine_types = { workspace = true }
 tari_template_lib = { workspace = true }
 tari_networking = { workspace = true }
 

--- a/crates/transaction_validation/src/builder.rs
+++ b/crates/transaction_validation/src/builder.rs
@@ -5,6 +5,7 @@ use tari_ootle_transaction::{Network, Transaction};
 
 use crate::{
     BasicValidations,
+    StealthTransactionLimitsValidator,
     TransactionNetworkValidator,
     TransactionSignatureValidator,
     TransactionValidationError,
@@ -27,5 +28,6 @@ pub fn create_structural_transaction_validator(
     TransactionNetworkValidator::new(network)
         .and_then(BasicValidations::new())
         .and_then(TransactionWeightValidator::new(max_transaction_weight))
+        .and_then(StealthTransactionLimitsValidator::new())
         .and_then(TransactionSignatureValidator)
 }

--- a/crates/transaction_validation/src/error.rs
+++ b/crates/transaction_validation/src/error.rs
@@ -54,4 +54,11 @@ pub enum TransactionValidationError {
         weight: u64,
         max_weight: u64,
     },
+    #[error("Transaction {transaction_id} exceeds the per-transaction stealth {limit} cap: max {max}, got {actual}")]
+    ExceedsStealthTransactionLimit {
+        transaction_id: TransactionId,
+        limit: &'static str,
+        max: usize,
+        actual: usize,
+    },
 }

--- a/crates/transaction_validation/src/lib.rs
+++ b/crates/transaction_validation/src/lib.rs
@@ -23,6 +23,8 @@ mod network;
 pub use network::*;
 mod signature;
 pub use signature::*;
+mod stealth_limits;
+pub use stealth_limits::*;
 mod template_exists;
 pub use template_exists::*;
 mod weight;

--- a/crates/transaction_validation/src/stealth_limits.rs
+++ b/crates/transaction_validation/src/stealth_limits.rs
@@ -9,12 +9,14 @@ use crate::{TransactionValidationError, Validator};
 
 const LOG_TARGET: &str = "tari::ootle::mempool::validators::stealth_limits";
 
-/// Rejects transactions whose aggregate stealth-transfer work exceeds the per-transaction caps in `STEALTH_LIMITS`.
+/// Rejects transactions whose stealth-transfer work exceeds the per-transfer or per-transaction caps in
+/// `STEALTH_LIMITS`.
 ///
 /// Verifying a stealth transfer is native, unmetered crypto (a bulletproof range proof plus an ElGamal proof per
 /// output), so without a per-transaction cap a single transaction could stack enough verification to push the
-/// proposing leader past the block time. The engine enforces the same caps during execution; this rejects such
-/// transactions at ingress, before they are gossiped, stored and executed.
+/// proposing leader past the block time. The engine enforces the same per-transfer and per-transaction caps during
+/// execution; this mirrors them to reject doomed transactions at ingress, before they are gossiped, stored and
+/// executed.
 #[derive(Debug, Clone, Default)]
 pub struct StealthTransactionLimitsValidator;
 
@@ -35,9 +37,25 @@ impl Validator<Transaction> for StealthTransactionLimitsValidator {
 
         for instruction in transaction.instructions().iter().chain(transaction.fee_instructions()) {
             if let Instruction::StealthTransfer { statement, .. } = instruction {
+                let transfer_inputs = statement.inputs_statement.inputs.len();
+                let transfer_outputs = statement.outputs_statement.outputs.len();
+                // Mirror the engine's per-transfer limits (check_stealth_transfer_limits) so a single oversized
+                // transfer is rejected at ingress rather than aborting during execution.
+                self.check(
+                    "per-transfer inputs",
+                    transfer_inputs,
+                    STEALTH_LIMITS.max_inputs,
+                    transaction,
+                )?;
+                self.check(
+                    "per-transfer outputs",
+                    transfer_outputs,
+                    STEALTH_LIMITS.max_outputs,
+                    transaction,
+                )?;
                 transfers += 1;
-                inputs += statement.inputs_statement.inputs.len();
-                outputs += statement.outputs_statement.outputs.len();
+                inputs += transfer_inputs;
+                outputs += transfer_outputs;
             }
         }
 
@@ -169,14 +187,39 @@ mod tests {
     #[test]
     fn accepts_transaction_at_the_caps() {
         let limits = STEALTH_LIMITS;
-        // One transfer that sits exactly on the input and output caps, plus filler transfers up to the transfer cap.
-        let mut statements = vec![statement(
-            limits.max_total_inputs_per_transaction,
-            limits.max_total_outputs_per_transaction,
-        )];
-        statements.extend((1..limits.max_transfers_per_transaction).map(|_| statement(0, 0)));
+        // Distribute the total input/output caps across transfers so every transfer also respects the per-transfer
+        // limits: 32 transfers of (32 inputs, 8 outputs) = 1024 inputs and 256 outputs (both exactly on the cap),
+        // padded with empty transfers up to the 64-transfer cap.
+        let mut statements = (0..32).map(|_| statement(32, limits.max_outputs)).collect::<Vec<_>>();
+        statements.extend((statements.len()..limits.max_transfers_per_transaction).map(|_| statement(0, 0)));
         let tx = tx_with_stealth_transfers(statements);
         StealthTransactionLimitsValidator::new().validate(&(), &tx).unwrap();
+    }
+
+    #[test]
+    fn rejects_transfer_exceeding_per_transfer_outputs() {
+        let tx = tx_with_stealth_transfers(vec![statement(0, STEALTH_LIMITS.max_outputs + 1)]);
+        let err = StealthTransactionLimitsValidator::new().validate(&(), &tx).unwrap_err();
+        assert!(matches!(
+            err,
+            TransactionValidationError::ExceedsStealthTransactionLimit {
+                limit: "per-transfer outputs",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn rejects_transfer_exceeding_per_transfer_inputs() {
+        let tx = tx_with_stealth_transfers(vec![statement(STEALTH_LIMITS.max_inputs + 1, 0)]);
+        let err = StealthTransactionLimitsValidator::new().validate(&(), &tx).unwrap_err();
+        assert!(matches!(
+            err,
+            TransactionValidationError::ExceedsStealthTransactionLimit {
+                limit: "per-transfer inputs",
+                ..
+            }
+        ));
     }
 
     #[test]
@@ -191,8 +234,12 @@ mod tests {
     }
 
     #[test]
-    fn rejects_too_many_total_inputs() {
-        let tx = tx_with_stealth_transfers(vec![statement(STEALTH_LIMITS.max_total_inputs_per_transaction + 1, 0)]);
+    fn rejects_too_many_total_inputs_summed_across_transfers() {
+        // Two transfers, each within the per-transfer input limit, that together exceed the per-transaction total —
+        // proving the validator sums across the transaction rather than catching it per-transfer.
+        let per = STEALTH_LIMITS.max_total_inputs_per_transaction / 2 + 1;
+        assert!(per <= STEALTH_LIMITS.max_inputs);
+        let tx = tx_with_stealth_transfers(vec![statement(per, 0), statement(per, 0)]);
         let err = StealthTransactionLimitsValidator::new().validate(&(), &tx).unwrap_err();
         assert!(matches!(
             err,
@@ -202,9 +249,14 @@ mod tests {
 
     #[test]
     fn rejects_too_many_total_outputs_summed_across_transfers() {
-        // Split the over-cap output total across two transfers to prove the validator sums across the transaction.
-        let per = STEALTH_LIMITS.max_total_outputs_per_transaction / 2 + 1;
-        let tx = tx_with_stealth_transfers(vec![statement(0, per), statement(0, per)]);
+        // Spread the over-cap output total across transfers that each respect the per-transfer output limit, proving
+        // the validator sums across the transaction.
+        let n_transfers = STEALTH_LIMITS.max_total_outputs_per_transaction / STEALTH_LIMITS.max_outputs + 1;
+        let tx = tx_with_stealth_transfers(
+            (0..n_transfers)
+                .map(|_| statement(0, STEALTH_LIMITS.max_outputs))
+                .collect(),
+        );
         let err = StealthTransactionLimitsValidator::new().validate(&(), &tx).unwrap_err();
         assert!(matches!(
             err,

--- a/crates/transaction_validation/src/stealth_limits.rs
+++ b/crates/transaction_validation/src/stealth_limits.rs
@@ -1,0 +1,214 @@
+// Copyright 2026 The Tari Project
+// SPDX-License-Identifier: BSD-3-Clause
+
+use log::warn;
+use tari_engine_types::limits::STEALTH_LIMITS;
+use tari_ootle_transaction::{Instruction, Transaction};
+
+use crate::{TransactionValidationError, Validator};
+
+const LOG_TARGET: &str = "tari::ootle::mempool::validators::stealth_limits";
+
+/// Rejects transactions whose aggregate stealth-transfer work exceeds the per-transaction caps in `STEALTH_LIMITS`.
+///
+/// Verifying a stealth transfer is native, unmetered crypto (a bulletproof range proof plus an ElGamal proof per
+/// output), so without a per-transaction cap a single transaction could stack enough verification to push the
+/// proposing leader past the block time. The engine enforces the same caps during execution; this rejects such
+/// transactions at ingress, before they are gossiped, stored and executed.
+#[derive(Debug, Clone, Default)]
+pub struct StealthTransactionLimitsValidator;
+
+impl StealthTransactionLimitsValidator {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Validator<Transaction> for StealthTransactionLimitsValidator {
+    type Context = ();
+    type Error = TransactionValidationError;
+
+    fn validate(&self, _context: &(), transaction: &Transaction) -> Result<(), Self::Error> {
+        let mut transfers = 0usize;
+        let mut inputs = 0usize;
+        let mut outputs = 0usize;
+
+        for instruction in transaction.instructions().iter().chain(transaction.fee_instructions()) {
+            if let Instruction::StealthTransfer { statement, .. } = instruction {
+                transfers += 1;
+                inputs += statement.inputs_statement.inputs.len();
+                outputs += statement.outputs_statement.outputs.len();
+            }
+        }
+
+        self.check(
+            "transfers",
+            transfers,
+            STEALTH_LIMITS.max_transfers_per_transaction,
+            transaction,
+        )?;
+        self.check(
+            "inputs",
+            inputs,
+            STEALTH_LIMITS.max_total_inputs_per_transaction,
+            transaction,
+        )?;
+        self.check(
+            "outputs",
+            outputs,
+            STEALTH_LIMITS.max_total_outputs_per_transaction,
+            transaction,
+        )?;
+        Ok(())
+    }
+}
+
+impl StealthTransactionLimitsValidator {
+    fn check(
+        &self,
+        limit: &'static str,
+        actual: usize,
+        max: usize,
+        transaction: &Transaction,
+    ) -> Result<(), TransactionValidationError> {
+        if actual > max {
+            let transaction_id = transaction.calculate_id();
+            warn!(
+                target: LOG_TARGET,
+                "StealthTransactionLimitsValidator - FAIL: {transaction_id} stealth {limit} {actual} exceeds maximum {max}"
+            );
+            return Err(TransactionValidationError::ExceedsStealthTransactionLimit {
+                transaction_id,
+                limit,
+                max,
+                actual,
+            });
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use indexmap::IndexSet;
+    use tari_ootle_transaction::{
+        Network,
+        ResourceAddressRef,
+        TransactionSealSignature,
+        TransactionSignature,
+        UnsealedTransactionV1,
+        UnsignedTransactionV1,
+    };
+    use tari_template_lib::types::{
+        Amount,
+        EncryptedData,
+        crypto::{PedersenCommitmentBytes, RistrettoPublicKeyBytes, SchnorrSignatureBytes, UtxoTag},
+        stealth::{SpendCondition, StealthInput, StealthTransferStatement, StealthUnspentOutput, UnspentOutput},
+    };
+
+    use super::*;
+
+    fn dummy_commitment() -> PedersenCommitmentBytes {
+        PedersenCommitmentBytes::from_bytes(&[0u8; 32]).unwrap()
+    }
+
+    fn dummy_output() -> StealthUnspentOutput {
+        StealthUnspentOutput {
+            output: UnspentOutput {
+                commitment: dummy_commitment(),
+                sender_public_nonce: RistrettoPublicKeyBytes::zero(),
+                encrypted_data: EncryptedData::try_from(vec![0u8; EncryptedData::min_size()]).unwrap(),
+                minimum_value_promise: 0,
+                viewable_balance_proof: None,
+            },
+            spend_condition: SpendCondition::Signed(RistrettoPublicKeyBytes::zero()),
+            tag: UtxoTag::new(0),
+        }
+    }
+
+    /// A stealth transfer statement with the given input/output counts. Only the counts matter to this validator, so
+    /// the commitments and proofs are dummies.
+    fn statement(n_inputs: usize, n_outputs: usize) -> StealthTransferStatement {
+        // A non-zero revealed amount keeps the statement constructor happy; only the input/output counts matter here.
+        let mut stmt = StealthTransferStatement::revealed_only(Amount::new(1), Amount::new(1));
+        stmt.inputs_statement.inputs = (0..n_inputs).map(|_| StealthInput::new(dummy_commitment())).collect();
+        stmt.outputs_statement.outputs = (0..n_outputs).map(|_| dummy_output()).collect();
+        stmt
+    }
+
+    fn tx_with_stealth_transfers(statements: Vec<StealthTransferStatement>) -> Transaction {
+        let instructions = statements
+            .into_iter()
+            .map(|statement| Instruction::StealthTransfer {
+                resource_address_ref: ResourceAddressRef::from(0u16),
+                statement,
+                revealed_input_bucket: None,
+            })
+            .collect();
+        Transaction::new(
+            UnsealedTransactionV1::new(
+                UnsignedTransactionV1::new(
+                    Network::LocalNet.as_byte(),
+                    vec![],
+                    instructions,
+                    IndexSet::new(),
+                    None,
+                    None,
+                    false,
+                ),
+                vec![TransactionSignature::new(
+                    RistrettoPublicKeyBytes::zero(),
+                    SchnorrSignatureBytes::zero(),
+                )],
+            )
+            .into(),
+            TransactionSealSignature::new(RistrettoPublicKeyBytes::zero(), SchnorrSignatureBytes::zero()),
+        )
+    }
+
+    #[test]
+    fn accepts_transaction_at_the_caps() {
+        let limits = STEALTH_LIMITS;
+        // One transfer that sits exactly on the input and output caps, plus filler transfers up to the transfer cap.
+        let mut statements = vec![statement(
+            limits.max_total_inputs_per_transaction,
+            limits.max_total_outputs_per_transaction,
+        )];
+        statements.extend((1..limits.max_transfers_per_transaction).map(|_| statement(0, 0)));
+        let tx = tx_with_stealth_transfers(statements);
+        StealthTransactionLimitsValidator::new().validate(&(), &tx).unwrap();
+    }
+
+    #[test]
+    fn rejects_too_many_transfers() {
+        let n = STEALTH_LIMITS.max_transfers_per_transaction + 1;
+        let tx = tx_with_stealth_transfers((0..n).map(|_| statement(0, 0)).collect());
+        let err = StealthTransactionLimitsValidator::new().validate(&(), &tx).unwrap_err();
+        assert!(matches!(
+            err,
+            TransactionValidationError::ExceedsStealthTransactionLimit { limit: "transfers", .. }
+        ));
+    }
+
+    #[test]
+    fn rejects_too_many_total_inputs() {
+        let tx = tx_with_stealth_transfers(vec![statement(STEALTH_LIMITS.max_total_inputs_per_transaction + 1, 0)]);
+        let err = StealthTransactionLimitsValidator::new().validate(&(), &tx).unwrap_err();
+        assert!(matches!(
+            err,
+            TransactionValidationError::ExceedsStealthTransactionLimit { limit: "inputs", .. }
+        ));
+    }
+
+    #[test]
+    fn rejects_too_many_total_outputs_summed_across_transfers() {
+        // Split the over-cap output total across two transfers to prove the validator sums across the transaction.
+        let per = STEALTH_LIMITS.max_total_outputs_per_transaction / 2 + 1;
+        let tx = tx_with_stealth_transfers(vec![statement(0, per), statement(0, per)]);
+        let err = StealthTransactionLimitsValidator::new().validate(&(), &tx).unwrap_err();
+        assert!(matches!(
+            err,
+            TransactionValidationError::ExceedsStealthTransactionLimit { limit: "outputs", .. }
+        ));
+    }
+}


### PR DESCRIPTION
## Problem

A `StealthTransfer` is a top-level instruction and nothing caps how many a transaction may contain — only `max_transaction_weight` (1,000,000). A minimal crypto-bearing transfer is ~100 weight, so one transaction could carry **~9,700 stealth transfers**.

Verifying a stealth transfer is **native, unmetered** crypto, dominated by the per-output aggregated bulletproof range proof + ElGamal viewable-balance proof. The WASM points budget never sees it, and the static transaction weight under-priced outputs (2 weight each). Two consensus facts make this a leader-stall DoS:

- A **single-transaction block is exempt** from `max_block_validation_weight` (`exceeds_block_validation_weight`), so the per-block execution backstop does not apply.
- Propose-time execution **always runs the first transaction to completion** (no intra-transaction abort) before honouring the 5s soft deadline.

So one transaction can force tens of seconds to minutes of crypto verification on the proposing leader (and every replica re-executing the block), pushing it past the 10s block time and tripping `missed_proposal_suspend_threshold`.

### Measured cost (criterion, x86-class dev hardware)

| outputs / transfer | 1 | 2 | 4 | 8 |
|---|---|---|---|---|
| `validate_transfer` (with view key) | 1.2ms | 2.1ms | 4.0ms | **8.2ms** |

Per-transfer cost is output-dominated (~1ms/output); inputs are ~5µs each. ~9,700 transfers ≈ tens of seconds here, multiples more on validator-grade hardware.

## Fix

**Per-transaction caps** (`STEALTH_LIMITS`): **64 transfers, 256 total outputs, 1024 total inputs** (per-transfer 1000 in / 8 out unchanged).
- Enforced in the engine working state **before each transfer's crypto runs**, aborting early — so the work performed is bounded no matter how many transfers the transaction carries. This is the consensus-relevant guard (deterministic, uniform).
- Mirrored as a structural mempool validator (`StealthTransactionLimitsValidator`) for early rejection at ingress on both the validator node and the indexer.

**Honest weight**: stealth output weight **2 → 8**, so the per-transaction and per-block weight budgets bound the aggregate native verification cost (~1,875 outputs per 15k-weight block, vs ~7,500 before).

**Bench**: adds `stealth_cost` criterion bench measuring `validate_transfer` vs input/output counts, used to calibrate the numbers.

Caps/weights derived from the measured ~1ms/output, derated ~3x for validator-grade hardware; a fully capped stealth transaction is ~9.5k weight and executes in well under 1s.

## Testing

- New unit tests for the engine accumulator (`StealthTransactionTotals::account_transfer`) — boundary + no-advance-on-rejection.
- New unit tests for the mempool validator (transfers / total-inputs / total-outputs caps, summed across transfers).
- Existing stealth + spend_script integration tests (41) pass; consensus-constants and transaction tests pass.