### PR TITLE
feat(indexer)!: serve Prometheus metrics on a dedicated listener

### DIFF
--- a/applications/tari_indexer/src/config.rs
+++ b/applications/tari_indexer/src/config.rs
@@ -99,6 +99,10 @@ pub struct IndexerConfig {
     pub p2p: P2pConfig,
     /// Listening address for the indexer API server
     pub api_listen_address: Option<SocketAddr>,
+    /// Listening address for the Prometheus metrics endpoint (`/_metrics`). This is served on a dedicated listener,
+    /// separate from the API server, so that metrics can be bound to a private interface while the API is public.
+    /// Only used when the `metrics` feature is enabled (default = "127.0.0.1:18302"); `None` disables the listener.
+    pub metrics_listen_address: Option<SocketAddr>,
     /// GraphQL port of the indexer application
     pub graphql_address: Option<SocketAddr>,
     /// The address of the Web UI
@@ -153,6 +157,7 @@ impl Default for IndexerConfig {
             data_dir: PathBuf::from("data/indexer"),
             p2p: P2pConfig::default(),
             api_listen_address: Some("127.0.0.1:18300".parse().unwrap()),
+            metrics_listen_address: Some("127.0.0.1:18302".parse().unwrap()),
             graphql_address: Some("127.0.0.1:18301".parse().unwrap()),
             web_ui_address: Some("127.0.0.1:15000".parse().unwrap()),
             web_ui_public_api_url: None,

--- a/applications/tari_indexer/src/lib.rs
+++ b/applications/tari_indexer/src/lib.rs
@@ -131,15 +131,14 @@ where
     // Run the REST API
     let listen_addr = config.indexer.api_listen_address;
     if let Some(listen_addr) = listen_addr {
-        #[cfg(not(feature = "metrics"))]
         let server = rest_api::Server::new();
-        #[cfg(feature = "metrics")]
-        let server = rest_api::Server::new(registry);
         let listen_address = server
             .spawn(
                 listen_addr,
                 &services,
                 &config.indexer.rate_limits,
+                #[cfg(feature = "metrics")]
+                &mut registry,
                 shutdown_signal.clone(),
             )
             .await
@@ -180,6 +179,15 @@ where
     }
     #[cfg(not(feature = "web_ui"))]
     info!(target: LOG_TARGET, "🕸️ Web UI not enabled. Compile with --features web_ui to enable it.");
+
+    // Serve Prometheus metrics on a dedicated listener, separate from the public REST API
+    #[cfg(feature = "metrics")]
+    if let Some(metrics_addr) = config.indexer.metrics_listen_address {
+        let metrics_address = rest_api::spawn_metrics_server(metrics_addr, registry, shutdown_signal.clone())
+            .await
+            .map_err(|e| ExitError::new(ExitCode::ConfigError, e))?;
+        debug!(target: LOG_TARGET, "Metrics address {}", metrics_address);
+    }
 
     // Create pid to allow watchers to know that the process has started
     fs::write(config.common.base_path.join("pid"), std::process::id().to_string())

--- a/applications/tari_indexer/src/rest_api/metrics.rs
+++ b/applications/tari_indexer/src/rest_api/metrics.rs
@@ -1,15 +1,18 @@
 //   Copyright 2025 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use std::{future, sync::Arc, time::Instant};
+use std::{future, net::SocketAddr, sync::Arc, time::Instant};
 
 use axum::{
+    Router,
     body::{Body, HttpBody},
     extract::State,
     http::{Request, StatusCode},
     middleware::Next,
     response::{IntoResponse, Response},
+    routing::get,
 };
+use log::*;
 use prometheus_client::{
     encoding::text::encode,
     metrics::{
@@ -19,8 +22,12 @@ use prometheus_client::{
     },
     registry::Registry,
 };
+use tari_ootle_app_utilities::tcp::try_bind_with_fallback;
+use tari_shutdown::ShutdownSignal;
 
 use crate::metrics::CollectorRegister;
+
+const LOG_TARGET: &str = "tari::ootle::indexer::rest_api::metrics";
 
 const METRICS_CONTENT_TYPE: &str = "application/openmetrics-text;charset=utf-8;version=1.0.0";
 #[derive(Debug, Clone)]
@@ -88,6 +95,30 @@ pub fn register(registry: &mut Registry) -> RequestMetrics {
     }
 }
 
+/// Serves `GET /_metrics` on its own listener, separate from the REST API, so that metrics can be bound to a
+/// private interface (e.g. localhost-only for a Prometheus sidecar) while the REST API remains public.
+pub async fn spawn_metrics_server(
+    preferred_addr: SocketAddr,
+    registry: Registry,
+    shutdown: ShutdownSignal,
+) -> anyhow::Result<SocketAddr> {
+    let router = Router::new().route("/_metrics", get(MetricsHandler::new(registry)));
+
+    let listener = try_bind_with_fallback(preferred_addr).await?;
+    let listen_addr = listener.local_addr()?;
+    info!(target: LOG_TARGET, "📊 Indexer metrics server listening on {listen_addr}");
+    tokio::spawn(async move {
+        if let Err(error) = axum::serve(listener, router.into_make_service())
+            .with_graceful_shutdown(shutdown)
+            .await
+        {
+            error!(target: LOG_TARGET, "Metrics HTTP server error: {error}");
+        }
+    });
+
+    Ok(listen_addr)
+}
+
 pub async fn layer(State(metrics): State<RequestMetrics>, req: Request<Body>, next: Next) -> Response {
     metrics.request_counter.inc();
     metrics.requests_pending.inc();
@@ -102,4 +133,62 @@ pub async fn layer(State(metrics): State<RequestMetrics>, req: Request<Body>, ne
     metrics.requests_pending.dec();
 
     response
+}
+
+#[cfg(test)]
+mod tests {
+    use tari_shutdown::Shutdown;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    use super::*;
+
+    async fn http_get(addr: SocketAddr, path: &str) -> String {
+        let mut stream = tokio::net::TcpStream::connect(addr).await.unwrap();
+        stream
+            .write_all(format!("GET {path} HTTP/1.1\r\nHost: {addr}\r\nConnection: close\r\n\r\n").as_bytes())
+            .await
+            .unwrap();
+        let mut buf = Vec::new();
+        stream.read_to_end(&mut buf).await.unwrap();
+        String::from_utf8(buf).unwrap()
+    }
+
+    #[tokio::test]
+    async fn it_serves_metrics_on_a_dedicated_listener() {
+        let shutdown = Shutdown::new();
+        let listen_addr = spawn_metrics_server(
+            "127.0.0.1:0".parse().unwrap(),
+            Registry::default(),
+            shutdown.to_signal(),
+        )
+        .await
+        .unwrap();
+
+        let response = http_get(listen_addr, "/_metrics").await;
+        assert!(
+            response.starts_with("HTTP/1.1 200 OK"),
+            "unexpected response: {response}"
+        );
+        assert!(
+            response.contains(METRICS_CONTENT_TYPE),
+            "unexpected response: {response}"
+        );
+        // The OpenMetrics text exposition always ends with an EOF marker
+        assert!(response.contains("# EOF"), "unexpected response: {response}");
+    }
+
+    #[tokio::test]
+    async fn it_serves_nothing_but_metrics() {
+        let shutdown = Shutdown::new();
+        let listen_addr = spawn_metrics_server(
+            "127.0.0.1:0".parse().unwrap(),
+            Registry::default(),
+            shutdown.to_signal(),
+        )
+        .await
+        .unwrap();
+
+        let response = http_get(listen_addr, "/transactions").await;
+        assert!(response.starts_with("HTTP/1.1 404"), "unexpected response: {response}");
+    }
 }

--- a/applications/tari_indexer/src/rest_api/mod.rs
+++ b/applications/tari_indexer/src/rest_api/mod.rs
@@ -12,5 +12,7 @@ mod rate_limit;
 mod server;
 mod streaming;
 
+#[cfg(feature = "metrics")]
+pub use metrics::spawn_metrics_server;
 pub use rate_limit::RefillRate;
 pub use server::*;

--- a/applications/tari_indexer/src/rest_api/server.rs
+++ b/applications/tari_indexer/src/rest_api/server.rs
@@ -76,28 +76,21 @@ const REQUEST_BODY_LIMIT: usize = 4 * 1024 * 1024; // 4 MB
 ))]
 pub struct ApiDoc;
 
-pub struct Server {
-    #[cfg(feature = "metrics")]
-    registry: prometheus_client::registry::Registry,
-}
+#[derive(Debug, Clone, Copy, Default)]
+pub struct Server;
 
 impl Server {
-    #[cfg(not(feature = "metrics"))]
     pub fn new() -> Self {
-        Self {}
-    }
-
-    #[cfg(feature = "metrics")]
-    pub fn new(registry: prometheus_client::registry::Registry) -> Self {
-        Self { registry }
+        Self
     }
 
     #[expect(clippy::too_many_lines)]
     pub async fn spawn(
-        #[allow(unused_mut)] mut self,
+        self,
         preferred_addr: SocketAddr,
         services: &Services,
         rate_limits: &IndexerRateLimitsConfig,
+        #[cfg(feature = "metrics")] registry: &mut prometheus_client::registry::Registry,
         shutdown: ShutdownSignal,
     ) -> anyhow::Result<SocketAddr> {
         let context = HandlerContext::from_services(services);
@@ -254,13 +247,14 @@ impl Server {
             .layer(Extension(context))
             .layer(TraceLayer::new_for_http());
 
+        // Note: `/_metrics` is deliberately not served here — it runs on its own listener bound to
+        // `metrics_listen_address` (see `metrics::spawn_metrics_server`), so internal operational
+        // metrics are not exposed on the public REST API.
         #[cfg(feature = "metrics")]
-        let router = router
-            .layer(axum::middleware::from_fn_with_state(
-                metrics::register(&mut self.registry),
-                metrics::layer,
-            ))
-            .route("/_metrics", get(metrics::MetricsHandler::new(self.registry)));
+        let router = router.layer(axum::middleware::from_fn_with_state(
+            metrics::register(registry),
+            metrics::layer,
+        ));
 
         let listener = try_bind_with_fallback(preferred_addr).await?;
 

--- a/applications/tari_ootle_app_utilities/config_presets/d_indexer.toml
+++ b/applications/tari_ootle_app_utilities/config_presets/d_indexer.toml
@@ -21,6 +21,11 @@
 # API listener address (default = "127.0.0.1:18300")
 #api_listen_address = "127.0.0.1:18300"
 
+# Prometheus metrics (/_metrics) listener address. Metrics are served on a dedicated listener, separate from the
+# API server, so they can be bound to a private interface while the API is public. Only used when the indexer is
+# compiled with the `metrics` feature (enabled by default). (default = "127.0.0.1:18302")
+#metrics_listen_address = "127.0.0.1:18302"
+
 # HTTP UI listener address (default = "127.0.0.1:15000")
 #web_ui_address = "127.0.0.1:15000"
 

--- a/integration_tests/src/indexer.rs
+++ b/integration_tests/src/indexer.rs
@@ -196,6 +196,8 @@ pub async fn spawn_indexer(world: &mut TariWorld, indexer_name: String, base_nod
 
         config.indexer.p2p.enable_mdns = false;
         config.indexer.api_listen_address = Some(format!("127.0.0.1:{}", api_port).parse().unwrap());
+        // OS-assigned port to avoid contention between concurrently running indexers
+        config.indexer.metrics_listen_address = Some("127.0.0.1:0".parse().unwrap());
         config.indexer.web_ui_address = Some(format!("127.0.0.1:{}", web_ui_port).parse().unwrap());
         config.indexer.graphql_address = Some(format!("127.0.0.1:{}", graphql_port).parse().unwrap());
 


### PR DESCRIPTION
Splits the indexer's Prometheus `/_metrics` endpoint off the public REST API listener onto its own dedicated, separately-configurable listener, so internal operational metrics can be bound to a private interface (e.g. localhost-only for a Prometheus sidecar) while the REST API remains public.

Fixes #2330

## Changes

- **New `metrics_listen_address` config field** on `IndexerConfig` (default `127.0.0.1:18302`, distinct from `api_listen_address`'s `127.0.0.1:18300`). The field is unconditional so config files parse under `deny_unknown_fields` regardless of compile features; it is only acted on when the `metrics` feature is enabled.
- **`/_metrics` removed from the REST router** — `GET /_metrics` on `api_listen_address` now returns 404. All other REST routes are untouched.
- **New dedicated metrics listener** (`spawn_metrics_server` in `rest_api/metrics.rs`) serving only `GET /_metrics`, bound via the same `try_bind_with_fallback` used by the REST listener and honoring graceful shutdown. Not started when the `metrics` feature is disabled.
- **Registry ownership**: the REST `Server` no longer takes ownership of the `Registry`. It registers its per-request HTTP metrics middleware through a `&mut Registry` borrow (same call-site pattern as `spawn_services`), and the registry is then handed to the metrics listener. Registration completes before the listener starts, so no `Arc`/locking is needed. The per-request middleware still instruments the REST API exactly as before — only the exposition endpoint moved.
- Config preset `d_indexer.toml` documents the new field; integration-test indexers bind metrics to an OS-assigned port (`127.0.0.1:0`) to avoid contention between concurrently spawned indexers.

## Verification

- `cargo test -p tari_indexer rest_api::metrics` — two new tests: the metrics listener serves the OpenMetrics text exposition (200, correct content type, `# EOF` marker) on `GET /_metrics`, and returns 404 for any other path.
- `cargo check -p tari_indexer --all-targets` (default features) and `cargo check -p tari_indexer --no-default-features` both build.
- `cargo lints clippy -p tari_indexer --all-targets --all-features` — no warnings in changed code; nightly `cargo fmt --check` clean.
- Manual: run the indexer, `curl 127.0.0.1:18300/_metrics` → 404; `curl 127.0.0.1:18302/_metrics` → Prometheus text exposition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
