### PR TITLE
feat: add wallet default account control

### DIFF
--- a/applications/tari_walletd/web_ui/src/routes/Wallet/Components/Accounts.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/Wallet/Components/Accounts.tsx
@@ -20,14 +20,19 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import { useAccountsCreate, useAccountsList } from "@api/hooks/useAccounts";
+import { useAccountsCreate, useAccountsList, useAccountsSetDefault } from "@api/hooks/useAccounts";
 import queryClient from "@api/queryClient";
 import CopyAddress from "@components/CopyAddress";
 import FetchStatusCheck from "@components/FetchStatusCheck";
 import { BoxHeading2, DataTableCell } from "@components/StyledComponents";
 import { ChevronRight } from "@mui/icons-material";
 import AddIcon from "@mui/icons-material/Add";
+import StarIcon from "@mui/icons-material/Star";
+import StarBorderIcon from "@mui/icons-material/StarBorder";
+import Alert from "@mui/material/Alert";
 import Button from "@mui/material/Button";
+import Chip from "@mui/material/Chip";
+import CircularProgress from "@mui/material/CircularProgress";
 import Fade from "@mui/material/Fade";
 import IconButton from "@mui/material/IconButton";
 import Table from "@mui/material/Table";
@@ -37,15 +42,31 @@ import TableContainer from "@mui/material/TableContainer";
 import TableHead from "@mui/material/TableHead";
 import TableRow from "@mui/material/TableRow";
 import TextField from "@mui/material/TextField";
+import Tooltip from "@mui/material/Tooltip";
 import { AccountInfo, shortenSubstateId, substateIdToString } from "@tari-project/ootle-ts-bindings";
 import { useState } from "react";
 import { Form, Link } from "react-router-dom";
 
-function Account({ account }: { account: AccountInfo }) {
+function getErrorMessage(error: unknown, fallback: string) {
+  return error instanceof Error ? error.message : fallback;
+}
+
+function Account({
+  account,
+  isSettingDefault,
+  isSetDefaultDisabled,
+  onSetDefault,
+}: {
+  account: AccountInfo;
+  isSettingDefault: boolean;
+  isSetDefaultDisabled: boolean;
+  onSetDefault: (account: AccountInfo) => void;
+}) {
   const {
     account: { name, component_address },
     address,
   } = account;
+  const accountLabel = name || shortenSubstateId(component_address);
   return (
     <TableRow>
       <DataTableCell>
@@ -56,7 +77,7 @@ function Account({ account }: { account: AccountInfo }) {
             color: "inherit",
           }}
         >
-          {name || shortenSubstateId(component_address)}
+          {accountLabel}
         </Link>
       </DataTableCell>
       <DataTableCell>
@@ -69,6 +90,24 @@ function Account({ account }: { account: AccountInfo }) {
       </DataTableCell>
       <DataTableCell>
         <CopyAddress address={address} />
+      </DataTableCell>
+      <DataTableCell>
+        {account.account.is_default ? (
+          <Chip icon={<StarIcon />} label="Default" color="primary" variant="outlined" size="small" />
+        ) : (
+          <Tooltip title={`Make ${accountLabel} the default account`}>
+            <span>
+              <IconButton
+                aria-label={`Make ${accountLabel} the default account`}
+                onClick={() => onSetDefault(account)}
+                disabled={isSetDefaultDisabled}
+                size="small"
+              >
+                {isSettingDefault ? <CircularProgress size={20} /> : <StarBorderIcon />}
+              </IconButton>
+            </span>
+          </Tooltip>
+        )}
       </DataTableCell>
       <DataTableCell>
         <IconButton component={Link} to={`/accounts/${substateIdToString(component_address)}`}>
@@ -86,6 +125,7 @@ function Accounts() {
     signingKeyIndex: "",
     fee: "",
   });
+  const [pendingDefaultAccount, setPendingDefaultAccount] = useState<string | null>(null);
   const {
     data: dataAccountsList,
     isLoading: isLoadingAccountsList,
@@ -94,6 +134,12 @@ function Accounts() {
   } = useAccountsList(0, 10);
 
   const { mutateAsync: mutateAddAccount } = useAccountsCreate();
+  const {
+    mutate: mutateSetDefault,
+    isPending: isSettingDefault,
+    isError: isSetDefaultError,
+    error: setDefaultError,
+  } = useAccountsSetDefault();
 
   const showAddAccountDialog = (setElseToggle: boolean = !showAccountDialog) => {
     setShowAddAccountDialog(setElseToggle);
@@ -129,6 +175,21 @@ function Accounts() {
       ...accountFormState,
       [e.target.name]: e.target.value,
     });
+  };
+
+  const onSetDefaultAccount = (account: AccountInfo) => {
+    const accountAddress = account.account.component_address;
+    setPendingDefaultAccount(substateIdToString(accountAddress));
+    mutateSetDefault(
+      {
+        account: accountAddress,
+      },
+      {
+        onSettled: () => {
+          setPendingDefaultAccount(null);
+        },
+      },
+    );
   };
 
   return (
@@ -169,6 +230,11 @@ function Accounts() {
           </Fade>
         )}
       </BoxHeading2>
+      {isSetDefaultError && (
+        <Alert severity="error" style={{ marginBottom: 16 }}>
+          {getErrorMessage(setDefaultError, "Error setting default account")}
+        </Alert>
+      )}
       <FetchStatusCheck
         isLoading={isLoadingAccountsList}
         isError={isErrorAccountsList}
@@ -183,13 +249,23 @@ function Accounts() {
                   <TableCell>Component</TableCell>
                   <TableCell>Key index</TableCell>
                   <TableCell>Address</TableCell>
+                  <TableCell>Default</TableCell>
                   <TableCell>Details</TableCell>
                 </TableRow>
               </TableHead>
               <TableBody>
                 {dataAccountsList &&
                   dataAccountsList.accounts.map((account: AccountInfo, index) => (
-                    <Account account={account} key={index} />
+                    <Account
+                      account={account}
+                      isSettingDefault={
+                        isSettingDefault &&
+                        pendingDefaultAccount === substateIdToString(account.account.component_address)
+                      }
+                      isSetDefaultDisabled={isSettingDefault}
+                      key={index}
+                      onSetDefault={onSetDefaultAccount}
+                    />
                   ))}
               </TableBody>
             </Table>

--- a/applications/tari_walletd/web_ui/src/services/api/hooks/useAccounts.ts
+++ b/applications/tari_walletd/web_ui/src/services/api/hooks/useAccounts.ts
@@ -48,6 +48,7 @@ import {
   accountsGetDefault,
   accountsList,
   accountsRename,
+  accountsSetDefault,
   accountsStealthTransfer,
   accountsTransfer,
   mintFaucetNfts,
@@ -112,6 +113,29 @@ export const useAccountsRename = () => {
       queryClient.invalidateQueries({ queryKey: ["accounts"] });
       queryClient.invalidateQueries({ queryKey: [`accounts_get_${variables.account}`] });
       queryClient.refetchQueries({ queryKey: ["accounts"] });
+    },
+  });
+};
+
+export type AccountsSetDefaultMutate = {
+  account: ComponentAddress;
+};
+
+export const useAccountsSetDefault = () => {
+  return useMutation({
+    mutationFn: async (req: AccountsSetDefaultMutate) => {
+      return await accountsSetDefault({
+        account: { ComponentAddress: req.account },
+      });
+    },
+    onError: (error: ApiError) => {
+      error;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["accounts"] });
+      queryClient.invalidateQueries({ queryKey: ["accounts_get_default"] });
+      queryClient.refetchQueries({ queryKey: ["accounts"] });
+      queryClient.refetchQueries({ queryKey: ["accounts_get_default"] });
     },
   });
 };


### PR DESCRIPTION
Description
---

Fixes #2308.

Adds default-account controls to the wallet accounts table:

- shows the current default account with a non-actionable default indicator
- adds a `Set default` control for non-default accounts
- calls the existing `accountsSetDefault` API helper
- invalidates/refetches `accounts` and `accounts_get_default` after a successful change
- surfaces mutation failures with an alert instead of failing silently

Motivation and Context
---

`walletd` already supports `accounts.set_default`, and `accounts.list` exposes `is_default`, but the web UI did not expose a way to see or change the default account from Settings -> Accounts.

How Has This Been Tested?
---

- `git diff --check origin/development...HEAD`
- `artifacts/bountyops-control/board-tracker/verify-git-identity.sh attempts/BOU-3887/tari-ootle`
- `pnpm --filter tari_ootle_wallet_web_ui exec prettier --check src/routes/Wallet/Components/Accounts.tsx src/services/api/hooks/useAccounts.ts --log-level=warn`
- `pnpm build` from `applications/tari_walletd/web_ui` (`tsc && vite build`; Vite emitted the existing chunk-size warning)

I did not run live browser mutation QA because I do not have a running `tari_ootle_walletd` in this environment.

What process can a PR reviewer use to test or verify this change?
---

1. Run `npm run dev` or the usual walletd web UI dev command in `applications/tari_walletd/web_ui` against a running `tari_ootle_walletd`.
2. Open Settings -> Accounts.
3. Confirm the current default account is marked as default and has no active set-default control.
4. Click `Set default` on a non-default account.
5. Confirm the table refreshes to show the new default account, and verify a failed request displays an error alert.

Risk notes
---

This is UI-only and uses the existing JSON-RPC helper. The main risk is walletd runtime/API shape drift during live manual testing; reverting this PR removes only the new account-table default controls.

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify
