### PR TITLE
fix(consensus): split exhaust burn across involved shard groups

### DIFF
--- a/crates/consensus/src/hotstuff/on_propose.rs
+++ b/crates/consensus/src/hotstuff/on_propose.rs
@@ -541,11 +541,15 @@ where TConsensusSpec: ConsensusSpec
                     .ok_or_else(|| {
                         HotStuffError::InvariantError("Leader fee overflow when summing for block".to_string())
                     })?;
-                accumulated_data.total_exhaust_burn += command
-                    .committing()
-                    .and_then(|tx| tx.leader_fee.as_ref())
-                    .map(|f| u128::from(f.exhaust_burn()))
-                    .unwrap_or(0);
+                let exhaust_burn_portion = command
+                    .exhaust_burn_portion(local_committee_info.shard_group())
+                    .ok_or_else(|| {
+                        HotStuffError::InvariantError(format!(
+                            "Local shard group {} is not in the evidence of committing command {command}",
+                            local_committee_info.shard_group(),
+                        ))
+                    })?;
+                accumulated_data.total_exhaust_burn += u128::from(exhaust_burn_portion);
                 // TODO: a BTreeSet changes the order from the original batch. Uncertain if this is a problem since the
                 // proposer also processes transactions in the completed block order, however on_propose does perform
                 // some operations (e.g. prepare, execute) in batch order. To ensure correctness, we should process

--- a/crates/consensus/src/hotstuff/on_ready_to_vote_on_local_block.rs
+++ b/crates/consensus/src/hotstuff/on_ready_to_vote_on_local_block.rs
@@ -1408,7 +1408,19 @@ where TConsensusSpec: ConsensusSpec
         })?;
 
         *total_leader_fee += leader_fee.fee();
-        *total_exhaust_burn += u128::from(leader_fee.exhaust_burn());
+        // Compute the portion from the local record's evidence: its key order is locally maintained (sorted), whereas
+        // the atom's wire-decoded key order is not consensus-checked (evidence equality is order-independent).
+        let exhaust_burn_portion = tx_rec
+            .evidence()
+            .exhaust_burn_portion(leader_fee.exhaust_burn(), local_committee_info.shard_group())
+            .ok_or_else(|| {
+                HotStuffError::InvariantError(format!(
+                    "evaluate_all_accept_command: local shard group {} is not in the evidence for transaction {}",
+                    local_committee_info.shard_group(),
+                    atom.id(),
+                ))
+            })?;
+        *total_exhaust_burn += u128::from(exhaust_burn_portion);
 
         substate_store.put_diff(&filter_diff_for_committee(local_committee_info, diff))?;
 

--- a/crates/consensus_tests/src/consensus.rs
+++ b/crates/consensus_tests/src/consensus.rs
@@ -329,7 +329,10 @@ async fn multi_shard_single_transaction() {
                 Ok::<_, HotStuffError>(block.header().total_accumulated_exhaust_burn())
             })
             .unwrap();
-        assert_eq!(accumulated_burn, expected_burn, "unexpected accumulated burn for validator {vn}");
+        assert_eq!(
+            accumulated_burn, expected_burn,
+            "unexpected accumulated burn for validator {vn}"
+        );
         network_total_burn += accumulated_burn;
     }
     assert_eq!(network_total_burn, 5);

--- a/crates/consensus_tests/src/consensus.rs
+++ b/crates/consensus_tests/src/consensus.rs
@@ -288,7 +288,7 @@ async fn multi_shard_single_transaction() {
         .start()
         .await;
 
-    let (tx, _, _) = test.send_transaction_to_all(Decision::Commit, 100, 2, 2).await;
+    let (tx, _, _) = test.send_transaction_to_all(Decision::Commit, 105, 2, 2).await;
 
     test.start_epoch(Epoch(1)).await;
 
@@ -315,10 +315,11 @@ async fn multi_shard_single_transaction() {
     test.assert_all_validators_committed(tx.id());
 
     // Each involved shard group accumulates only its portion of the transaction's exhaust burn, so the network-wide
-    // sum counts the burn exactly once. Fee 100 with divisor 20 and 2 involved shard groups pays each leader 48 and
-    // burns 4 (see calculate_leader_fee), split 2 per shard group.
+    // sum counts the burn exactly once. Fee 105 with divisor 20 and 2 involved shard groups pays each leader 50 and
+    // burns 5 (see calculate_leader_fee); the indivisible burn splits 3/2, with the extra unit going to the first
+    // shard group in ShardGroup order.
     let mut network_total_burn = 0u128;
-    for vn in ["1", "2"] {
+    for (vn, expected_burn) in [("1", 3u128), ("2", 2)] {
         let accumulated_burn = test
             .get_validator(&TestAddress::new(vn))
             .state_store
@@ -328,10 +329,10 @@ async fn multi_shard_single_transaction() {
                 Ok::<_, HotStuffError>(block.header().total_accumulated_exhaust_burn())
             })
             .unwrap();
-        assert_eq!(accumulated_burn, 2, "unexpected accumulated burn for validator {vn}");
+        assert_eq!(accumulated_burn, expected_burn, "unexpected accumulated burn for validator {vn}");
         network_total_burn += accumulated_burn;
     }
-    assert_eq!(network_total_burn, 4);
+    assert_eq!(network_total_burn, 5);
 
     log::info!("total messages sent: {}", test.network().total_messages_sent());
     test.assert_clean_shutdown().await;

--- a/crates/consensus_tests/src/consensus.rs
+++ b/crates/consensus_tests/src/consensus.rs
@@ -314,6 +314,25 @@ async fn multi_shard_single_transaction() {
         .await;
     test.assert_all_validators_committed(tx.id());
 
+    // Each involved shard group accumulates only its portion of the transaction's exhaust burn, so the network-wide
+    // sum counts the burn exactly once. Fee 100 with divisor 20 and 2 involved shard groups pays each leader 48 and
+    // burns 4 (see calculate_leader_fee), split 2 per shard group.
+    let mut network_total_burn = 0u128;
+    for vn in ["1", "2"] {
+        let accumulated_burn = test
+            .get_validator(&TestAddress::new(vn))
+            .state_store
+            .with_read_tx(|tx| {
+                let leaf = tx.leaf_block_get(Epoch(1))?;
+                let block = Block::get(tx, &leaf.block_id)?;
+                Ok::<_, HotStuffError>(block.header().total_accumulated_exhaust_burn())
+            })
+            .unwrap();
+        assert_eq!(accumulated_burn, 2, "unexpected accumulated burn for validator {vn}");
+        network_total_burn += accumulated_burn;
+    }
+    assert_eq!(network_total_burn, 4);
+
     log::info!("total messages sent: {}", test.network().total_messages_sent());
     test.assert_clean_shutdown().await;
 }

--- a/crates/storage/src/consensus_models/command.rs
+++ b/crates/storage/src/consensus_models/command.rs
@@ -241,6 +241,31 @@ impl Command {
             .filter(|t| t.decision.is_commit())
     }
 
+    /// Returns `local_shard_group`'s portion of the transaction's exhaust burn for accumulation into the block
+    /// header's burn total. Returns 0 if this command does not commit a transaction or carries no leader fee.
+    ///
+    /// A LocalOnly transaction is processed by a single shard group, which therefore accounts for the entire burn
+    /// (its leader fee is calculated with one involved shard group). An AllAccept transaction is processed by every
+    /// involved shard group, so the burn is split between them — see [Evidence::exhaust_burn_portion].
+    ///
+    /// Must only be called on locally-constructed commands (e.g. while proposing): the split relies on the locally
+    /// maintained evidence key order, which wire-decoded commands do not guarantee.
+    ///
+    /// Returns `None` if this is a committing AllAccept command whose evidence does not include `local_shard_group`.
+    pub fn exhaust_burn_portion(&self, local_shard_group: ShardGroup) -> Option<u64> {
+        let Some(atom) = self.committing() else {
+            return Some(0);
+        };
+        let Some(leader_fee) = atom.leader_fee.as_ref() else {
+            return Some(0);
+        };
+        if self.local_only().is_some() {
+            return Some(leader_fee.exhaust_burn());
+        }
+        atom.evidence
+            .exhaust_burn_portion(leader_fee.exhaust_burn(), local_shard_group)
+    }
+
     /// Returns Some if the command **will** result in aborting the transaction, otherwise None.
     pub fn aborting(&self) -> Option<&TransactionAtom> {
         self.some_accept()

--- a/crates/storage/src/consensus_models/evidence.rs
+++ b/crates/storage/src/consensus_models/evidence.rs
@@ -285,6 +285,26 @@ impl Evidence {
         self.evidence.len()
     }
 
+    /// Returns the portion of a transaction's exhaust burn attributed to `shard_group`, or `None` if the shard group
+    /// is not part of this evidence.
+    ///
+    /// The whole-transaction burn is divided evenly among the involved shard groups, with one extra unit going to each
+    /// of the first `exhaust_burn % num_shard_groups` groups in `ShardGroup` order, so the portions sum to exactly
+    /// `exhaust_burn`. Each shard group accumulates only its portion into its block header burn total, so summing the
+    /// accumulated burn across all shard groups counts each transaction's burn exactly once.
+    ///
+    /// CONSENSUS RULE: every involved shard group must attribute portions identically. Groups are ranked by
+    /// `ShardGroup` order, relying on the sorted-key invariant maintained by all local constructors
+    /// (`insert_sorted`/`sort_keys`). Wire-decoded evidence preserves the sender's key order and passes
+    /// order-independent equality checks, so callers must pass locally-constructed evidence (e.g. the local pool
+    /// record's), never evidence decoded from a received proposal.
+    pub fn exhaust_burn_portion(&self, exhaust_burn: u64, shard_group: ShardGroup) -> Option<u64> {
+        debug_assert!(self.evidence.keys().is_sorted(), "evidence keys must be sorted");
+        let index = self.evidence.keys().position(|sg| *sg == shard_group)? as u64;
+        let num_groups = self.evidence.keys().len() as u64;
+        Some(exhaust_burn / num_groups + u64::from(index < exhaust_burn % num_groups))
+    }
+
     /// Add or update shard groups, substates and locks into Evidence. Existing prepare/accept QC IDs are not changed.
     pub fn merge(&mut self, other: &Evidence) -> &mut Self {
         for (sg, evidence) in other.iter() {
@@ -650,6 +670,82 @@ mod tests {
 
     fn seed_lock_intent(seed: u8, ty: SubstateLockType) -> SubstateRequirementLockIntent {
         SubstateRequirementLockIntent::new(seed_substate_id(seed), 0, ty)
+    }
+
+    mod exhaust_burn_portion {
+        use super::*;
+
+        fn evidence_with_groups(groups: &[ShardGroup]) -> Evidence {
+            let mut evidence = Evidence::empty();
+            for (i, sg) in groups.iter().enumerate() {
+                evidence
+                    .add_shard_group(*sg)
+                    .insert_from_lock_intent(seed_lock_intent(i as u8 + 1, SubstateLockType::Write));
+            }
+            evidence
+        }
+
+        #[test]
+        fn it_assigns_the_remainder_to_the_first_groups_in_shard_group_order() {
+            let groups = [ShardGroup::new(0, 1), ShardGroup::new(2, 3), ShardGroup::new(4, 5)];
+            let evidence = evidence_with_groups(&groups);
+
+            assert_eq!(evidence.exhaust_burn_portion(19, groups[0]), Some(7));
+            assert_eq!(evidence.exhaust_burn_portion(19, groups[1]), Some(6));
+            assert_eq!(evidence.exhaust_burn_portion(19, groups[2]), Some(6));
+
+            // Burn smaller than the number of groups
+            assert_eq!(evidence.exhaust_burn_portion(2, groups[0]), Some(1));
+            assert_eq!(evidence.exhaust_burn_portion(2, groups[1]), Some(1));
+            assert_eq!(evidence.exhaust_burn_portion(2, groups[2]), Some(0));
+
+            assert_eq!(evidence.exhaust_burn_portion(0, groups[0]), Some(0));
+        }
+
+        #[test]
+        fn it_sums_to_exactly_the_whole_burn() {
+            let groups = [
+                ShardGroup::new(0, 1),
+                ShardGroup::new(2, 3),
+                ShardGroup::new(4, 5),
+                ShardGroup::new(6, 7),
+            ];
+            for num_groups in 1..=groups.len() {
+                let evidence = evidence_with_groups(&groups[..num_groups]);
+                for burn in [0u64, 1, 3, 5, 19, 20, 100, 1_000_003] {
+                    let total = groups[..num_groups]
+                        .iter()
+                        .map(|sg| evidence.exhaust_burn_portion(burn, *sg).unwrap())
+                        .sum::<u64>();
+                    assert_eq!(
+                        total, burn,
+                        "burn {burn} was created or lost across {num_groups} group(s)"
+                    );
+                }
+            }
+        }
+
+        #[test]
+        fn it_returns_none_for_an_uninvolved_shard_group() {
+            let evidence = evidence_with_groups(&[ShardGroup::new(0, 1)]);
+            assert_eq!(evidence.exhaust_burn_portion(10, ShardGroup::new(2, 3)), None);
+        }
+
+        #[test]
+        fn it_does_not_depend_on_insertion_order() {
+            let sg1 = ShardGroup::new(0, 1);
+            let sg2 = ShardGroup::new(2, 3);
+            let sg3 = ShardGroup::new(4, 5);
+
+            let mut evidence = Evidence::empty();
+            evidence.add_shard_group(sg3);
+            evidence.add_shard_group(sg1);
+            evidence.add_shard_group(sg2);
+
+            assert_eq!(evidence.exhaust_burn_portion(19, sg1), Some(7));
+            assert_eq!(evidence.exhaust_burn_portion(19, sg2), Some(6));
+            assert_eq!(evidence.exhaust_burn_portion(19, sg3), Some(6));
+        }
     }
 
     #[test]

--- a/crates/storage/src/consensus_models/leader_fee.rs
+++ b/crates/storage/src/consensus_models/leader_fee.rs
@@ -13,8 +13,12 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, BorshSerialize, Encode, Decode, CborLen)]
 #[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export))]
 pub struct LeaderFee {
+    /// The fee payable to the leader of each involved shard group.
     #[n(0)]
     pub fee: u64,
+    /// The amount burned for the whole transaction across all involved shard groups
+    /// (`fee * num_involved_shard_groups + exhaust_burn == transaction_fee`). Each shard group accumulates only its
+    /// portion of this into its block header burn total — see `Evidence::exhaust_burn_portion`.
     #[n(1)]
     pub exhaust_burn: u64,
 }


### PR DESCRIPTION
Closes #2299 

Human note: this fix only affects a multi-shard network (currently not in use on a live network) and enables indexers to calculate the correct TARI supply (doesn't affect actual supply/burn in any way)

## Problem

For a transaction spanning `G` shard groups, each involved group's block header accumulated the **whole-transaction** exhaust burn (`LeaderFee::exhaust_burn`), so the network-wide sum over shard groups — which the indexer's total-supply metric (`claimed − burnt`) relies on via epoch checkpoints — counted the burn `G` times. Total supply was under-reported whenever multishard traffic existed, and with enough multishard burn the supply endpoint hard-errors with `DataInconsistency` (burnt > claimed).

## Fix

Each involved shard group now accumulates only its portion of the burn, so the cross-group sum counts each transaction's burn exactly once:

- `Evidence::exhaust_burn_portion(burn, shard_group)` — splits the whole-transaction burn: `burn / G` per group, with one extra unit to the first `burn % G` groups in `ShardGroup` order. Portions sum to exactly `burn`, preserving `fee*G + burn == transaction_fee`.
- `Command::exhaust_burn_portion(local_shard_group)` — a committing LocalOnly command attributes the entire burn to the local shard group (its leader fee is calculated with one involved group and no other group processes the command); a committing AllAccept splits per the above.
- `on_propose` and the AllAccept vote path accumulate the local portion. The LocalOnly vote path is unchanged (whole burn, matching the propose path).

The AllAccept vote path computes the portion from the **local pool record's** evidence rather than the proposed atom's: all local Evidence constructors maintain sorted keys (`insert_sorted`/`sort_keys`), whereas wire-decoded evidence preserves the sender's key order and evidence equality is order-independent, so the atom's key order is not consensus-checked. A proposal accumulating burn under a permuted evidence map now fails with `TotalExhaustBurnDisagreement`.

The indexer needs no changes — its cross-group checkpoint sum is correct once each group records only its share.

Note: this changes the consensus-validated `total_accumulated_exhaust_burn` header value for multishard transactions, so all nodes must run the same rules.

## Testing

- Unit tests for the split: exact sum across 1–4 groups × several burn values (incl. burn < G and burn = 0), remainder assigned to the first groups in `ShardGroup` order, uninvolved group returns `None`, insertion-order independence.
- `multi_shard_single_transaction` now asserts each shard group's leaf header accumulates its portion (2 each for fee 100, divisor 20, `G=2` → `LeaderFee { fee: 48, exhaust_burn: 4 }`) and the cross-group sum equals the whole burn.
- `cargo nextest run -p tari_ootle_storage -p tari_consensus -p consensus_tests`: 95/95 passed.