### PR TITLE
fix(indexer): show consensus-aborted transactions as rejected in recent list

### DIFF
--- a/applications/tari_indexer/src/transaction_manager/mod.rs
+++ b/applications/tari_indexer/src/transaction_manager/mod.rs
@@ -108,41 +108,72 @@ where
         &self,
         transaction_id: TransactionId,
     ) -> Result<IndexerTransactionFinalizedResult, TransactionManagerError> {
-        // A transaction rejected by mempool validation is never sequenced, so the network would
-        // report it as pending forever. Report the locally recorded rejection instead.
-        let rejection = self
-            .store
-            .with_read_tx(move |tx| tx.get_transaction_rejection(transaction_id))
-            .await?;
-        if let Some((details, rejected_at)) = rejection {
-            return Ok(IndexerTransactionFinalizedResult::Rejected {
-                details,
-                rejected_time: rejected_at,
-            });
-        }
-
+        // The committee is authoritative for any sequenced transaction. This includes aborts, which
+        // commit no substate — and therefore no receipt for the indexer to sync — only a finalized
+        // decision. Query it first so the full result (including abort decision and execution
+        // details) is returned to callers.
         let transaction_substate_address = transaction_id.to_substate_address();
-        let result = self
+        let network_result = self
             .network_client
             .try_single_with_committee(transaction_substate_address, |mut client| async move {
                 client.get_finalized_transaction_result(transaction_id).await.optional()
             })
-            .await?
-            .ok_or_else(|| TransactionManagerError::NotFound {
-                entity: "Transaction result",
-                key: transaction_id.to_string(),
-            })?;
+            .await;
 
-        Ok(match result {
-            TransactionResultStatus::Pending => IndexerTransactionFinalizedResult::Pending,
-            TransactionResultStatus::Finalized(finalized) => IndexerTransactionFinalizedResult::Finalized {
-                final_decision: finalized.final_decision,
-                execution_result: finalized.execute_result.map(Box::new),
-                execution_time: finalized.execution_time,
-                finalized_time: finalized.finalized_time,
-                abort_details: finalized.abort_details,
+        match network_result {
+            Ok(Some(TransactionResultStatus::Finalized(finalized))) => {
+                // Record a terminal abort locally so the recent-transactions listing — which reads
+                // only local state — reflects it instead of showing the transaction as pending
+                // indefinitely. Committed transactions are surfaced via their synced receipt, so
+                // only aborts need recording here.
+                if finalized.final_decision.is_abort() {
+                    let details = finalized
+                        .abort_details
+                        .clone()
+                        .or_else(|| finalized.final_decision.abort_reason().map(|r| r.to_string()))
+                        .unwrap_or_else(|| "Transaction aborted".to_string());
+                    self.store
+                        .with_write_tx(move |tx| tx.set_transaction_rejected(transaction_id, &details))
+                        .await?;
+                }
+
+                Ok(IndexerTransactionFinalizedResult::Finalized {
+                    final_decision: finalized.final_decision,
+                    execution_result: finalized.execute_result.map(Box::new),
+                    execution_time: finalized.execution_time,
+                    finalized_time: finalized.finalized_time,
+                    abort_details: finalized.abort_details,
+                })
             },
-        })
+            // The committee has no finalized result: the transaction is genuinely pending, the
+            // committee is unreachable, or it was rejected by mempool validation and never sequenced
+            // (in which case the committee reports it as pending forever). Prefer a locally recorded
+            // rejection over those outcomes.
+            other => {
+                let rejection = self
+                    .store
+                    .with_read_tx(move |tx| tx.get_transaction_rejection(transaction_id))
+                    .await?;
+                if let Some((details, rejected_at)) = rejection {
+                    return Ok(IndexerTransactionFinalizedResult::Rejected {
+                        details,
+                        rejected_time: rejected_at,
+                    });
+                }
+
+                match other {
+                    Ok(Some(TransactionResultStatus::Pending)) => Ok(IndexerTransactionFinalizedResult::Pending),
+                    Ok(None) => Err(TransactionManagerError::NotFound {
+                        entity: "Transaction result",
+                        key: transaction_id.to_string(),
+                    }),
+                    Err(e) => Err(e.into()),
+                    Ok(Some(TransactionResultStatus::Finalized(_))) => {
+                        unreachable!("Finalized result is handled above")
+                    },
+                }
+            },
+        }
     }
 
     pub async fn list_recent_transactions(

--- a/applications/tari_indexer/src/transaction_manager/mod.rs
+++ b/applications/tari_indexer/src/transaction_manager/mod.rs
@@ -127,14 +127,23 @@ where
                 // indefinitely. Committed transactions are surfaced via their synced receipt, so
                 // only aborts need recording here.
                 if finalized.final_decision.is_abort() {
-                    let details = finalized
-                        .abort_details
-                        .clone()
-                        .or_else(|| finalized.final_decision.abort_reason().map(|r| r.to_string()))
-                        .unwrap_or_else(|| "Transaction aborted".to_string());
-                    self.store
-                        .with_write_tx(move |tx| tx.set_transaction_rejected(transaction_id, &details))
-                        .await?;
+                    // Record the abort only once. Re-recording it on every read would needlessly
+                    // take SQLite's single write lock and contend with other writers under load.
+                    let already_recorded = self
+                        .store
+                        .with_read_tx(move |tx| tx.get_transaction_rejection(transaction_id))
+                        .await?
+                        .is_some();
+                    if !already_recorded {
+                        let details = finalized
+                            .abort_details
+                            .clone()
+                            .or_else(|| finalized.final_decision.abort_reason().map(|r| r.to_string()))
+                            .unwrap_or_else(|| "Transaction aborted".to_string());
+                        self.store
+                            .with_write_tx(move |tx| tx.set_transaction_rejected(transaction_id, &details))
+                            .await?;
+                    }
                 }
 
                 Ok(IndexerTransactionFinalizedResult::Finalized {

--- a/crates/validator_node_rpc/src/client.rs
+++ b/crates/validator_node_rpc/src/client.rs
@@ -215,7 +215,7 @@ impl<TAddr: NodeAddressable + ToPeerId, TMsg: MessageSpec> ValidatorNodeRpcClien
                     final_decision,
                     execution_time,
                     finalized_time: PrimitiveDateTime::new(finalized_time.date(), finalized_time.time()),
-                    abort_details: Some(response.abort_details).filter(|s| s.is_empty()),
+                    abort_details: Some(response.abort_details).filter(|s| !s.is_empty()),
                 })))
             },
             Err(_) => Err(ValidatorNodeRpcClientError::InvalidResponse(anyhow!(


### PR DESCRIPTION
Description
---

The indexer's recent-transactions listing (`GET /transactions/recent`) showed
consensus-aborted transactions as **Pending** forever, while the detail view
(`GET /transactions/:id/result`) for the same transaction correctly reported
the rejection.

The listing reads only local state, deriving each row's status from either the
synced transaction receipt (→ `Commit`/`FeeIntentCommit`) or a locally recorded
mempool rejection (→ `Rejected`). A transaction aborted by consensus — e.g.
`Abort(OneOrMoreInputsNotFound)` — produces a `TransactionResult::Reject`, which
commits **no substate** and therefore **no receipt** for the indexer to sync, and
it was never mempool-rejected. So the listing had nothing local to read and fell
through to `Pending`. The detail view worked only because it queries the
committee on demand (which is authoritative and returns the abort).

This change makes `TransactionManager::get_transaction_result` query the
committee first and, when it returns a terminal **Abort**, persist it to the
local rejection record so the listing reflects it. The locally recorded rejection
becomes a **fallback**, consulted only when the committee has no finalized result.

Behaviour by case after the change:

| Case | Committee returns | Result returned | Listing shows |
|---|---|---|---|
| Committed | `Finalized{Commit}` | rich `Finalized` (no persist) | `Commit` (via receipt sync) |
| **Zero-fee consensus abort** | `Finalized{Abort}` | rich `Finalized` + persists abort | **`Rejected`** |
| In-flight | `Pending` (no local rejection) | `Pending` | `Pending` |
| Mempool-rejected (never sequenced) | `Pending`/unreachable → local fallback | `Rejected` (unchanged) | `Rejected` |
| Unknown id | `None` (no local rejection) | `NotFound` (unchanged) | — |

Because the committee result is returned directly, the detail view keeps its full
`Finalized` rendering for aborts (decision, instructions, inputs, signers, fees) —
persisting no longer collapses it to the minimal `Rejected` view on subsequent
loads.

Known, accepted limitation: a zero-fee abort that **nobody ever opens** still
shows `Pending` in the listing until its detail/result is requested once, after
which the next list refresh corrects it. Closing that gap fully would require the
indexer to learn aborts without a per-transaction fetch (e.g. streaming aborted
decisions over the VN↔indexer sync), which is a larger, separate change.

Motivation and Context
---

Reproduced against a running indexer:

- `GET /transactions/096ddb…/result` → `Finalized { final_decision: { Abort:
  "OneOrMoreInputsNotFound" }, … }` (detail view shows "Rejected").
- `GET /transactions/recent?limit=50` → same id with `summary: null,
  rejected_reason: null` (listing shows "Pending").

Root cause: the listing only has local state to read, and a pure abort leaves no
local trace (no receipt, no mempool rejection). Confirmed via `commit_result.rs`
(`TransactionResult::Reject` → `into_any_accept()` is `None`, so no diff/receipt)
and the engine `finalize` path (a receipt substate is only `up`'d for `Commit`
and `FeeIntentCommit`).

How Has This Been Tested?
---

- Root cause confirmed end-to-end against a live local indexer by comparing the
  `/result` and `/recent` endpoints for an `OneOrMoreInputsNotFound` abort (see
  above).
- `cargo check -p tari_indexer` passes; formatted with the workspace nightly.
- Behaviour reasoned through case-by-case (table above). Not yet exercised
  end-to-end with the patched binary.

What process can a PR reviewer use to test or verify this change?
---

1. Run a swarm/indexer and submit a transaction that will be aborted by consensus
   with no fees charged (e.g. one referencing a non-existent input substate →
   `OneOrMoreInputsNotFound`).
2. Open the transaction's detail/result once (or `GET /transactions/:id/result`).
3. Reload the recent-transactions listing (`GET /transactions/recent`): the row
   should now show **Rejected** with the abort reason as the tooltip, instead of
   **Pending**, and the detail view should still render the full finalized result.

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify
