### PR TITLE
ci: use App Store Connect API key for macOS notarization

### DIFF
--- a/.github/workflows/build_binaries.yml
+++ b/.github/workflows/build_binaries.yml
@@ -451,7 +451,7 @@ jobs:
           path: "${{ env.MTS_SOURCE }}/*"
 
       - name: Build the macOS Archive and code-sign
-        if: ${{ ( startsWith(runner.os,'macOS') ) && ( env.MACOS_NOTARIZE_USERNAME != '' ) }}
+        if: ${{ ( startsWith(runner.os,'macOS') ) && ( env.MACOS_NOTARY_ISSUER != '' ) }}
         continue-on-error: true
         env:
           MACOS_KEYCHAIN_PASS: ${{ secrets.MACOS_KEYCHAIN_PASS }}
@@ -461,9 +461,9 @@ jobs:
           # MACOS_INSTALLER_ID: ${{ secrets.MACOS_INSTALLER_ID }}
           # MACOS_INSTALLER_CERT: ${{ secrets.MACOS_INSTALLER_CERT }}
           # MACOS_INSTALLER_PASS: ${{ secrets.MACOS_INSTALLER_PASS }}
-          MACOS_NOTARIZE_USERNAME: ${{ secrets.MACOS_NOTARIZE_USERNAME }}
-          MACOS_NOTARIZE_PASSWORD: ${{ secrets.MACOS_NOTARIZE_PASSWORD }}
-          MACOS_ASC_PROVIDER: ${{ secrets.MACOS_ASC_PROVIDER }}
+          MACOS_NOTARY_KEY: ${{ secrets.MACOS_NOTARY_KEY }}
+          MACOS_NOTARY_KEY_ID: ${{ secrets.MACOS_NOTARY_KEY_ID }}
+          MACOS_NOTARY_ISSUER: ${{ secrets.MACOS_NOTARY_ISSUER }}
         run: |
           set -xo pipefail
           echo "${MACOS_APPLICATION_CERT}" | base64 --decode > application.p12
@@ -547,12 +547,14 @@ jobs:
           ${SHARUN} --check "${{ env.BINFILE }}.sha256"
           7z a "${{ env.BINFILE }}.zip" *
 
+          printf '%s' "${MACOS_NOTARY_KEY}" > "${RUNNER_TEMP}/notary_key.p8"
+
           echo -e "Submitting to Apple...\n\n"
           xcrun notarytool submit \
             "${{ env.BINFILE }}.zip" \
-            --apple-id "${MACOS_NOTARIZE_USERNAME}" \
-            --password ${MACOS_NOTARIZE_PASSWORD} \
-            --team-id ${MACOS_ASC_PROVIDER} \
+            --key "${RUNNER_TEMP}/notary_key.p8" \
+            --key-id "${MACOS_NOTARY_KEY_ID}" \
+            --issuer "${MACOS_NOTARY_ISSUER}" \
             --verbose --wait 2>&1 | tee -a notarisation.result
           # Maybe use line from with "Processing complete"?
           requestUUID=$(tail -n5 notarisation.result | grep "id:" | cut -d" " -f 4)
@@ -689,9 +691,9 @@ jobs:
           cargo audit bin *tari*
 
       - name: Archive and Checksum Binaries
-        if: ${{ ! ( ( startsWith(runner.os, 'macOS') && ( env.MACOS_NOTARIZE_USERNAME != '' ) ) ) }}
+        if: ${{ ! ( ( startsWith(runner.os, 'macOS') && ( env.MACOS_NOTARY_ISSUER != '' ) ) ) }}
         env:
-          MACOS_NOTARIZE_USERNAME: ${{ secrets.MACOS_NOTARIZE_USERNAME }}
+          MACOS_NOTARY_ISSUER: ${{ secrets.MACOS_NOTARY_ISSUER }}
         shell: bash
         run: |
           echo "Archive ${{ env.BINFILE }} too ${{ env.BINFILE }}.zip"
@@ -830,7 +832,7 @@ jobs:
           ls -alhtR macos-universal
 
       - name: Build the macOS universal Archive and code-sign
-        if: ${{ ( startsWith(runner.os,'macOS') ) && ( env.MACOS_NOTARIZE_USERNAME != '' ) }}
+        if: ${{ ( startsWith(runner.os,'macOS') ) && ( env.MACOS_NOTARY_ISSUER != '' ) }}
         continue-on-error: true
         env:
           MACOS_KEYCHAIN_PASS: ${{ secrets.MACOS_KEYCHAIN_PASS }}
@@ -840,9 +842,9 @@ jobs:
           # MACOS_INSTALLER_ID: ${{ secrets.MACOS_INSTALLER_ID }}
           # MACOS_INSTALLER_CERT: ${{ secrets.MACOS_INSTALLER_CERT }}
           # MACOS_INSTALLER_PASS: ${{ secrets.MACOS_INSTALLER_PASS }}
-          MACOS_NOTARIZE_USERNAME: ${{ secrets.MACOS_NOTARIZE_USERNAME }}
-          MACOS_NOTARIZE_PASSWORD: ${{ secrets.MACOS_NOTARIZE_PASSWORD }}
-          MACOS_ASC_PROVIDER: ${{ secrets.MACOS_ASC_PROVIDER }}
+          MACOS_NOTARY_KEY: ${{ secrets.MACOS_NOTARY_KEY }}
+          MACOS_NOTARY_KEY_ID: ${{ secrets.MACOS_NOTARY_KEY_ID }}
+          MACOS_NOTARY_ISSUER: ${{ secrets.MACOS_NOTARY_ISSUER }}
         run: |
           set -xo pipefail
           echo "${MACOS_APPLICATION_CERT}" | base64 --decode > application.p12
@@ -912,12 +914,14 @@ jobs:
           ${SHARUN} --check "${{ env.BINFILE }}.sha256"
           7z a "${{ env.BINFILE }}.zip" *
 
+          printf '%s' "${MACOS_NOTARY_KEY}" > "${RUNNER_TEMP}/notary_key.p8"
+
           echo -e "Submitting to Apple...\n\n"
           xcrun notarytool submit \
             "${{ env.BINFILE }}.zip" \
-            --apple-id "${MACOS_NOTARIZE_USERNAME}" \
-            --password ${MACOS_NOTARIZE_PASSWORD} \
-            --team-id ${MACOS_ASC_PROVIDER} \
+            --key "${RUNNER_TEMP}/notary_key.p8" \
+            --key-id "${MACOS_NOTARY_KEY_ID}" \
+            --issuer "${MACOS_NOTARY_ISSUER}" \
             --verbose --wait 2>&1 | tee -a notarisation.result
           # Maybe use line from with "Processing complete"?
           requestUUID=$(tail -n5 notarisation.result | grep "id:" | cut -d" " -f 4)


### PR DESCRIPTION
## Problem

macOS builds fail at notarization: the `notarytool submit` calls authenticate as an **individual team member's Apple ID** (`--apple-id`/`--password`/`--team-id`). That member was removed from the Apple developer team, so notary now returns:

```
HTTP status code: 403. Invalid or inaccessible developer team ID for the
provided Apple ID. Ensure the Team ID is correct and that you are a member
of that team.
```

Code-signing (team-level cert) still works — only notarization fails. Same root cause and fix as tari-core [tari#7913](https://github.com/tari-project/tari/pull/7913) and universe [universe#3313](https://github.com/tari-project/universe/pull/3313).

## Fix

Switch both `notarytool submit` calls to a **team-scoped App Store Connect API key** (`--key`/`--key-id`/`--issuer`), which survives membership changes.

## Required repo secrets (NOT yet set on this repo)

| Secret | Value |
|---|---|
| `MACOS_NOTARY_KEY` | contents of the `.p8` API key |
| `MACOS_NOTARY_KEY_ID` | Key ID |
| `MACOS_NOTARY_ISSUER` | Issuer ID (also the new signing gate) |

⚠️ Until these are set, the macOS signing step is skipped (gate keys off `MACOS_NOTARY_ISSUER`) and artifacts upload unsigned. The dead `MACOS_NOTARIZE_USERNAME`/`MACOS_NOTARIZE_PASSWORD`/`MACOS_ASC_PROVIDER` can be deleted after this merges. Signing-cert secrets (`MACOS_APPLICATION_*`, `MACOS_KEYCHAIN_PASS`) are unchanged.