### PR TITLE
feat(engine)!: reject published templates with disallowed custom sections

### DIFF
--- a/applications/tari_walletd/src/services/wasm_optimizer.rs
+++ b/applications/tari_walletd/src/services/wasm_optimizer.rs
@@ -5,7 +5,7 @@ use std::io;
 
 use tempfile::tempdir;
 use thiserror::Error;
-use wasm_opt::{Feature, OptimizationError, OptimizationOptions};
+use wasm_opt::{Feature, OptimizationError, OptimizationOptions, Pass};
 
 #[derive(Debug, Error)]
 pub enum Error {
@@ -45,6 +45,12 @@ pub async fn optimize_wasm_template(template_binary: &[u8]) -> Result<Vec<u8>, E
         .enable_feature(Feature::ReferenceTypes)
         .disable_feature(Feature::Simd)
         .disable_feature(Feature::RelaxedSimd)
+        // The engine rejects a published template carrying any custom section other than
+        // `tari_tdef` (`WasmModule::validate_code`). Strip the toolchain-emitted `name`,
+        // `producers` and `target_features` sections so the optimized binary is accepted.
+        .add_pass(Pass::StripDebug)
+        .add_pass(Pass::StripProducers)
+        .add_pass(Pass::StripTargetFeatuers)
         .run(input_file_path, output_file_path.as_path())?;
 
     let result = tokio::fs::read(output_file_path).await?;

--- a/crates/engine/src/wasm/error.rs
+++ b/crates/engine/src/wasm/error.rs
@@ -3,7 +3,7 @@
 
 use tari_bor::BorError;
 use tari_engine_types::indexed_value::IndexedValueError;
-use tari_template_abi::version::WasmAbiVersion;
+use tari_template_abi::{TEMPLATE_DEF_CUSTOM_SECTION, version::WasmAbiVersion};
 use wasmer::{ExportError, InstantiationError, MemoryAccessError};
 
 use crate::runtime::RuntimeError;
@@ -101,6 +101,12 @@ pub enum WasmValidationError {
         function_name: String,
         return_type: tari_template_abi::Type,
     },
+    #[error(
+        "Module contains disallowed custom section `{name}`; only `{TEMPLATE_DEF_CUSTOM_SECTION}` is permitted. Strip \
+         debug and metadata sections before publishing (e.g. `wasm-opt --strip-debug --strip-producers` or \
+         `wasm-strip`)."
+    )]
+    DisallowedCustomSection { name: String },
 }
 
 impl From<wasmer::InstantiationError> for WasmExecutionError {

--- a/crates/engine/src/wasm/module.rs
+++ b/crates/engine/src/wasm/module.rs
@@ -43,6 +43,7 @@ use wasmer::{
     WasmPtr,
     imports,
     sys::{BaseTunables, CompilerConfig, Cranelift, CraneliftOptLevel, EngineBuilder, Target},
+    wasmparser::{Parser, Payload},
 };
 
 use crate::{
@@ -69,6 +70,12 @@ impl WasmModule {
     }
 
     pub fn validate_code(code: &[u8]) -> Result<TemplateDef, TemplateLoaderError> {
+        // Admission rule for externally-published templates: reject custom
+        // sections the engine does not consume before paying for the cranelift
+        // compile below. Only the registration path runs this; already-stored
+        // templates (and built-ins) load via `load_template_from_code` without
+        // it.
+        reject_disallowed_custom_sections(code).map_err(WasmExecutionError::from)?;
         // TODO: evaluate if there are acceptable cheaper ways to fully validate
         let loaded = Self::load_template_from_code(code)?;
         Ok(loaded.into_template_def())
@@ -317,6 +324,37 @@ fn load_template_def_from_custom_section(module: &wasmer::Module) -> Result<Opti
     Ok(Some(template))
 }
 
+/// Custom sections the engine consumes and therefore admits into a published
+/// template. Everything else (DWARF `.debug_*`, the `name` section,
+/// `producers`, …) is semantically inert — cranelift ignores it — but is stored
+/// verbatim with the template and replicated across the whole validator
+/// committee, so it is rejected at registration.
+const ALLOWED_CUSTOM_SECTIONS: &[&str] = &[TEMPLATE_DEF_CUSTOM_SECTION];
+
+/// Reject a published template that carries any custom section other than those
+/// in [`ALLOWED_CUSTOM_SECTIONS`].
+///
+/// The scan defers to the cranelift compile in
+/// [`WasmModule::load_template_from_code`] for malformed input: a binary that
+/// `wasmparser` cannot parse will also fail wasmer's validation, so stopping at
+/// the first parse error lets that path report the canonical `CompileError`
+/// rather than a less precise one here.
+fn reject_disallowed_custom_sections(code: &[u8]) -> Result<(), WasmValidationError> {
+    for payload in Parser::new(0).parse_all(code) {
+        // Malformed wasm: stop and let the cranelift compile in
+        // `load_template_from_code` report the canonical CompileError.
+        let Ok(payload) = payload else { break };
+        if let Payload::CustomSection(reader) = payload &&
+            !ALLOWED_CUSTOM_SECTIONS.contains(&reader.name())
+        {
+            return Err(WasmValidationError::DisallowedCustomSection {
+                name: reader.name().to_string(),
+            });
+        }
+    }
+    Ok(())
+}
+
 fn validate_instance<S: AsStoreMut>(
     store: &mut S,
     instance: &Instance,
@@ -440,4 +478,80 @@ fn validate_functions(template_def: &TemplateDef) -> Result<(), WasmExecutionErr
         },
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_uleb128(out: &mut Vec<u8>, mut value: u32) {
+        loop {
+            let mut byte = (value & 0x7f) as u8;
+            value >>= 7;
+            if value != 0 {
+                byte |= 0x80;
+            }
+            out.push(byte);
+            if value == 0 {
+                break;
+            }
+        }
+    }
+
+    /// Build a header-only WASM module carrying the given named custom sections,
+    /// in order. `wasmparser` accepts magic+version plus custom sections, which
+    /// is all `reject_disallowed_custom_sections` inspects.
+    fn wasm_with_custom_sections(sections: &[(&str, &[u8])]) -> Vec<u8> {
+        let mut wasm = vec![0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00];
+        for (name, payload) in sections {
+            let mut body = Vec::new();
+            write_uleb128(&mut body, name.len() as u32);
+            body.extend_from_slice(name.as_bytes());
+            body.extend_from_slice(payload);
+            wasm.push(0); // custom section id
+            write_uleb128(&mut wasm, body.len() as u32);
+            wasm.extend_from_slice(&body);
+        }
+        wasm
+    }
+
+    #[test]
+    fn accepts_module_without_custom_sections() {
+        let wasm = wasm_with_custom_sections(&[]);
+        reject_disallowed_custom_sections(&wasm).expect("no custom sections is allowed");
+    }
+
+    #[test]
+    fn accepts_only_template_def_section() {
+        let wasm = wasm_with_custom_sections(&[(TEMPLATE_DEF_CUSTOM_SECTION, &[1, 2, 3, 4])]);
+        reject_disallowed_custom_sections(&wasm).expect("tari_tdef is allowed");
+    }
+
+    #[test]
+    fn rejects_name_section() {
+        let wasm = wasm_with_custom_sections(&[("name", &[0u8; 64])]);
+        match reject_disallowed_custom_sections(&wasm) {
+            Err(WasmValidationError::DisallowedCustomSection { name }) => assert_eq!(name, "name"),
+            other => panic!("expected DisallowedCustomSection, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rejects_dwarf_debug_section() {
+        let wasm = wasm_with_custom_sections(&[(".debug_info", &[0u8; 1024])]);
+        match reject_disallowed_custom_sections(&wasm) {
+            Err(WasmValidationError::DisallowedCustomSection { name }) => assert_eq!(name, ".debug_info"),
+            other => panic!("expected DisallowedCustomSection, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rejects_disallowed_section_alongside_template_def() {
+        let wasm =
+            wasm_with_custom_sections(&[(TEMPLATE_DEF_CUSTOM_SECTION, &[1, 2, 3, 4]), ("producers", &[0u8; 16])]);
+        match reject_disallowed_custom_sections(&wasm) {
+            Err(WasmValidationError::DisallowedCustomSection { name }) => assert_eq!(name, "producers"),
+            other => panic!("expected DisallowedCustomSection, got {other:?}"),
+        }
+    }
 }

--- a/crates/template_test_tooling/src/compile.rs
+++ b/crates/template_test_tooling/src/compile.rs
@@ -67,7 +67,17 @@ where
         .envs(envs)
         // CARGO_TARGET_DIR is resolved relative to the command's working directory (pkg_dir).
         .env("CARGO_TARGET_DIR", &target_subdir)
-        .args(["build", "--target", "wasm32-unknown-unknown", "--release"]);
+        .args([
+            "build",
+            "--target",
+            "wasm32-unknown-unknown",
+            "--release",
+            // Strip the `name`, `producers` and `target_features` custom sections the wasm
+            // toolchain emits. `WasmModule::validate_code` rejects a published template that
+            // carries any custom section other than `tari_tdef`, so templates must ship stripped.
+            "--config",
+            "profile.release.strip=\"symbols\"",
+        ]);
 
     if !features.is_empty() {
         command.arg("--features");


### PR DESCRIPTION
## Description

A published WASM template is stored verbatim and replicated across the entire validator committee. A standard `cargo build --release --target wasm32-unknown-unknown` template ships **inert custom sections the engine never reads** — measured on `hello_world`:

| section | size | consumed by engine? |
|---|---|---|
| `tari_tdef` | 137 B | ✅ the ABI |
| `name` | 19,680 B | ❌ |
| `producers` | 77 B | ❌ |
| `target_features` | 148 B | ❌ |

That's ~16% of the binary in dead weight, replicated across the committee, and a cheap state-bloat vector for a hand-crafted template.

## Change

`WasmModule::validate_code` — the single `PublishTemplate` registration gate — now **rejects any custom section other than `tari_tdef`** before paying for the cranelift compile. The check defers to wasmer for malformed input so compile errors stay canonical.

Design notes:
- **Reject, not strip-in-engine.** The template address is `hash_template_code(binary)` — the hash of the *submitted* bytes — so canonicalising in-engine would change the address and couple a stripper to consensus. Stripping is therefore done client-side, before publish.
- **Registration-gate only.** `validate_code` has exactly one caller; execution-time loading (`load_template_from_code`) and built-in templates are untouched.
- Allowlist (`ALLOWED_CUSTOM_SECTIONS`) rather than a DWARF-name match, so renaming a bloat section can't evade it and the policy is trivial to extend.

To keep legitimate publishes working, templates are stripped at the source:
- **`compile_template`** builds with `strip = \"symbols\"`, which removes `name` + `producers` + `target_features`, leaving only `tari_tdef`.
- **The walletd WASM optimizer** adds `StripDebug` / `StripProducers` / `StripTargetFeatuers` passes — bare `-Oz` (the previous behaviour) left `producers` + `target_features`, which the engine would now reject.

The rejection error message tells authors how to strip (`wasm-opt --strip-debug --strip-producers` / `wasm-strip`).

## Testing

- 5 new unit tests in `wasm::module` (no sections / only `tari_tdef` accepted; `name`, `.debug_info`, `producers`-alongside-`tari_tdef` rejected).
- `crates/engine/tests/publish_template.rs` — all 4 pass, incl. `publish_template_success` end-to-end through the stripped build.
- `tari_engine` lib tests + clippy clean; `tari_ootle_walletd` compiles.