### PR TITLE
feat(epoch-oracles): support scheduled validator claim key rotation

### DIFF
--- a/applications/tari_ootle_app_utilities/config_presets/f_epoch_oracle.toml
+++ b/applications/tari_ootle_app_utilities/config_presets/f_epoch_oracle.toml
@@ -29,14 +29,15 @@
 #
 # Set exactly one of `config_file` or `config_json` (setting both is an error). The config has the following shape:
 #{
-# "epoch_time: 120,
-# "initial_epoch": 3,
+#  "epoch_time": 120,
+#  "initial_epoch": 3,
+#  "base_time": "2026-02-23T13:08:42+0000",
 #  "validators": [{
 #    "public_key": "04efea68c9bff8f9c25fe89310abf91955e33344f4b77bb0d31ea80a80128e67",
 #    "claim_key": "04efea68c9bff8f9c25fe89310abf91955e33344f4b77bb0d31ea80a80128e67",
 #    "shard_group": {"start": 1,"end_inclusive": 256},
 #    "registration_epoch": 5,
-#    # Optional. Rotates the validator's claim key from the start of each `effective_epoch`.
+#    // Optional. Rotates the validator's claim key from the start of each `effective_epoch`.
 #    "claim_key_changes": [
 #      {"effective_epoch": 100, "claim_key": "9a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f9"}
 #    ]

--- a/applications/tari_ootle_app_utilities/config_presets/f_epoch_oracle.toml
+++ b/applications/tari_ootle_app_utilities/config_presets/f_epoch_oracle.toml
@@ -35,9 +35,23 @@
 #    "public_key": "04efea68c9bff8f9c25fe89310abf91955e33344f4b77bb0d31ea80a80128e67",
 #    "claim_key": "04efea68c9bff8f9c25fe89310abf91955e33344f4b77bb0d31ea80a80128e67",
 #    "shard_group": {"start": 1,"end_inclusive": 256},
-#    "registration_epoch": 5
+#    "registration_epoch": 5,
+#    # Optional. Rotates the validator's claim key from the start of each `effective_epoch`.
+#    "claim_key_changes": [
+#      {"effective_epoch": 100, "claim_key": "9a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f9"}
+#    ]
 #  }]
 #}
+#
+# Every validator node must run the same config: nodes derive each other's claim keys from it, so a node holding a
+# stale claim key for a proposer computes a different state merkle root and refuses to vote for its blocks. A
+# rotation therefore names the epoch it applies from rather than taking effect on restart, and each node only has to
+# be given the new config at any point before that epoch.
+#
+# To rotate a claim key, add an entry to `claim_key_changes`; do not edit `claim_key`, which is fixed once the
+# validator has activated (it is an input to shard key derivation). Fees already earned under the previous key stay
+# in the fee pool derived from it and remain claimable with that key — sweep them with the wallet's
+# `claim_validator_fees` using the previous key's index.
 #
 # Load it from a file:
 #config_file = "epoch_oracle_config.toml"

--- a/applications/tari_ootle_app_utilities/src/epoch_oracle_config.rs
+++ b/applications/tari_ootle_app_utilities/src/epoch_oracle_config.rs
@@ -105,7 +105,10 @@ impl ConfiguredOracleConfig {
                 bail!("No configured oracle source set: specify either `config_file` or `config_json`")
             },
             (None, Some(json)) => {
-                return serde_json5::from_str(json).context("Failed to parse inline oracle `config_json`");
+                let config: configured::Config =
+                    serde_json5::from_str(json).context("Failed to parse inline oracle `config_json`")?;
+                config.validate().context("Invalid inline oracle `config_json`")?;
+                return Ok(config);
             },
             (Some(config_file), None) => config_file,
         };
@@ -116,7 +119,7 @@ impl ConfiguredOracleConfig {
         let mut file = File::open(config_file)
             .await
             .with_context(|| format!("Failed to open config file {}", config_file.display()))?;
-        let config = match ext.as_str() {
+        let config: configured::Config = match ext.as_str() {
             "toml" => {
                 let mut s = String::with_capacity(1024);
                 file.read_to_string(&mut s)
@@ -130,6 +133,10 @@ impl ConfiguredOracleConfig {
             },
             ext => bail!("Failed to load oracle config. Unsupported file extension {}", ext),
         };
+
+        config
+            .validate()
+            .with_context(|| format!("Invalid oracle config file {}", config_file.display()))?;
 
         Ok(config)
     }
@@ -186,6 +193,66 @@ mod tests {
         let oracle = configured.load().await.unwrap();
         assert_eq!(oracle.initial_epoch, tari_ootle_common_types::Epoch(7));
         assert_eq!(oracle.epoch_time, Some(Duration::from_secs(120)));
+    }
+
+    #[tokio::test]
+    async fn invalid_config_json_is_rejected_at_load() {
+        // The claim key rotation lands before the validator activates at epoch 6.
+        let configured = ConfiguredOracleConfig {
+            config_file: None,
+            config_json: Some(
+                r#"{
+                    "epoch_time": 120,
+                    "initial_epoch": 0,
+                    "base_time": "2026-02-23T13:08:42+0000",
+                    "validators": [{
+                        "public_key": "d6da35adba3642e7d1343985d5e4f123f5230a74c5480bf2857aabe50bcd6362",
+                        "claim_key": "3c6eebdcb2939ebad646a9d464874005aa979f1e575b72cd2a690289f10e5e50",
+                        "shard_group": {"start": 1, "end_inclusive": 256},
+                        "registration_epoch": 5,
+                        "claim_key_changes": [
+                            {"effective_epoch": 3, "claim_key": "568adadd2744c7bb3ae4c58e26e83a49a5b5af3380edfcd6b5d7af315580552f"}
+                        ]
+                    }]
+                }"#
+                .to_string(),
+            ),
+        };
+
+        let err = configured.load().await.unwrap_err().to_string();
+        assert!(
+            err.contains("Invalid inline oracle `config_json`"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn claim_key_changes_round_trip_from_config_json() {
+        let configured = ConfiguredOracleConfig {
+            config_file: None,
+            config_json: Some(
+                r#"{
+                    "epoch_time": 120,
+                    "initial_epoch": 0,
+                    "base_time": "2026-02-23T13:08:42+0000",
+                    "validators": [{
+                        "public_key": "d6da35adba3642e7d1343985d5e4f123f5230a74c5480bf2857aabe50bcd6362",
+                        "claim_key": "3c6eebdcb2939ebad646a9d464874005aa979f1e575b72cd2a690289f10e5e50",
+                        "shard_group": {"start": 1, "end_inclusive": 256},
+                        "registration_epoch": 5,
+                        "claim_key_changes": [
+                            {"effective_epoch": 100, "claim_key": "568adadd2744c7bb3ae4c58e26e83a49a5b5af3380edfcd6b5d7af315580552f"}
+                        ]
+                    }]
+                }"#
+                .to_string(),
+            ),
+        };
+
+        let oracle = configured.load().await.unwrap();
+        let changes = &oracle.validators[0].claim_key_changes;
+        assert_eq!(changes.len(), 1);
+        assert_eq!(changes[0].effective_epoch, tari_ootle_common_types::Epoch(100));
     }
 
     #[tokio::test]

--- a/crates/epoch_oracles/src/configured/config.rs
+++ b/crates/epoch_oracles/src/configured/config.rs
@@ -7,6 +7,7 @@ use std::{
     time::Duration,
 };
 
+use anyhow::bail;
 use tari_ootle_common_types::{Epoch, NumPreshards, ShardGroup, SubstateAddress, displayable::Displayable};
 use tari_template_lib::types::crypto::RistrettoPublicKeyBytes;
 
@@ -19,6 +20,18 @@ pub struct Config {
     pub base_time: time::OffsetDateTime,
     #[serde(default)]
     pub validators: Vec<Validator>,
+}
+
+impl Config {
+    /// Checks the invariants the oracle relies on to emit a deterministic event stream. Every node must derive the
+    /// same event stream from the same config, so a config that could be read two ways is rejected outright rather
+    /// than resolved by a default.
+    pub fn validate(&self) -> anyhow::Result<()> {
+        for validator in &self.validators {
+            validator.validate()?;
+        }
+        Ok(())
+    }
 }
 
 impl Default for Config {
@@ -48,12 +61,74 @@ impl Display for Config {
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct Validator {
     pub public_key: RistrettoPublicKeyBytes,
+    /// The claim key this validator activates with.
+    ///
+    /// This is an input to shard key derivation and so is fixed once the validator has activated: a node replaying
+    /// an edited config from a fresh oracle store would derive a different shard key to its peers and disagree with
+    /// them on committee ordering. Use `claim_key_changes` to rotate the claim key.
     pub claim_key: RistrettoPublicKeyBytes,
     pub shard_group: ShardGroup,
     pub registration_epoch: Epoch,
+    /// Claim key rotations for this validator, each taking effect at the start of its `effective_epoch`. The shard
+    /// key is unaffected by a rotation.
+    #[serde(default)]
+    pub claim_key_changes: Vec<ClaimKeyChange>,
+}
+
+/// A scheduled claim key rotation for a [`Validator`].
+///
+/// Leader fees earned from `effective_epoch` onwards accrue to the fee pool derived from `claim_key`. Pools filled
+/// under a previous claim key are not migrated and remain claimable with that key.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct ClaimKeyChange {
+    pub effective_epoch: Epoch,
+    pub claim_key: RistrettoPublicKeyBytes,
 }
 
 impl Validator {
+    /// The epoch at which this validator's initial registration becomes active.
+    pub fn activation_epoch(&self) -> Epoch {
+        self.registration_epoch + Epoch(1)
+    }
+
+    fn validate(&self) -> anyhow::Result<()> {
+        let mut changes = self.claim_key_changes.iter().collect::<Vec<_>>();
+        changes.sort_by_key(|change| change.effective_epoch);
+
+        let mut previous_epoch = None;
+        let mut previous_key = &self.claim_key;
+        for change in changes {
+            if change.effective_epoch <= self.activation_epoch() {
+                bail!(
+                    "Validator {}: claim key change at epoch {} must be after the validator's activation epoch {}",
+                    self.public_key,
+                    change.effective_epoch,
+                    self.activation_epoch()
+                );
+            }
+            // Two rows sharing a start_epoch are resolved by row order in one query and by max(id) in another, so
+            // the subsystems that read them could disagree. Reject rather than pick a winner.
+            if previous_epoch == Some(change.effective_epoch) {
+                bail!(
+                    "Validator {}: multiple claim key changes at epoch {}",
+                    self.public_key,
+                    change.effective_epoch
+                );
+            }
+            if change.claim_key == *previous_key {
+                bail!(
+                    "Validator {}: claim key change at epoch {} does not change the claim key",
+                    self.public_key,
+                    change.effective_epoch
+                );
+            }
+            previous_epoch = Some(change.effective_epoch);
+            previous_key = &change.claim_key;
+        }
+
+        Ok(())
+    }
+
     /// Generates a deterministic shard key that naturally falls within the ShardGroup for this Validator node.
     pub(crate) fn calculate_shard_key(&self) -> SubstateAddress {
         let range = self.shard_group.to_substate_address_range(NumPreshards::current());
@@ -73,5 +148,144 @@ impl Validator {
             .expect("bounds checked")
             .copy_from_slice(&hash.to_be_bytes());
         SubstateAddress::from_array(start)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mk_key(seed: u8) -> RistrettoPublicKeyBytes {
+        RistrettoPublicKeyBytes::from_bytes(&[seed; 32]).unwrap()
+    }
+
+    fn mk_validator(claim_key_changes: Vec<ClaimKeyChange>) -> Validator {
+        Validator {
+            public_key: mk_key(1),
+            claim_key: mk_key(2),
+            shard_group: ShardGroup::new(1, 256),
+            registration_epoch: Epoch(10),
+            claim_key_changes,
+        }
+    }
+
+    fn validate(claim_key_changes: Vec<ClaimKeyChange>) -> anyhow::Result<()> {
+        mk_validator(claim_key_changes).validate()
+    }
+
+    #[test]
+    fn no_claim_key_changes_is_valid() {
+        validate(vec![]).unwrap();
+    }
+
+    #[test]
+    fn rotation_after_activation_is_valid() {
+        validate(vec![
+            ClaimKeyChange {
+                effective_epoch: Epoch(20),
+                claim_key: mk_key(3),
+            },
+            ClaimKeyChange {
+                effective_epoch: Epoch(30),
+                claim_key: mk_key(4),
+            },
+        ])
+        .unwrap();
+    }
+
+    #[test]
+    fn rotations_need_not_be_listed_in_epoch_order() {
+        validate(vec![
+            ClaimKeyChange {
+                effective_epoch: Epoch(30),
+                claim_key: mk_key(4),
+            },
+            ClaimKeyChange {
+                effective_epoch: Epoch(20),
+                claim_key: mk_key(3),
+            },
+        ])
+        .unwrap();
+    }
+
+    #[test]
+    fn rotation_at_or_before_activation_is_rejected() {
+        // The validator activates at 11, so there is no registration for these to supersede.
+        for epoch in [Epoch(5), Epoch(10), Epoch(11)] {
+            let err = validate(vec![ClaimKeyChange {
+                effective_epoch: epoch,
+                claim_key: mk_key(3),
+            }])
+            .unwrap_err()
+            .to_string();
+            assert!(err.contains("must be after the validator's activation epoch"), "{err}");
+        }
+    }
+
+    #[test]
+    fn duplicate_effective_epoch_is_rejected() {
+        let err = validate(vec![
+            ClaimKeyChange {
+                effective_epoch: Epoch(20),
+                claim_key: mk_key(3),
+            },
+            ClaimKeyChange {
+                effective_epoch: Epoch(20),
+                claim_key: mk_key(4),
+            },
+        ])
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("multiple claim key changes at epoch"), "{err}");
+    }
+
+    #[test]
+    fn rotation_to_the_same_key_is_rejected() {
+        let err = validate(vec![ClaimKeyChange {
+            effective_epoch: Epoch(20),
+            claim_key: mk_key(2),
+        }])
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("does not change the claim key"), "{err}");
+
+        let err = validate(vec![
+            ClaimKeyChange {
+                effective_epoch: Epoch(20),
+                claim_key: mk_key(3),
+            },
+            ClaimKeyChange {
+                effective_epoch: Epoch(30),
+                claim_key: mk_key(3),
+            },
+        ])
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("does not change the claim key"), "{err}");
+    }
+
+    #[test]
+    fn rotating_back_to_a_previously_used_key_is_valid() {
+        validate(vec![
+            ClaimKeyChange {
+                effective_epoch: Epoch(20),
+                claim_key: mk_key(3),
+            },
+            ClaimKeyChange {
+                effective_epoch: Epoch(30),
+                claim_key: mk_key(2),
+            },
+        ])
+        .unwrap();
+    }
+
+    #[test]
+    fn claim_key_rotation_does_not_move_the_shard_key() {
+        let without = mk_validator(vec![]);
+        let with = mk_validator(vec![ClaimKeyChange {
+            effective_epoch: Epoch(20),
+            claim_key: mk_key(3),
+        }]);
+        assert_eq!(without.calculate_shard_key(), with.calculate_shard_key());
     }
 }

--- a/crates/epoch_oracles/src/configured/config.rs
+++ b/crates/epoch_oracles/src/configured/config.rs
@@ -2,6 +2,7 @@
 //   SPDX-License-Identifier: BSD-3-Clause
 
 use std::{
+    collections::HashSet,
     fmt::Display,
     hash::{DefaultHasher, Hasher},
     time::Duration,
@@ -27,7 +28,18 @@ impl Config {
     /// same event stream from the same config, so a config that could be read two ways is rejected outright rather
     /// than resolved by a default.
     pub fn validate(&self) -> anyhow::Result<()> {
+        let mut seen = HashSet::with_capacity(self.validators.len());
         for validator in &self.validators {
+            // A second entry for a validator would activate it twice. Listing it twice at one registration epoch
+            // produces two rows sharing a start_epoch, which `distinct_validators` and `set_committee_shard` resolve
+            // by different tiebreaks; listing it at two registration epochs moves its shard key.
+            if !seen.insert(validator.public_key) {
+                bail!(
+                    "Validator {} is listed more than once. A validator has a single registration; rotate its claim \
+                     key with `claim_key_changes`.",
+                    validator.public_key
+                );
+            }
             validator.validate()?;
         }
         Ok(())
@@ -277,6 +289,45 @@ mod tests {
             },
         ])
         .unwrap();
+    }
+
+    fn mk_config(validators: Vec<Validator>) -> Config {
+        Config {
+            validators,
+            ..Config::default()
+        }
+    }
+
+    #[test]
+    fn a_validator_listed_twice_is_rejected() {
+        // Identical entries derive an identical shard key, so the shard key pin cannot catch this: it would emit two
+        // Adds at one epoch and land two rows sharing a start_epoch.
+        let err = mk_config(vec![mk_validator(vec![]), mk_validator(vec![])])
+            .validate()
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("is listed more than once"), "{err}");
+
+        // Differing entries for one validator would additionally move its shard key.
+        let second = Validator {
+            registration_epoch: Epoch(50),
+            claim_key: mk_key(3),
+            ..mk_validator(vec![])
+        };
+        let err = mk_config(vec![mk_validator(vec![]), second])
+            .validate()
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("is listed more than once"), "{err}");
+    }
+
+    #[test]
+    fn distinct_validators_are_valid() {
+        let second = Validator {
+            public_key: mk_key(9),
+            ..mk_validator(vec![])
+        };
+        mk_config(vec![mk_validator(vec![]), second]).validate().unwrap();
     }
 
     #[test]

--- a/crates/epoch_oracles/src/configured/oracle.rs
+++ b/crates/epoch_oracles/src/configured/oracle.rs
@@ -4,28 +4,48 @@
 use std::{
     collections::{BTreeMap, VecDeque},
     future::poll_fn,
+    iter,
     task::{Context, Poll},
 };
 
 use anyhow::Context as _;
 use log::*;
 use tari_epoch_manager::epoch_event_oracle::{EpochEvent, EpochEventOracle, ValidatorNodeChange};
-use tari_ootle_common_types::{Epoch, displayable::Displayable};
+use tari_ootle_common_types::{Epoch, SubstateAddress, displayable::Displayable};
+use tari_template_lib::types::crypto::RistrettoPublicKeyBytes;
 
 use super::config::Config;
 use crate::{
-    configured::{EpochTickerData, Validator, epoch_ticker::EpochTicker, real_time_ticker::RealTimeEpochTicker},
+    configured::{EpochTickerData, epoch_ticker::EpochTicker, real_time_ticker::RealTimeEpochTicker},
     store::{EpochOracleStore, StoreKey},
 };
 
 const LOG_TARGET: &str = "tari::ootle::epoch_oracles::configured";
+
+/// A validator node registration to announce at a given epoch. Both a validator's initial registration and each of
+/// its claim key rotations are emitted as a `ValidatorNodeChange::Add`, which is the only claim-key-bearing change
+/// the base layer can express. A rotation reuses the registration's shard key so that changing the claim key does
+/// not move the validator within its committee.
+#[derive(Debug, Clone)]
+struct QueuedActivation {
+    public_key: RistrettoPublicKeyBytes,
+    claim_key: RistrettoPublicKeyBytes,
+    shard_key: SubstateAddress,
+    kind: ActivationKind,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ActivationKind {
+    Registration,
+    ClaimKeyRotation,
+}
 
 pub struct ConfiguredEpochOracle<TStore, TTicker> {
     config: Config,
     pending_events: VecDeque<EpochEvent>,
     store: TStore,
     ticker: TTicker,
-    queued_validators: BTreeMap<Epoch, Vec<Validator>>,
+    queued_validators: BTreeMap<Epoch, Vec<QueuedActivation>>,
     is_initialized: bool,
     is_done: bool,
 }
@@ -66,7 +86,47 @@ impl<TStore: EpochOracleStore + Send, TTicker: EpochTicker> ConfiguredEpochOracl
         }
     }
 
+    /// Pins the shard key a validator activated with, and rejects a config that no longer derives it.
+    ///
+    /// The shard key is derived from config and written to the local validator_nodes table when a validator
+    /// activates, so editing any field that feeds `Validator::calculate_shard_key` afterwards diverges the network
+    /// silently: nodes holding the original row keep the original shard key while a node replaying the edited config
+    /// from a fresh store derives a different one, and the two disagree on committee ordering with no epoch boundary
+    /// at which to reconcile. Nothing downstream can attribute that, so refuse to start instead.
+    fn verify_or_record_shard_key(
+        &self,
+        public_key: RistrettoPublicKeyBytes,
+        shard_key: SubstateAddress,
+    ) -> anyhow::Result<()> {
+        let mut recorded = self
+            .store
+            .get::<Vec<(RistrettoPublicKeyBytes, SubstateAddress)>>(
+                StoreKey::ConfiguredValidatorShardKeys.as_key_bytes(),
+            )?
+            .unwrap_or_default();
+
+        match recorded.iter().find(|(pk, _)| *pk == public_key) {
+            Some((_, activated_with)) if *activated_with != shard_key => {
+                anyhow::bail!(
+                    "Validator {public_key} activated with shard key {activated_with} but the current config derives \
+                     {shard_key}. A validator's public_key, claim_key, shard_group and registration_epoch are fixed \
+                     once it has activated; rotate its claim key with `claim_key_changes` instead of editing \
+                     `claim_key`."
+                );
+            },
+            Some(_) => Ok(()),
+            None => {
+                recorded.push((public_key, shard_key));
+                self.store
+                    .set(StoreKey::ConfiguredValidatorShardKeys.as_key_bytes(), &recorded)?;
+                Ok(())
+            },
+        }
+    }
+
     fn initialize(&mut self) -> anyhow::Result<()> {
+        self.config.validate()?;
+
         let epoch = self
             .store
             .get(StoreKey::ConfiguredCurrentEpoch.as_key_bytes())?
@@ -74,23 +134,51 @@ impl<TStore: EpochOracleStore + Send, TTicker: EpochTicker> ConfiguredEpochOracl
 
         let mut skipped = 0usize;
         for vn in &self.config.validators {
-            let activation_epoch = vn.registration_epoch + Epoch(1);
-            // Skip validators whose activation epoch has already been processed in a previous run.
-            // Re-queuing them would emit a duplicate ActiveValidatorNodeSetChanged on the next tick,
-            // causing duplicate rows in the validator_nodes table. Config changes are only supported
-            // when starting from a fresh oracle store.
-            if activation_epoch <= epoch {
-                skipped += 1;
-                continue;
+            // Validators that activated before this node recorded shard keys are pinned to whatever the config
+            // derives now. Their rows already exist, so this run's config is the best available record of what they
+            // activated with, and it catches any subsequent edit.
+            if vn.activation_epoch() <= epoch {
+                self.verify_or_record_shard_key(vn.public_key, vn.calculate_shard_key())?;
             }
+        }
 
-            let vns = self.queued_validators.entry(activation_epoch).or_default();
-            vns.push(vn.clone());
+        for vn in &self.config.validators {
+            // A rotation carries the registration's shard key: the new claim key must not reach shard key
+            // derivation, or the validator would move within its committee when its claim key changes.
+            let shard_key = vn.calculate_shard_key();
+            let activations = iter::once((vn.activation_epoch(), vn.claim_key, ActivationKind::Registration)).chain(
+                vn.claim_key_changes.iter().map(|change| {
+                    (
+                        change.effective_epoch,
+                        change.claim_key,
+                        ActivationKind::ClaimKeyRotation,
+                    )
+                }),
+            );
+
+            for (activation_epoch, claim_key, kind) in activations {
+                // Skip activations whose epoch has already been processed in a previous run.
+                // Re-queuing them would emit a duplicate ActiveValidatorNodeSetChanged on the next tick,
+                // causing duplicate rows in the validator_nodes table. Config changes are only supported
+                // when starting from a fresh oracle store.
+                if activation_epoch <= epoch {
+                    skipped += 1;
+                    continue;
+                }
+
+                let vns = self.queued_validators.entry(activation_epoch).or_default();
+                vns.push(QueuedActivation {
+                    public_key: vn.public_key,
+                    claim_key,
+                    shard_key,
+                    kind,
+                });
+            }
         }
 
         info!(
             target: LOG_TARGET,
-            "☘️ Starting Configured epoch oracle from {epoch}. Epoch time is {}. {} validator(s) queued, {skipped} already activated",
+            "☘️ Starting Configured epoch oracle from {epoch}. Epoch time is {}. {} validator activation(s) queued, {skipped} already activated",
             self.config.epoch_time.as_ref().map(|d| d.display()).display(),
             self.queued_validators.values().map(|vns| vns.len()).sum::<usize>(),
         );
@@ -127,13 +215,17 @@ impl<TStore: EpochOracleStore + Send, TTicker: EpochTicker> ConfiguredEpochOracl
                 "☘️ {} VNS registered for epoch {next_next_epoch}",
                 vns.len()
             );
-            // Emit these one epoch before a VN becomes active
-            self.pending_events
-                .extend(vns.iter().map(|vn| EpochEvent::NewValidatorRegistered {
-                    epoch: next_epoch,
-                    claim_public_key: vn.claim_key,
-                    validator_node_public_key: vn.public_key,
-                }))
+            // Emit these one epoch before a VN becomes active. A claim key rotation is not a new registration, so
+            // it is not announced.
+            self.pending_events.extend(
+                vns.iter()
+                    .filter(|vn| vn.kind == ActivationKind::Registration)
+                    .map(|vn| EpochEvent::NewValidatorRegistered {
+                        epoch: next_epoch,
+                        claim_public_key: vn.claim_key,
+                        validator_node_public_key: vn.public_key,
+                    }),
+            )
         }
 
         // Activate all validators queued at or before next_epoch (handles skipped epochs).
@@ -147,6 +239,11 @@ impl<TStore: EpochOracleStore + Send, TTicker: EpochTicker> ConfiguredEpochOracl
                 "☘️ {} VNS activated for epoch {epoch} (current: {next_epoch})",
                 vns.len()
             );
+            // Pin each shard key as it is committed, so that a later edit to the config that derived it is caught on
+            // the next startup even if this node never restarted between the two.
+            for vn in vns.iter().filter(|vn| vn.kind == ActivationKind::Registration) {
+                self.verify_or_record_shard_key(vn.public_key, vn.shard_key)?;
+            }
             self.pending_events
                 .push_back(EpochEvent::ActiveValidatorNodeSetChanged {
                     epoch: current_epoch,
@@ -157,7 +254,7 @@ impl<TStore: EpochOracleStore + Send, TTicker: EpochTicker> ConfiguredEpochOracl
                             validator_node_public_key: vn.public_key,
                             activation_epoch: next_epoch,
                             minimum_value_promise: 0,
-                            shard_key: vn.calculate_shard_key(),
+                            shard_key: vn.shard_key,
                         })
                         .collect(),
                 });
@@ -237,13 +334,13 @@ mod tests {
 
     use serde::{Serialize, de::DeserializeOwned};
     use tari_common_types::types::FixedHash;
-    use tari_epoch_manager::epoch_event_oracle::EpochEvent;
-    use tari_ootle_common_types::{Epoch, ShardGroup};
+    use tari_epoch_manager::epoch_event_oracle::{EpochEvent, ValidatorNodeChange};
+    use tari_ootle_common_types::{Epoch, ShardGroup, SubstateAddress};
     use tari_template_lib::types::crypto::RistrettoPublicKeyBytes;
 
     use super::ConfiguredEpochOracle;
     use crate::{
-        configured::{Config, EpochTicker, EpochTickerData, Validator},
+        configured::{ClaimKeyChange, Config, EpochTicker, EpochTickerData, Validator},
         store::{EpochOracleStore, StoreKey},
     };
 
@@ -284,13 +381,53 @@ mod tests {
         }
     }
 
+    fn mk_key(seed: u8) -> RistrettoPublicKeyBytes {
+        RistrettoPublicKeyBytes::from_bytes(&[seed; 32]).unwrap()
+    }
+
     fn mk_validator(public_seed: u8, registration_epoch: Epoch) -> Validator {
         Validator {
-            public_key: RistrettoPublicKeyBytes::from_bytes(&[public_seed; 32]).unwrap(),
-            claim_key: RistrettoPublicKeyBytes::from_bytes(&[public_seed.wrapping_add(1); 32]).unwrap(),
+            public_key: mk_key(public_seed),
+            claim_key: mk_key(public_seed.wrapping_add(1)),
             shard_group: ShardGroup::new(1, 256),
             registration_epoch,
+            claim_key_changes: vec![],
         }
+    }
+
+    /// The `Add` changes emitted by each `ActiveValidatorNodeSetChanged`, flattened to
+    /// (announcing epoch, claim key, activation epoch, shard key).
+    fn added_validators(events: &[EpochEvent]) -> Vec<(Epoch, RistrettoPublicKeyBytes, Epoch, SubstateAddress)> {
+        events
+            .iter()
+            .filter_map(|e| match e {
+                EpochEvent::ActiveValidatorNodeSetChanged { epoch, node_changes } => Some((*epoch, node_changes)),
+                _ => None,
+            })
+            .flat_map(|(epoch, node_changes)| {
+                node_changes.iter().map(move |change| match change {
+                    ValidatorNodeChange::Add {
+                        claim_public_key,
+                        activation_epoch,
+                        shard_key,
+                        ..
+                    } => (epoch, *claim_public_key, *activation_epoch, *shard_key),
+                    ValidatorNodeChange::Remove { .. } => panic!("unexpected Remove change"),
+                })
+            })
+            .collect()
+    }
+
+    fn ticker_through(last_epoch: u64) -> ScriptedTicker {
+        ScriptedTicker::new(
+            (0..=last_epoch)
+                .map(|e| EpochTickerData {
+                    epoch: Epoch(e),
+                    epoch_hash: FixedHash::zero(),
+                    done_for_now: e == last_epoch,
+                })
+                .collect(),
+        )
     }
 
     fn mk_config(validators: Vec<Validator>) -> Config {
@@ -409,6 +546,198 @@ mod tests {
                 .iter()
                 .any(|e| matches!(e, EpochEvent::ActiveValidatorNodeSetChanged { .. })),
             "stale-config validator must not be retroactively activated; got {events:?}"
+        );
+    }
+
+    fn mk_validator_with_rotation(registration_epoch: Epoch, effective_epoch: Epoch) -> Validator {
+        Validator {
+            claim_key_changes: vec![ClaimKeyChange {
+                effective_epoch,
+                claim_key: mk_key(99),
+            }],
+            ..mk_validator(1, registration_epoch)
+        }
+    }
+
+    #[test]
+    fn claim_key_rotation_re_adds_validator_with_new_key_and_same_shard_key() {
+        let validator = mk_validator_with_rotation(Epoch(10), Epoch(20));
+        let expected_shard_key = validator.calculate_shard_key();
+        let original_claim_key = validator.claim_key;
+        let config = mk_config(vec![validator]);
+        let mut oracle = ConfiguredEpochOracle::with_custom_ticker(config, TestStore::default(), ticker_through(20));
+
+        let events = drive_events(&mut oracle);
+
+        assert_eq!(
+            added_validators(&events),
+            vec![
+                (Epoch(10), original_claim_key, Epoch(11), expected_shard_key),
+                (Epoch(19), mk_key(99), Epoch(20), expected_shard_key),
+            ],
+            "rotation should re-add the validator at its effective epoch with the new claim key and the \
+             registration's shard key"
+        );
+    }
+
+    #[test]
+    fn claim_key_rotation_is_not_announced_as_a_new_registration() {
+        let config = mk_config(vec![mk_validator_with_rotation(Epoch(10), Epoch(20))]);
+        let mut oracle = ConfiguredEpochOracle::with_custom_ticker(config, TestStore::default(), ticker_through(20));
+
+        let events = drive_events(&mut oracle);
+
+        let announced = events
+            .iter()
+            .filter(|e| matches!(e, EpochEvent::NewValidatorRegistered { .. }))
+            .count();
+        assert_eq!(
+            announced, 1,
+            "only the initial registration should be announced; got {events:?}"
+        );
+    }
+
+    #[test]
+    fn restart_before_effective_epoch_still_emits_the_rotation() {
+        let config = mk_config(vec![mk_validator_with_rotation(Epoch(10), Epoch(20))]);
+        let store = TestStore::default();
+        // A prior run activated the validator but has not yet reached the rotation.
+        store
+            .set(StoreKey::ConfiguredCurrentEpoch.as_key_bytes(), &Epoch(15))
+            .unwrap();
+        let mut oracle = ConfiguredEpochOracle::with_custom_ticker(config, store, ticker_through(20));
+
+        let events = drive_events(&mut oracle);
+
+        assert_eq!(
+            added_validators(&events)
+                .into_iter()
+                .map(|(_, claim_key, activation_epoch, _)| (claim_key, activation_epoch))
+                .collect::<Vec<_>>(),
+            vec![(mk_key(99), Epoch(20))],
+            "the already-activated registration must not be re-emitted, but the pending rotation must be"
+        );
+    }
+
+    #[test]
+    fn restart_after_effective_epoch_does_not_re_emit_the_rotation() {
+        let config = mk_config(vec![mk_validator_with_rotation(Epoch(10), Epoch(20))]);
+        let store = TestStore::default();
+        store
+            .set(StoreKey::ConfiguredCurrentEpoch.as_key_bytes(), &Epoch(25))
+            .unwrap();
+        let ticker = ScriptedTicker::new(vec![EpochTickerData {
+            epoch: Epoch(25),
+            epoch_hash: FixedHash::zero(),
+            done_for_now: true,
+        }]);
+        let mut oracle = ConfiguredEpochOracle::with_custom_ticker(config, store, ticker);
+
+        let events = drive_events(&mut oracle);
+
+        assert!(
+            added_validators(&events).is_empty(),
+            "an already-applied rotation must not be re-emitted; got {events:?}"
+        );
+    }
+
+    #[test]
+    fn fresh_store_replay_past_the_rotation_converges_on_the_new_key() {
+        let config = mk_config(vec![mk_validator_with_rotation(Epoch(10), Epoch(20))]);
+        // A node syncing from scratch replays every epoch, so it must arrive at the same final claim key as a node
+        // that was live across the boundary.
+        let mut oracle = ConfiguredEpochOracle::with_custom_ticker(config, TestStore::default(), ticker_through(30));
+
+        let events = drive_events(&mut oracle);
+
+        let (_, final_claim_key, final_activation_epoch, _) =
+            *added_validators(&events).last().expect("at least one Add");
+        assert_eq!(final_claim_key, mk_key(99));
+        assert_eq!(final_activation_epoch, Epoch(20));
+    }
+
+    #[test]
+    fn editing_the_claim_key_of_an_activated_validator_is_rejected() {
+        let store = TestStore::default();
+        // A prior run activated the validator and pinned the shard key it derived.
+        store
+            .set(StoreKey::ConfiguredCurrentEpoch.as_key_bytes(), &Epoch(15))
+            .unwrap();
+        let original = mk_validator(1, Epoch(10));
+        store
+            .set(StoreKey::ConfiguredValidatorShardKeys.as_key_bytes(), &vec![(
+                original.public_key,
+                original.calculate_shard_key(),
+            )])
+            .unwrap();
+
+        // The operator rotates by editing `claim_key` in place rather than adding a `claim_key_changes` entry. This
+        // is silently a no-op here but would derive a different shard key on a node replaying from a fresh store.
+        let edited = Validator {
+            claim_key: mk_key(99),
+            ..original
+        };
+        let mut oracle = ConfiguredEpochOracle::with_custom_ticker(mk_config(vec![edited]), store, ticker_through(20));
+
+        let events = drive_events(&mut oracle);
+
+        match events.as_slice() {
+            [EpochEvent::Error(err)] => {
+                let err = err.to_string();
+                assert!(err.contains("activated with shard key"), "{err}");
+            },
+            _ => panic!("editing an activated validator's claim key must be rejected; got {events:?}"),
+        }
+    }
+
+    #[test]
+    fn a_scheduled_rotation_does_not_trip_the_shard_key_check() {
+        let store = TestStore::default();
+        store
+            .set(StoreKey::ConfiguredCurrentEpoch.as_key_bytes(), &Epoch(15))
+            .unwrap();
+        let validator = mk_validator_with_rotation(Epoch(10), Epoch(20));
+        store
+            .set(StoreKey::ConfiguredValidatorShardKeys.as_key_bytes(), &vec![(
+                validator.public_key,
+                // Pinned from the config before the rotation was added.
+                mk_validator(1, Epoch(10)).calculate_shard_key(),
+            )])
+            .unwrap();
+        let mut oracle =
+            ConfiguredEpochOracle::with_custom_ticker(mk_config(vec![validator]), store, ticker_through(20));
+
+        let events = drive_events(&mut oracle);
+
+        assert!(
+            !events.iter().any(|e| matches!(e, EpochEvent::Error(_))),
+            "adding a claim key rotation must not change the shard key; got {events:?}"
+        );
+        assert_eq!(
+            added_validators(&events)
+                .into_iter()
+                .map(|(_, claim_key, _, _)| claim_key)
+                .collect::<Vec<_>>(),
+            vec![mk_key(99)]
+        );
+    }
+
+    #[test]
+    fn invalid_config_stops_the_oracle_with_an_error() {
+        let mut validator = mk_validator(1, Epoch(10));
+        // Rotating before the validator activates has no row to supersede.
+        validator.claim_key_changes = vec![ClaimKeyChange {
+            effective_epoch: Epoch(5),
+            claim_key: mk_key(99),
+        }];
+        let config = mk_config(vec![validator]);
+        let mut oracle = ConfiguredEpochOracle::with_custom_ticker(config, TestStore::default(), ticker_through(20));
+
+        let events = drive_events(&mut oracle);
+
+        assert!(
+            matches!(events.as_slice(), [EpochEvent::Error(_)]),
+            "an invalid config must surface as an error, not a partial event stream; got {events:?}"
         );
     }
 }

--- a/crates/epoch_oracles/src/store.rs
+++ b/crates/epoch_oracles/src/store.rs
@@ -18,6 +18,7 @@ pub enum StoreKey {
     BaseLayerLastEpochHash,
     ConfiguredIsInitialized,
     ConfiguredCurrentEpoch,
+    ConfiguredValidatorShardKeys,
 }
 
 impl StoreKey {
@@ -29,6 +30,7 @@ impl StoreKey {
             Self::BaseLayerLastEpochHash => b"base_layer.last_epoch_hash",
             Self::ConfiguredIsInitialized => b"configured_oracle.is_initialized",
             Self::ConfiguredCurrentEpoch => b"configured_oracle.current_epoch",
+            Self::ConfiguredValidatorShardKeys => b"configured_oracle.validator_shard_keys",
         }
     }
 }

--- a/crates/storage_sqlite/tests/global_db.rs
+++ b/crates/storage_sqlite/tests/global_db.rs
@@ -69,6 +69,85 @@ fn set_committee_shard_group(
         .unwrap();
 }
 
+/// A claim key rotation is expressed as a second registration row for the same validator: same shard key, a later
+/// start epoch, and the new claim key. The read that resolves it is consensus-critical — a voter looks up the
+/// proposer's claim key to re-derive its fee pool address and recompute the state merkle root — so it must return
+/// the key that was in effect for the epoch being validated, not the latest one.
+#[test]
+fn rotated_claim_key_resolves_per_epoch() {
+    let db = create_db();
+    let mut tx = db.create_transaction().unwrap();
+    let mut validator_nodes = db.validator_nodes(&mut tx);
+
+    let pk = new_public_key();
+    let pk_bytes = pk.to_byte_type();
+    let shard_key = derived_substate_address(&pk);
+    let old_claim_key = new_public_key().to_byte_type();
+    let new_claim_key = new_public_key().to_byte_type();
+
+    // Insert both rows before any committee assignment runs, as happens on a node rebuilding its global DB from
+    // scratch. Assignment must still resolve each epoch to the row that was in effect for it.
+    for (start_epoch, claim_key) in [(Epoch(10), old_claim_key), (Epoch(20), new_claim_key)] {
+        validator_nodes
+            .insert_validator_node(
+                pk.clone().into(),
+                pk_bytes,
+                shard_key,
+                start_epoch,
+                claim_key,
+                VotePower::of(1),
+            )
+            .unwrap();
+    }
+
+    for epoch in 10..=25 {
+        set_committee_shard_group(
+            &mut validator_nodes,
+            &pk,
+            ShardGroup::all_shards(NumPreshards::P256),
+            Epoch(epoch),
+        );
+    }
+
+    for epoch in 10..20 {
+        assert_eq!(
+            validator_nodes
+                .get_by_public_key(Epoch(epoch), &pk_bytes)
+                .unwrap()
+                .fee_claim_public_key,
+            old_claim_key,
+            "epoch {epoch} precedes the rotation and must still resolve to the old claim key"
+        );
+    }
+    for epoch in 20..=25 {
+        assert_eq!(
+            validator_nodes
+                .get_by_public_key(Epoch(epoch), &pk_bytes)
+                .unwrap()
+                .fee_claim_public_key,
+            new_claim_key,
+            "epoch {epoch} follows the rotation"
+        );
+    }
+
+    // The extra row must not make the validator count twice, which would change committee sizing.
+    assert_eq!(validator_nodes.count(Epoch(20)).unwrap(), 1);
+    assert_eq!(
+        validator_nodes
+            .get_all_registered_within_start_epoch(Epoch(20))
+            .unwrap()
+            .len(),
+        1
+    );
+    assert_eq!(
+        validator_nodes
+            .get_committee_for_shard_group(Epoch(20), ShardGroup::all_shards(NumPreshards::P256), 100)
+            .unwrap()
+            .len(),
+        1
+    );
+}
+
 #[test]
 fn insert_and_get_within_epoch() {
     let db = create_db();


### PR DESCRIPTION
## Motivation

The configured oracle writes a validator's claim key to the `validator_nodes` table once, at activation, and never revisits it. Editing `claim_key` in the oracle config afterwards is silently skipped on any node with an existing oracle store, so there is currently no supported way to change where a validator's leader fees accrue.

## Why a rotation cannot take effect on restart

The claim key is consensus-critical, which is not obvious from where it lives. A leader deposits its fee into a pool whose address is derived from its claim key, and that deposit feeds the state merkle root. A voter does **not** read the key from the block — there is no such field — it looks the proposer up in its own global DB (`on_receive_local_proposal.rs:298-305`) and re-derives the address itself.

So any window in which two nodes disagree about a proposer's claim key is a state merkle root split. Rolling out a new config and restarting "at roughly the same time" is exactly such a window. Worse, the failure is near-undiagnosable: it surfaces as an unattributed `NoVoteReason::StateMerkleRootMismatch`, and only once leader fees are non-zero, so a config skew can sit latent until fees start flowing.

Rotations therefore name the epoch they apply from. Restart timing stops mattering entirely — each node only needs the new config at some point before that epoch.

## What this adds

```json
{
  "public_key": "d6da35...",
  "claim_key": "3c6eeb...",
  "shard_group": {"start": 1, "end_inclusive": 256},
  "registration_epoch": 8367,
  "claim_key_changes": [
    {"effective_epoch": 10500, "claim_key": "9a1b2c..."}
  ]
}
```

Each entry is emitted at its effective epoch as a plain `ValidatorNodeChange::Add` carrying the new claim key and the registration's original shard key. This is the same event the base layer oracle relays for an L1 registration, and the only claim-key-bearing change the enum can express, so nothing downstream can tell the two apart.

It lands as a second `validator_nodes` row that supersedes the first from its `start_epoch` onwards. **No schema change, no migration, no new event variant** — the existing dedup (`distinct_validators` keeps the highest `start_epoch`) and committee indirection already do the work. Because `set_committee_shard` filters `start_epoch <= epoch`, this is replay-safe: a node rebuilding its global DB from scratch, with both rows present before any assignment runs, still resolves each epoch to the row in effect for it. Nothing is mutated, so catching up on earlier blocks recomputes the same merkle roots.

Fees already earned under a previous key stay in the pool derived from it and remain claimable with that key — the wallet's `claim_validator_fees` already accepts a `claim_key_index`, so sweeping needs no changes.

## Shard key stays put

The new key deliberately does not reach shard key derivation. On the base layer a shard key depends only on the validator's public key and block entropy (`validator_node_registration.rs:124-130`) — the configured oracle folding `claim_key` into its hash is a local quirk. Keeping the claim key orthogonal to placement is the L1-faithful semantic and keeps the leader schedule stable across a rotation.

## Guards

Config validation (at load, and in `initialize()` so no construction path escapes it) rejects rotations at or before activation, no-op rotations, and two rotations at one epoch. The last is load-bearing rather than tidiness: two rows sharing a `start_epoch` are resolved by row order in `distinct_validators` but by `max(id)` in `set_committee_shard`, so the two subsystems could disagree.

`claim_key` now doubles as shard key entropy, so editing it in place is the mistake this design invites — and it is silently bimodal: a no-op on a warm node, a different shard key on one replaying from a fresh store, diverging committee ordering permanently with no epoch boundary at which to reconcile. Each validator's shard key is therefore pinned in the oracle store, recorded as it is committed and back-filled on first startup for already-activated validators. That edit is now a startup error naming the field. It also catches `DefaultHasher` output drifting across a Rust toolchain bump, which previously had no detection at all.

## Tests

42 passing across the three crates. The load-bearing one is `rotated_claim_key_resolves_per_epoch` in `storage_sqlite`: it inserts both rows up front as a rebuilding node would, then asserts `get_by_public_key` returns the old key for epochs 10-19 and the new key for 20-25, with `count` still 1 and the committee still holding one member. That is the exact read a voter uses to re-derive a proposer's fee pool, so it pins the seam that would otherwise fail silently.

Oracle-level coverage: rotation re-adds with the new key and an identical shard key; a rotation is not announced as a new registration; restart before the effective epoch still emits it; restart after does not re-emit; fresh-store replay past it converges on the new key; an in-place `claim_key` edit is rejected; a scheduled rotation does not trip that check. The four pre-existing oracle tests are unchanged and still pass.

## Notes for review

- `activation_epoch: next_epoch` is left as-is rather than using the declared epoch. If the ticker skips epochs, a row's `start_epoch` becomes "the epoch we noticed" rather than "the epoch config declared". This is pre-existing behaviour for registrations that rotations inherit; changing it would diverge fresh nodes from the rows esmeralda already has, so it wants its own decision.
- `EpochManagerConfig.fee_claim_public_key` is still dead (written at `bootstrap.rs:228`, read nowhere) and implies node-local config controls fee destination, which in hybrid it does not. Left alone as unrelated; worth deleting separately.