### PR TITLE
feat(ootle-rs): schnorr adaptor signatures for scriptless-script atomic swaps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7678,7 +7678,7 @@ dependencies = [
 
 [[package]]
 name = "ootle-rs"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -12047,7 +12047,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_crypto"
-version = "0.35.0"
+version = "0.35.1"
 dependencies = [
  "argon2 0.5.3",
  "blake2 0.10.6",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,7 +103,7 @@ tari_engine = { path = "crates/engine", version = "0.35" }
 tari_ootle_p2p = { path = "crates/p2p" }
 tari_ootle_storage = { path = "crates/storage" }
 tari_ootle_storage_sqlite = { path = "crates/storage_sqlite" }
-tari_ootle_wallet_crypto = { path = "crates/wallet/crypto", version = "0.35" }
+tari_ootle_wallet_crypto = { path = "crates/wallet/crypto", version = "0.35.1" }
 tari_ootle_wallet_sdk = { path = "crates/wallet/sdk", version = "0.34" }
 tari_ootle_wallet_sdk_services = { path = "crates/wallet/sdk_services" }
 tari_ootle_wallet_storage_sqlite = { path = "crates/wallet/storage_sqlite", version = "0.34" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,7 +144,7 @@ tari_template_lib = { version = "0.28", path = "crates/template_lib" }
 tari_template_lib_types = { version = "0.28", path = "crates/template_lib_types", default-features = false }
 tari_template_abi = { version = "0.18", path = "crates/template_abi", default-features = false }
 tari_template_macros = { version = "0.21", path = "crates/template_macros" }
-tari_bor = { version = "0.14", path = "crates/tari_bor", default-features = false }
+tari_bor = { version = "0.14.2", path = "crates/tari_bor", default-features = false }
 
 ootle_byte_type = { path = "crates/ootle_byte_type", version = "0.9" }
 ootle_serde = { path = "crates/ootle_serde", version = "0.3" }

--- a/crates/wallet/crypto/Cargo.toml
+++ b/crates/wallet/crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_ootle_wallet_crypto"
-version = "0.35.0"
+version = "0.35.1"
 description = "Cryptographic utilities and types for Tari Ootle wallet"
 edition.workspace = true
 authors.workspace = true

--- a/crates/wallet/crypto/src/adaptor.rs
+++ b/crates/wallet/crypto/src/adaptor.rs
@@ -1,0 +1,173 @@
+//   Copyright 2026 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+//! Schnorr adaptor signatures over Ristretto ("scriptless scripts").
+//!
+//! An adaptor signature is a Schnorr signature "encrypted" under an adaptor point `T = t·G`: a
+//! valid-looking pre-signature anyone can verify, but which only the holder of the discrete log `t`
+//! can complete into a full signature. Completing it reveals `t` (recoverable by subtracting the
+//! pre-signature scalar from the completed one), which is what makes a cross-chain atomic swap
+//! atomic — completing one chain's signature publishes the secret that unlocks the other.
+//!
+//! The completed signature is an ordinary [`RistrettoSchnorr`] whose public nonce is `R + T`, so it
+//! verifies with the stock verifier and needs no consensus change. The challenge is built with
+//! tari_crypto's own [`RistrettoSchnorr::construct_domain_separated_challenge`] over the **offset**
+//! nonce `R + T`, so a completed adaptor signature is byte-for-byte one the standard signer could
+//! have produced over that nonce.
+
+use blake2::Blake2b;
+use digest::consts::U64;
+use tari_crypto::{
+    keys::{PublicKey, SecretKey},
+    ristretto::{RistrettoPublicKey, RistrettoSchnorr, RistrettoSecretKey},
+};
+
+/// A Schnorr adaptor pre-signature encrypted under an adaptor point `T = t·G`.
+///
+/// `public_nonce` is the offset nonce `R + T` that the completed signature will carry; `signature`
+/// is the pre-signature scalar `ŝ = r + e·x`, which does **not** include `t`. Completing with `t`
+/// yields `RistrettoSchnorr::new(R + T, ŝ + t)`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RistrettoAdaptorSignature {
+    public_nonce: RistrettoPublicKey,
+    signature: RistrettoSecretKey,
+}
+
+impl RistrettoAdaptorSignature {
+    /// The offset public nonce `R + T` the completed signature will carry.
+    pub fn public_nonce(&self) -> &RistrettoPublicKey {
+        &self.public_nonce
+    }
+
+    /// The pre-signature scalar `ŝ = r + e·x`.
+    pub fn signature(&self) -> &RistrettoSecretKey {
+        &self.signature
+    }
+}
+
+/// The challenge scalar the stock signer/verifier uses: `from_uniform_bytes(H(public_nonce ‖ public_key ‖ message))`,
+/// where `H` is tari_crypto's domain-separated `Blake2b<U64>` challenge. Reusing the library's own construction is
+/// what guarantees a completed adaptor signature verifies against the unchanged verifier.
+fn challenge(public_nonce: &RistrettoPublicKey, public_key: &RistrettoPublicKey, message: &[u8]) -> RistrettoSecretKey {
+    let hash =
+        RistrettoSchnorr::construct_domain_separated_challenge::<_, Blake2b<U64>>(public_nonce, public_key, message);
+    RistrettoSecretKey::from_uniform_bytes(hash.as_ref()).expect("Blake2b<U64> yields 64 uniform bytes")
+}
+
+/// Produces an adaptor pre-signature `ŝ = r + e·x` with `e = H((R + T) ‖ P ‖ message)`, where
+/// `R = r·G` for a freshly sampled nonce `r`, `P = secret·G`, and `T = adaptor_point`. The challenge
+/// binds the **offset** nonce `R + T` so [`complete`] yields a signature the stock verifier accepts.
+///
+/// The nonce is drawn internally from the OS CSPRNG on each call, so it cannot be reused across
+/// signatures (nonce reuse across two messages would leak `secret`).
+pub fn sign(
+    secret: &RistrettoSecretKey,
+    adaptor_point: &RistrettoPublicKey,
+    message: &[u8],
+) -> RistrettoAdaptorSignature {
+    let nonce = RistrettoSecretKey::random(&mut rand::rng());
+    let public_key = RistrettoPublicKey::from_secret_key(secret);
+    let r = RistrettoPublicKey::from_secret_key(&nonce);
+    let public_nonce = &r + adaptor_point; // R + T
+    let e = challenge(&public_nonce, &public_key, message);
+    let ek = &e * secret;
+    let s_hat = &nonce + &ek; // ŝ = r + e·x
+    RistrettoAdaptorSignature {
+        public_nonce,
+        signature: s_hat,
+    }
+}
+
+/// Verifies an adaptor pre-signature against `public_key`, `adaptor_point` (`T`) and `message`,
+/// checking `ŝ·G + T == (R + T) + e·P`. A `true` result guarantees that [`complete`] with
+/// the discrete log of `T` produces a signature valid under the stock verifier.
+pub fn verify(
+    pre: &RistrettoAdaptorSignature,
+    public_key: &RistrettoPublicKey,
+    adaptor_point: &RistrettoPublicKey,
+    message: &[u8],
+) -> bool {
+    if public_key == &RistrettoPublicKey::default() {
+        return false;
+    }
+    let e = challenge(&pre.public_nonce, public_key, message);
+    let s_hat_g = RistrettoPublicKey::from_secret_key(&pre.signature);
+    let lhs = &s_hat_g + adaptor_point;
+    let rhs = &pre.public_nonce + &e * public_key;
+    lhs == rhs
+}
+
+/// Completes the pre-signature with the adaptor secret `t` (`T = t·G`), yielding an ordinary
+/// signature `(R + T, ŝ + t)` that verifies with the stock [`RistrettoSchnorr`] verifier.
+///
+/// The caller is responsible for ensuring `t` is the discrete log of the adaptor point the
+/// pre-signature was produced under; verify with [`verify`] first if in doubt.
+pub fn complete(pre: &RistrettoAdaptorSignature, t: &RistrettoSecretKey) -> RistrettoSchnorr {
+    let s = &pre.signature + t;
+    RistrettoSchnorr::new(pre.public_nonce.clone(), s)
+}
+
+/// Recovers the adaptor secret `t` from a pre-signature and its completed signature: `t = s − ŝ`.
+///
+/// This is the swap-reveal primitive: a watcher who holds the pre-signature and observes the
+/// completed signature on-chain recovers the secret that unlocks the other leg.
+pub fn extract(pre: &RistrettoAdaptorSignature, completed: &RistrettoSchnorr) -> RistrettoSecretKey {
+    completed.get_signature() - &pre.signature
+}
+
+#[cfg(test)]
+mod tests {
+    use tari_crypto::ristretto::{RistrettoPublicKey, RistrettoSecretKey};
+
+    use super::*;
+
+    fn keypair() -> (RistrettoSecretKey, RistrettoPublicKey) {
+        let secret = RistrettoSecretKey::random(&mut rand::rng());
+        let public = RistrettoPublicKey::from_secret_key(&secret);
+        (secret, public)
+    }
+
+    const MESSAGE: &[u8] = b"adaptor signature test message";
+
+    #[test]
+    fn complete_yields_a_signature_the_stock_verifier_accepts() {
+        let (x, p) = keypair();
+        let (t, big_t) = keypair();
+        let pre = sign(&x, &big_t, MESSAGE);
+        assert!(verify(&pre, &p, &big_t, MESSAGE));
+
+        let sig = complete(&pre, &t);
+        // The completed signature is an ordinary RistrettoSchnorr with no adaptor awareness needed.
+        assert!(sig.verify(&p, MESSAGE));
+    }
+
+    #[test]
+    fn extract_recovers_the_adaptor_secret() {
+        let (x, _p) = keypair();
+        let (t, big_t) = keypair();
+        let pre = sign(&x, &big_t, MESSAGE);
+        let sig = complete(&pre, &t);
+
+        assert_eq!(extract(&pre, &sig), t);
+    }
+
+    #[test]
+    fn completing_with_the_wrong_secret_does_not_verify() {
+        let (x, p) = keypair();
+        let (_t, big_t) = keypair();
+        let (wrong_t, _) = keypair();
+        let pre = sign(&x, &big_t, MESSAGE);
+        let sig = complete(&pre, &wrong_t);
+        assert!(!sig.verify(&p, MESSAGE));
+    }
+
+    #[test]
+    fn verify_rejects_a_tampered_message_or_wrong_key() {
+        let (x, p) = keypair();
+        let (_t, big_t) = keypair();
+        let (_, other_p) = keypair();
+        let pre = sign(&x, &big_t, MESSAGE);
+        assert!(!verify(&pre, &p, &big_t, b"different message"));
+        assert!(!verify(&pre, &other_p, &big_t, MESSAGE));
+    }
+}

--- a/crates/wallet/crypto/src/adaptor.rs
+++ b/crates/wallet/crypto/src/adaptor.rs
@@ -21,6 +21,7 @@ use tari_crypto::{
     keys::{PublicKey, SecretKey},
     ristretto::{RistrettoPublicKey, RistrettoSchnorr, RistrettoSecretKey},
 };
+use tari_utilities::ByteArray;
 
 /// A Schnorr adaptor pre-signature encrypted under an adaptor point `T = t·G`.
 ///
@@ -52,6 +53,12 @@ fn challenge(public_nonce: &RistrettoPublicKey, public_key: &RistrettoPublicKey,
     let hash =
         RistrettoSchnorr::construct_domain_separated_challenge::<_, Blake2b<U64>>(public_nonce, public_key, message);
     RistrettoSecretKey::from_uniform_bytes(hash.as_ref()).expect("Blake2b<U64> yields 64 uniform bytes")
+}
+
+/// True if `point` is the Ristretto identity, whose canonical encoding is 32 zero bytes. Uses a plain
+/// byte comparison rather than the constant-time point `==`, since these are public values.
+fn is_identity(point: &RistrettoPublicKey) -> bool {
+    point.as_bytes().iter().all(|&b| b == 0)
 }
 
 /// Produces an adaptor pre-signature `ŝ = r + e·x` with `e = H((R + T) ‖ P ‖ message)`, where
@@ -87,14 +94,17 @@ pub fn verify(
     adaptor_point: &RistrettoPublicKey,
     message: &[u8],
 ) -> bool {
-    if public_key == &RistrettoPublicKey::default() {
+    // Reject identity points: a zero public key, nonce, or adaptor point yields a degenerate or
+    // malformed signature. These are public values, so compare the encoding, not the constant-time
+    // point equality.
+    if is_identity(public_key) || is_identity(&pre.public_nonce) || is_identity(adaptor_point) {
         return false;
     }
     let e = challenge(&pre.public_nonce, public_key, message);
     let s_hat_g = RistrettoPublicKey::from_secret_key(&pre.signature);
     let lhs = &s_hat_g + adaptor_point;
     let rhs = &pre.public_nonce + &e * public_key;
-    lhs == rhs
+    lhs.as_bytes() == rhs.as_bytes()
 }
 
 /// Completes the pre-signature with the adaptor secret `t` (`T = t·G`), yielding an ordinary
@@ -169,5 +179,16 @@ mod tests {
         let pre = sign(&x, &big_t, MESSAGE);
         assert!(!verify(&pre, &p, &big_t, b"different message"));
         assert!(!verify(&pre, &other_p, &big_t, MESSAGE));
+    }
+
+    #[test]
+    fn verify_rejects_identity_points() {
+        let (x, p) = keypair();
+        let (_t, big_t) = keypair();
+        let identity = RistrettoPublicKey::default();
+
+        let pre = sign(&x, &big_t, MESSAGE);
+        assert!(!verify(&pre, &identity, &big_t, MESSAGE), "identity public key");
+        assert!(!verify(&pre, &p, &identity, MESSAGE), "identity adaptor point");
     }
 }

--- a/crates/wallet/crypto/src/hashers.rs
+++ b/crates/wallet/crypto/src/hashers.rs
@@ -29,6 +29,14 @@ pub fn stealth_owner_hasher64(network: Network) -> OotleWalletHasher64<OotleWall
     wallet_hasher64(network, "stealth_owner")
 }
 
+/// Domain for per-party one-time spend-authorization keys committed inside a script-path AccessRule
+/// leaf. Distinct from [`stealth_owner_hasher64`] so a spend-authorization key can never collide with
+/// the value-owner key. The co-signer index is mixed into the hash state by the caller (see
+/// `spend_auth_dh_secret`), not into this domain label.
+pub fn stealth_spend_auth_hasher64(network: Network) -> OotleWalletHasher64<OotleWalletHashDomain> {
+    wallet_hasher64(network, "stealth_spend_auth")
+}
+
 pub fn stealth_output_tag_hasher64(network: Network) -> OotleWalletHasher64<OotleWalletHashDomain> {
     wallet_hasher64(network, "output_tag")
 }

--- a/crates/wallet/crypto/src/kdfs.rs
+++ b/crates/wallet/crypto/src/kdfs.rs
@@ -14,7 +14,7 @@ use tari_utilities::{Hidden, hidden_type, safe_array::SafeArray};
 use zeroize::Zeroize;
 
 use crate::{
-    hashers::{KdfHasher, stealth_output_tag_hasher64, stealth_owner_hasher64},
+    hashers::{KdfHasher, stealth_output_tag_hasher64, stealth_owner_hasher64, stealth_spend_auth_hasher64},
     safe_key::SafeAeadKey,
 };
 
@@ -110,6 +110,53 @@ pub fn owner_stealth_dh_stealth_address(
     c_g + public_key
 }
 
+fn stealth_spend_auth_dh(
+    network: Network,
+    public_key: &RistrettoPublicKey,
+    secret_nonce: &RistrettoSecretKey,
+    index: u32,
+) -> RistrettoSecretKey {
+    let mut hasher = stealth_spend_auth_hasher64(network);
+    hasher.update_consensus_encode(&index);
+    dh_kdf_aead(hasher, secret_nonce, public_key)
+}
+
+/// Derives the recovering party's one-time spend-authorization secret `p = H(s·R) + s` for co-signer
+/// `index`, from the party's `account_secret` and the output's `public_nonce` (`R`). The matching
+/// public key ([`spend_auth_dh_public_key`]) is what a funder commits inside a script-path
+/// `AccessRule` leaf; only the holder of `account_secret` can recover `p` and authorize the spend.
+/// `index` domain-separates co-signers so several independent keys hang off one output nonce (e.g. a
+/// 2-of-2 swap). Distinct from [`owner_stealth_dh_secret`] so a spend-authorization key can never
+/// collide with the value-owner key.
+pub fn spend_auth_dh_secret(
+    network: Network,
+    account_secret: &RistrettoSecretKey,
+    public_nonce: &RistrettoPublicKey,
+    index: u32,
+) -> RistrettoSecretKey {
+    // c = H(s·R)
+    let c = stealth_spend_auth_dh(network, public_nonce, account_secret, index);
+    // p = c + s
+    c + account_secret
+}
+
+/// Derives the one-time spend-authorization public key `P = H(r·S)·G + S` for co-signer `index`,
+/// which a funder computes from the party's account public key `S` (`public_key`) and the output's
+/// secret nonce `r` (`R = r·G`), then commits inside a script-path `AccessRule` leaf. The party later
+/// recovers the matching secret with [`spend_auth_dh_secret`].
+pub fn spend_auth_dh_public_key(
+    network: Network,
+    public_key: &RistrettoPublicKey,
+    secret_nonce: &RistrettoSecretKey,
+    index: u32,
+) -> RistrettoPublicKey {
+    // c = H(r·S)
+    let c = stealth_spend_auth_dh(network, public_key, secret_nonce, index);
+    // P = c.G + S
+    let c_g = RistrettoPublicKey::from_secret_key(&c);
+    c_g + public_key
+}
+
 pub fn utxo_tag_stealth_dh(
     network: Network,
     public_key: &RistrettoPublicKey,
@@ -158,5 +205,40 @@ mod tests {
         // c + k.G != c + r.G
         // Just makes this fact clear if it isn't obvious
         assert_ne!(stealth_address1, stealth_address2);
+    }
+
+    #[test]
+    fn spend_auth_public_matches_the_recovered_secret() {
+        let network = Network::LocalNet;
+        // `S` is the party's account key; `R = r.G` is the output nonce a funder chooses.
+        let (account_secret, account_public) = create_key_pair();
+        let (secret_nonce, public_nonce) = create_key_pair();
+
+        // Funder commits P; party recovers p; they must agree that P == p.G.
+        let public = spend_auth_dh_public_key(network, &account_public, &secret_nonce, 0);
+        let secret = spend_auth_dh_secret(network, &account_secret, &public_nonce, 0);
+        assert_eq!(public, RistrettoPublicKey::from_secret_key(&secret));
+    }
+
+    #[test]
+    fn spend_auth_keys_are_independent_per_index() {
+        let network = Network::LocalNet;
+        let (account_secret, _) = create_key_pair();
+        let (_, public_nonce) = create_key_pair();
+
+        let signer_0 = spend_auth_dh_secret(network, &account_secret, &public_nonce, 0);
+        let signer_1 = spend_auth_dh_secret(network, &account_secret, &public_nonce, 1);
+        assert_ne!(signer_0, signer_1);
+    }
+
+    #[test]
+    fn spend_auth_is_a_distinct_domain_from_the_owner_key() {
+        let network = Network::LocalNet;
+        let (account_secret, _) = create_key_pair();
+        let (_, public_nonce) = create_key_pair();
+
+        let owner = owner_stealth_dh_secret(network, &account_secret, &public_nonce);
+        let spend_auth = spend_auth_dh_secret(network, &account_secret, &public_nonce, 0);
+        assert_ne!(owner, spend_auth);
     }
 }

--- a/crates/wallet/crypto/src/lib.rs
+++ b/crates/wallet/crypto/src/lib.rs
@@ -1,6 +1,7 @@
 //   Copyright 2023 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
+pub mod adaptor;
 pub mod balance_proof;
 pub mod bullet_proof;
 pub mod confidential;

--- a/crates/wallet/ootle-rs/Cargo.toml
+++ b/crates/wallet/ootle-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ootle-rs"
-version = "0.13.0"
+version = "0.13.1"
 description = "A Rust library for interacting with the Tari Ootle network."
 edition.workspace = true
 authors.workspace = true

--- a/crates/wallet/ootle-rs/examples/adaptor_claim.rs
+++ b/crates/wallet/ootle-rs/examples/adaptor_claim.rs
@@ -1,0 +1,236 @@
+//   Copyright 2026 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+//! # Adaptor-signature claim of a 2-of-2 stealth output ("scriptless scripts")
+//!
+//! One leg of a cross-chain atomic swap, on Ootle. Funds are locked behind a script-path condition tree whose claim
+//! leaf is a 2-of-2 `AllOf[P_me, P_cp]` `AccessRule` — spendable only by a transaction carrying signatures from BOTH
+//! co-signers. Our side (`P_me`) we sign outright; the counterparty's side (`P_cp`) arrives as a Schnorr **adaptor
+//! pre-signature** encrypted under an adaptor point `T = t·G`, which we complete with the swap secret `t`.
+//!
+//! Completing the signature is what makes the swap atomic: the completed, on-chain signature reveals `t` to anyone
+//! holding the pre-signature (see [`adaptor_extract`]), so the counterparty can then unlock the other chain. This
+//! example assumes `t` has already been obtained from the other chain (L1) — the L1 half is out of scope.
+//!
+//! The two one-time co-signer keys are fresh here for clarity. In production they would be derived unlinkably from the
+//! output's nonce via [`ootle_rs::crypto::kdfs::spend_auth_dh_secret`] / `spend_auth_dh_public_key`, so the revealed
+//! leaf exposes only one-time keys, never account identities.
+//!
+//! Posts two transactions on localnet (default indexer `http://127.0.0.1:12500`):
+//!   1. **lock**  — faucet funds → a stealth output behind `[claim = AllOf[P_me, P_cp], refund = AfterEpoch & funder]`,
+//!   2. **claim** — spends it via the script path, attaching our signature and the completed adaptor signature.
+//!
+//! ```bash
+//! cargo run -p ootle-rs --example adaptor_claim
+//! ```
+
+use ootle_byte_type::ToByteType;
+use ootle_rs::{
+    Network,
+    TransactionRequest,
+    builtin_templates::{UnsignedTransactionBuilder, faucet::IFaucet},
+    const_nonzero_u64,
+    crypto::{adaptor, stealth::script_path_witness},
+    default_indexer_url,
+    key_provider::PrivateKeyProvider,
+    provider::{PendingTransaction, Provider, ProviderBuilder, WalletProvider},
+    stealth::{Output, SignatureRequirements, StealthTransfer},
+    template_types::{
+        UtxoAddress,
+        constants::TARI_TOKEN,
+        rule,
+        stealth::{AtomicCondition, BuiltinPredicate, SpendCondition, StealthInput},
+    },
+    transaction::{
+        TransactionSigner,
+        adaptor::{complete_authorization, pre_sign_authorization, sign_authorization},
+    },
+    wallet::OotleWallet,
+};
+use tari_crypto::{
+    keys::{PublicKey, SecretKey},
+    ristretto::{RistrettoPublicKey, RistrettoSecretKey},
+};
+use tari_ootle_common_types::engine_types::transaction_receipt::TransactionReceipt;
+use tari_ootle_transaction::Transaction;
+
+/// 1 TARI expressed in microTARI.
+const ONE_TARI: u64 = 1_000_000;
+const LOCKED_AMOUNT: u64 = 10 * ONE_TARI;
+const FEE: u64 = 2000;
+
+#[tokio::main]
+#[allow(clippy::too_many_lines)]
+async fn main() {
+    let network = Network::LocalNet;
+    let me = PrivateKeyProvider::random(network);
+    let my_address = me.address().clone();
+    println!("Account: {my_address}");
+
+    let wallet = OotleWallet::from(me.clone());
+    let mut provider = ProviderBuilder::new()
+        .wallet(wallet)
+        .connect(default_indexer_url(network))
+        .await
+        .unwrap();
+
+    let current_epoch = provider.get_epoch().await.unwrap().as_u64();
+    println!("Current epoch: {current_epoch}");
+
+    let mut rng = rand::rng();
+
+    // -------------------------------------------------------------------------------------------------
+    // Swap secret + co-signer keys.
+    // -------------------------------------------------------------------------------------------------
+    // `t` is the atomic-swap secret. In a real swap it is chosen on / learned from the other chain (L1); here we
+    // assume it has been obtained and it stands in for that value. `T = t·G` is the adaptor point.
+    let t = RistrettoSecretKey::random(&mut rng);
+    let big_t = RistrettoPublicKey::from_secret_key(&t);
+
+    // The two one-time keys of the 2-of-2 claim leaf. `p_me` is ours; `p_cp` is the counterparty's (we hold it here
+    // only to simulate their side of the protocol). See the module docs for the production (unlinkable) derivation.
+    let p_me = RistrettoSecretKey::random(&mut rng);
+    let pk_me = RistrettoPublicKey::from_secret_key(&p_me);
+    let p_cp = RistrettoSecretKey::random(&mut rng);
+    let pk_cp = RistrettoPublicKey::from_secret_key(&p_cp);
+
+    // -------------------------------------------------------------------------------------------------
+    // Condition tree: a 2-of-2 claim leaf, plus a timelocked refund to the funder.
+    // -------------------------------------------------------------------------------------------------
+    let deadline = current_epoch + 50;
+    let claim = SpendCondition::access_rule(rule!(all_of(
+        public_key(pk_me.to_byte_type()),
+        public_key(pk_cp.to_byte_type())
+    )));
+    let refund = SpendCondition::all([
+        AtomicCondition::Builtin(BuiltinPredicate::AfterEpoch(deadline)),
+        AtomicCondition::AccessRule(rule!(public_key(*my_address.account_public_key()))),
+    ]);
+    let conditions = vec![claim, refund];
+    println!("\nCondition tree ({} leaves):", conditions.len());
+    println!("  claim  : AllOf[P_me, P_cp]  (2-of-2)");
+    println!("  refund : All([AfterEpoch({deadline}), RequireKey(funder)])");
+
+    let tari_token = TARI_TOKEN;
+
+    // -------------------------------------------------------------------------------------------------
+    // TX 1 — lock: faucet funds → the 2-of-2 output.
+    // -------------------------------------------------------------------------------------------------
+    let (lock_transfer, lock_signers) = StealthTransfer::new(tari_token, &provider)
+        .spend_revealed_input(LOCKED_AMOUNT + FEE)
+        .to_revealed_output(FEE)
+        .to_stealth_output(
+            Output::new(my_address.clone(), tari_token, const_nonzero_u64!(LOCKED_AMOUNT))
+                .with_spend_conditions(conditions.clone())
+                .with_memo_message("2-of-2 swap output: claim via P_me + P_cp, or refund after the deadline"),
+        )
+        .prepare()
+        .await
+        .unwrap();
+
+    let swap_commitment = *lock_transfer.stealth_outputs()[0].commitment();
+
+    let lock_tx = IFaucet::new(&provider)
+        .take_faucet_funds()
+        .into_stealth_transfer(lock_transfer)
+        .and_pay_fee_from_revealed_output()
+        .prepare()
+        .await
+        .expect("Failed to prepare lock transaction");
+
+    let authorizer = provider.wallet().stealth_authorizer(lock_signers);
+    let transaction = TransactionRequest::default()
+        .with_transaction(lock_tx)
+        .build(&authorizer)
+        .await
+        .unwrap();
+    let pending_tx = provider.send_transaction(transaction).await.unwrap();
+    print_results("Lock (faucet → 2-of-2 output)", &pending_tx).await;
+
+    // -------------------------------------------------------------------------------------------------
+    // TX 2 — claim: spend the 2-of-2 output via its script path.
+    // -------------------------------------------------------------------------------------------------
+    // Reveal the claim leaf (index 0) and its inclusion proof; the `AllOf` leaf takes no witness data — it is
+    // satisfied by the two signer badges we attach below.
+    let (claim_witness, _root) =
+        script_path_witness(&conditions, &conditions[0]).expect("claim leaf is a member of the condition tree");
+    let swap_input = StealthInput::with_witness(swap_commitment, claim_witness);
+
+    let (claim_transfer, _) = StealthTransfer::new(tari_token, &provider)
+        .spend_stealth_input(my_address.clone(), swap_input)
+        .to_revealed_output(FEE)
+        .to_stealth_output(Output::new(
+            my_address.clone(),
+            tari_token,
+            const_nonzero_u64!(LOCKED_AMOUNT - FEE),
+        ))
+        .prepare()
+        .await
+        .unwrap();
+
+    let claim_tx = Transaction::builder(provider.network())
+        .with_fee_instructions_builder(|builder| {
+            builder
+                .stealth_transfer(tari_token, claim_transfer)
+                .put_last_instruction_output_on_workspace("fees")
+                .pay_fee_from_bucket("fees")
+        })
+        .add_input(tari_token)
+        // The 2-of-2 UTXO being spent — DOWNed if the transaction succeeds.
+        .add_input(UtxoAddress::new(tari_token, swap_commitment.into()))
+        .build_unsigned();
+
+    // Seal with the account key so the seal signer — and hence the authorization message — is fixed and known before
+    // we produce the two authorizations. Both signer keys are supplied externally, so no stealth signers are derived.
+    let authorizer = provider
+        .wallet()
+        .stealth_authorizer(SignatureRequirements::account_key_seal());
+    let claim_msg = authorizer
+        .authorization_message(&claim_tx)
+        .expect("account-key seal yields an authorization message");
+
+    // Our side of the 2-of-2: an ordinary signature we make outright.
+    let auth_me = sign_authorization(&p_me, &claim_msg);
+
+    // The counterparty's side arrives as an adaptor pre-signature under `T = t·G` (simulated here). We verify it can
+    // only be completed with the discrete log of `T`.
+    let pre = pre_sign_authorization(&p_cp, &big_t, &claim_msg);
+    assert!(
+        adaptor::verify(&pre, &pk_cp, &big_t, &claim_msg),
+        "counterparty adaptor pre-signature must verify",
+    );
+
+    // The swap is atomic because the completed, on-chain signature reveals `t` to anyone holding the pre-signature.
+    let signature_on_other_chain = adaptor::complete(&pre, &t);
+    let revealed = adaptor::extract(&pre, &signature_on_other_chain);
+    assert_eq!(revealed, t, "completing the signature reveals the swap secret");
+    println!("\nAdaptor signature completed; the swap secret t is now recoverable from the on-chain signature.");
+
+    // Having obtained `t` from the other chain (L1), we complete the counterparty's leg.
+    let auth_cp = complete_authorization(&pre, &revealed, &pk_cp);
+
+    let transaction = TransactionRequest::default()
+        .with_transaction(claim_tx)
+        .with_authorizations([auth_me, auth_cp])
+        .build(&authorizer)
+        .await
+        .unwrap();
+    let pending_tx = provider.send_transaction(transaction).await.unwrap();
+    print_results("Claim (2-of-2 via adaptor signature)", &pending_tx).await;
+}
+
+async fn print_results(label: &str, pending_tx: &PendingTransaction) -> TransactionReceipt {
+    println!("\n⌛️ {label} transaction pending... {}", pending_tx.tx_id());
+    let outcome = pending_tx.watch().await.unwrap();
+    println!("🏁 Transaction Finalized {}", pending_tx.tx_id());
+    println!("✅ Outcome: {outcome:?}");
+
+    let receipt = pending_tx.get_receipt().await.unwrap();
+    println!("-------------------------------------------");
+    println!("🔹 Epoch: {}", receipt.epoch);
+    println!("🔹 Transaction ID: {}", pending_tx.tx_id());
+    println!("🔹 Outcome: {:?}", receipt.outcome);
+    println!("🔹 Fees Paid: {}", receipt.fee_receipt.total_fees_paid());
+    println!("-------------------------------------------");
+    receipt
+}

--- a/crates/wallet/ootle-rs/src/stealth/spec.rs
+++ b/crates/wallet/ootle-rs/src/stealth/spec.rs
@@ -57,6 +57,15 @@ impl SignatureRequirements {
         }
     }
 
+    /// A requirement where the wallet's account key seals the transaction and no stealth signers are derived. The
+    /// account key is the seal signer only (`is_seal_signer_authorized` stays false when authorizations are attached),
+    /// so its badge is not added to the auth scope. Use this when every authorization is supplied externally — e.g. a
+    /// script-path `AccessRule` leaf whose keys the wallet does not own (adaptor-signature co-signers) — so the seal
+    /// signer, and hence the authorization message, is fixed and known before the authorizations are produced.
+    pub fn account_key_seal() -> Self {
+        Self::new_must_sign_with_account_key(IndexSet::new())
+    }
+
     /// Creates a new `SignatureSpec` with the provided required signers and an optional seal signer.
     /// The account key is not required to sign the transaction. If there are no required signers, an ephemeral key
     /// will be used to seal the transaction.

--- a/crates/wallet/ootle-rs/src/transaction/adaptor.rs
+++ b/crates/wallet/ootle-rs/src/transaction/adaptor.rs
@@ -1,0 +1,67 @@
+//   Copyright 2026 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+//! Adaptor-signature authorizations ("scriptless scripts") for stealth transactions.
+//!
+//! These helpers bridge the pure Schnorr adaptor primitives in [`tari_ootle_wallet_crypto::adaptor`] to a
+//! [`TransactionAuthorization`] that attaches to a transaction via
+//! [`TransactionRequest::add_authorization`](crate::TransactionRequest::add_authorization). The message every
+//! authorization signs is obtained from
+//! [`WalletStealthAuthorizer::authorization_message`](crate::wallet::WalletStealthAuthorizer::authorization_message).
+//!
+//! The canonical flow for one leg of an atomic swap, spending a 2-of-2 `AllOf[P_me, P_cp]` script-path leaf:
+//! 1. build the unsigned claim and take its `authorization_message`,
+//! 2. the counterparty produces an adaptor pre-signature for `P_cp` under `T = t·G` ([`pre_sign_authorization`]),
+//! 3. we verify it, obtain `t` from the other chain, and [`complete_authorization`] it,
+//! 4. we [`sign_authorization`] for our own key `P_me`,
+//! 5. attach both authorizations and seal.
+
+use ootle_byte_type::ToByteType;
+use tari_crypto::{
+    keys::PublicKey,
+    ristretto::{RistrettoPublicKey, RistrettoSchnorr, RistrettoSecretKey},
+};
+use tari_ootle_transaction::TransactionSignature;
+pub use tari_ootle_wallet_crypto::adaptor::{RistrettoAdaptorSignature, extract, verify};
+use tari_ootle_wallet_crypto::adaptor::{complete, sign};
+
+use crate::wallet::TransactionAuthorization;
+
+/// Signs `message` with `secret`, producing an authorization ready to attach for the signer's public key. Use for a
+/// key-path or `AccessRule` co-signer whose secret this party holds outright (e.g. our own side of a 2-of-2).
+pub fn sign_authorization(secret: &RistrettoSecretKey, message: &[u8]) -> TransactionAuthorization {
+    let public_key = RistrettoPublicKey::from_secret_key(secret);
+    let signature =
+        RistrettoSchnorr::sign(secret, message, &mut rand::rng()).expect("sign is infallible with Ristretto keys");
+    authorization_from_parts(&public_key, signature)
+}
+
+/// Produces an adaptor pre-signature over `message` for `secret`, encrypted under `adaptor_point` (`T = t·G`). The
+/// holder cannot complete it without the discrete log `t`; the counterparty verifies it with [`verify`] and later
+/// completes it with [`complete_authorization`]. The nonce is sampled internally, so it cannot be reused.
+pub fn pre_sign_authorization(
+    secret: &RistrettoSecretKey,
+    adaptor_point: &RistrettoPublicKey,
+    message: &[u8],
+) -> RistrettoAdaptorSignature {
+    sign(secret, adaptor_point, message)
+}
+
+/// Completes an adaptor pre-signature with the adaptor secret `t`, yielding an authorization ready to attach for
+/// `public_key` (the pre-signer's public key — the badge the completed signature proves). The completed signature is
+/// an ordinary Schnorr signature, so the engine verifies it with no adaptor awareness.
+pub fn complete_authorization(
+    pre: &RistrettoAdaptorSignature,
+    t: &RistrettoSecretKey,
+    public_key: &RistrettoPublicKey,
+) -> TransactionAuthorization {
+    let signature = complete(pre, t);
+    authorization_from_parts(public_key, signature)
+}
+
+fn authorization_from_parts(public_key: &RistrettoPublicKey, signature: RistrettoSchnorr) -> TransactionAuthorization {
+    TransactionAuthorization::new(TransactionSignature::new(
+        public_key.to_byte_type(),
+        signature.to_byte_type(),
+    ))
+}

--- a/crates/wallet/ootle-rs/src/transaction/mod.rs
+++ b/crates/wallet/ootle-rs/src/transaction/mod.rs
@@ -9,6 +9,7 @@
 //! - [`TransactionSealSigner`] — applies the final seal signature to a transaction.
 //! - [`TransactionStealthKeySigner`] — signs using derived stealth keys for confidential transactions.
 
+pub mod adaptor;
 pub mod ephemeral_signer;
 mod signer;
 

--- a/crates/wallet/ootle-rs/src/wallet/stealth.rs
+++ b/crates/wallet/ootle-rs/src/wallet/stealth.rs
@@ -4,7 +4,8 @@
 use std::ops::Not;
 
 use async_trait::async_trait;
-use tari_ootle_transaction::{Transaction, UnsealedTransaction, UnsignedTransaction};
+use tari_ootle_transaction::{Transaction, TransactionSignature, UnsealedTransaction, UnsignedTransaction};
+use tari_template_lib_types::crypto::RistrettoPublicKeyBytes;
 
 use crate::{
     Address,
@@ -29,21 +30,33 @@ impl<'a, W: ?Sized> WalletStealthAuthorizer<'a, W> {
 }
 
 impl WalletStealthAuthorizer<'_, OotleWallet> {
+    /// The public key that will seal the transaction: the wallet's default account key when an account-key seal is
+    /// required, otherwise the designated stealth seal signer. `None` when there is nothing to seal for (no inputs).
+    pub fn seal_signer(&self) -> Option<&RistrettoPublicKeyBytes> {
+        if self.required_signatures.must_sign_with_account_key() {
+            Some(self.wallet.default_address().account_public_key())
+        } else {
+            self.required_signatures
+                .seal_signer()
+                .map(|s| s.signer().account_public_key())
+        }
+    }
+
+    /// The exact message every authorization signature for this transaction must sign. An external co-signer (or an
+    /// adaptor pre-signer) produces its signature over these bytes; the resulting [`TransactionAuthorization`] is
+    /// attached via [`crate::TransactionRequest::add_authorization`]. Returns `None` when there is no seal signer to
+    /// bind the authorization to (no inputs to spend).
+    pub fn authorization_message(&self, unsigned: &UnsignedTransaction) -> Option<[u8; 64]> {
+        let seal_signer = self.seal_signer()?;
+        let UnsignedTransaction::V1(unsigned_v1) = unsigned;
+        Some(TransactionSignature::create_message_v1(seal_signer, unsigned_v1))
+    }
+
     pub async fn create_authorizations(
         &self,
         unsigned: &UnsignedTransaction,
     ) -> signer::Result<Vec<TransactionAuthorization>> {
-        let seal_signer = if self.required_signatures.must_sign_with_account_key() {
-            // We'll seal with the wallet's default key (seal_signer() is None)
-            Some(self.wallet.default_address().account_public_key())
-        } else {
-            // We'll seal with the seal signer
-            self.required_signatures
-                .seal_signer()
-                .map(|s| s.signer().account_public_key())
-        };
-
-        let Some(seal_signer) = seal_signer else {
+        let Some(seal_signer) = self.seal_signer() else {
             // There are no inputs to sign for
             return Ok(vec![]);
         };


### PR DESCRIPTION
Description
---

Adds Schnorr adaptor signature ("scriptless script") primitives and the `ootle-rs` wiring to complete an adaptor-signed authorization inside a real transaction.

**`tari_ootle_wallet_crypto`**
- New `adaptor` module: `sign` / `verify` / `complete` / `extract` over Ristretto. The challenge binds the offset nonce `R + T` using tari_crypto's own challenge construction, so a **completed adaptor signature verifies under the stock verifier with no engine or consensus change**. The signing nonce is sampled internally, so it cannot be reused.
- Domain-generic stealth spend-authorization key derivation (`spend_auth_dh_secret` / `spend_auth_dh_public_key`): per-party one-time keys derived off a single output nonce, domain-separated from the value-owner key and per co-signer index.

**`ootle-rs`**
- `WalletStealthAuthorizer::authorization_message` exposes the exact message an external co-signer must sign; `SignatureRequirements::account_key_seal` fixes the seal signer for the case where every authorization is supplied externally (a script-path `AccessRule` leaf whose keys the wallet does not own).
- New `transaction::adaptor` helpers bridge the adaptor primitives to a `TransactionAuthorization` attachable via `TransactionRequest`.
- New `examples/adaptor_claim` funds a 2-of-2 script-path output and then claims it, completing the counterparty's leg with an adaptor signature.

Motivation and Context
---

Adaptor signatures are the foundational primitive for trust-minimised cross-chain atomic swaps on top of the TIP-0007 condition-tree spend model: completing (and broadcasting) one chain's signature reveals the scalar that unlocks the other chain, without putting a hash or any swap-specific data on chain. This PR lands the crypto and the `ootle-rs` authorization seam for one leg; the swap counterparty's chain is out of scope here.

The change is purely additive — new module, functions, methods, and an example. No existing APIs change.

How Has This Been Tested?
---

- Unit tests in `tari_ootle_wallet_crypto`:
  - adaptor: a completed adaptor signature verifies under the unchanged `RistrettoSchnorr` verifier; `extract` recovers the secret; completing with the wrong secret and tampered messages/keys are rejected.
  - derivation: committed public key matches the recovered secret, keys are independent per index, and are a distinct domain from the value-owner key.
- `cargo build -p ootle-rs --example adaptor_claim` compiles.
- `cargo clippy -p tari_ootle_wallet_crypto -p ootle-rs --examples` is clean for the changed code.

What process can a PR reviewer use to test or verify this change?
---

- `cargo test -p tari_ootle_wallet_crypto`
- With a localnet swarm running (indexer on `http://127.0.0.1:12500`): `cargo run -p ootle-rs --example adaptor_claim` — posts the lock transaction, then the script-path claim whose counterparty authorization is an adaptor signature completed with the swap secret.

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify
