### PR TITLE
fix(wallet-ui): use colon separator for string-based NFT ID display (closes #1873)

### DIFF
--- a/applications/tari_walletd/web_ui/src/utils/helpers.tsx
+++ b/applications/tari_walletd/web_ui/src/utils/helpers.tsx
@@ -356,10 +356,10 @@ export function displayNftId(nftId: NonFungibleId): string {
     return `NFT #${nftId.Uint32}`;
   }
   if ("String" in nftId) {
-    return `NFT #${nftId.String}`;
+    return `NFT: ${nftId.String}`;
   }
 
-  return `NFT #${JSON.stringify(nftId)}`;
+  return `NFT ${JSON.stringify(nftId)}`;
 }
 
 /**


### PR DESCRIPTION
### Description

Fixes the formatting issue where string-based \NonFungibleId\ values were displayed with a redundant \#\ prefix in the wallet WebUI.

**Before:** \NFT #Item #1\ (confusing duplicate \#\)
**After:** \NFT: Item #1\ (clean, no ambiguity)

### Changes

- Updated \displayNftId()\ in \helpers.tsx\ to use \NFT: {string}\ format for string-based IDs instead of \NFT #{string}\.
- Numeric IDs (\Uint32\, \Uint64\, \U256\) retain the existing \NFT #{number}\ format since the \#\ prefix is natural for numeric identifiers.

### Formatting Examples

| ID Type | Value | Before | After |
|---------|-------|--------|-------|
| String | \Item #1\ | \NFT #Item #1\ | \NFT: Item #1\ |
| String | \Gold Card\ | \NFT #Gold Card\ | \NFT: Gold Card\ |
| Uint64 | \42\ | \NFT #42\ | \NFT #42\ (unchanged) |
| Uint32 | \1\ | \NFT #1\ | \NFT #1\ (unchanged) |

Closes #1873.