### PR TITLE
feat(ootle-rs): stealth UTXO stream, batched fetch, and per-UTXO decrypt primitives

### DIFF
--- a/crates/wallet/ootle-rs/src/provider/balance.rs
+++ b/crates/wallet/ootle-rs/src/provider/balance.rs
@@ -7,11 +7,12 @@ use ootle_byte_type::ConvertFromByteType;
 use tari_crypto::ristretto::RistrettoSecretKey;
 use tari_indexer_client::types::GetSubstatesRequest;
 use tari_ootle_common_types::engine_types::{
+    Utxo,
     crypto::{ElgamalVerifiableBalance, ValueLookup},
     indexed_value::IndexedWellKnownTypes,
     substate::{Substate, SubstateId},
 };
-use tari_template_lib_types::{Amount, ComponentAddress, ResourceAddress, UtxoAddress, VaultId};
+use tari_template_lib_types::{Amount, ComponentAddress, ResourceAddress, UtxoAddress, UtxoId, VaultId};
 
 use crate::provider::{ProviderError, ProviderResult, indexer::IndexerProvider};
 
@@ -22,6 +23,20 @@ pub struct VaultBalance {
     pub resource_address: ResourceAddress,
     pub balance: Amount,
     pub locked_balance: Amount,
+}
+
+/// Per-UTXO outcome of decrypting a stealth output's viewable balance.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StealthUtxoValue {
+    /// Successfully decrypted plaintext value (microtari).
+    Value(u64),
+    /// The viewable-balance ciphertext is valid but its value is outside the lookup's coverage.
+    /// Retryable with a wider lookup file (assuming the view key is correct for the resource).
+    OutOfRange,
+    /// The output carries no viewable-balance proof, so it cannot be decrypted.
+    NoViewableBalance,
+    /// The viewable-balance proof bytes could not be decompressed to a valid ElGamal ciphertext.
+    MalformedProof,
 }
 
 impl<Wallet> IndexerProvider<Wallet> {
@@ -102,6 +117,59 @@ impl<Wallet> IndexerProvider<Wallet> {
             .collect();
 
         Ok(values)
+    }
+
+    /// Decrypts the viewable balance of each stealth UTXO, preserving a per-UTXO [`StealthUtxoValue`]
+    /// in input order.
+    ///
+    /// Unlike [`Self::decrypt_stealth_utxo_values`], this does not silently drop UTXOs whose value is
+    /// outside the lookup's coverage or that lack a proof — a monitor can therefore record
+    /// `OutOfRange` (retryable with a wider lookup) distinctly from a decrypted value. The expensive
+    /// batch lookup runs only over well-formed ciphertexts.
+    ///
+    /// The view key is not validated against any resource here; a key that does not match the
+    /// resource's view key yields `OutOfRange` for every output, so validate it against
+    /// `resource.view_key()` beforehand to disambiguate `OutOfRange` from a key mismatch.
+    pub fn decrypt_stealth_utxo_values_opt<L: ValueLookup>(
+        &self,
+        view_secret_key: &RistrettoSecretKey,
+        utxos: &[(UtxoId, Utxo)],
+        lookup: &L,
+    ) -> ProviderResult<Vec<(UtxoId, StealthUtxoValue)>> {
+        let mut outcomes: Vec<Option<StealthUtxoValue>> = Vec::with_capacity(utxos.len());
+        let mut proofs = Vec::new();
+        let mut proof_indexes = Vec::new();
+
+        for (i, (_, utxo)) in utxos.iter().enumerate() {
+            match utxo.output().and_then(|o| o.output.viewable_balance.as_ref()) {
+                None => outcomes.push(Some(StealthUtxoValue::NoViewableBalance)),
+                Some(bytes) => match ElgamalVerifiableBalance::convert_from_byte_type(bytes) {
+                    Ok(proof) => {
+                        outcomes.push(None);
+                        proof_indexes.push(i);
+                        proofs.push(proof);
+                    },
+                    Err(_) => outcomes.push(Some(StealthUtxoValue::MalformedProof)),
+                },
+            }
+        }
+
+        if !proofs.is_empty() {
+            let results = ElgamalVerifiableBalance::decrypt_many(view_secret_key, &proofs, lookup)
+                .map_err(|e| ProviderError::other(format!("Value lookup error: {e}")))?;
+            for (index, value) in proof_indexes.into_iter().zip(results) {
+                outcomes[index] = Some(match value {
+                    Some(v) => StealthUtxoValue::Value(v),
+                    None => StealthUtxoValue::OutOfRange,
+                });
+            }
+        }
+
+        Ok(utxos
+            .iter()
+            .zip(outcomes)
+            .map(|((id, _), outcome)| (*id, outcome.expect("outcome assigned for every utxo index")))
+            .collect())
     }
 
     /// Fetches a UTXO from the network and decrypts its value using the given ElGamal view secret key.

--- a/crates/wallet/ootle-rs/src/provider/indexer.rs
+++ b/crates/wallet/ootle-rs/src/provider/indexer.rs
@@ -13,6 +13,7 @@ use tari_indexer_client::{
 };
 use tari_ootle_common_types::{
     Epoch,
+    NumPreshards,
     engine_types::{
         Utxo,
         commit_result::ExecuteResult,
@@ -98,6 +99,14 @@ impl<Wallet> IndexerProvider<Wallet> {
     pub async fn get_epoch(&self) -> ProviderResult<Epoch> {
         let resp = self.client.get_network_info().await?;
         Ok(resp.epoch)
+    }
+
+    /// The number of preshards the network is partitioned into. Needed to enumerate the full shard
+    /// set when resuming a [`ShardCursor`](crate::provider::ShardCursor), since the UTXO update
+    /// stream emits nothing for shards with no updates.
+    pub async fn get_num_preshards(&self) -> ProviderResult<NumPreshards> {
+        let resp = self.client.get_network_sync_state().await?;
+        Ok(resp.network_desc.num_preshards)
     }
 
     /// Subscribe to a filtered stream of template-emitted events via SSE.

--- a/crates/wallet/ootle-rs/src/provider/indexer.rs
+++ b/crates/wallet/ootle-rs/src/provider/indexer.rs
@@ -144,7 +144,7 @@ impl<Wallet> IndexerProvider<Wallet> {
     pub async fn fetch_unspent_utxos(
         &self,
         resource_address: ResourceAddress,
-        tag_and_nonce_pairs: Vec<(UtxoTag, RistrettoPublicKeyBytes)>,
+        tag_and_nonce_pairs: &[(UtxoTag, RistrettoPublicKeyBytes)],
     ) -> ProviderResult<Vec<(UtxoId, Utxo)>> {
         const MAX_PAIRS_PER_REQUEST: usize = 1000;
         if tag_and_nonce_pairs.is_empty() {

--- a/crates/wallet/ootle-rs/src/provider/indexer.rs
+++ b/crates/wallet/ootle-rs/src/provider/indexer.rs
@@ -9,17 +9,24 @@ use std::{
 
 use tari_indexer_client::{
     rest_api_client::IndexerRestApiClient,
-    types::{GetSubstateRequest, GetSubstatesRequest, SubmitTransactionRequest},
+    types::{GetSubstateRequest, GetSubstatesRequest, GetUtxosRequest, SubmitTransactionRequest},
 };
 use tari_ootle_common_types::{
     Epoch,
     engine_types::{
+        Utxo,
         commit_result::ExecuteResult,
+        resource::Resource,
         substate::{Substate, SubstateId},
     },
     optional::Optional,
 };
 use tari_ootle_transaction::{Transaction, TransactionEnvelope, UnsignedTransaction};
+use tari_template_lib_types::{
+    ResourceAddress,
+    UtxoId,
+    crypto::{RistrettoPublicKeyBytes, UtxoTag},
+};
 use tracing::debug;
 
 use crate::{
@@ -30,6 +37,8 @@ use crate::{
         Provider,
         ProviderError,
         ProviderResult,
+        StealthUtxoStream,
+        StealthUtxoWatchRequest,
         TransactionEventFilter,
         TransactionEventStream,
         TransactionWatcher,
@@ -106,6 +115,53 @@ impl<Wallet> IndexerProvider<Wallet> {
             .await
             .optional()?;
         Ok(resp.map(|r| Substate::new(r.version, r.substate)))
+    }
+
+    /// Fetch a resource by address. The returned [`Resource`] carries its type, optional view key,
+    /// divisibility, and total supply.
+    pub async fn get_resource(&self, resource_address: ResourceAddress) -> ProviderResult<Resource> {
+        let resp = self.client.get_resource(resource_address).await?;
+        Ok(resp.resource)
+    }
+
+    /// Watch stealth UTXO updates for a resource, resuming from a per-shard cursor.
+    ///
+    /// Each drained pass yields typed [`StealthUtxoFrame`](crate::provider::StealthUtxoFrame)s. An
+    /// `Unspent` frame carries only the `(tag, public_nonce)` fetch key — resolve the commitment and
+    /// viewable-balance ciphertext with [`Self::fetch_unspent_utxos`]. Set `unspent_only = false` on
+    /// the request to also receive `Spent`/`Burnt` frames.
+    pub fn watch_stealth_utxos(&self, request: StealthUtxoWatchRequest) -> StealthUtxoStream {
+        StealthUtxoStream::new(Arc::downgrade(&self.client), request)
+    }
+
+    /// Fetch full stealth UTXO outputs by their `(tag, public_nonce)` fetch keys (as delivered by
+    /// `StealthUtxoFrame::Unspent`). Returns `(UtxoId, Utxo)` pairs including the commitment and the
+    /// viewable-balance ciphertext.
+    ///
+    /// Only currently-unspent outputs are returned — the indexer prunes an output's ciphertext once
+    /// it is spent, so a key whose output has since been spent is simply absent from the result.
+    /// Requests are automatically chunked to the indexer's per-request limit.
+    pub async fn fetch_unspent_utxos(
+        &self,
+        resource_address: ResourceAddress,
+        tag_and_nonce_pairs: Vec<(UtxoTag, RistrettoPublicKeyBytes)>,
+    ) -> ProviderResult<Vec<(UtxoId, Utxo)>> {
+        const MAX_PAIRS_PER_REQUEST: usize = 1000;
+        if tag_and_nonce_pairs.is_empty() {
+            return Ok(Vec::new());
+        }
+        let mut utxos = Vec::with_capacity(tag_and_nonce_pairs.len());
+        for chunk in tag_and_nonce_pairs.chunks(MAX_PAIRS_PER_REQUEST) {
+            let resp = self
+                .client
+                .get_utxos(GetUtxosRequest {
+                    resource_address,
+                    tag_and_nonce_pairs: chunk.to_vec(),
+                })
+                .await?;
+            utxos.extend(resp.utxos);
+        }
+        Ok(utxos)
     }
 }
 

--- a/crates/wallet/ootle-rs/src/provider/mod.rs
+++ b/crates/wallet/ootle-rs/src/provider/mod.rs
@@ -28,6 +28,7 @@ mod input_resolver;
 mod traits;
 mod tx_stream;
 mod tx_watcher;
+mod utxo_watcher;
 mod want_input;
 
 pub use balance::*;
@@ -37,4 +38,5 @@ pub use event_watcher::*;
 pub use indexer::*;
 pub use traits::*;
 pub use tx_watcher::*;
+pub use utxo_watcher::*;
 pub use want_input::*;

--- a/crates/wallet/ootle-rs/src/provider/utxo_watcher.rs
+++ b/crates/wallet/ootle-rs/src/provider/utxo_watcher.rs
@@ -155,7 +155,10 @@ impl StealthUtxoStream {
                             }
                         }
                         if let Some(eos) = eos {
-                            let Some(shard) = current_shard else {
+                            // Take the shard so a following `EndOfShard` (or any frame) that is not
+                            // preceded by a fresh `StartOfShard` errors out rather than being
+                            // misattributed to this shard and corrupting its cursor.
+                            let Some(shard) = current_shard.take() else {
                                 yield Err(UtxoWatcherError::DecodeError(
                                     "EndOfShard received before any StartOfShard".to_string(),
                                 ));

--- a/crates/wallet/ootle-rs/src/provider/utxo_watcher.rs
+++ b/crates/wallet/ootle-rs/src/provider/utxo_watcher.rs
@@ -1,0 +1,258 @@
+//   Copyright 2026 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+use std::{collections::BTreeMap, sync::Weak};
+
+use futures::{Stream, StreamExt};
+use tari_indexer_client::{
+    error::IndexerRestClientError,
+    protobuf::{self, UtxoUpdatePayload},
+    protobuf_stream::ProtobufStreamError,
+    rest_api_client::IndexerRestApiClient,
+    types::GetUtxoUpdatesRequest,
+};
+use tari_ootle_common_types::{Epoch, NumPreshards, StateVersion, array_utils::copy_fixed_checked, shard::Shard};
+use tari_template_lib_types::{
+    ResourceAddress,
+    UtxoId,
+    crypto::{RistrettoPublicKeyBytes, UtxoTag},
+};
+use tracing::error;
+
+/// Request to watch stealth UTXO updates for a resource, resuming from a per-shard cursor.
+#[derive(Debug, Clone)]
+pub struct StealthUtxoWatchRequest {
+    pub resource_address: ResourceAddress,
+    /// Lower bound epoch for the scan. Individual shards resume from `shard_state_versions`.
+    pub from_epoch: Epoch,
+    /// Per-shard resume cursor. Shards not present default to `StateVersion::zero` on the indexer.
+    pub shard_state_versions: Vec<(Shard, StateVersion)>,
+    /// When true, only currently-unspent UTXOs are streamed (no `Spent`/`Burnt` frames).
+    /// A monitor that must track spends has to set this to `false`.
+    pub unspent_only: bool,
+    /// Maximum updates returned per shard per pass. `StartOfShard::num_updates == per_shard_limit`
+    /// indicates the shard has more updates to drain on a subsequent request.
+    pub per_shard_limit: u32,
+}
+
+impl StealthUtxoWatchRequest {
+    fn into_request(self) -> GetUtxoUpdatesRequest {
+        GetUtxoUpdatesRequest {
+            from_epoch: self.from_epoch,
+            shard_state_versions: self.shard_state_versions,
+            resource_address: self.resource_address,
+            unspent_only: self.unspent_only,
+            per_shard_limit: self.per_shard_limit,
+        }
+    }
+}
+
+/// A single decoded frame from the stealth UTXO update stream.
+///
+/// Frames arrive grouped per shard: a `StartOfShard`, then zero or more `Unspent`/`Spent`/`Burnt`
+/// updates, terminated by an `EndOfShard` carrying the shard's high-watermark state version — use
+/// it to advance the resume cursor for that shard (see [`ShardCursor::observe`]).
+#[derive(Debug, Clone)]
+pub enum StealthUtxoFrame {
+    StartOfShard {
+        shard: Shard,
+        max_state_version: StateVersion,
+        num_updates: u32,
+    },
+    /// A currently-unspent output. Carries only the `(tag, public_nonce)` fetch key — the commitment
+    /// and viewable-balance ciphertext must be resolved via
+    /// [`fetch_unspent_utxos`](crate::provider::IndexerProvider::fetch_unspent_utxos).
+    Unspent {
+        tag: UtxoTag,
+        public_nonce: RistrettoPublicKeyBytes,
+    },
+    Spent {
+        id: UtxoId,
+        version: u32,
+    },
+    Burnt {
+        id: UtxoId,
+        version: u32,
+    },
+    EndOfShard {
+        shard: Shard,
+        max_state_version: StateVersion,
+    },
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum UtxoWatcherError {
+    #[error("Indexer REST client has been dropped")]
+    ClientDropped,
+    #[error("Indexer REST client error: {0}")]
+    IndexerClientError(#[from] IndexerRestClientError),
+    #[error("UTXO stream error: {0}")]
+    StreamError(#[from] ProtobufStreamError),
+    #[error("Failed to decode UTXO update frame: {0}")]
+    DecodeError(String),
+}
+
+/// A stream of stealth UTXO updates for a resource. Created via
+/// [`IndexerProvider::watch_stealth_utxos`](crate::provider::IndexerProvider::watch_stealth_utxos).
+///
+/// Each call drains a single pass over the requested shards (paged by `per_shard_limit`) and then
+/// ends. A monitor loops: build the request from its persisted [`ShardCursor`], drain the stream,
+/// advance the cursor from `EndOfShard` watermarks, then poll again.
+pub struct StealthUtxoStream {
+    client: Weak<IndexerRestApiClient>,
+    request: StealthUtxoWatchRequest,
+}
+
+impl StealthUtxoStream {
+    pub(crate) fn new(client: Weak<IndexerRestApiClient>, request: StealthUtxoWatchRequest) -> Self {
+        Self { client, request }
+    }
+
+    /// Consume into a futures Stream of typed [`StealthUtxoFrame`] items.
+    pub fn into_stream(self) -> impl Stream<Item = Result<StealthUtxoFrame, UtxoWatcherError>> {
+        async_stream::stream! {
+            let client = match self.client.upgrade() {
+                Some(client) => client,
+                None => {
+                    error!("Indexer REST client has been dropped");
+                    yield Err(UtxoWatcherError::ClientDropped);
+                    return;
+                },
+            };
+
+            let mut stream = match client.stream_utxo_updates_protobuf(self.request.into_request()).await {
+                Ok(stream) => stream,
+                Err(err) => {
+                    error!(%err, "Failed to start stealth UTXO update stream");
+                    yield Err(UtxoWatcherError::IndexerClientError(err));
+                    return;
+                },
+            };
+
+            // `EndOfShard` on the wire does not carry the shard number; stamp it from the preceding
+            // `StartOfShard` so each frame is self-describing.
+            let mut current_shard: Option<Shard> = None;
+            loop {
+                match stream.next().await {
+                    Some(Ok(payload)) => {
+                        let UtxoUpdatePayload { sos, update, eos } = payload;
+                        if let Some(sos) = sos {
+                            let shard = Shard::from(sos.shard);
+                            current_shard = Some(shard);
+                            yield Ok(StealthUtxoFrame::StartOfShard {
+                                shard,
+                                max_state_version: StateVersion::from(sos.max_state_version),
+                                num_updates: sos.num_updates,
+                            });
+                        }
+                        if let Some(update) = update {
+                            match convert_update(update) {
+                                Ok(frame) => yield Ok(frame),
+                                Err(err) => {
+                                    yield Err(err);
+                                    return;
+                                },
+                            }
+                        }
+                        if let Some(eos) = eos {
+                            let Some(shard) = current_shard else {
+                                yield Err(UtxoWatcherError::DecodeError(
+                                    "EndOfShard received before any StartOfShard".to_string(),
+                                ));
+                                return;
+                            };
+                            yield Ok(StealthUtxoFrame::EndOfShard {
+                                shard,
+                                max_state_version: StateVersion::from(eos.max_state_version),
+                            });
+                        }
+                    },
+                    Some(Err(err)) => {
+                        error!(%err, "Error receiving stealth UTXO update");
+                        yield Err(UtxoWatcherError::StreamError(err));
+                        return;
+                    },
+                    None => return,
+                }
+            }
+        }
+    }
+}
+
+fn convert_update(update: protobuf::WalletUtxoUpdate) -> Result<StealthUtxoFrame, UtxoWatcherError> {
+    match update {
+        protobuf::WalletUtxoUpdate::Unspent(unspent) => {
+            let public_nonce = RistrettoPublicKeyBytes::from_bytes(&unspent.public_nonce)
+                .map_err(|e| UtxoWatcherError::DecodeError(format!("public nonce: {e}")))?;
+            Ok(StealthUtxoFrame::Unspent {
+                tag: unspent.tag.into(),
+                public_nonce,
+            })
+        },
+        protobuf::WalletUtxoUpdate::Spent(spent) => {
+            let id = copy_fixed_checked(&spent.id)
+                .map(UtxoId::from_array)
+                .ok_or_else(|| UtxoWatcherError::DecodeError("UTXO id: incorrect length".to_string()))?;
+            Ok(StealthUtxoFrame::Spent {
+                id,
+                version: spent.version,
+            })
+        },
+        protobuf::WalletUtxoUpdate::Burnt(burnt) => {
+            let id = copy_fixed_checked(&burnt.id)
+                .map(UtxoId::from_array)
+                .ok_or_else(|| UtxoWatcherError::DecodeError("UTXO id: incorrect length".to_string()))?;
+            Ok(StealthUtxoFrame::Burnt {
+                id,
+                version: burnt.version,
+            })
+        },
+    }
+}
+
+/// A per-shard resume cursor for the stealth UTXO stream.
+///
+/// Seed a fresh monitor with [`ShardCursor::genesis`] (all shards at `StateVersion::zero`), pass
+/// [`ShardCursor::to_pairs`] into a [`StealthUtxoWatchRequest`], and advance it from each
+/// [`StealthUtxoFrame::EndOfShard`] watermark via [`ShardCursor::observe`].
+#[derive(Debug, Clone, Default)]
+pub struct ShardCursor {
+    versions: BTreeMap<Shard, StateVersion>,
+}
+
+impl ShardCursor {
+    /// A cursor covering every shard of `num_preshards`, each at `StateVersion::zero` (full backfill).
+    pub fn genesis(num_preshards: NumPreshards) -> Self {
+        Self {
+            versions: num_preshards
+                .all_shards_iter()
+                .map(|shard| (shard, StateVersion::zero()))
+                .collect(),
+        }
+    }
+
+    /// Build a cursor from persisted `(shard, state_version)` pairs.
+    pub fn from_pairs(pairs: impl IntoIterator<Item = (Shard, StateVersion)>) -> Self {
+        Self {
+            versions: pairs.into_iter().collect(),
+        }
+    }
+
+    /// The cursor as `(shard, state_version)` pairs (ascending by shard) for a watch request.
+    pub fn to_pairs(&self) -> Vec<(Shard, StateVersion)> {
+        self.versions.iter().map(|(shard, v)| (*shard, *v)).collect()
+    }
+
+    /// The resume state version for a shard (`StateVersion::zero` if untracked).
+    pub fn get(&self, shard: Shard) -> StateVersion {
+        self.versions.get(&shard).copied().unwrap_or_else(StateVersion::zero)
+    }
+
+    /// Advance a shard's cursor to `max_state_version`. Monotonic — never moves backwards.
+    pub fn observe(&mut self, shard: Shard, max_state_version: StateVersion) {
+        let entry = self.versions.entry(shard).or_insert_with(StateVersion::zero);
+        if max_state_version > *entry {
+            *entry = max_state_version;
+        }
+    }
+}


### PR DESCRIPTION
## Motivation

Adds the `ootle-rs` provider primitives needed to continuously monitor and value a resource's stealth UTXOs. These back an upcoming stealth-UTXO monitoring reference app; without them a consumer has to reach around the provider directly into `tari_indexer_client` / `tari_engine_types`. All changes are additive — no existing APIs change.

## Changes

- **`watch_stealth_utxos`** — a typed `StealthUtxoStream` over the indexer UTXO update stream, yielding `StartOfShard` / `Unspent` / `Spent` / `Burnt` / `EndOfShard` frames. `EndOfShard` is stamped with its shard number (the wire representation omits it) so frames are self-describing for per-shard cursor advancement.
- **`ShardCursor`** — `genesis` / `from_pairs` / `to_pairs` / `observe` helper for the per-shard `(Shard, StateVersion)` resume cursor.
- **`fetch_unspent_utxos`** — batched `(tag, public_nonce)` → `(UtxoId, Utxo)` lookup, auto-chunked to the indexer's 1000-pair per-request limit.
- **`decrypt_stealth_utxo_values_opt`** — per-UTXO decrypt that preserves a `StealthUtxoValue` outcome (`Value` / `OutOfRange` / `NoViewableBalance` / `MalformedProof`) in input order, unlike `decrypt_stealth_utxo_values` which drops non-covered outputs. This lets a monitor record out-of-lookup-range values (retryable) distinctly from decrypted ones.
- **`get_resource`** — typed convenience returning the engine `Resource`.

## Testing

- `cargo clippy -p ootle-rs --features mmap-value-lookup` and `--all-targets`: clean.
- Integration coverage against a live indexer will land with the consuming reference app.
