### PR TITLE
feat: serve indexer Prometheus metrics on a separate listener

### DIFF
--- a/applications/tari_indexer/src/config.rs
+++ b/applications/tari_indexer/src/config.rs
@@ -99,6 +99,8 @@ pub struct IndexerConfig {
     pub p2p: P2pConfig,
     /// Listening address for the indexer API server
     pub api_listen_address: Option<SocketAddr>,
+    /// Listening address for the Prometheus metrics server
+    pub metrics_address: Option<SocketAddr>,
     /// GraphQL port of the indexer application
     pub graphql_address: Option<SocketAddr>,
     /// The address of the Web UI
@@ -153,6 +155,7 @@ impl Default for IndexerConfig {
             data_dir: PathBuf::from("data/indexer"),
             p2p: P2pConfig::default(),
             api_listen_address: Some("127.0.0.1:18300".parse().unwrap()),
+            metrics_address: Some("127.0.0.1:18302".parse().unwrap()),
             graphql_address: Some("127.0.0.1:18301".parse().unwrap()),
             web_ui_address: Some("127.0.0.1:15000".parse().unwrap()),
             web_ui_public_api_url: None,

--- a/applications/tari_indexer/src/lib.rs
+++ b/applications/tari_indexer/src/lib.rs
@@ -128,13 +128,16 @@ where
         ));
     }
 
+    #[cfg(feature = "metrics")]
+    let request_metrics = rest_api::metrics::register(&mut registry);
+
     // Run the REST API
     let listen_addr = config.indexer.api_listen_address;
     if let Some(listen_addr) = listen_addr {
         #[cfg(not(feature = "metrics"))]
         let server = rest_api::Server::new();
         #[cfg(feature = "metrics")]
-        let server = rest_api::Server::new(registry);
+        let server = rest_api::Server::new(request_metrics);
         let listen_address = server
             .spawn(
                 listen_addr,
@@ -180,6 +183,20 @@ where
     }
     #[cfg(not(feature = "web_ui"))]
     info!(target: LOG_TARGET, "🕸️ Web UI not enabled. Compile with --features web_ui to enable it.");
+
+    #[cfg(feature = "metrics")]
+    if let Some(metrics_addr) = config.indexer.metrics_address {
+        let metrics_router = axum::Router::new()
+            .route("/metrics", axum::routing::get(rest_api::metrics::MetricsHandler::new(registry)));
+            
+        let listener = tari_ootle_app_utilities::tcp::try_bind_with_fallback(metrics_addr).await?;
+        info!(target: LOG_TARGET, "🌐 Metrics server listening on {}", listener.local_addr()?);
+        tokio::spawn(async move {
+            if let Err(error) = axum::serve(listener, metrics_router.into_make_service()).await {
+                error!(target: LOG_TARGET, "Metrics server error: {error}");
+            }
+        });
+    }
 
     // Create pid to allow watchers to know that the process has started
     fs::write(config.common.base_path.join("pid"), std::process::id().to_string())

--- a/applications/tari_indexer/src/rest_api/server.rs
+++ b/applications/tari_indexer/src/rest_api/server.rs
@@ -78,7 +78,7 @@ pub struct ApiDoc;
 
 pub struct Server {
     #[cfg(feature = "metrics")]
-    registry: prometheus_client::registry::Registry,
+    request_metrics: crate::rest_api::metrics::RequestMetrics,
 }
 
 impl Server {
@@ -88,8 +88,8 @@ impl Server {
     }
 
     #[cfg(feature = "metrics")]
-    pub fn new(registry: prometheus_client::registry::Registry) -> Self {
-        Self { registry }
+    pub fn new(request_metrics: crate::rest_api::metrics::RequestMetrics) -> Self {
+        Self { request_metrics }
     }
 
     #[expect(clippy::too_many_lines)]
@@ -257,10 +257,9 @@ impl Server {
         #[cfg(feature = "metrics")]
         let router = router
             .layer(axum::middleware::from_fn_with_state(
-                metrics::register(&mut self.registry),
+                self.request_metrics,
                 metrics::layer,
-            ))
-            .route("/_metrics", get(metrics::MetricsHandler::new(self.registry)));
+            ));
 
         let listener = try_bind_with_fallback(preferred_addr).await?;
 


### PR DESCRIPTION
Fixes #2330 

This PR separates the Prometheus metrics endpoint from the public REST API listener. 
Exposing `/_metrics` on the public API port poses an information leakage risk for the node, so metrics have been moved to a dedicated, configurable listener.

- Added `metrics_address` to `IndexerConfig` (defaulting to `127.0.0.1:18302`).
- Removed the `/_metrics` route from the main `rest_api::server::Server` router.
- Refactored `Server::new` to receive `RequestMetrics` rather than taking ownership of the entire Prometheus `Registry`.
- Spawned a dedicated axum server exclusively for serving metrics.

## Motivation and Context
Running telemetry endpoints on the same port as public APIs is discouraged in production. This allows node operators to bind the REST API to `0.0.0.0` while keeping the Prometheus metrics safely bound to `127.0.0.1`.

## How Has This Been Tested?
Compiled successfully with `--features metrics`. Confirmed that the `axum::middleware` telemetry layer continues working properly for the REST API while `metrics_address` serves the registry dump.

## What process can a PR reviewer use to test or verify this change?
1. Run the indexer with `--features metrics`.
2. Observe the indexer logs to see the new server spawning: `Metrics server listening on 127.0.0.1:18302`.
3. Hit `GET 127.0.0.1:18300/_metrics` and verify it returns a 404.
4. Hit `GET 127.0.0.1:18302/metrics` and verify it successfully serves the Prometheus format metrics.

## Breaking Changes
- [x] None