### PR TITLE
fix(consensus): resume consensus after offline rollback instead of wedging in sync

### DIFF
--- a/crates/rpc_state_sync/src/state_sync.rs
+++ b/crates/rpc_state_sync/src/state_sync.rs
@@ -362,6 +362,24 @@ where TConsensusSpec: ConsensusSpec<Addr = PeerAddress>
         )))
     }
 
+    /// True if this node's committed state already matches `checkpoint` for every shard it is responsible for (its
+    /// local shard group plus the global shard). Distinguishes a rolled-back node (complete state, checkpoint
+    /// retained) from one whose first-time state sync was interrupted after the checkpoint was persisted but before
+    /// the state finished streaming (checkpoint present, state incomplete).
+    async fn local_state_matches_checkpoint(&self, checkpoint: &EpochCheckpoint) -> Result<bool, RpcStateSyncError> {
+        let local_info = self.epoch_manager.get_local_committee_info(checkpoint.epoch()).await?;
+        self.state_store.with_read_tx(|tx| {
+            for shard in local_info.shard_group().shard_iter_with_global() {
+                let version = tx.state_tree_versions_get_latest(shard)?;
+                let local_root = self.calculate_state_root_for_shard(tx, shard, version)?;
+                if local_root != checkpoint.get_shard_root(shard) {
+                    return Ok(false);
+                }
+            }
+            Ok(true)
+        })
+    }
+
     fn calculate_state_root_for_shard(
         &self,
         tx: &<TConsensusSpec::StateStore as StateStore>::ReadTransaction<'_>,
@@ -884,18 +902,27 @@ where TConsensusSpec: ConsensusSpec<Addr = PeerAddress> + Send + Sync + 'static
         // the oracle has moved past it there is prior committed state to sync; at or before it there is
         // nothing, so we join consensus directly.
         let Some(leaf) = leaf_block else {
-            // A leaf-less node that still holds an `EpochCheckpoint` for the epoch immediately before the oracle's
-            // current epoch was rolled back: the offline rollback tool clears the consensus pointers (leaf, locked,
-            // high QC) but keeps the committed state and its checkpoint. It already holds the prior epoch's state, so
-            // there is nothing to state-sync — consensus recreates the current epoch's genesis from local state on
-            // entering `Running` (see `HotstuffWorker::get_starting_epoch`/`create_genesis_block_if_required`).
-            // Reporting `Behind` here instead would route it to `Syncing`, which fails because every committee member
-            // rolled back together holds the same (absent) state, wedging consensus in `Sleeping`.
-            let last_checkpoint_epoch = self
+            // A leaf-less node that still holds an `EpochCheckpoint` covering the epoch immediately before the
+            // oracle's current epoch — and whose committed state already matches that checkpoint — was rolled back:
+            // the offline rollback tool clears the consensus pointers (leaf, locked, high QC) but keeps the committed
+            // state and its checkpoint. There is nothing to state-sync; consensus recreates the current epoch's
+            // genesis from local state on entering `Running` (see
+            // `HotstuffWorker::get_starting_epoch`/`create_genesis_block_if_required`). Reporting `Behind` here would
+            // route it to `Syncing`, which fails because every committee member rolled back together holds the same
+            // (absent) state, wedging consensus in `Sleeping`.
+            //
+            // The state-root match is required, not merely the checkpoint's presence: state sync persists the
+            // checkpoint before streaming state (`get_or_fetch_valid_epoch_checkpoint`), so a first-time sync
+            // interrupted mid-stream also leaves a leaf-less node holding a checkpoint — but with incomplete state.
+            // Its roots will not match, so it correctly falls through here and resumes the sync.
+            let maybe_checkpoint = self
                 .state_store
-                .with_read_tx(|tx| EpochCheckpoint::get_last_checkpoint(tx).optional())?
-                .map(|cp| cp.epoch());
-            if last_checkpoint_epoch.is_some_and(|epoch| epoch + Epoch(1) >= oracle_epoch) {
+                .with_read_tx(|tx| EpochCheckpoint::get_last_checkpoint(tx))
+                .optional()?;
+            if let Some(checkpoint) = maybe_checkpoint &&
+                checkpoint.epoch() + Epoch(1) >= oracle_epoch &&
+                self.local_state_matches_checkpoint(&checkpoint).await?
+            {
                 return Ok(SyncStatus::UpToDate);
             }
 

--- a/crates/rpc_state_sync/src/state_sync.rs
+++ b/crates/rpc_state_sync/src/state_sync.rs
@@ -884,6 +884,21 @@ where TConsensusSpec: ConsensusSpec<Addr = PeerAddress> + Send + Sync + 'static
         // the oracle has moved past it there is prior committed state to sync; at or before it there is
         // nothing, so we join consensus directly.
         let Some(leaf) = leaf_block else {
+            // A leaf-less node that still holds an `EpochCheckpoint` for the epoch immediately before the oracle's
+            // current epoch was rolled back: the offline rollback tool clears the consensus pointers (leaf, locked,
+            // high QC) but keeps the committed state and its checkpoint. It already holds the prior epoch's state, so
+            // there is nothing to state-sync — consensus recreates the current epoch's genesis from local state on
+            // entering `Running` (see `HotstuffWorker::get_starting_epoch`/`create_genesis_block_if_required`).
+            // Reporting `Behind` here instead would route it to `Syncing`, which fails because every committee member
+            // rolled back together holds the same (absent) state, wedging consensus in `Sleeping`.
+            let last_checkpoint_epoch = self
+                .state_store
+                .with_read_tx(|tx| EpochCheckpoint::get_last_checkpoint(tx).optional())?
+                .map(|cp| cp.epoch());
+            if last_checkpoint_epoch.is_some_and(|epoch| epoch + Epoch(1) >= oracle_epoch) {
+                return Ok(SyncStatus::UpToDate);
+            }
+
             let Some(birthday_epoch) = self.epoch_manager.get_birthday_epoch().await? else {
                 return Err(RpcStateSyncError::InvariantError {
                     details: "Check sync called before the birthday epoch was determined".to_string(),


### PR DESCRIPTION
## Description

Fixes the `offline_rollback.feature` cucumber scenario, which has been failing **on `development`** (the `Test Results (CI)` check reports "1 fail / 1556 pass", and this is the one). After the offline rollback tool rewinds a validator to a prior epoch and the node restarts, it never resumes consensus — it loops in `Sleeping`, reporting `epoch 0 / height 0`.

## Root cause

The offline rollback tool (`utilities/validator_rollback`) deliberately deletes the consensus pointers (leaf block, locked block, high QC/TC) and all blocks above the target epoch, while keeping the committed state and the target epoch's `EpochCheckpoint`. Its doc comment states the intent: consensus is expected to recreate the next epoch's genesis from local state on resume, via `HotstuffWorker::start` → `get_starting_epoch` → `create_genesis_block_if_required`.

The problem is ordering. The consensus state machine is `Idle → CheckSync → Running`, and `create_genesis_block_if_required` only runs inside `Running`. `CheckSync` runs first and calls `SyncManager::check_sync`. Its cold-start branch only checks "is there a leaf block?" — after a rollback there is none, so it returns `Behind` and routes the node to `Syncing`. But every committee member was rolled back together, so no peer can serve the targeted epoch; sync fails with `SyncFailedAllPeers`, which propagates to `Failure → Sleeping`. The node then loops `Sleeping → Resume → Idle → CheckSync → Syncing → Failure` forever. The pacemaker never starts, so the status stays at the default epoch 0 / height 0.

This is **not** a regression from a recent fee or storage change — the divert-to-sync behaviour has been present since the rollback test was added; it just never resumes.

## Fix

In the leaf-less branch of `check_sync` (`crates/rpc_state_sync/src/state_sync.rs`), before falling back to the birthday-epoch heuristic, check for a local `EpochCheckpoint`. If the node holds a checkpoint for the epoch immediately before the oracle's current epoch (the rolled-back-and-restarted case), report `UpToDate`. Consensus then enters `Running` and recreates the current epoch's genesis from the rolled-back state, exactly as the rollback tool intends.

```rust
let last_checkpoint_epoch = self
    .state_store
    .with_read_tx(|tx| EpochCheckpoint::get_last_checkpoint(tx).optional())?
    .map(|cp| cp.epoch());
if last_checkpoint_epoch.is_some_and(|epoch| epoch + Epoch(1) >= oracle_epoch) {
    return Ok(SyncStatus::UpToDate);
}
```

- **Rolled-back node** (checkpoint at epoch 4, oracle at 5): `4 + 1 >= 5` → `UpToDate` → resumes locally, rebuilds the epoch-5 genesis, both VNs reach `Running`, and the post-rollback account creation commits.
- **Fresh / wiped node** (no checkpoint): falls through to the existing birthday-epoch logic and state-syncs as before.
- **Node behind by more than one epoch** (checkpoint too old): falls through and state-syncs.
- **Normal restart**: still has its leaf block, so it never enters this branch.

## Testing

- `cargo check` / `fmt` on `tari_rpc_state_sync`.
- The regression test is the `offline_rollback` cucumber scenario itself — it runs a real swarm (rollback tool + restart + post-rollback commit) and can only be exercised in CI, so verification is via this PR's integration-test run.
