### PR TITLE
fix(ci): prevent release text being overwritten by build binary task

### DIFF
--- a/.github/workflows/build_binaries.yml
+++ b/.github/workflows/build_binaries.yml
@@ -750,10 +750,10 @@ jobs:
             ${{ github.workspace }}${{ env.TS_DIST }}/tari_ootle_walletd-${{ env.TARI_VERSION }}-${{ env.VSHA_SHORT }}-${{ matrix.builds.name }}${{ env.TS_EXT }}.sha256
           token: ${{ secrets.GITHUB_TOKEN }}
           prerelease: true
-          draft: true
           allowUpdates: true
           updateOnlyUnreleased: true
           replacesArtifacts: true
+          omitDraftDuringUpdate: true
           omitBodyDuringUpdate: true
           omitNameDuringUpdate: true
 
@@ -1007,10 +1007,12 @@ jobs:
           artifacts: "${{ env.TS_FILENAME }}*/**/*"
           token: ${{ secrets.GITHUB_TOKEN }}
           prerelease: true
-          draft: true
           allowUpdates: true
           updateOnlyUnreleased: true
           replacesArtifacts: true
+          omitDraftDuringUpdate: true
+          omitBodyDuringUpdate: true
+          omitNameDuringUpdate: true
 
       - name: Sync assets to S3
         continue-on-error: true


### PR DESCRIPTION
Description
---
I'll typically create a draft release from a tag before the build binaries task has completed. Previously when the task completes it will clear the release text, title and draft status. This PR changes that behaviour to only do so when the release doesn't already exist.

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify