### PR TITLE
fix(walletd): record locally-submitted transaction effects as one attributed balance-change row

### DIFF
--- a/applications/tari_walletd/web_ui/src/routes/AccountDetails/BalanceChangeHistory.tsx
+++ b/applications/tari_walletd/web_ui/src/routes/AccountDetails/BalanceChangeHistory.tsx
@@ -4,6 +4,7 @@
 import CopyAddress from "@components/CopyAddress";
 import FetchStatusCheck from "@components/FetchStatusCheck";
 import { DataTableCell } from "@components/StyledComponents";
+import { useTimeAgo } from "@hooks/useTimeAgo";
 import {
   Button,
   Dialog,
@@ -94,6 +95,14 @@ function NewBalance({ change, showBalance }: { change: BalanceChange; showBalanc
       )}
     </Stack>
   );
+}
+
+function ChangeTimestamp({ timestamp }: { timestamp: string | null | undefined }) {
+  const timeAgo = useTimeAgo(timestamp);
+  if (!timeAgo) {
+    return <>Unknown</>;
+  }
+  return <span title={formatTimestamp(timestamp) || undefined}>{timeAgo}</span>;
 }
 
 function Source({ change }: { change: BalanceChange }) {
@@ -213,7 +222,7 @@ export function BalanceChangeHistory({ accountAddress, resourceAddress }: Balanc
           <TableHead>
             <TableRow>
               <TableCell>Timestamp</TableCell>
-              <TableCell>Resource</TableCell>
+              {!resourceAddress && <TableCell>Resource</TableCell>}
               <TableCell>Change</TableCell>
               <TableCell>New Balance</TableCell>
               <TableCell>Source</TableCell>
@@ -222,10 +231,14 @@ export function BalanceChangeHistory({ accountAddress, resourceAddress }: Balanc
           <TableBody>
             {data?.changes.map((change) => (
               <TableRow key={change.id}>
-                <DataTableCell>{formatTimestamp(change.created_at) || "Unknown"}</DataTableCell>
                 <DataTableCell>
-                  <CopyAddress address={change.resource_address} display={change.token_symbol || undefined} />
+                  <ChangeTimestamp timestamp={change.created_at} />
                 </DataTableCell>
+                {!resourceAddress && (
+                  <DataTableCell>
+                    <CopyAddress address={change.resource_address} display={change.token_symbol || undefined} />
+                  </DataTableCell>
+                )}
                 <DataTableCell>
                   <ChangeValues change={change} showBalance={showBalance} />
                 </DataTableCell>
@@ -239,7 +252,7 @@ export function BalanceChangeHistory({ accountAddress, resourceAddress }: Balanc
             ))}
             {data?.changes.length === 0 && (
               <TableRow>
-                <TableCell colSpan={5} align="center">
+                <TableCell colSpan={resourceAddress ? 4 : 5} align="center">
                   No balance changes recorded yet.
                 </TableCell>
               </TableRow>

--- a/crates/wallet/sdk/src/apis/accounts.rs
+++ b/crates/wallet/sdk/src/apis/accounts.rs
@@ -504,6 +504,16 @@ impl<'a, TSpec: WalletSdkSpec> AccountsApi<'a, TSpec> {
         divisibility: u8,
     ) -> Result<(), AccountsApiError> {
         let mut tx = self.store.create_write_tx()?;
+        // A stealth resource's confidential balance is the account's UTXO sum, which may already have a
+        // recorded history before the vault exists. Seed the vault with the last recorded balance so the
+        // vault refresh states only what the current transaction changed, not the whole prior balance.
+        let confidential_balance = if resource_type.is_stealth() {
+            tx.balance_changes_get_latest_recorded(&account_address, &resource_address)?
+                .map(|change| change.confidential_after)
+                .unwrap_or_default()
+        } else {
+            Amount::zero()
+        };
         tx.vaults_insert(VaultModel {
             account_address,
             id: vault_address,
@@ -511,7 +521,7 @@ impl<'a, TSpec: WalletSdkSpec> AccountsApi<'a, TSpec> {
             resource_address,
             resource_type,
             revealed_balance: Amount::zero(),
-            confidential_balance: Amount::zero(),
+            confidential_balance,
             locked_revealed_balance: Amount::zero(),
             token_symbol,
             divisibility,

--- a/crates/wallet/sdk/src/apis/transaction.rs
+++ b/crates/wallet/sdk/src/apis/transaction.rs
@@ -429,13 +429,14 @@ where
                                 )?;
                             }
                         } else {
-                            tx.substates_upsert_root(
+                            // A vault created by this transaction is not in the wallet's vault table yet,
+                            // but it is referenced by this component, so record the parent linkage.
+                            tx.substates_upsert_child(
+                                &parent,
                                 VersionedSubstateIdRef::new(&owned_id, child.version()),
                                 [(*child.substate_value().vault().unwrap().resource_address()).into()]
                                     .into_iter()
                                     .collect(),
-                                None,
-                                None,
                             )?;
                         }
                         continue;

--- a/crates/wallet/sdk/src/storage/reader.rs
+++ b/crates/wallet/sdk/src/storage/reader.rs
@@ -119,6 +119,13 @@ pub trait WalletStoreReader {
         account_addr: &ComponentAddress,
         resource_address: &ResourceAddress,
     ) -> Result<Option<crate::models::BalanceChange>, WalletStorageError>;
+    /// Returns the most recent balance change for the account and resource across both vault-keyed and
+    /// vault-less rows, i.e. the last recorded absolute balances for the pair.
+    fn balance_changes_get_latest_recorded(
+        &mut self,
+        account_addr: &ComponentAddress,
+        resource_address: &ResourceAddress,
+    ) -> Result<Option<crate::models::BalanceChange>, WalletStorageError>;
 
     // Resources
     fn resources_get(&mut self, resource_address: &ResourceAddress) -> Result<ResourceModel, WalletStorageError>;

--- a/crates/wallet/sdk_services/src/account_monitor/scanner.rs
+++ b/crates/wallet/sdk_services/src/account_monitor/scanner.rs
@@ -231,17 +231,12 @@ where TSpec: WalletSdkSpec
             },
         }
 
-        if let Some(transaction_id) = source.transaction_id() &&
-            accounts_api.attribute_balance_change_to_transaction(&vault_id, vault_version, transaction_id)?
-        {
-            info!(
-                target: LOG_TARGET,
-                "🔒️ transaction {} already attributed to vault {} version {}; skipping replayed vault update",
-                transaction_id,
-                vault_id,
-                vault_version,
-            );
-            return Ok(false);
+        if let Some(transaction_id) = source.transaction_id() {
+            // Claim a scan-recorded change at this vault version for the transaction. A record already
+            // existing for this transaction (e.g. its finalize record) must not skip the update below: the
+            // balance-change insert merges the dimension this update adds and rejects replayed
+            // re-statements, and the vault snapshot comparison makes a full replay a no-op.
+            accounts_api.attribute_balance_change_to_transaction(&vault_id, vault_version, transaction_id)?;
         }
 
         info!(

--- a/crates/wallet/sdk_tests/tests/balance_changes.rs
+++ b/crates/wallet/sdk_tests/tests/balance_changes.rs
@@ -350,6 +350,57 @@ fn resource_balance_history_does_not_require_a_vault() {
     assert_eq!(page.changes[1].confidential_delta, "25");
 }
 
+// A stealth vault created for an account with prior confidential history starts from the last recorded
+// balance, so the first vault refresh states only what its transaction changed.
+#[test]
+fn adding_a_stealth_vault_seeds_confidential_balance_from_history() {
+    let test = Test::new();
+    let accounts = test.sdk().accounts_api();
+    let second_account =
+        ComponentAddress::from_str("component_91bef6af37bfb39b20260275c37a9e8acfc0517127284cd8f05944c8dddddddd")
+            .unwrap();
+    let second_vault =
+        VaultId::from_str("vault_00000000000000000000000000000000000000000000000000000000000000dd").unwrap();
+    accounts
+        .add_account(
+            Some("second"),
+            &second_account,
+            KeyId::derived(KeyBranch::ViewOnlyKey, 1),
+            KeyId::derived(KeyBranch::Account, 1),
+            Epoch::zero(),
+            true,
+            false,
+        )
+        .unwrap();
+    assert!(
+        accounts
+            .record_resource_balance_change(
+                second_account,
+                TARI_TOKEN,
+                Amount::zero(),
+                Amount::from(1_000u64),
+                BalanceChangeSource::Scan,
+            )
+            .unwrap()
+    );
+
+    accounts
+        .add_vault(
+            second_account,
+            second_vault,
+            0,
+            TARI_TOKEN,
+            ResourceType::Stealth,
+            Some("TEST".to_string()),
+            6,
+        )
+        .unwrap();
+
+    let vault = accounts.get_vault_by_resource(&second_account, &TARI_TOKEN).unwrap();
+    assert_eq!(vault.confidential_balance, Amount::from(1_000u64));
+    assert_eq!(vault.revealed_balance, Amount::zero());
+}
+
 #[test]
 fn uncached_vaultless_resource_balance_change_is_skipped() {
     let test = Test::new();

--- a/crates/wallet/storage_sqlite/src/reader.rs
+++ b/crates/wallet/storage_sqlite/src/reader.rs
@@ -810,6 +810,28 @@ impl WalletStoreReader for ReadTransaction<'_> {
             .transpose()
     }
 
+    fn balance_changes_get_latest_recorded(
+        &mut self,
+        account_addr: &ComponentAddress,
+        resource_address: &ResourceAddress,
+    ) -> Result<Option<BalanceChange>, WalletStorageError> {
+        const OPERATION: &str = "balance_changes_get_latest_recorded";
+        use crate::schema::account_balance_changes;
+
+        account_balance_changes::table
+            .filter(account_balance_changes::account_address.eq(account_addr.to_string()))
+            .filter(account_balance_changes::resource_address.eq(resource_address.to_string()))
+            .order((
+                account_balance_changes::created_at.desc(),
+                account_balance_changes::id.desc(),
+            ))
+            .first::<models::BalanceChangeRecord>(self.connection())
+            .optional()
+            .map_err(|e| WalletStorageError::general(OPERATION, e))?
+            .map(models::BalanceChangeRecord::try_into_balance_change)
+            .transpose()
+    }
+
     // -------------------------------- Resources -------------------------------- //
     fn resources_get(&mut self, resource_address: &ResourceAddress) -> Result<ResourceModel, WalletStorageError> {
         const OPERATION: &str = "resources_get";

--- a/crates/wallet/storage_sqlite/src/writer.rs
+++ b/crates/wallet/storage_sqlite/src/writer.rs
@@ -153,11 +153,13 @@ impl<'a> WriteTransaction<'a> {
         Ok(())
     }
 
+    /// Finalizes the stealth outputs held by `lock_id` against the transaction's diff and returns the
+    /// `(account_id, resource_address)` pairs whose unspent balance the finalize changed.
     fn stealth_outputs_finalize_by_lock_id(
         &mut self,
         lock_id: WalletLockId,
         diff: &SubstateDiff,
-    ) -> Result<(), WalletStorageError> {
+    ) -> Result<HashSet<(i32, ResourceAddress)>, WalletStorageError> {
         const OPERATION: &str = "stealth_outputs_finalize_by_lock_id";
         use crate::schema::stealth_outputs;
 
@@ -165,11 +167,12 @@ impl<'a> WriteTransaction<'a> {
         let locked_outputs = stealth_outputs::table
             .select((
                 stealth_outputs::id,
+                stealth_outputs::owner_account_id,
                 stealth_outputs::resource_address,
                 stealth_outputs::commitment,
             ))
             .filter(stealth_outputs::lock_id.eq(lock_id))
-            .load_iter::<(i32, String, String), _>(self.connection())
+            .load_iter::<(i32, i32, String, String), _>(self.connection())
             .map_err(|e| WalletStorageError::general(OPERATION, e))?;
 
         let up_id_index = diff
@@ -182,10 +185,12 @@ impl<'a> WriteTransaction<'a> {
             .collect::<HashSet<_>>();
         let mut to_confirm = vec![];
         let mut to_spend = vec![];
+        let mut affected_balances = HashSet::new();
 
         for res in locked_outputs {
-            let (id, resx, commitment) = res.map_err(|e| WalletStorageError::general(OPERATION, e))?;
-            let resource_address = resx.parse().map_err(|_| WalletStorageError::DecodingError {
+            let (id, owner_account_id, resx, commitment) =
+                res.map_err(|e| WalletStorageError::general(OPERATION, e))?;
+            let resource_address: ResourceAddress = resx.parse().map_err(|_| WalletStorageError::DecodingError {
                 operation: "try_to_substate_id",
                 item: "output",
                 details: format!("Corrupt db: invalid resource address '{resx}' for id {id}"),
@@ -203,8 +208,10 @@ impl<'a> WriteTransaction<'a> {
 
             if is_upped {
                 to_confirm.push(id);
+                affected_balances.insert((owner_account_id, resource_address));
             } else if is_downed {
                 to_spend.push(id);
+                affected_balances.insert((owner_account_id, resource_address));
             } else {
                 // Lock will be released (i.e. LockedUnconfirmed outputs deleted, LockedForSpend -> Unspent)
             }
@@ -244,7 +251,277 @@ impl<'a> WriteTransaction<'a> {
         // Any outputs that were not confirmed or spent are released
         self.stealth_outputs_release_by_lock_id(lock_id)?;
 
+        Ok(affected_balances)
+    }
+
+    /// Reads the vault and revealed amount reserved by `lock_id` before the lock is finalized, so the
+    /// resulting revealed-balance decrease can be recorded. Returns `(vault, revealed_before, amount)`.
+    fn locked_revealed_spend(
+        &mut self,
+        lock_id: WalletLockId,
+    ) -> Result<Option<(VaultId, Amount, Amount)>, WalletStorageError> {
+        const OPERATION: &str = "locked_revealed_spend";
+        use crate::schema::{vault_locks, vaults};
+
+        let row = vault_locks::table
+            .inner_join(vaults::table.on(vaults::id.eq(vault_locks::vault_id)))
+            .select((vaults::address, vaults::revealed_balance, vault_locks::amount))
+            .filter(vault_locks::lock_id.eq(lock_id))
+            .first::<(String, String, String)>(self.connection())
+            .optional()
+            .map_err(|e| WalletStorageError::general(OPERATION, e))?;
+        let Some((vault_address, revealed_before, amount)) = row else {
+            return Ok(None);
+        };
+        let vault_address = VaultId::from_str(&vault_address).map_err(|e| WalletStorageError::DecodingError {
+            operation: OPERATION,
+            item: "vault.address",
+            details: e.to_string(),
+        })?;
+        let revealed_before = Amount::from_str(&revealed_before).map_err(|e| WalletStorageError::DataInconsistent {
+            operation: OPERATION,
+            details: format!("Corrupt db: invalid revealed balance '{revealed_before}' for lock {lock_id}: {e}"),
+        })?;
+        let amount = Amount::from_str(&amount).map_err(|e| WalletStorageError::DataInconsistent {
+            operation: OPERATION,
+            details: format!("Corrupt db: invalid lock amount '{amount}' for lock {lock_id}: {e}"),
+        })?;
+        Ok(Some((vault_address, revealed_before, amount)))
+    }
+
+    fn lock_transaction_id(&mut self, lock_id: WalletLockId) -> Result<Option<TransactionId>, WalletStorageError> {
+        const OPERATION: &str = "lock_transaction_id";
+        use crate::schema::locks;
+
+        let Some(transaction_id_hex) = locks::table
+            .select(locks::transaction_id)
+            .filter(locks::id.eq(lock_id))
+            .first::<Option<String>>(self.connection())
+            .optional()
+            .map_err(|e| WalletStorageError::general(OPERATION, e))?
+            .flatten()
+        else {
+            return Ok(None);
+        };
+        let transaction_id: TransactionId =
+            deserialize_hex_try_from(&transaction_id_hex).map_err(|e| WalletStorageError::DecodingError {
+                operation: OPERATION,
+                item: "lock.transaction_id",
+                details: e.to_string(),
+            })?;
+        Ok(Some(transaction_id))
+    }
+
+    /// Records the revealed-balance movement of a finalized spend as a `Transaction`-sourced balance change
+    /// and syncs the wallet vault to it. The vault substate in the finalized diff is the authoritative
+    /// post-transaction revealed balance: the locked amount is only the wallet's reservation, which the
+    /// transaction may not fully (or at all) withdraw from the vault. The row is keyed on the vault's
+    /// post-transaction version so that the account refresh's later record of the same transaction's
+    /// confidential effect merges onto this one row.
+    fn record_finalized_revealed_spend(
+        &mut self,
+        lock_id: WalletLockId,
+        vault_address: VaultId,
+        revealed_before: Amount,
+        amount: Amount,
+        diff: &SubstateDiff,
+    ) -> Result<(), WalletStorageError> {
+        const OPERATION: &str = "record_finalized_revealed_spend";
+
+        let Some(transaction_id) = self.lock_transaction_id(lock_id)? else {
+            // No transaction linked to the lock — the spend cannot be attributed, so skip recording.
+            return Ok(());
+        };
+
+        let diff_vault = diff
+            .up_iter()
+            .find(|(id, _)| *id == SubstateId::Vault(vault_address))
+            .and_then(|(_, substate)| {
+                substate
+                    .substate_value()
+                    .vault()
+                    .map(|vault| (vault.balance(), substate.version()))
+            });
+
+        let vault = self.vaults_get(&vault_address)?;
+        let (revealed_after, vault_version) = match diff_vault {
+            Some((revealed_after, version)) => (revealed_after, version),
+            None => {
+                let revealed_after =
+                    revealed_before
+                        .checked_sub(amount)
+                        .ok_or_else(|| WalletStorageError::OperationError {
+                            operation: OPERATION,
+                            details: format!("revealed balance {revealed_before} is less than spent amount {amount}"),
+                        })?;
+                (revealed_after, vault.vault_version)
+            },
+        };
+        if revealed_after == revealed_before {
+            return Ok(());
+        }
+
+        self.balance_changes_insert(
+            BalanceChangeSnapshot {
+                account_address: vault.account_address,
+                vault_address: Some(vault_address),
+                vault_version: Some(vault_version),
+                resource_address: vault.resource_address,
+                token_symbol: vault.token_symbol,
+                divisibility: vault.divisibility,
+                revealed_before,
+                revealed_after,
+                confidential_before: vault.confidential_balance,
+                confidential_after: vault.confidential_balance,
+            },
+            BalanceChangeSource::Transaction { transaction_id },
+        )?;
+        self.vaults_update(vault_address, vault_version, revealed_after, vault.confidential_balance)?;
         Ok(())
+    }
+
+    /// Records the confidential (stealth UTXO) balance movement of a finalized spend for each affected
+    /// account as a `Transaction`-sourced balance change, so a locally-submitted transaction's full effect is
+    /// attributed to it rather than to a later scan. The row is keyed so that later records of the same
+    /// transaction converge onto it: when the transaction's diff contains the account's vault for the
+    /// resource, the change is keyed on that vault at its post-transaction version (the account refresh then
+    /// merges the revealed effect onto the same row); otherwise it is a vault-less row keyed by
+    /// (account, resource, transaction). The scanner's later pass re-derives the same balance, so its record
+    /// nets to zero and is not duplicated.
+    fn record_finalized_stealth_spends(
+        &mut self,
+        lock_id: WalletLockId,
+        affected_balances: HashSet<(i32, ResourceAddress)>,
+        diff: &SubstateDiff,
+    ) -> Result<(), WalletStorageError> {
+        const OPERATION: &str = "record_finalized_stealth_spends";
+        use crate::schema::accounts;
+
+        if affected_balances.is_empty() {
+            return Ok(());
+        }
+        let Some(transaction_id) = self.lock_transaction_id(lock_id)? else {
+            // No transaction linked to the lock — the spend cannot be attributed, so skip recording.
+            return Ok(());
+        };
+
+        for (account_id, resource_address) in affected_balances {
+            let address = accounts::table
+                .select(accounts::address)
+                .filter(accounts::id.eq(account_id))
+                .first::<String>(self.connection())
+                .map_err(|e| WalletStorageError::general(OPERATION, e))?;
+            let account_address =
+                ComponentAddress::from_str(&address).map_err(|e| WalletStorageError::DecodingError {
+                    operation: OPERATION,
+                    item: "account.address",
+                    details: e.to_string(),
+                })?;
+
+            let confidential_after = self
+                .stealth_outputs_get_unspent_by_account(&account_address, Some(&resource_address), false)?
+                .into_iter()
+                .map(|output| Amount::from(output.value))
+                .sum::<Amount>();
+
+            let maybe_vault = self
+                .vaults_get_by_resource(&account_address, &resource_address)
+                .optional()?;
+            let maybe_diff_vault = self.account_vault_in_diff(&account_address, &resource_address, diff)?;
+
+            let (token_symbol, divisibility) = if let Some(vault) = &maybe_vault {
+                (vault.token_symbol.clone(), vault.divisibility)
+            } else {
+                let Some(resource) = self.resources_get(&resource_address).optional()? else {
+                    warn!(
+                        target: LOG_TARGET,
+                        "Skipping balance-change record for account {} resource {} because resource metadata is not \
+                         cached",
+                        account_address,
+                        resource_address
+                    );
+                    continue;
+                };
+                (
+                    resource.resource.token_symbol().map(ToOwned::to_owned),
+                    resource.resource.divisibility(),
+                )
+            };
+
+            let (revealed_balance, confidential_before) = if let Some(vault) = &maybe_vault {
+                (vault.revealed_balance, vault.confidential_balance)
+            } else {
+                let latest =
+                    self.balance_changes_get_latest_by_account_resource(&account_address, &resource_address)?;
+                (
+                    latest.as_ref().map(|change| change.revealed_after).unwrap_or_default(),
+                    latest
+                        .as_ref()
+                        .map(|change| change.confidential_after)
+                        .unwrap_or_default(),
+                )
+            };
+
+            let (vault_address, vault_version) = match maybe_diff_vault {
+                Some((vault_id, version)) => (Some(vault_id), Some(version)),
+                None => (None, None),
+            };
+
+            self.balance_changes_insert(
+                BalanceChangeSnapshot {
+                    account_address,
+                    vault_address,
+                    vault_version,
+                    resource_address,
+                    token_symbol,
+                    divisibility,
+                    revealed_before: revealed_balance,
+                    revealed_after: revealed_balance,
+                    confidential_before,
+                    confidential_after,
+                },
+                BalanceChangeSource::Transaction { transaction_id },
+            )?;
+
+            // Keep the vault's confidential balance in sync so the account refresh and scanner re-derive an
+            // unchanged balance instead of re-recording this transaction's effect.
+            if let Some(vault) = &maybe_vault {
+                let version = maybe_diff_vault
+                    .map(|(_, version)| version)
+                    .unwrap_or(vault.vault_version);
+                self.vaults_update(vault.id, version, vault.revealed_balance, confidential_after)?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Finds the account's vault for `resource_address` in the transaction diff, using the substate parent
+    /// linkage recorded by the diff commit. Returns the vault and its post-transaction version.
+    fn account_vault_in_diff(
+        &mut self,
+        account_address: &ComponentAddress,
+        resource_address: &ResourceAddress,
+        diff: &SubstateDiff,
+    ) -> Result<Option<(VaultId, u32)>, WalletStorageError> {
+        for (id, substate) in diff.up_iter() {
+            let Some(vault_id) = id.as_vault_id() else {
+                continue;
+            };
+            let Some(vault) = substate.substate_value().vault() else {
+                continue;
+            };
+            if vault.resource_address() != resource_address {
+                continue;
+            }
+            let parent = self
+                .substates_get(&SubstateId::Vault(vault_id))
+                .optional()?
+                .and_then(|substate| substate.parent_address);
+            if parent.is_some_and(|parent| parent == SubstateId::Component(*account_address)) {
+                return Ok(Some((vault_id, substate.version())));
+            }
+        }
+        Ok(None)
     }
 }
 
@@ -795,6 +1072,7 @@ impl WalletStoreWriter for WriteTransaction<'_> {
         Ok(())
     }
 
+    #[allow(clippy::too_many_lines)]
     fn balance_changes_insert(
         &mut self,
         change: BalanceChangeSnapshot,
@@ -845,7 +1123,62 @@ impl WalletStoreWriter for WriteTransaction<'_> {
         }
 
         let (Some(vault_address), Some(vault_version)) = (change.vault_address.as_ref(), change.vault_version) else {
-            return Ok(false);
+            // A vault-less conflict can only be with the same transaction's row for this account and
+            // resource (the unique index includes the transaction id). Later records of the transaction's
+            // effect (e.g. an output of the transaction discovered after the finalize record) extend the
+            // row's after-balances so the single row holds the transaction's net effect.
+            let Some(transaction_id) = source.transaction_id().map(|id| id.to_string()) else {
+                return Ok(false);
+            };
+            let maybe_existing = account_balance_changes::table
+                .filter(account_balance_changes::account_id.eq(account_id))
+                .filter(account_balance_changes::resource_id.eq(resource_id))
+                .filter(account_balance_changes::transaction_id.eq(Some(&transaction_id)))
+                .select((
+                    account_balance_changes::id,
+                    account_balance_changes::revealed_before,
+                    account_balance_changes::revealed_after,
+                    account_balance_changes::confidential_before,
+                    account_balance_changes::confidential_after,
+                ))
+                .first::<(i32, String, String, String, String)>(self.connection())
+                .optional()
+                .map_err(|e| WalletStorageError::general(OPERATION, e))?;
+            let Some((id, revealed_before, existing_revealed_after, confidential_before, existing_confidential_after)) =
+                maybe_existing
+            else {
+                return Ok(false);
+            };
+
+            let merged_revealed_after = if change.revealed_before == change.revealed_after {
+                existing_revealed_after.clone()
+            } else {
+                change.revealed_after.to_string()
+            };
+            let merged_confidential_after = if change.confidential_before == change.confidential_after {
+                existing_confidential_after.clone()
+            } else {
+                change.confidential_after.to_string()
+            };
+            if merged_revealed_after == existing_revealed_after &&
+                merged_confidential_after == existing_confidential_after
+            {
+                return Ok(false);
+            }
+            if revealed_before == merged_revealed_after && confidential_before == merged_confidential_after {
+                let deleted = diesel::delete(account_balance_changes::table.filter(account_balance_changes::id.eq(id)))
+                    .execute(self.connection())
+                    .map_err(|e| WalletStorageError::general(OPERATION, e))?;
+                return Ok(deleted == 1);
+            }
+            let updated = diesel::update(account_balance_changes::table.filter(account_balance_changes::id.eq(id)))
+                .set((
+                    account_balance_changes::revealed_after.eq(merged_revealed_after),
+                    account_balance_changes::confidential_after.eq(merged_confidential_after),
+                ))
+                .execute(self.connection())
+                .map_err(|e| WalletStorageError::general(OPERATION, e))?;
+            return Ok(updated == 1);
         };
         let vault_address = vault_address.to_string();
         let maybe_existing = account_balance_changes::table
@@ -854,25 +1187,147 @@ impl WalletStoreWriter for WriteTransaction<'_> {
             .select((
                 account_balance_changes::id,
                 account_balance_changes::source_type,
+                account_balance_changes::transaction_id,
                 account_balance_changes::revealed_before,
+                account_balance_changes::revealed_after,
                 account_balance_changes::confidential_before,
+                account_balance_changes::confidential_after,
             ))
-            .first::<(i32, String, String, String)>(self.connection())
+            .first::<(i32, String, Option<String>, String, String, String, String)>(self.connection())
             .optional()
             .map_err(|e| WalletStorageError::general(OPERATION, e))?;
-        let Some((id, source_type, revealed_before, confidential_before)) = maybe_existing else {
-            return Ok(false);
+        let Some((
+            id,
+            source_type,
+            existing_transaction_id,
+            revealed_before,
+            existing_revealed_after,
+            confidential_before,
+            existing_confidential_after,
+        )) = maybe_existing
+        else {
+            // The insert conflicted on the transaction key rather than the vault version: the transaction's
+            // effect was first recorded under a different key shape (e.g. a vault-less finalize record made
+            // before the vault row existed). Fill only the balance dimension this record adds — a
+            // re-statement of an already-recorded dimension is a replay and must not modify the row.
+            let Some(transaction_id) = source.transaction_id().map(|id| id.to_string()) else {
+                return Ok(false);
+            };
+            let maybe_row = account_balance_changes::table
+                .filter(account_balance_changes::account_id.eq(account_id))
+                .filter(account_balance_changes::resource_id.eq(resource_id))
+                .filter(account_balance_changes::transaction_id.eq(Some(&transaction_id)))
+                .select((
+                    account_balance_changes::id,
+                    account_balance_changes::revealed_before,
+                    account_balance_changes::revealed_after,
+                    account_balance_changes::confidential_before,
+                    account_balance_changes::confidential_after,
+                ))
+                .first::<(i32, String, String, String, String)>(self.connection())
+                .optional()
+                .map_err(|e| WalletStorageError::general(OPERATION, e))?;
+            let Some((id, revealed_before, existing_revealed_after, confidential_before, existing_confidential_after)) =
+                maybe_row
+            else {
+                return Ok(false);
+            };
+
+            let incoming_changes_revealed = change.revealed_before != change.revealed_after;
+            let incoming_changes_confidential = change.confidential_before != change.confidential_after;
+            let existing_changed_revealed = revealed_before != existing_revealed_after;
+            let existing_changed_confidential = confidential_before != existing_confidential_after;
+            if (incoming_changes_revealed && existing_changed_revealed) ||
+                (incoming_changes_confidential && existing_changed_confidential)
+            {
+                return Ok(false);
+            }
+            let merged_revealed_after = if incoming_changes_revealed {
+                change.revealed_after.to_string()
+            } else {
+                existing_revealed_after.clone()
+            };
+            let merged_confidential_after = if incoming_changes_confidential {
+                change.confidential_after.to_string()
+            } else {
+                existing_confidential_after.clone()
+            };
+            if merged_revealed_after == existing_revealed_after &&
+                merged_confidential_after == existing_confidential_after
+            {
+                return Ok(false);
+            }
+            if revealed_before == merged_revealed_after && confidential_before == merged_confidential_after {
+                let deleted = diesel::delete(account_balance_changes::table.filter(account_balance_changes::id.eq(id)))
+                    .execute(self.connection())
+                    .map_err(|e| WalletStorageError::general(OPERATION, e))?;
+                return Ok(deleted == 1);
+            }
+            let updated = diesel::update(account_balance_changes::table.filter(account_balance_changes::id.eq(id)))
+                .set((
+                    account_balance_changes::revealed_after.eq(merged_revealed_after),
+                    account_balance_changes::confidential_after.eq(merged_confidential_after),
+                ))
+                .execute(self.connection())
+                .map_err(|e| WalletStorageError::general(OPERATION, e))?;
+            return Ok(updated == 1);
         };
 
-        if source_type == BalanceChangeSourceType::Transaction.as_key_str() {
-            return Ok(false);
-        }
-        if source.transaction_id().is_some() {
-            return Ok(false);
-        }
-
+        let incoming_transaction_id = source.transaction_id().map(|id| id.to_string());
+        let existing_is_transaction = source_type == BalanceChangeSourceType::Transaction.as_key_str();
         let revealed_after = change.revealed_after.to_string();
         let confidential_after = change.confidential_after.to_string();
+
+        if existing_is_transaction {
+            // A transaction row is written in up to two steps that converge onto one row: its revealed spend
+            // when the transaction is finalized, and its confidential effect on the next account refresh. It
+            // may therefore only be extended by a further record of the SAME transaction, and only for a
+            // balance dimension it has not already recorded. A different transaction, or a re-statement of an
+            // already-recorded dimension (a replayed event), must not modify it.
+            if incoming_transaction_id != existing_transaction_id {
+                return Ok(false);
+            }
+            let incoming_changes_revealed = change.revealed_before != change.revealed_after;
+            let incoming_changes_confidential = change.confidential_before != change.confidential_after;
+            let existing_changed_revealed = revealed_before != existing_revealed_after;
+            let existing_changed_confidential = confidential_before != existing_confidential_after;
+            if (incoming_changes_revealed && existing_changed_revealed) ||
+                (incoming_changes_confidential && existing_changed_confidential)
+            {
+                return Ok(false);
+            }
+            let merged_revealed_after = if incoming_changes_revealed {
+                revealed_after
+            } else {
+                existing_revealed_after
+            };
+            let merged_confidential_after = if incoming_changes_confidential {
+                confidential_after
+            } else {
+                existing_confidential_after
+            };
+            if revealed_before == merged_revealed_after && confidential_before == merged_confidential_after {
+                let deleted = diesel::delete(account_balance_changes::table.filter(account_balance_changes::id.eq(id)))
+                    .execute(self.connection())
+                    .map_err(|e| WalletStorageError::general(OPERATION, e))?;
+                return Ok(deleted == 1);
+            }
+            let updated = diesel::update(account_balance_changes::table.filter(account_balance_changes::id.eq(id)))
+                .set((
+                    account_balance_changes::revealed_after.eq(merged_revealed_after),
+                    account_balance_changes::confidential_after.eq(merged_confidential_after),
+                ))
+                .execute(self.connection())
+                .map_err(|e| WalletStorageError::general(OPERATION, e))?;
+            return Ok(updated == 1);
+        }
+
+        // The existing row is a scan/recovery record. An incoming transaction is linked to it via
+        // balance_changes_attribute_transaction rather than here, so it does not upsert. A scan/recovery
+        // updates the cumulative after-balances, deleting the row if the change now nets to zero.
+        if incoming_transaction_id.is_some() {
+            return Ok(false);
+        }
         if revealed_before == revealed_after && confidential_before == confidential_after {
             let deleted = diesel::delete(account_balance_changes::table.filter(account_balance_changes::id.eq(id)))
                 .execute(self.connection())
@@ -1601,9 +2056,16 @@ impl WalletStoreWriter for WriteTransaction<'_> {
     }
 
     fn locks_unlock_finalized(&mut self, lock_id: WalletLockId, diff: &SubstateDiff) -> Result<(), WalletStorageError> {
-        self.stealth_outputs_finalize_by_lock_id(lock_id, diff)?;
+        let affected_stealth_balances = self.stealth_outputs_finalize_by_lock_id(lock_id, diff)?;
         self.confidential_outputs_finalize_by_lock_id(lock_id)?;
+        // Capture the revealed spend before vaults_finalized_locked_revealed_funds deletes the vault lock
+        // and decrements the vault's revealed balance, so the decrease can be recorded as a balance change.
+        let revealed_spend = self.locked_revealed_spend(lock_id)?;
         self.vaults_finalized_locked_revealed_funds(lock_id).optional()?;
+        if let Some((vault_address, revealed_before, amount)) = revealed_spend {
+            self.record_finalized_revealed_spend(lock_id, vault_address, revealed_before, amount, diff)?;
+        }
+        self.record_finalized_stealth_spends(lock_id, affected_stealth_balances, diff)?;
         self.locks_delete(lock_id)?;
         Ok(())
     }

--- a/crates/wallet/storage_sqlite/tests/balance_changes.rs
+++ b/crates/wallet/storage_sqlite/tests/balance_changes.rs
@@ -14,17 +14,34 @@ use tari_crypto::{
     keys::PublicKey,
     ristretto::{RistrettoPublicKey, RistrettoSecretKey},
 };
-use tari_engine_types::resource::Resource;
-use tari_ootle_common_types::Epoch;
+use tari_engine_types::{
+    Utxo,
+    resource::Resource,
+    resource_container::ResourceContainer,
+    substate::{Substate, SubstateDiff, SubstateId},
+    vault::Vault,
+};
+use tari_ootle_common_types::{Epoch, VersionedSubstateIdRef};
 use tari_ootle_transaction::{Transaction, args};
 use tari_ootle_wallet_sdk::{
-    models::{BalanceChangeSnapshot, BalanceChangeSource, BalanceChangeSourceType, KeyBranch, KeyId, VaultModel},
+    models::{
+        BalanceChangeSnapshot,
+        BalanceChangeSource,
+        BalanceChangeSourceType,
+        KeyBranch,
+        KeyId,
+        OutputStatus,
+        StealthOutputModel,
+        VaultModel,
+        WalletLockId,
+    },
     storage::{CommittableStore, ReadableWalletStore, WalletStoreReader, WalletStoreWriter, WriteableWalletStore},
 };
 use tari_ootle_wallet_storage_sqlite::SqliteWalletStore;
 use tari_template_lib_types::{
     Amount,
     ComponentAddress,
+    EncryptedData,
     Metadata,
     ResourceAddress,
     ResourceType,
@@ -32,6 +49,8 @@ use tari_template_lib_types::{
     VaultId,
     access_rules::ResourceAccessRules,
     constants::TOKEN_SYMBOL,
+    crypto::{PedersenCommitmentBytes, RistrettoPublicKeyBytes, UtxoTag},
+    stealth::SpendAuthorization,
 };
 
 fn build_transaction(seed: u64) -> Transaction {
@@ -652,6 +671,663 @@ fn same_version_scan_does_not_clobber_transaction_row() {
     assert_eq!(page.changes[0].revealed_after, Amount::from(10u64));
     let vault = tx.vaults_get(&first_vault).unwrap();
     assert_eq!(vault.revealed_balance, Amount::from(20u64));
+}
+
+// A finalized spend records its revealed decrease (at lock-finalize) and the account refresh later records
+// the same transaction's confidential effect; both must converge onto one row rather than the second being
+// dropped by the "never clobber a transaction row" rule.
+#[test]
+fn same_transaction_merges_revealed_finalize_and_confidential_refresh() {
+    let (store, first_vault, _, _, _) = setup_store();
+    let transaction = build_transaction(6);
+    let transaction_id = transaction.calculate_id();
+    let other = build_transaction(7);
+    let other_id = other.calculate_id();
+    let mut tx = store.create_write_tx().unwrap();
+    tx.transactions_insert(&transaction, None, &[account_address()], false)
+        .unwrap();
+    tx.transactions_insert(&other, None, &[account_address()], false)
+        .unwrap();
+    tx.commit().unwrap();
+    drop(tx);
+
+    let snapshot = |revealed_before: u64, revealed_after: u64, confidential_before: u64, confidential_after: u64| {
+        BalanceChangeSnapshot {
+            account_address: account_address(),
+            vault_address: Some(first_vault),
+            vault_version: Some(1),
+            resource_address: resource_address(1),
+            token_symbol: Some("COIN".to_string()),
+            divisibility: 6,
+            revealed_before: Amount::from(revealed_before),
+            revealed_after: Amount::from(revealed_after),
+            confidential_before: Amount::from(confidential_before),
+            confidential_after: Amount::from(confidential_after),
+        }
+    };
+
+    // Lock-finalize records the revealed spend (100 -> 90), confidential untouched.
+    let mut tx = store.create_write_tx().unwrap();
+    assert!(
+        tx.balance_changes_insert(snapshot(100, 90, 0, 0), BalanceChangeSource::Transaction {
+            transaction_id
+        })
+        .unwrap()
+    );
+    // The account refresh records the same transaction's confidential effect (0 -> 50) at the same version.
+    assert!(
+        tx.balance_changes_insert(snapshot(90, 90, 0, 50), BalanceChangeSource::Transaction {
+            transaction_id
+        })
+        .unwrap()
+    );
+    // A different transaction at the same (vault, version) must not overwrite the row.
+    assert!(
+        !tx.balance_changes_insert(snapshot(90, 80, 50, 50), BalanceChangeSource::Transaction {
+            transaction_id: other_id
+        })
+        .unwrap()
+    );
+    tx.commit().unwrap();
+    drop(tx);
+
+    let mut tx = store.create_read_tx().unwrap();
+    let page = tx
+        .balance_changes_get_page_by_account(&account_address(), 0, 10, None, None, None)
+        .unwrap();
+    assert_eq!(page.total, 1);
+    let change = &page.changes[0];
+    assert_eq!(change.source, BalanceChangeSource::Transaction { transaction_id });
+    assert_eq!(change.revealed_before, Amount::from(100u64));
+    assert_eq!(change.revealed_after, Amount::from(90u64));
+    assert_eq!(change.revealed_delta, "-10");
+    assert_eq!(change.confidential_after, Amount::from(50u64));
+    assert_eq!(change.confidential_delta, "50");
+}
+
+fn stealth_output(
+    account: ComponentAddress,
+    resource_address: ResourceAddress,
+    value: u64,
+    seed: u8,
+    status: OutputStatus,
+    lock_id: Option<WalletLockId>,
+) -> StealthOutputModel {
+    StealthOutputModel {
+        owner_account: account,
+        resource_address,
+        commitment: PedersenCommitmentBytes::from_array([seed; PedersenCommitmentBytes::length()]),
+        value,
+        sender_public_nonce: RistrettoPublicKeyBytes::from_bytes(
+            &[seed.wrapping_add(1); RistrettoPublicKeyBytes::length()],
+        )
+        .unwrap(),
+        view_only_key_id: KeyId::derived(KeyBranch::ViewOnlyKey, 0),
+        owner_key_id: Some(KeyId::derived(KeyBranch::Account, 0)),
+        encrypted_data: EncryptedData::try_from(vec![0; EncryptedData::min_size()]).unwrap(),
+        tag_byte: UtxoTag::new(u32::from(seed)),
+        memo: None,
+        auth: SpendAuthorization::Key(RistrettoPublicKeyBytes::default()),
+        minimum_value_promise: 0,
+        status,
+        is_burnt: false,
+        is_frozen: false,
+        is_on_chain: !matches!(status, OutputStatus::LockedUnconfirmed),
+        is_condition_spendable: true,
+        lock_id,
+    }
+}
+
+fn upsert_stealth_resource(tx: &mut impl WalletStoreWriter, resource_address: &ResourceAddress) {
+    tx.resources_upsert(
+        resource_address,
+        &Resource::new(
+            ResourceType::Stealth,
+            SubstateOwnerRule::None,
+            ResourceAccessRules::new(),
+            Metadata::from([(TOKEN_SYMBOL, "STEALTH".to_string())]),
+            None,
+            None,
+            6,
+            false,
+        ),
+    )
+    .unwrap();
+}
+
+// A confidential spend from a vault-less account must be recorded at lock-finalize as a
+// transaction-sourced change so the spend is attributed to its transaction; the scanner's later
+// pass over the same balance then has nothing new to record.
+#[test]
+fn lock_finalize_records_confidential_spend_for_vaultless_account() {
+    let (store, _, _, _, _) = setup_store();
+    let stealth_resource = resource_address(3);
+    let account = account_address();
+    let transaction = build_transaction(8);
+    let transaction_id = transaction.calculate_id();
+
+    let mut tx = store.create_write_tx().unwrap();
+    upsert_stealth_resource(&mut tx, &stealth_resource);
+    tx.transactions_insert(&transaction, None, &[account], false).unwrap();
+
+    // Prior received balance recorded by an earlier scan.
+    assert!(
+        tx.balance_changes_insert(
+            BalanceChangeSnapshot {
+                account_address: account,
+                vault_address: None,
+                vault_version: None,
+                resource_address: stealth_resource,
+                token_symbol: Some("STEALTH".to_string()),
+                divisibility: 6,
+                revealed_before: Amount::zero(),
+                revealed_after: Amount::zero(),
+                confidential_before: Amount::zero(),
+                confidential_after: Amount::from(1_000_000u64),
+            },
+            BalanceChangeSource::Scan,
+        )
+        .unwrap()
+    );
+
+    let spent = stealth_output(account, stealth_resource, 1_000_000, 7, OutputStatus::Unspent, None);
+    tx.stealth_outputs_insert(&spent).unwrap();
+    let lock_id = tx.locks_create(None).unwrap();
+    tx.locks_link_transaction(lock_id, transaction_id).unwrap();
+    tx.stealth_outputs_lock_many(&stealth_resource, &[&spent.commitment], lock_id)
+        .unwrap();
+    let change = stealth_output(
+        account,
+        stealth_resource,
+        989_343,
+        8,
+        OutputStatus::LockedUnconfirmed,
+        Some(lock_id),
+    );
+    tx.stealth_outputs_insert(&change).unwrap();
+
+    let mut diff = SubstateDiff::new();
+    diff.down(SubstateId::Utxo(spent.to_utxo_address()), 0);
+    diff.up(
+        SubstateId::Utxo(change.to_utxo_address()),
+        Substate::new(0, Utxo {
+            output: None,
+            is_frozen: false,
+        }),
+    );
+    tx.locks_unlock_finalized(lock_id, &diff).unwrap();
+    tx.commit().unwrap();
+    drop(tx);
+
+    let mut tx = store.create_read_tx().unwrap();
+    let page = tx
+        .balance_changes_get_page_by_account(&account, 0, 10, Some(&stealth_resource), None, None)
+        .unwrap();
+    assert_eq!(page.total, 2);
+    let spend_change = &page.changes[0];
+    assert_eq!(spend_change.source, BalanceChangeSource::Transaction { transaction_id });
+    assert_eq!(spend_change.vault_address, None);
+    assert_eq!(spend_change.confidential_before, Amount::from(1_000_000u64));
+    assert_eq!(spend_change.confidential_after, Amount::from(989_343u64));
+    assert_eq!(spend_change.confidential_delta, "-10657");
+    assert_eq!(spend_change.revealed_delta, "0");
+    drop(tx);
+
+    // The scanner later re-derives the same balance from the outputs; that must be a no-op.
+    let mut tx = store.create_write_tx().unwrap();
+    assert!(
+        !tx.balance_changes_insert(
+            BalanceChangeSnapshot {
+                account_address: account,
+                vault_address: None,
+                vault_version: None,
+                resource_address: stealth_resource,
+                token_symbol: Some("STEALTH".to_string()),
+                divisibility: 6,
+                revealed_before: Amount::zero(),
+                revealed_after: Amount::zero(),
+                confidential_before: Amount::from(989_343u64),
+                confidential_after: Amount::from(989_343u64),
+            },
+            BalanceChangeSource::Scan,
+        )
+        .unwrap()
+    );
+    tx.rollback().unwrap();
+}
+
+// A confidential spend from an account whose stealth vault is untouched by the transaction records a
+// no-vault transaction row against the vault's balance and keeps the vault in sync, so the scanner's
+// later pass re-derives an unchanged balance.
+#[test]
+fn lock_finalize_records_confidential_spend_for_vault_backed_resource() {
+    let (store, _, _, _, _) = setup_store();
+    let stealth_resource = resource_address(3);
+    let stealth_vault = vault_address(3);
+    let account = account_address();
+    let transaction = build_transaction(9);
+    let transaction_id = transaction.calculate_id();
+
+    let mut tx = store.create_write_tx().unwrap();
+    upsert_stealth_resource(&mut tx, &stealth_resource);
+    tx.vaults_insert(VaultModel {
+        account_address: account,
+        id: stealth_vault,
+        vault_version: 0,
+        resource_address: stealth_resource,
+        resource_type: ResourceType::Stealth,
+        confidential_balance: Amount::from(1_000_000u64),
+        revealed_balance: Amount::from(500u64),
+        locked_revealed_balance: Amount::zero(),
+        token_symbol: Some("STEALTH".to_string()),
+        divisibility: 6,
+    })
+    .unwrap();
+    tx.transactions_insert(&transaction, None, &[account], false).unwrap();
+
+    let spent = stealth_output(account, stealth_resource, 1_000_000, 9, OutputStatus::Unspent, None);
+    tx.stealth_outputs_insert(&spent).unwrap();
+    let lock_id = tx.locks_create(None).unwrap();
+    tx.locks_link_transaction(lock_id, transaction_id).unwrap();
+    tx.stealth_outputs_lock_many(&stealth_resource, &[&spent.commitment], lock_id)
+        .unwrap();
+    let change = stealth_output(
+        account,
+        stealth_resource,
+        900_000,
+        10,
+        OutputStatus::LockedUnconfirmed,
+        Some(lock_id),
+    );
+    tx.stealth_outputs_insert(&change).unwrap();
+
+    let mut diff = SubstateDiff::new();
+    diff.down(SubstateId::Utxo(spent.to_utxo_address()), 0);
+    diff.up(
+        SubstateId::Utxo(change.to_utxo_address()),
+        Substate::new(0, Utxo {
+            output: None,
+            is_frozen: false,
+        }),
+    );
+    tx.locks_unlock_finalized(lock_id, &diff).unwrap();
+    tx.commit().unwrap();
+    drop(tx);
+
+    let mut tx = store.create_read_tx().unwrap();
+    let page = tx
+        .balance_changes_get_page_by_account(&account, 0, 10, Some(&stealth_resource), None, None)
+        .unwrap();
+    assert_eq!(page.total, 1);
+    let change_row = &page.changes[0];
+    assert_eq!(change_row.source, BalanceChangeSource::Transaction { transaction_id });
+    assert_eq!(change_row.vault_address, None);
+    assert_eq!(change_row.confidential_before, Amount::from(1_000_000u64));
+    assert_eq!(change_row.confidential_after, Amount::from(900_000u64));
+    assert_eq!(change_row.revealed_delta, "0");
+    let vault = tx.vaults_get(&stealth_vault).unwrap();
+    assert_eq!(vault.confidential_balance, Amount::from(900_000u64));
+    assert_eq!(vault.revealed_balance, Amount::from(500u64));
+}
+
+// A transaction that creates the account's vault for the resource (e.g. a self-transfer of UTXOs into a
+// revealed balance) keys the confidential movement on that vault at its post-transaction version, so the
+// account refresh's revealed record merges onto the same row: one row holds the transaction's net effect.
+#[allow(clippy::too_many_lines)]
+#[test]
+fn lock_finalize_records_on_vault_created_by_transaction() {
+    let (store, _, _, _, _) = setup_store();
+    let stealth_resource = resource_address(3);
+    let new_vault = vault_address(4);
+    let account = account_address();
+    let transaction = build_transaction(10);
+    let transaction_id = transaction.calculate_id();
+
+    let mut tx = store.create_write_tx().unwrap();
+    upsert_stealth_resource(&mut tx, &stealth_resource);
+    tx.transactions_insert(&transaction, None, &[account], false).unwrap();
+
+    // Prior received balance recorded by an earlier scan.
+    assert!(
+        tx.balance_changes_insert(
+            BalanceChangeSnapshot {
+                account_address: account,
+                vault_address: None,
+                vault_version: None,
+                resource_address: stealth_resource,
+                token_symbol: Some("STEALTH".to_string()),
+                divisibility: 6,
+                revealed_before: Amount::zero(),
+                revealed_after: Amount::zero(),
+                confidential_before: Amount::zero(),
+                confidential_after: Amount::from(1_000_000u64),
+            },
+            BalanceChangeSource::Scan,
+        )
+        .unwrap()
+    );
+
+    let spent = stealth_output(account, stealth_resource, 1_000_000, 11, OutputStatus::Unspent, None);
+    tx.stealth_outputs_insert(&spent).unwrap();
+    let lock_id = tx.locks_create(None).unwrap();
+    tx.locks_link_transaction(lock_id, transaction_id).unwrap();
+    tx.stealth_outputs_lock_many(&stealth_resource, &[&spent.commitment], lock_id)
+        .unwrap();
+    let change = stealth_output(
+        account,
+        stealth_resource,
+        989_343,
+        12,
+        OutputStatus::LockedUnconfirmed,
+        Some(lock_id),
+    );
+    tx.stealth_outputs_insert(&change).unwrap();
+
+    // The diff commit links the transaction's new vault to the account before locks are finalized.
+    tx.substates_upsert_root(
+        VersionedSubstateIdRef::new(&SubstateId::Component(account), 1),
+        HashSet::new(),
+        None,
+        None,
+    )
+    .unwrap();
+    tx.substates_upsert_child(
+        &SubstateId::Component(account),
+        VersionedSubstateIdRef::new(&SubstateId::Vault(new_vault), 0),
+        HashSet::new(),
+    )
+    .unwrap();
+
+    let mut diff = SubstateDiff::new();
+    diff.down(SubstateId::Utxo(spent.to_utxo_address()), 0);
+    diff.up(
+        SubstateId::Utxo(change.to_utxo_address()),
+        Substate::new(0, Utxo {
+            output: None,
+            is_frozen: false,
+        }),
+    );
+    diff.up(
+        SubstateId::Vault(new_vault),
+        Substate::new(
+            0,
+            Vault::new(ResourceContainer::stealth(stealth_resource, Amount::from(10_000u64))),
+        ),
+    );
+    tx.locks_unlock_finalized(lock_id, &diff).unwrap();
+
+    // The account refresh later records the same transaction's revealed effect at the same vault version;
+    // it must merge onto the finalize row.
+    assert!(
+        tx.balance_changes_insert(
+            BalanceChangeSnapshot {
+                account_address: account,
+                vault_address: Some(new_vault),
+                vault_version: Some(0),
+                resource_address: stealth_resource,
+                token_symbol: Some("STEALTH".to_string()),
+                divisibility: 6,
+                revealed_before: Amount::zero(),
+                revealed_after: Amount::from(10_000u64),
+                confidential_before: Amount::from(989_343u64),
+                confidential_after: Amount::from(989_343u64),
+            },
+            BalanceChangeSource::Transaction { transaction_id },
+        )
+        .unwrap()
+    );
+    tx.commit().unwrap();
+    drop(tx);
+
+    let mut tx = store.create_read_tx().unwrap();
+    let page = tx
+        .balance_changes_get_page_by_account(&account, 0, 10, Some(&stealth_resource), None, None)
+        .unwrap();
+    assert_eq!(page.total, 2);
+    let spend_change = &page.changes[0];
+    assert_eq!(spend_change.source, BalanceChangeSource::Transaction { transaction_id });
+    assert_eq!(spend_change.vault_address, Some(new_vault));
+    assert_eq!(spend_change.confidential_before, Amount::from(1_000_000u64));
+    assert_eq!(spend_change.confidential_after, Amount::from(989_343u64));
+    assert_eq!(spend_change.confidential_delta, "-10657");
+    assert_eq!(spend_change.revealed_before, Amount::zero());
+    assert_eq!(spend_change.revealed_after, Amount::from(10_000u64));
+    assert_eq!(spend_change.revealed_delta, "10000");
+}
+
+// The vault substate in the finalized diff is the authoritative post-transaction revealed balance: the
+// wallet's revealed lock is only a reservation, and a transaction may withdraw less than was locked (e.g.
+// only the fee). The finalize record and the wallet vault must both follow the substate, or the wallet
+// balance diverges from chain and the next transaction's row absorbs the difference.
+#[test]
+fn lock_finalize_records_revealed_movement_from_diff_not_lock_amount() {
+    let (store, _, _, _, _) = setup_store();
+    let stealth_resource = resource_address(3);
+    let stealth_vault = vault_address(6);
+    let account = account_address();
+    let transaction = build_transaction(13);
+    let transaction_id = transaction.calculate_id();
+
+    let mut tx = store.create_write_tx().unwrap();
+    upsert_stealth_resource(&mut tx, &stealth_resource);
+    tx.vaults_insert(VaultModel {
+        account_address: account,
+        id: stealth_vault,
+        vault_version: 1,
+        resource_address: stealth_resource,
+        resource_type: ResourceType::Stealth,
+        confidential_balance: Amount::from(5_000_000u64),
+        revealed_balance: Amount::from(2_000_000u64),
+        locked_revealed_balance: Amount::zero(),
+        token_symbol: Some("STEALTH".to_string()),
+        divisibility: 6,
+    })
+    .unwrap();
+    tx.transactions_insert(&transaction, None, &[account], false).unwrap();
+
+    let lock_id = tx.locks_create(None).unwrap();
+    tx.locks_link_transaction(lock_id, transaction_id).unwrap();
+    tx.vaults_lock_revealed_funds(lock_id, &stealth_vault, Amount::from(1_000_255u64))
+        .unwrap();
+
+    // The transaction only moves the fee out of the vault's revealed balance.
+    let mut diff = SubstateDiff::new();
+    diff.up(
+        SubstateId::Vault(stealth_vault),
+        Substate::new(
+            2,
+            Vault::new(ResourceContainer::stealth(stealth_resource, Amount::from(1_999_745u64))),
+        ),
+    );
+    tx.locks_unlock_finalized(lock_id, &diff).unwrap();
+    tx.commit().unwrap();
+    drop(tx);
+
+    let mut tx = store.create_read_tx().unwrap();
+    let page = tx
+        .balance_changes_get_page_by_account(&account, 0, 10, Some(&stealth_resource), None, None)
+        .unwrap();
+    assert_eq!(page.total, 1);
+    let change = &page.changes[0];
+    assert_eq!(change.source, BalanceChangeSource::Transaction { transaction_id });
+    assert_eq!(change.vault_address, Some(stealth_vault));
+    assert_eq!(change.revealed_before, Amount::from(2_000_000u64));
+    assert_eq!(change.revealed_after, Amount::from(1_999_745u64));
+    assert_eq!(change.revealed_delta, "-255");
+    let vault = tx.vaults_get(&stealth_vault).unwrap();
+    assert_eq!(vault.revealed_balance, Amount::from(1_999_745u64));
+    assert_eq!(vault.vault_version, 2);
+}
+
+// The unique (account, resource, transaction) index spans both key shapes: when a transaction's effect is
+// first recorded as a vault-less row, a later vault-keyed record of the same transaction (the account
+// refresh after the vault appears) must fill its untouched balance dimension on that row rather than being
+// dropped — while a re-statement of an already-recorded dimension is a replay and must not modify it.
+#[test]
+fn same_transaction_vault_record_fills_dimension_on_no_vault_row() {
+    let (store, _, _, _, _) = setup_store();
+    let stealth_resource = resource_address(3);
+    let new_vault = vault_address(5);
+    let account = account_address();
+    let transaction = build_transaction(12);
+    let transaction_id = transaction.calculate_id();
+
+    let mut tx = store.create_write_tx().unwrap();
+    upsert_stealth_resource(&mut tx, &stealth_resource);
+    tx.transactions_insert(&transaction, None, &[account], false).unwrap();
+
+    // Finalize records the confidential spend before the wallet knows the transaction created a vault.
+    assert!(
+        tx.balance_changes_insert(
+            BalanceChangeSnapshot {
+                account_address: account,
+                vault_address: None,
+                vault_version: None,
+                resource_address: stealth_resource,
+                token_symbol: Some("STEALTH".to_string()),
+                divisibility: 6,
+                revealed_before: Amount::zero(),
+                revealed_after: Amount::zero(),
+                confidential_before: Amount::from(1_000_000u64),
+                confidential_after: Amount::from(989_000u64),
+            },
+            BalanceChangeSource::Transaction { transaction_id },
+        )
+        .unwrap()
+    );
+    // The account refresh then records the revealed deposit against the new vault.
+    assert!(
+        tx.balance_changes_insert(
+            BalanceChangeSnapshot {
+                account_address: account,
+                vault_address: Some(new_vault),
+                vault_version: Some(0),
+                resource_address: stealth_resource,
+                token_symbol: Some("STEALTH".to_string()),
+                divisibility: 6,
+                revealed_before: Amount::zero(),
+                revealed_after: Amount::from(10_000u64),
+                confidential_before: Amount::from(989_000u64),
+                confidential_after: Amount::from(989_000u64),
+            },
+            BalanceChangeSource::Transaction { transaction_id },
+        )
+        .unwrap()
+    );
+    // A replayed vault-keyed re-statement of the confidential dimension must not modify the row.
+    assert!(
+        !tx.balance_changes_insert(
+            BalanceChangeSnapshot {
+                account_address: account,
+                vault_address: Some(new_vault),
+                vault_version: Some(1),
+                resource_address: stealth_resource,
+                token_symbol: Some("STEALTH".to_string()),
+                divisibility: 6,
+                revealed_before: Amount::zero(),
+                revealed_after: Amount::zero(),
+                confidential_before: Amount::from(1_000_000u64),
+                confidential_after: Amount::from(500u64),
+            },
+            BalanceChangeSource::Transaction { transaction_id },
+        )
+        .unwrap()
+    );
+    tx.commit().unwrap();
+    drop(tx);
+
+    let mut tx = store.create_read_tx().unwrap();
+    let page = tx
+        .balance_changes_get_page_by_account(&account, 0, 10, Some(&stealth_resource), None, None)
+        .unwrap();
+    assert_eq!(page.total, 1);
+    let change = &page.changes[0];
+    assert_eq!(change.vault_address, None);
+    assert_eq!(change.confidential_delta, "-11000");
+    assert_eq!(change.revealed_delta, "10000");
+}
+
+// A transaction output for the sender that is only discovered after the finalize record (it is not held by
+// the lock) extends the same transaction row's after-balances, so the row holds the transaction's net
+// effect and the scanner has nothing left to record.
+#[test]
+fn same_transaction_no_vault_records_merge_into_net_effect() {
+    let (store, _, _, _, _) = setup_store();
+    let stealth_resource = resource_address(3);
+    let account = account_address();
+    let transaction = build_transaction(11);
+    let transaction_id = transaction.calculate_id();
+
+    let mut tx = store.create_write_tx().unwrap();
+    upsert_stealth_resource(&mut tx, &stealth_resource);
+    tx.transactions_insert(&transaction, None, &[account], false).unwrap();
+
+    let snapshot = |revealed: (u64, u64), confidential: (u64, u64)| BalanceChangeSnapshot {
+        account_address: account,
+        vault_address: None,
+        vault_version: None,
+        resource_address: stealth_resource,
+        token_symbol: Some("STEALTH".to_string()),
+        divisibility: 6,
+        revealed_before: Amount::from(revealed.0),
+        revealed_after: Amount::from(revealed.1),
+        confidential_before: Amount::from(confidential.0),
+        confidential_after: Amount::from(confidential.1),
+    };
+
+    // Lock-finalize records the spend before the transaction's output to self is discovered.
+    assert!(
+        tx.balance_changes_insert(
+            snapshot((0, 0), (1_000_000, 900_000)),
+            BalanceChangeSource::Transaction { transaction_id }
+        )
+        .unwrap()
+    );
+    // The discovered output extends the row to the transaction's net effect.
+    assert!(
+        tx.balance_changes_insert(snapshot((0, 0), (900_000, 989_343)), BalanceChangeSource::Transaction {
+            transaction_id
+        })
+        .unwrap()
+    );
+    // A re-derivation of the same balances is a no-op.
+    assert!(
+        !tx.balance_changes_insert(snapshot((0, 0), (989_343, 989_343)), BalanceChangeSource::Transaction {
+            transaction_id
+        })
+        .unwrap()
+    );
+    tx.commit().unwrap();
+    drop(tx);
+
+    let mut tx = store.create_read_tx().unwrap();
+    let page = tx
+        .balance_changes_get_page_by_account(&account, 0, 10, Some(&stealth_resource), None, None)
+        .unwrap();
+    assert_eq!(page.total, 1);
+    let change = &page.changes[0];
+    assert_eq!(change.confidential_before, Amount::from(1_000_000u64));
+    assert_eq!(change.confidential_after, Amount::from(989_343u64));
+    assert_eq!(change.confidential_delta, "-10657");
+    drop(tx);
+
+    // A record that returns the balance to its starting point nets the row to zero and removes it.
+    let mut tx = store.create_write_tx().unwrap();
+    assert!(
+        tx.balance_changes_insert(
+            snapshot((0, 0), (989_343, 1_000_000)),
+            BalanceChangeSource::Transaction { transaction_id }
+        )
+        .unwrap()
+    );
+    tx.commit().unwrap();
+    drop(tx);
+
+    let mut tx = store.create_read_tx().unwrap();
+    let page = tx
+        .balance_changes_get_page_by_account(&account, 0, 10, Some(&stealth_resource), None, None)
+        .unwrap();
+    assert_eq!(page.total, 0);
 }
 
 #[test]


### PR DESCRIPTION
Follow-up to #2261.

## Problem

Balance-change history missed or mis-recorded effects of locally-submitted transactions:

1. A confidential (stealth UTXO) spend from a vault-less sender recorded no transaction row - the decrement only appeared ~1 min later as an unattributed `Scan` row (scanner UtxoSpent path). Root cause: `process_result` only feeds up-UTXOs to `verify_and_update_outputs`, and already-known change outputs don't mark balances as touched.
2. A self-transfer UTXO->revealed split its effect across rows or dropped dimensions entirely: `commit_diff` upserted transaction-created vaults as parentless roots; the unique `(account, resource, transaction)` index spans both key shapes so the refresh's vault-keyed insert conflicted with the finalize row and was dropped; `refresh_vault`'s attribution guard treated the finalize record as a replay and skipped the vault update (revealed balance silently lost).
3. Revealed spends recorded the wallet lock's reserved amount instead of the actual on-chain movement. A revealed self-transfer round-trips the withdrawn amount back into the vault in the same transaction, so only the fee leaves on-chain - the wallet recorded the full locked amount, its vault balance diverged from chain, and the next transaction's row absorbed the accumulated drift (observed as a "+3 tTARI" row for a 1 tTARI transfer).

## Fix

Design rule: a locally-submitted transaction's whole net effect lands on ONE `Transaction`-sourced row per (account, resource); the scanner's later pass re-derives the same balances and records nothing.

- `locks_unlock_finalized` records the confidential movement per affected (account, resource) at finalize: keyed on the diff's vault (post-tx version) when the tx touches/creates the account's vault so the refresh merges the revealed dimension onto the same row; otherwise a vault-less row. Vault confidential balance is synced so refresh/scan re-derive an unchanged balance.
- The revealed record now takes the post-transaction revealed balance from the diff's vault substate (authoritative) instead of subtracting the locked amount, and syncs the wallet vault to it. Lock-amount subtraction remains only as fallback when the vault is not in the diff.
- `balance_changes_insert` converges same-transaction records across key shapes: cumulative after-balance extension for vault-less records (later-discovered outputs of the same tx), strict fill-only-untouched-dimension merge when a vault-keyed record conflicts with an existing same-transaction row; rows that net to zero are deleted.
- `commit_diff` records parent linkage for vaults created by the transaction.
- `add_vault` seeds a new stealth vault's confidential balance from the latest recorded balance (new `balance_changes_get_latest_recorded` reader) so the first refresh states only what its transaction changed.
- `refresh_vault` no longer skips the vault update when the transaction already has a record - the insert merge and vault snapshot comparison provide replay protection.
- Web UI (view-changes dialog): timestamp column shows relative time (same hook as the transaction list) with the full date in the title attribute; the resource column is hidden when the history is already filtered to a single resource.

## Testing

16 storage-seam regression tests in `crates/wallet/storage_sqlite/tests/balance_changes.rs` (new: vault-less spend at lock-finalize, vault-backed spend sync, vault-created-by-tx one-row merge, cross-key dimension fill, cumulative no-vault merge + net-zero delete, revealed-from-diff-not-lock-amount), sdk_tests 19 passing incl. new vault-seeding test. Verified end-to-end against a local swarm walletd: plain sends, UTXO->revealed and revealed->UTXO self-transfers each produce exactly one attributed row matching the on-chain vault substate, with no scan rows afterwards.

## Files changed

`crates/wallet/storage_sqlite/{src/writer.rs,src/reader.rs,tests/balance_changes.rs}`, `crates/wallet/sdk/src/{apis/accounts.rs,apis/transaction.rs,storage/reader.rs}`, `crates/wallet/sdk_services/src/account_monitor/scanner.rs`, `crates/wallet/sdk_tests/tests/balance_changes.rs`, `applications/tari_walletd/web_ui/src/routes/AccountDetails/BalanceChangeHistory.tsx`