### PR TITLE
feat(wallet-sdk): lock specific stealth outputs

### DIFF
--- a/crates/wallet/sdk/src/apis/stealth_outputs.rs
+++ b/crates/wallet/sdk/src/apis/stealth_outputs.rs
@@ -152,6 +152,180 @@ impl<'a, TSpec: WalletSdkSpec> StealthOutputsApi<'a, TSpec> {
         })
     }
 
+    /// Atomically resolves, validates, and locks the exact wallet-owned stealth outputs named by `utxo_addresses` for
+    /// spending under `lock_id`. This is the specific-input counterpart to [`Self::lock_outputs_for_at_least_amount`]:
+    /// the caller names precise UTXOs (by [`UtxoAddress`]) rather than an amount plus a selection strategy.
+    ///
+    /// Every requested output must use `resource_address`, belong to `account_address`, be wallet-owned (its one-time
+    /// spend key is held) and currently eligible for the key-path statement flow — the same eligibility rules as
+    /// [`WalletStoreReader::stealth_outputs_get_unspent_for_spending`] (owner key present, not burnt, not frozen,
+    /// condition-spendable / key path), with status and on-chain handled as follows:
+    /// - `Unspent` outputs must be confirmed on-chain.
+    /// - `LockedUnconfirmed` outputs are accepted only when already associated with `lock_id` (they are off-chain by
+    ///   construction, created earlier in this lock's transaction chain).
+    /// - Any other status, a `LockedUnconfirmed` under a different lock, or any other off-chain output is rejected.
+    ///
+    /// Script-path/condition-tree outputs are rejected — spending those requires the separate generic `SpendWitness`
+    /// follow-up.
+    ///
+    /// Resolution/validation and locking run inside a single write transaction, so the result is all-or-nothing: if any
+    /// requested output is missing or ineligible the transaction rolls back and none are newly locked. The returned
+    /// [`InputSpendData`] preserve the caller's requested `utxo_addresses` order.
+    pub fn lock_specific_outputs(
+        &self,
+        account_address: &ComponentAddress,
+        resource_address: &ResourceAddress,
+        lock_id: WalletLockId,
+        utxo_addresses: &[UtxoAddress],
+    ) -> Result<Vec<InputSpendData>, StealthOutputsApiError> {
+        if utxo_addresses.is_empty() {
+            return Err(StealthOutputsApiError::InvalidParameter {
+                param: "utxo_addresses",
+                reason: "At least one UTXO address is required".to_string(),
+            });
+        }
+
+        const INPUT_LIMIT: usize = limits::STEALTH_LIMITS.max_inputs;
+        if utxo_addresses.len() > INPUT_LIMIT {
+            return Err(StealthOutputsApiError::InvalidParameter {
+                param: "utxo_addresses",
+                reason: format!(
+                    "Requested {} inputs which exceeds the maximum of {} stealth inputs",
+                    utxo_addresses.len(),
+                    INPUT_LIMIT
+                ),
+            });
+        }
+
+        // Reject wrong-resource / mixed-resource requests and duplicates before touching the database.
+        let mut seen = HashSet::with_capacity(utxo_addresses.len());
+        for address in utxo_addresses {
+            if address.resource_address() != resource_address {
+                return Err(StealthOutputsApiError::InvalidParameter {
+                    param: "utxo_addresses",
+                    reason: format!("UTXO {} does not use resource {}", address, resource_address),
+                });
+            }
+            if !seen.insert(address) {
+                return Err(StealthOutputsApiError::InvalidParameter {
+                    param: "utxo_addresses",
+                    reason: format!("Duplicate UTXO address {}", address),
+                });
+            }
+        }
+
+        self.store.with_write_tx(|tx| {
+            let mut inputs = Vec::with_capacity(utxo_addresses.len());
+            // Resolve and validate every requested UTXO before locking anything.
+            for address in utxo_addresses {
+                let commitment = address.id().into_commitment_bytes();
+                let output = tx
+                    .stealth_outputs_get_by_commitment(resource_address, &commitment)
+                    .optional()?
+                    .ok_or_else(|| StealthOutputsApiError::InvalidParameter {
+                        param: "utxo_addresses",
+                        reason: format!("UTXO {} is not known to this wallet", address),
+                    })?;
+                self.validate_output_for_specific_spend(account_address, lock_id, address, &output)?;
+                inputs.push(output.into_spend_data());
+            }
+
+            // Account-scoped lock (defence in depth): ownership was validated above, but the storage update is also
+            // restricted to this account so a caller-supplied commitment can never lock another account's row.
+            let commitments = inputs.iter().map(|i| &i.commitment).collect::<Vec<_>>();
+            tx.stealth_outputs_lock_many_for_account(account_address, resource_address, &commitments, lock_id)?;
+
+            Ok(inputs)
+        })
+    }
+
+    /// Validates that a resolved stealth output is a wallet-owned, key-path-spendable input for `account_address` that
+    /// is currently eligible to be locked under `lock_id`. Mirrors the eligibility predicate of
+    /// [`WalletStoreReader::stealth_outputs_get_unspent_for_spending`], with an explicit account-ownership check so a
+    /// caller cannot select another account's output. Status and on-chain are evaluated together: an `Unspent` output
+    /// must be on-chain, while a `LockedUnconfirmed` output is accepted only when already bound to `lock_id` (such
+    /// outputs are off-chain by construction).
+    fn validate_output_for_specific_spend(
+        &self,
+        account_address: &ComponentAddress,
+        lock_id: WalletLockId,
+        address: &UtxoAddress,
+        output: &StealthOutputModel,
+    ) -> Result<(), StealthOutputsApiError> {
+        if output.owner_account != *account_address {
+            return Err(StealthOutputsApiError::InvalidParameter {
+                param: "utxo_addresses",
+                reason: format!("UTXO {} does not belong to account {}", address, account_address),
+            });
+        }
+        if output.owner_key_id.is_none() {
+            return Err(StealthOutputsApiError::InvalidParameter {
+                param: "utxo_addresses",
+                reason: format!("UTXO {} is view-only and cannot be spent by this wallet", address),
+            });
+        }
+        if output.is_burnt {
+            return Err(StealthOutputsApiError::InvalidParameter {
+                param: "utxo_addresses",
+                reason: format!("UTXO {} is burnt", address),
+            });
+        }
+        if output.is_frozen {
+            return Err(StealthOutputsApiError::InvalidParameter {
+                param: "utxo_addresses",
+                reason: format!("UTXO {} is frozen", address),
+            });
+        }
+        // Key-path eligibility: a script-path/condition-tree output (no owned spend key) cannot be spent through the
+        // key-path statement flow. Those require the separate generic SpendWitness follow-up.
+        if !output.is_condition_spendable {
+            return Err(StealthOutputsApiError::InvalidParameter {
+                param: "utxo_addresses",
+                reason: format!(
+                    "UTXO {} is a condition-tree output and is not key-path spendable",
+                    address
+                ),
+            });
+        }
+        // Status and on-chain eligibility, evaluated together:
+        // - Unspent outputs must be confirmed on-chain.
+        // - LockedUnconfirmed outputs are accepted only when already bound to this lock (they are off-chain by
+        //   construction, created earlier in this lock's transaction chain).
+        // - Any other status, a LockedUnconfirmed under a different lock, or any other off-chain output is rejected.
+        match output.status {
+            OutputStatus::Unspent => {
+                if !output.is_on_chain {
+                    return Err(StealthOutputsApiError::InvalidParameter {
+                        param: "utxo_addresses",
+                        reason: format!("UTXO {} is Unspent but not yet on-chain", address),
+                    });
+                }
+            },
+            OutputStatus::LockedUnconfirmed => {
+                if output.lock_id != Some(lock_id) {
+                    return Err(StealthOutputsApiError::InvalidParameter {
+                        param: "utxo_addresses",
+                        reason: format!(
+                            "UTXO {} is locked under a different lock (lock {:?}, requested lock {})",
+                            address, output.lock_id, lock_id
+                        ),
+                    });
+                }
+                // LockedUnconfirmed is off-chain by construction; is_on_chain is not required here.
+            },
+            _ => {
+                return Err(StealthOutputsApiError::InvalidParameter {
+                    param: "utxo_addresses",
+                    reason: format!(
+                        "UTXO {} is not available to spend (status {:?}, lock {:?})",
+                        address, output.status, output.lock_id
+                    ),
+                });
+            },
+        }
+        Ok(())
+    }
+
     fn lock_outputs_internal(
         &self,
         tx: &mut <TSpec::Store as WriteableWalletStore>::WriteTransaction<'_>,

--- a/crates/wallet/sdk/src/storage/writer.rs
+++ b/crates/wallet/sdk/src/storage/writer.rs
@@ -178,6 +178,24 @@ pub trait WalletStoreWriter: CommittableStore {
         utxos: &[&PedersenCommitmentBytes],
         lock_id: WalletLockId,
     ) -> Result<(), WalletStorageError>;
+
+    /// Account-scoped lock: flips the named outputs to `LockedForSpend` and binds them to `lock_id`, restricted to
+    /// rows owned by `account_address`. The account condition on the update is what makes caller-supplied commitments
+    /// safe to lock: a commitment belonging to another account cannot be locked through this path even if it shares
+    /// the resource. Errors (leaving the write transaction to roll back) unless every requested commitment matched an
+    /// owned row.
+    ///
+    /// This method performs only the account-scoped status/lock flip; it does **not** independently validate
+    /// spend-eligibility (e.g. `Unspent`/same-lock `LockedUnconfirmed` status, `owner_key_id`, `is_burnt`,
+    /// `is_frozen`, `is_condition_spendable`). Callers must validate status and eligibility within the same write
+    /// transaction before invoking this, otherwise ineligible outputs would be silently locked.
+    fn stealth_outputs_lock_many_for_account(
+        &mut self,
+        account_address: &ComponentAddress,
+        resource_address: &ResourceAddress,
+        utxos: &[&PedersenCommitmentBytes],
+        lock_id: WalletLockId,
+    ) -> Result<(), WalletStorageError>;
     fn stealth_outputs_insert(&mut self, output: &StealthOutputModel) -> Result<(), WalletStorageError>;
     fn stealth_outputs_mark_as_spent(
         &mut self,

--- a/crates/wallet/sdk_tests/tests/stealth_output_api.rs
+++ b/crates/wallet/sdk_tests/tests/stealth_output_api.rs
@@ -3,17 +3,27 @@
 
 mod support;
 
-use tari_ootle_wallet_sdk::models::{KeyBranch, KeyId, OutputStatus, StealthOutputModel};
+use tari_engine_types::limits;
+use tari_ootle_common_types::Epoch;
+use tari_ootle_wallet_sdk::{
+    apis::stealth_outputs::StealthOutputsApiError,
+    models::{KeyBranch, KeyId, OutputStatus, StealthOutputModel, WalletLockId},
+};
 use tari_template_lib::types::{
     Amount,
+    ComponentAddress,
     EncryptedData,
+    Hash32,
+    UtxoAddress,
     constants::STEALTH_TARI_RESOURCE_ADDRESS,
     crypto::{PedersenCommitmentBytes, RistrettoPublicKeyBytes, UtxoTag},
     stealth::SpendAuthorization,
 };
 
-use crate::support::Test;
+use crate::support::{Test, resource_address_from_seed};
 
+/// A key-path, on-chain, wallet-owned, currently spendable stealth output for the default test account. Tests mutate
+/// individual fields to exercise the rejection paths.
 fn stealth_output(value: u64, seed: u8) -> StealthOutputModel {
     StealthOutputModel {
         owner_account: Test::test_account_address(),
@@ -35,6 +45,59 @@ fn stealth_output(value: u64, seed: u8) -> StealthOutputModel {
         is_condition_spendable: true,
         lock_id: None,
     }
+}
+
+/// A second wallet account, used to prove that a caller cannot select or lock another account's outputs.
+fn other_account_address() -> ComponentAddress {
+    "component_0dc41b5cc74b36d696c7b140323a40a2f98b71df5d60e5a6bf4c1a07fffffffe"
+        .parse()
+        .unwrap()
+}
+
+fn add_other_account(test: &Test) -> ComponentAddress {
+    let address = other_account_address();
+    test.sdk()
+        .accounts_api()
+        .add_account(
+            Some("other"),
+            &address,
+            KeyId::derived(KeyBranch::ViewOnlyKey, 1),
+            KeyId::derived(KeyBranch::Account, 1),
+            Epoch::zero(),
+            true,
+            false,
+        )
+        .unwrap();
+    address
+}
+
+/// Reads a stored output back for assertions about its post-call status and lock.
+fn stored_output(test: &Test, owner: &ComponentAddress, commitment: &PedersenCommitmentBytes) -> StealthOutputModel {
+    test.sdk()
+        .stealth_outputs_api()
+        .utxos_get_many(&STEALTH_TARI_RESOURCE_ADDRESS, Some(owner), None)
+        .unwrap()
+        .into_iter()
+        .find(|o| &o.commitment == commitment)
+        .expect("output present in store")
+}
+
+fn expect_rejected(
+    test: &Test,
+    account: &ComponentAddress,
+    lock_id: WalletLockId,
+    addresses: &[UtxoAddress],
+) -> StealthOutputsApiError {
+    let err = test
+        .sdk()
+        .stealth_outputs_api()
+        .lock_specific_outputs(account, &STEALTH_TARI_RESOURCE_ADDRESS, lock_id, addresses)
+        .expect_err("request should be rejected");
+    assert!(
+        matches!(err, StealthOutputsApiError::InvalidParameter { .. }),
+        "expected InvalidParameter, got: {err}"
+    );
+    err
 }
 
 #[test]
@@ -83,4 +146,462 @@ fn burnt_outputs_are_excluded_from_the_unspent_balance() {
             .sum::<Amount>(),
         Amount::from(10u64)
     );
+}
+
+#[test]
+fn locks_exactly_the_requested_outputs_and_returns_values() {
+    let test = Test::new();
+    let outputs = test.sdk().stealth_outputs_api();
+    let account = Test::test_account_address();
+
+    let a = stealth_output(10, 1);
+    let b = stealth_output(20, 2);
+    let c = stealth_output(30, 3);
+    // A fourth output that is not requested and must remain untouched.
+    let untouched = stealth_output(40, 4);
+    for output in [&a, &b, &c, &untouched] {
+        outputs.add_output(output).unwrap();
+    }
+
+    let lock = test.new_lock();
+    let selected = outputs
+        .lock_specific_outputs(&account, &STEALTH_TARI_RESOURCE_ADDRESS, lock.id(), &[
+            a.to_utxo_address(),
+            b.to_utxo_address(),
+            c.to_utxo_address(),
+        ])
+        .unwrap();
+
+    // Exactly the requested inputs are returned, carrying their decrypted values.
+    assert_eq!(selected.len(), 3);
+    assert_eq!(selected.iter().map(|i| i.value).collect::<Vec<_>>(), vec![10, 20, 30]);
+    assert_eq!(selected.iter().map(|i| i.commitment).collect::<Vec<_>>(), vec![
+        a.commitment,
+        b.commitment,
+        c.commitment
+    ]);
+
+    // The three requested outputs are now locked under this lock.
+    for output in [&a, &b, &c] {
+        let stored = stored_output(&test, &account, &output.commitment);
+        assert!(
+            matches!(stored.status, OutputStatus::LockedForSpend),
+            "expected LockedForSpend, got {:?}",
+            stored.status
+        );
+        assert_eq!(stored.lock_id, Some(lock.id()));
+    }
+    // The unrequested output is untouched.
+    let stored = stored_output(&test, &account, &untouched.commitment);
+    assert!(
+        matches!(stored.status, OutputStatus::Unspent),
+        "expected Unspent, got {:?}",
+        stored.status
+    );
+    assert_eq!(stored.lock_id, None);
+}
+
+#[test]
+fn preserves_requested_order() {
+    let test = Test::new();
+    let outputs = test.sdk().stealth_outputs_api();
+    let account = Test::test_account_address();
+
+    let a = stealth_output(10, 1);
+    let b = stealth_output(20, 2);
+    let c = stealth_output(30, 3);
+    for output in [&a, &b, &c] {
+        outputs.add_output(output).unwrap();
+    }
+
+    let lock = test.new_lock();
+    // Request order c, a, b — deliberately different from insertion and value order.
+    let selected = outputs
+        .lock_specific_outputs(&account, &STEALTH_TARI_RESOURCE_ADDRESS, lock.id(), &[
+            c.to_utxo_address(),
+            a.to_utxo_address(),
+            b.to_utxo_address(),
+        ])
+        .unwrap();
+
+    assert_eq!(selected.iter().map(|i| i.value).collect::<Vec<_>>(), vec![30, 10, 20]);
+    assert_eq!(selected.iter().map(|i| i.commitment).collect::<Vec<_>>(), vec![
+        c.commitment,
+        a.commitment,
+        b.commitment
+    ]);
+}
+
+#[test]
+fn rejects_empty_input_list() {
+    let test = Test::new();
+    let lock = test.new_lock();
+    expect_rejected(&test, &Test::test_account_address(), lock.id(), &[]);
+}
+
+#[test]
+fn rejects_input_count_above_stealth_limit() {
+    let test = Test::new();
+    let lock = test.new_lock();
+
+    // One more than the maximum. No outputs need to exist: the count is checked before any lookup.
+    let too_many = limits::STEALTH_LIMITS.max_inputs + 1;
+    let addresses = (0..too_many)
+        .map(|i| {
+            let mut bytes = [0u8; PedersenCommitmentBytes::length()];
+            bytes[0] = (i & 0xff) as u8;
+            bytes[1] = ((i >> 8) & 0xff) as u8;
+            UtxoAddress::new(
+                STEALTH_TARI_RESOURCE_ADDRESS,
+                PedersenCommitmentBytes::from_array(bytes).into(),
+            )
+        })
+        .collect::<Vec<_>>();
+
+    expect_rejected(&test, &Test::test_account_address(), lock.id(), &addresses);
+}
+
+#[test]
+fn rejects_duplicate_input_addresses() {
+    let test = Test::new();
+    let outputs = test.sdk().stealth_outputs_api();
+    let account = Test::test_account_address();
+
+    let a = stealth_output(10, 1);
+    outputs.add_output(&a).unwrap();
+
+    let lock = test.new_lock();
+    expect_rejected(&test, &account, lock.id(), &[a.to_utxo_address(), a.to_utxo_address()]);
+
+    // The output was never locked.
+    assert!(matches!(
+        stored_output(&test, &account, &a.commitment).status,
+        OutputStatus::Unspent
+    ));
+}
+
+#[test]
+fn rejects_wrong_resource_address() {
+    let test = Test::new();
+    let account = Test::test_account_address();
+    let lock = test.new_lock();
+
+    // A UtxoAddress whose resource is not the resource we are selecting for.
+    let wrong_resource = resource_address_from_seed(9);
+    let address = UtxoAddress::new(
+        wrong_resource,
+        PedersenCommitmentBytes::from_array([1u8; PedersenCommitmentBytes::length()]).into(),
+    );
+
+    expect_rejected(&test, &account, lock.id(), &[address]);
+}
+
+#[test]
+fn rejects_unknown_output() {
+    let test = Test::new();
+    let account = Test::test_account_address();
+    let lock = test.new_lock();
+
+    // A well-formed address for the correct resource that was never added to the wallet.
+    let address = UtxoAddress::new(
+        STEALTH_TARI_RESOURCE_ADDRESS,
+        PedersenCommitmentBytes::from_array([7u8; PedersenCommitmentBytes::length()]).into(),
+    );
+
+    expect_rejected(&test, &account, lock.id(), &[address]);
+}
+
+#[test]
+fn rejects_output_belonging_to_another_account() {
+    let test = Test::new();
+    let outputs = test.sdk().stealth_outputs_api();
+    let account = Test::test_account_address();
+    let other = add_other_account(&test);
+
+    let mut foreign = stealth_output(10, 1);
+    foreign.owner_account = other;
+    outputs.add_output(&foreign).unwrap();
+
+    let lock = test.new_lock();
+    // The default account attempts to lock the other account's output.
+    expect_rejected(&test, &account, lock.id(), &[foreign.to_utxo_address()]);
+
+    // Account scoping guarantee: the other account's output was not touched.
+    let stored = stored_output(&test, &other, &foreign.commitment);
+    assert!(
+        matches!(stored.status, OutputStatus::Unspent),
+        "expected Unspent, got {:?}",
+        stored.status
+    );
+    assert_eq!(stored.lock_id, None);
+}
+
+#[test]
+fn rejects_view_only_output() {
+    let test = Test::new();
+    let outputs = test.sdk().stealth_outputs_api();
+    let account = Test::test_account_address();
+
+    let mut view_only = stealth_output(10, 1);
+    view_only.owner_key_id = None;
+    outputs.add_output(&view_only).unwrap();
+
+    let lock = test.new_lock();
+    expect_rejected(&test, &account, lock.id(), &[view_only.to_utxo_address()]);
+
+    assert!(matches!(
+        stored_output(&test, &account, &view_only.commitment).status,
+        OutputStatus::Unspent
+    ));
+}
+
+#[test]
+fn rejects_burnt_output() {
+    let test = Test::new();
+    let outputs = test.sdk().stealth_outputs_api();
+    let account = Test::test_account_address();
+
+    let mut burnt = stealth_output(10, 1);
+    burnt.is_burnt = true;
+    outputs.add_output(&burnt).unwrap();
+
+    let lock = test.new_lock();
+    expect_rejected(&test, &account, lock.id(), &[burnt.to_utxo_address()]);
+
+    assert!(matches!(
+        stored_output(&test, &account, &burnt.commitment).status,
+        OutputStatus::Unspent
+    ));
+}
+
+#[test]
+fn rejects_frozen_output() {
+    let test = Test::new();
+    let outputs = test.sdk().stealth_outputs_api();
+    let account = Test::test_account_address();
+
+    let mut frozen = stealth_output(10, 1);
+    frozen.is_frozen = true;
+    outputs.add_output(&frozen).unwrap();
+
+    let lock = test.new_lock();
+    expect_rejected(&test, &account, lock.id(), &[frozen.to_utxo_address()]);
+
+    assert!(matches!(
+        stored_output(&test, &account, &frozen.commitment).status,
+        OutputStatus::Unspent
+    ));
+}
+
+#[test]
+fn rejects_off_chain_output() {
+    let test = Test::new();
+    let outputs = test.sdk().stealth_outputs_api();
+    let account = Test::test_account_address();
+
+    // A corrupt/impossible state: Unspent but flagged off-chain. An Unspent output must be confirmed on-chain, so this
+    // is rejected (fail-closed on inconsistent state).
+    let mut off_chain = stealth_output(10, 1);
+    off_chain.is_on_chain = false;
+    outputs.add_output(&off_chain).unwrap();
+
+    let lock = test.new_lock();
+    expect_rejected(&test, &account, lock.id(), &[off_chain.to_utxo_address()]);
+
+    assert!(matches!(
+        stored_output(&test, &account, &off_chain.commitment).status,
+        OutputStatus::Unspent
+    ));
+}
+
+#[test]
+fn rejects_condition_tree_output() {
+    let test = Test::new();
+    let outputs = test.sdk().stealth_outputs_api();
+    let account = Test::test_account_address();
+
+    // A script-path (condition-tree) output: no owned spend key, so not key-path spendable.
+    let mut condition_tree = stealth_output(10, 1);
+    condition_tree.auth = SpendAuthorization::Script(Hash32::from_array([1u8; Hash32::LENGTH]));
+    condition_tree.is_condition_spendable = false;
+    outputs.add_output(&condition_tree).unwrap();
+
+    let lock = test.new_lock();
+    expect_rejected(&test, &account, lock.id(), &[condition_tree.to_utxo_address()]);
+
+    assert!(matches!(
+        stored_output(&test, &account, &condition_tree.commitment).status,
+        OutputStatus::Unspent
+    ));
+}
+
+#[test]
+fn rejects_output_already_locked_under_another_lock() {
+    let test = Test::new();
+    let outputs = test.sdk().stealth_outputs_api();
+    let account = Test::test_account_address();
+
+    let a = stealth_output(10, 1);
+    outputs.add_output(&a).unwrap();
+
+    let lock_a = test.new_lock();
+    outputs
+        .lock_specific_outputs(&account, &STEALTH_TARI_RESOURCE_ADDRESS, lock_a.id(), &[
+            a.to_utxo_address()
+        ])
+        .unwrap();
+
+    // A different lock cannot claim the already-locked output.
+    let lock_b = test.new_lock();
+    expect_rejected(&test, &account, lock_b.id(), &[a.to_utxo_address()]);
+
+    // It remains locked under the first lock.
+    let stored = stored_output(&test, &account, &a.commitment);
+    assert!(
+        matches!(stored.status, OutputStatus::LockedForSpend),
+        "expected LockedForSpend, got {:?}",
+        stored.status
+    );
+    assert_eq!(stored.lock_id, Some(lock_a.id()));
+}
+
+#[test]
+fn all_or_nothing_when_one_input_is_invalid() {
+    let test = Test::new();
+    let outputs = test.sdk().stealth_outputs_api();
+    let account = Test::test_account_address();
+
+    let valid = stealth_output(10, 1);
+    let mut frozen = stealth_output(20, 2);
+    frozen.is_frozen = true;
+    outputs.add_output(&valid).unwrap();
+    outputs.add_output(&frozen).unwrap();
+
+    let lock = test.new_lock();
+    // The valid input is listed first, then the invalid one: the whole request must fail with nothing locked.
+    expect_rejected(&test, &account, lock.id(), &[
+        valid.to_utxo_address(),
+        frozen.to_utxo_address(),
+    ]);
+
+    assert!(matches!(
+        stored_output(&test, &account, &valid.commitment).status,
+        OutputStatus::Unspent
+    ));
+    assert_eq!(stored_output(&test, &account, &valid.commitment).lock_id, None);
+    assert!(matches!(
+        stored_output(&test, &account, &frozen.commitment).status,
+        OutputStatus::Unspent
+    ));
+}
+
+#[test]
+fn sequential_overlapping_requests_do_not_double_lock_the_same_output() {
+    let test = Test::new();
+    let outputs = test.sdk().stealth_outputs_api();
+    let account = Test::test_account_address();
+
+    let a = stealth_output(10, 1);
+    let b = stealth_output(20, 2);
+    outputs.add_output(&a).unwrap();
+    outputs.add_output(&b).unwrap();
+
+    // First request locks `a`.
+    let lock_a = test.new_lock();
+    outputs
+        .lock_specific_outputs(&account, &STEALTH_TARI_RESOURCE_ADDRESS, lock_a.id(), &[
+            a.to_utxo_address()
+        ])
+        .unwrap();
+
+    // A second, sequential request overlapping on `a` (also wanting `b`) must fail without locking anything new.
+    // (This is not a multithreaded concurrency test; SQLite serialises writers, so sequential exclusivity is the
+    // guarantee exercised here.)
+    let lock_b = test.new_lock();
+    expect_rejected(&test, &account, lock_b.id(), &[
+        a.to_utxo_address(),
+        b.to_utxo_address(),
+    ]);
+
+    let stored_a = stored_output(&test, &account, &a.commitment);
+    assert!(
+        matches!(stored_a.status, OutputStatus::LockedForSpend),
+        "expected LockedForSpend, got {:?}",
+        stored_a.status
+    );
+    assert_eq!(stored_a.lock_id, Some(lock_a.id()));
+
+    let stored_b = stored_output(&test, &account, &b.commitment);
+    assert!(
+        matches!(stored_b.status, OutputStatus::Unspent),
+        "expected Unspent, got {:?}",
+        stored_b.status
+    );
+    assert_eq!(stored_b.lock_id, None);
+}
+
+/// Builds a `LockedUnconfirmed` output bound to `lock_id`, matching storage semantics (off-chain by construction).
+fn locked_unconfirmed_output(value: u64, seed: u8, lock_id: WalletLockId) -> StealthOutputModel {
+    let mut output = stealth_output(value, seed);
+    output.status = OutputStatus::LockedUnconfirmed;
+    output.lock_id = Some(lock_id);
+    output.is_on_chain = false;
+    output
+}
+
+#[test]
+fn accepts_locked_unconfirmed_under_same_lock() {
+    let test = Test::new();
+    let outputs = test.sdk().stealth_outputs_api();
+    let account = Test::test_account_address();
+
+    let lock = test.new_lock();
+    // An output created earlier in this lock's transaction chain: LockedUnconfirmed, off-chain, bound to this lock.
+    let earlier = locked_unconfirmed_output(10, 1, lock.id());
+    outputs.add_output(&earlier).unwrap();
+
+    // Re-locking it under the same lock must succeed: the same-lock LockedUnconfirmed allowance is reachable here.
+    let selected = outputs
+        .lock_specific_outputs(&account, &STEALTH_TARI_RESOURCE_ADDRESS, lock.id(), &[
+            earlier.to_utxo_address()
+        ])
+        .unwrap();
+
+    assert_eq!(selected.len(), 1);
+    assert_eq!(selected[0].value, 10);
+    assert_eq!(selected[0].commitment, earlier.commitment);
+
+    // The output is now LockedForSpend under the same lock (re-locked).
+    let stored = stored_output(&test, &account, &earlier.commitment);
+    assert!(
+        matches!(stored.status, OutputStatus::LockedForSpend),
+        "expected LockedForSpend, got {:?}",
+        stored.status
+    );
+    assert_eq!(stored.lock_id, Some(lock.id()));
+}
+
+#[test]
+fn rejects_locked_unconfirmed_under_a_different_lock() {
+    let test = Test::new();
+    let outputs = test.sdk().stealth_outputs_api();
+    let account = Test::test_account_address();
+
+    // An output locked unconfirmed under lock_a.
+    let lock_a = test.new_lock();
+    let earlier = locked_unconfirmed_output(10, 1, lock_a.id());
+    outputs.add_output(&earlier).unwrap();
+
+    // A different lock cannot claim the LockedUnconfirmed output.
+    let lock_b = test.new_lock();
+    expect_rejected(&test, &account, lock_b.id(), &[earlier.to_utxo_address()]);
+
+    // The output is untouched: still LockedUnconfirmed under lock_a.
+    let stored = stored_output(&test, &account, &earlier.commitment);
+    assert!(
+        matches!(stored.status, OutputStatus::LockedUnconfirmed),
+        "expected LockedUnconfirmed, got {:?}",
+        stored.status
+    );
+    assert_eq!(stored.lock_id, Some(lock_a.id()));
 }

--- a/crates/wallet/storage_sqlite/src/writer.rs
+++ b/crates/wallet/storage_sqlite/src/writer.rs
@@ -1893,6 +1893,56 @@ impl WalletStoreWriter for WriteTransaction<'_> {
         Ok(())
     }
 
+    fn stealth_outputs_lock_many_for_account(
+        &mut self,
+        account_address: &ComponentAddress,
+        resource_address: &ResourceAddress,
+        utxos: &[&PedersenCommitmentBytes],
+        lock_id: WalletLockId,
+    ) -> Result<(), WalletStorageError> {
+        const OPERATION: &str = "stealth_outputs_lock_many_for_account";
+        use crate::schema::{accounts, stealth_outputs};
+
+        self.ensure_lock_exists(lock_id)?;
+
+        let account_id = accounts::table
+            .select(accounts::id)
+            .filter(accounts::address.eq(account_address.to_string()))
+            .first::<i32>(self.connection())
+            .map_err(|e| WalletStorageError::general(OPERATION, e))?;
+
+        // The `owner_account_id` filter is the account-scoping guard: caller-supplied commitments can only ever match
+        // rows owned by this account, so a commitment belonging to another account is never locked here.
+        let num_rows = diesel::update(stealth_outputs::table)
+            .set((
+                stealth_outputs::status.eq(OutputStatus::LockedForSpend.as_key_str()),
+                stealth_outputs::lock_id.eq(lock_id),
+                stealth_outputs::locked_at.eq(dsl::now),
+            ))
+            .filter(stealth_outputs::owner_account_id.eq(account_id))
+            .filter(stealth_outputs::resource_address.eq(resource_address.to_string()))
+            .filter(stealth_outputs::commitment.eq_any(utxos.iter().map(|id| serialize_hex(id.as_ref()))))
+            .execute(self.connection())
+            .map_err(|e| WalletStorageError::general(OPERATION, e))?;
+
+        if num_rows != utxos.len() {
+            return Err(WalletStorageError::NotFound {
+                operation: OPERATION,
+                entity: "stealth_output".to_string(),
+                key: format!(
+                    "{}/{} found: account={}, resource_address={}, utxos={}",
+                    num_rows,
+                    utxos.len(),
+                    account_address,
+                    resource_address,
+                    utxos.display()
+                ),
+            });
+        }
+
+        Ok(())
+    }
+
     fn stealth_outputs_insert(&mut self, output: &StealthOutputModel) -> Result<(), WalletStorageError> {
         const OPERATION: &str = "stealth_outputs_insert";
         use crate::schema::{accounts, stealth_outputs};


### PR DESCRIPTION
## Summary

- Adds `StealthOutputsApi::lock_specific_outputs` for exact `UtxoAddress` selection.
- Validates resource, selected-account ownership, spend eligibility, and status before locking.
- Locks account-scoped rows atomically and returns `InputSpendData` in caller-request order.
- Adds focused SDK tests for account isolation, rollback, ordering, and status handling.

## Motivation

This is the first wallet-SDK foundation for the stealth-statement RPC side of #2343.

It enables a later extension of `accounts.create_stealth_transfer_statement` to accept exact inputs, and complements #2348's transaction create/approve/submit flow.

## Security properties

- Rejects unknown, duplicate, wrong-resource, foreign-account, frozen, burnt, off-chain unspent, and condition-tree outputs.
- Validation and locking occur inside one write transaction.
- The SQLite update includes `owner_account_id`.
- The update fails closed unless every requested output is locked.
- `LockedUnconfirmed` inputs are accepted only when associated with the same lock.
- ScriptPath/condition-tree spending remains outside this PR.

## Verification

Formatting:

```text
cargo +nightly-2025-12-05 fmt --package tari_ootle_wallet_sdk --package tari_ootle_wallet_storage_sqlite --package tari_ootle_wallet_sdk_tests -- --check
```

Compile-only test build:

```text
cargo test --locked -p tari_ootle_wallet_sdk_tests --test stealth_output_api --no-run
```

Focused tests:

```text
cargo test --locked -p tari_ootle_wallet_sdk_tests --test stealth_output_api
```

Result:

```text
19 passed; 0 failed; 0 ignored
```

Targeted Clippy:

```text
cargo clippy --locked -p tari_ootle_wallet_sdk -p tari_ootle_wallet_storage_sqlite -p tari_ootle_wallet_sdk_tests --all-targets --no-deps -- -D warnings -A clippy::too_many_arguments
```

The `too_many_arguments` exemption covers existing warnings in untouched Tari code.

## Scope

SDK, SQLite storage, and focused tests only.

This PR does not add:

- walletd RPC or handler wiring;
- transaction-request changes;
- generic `SpendWitness` support;
- ScriptPath HTLC spending.

Related to #2343.