### PR TITLE
fix(state-sync): terminate sync streams with a SyncComplete watermark

### DIFF
--- a/applications/tari_indexer/src/network_state_sync/worker.rs
+++ b/applications/tari_indexer/src/network_state_sync/worker.rs
@@ -503,17 +503,57 @@ impl NetworkWideStateSync {
                 is_first_iter = false;
             }
             let msg = result?;
-            let msg_epoch = msg
+            let batch =
+                match msg.response {
+                    Some(rpc::sync_state_response::Response::Batch(batch)) => batch,
+                    Some(rpc::sync_state_response::Response::Complete(complete)) => {
+                        // Terminal watermark: advance recorded progress to the version the producer is
+                        // synced to. This covers trailing versions that streamed no updates because their
+                        // substates are all filtered out for our subscription - without it we could never
+                        // observe that we have caught up to such a shard and would re-sync it from scratch
+                        // every round.
+                        let synced_to = StateVersion::new(complete.synced_to_version);
+                        let msg_epoch = complete.epoch.map(Epoch::from).ok_or_else(|| {
+                            NetworkStateSyncError::InvalidStateUpdate {
+                                details: "Received sync completion without epoch".to_string(),
+                            }
+                        })?;
+                        last_version = synced_to;
+                        last_epoch = Some(msg_epoch);
+                        // Only persist when the watermark advances - a caught-up shard re-sends the same
+                        // version every round, and we must not write on every empty round.
+                        let already_synced = sync_plan_mut
+                            .sync_progress()
+                            .last_state_versions
+                            .get(&shard)
+                            .is_some_and(|(v, _)| synced_to <= *v);
+                        if !already_synced {
+                            sync_plan_mut.add_state_sync_progress(shard, synced_to, msg_epoch);
+                            let sync_progress_snapshot = sync_plan_mut.sync_progress().clone();
+                            self.store
+                                .clone()
+                                .with_write_tx(move |tx| tx.key_value_set(Key::SyncProgress, sync_progress_snapshot))
+                                .await?;
+                        }
+                        break;
+                    },
+                    None => {
+                        return Err(NetworkStateSyncError::InvalidStateUpdate {
+                            details: "Received sync state response with no variant set".to_string(),
+                        });
+                    },
+                };
+            let msg_epoch = batch
                 .epoch
                 .map(Epoch::from)
                 .ok_or_else(|| NetworkStateSyncError::InvalidStateUpdate {
                     details: "Received state update without epoch".to_string(),
                 })?;
             last_epoch = Some(msg_epoch);
-            let state_version = StateVersion::new(msg.state_version);
+            let state_version = StateVersion::new(batch.state_version);
             last_version = state_version;
 
-            for update in msg.updates {
+            for update in batch.updates {
                 let update =
                     SubstateUpdateProof::try_from(update).map_err(|e| NetworkStateSyncError::InvalidStateUpdate {
                         details: format!("Failed to convert substate update: {}", e),
@@ -533,7 +573,7 @@ impl NetworkWideStateSync {
                     &mut xtr_claimed,
                 )?;
             }
-            if msg.has_more {
+            if batch.has_more {
                 debug!(target: LOG_TARGET, "🌍️ more updates for shard {shard} (epoch: {msg_epoch}, state version: {state_version})");
                 continue;
             }

--- a/applications/tari_validator_node/src/p2p/rpc/rpc_impl.rs
+++ b/applications/tari_validator_node/src/p2p/rpc/rpc_impl.rs
@@ -515,6 +515,7 @@ impl<TStateStore: StateStore + Clone + Send + Sync + 'static> ValidatorNodeRpcSe
                 shard,
                 req.start_state_version,
                 end_epoch,
+                self.consensus.current_epoch(),
                 STATE_SYNC_MAX_BATCH_SIZE
                     .try_into()
                     .expect("STATE_SYNC_MAX_BATCH_SIZE is not zero"),

--- a/applications/tari_validator_node/src/p2p/rpc/state_sync_task.rs
+++ b/applications/tari_validator_node/src/p2p/rpc/state_sync_task.rs
@@ -8,6 +8,7 @@ use tari_ootle_common_types::{Epoch, optional::Optional, shard::Shard};
 use tari_ootle_p2p::proto::rpc;
 use tari_ootle_storage::{
     StateStore,
+    StateStoreReadTransaction,
     StorageError,
     consensus_models::{StateTransition, StateVersionTransitions, SubstateValueFilterFlags},
 };
@@ -23,6 +24,7 @@ pub struct StateSyncTask<TStateStore: StateStore> {
     shard: Shard,
     start_state_version: Version,
     end_epoch: Option<Epoch>,
+    current_epoch: Epoch,
     batch_size: NonZeroUsize,
     value_filters: SubstateValueFilterFlags,
 }
@@ -34,6 +36,7 @@ impl<TStateStore: StateStore> StateSyncTask<TStateStore> {
         shard: Shard,
         start_state_version: Version,
         end_epoch: Option<Epoch>,
+        current_epoch: Epoch,
         batch_size: NonZeroUsize,
         value_filters: SubstateValueFilterFlags,
     ) -> Self {
@@ -43,44 +46,57 @@ impl<TStateStore: StateStore> StateSyncTask<TStateStore> {
             shard,
             start_state_version,
             end_epoch,
+            current_epoch,
             batch_size,
             value_filters,
         }
     }
 
     pub async fn run(mut self) -> Result<(), ()> {
+        // For an unbounded (sync-to-tip) request, snapshot the committed tree tip before scanning. The
+        // completion marker advances the client over trailing versions that stream no updates (all
+        // filtered out for its subscription). Snapshotting first ensures the marker never reports
+        // beyond what we streamed: anything committed after this point is left for the next round.
+        let tip_at_start = if self.end_epoch.is_none() {
+            self.read_latest_tree_version()
+        } else {
+            None
+        };
+
         let mut current_state_version = self.start_state_version;
         let mut counter = 0usize;
+        let mut last_sent_version: Option<Version> = None;
         loop {
             match self.fetch_next_batch(current_state_version) {
                 Ok(Some(transitions)) => {
-                    if !transitions.updates.is_empty() {
-                        debug!(target: LOG_TARGET, "🌍 Fetched {} state transition(s) up to v{}", transitions.updates.len(), transitions.state_version);
-                    }
                     if let Some(end_epoch) = self.end_epoch {
                         // TODO(perf): might be better to not load in the first place, however also might incur the cost
                         // of a db index, more complex keys or loading from db anyway
                         if transitions.epoch > end_epoch {
                             info!(target: LOG_TARGET, "🌍 Reached end of requested epoch: {}", end_epoch);
-                            return Ok(());
+                            break;
                         }
+                    }
+                    if !transitions.updates.is_empty() {
+                        debug!(target: LOG_TARGET, "🌍 Fetched {} state transition(s) up to v{}", transitions.updates.len(), transitions.state_version);
                     }
 
                     current_state_version = transitions.state_version + 1;
                     counter += transitions.updates.len();
 
-                    self.send_responses(transitions).await?;
+                    let state_version = transitions.state_version;
+                    let has_updates = !transitions.updates.is_empty();
+                    self.send_batches(transitions).await?;
+                    // A version whose updates are all filtered out streams no batch, so only versions we
+                    // actually sent count towards the client's recorded progress.
+                    if has_updates {
+                        last_sent_version = Some(state_version);
+                    }
                 },
                 Ok(None) => {
                     // TODO: differentiate between not found and end of stream
-                    // self.send(Err(RpcStatus::not_found(format!(
-                    //     "State transition not found with id={current_state_version}"
-                    // ))))
-                    // .await?;
-
                     debug!(target: LOG_TARGET, "🌍sync complete ({}). {} update(s) sent.", current_state_version, counter);
-                    // Finished
-                    return Ok(());
+                    break;
                 },
                 Err(err) => {
                     error!(target: LOG_TARGET, "🌍 Error fetching state transitions: {}", err);
@@ -89,6 +105,53 @@ impl<TStateStore: StateStore> StateSyncTask<TStateStore> {
                 },
             }
         }
+
+        self.send_complete(tip_at_start, last_sent_version).await
+    }
+
+    fn read_latest_tree_version(&self) -> Option<Version> {
+        match self
+            .store
+            .with_read_tx(|tx| tx.state_tree_versions_get_latest(self.shard))
+        {
+            Ok(version) => version,
+            Err(err) => {
+                // Non-fatal: the completion marker is an optimisation; streamed batches are unaffected.
+                warn!(target: LOG_TARGET, "🌍 Failed to read latest tree version for {}: {}", self.shard, err);
+                None
+            },
+        }
+    }
+
+    /// Terminates every stream with a `SyncComplete` stating the version the client is now synced to.
+    ///
+    /// For an unbounded request this is the committed tree tip (capped to what we streamed), letting the
+    /// client advance over trailing versions that streamed no updates - e.g. a shard whose latest
+    /// transitions are all substate types the client filtered out. Such a shard otherwise streams no
+    /// message at all, so the client could never observe that it has caught up and would re-scan it from
+    /// scratch every round, leaving any version comparison against the committed version unsatisfiable.
+    ///
+    /// For a bounded request the consumer verifies against its own checkpoint, so the reported version is
+    /// just our last streamed version - the consumer does not trust it as the sync target.
+    async fn send_complete(
+        &mut self,
+        tip_at_start: Option<Version>,
+        last_sent_version: Option<Version>,
+    ) -> Result<(), ()> {
+        let synced_to_version = match tip_at_start {
+            // Unbounded: advance to the committed tip, but never past a version we actually streamed.
+            Some(tip) => tip.max(last_sent_version.unwrap_or(0)),
+            // Bounded, or an unbounded shard with no committed state: report the last streamed version.
+            None => last_sent_version.unwrap_or_else(|| self.start_state_version.saturating_sub(1)),
+        };
+
+        self.send(Ok(rpc::SyncStateResponse {
+            response: Some(rpc::sync_state_response::Response::Complete(rpc::SyncComplete {
+                synced_to_version,
+                epoch: Some(self.current_epoch.into()),
+            })),
+        }))
+        .await
     }
 
     fn fetch_next_batch(
@@ -112,7 +175,7 @@ impl<TStateStore: StateStore> StateSyncTask<TStateStore> {
         Ok(())
     }
 
-    async fn send_responses(&mut self, transitions: StateVersionTransitions) -> Result<(), ()> {
+    async fn send_batches(&mut self, transitions: StateVersionTransitions) -> Result<(), ()> {
         let chunks = transitions.into_chunks(self.batch_size);
         let num_chunks = chunks.len();
 
@@ -120,10 +183,12 @@ impl<TStateStore: StateStore> StateSyncTask<TStateStore> {
             let updates = chunk.updates.into_iter().map(Into::into).collect();
 
             self.send(Ok(rpc::SyncStateResponse {
-                state_version: chunk.state_version,
-                updates,
-                has_more: i < num_chunks - 1,
-                epoch: Some(chunk.epoch.into()),
+                response: Some(rpc::sync_state_response::Response::Batch(rpc::SubstateBatch {
+                    state_version: chunk.state_version,
+                    updates,
+                    has_more: i < num_chunks - 1,
+                    epoch: Some(chunk.epoch.into()),
+                })),
             }))
             .await?;
         }

--- a/applications/tari_validator_node/src/p2p/rpc/state_sync_task.rs
+++ b/applications/tari_validator_node/src/p2p/rpc/state_sync_task.rs
@@ -58,7 +58,14 @@ impl<TStateStore: StateStore> StateSyncTask<TStateStore> {
         // filtered out for its subscription). Snapshotting first ensures the marker never reports
         // beyond what we streamed: anything committed after this point is left for the next round.
         let tip_at_start = if self.end_epoch.is_none() {
-            self.read_latest_tree_version()
+            match self.read_latest_tree_version() {
+                Ok(version) => version,
+                Err(err) => {
+                    error!(target: LOG_TARGET, "🌍 Error reading latest tree version for {}: {}", self.shard, err);
+                    self.send(Err(RpcStatus::log_internal_error(LOG_TARGET)(err))).await?;
+                    return Err(());
+                },
+            }
         } else {
             None
         };
@@ -109,18 +116,9 @@ impl<TStateStore: StateStore> StateSyncTask<TStateStore> {
         self.send_complete(tip_at_start, last_sent_version).await
     }
 
-    fn read_latest_tree_version(&self) -> Option<Version> {
-        match self
-            .store
+    fn read_latest_tree_version(&self) -> Result<Option<Version>, StorageError> {
+        self.store
             .with_read_tx(|tx| tx.state_tree_versions_get_latest(self.shard))
-        {
-            Ok(version) => version,
-            Err(err) => {
-                // Non-fatal: the completion marker is an optimisation; streamed batches are unaffected.
-                warn!(target: LOG_TARGET, "🌍 Failed to read latest tree version for {}: {}", self.shard, err);
-                None
-            },
-        }
     }
 
     /// Terminates every stream with a `SyncComplete` stating the version the client is now synced to.

--- a/crates/epoch_manager/src/service/epoch_manager_service.rs
+++ b/crates/epoch_manager/src/service/epoch_manager_service.rs
@@ -173,8 +173,17 @@ impl<TSpec: EpochManagerSpec> EpochManagerService<TSpec> {
                     target: LOG_TARGET,
                     "⛓️ {} validator node change(s) for epoch {}", node_changes.len(), epoch,
                 );
-                // Mark it as a birthday epoch if not already set
-                self.inner.set_birthday_epoch_if_unset(epoch + Epoch(1))?;
+                // The birthday epoch is the first epoch any validator became active on the network; it
+                // is used as a cheap floor for whether there is a previous epoch's checkpoint to sync.
+                // Derive it from an activation epoch in this change set rather than the triggering
+                // event's epoch, whose offset from the activation epoch differs between epoch oracle
+                // implementations.
+                if let Some(activation_epoch) = node_changes.iter().find_map(|c| match c {
+                    ValidatorNodeChange::Add { activation_epoch, .. } => Some(*activation_epoch),
+                    ValidatorNodeChange::Remove { .. } => None,
+                }) {
+                    self.inner.set_birthday_epoch_if_unset(activation_epoch)?;
+                }
 
                 for node_change in node_changes {
                     match node_change {

--- a/crates/p2p/proto/rpc.proto
+++ b/crates/p2p/proto/rpc.proto
@@ -262,10 +262,29 @@ message SyncStateRequest {
 }
 
 message SyncStateResponse {
+  oneof response {
+    SubstateBatch batch = 1;
+    SyncComplete complete = 2;
+  }
+}
+
+// A batch of substate updates at a single state version. A state version whose updates exceed the
+// stream batch size is split into multiple batches, all but the last carrying has_more = true.
+message SubstateBatch {
   uint64 state_version = 1;
   repeated SubstateUpdate updates = 2;
   bool has_more = 3;
   tari.ootle.common.Epoch epoch = 4;
+}
+
+// Terminal message of every sync_state stream, stating the version the shard is now synced to.
+// For an unbounded (sync-to-tip) request this is the committed state-tree tip and is authoritative
+// for the client's cursor - it advances the client over trailing versions that streamed no updates
+// (filtered out, or tree-only bumps). For a bounded (checkpoint) request the client verifies against
+// its own checkpoint, so this carries the producer's last streamed version.
+message SyncComplete {
+  uint64 synced_to_version = 1;
+  tari.ootle.common.Epoch epoch = 2;
 }
 
 enum TemplateType {

--- a/crates/rpc_state_sync/src/state_sync.rs
+++ b/crates/rpc_state_sync/src/state_sync.rs
@@ -876,16 +876,18 @@ where TConsensusSpec: ConsensusSpec<Addr = PeerAddress> + Send + Sync + 'static
         // case and conflates "no leaf at this epoch" with "no leaf at all".
         let leaf_block = self.state_store.with_read_tx(|tx| LeafBlock::get_any(tx).optional())?;
 
-        // Cold-start: no leaf has ever been written. Sync iff the oracle has moved past the
-        // birthday epoch — replicates pre-existing behaviour.
+        // Cold start: a node that has never entered consensus has no leaf block (a fresh node, or one
+        // whose state was wiped). The birthday epoch - the first epoch any validator was active on the
+        // network - is a cheap local proxy for "is there a previous epoch's checkpoint to adopt": if
+        // the oracle has moved past it there is prior committed state to sync; at or before it there is
+        // nothing, so we join consensus directly.
         let Some(leaf) = leaf_block else {
             let Some(birthday_epoch) = self.epoch_manager.get_birthday_epoch().await? else {
                 return Err(RpcStateSyncError::InvariantError {
-                    details: "Check sync called before epoch birthday was determined".to_string(),
+                    details: "Check sync called before the birthday epoch was determined".to_string(),
                 });
             };
             return Ok(if oracle_epoch > birthday_epoch {
-                // Cold start: no leaf, no probe — fall back to the oracle's current epoch.
                 SyncStatus::Behind { target_epoch: None }
             } else {
                 SyncStatus::UpToDate

--- a/crates/rpc_state_sync/src/state_sync.rs
+++ b/crates/rpc_state_sync/src/state_sync.rs
@@ -26,7 +26,13 @@ use tari_ootle_common_types::{
 };
 use tari_ootle_p2p::{
     PeerAddress,
-    proto::rpc::{GetCheckpointsRequest, GetCheckpointsResponse, GetHighQcRequest, SyncStateRequest},
+    proto::rpc::{
+        GetCheckpointsRequest,
+        GetCheckpointsResponse,
+        GetHighQcRequest,
+        SyncStateRequest,
+        sync_state_response,
+    },
 };
 use tari_ootle_storage::{
     ShardScopedTreeStoreReader,
@@ -158,7 +164,6 @@ where TConsensusSpec: ConsensusSpec<Addr = PeerAddress>
         mut maybe_persisted_state_version: Option<Version>,
     ) -> Result<Option<Version>, RpcStateSyncError> {
         let checkpoint_shard_root = checkpoint.get_shard_root(shard);
-        let checkpoint_state_version = checkpoint.get_shard_state_version(shard);
 
         let initial_local_state_root = self
             .state_store
@@ -193,36 +198,79 @@ where TConsensusSpec: ConsensusSpec<Addr = PeerAddress>
         // syncing states
         while let Some(result) = state_stream.next().await {
             let msg = result?;
+            let batch = match msg.response {
+                Some(sync_state_response::Response::Batch(batch)) => batch,
+                Some(sync_state_response::Response::Complete(complete)) => {
+                    // The stream always terminates with a completion marker. Verify the synced shard
+                    // root against the trusted checkpoint at our last committed version: the producer
+                    // streamed every transition up to the checkpoint epoch, so any gap to
+                    // checkpoint_state_version is tree-only (no substate change) and the root at our
+                    // last written version equals the checkpoint root. The marker's own version is the
+                    // producer's claim and is not trusted as the verification target.
+                    debug!(
+                        target: LOG_TARGET,
+                        "🛜 Stream complete for {shard} (peer reported v{}, locally committed v{})",
+                        complete.synced_to_version,
+                        maybe_persisted_state_version.unwrap_or(0),
+                    );
+                    let local_state_root = self.state_store.with_read_tx(|tx| {
+                        self.calculate_state_root_for_shard(tx, shard, maybe_persisted_state_version)
+                    })?;
+                    if local_state_root != checkpoint_shard_root {
+                        error!(
+                            target: LOG_TARGET,
+                            "❌ State root mismatch for {shard}. Checkpoint {expected} but got {actual}. Rolling back.",
+                            expected = checkpoint_shard_root,
+                            actual = local_state_root,
+                        );
+                        return Err(RpcStateSyncError::StateRootMismatch {
+                            expected: checkpoint_shard_root,
+                            actual: local_state_root,
+                        });
+                    }
+                    info!(
+                        target: LOG_TARGET,
+                        "🛜 ✅ State root for {shard} matches checkpoint: {local_state_root} (v{})",
+                        maybe_persisted_state_version.unwrap_or(0),
+                    );
+                    return Ok(maybe_persisted_state_version);
+                },
+                None => {
+                    return Err(RpcStateSyncError::InvalidResponse(anyhow!(
+                        "Received sync state response with no variant set."
+                    )));
+                },
+            };
 
-            if msg.updates.is_empty() {
+            if batch.updates.is_empty() {
                 return Err(RpcStateSyncError::InvalidResponse(anyhow!(
                     "Received empty state transition batch."
                 )));
             }
-            if msg.updates.len() > STATE_SYNC_MAX_BATCH_SIZE {
+            if batch.updates.len() > STATE_SYNC_MAX_BATCH_SIZE {
                 return Err(RpcStateSyncError::InvalidResponse(anyhow!(
                     "Received too many state updates in a batch: {}. Expected at most {}.",
-                    msg.updates.len(),
+                    batch.updates.len(),
                     STATE_SYNC_MAX_BATCH_SIZE
                 )));
             }
-            if msg.state_version < start_state_version {
+            if batch.state_version < start_state_version {
                 return Err(RpcStateSyncError::InvalidResponse(anyhow!(
                     "Received state version {} that is less than the persisted state version {}.",
-                    msg.state_version,
+                    batch.state_version,
                     start_state_version
                 )));
             }
 
-            if expected_state_version.is_some_and(|v| v != msg.state_version) {
+            if expected_state_version.is_some_and(|v| v != batch.state_version) {
                 return Err(RpcStateSyncError::InvalidResponse(anyhow!(
                     "Received state version {} that is not the expected state version {}.",
-                    msg.state_version,
+                    batch.state_version,
                     expected_state_version.unwrap()
                 )));
             }
 
-            let state_version = msg.state_version;
+            let state_version = batch.state_version;
             if state_version < last_state_version {
                 return Err(RpcStateSyncError::InvalidResponse(anyhow!(
                     "Received state version {} that is less than the last state version {}.",
@@ -233,16 +281,16 @@ where TConsensusSpec: ConsensusSpec<Addr = PeerAddress>
 
             last_state_version = state_version;
 
-            self.stats.total_transitions += msg.updates.len() as u64;
+            self.stats.total_transitions += batch.updates.len() as u64;
 
-            tree_changes.reserve_exact(msg.updates.len());
-            updates.reserve_exact(msg.updates.len());
+            tree_changes.reserve_exact(batch.updates.len());
+            updates.reserve_exact(batch.updates.len());
 
-            let updates_for_state_version = msg
+            let updates_for_state_version = batch
                 .updates
                 .into_iter()
                 .map(|t| SubstateUpdateProof::try_from(t).map_err(RpcStateSyncError::InvalidResponse));
-            let msg_epoch = msg.epoch.map(Epoch::from).ok_or_else(|| {
+            let msg_epoch = batch.epoch.map(Epoch::from).ok_or_else(|| {
                 RpcStateSyncError::InvalidResponse(anyhow!("Received state transition with no epoch"))
             })?;
 
@@ -258,7 +306,7 @@ where TConsensusSpec: ConsensusSpec<Addr = PeerAddress>
 
             info!(target: LOG_TARGET, "🛜 Sync: {} state update(s), state version: v{}", updates.len(), state_version);
 
-            if msg.has_more {
+            if batch.has_more {
                 info!(
                     target: LOG_TARGET,
                     "🛜 Received more state updates for v{}. Continuing to buffer...",
@@ -272,7 +320,8 @@ where TConsensusSpec: ConsensusSpec<Addr = PeerAddress>
 
             expected_state_version = None;
 
-            // Verify and commit changes
+            // Commit the buffered changes for this state version. The shard root is verified once, on
+            // the terminal SyncComplete, against the trusted checkpoint.
             self.state_store.with_write_tx(|tx| {
                 info!(
                     target: LOG_TARGET,
@@ -288,7 +337,7 @@ where TConsensusSpec: ConsensusSpec<Addr = PeerAddress>
                     store.transaction(),
                     shard,
                     msg_epoch,
-                    msg.state_version,
+                    state_version,
                     updates.drain(..),
                 )?;
 
@@ -296,35 +345,7 @@ where TConsensusSpec: ConsensusSpec<Addr = PeerAddress>
                 if !tree_changes.is_empty() {
                     let mut state_tree = SpreadPrefixStateTree::new(&mut store);
                     info!(target: LOG_TARGET, "🛜 Committing {} state tree changes batch v{}", tree_changes.len(), state_version);
-                    let local_state_root = state_tree.batch_put_substate_changes(maybe_persisted_state_version, state_version, tree_changes.drain(..))?;
-                    // Only check the state root once we have reached the checkpoint state version
-                    // TODO: we should sync to multiple checkpoints to catch misbehaviour earlier
-                    if state_version == checkpoint_state_version {
-                        if local_state_root != checkpoint_shard_root {
-                            error!(
-                                target: LOG_TARGET,
-                                "❌ State root mismatch for {shard}. Checkpoint {expected} but got {actual}. Rolling back.",
-                                expected = checkpoint_shard_root,
-                                actual = local_state_root,
-                            );
-
-                            // rollback!
-                            return Err(RpcStateSyncError::StateRootMismatch {
-                                expected: checkpoint_shard_root,
-                                actual: local_state_root,
-                            });
-                        }
-                        info!(
-                            target: LOG_TARGET,
-                            "🛜 ✅ State root for {shard} matches checkpoint: {local_state_root} (v{state_version})",
-                        );
-
-                        maybe_persisted_state_version = Some(state_version);
-                        store.set_state_version(state_version)?;
-                        // Done
-                        return Ok(());
-                    }
-
+                    state_tree.batch_put_substate_changes(maybe_persisted_state_version, state_version, tree_changes.drain(..))?;
                     maybe_persisted_state_version = Some(state_version);
                     store.set_state_version(state_version)?;
                 }
@@ -333,9 +354,10 @@ where TConsensusSpec: ConsensusSpec<Addr = PeerAddress>
             })?;
         }
 
-        info!(target: LOG_TARGET, "🛜 Synced state for {shard} to v{}", maybe_persisted_state_version.unwrap_or(1));
-
-        Ok(maybe_persisted_state_version)
+        // The stream ended without a SyncComplete - the peer closed early, so the sync is unverified.
+        Err(RpcStateSyncError::InvalidResponse(anyhow!(
+            "State sync stream for {shard} ended without a completion marker"
+        )))
     }
 
     fn calculate_state_root_for_shard(

--- a/networking/core/src/worker.rs
+++ b/networking/core/src/worker.rs
@@ -767,6 +767,14 @@ where
             mdns::Event::Discovered(peers_and_addrs) => {
                 for (peer, addr) in peers_and_addrs {
                     debug!(target: LOG_TARGET, "📡 mDNS discovered peer {} at {}", peer, addr);
+                    // Persist the address so a later peer-id-only dial (e.g. an RPC session) can
+                    // resolve it through the peer store, rather than only succeeding while the
+                    // connection opened below is still live.
+                    self.swarm
+                        .behaviour_mut()
+                        .peer_store
+                        .store_mut()
+                        .add_address(&peer, &addr);
                     self.swarm
                         .dial(
                             DialOpts::peer_id(peer)


### PR DESCRIPTION
## Problem

The `sync_state` RPC only ever emits *update* messages, so a client infers its synced cursor from the last update it received. That assumption breaks whenever a shard's committed state-**tree** version is ahead of its last streamed update — which is common, because tree versions advance for every substate change while a client only receives the subset it subscribes to.

This surfaced two ways:

1. **Indexer sync hangs (the flaky `indexer.feature` scenarios).** The indexer only requests `TRANSACTION_RECEIPT | VALIDATOR_FEE_POOL | UTXO | CLAIMED_OUTPUT_TOMBSTONE | TEMPLATE_METADATA`. For a shard whose latest transitions are all *other* types (component/vault/resource/etc.), the producer finds the records but filters every update out, so `into_chunks` emits nothing and the stream is empty. The indexer therefore never advances its cursor for that shard, **re-scans it from version 0 on every round**, and the `I wait for the indexer {word} to sync with the network` step — which compares the indexer's per-shard version against the validator's committed `state_versions` — can never be satisfied and burns its whole timeout. (This is why #2279 didn't fix it: comparing the indexer's filtered cursor against the validator's tree version is unsatisfiable for these shards.)

   Proof from a failing run's validator logs — ~2,600 streams `sync complete (N>1)` with `0 update(s) sent`, i.e. real records existed but were all filtered out:
   ```
   1804 × "sync complete (2). 0 update(s) sent"
    386 × "sync complete (3). 0 update(s) sent"
    ... (4, 5, 7, 8, 9, 10)
   ```

2. **VN→VN checkpoint sync could skip verification.** Root verification only fired `if state_version == checkpoint_state_version`. When `checkpoint_state_version` is a tree-only tip with no transition at it, that branch never fired and the sync returned `Ok` **unverified**.

## Change

Replace `SyncStateResponse` with a `oneof`:

```proto
message SyncStateResponse {
  oneof response {
    SubstateBatch batch = 1;     // the old fields: state_version, updates, has_more, epoch
    SyncComplete  complete = 2;  // synced_to_version, epoch
  }
}
```

Every stream now ends with exactly one `SyncComplete` watermark stating the version the shard is synced to. The producer is the authority on "how far this shard is committed" — the only party that can tell a filtered client it has caught up.

- **Producer** (`state_sync_task.rs`): streams `SubstateBatch`es as before, then always emits one `SyncComplete`.
  - Unbounded (indexer): `synced_to` = committed tree tip, snapshotted *before* the scan and capped to what was actually streamed, so it never reports past a transition the client didn't receive.
  - Bounded (VN→VN): `synced_to` = last streamed version; the consumer does not trust it (see below).
- **Indexer** (`worker.rs`): records progress from `SyncComplete`, advancing over filtered/empty trailing versions. Guarded so a caught-up shard that re-sends the same version each round doesn't write to the DB.
- **VN→VN** (`rpc_state_sync`): drops the now-impossible empty-batch error and verifies `root_at(last_committed) == checkpoint_shard_root` on `SyncComplete`. This is sound because the root is the state commitment, so verifying at the consumer's last written version is equivalent to verifying at the checkpoint tip (the gap between them is tree-only). The verification target is the consumer's **own** trusted checkpoint, never the producer's claim.

## Why a single mode (breaking wire change)

This unifies the two implicit "modes" (update-only stream + inferred cursor) into one explicit protocol: `Update* , Complete`. Both consumers finalize on the watermark; "empty updates" stops being a special/error case. The wire format is incompatible with the old one, which is fine for a coordinated validator upgrade.

## Bonus fixes
- The indexer no longer re-syncs filtered-only shards from version 0 every round.
- VN→VN sync no longer silently accepts an unverified/incomplete state sync.

## Testing
- Workspace compiles (libs, bins, tests); `cargo +nightly-2025-12-05 fmt --all` applied; touched-crate unit tests pass (29/29).
- The definitive check is the `indexer.feature` cucumber scenarios in CI.

---

## Also fixed: a node skips state sync when (re)joining a committee

Surfaced while validating on a local swarm (wipe a validator's data, restart). On cold start (a fresh node, or one whose state was wiped) `check_sync` uses the **birthday epoch** — the first epoch any validator was active on the network — as a cheap floor for whether a previous epoch's checkpoint exists to adopt: if the oracle has moved past it, sync the previous epoch; otherwise join consensus directly.

The birthday was computed as `event.epoch + 1`, which is only correct for the *configured* (test) oracle, where `event.epoch == activation_epoch - 1`. The *base-layer* (production) oracle emits `event.epoch == activation_epoch`, so the birthday came out one epoch too high (a node active from epoch N got birthday N+1). With `birthday == current_epoch`, the cold-start check reported `UpToDate`, so a wiped/(re)joining validator bootstrapped an empty genesis at the current epoch and ran consensus **without adopting the previous epoch's committed state**. The birthday is now derived from an `activation_epoch` in the change set, correct for both oracles.