### PR TITLE
fix(template-lib-types): bound RestrictedAccessRule decode recursion (pre-validation DoS)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11059,7 +11059,7 @@ dependencies = [
 
 [[package]]
 name = "tari_bor"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "borsh",
  "indexmap 2.13.0",

--- a/crates/tari_bor/Cargo.toml
+++ b/crates/tari_bor/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_bor"
 description = "The binary object representation (BOR) crate provides a binary encoding for template/engine data types"
-version = "0.14.1"
+version = "0.14.2"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/tari_bor/src/adapters.rs
+++ b/crates/tari_bor/src/adapters.rs
@@ -34,12 +34,24 @@ pub mod boxed_slice {
 
     pub fn decode<'b, C, T>(d: &mut Decoder<'b>, ctx: &mut C) -> Result<Box<[T]>, minicbor::decode::Error>
     where T: Decode<'b, C> {
+        decode_with_fn(d, ctx, T::decode)
+    }
+
+    /// Like [`decode`], but decodes each element with a caller-supplied function rather than the
+    /// element's [`Decode`] impl. This lets a self-recursive type thread decode state — such as a
+    /// nesting-depth bound — through the element decode, which a derived `Decode` cannot. The
+    /// `MAX_PREALLOC` cap on the untrusted length header still applies.
+    pub fn decode_with_fn<'b, C, T>(
+        d: &mut Decoder<'b>,
+        ctx: &mut C,
+        mut decode_elem: impl FnMut(&mut Decoder<'b>, &mut C) -> Result<T, minicbor::decode::Error>,
+    ) -> Result<Box<[T]>, minicbor::decode::Error> {
         let len = d.array()?;
         match len {
             Some(n) => {
                 let mut out = Vec::with_capacity(n.min(super::MAX_PREALLOC) as usize);
                 for _ in 0..n {
-                    out.push(T::decode(d, ctx)?);
+                    out.push(decode_elem(d, ctx)?);
                 }
                 Ok(out.into_boxed_slice())
             },
@@ -50,7 +62,7 @@ pub mod boxed_slice {
                         d.skip()?;
                         break;
                     }
-                    out.push(T::decode(d, ctx)?);
+                    out.push(decode_elem(d, ctx)?);
                 }
                 Ok(out.into_boxed_slice())
             },

--- a/crates/template_lib_types/src/access_rules.rs
+++ b/crates/template_lib_types/src/access_rules.rs
@@ -2,7 +2,7 @@
 //   SPDX-License-Identifier: BSD-3-Clause
 //! Access control rules for template-related data like component methods and resources
 
-use minicbor::{CborLen, Decode, Encode};
+use minicbor::{CborLen, Decode, Decoder, Encode, data::Type, decode};
 use tari_bor::adapters::boxed_slice;
 use tari_template_abi::rust::{collections::BTreeMap, prelude::*};
 
@@ -48,7 +48,7 @@ impl AccessRule {
 }
 
 /// An enum that represents the possible ways to restrict access to components or resources
-#[derive(Debug, Clone, Encode, Decode, CborLen, PartialEq, Eq)]
+#[derive(Debug, Clone, Encode, CborLen, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "borsh", derive(borsh::BorshSerialize))]
 #[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export))]
@@ -79,6 +79,88 @@ impl RestrictedAccessRule {
 
     pub fn or(self, other: Self) -> Self {
         Self::AnyOf(Box::new([self, other]))
+    }
+}
+
+// `Decode` is hand-written (not derived) because `RestrictedAccessRule` is self-recursive through
+// `AnyOf`/`AllOf` and decode input is untrusted: a derived recursive decode would overflow the stack
+// — an uncatchable process abort, not a recoverable error — on a maliciously deep payload, before any
+// validation runs. Threading the nesting depth bounds the recursion and turns over-nested input into
+// a clean error, mirroring the guard `tari_bor` applies to the dynamic `Value` tree. `Encode` and
+// `CborLen` stay derived, so this decode must match their wire framing; the round-trip tests enforce
+// that.
+impl<'b, C> Decode<'b, C> for RestrictedAccessRule {
+    fn decode(d: &mut Decoder<'b>, ctx: &mut C) -> Result<Self, decode::Error> {
+        decode_restricted_access_rule(d, ctx, 0)
+    }
+}
+
+fn decode_restricted_access_rule<'b, C>(
+    d: &mut Decoder<'b>,
+    ctx: &mut C,
+    depth: usize,
+) -> Result<RestrictedAccessRule, decode::Error> {
+    if depth >= tari_bor::MAX_DECODE_DEPTH {
+        return Err(decode::Error::message(
+            "RestrictedAccessRule nesting exceeds the maximum decode depth",
+        ));
+    }
+
+    // minicbor's derived enum framing is a definite 2-element array of `[variant index, body]`.
+    let pos = d.position();
+    if d.array()? != Some(2) {
+        return Err(decode::Error::message("expected RestrictedAccessRule enum (2-element array)").at(pos));
+    }
+    let variant_pos = d.position();
+    match d.i64()? {
+        0 => decode_variant_field(d, ctx, |d, ctx| RequireRule::decode(d, ctx)).map(RestrictedAccessRule::Require),
+        1 => decode_variant_field(d, ctx, |d, ctx| decode_restricted_slice(d, ctx, depth + 1))
+            .map(RestrictedAccessRule::AnyOf),
+        2 => decode_variant_field(d, ctx, |d, ctx| decode_restricted_slice(d, ctx, depth + 1))
+            .map(RestrictedAccessRule::AllOf),
+        n => Err(decode::Error::unknown_variant(n).at(variant_pos)),
+    }
+}
+
+// Decodes one `AnyOf`/`AllOf` boxed slice, recursing at the incremented depth. Reuses the
+// `boxed_slice` adapter's element loop (and its `MAX_PREALLOC` cap) via a depth-threading decoder.
+fn decode_restricted_slice<'b, C>(
+    d: &mut Decoder<'b>,
+    ctx: &mut C,
+    depth: usize,
+) -> Result<Box<[RestrictedAccessRule]>, decode::Error> {
+    boxed_slice::decode_with_fn(d, ctx, |d, ctx| decode_restricted_access_rule(d, ctx, depth))
+}
+
+// Every `RestrictedAccessRule` variant carries a single field at index 0. minicbor's derive encodes a
+// variant body as an array and reads its fields by position; this mirrors that — decode position 0,
+// skip any further positions — so it accepts exactly what the derived decode would.
+fn decode_variant_field<'b, C, T>(
+    d: &mut Decoder<'b>,
+    ctx: &mut C,
+    decode_field: impl FnOnce(&mut Decoder<'b>, &mut C) -> Result<T, decode::Error>,
+) -> Result<T, decode::Error> {
+    let pos = d.position();
+    match d.array()? {
+        Some(0) => Err(decode::Error::missing_value(0).at(pos)),
+        Some(len) => {
+            let field = decode_field(d, ctx)?;
+            for _ in 1..len {
+                d.skip()?;
+            }
+            Ok(field)
+        },
+        None => {
+            if matches!(d.datatype()?, Type::Break) {
+                return Err(decode::Error::missing_value(0).at(pos));
+            }
+            let field = decode_field(d, ctx)?;
+            while !matches!(d.datatype()?, Type::Break) {
+                d.skip()?;
+            }
+            d.skip()?;
+            Ok(field)
+        },
     }
 }
 
@@ -718,5 +800,68 @@ mod tests {
 
     fn access_rule_from_requirement(requirement: RuleRequirement) -> AccessRule {
         AccessRule::Restricted(RestrictedAccessRule::Require(RequireRule::Require(requirement)))
+    }
+
+    fn leaf_rule() -> RestrictedAccessRule {
+        RestrictedAccessRule::Require(RequireRule::Require(RuleRequirement::Resource(ResourceAddress::new(
+            ObjectKey::default(),
+        ))))
+    }
+
+    fn nested_any_of(depth: usize) -> RestrictedAccessRule {
+        let mut rule = leaf_rule();
+        for _ in 0..depth {
+            rule = RestrictedAccessRule::AnyOf(Box::new([rule]));
+        }
+        rule
+    }
+
+    #[test]
+    fn restricted_access_rule_roundtrips_all_variants() {
+        let component_address = ComponentAddress::new(ObjectKey::default());
+        let resource_address = ResourceAddress::new(ObjectKey::default());
+        let rules = [
+            leaf_rule(),
+            RestrictedAccessRule::Require(RequireRule::MOfN(
+                1,
+                Box::new([
+                    RuleRequirement::ScopedToComponent(component_address),
+                    RuleRequirement::Resource(resource_address),
+                ]),
+            )),
+            RestrictedAccessRule::AnyOf(Box::new([
+                RestrictedAccessRule::Require(RequireRule::Require(RuleRequirement::ScopedToComponent(
+                    component_address,
+                ))),
+                RestrictedAccessRule::AllOf(Box::new([leaf_rule()])),
+            ])),
+            nested_any_of(8),
+        ];
+        for rule in rules {
+            let bytes = tari_bor::encode(&rule).unwrap();
+            let decoded: RestrictedAccessRule = tari_bor::decode(&bytes).unwrap();
+            assert_eq!(decoded, rule);
+        }
+    }
+
+    #[test]
+    fn restricted_access_rule_decodes_up_to_max_depth() {
+        // One level below the limit decodes and round-trips; at the limit it is rejected.
+        let ok = nested_any_of(tari_bor::MAX_DECODE_DEPTH - 1);
+        let bytes = tari_bor::encode(&ok).unwrap();
+        assert_eq!(tari_bor::decode::<RestrictedAccessRule>(&bytes).unwrap(), ok);
+
+        let too_deep = nested_any_of(tari_bor::MAX_DECODE_DEPTH);
+        let bytes = tari_bor::encode(&too_deep).unwrap();
+        assert!(tari_bor::decode::<RestrictedAccessRule>(&bytes).is_err());
+    }
+
+    #[test]
+    fn restricted_access_rule_rejects_deeply_nested_payload_without_overflow() {
+        // A tiny-per-level payload that, decoded by a recursive decode without a depth bound, would
+        // overflow the stack (a process abort). Each `AnyOf` level is the 4 bytes `82 01 81 81`. The
+        // depth guard must reject it as a clean error long before the recursion can overflow.
+        let bytes: Vec<u8> = (0..100_000).flat_map(|_| [0x82u8, 0x01, 0x81, 0x81]).collect();
+        assert!(tari_bor::decode::<RestrictedAccessRule>(&bytes).is_err());
     }
 }


### PR DESCRIPTION
## Problem

`RestrictedAccessRule` is self-recursive through its `AnyOf`/`AllOf` boxed-slice children, and its `Decode` was `#[derive]`d. A maliciously deep payload — roughly 4 bytes per nesting level — drives the derived recursive decode into a **stack overflow**, which is an *uncatchable process abort* (not a recoverable error), **during** `tari_bor::decode_exact::<Transaction>` of an incoming transaction, **before** any validation or weight check runs.

This is an unauthenticated remote DoS on the p2p gossip path:
`gossip → protobuf wrapper → bor_encoded → crates/p2p/src/encoding.rs decode_exact::<Transaction> → derived Decode`. `max_transaction_weight` is computed *post*-decode, so it offers no protection, and it's worse on validators (decode runs on tokio worker threads with smaller stacks). `MAX_DECODE_DEPTH = 64` already existed but **only** guards the dynamic `tari_bor::Value` tree; typed decode bypassed it.

`RestrictedAccessRule` is reachable typed-on-the-wire via `Instruction::CreateAccount` and other access-rule-bearing instructions.

## Fix

Single-pass, depth-bounded decode — no `Value` round-trip, no global state, no fork:

- **`RestrictedAccessRule`** — hand-write `Decode` (it's the only self-recursive type in the graph; `RuleRequirement`/`RequireRule` are leaves, so the lone recursive edge is `AnyOf`/`AllOf`). It threads the nesting depth and rejects over-nested input as a clean `Err`, mirroring the existing `value.rs::decode_value(d, ctx, depth)` precedent and reusing `tari_bor::MAX_DECODE_DEPTH` (64). `Encode`/`CborLen` stay derived; the hand impl matches their wire framing exactly (enum = definite `array(2)[i64 index, body]`, single field at body index 0), enforced by a round-trip test.
- **`tari_bor::adapters::boxed_slice::decode_with_fn`** — new helper that injects a per-element decoder so a recursive type can thread depth through the slice, while reusing the existing `MAX_PREALLOC` cap. The original `decode` now delegates to it.
- **`tari_bor` 0.14.1 → 0.14.2** (additive, non-breaking; dependents auto-pick-up via `^0.y`).

### Alternatives considered (and why not)

- *Decode-to-`Value` then re-decode* — two passes; rejected.
- *Thread-local depth counter in the codec* — hidden global state with a real re-entrancy hazard if any `Decode` nests an independent `tari_bor::decode`.
- *Non-`()` decode context (`#[cbor(context_bound)]`)* — poisons the entire ~15–40-type containment closure with a bound and needs a no-op `impl for ()`, leaving protection opt-in at each ingress.
- *Fork minicbor* — clean but requires forking the **proc-macro** (derive calls `Decode::decode` directly, bypassing the `Decoder` dispatcher), plus ecosystem ripple — disproportionate to one fix.

## Testing

- `cargo nextest run -p tari_bor -p tari_template_lib_types --features tari_template_lib_types/serde` — 110/110 pass, including:
  - round-trip of every `RestrictedAccessRule` variant (proves the hand-written framing matches the derived `Encode`),
  - depth boundary: `MAX_DECODE_DEPTH - 1` decodes, `MAX_DECODE_DEPTH` is rejected,
  - a 100k-level payload decodes to a clean error instead of overflowing the stack.
- `cargo clippy` clean; `no_std` (`--no-default-features`) builds.

## Follow-up

`SpendCondition::All(Box<[SpendCondition]>)` (on the TIP-0006 `engine-utxo-mast-execution` branch) is the same shape and needs the identical hand-written `Decode` there; it depends on `boxed_slice::decode_with_fn` from this PR.
