### PR TITLE
feat(walletd web UI): set the default account from Settings (closes #2308)

### DIFF
--- a/applications/tari_walletd/web_ui/src/routes/Wallet/Components/Accounts.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/Wallet/Components/Accounts.tsx
@@ -20,16 +20,17 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import { useAccountsCreate, useAccountsList } from "@api/hooks/useAccounts";
+import { useAccountsCreate, useAccountsList, useAccountsSetDefault } from "@api/hooks/useAccounts";
 import queryClient from "@api/queryClient";
 import CopyAddress from "@components/CopyAddress";
 import FetchStatusCheck from "@components/FetchStatusCheck";
 import { BoxHeading2, DataTableCell } from "@components/StyledComponents";
-import { ChevronRight } from "@mui/icons-material";
+import { ChevronRight, Star, StarBorder } from "@mui/icons-material";
 import AddIcon from "@mui/icons-material/Add";
 import Button from "@mui/material/Button";
 import Fade from "@mui/material/Fade";
 import IconButton from "@mui/material/IconButton";
+import Tooltip from "@mui/material/Tooltip";
 import Table from "@mui/material/Table";
 import TableBody from "@mui/material/TableBody";
 import TableCell from "@mui/material/TableCell";
@@ -40,10 +41,19 @@ import TextField from "@mui/material/TextField";
 import { AccountInfo, shortenSubstateId, substateIdToString } from "@tari-project/ootle-ts-bindings";
 import { useState } from "react";
 import { Form, Link } from "react-router-dom";
+import { useErrorNotification } from "../../../contexts/ErrorNotificationContext";
 
-function Account({ account }: { account: AccountInfo }) {
+function Account({
+  account,
+  onSetDefault,
+  isSettingDefault,
+}: {
+  account: AccountInfo;
+  onSetDefault: (account: AccountInfo) => void;
+  isSettingDefault: boolean;
+}) {
   const {
-    account: { name, component_address },
+    account: { name, component_address, is_default },
     address,
   } = account;
   return (
@@ -71,6 +81,26 @@ function Account({ account }: { account: AccountInfo }) {
         <CopyAddress address={address} />
       </DataTableCell>
       <DataTableCell>
+        {is_default ? (
+          <Tooltip title="Default account">
+            <Star color="primary" fontSize="small" data-testid="default-account-indicator" />
+          </Tooltip>
+        ) : (
+          <Tooltip title="Set as default">
+            <span>
+              <IconButton
+                aria-label="Set as default account"
+                size="small"
+                disabled={isSettingDefault}
+                onClick={() => onSetDefault(account)}
+              >
+                <StarBorder fontSize="small" />
+              </IconButton>
+            </span>
+          </Tooltip>
+        )}
+      </DataTableCell>
+      <DataTableCell>
         <IconButton component={Link} to={`/accounts/${substateIdToString(component_address)}`}>
           <ChevronRight />
         </IconButton>
@@ -94,6 +124,19 @@ function Accounts() {
   } = useAccountsList(0, 10);
 
   const { mutateAsync: mutateAddAccount } = useAccountsCreate();
+  const { showError, showSuccess } = useErrorNotification();
+  const { mutate: setDefaultAccount, isPending: isSettingDefault } = useAccountsSetDefault();
+
+  const onSetDefault = (account: AccountInfo) => {
+    setDefaultAccount(
+      { account: account.account.component_address },
+      {
+        onSuccess: () => showSuccess("Default account updated"),
+        onError: (error: unknown) =>
+          showError(error instanceof Error ? error.message : "Failed to set default account"),
+      },
+    );
+  };
 
   const showAddAccountDialog = (setElseToggle: boolean = !showAccountDialog) => {
     setShowAddAccountDialog(setElseToggle);
@@ -183,13 +226,19 @@ function Accounts() {
                   <TableCell>Component</TableCell>
                   <TableCell>Key index</TableCell>
                   <TableCell>Address</TableCell>
+                  <TableCell>Default</TableCell>
                   <TableCell>Details</TableCell>
                 </TableRow>
               </TableHead>
               <TableBody>
                 {dataAccountsList &&
                   dataAccountsList.accounts.map((account: AccountInfo, index) => (
-                    <Account account={account} key={index} />
+                    <Account
+                      account={account}
+                      key={index}
+                      onSetDefault={onSetDefault}
+                      isSettingDefault={isSettingDefault}
+                    />
                   ))}
               </TableBody>
             </Table>

--- a/applications/tari_walletd/web_ui/src/services/api/hooks/useAccounts.ts
+++ b/applications/tari_walletd/web_ui/src/services/api/hooks/useAccounts.ts
@@ -48,6 +48,7 @@ import {
   accountsGetDefault,
   accountsList,
   accountsRename,
+  accountsSetDefault,
   accountsStealthTransfer,
   accountsTransfer,
   mintFaucetNfts,
@@ -111,6 +112,24 @@ export const useAccountsRename = () => {
     onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({ queryKey: ["accounts"] });
       queryClient.invalidateQueries({ queryKey: [`accounts_get_${variables.account}`] });
+      queryClient.refetchQueries({ queryKey: ["accounts"] });
+    },
+  });
+};
+
+export type AccountsSetDefaultMutate = {
+  account: ComponentAddress;
+};
+
+export const useAccountsSetDefault = () => {
+  return useMutation({
+    mutationFn: async (req: AccountsSetDefaultMutate) => {
+      return await accountsSetDefault({
+        account: { ComponentAddress: req.account },
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["accounts"] });
       queryClient.refetchQueries({ queryKey: ["accounts"] });
     },
   });


### PR DESCRIPTION
Closes #2308.

Adds a way to see and change the wallet's default account from the accounts table (shared by **Settings → Accounts** and the Accounts page, so both get it). UI-only — no Rust/backend changes.

### Implementation
- New **Default** column in the accounts table.
- New `useAccountsSetDefault` react-query mutation (in `hooks/useAccounts.ts`), modeled on the existing `useAccountsRename`, calling the existing `accountsSetDefault` JSON-RPC helper with `{ account: { ComponentAddress } }`.
- Uses the `is_default` flag already present on each account.
- Errors/success go through the existing `useErrorNotification` system.

### Acceptance criteria
- [x] Table visually indicates the current default (filled ⭐ `Star`, with a "Default account" tooltip)
- [x] Every non-default account has a control (⭐ `StarBorder` icon button) to make it the default
- [x] Activating it calls `accounts.set_default` and the table reflects the new default without a manual reload (`invalidateQueries` + `refetchQueries` on `["accounts"]`)
- [x] A failed request surfaces to the user (`showError`) instead of failing silently; success shows `showSuccess`
- [x] The default indicator is **not** an actionable control on the account that is already the default (it renders a static star, no button)

### Testing
- `tsc --noEmit` on the web UI: the change introduces **0 new type errors** (identical error count with and without the change; the remaining pre-existing errors are unrelated to these files).
- The button is disabled while a set-default request is in flight (`isPending`) to avoid duplicate requests.
