### PR TITLE
fix(indexer): return not-found over transport errors when committee agrees substate does not exist

### DIFF
--- a/crates/indexer_lib/src/cached_substate_manager.rs
+++ b/crates/indexer_lib/src/cached_substate_manager.rs
@@ -423,6 +423,16 @@ where
             });
         }
 
+        // Reaching here means no member returned the substate, so more than f DoesNotExist
+        // responses is f+1 agreement that it does not exist. This answer takes precedence over
+        // errors from unreachable members.
+        if num_nexist_substate_results > f {
+            return Ok(SubstateLookupResult {
+                result: SubstateResult::DoesNotExist,
+                verified: false,
+            });
+        }
+
         warn!(
             target: LOG_TARGET,
             "Could not get substate for shard {} from any of the validator nodes", substate_req,


### PR DESCRIPTION
## Motivation

Observed on a local 2-VN swarm: indexer `GET /substates/<id>?local_search_only=false` returned HTTP 500 `NetworkingError: Failed to open substream: No addresses for peer` when one VN was unreachable and the other correctly reported the substate does not exist. The wallet expected a 404 to treat this as not-found.

The substate scanner returns immediately when any committee member supplies an Up/Down result, but a `DoesNotExist` answer requires more than `f` prior `DoesNotExist` responses (checked before increment), which on a 2-validator committee (`f=0`) requires both members to respond. If one member is unreachable, that threshold is unattainable and the scanner falls through to returning the last transport error, so a lookup for a substate that genuinely does not exist returns a transport error instead of not-found. Wallet flows that probe for component existence (e.g. `nfts.mint_faucet_nft` -> `locate_dependent_substates`) then fail with a network interface error instead of handling not-found.

## How

Adds an end-of-loop `f+1` agreement check in `get_specific_substate_from_committee`: after querying all committee members, return an unverified `DoesNotExist` when more than `f` members responded `DoesNotExist`, taking precedence over transport errors from unreachable members. Fail-closed behaviour is unchanged when fewer than `f+1` members respond.

## How Has This Been Tested?

- Manually verified against the failing wallet flow scenario.
- `cargo check` passes.