### PR TITLE
feat(transaction_generator): publish-template stress flow with random signer

### DIFF
--- a/crates/transaction_manifest/src/generator.rs
+++ b/crates/transaction_manifest/src/generator.rs
@@ -36,6 +36,9 @@ pub struct ManifestInstructionGenerator {
     templates: HashMap<String, TemplateAddress>,
     /// Caller-supplied blob payloads keyed by name. Used to resolve `blob!(name)` references.
     blob_inputs: HashMap<String, Blob>,
+    /// Variables bound to a blob with `let x = blob!("name")`, mapping the variable name to the
+    /// blob name it references. Lets `publish_template!(x)` resolve `x` back to its blob.
+    blob_vars: HashMap<String, String>,
     /// Output blob list — populated lazily as `blob!(name)` is encountered. The order matches
     /// the order of first reference, so emitted `BlobIndex`es match the returned `Blobs`.
     blob_indices: HashMap<String, BlobIndex>,
@@ -58,6 +61,7 @@ impl ManifestInstructionGenerator {
             workspace_ids: HashMap::new(),
             templates,
             blob_inputs,
+            blob_vars: HashMap::new(),
             blob_indices: HashMap::new(),
             output_blobs: Blobs::empty(),
             functions: HashMap::new(),
@@ -227,6 +231,11 @@ impl ManifestInstructionGenerator {
                 );
                 Ok(vec![])
             },
+            ManifestIntent::AssignBlob(assign) => {
+                self.blob_vars
+                    .insert(assign.variable_name.to_string(), assign.blob_name.to_string());
+                Ok(vec![])
+            },
             ManifestIntent::Log(log) => Ok(vec![Instruction::EmitLog {
                 level: log.level,
                 message: log.message.try_into().map_err(|e| ManifestError::InvalidInstruction {
@@ -247,10 +256,13 @@ impl ManifestInstructionGenerator {
                 Ok(vec![Instruction::PutIntoBucket { src, dest }])
             },
             ManifestIntent::PublishTemplate(pt) => {
-                // Reuse the same blob-resolution path as `blob!(name)` — the binary is
-                // registered in the output Blobs on first reference and assigned the next
-                // BlobIndex.
-                let arg = self.resolve_blob_arg(&pt.blob_name.to_string())?;
+                // `pt.blob_name` is either a blob variable bound with `let x = blob!("name")` or a
+                // blob name directly; resolve a variable to its blob name, then reuse the same
+                // blob-resolution path as `blob!(name)` — the binary is registered in the output
+                // Blobs on first reference and assigned the next BlobIndex.
+                let ident = pt.blob_name.to_string();
+                let blob_name = self.blob_vars.get(&ident).cloned().unwrap_or(ident);
+                let arg = self.resolve_blob_arg(&blob_name)?;
                 let binary = arg.as_blob_index().ok_or_else(|| ManifestError::InvalidInstruction {
                     reason: "publish_template! resolved to a non-Blob arg".to_string(),
                 })?;

--- a/crates/transaction_manifest/src/parser.rs
+++ b/crates/transaction_manifest/src/parser.rs
@@ -51,6 +51,7 @@ pub enum ManifestIntent {
     InvokeTemplate(InvokeIntent),
     InvokeComponent(InvokeIntent),
     AssignInput(AssignInputStmt),
+    AssignBlob(AssignBlobStmt),
     AllocateAddress(AllocateAddressStmt),
     CreateAccount(CreateAccountIntent),
     Log(LogIntent),
@@ -66,13 +67,23 @@ pub struct PutIntoBucketIntent {
     pub dest: Ident,
 }
 
-/// `publish_template!(blob!(name))` — publishes the WASM binary referenced by the named blob.
+/// `publish_template!(name)` — publishes the WASM binary referenced by `name`, which is either a
+/// blob variable bound with `let name = blob!("...")` or a blob name supplied via `blob_inputs`.
 #[derive(Debug, Clone)]
 pub struct PublishTemplateIntent {
-    /// Name of the blob containing the WASM binary. Must have been provided via `blob_inputs`.
+    /// A blob variable (from `let x = blob!(...)`) or a blob name. Either way it resolves to a blob
+    /// provided via `blob_inputs`.
     pub blob_name: Ident,
     /// Optional off-chain CBOR metadata multihash (hex-encoded literal).
     pub metadata_hash_hex: Option<String>,
+}
+
+/// `let x = blob!("name")` — binds the variable `x` to the blob named `name` (supplied via
+/// `blob_inputs`) so it can be referenced by name later, e.g. `publish_template!(x)`.
+#[derive(Debug, Clone)]
+pub struct AssignBlobStmt {
+    pub variable_name: Ident,
+    pub blob_name: Ident,
 }
 
 #[derive(Debug, Clone)]
@@ -437,6 +448,20 @@ fn assignment_from_macro(var_name: Ident, mac: &Ident, tokens: TokenStream) -> R
             variable_name: var_name,
             global_variable_name: parse2(tokens)?,
         })),
+        "blob" => {
+            // Accept `blob!("name")` or `blob!(name)`, mirroring the argument-position `blob!`.
+            let blob_name = if let Ok(lit_str) = parse2::<LitStr>(tokens.clone()) {
+                Ident::new(&lit_str.value(), lit_str.span())
+            } else {
+                parse2::<Ident>(tokens).map_err(|e| {
+                    syn::Error::new_spanned(mac, format!("Expected identifier or string literal in blob!: {}", e))
+                })?
+            };
+            Ok(ManifestIntent::AssignBlob(AssignBlobStmt {
+                variable_name: var_name,
+                blob_name,
+            }))
+        },
         "new_component_addr" => Ok(ManifestIntent::AllocateAddress(AllocateAddressStmt {
             output_variable: var_name,
             allocatable_type: AllocatableAddressType::Component,

--- a/crates/transaction_manifest/tests/parser.rs
+++ b/crates/transaction_manifest/tests/parser.rs
@@ -672,6 +672,34 @@ fn publish_template_macro_resolves_to_publish_template_instruction() {
 }
 
 #[test]
+fn publish_template_resolves_blob_let_binding() {
+    let manifest = r#"
+        fn main() {
+            let template = blob!("wasm");
+            publish_template!(template);
+        }
+    "#;
+
+    let mut blob_inputs = HashMap::new();
+    blob_inputs.insert(
+        "wasm".to_string(),
+        tari_ootle_transaction::Blob::from(vec![1u8, 2, 3, 4]),
+    );
+
+    let ManifestInstructions {
+        instructions, blobs, ..
+    } = parse_manifest(manifest, HashMap::new(), Default::default(), blob_inputs).unwrap();
+
+    assert_eq!(blobs.len(), 1);
+    assert_eq!(blobs.get(0).unwrap().as_bytes(), &[1u8, 2, 3, 4]);
+    assert_eq!(instructions.len(), 1);
+    assert_eq!(instructions[0], Instruction::PublishTemplate {
+        binary: 0,
+        metadata_hash: None,
+    });
+}
+
+#[test]
 fn publish_template_macro_unknown_blob_errors() {
     let manifest = r#"
         fn main() {

--- a/utilities/transaction_generator/manifests/publish_template.rs
+++ b/utilities/transaction_generator/manifests/publish_template.rs
@@ -35,5 +35,6 @@ fn fee_main() {
 }
 
 fn main() {
+    let template = blob!("template");
     publish_template!(template);
 }

--- a/utilities/transaction_generator/manifests/publish_template.rs
+++ b/utilities/transaction_generator/manifests/publish_template.rs
@@ -1,0 +1,39 @@
+//   Copyright 2026 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+// Generates transactions that each publish the SAME WASM template binary while paying the fee from
+// a single given account. A template's on-chain address is H(author_public_key, binary_hash), so
+// publishing one binary repeatedly would collide on a duplicate substate. Run this manifest with
+// `--random-signer`: the generator seals every transaction with a fresh random keypair (giving each
+// publish a distinct author and so a distinct address) and adds the fee-paying account's owner as a
+// second signer so it can authorise pay_fee.
+//
+// The binary is supplied as a manifest blob via `--blob template=<path/to/template.wasm>` and
+// referenced below as `publish_template!(template)`. Reuse the max_compute stress template (build
+// it with `cargo build --release --target wasm32-unknown-unknown` in templates/max_compute) or
+// point at any other WASM template.
+//
+//   transaction_generator write -n 100 -o publish.bin \
+//     -m utilities/transaction_generator/manifests/publish_template.rs \
+//     --blob template=<path/to/max_compute.wasm> \
+//     --arg account=component_<hex> \
+//     --input vault_<hex> \
+//     --signer <account_owner_secret_key_hex> \
+//     --random-signer
+//
+// The account is referenced via `arg!["account"]`, so the generator declares it as an input
+// automatically. The fee vault is debited by pay_fee but never named in the instructions, so it
+// must be declared explicitly with `--input vault_<hex>` — otherwise execution fails with
+// SubstateNotFound.
+
+fn fee_main() {
+    let account = arg!["account"];
+    // pay_fee locks a ceiling and refunds the unused remainder. Publishing costs roughly
+    // binary_size µT (storage) + binary_size/3 µT (transaction weight); 1 tTARI covers the small
+    // max_compute binary with head-room. Raise it for larger templates (binary cap is 1.5 MiB).
+    account.pay_fee(1_000_000);
+}
+
+fn main() {
+    publish_template!(template);
+}

--- a/utilities/transaction_generator/src/cli.rs
+++ b/utilities/transaction_generator/src/cli.rs
@@ -50,6 +50,19 @@ pub struct WriteArgs {
     pub inputs: Vec<String>,
     #[clap(long, alias = "args-file")]
     pub manifest_args_file: Option<PathBuf>,
+    /// Load a file as a named manifest blob, e.g. `--blob template=path/to/template.wasm`. The name
+    /// is resolved by `blob!(name)` / `publish_template!(name)` in the manifest and the file's bytes
+    /// become the blob payload. May be repeated.
+    #[clap(long = "blob", alias = "blobs")]
+    pub blobs: Vec<String>,
+    /// Seal each generated transaction with a fresh random keypair instead of with `--signer`, and
+    /// add `--signer` as an additional signer (so its badge still authorises e.g. fee payment from
+    /// its account). Requires `--signer`. Primarily useful for publishing the same template binary
+    /// repeatedly: the random seal key becomes the template's author, so each publish yields a unique
+    /// template address (H(author_public_key, binary_hash)) instead of colliding on a duplicate
+    /// substate.
+    #[clap(long, alias = "random-author")]
+    pub random_signer: bool,
     #[clap(long, short = 'k', alias = "signer")]
     pub signer_secret_key: Option<String>,
     #[clap(long, short = 't')]

--- a/utilities/transaction_generator/src/main.rs
+++ b/utilities/transaction_generator/src/main.rs
@@ -15,7 +15,7 @@ use anyhow::anyhow;
 use cli::Cli;
 use tari_crypto::{keys::SecretKey, ristretto::RistrettoSecretKey, tari_utilities::hex::Hex};
 use tari_ootle_common_types::SubstateRequirement;
-use tari_ootle_transaction::Network;
+use tari_ootle_transaction::{Blob, Network};
 use tari_template_lib_types::TemplateAddress;
 use tari_transaction_manifest::ManifestValue;
 use transaction_generator::{
@@ -84,6 +84,12 @@ fn get_transaction_builder(args: &WriteArgs) -> anyhow::Result<BoxedTransactionB
     let network = args.network.unwrap_or(Network::LocalNet);
     match args.manifest.as_ref() {
         Some(manifest) => {
+            if args.random_signer && args.signer_secret_key.is_none() {
+                anyhow::bail!(
+                    "--random-signer requires --signer: a fresh random key seals each transaction, while the --signer \
+                     key is added as an additional signer (e.g. it owns the fee-paying account and authorises pay_fee)"
+                );
+            }
             let signer_key = args
                 .signer_secret_key
                 .as_ref()
@@ -105,7 +111,17 @@ fn get_transaction_builder(args: &WriteArgs) -> anyhow::Result<BoxedTransactionB
             }
             let templates = parse_templates(&args.templates)?;
             let inputs = parse_inputs(&args.inputs)?;
-            manifest::builder(signer_key, network, manifest, manifest_args, templates, inputs)
+            let blobs = parse_blobs(&args.blobs)?;
+            manifest::builder(
+                signer_key,
+                network,
+                manifest,
+                manifest_args,
+                templates,
+                inputs,
+                blobs,
+                args.random_signer,
+            )
         },
         None => Ok(Box::new(free_coins::builder(network))),
     }
@@ -118,6 +134,22 @@ fn parse_inputs(items: &[String]) -> anyhow::Result<Vec<SubstateRequirement>> {
             s.trim()
                 .parse::<SubstateRequirement>()
                 .map_err(|e| anyhow!("Invalid --input '{}': {}", s, e))
+        })
+        .collect()
+}
+
+fn parse_blobs(items: &[String]) -> anyhow::Result<HashMap<String, Blob>> {
+    items
+        .iter()
+        .map(|s| {
+            let (name, path) = s
+                .split_once('=')
+                .ok_or_else(|| anyhow!("Invalid --blob mapping '{}' (expected <name>=<file_path>)", s))?;
+            let name = name.trim();
+            let path = path.trim();
+            let bytes =
+                fs::read(path).map_err(|e| anyhow!("Failed to read blob '{}' from file '{}': {}", name, path, e))?;
+            Ok((name.to_string(), Blob::from(bytes)))
         })
         .collect()
 }

--- a/utilities/transaction_generator/src/main.rs
+++ b/utilities/transaction_generator/src/main.rs
@@ -147,6 +147,9 @@ fn parse_blobs(items: &[String]) -> anyhow::Result<HashMap<String, Blob>> {
                 .ok_or_else(|| anyhow!("Invalid --blob mapping '{}' (expected <name>=<file_path>)", s))?;
             let name = name.trim();
             let path = path.trim();
+            if name.is_empty() || path.is_empty() {
+                anyhow::bail!("Invalid --blob mapping '{}' (expected <name>=<file_path>)", s);
+            }
             let bytes =
                 fs::read(path).map_err(|e| anyhow!("Failed to read blob '{}' from file '{}': {}", name, path, e))?;
             Ok((name.to_string(), Blob::from(bytes)))

--- a/utilities/transaction_generator/src/transaction_builders/manifest.rs
+++ b/utilities/transaction_generator/src/transaction_builders/manifest.rs
@@ -3,14 +3,19 @@
 
 use std::{collections::HashMap, fs, path::Path};
 
-use tari_crypto::ristretto::RistrettoSecretKey;
+use ootle_byte_type::ToByteType;
+use tari_crypto::{
+    keys::PublicKey,
+    ristretto::{RistrettoPublicKey, RistrettoSecretKey},
+};
 use tari_ootle_common_types::SubstateRequirement;
-use tari_ootle_transaction::{Network, Transaction};
+use tari_ootle_transaction::{Blob, Network, Transaction};
 use tari_template_lib_types::TemplateAddress;
 use tari_transaction_manifest::ManifestValue;
 
 use crate::BoxedTransactionBuilder;
 
+#[allow(clippy::too_many_arguments)]
 pub fn builder<P: AsRef<Path>>(
     signer_secret_key: RistrettoSecretKey,
     network: Network,
@@ -18,8 +23,10 @@ pub fn builder<P: AsRef<Path>>(
     globals: HashMap<String, ManifestValue>,
     templates: HashMap<String, TemplateAddress>,
     extra_inputs: Vec<SubstateRequirement>,
+    blob_inputs: HashMap<String, Blob>,
+    random_signer: bool,
 ) -> anyhow::Result<BoxedTransactionBuilder> {
-    let contents = fs::read_to_string(manifest).unwrap();
+    let contents = fs::read_to_string(manifest)?;
     // Every substate referenced by the transaction must be declared as an input, otherwise the
     // executor never loads it and the instructions fail with SubstateNotFound. Substate-typed
     // globals (e.g. the fee account) are auto-declared; `extra_inputs` (from `--input`) cover
@@ -31,12 +38,36 @@ pub fn builder<P: AsRef<Path>>(
         .map(SubstateRequirement::unversioned)
         .chain(extra_inputs)
         .collect::<Vec<_>>();
-    let instructions = tari_transaction_manifest::parse_manifest(&contents, globals, templates, Default::default())?;
+    let instructions = tari_transaction_manifest::parse_manifest(&contents, globals, templates, blob_inputs)?;
+    let fee_instructions = instructions.fee_instructions;
+    let main_instructions = instructions.instructions;
+    // Blobs referenced by the manifest (e.g. the WASM binary for `publish_template!`), in the order
+    // the generator assigned their `BlobIndex`es. They must be attached to every transaction in the
+    // same order so the indices in `Instruction::PublishTemplate` resolve correctly.
+    let blobs = instructions.blobs;
+
     Ok(Box::new(move |_| {
-        Transaction::builder(network.as_byte())
-            .with_fee_instructions(instructions.fee_instructions.clone())
-            .with_instructions(instructions.instructions.clone())
-            .with_inputs(inputs.clone())
-            .build_and_seal(&signer_secret_key)
+        let mut builder = Transaction::builder(network.as_byte())
+            .with_fee_instructions(fee_instructions.clone())
+            .with_instructions(main_instructions.clone());
+        for (i, blob) in blobs.iter().enumerate() {
+            builder = builder.add_blob(i.to_string(), blob.clone());
+        }
+        let builder = builder.with_inputs(inputs.clone());
+
+        if random_signer {
+            // Seal with a fresh random keypair per transaction and add `signer_secret_key` as an
+            // additional signer, so its badge stays in the auth scope (e.g. to authorise pay_fee on
+            // its account). For publish_template this also makes each publish unique: the engine
+            // records the template's author from the transaction's main signer — the authorised seal
+            // signer — so a fresh seal key gives a unique template address (H(author, binary_hash))
+            // instead of colliding on a duplicate substate.
+            let (random_secret, random_public) = RistrettoPublicKey::random_keypair(&mut rand::rng());
+            builder
+                .add_signer(&random_public.to_byte_type(), &signer_secret_key)
+                .seal(&random_secret)
+        } else {
+            builder.build_and_seal(&signer_secret_key)
+        }
     }))
 }

--- a/utilities/transaction_generator/tests/manifest_inputs.rs
+++ b/utilities/transaction_generator/tests/manifest_inputs.rs
@@ -34,6 +34,8 @@ fn declares_account_arg_and_explicit_input_as_transaction_inputs() {
         globals,
         templates,
         extra_inputs,
+        HashMap::new(),
+        false,
     )
     .unwrap();
 

--- a/utilities/transaction_generator/tests/publish_template.rs
+++ b/utilities/transaction_generator/tests/publish_template.rs
@@ -1,0 +1,128 @@
+//   Copyright 2026 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+//! Guards the publish-template stress flow (manifests/publish_template.rs + the `--random-signer`
+//! generator mode): publishing one binary many times must produce a unique template address per
+//! transaction while the fee is authorised by a single fixed account owner.
+
+use std::collections::{HashMap, HashSet};
+
+use tari_crypto::{
+    keys::{PublicKey, SecretKey},
+    ristretto::{RistrettoPublicKey, RistrettoSecretKey},
+};
+use tari_ootle_transaction::{Blob, Instruction, Network};
+use tari_transaction_manifest::ManifestValue;
+use transaction_generator::transaction_builders::manifest;
+
+const MANIFEST: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/manifests/publish_template.rs");
+const ACCOUNT: &str = "component_f29021e8945394114b97c4b56c41fdf62a28e35fb8b6c1bff1c574f68ae28a54";
+
+fn globals() -> HashMap<String, ManifestValue> {
+    let mut g = HashMap::new();
+    g.insert("account".to_string(), ACCOUNT.parse().unwrap());
+    g
+}
+
+fn blob_inputs() -> HashMap<String, Blob> {
+    // The manifest never validates the binary (that happens at execution); any bytes exercise the
+    // blob-attachment and address-derivation paths.
+    let mut b = HashMap::new();
+    b.insert("template".to_string(), Blob::from(b"\0asm\x01\0\0\0dummy".to_vec()));
+    b
+}
+
+#[test]
+fn random_signer_makes_each_publish_address_distinct() {
+    let owner_secret = RistrettoSecretKey::random(&mut rand::rng());
+    let owner_public = RistrettoPublicKey::from_secret_key(&owner_secret);
+
+    let build = manifest::builder(
+        owner_secret,
+        Network::LocalNet,
+        MANIFEST,
+        globals(),
+        HashMap::new(),
+        Vec::new(),
+        blob_inputs(),
+        true,
+    )
+    .unwrap();
+
+    let mut seal_signers = HashSet::new();
+    let mut template_addresses = HashSet::new();
+
+    for i in 0..5 {
+        let tx = build(i);
+
+        assert!(tx.verify_all_signatures(), "all signatures must verify");
+
+        // The fresh seal key is the authorised main signer, which the engine records as the template
+        // author — that is what makes each published address unique.
+        assert!(tx.is_seal_signer_authorized());
+        let author = tx.seal_signature().public_key().to_string();
+        assert!(
+            seal_signers.insert(author),
+            "each transaction must seal with a fresh author key"
+        );
+
+        // Exactly one additional signer: the fixed fee-paying account owner.
+        let extra = tx.signatures();
+        assert_eq!(extra.len(), 1, "expected exactly the fee-owner signature");
+        assert_eq!(
+            *extra[0].public_key(),
+            ootle_byte_type::ToByteType::to_byte_type(&owner_public),
+            "the additional signer must be the fee-paying account owner",
+        );
+
+        // The transaction publishes exactly one template.
+        let publishes = tx
+            .instructions()
+            .iter()
+            .chain(tx.fee_instructions())
+            .filter(|i| matches!(i, Instruction::PublishTemplate { .. }))
+            .count();
+        assert_eq!(publishes, 1, "expected a single PublishTemplate instruction");
+
+        // The derived on-chain address (H(author_pk, binary_hash)) must be unique per transaction.
+        let (addr, _bytes) = tx
+            .all_published_templates_iter()
+            .next()
+            .expect("a published template address");
+        assert!(
+            template_addresses.insert(addr.to_string()),
+            "republishing the same binary must yield a distinct template address",
+        );
+    }
+
+    assert_eq!(seal_signers.len(), 5);
+    assert_eq!(template_addresses.len(), 5);
+}
+
+#[test]
+fn without_random_signer_a_single_signer_seals() {
+    let signer = RistrettoSecretKey::random(&mut rand::rng());
+    let signer_public = RistrettoPublicKey::from_secret_key(&signer);
+
+    let build = manifest::builder(
+        signer,
+        Network::LocalNet,
+        MANIFEST,
+        globals(),
+        HashMap::new(),
+        Vec::new(),
+        blob_inputs(),
+        false,
+    )
+    .unwrap();
+
+    let tx = build(0);
+    assert!(tx.verify_all_signatures());
+    // With no `--random-signer`, the lone signer seals and is authorised; there are no extra signers.
+    assert!(tx.is_seal_signer_authorized());
+    assert!(tx.signatures().is_empty());
+    assert_eq!(
+        *tx.seal_signature().public_key(),
+        ootle_byte_type::ToByteType::to_byte_type(&signer_public),
+    );
+}

--- a/utilities/transaction_generator/tests/publish_template_engine.rs
+++ b/utilities/transaction_generator/tests/publish_template_engine.rs
@@ -1,0 +1,98 @@
+//   Copyright 2026 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+//! End-to-end engine proof of the publish-template stress flow: a transaction sealed by a fresh
+//! random "author" key publishes a binary while the fee is authorised by a *different* fixed account
+//! owner, and republishing the same binary under a new author does not collide on a duplicate
+//! substate.
+//!
+//! This exercises the real auth path: the processor takes the published template's author from the
+//! transaction's main signer (the random seal key) and `try_execute` derives the authorisation scope
+//! from `signers_iter()` (which includes the fee owner's additional signature), mirroring the
+//! validator-node executor.
+
+use std::collections::HashMap;
+
+use tari_engine_types::{
+    commit_result::ExecuteResult,
+    substate::{SubstateId, SubstateValue},
+};
+use tari_ootle_transaction::{Blob, Network};
+use tari_template_test_tooling::{TemplateTest, compile::compile_template};
+use tari_transaction_manifest::ManifestValue;
+use transaction_generator::transaction_builders::manifest;
+
+const CRATE_PATH: &str = env!("CARGO_MANIFEST_DIR");
+const MANIFEST: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/manifests/publish_template.rs");
+
+#[test]
+fn random_signer_publishes_same_binary_twice_without_duplicating() {
+    let mut test = TemplateTest::new(CRATE_PATH, &[] as &[&str]);
+    test.enable_fees();
+
+    // The fee-paying account and its owner key. The owner authorises pay_fee but is NOT the template
+    // author.
+    let (account_address, _owner_proof, account_key, _owner_public) = test.create_funded_account_with_keypair();
+
+    // Reuse the max_compute stress template's WASM as the binary to publish.
+    let compiled = compile_template("templates/max_compute", &[]).unwrap();
+    let wasm = compiled.code().to_vec();
+
+    let mut globals = HashMap::new();
+    globals.insert(
+        "account".to_string(),
+        account_address.to_string().parse::<ManifestValue>().unwrap(),
+    );
+    let mut blob_inputs = HashMap::new();
+    blob_inputs.insert("template".to_string(), Blob::from(wasm));
+
+    let build = manifest::builder(
+        account_key,
+        Network::LocalNet,
+        MANIFEST,
+        globals,
+        HashMap::new(),
+        Vec::new(),
+        blob_inputs,
+        true,
+    )
+    .unwrap();
+
+    // First publish: sealed by a random author, fee authorised by the account owner (auto-derived
+    // from the transaction signers — pass no explicit proofs).
+    let tx0 = build(0);
+    let author0 = tx0.seal_signature().public_key().to_string();
+    let result0 = test.execute_expect_success(tx0, vec![]);
+    let (addr0, recorded_author0) = published_template(&result0);
+    assert_eq!(
+        recorded_author0, author0,
+        "the template author must be the random seal key"
+    );
+
+    // Second publish of the SAME binary under a fresh author must succeed with a different address —
+    // proving the per-transaction author keeps republishes from colliding on a duplicate substate.
+    let tx1 = build(1);
+    let author1 = tx1.seal_signature().public_key().to_string();
+    assert_ne!(author0, author1, "each transaction must seal with a fresh author key");
+    let result1 = test.execute_expect_success(tx1, vec![]);
+    let (addr1, _recorded_author1) = published_template(&result1);
+
+    assert_ne!(
+        addr0, addr1,
+        "republishing the same binary must yield a distinct template address"
+    );
+}
+
+/// Extracts the (address, author) of the single template published in a result's accepted diff.
+fn published_template(result: &ExecuteResult) -> (SubstateId, String) {
+    result
+        .expect_success()
+        .up_iter()
+        .find_map(|(id, substate)| match substate.substate_value() {
+            SubstateValue::Template(t) if matches!(id, SubstateId::Template(_)) => {
+                Some((id.clone(), t.author.to_string()))
+            },
+            _ => None,
+        })
+        .expect("a published template in the diff")
+}


### PR DESCRIPTION
## Description

Adds a transaction-generator stress flow that publishes the **same** template binary many times without colliding on a duplicate substate, with fees paid from a single fixed account.

A published template's address is `H(author, binary_hash)`, where the engine takes `author` from the transaction's main signer. Republishing one binary under the same signer therefore collides. This change seals each generated transaction with a fresh random key so every publish gets a unique author (and address), while a fixed account owner authorises the fee as an additional signer.

## What's included

- **`--blob name=path`** — loads a file as a named manifest blob, resolving `blob!(name)` / `publish_template!(name)`. (The transaction generator previously had no way to feed a binary into a publish manifest.)
- **`--random-signer`** (alias `--random-author`) — seals each transaction with a fresh random key and adds `--signer` as an additional signer, so the signer's badge stays in the auth scope (e.g. to authorise `pay_fee`). Requires `--signer`. General-purpose, but its key use is making repeated publishes of one binary unique.
- `manifest::builder` now **attaches manifest blobs** to the built transaction — previously the blobs returned by `parse_manifest` were dropped, so any `publish_template!` manifest produced a transaction with no binary.
- New `manifests/publish_template.rs` publishing the binary supplied via `--blob` and paying the fee from `arg!["account"]`.

## Tests

- `tests/publish_template.rs` — structural: each transaction seals with a fresh authorised author, carries exactly the fee-owner additional signature, has one `PublishTemplate` instruction, and derives a distinct template address.
- `tests/publish_template_engine.rs` — end-to-end through the engine: a random-author publish whose fee is authorised by a *different* account owner is accepted, and republishing the same binary under a fresh author succeeds with a distinct address (no duplicate-substate collision).

## Usage

```
transaction_generator write -n 100 -o publish.bin \
  -m utilities/transaction_generator/manifests/publish_template.rs \
  --blob template=<path>/max_compute.wasm \
  --arg account=component_<hex> \
  --input vault_<hex> \
  --signer <account_owner_secret_key_hex> \
  --random-signer
```

The WASM must be built stripped or on-chain validation rejects it:

```
cargo build --target wasm32-unknown-unknown --release --config 'profile.release.strip="symbols"'
```

## Notes

- All publishes pay from the same account, so they share that account's vault as an input and are sequenced (not fully parallel) in consensus — inherent to "fees from one account", same as the existing `max_compute` stress.
- Running the full `cargo test -p transaction_generator` races on nested `compile_template` WASM builds across parallel test binaries (pre-existing); run the WASM-compiling test binaries one at a time.
