### PR TITLE
Split indexer metrics listener

### DIFF
--- a/applications/tari_indexer/README.md
+++ b/applications/tari_indexer/README.md
@@ -80,6 +80,7 @@ The following options are available (use `tari_indexer --help` for the most up-t
 
 #### API Server
 - `-r, --api-listen-address <API_LISTEN_ADDRESS>`: Bind address for REST API server
+- `--metrics-listen-address <METRICS_LISTEN_ADDRESS>`: Bind address for Prometheus metrics server
 - `--web-ui-public-api-url <WEB_UI_PUBLIC_API_URL>`: Public API URL for web UI [env: `TARI_INDEXER_WEB_UI_PUBLIC_API_URL`]
 - `--web-ui-public-graphql-url <WEB_UI_PUBLIC_GRAPHQL_URL>`: Public GraphQL URL for web UI [env: `TARI_INDEXER_WEB_UI_PUBLIC_GRAPHQL_URL`]
 

--- a/applications/tari_indexer/docs/configuration.md
+++ b/applications/tari_indexer/docs/configuration.md
@@ -47,6 +47,9 @@ Main indexer application settings.
 # API server listening address (default: "127.0.0.1:18300")
 #api_listen_address = "127.0.0.1:18300"
 
+# Prometheus metrics server listening address (default: "127.0.0.1:18302")
+#metrics_listen_address = "127.0.0.1:18302"
+
 # GraphQL server address (default: "127.0.0.1:18301")
 #graphql_address = "127.0.0.1:18301"
 

--- a/applications/tari_indexer/src/cli.rs
+++ b/applications/tari_indexer/src/cli.rs
@@ -51,6 +51,9 @@ pub struct Cli {
     /// Bind address for API server
     #[clap(long, short = 'r', alias = "api-address")]
     pub api_listen_address: Option<SocketAddr>,
+    /// Bind address for Prometheus metrics server
+    #[clap(long, alias = "metrics-address")]
+    pub metrics_listen_address: Option<SocketAddr>,
     #[clap(long, alias = "node-grpc", short = 'g', env = "TARI_INDEXER_MINOTARI_NODE_GRPC_URL")]
     pub epoch_oracle_minotari_node_grpc_url: Option<Url>,
     #[clap(long, alias = "oracle-config")]
@@ -95,6 +98,9 @@ impl ConfigOverrideProvider for Cli {
 
         if let Some(ref addr) = self.api_listen_address {
             overrides.push(("indexer.api_listen_address".to_string(), addr.to_string()));
+        }
+        if let Some(ref addr) = self.metrics_listen_address {
+            overrides.push(("indexer.metrics_listen_address".to_string(), addr.to_string()));
         }
 
         if !self.peer_seeds.is_empty() {

--- a/applications/tari_indexer/src/config.rs
+++ b/applications/tari_indexer/src/config.rs
@@ -99,6 +99,8 @@ pub struct IndexerConfig {
     pub p2p: P2pConfig,
     /// Listening address for the indexer API server
     pub api_listen_address: Option<SocketAddr>,
+    /// Listening address for the Prometheus metrics server
+    pub metrics_listen_address: Option<SocketAddr>,
     /// GraphQL port of the indexer application
     pub graphql_address: Option<SocketAddr>,
     /// The address of the Web UI
@@ -153,6 +155,7 @@ impl Default for IndexerConfig {
             data_dir: PathBuf::from("data/indexer"),
             p2p: P2pConfig::default(),
             api_listen_address: Some("127.0.0.1:18300".parse().unwrap()),
+            metrics_listen_address: Some("127.0.0.1:18302".parse().unwrap()),
             graphql_address: Some("127.0.0.1:18301".parse().unwrap()),
             web_ui_address: Some("127.0.0.1:15000".parse().unwrap()),
             web_ui_public_api_url: None,

--- a/applications/tari_indexer/src/lib.rs
+++ b/applications/tari_indexer/src/lib.rs
@@ -138,6 +138,8 @@ where
         let listen_address = server
             .spawn(
                 listen_addr,
+                #[cfg(feature = "metrics")]
+                config.indexer.metrics_listen_address,
                 &services,
                 &config.indexer.rate_limits,
                 shutdown_signal.clone(),

--- a/applications/tari_indexer/src/rest_api/metrics.rs
+++ b/applications/tari_indexer/src/rest_api/metrics.rs
@@ -1,7 +1,7 @@
 //   Copyright 2025 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use std::{future, sync::Arc, time::Instant};
+use std::{future, net::SocketAddr, sync::Arc, time::Instant};
 
 use axum::{
     body::{Body, HttpBody},
@@ -9,7 +9,10 @@ use axum::{
     http::{Request, StatusCode},
     middleware::Next,
     response::{IntoResponse, Response},
+    routing::get,
+    Router,
 };
+use log::*;
 use prometheus_client::{
     encoding::text::encode,
     metrics::{
@@ -19,9 +22,12 @@ use prometheus_client::{
     },
     registry::Registry,
 };
+use tari_ootle_app_utilities::tcp::try_bind_with_fallback;
+use tari_shutdown::ShutdownSignal;
 
 use crate::metrics::CollectorRegister;
 
+const LOG_TARGET: &str = "tari::ootle::indexer::rest_api::metrics";
 const METRICS_CONTENT_TYPE: &str = "application/openmetrics-text;charset=utf-8;version=1.0.0";
 #[derive(Debug, Clone)]
 pub struct MetricsHandler(Arc<Registry>);
@@ -54,6 +60,25 @@ impl<S> axum::handler::Handler<(), S> for MetricsHandler {
                 .into_response(),
         )
     }
+}
+
+pub async fn spawn_server(
+    preferred_addr: SocketAddr,
+    registry: Registry,
+    shutdown: ShutdownSignal,
+) -> anyhow::Result<SocketAddr> {
+    let listener = try_bind_with_fallback(preferred_addr).await?;
+    let listen_addr = listener.local_addr()?;
+    let router = Router::new().route("/_metrics", get(MetricsHandler::new(registry)));
+
+    info!(target: LOG_TARGET, "Indexer metrics server listening on {listen_addr}");
+    tokio::spawn(async move {
+        if let Err(error) = axum::serve(listener, router).with_graceful_shutdown(shutdown).await {
+            error!(target: LOG_TARGET, "Indexer metrics HTTP server error: {error}");
+        }
+    });
+
+    Ok(listen_addr)
 }
 
 #[derive(Clone)]

--- a/applications/tari_indexer/src/rest_api/server.rs
+++ b/applications/tari_indexer/src/rest_api/server.rs
@@ -96,6 +96,7 @@ impl Server {
     pub async fn spawn(
         #[allow(unused_mut)] mut self,
         preferred_addr: SocketAddr,
+        #[cfg(feature = "metrics")] metrics_preferred_addr: Option<SocketAddr>,
         services: &Services,
         rate_limits: &IndexerRateLimitsConfig,
         shutdown: ShutdownSignal,
@@ -255,12 +256,18 @@ impl Server {
             .layer(TraceLayer::new_for_http());
 
         #[cfg(feature = "metrics")]
-        let router = router
-            .layer(axum::middleware::from_fn_with_state(
+        let router = if let Some(metrics_preferred_addr) = metrics_preferred_addr {
+            let router = router.layer(axum::middleware::from_fn_with_state(
                 metrics::register(&mut self.registry),
                 metrics::layer,
-            ))
-            .route("/_metrics", get(metrics::MetricsHandler::new(self.registry)));
+            ));
+            let metrics_listen_addr =
+                metrics::spawn_server(metrics_preferred_addr, self.registry, shutdown.clone()).await?;
+            debug!(target: LOG_TARGET, "Metrics address {}", metrics_listen_addr);
+            router
+        } else {
+            router
+        };
 
         let listener = try_bind_with_fallback(preferred_addr).await?;
 

--- a/applications/tari_ootle_app_utilities/config_presets/d_indexer.toml
+++ b/applications/tari_ootle_app_utilities/config_presets/d_indexer.toml
@@ -21,6 +21,9 @@
 # API listener address (default = "127.0.0.1:18300")
 #api_listen_address = "127.0.0.1:18300"
 
+# Prometheus metrics listener address (default = "127.0.0.1:18302")
+#metrics_listen_address = "127.0.0.1:18302"
+
 # HTTP UI listener address (default = "127.0.0.1:15000")
 #web_ui_address = "127.0.0.1:15000"
 

--- a/applications/tari_swarm_daemon/src/process_definitions/indexer.rs
+++ b/applications/tari_swarm_daemon/src/process_definitions/indexer.rs
@@ -23,6 +23,7 @@ impl ProcessDefinition for Indexer {
     async fn get_command(&self, mut context: ProcessContext<'_>) -> anyhow::Result<Command> {
         let mut command = Command::new(context.bin());
         let api_port = context.get_free_port("api").await?;
+        let metrics_port = context.get_free_port("metrics").await?;
         let graphql_port = context.get_free_port("graphql").await?;
         let web_ui_port = context.get_free_port("web").await?;
         let listen_ip = context.listen_ip();
@@ -30,6 +31,7 @@ impl ProcessDefinition for Indexer {
         let api_public_url = context.get_public_api_url();
         let graphql_public_url = context.get_public_graphql_url();
         let api_listener_address = format!("{listen_ip}:{api_port}");
+        let metrics_listener_address = format!("{listen_ip}:{metrics_port}");
         let graphql_listener_address = format!("{listen_ip}:{graphql_port}");
         let web_ui_listener_address = format!("{listen_ip}:{web_ui_port}");
 
@@ -60,6 +62,9 @@ impl ProcessDefinition for Indexer {
                 "-pepoch_oracle.base_layer.base_node_grpc_url={base_node_grpc_url}"
             ))
             .arg(format!("-pindexer.api_listen_address={api_listener_address}"))
+            .arg(format!(
+                "-pindexer.metrics_listen_address={metrics_listener_address}"
+            ))
             .arg(format!("-pindexer.graphql_address={graphql_listener_address}"))
             .arg(format!("-pindexer.web_ui_address={web_ui_listener_address}"))
             .arg(format!("-pindexer.web_ui_public_api_url={api_public_url}"))


### PR DESCRIPTION
Fixes #2330
/claim #2330

## Summary
- add `indexer.metrics_listen_address` and CLI/config documentation for the Prometheus listener
- serve `/_metrics` from a dedicated metrics listener instead of the REST API router
- keep REST request metrics middleware enabled and wire swarm indexers to separate metrics ports

## Validation
- `git diff --check`
- `cargo check -p tari_indexer` (blocked locally: after using a local `protoc`, the build requires `cmake`/MSVC for `randomx-rs`, which is not installed in this environment)