### PR TITLE
fix(indexer): serve Prometheus metrics on a separate listener

### DIFF
--- a/applications/tari_indexer/src/config.rs
+++ b/applications/tari_indexer/src/config.rs
@@ -99,6 +99,11 @@ pub struct IndexerConfig {
     pub p2p: P2pConfig,
     /// Listening address for the indexer API server
     pub api_listen_address: Option<SocketAddr>,
+    /// Listening address for the Prometheus metrics endpoint (`GET /_metrics`).
+    /// Kept separate from `api_listen_address` so metrics can bind privately
+    /// (e.g. localhost for a sidecar) while the REST API remains public.
+    /// Defaults to `127.0.0.1:18302` when not set.
+    pub metrics_listen_address: Option<SocketAddr>,
     /// GraphQL port of the indexer application
     pub graphql_address: Option<SocketAddr>,
     /// The address of the Web UI
@@ -153,6 +158,7 @@ impl Default for IndexerConfig {
             data_dir: PathBuf::from("data/indexer"),
             p2p: P2pConfig::default(),
             api_listen_address: Some("127.0.0.1:18300".parse().unwrap()),
+            metrics_listen_address: Some("127.0.0.1:18302".parse().unwrap()),
             graphql_address: Some("127.0.0.1:18301".parse().unwrap()),
             web_ui_address: Some("127.0.0.1:15000".parse().unwrap()),
             web_ui_public_api_url: None,

--- a/applications/tari_indexer/src/lib.rs
+++ b/applications/tari_indexer/src/lib.rs
@@ -128,16 +128,23 @@ where
         ));
     }
 
-    // Run the REST API
+    // Run the REST API (and, when metrics are enabled, a separate Prometheus listener)
     let listen_addr = config.indexer.api_listen_address;
     if let Some(listen_addr) = listen_addr {
         #[cfg(not(feature = "metrics"))]
         let server = rest_api::Server::new();
         #[cfg(feature = "metrics")]
         let server = rest_api::Server::new(registry);
+        #[cfg(feature = "metrics")]
+        let metrics_listen_addr = config
+            .indexer
+            .metrics_listen_address
+            .unwrap_or_else(|| "127.0.0.1:18302".parse().expect("valid default metrics address"));
         let listen_address = server
             .spawn(
                 listen_addr,
+                #[cfg(feature = "metrics")]
+                metrics_listen_addr,
                 &services,
                 &config.indexer.rate_limits,
                 shutdown_signal.clone(),

--- a/applications/tari_indexer/src/rest_api/metrics.rs
+++ b/applications/tari_indexer/src/rest_api/metrics.rs
@@ -30,6 +30,11 @@ impl MetricsHandler {
     pub fn new(registry: Registry) -> Self {
         Self(Arc::new(registry))
     }
+
+    /// Share a registry already wrapped in `Arc` (e.g. REST metrics middleware + dedicated listener).
+    pub fn from_arc(registry: Arc<Registry>) -> Self {
+        Self(registry)
+    }
 }
 
 impl<S> axum::handler::Handler<(), S> for MetricsHandler {

--- a/applications/tari_indexer/src/rest_api/server.rs
+++ b/applications/tari_indexer/src/rest_api/server.rs
@@ -1,7 +1,9 @@
 //   Copyright 2025 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use std::{net::SocketAddr, sync::Arc};
+use std::net::SocketAddr;
+#[cfg(feature = "metrics")]
+use std::sync::Arc;
 
 use axum::{
     Extension,

--- a/applications/tari_indexer/src/rest_api/server.rs
+++ b/applications/tari_indexer/src/rest_api/server.rs
@@ -1,7 +1,7 @@
 //   Copyright 2025 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use std::net::SocketAddr;
+use std::{net::SocketAddr, sync::Arc};
 
 use axum::{
     Extension,
@@ -96,6 +96,7 @@ impl Server {
     pub async fn spawn(
         #[allow(unused_mut)] mut self,
         preferred_addr: SocketAddr,
+        #[cfg(feature = "metrics")] metrics_preferred_addr: SocketAddr,
         services: &Services,
         rate_limits: &IndexerRateLimitsConfig,
         shutdown: ShutdownSignal,
@@ -255,12 +256,32 @@ impl Server {
             .layer(TraceLayer::new_for_http());
 
         #[cfg(feature = "metrics")]
-        let router = router
-            .layer(axum::middleware::from_fn_with_state(
-                metrics::register(&mut self.registry),
-                metrics::layer,
-            ))
-            .route("/_metrics", get(metrics::MetricsHandler::new(self.registry)));
+        let router = {
+            // Register HTTP request metrics on the REST path, then share the full
+            // registry with a dedicated metrics listener (not exposed on the REST API).
+            let request_metrics = metrics::register(&mut self.registry);
+            let registry = Arc::new(self.registry);
+            let metrics_shutdown = shutdown.clone();
+            let metrics_listener = try_bind_with_fallback(metrics_preferred_addr).await?;
+            let metrics_listen_addr = metrics_listener.local_addr()?;
+            info!(
+                target: LOG_TARGET,
+                "📊 Indexer Prometheus metrics listening on {metrics_listen_addr} (separate from REST API)"
+            );
+            let metrics_router = Router::new().route(
+                "/_metrics",
+                get(metrics::MetricsHandler::from_arc(registry)),
+            );
+            tokio::spawn(async move {
+                if let Err(error) = axum::serve(metrics_listener, metrics_router)
+                    .with_graceful_shutdown(metrics_shutdown)
+                    .await
+                {
+                    error!(target: LOG_TARGET, "Indexer metrics HTTP server error: {error}");
+                }
+            });
+            router.layer(axum::middleware::from_fn_with_state(request_metrics, metrics::layer))
+        };
 
         let listener = try_bind_with_fallback(preferred_addr).await?;
 


### PR DESCRIPTION
## Summary

Fixes #2330 (bounty-S).

The indexer previously chained `GET /_metrics` onto the same HTTP router and listener as the public REST API. This change:

- Adds `indexer.metrics_listen_address` (default `127.0.0.1:18302`)
- Serves `/_metrics` only on a dedicated listener
- Removes `/_metrics` from the REST router (request metrics middleware remains on REST)
- Shares the Prometheus registry via `Arc` (`MetricsHandler::from_arc`)

## Acceptance checklist

- [x] New metrics bind-address config field distinct from `api_listen_address`
- [x] `/_metrics` on metrics listener only; not on REST router
- [x] REST endpoints unchanged (metrics middleware still applied on REST)
- [x] `metrics` feature: listener only when feature enabled (gated as before)
- [x] `cargo check -p tari_indexer` green locally

## Test plan

- [x] `cargo check -p tari_indexer` on aarch64-darwin (rustc 1.97)
- [ ] Manual: start indexer, confirm REST `/_metrics` → 404 and metrics bind serves exposition
- [ ] CI

AI-assisted development used per issue notes.