### PR TITLE
refactor(consensus): unify exhaust burn split and enforce LocalOnly evidence invariant

### DIFF
--- a/crates/consensus/src/hotstuff/on_propose.rs
+++ b/crates/consensus/src/hotstuff/on_propose.rs
@@ -800,6 +800,16 @@ where TConsensusSpec: ConsensusSpec
                     );
 
                     if pool_tx.current_decision().is_commit() {
+                        // STRICT INVARIANT: a LocalOnly transaction involves exactly the local shard group, so its
+                        // leader fee is calculated with one involved shard group and it accounts for the entire
+                        // exhaust burn.
+                        if pool_tx.evidence().num_shard_groups() != 1 {
+                            return Err(HotStuffError::InvariantError(format!(
+                                "PROPOSE: LocalOnly transaction {} has evidence for {} shard groups",
+                                pool_tx.id(),
+                                pool_tx.evidence().num_shard_groups(),
+                            )));
+                        }
                         let involved = NonZeroU64::new(1).expect("1 > 0");
                         let leader_fee = calculate_leader_fee(
                             pool_tx.transaction_fee(),

--- a/crates/consensus/src/hotstuff/on_ready_to_vote_on_local_block.rs
+++ b/crates/consensus/src/hotstuff/on_ready_to_vote_on_local_block.rs
@@ -707,7 +707,36 @@ where TConsensusSpec: ConsensusSpec
                             }
 
                             *total_leader_fee += calculated_leader_fee.fee();
-                            *total_exhaust_burn += u128::from(calculated_leader_fee.exhaust_burn());
+                            // A LocalOnly transaction's evidence must contain exactly the local shard group, so its
+                            // portion of the exhaust burn is the entire burn.
+                            if pool_tx.evidence().num_shard_groups() != 1 {
+                                warn!(
+                                    target: LOG_TARGET,
+                                    "❌ NO VOTE: LocalOnly transaction {} in block {} has evidence for {} shard groups",
+                                    pool_tx.id(),
+                                    block,
+                                    pool_tx.evidence().num_shard_groups(),
+                                );
+                                return Ok(Some(NoVoteReason::LocalOnlyProposedForMultiShard));
+                            }
+                            let Some(exhaust_burn_portion) = pool_tx.evidence().exhaust_burn_portion(
+                                calculated_leader_fee.exhaust_burn(),
+                                local_committee_info.shard_group(),
+                            ) else {
+                                warn!(
+                                    target: LOG_TARGET,
+                                    "❌ NO VOTE: local shard group {} is not in the evidence for LocalOnly transaction {} in block {}",
+                                    local_committee_info.shard_group(),
+                                    pool_tx.id(),
+                                    block,
+                                );
+                                return Ok(Some(NoVoteReason::InvalidEvidence {
+                                    reason: InvalidEvidenceReason::MissingInvolvedShardGroup {
+                                        shard_group: local_committee_info.shard_group(),
+                                    },
+                                }));
+                            };
+                            *total_exhaust_burn += u128::from(exhaust_burn_portion);
                         }
 
                         proposed_block_change_set.add_transaction_execution(*pool_tx.id(), execution)?;
@@ -1410,16 +1439,23 @@ where TConsensusSpec: ConsensusSpec
         *total_leader_fee += leader_fee.fee();
         // Compute the portion from the local record's evidence: its key order is locally maintained (sorted), whereas
         // the atom's wire-decoded key order is not consensus-checked (evidence equality is order-independent).
-        let exhaust_burn_portion = tx_rec
+        let Some(exhaust_burn_portion) = tx_rec
             .evidence()
             .exhaust_burn_portion(leader_fee.exhaust_burn(), local_committee_info.shard_group())
-            .ok_or_else(|| {
-                HotStuffError::InvariantError(format!(
-                    "evaluate_all_accept_command: local shard group {} is not in the evidence for transaction {}",
-                    local_committee_info.shard_group(),
-                    atom.id(),
-                ))
-            })?;
+        else {
+            warn!(
+                target: LOG_TARGET,
+                "❌ NO VOTE: local shard group {} is not in the evidence for transaction {} in block {}",
+                local_committee_info.shard_group(),
+                atom.id(),
+                block,
+            );
+            return Ok(Some(NoVoteReason::InvalidEvidence {
+                reason: InvalidEvidenceReason::MissingInvolvedShardGroup {
+                    shard_group: local_committee_info.shard_group(),
+                },
+            }));
+        };
         *total_exhaust_burn += u128::from(exhaust_burn_portion);
 
         substate_store.put_diff(&filter_diff_for_committee(local_committee_info, diff))?;

--- a/crates/storage/src/consensus_models/command.rs
+++ b/crates/storage/src/consensus_models/command.rs
@@ -244,14 +244,14 @@ impl Command {
     /// Returns `local_shard_group`'s portion of the transaction's exhaust burn for accumulation into the block
     /// header's burn total. Returns 0 if this command does not commit a transaction or carries no leader fee.
     ///
-    /// A LocalOnly transaction is processed by a single shard group, which therefore accounts for the entire burn
-    /// (its leader fee is calculated with one involved shard group). An AllAccept transaction is processed by every
-    /// involved shard group, so the burn is split between them — see [Evidence::exhaust_burn_portion].
+    /// The burn is split between the shard groups in the atom's evidence — see [Evidence::exhaust_burn_portion].
+    /// A LocalOnly transaction's evidence contains exactly the local shard group (a strict invariant enforced where
+    /// LocalOnly commands are proposed and voted on), so its portion is the entire burn.
     ///
     /// Must only be called on locally-constructed commands (e.g. while proposing): the split relies on the locally
     /// maintained evidence key order, which wire-decoded commands do not guarantee.
     ///
-    /// Returns `None` if this is a committing AllAccept command whose evidence does not include `local_shard_group`.
+    /// Returns `None` if this is a committing command whose evidence does not include `local_shard_group`.
     pub fn exhaust_burn_portion(&self, local_shard_group: ShardGroup) -> Option<u64> {
         let Some(atom) = self.committing() else {
             return Some(0);
@@ -259,9 +259,6 @@ impl Command {
         let Some(leader_fee) = atom.leader_fee.as_ref() else {
             return Some(0);
         };
-        if self.local_only().is_some() {
-            return Some(leader_fee.exhaust_burn());
-        }
         atom.evidence
             .exhaust_burn_portion(leader_fee.exhaust_burn(), local_shard_group)
     }

--- a/crates/storage/src/consensus_models/evidence.rs
+++ b/crates/storage/src/consensus_models/evidence.rs
@@ -301,8 +301,12 @@ impl Evidence {
     pub fn exhaust_burn_portion(&self, exhaust_burn: u64, shard_group: ShardGroup) -> Option<u64> {
         debug_assert!(self.evidence.keys().is_sorted(), "evidence keys must be sorted");
         let index = self.evidence.keys().position(|sg| *sg == shard_group)? as u64;
-        let num_groups = self.evidence.keys().len() as u64;
-        Some(exhaust_burn / num_groups + u64::from(index < exhaust_burn % num_groups))
+        let num_groups = self.evidence.len() as u64;
+        let base_portion = exhaust_burn / num_groups;
+        let remainder = exhaust_burn % num_groups;
+        // The first `remainder` groups in ShardGroup order each take one extra unit of the burn
+        let extra = if index < remainder { 1 } else { 0 };
+        Some(base_portion + extra)
     }
 
     /// Add or update shard groups, substates and locks into Evidence. Existing prepare/accept QC IDs are not changed.


### PR DESCRIPTION
Follow-up to #2302, addressing review feedback.

## Changes

- **Uniform burn split:** `Command::exhaust_burn_portion` no longer special-cases LocalOnly — the portion is always computed via `Evidence::exhaust_burn_portion`, for single-group and multi-group evidence alike. For a single group this yields the entire burn, so behaviour is unchanged.
- **Strict invariant — LocalOnly evidence contains exactly the local shard group:**
  - Propose path: the leader refuses to build the block (`InvariantError`) if its own record violates this.
  - Vote path: a proposal violating it is **rejected with a no-vote** (`LocalOnlyProposedForMultiShard`, or `InvalidEvidence::MissingInvolvedShardGroup` if the single group is not the local one) — a remote leader must not be able to wedge consensus with a malformed proposal.
  - The AllAccept vote path's missing-local-group case is likewise downgraded from `InvariantError` to a no-vote.
- **Clearer remainder arithmetic:** `Evidence::exhaust_burn_portion` now names its terms (`base_portion`, `remainder`, `extra`) instead of packing the remainder assignment into a single comparison expression.

## Testing

- `cargo nextest run -p consensus_tests`: 62/62 passed
- `Evidence::exhaust_burn_portion` unit tests: 4/4 passed (sum-exactness, remainder ordering, uninvolved group, insertion-order independence)