### PR TITLE
chore: bump version 0.35.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1744,7 +1744,7 @@ dependencies = [
 
 [[package]]
 name = "consensus_tests"
-version = "0.35.0"
+version = "0.35.1"
 dependencies = [
  "fern",
  "futures 0.3.31",
@@ -2754,7 +2754,7 @@ dependencies = [
 
 [[package]]
 name = "db-inspector"
-version = "0.35.0"
+version = "0.35.1"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -5109,7 +5109,7 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "integration_tests"
-version = "0.35.0"
+version = "0.35.1"
 dependencies = [
  "anyhow",
  "config",
@@ -5877,7 +5877,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-messaging"
-version = "0.35.0"
+version = "0.35.1"
 dependencies = [
  "async-trait",
  "futures-bounded 0.2.4",
@@ -6055,7 +6055,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-substream"
-version = "0.35.0"
+version = "0.35.1"
 dependencies = [
  "libp2p",
  "prometheus-client",
@@ -7709,7 +7709,7 @@ dependencies = [
 
 [[package]]
 name = "ootle-wasm"
-version = "0.35.0"
+version = "0.35.1"
 dependencies = [
  "console_error_panic_hook",
  "getrandom 0.2.17",
@@ -7720,7 +7720,7 @@ dependencies = [
 
 [[package]]
 name = "ootle-wasm-core"
-version = "0.35.0"
+version = "0.35.1"
 dependencies = [
  "base64 0.22.1",
  "hex",
@@ -7780,7 +7780,7 @@ dependencies = [
 
 [[package]]
 name = "ootle_sdk_core"
-version = "0.35.0"
+version = "0.35.1"
 dependencies = [
  "blake2 0.10.6",
  "hex",
@@ -7806,7 +7806,7 @@ dependencies = [
 
 [[package]]
 name = "ootle_sdk_ffi_c"
-version = "0.35.0"
+version = "0.35.1"
 dependencies = [
  "cbindgen",
  "hex",
@@ -8801,7 +8801,7 @@ dependencies = [
 
 [[package]]
 name = "proto_builder"
-version = "0.35.0"
+version = "0.35.1"
 dependencies = [
  "prost-build 0.14.3",
  "sha2 0.10.9",
@@ -10666,7 +10666,7 @@ dependencies = [
 
 [[package]]
 name = "sqlite_message_logger"
-version = "0.35.0"
+version = "0.35.1"
 dependencies = [
  "chrono",
  "diesel",
@@ -11038,7 +11038,7 @@ dependencies = [
 
 [[package]]
 name = "tari_base_node_client"
-version = "0.35.0"
+version = "0.35.1"
 dependencies = [
  "futures-util",
  "log",
@@ -11270,7 +11270,7 @@ dependencies = [
 
 [[package]]
 name = "tari_consensus"
-version = "0.35.0"
+version = "0.35.1"
 dependencies = [
  "anyhow",
  "indexmap 2.13.0",
@@ -11295,7 +11295,7 @@ dependencies = [
 
 [[package]]
 name = "tari_consensus_types"
-version = "0.35.0"
+version = "0.35.1"
 dependencies = [
  "borsh",
  "minicbor",
@@ -11398,7 +11398,7 @@ dependencies = [
 
 [[package]]
 name = "tari_engine"
-version = "0.35.0"
+version = "0.35.1"
 dependencies = [
  "blake2 0.10.6",
  "bytes",
@@ -11430,7 +11430,7 @@ dependencies = [
 
 [[package]]
 name = "tari_engine_types"
-version = "0.35.0"
+version = "0.35.1"
 dependencies = [
  "blake2 0.10.6",
  "borsh",
@@ -11460,7 +11460,7 @@ dependencies = [
 
 [[package]]
 name = "tari_epoch_manager"
-version = "0.35.0"
+version = "0.35.1"
 dependencies = [
  "anyhow",
  "log",
@@ -11480,7 +11480,7 @@ dependencies = [
 
 [[package]]
 name = "tari_epoch_oracles"
-version = "0.35.0"
+version = "0.35.1"
 dependencies = [
  "anyhow",
  "blake2 0.10.6",
@@ -11526,7 +11526,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer"
-version = "0.35.0"
+version = "0.35.1"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -11602,7 +11602,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer_client"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "anyhow",
  "bounded-vec",
@@ -11631,7 +11631,7 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer_lib"
-version = "0.35.0"
+version = "0.35.1"
 dependencies = [
  "async-trait",
  "log",
@@ -11728,7 +11728,7 @@ dependencies = [
 
 [[package]]
 name = "tari_networking"
-version = "0.35.0"
+version = "0.35.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11782,7 +11782,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_app_utilities"
-version = "0.35.0"
+version = "0.35.1"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -11823,7 +11823,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_common_types"
-version = "0.35.0"
+version = "0.35.1"
 dependencies = [
  "blake2 0.10.6",
  "borsh",
@@ -11852,7 +11852,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_p2p"
-version = "0.35.0"
+version = "0.35.1"
 dependencies = [
  "anyhow",
  "libp2p-identity 0.2.14",
@@ -11876,7 +11876,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_storage"
-version = "0.35.0"
+version = "0.35.1"
 dependencies = [
  "anyhow",
  "bitflags 2.13.0",
@@ -11905,7 +11905,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_storage_sqlite"
-version = "0.35.0"
+version = "0.35.1"
 dependencies = [
  "diesel",
  "diesel_migrations",
@@ -11958,7 +11958,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_template_provider"
-version = "0.35.0"
+version = "0.35.1"
 dependencies = [
  "anyhow",
  "dashmap 5.5.3",
@@ -11975,7 +11975,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_transaction"
-version = "0.35.0"
+version = "0.35.1"
 dependencies = [
  "borsh",
  "hex",
@@ -12001,7 +12001,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_transaction_validation"
-version = "0.35.0"
+version = "0.35.1"
 dependencies = [
  "anyhow",
  "indexmap 2.13.0",
@@ -12017,7 +12017,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_cli"
-version = "0.35.0"
+version = "0.35.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -12077,7 +12077,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_sdk"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -12112,7 +12112,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_sdk_services"
-version = "0.2.0"
+version = "0.34.1"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -12139,7 +12139,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_sdk_tests"
-version = "0.35.0"
+version = "0.35.1"
 dependencies = [
  "digest 0.10.7",
  "ootle_byte_type",
@@ -12161,7 +12161,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_storage_sqlite"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "diesel",
  "diesel_migrations",
@@ -12185,7 +12185,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_walletd"
-version = "0.35.0"
+version = "0.35.1"
 dependencies = [
  "anyhow",
  "apple-native-keyring-store",
@@ -12256,7 +12256,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_walletd_client"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "hex",
  "ootle_serde",
@@ -12311,7 +12311,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_framework"
-version = "0.35.0"
+version = "0.35.1"
 dependencies = [
  "async-trait",
  "bitflags 2.13.0",
@@ -12335,7 +12335,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_macros"
-version = "0.35.0"
+version = "0.35.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12344,7 +12344,7 @@ dependencies = [
 
 [[package]]
 name = "tari_rpc_state_sync"
-version = "0.35.0"
+version = "0.35.1"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -12426,7 +12426,7 @@ dependencies = [
 
 [[package]]
 name = "tari_state_store_rocksdb"
-version = "0.35.0"
+version = "0.35.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12458,7 +12458,7 @@ dependencies = [
 
 [[package]]
 name = "tari_state_tree"
-version = "0.35.0"
+version = "0.35.1"
 dependencies = [
  "indexmap 2.13.0",
  "log",
@@ -12487,7 +12487,7 @@ dependencies = [
 
 [[package]]
 name = "tari_swarm"
-version = "0.35.0"
+version = "0.35.1"
 dependencies = [
  "libp2p",
  "libp2p-messaging",
@@ -12499,7 +12499,7 @@ dependencies = [
 
 [[package]]
 name = "tari_swarm_daemon"
-version = "0.35.0"
+version = "0.35.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12612,7 +12612,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_test_tooling"
-version = "0.35.0"
+version = "0.35.1"
 dependencies = [
  "anyhow",
  "cargo_toml 0.22.3",
@@ -12728,7 +12728,7 @@ dependencies = [
 
 [[package]]
 name = "tari_transaction_manifest"
-version = "0.35.0"
+version = "0.35.1"
 dependencies = [
  "proc-macro2",
  "serde_json",
@@ -12763,7 +12763,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node"
-version = "0.35.0"
+version = "0.35.1"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -12826,7 +12826,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node_client"
-version = "0.35.0"
+version = "0.35.1"
 dependencies = [
  "indexmap 2.13.0",
  "multiaddr 0.18.3",
@@ -12850,7 +12850,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_node_rpc"
-version = "0.35.0"
+version = "0.35.1"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -12874,7 +12874,7 @@ dependencies = [
 
 [[package]]
 name = "tari_validator_rollback"
-version = "0.35.0"
+version = "0.35.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12909,7 +12909,7 @@ dependencies = [
 
 [[package]]
 name = "tari_watcher"
-version = "0.35.0"
+version = "0.35.1"
 dependencies = [
  "anyhow",
  "clap 3.2.25",
@@ -12938,7 +12938,7 @@ dependencies = [
 
 [[package]]
 name = "tariswap_bench"
-version = "0.35.0"
+version = "0.35.1"
 dependencies = [
  "anyhow",
  "clap 4.5.54",
@@ -13630,7 +13630,7 @@ dependencies = [
 
 [[package]]
 name = "traffic-sim"
-version = "0.35.0"
+version = "0.35.1"
 dependencies = [
  "anyhow",
  "clap 4.5.54",
@@ -13652,7 +13652,7 @@ dependencies = [
 
 [[package]]
 name = "transaction_generator"
-version = "0.35.0"
+version = "0.35.1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -13673,7 +13673,7 @@ dependencies = [
 
 [[package]]
 name = "transaction_submitter"
-version = "0.35.0"
+version = "0.35.1"
 dependencies = [
  "anyhow",
  "clap 4.5.54",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.35.0"
+version = "0.35.1"
 edition = "2024"
 authors = ["The Tari Development Community"]
 repository = "https://github.com/tari-project/tari-ootle"

--- a/clients/tari_indexer_client/Cargo.toml
+++ b/clients/tari_indexer_client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_indexer_client"
 description = "Tari indexer client library"
-version = "0.34.0"
+version = "0.34.1"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/clients/wallet_daemon_client/Cargo.toml
+++ b/clients/wallet_daemon_client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_ootle_walletd_client"
 description = "Tari wallet daemon client library"
-version = "0.34.0"
+version = "0.34.1"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/wallet/sdk/Cargo.toml
+++ b/crates/wallet/sdk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_ootle_wallet_sdk"
 description = "The Tari wallet library"
-version = "0.34.0"
+version = "0.34.1"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/wallet/sdk_services/Cargo.toml
+++ b/crates/wallet/sdk_services/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_ootle_wallet_sdk_services"
 description = "High-level wallet services and abstractions for the Tari Ootle wallet"
-version = "0.2.0"
+version = "0.34.1"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/wallet/storage_sqlite/Cargo.toml
+++ b/crates/wallet/storage_sqlite/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_ootle_wallet_storage_sqlite"
 description = "The Tari wallet SQLite storage library"
-version = "0.34.0"
+version = "0.34.1"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true


### PR DESCRIPTION
Description
---
chore: bump version 0.35.1

  - tari_engine_types 0.35.1
  - tari_ootle_common_types 0.35.1
  - tari_ootle_wallet_crypto 0.35.1
  - tari_ootle_transaction 0.35.1
  - tari_transaction_manifest 0.35.1
  - tari_engine 0.35.1
  - tari_consensus_types 0.35.1
  - tari_indexer_client 0.34.1
  - ootle-wasm-core 0.35.1
  - ootle-wasm 0.35.1
  - tari_template_test_tooling 0.35.1
  - ootle-rs 0.13.1
  - tari_ootle_wallet_sdk 0.34.1
  - tari_ootle_wallet_storage_sqlite 0.34.1
  - tari_ootle_walletd_client 0.34.1

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify