### PR TITLE
fix(indexer): serve Prometheus metrics on a dedicated listener

### DIFF
--- a/applications/tari_indexer/docs/configuration.md
+++ b/applications/tari_indexer/docs/configuration.md
@@ -47,6 +47,10 @@ Main indexer application settings.
 # API server listening address (default: "127.0.0.1:18300")
 #api_listen_address = "127.0.0.1:18300"
 
+# Prometheus metrics (`GET /_metrics`) listen address (default: "127.0.0.1:18302").
+# Separate from api_listen_address so scrape traffic can stay private.
+#metrics_listen_address = "127.0.0.1:18302"
+
 # GraphQL server address (default: "127.0.0.1:18301")
 #graphql_address = "127.0.0.1:18301"
 

--- a/applications/tari_indexer/src/cli.rs
+++ b/applications/tari_indexer/src/cli.rs
@@ -51,6 +51,9 @@ pub struct Cli {
     /// Bind address for API server
     #[clap(long, short = 'r', alias = "api-address")]
     pub api_listen_address: Option<SocketAddr>,
+    /// Bind address for Prometheus metrics (`GET /_metrics`), separate from the API
+    #[clap(long, alias = "metrics-address", env = "TARI_INDEXER_METRICS_LISTEN_ADDRESS")]
+    pub metrics_listen_address: Option<SocketAddr>,
     #[clap(long, alias = "node-grpc", short = 'g', env = "TARI_INDEXER_MINOTARI_NODE_GRPC_URL")]
     pub epoch_oracle_minotari_node_grpc_url: Option<Url>,
     #[clap(long, alias = "oracle-config")]
@@ -95,6 +98,9 @@ impl ConfigOverrideProvider for Cli {
 
         if let Some(ref addr) = self.api_listen_address {
             overrides.push(("indexer.api_listen_address".to_string(), addr.to_string()));
+        }
+        if let Some(ref addr) = self.metrics_listen_address {
+            overrides.push(("indexer.metrics_listen_address".to_string(), addr.to_string()));
         }
 
         if !self.peer_seeds.is_empty() {

--- a/applications/tari_indexer/src/config.rs
+++ b/applications/tari_indexer/src/config.rs
@@ -99,6 +99,10 @@ pub struct IndexerConfig {
     pub p2p: P2pConfig,
     /// Listening address for the indexer API server
     pub api_listen_address: Option<SocketAddr>,
+    /// Listening address for the Prometheus metrics server (`GET /_metrics`).
+    /// Kept separate from `api_listen_address` so scrape traffic can be bound to a
+    /// private interface while REST remains public.
+    pub metrics_listen_address: Option<SocketAddr>,
     /// GraphQL port of the indexer application
     pub graphql_address: Option<SocketAddr>,
     /// The address of the Web UI
@@ -153,6 +157,7 @@ impl Default for IndexerConfig {
             data_dir: PathBuf::from("data/indexer"),
             p2p: P2pConfig::default(),
             api_listen_address: Some("127.0.0.1:18300".parse().unwrap()),
+            metrics_listen_address: Some("127.0.0.1:18302".parse().unwrap()),
             graphql_address: Some("127.0.0.1:18301".parse().unwrap()),
             web_ui_address: Some("127.0.0.1:15000".parse().unwrap()),
             web_ui_public_api_url: None,

--- a/applications/tari_indexer/src/lib.rs
+++ b/applications/tari_indexer/src/lib.rs
@@ -157,13 +157,10 @@ where
             .map_err(|e| ExitError::new(ExitCode::ConfigError, e))?;
         #[cfg(feature = "metrics")]
         if let Some(metrics_addr) = config.indexer.metrics_listen_address {
-            let metrics_listen = rest_api::Server::spawn_metrics_server(
-                metrics_registry,
-                metrics_addr,
-                shutdown_signal.clone(),
-            )
-            .await
-            .map_err(|e| ExitError::new(ExitCode::ConfigError, e))?;
+            let metrics_listen =
+                rest_api::Server::spawn_metrics_server(metrics_registry, metrics_addr, shutdown_signal.clone())
+                    .await
+                    .map_err(|e| ExitError::new(ExitCode::ConfigError, e))?;
             info!(target: LOG_TARGET, "📈 Metrics endpoint on {metrics_listen} (not on REST API)");
         } else {
             info!(target: LOG_TARGET, "📈 metrics_listen_address not set; /_metrics not served");

--- a/applications/tari_indexer/src/lib.rs
+++ b/applications/tari_indexer/src/lib.rs
@@ -128,13 +128,14 @@ where
         ));
     }
 
-    // Run the REST API
+    // Run the REST API (and optional dedicated metrics listener)
     let listen_addr = config.indexer.api_listen_address;
     if let Some(listen_addr) = listen_addr {
         #[cfg(not(feature = "metrics"))]
         let server = rest_api::Server::new();
         #[cfg(feature = "metrics")]
         let server = rest_api::Server::new(registry);
+        #[cfg(not(feature = "metrics"))]
         let listen_address = server
             .spawn(
                 listen_addr,
@@ -144,6 +145,29 @@ where
             )
             .await
             .map_err(|e| ExitError::new(ExitCode::ConfigError, e))?;
+        #[cfg(feature = "metrics")]
+        let (listen_address, metrics_registry) = server
+            .spawn(
+                listen_addr,
+                &services,
+                &config.indexer.rate_limits,
+                shutdown_signal.clone(),
+            )
+            .await
+            .map_err(|e| ExitError::new(ExitCode::ConfigError, e))?;
+        #[cfg(feature = "metrics")]
+        if let Some(metrics_addr) = config.indexer.metrics_listen_address {
+            let metrics_listen = rest_api::Server::spawn_metrics_server(
+                metrics_registry,
+                metrics_addr,
+                shutdown_signal.clone(),
+            )
+            .await
+            .map_err(|e| ExitError::new(ExitCode::ConfigError, e))?;
+            info!(target: LOG_TARGET, "📈 Metrics endpoint on {metrics_listen} (not on REST API)");
+        } else {
+            info!(target: LOG_TARGET, "📈 metrics_listen_address not set; /_metrics not served");
+        }
         debug!(target: LOG_TARGET, "API address {}", listen_address);
         // Run the web ui
         #[cfg(feature = "web_ui")]

--- a/applications/tari_indexer/src/rest_api/metrics.rs
+++ b/applications/tari_indexer/src/rest_api/metrics.rs
@@ -27,10 +27,6 @@ const METRICS_CONTENT_TYPE: &str = "application/openmetrics-text;charset=utf-8;v
 pub struct MetricsHandler(Arc<Registry>);
 
 impl MetricsHandler {
-    pub fn new(registry: Registry) -> Self {
-        Self(Arc::new(registry))
-    }
-
     pub fn from_arc(registry: Arc<Registry>) -> Self {
         Self(registry)
     }

--- a/applications/tari_indexer/src/rest_api/metrics.rs
+++ b/applications/tari_indexer/src/rest_api/metrics.rs
@@ -30,6 +30,10 @@ impl MetricsHandler {
     pub fn new(registry: Registry) -> Self {
         Self(Arc::new(registry))
     }
+
+    pub fn from_arc(registry: Arc<Registry>) -> Self {
+        Self(registry)
+    }
 }
 
 impl<S> axum::handler::Handler<(), S> for MetricsHandler {
@@ -84,6 +88,11 @@ pub fn register(registry: &mut Registry) -> RequestMetrics {
         ),
         response_body_size_histogram: Histogram::new(
             exponential_buckets(100.0, 2.0, 15), // buckets from 100B, doubling, 15 buckets
+        )
+        .register_at(
+            "http_response_body_size_bytes",
+            "HTTP response body size in bytes",
+            registry,
         ),
     }
 }

--- a/applications/tari_indexer/src/rest_api/server.rs
+++ b/applications/tari_indexer/src/rest_api/server.rs
@@ -20,8 +20,6 @@ use utoipa_swagger_ui::SwaggerUi;
 
 #[cfg(feature = "metrics")]
 use crate::rest_api::metrics;
-#[cfg(feature = "metrics")]
-
 use crate::{
     bootstrap::Services,
     config::IndexerRateLimitsConfig,
@@ -96,6 +94,7 @@ impl Server {
         Self { registry }
     }
 
+    /// Spawns the REST API server (no metrics feature).
     #[expect(clippy::too_many_lines)]
     #[cfg(not(feature = "metrics"))]
     pub async fn spawn(
@@ -105,37 +104,87 @@ impl Server {
         rate_limits: &IndexerRateLimitsConfig,
         shutdown: ShutdownSignal,
     ) -> anyhow::Result<SocketAddr> {
-        self.spawn_inner(preferred_addr, services, rate_limits, shutdown)
+        self.spawn_rest(preferred_addr, services, rate_limits, shutdown)
             .await
-            .map(|(addr, _)| addr)
     }
 
-    /// Spawns the REST API. When the `metrics` feature is enabled, also returns the
-    /// shared Prometheus registry so `/_metrics` can be bound separately.
+    /// Spawns the REST API. Also returns the shared Prometheus registry so
+    /// `/_metrics` can be bound on a separate listener via `spawn_metrics_server`.
     #[expect(clippy::too_many_lines)]
     #[cfg(feature = "metrics")]
     pub async fn spawn(
-        #[allow(unused_mut)] mut self,
+        mut self,
         preferred_addr: SocketAddr,
         services: &Services,
         rate_limits: &IndexerRateLimitsConfig,
         shutdown: ShutdownSignal,
     ) -> anyhow::Result<(SocketAddr, Arc<prometheus_client::registry::Registry>)> {
-        self.spawn_inner(preferred_addr, services, rate_limits, shutdown)
-            .await
-            .map(|(addr, reg)| (addr, reg.expect("metrics registry")))
+        let context = HandlerContext::from_services(services);
+        let router = Self::build_router(rate_limits, context);
+        // Request metrics middleware stays on REST; `/_metrics` is a separate listener.
+        let request_metrics = metrics::register(&mut self.registry);
+        let router = router.layer(axum::middleware::from_fn_with_state(request_metrics, metrics::layer));
+        let metrics_registry = Arc::new(self.registry);
+        let listen_addr = Self::serve_router(router, preferred_addr, shutdown).await?;
+        Ok((listen_addr, metrics_registry))
     }
 
-    #[expect(clippy::too_many_lines)]
-    async fn spawn_inner(
-        #[allow(unused_mut)] mut self,
+    #[cfg(not(feature = "metrics"))]
+    async fn spawn_rest(
+        self,
         preferred_addr: SocketAddr,
         services: &Services,
         rate_limits: &IndexerRateLimitsConfig,
         shutdown: ShutdownSignal,
-    ) -> anyhow::Result<(SocketAddr, Option<Arc<prometheus_client::registry::Registry>>)> {
+    ) -> anyhow::Result<SocketAddr> {
         let context = HandlerContext::from_services(services);
+        let router = Self::build_router(rate_limits, context);
+        Self::serve_router(router, preferred_addr, shutdown).await
+    }
 
+    /// Serve Prometheus `/_metrics` on a dedicated bind address (not the REST router).
+    #[cfg(feature = "metrics")]
+    pub async fn spawn_metrics_server(
+        registry: Arc<prometheus_client::registry::Registry>,
+        preferred_addr: SocketAddr,
+        shutdown: ShutdownSignal,
+    ) -> anyhow::Result<SocketAddr> {
+        let router = Router::new().route("/_metrics", get(metrics::MetricsHandler::from_arc(registry)));
+        let listener = try_bind_with_fallback(preferred_addr).await?;
+        let listen_addr = listener.local_addr()?;
+        info!(target: LOG_TARGET, "📈 Indexer metrics server listening on {listen_addr}");
+        tokio::spawn(async move {
+            if let Err(error) = axum::serve(listener, router).with_graceful_shutdown(shutdown).await {
+                error!(target: LOG_TARGET, "Indexer metrics HTTP server error: {error}");
+            }
+        });
+        Ok(listen_addr)
+    }
+
+    async fn serve_router(
+        router: Router,
+        preferred_addr: SocketAddr,
+        shutdown: ShutdownSignal,
+    ) -> anyhow::Result<SocketAddr> {
+        let listener = try_bind_with_fallback(preferred_addr).await?;
+        let listen_addr = listener.local_addr()?;
+        info!(target: LOG_TARGET, "🌐 Indexer REST API server listening on {listen_addr}");
+        tokio::spawn(async move {
+            // `into_make_service_with_connect_info` populates `ConnectInfo<SocketAddr>`
+            // for each connection, which the per-IP rate limiter middleware uses to
+            // identify the remote peer when no proxy headers are present.
+            if let Err(error) = axum::serve(listener, router.into_make_service_with_connect_info::<SocketAddr>())
+                .with_graceful_shutdown(shutdown)
+                .await
+            {
+                error!(target: LOG_TARGET, "Wallet query HTTP server error: {error}");
+            }
+        });
+        Ok(listen_addr)
+    }
+
+    #[expect(clippy::too_many_lines)]
+    fn build_router(rate_limits: &IndexerRateLimitsConfig, context: HandlerContext) -> Router {
         // Per-IP rate limiters for specific endpoint groups.
         // `trust_proxy_headers` mirrors the value from config – enable only when
         // the indexer is behind a trusted reverse proxy.
@@ -192,152 +241,179 @@ impl Server {
             // ----------------------------------------------------------------
             // /substates/* – per-IP rate limit (rate_limits.substates_rate)
             // ----------------------------------------------------------------
-            .nest("/substates", Router::new()
-                .route("/fetch", post(handlers::substates::fetch_substates)
-                    .route_layer(middleware::from_fn_with_state(substates_fetch_limiter.clone(), rate_limit_middleware)))
-                .route("/watched", get(handlers::watched::list_watched_substates)
-                    .route_layer(middleware::from_fn_with_state(substates_fetch_limiter.clone(), rate_limit_middleware)))
-                .route("/{substate_id}", get(handlers::substates::get_substate)
-                .route_layer(middleware::from_fn_with_state(substates_fetch_limiter, rate_limit_middleware)))
+            .nest(
+                "/substates",
+                Router::new()
+                    .route(
+                        "/fetch",
+                        post(handlers::substates::fetch_substates).route_layer(middleware::from_fn_with_state(
+                            substates_fetch_limiter.clone(),
+                            rate_limit_middleware,
+                        )),
+                    )
+                    .route(
+                        "/watched",
+                        get(handlers::watched::list_watched_substates).route_layer(middleware::from_fn_with_state(
+                            substates_fetch_limiter.clone(),
+                            rate_limit_middleware,
+                        )),
+                    )
+                    .route(
+                        "/{substate_id}",
+                        get(handlers::substates::get_substate).route_layer(middleware::from_fn_with_state(
+                            substates_fetch_limiter,
+                            rate_limit_middleware,
+                        )),
+                    ),
             )
             // ----------------------------------------------------------------
             // Transactions
             // ----------------------------------------------------------------
-            .nest("/transactions", Router::new()
-                // POST /transactions – per-IP rate limit (rate_limits.transactions_submit_rate)
-                .route("/", post(handlers::transactions::submit_transaction)
-                    .route_layer(middleware::from_fn_with_state(tx_submit_limiter, rate_limit_middleware)))
-                // POST /transactions/dry-run – per-IP rate limit on a separate limiter instance so a
-                // burst of dry-runs doesn't starve the submit budget for the same IP
-                .route("/dry-run", post(handlers::transactions::submit_transaction_dry_run)
-                    .route_layer(middleware::from_fn_with_state(tx_dry_run_limiter, rate_limit_middleware))
-                )
-                // GET /transactions/recent – per-IP rate limit (rate_limits.transactions_rate)
-                .route(
-                    "/recent",
-                    get(handlers::transactions::list_recent_transactions)
-                    .route_layer(middleware::from_fn_with_state(transactions_fetch_limiter.clone(), rate_limit_middleware))
-                )
-                .route(
-                    "/{transaction_id}/result",
-                    get(handlers::transactions::get_transaction_result)
-                    .route_layer(middleware::from_fn_with_state(transactions_fetch_limiter.clone(), rate_limit_middleware))
-                )
-                .route(
-                    "/{transaction_id}",
-                    get(handlers::transactions::get_transaction)
-                    .route_layer(middleware::from_fn_with_state(transactions_fetch_limiter.clone(), rate_limit_middleware))
-                )
-                .route("/events", get(handlers::transactions::query_transaction_events))
-                // SSE stream – per-IP concurrent connection limit
-                .route("/events/stream", get(handlers::transaction_events::sse_transaction_events)
-                    .route_layer(middleware::from_fn_with_state(sse_limiter.clone(), sse_limit_middleware)))
+            .nest(
+                "/transactions",
+                Router::new()
+                    // POST /transactions – per-IP rate limit (rate_limits.transactions_submit_rate)
+                    .route(
+                        "/",
+                        post(handlers::transactions::submit_transaction).route_layer(
+                            middleware::from_fn_with_state(tx_submit_limiter, rate_limit_middleware),
+                        ),
+                    )
+                    // POST /transactions/dry-run – per-IP rate limit on a separate limiter instance so a
+                    // burst of dry-runs doesn't starve the submit budget for the same IP
+                    .route(
+                        "/dry-run",
+                        post(handlers::transactions::submit_transaction_dry_run).route_layer(
+                            middleware::from_fn_with_state(tx_dry_run_limiter, rate_limit_middleware),
+                        ),
+                    )
+                    // GET /transactions/recent – per-IP rate limit (rate_limits.transactions_rate)
+                    .route(
+                        "/recent",
+                        get(handlers::transactions::list_recent_transactions).route_layer(
+                            middleware::from_fn_with_state(
+                                transactions_fetch_limiter.clone(),
+                                rate_limit_middleware,
+                            ),
+                        ),
+                    )
+                    .route(
+                        "/{transaction_id}/result",
+                        get(handlers::transactions::get_transaction_result).route_layer(
+                            middleware::from_fn_with_state(
+                                transactions_fetch_limiter.clone(),
+                                rate_limit_middleware,
+                            ),
+                        ),
+                    )
+                    .route(
+                        "/{transaction_id}",
+                        get(handlers::transactions::get_transaction).route_layer(middleware::from_fn_with_state(
+                            transactions_fetch_limiter.clone(),
+                            rate_limit_middleware,
+                        )),
+                    )
+                    .route("/events", get(handlers::transactions::query_transaction_events))
+                    // SSE stream – per-IP concurrent connection limit
+                    .route(
+                        "/events/stream",
+                        get(handlers::transaction_events::sse_transaction_events).route_layer(
+                            middleware::from_fn_with_state(sse_limiter.clone(), sse_limit_middleware),
+                        ),
+                    ),
             )
-            .nest("/templates", Router::new()
-                .route("/cached", get(handlers::templates::list_cached_templates))
-                .route("/watched", get(handlers::watched::list_watched_templates))
-                .route("/catalogue", get(handlers::templates::list_template_catalogue))
-                .route(
-                    "/catalogue/{template_address}",
-                    get(handlers::templates::get_template_catalogue_entry),
-                )
-                .route(
-                    "/{template_address}",
-                    get(handlers::templates::get_template_definition),
-                )
+            .nest(
+                "/templates",
+                Router::new()
+                    .route("/cached", get(handlers::templates::list_cached_templates))
+                    .route("/watched", get(handlers::watched::list_watched_templates))
+                    .route("/catalogue", get(handlers::templates::list_template_catalogue))
+                    .route(
+                        "/catalogue/{template_address}",
+                        get(handlers::templates::get_template_catalogue_entry),
+                    )
+                    .route(
+                        "/{template_address}",
+                        get(handlers::templates::get_template_definition),
+                    ),
             )
             // GET /non-fungibles – per-IP rate limit (rate_limits.non_fungibles_rate)
-            .route("/non-fungibles", get(handlers::nfts::get_non_fungibles)
-                .route_layer(middleware::from_fn_with_state(non_fungibles_limiter, rate_limit_middleware)))
-            .nest("/utxos", Router::new()
-                // GET /utxos – per-IP rate limit (rate_limits.utxos_fetch_rate)
-                .route("/", get(handlers::utxos::list_utxos)
-                .route_layer(middleware::from_fn_with_state(utxos_fetch_limiter.clone(), rate_limit_middleware)))
-                // POST /utxos/fetch – per-IP rate limit (rate_limits.utxos_fetch_rate)
-                .route("/fetch", post(handlers::utxos::fetch_utxos)
-                    .route_layer(middleware::from_fn_with_state(utxos_fetch_limiter, rate_limit_middleware)))
-                // POST /utxos/stream (SSE-like streaming) – per-IP concurrent connection limit
-                .route("/stream", post(handlers::utxos::stream_utxo_updates)
-                    .route_layer(middleware::from_fn_with_state(sse_limiter.clone(), sse_limit_middleware)))
+            .route(
+                "/non-fungibles",
+                get(handlers::nfts::get_non_fungibles)
+                    .route_layer(middleware::from_fn_with_state(non_fungibles_limiter, rate_limit_middleware)),
+            )
+            .nest(
+                "/utxos",
+                Router::new()
+                    // GET /utxos – per-IP rate limit (rate_limits.utxos_fetch_rate)
+                    .route(
+                        "/",
+                        get(handlers::utxos::list_utxos).route_layer(middleware::from_fn_with_state(
+                            utxos_fetch_limiter.clone(),
+                            rate_limit_middleware,
+                        )),
+                    )
+                    // POST /utxos/fetch – per-IP rate limit (rate_limits.utxos_fetch_rate)
+                    .route(
+                        "/fetch",
+                        post(handlers::utxos::fetch_utxos)
+                            .route_layer(middleware::from_fn_with_state(utxos_fetch_limiter, rate_limit_middleware)),
+                    )
+                    // POST /utxos/stream (SSE-like streaming) – per-IP concurrent connection limit
+                    .route(
+                        "/stream",
+                        post(handlers::utxos::stream_utxo_updates).route_layer(middleware::from_fn_with_state(
+                            sse_limiter.clone(),
+                            sse_limit_middleware,
+                        )),
+                    ),
             )
             .nest(
                 "/transaction-receipts",
                 Router::new()
-                    .route("/", get(handlers::transaction_receipts::list_transaction_receipts)
-                        .route_layer(middleware::from_fn_with_state(transactions_fetch_limiter.clone(), rate_limit_middleware)))
+                    .route(
+                        "/",
+                        get(handlers::transaction_receipts::list_transaction_receipts).route_layer(
+                            middleware::from_fn_with_state(
+                                transactions_fetch_limiter.clone(),
+                                rate_limit_middleware,
+                            ),
+                        ),
+                    )
                     .route(
                         "/{address}",
-                        get(handlers::transaction_receipts::get_transaction_receipt)
-                           .route_layer(middleware::from_fn_with_state(transactions_fetch_limiter, rate_limit_middleware)))
+                        get(handlers::transaction_receipts::get_transaction_receipt).route_layer(
+                            middleware::from_fn_with_state(transactions_fetch_limiter, rate_limit_middleware),
+                        ),
+                    ),
             )
-            .nest("/resources/", Router::new()
-                // Convenience Shortcut
-                .route("/xtr" , get(handlers::resources::get_tari))
-                .route("/tari" , get(handlers::resources::get_tari))
-                .route("/{resource_address}" , get(handlers::resources::get_resource)))
+            .nest(
+                "/resources/",
+                Router::new()
+                    // Convenience Shortcut
+                    .route("/xtr", get(handlers::resources::get_tari))
+                    .route("/tari", get(handlers::resources::get_tari))
+                    .route("/{resource_address}", get(handlers::resources::get_resource)),
+            )
             // SSE /events – per-IP concurrent connection limit
-            .nest("/epoch-checkpoints", Router::new()
-                .route("/", get(handlers::epoch_checkpoints::list_epoch_checkpoints))
-                .route("/latest", get(handlers::epoch_checkpoints::get_latest_epoch_checkpoint))
+            .nest(
+                "/epoch-checkpoints",
+                Router::new()
+                    .route("/", get(handlers::epoch_checkpoints::list_epoch_checkpoints))
+                    .route("/latest", get(handlers::epoch_checkpoints::get_latest_epoch_checkpoint)),
             )
-            .route("/events", get(handlers::indexer_events::sse_events)
-                .route_layer(middleware::from_fn_with_state(sse_limiter.clone(), sse_limit_middleware)))
+            .route(
+                "/events",
+                get(handlers::indexer_events::sse_events)
+                    .route_layer(middleware::from_fn_with_state(sse_limiter.clone(), sse_limit_middleware)),
+            )
             .layer(CorsLayer::permissive())
             .layer(RequestBodyLimitLayer::new(REQUEST_BODY_LIMIT))
             .merge(SwaggerUi::new("/swagger-ui").url("/openapi.json", ApiDoc::openapi()))
             .layer(Extension(context))
             .layer(TraceLayer::new_for_http());
 
-        // Request metrics middleware stays on the REST API; `/_metrics` is served on a
-        // dedicated listener (see `spawn_metrics_server`) so scrape traffic can be bound
-        // separately from the public REST surface.
-        #[cfg(feature = "metrics")]
-        let (router, metrics_registry) = {
-            let request_metrics = metrics::register(&mut self.registry);
-            let router = router.layer(axum::middleware::from_fn_with_state(request_metrics, metrics::layer));
-            (router, Arc::new(self.registry))
-        };
-
-        let listener = try_bind_with_fallback(preferred_addr).await?;
-
-        // spawn server
-        let listen_addr = listener.local_addr()?;
-        info!(target: LOG_TARGET, "🌐 Indexer REST API server listening on {listen_addr}");
-        let rest_shutdown = shutdown;
-        tokio::spawn(async move {
-            // `into_make_service_with_connect_info` populates `ConnectInfo<SocketAddr>`
-            // for each connection, which the per-IP rate limiter middleware uses to
-            // identify the remote peer when no proxy headers are present.
-            if let Err(error) = axum::serve(listener, router.into_make_service_with_connect_info::<SocketAddr>())
-                .with_graceful_shutdown(rest_shutdown)
-                .await
-            {
-                error!(target: LOG_TARGET, "Wallet query HTTP server error: {error}");
-            }
-        });
-
-        #[cfg(feature = "metrics")]
-        return Ok((listen_addr, Some(metrics_registry)));
-        #[cfg(not(feature = "metrics"))]
-        Ok((listen_addr, None))
-    }
-
-    /// Serve Prometheus `/_metrics` on a dedicated bind address (not the REST router).
-    #[cfg(feature = "metrics")]
-    pub async fn spawn_metrics_server(
-        registry: Arc<prometheus_client::registry::Registry>,
-        preferred_addr: SocketAddr,
-        shutdown: ShutdownSignal,
-    ) -> anyhow::Result<SocketAddr> {
-        let router = Router::new().route("/_metrics", get(metrics::MetricsHandler::from_arc(registry)));
-        let listener = try_bind_with_fallback(preferred_addr).await?;
-        let listen_addr = listener.local_addr()?;
-        info!(target: LOG_TARGET, "📈 Indexer metrics server listening on {listen_addr}");
-        tokio::spawn(async move {
-            if let Err(error) = axum::serve(listener, router).with_graceful_shutdown(shutdown).await {
-                error!(target: LOG_TARGET, "Indexer metrics HTTP server error: {error}");
-            }
-        });
-        Ok(listen_addr)
+        router
     }
 }

--- a/applications/tari_indexer/src/rest_api/server.rs
+++ b/applications/tari_indexer/src/rest_api/server.rs
@@ -2,6 +2,8 @@
 //   SPDX-License-Identifier: BSD-3-Clause
 
 use std::net::SocketAddr;
+#[cfg(feature = "metrics")]
+use std::sync::Arc;
 
 use axum::{
     Extension,
@@ -18,6 +20,8 @@ use utoipa_swagger_ui::SwaggerUi;
 
 #[cfg(feature = "metrics")]
 use crate::rest_api::metrics;
+#[cfg(feature = "metrics")]
+
 use crate::{
     bootstrap::Services,
     config::IndexerRateLimitsConfig,
@@ -93,13 +97,43 @@ impl Server {
     }
 
     #[expect(clippy::too_many_lines)]
+    #[cfg(not(feature = "metrics"))]
+    pub async fn spawn(
+        self,
+        preferred_addr: SocketAddr,
+        services: &Services,
+        rate_limits: &IndexerRateLimitsConfig,
+        shutdown: ShutdownSignal,
+    ) -> anyhow::Result<SocketAddr> {
+        self.spawn_inner(preferred_addr, services, rate_limits, shutdown)
+            .await
+            .map(|(addr, _)| addr)
+    }
+
+    /// Spawns the REST API. When the `metrics` feature is enabled, also returns the
+    /// shared Prometheus registry so `/_metrics` can be bound separately.
+    #[expect(clippy::too_many_lines)]
+    #[cfg(feature = "metrics")]
     pub async fn spawn(
         #[allow(unused_mut)] mut self,
         preferred_addr: SocketAddr,
         services: &Services,
         rate_limits: &IndexerRateLimitsConfig,
         shutdown: ShutdownSignal,
-    ) -> anyhow::Result<SocketAddr> {
+    ) -> anyhow::Result<(SocketAddr, Arc<prometheus_client::registry::Registry>)> {
+        self.spawn_inner(preferred_addr, services, rate_limits, shutdown)
+            .await
+            .map(|(addr, reg)| (addr, reg.expect("metrics registry")))
+    }
+
+    #[expect(clippy::too_many_lines)]
+    async fn spawn_inner(
+        #[allow(unused_mut)] mut self,
+        preferred_addr: SocketAddr,
+        services: &Services,
+        rate_limits: &IndexerRateLimitsConfig,
+        shutdown: ShutdownSignal,
+    ) -> anyhow::Result<(SocketAddr, Option<Arc<prometheus_client::registry::Registry>>)> {
         let context = HandlerContext::from_services(services);
 
         // Per-IP rate limiters for specific endpoint groups.
@@ -254,31 +288,56 @@ impl Server {
             .layer(Extension(context))
             .layer(TraceLayer::new_for_http());
 
+        // Request metrics middleware stays on the REST API; `/_metrics` is served on a
+        // dedicated listener (see `spawn_metrics_server`) so scrape traffic can be bound
+        // separately from the public REST surface.
         #[cfg(feature = "metrics")]
-        let router = router
-            .layer(axum::middleware::from_fn_with_state(
-                metrics::register(&mut self.registry),
-                metrics::layer,
-            ))
-            .route("/_metrics", get(metrics::MetricsHandler::new(self.registry)));
+        let (router, metrics_registry) = {
+            let request_metrics = metrics::register(&mut self.registry);
+            let router = router.layer(axum::middleware::from_fn_with_state(request_metrics, metrics::layer));
+            (router, Arc::new(self.registry))
+        };
 
         let listener = try_bind_with_fallback(preferred_addr).await?;
 
         // spawn server
         let listen_addr = listener.local_addr()?;
         info!(target: LOG_TARGET, "🌐 Indexer REST API server listening on {listen_addr}");
+        let rest_shutdown = shutdown;
         tokio::spawn(async move {
             // `into_make_service_with_connect_info` populates `ConnectInfo<SocketAddr>`
             // for each connection, which the per-IP rate limiter middleware uses to
             // identify the remote peer when no proxy headers are present.
             if let Err(error) = axum::serve(listener, router.into_make_service_with_connect_info::<SocketAddr>())
-                .with_graceful_shutdown(shutdown)
+                .with_graceful_shutdown(rest_shutdown)
                 .await
             {
                 error!(target: LOG_TARGET, "Wallet query HTTP server error: {error}");
             }
         });
 
+        #[cfg(feature = "metrics")]
+        return Ok((listen_addr, Some(metrics_registry)));
+        #[cfg(not(feature = "metrics"))]
+        Ok((listen_addr, None))
+    }
+
+    /// Serve Prometheus `/_metrics` on a dedicated bind address (not the REST router).
+    #[cfg(feature = "metrics")]
+    pub async fn spawn_metrics_server(
+        registry: Arc<prometheus_client::registry::Registry>,
+        preferred_addr: SocketAddr,
+        shutdown: ShutdownSignal,
+    ) -> anyhow::Result<SocketAddr> {
+        let router = Router::new().route("/_metrics", get(metrics::MetricsHandler::from_arc(registry)));
+        let listener = try_bind_with_fallback(preferred_addr).await?;
+        let listen_addr = listener.local_addr()?;
+        info!(target: LOG_TARGET, "📈 Indexer metrics server listening on {listen_addr}");
+        tokio::spawn(async move {
+            if let Err(error) = axum::serve(listener, router).with_graceful_shutdown(shutdown).await {
+                error!(target: LOG_TARGET, "Indexer metrics HTTP server error: {error}");
+            }
+        });
         Ok(listen_addr)
     }
 }

--- a/applications/tari_indexer/src/rest_api/server.rs
+++ b/applications/tari_indexer/src/rest_api/server.rs
@@ -95,7 +95,6 @@ impl Server {
     }
 
     /// Spawns the REST API server (no metrics feature).
-    #[expect(clippy::too_many_lines)]
     #[cfg(not(feature = "metrics"))]
     pub async fn spawn(
         self,
@@ -110,7 +109,6 @@ impl Server {
 
     /// Spawns the REST API. Also returns the shared Prometheus registry so
     /// `/_metrics` can be bound on a separate listener via `spawn_metrics_server`.
-    #[expect(clippy::too_many_lines)]
     #[cfg(feature = "metrics")]
     pub async fn spawn(
         mut self,

--- a/applications/tari_ootle_app_utilities/config_presets/d_indexer.toml
+++ b/applications/tari_ootle_app_utilities/config_presets/d_indexer.toml
@@ -21,6 +21,12 @@
 # API listener address (default = "127.0.0.1:18300")
 #api_listen_address = "127.0.0.1:18300"
 
+# Prometheus metrics (/_metrics) listener address. Metrics are served on a dedicated listener,
+# separate from the API server, so they can be bound to a private interface while the API is public.
+# Only used when the indexer is compiled with the `metrics` feature (enabled by default).
+# (default = "127.0.0.1:18302")
+#metrics_listen_address = "127.0.0.1:18302"
+
 # HTTP UI listener address (default = "127.0.0.1:15000")
 #web_ui_address = "127.0.0.1:15000"
 

--- a/integration_tests/src/indexer.rs
+++ b/integration_tests/src/indexer.rs
@@ -196,6 +196,8 @@ pub async fn spawn_indexer(world: &mut TariWorld, indexer_name: String, base_nod
 
         config.indexer.p2p.enable_mdns = false;
         config.indexer.api_listen_address = Some(format!("127.0.0.1:{}", api_port).parse().unwrap());
+        // OS-assigned port to avoid contention between concurrently running indexers
+        config.indexer.metrics_listen_address = Some("127.0.0.1:0".parse().unwrap());
         config.indexer.web_ui_address = Some(format!("127.0.0.1:{}", web_ui_port).parse().unwrap());
         config.indexer.graphql_address = Some(format!("127.0.0.1:{}", graphql_port).parse().unwrap());
 


### PR DESCRIPTION
## Summary
Fixes #2330 (bounty-S — 15,000 XTM).

Split `GET /_metrics` off the public REST listener onto a dedicated, configurable bind address.

## Changes
- `indexer.metrics_listen_address` (default `127.0.0.1:18302`)
- CLI/env: `--metrics-address` / `TARI_INDEXER_METRICS_LISTEN_ADDRESS`
- REST keeps request-metrics middleware; **no** `/_metrics` on REST
- Metrics-only server serves `GET /_metrics`
- Docs: configuration.md

## Payout
Per bounty: Tari address via Discord @Possum after award.
Also USDC Base if applicable: `0xfd3600efdfcd6f02c515f93237e2caaff293769f`
