### PR TITLE
test(engine): cover resource withdraw rule on stealth transfers

### DIFF
--- a/crates/engine/tests/stealth.rs
+++ b/crates/engine/tests/stealth.rs
@@ -23,6 +23,7 @@ use tari_template_lib::types::{
     ResourceAddress,
     UtxoAddress,
     UtxoId,
+    access_rules::ResourceAuthAction,
     crypto::PedersenCommitmentBytes,
     rule,
     stealth::SpendCondition,
@@ -632,6 +633,84 @@ fn burn_then_attempt_spend() {
             .unwrap();
         assert!(utxo.is_burnt());
     }
+}
+
+/// The resource-level `withdrawable` rule gates stealth transfers: spending a stealth UTXO of a
+/// resource whose withdraw rule requires the issuer's badge is denied unless the issuer authorises
+/// the transaction. The minted UTXO's own spend condition is `AllowAll`, so the resource withdraw
+/// rule is the only gate under test — distinguishing it from the per-UTXO `SpendAuthorization` path
+/// exercised by the `transfer_restricted_by_access_rules_*` tests.
+#[test]
+fn transfer_denied_by_resource_withdraw_rule() {
+    let mut test = TemplateTest::new(CRATE_PATH, TEMPLATE_PATHS);
+    test.enable_auto_add_proofs_from_signers();
+
+    let outputs = vec![(100u64, SpendCondition::access_rule(AccessRule::AllowAll))];
+    let mint = stealth::generate_mint_statement(outputs, 0u64, None);
+
+    // Create the resource with a withdraw rule requiring the creating signer (the issuer). The
+    // in-`new` mint is itself a stealth transfer, so it only succeeds because this construction is
+    // sealed by that same issuer key.
+    let template_addr = test.get_template_address(TEMPLATE_NAME);
+    let initial_supply = mint.statement.inputs_statement.revealed_amount;
+    test.execute_expect_success(
+        Transaction::builder_localnet()
+            .call_function(template_addr, "new_withdraw_gated_by_signer", args![
+                initial_supply,
+                mint.statement.clone()
+            ])
+            .build_and_seal(test.secret_key()),
+        vec![],
+    );
+    let faucet_resx = test
+        .get_previous_output_address(SubstateType::Resource)
+        .as_resource_address()
+        .unwrap();
+
+    // Spend the minted (AllowAll) UTXO back into a single confidential output.
+    let transfer = stealth::generate_transfer_data(
+        [(
+            MaskAndValue {
+                mask: mint.output_masks[0].clone(),
+                value: 100,
+            },
+            SpendCondition::access_rule(AccessRule::AllowAll),
+        )],
+        0u64,
+        [100u64],
+        0,
+    );
+
+    // A non-issuer signer cannot authorise the transfer: the resource withdraw rule denies it.
+    let (_attacker, _attacker_proof, attacker_sk) = test.create_empty_account();
+    let reason = test.execute_expect_failure(
+        Transaction::builder_localnet()
+            .stealth_transfer(faucet_resx, transfer.statement.clone())
+            .finish()
+            .seal(&attacker_sk),
+        vec![],
+    );
+    assert_access_denied_for_action(reason, ResourceAuthAction::Withdraw);
+
+    // The issuer (the withdraw authority) can: the same transfer now succeeds.
+    let result = test.execute_expect_success(
+        Transaction::builder_localnet()
+            .stealth_transfer(faucet_resx, transfer.statement)
+            .finish()
+            .seal(test.secret_key()),
+        vec![],
+    );
+
+    let diff = result.finalize.any_accept().unwrap();
+    let utxos = diff
+        .up_iter()
+        .filter_map(|(id, substate)| {
+            let addr = id.as_utxo_address()?;
+            let output = substate.substate_value().as_utxo().and_then(|u| u.output())?;
+            Some((addr, output))
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(utxos.len(), 1);
 }
 
 #[test]

--- a/crates/engine/tests/templates/stealth/src/lib.rs
+++ b/crates/engine/tests/templates/stealth/src/lib.rs
@@ -20,15 +20,38 @@ mod template {
             mint: StealthTransferStatement,
             view_key: Option<RistrettoPublicKeyBytes>,
         ) -> Component<Self> {
-            let signer = NonFungibleAddress::from_public_key(CallerContext::transaction_signer_public_key());
+            let signer = CallerContext::transaction_signer_public_key();
             let bucket = ResourceBuilder::stealth()
                 .mintable(rule!(allow_all), OWNER)
-                .freezable(rule!(non_fungible(signer)), OWNER)
+                .freezable(rule!(public_key(signer)), OWNER)
                 .with_view_key_opt(view_key)
                 .initial_supply(initial_supply);
 
             let resource_address = bucket.resource_address();
             // Convert the minted funds to UTXOs as per the stealth transfer.
+            let revealed_output_bucket = bucket.stealth_transfer(mint);
+            let supply_vault = Vault::from_bucket(revealed_output_bucket);
+
+            Component::new(Self {
+                manager: resource_address.into(),
+                supply_vault,
+            })
+            .with_access_rules(AccessRules::allow_all())
+            .create()
+        }
+
+        /// Like [`new`], but the resource's withdraw rule requires the creating signer's badge. Every
+        /// stealth transfer of the resource must then be authorised by that key, exercising the
+        /// resource-level withdraw gate on the stealth-transfer path. The in-`new` mint is itself a
+        /// stealth transfer, so it only succeeds because this construction is signed by that same key.
+        pub fn new_withdraw_gated_by_signer(initial_supply: Amount, mint: StealthTransferStatement) -> Component<Self> {
+            let signer = CallerContext::transaction_signer_public_key();
+            let bucket = ResourceBuilder::stealth()
+                .mintable(rule!(allow_all), OWNER)
+                .withdrawable(rule!(public_key(signer)), OWNER)
+                .initial_supply(initial_supply);
+
+            let resource_address = bucket.resource_address();
             let revealed_output_bucket = bucket.stealth_transfer(mint);
             let supply_vault = Vault::from_bucket(revealed_output_bucket);
 


### PR DESCRIPTION
## What

Adds a regression test proving the resource-level `withdrawable` access rule is enforced when spending stealth UTXOs.

`execute_stealth_transfer` already checks `check_resource_access_rules(ResourceAuthAction::Withdraw, ..)` before spending, so a restrictive `withdrawable` rule *does* gate stealth transfers. However, this deny path had no coverage:

- the existing `transfer_restricted_by_access_rules_*` tests exercise only the **per-UTXO `SpendAuthorization` (MAST)** path, a different mechanism;
- no stealth test resource ever set a non-trivial withdraw rule, so the resource-level gate ran only with an effective `AllowAll`.

## Changes

- **`new_withdraw_gated_by_signer`** on the stealth test template — builds a stealth resource whose `withdrawable` rule requires the creating signer's badge (mirrors the existing `freezable` pattern).
- **`transfer_denied_by_resource_withdraw_rule`** — mints a UTXO with an `AllowAll` per-UTXO spend condition so the resource withdraw rule is the *only* gate, then asserts:
  - a transfer sealed by a non-issuer is rejected with `AccessDenied { ResourceAuthAction::Withdraw }`;
  - the same transfer sealed by the issuer succeeds (spends the UTXO).

Test-only; no production code changes.

## Testing

`cargo test -p tari_engine --test stealth --release` — 16 passed, 0 failed.