### PR TITLE
refactor(engine)!: remove module_name from component updated event

### DIFF
--- a/crates/engine/src/runtime/impl.rs
+++ b/crates/engine/src/runtime/impl.rs
@@ -343,8 +343,14 @@ impl<TStore: StateReader + Clone + 'static, TTemplateProvider: TemplateProvider<
         payload: Metadata,
         state_mut: &mut WorkingState<TStore>,
     ) -> Result<(), RuntimeError> {
-        let (&template_address, _) = state_mut.current_template()?;
-        let event = Event::std(Some(substate_id.into()), template_address, object_name, action, payload);
+        let template_address = state_mut.current_template()?;
+        let event = Event::std(
+            Some(substate_id.into()),
+            *template_address,
+            object_name,
+            action,
+            payload,
+        );
         debug!(target: LOG_TARGET, "Emitted event {}", event);
         state_mut.push_event(event)?;
         Ok(())
@@ -3316,7 +3322,7 @@ where
                         })
                         .transpose()?;
 
-                    let (template, _) = state.current_template()?;
+                    let template = state.current_template()?;
                     let id_provider = state.id_provider()?;
                     let address = public_key
                         .as_ref()

--- a/crates/engine/src/runtime/impl.rs
+++ b/crates/engine/src/runtime/impl.rs
@@ -343,14 +343,8 @@ impl<TStore: StateReader + Clone + 'static, TTemplateProvider: TemplateProvider<
         payload: Metadata,
         state_mut: &mut WorkingState<TStore>,
     ) -> Result<(), RuntimeError> {
-        let template_address = state_mut.current_template()?;
-        let event = Event::std(
-            Some(substate_id.into()),
-            *template_address,
-            object_name,
-            action,
-            payload,
-        );
+        let template_address = *state_mut.current_template()?;
+        let event = Event::std(Some(substate_id.into()), template_address, object_name, action, payload);
         debug!(target: LOG_TARGET, "Emitted event {}", event);
         state_mut.push_event(event)?;
         Ok(())

--- a/crates/engine/src/runtime/scope.rs
+++ b/crates/engine/src/runtime/scope.rs
@@ -280,7 +280,7 @@ impl Display for CallScope {
 pub struct CallFrame {
     scope: CallScope,
     current_template: TemplateAddress,
-    current_module: String,
+    current_template_name: String,
     entity_id: EntityId,
     allow_cross_template_calls: bool,
     allow_migration_calls: bool,
@@ -295,7 +295,7 @@ impl CallFrame {
         Self {
             scope: CallScope::new(),
             current_template,
-            current_module,
+            current_template_name: current_module,
             entity_id,
             allow_cross_template_calls: true,
             allow_migration_calls: false,
@@ -312,7 +312,7 @@ impl CallFrame {
         Self {
             scope: CallScope::for_component(component_lock),
             current_template,
-            current_module,
+            current_template_name: current_module,
             entity_id,
             allow_cross_template_calls: true,
             allow_migration_calls: false,
@@ -329,7 +329,7 @@ impl CallFrame {
         Self {
             scope: CallScope::for_component(component_lock),
             current_template,
-            current_module,
+            current_template_name: current_module,
             entity_id,
             allow_cross_template_calls: false,
             allow_migration_calls: true,
@@ -357,8 +357,12 @@ impl CallFrame {
         self.entity_id = entity_id;
     }
 
-    pub fn current_template(&self) -> (&TemplateAddress, &str) {
-        (&self.current_template, &self.current_module)
+    pub fn current_template(&self) -> &TemplateAddress {
+        &self.current_template
+    }
+
+    pub fn current_template_name(&self) -> &str {
+        &self.current_template_name
     }
 
     pub fn is_cross_template_calls_allowed(&self) -> bool {

--- a/crates/engine/src/runtime/tracker.rs
+++ b/crates/engine/src/runtime/tracker.rs
@@ -158,11 +158,11 @@ impl<TStore: StateReader> StateTracker<TStore> {
     }
 
     pub fn get_template_address(&self) -> Result<TemplateAddress, RuntimeError> {
-        self.read_with(|state| state.current_template().map(|(a, _)| *a))
+        self.read_with(|state| state.current_template().copied())
     }
 
     pub fn get_template_module_name(&self) -> Result<String, RuntimeError> {
-        self.read_with(|state| state.current_template().map(|(_, name)| name.to_string()))
+        self.read_with(|state| state.current_template_name().map(ToOwned::to_owned))
     }
 
     pub fn new_component(
@@ -173,7 +173,7 @@ impl<TStore: StateReader> StateTracker<TStore> {
         address_allocation: Option<ComponentAddressAllocation>,
     ) -> Result<ComponentAddress, RuntimeError> {
         self.write_with(|state| {
-            let template_address = state.current_template().map(|(addr, _)| *addr)?;
+            let template_address = *state.current_template()?;
 
             let component_address = match address_allocation {
                 Some(address_allocation) => {

--- a/crates/engine/src/runtime/tracker_auth.rs
+++ b/crates/engine/src/runtime/tracker_auth.rs
@@ -260,7 +260,7 @@ fn check_requirement<TStore: StateReader>(
         },
         RuleRequirement::ScopedToComponent(address) => Ok(state.current_component()? == Some(*address)),
         RuleRequirement::ScopedToTemplate(address) => {
-            let (current, _) = state.current_template()?;
+            let current = state.current_template()?;
             Ok(current == address)
         },
     }

--- a/crates/engine/src/runtime/working_state.rs
+++ b/crates/engine/src/runtime/working_state.rs
@@ -270,15 +270,13 @@ impl<TStore: StateReader> WorkingState<TStore> {
         self.validate_component_state(Some(&before), &after)?;
 
         // add event to indicate that there is a change in component
-        let (template_address, module_name) = self.current_template().map(|(addr, name)| (*addr, name.to_string()))?;
+        let template_address = *self.current_template()?;
         self.push_event(Event::std(
             Some(locked.substate_id().clone()),
             template_address,
             "component",
             "updated",
-            metadata!(
-                "module_name" => module_name,
-            ),
+            metadata!(),
         ))?;
 
         Ok(())
@@ -744,7 +742,7 @@ impl<TStore: StateReader> WorkingState<TStore> {
         let vault_mut = self.get_vault_mut(vault_lock)?;
         vault_mut.set_freeze(flags);
 
-        let template_address = self.current_template().map(|(addr, _)| *addr)?;
+        let template_address = *self.current_template()?;
         let event = if flags.is_empty() {
             Event::std(
                 Some(vault_lock.substate_id().clone()),
@@ -897,7 +895,7 @@ impl<TStore: StateReader> WorkingState<TStore> {
     ) -> Result<AddressAllocationId, RuntimeError> {
         let id = self.address_allocation_id;
         self.address_allocation_id += 1;
-        let current_template = self.current_template().ok().map(|(template_addr, _)| *template_addr);
+        let current_template = self.current_template().ok().copied();
         self.address_allocations
             .insert(id, AllocatedAddress::new(address.into(), current_template));
         Ok(id)
@@ -1129,10 +1127,16 @@ impl<TStore: StateReader> WorkingState<TStore> {
         self.call_frames.len()
     }
 
-    /// Returns template address and module name
-    pub fn current_template(&self) -> Result<(&TemplateAddress, &str), RuntimeError> {
+    /// Returns template address
+    pub fn current_template(&self) -> Result<&TemplateAddress, RuntimeError> {
         let frame = self.current_call_frame()?;
         Ok(frame.current_template())
+    }
+
+    /// Returns template address
+    pub fn current_template_name(&self) -> Result<&str, RuntimeError> {
+        let frame = self.current_call_frame()?;
+        Ok(frame.current_template_name())
     }
 
     pub fn id_provider(&self) -> Result<IdProvider<'_>, RuntimeError> {
@@ -1161,7 +1165,7 @@ impl<TStore: StateReader> WorkingState<TStore> {
 
     pub fn get_auth_caller(&self) -> Result<AuthHookCaller, RuntimeError> {
         let frame = self.call_frames.last().ok_or(RuntimeError::NoActiveCallFrame)?;
-        let (template, _) = frame.current_template();
+        let template = frame.current_template();
         let component = frame
             .scope()
             .get_current_component_lock()

--- a/crates/engine/src/runtime/working_state.rs
+++ b/crates/engine/src/runtime/working_state.rs
@@ -1133,7 +1133,7 @@ impl<TStore: StateReader> WorkingState<TStore> {
         Ok(frame.current_template())
     }
 
-    /// Returns template address
+    /// Returns template name
     pub fn current_template_name(&self) -> Result<&str, RuntimeError> {
         let frame = self.current_call_frame()?;
         Ok(frame.current_template_name())


### PR DESCRIPTION
## Description

Removes the `module_name` metadata field from the `component.updated` event. The module name duplicated information already carried by the event's template address, so it was redundant.

While cleaning this up, the `current_template()` accessor is split so callers only resolve the template name when they actually need it:

- `current_template()` now returns just the `TemplateAddress`
- new `current_template_name()` returns the template/module name

This removes the tuple-destructuring boilerplate (`(addr, _)` / `(_, name)`) at the many call sites that only wanted the address.

## Motivation and Context

The `component.updated` event payload carried a `module_name` that was redundant with the template address already present on every event. Emitting it added noise to the event without conveying anything not already derivable.

## Breaking change

The `component.updated` event no longer includes a `module_name` metadata field. Any consumer relying on that key should derive the module/template name from the event's template address instead.

## How Has This Been Tested?

- `cargo check -p tari_engine` passes.

## What process can a PR reviewer use to test or verify this change?

Submit a transaction that mutates a component and inspect the resulting `component.updated` event — it should no longer carry a `module_name` field, only the substate id, template address, topic, and (empty) metadata.