### PR TITLE
fix(validator_rollback): keep genesis v0 state-tree version pointer when truncating

### DIFF
--- a/crates/state_store_rocksdb/tests/state_tree.rs
+++ b/crates/state_store_rocksdb/tests/state_tree.rs
@@ -187,11 +187,75 @@ fn truncate_to_version_is_shard_scoped() {
             assert!(tx.state_tree_nodes_get(shard_b, key).optional().unwrap().is_some());
         }
         assert_eq!(tx.state_tree_versions_get_latest(shard_b).unwrap(), Some(3));
-        // shard_a truncated.
+        // shard_a truncated. No nodes survive at or below the target version, so the version
+        // pointer is removed and the shard reads as an empty tree.
         for (key, _) in &nodes_v3 {
             assert!(tx.state_tree_nodes_get(shard_a, key).optional().unwrap().is_none());
         }
-        assert_eq!(tx.state_tree_versions_get_latest(shard_a).unwrap(), Some(1));
+        assert_eq!(tx.state_tree_versions_get_latest(shard_a).unwrap(), None);
+        Ok::<_, StorageError>(())
+    })
+    .unwrap();
+}
+
+#[test]
+fn truncate_to_version_zero_keeps_genesis_v0_pointer() {
+    // Genesis substates are bootstrapped into the tree at version 0, so a shard rolled back to a
+    // checkpoint that recorded state_version 0 must keep its v0 nodes and a version pointer of 0.
+    let (db, _tmp) = create_rocksdb_with_opts(DatabaseOptions::default().with_state_history_length(0));
+    let genesis_shard = Shard::first();
+    let empty_shard = Shard::from_u32(42);
+
+    let nodes_v0 = gen_nodes(0, 5).collect::<Vec<_>>();
+    let nodes_v1 = gen_nodes(1, 5).collect::<Vec<_>>();
+    let nodes_v2 = gen_nodes(2, 5).collect::<Vec<_>>();
+
+    db.with_write_tx(|tx| {
+        // genesis_shard: bootstrapped at v0, then two consensus commits.
+        tx.state_tree_nodes_batch_insert(genesis_shard, nodes_v0.clone())
+            .unwrap();
+        tx.state_tree_nodes_batch_insert(genesis_shard, nodes_v1.clone())
+            .unwrap();
+        tx.state_tree_nodes_batch_insert(genesis_shard, nodes_v2.clone())
+            .unwrap();
+        tx.state_tree_shard_versions_set(genesis_shard, 2).unwrap();
+        // empty_shard: first state committed at v1 (no genesis substates).
+        tx.state_tree_nodes_batch_insert(empty_shard, nodes_v1.clone()).unwrap();
+        tx.state_tree_shard_versions_set(empty_shard, 1).unwrap();
+        Ok::<_, StorageError>(())
+    })
+    .unwrap();
+
+    db.with_write_tx(|tx| state_tree_truncate_to_version(tx, genesis_shard, 0))
+        .unwrap();
+    db.with_write_tx(|tx| state_tree_truncate_to_version(tx, empty_shard, 0))
+        .unwrap();
+
+    db.with_read_tx(|tx| {
+        // genesis_shard: v0 nodes survive and the pointer stays at 0.
+        for (key, _) in &nodes_v0 {
+            assert!(
+                tx.state_tree_nodes_get(genesis_shard, key)
+                    .optional()
+                    .unwrap()
+                    .is_some()
+            );
+        }
+        for (key, _) in nodes_v1.iter().chain(&nodes_v2) {
+            assert!(
+                tx.state_tree_nodes_get(genesis_shard, key)
+                    .optional()
+                    .unwrap()
+                    .is_none()
+            );
+        }
+        assert_eq!(tx.state_tree_versions_get_latest(genesis_shard).unwrap(), Some(0));
+
+        // empty_shard: nothing survives at or below v0, so the pointer is removed.
+        for (key, _) in &nodes_v1 {
+            assert!(tx.state_tree_nodes_get(empty_shard, key).optional().unwrap().is_none());
+        }
+        assert_eq!(tx.state_tree_versions_get_latest(empty_shard).unwrap(), None);
         Ok::<_, StorageError>(())
     })
     .unwrap();

--- a/utilities/validator_rollback/src/storage/write.rs
+++ b/utilities/validator_rollback/src/storage/write.rs
@@ -78,8 +78,9 @@ where
 /// Truncate the state tree for `shard` back to `target_version`.
 ///
 /// After this call:
-/// - `state_tree_versions_get_latest(shard)` returns `target_version` (or `None` if the shard had no state at or below
-///   `target_version`).
+/// - `state_tree_versions_get_latest(shard)` returns the highest committed version at or below `target_version` (or
+///   `None` if the shard has no state at or below `target_version`). Version 0 counts as committed state: bootstrapped
+///   genesis substates are written to the tree at version 0.
 /// - All nodes at versions > `target_version` are deleted from the tree store.
 /// - All stale-node records at versions > `target_version` are deleted.
 pub fn state_tree_truncate_to_version<'a, TAddr>(
@@ -127,15 +128,23 @@ where
         stale_cf.delete(key, OPERATION)?;
     }
 
-    // 3. Reset the latest-version pointer. State versions start at 1, so an entry with value 0 is never valid: a shard
-    //    with no committed state has *no entry*, and downstream readers (JMT root lookup, state-sync's
-    //    `calculate_state_root_for_shard`) distinguish None (empty tree → placeholder hash) from Some(v) (load root at
-    //    v). If we wrote 0 here, those readers would try to load a v0 root node that never existed and error with JMT
-    //    NotFound.
-    if target_version == 0 {
-        versions_cf.delete(&shard, OPERATION)?;
-    } else {
-        versions_cf.put(&shard, &target_version, OPERATION)?;
+    // 3. Reset the latest-version pointer to the highest version with surviving tree nodes. The pointer must reference
+    //    a version at which a JMT root node exists — downstream readers (JMT root lookup, state-sync's
+    //    `calculate_state_root_for_shard`) load the root at Some(v) and treat a missing entry as the empty tree
+    //    (placeholder hash). Version 0 is a valid committed version: genesis substates are bootstrapped into the tree
+    //    at version 0, so a shard whose only state is genesis must keep a pointer at 0 or it reads as empty and no
+    //    longer matches the checkpoint being rolled back to.
+    let latest_surviving_version = version_query
+        .query_range_key_iterator(
+            Ordering::Descending,
+            (shard, 0)..(shard, target_version.saturating_add(1)),
+        )
+        .next()
+        .transpose()?
+        .map(|(_, node_key)| node_key.version());
+    match latest_surviving_version {
+        Some(version) => versions_cf.put(&shard, &version, OPERATION)?,
+        None => versions_cf.delete(&shard, OPERATION)?,
     }
 
     debug!(


### PR DESCRIPTION
## Description

Fixes the `offline_rollback.feature` cucumber scenario, which continued to fail on `development` after #2293 (the `Test Results (CI)` check still reports 1 fail; e.g. run for 67baedd6). After the offline rollback both validators wedge in `Sleeping` at epoch 0 / height 0.

## Root cause

#2293's leaf-less rolled-back branch in `check_sync` is reached and behaves as designed — its state-root guard (`local_state_matches_checkpoint`) rejects the node because the rolled-back state genuinely no longer matches the checkpoint. The CI logs show the subsequent sync failing the same comparison:

```
TRANSITION: CheckSync --- Behind peers ---> Syncing
❌ State root mismatch for Shard(2). Checkpoint a55aff… but got 000000…  (0 transitions streamed, peer reported v0)
TRANSITION: Syncing --- Failure(…) ---> Sleeping
```

The corruption is introduced by the rollback tool itself:

1. Genesis substates are bootstrapped into each shard's state tree at **version 0** (`genesis_state.rs`: `GENESIS_STATE_VERSION = 0`), with the shard's latest-version pointer set to `Some(0)`.
2. `generate_epoch_checkpoint` therefore records a genesis-bearing shard untouched since bootstrap as `{root_hash: <real root>, state_version: 0}`.
3. `state_tree_truncate_to_version(shard, 0)` special-cased `target_version == 0` by **deleting the version pointer**, on the premise that "an entry with value 0 is never valid". That premise is wrong for genesis shards: after rollback they read as an empty tree (placeholder root) while the retained checkpoint holds a real root.

Since every committee member is rolled back with the same tool, every node is corrupted identically: `local_state_matches_checkpoint` correctly returns false → `Behind` → state sync streams nothing from the equally-empty peer → root mismatch → `Failure → Sleeping`, looping forever.

## Fix

`state_tree_truncate_to_version` now sets the latest-version pointer to the highest version with surviving tree nodes at or below `target_version` (via a descending `ByShardStateVersionQuery` scan), and removes the pointer only when no nodes survive. A genesis-only shard rolled back to a checkpoint with `state_version: 0` keeps its v0 nodes and a `Some(0)` pointer, so its JMT root again matches the checkpoint and consensus resumes via the #2293 `UpToDate` path.

## Testing

- New regression test `truncate_to_version_zero_keeps_genesis_v0_pointer`: a genesis-shaped shard (nodes at v0..v2) truncated to 0 keeps its v0 nodes and `Some(0)` pointer; a shard whose first state landed at v1 gets its pointer removed.
- Fixed `truncate_to_version_is_shard_scoped`, which asserted `Some(1)` for a shard with no nodes at or below v1 — a pointer at which no JMT root exists, contradicting the function's documented contract ("None if the shard had no state at or below target_version").
- `cargo nextest -p tari_state_store_rocksdb --test state_tree` (4/4 pass) and `-p tari_validator_rollback` (4/4 pass).
- End-to-end verification is the `offline_rollback` cucumber scenario in this PR's integration-test run.