### PR TITLE
fix(template_test_tooling): isolate template wasm builds per feature set

### DIFF
--- a/crates/template_test_tooling/src/compile.rs
+++ b/crates/template_test_tooling/src/compile.rs
@@ -1,7 +1,16 @@
 //   Copyright 2026 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use std::{ffi::OsStr, fs, io, io::ErrorKind, path::Path, process::Command};
+use std::{
+    collections::hash_map::DefaultHasher,
+    ffi::{OsStr, OsString},
+    fs,
+    hash::{Hash, Hasher},
+    io,
+    io::ErrorKind,
+    path::Path,
+    process::Command,
+};
 
 use cargo_toml::{Manifest, Product};
 use tari_engine::wasm::WasmModule;
@@ -40,10 +49,24 @@ where
         ));
     }
 
+    let envs = envs
+        .into_iter()
+        .map(|(k, v)| (k.as_ref().to_os_string(), v.as_ref().to_os_string()))
+        .collect::<Vec<_>>();
+
+    // Compile each (features, envs) combination into a dedicated target directory. Cargo writes the
+    // same `release/<name>.wasm` path regardless of feature set, so sharing one target directory lets
+    // concurrent test compilations clobber each other: a build that rebuilds for a different
+    // fingerprint replaces the artifact while another process is reading it, surfacing as a spurious
+    // "No such file or directory" error.
+    let target_subdir = Path::new("target").join(target_dir_key(features, &envs));
+
     let mut command = Command::new("cargo");
     command
         .current_dir(pkg_dir)
         .envs(envs)
+        // CARGO_TARGET_DIR is resolved relative to the command's working directory (pkg_dir).
+        .env("CARGO_TARGET_DIR", &target_subdir)
         .args(["build", "--target", "wasm32-unknown-unknown", "--release"]);
 
     if !features.is_empty() {
@@ -85,7 +108,7 @@ where
 
     // path of the wasm executable
     let path = pkg_dir
-        .join("target")
+        .join(&target_subdir)
         .join("wasm32-unknown-unknown")
         .join("release")
         .join(wasm_name)
@@ -93,4 +116,24 @@ where
 
     let code = fs::read(path).map_err(|e| io::Error::other(format!("Failed to read wasm file: {}", e)))?;
     Ok(WasmModule::from_code(code))
+}
+
+/// Builds a stable, per-(features, envs) subdirectory name for the package's cargo target directory.
+///
+/// Distinct feature sets and environments produce distinct cargo fingerprints yet the same
+/// `release/<name>.wasm` output path. Giving each combination its own target directory prevents a
+/// concurrent compile from replacing another's artifact while it is being read.
+fn target_dir_key(features: &[&str], envs: &[(OsString, OsString)]) -> String {
+    if features.is_empty() && envs.is_empty() {
+        return "default".to_string();
+    }
+
+    let mut hasher = DefaultHasher::new();
+    let mut features = features.to_vec();
+    features.sort_unstable();
+    features.hash(&mut hasher);
+    let mut envs = envs.iter().collect::<Vec<_>>();
+    envs.sort_unstable();
+    envs.hash(&mut hasher);
+    format!("{:016x}", hasher.finish())
 }


### PR DESCRIPTION
## Description

Engine tests run under `cargo nextest` could intermittently fail with:

```
Failed to read wasm file: No such file or directory (os error 2)
```

Each template package is a standalone crate compiled at test runtime via `cargo build` in `crates/template_test_tooling/src/compile.rs`, then the resulting wasm is read from `target/wasm32-unknown-unknown/release/<name>.wasm`. That output path is identical regardless of the feature set or env vars used. When concurrent test processes built the same package with *different* feature sets — most notably `tests/templates/buggy`, the only multi-feature template, compiled four different ways — cargo would rebuild and atomically replace that single artifact (unlink + relink) while another process's `fs::read` landed in the replace window, yielding `ENOENT`. The cargo build-directory lock serializes the builds against each other but does not cover the bare `fs::read` in a different process.

The `ENOENT` (vs a truncated/corrupt read) confirms the file was *removed/replaced* by a concurrent recompile, not partially written.

## Motivation

Intermittent `No such file or directory` failures in engine tests under `cargo nextest` were non-deterministic and hard to reproduce locally, masking real failures. The root cause was a shared wasm output path across concurrent compilations with different feature sets.

## Changes

- Give each `(features, envs)` combination its own target directory via `CARGO_TARGET_DIR`, keyed by `"default"` (no features/envs) or a stable hash of the sorted features + envs otherwise.
- Distinct feature sets no longer share an output path, so concurrent compiles can't clobber each other mid-read.
- As a bonus, the four `buggy` feature builds stop serially rebuilding over one another.

## Verification

- `cargo check -p tari_template_test_tooling` — clean
- Formatted with `cargo +nightly-2025-12-05 fmt --all`
- `test_buggy_template` (the multi-feature trigger) passes and produces four distinct hashed target dirs, each with its own `buggy.wasm`
- Full `test.rs` binary (30 tests) under `cargo nextest` — 30 passed