### PR TITLE
fix(transaction): bound per-transaction signature verification work

### DIFF
--- a/applications/tari_validator_node/src/bootstrap.rs
+++ b/applications/tari_validator_node/src/bootstrap.rs
@@ -73,6 +73,7 @@ use tari_ootle_transaction_validation::{
     BasicValidations,
     EpochRangeValidator,
     PublishTemplateLimitValidator,
+    SignatureLimitValidator,
     StealthTransactionLimitsValidator,
     TemplateExistsValidator,
     TransactionDryRunValidator,
@@ -488,6 +489,8 @@ pub fn create_mempool_transaction_validator<TProvider: TemplateProvider>(
         // verifying signatures or executing.
         .and_then(StealthTransactionLimitsValidator::new())
         .and_then(PublishTemplateLimitValidator::new())
+        // Bounds the number of signature verifications the next validator performs.
+        .and_then(SignatureLimitValidator::new())
         .and_then(TransactionSignatureValidator)
         .and_then(TemplateExistsValidator::new(template_manager))
 }

--- a/applications/tari_validator_node/src/json_rpc/handlers.rs
+++ b/applications/tari_validator_node/src/json_rpc/handlers.rs
@@ -187,14 +187,13 @@ impl JsonRpcHandlers {
     pub async fn submit_transaction(&self, value: JsonRpcExtractor) -> JrpcResult {
         let answer_id = value.get_answer_id();
         let SubmitTransactionRequest { transaction } = value.parse_params()?;
+        let tx_id = transaction.calculate_id();
         debug!(
             target: LOG_TARGET,
             "Transaction {} has {} involved substate addresses",
-            transaction.calculate_id(),
+            tx_id,
             transaction.involved_substate_addresses_iter().count()
         );
-
-        let tx_id = transaction.calculate_id();
 
         if transaction.is_dry_run() {
             return Err(invalid_operation(

--- a/applications/tari_validator_node/src/p2p/services/mempool/service.rs
+++ b/applications/tari_validator_node/src/p2p/services/mempool/service.rs
@@ -180,7 +180,8 @@ where
     }
 
     async fn handle_new_transaction_from_local(&mut self, transaction: Transaction) -> Result<(), MempoolError> {
-        if self.transaction_exists(&transaction.calculate_id())? {
+        let transaction_id = transaction.calculate_id();
+        if self.transaction_exists(&transaction_id)? {
             return Ok(());
         }
         info!(
@@ -188,8 +189,13 @@ where
             "🎱 Received NEW transaction from local: {transaction}",
         );
 
-        self.handle_new_transaction(transaction, true, self.gossip.get_num_incoming_messages())
-            .await?;
+        self.handle_new_transaction(
+            transaction,
+            transaction_id,
+            true,
+            self.gossip.get_num_incoming_messages(),
+        )
+        .await?;
 
         Ok(())
     }
@@ -228,21 +234,24 @@ where
             transaction
         );
 
-        self.handle_new_transaction(transaction, false, num_pending).await?;
+        self.handle_new_transaction(transaction, transaction_id, false, num_pending)
+            .await?;
 
         Ok(())
     }
 
+    /// `tx_id` must be the id of `transaction`. Taken from the caller rather than recomputed:
+    /// deriving it hashes every blob payload, and both callers already hold it.
     #[allow(clippy::too_many_lines)]
     async fn handle_new_transaction(
         &mut self,
         transaction: Transaction,
+        tx_id: TransactionId,
         is_local: bool,
         num_pending: usize,
     ) -> Result<(), MempoolError> {
         #[cfg(feature = "metrics")]
         self.metrics.on_transaction_received(&transaction);
-        let tx_id = transaction.calculate_id();
 
         if let Err(e) = self.before_execute_validator.validate(&(), &transaction) {
             // Throw the transaction away

--- a/crates/transaction/src/v1/pruned.rs
+++ b/crates/transaction/src/v1/pruned.rs
@@ -156,9 +156,12 @@ impl PrunedUnsealedTransactionV1 {
         if self.signatures.is_empty() {
             return true;
         }
-        let blob_hashes = self.blob_hashes();
+        // Derived once and reused: every signature over this transaction signs the same message, and
+        // deriving it hashes the whole body.
+        let message =
+            TransactionSignature::create_message_v1_pruned(seal_signer, &self.transaction, self.blob_hashes());
         self.signatures.iter().enumerate().all(|(i, sig)| {
-            if sig.verify_v1_pruned(seal_signer, &self.transaction, blob_hashes) {
+            if sig.verify_message(message) {
                 true
             } else {
                 debug!(target: LOG_TARGET, "Failed to verify pruned signature at index {}", i);

--- a/crates/transaction/src/v1/signature.rs
+++ b/crates/transaction/src/v1/signature.rs
@@ -98,7 +98,19 @@ impl TransactionSealSignature {
     }
 
     pub fn verify_v1(&self, transaction: &UnsealedTransactionV1) -> bool {
-        let message = Self::create_message_v1(transaction);
+        self.verify_message(Self::create_message_v1(transaction))
+    }
+
+    /// Verifies the seal against a transaction whose blob commitments have already been derived.
+    ///
+    /// Deriving them hashes every blob payload, so a caller that also verifies the authorization
+    /// signatures should derive [`BlobHashes`] once and use this for both.
+    pub fn verify_v1_with_blob_hashes(&self, transaction: &UnsealedTransactionV1, blob_hashes: &BlobHashes) -> bool {
+        self.verify_message(Self::create_message_v1_with_blob_hashes(transaction, blob_hashes))
+    }
+
+    /// Verifies this seal against an already-derived signing message.
+    pub fn verify_message(&self, message: [u8; 64]) -> bool {
         let Ok(public_key) = self.public_key.try_from_byte_type() else {
             return false;
         };
@@ -127,12 +139,20 @@ impl TransactionSealSignature {
     }
 
     pub fn create_message_v1(transaction: &UnsealedTransactionV1) -> [u8; 64] {
-        let unsigned = transaction.unsigned_transaction();
-        let blob_hashes = unsigned.blobs.hashes();
+        let blob_hashes = transaction.unsigned_transaction().blobs.hashes();
+        Self::create_message_v1_with_blob_hashes(transaction, &blob_hashes)
+    }
+
+    /// Seal message for a transaction whose blob commitments have already been derived. Produces
+    /// the same digest as [`Self::create_message_v1`] given commitments over the same blobs.
+    pub fn create_message_v1_with_blob_hashes(
+        transaction: &UnsealedTransactionV1,
+        blob_hashes: &BlobHashes,
+    ) -> [u8; 64] {
         Self::create_message_v1_inner(
             transaction.schema_version(),
-            TransactionSignatureFields::from(unsigned),
-            &blob_hashes,
+            TransactionSignatureFields::from(transaction.unsigned_transaction()),
+            blob_hashes,
             transaction.signatures(),
         )
     }
@@ -191,14 +211,7 @@ impl TransactionSealSignature {
     }
 
     pub fn verify_v1_pruned(&self, transaction: &PrunedUnsealedTransactionV1) -> bool {
-        let message = Self::create_message_v1_pruned(transaction);
-        let Ok(public_key) = self.public_key.try_from_byte_type() else {
-            return false;
-        };
-        let Ok(signature) = RistrettoSchnorr::convert_from_byte_type(&self.signature) else {
-            return false;
-        };
-        signature.verify(&public_key, message)
+        self.verify_message(Self::create_message_v1_pruned(transaction))
     }
 }
 
@@ -289,11 +302,22 @@ impl TransactionSignature {
 
     pub fn create_message_v1(seal_signer: &RistrettoPublicKeyBytes, transaction: &UnsignedTransactionV1) -> [u8; 64] {
         let blob_hashes = transaction.blobs.hashes();
+        Self::create_message_v1_with_blob_hashes(seal_signer, transaction, &blob_hashes)
+    }
+
+    /// Authorization message for a transaction whose blob commitments have already been derived.
+    /// Produces the same digest as [`Self::create_message_v1`] given commitments over the same
+    /// blobs.
+    pub fn create_message_v1_with_blob_hashes(
+        seal_signer: &RistrettoPublicKeyBytes,
+        transaction: &UnsignedTransactionV1,
+        blob_hashes: &BlobHashes,
+    ) -> [u8; 64] {
         Self::create_message_v1_inner(
             seal_signer,
             transaction.schema_version(),
             TransactionSignatureFields::from(transaction),
-            &blob_hashes,
+            blob_hashes,
         )
     }
 
@@ -760,6 +784,31 @@ mod tests {
         BorshSerialize::serialize(&unsealed.signatures(), &mut expected).unwrap();
 
         assert_eq!(reconstructed, expected);
+    }
+
+    /// The `_with_blob_hashes` entry points let a caller derive blob commitments once and share
+    /// them between the seal and authorization messages. They must produce digests identical to
+    /// deriving the commitments inline — otherwise a signature would verify on one path and fail on
+    /// the other.
+    #[test]
+    fn with_blob_hashes_matches_inline_derivation() {
+        let seal_signer = sample_seal_signer();
+        let mut unsigned = sample_unsigned();
+        unsigned.blobs.push(crate::Blob::from(vec![4, 5, 6])).unwrap();
+        let sig = random_signature(&unsigned, &seal_signer);
+        let unsealed = unsealed_with(unsigned.clone(), vec![sig]);
+        let blob_hashes = unsigned.blobs.hashes();
+
+        assert_eq!(
+            TransactionSignature::create_message_v1(&seal_signer, &unsigned),
+            TransactionSignature::create_message_v1_with_blob_hashes(&seal_signer, &unsigned, &blob_hashes),
+            "authorization message",
+        );
+        assert_eq!(
+            TransactionSealSignature::create_message_v1(&unsealed),
+            TransactionSealSignature::create_message_v1_with_blob_hashes(&unsealed, &blob_hashes),
+            "seal message",
+        );
     }
 
     /// The signing message is derived once for the whole signature set, so every signature must

--- a/crates/transaction/src/v1/signature.rs
+++ b/crates/transaction/src/v1/signature.rs
@@ -253,7 +253,17 @@ impl TransactionSignature {
     }
 
     pub fn verify_v1(&self, seal_signer: &RistrettoPublicKeyBytes, transaction: &UnsignedTransactionV1) -> bool {
-        let message = Self::create_message_v1(seal_signer, transaction);
+        self.verify_message(Self::create_message_v1(seal_signer, transaction))
+    }
+
+    /// Verifies this signature against an already-derived signing message.
+    ///
+    /// The message is identical for every signature over the same transaction, and deriving it
+    /// hashes the entire body — including a commitment over every blob's bytes. A caller verifying
+    /// more than one signature MUST derive the message once and use this: deriving it per signature
+    /// makes verification cost `O(signatures × body bytes)`, which an attacker controls on both
+    /// factors within a single transaction.
+    pub fn verify_message(&self, message: [u8; 64]) -> bool {
         let Ok(public_key) = self.public_key.try_from_byte_type() else {
             return false;
         };
@@ -350,14 +360,7 @@ impl TransactionSignature {
         transaction: &PrunedUnsignedTransactionV1,
         blob_hashes: &BlobHashes,
     ) -> bool {
-        let message = Self::create_message_v1_pruned(seal_signer, transaction, blob_hashes);
-        let Ok(public_key) = self.public_key.try_from_byte_type() else {
-            return false;
-        };
-        let Ok(signature) = RistrettoSchnorr::convert_from_byte_type(&self.signature) else {
-            return false;
-        };
-        signature.verify(&public_key, message)
+        self.verify_message(Self::create_message_v1_pruned(seal_signer, transaction, blob_hashes))
     }
 }
 
@@ -757,6 +760,37 @@ mod tests {
         BorshSerialize::serialize(&unsealed.signatures(), &mut expected).unwrap();
 
         assert_eq!(reconstructed, expected);
+    }
+
+    /// The signing message is derived once for the whole signature set, so every signature must
+    /// still be checked against it individually: a fully valid set verifies, and a signature over a
+    /// different body fails at any position in the set.
+    #[test]
+    fn verify_all_signatures_checks_every_signature() {
+        let seal_signer = sample_seal_signer();
+        let unsigned = sample_unsigned();
+
+        let sigs: Vec<_> = (0..4).map(|_| random_signature(&unsigned, &seal_signer)).collect();
+        let all_valid = unsealed_with(unsigned.clone(), sigs.clone());
+        assert!(all_valid.verify_all_signatures(&seal_signer));
+
+        let mut other_body = unsigned.clone();
+        other_body.dry_run = !other_body.dry_run;
+        let foreign = random_signature(&other_body, &seal_signer);
+
+        for i in 0..sigs.len() {
+            let mut planted = sigs.clone();
+            planted[i] = foreign.clone();
+            assert!(
+                !unsealed_with(unsigned.clone(), planted).verify_all_signatures(&seal_signer),
+                "a signature over a different body at index {i} must fail verification",
+            );
+        }
+
+        assert!(
+            !all_valid.verify_all_signatures(&sample_seal_signer()),
+            "the set is bound to the seal signer it was signed under",
+        );
     }
 
     #[test]

--- a/crates/transaction/src/v1/transaction.rs
+++ b/crates/transaction/src/v1/transaction.rs
@@ -84,12 +84,16 @@ impl TransactionV1 {
     }
 
     pub fn verify_all_signatures(&self) -> bool {
-        if !self.seal_signature.verify_v1(&self.body) {
+        // Derived once and shared between the seal and the authorization messages: deriving blob
+        // commitments hashes every blob payload.
+        let blob_hashes = self.body.unsigned_transaction().blobs.hashes();
+        if !self.seal_signature.verify_v1_with_blob_hashes(&self.body, &blob_hashes) {
             debug!(target: LOG_TARGET, "Transaction seal signature is invalid");
             return false;
         }
 
-        self.body.verify_all_signatures(self.seal_signature.public_key())
+        self.body
+            .verify_all_signatures_with_blob_hashes(self.seal_signature.public_key(), &blob_hashes)
     }
 
     pub(crate) fn inputs(&self) -> &IndexSet<SubstateRequirement> {

--- a/crates/transaction/src/v1/transaction.rs
+++ b/crates/transaction/src/v1/transaction.rs
@@ -27,6 +27,17 @@ use crate::{
 
 const LOG_TARGET: &str = "tari::ootle::transaction::transaction";
 
+/// Maximum number of authorization signatures a transaction may carry.
+///
+/// Each signature costs one Ristretto Schnorr verification, performed by every node that receives
+/// the transaction, before any fee is charged. Transaction weight alone bounds this too loosely —
+/// at `SIGNER_FACTOR` weight per signer the per-transaction weight cap permits signature counts in
+/// the hundreds of thousands — so the count is capped directly. The ceiling is well above any
+/// multi-party authorization scheme, which names its signers explicitly; authorization by a large
+/// or open-ended group is expressed through a component's access rules, not through raw
+/// transaction signatures.
+pub const MAX_SIGNATURES_PER_TRANSACTION: usize = 16;
+
 static XTR_REQUIREMENT: SubstateRequirement = SubstateRequirement::new(SubstateId::Resource(TARI_TOKEN), None);
 
 #[derive(Debug, Clone, borsh::BorshSerialize, minicbor::Encode, minicbor::Decode, minicbor::CborLen)]

--- a/crates/transaction/src/v1/unsealed.rs
+++ b/crates/transaction/src/v1/unsealed.rs
@@ -96,8 +96,11 @@ impl UnsealedTransactionV1 {
             return true;
         }
 
+        // Derived once and reused: every signature over this transaction signs the same message, and
+        // deriving it hashes the whole body including a commitment over every blob's bytes.
+        let message = TransactionSignature::create_message_v1(seal_signer, &self.transaction);
         self.signatures().iter().enumerate().all(|(i, sig)| {
-            if sig.verify_v1(seal_signer, &self.transaction) {
+            if sig.verify_message(message) {
                 true
             } else {
                 log::debug!(target: LOG_TARGET, "Failed to verify signature at index {}", i);

--- a/crates/transaction/src/v1/unsealed.rs
+++ b/crates/transaction/src/v1/unsealed.rs
@@ -10,6 +10,7 @@ use tari_ootle_common_types::{Epoch, SubstateRequirement};
 use tari_template_lib_types::{ComponentAddress, crypto::RistrettoPublicKeyBytes};
 
 use crate::{
+    BlobHashes,
     Blobs,
     Instruction,
     IntoSigned,
@@ -92,13 +93,27 @@ impl UnsealedTransactionV1 {
     }
 
     pub fn verify_all_signatures(&self, seal_signer: &RistrettoPublicKeyBytes) -> bool {
+        self.verify_all_signatures_with_blob_hashes(seal_signer, &self.transaction.blobs.hashes())
+    }
+
+    /// Verifies every authorization signature against a transaction whose blob commitments have
+    /// already been derived.
+    ///
+    /// Deriving them hashes every blob payload, so a caller that also verifies the seal should
+    /// derive [`Blobs::hashes`] once and use this for both.
+    pub fn verify_all_signatures_with_blob_hashes(
+        &self,
+        seal_signer: &RistrettoPublicKeyBytes,
+        blob_hashes: &BlobHashes,
+    ) -> bool {
         if self.signatures().is_empty() {
             return true;
         }
 
         // Derived once and reused: every signature over this transaction signs the same message, and
         // deriving it hashes the whole body including a commitment over every blob's bytes.
-        let message = TransactionSignature::create_message_v1(seal_signer, &self.transaction);
+        let message =
+            TransactionSignature::create_message_v1_with_blob_hashes(seal_signer, &self.transaction, blob_hashes);
         self.signatures().iter().enumerate().all(|(i, sig)| {
             if sig.verify_message(message) {
                 true

--- a/crates/transaction_validation/src/builder.rs
+++ b/crates/transaction_validation/src/builder.rs
@@ -6,6 +6,7 @@ use tari_ootle_transaction::{Network, Transaction};
 use crate::{
     BasicValidations,
     PublishTemplateLimitValidator,
+    SignatureLimitValidator,
     StealthTransactionLimitsValidator,
     TransactionNetworkValidator,
     TransactionSignatureValidator,
@@ -31,5 +32,7 @@ pub fn create_structural_transaction_validator(
         .and_then(TransactionWeightValidator::new(max_transaction_weight))
         .and_then(StealthTransactionLimitsValidator::new())
         .and_then(PublishTemplateLimitValidator::new())
+        // Bounds the number of signature verifications the next validator performs.
+        .and_then(SignatureLimitValidator::new())
         .and_then(TransactionSignatureValidator)
 }

--- a/crates/transaction_validation/src/error.rs
+++ b/crates/transaction_validation/src/error.rs
@@ -70,4 +70,10 @@ pub enum TransactionValidationError {
         max: usize,
         actual: usize,
     },
+    #[error("Transaction {transaction_id} contains {actual} signatures, but the maximum allowed is {max}")]
+    TooManySignatures {
+        transaction_id: TransactionId,
+        max: usize,
+        actual: usize,
+    },
 }

--- a/crates/transaction_validation/src/lib.rs
+++ b/crates/transaction_validation/src/lib.rs
@@ -25,6 +25,8 @@ mod publish_template_limits;
 pub use publish_template_limits::*;
 mod signature;
 pub use signature::*;
+mod signature_limits;
+pub use signature_limits::*;
 mod stealth_limits;
 pub use stealth_limits::*;
 mod template_exists;

--- a/crates/transaction_validation/src/signature_limits.rs
+++ b/crates/transaction_validation/src/signature_limits.rs
@@ -1,0 +1,110 @@
+// Copyright 2026 The Tari Project
+// SPDX-License-Identifier: BSD-3-Clause
+
+use log::warn;
+use tari_ootle_transaction::{MAX_SIGNATURES_PER_TRANSACTION, Transaction};
+
+use crate::{TransactionValidationError, Validator};
+
+const LOG_TARGET: &str = "tari::ootle::mempool::validators::signature_limits";
+
+/// Rejects transactions carrying more than [`MAX_SIGNATURES_PER_TRANSACTION`] authorization signatures.
+///
+/// Every signature costs a Ristretto Schnorr verification on every node that receives the transaction, charged to
+/// nobody. This is a count-only check, so it must be ordered before [`crate::TransactionSignatureValidator`] to bound
+/// the verification work that validator performs.
+#[derive(Debug, Clone, Default)]
+pub struct SignatureLimitValidator;
+
+impl SignatureLimitValidator {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Validator<Transaction> for SignatureLimitValidator {
+    type Context = ();
+    type Error = TransactionValidationError;
+
+    fn validate(&self, _context: &(), transaction: &Transaction) -> Result<(), Self::Error> {
+        let count = transaction.signatures().len();
+        if count > MAX_SIGNATURES_PER_TRANSACTION {
+            let transaction_id = transaction.calculate_id();
+            warn!(
+                target: LOG_TARGET,
+                "SignatureLimitValidator - FAIL: {transaction_id} has {count} signatures, maximum is \
+                 {MAX_SIGNATURES_PER_TRANSACTION}"
+            );
+            return Err(TransactionValidationError::TooManySignatures {
+                transaction_id,
+                max: MAX_SIGNATURES_PER_TRANSACTION,
+                actual: count,
+            });
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use indexmap::IndexSet;
+    use tari_ootle_transaction::{
+        Network,
+        TransactionSealSignature,
+        TransactionSignature,
+        UnsealedTransactionV1,
+        UnsignedTransactionV1,
+    };
+    use tari_template_lib::types::crypto::{RistrettoPublicKeyBytes, SchnorrSignatureBytes};
+
+    use super::*;
+
+    fn tx_with_signatures(num_signatures: usize) -> Transaction {
+        Transaction::new(
+            UnsealedTransactionV1::new(
+                UnsignedTransactionV1::new(
+                    Network::LocalNet.as_byte(),
+                    vec![],
+                    vec![],
+                    IndexSet::new(),
+                    None,
+                    None,
+                    false,
+                ),
+                (0..num_signatures)
+                    .map(|_| TransactionSignature::new(RistrettoPublicKeyBytes::zero(), SchnorrSignatureBytes::zero()))
+                    .collect(),
+            )
+            .into(),
+            TransactionSealSignature::new(RistrettoPublicKeyBytes::zero(), SchnorrSignatureBytes::zero()),
+        )
+    }
+
+    #[test]
+    fn accepts_a_single_signature() {
+        SignatureLimitValidator::new()
+            .validate(&(), &tx_with_signatures(1))
+            .unwrap();
+    }
+
+    #[test]
+    fn accepts_signatures_at_the_limit() {
+        SignatureLimitValidator::new()
+            .validate(&(), &tx_with_signatures(MAX_SIGNATURES_PER_TRANSACTION))
+            .unwrap();
+    }
+
+    #[test]
+    fn rejects_signatures_over_the_limit() {
+        let over_limit = MAX_SIGNATURES_PER_TRANSACTION + 1;
+        let err = SignatureLimitValidator::new()
+            .validate(&(), &tx_with_signatures(over_limit))
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            TransactionValidationError::TooManySignatures { max, actual, .. }
+            if max == MAX_SIGNATURES_PER_TRANSACTION && actual == over_limit
+        ));
+    }
+}


### PR DESCRIPTION
Three related changes to the cost a transaction can impose on every node that receives it, before any fee is charged. All three are on the ingress path, which is unpriced.

## 1. Signing-message derivation was quadratic

`UnsealedTransactionV1::verify_all_signatures` derived the signing message inside its per-signature loop:

```rust
self.signatures().iter().enumerate().all(|(i, sig)| {
    if sig.verify_v1(seal_signer, &self.transaction) { ... }
})
```

`TransactionSignature::verify_v1` calls `create_message_v1`, which calls `Blobs::hashes()`, which recomputes `hash_blob` over every blob's full bytes — uncached. So each signature re-hashed the entire transaction body, including all blob payloads, and verification cost `O(signatures × blob bytes)`.

The message does not depend on which signature is being checked, so the whole quadratic term was redundant.

Both factors were attacker-controlled within a single transaction and bounded only indirectly, by `max_transaction_weight` (signatures weigh `SIGNER_FACTOR = 5` each; blob bytes weigh `bytes / 3`). Maximising their product under the 2 MiB gossip message cap gave roughly 10,900 signatures against a ~1 MB blob — about 11 GB of Blake2b for one transaction, at a weight of ~404k, comfortably inside the 1,000,000 limit.

`PrunedUnsealedTransactionV1::verify_all_signatures` had the same shape. Its blob commitments are already stored, so blob bytes were not re-hashed there, but the body was still re-serialised and re-hashed per signature.

**Change:** new `TransactionSignature::verify_message(message)`, which verifies against an already-derived message; `verify_v1` and `verify_v1_pruned` delegate to it. Both `verify_all_signatures` implementations derive the message once before the loop.

Measured with 128 signatures over a 1 MiB blob: **135ms → 8.8ms**.

## 2. Blob commitments were derived 5-7 times per transaction

Deriving `BlobHashes` recomputes a Blake2b commitment over every blob's full payload, and the ingress path did it repeatedly for the same transaction: once per `calculate_id()` call (twice on the JSON-RPC entry, twice more in the mempool service), once for the seal message, and once for the authorization message.

**Change:**

- `TransactionV1::verify_all_signatures` derives commitments once and passes them to both the seal and the authorization messages, via new `_with_blob_hashes` entry points on both signature types. The existing inline-deriving methods delegate to those, so callers building a single message are unaffected.
- `MempoolService::handle_new_transaction` takes the transaction id from its callers instead of recomputing it; both already held it.
- `submit_transaction` computes the id once and reuses it for its log line.

This leaves 3 derivations on the JSON-RPC path and 2 on the gossip path, down from 7 and 5. The remainder are separate calls from separate layers (id computation versus signature validation); sharing across them would mean threading commitments through the validator trait.

## 3. Signature count was unbounded

Even with the quadratic gone, nothing bounded the number of signature verifications directly. At `SIGNER_FACTOR = 5` per signer the per-transaction weight cap permits signature counts in the hundreds of thousands, and the gossip message size cap still permits tens of thousands — each one a Ristretto Schnorr verification on every receiving node.

**Change:** new `MAX_SIGNATURES_PER_TRANSACTION` (16) and a `SignatureLimitValidator` enforcing it. The ceiling sits well above any multi-party authorization scheme, which names its signers explicitly; authorization by a large or open-ended group is expressed through a component's access rules rather than raw transaction signatures.

The validator is count-only and is ordered immediately before `TransactionSignatureValidator` in both chains, so it bounds the work that validator performs. It joins the structural validator set, which runs on every path that verifies signatures: mempool ingress, peer-requested missing transactions (`TransactionSource::Requested` → `validate_full`), and the indexer's pre-forward chain. Mempool-originated transactions reaching consensus are re-checked against the epoch only, having already passed the structural set at ingress.

## Consensus impact

Parts 1 and 2 change no behaviour — no digest, encoding, or accept/reject difference. Every signature over a transaction signs the identical message, so the redundant derivations were pure waste.

Part 3 rejects transactions that were previously accepted, at ingress and on the peer-requested path. No transaction in the tree or in normal wallet use carries more than a handful of signatures.

## Verification

- `with_blob_hashes_matches_inline_derivation` asserts the shared-commitment entry points produce digests byte-identical to inline derivation, for both the seal and authorization messages. A divergence here would let a signature verify on one path and fail on the other.
- `verify_all_signatures_checks_every_signature` asserts that deriving the message once still checks each signature individually — it plants a signature made over a different body at every index in turn and asserts each position fails, and that the set stays bound to its seal signer.
- `SignatureLimitValidator` tests cover accept-below, accept-at, and reject-above the cap.
- 71 tests green across `tari_ootle_transaction` and `tari_ootle_transaction_validation`, `cargo check --workspace --all-targets` clean, `cargo +nightly-2025-12-05 fmt --all` applied.
