### PR TITLE
fix(engine): fix race condition in stealth claim_validator_fees (closes #2149)

### DIFF
--- a/applications/tari_indexer/README.md
+++ b/applications/tari_indexer/README.md
@@ -80,6 +80,7 @@ The following options are available (use `tari_indexer --help` for the most up-t
 
 #### API Server
 - `-r, --api-listen-address <API_LISTEN_ADDRESS>`: Bind address for REST API server
+- `--metrics-listen-address <METRICS_LISTEN_ADDRESS>`: Bind address for Prometheus metrics server
 - `--web-ui-public-api-url <WEB_UI_PUBLIC_API_URL>`: Public API URL for web UI [env: `TARI_INDEXER_WEB_UI_PUBLIC_API_URL`]
 - `--web-ui-public-graphql-url <WEB_UI_PUBLIC_GRAPHQL_URL>`: Public GraphQL URL for web UI [env: `TARI_INDEXER_WEB_UI_PUBLIC_GRAPHQL_URL`]
 

--- a/applications/tari_indexer/docs/configuration.md
+++ b/applications/tari_indexer/docs/configuration.md
@@ -47,6 +47,9 @@ Main indexer application settings.
 # API server listening address (default: "127.0.0.1:18300")
 #api_listen_address = "127.0.0.1:18300"
 
+# Prometheus metrics server listening address (default: "127.0.0.1:18302")
+#metrics_listen_address = "127.0.0.1:18302"
+
 # GraphQL server address (default: "127.0.0.1:18301")
 #graphql_address = "127.0.0.1:18301"
 

--- a/applications/tari_indexer/src/cli.rs
+++ b/applications/tari_indexer/src/cli.rs
@@ -51,6 +51,9 @@ pub struct Cli {
     /// Bind address for API server
     #[clap(long, short = 'r', alias = "api-address")]
     pub api_listen_address: Option<SocketAddr>,
+    /// Bind address for Prometheus metrics server
+    #[clap(long, alias = "metrics-address")]
+    pub metrics_listen_address: Option<SocketAddr>,
     #[clap(long, alias = "node-grpc", short = 'g', env = "TARI_INDEXER_MINOTARI_NODE_GRPC_URL")]
     pub epoch_oracle_minotari_node_grpc_url: Option<Url>,
     #[clap(long, alias = "oracle-config")]
@@ -95,6 +98,9 @@ impl ConfigOverrideProvider for Cli {
 
         if let Some(ref addr) = self.api_listen_address {
             overrides.push(("indexer.api_listen_address".to_string(), addr.to_string()));
+        }
+        if let Some(ref addr) = self.metrics_listen_address {
+            overrides.push(("indexer.metrics_listen_address".to_string(), addr.to_string()));
         }
 
         if !self.peer_seeds.is_empty() {

--- a/applications/tari_indexer/src/config.rs
+++ b/applications/tari_indexer/src/config.rs
@@ -99,6 +99,8 @@ pub struct IndexerConfig {
     pub p2p: P2pConfig,
     /// Listening address for the indexer API server
     pub api_listen_address: Option<SocketAddr>,
+    /// Listening address for the Prometheus metrics server
+    pub metrics_listen_address: Option<SocketAddr>,
     /// GraphQL port of the indexer application
     pub graphql_address: Option<SocketAddr>,
     /// The address of the Web UI
@@ -153,6 +155,7 @@ impl Default for IndexerConfig {
             data_dir: PathBuf::from("data/indexer"),
             p2p: P2pConfig::default(),
             api_listen_address: Some("127.0.0.1:18300".parse().unwrap()),
+            metrics_listen_address: Some("127.0.0.1:18302".parse().unwrap()),
             graphql_address: Some("127.0.0.1:18301".parse().unwrap()),
             web_ui_address: Some("127.0.0.1:15000".parse().unwrap()),
             web_ui_public_api_url: None,

--- a/applications/tari_indexer/src/lib.rs
+++ b/applications/tari_indexer/src/lib.rs
@@ -138,6 +138,8 @@ where
         let listen_address = server
             .spawn(
                 listen_addr,
+                #[cfg(feature = "metrics")]
+                config.indexer.metrics_listen_address,
                 &services,
                 &config.indexer.rate_limits,
                 shutdown_signal.clone(),

--- a/applications/tari_indexer/src/rest_api/metrics.rs
+++ b/applications/tari_indexer/src/rest_api/metrics.rs
@@ -1,7 +1,7 @@
 //   Copyright 2025 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use std::{future, sync::Arc, time::Instant};
+use std::{future, net::SocketAddr, sync::Arc, time::Instant};
 
 use axum::{
     body::{Body, HttpBody},
@@ -9,7 +9,10 @@ use axum::{
     http::{Request, StatusCode},
     middleware::Next,
     response::{IntoResponse, Response},
+    routing::get,
+    Router,
 };
+use log::*;
 use prometheus_client::{
     encoding::text::encode,
     metrics::{
@@ -19,9 +22,12 @@ use prometheus_client::{
     },
     registry::Registry,
 };
+use tari_ootle_app_utilities::tcp::try_bind_with_fallback;
+use tari_shutdown::ShutdownSignal;
 
 use crate::metrics::CollectorRegister;
 
+const LOG_TARGET: &str = "tari::ootle::indexer::rest_api::metrics";
 const METRICS_CONTENT_TYPE: &str = "application/openmetrics-text;charset=utf-8;version=1.0.0";
 #[derive(Debug, Clone)]
 pub struct MetricsHandler(Arc<Registry>);
@@ -54,6 +60,25 @@ impl<S> axum::handler::Handler<(), S> for MetricsHandler {
                 .into_response(),
         )
     }
+}
+
+pub async fn spawn_server(
+    preferred_addr: SocketAddr,
+    registry: Registry,
+    shutdown: ShutdownSignal,
+) -> anyhow::Result<SocketAddr> {
+    let listener = try_bind_with_fallback(preferred_addr).await?;
+    let listen_addr = listener.local_addr()?;
+    let router = Router::new().route("/_metrics", get(MetricsHandler::new(registry)));
+
+    info!(target: LOG_TARGET, "Indexer metrics server listening on {listen_addr}");
+    tokio::spawn(async move {
+        if let Err(error) = axum::serve(listener, router).with_graceful_shutdown(shutdown).await {
+            error!(target: LOG_TARGET, "Indexer metrics HTTP server error: {error}");
+        }
+    });
+
+    Ok(listen_addr)
 }
 
 #[derive(Clone)]

--- a/applications/tari_indexer/src/rest_api/server.rs
+++ b/applications/tari_indexer/src/rest_api/server.rs
@@ -96,6 +96,7 @@ impl Server {
     pub async fn spawn(
         #[allow(unused_mut)] mut self,
         preferred_addr: SocketAddr,
+        #[cfg(feature = "metrics")] metrics_preferred_addr: Option<SocketAddr>,
         services: &Services,
         rate_limits: &IndexerRateLimitsConfig,
         shutdown: ShutdownSignal,
@@ -255,12 +256,18 @@ impl Server {
             .layer(TraceLayer::new_for_http());
 
         #[cfg(feature = "metrics")]
-        let router = router
-            .layer(axum::middleware::from_fn_with_state(
+        let router = if let Some(metrics_preferred_addr) = metrics_preferred_addr {
+            let router = router.layer(axum::middleware::from_fn_with_state(
                 metrics::register(&mut self.registry),
                 metrics::layer,
-            ))
-            .route("/_metrics", get(metrics::MetricsHandler::new(self.registry)));
+            ));
+            let metrics_listen_addr =
+                metrics::spawn_server(metrics_preferred_addr, self.registry, shutdown.clone()).await?;
+            debug!(target: LOG_TARGET, "Metrics address {}", metrics_listen_addr);
+            router
+        } else {
+            router
+        };
 
         let listener = try_bind_with_fallback(preferred_addr).await?;
 

--- a/applications/tari_ootle_app_utilities/config_presets/d_indexer.toml
+++ b/applications/tari_ootle_app_utilities/config_presets/d_indexer.toml
@@ -21,6 +21,9 @@
 # API listener address (default = "127.0.0.1:18300")
 #api_listen_address = "127.0.0.1:18300"
 
+# Prometheus metrics listener address (default = "127.0.0.1:18302")
+#metrics_listen_address = "127.0.0.1:18302"
+
 # HTTP UI listener address (default = "127.0.0.1:15000")
 #web_ui_address = "127.0.0.1:15000"
 

--- a/applications/tari_swarm_daemon/src/process_definitions/indexer.rs
+++ b/applications/tari_swarm_daemon/src/process_definitions/indexer.rs
@@ -23,6 +23,7 @@ impl ProcessDefinition for Indexer {
     async fn get_command(&self, mut context: ProcessContext<'_>) -> anyhow::Result<Command> {
         let mut command = Command::new(context.bin());
         let api_port = context.get_free_port("api").await?;
+        let metrics_port = context.get_free_port("metrics").await?;
         let graphql_port = context.get_free_port("graphql").await?;
         let web_ui_port = context.get_free_port("web").await?;
         let listen_ip = context.listen_ip();
@@ -30,6 +31,7 @@ impl ProcessDefinition for Indexer {
         let api_public_url = context.get_public_api_url();
         let graphql_public_url = context.get_public_graphql_url();
         let api_listener_address = format!("{listen_ip}:{api_port}");
+        let metrics_listener_address = format!("{listen_ip}:{metrics_port}");
         let graphql_listener_address = format!("{listen_ip}:{graphql_port}");
         let web_ui_listener_address = format!("{listen_ip}:{web_ui_port}");
 
@@ -60,6 +62,9 @@ impl ProcessDefinition for Indexer {
                 "-pepoch_oracle.base_layer.base_node_grpc_url={base_node_grpc_url}"
             ))
             .arg(format!("-pindexer.api_listen_address={api_listener_address}"))
+            .arg(format!(
+                "-pindexer.metrics_listen_address={metrics_listener_address}"
+            ))
             .arg(format!("-pindexer.graphql_address={graphql_listener_address}"))
             .arg(format!("-pindexer.web_ui_address={web_ui_listener_address}"))
             .arg(format!("-pindexer.web_ui_public_api_url={api_public_url}"))

--- a/applications/tari_walletd/src/handlers/validator.rs
+++ b/applications/tari_walletd/src/handlers/validator.rs
@@ -171,22 +171,22 @@ pub async fn handle_claim_validator_fees(
             })
             .with_inputs(inputs.into_iter().map(|input| input.into_unversioned()))
     } else {
-        let statement =
+        let (statement, pool_amounts) =
             build_self_stealth_statement(&sdk, &account, account_key_id, &fee_pool_addresses, max_fee).await?;
-        let (first, rest) = fee_pool_addresses
+        let (first, rest) = pool_amounts
             .split_first()
             .ok_or_else(|| invalid_params("shards", Some("At least one shard must be specified")))?;
-        let first = *first;
+        let (first_address, first_amount) = *first;
         let rest = rest.to_vec();
         builder.with_fee_instructions_builder(move |builder| {
             let builder = builder
-                .claim_validator_fees(first)
+                .claim_validator_fees_up_to(first_address, first_amount)
                 .put_last_instruction_output_on_workspace("joined");
             rest.into_iter()
                 .enumerate()
-                .fold(builder, |b, (i, address)| {
+                .fold(builder, |b, (i, (address, amount))| {
                     let tmp = format!("tmp{i}");
-                    b.claim_validator_fees(address)
+                    b.claim_validator_fees_up_to(address, amount)
                         .put_last_instruction_output_on_workspace(tmp.clone())
                         .put_into_bucket(tmp, "joined")
                 })
@@ -278,7 +278,7 @@ async fn build_self_stealth_statement(
     account_owner_key_id: tari_ootle_wallet_sdk::models::KeyId,
     fee_pool_addresses: &[ValidatorFeePoolAddress],
     max_fee: u64,
-) -> Result<StealthTransferStatement, anyhow::Error> {
+) -> Result<(StealthTransferStatement, Vec<(ValidatorFeePoolAddress, u64)>), anyhow::Error> {
     let network = sdk.config_api().get_network()?;
     let account_owner = sdk.key_manager_api().get_public_key(account_owner_key_id)?;
     let view_only = sdk.key_manager_api().get_public_key(account.view_only_key_id())?;
@@ -299,6 +299,7 @@ async fn build_self_stealth_statement(
         }
     }
 
+    let mut pool_amounts = Vec::with_capacity(fee_pool_addresses.len());
     let mut total: u64 = 0;
     for address in fee_pool_addresses {
         let amount = amounts.get(address).copied().unwrap_or(0);
@@ -311,6 +312,7 @@ async fn build_self_stealth_statement(
         total = total
             .checked_add(amount)
             .ok_or_else(|| invalid_params("shards", Some("Total claimable fee pool amount overflows u64")))?;
+        pool_amounts.push((*address, amount));
     }
 
     if total <= max_fee {
@@ -368,5 +370,5 @@ async fn build_self_stealth_statement(
         0,
     )?;
 
-    Ok(statement)
+    Ok((statement, pool_amounts))
 }

--- a/crates/engine/src/runtime/impl.rs
+++ b/crates/engine/src/runtime/impl.rs
@@ -3204,9 +3204,16 @@ where
         Ok(())
     }
 
-    fn claim_validator_fees(&mut self, pool_address: ValidatorFeePoolAddress) -> Result<(), RuntimeError> {
+    fn claim_validator_fees(
+        &mut self,
+        pool_address: ValidatorFeePoolAddress,
+        max_amount: Option<Amount>,
+    ) -> Result<(), RuntimeError> {
         self.tracker.write_with(|state| {
-            let resource = state.withdraw_all_fees_from_pool(pool_address)?;
+            let resource = match max_amount {
+                Some(max_amount) => state.withdraw_fees_from_pool_up_to(pool_address, max_amount)?,
+                None => state.withdraw_all_fees_from_pool(pool_address)?,
+            };
             let bucket_id = state.new_bucket_id();
             state.new_bucket(bucket_id, resource)?;
             state.set_last_instruction_output(IndexedValue::from_type(&bucket_id)?);

--- a/crates/engine/src/runtime/mod.rs
+++ b/crates/engine/src/runtime/mod.rs
@@ -97,6 +97,7 @@ use tari_template_lib::{
     },
     models::{BucketId, VaultRef},
     types::{
+        Amount,
         ComponentAddress,
         EntityId,
         LogLevel,
@@ -183,7 +184,11 @@ pub trait RuntimeInterface {
         output_data: ClaimBurnOutputData,
     ) -> Result<(), RuntimeError>;
 
-    fn claim_validator_fees(&mut self, address: ValidatorFeePoolAddress) -> Result<(), RuntimeError>;
+    fn claim_validator_fees(
+        &mut self,
+        address: ValidatorFeePoolAddress,
+        max_amount: Option<Amount>,
+    ) -> Result<(), RuntimeError>;
 
     fn checkpoint_fee_intent(&mut self) -> Result<(), RuntimeError>;
     fn finalize(&mut self) -> Result<FinalizeResult, RuntimeError>;

--- a/crates/engine/src/runtime/working_state.rs
+++ b/crates/engine/src/runtime/working_state.rs
@@ -963,14 +963,22 @@ impl<TStore: StateReader> WorkingState<TStore> {
         &mut self,
         address: ValidatorFeePoolAddress,
     ) -> Result<ResourceContainer, RuntimeError> {
+        self.withdraw_fees_from_pool_up_to(address, Amount::MAX)
+    }
+
+    pub fn withdraw_fees_from_pool_up_to(
+        &mut self,
+        address: ValidatorFeePoolAddress,
+        max_amount: Amount,
+    ) -> Result<ResourceContainer, RuntimeError> {
         let locked_substate = self.lock_substate(SubstateId::ValidatorFeePool(address), LockFlag::Write)?;
         {
             let fee_pool = self
                 .get_locked_substate(&locked_substate)?
                 .as_validator_fee_pool()
                 .ok_or_else(|| RuntimeError::InvariantError {
-                    function: "StateTracker::withdraw_all_fees_from_pool",
-                    details: format!("Expected substate at address {address} to be an ValidatorFeePool",),
+                    function: "StateTracker::withdraw_fees_from_pool_up_to",
+                    details: format!("Expected substate at address {address} to be an ValidatorFeePool"),
                 })?;
 
             self.authorization()
@@ -981,12 +989,12 @@ impl<TStore: StateReader> WorkingState<TStore> {
             .get_locked_substate_mut(&locked_substate)?
             .as_validator_fee_pool_mut()
             .ok_or_else(|| RuntimeError::InvariantError {
-                function: "StateTracker::withdraw_all_fees_from_pool",
-                details: format!("Expected substate at address {address} to be an ValidatorFeePool",),
+                function: "StateTracker::withdraw_fees_from_pool_up_to",
+                details: format!("Expected substate at address {address} to be an ValidatorFeePool"),
             })?;
 
-        let amount = pool_mut.amount();
-        let resource_container = pool_mut.withdraw_all()?;
+        let resource_container = pool_mut.withdraw_up_to(max_amount)?;
+        let amount = u64::try_from(resource_container.unlocked_amount().to_u128()).unwrap_or(0);
         self.validator_fee_withdrawals
             .push(ValidatorFeeWithdrawal { address, amount });
         Ok(resource_container)

--- a/crates/engine/src/transaction/processor.rs
+++ b/crates/engine/src/transaction/processor.rs
@@ -380,8 +380,8 @@ where
                 runtime.interface_mut().claim_burn(*claim, output_data)?;
                 Ok(InstructionResult::empty())
             },
-            Instruction::ClaimValidatorFees { address } => {
-                runtime.interface_mut().claim_validator_fees(address)?;
+            Instruction::ClaimValidatorFees { address, max_amount } => {
+                runtime.interface_mut().claim_validator_fees(address, max_amount)?;
                 Ok(InstructionResult::empty())
             },
             Instruction::Assert { key, assertion } => {

--- a/crates/engine_types/src/validator_fee.rs
+++ b/crates/engine_types/src/validator_fee.rs
@@ -85,13 +85,19 @@ impl ValidatorFeePool {
     /// If the pool has insufficient funds, an error is returned.
     /// This function is used in the engine to withdraw the funds from the pool and create a Bucket.
     pub fn withdraw_all(&mut self) -> Result<ResourceContainer, ResourceError> {
+        self.withdraw_up_to(Amount::MAX)
+    }
+
+    /// Withdraws up to max_amount from the pool and returns them in a ResourceContainer.
+    pub fn withdraw_up_to(&mut self, max_amount: Amount) -> Result<ResourceContainer, ResourceError> {
         if self.amount == 0 {
             return Err(ResourceError::InsufficientBalance {
                 details: "ValidatorFeePool has insufficient balance. Current balance is 0".to_string(),
             });
         }
-        let amount = self.amount;
-        self.amount = 0;
+        let max_u64 = u64::try_from(max_amount.to_u128()).unwrap_or(u64::MAX);
+        let amount = self.amount.min(max_u64);
+        self.amount -= amount;
         Ok(ResourceContainer::Stealth {
             address: TARI_TOKEN,
             revealed_amount: amount.into(),

--- a/crates/transaction/src/builder/mod.rs
+++ b/crates/transaction/src/builder/mod.rs
@@ -777,7 +777,19 @@ impl<D> TransactionBuilder<D> {
 
     pub fn claim_validator_fees(self, address: ValidatorFeePoolAddress) -> Self {
         self.then(|b| if b.fill_inputs { b.add_input(address) } else { b })
-            .add_instruction(Instruction::ClaimValidatorFees { address })
+            .add_instruction(Instruction::ClaimValidatorFees {
+                address,
+                max_amount: None,
+            })
+    }
+
+    pub fn claim_validator_fees_up_to<A: Into<Amount>>(self, address: ValidatorFeePoolAddress, max_amount: A) -> Self {
+        let max_amount = max_amount.into();
+        self.then(|b| if b.fill_inputs { b.add_input(address) } else { b })
+            .add_instruction(Instruction::ClaimValidatorFees {
+                address,
+                max_amount: Some(max_amount),
+            })
     }
 
     pub fn create_proof<A: Into<ComponentReference>>(self, account: A, resource_addr: ResourceAddress) -> Self {
@@ -899,7 +911,7 @@ impl<D> TransactionBuilder<D> {
 
                 self.add_input_for_resource_ref(resource_address_ref);
             },
-            Instruction::ClaimValidatorFees { address } => {
+            Instruction::ClaimValidatorFees { address, .. } => {
                 self.unsigned_transaction.inputs_mut().insert((*address).into());
             },
             Instruction::Assert {

--- a/crates/transaction/src/v1/instruction.rs
+++ b/crates/transaction/src/v1/instruction.rs
@@ -90,6 +90,8 @@ pub enum Instruction {
     ClaimValidatorFees {
         #[n(0)]
         address: ValidatorFeePoolAddress,
+        #[n(1)]
+        max_amount: Option<Amount>,
     },
     #[n(7)]
     DropAllProofsInWorkspace,
@@ -415,8 +417,12 @@ impl Display for Instruction {
             Self::ClaimBurn { claim, .. } => {
                 write!(f, "ClaimBurn {{ {claim} }}",)
             },
-            Self::ClaimValidatorFees { address } => {
-                write!(f, "ClaimValidatorFees {{ address: {} }}", address)
+            Self::ClaimValidatorFees { address, max_amount } => {
+                if let Some(max_amount) = max_amount {
+                    write!(f, "ClaimValidatorFees {{ address: {address}, max_amount: {max_amount} }}")
+                } else {
+                    write!(f, "ClaimValidatorFees {{ address: {address} }}")
+                }
             },
 
             Self::DropAllProofsInWorkspace => {


### PR DESCRIPTION
### Description
Fixes a race condition in stealth \claim_validator_fees\ when additional blocks land between fetching the fee pool balance from the network and transaction execution on-chain (#2149).

### Changes
- Added \withdraw_up_to(&mut self, max_amount: Amount)\ to \ValidatorFeePool\ in \	ari_engine_types\.
- Added optional \max_amount: Option<Amount>\ to \Instruction::ClaimValidatorFees\ and added \claim_validator_fees_up_to\ on \TransactionBuilder\.
- Updated \StateTracker\ and \RuntimeInterface\ to support partial pool withdrawals up to \max_amount\.
- Updated \	ari_walletd\ stealth fee claim handler to pass the snapshot fee balance as \max_amount\, guaranteeing total claimed funds match the stealth commitment proof.

Closes #2149.