### PR TITLE
refactor(ootle-rs)!: raise the stealth custody seam to statement level

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7656,7 +7656,7 @@ dependencies = [
 
 [[package]]
 name = "ootle-rs"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/crates/wallet/ootle-rs/Cargo.toml
+++ b/crates/wallet/ootle-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ootle-rs"
-version = "0.14.0"
+version = "0.15.0"
 description = "A Rust library for interacting with the Tari Ootle network."
 edition.workspace = true
 authors.workspace = true

--- a/crates/wallet/ootle-rs/src/claim_burn/mod.rs
+++ b/crates/wallet/ootle-rs/src/claim_burn/mod.rs
@@ -47,19 +47,14 @@ use tari_crypto::{
 pub use tari_ootle_common_types::engine_types::confidential::{ClaimBurnOutputData, MinotariBurnClaimProof};
 use tari_ootle_common_types::engine_types::stealth::validate_transfer;
 use tari_ootle_transaction::{Transaction, UnsealedTransaction, UnsignedTransaction};
-use tari_ootle_wallet_crypto::{StealthCryptoApi, balance_proof::generate_stealth_balance_proof_signature, memo::Memo};
-use tari_template_lib_types::{
-    Amount,
-    EncryptedData,
-    constants::TARI_TOKEN,
-    stealth::{StealthInput, StealthInputsStatement, StealthTransferStatement},
-};
+use tari_ootle_wallet_crypto::{StealthCryptoApi, memo::Memo};
+use tari_template_lib_types::{Amount, EncryptedData, constants::TARI_TOKEN};
 
 use crate::{
     Address,
     provider::{Provider, WalletProvider},
     signer,
-    stealth::{Output, StealthProviderError},
+    stealth::{BurnClaimStatementSpec, Output, StealthProviderError},
     transaction::TransactionSealSigner,
     wallet::{NetworkWallet, OotleWallet, WalletResult},
 };
@@ -197,29 +192,15 @@ impl<'a, P: WalletProvider<Wallet = OotleWallet>> ClaimBurn<'a, P> {
         let recipient = recipient.unwrap_or_else(|| claimant.clone());
         let memo = memo.unwrap_or_else(|| Memo::new_message(DEFAULT_CLAIM_MEMO).expect("valid memo"));
         let output = Output::new(recipient, TARI_TOKEN, final_amount).with_memo(memo);
-        let (outputs_statement, agg_output_mask) = wallet
-            .generate_outputs_statement(vec![output], Amount::from(max_fee))
+        let transfer = wallet
+            .create_burn_claim_statement(BurnClaimStatementSpec {
+                commitment: claim_proof.commitment,
+                encrypted_data: encrypted_data.clone(),
+                sender_offset_public_key,
+                output,
+                revealed_output_amount: Amount::from(max_fee),
+            })
             .await?;
-
-        // The single stealth input is the burn UTXO minted by the `claim_burn` instruction. Its
-        // commitment comes from the proof and its mask from decrypting the L1 output.
-        let inputs_statement =
-            StealthInputsStatement::new(vec![StealthInput::from(claim_proof.commitment)], Amount::zero());
-        let agg_input_mask = decrypted.mask().clone();
-
-        let balance_proof = generate_stealth_balance_proof_signature(
-            &agg_input_mask,
-            &agg_output_mask,
-            &inputs_statement,
-            &outputs_statement,
-        );
-
-        let transfer = StealthTransferStatement {
-            inputs_statement,
-            outputs_statement,
-            balance_proof: Some(balance_proof),
-            covenant_claims: Vec::new(),
-        };
 
         // Sanity check the constructed transfer balances before paying any fees.
         if let Err(err) = validate_transfer(&transfer, None) {

--- a/crates/wallet/ootle-rs/src/key_provider/local/generic_impls.rs
+++ b/crates/wallet/ootle-rs/src/key_provider/local/generic_impls.rs
@@ -308,3 +308,261 @@ impl<C: StealthKeyPrehashSigner<(RistrettoSchnorr, RistrettoPublicKey)> + Send +
         Ok(sig)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::num::NonZeroU64;
+
+    use tari_crypto::keys::SecretKey;
+    use tari_ootle_common_types::engine_types::{crypto::OutputBody, stealth::validate_transfer};
+    use tari_ootle_wallet_crypto::MaskAndValue;
+    use tari_template_lib_types::{ResourceAddress, constants::TARI_TOKEN, stealth::StealthInput};
+
+    use super::*;
+    use crate::{
+        Network,
+        key_provider::PrivateKeyProvider,
+        stealth::{BurnClaimKeyProvider, BurnClaimStatementSpec, ResolvedStealthInput},
+    };
+
+    const VALUE: u64 = 1_000_000;
+
+    fn resource() -> ResourceAddress {
+        TARI_TOKEN
+    }
+
+    /// Mint a stealth output owned by `provider` and return it shaped as an input ready to spend.
+    ///
+    /// The output is encrypted to the destination's view-only key, so a provider spending its own
+    /// output recovers the same mask and value the mint committed to.
+    async fn owned_input(provider: &PrivateKeyProvider, value: u64) -> ResolvedStealthInput {
+        let spec = Output::new(
+            provider.address().clone(),
+            resource(),
+            NonZeroU64::new(value).expect("test value is non-zero"),
+        );
+        let (statement, _agg_mask) = provider
+            .generate_outputs_statement(vec![spec], Amount::zero())
+            .await
+            .expect("minting a stealth output must succeed");
+
+        let minted = statement.outputs.into_iter().next().expect("one output was requested");
+        ResolvedStealthInput::new(StealthInput::from(minted.output.commitment), OutputBody {
+            public_nonce: minted.output.sender_public_nonce,
+            encrypted_data: minted.output.encrypted_data,
+            minimum_value_promise: minted.output.minimum_value_promise,
+            viewable_balance: None,
+        })
+    }
+
+    fn output_to_self(provider: &PrivateKeyProvider, value: u64) -> Output {
+        Output::new(
+            provider.address().clone(),
+            resource(),
+            NonZeroU64::new(value).expect("test value is non-zero"),
+        )
+    }
+
+    /// A stealth input spent into an output of equal value produces a statement the engine accepts.
+    #[tokio::test]
+    async fn spending_a_stealth_input_produces_a_valid_statement() {
+        let provider = PrivateKeyProvider::random(Network::LocalNet);
+        let input = owned_input(&provider, VALUE).await;
+
+        let statement = provider
+            .create_transfer_statement(ResolvedStealthTransferSpec {
+                inputs: vec![input],
+                revealed_input_amount: Amount::zero(),
+                outputs: vec![output_to_self(&provider, VALUE)],
+                revealed_output_amount: Amount::zero(),
+            })
+            .await
+            .expect("a balanced transfer must produce a statement");
+
+        assert!(statement.balance_proof.is_some());
+        assert_eq!(statement.inputs_statement.inputs.len(), 1);
+        assert_eq!(statement.outputs_statement.outputs.len(), 1);
+        validate_transfer(&statement, None).expect("the engine must accept the statement");
+    }
+
+    /// Several inputs and outputs balance in aggregate, and the input order is preserved.
+    #[tokio::test]
+    async fn multiple_inputs_and_outputs_balance_in_aggregate() {
+        let provider = PrivateKeyProvider::random(Network::LocalNet);
+        let inputs = vec![
+            owned_input(&provider, VALUE).await,
+            owned_input(&provider, VALUE * 2).await,
+        ];
+        let expected_commitments: Vec<_> = inputs.iter().map(|i| *i.commitment()).collect();
+
+        let statement = provider
+            .create_transfer_statement(ResolvedStealthTransferSpec {
+                inputs,
+                revealed_input_amount: Amount::zero(),
+                outputs: vec![output_to_self(&provider, VALUE), output_to_self(&provider, VALUE * 2)],
+                revealed_output_amount: Amount::zero(),
+            })
+            .await
+            .expect("a balanced transfer must produce a statement");
+
+        let actual_commitments: Vec<_> = statement.inputs_statement.inputs.iter().map(|i| i.commitment).collect();
+        assert_eq!(actual_commitments, expected_commitments);
+        validate_transfer(&statement, None).expect("the engine must accept the statement");
+    }
+
+    /// A revealed input covers a stealth output of the same value.
+    #[tokio::test]
+    async fn revealed_input_funding_a_stealth_output_validates() {
+        let provider = PrivateKeyProvider::random(Network::LocalNet);
+
+        let statement = provider
+            .create_transfer_statement(ResolvedStealthTransferSpec {
+                inputs: vec![],
+                revealed_input_amount: Amount::from(VALUE),
+                outputs: vec![output_to_self(&provider, VALUE)],
+                revealed_output_amount: Amount::zero(),
+            })
+            .await
+            .expect("a balanced transfer must produce a statement");
+
+        assert!(statement.balance_proof.is_some());
+        validate_transfer(&statement, None).expect("the engine must accept the statement");
+    }
+
+    /// Inputs that do not cover the outputs are rejected rather than yielding a statement the engine
+    /// would later refuse.
+    #[tokio::test]
+    async fn an_unbalanced_transfer_is_rejected() {
+        let provider = PrivateKeyProvider::random(Network::LocalNet);
+        let input = owned_input(&provider, VALUE).await;
+
+        let err = provider
+            .create_transfer_statement(ResolvedStealthTransferSpec {
+                inputs: vec![input],
+                revealed_input_amount: Amount::zero(),
+                // Spend more than the input holds.
+                outputs: vec![output_to_self(&provider, VALUE + 1)],
+                revealed_output_amount: Amount::zero(),
+            })
+            .await
+            .expect_err("an unbalanced transfer must be rejected");
+
+        assert!(
+            matches!(err, StealthProviderError::UnbalancedTransfer { .. }),
+            "expected UnbalancedTransfer, got {err:?}"
+        );
+    }
+
+    /// A transfer that moves only revealed value has nothing to balance, so it carries no balance
+    /// proof.
+    #[tokio::test]
+    async fn a_revealed_only_transfer_has_no_balance_proof() {
+        let provider = PrivateKeyProvider::random(Network::LocalNet);
+
+        let statement = provider
+            .create_transfer_statement(ResolvedStealthTransferSpec {
+                inputs: vec![],
+                revealed_input_amount: Amount::from(VALUE),
+                outputs: vec![],
+                revealed_output_amount: Amount::from(VALUE),
+            })
+            .await
+            .expect("a revealed-only transfer must produce a statement");
+
+        assert!(statement.balance_proof.is_none());
+    }
+
+    /// A statement built by one wallet does not validate against another wallet's input: the mask
+    /// recovered from a foreign output is not the one the commitment was built with.
+    #[tokio::test]
+    async fn an_input_owned_by_another_wallet_does_not_balance() {
+        let alice = PrivateKeyProvider::random(Network::LocalNet);
+        let bob = PrivateKeyProvider::random(Network::LocalNet);
+        let alices_input = owned_input(&alice, VALUE).await;
+
+        let err = bob
+            .create_transfer_statement(ResolvedStealthTransferSpec {
+                inputs: vec![alices_input],
+                revealed_input_amount: Amount::zero(),
+                outputs: vec![output_to_self(&bob, VALUE)],
+                revealed_output_amount: Amount::zero(),
+            })
+            .await
+            .expect_err("bob must not be able to spend alice's output");
+
+        assert!(
+            matches!(
+                err,
+                StealthProviderError::UnbalancedTransfer { .. } | StealthProviderError::DecryptionFailed { .. }
+            ),
+            "expected the spend to fail, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn total_output_amount_sums_stealth_and_revealed_outputs() {
+        let provider = PrivateKeyProvider::random(Network::LocalNet);
+        let spec = ResolvedStealthTransferSpec {
+            inputs: vec![],
+            revealed_input_amount: Amount::zero(),
+            outputs: vec![output_to_self(&provider, 300), output_to_self(&provider, 700)],
+            revealed_output_amount: Amount::from(1000u128),
+        };
+        assert_eq!(spec.total_output_amount(), Amount::from(2000u128));
+    }
+
+    #[test]
+    fn a_transfer_needs_a_balance_proof_only_when_stealth_value_moves() {
+        let provider = PrivateKeyProvider::random(Network::LocalNet);
+        let revealed_only = ResolvedStealthTransferSpec {
+            inputs: vec![],
+            revealed_input_amount: Amount::from(VALUE),
+            outputs: vec![],
+            revealed_output_amount: Amount::from(VALUE),
+        };
+        assert!(!revealed_only.requires_balance_proof());
+
+        let with_stealth_output = ResolvedStealthTransferSpec {
+            outputs: vec![output_to_self(&provider, VALUE)],
+            ..revealed_only
+        };
+        assert!(with_stealth_output.requires_balance_proof());
+    }
+
+    /// A burn claim spends the minted burn UTXO into a stealth output plus a revealed fee, and the
+    /// engine accepts the resulting statement.
+    ///
+    /// The L1 burn output is encrypted to the claimant's *account* key (not its view-only key) with the
+    /// burn's sender-offset nonce, which is the shape `decrypt_burn_claim_output` expects.
+    #[tokio::test]
+    async fn a_burn_claim_statement_balances_and_validates() {
+        const FEE: u64 = 1000;
+
+        let provider = PrivateKeyProvider::random(Network::LocalNet);
+        let account_pk = RistrettoPublicKey::from_secret_key(provider.credentials().account_secret());
+
+        // Stand in for the L1 burn: a commitment to `VALUE` under `mask`, encrypted to the claimant.
+        let (sender_offset_secret, sender_offset_public_key) = RistrettoPublicKey::random_keypair(&mut rand::rng());
+        let mask = RistrettoSecretKey::random(&mut rand::rng());
+        let commitment = MaskAndValue::new(VALUE, mask.clone()).to_commitment().to_byte_type();
+        let encrypted_data = StealthCryptoApi::new()
+            .encrypt_value_and_mask(VALUE, &mask, &account_pk, &sender_offset_secret, None)
+            .expect("encrypting the burn output must succeed");
+
+        let statement = provider
+            .create_burn_claim_statement(BurnClaimStatementSpec {
+                commitment,
+                encrypted_data,
+                sender_offset_public_key,
+                output: output_to_self(&provider, VALUE - FEE),
+                revealed_output_amount: Amount::from(u128::from(FEE)),
+            })
+            .await
+            .expect("a balanced burn claim must produce a statement");
+
+        assert!(statement.balance_proof.is_some());
+        assert_eq!(statement.inputs_statement.inputs.len(), 1);
+        assert_eq!(statement.inputs_statement.inputs[0].commitment, commitment);
+        validate_transfer(&statement, None).expect("the engine must accept the burn claim statement");
+    }
+}

--- a/crates/wallet/ootle-rs/src/key_provider/local/generic_impls.rs
+++ b/crates/wallet/ootle-rs/src/key_provider/local/generic_impls.rs
@@ -22,6 +22,7 @@ use tari_ootle_wallet_crypto::{
     OutputWitness,
     StealthCryptoApi,
     StealthOutputWitness,
+    balance_proof::{generate_stealth_balance_proof_signature, validate_balance_proof_signature},
     bullet_proof::generate_extended_bullet_proof,
     stealth::pay_to_output_authorization,
     viewable_balance_proof::generate_elgamal_viewable_balance_proof,
@@ -30,7 +31,13 @@ use tari_template_lib_types::{
     Amount,
     EncryptedData,
     crypto::RistrettoPublicKeyBytes,
-    stealth::{StealthOutputsStatement, StealthUnspentOutput, UnspentOutput},
+    stealth::{
+        StealthInputsStatement,
+        StealthOutputsStatement,
+        StealthTransferStatement,
+        StealthUnspentOutput,
+        UnspentOutput,
+    },
 };
 use tokio::task;
 
@@ -39,7 +46,15 @@ use crate::{
     key_provider::{LocalKeyProvider, OutputMaskProvider},
     signer,
     signer::StealthKeyPrehashSigner,
-    stealth::{Output, StealthOutputStatementFactory, StealthProviderError, StealthResult},
+    stealth::{
+        InputDecryptor,
+        Output,
+        ResolvedStealthTransferSpec,
+        StealthOutputStatementFactory,
+        StealthProviderError,
+        StealthResult,
+        StealthStatementProvider,
+    },
     transaction::{TransactionSigner, TransactionStealthKeySigner},
     wallet::TransactionAuthorization,
 };
@@ -123,6 +138,72 @@ impl<C: OutputMaskProvider + Send + Sync> StealthOutputStatementFactory for Loca
             },
             agg_output_mask,
         ))
+    }
+}
+
+#[async_trait]
+impl<C> StealthStatementProvider for LocalKeyProvider<C>
+where LocalKeyProvider<C>: StealthOutputStatementFactory + InputDecryptor + Send + Sync
+{
+    async fn create_transfer_statement(
+        &self,
+        spec: ResolvedStealthTransferSpec,
+    ) -> StealthResult<StealthTransferStatement> {
+        let total_output_amount = spec.total_output_amount();
+        let total_revealed_input = spec.revealed_input_amount;
+        let requires_balance_proof = spec.requires_balance_proof();
+
+        let ResolvedStealthTransferSpec {
+            inputs,
+            revealed_input_amount,
+            outputs,
+            revealed_output_amount,
+        } = spec;
+
+        let mut agg_input_mask = RistrettoSecretKey::default();
+        let mut statement_inputs = Vec::with_capacity(inputs.len());
+        for resolved in inputs {
+            let decrypted = self
+                .decrypt_input_data(resolved.commitment(), &resolved.output, true)
+                .await?;
+            agg_input_mask = &agg_input_mask + decrypted.mask();
+            statement_inputs.push(resolved.input);
+        }
+
+        let (outputs_statement, agg_output_mask) =
+            self.generate_outputs_statement(outputs, revealed_output_amount).await?;
+
+        let inputs_statement = StealthInputsStatement {
+            inputs: statement_inputs,
+            revealed_amount: revealed_input_amount,
+        };
+
+        let balance_proof = requires_balance_proof.then(|| {
+            generate_stealth_balance_proof_signature(
+                &agg_input_mask,
+                &agg_output_mask,
+                &inputs_statement,
+                &outputs_statement,
+            )
+        });
+
+        if let Some(balance_proof) = &balance_proof {
+            // Every proof above is generated from our own key material, so a balance proof that does not
+            // verify means the caller's input and output values do not balance.
+            if !validate_balance_proof_signature(balance_proof, &inputs_statement, &outputs_statement) {
+                return Err(StealthProviderError::UnbalancedTransfer {
+                    total_revealed_input,
+                    output_amount: total_output_amount,
+                });
+            }
+        }
+
+        Ok(StealthTransferStatement {
+            inputs_statement,
+            outputs_statement,
+            balance_proof,
+            covenant_claims: Vec::new(),
+        })
     }
 }
 

--- a/crates/wallet/ootle-rs/src/keys/secret.rs
+++ b/crates/wallet/ootle-rs/src/keys/secret.rs
@@ -10,15 +10,33 @@ use tari_crypto::{
 };
 use tari_ootle_address::{Network, OotleAddress};
 use tari_ootle_common_types::{base_layer_hashing::encrypted_data_hasher, engine_types::crypto::OutputBody};
-use tari_ootle_wallet_crypto::{DecryptedData, StealthCryptoApi, encrypted_data, kdfs};
-use tari_template_lib_types::{EncryptedData, crypto::PedersenCommitmentBytes};
+use tari_ootle_wallet_crypto::{
+    DecryptedData,
+    StealthCryptoApi,
+    balance_proof::generate_stealth_balance_proof_signature,
+    encrypted_data,
+    kdfs,
+};
+use tari_template_lib_types::{
+    Amount,
+    EncryptedData,
+    crypto::PedersenCommitmentBytes,
+    stealth::{StealthInput, StealthInputsStatement, StealthTransferStatement},
+};
 
 use crate::{
     key_provider,
     key_provider::{DiffieHellmanKdfKeyProvider, LocalKeyProvider, OutputMaskProvider},
     signer,
     signer::StealthKeyPrehashSigner,
-    stealth::{BurnClaimKeyProvider, InputDecryptor, StealthProviderError, StealthResult},
+    stealth::{
+        BurnClaimKeyProvider,
+        BurnClaimStatementSpec,
+        InputDecryptor,
+        StealthOutputStatementFactory,
+        StealthProviderError,
+        StealthResult,
+    },
 };
 
 #[derive(Clone)]
@@ -175,6 +193,46 @@ impl BurnClaimKeyProvider for LocalKeyProvider<OotleSecretKey> {
             true,
         )?;
         Ok(decrypted)
+    }
+
+    async fn create_burn_claim_statement(
+        &self,
+        spec: BurnClaimStatementSpec,
+    ) -> StealthResult<StealthTransferStatement> {
+        let BurnClaimStatementSpec {
+            commitment,
+            encrypted_data,
+            sender_offset_public_key,
+            output,
+            revealed_output_amount,
+        } = spec;
+
+        let decrypted = self
+            .decrypt_burn_claim_output(&encrypted_data, &commitment, &sender_offset_public_key)
+            .await?;
+        let agg_input_mask = decrypted.mask().clone();
+
+        let (outputs_statement, agg_output_mask) = self
+            .generate_outputs_statement(vec![output], revealed_output_amount)
+            .await?;
+
+        // The single stealth input is the burn UTXO minted by the `claim_burn` instruction, which the
+        // instruction itself authorises — hence a bare commitment with no witness.
+        let inputs_statement = StealthInputsStatement::new(vec![StealthInput::from(commitment)], Amount::zero());
+
+        let balance_proof = generate_stealth_balance_proof_signature(
+            &agg_input_mask,
+            &agg_output_mask,
+            &inputs_statement,
+            &outputs_statement,
+        );
+
+        Ok(StealthTransferStatement {
+            inputs_statement,
+            outputs_statement,
+            balance_proof: Some(balance_proof),
+            covenant_claims: Vec::new(),
+        })
     }
 }
 

--- a/crates/wallet/ootle-rs/src/stealth/builder.rs
+++ b/crates/wallet/ootle-rs/src/stealth/builder.rs
@@ -5,23 +5,20 @@ use std::collections::HashMap;
 
 use indexmap::IndexSet;
 use ootle_byte_type::FromByteType;
-use tari_crypto::ristretto::RistrettoSecretKey;
 use tari_ootle_common_types::engine_types::{stealth::validate_transfer, substate::SubstateId};
-use tari_ootle_wallet_crypto::balance_proof::{
-    generate_stealth_balance_proof_signature,
-    validate_balance_proof_signature,
-};
 use tari_template_lib_types::{
     Amount,
     ResourceAddress,
     UtxoAddress,
-    stealth::{StealthInput, StealthInputsStatement, StealthTransferStatement},
+    stealth::{StealthInput, StealthTransferStatement},
 };
 
 use crate::{
     Address,
     provider::{Provider, WalletProvider},
     stealth::{
+        ResolvedStealthInput,
+        ResolvedStealthTransferSpec,
         SignatureRequirements,
         StealthSignerRequirement,
         error::{InvalidStealthInputError, StealthProviderError},
@@ -58,8 +55,40 @@ impl<'a, P: Provider> StealthTransfer<'a, P> {
 
 impl<'a, P: WalletProvider<Wallet = OotleWallet>> StealthTransfer<'a, P> {
     /// Build the stealth transfer statement without constructing the transaction
-    #[allow(clippy::too_many_lines)]
-    pub async fn prepare(self) -> WalletResult<(StealthTransferStatement, SignatureRequirements)> {
+    pub async fn prepare(mut self) -> WalletResult<(StealthTransferStatement, SignatureRequirements)> {
+        let total_output_amount = self.spec.total_output_amount();
+        let total_revealed_input = self.spec.revealed_input_amount;
+
+        let (resolved_inputs, signatures) = self.resolve_inputs().await?;
+
+        let spec = ResolvedStealthTransferSpec {
+            inputs: resolved_inputs,
+            revealed_input_amount: total_revealed_input,
+            outputs: self.spec.outputs,
+            revealed_output_amount: self.spec.revealed_output_amount,
+        };
+
+        let transfer = self.provider.wallet().create_transfer_statement(spec).await?;
+
+        if let Err(err) = validate_transfer(&transfer, None) {
+            tracing::warn!("The constructed stealth transfer is unbalanced: {}", err);
+            return Err(StealthProviderError::UnbalancedTransfer {
+                total_revealed_input,
+                output_amount: total_output_amount,
+            }
+            .into());
+        }
+
+        Ok((transfer, signatures))
+    }
+
+    /// Fetch each input's UTXO substate and pair it with the output body its mask is recovered from,
+    /// deriving the transfer's signature requirements along the way.
+    ///
+    /// This is the network-dependent, key-independent half of [`prepare`](Self::prepare): everything
+    /// here is public material, so it stays on this side of the
+    /// [`StealthStatementProvider`](crate::stealth::StealthStatementProvider) boundary.
+    async fn resolve_inputs(&mut self) -> WalletResult<(Vec<ResolvedStealthInput>, SignatureRequirements)> {
         let substate_id_to_addr_map = self
             .spec
             .inputs_to_spend
@@ -67,7 +96,7 @@ impl<'a, P: WalletProvider<Wallet = OotleWallet>> StealthTransfer<'a, P> {
             .map(|(addr, i)| {
                 (
                     SubstateId::from(UtxoAddress::new(self.spec.resource_address, i.commitment.into())),
-                    addr,
+                    addr.clone(),
                 )
             })
             .collect::<HashMap<_, _>>();
@@ -89,8 +118,8 @@ impl<'a, P: WalletProvider<Wallet = OotleWallet>> StealthTransfer<'a, P> {
         let mut required_signers = IndexSet::with_capacity(found_substates.len());
         let mut seal_signer = None;
         let must_sign_with_account_key = self.spec.revealed_input_amount.is_positive();
+        let mut resolved_inputs = Vec::with_capacity(found_substates.len());
 
-        let mut agg_input_mask = RistrettoSecretKey::default();
         for (id, substate) in found_substates {
             // TODO: work on the error types
             let Some(address) = id.as_utxo_address() else {
@@ -127,7 +156,7 @@ impl<'a, P: WalletProvider<Wallet = OotleWallet>> StealthTransfer<'a, P> {
                 }
                 .into());
             };
-            let Some(spender_addr) = substate_id_to_addr_map.get(&id).copied() else {
+            let Some(spender_addr) = substate_id_to_addr_map.get(&id) else {
                 tracing::warn!(
                     "The provider returned a substate that we did not request: {id}. We'll continue but that should \
                      never happen!"
@@ -140,54 +169,14 @@ impl<'a, P: WalletProvider<Wallet = OotleWallet>> StealthTransfer<'a, P> {
                 required_signers.insert(StealthSignerRequirement::new(spender_addr.clone(), public_nonce));
             }
 
-            let commitment = address.id().into_commitment_bytes();
-
-            let decrypted = self
-                .provider
-                .wallet()
-                .decrypt_input_data(&commitment, input.output(), true)
-                .await?;
-
-            agg_input_mask = &agg_input_mask + decrypted.mask();
-        }
-
-        let total_output_amount = self.spec.total_output_amount();
-        let total_revealed_input = self.spec.revealed_input_amount;
-
-        let (outputs_statement, agg_output_mask) = self
-            .provider
-            .wallet()
-            .generate_outputs_statement(self.spec.outputs, self.spec.revealed_output_amount)
-            .await?;
-
-        let inputs_statement = StealthInputsStatement {
-            inputs: self.spec.inputs_to_spend.into_values().collect(),
-            revealed_amount: total_revealed_input,
-        };
-
-        // If the transfer does not use any stealth inputs or outputs, no balance proof is required.
-        let requires_balance_proof = !inputs_statement.inputs.is_empty() || !outputs_statement.outputs.is_empty();
-
-        let balance_proof = requires_balance_proof.then(|| {
-            generate_stealth_balance_proof_signature(
-                &agg_input_mask,
-                &agg_output_mask,
-                &inputs_statement,
-                &outputs_statement,
-            )
-        });
-
-        if let Some(balance_proof) = &balance_proof {
-            // Check that the provided inputs and outputs balance
-            // We assume that the code has otherwise generated valid proofs, so the only reason this can fail
-            // is if the input values and output values do not balance.
-            if !validate_balance_proof_signature(balance_proof, &inputs_statement, &outputs_statement) {
-                return Err(StealthProviderError::UnbalancedTransfer {
-                    total_revealed_input,
-                    output_amount: total_output_amount,
+            let Some(to_spend) = self.spec.inputs_to_spend.remove(spender_addr) else {
+                return Err(StealthProviderError::UnexpectedError {
+                    details: format!("No stealth input to spend for resolved address {spender_addr}"),
                 }
                 .into());
-            }
+            };
+
+            resolved_inputs.push(ResolvedStealthInput::new(to_spend, input.output().clone()));
         }
 
         let signatures = if must_sign_with_account_key {
@@ -196,23 +185,7 @@ impl<'a, P: WalletProvider<Wallet = OotleWallet>> StealthTransfer<'a, P> {
             SignatureRequirements::new_opt_with_seal_signer(required_signers, seal_signer)
         };
 
-        let transfer = StealthTransferStatement {
-            inputs_statement,
-            outputs_statement,
-            balance_proof,
-            covenant_claims: Vec::new(),
-        };
-
-        if let Err(err) = validate_transfer(&transfer, None) {
-            tracing::warn!("The constructed stealth transfer is unbalanced: {}", err);
-            return Err(StealthProviderError::UnbalancedTransfer {
-                total_revealed_input,
-                output_amount: total_output_amount,
-            }
-            .into());
-        }
-
-        Ok((transfer, signatures))
+        Ok((resolved_inputs, signatures))
     }
 
     /// When the stealth transfer is executed, it will expect some revealed amount as input from a bucket.

--- a/crates/wallet/ootle-rs/src/stealth/spec.rs
+++ b/crates/wallet/ootle-rs/src/stealth/spec.rs
@@ -5,11 +5,14 @@ use std::{num::NonZeroU64, ops::Not};
 
 use indexmap::IndexSet;
 use tari_crypto::ristretto::RistrettoPublicKey;
+use tari_ootle_common_types::engine_types::crypto::OutputBody;
 use tari_ootle_wallet_crypto::{memo::Memo, pay_to::PayTo};
 use tari_template_lib_types::{
+    Amount,
+    EncryptedData,
     ResourceAddress,
-    crypto::UtxoTag,
-    stealth::{SpendCondition, TemplateFunction},
+    crypto::{PedersenCommitmentBytes, UtxoTag},
+    stealth::{SpendCondition, StealthInput, TemplateFunction},
 };
 
 use crate::Address;
@@ -185,6 +188,73 @@ impl Output {
         self.utxo_tag = Some(utxo_tag);
         self
     }
+}
+
+/// A stealth input resolved against the network and ready for statement construction.
+///
+/// Resolving an input — fetching its UTXO substate, rejecting frozen or burnt ones and recovering its
+/// public nonce — needs network access but no keys, so it happens on the caller's side of
+/// [`StealthStatementProvider`](crate::stealth::StealthStatementProvider). What remains is
+/// key-dependent: recovering the input's mask from `output`.
+#[derive(Debug, Clone)]
+pub struct ResolvedStealthInput {
+    /// The input as it appears in the statement: the commitment being spent plus the spend witness
+    /// selecting its authorisation path.
+    pub input: StealthInput,
+    /// The on-chain output body the input's mask is recovered from.
+    pub output: OutputBody,
+}
+
+impl ResolvedStealthInput {
+    pub fn new(input: StealthInput, output: OutputBody) -> Self {
+        Self { input, output }
+    }
+
+    pub fn commitment(&self) -> &PedersenCommitmentBytes {
+        &self.input.commitment
+    }
+}
+
+/// A stealth transfer whose inputs are resolved, ready to be turned into a
+/// [`StealthTransferStatement`](tari_template_lib_types::stealth::StealthTransferStatement) by a
+/// [`StealthStatementProvider`](crate::stealth::StealthStatementProvider).
+#[derive(Debug, Clone)]
+pub struct ResolvedStealthTransferSpec {
+    pub inputs: Vec<ResolvedStealthInput>,
+    /// Revealed amount the transfer consumes from a bucket.
+    pub revealed_input_amount: Amount,
+    pub outputs: Vec<Output>,
+    /// Revealed amount the transfer pays out, e.g. to cover a fee.
+    pub revealed_output_amount: Amount,
+}
+
+impl ResolvedStealthTransferSpec {
+    pub fn total_output_amount(&self) -> Amount {
+        let stealth_output_total: Amount = self.outputs.iter().map(|o| Amount::from(o.amount.get())).sum();
+        stealth_output_total + self.revealed_output_amount
+    }
+
+    /// Whether the transfer needs a balance proof. A transfer with no stealth inputs and no stealth
+    /// outputs moves only revealed value and has nothing to balance.
+    pub fn requires_balance_proof(&self) -> bool {
+        !self.inputs.is_empty() || !self.outputs.is_empty()
+    }
+}
+
+/// The claimed-funds side of an L1 burn claim, ready to be turned into a statement by
+/// [`BurnClaimKeyProvider::create_burn_claim_statement`](crate::stealth::BurnClaimKeyProvider::create_burn_claim_statement).
+#[derive(Debug, Clone)]
+pub struct BurnClaimStatementSpec {
+    /// The burn UTXO's commitment, taken from the L1 burn proof.
+    pub commitment: PedersenCommitmentBytes,
+    /// The L1 output's encrypted data, which the burn UTXO's mask is recovered from.
+    pub encrypted_data: EncryptedData,
+    /// `R`, the public nonce the L1 UTXO was burnt with.
+    pub sender_offset_public_key: RistrettoPublicKey,
+    /// The stealth output the claimed funds are paid into.
+    pub output: Output,
+    /// Revealed amount reserved to pay the claim transaction's fee.
+    pub revealed_output_amount: Amount,
 }
 
 #[cfg(test)]

--- a/crates/wallet/ootle-rs/src/stealth/traits.rs
+++ b/crates/wallet/ootle-rs/src/stealth/traits.rs
@@ -9,15 +9,48 @@ use tari_template_lib_types::{
     Amount,
     EncryptedData,
     crypto::PedersenCommitmentBytes,
-    stealth::StealthOutputsStatement,
+    stealth::{StealthOutputsStatement, StealthTransferStatement},
 };
 
-use crate::stealth::{Output, error::StealthProviderError};
+use crate::stealth::{BurnClaimStatementSpec, Output, ResolvedStealthTransferSpec, error::StealthProviderError};
 
 pub type StealthResult<T> = Result<T, StealthProviderError>;
 
+/// Produces a complete [`StealthTransferStatement`] from a resolved transfer spec.
+///
+/// This is the custody boundary for stealth transfers. A statement's balance proof is a Schnorr
+/// signature whose private key is `Σoutput_mask - Σinput_mask`, so whichever component builds it must
+/// hold every mask in the transfer. Confining that to the implementor is what lets a key store that
+/// is not in-process — a wallet daemon behind an RPC, or a hardware wallet — implement this trait:
+/// only the finished statement crosses the boundary, never a mask or any other secret.
+///
+/// The balance proof commits to the inputs and outputs statements alone, not to the transaction that
+/// carries them, so a statement is self-contained. An implementor needs to know nothing about the
+/// transaction being built, and callers are free to embed the returned statement in any transaction.
 #[async_trait]
-pub trait StealthOutputStatementFactory {
+pub trait StealthStatementProvider {
+    /// Build the inputs statement, outputs statement, aggregate range proof and balance proof for
+    /// `spec`, returning them as one statement.
+    ///
+    /// The spec's inputs must already be resolved against the network — see
+    /// [`ResolvedStealthInput`](crate::stealth::ResolvedStealthInput). Implementors recover each
+    /// input's mask from its output body, and must return
+    /// [`StealthProviderError::UnbalancedTransfer`] if the inputs and outputs do not balance.
+    async fn create_transfer_statement(
+        &self,
+        spec: ResolvedStealthTransferSpec,
+    ) -> StealthResult<StealthTransferStatement>;
+}
+
+/// Creates stealth outputs and the aggregate range proof over them.
+///
+/// Internal to local (in-process) custody: `generate_outputs_statement` returns the aggregate output
+/// mask, so it must never be reachable across a process boundary. [`StealthStatementProvider`] is the
+/// boundary-safe seam built on top of this.
+#[async_trait]
+pub(crate) trait StealthOutputStatementFactory {
+    /// Create an output per spec and return the outputs statement alongside `Σoutput_mask`, which the
+    /// caller needs to sign the transfer's balance proof.
     async fn generate_outputs_statement(
         &self,
         specs: Vec<Output>,
@@ -25,8 +58,13 @@ pub trait StealthOutputStatementFactory {
     ) -> StealthResult<(StealthOutputsStatement, RistrettoSecretKey)>;
 }
 
+/// Recovers the value and mask committed to by a stealth input.
+///
+/// Internal to local (in-process) custody: [`DecryptedData`] carries the input's mask, so this must
+/// never be reachable across a process boundary. [`StealthStatementProvider`] is the boundary-safe
+/// seam built on top of this.
 #[async_trait]
-pub trait InputDecryptor {
+pub(crate) trait InputDecryptor {
     async fn decrypt_input_data(
         &self,
         commitment: &PedersenCommitmentBytes,
@@ -40,6 +78,10 @@ pub trait InputDecryptor {
 /// Unlike a regular stealth transfer (which decrypts inputs with the view-only key), a burn claim
 /// uses the account secret directly: the L1 burn output is a stealth output addressed to the
 /// claiming account, and only the account secret can derive the key that spends the minted UTXO.
+///
+/// A burn claim is inherently local-custody: [`derive_burn_claim_secret`](Self::derive_burn_claim_secret)
+/// hands out the key that seals the claim transaction, so unlike [`StealthStatementProvider`] this
+/// trait cannot be satisfied by a remote key store as it stands.
 #[async_trait]
 pub trait BurnClaimKeyProvider {
     /// Derive the L1 burn-claim stealth secret `s = H(p·R) + p`, where `p` is the account secret and
@@ -60,6 +102,16 @@ pub trait BurnClaimKeyProvider {
         commitment: &PedersenCommitmentBytes,
         sender_offset_public_key: &RistrettoPublicKey,
     ) -> StealthResult<DecryptedData>;
+
+    /// Build the statement that spends the minted burn UTXO into `spec.output`.
+    ///
+    /// The burn UTXO's mask is recovered from `spec.encrypted_data` internally, so — as with
+    /// [`StealthStatementProvider::create_transfer_statement`] — only the finished statement is
+    /// returned.
+    async fn create_burn_claim_statement(
+        &self,
+        spec: BurnClaimStatementSpec,
+    ) -> StealthResult<StealthTransferStatement>;
 }
 
 pub trait StealthSigner {
@@ -67,6 +119,3 @@ pub trait StealthSigner {
 
     fn sign_with_stealth_key(&self, public_key: &RistrettoPublicKey) -> Result<Self::Signature, String>;
 }
-
-pub trait StealthProvider: StealthOutputStatementFactory + InputDecryptor {}
-impl<T> StealthProvider for T where T: StealthOutputStatementFactory + InputDecryptor {}

--- a/crates/wallet/ootle-rs/src/wallet/ootle.rs
+++ b/crates/wallet/ootle-rs/src/wallet/ootle.rs
@@ -5,19 +5,17 @@ use std::{collections::HashMap, sync::Arc};
 
 use async_trait::async_trait;
 use tari_crypto::ristretto::{RistrettoPublicKey, RistrettoSecretKey};
-use tari_ootle_common_types::engine_types::crypto::OutputBody;
 use tari_ootle_transaction::{IntoSigned, Transaction, TransactionSignature, UnsealedTransaction, UnsignedTransaction};
 use tari_ootle_wallet_crypto::DecryptedData;
 use tari_template_lib_types::{
-    Amount,
     EncryptedData,
     crypto::{PedersenCommitmentBytes, RistrettoPublicKeyBytes},
-    stealth::StealthOutputsStatement,
+    stealth::StealthTransferStatement,
 };
 
 use crate::{
     signer,
-    stealth::{Output, SignatureRequirements},
+    stealth::{BurnClaimStatementSpec, ResolvedStealthTransferSpec, SignatureRequirements},
     transaction::TransactionSealSigner,
     types::Address,
     wallet::{NetworkWallet, WalletStealthAuthorizer, error::WalletError, traits::WalletKeyProvider},
@@ -116,12 +114,12 @@ impl OotleWallet {
         self.key_providers.keys()
     }
 
-    pub async fn decrypt_input_data(
+    /// Build the complete stealth transfer statement for `spec` using the default key provider.
+    /// See [`crate::stealth::StealthStatementProvider::create_transfer_statement`].
+    pub async fn create_transfer_statement(
         &self,
-        commitment: &PedersenCommitmentBytes,
-        input: &OutputBody,
-        skip_memo: bool,
-    ) -> WalletResult<DecryptedData> {
+        spec: ResolvedStealthTransferSpec,
+    ) -> WalletResult<StealthTransferStatement> {
         let address = self.default_address();
         let signer = self
             .key_providers
@@ -129,24 +127,8 @@ impl OotleWallet {
             .ok_or_else(|| WalletError::KeyProviderNotFound {
                 address: address.clone(),
             })?;
-        let decrypted_data = signer.decrypt_input_data(commitment, input, skip_memo).await?;
-        Ok(decrypted_data)
-    }
-
-    pub async fn generate_outputs_statement(
-        &self,
-        specs: Vec<Output>,
-        revealed_output_amount: Amount,
-    ) -> WalletResult<(StealthOutputsStatement, RistrettoSecretKey)> {
-        let address = self.default_address();
-        let signer = self
-            .key_providers
-            .get(address)
-            .ok_or_else(|| WalletError::KeyProviderNotFound {
-                address: address.clone(),
-            })?;
-        let (statement, agg_output_mask) = signer.generate_outputs_statement(specs, revealed_output_amount).await?;
-        Ok((statement, agg_output_mask))
+        let statement = signer.create_transfer_statement(spec).await?;
+        Ok(statement)
     }
 
     /// Derive the L1 burn-claim stealth secret `s = H(p·R) + p` using the default key provider.
@@ -185,6 +167,23 @@ impl OotleWallet {
             .decrypt_burn_claim_output(encrypted_data, commitment, sender_offset_public_key)
             .await?;
         Ok(decrypted)
+    }
+
+    /// Build the statement that spends a minted burn UTXO using the default key provider.
+    /// See [`crate::stealth::BurnClaimKeyProvider::create_burn_claim_statement`].
+    pub async fn create_burn_claim_statement(
+        &self,
+        spec: BurnClaimStatementSpec,
+    ) -> WalletResult<StealthTransferStatement> {
+        let address = self.default_address();
+        let signer = self
+            .key_providers
+            .get(address)
+            .ok_or_else(|| WalletError::KeyProviderNotFound {
+                address: address.clone(),
+            })?;
+        let statement = signer.create_burn_claim_statement(spec).await?;
+        Ok(statement)
     }
 
     pub fn stealth_authorizer(&self, required_signatures: SignatureRequirements) -> WalletStealthAuthorizer<'_, Self> {

--- a/crates/wallet/ootle-rs/src/wallet/traits.rs
+++ b/crates/wallet/ootle-rs/src/wallet/traits.rs
@@ -7,7 +7,7 @@ use tari_ootle_transaction::{Transaction, UnsignedTransaction};
 
 use crate::{
     Address,
-    stealth::{BurnClaimKeyProvider, InputDecryptor, StealthOutputStatementFactory},
+    stealth::{BurnClaimKeyProvider, StealthStatementProvider},
     transaction::{TransactionSigner, TransactionStealthKeySigner},
     wallet::WalletResult,
 };
@@ -20,18 +20,20 @@ pub trait NetworkWallet {
     -> impl Future<Output = WalletResult<Transaction>> + Send;
 }
 
-/// A key provider that can sign transactions, derive stealth keys, generate output
-/// statements, decrypt stealth inputs, and claim Layer 1 burns. Automatically implemented
-/// for any type implementing all constituent traits.
+/// A key provider that can sign transactions, derive stealth keys, produce stealth transfer
+/// statements, and claim Layer 1 burns. Automatically implemented for any type implementing all
+/// constituent traits.
+///
+/// On the stealth transfer path every method here takes and returns public material only — signatures
+/// and statements, never keys or masks — so an implementor's key material never has to leave it. That
+/// is what allows a provider backed by a wallet daemon or a hardware wallet.
+///
+/// [`BurnClaimKeyProvider`] is the exception and is local-custody only: it hands out both the key that
+/// seals a burn claim and the burn output's mask. A remote provider cannot satisfy it as it stands.
 pub trait WalletKeyProvider:
-    TransactionSigner + TransactionStealthKeySigner + StealthOutputStatementFactory + InputDecryptor + BurnClaimKeyProvider
+    TransactionSigner + TransactionStealthKeySigner + StealthStatementProvider + BurnClaimKeyProvider
 {
 }
 
-impl<T> WalletKeyProvider for T where T: TransactionSigner
-        + TransactionStealthKeySigner
-        + StealthOutputStatementFactory
-        + InputDecryptor
-        + BurnClaimKeyProvider
-{
-}
+impl<T> WalletKeyProvider for T where T: TransactionSigner + TransactionStealthKeySigner + StealthStatementProvider + BurnClaimKeyProvider
+{}


### PR DESCRIPTION
## Problem

The two stealth provider traits both handed secret material to their caller:

- `StealthOutputStatementFactory::generate_outputs_statement` returned the aggregate output mask.
- `InputDecryptor::decrypt_input_data` returned `DecryptedData`, which carries each input's mask.

Both sat on `WalletKeyProvider`, and `StealthTransfer::prepare` was the caller that collected the masks and signed the balance proof itself:

```rust
let balance_proof = requires_balance_proof.then(|| {
    generate_stealth_balance_proof_signature(
        &agg_input_mask,   // from InputDecryptor
        &agg_output_mask,  // from StealthOutputStatementFactory
        &inputs_statement, &outputs_statement,
    )
});
```

That makes the seam unimplementable by any key store that is not in-process. A wallet daemon behind an RPC would have to put masks on the wire.

It is also why `LedgerSigner` implements `TransactionSigner` and `TransactionStealthKeySigner` but neither stealth provider trait — you cannot get masks off the device. **Stealth transfers are currently local-software-custody only**, hardware wallets included.

## Approach

The balance proof is a Schnorr signature over `Σoutput_mask - Σinput_mask`, so whoever builds it must hold every mask. The fix is to move that work *behind* the boundary rather than pass masks *across* it.

This works cleanly because the balance proof commits to the inputs and outputs statements alone — not to the transaction carrying them. A statement is self-contained, so an implementor needs to know nothing about the transaction being built, and callers can embed the returned statement in any transaction.

- **Add `StealthStatementProvider::create_transfer_statement`** — takes a `ResolvedStealthTransferSpec`, returns a complete `StealthTransferStatement`. This is the new custody boundary.
- **Demote `StealthOutputStatementFactory` and `InputDecryptor` to `pub(crate)`** — they remain the local implementation's building blocks, but can no longer cross a process boundary.
- **Split `StealthTransfer::prepare`** into `resolve_inputs` (fetches UTXO substates and derives `SignatureRequirements` — network-dependent but key-independent, so it stays caller-side) and the provider call.
- **Add `BurnClaimKeyProvider::create_burn_claim_statement`** so `claim_burn` no longer reaches for `generate_outputs_statement`.

The signer traits are untouched — they already return signatures rather than keys, which `LedgerSigner` demonstrates works remotely.

`StealthTransfer::prepare`'s signature is unchanged, so the builder DSL and the examples are unaffected.

## Scope / what this does not do

`BurnClaimKeyProvider` stays local-custody only and is now documented as such: `derive_burn_claim_secret` hands out the key that seals the claim and `BurnClaimSealer` holds it, so a remote provider cannot satisfy it as it stands. It remains a supertrait of `WalletKeyProvider`, so **a walletd- or Ledger-backed provider still cannot implement the full bundle** — splitting burn claim out of the seam is follow-up work.

No walletd-backed provider is added here. This only makes one possible.

## Testing

The statement-building path had no coverage before this PR (the existing tests covered macros and `SignatureRequirements` invariants only). Second commit adds it.

The tests exercise real crypto rather than mocking it: they mint an actual stealth output via the outputs-statement factory, feed it back as a resolved input, and assert the engine's own `validate_transfer` accepts the result.

- spending a stealth input into an equal output validates
- multiple inputs/outputs balance in aggregate, and input order is preserved
- a revealed input funding a stealth output validates
- an unbalanced transfer is rejected as `UnbalancedTransfer`
- a revealed-only transfer carries no balance proof
- one wallet cannot spend another wallet's output
- a burn claim spends the minted UTXO into a stealth output plus a revealed fee
- `total_output_amount` / `requires_balance_proof` unit cases

Each proof-carrying test was verified against a deliberate mutation to confirm it can fail: dropping the input-mask accumulation fails the two stealth-input tests; stubbing out the balance check fails the unbalanced test; using a wrong mask for the burn input fails the burn claim test.

Gates:
- `cargo lints clippy -p ootle-rs --all-targets` — clean
- `cargo +nightly-2025-12-05 fmt -p ootle-rs --check` — clean
- `cargo nextest r -p ootle-rs` — 16/16 pass

The refactor is behaviour-preserving: the same masks are aggregated in the same order into the same balance proof, just on the other side of a trait boundary. The end-to-end flow is still only exercised by `examples/stealth_transfer.rs` and `examples/stealth_spend_conditions.rs` against a localnet, which I have not run.

## Versioning

`ootle-rs` 0.14.0 → 0.15.0 per `scripts/crate_versioning.py impact ootle-rs --breaking`. It is a leaf crate with no reverse dependencies in the workspace, so nothing else moves.

## Breaking changes

- `StealthOutputStatementFactory` and `InputDecryptor` are no longer public.
- The blanket `StealthProvider` trait is removed.
- `OotleWallet::generate_outputs_statement` / `decrypt_input_data` are replaced by `create_transfer_statement`.
- `WalletKeyProvider` now requires `StealthStatementProvider`.
