### PR TITLE
fix(mempool): withhold invalid transactions from gossip propagation

### DIFF
--- a/applications/tari_validator_node/src/p2p/services/consensus_gossip/initializer.rs
+++ b/applications/tari_validator_node/src/p2p/services/consensus_gossip/initializer.rs
@@ -20,11 +20,11 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use libp2p::{PeerId, gossipsub};
+use libp2p::PeerId;
 use log::*;
 use tari_consensus::hotstuff::HotstuffEvent;
 use tari_epoch_manager::EpochManagerEvent;
-use tari_networking::NetworkingHandle;
+use tari_networking::{GossipMessage, NetworkingHandle};
 use tari_ootle_p2p::{TariMessagingSpec, proto};
 use tokio::{
     sync::{broadcast, mpsc},
@@ -40,7 +40,7 @@ pub fn spawn(
     epoch_manager_events: broadcast::Receiver<EpochManagerEvent>,
     consensus_events: broadcast::Receiver<HotstuffEvent>,
     networking: NetworkingHandle<TariMessagingSpec>,
-    rx_gossip: mpsc::UnboundedReceiver<(PeerId, gossipsub::Message)>,
+    rx_gossip: mpsc::UnboundedReceiver<GossipMessage>,
 ) -> (
     ConsensusGossipHandle,
     JoinHandle<anyhow::Result<()>>,

--- a/applications/tari_validator_node/src/p2p/services/consensus_gossip/service.rs
+++ b/applications/tari_validator_node/src/p2p/services/consensus_gossip/service.rs
@@ -20,11 +20,11 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use libp2p::{PeerId, gossipsub};
+use libp2p::{PeerId, gossipsub::MessageAcceptance};
 use log::*;
 use tari_consensus::hotstuff::HotstuffEvent;
 use tari_epoch_manager::EpochManagerEvent;
-use tari_networking::{NetworkingHandle, NetworkingService};
+use tari_networking::{GossipMessage, NetworkingHandle, NetworkingService};
 use tari_ootle_p2p::{TariMessagingSpec, proto};
 use tari_swarm::messaging::{Codec, prost::ProstCodec};
 use tokio::sync::{broadcast, mpsc};
@@ -45,7 +45,7 @@ pub(super) struct ConsensusGossipService {
     is_subscribed: bool,
     networking: NetworkingHandle<TariMessagingSpec>,
     codec: ProstCodec<proto::consensus::HotStuffMessage>,
-    rx_gossip: mpsc::UnboundedReceiver<(PeerId, gossipsub::Message)>,
+    rx_gossip: mpsc::UnboundedReceiver<GossipMessage>,
     tx_consensus_gossip: mpsc::Sender<(PeerId, proto::consensus::HotStuffMessage)>,
 }
 
@@ -54,7 +54,7 @@ impl ConsensusGossipService {
         epoch_manager_events: broadcast::Receiver<EpochManagerEvent>,
         consensus_events: broadcast::Receiver<HotstuffEvent>,
         networking: NetworkingHandle<TariMessagingSpec>,
-        rx_gossip: mpsc::UnboundedReceiver<(PeerId, gossipsub::Message)>,
+        rx_gossip: mpsc::UnboundedReceiver<GossipMessage>,
         tx_consensus_gossip: mpsc::Sender<(PeerId, proto::consensus::HotStuffMessage)>,
     ) -> Self {
         Self {
@@ -102,17 +102,29 @@ impl ConsensusGossipService {
         Ok(())
     }
 
-    async fn handle_incoming_gossip_message(
-        &mut self,
-        msg: (PeerId, gossipsub::Message),
-    ) -> Result<(), ConsensusGossipError> {
-        let (from, msg) = msg;
+    async fn handle_incoming_gossip_message(&mut self, gossip: GossipMessage) -> Result<(), ConsensusGossipError> {
+        let (message_id, propagation_source) = gossip.validation_key();
+        let from = gossip.source;
 
-        let (_, msg) = self
-            .codec
-            .decode_from(&mut msg.data.as_slice())
+        let decoded = self.codec.decode_from(&mut gossip.message.data.as_slice()).await;
+
+        // gossipsub withholds the message from the mesh until a verdict is reported. A message we
+        // cannot decode is withheld and counted against the peer that sent it; anything well-formed
+        // is accepted so it continues to propagate.
+        let acceptance = if decoded.is_ok() {
+            MessageAcceptance::Accept
+        } else {
+            MessageAcceptance::Reject
+        };
+        if let Err(e) = self
+            .networking
+            .report_gossip_validation(message_id, propagation_source, acceptance)
             .await
-            .map_err(|e| ConsensusGossipError::InvalidMessage(e.into()))?;
+        {
+            warn!(target: LOG_TARGET, "Failed to report gossip validation result: {e}");
+        }
+
+        let (_, msg) = decoded.map_err(|e| ConsensusGossipError::InvalidMessage(e.into()))?;
 
         self.tx_consensus_gossip
             .send((from, msg))

--- a/applications/tari_validator_node/src/p2p/services/mempool/gossip.rs
+++ b/applications/tari_validator_node/src/p2p/services/mempool/gossip.rs
@@ -3,7 +3,7 @@
 
 use libp2p::{PeerId, gossipsub};
 use log::*;
-use tari_networking::{NetworkingHandle, NetworkingService};
+use tari_networking::{GossipMessage, NetworkingHandle, NetworkingService};
 use tari_ootle_p2p::{NewTransactionMessage, PeerAddress, TariMessage, TariMessagingSpec, proto};
 use tari_swarm::messaging::{Codec, prost::ProstCodec};
 use tokio::sync::mpsc;
@@ -48,14 +48,14 @@ impl MempoolGossipCodec {
 pub(super) struct MempoolGossip {
     is_subscribed: bool,
     networking: NetworkingHandle<TariMessagingSpec>,
-    rx_gossip: mpsc::UnboundedReceiver<(PeerId, gossipsub::Message)>,
+    rx_gossip: mpsc::UnboundedReceiver<GossipMessage>,
     codec: MempoolGossipCodec,
 }
 
 impl MempoolGossip {
     pub fn new(
         networking: NetworkingHandle<TariMessagingSpec>,
-        rx_gossip: mpsc::UnboundedReceiver<(PeerId, gossipsub::Message)>,
+        rx_gossip: mpsc::UnboundedReceiver<GossipMessage>,
     ) -> Self {
         Self {
             is_subscribed: false,
@@ -66,17 +66,38 @@ impl MempoolGossip {
     }
 
     pub async fn next_message(&mut self) -> Option<Result<IncomingMessage, MempoolError>> {
-        let (from, msg) = self.rx_gossip.recv().await?;
+        let gossip = self.rx_gossip.recv().await?;
         // Number of transactions still to receive
         let num_pending = self.rx_gossip.len();
-        match self.codec.decode(msg).await {
+        let validation = GossipValidation::new(gossip.validation_key());
+        let from = gossip.source;
+        match self.codec.decode(gossip.message).await {
             Ok((msg_len, msg)) => Some(Ok(IncomingMessage {
                 address: from.into(),
                 message: msg,
                 num_pending,
                 message_size: msg_len,
+                validation,
             })),
-            Err(e) => Some(Err(MempoolError::InvalidMessage(e.into()))),
+            Err(e) => {
+                // Undecodable: withhold from the mesh and count it against the peer that sent it.
+                self.report(validation, gossipsub::MessageAcceptance::Reject).await;
+                Some(Err(MempoolError::InvalidMessage(e.into())))
+            },
+        }
+    }
+
+    /// Reports an inbound message's validation verdict. gossipsub withholds the message from the
+    /// rest of the mesh until this is called, so every message taken from `next_message` must be
+    /// reported exactly once.
+    pub async fn report(&mut self, validation: GossipValidation, acceptance: gossipsub::MessageAcceptance) {
+        let (message_id, propagation_source) = validation.into_key();
+        if let Err(e) = self
+            .networking
+            .report_gossip_validation(message_id, propagation_source, acceptance)
+            .await
+        {
+            warn!(target: LOG_TARGET, "Failed to report gossip validation result: {e}");
         }
     }
 
@@ -127,4 +148,24 @@ pub struct IncomingMessage {
     pub message: TariMessage,
     pub num_pending: usize,
     pub message_size: usize,
+    /// Identifies this message when reporting its validation verdict. Must be passed to
+    /// [`MempoolGossip::report`] exactly once, or the message is never propagated onward.
+    pub validation: GossipValidation,
+}
+
+/// Handle identifying one inbound gossip message for the purpose of reporting its validation
+/// verdict. Deliberately not `Clone`: a verdict is reported once per message.
+#[derive(Debug)]
+pub struct GossipValidation {
+    key: (gossipsub::MessageId, PeerId),
+}
+
+impl GossipValidation {
+    fn new(key: (gossipsub::MessageId, PeerId)) -> Self {
+        Self { key }
+    }
+
+    fn into_key(self) -> (gossipsub::MessageId, PeerId) {
+        self.key
+    }
 }

--- a/applications/tari_validator_node/src/p2p/services/mempool/initializer.rs
+++ b/applications/tari_validator_node/src/p2p/services/mempool/initializer.rs
@@ -20,10 +20,9 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use libp2p::{PeerId, gossipsub};
 use log::*;
 use tari_epoch_manager::service::EpochManagerHandle;
-use tari_networking::NetworkingHandle;
+use tari_networking::{GossipMessage, NetworkingHandle};
 use tari_ootle_p2p::{PeerAddress, TariMessagingSpec};
 use tari_ootle_storage::StateStore;
 use tari_ootle_transaction::Transaction;
@@ -45,7 +44,7 @@ pub fn spawn<TValidator, TStateStore>(
     state_store: TStateStore,
     consensus_handle: ConsensusHandle,
     networking: NetworkingHandle<TariMessagingSpec>,
-    rx_gossip: mpsc::UnboundedReceiver<(PeerId, gossipsub::Message)>,
+    rx_gossip: mpsc::UnboundedReceiver<GossipMessage>,
     #[cfg(feature = "metrics")] metrics_registry: &mut prometheus_client::registry::Registry,
 ) -> (MempoolHandle, JoinHandle<anyhow::Result<()>>)
 where

--- a/applications/tari_validator_node/src/p2p/services/mempool/service.rs
+++ b/applications/tari_validator_node/src/p2p/services/mempool/service.rs
@@ -22,11 +22,11 @@
 
 use std::{collections::HashSet, fmt::Display};
 
-use libp2p::{PeerId, gossipsub};
+use libp2p::gossipsub::MessageAcceptance;
 use log::*;
 use tari_consensus::hotstuff::HotstuffEvent;
 use tari_epoch_manager::{EpochManagerReader, service::EpochManagerHandle};
-use tari_networking::NetworkingHandle;
+use tari_networking::{GossipMessage, NetworkingHandle};
 use tari_ootle_common_types::optional::Optional;
 use tari_ootle_p2p::{NewTransactionMessage, PeerAddress, TariMessage, TariMessagingSpec};
 use tari_ootle_storage::{StateStore, StateStoreReadTransaction, consensus_models::TransactionRecord};
@@ -40,7 +40,7 @@ use super::metrics::PrometheusMempoolMetrics;
 use crate::{
     consensus::ConsensusHandle,
     p2p::services::mempool::{
-        gossip::{IncomingMessage, MempoolGossip},
+        gossip::{GossipValidation, IncomingMessage, MempoolGossip},
         handle::MempoolRequest,
     },
 };
@@ -74,7 +74,7 @@ where
         state_store: TStateStore,
         consensus_handle: ConsensusHandle,
         networking: NetworkingHandle<TariMessagingSpec>,
-        rx_gossip: mpsc::UnboundedReceiver<(PeerId, gossipsub::Message)>,
+        rx_gossip: mpsc::UnboundedReceiver<GossipMessage>,
         #[cfg(feature = "metrics")] metrics: PrometheusMempoolMetrics,
     ) -> Self {
         Self {
@@ -192,7 +192,7 @@ where
         self.handle_new_transaction(
             transaction,
             transaction_id,
-            true,
+            None,
             self.gossip.get_num_incoming_messages(),
         )
         .await?;
@@ -209,20 +209,25 @@ where
             message: msg,
             num_pending,
             message_size,
+            validation,
         } = result?;
         let TariMessage::NewTransaction(msg) = msg;
         let NewTransactionMessage { transaction } = *msg;
         let transaction_id = transaction.calculate_id();
 
+        // Well-formed but of no interest to us: withhold it without penalising the sender. Another
+        // node still holding it will propagate it if it is useful to them.
         if !self.consensus_handle.is_running() {
             info!(
                 target: LOG_TARGET,
                 "🎱 Transaction {transaction_id} received while not in running state. Ignoring",
             );
+            self.gossip.report(validation, MessageAcceptance::Ignore).await;
             return Ok(());
         }
 
         if self.transaction_exists(&transaction_id)? {
+            self.gossip.report(validation, MessageAcceptance::Ignore).await;
             return Ok(());
         }
         debug!(
@@ -234,7 +239,7 @@ where
             transaction
         );
 
-        self.handle_new_transaction(transaction, transaction_id, false, num_pending)
+        self.handle_new_transaction(transaction, transaction_id, Some(validation), num_pending)
             .await?;
 
         Ok(())
@@ -242,18 +247,38 @@ where
 
     /// `tx_id` must be the id of `transaction`. Taken from the caller rather than recomputed:
     /// deriving it hashes every blob payload, and both callers already hold it.
+    ///
+    /// `gossip_validation` is `Some` for a transaction that arrived over gossip, and carries the
+    /// handle its verdict must be reported against; `None` marks a transaction introduced by a local
+    /// client, which we are responsible for publishing.
     #[allow(clippy::too_many_lines)]
     async fn handle_new_transaction(
         &mut self,
         transaction: Transaction,
         tx_id: TransactionId,
-        is_local: bool,
+        gossip_validation: Option<GossipValidation>,
         num_pending: usize,
     ) -> Result<(), MempoolError> {
         #[cfg(feature = "metrics")]
         self.metrics.on_transaction_received(&transaction);
+        let is_local = gossip_validation.is_none();
 
-        if let Err(e) = self.before_execute_validator.validate(&(), &transaction) {
+        let validation_result = self.before_execute_validator.validate(&(), &transaction);
+
+        // Reported here rather than at the end of this function: everything below is about whether
+        // *we* act on the transaction, not whether it is valid, and gossipsub only holds a message
+        // in its validation cache for a few heartbeats. A transaction we are not involved in is
+        // still accepted — other shard groups need it.
+        if let Some(validation) = gossip_validation {
+            let acceptance = if validation_result.is_ok() {
+                MessageAcceptance::Accept
+            } else {
+                MessageAcceptance::Reject
+            };
+            self.gossip.report(validation, acceptance).await;
+        }
+
+        if let Err(e) = validation_result {
             // Throw the transaction away
             #[cfg(feature = "metrics")]
             self.metrics.on_transaction_validation_error(&tx_id, &e);

--- a/networking/core/src/handle.rs
+++ b/networking/core/src/handle.rs
@@ -23,7 +23,7 @@
 use std::collections::HashSet;
 
 use async_trait::async_trait;
-use libp2p::{PeerId, StreamProtocol, gossipsub::IdentTopic, swarm::dial_opts::DialOpts};
+use libp2p::{PeerId, StreamProtocol, gossipsub, gossipsub::IdentTopic, swarm::dial_opts::DialOpts};
 use log::*;
 use tari_rpc_framework::{
     NamedProtocolService,
@@ -78,6 +78,13 @@ pub enum NetworkingRequest<TMsg: MessageSpec> {
         topic: IdentTopic,
         explicit_topic_peers: Vec<PeerId>,
         reply_tx: Reply<()>,
+    },
+    /// Fire-and-forget: gossip validation verdicts are reported once per inbound message, so they
+    /// carry no reply channel.
+    ReportGossipValidation {
+        message_id: gossipsub::MessageId,
+        propagation_source: PeerId,
+        acceptance: gossipsub::MessageAcceptance,
     },
     UnsubscribeTopic {
         topic: IdentTopic,
@@ -366,6 +373,23 @@ impl<TMsg: MessageSpec + Send + 'static> NetworkingService<TMsg> for NetworkingH
             .await
             .map_err(|_| NetworkingHandleError::ServiceHasShutdown)?;
         rx.await?
+    }
+
+    async fn report_gossip_validation(
+        &mut self,
+        message_id: gossipsub::MessageId,
+        propagation_source: PeerId,
+        acceptance: gossipsub::MessageAcceptance,
+    ) -> Result<(), NetworkingError> {
+        self.tx_request
+            .send(NetworkingRequest::ReportGossipValidation {
+                message_id,
+                propagation_source,
+                acceptance,
+            })
+            .await
+            .map_err(|_| NetworkingHandleError::ServiceHasShutdown)?;
+        Ok(())
     }
 
     async fn subscribe_topic_with_explicit_peers<T: Into<String> + Send>(

--- a/networking/core/src/lib.rs
+++ b/networking/core/src/lib.rs
@@ -8,6 +8,7 @@ use std::{
 };
 
 use async_trait::async_trait;
+use libp2p::gossipsub;
 use tokio::sync::oneshot;
 
 mod worker;
@@ -66,6 +67,20 @@ pub trait NetworkingService<TMsg: MessageSpec> {
         &mut self,
         topic: TTopic,
         message: Vec<u8>,
+    ) -> Result<(), NetworkingError>;
+
+    /// Reports the outcome of validating an inbound gossip message.
+    ///
+    /// gossipsub runs in `validate_messages` mode: a message is propagated to the rest of the mesh
+    /// only once `Accept` is reported for it, so every message a consumer receives must be reported
+    /// exactly once or that topic stops propagating. `Reject` withholds it and counts against the
+    /// propagating peer's score; `Ignore` withholds it without penalty, for messages that are
+    /// well-formed but uninteresting to us (duplicates, wrong epoch).
+    async fn report_gossip_validation(
+        &mut self,
+        message_id: gossipsub::MessageId,
+        propagation_source: PeerId,
+        acceptance: gossipsub::MessageAcceptance,
     ) -> Result<(), NetworkingError>;
 
     async fn subscribe_topic<T: Into<String> + Send>(&mut self, topic: T) -> Result<(), NetworkingError> {

--- a/networking/core/src/message_mode.rs
+++ b/networking/core/src/message_mode.rs
@@ -18,16 +18,39 @@ pub enum GossipSendError {
     InboundGossipChannelClosed,
 }
 
-impl From<mpsc::error::SendError<(PeerId, gossipsub::Message)>> for GossipSendError {
-    fn from(_: mpsc::error::SendError<(PeerId, gossipsub::Message)>) -> Self {
+impl From<mpsc::error::SendError<GossipMessage>> for GossipSendError {
+    fn from(_: mpsc::error::SendError<GossipMessage>) -> Self {
         Self::InboundGossipChannelClosed
+    }
+}
+
+/// An inbound gossipsub message, carrying the identifiers needed to report its validation verdict.
+///
+/// gossipsub runs in `validate_messages` mode, so a message is held and propagated to nobody until a
+/// verdict is reported for it. A consumer MUST call
+/// [`crate::NetworkingService::report_gossip_validation`] for every message it receives, or that
+/// topic stops propagating across the network.
+#[derive(Debug)]
+pub struct GossipMessage {
+    /// The peer that authored the message.
+    pub source: PeerId,
+    /// The peer we received it from, which may differ from `source`.
+    pub propagation_source: PeerId,
+    pub message_id: gossipsub::MessageId,
+    pub message: gossipsub::Message,
+}
+
+impl GossipMessage {
+    /// The pair identifying this message to [`crate::NetworkingService::report_gossip_validation`].
+    pub fn validation_key(&self) -> (gossipsub::MessageId, PeerId) {
+        (self.message_id.clone(), self.propagation_source)
     }
 }
 
 pub enum MessagingMode<TMsg: MessageSpec> {
     Enabled {
         tx_messages: mpsc::UnboundedSender<(PeerId, TMsg::Message)>,
-        tx_gossip_messages_by_topic: HashMap<String, mpsc::UnboundedSender<(PeerId, gossipsub::Message)>>,
+        tx_gossip_messages_by_topic: HashMap<String, mpsc::UnboundedSender<GossipMessage>>,
     },
     Disabled,
 }
@@ -50,7 +73,7 @@ impl<TMsg: MessageSpec> MessagingMode<TMsg> {
         Ok(())
     }
 
-    pub fn send_gossip_message(&self, peer_id: PeerId, msg: gossipsub::Message) -> Result<(), GossipSendError> {
+    pub fn send_gossip_message(&self, msg: GossipMessage) -> Result<(), GossipSendError> {
         if let MessagingMode::Enabled {
             tx_gossip_messages_by_topic,
             ..
@@ -59,15 +82,12 @@ impl<TMsg: MessageSpec> MessagingMode<TMsg> {
             // Topics may be a bare prefix (single global topic, e.g. "consensus") or a prefixed topic
             // (e.g. "transactions-0-15"). Route on the prefix before the first delimiter, falling back to the
             // whole topic when there is no delimiter.
-            let prefix = msg
-                .topic
-                .as_str()
-                .split_once(TOPIC_DELIMITER)
-                .map_or_else(|| msg.topic.as_str(), |(prefix, _)| prefix);
+            let topic = msg.message.topic.as_str();
+            let prefix = topic.split_once(TOPIC_DELIMITER).map_or(topic, |(prefix, _)| prefix);
             let tx_gossip_messages = tx_gossip_messages_by_topic
                 .get(prefix)
-                .ok_or_else(|| GossipSendError::InvalidToken(msg.topic.clone().into_string()))?;
-            tx_gossip_messages.send((peer_id, msg))?;
+                .ok_or_else(|| GossipSendError::InvalidToken(topic.to_string()))?;
+            tx_gossip_messages.send(msg)?;
         }
         Ok(())
     }

--- a/networking/core/src/worker.rs
+++ b/networking/core/src/worker.rs
@@ -53,6 +53,7 @@ use tokio::{
 };
 
 use crate::{
+    GossipMessage,
     MessageSpec,
     MessagingMode,
     NetworkingError,
@@ -306,6 +307,19 @@ where
                     debug!(target: LOG_TARGET, "🚨 Failed to publish gossipsub message on {topic}: {}", err);
                     let _ignore = reply_tx.send(Err(err.into()));
                 },
+            },
+            NetworkingRequest::ReportGossipValidation {
+                message_id,
+                propagation_source,
+                acceptance,
+            } => {
+                if !self.swarm.behaviour_mut().gossipsub.report_message_validation_result(
+                    &message_id,
+                    &propagation_source,
+                    acceptance,
+                ) {
+                    warn!(target: LOG_TARGET, "Unable to report gossip validation result for {message_id} because message was not in cache");
+                }
             },
             NetworkingRequest::SubscribeTopic {
                 topic,
@@ -738,20 +752,45 @@ where
         source: PeerId,
         message: gossipsub::Message,
     ) -> Result<(), NetworkingError> {
-        // We accept all messages as we cannot validate them in this service.
-        // We could allow users to report back the validation result e.g. if a proposal is valid, however a naive
-        // implementation would likely incur a substantial cost for many messages.
-        if !self.swarm.behaviour_mut().gossipsub.report_message_validation_result(
-            &message_id,
-            &propagation_source,
-            gossipsub::MessageAcceptance::Accept,
-        ) {
-            warn!(target: LOG_TARGET, "Unable to report_message_validation_result accept for topic {}, {} bytes because message was not in cache", message.topic, message.data.len());
-        }
-        if let Err(e) = self.messaging_mode.send_gossip_message(source, message) {
+        // Propagation is withheld until the consumer reports a verdict via
+        // `NetworkingRequest::ReportGossipValidation`, so an invalid message is never relayed on our
+        // behalf. If no consumer is subscribed to the topic there is nobody to produce a verdict, so
+        // report `Ignore` here rather than leaving the message pinned in the validation cache.
+        let topic = message.topic.clone();
+        let len = message.data.len();
+        if let Err(e) = self.messaging_mode.send_gossip_message(GossipMessage {
+            source,
+            propagation_source,
+            message_id: message_id.clone(),
+            message,
+        }) {
             warn!(target: LOG_TARGET, "📢 Gossipsub message failed to be handled: {}", e);
+            self.report_gossip_validation(
+                &message_id,
+                &propagation_source,
+                gossipsub::MessageAcceptance::Ignore,
+                &topic,
+                len,
+            );
         }
         Ok(())
+    }
+
+    fn report_gossip_validation(
+        &mut self,
+        message_id: &gossipsub::MessageId,
+        propagation_source: &PeerId,
+        acceptance: gossipsub::MessageAcceptance,
+        topic: &gossipsub::TopicHash,
+        len: usize,
+    ) {
+        if !self.swarm.behaviour_mut().gossipsub.report_message_validation_result(
+            message_id,
+            propagation_source,
+            acceptance,
+        ) {
+            warn!(target: LOG_TARGET, "Unable to report gossip validation result for topic {topic}, {len} bytes because message was not in cache");
+        }
     }
 
     #[cfg(feature = "metrics")]


### PR DESCRIPTION
## Motivation

gossipsub is configured with `validate_messages`, which exists so that an application can decide whether a message is worth relaying. The networking worker did not use it: `on_gossipsub_message` reported `MessageAcceptance::Accept` unconditionally, *before* handing the message to the application, with a comment acknowledging that the service cannot validate messages itself.

Two consequences:

- Every message was relayed across the mesh regardless of validity. An invalid transaction reached, and was validated by, every node in the network before anyone rejected it — transactions are gossiped on a single network-wide topic, so the shard-scoping in the mempool happens only *after* validation.
- Peer scoring had nothing to act on. A peer flooding invalid transactions was indistinguishable from an honest one, which is why no `ScoreParams` are configured today: without `Reject` verdicts, scoring cannot be meaningful.

## Changes

The verdict is plumbed back from the application to the worker.

- The inbound gossip channel carries a `GossipMessage` (`source`, `propagation_source`, `message_id`, `message`) rather than a bare `(PeerId, Message)` tuple — a consumer cannot report a verdict without the identifiers.
- New `NetworkingRequest::ReportGossipValidation` and `NetworkingService::report_gossip_validation`. Reporting is fire-and-forget: it happens once per inbound message, so a reply channel would only add latency.
- The worker no longer accepts on the application's behalf. If no consumer is subscribed to a topic there is nobody to produce a verdict, so it reports `Ignore` itself rather than leaving the message pinned in the validation cache.

Verdicts:

| source | outcome | verdict |
|---|---|---|
| mempool | undecodable, or fails the validator chain | `Reject` |
| mempool | duplicate, or consensus not running | `Ignore` |
| mempool | valid | `Accept` |
| consensus gossip | does not decode | `Reject` |
| consensus gossip | decodes | `Accept` |

A valid transaction is accepted even when this node is not in the involved committee — other shard groups still need it, and withholding it would break propagation for them. `Ignore` is used where the message is well-formed but uninteresting to us, so the sending peer is not penalised.

The mempool reports its verdict immediately after the validator chain rather than at the end of `handle_new_transaction`. Everything after that point concerns whether *this node* acts on the transaction, not whether it is valid, and gossipsub only retains a message in its validation cache for a few heartbeats — the epoch-manager round-trip could push the report past eviction.

`IncomingMessage` carries a `GossipValidation` handle that is deliberately not `Clone`: exactly one verdict is reported per message.

## Deliberately not included

**Peer scoring.** `with_peer_score` remains unset. `Reject` verdicts now give it something to act on, which is the prerequisite, but the score parameters need tuning against a live mesh and bad ones partition the network. That belongs in its own change with its own testing.

## Verification

- `cargo check --workspace --all-targets` clean, `cargo +nightly-2025-12-05 fmt --all` applied, `tari_validator_node` and `tari_networking` suites green.
- **Wants a swarm run before merge.** Static checks cannot prove propagation still works: if any consumer path fails to report a verdict, that topic goes quiet with no error surfaced. Both consumers have been traced and every path reports exactly once, but the failure mode here is a silent partition rather than a test failure, so end-to-end confirmation that transactions still reach their committees is worth doing.
