### PR TITLE
fix(ci): install a protoc that supports proto3 optional on the linux legs

### DIFF
--- a/.github/workflows/build_binaries.yml
+++ b/.github/workflows/build_binaries.yml
@@ -18,6 +18,8 @@ name: Build Matrix of Binaries
         default: "development-tag"
 
 env:
+  # Matches the protoc that ubuntu-latest ships, which the ci workflow builds these protos against.
+  PROTOC_VERSION: "21.12"
   TS_FILENAME: "tari_ootle"
   TS_BUNDLE_ID_BASE: "com.tari.ootle.pkg"
   TS_SIG_FN: "sha256-unsigned.txt"
@@ -188,6 +190,26 @@ jobs:
         run: |
           sudo apt-get update
           sudo bash scripts/install_ubuntu_dependencies.sh
+
+      # The upstream grpc protos use proto3 optional fields, which protoc only accepts natively from
+      # 3.15 on. The Linux legs pin an older image for its lower glibc floor, and that image's apt
+      # protoc predates 3.15, so a current protoc must take precedence over the distro one on PATH.
+      - name: Install protoc - Ubuntu
+        if: ${{ startsWith(runner.os,'Linux') && ( ! matrix.builds.cross ) }}
+        run: |
+          set -euo pipefail
+          case "${{ runner.arch }}" in
+            X64) protoc_arch=x86_64 ;;
+            ARM64) protoc_arch=aarch_64 ;;
+            *) echo "Unsupported runner arch: ${{ runner.arch }}" >&2; exit 1 ;;
+          esac
+          curl -fsSL -o /tmp/protoc.zip \
+            "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-${protoc_arch}.zip"
+          sudo unzip -o -q /tmp/protoc.zip -d /usr/local bin/protoc 'include/*'
+          sudo chmod +x /usr/local/bin/protoc
+          rm -f /tmp/protoc.zip
+          command -v protoc
+          protoc --version
 
       - name: Install Linux dependencies - Ubuntu - local cross-compiled ${{ env.TARI_BUILD_ISA_CPU }} on x86-64
         # Disabled
@@ -750,6 +772,7 @@ jobs:
             ${{ github.workspace }}${{ env.TS_DIST }}/tari_ootle_walletd-${{ env.TARI_VERSION }}-${{ env.VSHA_SHORT }}-${{ matrix.builds.name }}${{ env.TS_EXT }}.sha256
           token: ${{ secrets.GITHUB_TOKEN }}
           prerelease: true
+          draft: true
           allowUpdates: true
           updateOnlyUnreleased: true
           replacesArtifacts: true
@@ -1007,6 +1030,7 @@ jobs:
           artifacts: "${{ env.TS_FILENAME }}*/**/*"
           token: ${{ secrets.GITHUB_TOKEN }}
           prerelease: true
+          draft: true
           allowUpdates: true
           updateOnlyUnreleased: true
           replacesArtifacts: true

--- a/.github/workflows/ffi_libs.yml
+++ b/.github/workflows/ffi_libs.yml
@@ -141,5 +141,6 @@ jobs:
           allowUpdates: true
           updateOnlyUnreleased: true
           replacesArtifacts: true
+          omitDraftDuringUpdate: true
           omitBodyDuringUpdate: true
           omitNameDuringUpdate: true

--- a/scripts/install_ubuntu_dependencies.sh
+++ b/scripts/install_ubuntu_dependencies.sh
@@ -26,4 +26,5 @@ apt-get install --no-install-recommends --assume-yes \
   libudev-dev \
   libhidapi-dev \
   libdbus-1-dev \
-  zip
+  zip \
+  unzip


### PR DESCRIPTION
## Description

The linux build legs of `build_binaries` have been failing on every run, so tagged releases ship without linux binaries (v0.36.0's draft currently holds only the ffi zips). Root cause is a runner-image split, not a code change:

| Workflow | Runner | apt `protobuf-compiler` | proto3 optional |
|---|---|---|---|
| `ci.yml` | `ubuntu-latest` (24.04) | 3.21.12 | native → passes |
| `build_binaries` linux-x86_64 | `ubuntu-22.04` | 3.12.4 | needs flag → **fails** |
| `build_binaries` linux-arm64 | `ubuntu-22.04-arm` | 3.12.4 | needs flag → **fails** |

Both call the same `scripts/install_ubuntu_dependencies.sh`; only the base image differs. protoc only accepts proto3 optional natively from 3.15 on, so jammy's 3.12.4 rejects `minotari_app_grpc`'s protos:

```
Error: Custom { kind: Other, error: "protoc failed: wallet.proto: This file contains
proto3 optional fields, but --experimental_allow_proto3_optional was not set." }
```

Passing `--experimental_allow_proto3_optional` isn't an option from here — the failing build script is upstream in `minotari_app_grpc`, so we'd need *its* `prost_build`/`tonic_build` to set `protoc_arg`. Bumping the runners to 24.04 would also fix it, but these are release binaries and 22.04 is pinned deliberately for its lower glibc floor (2.35 → 2.39 would break users on older distros). So this installs protoc 21.12 ahead of the distro one on PATH — the same version `ci.yml` already builds these protos against. The `cross: true` legs are excluded since they build inside a container.

`unzip` is added to the dependency script; the script only installed `zip`, so the new step would have depended on the runner image happening to provide unzip.

## Release draft state

`ffi_libs` and `build_binaries` both write artifacts to the same tag's release, and whichever ran first decided the draft state — `ffi_libs` passes `draft: true`, while `build_binaries` left `draft` unset and would have created a *published* prerelease holding only a partial artifact set. `ffi_libs` also force-set `draft: true` on update, which could yank a published release back to draft. Now both pin `draft: true` + `omitDraftDuringUpdate: true`, so first writer creates the draft, the other adds to it, and it's published by hand — which is what v0.35.0/1/2 already did in practice.

Note `replacesArtifacts` is deliberately left `true`: it only deletes assets whose name collides with one the same step uploads (`ArtifactUploader.deleteUpdatedArtifacts`), so it never touches the other workflow's artifacts. Setting it `false` would break re-run idempotency, since GitHub 422s duplicate asset names and ncipollo only warns unless `artifactErrorsFailBuild` is set.

## How Has This Been Tested?

Reproduced and verified in docker on `ubuntu:22.04`, for both `linux/amd64` and `linux/arm64` (covering `ubuntu-22.04` and `ubuntu-22.04-arm`). Running the real `install_ubuntu_dependencies.sh` then the new step verbatim on a bare image:

```
BEFORE: libprotoc 3.12.4 at /usr/bin/protoc      # reproduces the exact CI error
/usr/local/bin/protoc                            # shadows the apt one
libprotoc 3.21.12
PROTOC OK — proto3 optional accepted
```

This proves protoc parses a proto3-optional file, not that the full `minotari_app_grpc` crate builds — that needs the real dependency tree and a Rust toolchain. The failure was purely in protoc's parse step, so the mechanism is covered, but the first tagged run is the real proof.

`linux-riscv64` and `windows-arm64` fail for unrelated reasons and are untouched here; both are `best_effort: true` and don't gate the release.

## What process can a PR reviewer use to test or verify this change?

- Dispatch `build_binaries` on this branch and confirm the linux-x86_64 leg gets past `minotari_app_grpc`'s build script; the `Install protoc - Ubuntu` step logs `libprotoc 3.21.12` from `/usr/local/bin/protoc`.
- Or locally: `docker run --rm -it --platform linux/amd64 ubuntu:22.04`, install `protobuf-compiler`, and confirm `protoc --version` is 3.12.4 and a proto with an `optional` scalar fails; then run the step's commands and confirm it compiles.

<!-- Checklist -->
## Breaking Changes

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify