### PR TITLE
fix(swarm): re-wire validator peers when a validator is restarted

### DIFF
--- a/applications/tari_swarm_daemon/src/process_manager/manager.rs
+++ b/applications/tari_swarm_daemon/src/process_manager/manager.rs
@@ -485,10 +485,12 @@ impl ProcessManager {
                 // A restarted validator comes up with an empty in-memory peer store and no seed
                 // peers, so it cannot rediscover its committee on its own (mDNS is unreliable on
                 // some hosts). Re-run manual peer wiring so the committee reconnects.
-                if result.is_ok() && is_validator && self.enable_manual_connect {
-                    if let Err(err) = self.connect_all_validators().await {
-                        log::error!("Failed to reconnect validators after restarting instance {instance_id}: {err}");
-                    }
+                if result.is_ok() &&
+                    is_validator &&
+                    self.enable_manual_connect &&
+                    let Err(err) = self.connect_all_validators().await
+                {
+                    log::error!("Failed to reconnect validators after restarting instance {instance_id}: {err}");
                 }
 
                 if reply.send(result).is_err() {

--- a/applications/tari_swarm_daemon/src/process_manager/manager.rs
+++ b/applications/tari_swarm_daemon/src/process_manager/manager.rs
@@ -464,19 +464,37 @@ impl ProcessManager {
                 }
             },
             StartInstance { instance_id, reply } => {
-                let executable = {
-                    let instance = self
-                        .instance_manager
-                        .instances()
-                        .find(|i| i.id() == instance_id)
-                        .ok_or_else(|| anyhow!("Instance with ID '{}' not found", instance_id))?;
-                    let instance_type = instance.instance_type();
-                    self.executable_manager
-                        .compile_executable_if_required(instance_type)
-                        .await?
+                let is_validator = self
+                    .instance_manager
+                    .instances()
+                    .find(|i| i.id() == instance_id)
+                    .map(|i| i.instance_type().is_validator())
+                    .ok_or_else(|| anyhow!("Instance with ID '{}' not found", instance_id))?;
+
+                let result = {
+                    let executable = {
+                        let instance = self
+                            .instance_manager
+                            .instances()
+                            .find(|i| i.id() == instance_id)
+                            .ok_or_else(|| anyhow!("Instance with ID '{}' not found", instance_id))?;
+                        let instance_type = instance.instance_type();
+                        self.executable_manager
+                            .compile_executable_if_required(instance_type)
+                            .await?
+                    };
+                    self.instance_manager.start_instance(instance_id, executable).await
                 };
 
-                let result = self.instance_manager.start_instance(instance_id, executable).await;
+                // A restarted validator comes up with an empty in-memory peer store and no seed
+                // peers, so it cannot rediscover its committee on its own (mDNS is unreliable on
+                // some hosts). Re-run manual peer wiring so the committee reconnects.
+                if result.is_ok() && is_validator && self.enable_manual_connect {
+                    if let Err(err) = self.connect_all_validators().await {
+                        log::error!("Failed to reconnect validators after restarting instance {instance_id}: {err}");
+                    }
+                }
+
                 if reply.send(result).is_err() {
                     log::warn!("Request cancelled before response could be sent")
                 }

--- a/applications/tari_swarm_daemon/src/process_manager/manager.rs
+++ b/applications/tari_swarm_daemon/src/process_manager/manager.rs
@@ -464,25 +464,21 @@ impl ProcessManager {
                 }
             },
             StartInstance { instance_id, reply } => {
-                let is_validator = self
+                let (instance_type, is_validator) = self
                     .instance_manager
                     .instances()
                     .find(|i| i.id() == instance_id)
-                    .map(|i| i.instance_type().is_validator())
+                    .map(|i| {
+                        let instance_type = i.instance_type();
+                        (instance_type, instance_type.is_validator())
+                    })
                     .ok_or_else(|| anyhow!("Instance with ID '{}' not found", instance_id))?;
 
                 let result = {
-                    let executable = {
-                        let instance = self
-                            .instance_manager
-                            .instances()
-                            .find(|i| i.id() == instance_id)
-                            .ok_or_else(|| anyhow!("Instance with ID '{}' not found", instance_id))?;
-                        let instance_type = instance.instance_type();
-                        self.executable_manager
-                            .compile_executable_if_required(instance_type)
-                            .await?
-                    };
+                    let executable = self
+                        .executable_manager
+                        .compile_executable_if_required(instance_type)
+                        .await?;
                     self.instance_manager.start_instance(instance_id, executable).await
                 };
 


### PR DESCRIPTION
## Problem

Restarting a single validator instance in the local swarm (e.g. via the web UI / `start_instance`) leaves it **partitioned from the rest of the committee**, so consensus stalls in a permanent `Leader timeout / NEXTSYNCVIEW` loop that survives further restarts. The only recovery was a full swarm restart or manually calling the validator's `add_peer` JSON-RPC.

### Why it happens

A restarted validator comes up with:
- an **empty in-memory peer store** (`MemoryStore`) — learned addresses don't survive restart,
- **no seed peers** on localnet (`🥾 BOOTSTRAP: dialing 0 seed peers`),
- and mDNS frequently unavailable (e.g. `libp2p_mdns ... error sending packet ... No route to host` on hosts where the LAN interface can't multicast).

The swarm wires validators together manually via `connect_all_validators()` (`add_peer` over each VN's JSON-RPC), but that only runs **once**, during the daemon's initial `start_up()` sequence — **not** in the `StartInstance` handler used to restart an instance. So a restarted validator never relearns its committee's addresses → `DialFailure` on every consensus message → partition.

The indexer keeps working because it is seeded with both VN addresses, but it does not bridge the validators to each other.

## Fix

Re-run the manual peer wiring after a validator instance is (re)started, guarded by the existing `enable_manual_validator_connect` setting. The committee reconnects automatically and the (at most one-block) divergence self-heals via NEWVIEW / catch-up on reconnect.

The wiring is idempotent and only triggers for validator instances when manual connect is enabled, so initial bulk startup behaviour is unchanged.

## Testing

- `cargo check -p tari_swarm_daemon` passes.
- Manually verified the underlying cause: a stuck validator's `get_connections` showed only the indexer (not the peer VN); a manual `add_peer` reconnected them and consensus resumed.