### PR TITLE
feat: restrict transactions to a single publish-template instruction

### DIFF
--- a/applications/tari_validator_node/src/bootstrap.rs
+++ b/applications/tari_validator_node/src/bootstrap.rs
@@ -71,6 +71,7 @@ use tari_ootle_transaction::{Network, Transaction};
 use tari_ootle_transaction_validation::{
     BasicValidations,
     EpochRangeValidator,
+    PublishTemplateLimitValidator,
     StealthTransactionLimitsValidator,
     TemplateExistsValidator,
     TransactionDryRunValidator,
@@ -485,6 +486,7 @@ pub fn create_mempool_transaction_validator<TProvider: TemplateProvider>(
         // Reject transactions whose aggregate stealth-transfer work exceeds the per-transaction caps before
         // verifying signatures or executing.
         .and_then(StealthTransactionLimitsValidator::new())
+        .and_then(PublishTemplateLimitValidator::new())
         .and_then(TransactionSignatureValidator)
         .and_then(TemplateExistsValidator::new(template_manager))
 }

--- a/crates/engine/src/transaction/processor.rs
+++ b/crates/engine/src/transaction/processor.rs
@@ -188,8 +188,8 @@ where
                 finalize: FinalizeResult::new_rejected(
                     id.as_hash(),
                     RejectReason::ExecutionFailure(format!(
-                        "Transaction contains {publish_template_count} publish-template instructions, but at most {} \
-                         is allowed",
+                        "Transaction contains {publish_template_count} publish-template instructions, but the maximum \
+                         allowed is {}",
                         limits::MAX_PUBLISH_TEMPLATES_PER_TRANSACTION
                     )),
                 ),

--- a/crates/engine/src/transaction/processor.rs
+++ b/crates/engine/src/transaction/processor.rs
@@ -24,7 +24,7 @@ use std::{sync::Arc, time::Instant};
 
 use log::*;
 use tari_engine_types::{
-    commit_result::{ExecuteResult, FinalizeResult},
+    commit_result::{ExecuteResult, FinalizeResult, RejectReason},
     component::{Component, derive_component_address_from_public_key},
     entity_id_provider::EntityIdProvider,
     indexed_value::{IndexedValue, IndexedWellKnownTypes},
@@ -173,6 +173,32 @@ where
                 })?;
 
         let instructions = executable.into_instructions();
+
+        // A transaction may publish at most one template. Enforced here during execution — a consensus rule every
+        // validator applies deterministically — so it holds even for transactions that reach execution without
+        // passing the mempool ingress validator that mirrors it.
+        let publish_template_count = instructions
+            .fee
+            .iter()
+            .chain(&instructions.main)
+            .filter(|instruction| matches!(instruction, Instruction::PublishTemplate { .. }))
+            .count();
+        if publish_template_count > limits::MAX_PUBLISH_TEMPLATES_PER_TRANSACTION {
+            return Ok(ExecuteResult {
+                finalize: FinalizeResult::new_rejected(
+                    id.as_hash(),
+                    RejectReason::ExecutionFailure(format!(
+                        "Transaction contains {publish_template_count} publish-template instructions, but at most {} \
+                         is allowed",
+                        limits::MAX_PUBLISH_TEMPLATES_PER_TRANSACTION
+                    )),
+                ),
+                execution_time: timer.elapsed(),
+                execute_epoch: execute_epoch.map(Into::into),
+                wasm_execution_points: 0,
+            });
+        }
+
         let blobs = std::sync::Arc::new(instructions.blobs);
 
         let mut runtime_interface = Box::new(RuntimeInterfaceImpl::initialize(

--- a/crates/engine/tests/publish_template.rs
+++ b/crates/engine/tests/publish_template.rs
@@ -105,15 +105,12 @@ fn rejects_more_than_one_publish_template() {
     let (account_address, owner_proof, account_key, _) = test.create_funded_account_with_keypair();
 
     // The per-transaction publish-template cap is checked before any binary is validated, so these (invalid) binaries
-    // never reach WASM validation: the transaction is rejected for carrying two PublishTemplate instructions.
-    let reason = test.execute_expect_failure(
-        Transaction::builder_localnet()
-            .pay_fee_from_component(account_address, 200_000u64)
-            .publish_template(vec![1u8, 2, 3])
-            .publish_template(vec![4u8, 5, 6])
-            .build_and_seal(&account_key),
-        vec![owner_proof],
-    );
+    // never reach WASM validation: the transaction is rejected for carrying too many PublishTemplate instructions.
+    let mut builder = Transaction::builder_localnet().pay_fee_from_component(account_address, 200_000u64);
+    for i in 0..=limits::MAX_PUBLISH_TEMPLATES_PER_TRANSACTION {
+        builder = builder.publish_template(vec![i as u8]);
+    }
+    let reason = test.execute_expect_failure(builder.build_and_seal(&account_key), vec![owner_proof]);
 
     let RejectReason::ExecutionFailure(error) = reason else {
         panic!("expected ExecutionFailure, got {reason:?}");
@@ -121,7 +118,7 @@ fn rejects_more_than_one_publish_template() {
     assert!(
         error.contains("publish-template instructions") &&
             error.contains(&format!(
-                "at most {} is allowed",
+                "the maximum allowed is {}",
                 limits::MAX_PUBLISH_TEMPLATES_PER_TRANSACTION
             )),
         "unexpected reject reason: {error}"

--- a/crates/engine/tests/publish_template.rs
+++ b/crates/engine/tests/publish_template.rs
@@ -99,6 +99,35 @@ fn publish_template_too_big_binary() {
     });
 }
 
+#[test]
+fn rejects_more_than_one_publish_template() {
+    let mut test = TemplateTest::new(CRATE_PATH, &[] as &[&str]);
+    let (account_address, owner_proof, account_key, _) = test.create_funded_account_with_keypair();
+
+    // The per-transaction publish-template cap is checked before any binary is validated, so these (invalid) binaries
+    // never reach WASM validation: the transaction is rejected for carrying two PublishTemplate instructions.
+    let reason = test.execute_expect_failure(
+        Transaction::builder_localnet()
+            .pay_fee_from_component(account_address, 200_000u64)
+            .publish_template(vec![1u8, 2, 3])
+            .publish_template(vec![4u8, 5, 6])
+            .build_and_seal(&account_key),
+        vec![owner_proof],
+    );
+
+    let RejectReason::ExecutionFailure(error) = reason else {
+        panic!("expected ExecutionFailure, got {reason:?}");
+    };
+    assert!(
+        error.contains("publish-template instructions") &&
+            error.contains(&format!(
+                "at most {} is allowed",
+                limits::MAX_PUBLISH_TEMPLATES_PER_TRANSACTION
+            )),
+        "unexpected reject reason: {error}"
+    );
+}
+
 fn generate_random_binary(size_in_bytes: usize) -> Vec<u8> {
     iter::repeat_with(random).take(size_in_bytes).collect()
 }

--- a/crates/engine_types/src/limits.rs
+++ b/crates/engine_types/src/limits.rs
@@ -67,6 +67,16 @@ pub const MAX_DIVISIBILITY: u8 = 18;
 
 pub const MAX_TOKEN_SYMBOL_LEN: usize = 10;
 
+/// Maximum number of `PublishTemplate` instructions a single transaction may contain.
+///
+/// Publishing a template registers a new global substate and carries a WASM binary up to
+/// [`ENGINE_LIMITS`]`.max_template_binary_size_bytes`. Capping at one keeps each publishing transaction to a single,
+/// bounded template registration; multiple publishes would stack several large binaries and their validation/storage
+/// cost into one transaction with no benefit a caller cannot get from separate transactions. The engine enforces this
+/// during execution — a consensus rule applied uniformly by every validator — and the mempool mirrors it to reject
+/// such transactions at ingress.
+pub const MAX_PUBLISH_TEMPLATES_PER_TRANSACTION: usize = 1;
+
 pub struct StealthLimits {
     /// Maximum stealth inputs in a single transfer statement.
     pub max_inputs: usize,

--- a/crates/transaction_validation/src/builder.rs
+++ b/crates/transaction_validation/src/builder.rs
@@ -5,6 +5,7 @@ use tari_ootle_transaction::{Network, Transaction};
 
 use crate::{
     BasicValidations,
+    PublishTemplateLimitValidator,
     StealthTransactionLimitsValidator,
     TransactionNetworkValidator,
     TransactionSignatureValidator,
@@ -29,5 +30,6 @@ pub fn create_structural_transaction_validator(
         .and_then(BasicValidations::new())
         .and_then(TransactionWeightValidator::new(max_transaction_weight))
         .and_then(StealthTransactionLimitsValidator::new())
+        .and_then(PublishTemplateLimitValidator::new())
         .and_then(TransactionSignatureValidator)
 }

--- a/crates/transaction_validation/src/error.rs
+++ b/crates/transaction_validation/src/error.rs
@@ -61,4 +61,12 @@ pub enum TransactionValidationError {
         max: usize,
         actual: usize,
     },
+    #[error(
+        "Transaction {transaction_id} contains {actual} publish-template instructions, but at most {max} is allowed"
+    )]
+    TooManyPublishTemplateInstructions {
+        transaction_id: TransactionId,
+        max: usize,
+        actual: usize,
+    },
 }

--- a/crates/transaction_validation/src/error.rs
+++ b/crates/transaction_validation/src/error.rs
@@ -62,7 +62,8 @@ pub enum TransactionValidationError {
         actual: usize,
     },
     #[error(
-        "Transaction {transaction_id} contains {actual} publish-template instructions, but at most {max} is allowed"
+        "Transaction {transaction_id} contains {actual} publish-template instructions, but the maximum allowed is \
+         {max}"
     )]
     TooManyPublishTemplateInstructions {
         transaction_id: TransactionId,

--- a/crates/transaction_validation/src/lib.rs
+++ b/crates/transaction_validation/src/lib.rs
@@ -21,6 +21,8 @@ mod epoch_range;
 pub use epoch_range::*;
 mod network;
 pub use network::*;
+mod publish_template_limits;
+pub use publish_template_limits::*;
 mod signature;
 pub use signature::*;
 mod stealth_limits;

--- a/crates/transaction_validation/src/publish_template_limits.rs
+++ b/crates/transaction_validation/src/publish_template_limits.rs
@@ -104,18 +104,24 @@ mod tests {
     }
 
     #[test]
-    fn accepts_single_publish_template() {
-        let tx = tx_with_instructions(vec![publish_template()]);
+    fn accepts_publish_templates_at_the_limit() {
+        let tx = tx_with_instructions(
+            (0..MAX_PUBLISH_TEMPLATES_PER_TRANSACTION)
+                .map(|_| publish_template())
+                .collect(),
+        );
         PublishTemplateLimitValidator::new().validate(&(), &tx).unwrap();
     }
 
     #[test]
     fn rejects_multiple_publish_templates() {
-        let tx = tx_with_instructions(vec![publish_template(), publish_template()]);
+        let over_limit = MAX_PUBLISH_TEMPLATES_PER_TRANSACTION + 1;
+        let tx = tx_with_instructions((0..over_limit).map(|_| publish_template()).collect());
         let err = PublishTemplateLimitValidator::new().validate(&(), &tx).unwrap_err();
         assert!(matches!(
             err,
-            TransactionValidationError::TooManyPublishTemplateInstructions { max: 1, actual: 2, .. }
+            TransactionValidationError::TooManyPublishTemplateInstructions { max, actual, .. }
+            if max == MAX_PUBLISH_TEMPLATES_PER_TRANSACTION && actual == over_limit
         ));
     }
 }

--- a/crates/transaction_validation/src/publish_template_limits.rs
+++ b/crates/transaction_validation/src/publish_template_limits.rs
@@ -1,0 +1,125 @@
+// Copyright 2026 The Tari Project
+// SPDX-License-Identifier: BSD-3-Clause
+
+use log::warn;
+use tari_ootle_transaction::{Instruction, Transaction};
+
+use crate::{TransactionValidationError, Validator};
+
+const LOG_TARGET: &str = "tari::ootle::mempool::validators::publish_template_limits";
+
+/// Maximum number of `PublishTemplate` instructions permitted in a single transaction.
+///
+/// Publishing a template registers a new global substate and carries a WASM binary up to
+/// `ENGINE_LIMITS.max_template_binary_size_bytes` (1.5 MiB). A transaction is treated as global as soon as it
+/// contains one (`Transaction::is_global`). Capping at one keeps each publishing transaction to a single, bounded
+/// template registration: multiple publishes would multiply binary size, template validation and storage cost in one
+/// transaction with no benefit a caller cannot get by submitting separate transactions.
+pub const MAX_PUBLISH_TEMPLATES_PER_TRANSACTION: usize = 1;
+
+/// Rejects transactions carrying more than [`MAX_PUBLISH_TEMPLATES_PER_TRANSACTION`] `PublishTemplate` instructions.
+#[derive(Debug, Clone, Default)]
+pub struct PublishTemplateLimitValidator;
+
+impl PublishTemplateLimitValidator {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Validator<Transaction> for PublishTemplateLimitValidator {
+    type Context = ();
+    type Error = TransactionValidationError;
+
+    fn validate(&self, _context: &(), transaction: &Transaction) -> Result<(), Self::Error> {
+        // Count across both instruction lists, matching `Transaction::has_publish_template`.
+        let count = transaction
+            .instructions()
+            .iter()
+            .chain(transaction.fee_instructions())
+            .filter(|instruction| matches!(instruction, Instruction::PublishTemplate { .. }))
+            .count();
+
+        if count > MAX_PUBLISH_TEMPLATES_PER_TRANSACTION {
+            let transaction_id = transaction.calculate_id();
+            warn!(
+                target: LOG_TARGET,
+                "PublishTemplateLimitValidator - FAIL: {transaction_id} has {count} publish-template instructions, \
+                 maximum is {MAX_PUBLISH_TEMPLATES_PER_TRANSACTION}"
+            );
+            return Err(TransactionValidationError::TooManyPublishTemplateInstructions {
+                transaction_id,
+                max: MAX_PUBLISH_TEMPLATES_PER_TRANSACTION,
+                actual: count,
+            });
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use indexmap::IndexSet;
+    use tari_ootle_transaction::{
+        Network,
+        TransactionSealSignature,
+        TransactionSignature,
+        UnsealedTransactionV1,
+        UnsignedTransactionV1,
+    };
+    use tari_template_lib::types::crypto::{RistrettoPublicKeyBytes, SchnorrSignatureBytes};
+
+    use super::*;
+
+    fn publish_template() -> Instruction {
+        Instruction::PublishTemplate {
+            binary: 0,
+            metadata_hash: None,
+        }
+    }
+
+    fn tx_with_instructions(instructions: Vec<Instruction>) -> Transaction {
+        Transaction::new(
+            UnsealedTransactionV1::new(
+                UnsignedTransactionV1::new(
+                    Network::LocalNet.as_byte(),
+                    vec![],
+                    instructions,
+                    IndexSet::new(),
+                    None,
+                    None,
+                    false,
+                ),
+                vec![TransactionSignature::new(
+                    RistrettoPublicKeyBytes::zero(),
+                    SchnorrSignatureBytes::zero(),
+                )],
+            )
+            .into(),
+            TransactionSealSignature::new(RistrettoPublicKeyBytes::zero(), SchnorrSignatureBytes::zero()),
+        )
+    }
+
+    #[test]
+    fn accepts_no_publish_template() {
+        let tx = tx_with_instructions(vec![]);
+        PublishTemplateLimitValidator::new().validate(&(), &tx).unwrap();
+    }
+
+    #[test]
+    fn accepts_single_publish_template() {
+        let tx = tx_with_instructions(vec![publish_template()]);
+        PublishTemplateLimitValidator::new().validate(&(), &tx).unwrap();
+    }
+
+    #[test]
+    fn rejects_multiple_publish_templates() {
+        let tx = tx_with_instructions(vec![publish_template(), publish_template()]);
+        let err = PublishTemplateLimitValidator::new().validate(&(), &tx).unwrap_err();
+        assert!(matches!(
+            err,
+            TransactionValidationError::TooManyPublishTemplateInstructions { max: 1, actual: 2, .. }
+        ));
+    }
+}

--- a/crates/transaction_validation/src/publish_template_limits.rs
+++ b/crates/transaction_validation/src/publish_template_limits.rs
@@ -2,22 +2,18 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 use log::warn;
+use tari_engine_types::limits::MAX_PUBLISH_TEMPLATES_PER_TRANSACTION;
 use tari_ootle_transaction::{Instruction, Transaction};
 
 use crate::{TransactionValidationError, Validator};
 
 const LOG_TARGET: &str = "tari::ootle::mempool::validators::publish_template_limits";
 
-/// Maximum number of `PublishTemplate` instructions permitted in a single transaction.
-///
-/// Publishing a template registers a new global substate and carries a WASM binary up to
-/// `ENGINE_LIMITS.max_template_binary_size_bytes` (1.5 MiB). A transaction is treated as global as soon as it
-/// contains one (`Transaction::is_global`). Capping at one keeps each publishing transaction to a single, bounded
-/// template registration: multiple publishes would multiply binary size, template validation and storage cost in one
-/// transaction with no benefit a caller cannot get by submitting separate transactions.
-pub const MAX_PUBLISH_TEMPLATES_PER_TRANSACTION: usize = 1;
-
 /// Rejects transactions carrying more than [`MAX_PUBLISH_TEMPLATES_PER_TRANSACTION`] `PublishTemplate` instructions.
+///
+/// This mirrors the engine's execution-time cap at ingress, rejecting such transactions before they are gossiped,
+/// stored and executed. The engine remains the consensus authority; see
+/// [`tari_engine_types::limits::MAX_PUBLISH_TEMPLATES_PER_TRANSACTION`].
 #[derive(Debug, Clone, Default)]
 pub struct PublishTemplateLimitValidator;
 


### PR DESCRIPTION
## What

Caps the number of `PublishTemplate` instructions a single transaction may contain at **one**, enforced at two layers:

- **Consensus (execution):** `TransactionProcessor::execute` counts publish-template instructions across the fee and main intents and rejects the transaction (`RejectReason::ExecutionFailure`) before any instruction runs — i.e. before any WASM binary is validated. Because every validator runs this deterministically, it is a consensus rule, not just a mempool heuristic: a transaction that reaches execution without passing mempool ingress (e.g. proposed directly by a faulty leader) is still rejected uniformly.
- **Mempool ingress:** a new `PublishTemplateLimitValidator` mirrors the cap at ingress, rejecting such transactions before they are gossiped, stored and executed. It is wired into both `create_structural_transaction_validator` (indexer) and `create_mempool_transaction_validator` (validator node), alongside the existing stealth-limits validator. The validator counts across both the regular and fee instruction lists, so a publish cannot be smuggled in via fee instructions.

The limit constant `MAX_PUBLISH_TEMPLATES_PER_TRANSACTION` lives in `tari_engine_types::limits` as the single source of truth, referenced by both the engine and the ingress validator so the two cannot drift.

## Why

Publishing a template registers a new global substate and carries a WASM binary up to `ENGINE_LIMITS.max_template_binary_size_bytes` (1.5 MiB). Allowing several publishes per transaction stacks several large binaries plus their validation and storage cost into one transaction with no benefit a caller cannot get by submitting separate transactions. Capping at one keeps each publishing transaction to a single, bounded template registration.

## Tests

- `crates/engine/tests/publish_template.rs::rejects_more_than_one_publish_template` — end-to-end: a transaction with two publish-template instructions is rejected with the expected reason (and proves the cap is checked before binary validation).
- Unit tests for `PublishTemplateLimitValidator` (accepts 0 and 1, rejects 2+).