### PR TITLE
fix(engine)!: cap unpaid WASM compute by fees paid to prevent free-compute DoS

### DIFF
--- a/applications/tari_ootle_app_utilities/src/transaction_executor.rs
+++ b/applications/tari_ootle_app_utilities/src/transaction_executor.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use tari_engine::{
     executables::Executable,
-    fees::{FeeModule, FeeTable},
+    fees::{FeeModule, FeeTable, WasmMeteringRate},
     runtime::{AuthParams, RuntimeModule},
     state_store::{StateReader, StateStoreError},
     template::LoadedTemplate,
@@ -87,6 +87,7 @@ pub struct TariTransactionProcessor<TStore, TTemplateProvider> {
     template_provider: Arc<TTemplateProvider>,
     modules: ModulesCollection<TStore>,
     claim_burn_proof_verifier: Arc<dyn ClaimProofVerifier + Send + Sync + 'static>,
+    wasm_metering_rate: WasmMeteringRate,
 }
 
 impl<TStore: StateReader + 'static, TTemplateProvider> TariTransactionProcessor<TStore, TTemplateProvider> {
@@ -96,11 +97,13 @@ impl<TStore: StateReader + 'static, TTemplateProvider> TariTransactionProcessor<
         dry_run: bool,
         claim_burn_proof_verifier: Arc<dyn ClaimProofVerifier + Send + Sync + 'static>,
     ) -> Self {
+        let wasm_metering_rate = WasmMeteringRate::from_fee_table(&fee_table);
         let modules = vec![Box::new(FeeModule::new(0, fee_table, dry_run)) as Box<dyn RuntimeModule<TStore>>];
         Self {
             template_provider: Arc::new(template_provider),
             modules: Arc::from(modules),
             claim_burn_proof_verifier,
+            wasm_metering_rate,
         }
     }
 }
@@ -134,6 +137,7 @@ where TTemplateProvider: TemplateProvider<Template = LoadedTemplate>
             virtual_substates,
             self.modules.clone(),
             self.claim_burn_proof_verifier.clone(),
+            self.wasm_metering_rate,
         );
         let result = processor.execute(transaction.clone())?;
 

--- a/crates/engine/benches/benchmarks.rs
+++ b/crates/engine/benches/benchmarks.rs
@@ -8,6 +8,7 @@ use std::{hint::black_box, iter, sync::Arc};
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use tari_engine::{
     executables::{Executable, Instructions, WeightedExecutable},
+    fees::WasmMeteringRate,
     runtime::AuthParams,
     state_store::memory::ReadOnlyMemoryStateStore,
     transaction::TransactionProcessor,
@@ -90,6 +91,7 @@ fn setup(shared: &SharedState) -> BenchTxProcessor {
         shared.virtual_substates.clone(),
         modules,
         shared.claim_burn_proof_verifier.clone(),
+        WasmMeteringRate::unmetered(),
     )
 }
 

--- a/crates/engine/src/fees/fee_table.rs
+++ b/crates/engine/src/fees/fee_table.rs
@@ -90,3 +90,44 @@ impl FeeTable {
 fn non_zero(divisor: u64) -> u64 {
     if divisor == 0 { 1 } else { divisor }
 }
+
+/// The WASM-execution fee rate extracted from a [`FeeTable`], plus the conversion from fees paid
+/// into the compute budget they unlock. Lives outside [`FeeTable`] so the execution core
+/// (`StateTracker`) can enforce the per-transaction compute budget without depending on the
+/// `FeeModule`, which is an optional, observer-style runtime module.
+#[derive(Debug, Clone, Copy)]
+pub struct WasmMeteringRate {
+    per_point_cost: u64,
+    points_divisor: u64,
+}
+
+impl WasmMeteringRate {
+    pub fn from_fee_table(fee_table: &FeeTable) -> Self {
+        Self {
+            per_point_cost: fee_table.per_wasm_point_cost(),
+            points_divisor: fee_table.wasm_points_cost_divisor(),
+        }
+    }
+
+    /// A rate that does not price WASM execution, so no payment-funded compute bound applies (only
+    /// the per-transaction hard cap). Used when fees are disabled.
+    pub fn unmetered() -> Self {
+        Self {
+            per_point_cost: 0,
+            points_divisor: 1,
+        }
+    }
+
+    /// The WASM metering points that `fees_paid` microtari pre-fund: the inverse of the fee module's
+    /// charge (`points / divisor * per_point_cost`). `None` when WASM execution is not priced
+    /// (`per_point_cost == 0`) — payment cannot fund what is not charged, so no payment-derived
+    /// bound applies.
+    pub fn points_funded_by(&self, fees_paid: u64) -> Option<u64> {
+        if self.per_point_cost == 0 {
+            return None;
+        }
+        let funded =
+            u128::from(fees_paid).saturating_mul(u128::from(self.points_divisor)) / u128::from(self.per_point_cost);
+        Some(u64::try_from(funded).unwrap_or(u64::MAX))
+    }
+}

--- a/crates/engine/src/fees/mod.rs
+++ b/crates/engine/src/fees/mod.rs
@@ -2,7 +2,7 @@
 //   SPDX-License-Identifier: BSD-3-Clause
 
 mod fee_table;
-pub use fee_table::FeeTable;
+pub use fee_table::{FeeTable, WasmMeteringRate};
 
 mod fee_module;
 pub use fee_module::FeeModule;

--- a/crates/engine/src/runtime/impl.rs
+++ b/crates/engine/src/runtime/impl.rs
@@ -3409,6 +3409,10 @@ where
         self.tracker.accumulated_wasm_points()
     }
 
+    fn wasm_point_allowance(&self) -> Option<u64> {
+        self.tracker.wasm_point_allowance()
+    }
+
     fn resolve_args(
         &self,
         prepend: Option<InstructionArg>,

--- a/crates/engine/src/runtime/mod.rs
+++ b/crates/engine/src/runtime/mod.rs
@@ -259,6 +259,11 @@ pub trait RuntimeInterface {
     /// invocation. Used by `WasmProcess::invoke` to enforce `MAX_WASM_POINTS_PER_TRANSACTION`.
     fn wasm_points_consumed(&self) -> u64;
 
+    /// The maximum Wasmer metering points the transaction may consume given the fees paid so far,
+    /// used by `WasmProcess::invoke` to cap each call's allowance so unpaid compute cannot exceed
+    /// the grace. `None` means no payment-funded bound applies (only the per-transaction hard cap).
+    fn wasm_point_allowance(&self) -> Option<u64>;
+
     fn resolve_args(
         &self,
         prepend: Option<InstructionArg>,

--- a/crates/engine/src/runtime/tracker.rs
+++ b/crates/engine/src/runtime/tracker.rs
@@ -50,6 +50,7 @@ use tari_template_lib::{
 };
 
 use crate::{
+    fees::WasmMeteringRate,
     runtime::{
         RuntimeError,
         locking::LockedSubstate,
@@ -67,6 +68,7 @@ pub struct StateTracker<TStore> {
     working_state: Option<WorkingState<TStore>>,
     fee_checkpoint: Option<WorkingState<TStore>>,
     transaction_weight: TransactionWeight,
+    wasm_metering_rate: WasmMeteringRate,
 }
 
 impl<TStore: StateReader> StateTracker<TStore> {
@@ -76,6 +78,7 @@ impl<TStore: StateReader> StateTracker<TStore> {
         initial_call_scope: CallScope,
         transaction_hash: Hash32,
         transaction_weight: TransactionWeight,
+        wasm_metering_rate: WasmMeteringRate,
     ) -> Self {
         Self {
             working_state: Some(WorkingState::new(
@@ -86,11 +89,32 @@ impl<TStore: StateReader> StateTracker<TStore> {
             )),
             fee_checkpoint: None,
             transaction_weight,
+            wasm_metering_rate,
         }
     }
 
     pub fn get_transaction_weight(&self) -> TransactionWeight {
         self.transaction_weight
+    }
+
+    /// The maximum WASM metering points this transaction may consume given the fees it has paid so
+    /// far, used by `WasmProcess::invoke` to cap each call's metering allowance. Returns `None` when
+    /// no payment-funded bound applies (WASM execution is not priced, or this is a dry run) — only
+    /// the per-transaction hard cap then constrains compute.
+    ///
+    /// The allowance is the points the fees paid can cover plus [`limits::FREE_COMPUTE_GRACE_POINTS`]
+    /// of credit, so a transaction can run its fee-sourcing instructions before it pays while a
+    /// transaction that never pays cannot consume more than the grace.
+    pub fn wasm_point_allowance(&self) -> Option<u64> {
+        let rate = self.wasm_metering_rate;
+        self.read_with(|state| {
+            let fee_state = state.fee_state();
+            if fee_state.is_dry_run() {
+                return None;
+            }
+            let funded = rate.points_funded_by(fee_state.total_payments())?;
+            Some(funded.saturating_add(limits::FREE_COMPUTE_GRACE_POINTS))
+        })
     }
 
     pub fn get_current_epoch(&self) -> Result<Epoch, RuntimeError> {

--- a/crates/engine/src/transaction/processor.rs
+++ b/crates/engine/src/transaction/processor.rs
@@ -67,6 +67,7 @@ use tari_template_lib::{
 
 use crate::{
     executables::{Executable, WeightedExecutable},
+    fees::WasmMeteringRate,
     runtime::{
         AuthParams,
         AuthorizationScope,
@@ -100,6 +101,7 @@ pub struct TransactionProcessor<TStore, TTemplateProvider> {
     virtual_substates: VirtualSubstates,
     modules: ModulesCollection<TStore>,
     claim_burn_proof_verifier: Arc<dyn ClaimProofVerifier + Send + Sync + 'static>,
+    wasm_metering_rate: WasmMeteringRate,
 }
 
 impl<TStore, TTemplateProvider> TransactionProcessor<TStore, TTemplateProvider>
@@ -114,6 +116,7 @@ where
         virtual_substates: VirtualSubstates,
         modules: ModulesCollection<TStore>,
         claim_burn_proof_verifier: Arc<dyn ClaimProofVerifier + Send + Sync + 'static>,
+        wasm_metering_rate: WasmMeteringRate,
     ) -> Self {
         Self {
             template_provider,
@@ -122,6 +125,7 @@ where
             virtual_substates,
             modules,
             claim_burn_proof_verifier,
+            wasm_metering_rate,
         }
     }
 
@@ -137,6 +141,7 @@ where
             virtual_substates,
             modules,
             claim_burn_proof_verifier,
+            wasm_metering_rate,
         } = self;
 
         let execute_epoch = virtual_substates.current_epoch();
@@ -163,6 +168,7 @@ where
             initial_call_scope,
             id.as_hash(),
             transaction_weight,
+            wasm_metering_rate,
         );
 
         let transaction_signer_public_key =

--- a/crates/engine/src/wasm/error.rs
+++ b/crates/engine/src/wasm/error.rs
@@ -23,6 +23,11 @@ pub enum WasmExecutionError {
     // NOTE this renders as "Wasm RuntimeError: <message>"
     #[error("Wasm {0}")]
     WasmRuntimeError(#[from] wasmer::RuntimeError),
+    #[error(
+        "Insufficient fees to pay for compute: consumed {consumed_points} WASM metering points, which exceeds what \
+         the paid fees cover. Increase the transaction fee."
+    )]
+    InsufficientFeesForCompute { consumed_points: u64 },
     #[error("Expected function {function} to return a pointer")]
     ExpectedPointerReturn { function: String },
     #[error("Memory access error: {0}")]

--- a/crates/engine/src/wasm/process.rs
+++ b/crates/engine/src/wasm/process.rs
@@ -356,13 +356,31 @@ impl Invokable<Store> for WasmProcess {
         };
         let consumed = self.env.state().interface().wasm_points_consumed();
         let budget_remaining = limits::MAX_WASM_POINTS_PER_TRANSACTION.saturating_sub(consumed);
-        let points_before = per_call_cap.min(budget_remaining);
+        // Cap further to the compute the fees paid so far can cover (plus the free-compute grace).
+        // This bounds the compute an under-paying transaction can extract: it traps out-of-gas once
+        // it exhausts the paid allowance rather than running up to the per-transaction hard cap.
+        let paid_allowance_remaining = self
+            .env
+            .state()
+            .interface()
+            .wasm_point_allowance()
+            .map(|allowance| allowance.saturating_sub(consumed));
+        let points_before = match paid_allowance_remaining {
+            Some(remaining) => per_call_cap.min(budget_remaining).min(remaining),
+            None => per_call_cap.min(budget_remaining),
+        };
+        // Whether the paid-fee allowance — not the per-transaction hard cap — is what bounds this
+        // call. Used to report an out-of-gas trap here as insufficient fees rather than a hit cap.
+        let fee_allowance_is_binding =
+            paid_allowance_remaining.is_some_and(|remaining| remaining < budget_remaining && remaining <= per_call_cap);
         set_remaining_points(store, &self.instance, points_before);
 
         // Call the contract entrypoint
         let res = func.call(store, call_info_ptr.as_wasm_ptr(), call_info_ptr.len());
 
-        let points_consumed = match get_remaining_points(store, &self.instance) {
+        let remaining_after_call = get_remaining_points(store, &self.instance);
+        let exhausted = matches!(remaining_after_call, MeteringPoints::Exhausted);
+        let points_consumed = match remaining_after_call {
             MeteringPoints::Remaining(n) => points_before.saturating_sub(n),
             // Out-of-gas trap: the meter says zero remaining. Charge for the entire pre-call
             // budget — the host will report a runtime error and the partial work was already done.
@@ -405,6 +423,11 @@ impl Invokable<Store> for WasmProcess {
                     return Err(WasmExecutionError::Panic {
                         message,
                         runtime_error: err,
+                    });
+                }
+                if exhausted && fee_allowance_is_binding {
+                    return Err(WasmExecutionError::InsufficientFeesForCompute {
+                        consumed_points: consumed.saturating_add(points_consumed),
                     });
                 }
                 error!(target: LOG_TARGET, "Error calling function: {}", err);

--- a/crates/engine/tests/complex_fee_payment.rs
+++ b/crates/engine/tests/complex_fee_payment.rs
@@ -1,0 +1,132 @@
+//   Copyright 2026 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+//! The grace ([`FREE_COMPUTE_GRACE_POINTS`]) must accommodate the most complex *legitimate* way to
+//! source a fee: a transaction that holds no TARI and acquires it inside the fee intent by swapping
+//! another resource through an AMM pool, then pays from the resulting bucket. All of that runs on
+//! credit before `pay_fee`, so it must fit within the grace. This test exercises that worst-case
+//! flow end-to-end and asserts it both succeeds and keeps a safety margin below the grace — it fails
+//! if the grace is ever set too low for a realistic fee-payment swap.
+
+use tari_engine::fees::FeeTable;
+use tari_engine_types::{fees::FeeSource, limits::FREE_COMPUTE_GRACE_POINTS};
+use tari_ootle_common_types::substate_type::SubstateType;
+use tari_ootle_transaction::{Transaction, args};
+use tari_template_lib::types::{Amount, ComponentAddress, ResourceAddress, constants::TARI_TOKEN};
+use tari_template_test_tooling::TemplateTest;
+
+const CRATE_PATH: &str = env!("CARGO_MANIFEST_DIR");
+
+/// The grace must stay at least this many times above the measured worst-case fee-sourcing compute.
+/// The grace constant itself is sized with a larger margin; this guards against it drifting too low.
+const SAFETY_FACTOR: u64 = 2;
+
+const POOL_LIQUIDITY: u64 = 100_000_000;
+const SWAP_INPUT: u64 = 20_000_000;
+
+fn create_faucet(test: &mut TemplateTest, symbol: &str) -> (ComponentAddress, ResourceAddress) {
+    let component: ComponentAddress = test.call_function(
+        "TestFaucet",
+        "mint_with_symbol",
+        args![Amount::from(1_000_000_000_000u64), symbol.to_string()],
+        vec![],
+    );
+    let resource = test
+        .get_previous_output_address(SubstateType::Resource)
+        .as_resource_address()
+        .unwrap();
+    (component, resource)
+}
+
+fn create_pool(test: &mut TemplateTest, a: ResourceAddress, b: ResourceAddress) -> ComponentAddress {
+    let template = test.get_template_address("TariSwapPool");
+    let result = test.execute_expect_success(
+        test.transaction()
+            .call_function(template, "new", args![a, b, 5u16])
+            .build_and_seal(test.secret_key()),
+        vec![],
+    );
+    let (addr, _) = result
+        .expect_success()
+        .up_iter()
+        .find(|(address, substate)| {
+            address.is_component() && *substate.substate_value().component().unwrap().template_address() == template
+        })
+        .unwrap();
+    addr.as_component_address().unwrap()
+}
+
+#[test]
+fn fee_paid_via_amm_swap_fits_within_grace() {
+    let mut test = TemplateTest::new(CRATE_PATH, ["tests/templates/tariswap", "tests/templates/faucet"]);
+    let (account, owner, key) = test.create_funded_account();
+
+    // A non-TARI resource the account holds and will swap for TARI to pay its fee.
+    let (token_faucet, token) = create_faucet(&mut test, "SWAP");
+    test.build_and_execute(
+        Transaction::builder_localnet()
+            .call_method(token_faucet, "take_free_coins_custom", args![Amount::from(
+                1_000_000_000u64
+            )])
+            .put_last_instruction_output_on_workspace("coins")
+            .call_method(account, "deposit", args![Workspace("coins")]),
+        vec![],
+    )
+    .expect_success();
+
+    // A (TARI, token) pool, seeded with liquidity from the funded account.
+    let pool = create_pool(&mut test, TARI_TOKEN, token);
+    test.build_and_execute(
+        Transaction::builder_localnet()
+            .call_method(account, "withdraw", args![TARI_TOKEN, Amount::from(POOL_LIQUIDITY)])
+            .put_last_instruction_output_on_workspace("tari")
+            .call_method(account, "withdraw", args![token, Amount::from(POOL_LIQUIDITY)])
+            .put_last_instruction_output_on_workspace("token")
+            .call_method(pool, "add_liquidity", args![Workspace("tari"), Workspace("token")])
+            .put_last_instruction_output_on_workspace("lp")
+            .call_method(account, "deposit", args![Workspace("lp")]),
+        vec![owner.clone(), test.owner_proof()],
+    )
+    .expect_success();
+
+    // Price WASM execution at 1 fee unit per metering point so the WasmExecution charge equals the
+    // points consumed, then enable fees so the swap-to-pay-fee flow is metered under the real grace.
+    let mut fee_table = FeeTable::zero_rated();
+    fee_table.per_wasm_point_cost = 1;
+    fee_table.wasm_points_cost_divisor = 1;
+    test.set_fee_table(fee_table);
+    test.enable_fees();
+
+    // The worst-case fee payment: source TARI by swapping `token` through the pool inside the fee
+    // intent, then pay from the resulting bucket. Runs entirely on credit before `pay_fee`.
+    let tx = Transaction::builder_localnet()
+        .with_fee_instructions_builder(|builder| {
+            builder
+                .call_method(account, "withdraw", args![token, Amount::from(SWAP_INPUT)])
+                .put_last_instruction_output_on_workspace("input")
+                .call_method(pool, "swap", args![Workspace("input"), TARI_TOKEN])
+                .put_last_instruction_output_on_workspace("fee_tari")
+                .pay_fee_from_bucket("fee_tari")
+        })
+        .build_and_seal(&key);
+
+    let result = test.execute_expect_success(tx, vec![owner]);
+
+    let worst_case_points = result
+        .finalize
+        .fee_receipt
+        .fee_breakdown()
+        .iter()
+        .find_map(|(s, a)| (*s == FeeSource::WasmExecution).then_some(*a))
+        .expect("WasmExecution charge present");
+
+    eprintln!(
+        "worst-case fee-sourcing compute (AMM swap to TARI): {worst_case_points} points; FREE_COMPUTE_GRACE_POINTS = \
+         {FREE_COMPUTE_GRACE_POINTS}",
+    );
+    assert!(
+        worst_case_points.saturating_mul(SAFETY_FACTOR) <= FREE_COMPUTE_GRACE_POINTS,
+        "FREE_COMPUTE_GRACE_POINTS ({FREE_COMPUTE_GRACE_POINTS}) must stay at least {SAFETY_FACTOR}x above the \
+         worst-case fee-sourcing compute ({worst_case_points}); re-measure and adjust the grace constant",
+    );
+}

--- a/crates/engine/tests/compute_fee_budget.rs
+++ b/crates/engine/tests/compute_fee_budget.rs
@@ -1,0 +1,205 @@
+//   Copyright 2026 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+//! The per-transaction WASM compute budget is bounded by the fees paid. A transaction may run up to
+//! `FREE_COMPUTE_GRACE_POINTS` of compute on credit — enough to source its fee (withdraw, claim-burn,
+//! AMM swap, …) before it calls `pay_fee` — and beyond that each WASM call's metering allowance is
+//! capped to the points the fees paid so far can cover. These tests prove a transaction cannot
+//! extract more than the grace of unpaid compute, that paying more raises the allowance, and that
+//! fee-sourcing compute within the grace is allowed in the fee intent.
+
+use tari_crypto::ristretto::RistrettoSecretKey;
+use tari_engine::fees::FeeTable;
+use tari_engine_types::{commit_result::RejectReason, fees::FeeSource, limits::FREE_COMPUTE_GRACE_POINTS};
+use tari_ootle_transaction::{Transaction, args};
+use tari_template_lib::types::{ComponentAddress, NonFungibleAddress, TemplateAddress};
+use tari_template_test_tooling::TemplateTest;
+
+const CRATE_PATH: &str = env!("CARGO_MANIFEST_DIR");
+const METERING_BENCH: &str = "tests/templates/metering_bench";
+
+/// A call sized above the grace (and above `grace + the tests' fee payment`, so it still traps when
+/// a tiny fee is paid) but well under `MAX_WASM_POINTS_PER_TRANSACTION`, so the per-transaction hard
+/// cap is never the binding constraint — only the payment-funded allowance is.
+const ABOVE_GRACE_POINTS: u64 = FREE_COMPUTE_GRACE_POINTS * 2;
+/// A call sized below the grace, runnable on credit before any fee is paid.
+const BELOW_GRACE_POINTS: u64 = FREE_COMPUTE_GRACE_POINTS / 2;
+
+struct Harness {
+    test: TemplateTest,
+    bench: TemplateAddress,
+    account: ComponentAddress,
+    owner: NonFungibleAddress,
+    key: RistrettoSecretKey,
+    per_round: u64,
+}
+
+/// Builds a test where only WASM execution is priced (1 fee unit per metering point) so a
+/// transaction's fee charge equals the points it consumed and a small payment isolates the compute
+/// budget, then calibrates points-per-round so calls can be sized to a known multiple of the grace.
+fn setup() -> Harness {
+    let mut test = TemplateTest::new(CRATE_PATH, [METERING_BENCH]);
+    let bench = test.get_template_address("MeteringBench");
+    let (account, owner, key) = test.create_funded_account();
+
+    let mut fee_table = FeeTable::zero_rated();
+    fee_table.per_wasm_point_cost = 1;
+    fee_table.wasm_points_cost_divisor = 1;
+    test.set_fee_table(fee_table);
+    test.enable_fees();
+
+    let per_round = {
+        let mut points = |rounds: u64| -> u64 {
+            let tx = Transaction::builder_localnet()
+                .pay_fee_from_component(account, 900_000_000u64)
+                .call_function(bench, "bench_div_u64", args![rounds])
+                .build_and_seal(&key);
+            let result = test.execute_expect_success(tx, vec![owner.clone()]);
+            result
+                .finalize
+                .fee_receipt
+                .fee_breakdown()
+                .iter()
+                .find_map(|(s, a)| (*s == FeeSource::WasmExecution).then_some(*a))
+                .expect("WasmExecution charge present")
+        };
+        (points(20_000) - points(10_000)) / 10_000
+    };
+
+    Harness {
+        test,
+        bench,
+        account,
+        owner,
+        key,
+        per_round,
+    }
+}
+
+fn assert_insufficient_fees(reason: &RejectReason) {
+    assert!(
+        matches!(reason, RejectReason::ExecutionFailure(msg) if msg.contains("Insufficient fees")),
+        "expected an insufficient-fees-for-compute failure, got {reason:?}",
+    );
+}
+
+/// A transaction that pays only a tiny fee cannot run more than the grace of compute, even though the
+/// call is well under the per-transaction hard cap and would otherwise succeed. The fee intent still
+/// commits and the whole payment is collected — the validator is paid for the grace compute it ran,
+/// and only the compute beyond the payment is the (bounded) absorbed loss.
+#[test]
+fn underpaid_compute_is_capped_at_grace() {
+    const FEE_PAYMENT: u64 = 1_000_000;
+
+    let Harness {
+        mut test,
+        bench,
+        account,
+        owner,
+        key,
+        per_round,
+    } = setup();
+
+    let rounds = ABOVE_GRACE_POINTS / per_round;
+    let tx = Transaction::builder_localnet()
+        .pay_fee_from_component(account, FEE_PAYMENT)
+        .call_function(bench, "bench_div_u64", args![rounds])
+        .build_and_seal(&key);
+
+    let result = test.try_execute(tx, vec![owner]).unwrap();
+    assert_insufficient_fees(result.expect_failure());
+
+    assert!(
+        result.finalize.is_fee_only(),
+        "expected the fee intent to commit and the rest to be rejected (AcceptFeeRejectRest)",
+    );
+    let fee_receipt = &result.finalize.fee_receipt;
+    assert_eq!(
+        fee_receipt.total_fees_paid(),
+        FEE_PAYMENT,
+        "the entire fee payment should be collected",
+    );
+    assert_eq!(
+        fee_receipt.total_refunded(),
+        0,
+        "nothing is refunded when compute exceeds the payment"
+    );
+    assert!(
+        fee_receipt.unpaid_debt() > 0,
+        "compute charged beyond the payment is the bounded, absorbed loss",
+    );
+}
+
+/// Paying more fees raises the compute allowance: the same call that fails when underpaid commits
+/// when the fee funds compute beyond the grace.
+#[test]
+fn paying_more_raises_the_compute_allowance() {
+    let Harness {
+        mut test,
+        bench,
+        account,
+        owner,
+        key,
+        per_round,
+    } = setup();
+
+    let rounds = ABOVE_GRACE_POINTS / per_round;
+    let tx = Transaction::builder_localnet()
+        .pay_fee_from_component(account, 50_000_000u64)
+        .call_function(bench, "bench_div_u64", args![rounds])
+        .build_and_seal(&key);
+
+    test.execute_expect_success(tx, vec![owner]);
+}
+
+/// The fee intent may spend real compute to source its fee before it pays, as long as it stays within
+/// the grace.
+#[test]
+fn fee_intent_may_spend_compute_within_grace_before_paying() {
+    let Harness {
+        mut test,
+        bench,
+        account,
+        owner,
+        key,
+        per_round,
+    } = setup();
+
+    let rounds = BELOW_GRACE_POINTS / per_round;
+    let tx = Transaction::builder_localnet()
+        .with_fee_instructions_builder(|builder| {
+            builder
+                .call_function(bench, "bench_div_u64", args![rounds])
+                .pay_fee_from_component(account, 20_000_000u64)
+        })
+        .build_and_seal(&key);
+
+    test.execute_expect_success(tx, vec![owner]);
+}
+
+/// A fee intent that tries to run more than the grace of compute before paying traps out-of-gas and
+/// the whole transaction is rejected — bounding the free compute extractable by stuffing an unbounded
+/// loop into the fee intent.
+#[test]
+fn fee_intent_cannot_exceed_grace_compute() {
+    let Harness {
+        mut test,
+        bench,
+        account,
+        owner,
+        key,
+        per_round,
+    } = setup();
+
+    let rounds = ABOVE_GRACE_POINTS / per_round;
+    let tx = Transaction::builder_localnet()
+        .with_fee_instructions_builder(|builder| {
+            builder
+                .call_function(bench, "bench_div_u64", args![rounds])
+                .pay_fee_from_component(account, 50_000_000u64)
+        })
+        .build_and_seal(&key);
+
+    let reason = test.execute_expect_failure(tx, vec![owner]);
+    assert_insufficient_fees(&reason);
+}

--- a/crates/engine_types/src/limits.rs
+++ b/crates/engine_types/src/limits.rs
@@ -33,6 +33,21 @@ pub const MAX_WASM_POINTS_PER_CALL: u64 = 100_000_000;
 /// all its calls. The aggregate across a *block* still needs a separate per-block budget.
 pub const MAX_WASM_POINTS_PER_TRANSACTION: u64 = 100_000_000;
 
+/// Wasmer metering points a transaction may consume *before* its fee payments cover them. A
+/// transaction sources its fee in the fee intent (withdraw, claim-burn, AMM swap to TARI, stealth
+/// transfer, …) and only then calls `pay_fee`, so it must be allowed to run some compute on credit;
+/// this bounds that credit. Beyond it, each WASM call's metering allowance is capped to the points
+/// the fees paid so far can cover (`WasmProcess::invoke`), so a transaction that does not pay traps
+/// out-of-gas here rather than consuming the full [`MAX_WASM_POINTS_PER_TRANSACTION`] for free. This
+/// is the bound on free compute a non-paying transaction can extract from a validator. Payments
+/// raise the allowance above this value proportionally to the WASM fee rate.
+///
+/// Sized with generous margin over the most expensive legitimate fee-sourcing flow: acquiring TARI
+/// by swapping another resource through an AMM pool inside the fee intent costs ~143k points (see
+/// `tari_engine`'s `complex_fee_payment` test, which guards that this stays comfortably above it),
+/// so this is ~14x that worst case while staying far below the per-transaction cap.
+pub const FREE_COMPUTE_GRACE_POINTS: u64 = 2_000_000;
+
 pub struct EngineLimits {
     pub max_substate_outputs: usize,
     pub max_substate_size: usize,

--- a/crates/template_test_tooling/src/template_test.rs
+++ b/crates/template_test_tooling/src/template_test.rs
@@ -21,7 +21,7 @@ use tari_crypto::{
 };
 use tari_engine::{
     executables::Executable,
-    fees::{FeeModule, FeeTable},
+    fees::{FeeModule, FeeTable, WasmMeteringRate},
     runtime::{AuthParams, RuntimeModule},
     state_store::{
         StateWriter,
@@ -685,9 +685,14 @@ impl TemplateTest {
 
         modules.push(Box::new(self.track_calls.clone()));
 
-        if self.enable_fees {
+        // When fees are disabled there is no payment-funded compute bound (only the per-transaction
+        // hard cap), matching the absence of a fee module.
+        let wasm_metering_rate = if self.enable_fees {
             modules.push(Box::new(FeeModule::new(0, self.fee_table.clone(), false)));
-        }
+            WasmMeteringRate::from_fee_table(&self.fee_table)
+        } else {
+            WasmMeteringRate::unmetered()
+        };
 
         if self.auto_add_proofs_from_signers && proofs.is_empty() {
             proofs.extend(
@@ -708,6 +713,7 @@ impl TemplateTest {
             self.virtual_substates.clone().into(),
             Arc::from(modules.into_boxed_slice()),
             Arc::new(AlwaysPassesProofVerifier),
+            wasm_metering_rate,
         );
 
         let mut wrapped_transaction = WrappedTransaction::new(transaction);


### PR DESCRIPTION
## Problem

A transaction can put all of its real work in the **fee intent** (or anywhere) and consume up to the full per-transaction WASM metering budget (`MAX_WASM_POINTS_PER_TRANSACTION` = 100M points) while paying little or no fee:

- The fee-sufficiency check (`payments >= charges`) only runs at the **fee-intent checkpoint** and at **successful finalize** — never continuously.
- The WASM execution charge is only levied at `on_before_finalize`, so the checkpoint's payment check is **compute-blind**.
- On under-payment / failure, `finalize_fees_and_refunds` simply collects whatever was paid and **absorbs the rest**.

So a transaction that loops and then under-pays (or fails the checkpoint after the work is already done) gets its compute run by the validator for free — a leader-stall / free-compute DoS, in the same family as the stealth-transfer budget caps (#2272).

## Fix

Bound the compute a transaction can run **on credit**. Each WASM call's metering allowance is capped to:

```
allowance = points_funded_by(fees_paid_so_far) + FREE_COMPUTE_GRACE_POINTS
```

A transaction legitimately sources its fee in the fee intent (withdraw / claim-burn / AMM swap to TARI / stealth transfer) *before* calling `pay_fee`, so it must run some compute on credit — the grace covers that. Beyond it, an under-paying transaction traps out-of-gas (`InsufficientFeesForCompute`) instead of running to the hard cap. Paying more raises the allowance proportionally to the WASM fee rate.

This drops the free compute extractable per transaction from the 100M hard cap to the grace.

### Where it's enforced

Entirely in the **core** engine path (`WasmProcess::invoke`), exactly where the per-transaction hard cap already lives — *not* in the `FeeModule`. The WASM fee rate is threaded into the `StateTracker` as plain config (a `WasmMeteringRate` derived from the `FeeTable`), so dropping the optional, observer-style fee module falls back to the existing hard cap rather than silently removing the bound. (Per the principle stated at `runtime/impl.rs`'s read-only sandbox comment.)

## Sizing the grace

`FREE_COMPUTE_GRACE_POINTS = 2,000,000`, sized from the most expensive *legitimate* fee-sourcing flow — acquiring TARI by swapping another resource through an AMM pool **inside the fee intent** — measured at **~143k points**, with generous margin (~14x). The kept `complex_fee_payment` test exercises that flow end-to-end and asserts the grace stays comfortably above it, so the constant can't silently drift below a realistic fee-payment swap.

## Tests

- `crates/engine/tests/complex_fee_payment.rs` — builds a `(TARI, token)` AMM pool, then pays a fee by swapping `token` → TARI inside the fee intent; measures the worst-case fee-sourcing compute and guards the grace margin.
- `crates/engine/tests/compute_fee_budget.rs` —
  - under-paid call above the grace is rejected (`InsufficientFeesForCompute`), the fee intent still commits (`AcceptFeeRejectRest`) and the whole payment is collected;
  - paying more raises the allowance so the same call commits;
  - the fee intent may spend compute within the grace before paying;
  - a fee intent that exceeds the grace before paying is rejected.
- Existing `metering_budget` test (hard cap) still passes.

## Note

Breaking: `TransactionProcessor::new` and `StateTracker::new` gain a `WasmMeteringRate` parameter and `RuntimeInterface` gains `wasm_point_allowance()`.
