### PR TITLE
fix(mempool): bound inbound gossip queues and the seen-transaction cache

### DIFF
--- a/applications/tari_validator_node/src/bootstrap.rs
+++ b/applications/tari_validator_node/src/bootstrap.rs
@@ -59,6 +59,7 @@ use tari_networking::{
     RelayReservationLimits,
     SwarmConfig,
     gossip_queue,
+    message_queue,
 };
 use tari_ootle_app_utilities::{
     claim_burn_proof_verifier::TariClaimBurnProofVerifier,
@@ -143,21 +144,23 @@ pub async fn spawn_services(
 
     ensure_directories_exist(&config)?;
 
-    // Networking
-    let (tx_consensus_messages, rx_consensus_messages) = mpsc::unbounded_channel();
+    // Bounded ingress queues. Each is drained serially by its service, so a queue absorbs arrival
+    // bursts that outpace processing; beyond its budget messages are dropped rather than queued
+    // without limit. Budgets are per-queue — see `ValidatorNodeConfig`. The message-count bound is
+    // a secondary guard against a flood of tiny messages, whose per-message overhead the byte
+    // budget does not capture.
+    const MAX_QUEUED_INBOUND_MESSAGES: usize = 100_000;
 
-    // Bounded gossip ingress queues. Each is drained serially by its service, so the queue absorbs
-    // arrival bursts that outpace processing; beyond its budget messages are dropped rather than
-    // queued without limit. See `ValidatorNodeConfig::max_transaction_gossip_queue_bytes`. The
-    // message-count bound is a secondary guard against a flood of tiny messages, whose per-message
-    // overhead the byte budget does not capture.
-    const MAX_QUEUED_GOSSIP_MESSAGES: usize = 100_000;
+    let (tx_consensus_messages, rx_consensus_messages) = message_queue(
+        MAX_QUEUED_INBOUND_MESSAGES,
+        config.validator_node.max_consensus_messaging_queue_bytes,
+    );
     let (tx_transaction_gossip_messages, rx_transaction_gossip_messages) = gossip_queue(
-        MAX_QUEUED_GOSSIP_MESSAGES,
+        MAX_QUEUED_INBOUND_MESSAGES,
         config.validator_node.max_transaction_gossip_queue_bytes,
     );
     let (tx_consensus_gossip_messages, rx_consensus_gossip_messages) = gossip_queue(
-        MAX_QUEUED_GOSSIP_MESSAGES,
+        MAX_QUEUED_INBOUND_MESSAGES,
         config.validator_node.max_consensus_gossip_queue_bytes,
     );
     let mut tx_gossip_messages_by_topic = HashMap::new();

--- a/applications/tari_validator_node/src/bootstrap.rs
+++ b/applications/tari_validator_node/src/bootstrap.rs
@@ -52,7 +52,14 @@ use tari_epoch_oracles::{
     hybrid::{HybridEpochOracle, mpsc_ticker},
     store::EpochOracleStore,
 };
-use tari_networking::{MessagingMode, NetworkingHandle, RelayCircuitLimits, RelayReservationLimits, SwarmConfig};
+use tari_networking::{
+    MessagingMode,
+    NetworkingHandle,
+    RelayCircuitLimits,
+    RelayReservationLimits,
+    SwarmConfig,
+    gossip_queue,
+};
 use tari_ootle_app_utilities::{
     claim_burn_proof_verifier::TariClaimBurnProofVerifier,
     configuration::convert_network_to_l1_network,
@@ -139,9 +146,20 @@ pub async fn spawn_services(
     // Networking
     let (tx_consensus_messages, rx_consensus_messages) = mpsc::unbounded_channel();
 
-    // gossip channels
-    let (tx_transaction_gossip_messages, rx_transaction_gossip_messages) = mpsc::unbounded_channel();
-    let (tx_consensus_gossip_messages, rx_consensus_gossip_messages) = mpsc::unbounded_channel();
+    // Bounded gossip ingress queues. Each is drained serially by its service, so the queue absorbs
+    // arrival bursts that outpace processing; beyond its budget messages are dropped rather than
+    // queued without limit. See `ValidatorNodeConfig::max_transaction_gossip_queue_bytes`. The
+    // message-count bound is a secondary guard against a flood of tiny messages, whose per-message
+    // overhead the byte budget does not capture.
+    const MAX_QUEUED_GOSSIP_MESSAGES: usize = 100_000;
+    let (tx_transaction_gossip_messages, rx_transaction_gossip_messages) = gossip_queue(
+        MAX_QUEUED_GOSSIP_MESSAGES,
+        config.validator_node.max_transaction_gossip_queue_bytes,
+    );
+    let (tx_consensus_gossip_messages, rx_consensus_gossip_messages) = gossip_queue(
+        MAX_QUEUED_GOSSIP_MESSAGES,
+        config.validator_node.max_consensus_gossip_queue_bytes,
+    );
     let mut tx_gossip_messages_by_topic = HashMap::new();
     tx_gossip_messages_by_topic.insert(mempool::TOPIC_PREFIX.to_string(), tx_transaction_gossip_messages);
     tx_gossip_messages_by_topic.insert(consensus_gossip::TOPIC_PREFIX.to_string(), tx_consensus_gossip_messages);

--- a/applications/tari_validator_node/src/bootstrap.rs
+++ b/applications/tari_validator_node/src/bootstrap.rs
@@ -104,6 +104,8 @@ use tokio::{
 use crate::consensus::metrics::PrometheusConsensusMetrics;
 #[cfg(feature = "metrics")]
 use crate::epoch_metrics::{EpochManagerCollector, MeteredEpochOracle, PrometheusEpochOracleMetrics};
+#[cfg(feature = "metrics")]
+use crate::inbound_queue_metrics::InboundQueueCollector;
 use crate::{
     ApplicationConfig,
     ValidatorNodeEpochManagerSpec,
@@ -163,6 +165,14 @@ pub async fn spawn_services(
         MAX_QUEUED_INBOUND_MESSAGES,
         config.validator_node.max_consensus_gossip_queue_bytes,
     );
+    #[cfg(feature = "metrics")]
+    InboundQueueCollector::new(
+        tx_transaction_gossip_messages.clone(),
+        tx_consensus_gossip_messages.clone(),
+        tx_consensus_messages.clone(),
+    )
+    .register(metrics_registry);
+
     let mut tx_gossip_messages_by_topic = HashMap::new();
     tx_gossip_messages_by_topic.insert(mempool::TOPIC_PREFIX.to_string(), tx_transaction_gossip_messages);
     tx_gossip_messages_by_topic.insert(consensus_gossip::TOPIC_PREFIX.to_string(), tx_consensus_gossip_messages);

--- a/applications/tari_validator_node/src/config.rs
+++ b/applications/tari_validator_node/src/config.rs
@@ -112,19 +112,31 @@ pub struct ValidatorNodeConfig {
     /// sizes this admits a very deep backlog, while capping a flood of maximum-size messages.
     #[serde(default = "default_max_transaction_gossip_queue_bytes")]
     pub max_transaction_gossip_queue_bytes: usize,
-    /// Maximum total size of inbound consensus gossip awaiting processing. Consensus carries far
-    /// less volume than transactions — one proposal per block plus a vote per committee member — so
-    /// this queue should never run deep, and dropping from it indicates the node has fallen behind.
+    /// Maximum total size of inbound consensus gossip awaiting processing. This topic carries
+    /// `HotStuffMessage`s between shard groups, including block-sized foreign proposals, and it
+    /// feeds a short blocking channel into consensus — so this queue absorbs real bursts rather
+    /// than sitting idle. Budgeted above transactions because a dropped proposal or vote can cost a
+    /// view, whereas a dropped transaction can be re-requested.
     #[serde(default = "default_max_consensus_gossip_queue_bytes")]
     pub max_consensus_gossip_queue_bytes: usize,
+    /// Maximum total size of inbound direct consensus messages awaiting processing. Carries
+    /// intra-committee `HotStuffMessage`s. Reaching this queue requires an established connection
+    /// rather than a topic publish, so it is harder to flood than the gossip topics, but it is
+    /// equally liveness-critical.
+    #[serde(default = "default_max_consensus_messaging_queue_bytes")]
+    pub max_consensus_messaging_queue_bytes: usize,
 }
 
 fn default_max_transaction_gossip_queue_bytes() -> usize {
-    256 * 1024 * 1024
+    128 * 1024 * 1024
 }
 
 fn default_max_consensus_gossip_queue_bytes() -> usize {
-    64 * 1024 * 1024
+    256 * 1024 * 1024
+}
+
+fn default_max_consensus_messaging_queue_bytes() -> usize {
+    128 * 1024 * 1024
 }
 
 impl ValidatorNodeConfig {
@@ -183,6 +195,7 @@ impl Default for ValidatorNodeConfig {
             consensus: ConsensusConfig::default(),
             max_transaction_gossip_queue_bytes: default_max_transaction_gossip_queue_bytes(),
             max_consensus_gossip_queue_bytes: default_max_consensus_gossip_queue_bytes(),
+            max_consensus_messaging_queue_bytes: default_max_consensus_messaging_queue_bytes(),
         }
     }
 }

--- a/applications/tari_validator_node/src/config.rs
+++ b/applications/tari_validator_node/src/config.rs
@@ -105,6 +105,26 @@ pub struct ValidatorNodeConfig {
     pub layer_one_transaction_path: PathBuf,
     /// Consensus configuration
     pub consensus: ConsensusConfig,
+    /// Maximum total size of inbound transaction gossip awaiting mempool validation. The mempool
+    /// drains this queue serially, so it absorbs bursts that arrive faster than validation; once it
+    /// is full, further messages are dropped rather than queued without limit. Sized in bytes
+    /// because every message may be up to `gossip_sub_max_message_size`: at ordinary transaction
+    /// sizes this admits a very deep backlog, while capping a flood of maximum-size messages.
+    #[serde(default = "default_max_transaction_gossip_queue_bytes")]
+    pub max_transaction_gossip_queue_bytes: usize,
+    /// Maximum total size of inbound consensus gossip awaiting processing. Consensus carries far
+    /// less volume than transactions — one proposal per block plus a vote per committee member — so
+    /// this queue should never run deep, and dropping from it indicates the node has fallen behind.
+    #[serde(default = "default_max_consensus_gossip_queue_bytes")]
+    pub max_consensus_gossip_queue_bytes: usize,
+}
+
+fn default_max_transaction_gossip_queue_bytes() -> usize {
+    256 * 1024 * 1024
+}
+
+fn default_max_consensus_gossip_queue_bytes() -> usize {
+    64 * 1024 * 1024
 }
 
 impl ValidatorNodeConfig {
@@ -161,6 +181,8 @@ impl Default for ValidatorNodeConfig {
             sidechain_id: None,
             layer_one_transaction_path: PathBuf::from("data/layer_one_transactions"),
             consensus: ConsensusConfig::default(),
+            max_transaction_gossip_queue_bytes: default_max_transaction_gossip_queue_bytes(),
+            max_consensus_gossip_queue_bytes: default_max_consensus_gossip_queue_bytes(),
         }
     }
 }

--- a/applications/tari_validator_node/src/inbound_queue_metrics.rs
+++ b/applications/tari_validator_node/src/inbound_queue_metrics.rs
@@ -1,0 +1,196 @@
+//   Copyright 2026 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+//! Metrics for the bounded inbound queues that buffer network traffic ahead of the services that
+//! consume it.
+//!
+//! Each queue already tracks its own depth and what it has turned away, so
+//! [`InboundQueueCollector`] reads them on each scrape rather than maintaining separate gauges —
+//! the metrics are always exactly in sync with the queues and there is no background task to spawn.
+//! This mirrors [`crate::epoch_metrics::EpochManagerCollector`].
+//!
+//! Depth against budget is the number to watch when sizing the budgets: a queue that never rises
+//! above a small fraction of its budget under load is over-provisioned, while a non-zero drop count
+//! means traffic is being discarded and the budget (or the drain rate behind it) needs attention.
+
+use std::fmt;
+
+use prometheus_client::{
+    collector::Collector,
+    encoding::{DescriptorEncoder, EncodeMetric},
+    metrics::{counter::ConstCounter, gauge::ConstGauge},
+    registry::Registry,
+};
+use tari_networking::{GossipQueueSender, MessageQueueSender};
+use tari_ootle_p2p::proto;
+
+/// One queue's readings, taken at scrape time.
+struct QueueReading {
+    queue: &'static str,
+    queued_bytes: u64,
+    max_queued_bytes: u64,
+    queued_messages: u64,
+    dropped_messages: u64,
+    dropped_bytes: u64,
+}
+
+/// Reports depth, budget and drop totals for every inbound queue, labelled by `queue`.
+pub struct InboundQueueCollector {
+    transaction_gossip: GossipQueueSender,
+    consensus_gossip: GossipQueueSender,
+    consensus_messaging: MessageQueueSender<proto::consensus::HotStuffMessage>,
+}
+
+impl InboundQueueCollector {
+    pub fn new(
+        transaction_gossip: GossipQueueSender,
+        consensus_gossip: GossipQueueSender,
+        consensus_messaging: MessageQueueSender<proto::consensus::HotStuffMessage>,
+    ) -> Self {
+        Self {
+            transaction_gossip,
+            consensus_gossip,
+            consensus_messaging,
+        }
+    }
+
+    /// Registers under the `inbound_queue` sub-registry, so the metric names on the wire are
+    /// `inbound_queue_queued_bytes`, `inbound_queue_dropped_messages_total`, and so on.
+    pub fn register(self, registry: &mut Registry) {
+        let registry = registry.sub_registry_with_prefix("inbound_queue");
+        registry.register_collector(Box::new(self));
+    }
+
+    fn readings(&self) -> [QueueReading; 3] {
+        [
+            QueueReading {
+                queue: "transaction_gossip",
+                queued_bytes: self.transaction_gossip.queued_bytes() as u64,
+                max_queued_bytes: self.transaction_gossip.max_queued_bytes() as u64,
+                queued_messages: self.transaction_gossip.queued_messages() as u64,
+                dropped_messages: self.transaction_gossip.dropped_messages(),
+                dropped_bytes: self.transaction_gossip.dropped_bytes(),
+            },
+            QueueReading {
+                queue: "consensus_gossip",
+                queued_bytes: self.consensus_gossip.queued_bytes() as u64,
+                max_queued_bytes: self.consensus_gossip.max_queued_bytes() as u64,
+                queued_messages: self.consensus_gossip.queued_messages() as u64,
+                dropped_messages: self.consensus_gossip.dropped_messages(),
+                dropped_bytes: self.consensus_gossip.dropped_bytes(),
+            },
+            QueueReading {
+                queue: "consensus_messaging",
+                queued_bytes: self.consensus_messaging.queued_bytes() as u64,
+                max_queued_bytes: self.consensus_messaging.max_queued_bytes() as u64,
+                queued_messages: self.consensus_messaging.queued_messages() as u64,
+                dropped_messages: self.consensus_messaging.dropped_messages(),
+                dropped_bytes: self.consensus_messaging.dropped_bytes(),
+            },
+        ]
+    }
+}
+
+impl Collector for InboundQueueCollector {
+    fn encode(&self, mut encoder: DescriptorEncoder) -> Result<(), fmt::Error> {
+        let readings = self.readings();
+
+        // Units are carried in the metric names rather than passed to the encoder, which would
+        // append them a second time; counter names omit `_total`, which prometheus-client appends
+        // itself. Both match `EpochManagerCollector`.
+        let families: [(&str, &str, fn(&QueueReading) -> Reading); 5] = [
+            (
+                "queued_bytes",
+                "Bytes currently held by messages awaiting processing",
+                |r| Reading::Gauge(r.queued_bytes),
+            ),
+            (
+                "max_queued_bytes",
+                "Byte budget this queue admits up to before dropping",
+                |r| Reading::Gauge(r.max_queued_bytes),
+            ),
+            ("queued_messages", "Messages currently awaiting processing", |r| {
+                Reading::Gauge(r.queued_messages)
+            }),
+            (
+                "dropped_messages",
+                "Messages discarded because the queue was full",
+                |r| Reading::Counter(r.dropped_messages),
+            ),
+            ("dropped_bytes", "Bytes discarded because the queue was full", |r| {
+                Reading::Counter(r.dropped_bytes)
+            }),
+        ];
+
+        for (name, help, read) in families {
+            let metric_type = match read(&readings[0]) {
+                Reading::Gauge(_) => ConstGauge::<u64>::new(0).metric_type(),
+                Reading::Counter(_) => ConstCounter::<u64>::new(0).metric_type(),
+            };
+            let mut family = encoder.encode_descriptor(name, help, None, metric_type)?;
+            for reading in &readings {
+                let labels = [("queue", reading.queue)];
+                match read(reading) {
+                    Reading::Gauge(v) => ConstGauge::<u64>::new(v).encode(family.encode_family(&labels)?)?,
+                    Reading::Counter(v) => ConstCounter::<u64>::new(v).encode(family.encode_family(&labels)?)?,
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+enum Reading {
+    Gauge(u64),
+    Counter(u64),
+}
+
+impl fmt::Debug for InboundQueueCollector {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("InboundQueueCollector").finish_non_exhaustive()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use prometheus_client::encoding::text::encode;
+    use tari_networking::{gossip_queue, message_queue};
+
+    use super::*;
+
+    /// Pins the exported names and labels. Metric naming here is not free-form: the sub-registry
+    /// prefix, the `queue` label and prometheus-client's own `_total` suffix on counters all
+    /// combine, and a dashboard built against the wrong names is silently empty.
+    #[test]
+    fn exports_each_queue_under_its_own_label() {
+        let (transaction_gossip, _rx_a) = gossip_queue(8, 1024);
+        let (consensus_gossip, _rx_b) = gossip_queue(8, 2048);
+        let (consensus_messaging, _rx_c) = message_queue::<proto::consensus::HotStuffMessage>(8, 4096);
+
+        let mut registry = Registry::default();
+        InboundQueueCollector::new(transaction_gossip, consensus_gossip, consensus_messaging).register(&mut registry);
+
+        let mut out = String::new();
+        encode(&mut out, &registry).unwrap();
+
+        for (queue, budget) in [
+            ("transaction_gossip", 1024),
+            ("consensus_gossip", 2048),
+            ("consensus_messaging", 4096),
+        ] {
+            assert!(
+                out.contains(&format!("inbound_queue_max_queued_bytes{{queue=\"{queue}\"}} {budget}")),
+                "{queue} budget missing from:\n{out}"
+            );
+            assert!(
+                out.contains(&format!("inbound_queue_queued_bytes{{queue=\"{queue}\"}} 0")),
+                "{queue} depth missing from:\n{out}"
+            );
+            assert!(
+                out.contains(&format!("inbound_queue_dropped_messages_total{{queue=\"{queue}\"}} 0")),
+                "{queue} drop counter missing from:\n{out}"
+            );
+        }
+    }
+}

--- a/applications/tari_validator_node/src/lib.rs
+++ b/applications/tari_validator_node/src/lib.rs
@@ -31,6 +31,8 @@ mod file_l1_submitter;
 mod genesis_state;
 #[cfg(feature = "web_ui")]
 mod http_ui;
+#[cfg(feature = "metrics")]
+mod inbound_queue_metrics;
 mod json_rpc;
 #[cfg(feature = "metrics")]
 mod metrics;

--- a/applications/tari_validator_node/src/p2p/services/consensus_gossip/initializer.rs
+++ b/applications/tari_validator_node/src/p2p/services/consensus_gossip/initializer.rs
@@ -40,7 +40,7 @@ pub fn spawn(
     epoch_manager_events: broadcast::Receiver<EpochManagerEvent>,
     consensus_events: broadcast::Receiver<HotstuffEvent>,
     networking: NetworkingHandle<TariMessagingSpec>,
-    rx_gossip: mpsc::UnboundedReceiver<GossipMessage>,
+    rx_gossip: mpsc::Receiver<GossipMessage>,
 ) -> (
     ConsensusGossipHandle,
     JoinHandle<anyhow::Result<()>>,

--- a/applications/tari_validator_node/src/p2p/services/consensus_gossip/service.rs
+++ b/applications/tari_validator_node/src/p2p/services/consensus_gossip/service.rs
@@ -45,7 +45,7 @@ pub(super) struct ConsensusGossipService {
     is_subscribed: bool,
     networking: NetworkingHandle<TariMessagingSpec>,
     codec: ProstCodec<proto::consensus::HotStuffMessage>,
-    rx_gossip: mpsc::UnboundedReceiver<GossipMessage>,
+    rx_gossip: mpsc::Receiver<GossipMessage>,
     tx_consensus_gossip: mpsc::Sender<(PeerId, proto::consensus::HotStuffMessage)>,
 }
 
@@ -54,7 +54,7 @@ impl ConsensusGossipService {
         epoch_manager_events: broadcast::Receiver<EpochManagerEvent>,
         consensus_events: broadcast::Receiver<HotstuffEvent>,
         networking: NetworkingHandle<TariMessagingSpec>,
-        rx_gossip: mpsc::UnboundedReceiver<GossipMessage>,
+        rx_gossip: mpsc::Receiver<GossipMessage>,
         tx_consensus_gossip: mpsc::Sender<(PeerId, proto::consensus::HotStuffMessage)>,
     ) -> Self {
         Self {

--- a/applications/tari_validator_node/src/p2p/services/mempool/gossip.rs
+++ b/applications/tari_validator_node/src/p2p/services/mempool/gossip.rs
@@ -48,15 +48,12 @@ impl MempoolGossipCodec {
 pub(super) struct MempoolGossip {
     is_subscribed: bool,
     networking: NetworkingHandle<TariMessagingSpec>,
-    rx_gossip: mpsc::UnboundedReceiver<GossipMessage>,
+    rx_gossip: mpsc::Receiver<GossipMessage>,
     codec: MempoolGossipCodec,
 }
 
 impl MempoolGossip {
-    pub fn new(
-        networking: NetworkingHandle<TariMessagingSpec>,
-        rx_gossip: mpsc::UnboundedReceiver<GossipMessage>,
-    ) -> Self {
+    pub fn new(networking: NetworkingHandle<TariMessagingSpec>, rx_gossip: mpsc::Receiver<GossipMessage>) -> Self {
         Self {
             is_subscribed: false,
             networking,

--- a/applications/tari_validator_node/src/p2p/services/mempool/initializer.rs
+++ b/applications/tari_validator_node/src/p2p/services/mempool/initializer.rs
@@ -44,7 +44,7 @@ pub fn spawn<TValidator, TStateStore>(
     state_store: TStateStore,
     consensus_handle: ConsensusHandle,
     networking: NetworkingHandle<TariMessagingSpec>,
-    rx_gossip: mpsc::UnboundedReceiver<GossipMessage>,
+    rx_gossip: mpsc::Receiver<GossipMessage>,
     #[cfg(feature = "metrics")] metrics_registry: &mut prometheus_client::registry::Registry,
 ) -> (MempoolHandle, JoinHandle<anyhow::Result<()>>)
 where

--- a/applications/tari_validator_node/src/p2p/services/mempool/service.rs
+++ b/applications/tari_validator_node/src/p2p/services/mempool/service.rs
@@ -20,10 +20,7 @@
 //   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //   USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::{
-    collections::{HashSet, VecDeque},
-    fmt::Display,
-};
+use std::{collections::HashSet, fmt::Display, mem};
 
 use libp2p::gossipsub::MessageAcceptance;
 use log::*;
@@ -50,7 +47,9 @@ use crate::{
 
 const LOG_TARGET: &str = "tari::validator_node::mempool::service";
 
-/// Ids retained by the seen-transaction cache. Each is 32 bytes, so this bounds it at ~32 MiB.
+/// Transaction ids the mempool remembers having seen. See [`SeenTransactions`] for the footprint
+/// this implies; it is a cache with a database fallback, so this trades memory against how often a
+/// re-gossiped transaction costs a lookup, not against correctness.
 const MEM_MAX_TRANSACTIONS_DEDUP: usize = 1_000_000;
 
 #[derive(Debug)]
@@ -370,51 +369,59 @@ where
 /// Bounded cache of transaction ids the mempool has already seen.
 ///
 /// Purely a fast path: [`MempoolService::transaction_exists`] falls through to the state store on a
-/// miss, so evicting an id costs one extra database read should that transaction arrive again, and
-/// nothing more. That is what makes a hard bound safe here — without one the cache grows with the
-/// unfinalized backlog, which nothing else bounds.
+/// miss, so forgetting an id costs one extra database read should that transaction arrive again,
+/// and nothing more. That is what makes a hard bound safe here — without one the cache grows with
+/// the unfinalized backlog, which nothing else bounds. It is also what makes coarse eviction
+/// acceptable, which is what keeps the footprint down.
 ///
-/// Eviction is oldest-first. Ids removed by [`Self::remove`] are dropped from the set immediately
-/// but left in the eviction order to be skipped when they surface, which keeps removal O(1); the
-/// order therefore bounds the set rather than matching it exactly.
+/// Ids are held in two generations rather than a set alongside an eviction queue: a queue would
+/// store every id a second time, and exact eviction order is worth less than that memory when a
+/// miss is merely a database read. Inserts land in the current generation; when it fills, it
+/// becomes the previous generation and the older one is dropped wholesale. Lookups check both, so
+/// an id is remembered for between `capacity / 2` and `capacity` subsequent inserts.
+///
+/// Footprint is roughly `capacity` × 33 bytes across the two tables, rounded up to whatever
+/// power-of-two bucket count each needs — so tens of MiB at the capacity used here, against
+/// roughly double that for a set plus a queue.
 #[derive(Debug)]
 struct SeenTransactions {
-    ids: HashSet<TransactionId>,
-    eviction_order: VecDeque<TransactionId>,
-    capacity: usize,
+    current: HashSet<TransactionId>,
+    previous: HashSet<TransactionId>,
+    generation_capacity: usize,
 }
 
 impl SeenTransactions {
     fn new(capacity: usize) -> Self {
         Self {
-            ids: HashSet::new(),
-            eviction_order: VecDeque::new(),
-            capacity,
+            current: HashSet::new(),
+            previous: HashSet::new(),
+            generation_capacity: capacity.div_ceil(2).max(1),
         }
     }
 
     fn contains(&self, id: &TransactionId) -> bool {
-        self.ids.contains(id)
+        self.current.contains(id) || self.previous.contains(id)
     }
 
     fn insert(&mut self, id: TransactionId) {
-        if !self.ids.insert(id) {
+        if self.contains(&id) {
             return;
         }
-        self.eviction_order.push_back(id);
-        while self.eviction_order.len() > self.capacity {
-            if let Some(evicted) = self.eviction_order.pop_front() {
-                self.ids.remove(&evicted);
-            }
+        if self.current.len() >= self.generation_capacity {
+            self.previous = mem::take(&mut self.current);
         }
+        self.current.insert(id);
     }
 
     fn remove(&mut self, id: &TransactionId) -> bool {
-        self.ids.remove(id)
+        // Which generation holds the id is not tracked, so both are cleared.
+        let was_current = self.current.remove(id);
+        let was_previous = self.previous.remove(id);
+        was_current || was_previous
     }
 
     fn len(&self) -> usize {
-        self.ids.len()
+        self.current.len() + self.previous.len()
     }
 }
 
@@ -455,26 +462,30 @@ mod tests {
             seen.insert(id(1));
         }
         assert_eq!(seen.len(), 1);
-        assert_eq!(
-            seen.eviction_order.len(),
-            1,
-            "duplicates must not stack up for eviction"
-        );
+        assert!(seen.previous.is_empty(), "duplicates must not drive a rotation");
     }
 
     #[test]
-    fn removed_ids_are_forgotten_without_unbounding_the_eviction_order() {
+    fn removed_ids_are_forgotten_from_either_generation() {
         let mut seen = SeenTransactions::new(2);
         seen.insert(id(1));
+        seen.insert(id(2));
+        // One id per generation at this capacity, so these are now in different generations.
         assert!(seen.remove(&id(1)));
+        assert!(seen.remove(&id(2)));
         assert!(!seen.contains(&id(1)));
+        assert!(!seen.contains(&id(2)));
+        assert_eq!(seen.len(), 0);
+        assert!(!seen.remove(&id(1)), "removing an unknown id reports nothing found");
+    }
 
-        // The removed id lingers in the eviction order and is skipped when it surfaces, so the
-        // order stays bounded by capacity rather than by how much has passed through.
-        for n in 2..=10 {
+    #[test]
+    fn total_retained_never_exceeds_capacity() {
+        let mut seen = SeenTransactions::new(8);
+        for n in 0..=255u8 {
             seen.insert(id(n));
+            assert!(seen.len() <= 8, "cache grew past its bound at id {n}");
         }
-        assert!(seen.eviction_order.len() <= 2);
-        assert_eq!(seen.len(), 2);
+        assert!(seen.contains(&id(255)), "the most recent id is always retained");
     }
 }

--- a/applications/tari_validator_node/src/p2p/services/mempool/service.rs
+++ b/applications/tari_validator_node/src/p2p/services/mempool/service.rs
@@ -20,7 +20,10 @@
 //   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //   USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::{collections::HashSet, fmt::Display};
+use std::{
+    collections::{HashSet, VecDeque},
+    fmt::Display,
+};
 
 use libp2p::gossipsub::MessageAcceptance;
 use log::*;
@@ -47,11 +50,12 @@ use crate::{
 
 const LOG_TARGET: &str = "tari::validator_node::mempool::service";
 
-const MEM_MAX_TRANSACTIONS_DEDUP_ALLOC: usize = 1_000_000; // 32Mb
+/// Ids retained by the seen-transaction cache. Each is 32 bytes, so this bounds it at ~32 MiB.
+const MEM_MAX_TRANSACTIONS_DEDUP: usize = 1_000_000;
 
 #[derive(Debug)]
 pub struct MempoolService<TValidator, TStateStore> {
-    transactions: HashSet<TransactionId>,
+    transactions: SeenTransactions,
     mempool_requests: mpsc::Receiver<MempoolRequest>,
     epoch_manager: EpochManagerHandle<PeerAddress>,
     before_execute_validator: TValidator,
@@ -74,12 +78,12 @@ where
         state_store: TStateStore,
         consensus_handle: ConsensusHandle,
         networking: NetworkingHandle<TariMessagingSpec>,
-        rx_gossip: mpsc::UnboundedReceiver<GossipMessage>,
+        rx_gossip: mpsc::Receiver<GossipMessage>,
         #[cfg(feature = "metrics")] metrics: PrometheusMempoolMetrics,
     ) -> Self {
         Self {
             gossip: MempoolGossip::new(networking, rx_gossip),
-            transactions: Default::default(),
+            transactions: SeenTransactions::new(MEM_MAX_TRANSACTIONS_DEDUP),
             mempool_requests,
             epoch_manager,
             before_execute_validator,
@@ -172,9 +176,6 @@ where
             if self.transactions.remove(id) {
                 num_found += 1;
             }
-        }
-        if self.transactions.capacity() > MEM_MAX_TRANSACTIONS_DEDUP_ALLOC {
-            self.transactions.shrink_to(MEM_MAX_TRANSACTIONS_DEDUP_ALLOC);
         }
         num_found
     }
@@ -366,11 +367,114 @@ where
     }
 }
 
+/// Bounded cache of transaction ids the mempool has already seen.
+///
+/// Purely a fast path: [`MempoolService::transaction_exists`] falls through to the state store on a
+/// miss, so evicting an id costs one extra database read should that transaction arrive again, and
+/// nothing more. That is what makes a hard bound safe here — without one the cache grows with the
+/// unfinalized backlog, which nothing else bounds.
+///
+/// Eviction is oldest-first. Ids removed by [`Self::remove`] are dropped from the set immediately
+/// but left in the eviction order to be skipped when they surface, which keeps removal O(1); the
+/// order therefore bounds the set rather than matching it exactly.
+#[derive(Debug)]
+struct SeenTransactions {
+    ids: HashSet<TransactionId>,
+    eviction_order: VecDeque<TransactionId>,
+    capacity: usize,
+}
+
+impl SeenTransactions {
+    fn new(capacity: usize) -> Self {
+        Self {
+            ids: HashSet::new(),
+            eviction_order: VecDeque::new(),
+            capacity,
+        }
+    }
+
+    fn contains(&self, id: &TransactionId) -> bool {
+        self.ids.contains(id)
+    }
+
+    fn insert(&mut self, id: TransactionId) {
+        if !self.ids.insert(id) {
+            return;
+        }
+        self.eviction_order.push_back(id);
+        while self.eviction_order.len() > self.capacity {
+            if let Some(evicted) = self.eviction_order.pop_front() {
+                self.ids.remove(&evicted);
+            }
+        }
+    }
+
+    fn remove(&mut self, id: &TransactionId) -> bool {
+        self.ids.remove(id)
+    }
+
+    fn len(&self) -> usize {
+        self.ids.len()
+    }
+}
+
 fn handle<T, E: Display>(reply: oneshot::Sender<Result<T, E>>, result: Result<T, E>) {
     if let Err(ref e) = result {
         error!(target: LOG_TARGET, "Request failed with error: {}", e);
     }
     if reply.send(result).is_err() {
         error!(target: LOG_TARGET, "Requester abandoned request");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn id(n: u8) -> TransactionId {
+        TransactionId::new([n; 32])
+    }
+
+    #[test]
+    fn evicts_oldest_ids_beyond_capacity() {
+        let mut seen = SeenTransactions::new(2);
+        seen.insert(id(1));
+        seen.insert(id(2));
+        seen.insert(id(3));
+
+        assert!(!seen.contains(&id(1)), "the oldest id is evicted");
+        assert!(seen.contains(&id(2)));
+        assert!(seen.contains(&id(3)));
+        assert_eq!(seen.len(), 2);
+    }
+
+    #[test]
+    fn reinserting_a_known_id_does_not_consume_capacity() {
+        let mut seen = SeenTransactions::new(4);
+        for _ in 0..10 {
+            seen.insert(id(1));
+        }
+        assert_eq!(seen.len(), 1);
+        assert_eq!(
+            seen.eviction_order.len(),
+            1,
+            "duplicates must not stack up for eviction"
+        );
+    }
+
+    #[test]
+    fn removed_ids_are_forgotten_without_unbounding_the_eviction_order() {
+        let mut seen = SeenTransactions::new(2);
+        seen.insert(id(1));
+        assert!(seen.remove(&id(1)));
+        assert!(!seen.contains(&id(1)));
+
+        // The removed id lingers in the eviction order and is skipped when it surfaces, so the
+        // order stays bounded by capacity rather than by how much has passed through.
+        for n in 2..=10 {
+            seen.insert(id(n));
+        }
+        assert!(seen.eviction_order.len() <= 2);
+        assert_eq!(seen.len(), 2);
     }
 }

--- a/applications/tari_validator_node/src/p2p/services/messaging/inbound.rs
+++ b/applications/tari_validator_node/src/p2p/services/messaging/inbound.rs
@@ -3,6 +3,7 @@
 
 use libp2p::PeerId;
 use tari_consensus::{messages::HotstuffMessage, traits::InboundMessagingError};
+use tari_networking::InboundMessage;
 use tari_ootle_p2p::{PeerAddress, proto};
 use tokio::sync::mpsc;
 
@@ -10,7 +11,7 @@ use crate::p2p::logging::MessageLogger;
 
 pub struct ConsensusInboundMessaging<TMsgLogger> {
     local_address: PeerAddress,
-    rx_inbound_msg: mpsc::UnboundedReceiver<(PeerId, proto::consensus::HotStuffMessage)>,
+    rx_inbound_msg: mpsc::Receiver<InboundMessage<proto::consensus::HotStuffMessage>>,
     rx_gossip: mpsc::Receiver<(PeerId, proto::consensus::HotStuffMessage)>,
     rx_loopback: mpsc::UnboundedReceiver<HotstuffMessage>,
     msg_logger: TMsgLogger,
@@ -19,7 +20,7 @@ pub struct ConsensusInboundMessaging<TMsgLogger> {
 impl<TMsgLogger: MessageLogger> ConsensusInboundMessaging<TMsgLogger> {
     pub fn new(
         local_address: PeerAddress,
-        rx_inbound_msg: mpsc::UnboundedReceiver<(PeerId, proto::consensus::HotStuffMessage)>,
+        rx_inbound_msg: mpsc::Receiver<InboundMessage<proto::consensus::HotStuffMessage>>,
         rx_gossip: mpsc::Receiver<(PeerId, proto::consensus::HotStuffMessage)>,
         rx_loopback: mpsc::UnboundedReceiver<HotstuffMessage>,
         msg_logger: TMsgLogger,
@@ -70,8 +71,8 @@ impl<TMsgLogger: MessageLogger + Send> tari_consensus::traits::InboundMessaging
                 Ok((self.local_address, msg))
             }),
             maybe_msg = self.rx_inbound_msg.recv() => {
-                let (from, msg) = maybe_msg?;
-                self.handle_message(from, msg)
+                let inbound = maybe_msg?;
+                self.handle_message(inbound.peer_id, inbound.message)
             },
             maybe_msg = self.rx_gossip.recv() => {
                 let (from, msg) = maybe_msg?;

--- a/networking/core/src/message_mode.rs
+++ b/networking/core/src/message_mode.rs
@@ -34,6 +34,22 @@ pub enum GossipSendError {
     },
 }
 
+#[derive(Debug, thiserror::Error)]
+pub enum MessageSendError {
+    #[error("Inbound message channel closed")]
+    InboundMessageChannelClosed,
+    #[error(
+        "Inbound message queue is full ({queued_messages} messages, {queued_bytes} bytes queued); dropped a {len} \
+         byte message from {peer_id}"
+    )]
+    QueueFull {
+        peer_id: PeerId,
+        queued_messages: usize,
+        queued_bytes: usize,
+        len: usize,
+    },
+}
+
 /// An inbound gossipsub message, carrying the identifiers needed to report its validation verdict.
 ///
 /// gossipsub runs in `validate_messages` mode, so a message is held and propagated to nobody until a
@@ -97,8 +113,7 @@ impl GossipMessage {
 #[derive(Debug, Clone)]
 pub struct GossipQueueSender {
     tx: mpsc::Sender<GossipMessage>,
-    queued_bytes: Arc<AtomicUsize>,
-    max_queued_bytes: usize,
+    budget: ByteBudget,
 }
 
 /// Creates a bounded inbound gossip queue for a single topic.
@@ -110,8 +125,7 @@ pub fn gossip_queue(
     (
         GossipQueueSender {
             tx,
-            queued_bytes: Arc::new(AtomicUsize::new(0)),
-            max_queued_bytes,
+            budget: ByteBudget::new(max_queued_bytes),
         },
         rx,
     )
@@ -120,7 +134,7 @@ pub fn gossip_queue(
 impl GossipQueueSender {
     /// Bytes currently held by queued messages.
     pub fn queued_bytes(&self) -> usize {
-        self.queued_bytes.load(Ordering::Relaxed)
+        self.budget.queued()
     }
 
     /// Messages currently queued.
@@ -137,7 +151,7 @@ impl GossipQueueSender {
             len,
         };
 
-        let Some(permit) = self.reserve(len) else {
+        let Some(permit) = self.budget.reserve(len) else {
             return Err(full(&msg));
         };
 
@@ -148,18 +162,111 @@ impl GossipQueueSender {
             Err(mpsc::error::TrySendError::Closed(_)) => Err(GossipSendError::InboundGossipChannelClosed),
         }
     }
+}
 
-    /// Reserves `len` bytes of this queue's budget, or `None` when that would exceed it. The
-    /// reservation is released when the returned permit drops, i.e. once the consumer is done with
-    /// the message it travels with.
+/// An inbound direct message, carrying its reservation against the inbound queue's byte budget.
+#[derive(Debug)]
+pub struct InboundMessage<TMsg> {
+    pub peer_id: PeerId,
+    pub message: TMsg,
+    /// Released when this message is dropped by the consumer. `None` until it is admitted.
+    _queue_permit: Option<QueuePermit>,
+}
+
+/// Sender half of the bounded inbound queue for direct (non-gossip) messages.
+///
+/// Bounded on the same basis as [`GossipQueueSender`], and for the same reason: the queue drains
+/// serially into consensus while messages vary from small votes to block-sized proposals, so a
+/// count alone cannot bound memory without also throttling ordinary traffic. Admission does not
+/// block the networking worker; a message that does not fit is dropped.
+#[derive(Debug)]
+pub struct MessageQueueSender<TMsg> {
+    tx: mpsc::Sender<InboundMessage<TMsg>>,
+    budget: ByteBudget,
+}
+
+/// Creates a bounded inbound queue for direct messages.
+pub fn message_queue<TMsg>(
+    max_queued_messages: usize,
+    max_queued_bytes: usize,
+) -> (MessageQueueSender<TMsg>, mpsc::Receiver<InboundMessage<TMsg>>) {
+    let (tx, rx) = mpsc::channel(max_queued_messages);
+    (
+        MessageQueueSender {
+            tx,
+            budget: ByteBudget::new(max_queued_bytes),
+        },
+        rx,
+    )
+}
+
+impl<TMsg> MessageQueueSender<TMsg> {
+    /// Bytes currently held by queued messages.
+    pub fn queued_bytes(&self) -> usize {
+        self.budget.queued()
+    }
+
+    /// Messages currently queued.
+    pub fn queued_messages(&self) -> usize {
+        self.tx.max_capacity() - self.tx.capacity()
+    }
+
+    /// `len` is the message's encoded size on the wire; the decoded form is not measurable here, so
+    /// the wire size stands in for it.
+    fn try_send(&self, peer_id: PeerId, message: TMsg, len: usize) -> Result<(), MessageSendError> {
+        let full = || MessageSendError::QueueFull {
+            peer_id,
+            queued_messages: self.queued_messages(),
+            queued_bytes: self.queued_bytes(),
+            len,
+        };
+
+        let Some(permit) = self.budget.reserve(len) else {
+            return Err(full());
+        };
+
+        match self.tx.try_send(InboundMessage {
+            peer_id,
+            message,
+            _queue_permit: Some(permit),
+        }) {
+            Ok(()) => Ok(()),
+            // The rejected message carries its permit, so the reservation is released as it drops.
+            Err(mpsc::error::TrySendError::Full(_)) => Err(full()),
+            Err(mpsc::error::TrySendError::Closed(_)) => Err(MessageSendError::InboundMessageChannelClosed),
+        }
+    }
+}
+
+/// Tracks the bytes held by one bounded inbound queue, handing out reservations that are released
+/// when the message they travel with is dropped.
+#[derive(Debug, Clone)]
+struct ByteBudget {
+    queued: Arc<AtomicUsize>,
+    max: usize,
+}
+
+impl ByteBudget {
+    fn new(max: usize) -> Self {
+        Self {
+            queued: Arc::new(AtomicUsize::new(0)),
+            max,
+        }
+    }
+
+    fn queued(&self) -> usize {
+        self.queued.load(Ordering::Relaxed)
+    }
+
+    /// Reserves `len` bytes, or `None` when that would exceed the budget.
     fn reserve(&self, len: usize) -> Option<QueuePermit> {
-        let previous = self.queued_bytes.fetch_add(len, Ordering::AcqRel);
-        if previous.saturating_add(len) > self.max_queued_bytes {
-            self.queued_bytes.fetch_sub(len, Ordering::AcqRel);
+        let previous = self.queued.fetch_add(len, Ordering::AcqRel);
+        if previous.saturating_add(len) > self.max {
+            self.queued.fetch_sub(len, Ordering::AcqRel);
             return None;
         }
         Some(QueuePermit {
-            queued_bytes: self.queued_bytes.clone(),
+            queued_bytes: self.queued.clone(),
             len,
         })
     }
@@ -180,7 +287,7 @@ impl Drop for QueuePermit {
 
 pub enum MessagingMode<TMsg: MessageSpec> {
     Enabled {
-        tx_messages: mpsc::UnboundedSender<(PeerId, TMsg::Message)>,
+        tx_messages: MessageQueueSender<TMsg::Message>,
         tx_gossip_messages_by_topic: HashMap<String, GossipQueueSender>,
     },
     Disabled,
@@ -193,13 +300,11 @@ impl<TMsg: MessageSpec> MessagingMode<TMsg> {
 }
 
 impl<TMsg: MessageSpec> MessagingMode<TMsg> {
-    pub fn send_message(
-        &self,
-        peer_id: PeerId,
-        msg: TMsg::Message,
-    ) -> Result<(), mpsc::error::SendError<(PeerId, TMsg::Message)>> {
+    /// `len` is the message's encoded size on the wire, used to charge the inbound queue's byte
+    /// budget.
+    pub fn send_message(&self, peer_id: PeerId, msg: TMsg::Message, len: usize) -> Result<(), MessageSendError> {
         if let MessagingMode::Enabled { tx_messages, .. } = self {
-            tx_messages.send((peer_id, msg))?;
+            tx_messages.try_send(peer_id, msg, len)?;
         }
         Ok(())
     }
@@ -270,6 +375,25 @@ mod tests {
         drop(rx.try_recv().unwrap());
         assert_eq!(tx.queued_bytes(), 0);
         tx.try_send(message(100)).unwrap();
+    }
+
+    #[test]
+    fn direct_messages_are_bounded_by_wire_size() {
+        // The decoded message is not measurable here, so admission charges the wire size reported
+        // by the messaging layer rather than anything derived from the payload.
+        let (tx, mut rx) = message_queue::<&str>(16, 100);
+        let peer = PeerId::random();
+
+        tx.try_send(peer, "small payload, large wire size", 60).unwrap();
+        assert_eq!(tx.queued_bytes(), 60);
+
+        let err = tx.try_send(peer, "rejected", 60).unwrap_err();
+        assert!(matches!(err, MessageSendError::QueueFull { .. }));
+        assert_eq!(tx.queued_bytes(), 60, "a rejected message must not hold budget");
+
+        drop(rx.try_recv().unwrap());
+        assert_eq!(tx.queued_bytes(), 0);
+        tx.try_send(peer, "fits again", 100).unwrap();
     }
 
     #[test]

--- a/networking/core/src/message_mode.rs
+++ b/networking/core/src/message_mode.rs
@@ -5,7 +5,7 @@ use std::{
     collections::HashMap,
     sync::{
         Arc,
-        atomic::{AtomicUsize, Ordering},
+        atomic::{AtomicU64, AtomicUsize, Ordering},
     },
 };
 
@@ -113,7 +113,7 @@ impl GossipMessage {
 #[derive(Debug, Clone)]
 pub struct GossipQueueSender {
     tx: mpsc::Sender<GossipMessage>,
-    budget: ByteBudget,
+    budget: QueueAccounting,
 }
 
 /// Creates a bounded inbound gossip queue for a single topic.
@@ -125,7 +125,7 @@ pub fn gossip_queue(
     (
         GossipQueueSender {
             tx,
-            budget: ByteBudget::new(max_queued_bytes),
+            budget: QueueAccounting::new(max_queued_bytes),
         },
         rx,
     )
@@ -137,18 +137,36 @@ impl GossipQueueSender {
         self.budget.queued()
     }
 
+    /// The byte budget this queue admits up to.
+    pub fn max_queued_bytes(&self) -> usize {
+        self.budget.max
+    }
+
     /// Messages currently queued.
     pub fn queued_messages(&self) -> usize {
         self.tx.max_capacity() - self.tx.capacity()
     }
 
+    /// Messages turned away because the queue was full, since start-up.
+    pub fn dropped_messages(&self) -> u64 {
+        self.budget.dropped_messages()
+    }
+
+    /// Bytes turned away because the queue was full, since start-up.
+    pub fn dropped_bytes(&self) -> u64 {
+        self.budget.dropped_bytes()
+    }
+
     fn try_send(&self, msg: GossipMessage) -> Result<(), GossipSendError> {
         let len = msg.message.data.len();
-        let full = |msg: &GossipMessage| GossipSendError::QueueFull {
-            topic: msg.message.topic.to_string(),
-            queued_messages: self.queued_messages(),
-            queued_bytes: self.queued_bytes(),
-            len,
+        let full = |msg: &GossipMessage| {
+            self.budget.record_drop(len);
+            GossipSendError::QueueFull {
+                topic: msg.message.topic.to_string(),
+                queued_messages: self.queued_messages(),
+                queued_bytes: self.queued_bytes(),
+                len,
+            }
         };
 
         let Some(permit) = self.budget.reserve(len) else {
@@ -182,7 +200,7 @@ pub struct InboundMessage<TMsg> {
 #[derive(Debug)]
 pub struct MessageQueueSender<TMsg> {
     tx: mpsc::Sender<InboundMessage<TMsg>>,
-    budget: ByteBudget,
+    budget: QueueAccounting,
 }
 
 /// Creates a bounded inbound queue for direct messages.
@@ -194,10 +212,21 @@ pub fn message_queue<TMsg>(
     (
         MessageQueueSender {
             tx,
-            budget: ByteBudget::new(max_queued_bytes),
+            budget: QueueAccounting::new(max_queued_bytes),
         },
         rx,
     )
+}
+
+/// Cloning yields another handle to the same queue, independent of whether `TMsg` is itself
+/// cloneable — so `#[derive(Clone)]`, which would demand `TMsg: Clone`, is not usable here.
+impl<TMsg> Clone for MessageQueueSender<TMsg> {
+    fn clone(&self) -> Self {
+        Self {
+            tx: self.tx.clone(),
+            budget: self.budget.clone(),
+        }
+    }
 }
 
 impl<TMsg> MessageQueueSender<TMsg> {
@@ -206,19 +235,37 @@ impl<TMsg> MessageQueueSender<TMsg> {
         self.budget.queued()
     }
 
+    /// The byte budget this queue admits up to.
+    pub fn max_queued_bytes(&self) -> usize {
+        self.budget.max
+    }
+
     /// Messages currently queued.
     pub fn queued_messages(&self) -> usize {
         self.tx.max_capacity() - self.tx.capacity()
     }
 
+    /// Messages turned away because the queue was full, since start-up.
+    pub fn dropped_messages(&self) -> u64 {
+        self.budget.dropped_messages()
+    }
+
+    /// Bytes turned away because the queue was full, since start-up.
+    pub fn dropped_bytes(&self) -> u64 {
+        self.budget.dropped_bytes()
+    }
+
     /// `len` is the message's encoded size on the wire; the decoded form is not measurable here, so
     /// the wire size stands in for it.
     fn try_send(&self, peer_id: PeerId, message: TMsg, len: usize) -> Result<(), MessageSendError> {
-        let full = || MessageSendError::QueueFull {
-            peer_id,
-            queued_messages: self.queued_messages(),
-            queued_bytes: self.queued_bytes(),
-            len,
+        let full = || {
+            self.budget.record_drop(len);
+            MessageSendError::QueueFull {
+                peer_id,
+                queued_messages: self.queued_messages(),
+                queued_bytes: self.queued_bytes(),
+                len,
+            }
         };
 
         let Some(permit) = self.budget.reserve(len) else {
@@ -238,24 +285,45 @@ impl<TMsg> MessageQueueSender<TMsg> {
     }
 }
 
-/// Tracks the bytes held by one bounded inbound queue, handing out reservations that are released
-/// when the message they travel with is dropped.
+/// Accounting for one bounded inbound queue: the bytes it currently holds, and what it has turned
+/// away. Reservations are released when the message they travel with is dropped.
+///
+/// Drop counters are maintained unconditionally rather than behind a metrics feature — they are two
+/// relaxed atomic adds on a path that has already decided to discard a message, and a queue whose
+/// drops are invisible cannot be sized against real traffic.
 #[derive(Debug, Clone)]
-struct ByteBudget {
+struct QueueAccounting {
     queued: Arc<AtomicUsize>,
     max: usize,
+    dropped_messages: Arc<AtomicU64>,
+    dropped_bytes: Arc<AtomicU64>,
 }
 
-impl ByteBudget {
+impl QueueAccounting {
     fn new(max: usize) -> Self {
         Self {
             queued: Arc::new(AtomicUsize::new(0)),
             max,
+            dropped_messages: Arc::new(AtomicU64::new(0)),
+            dropped_bytes: Arc::new(AtomicU64::new(0)),
         }
     }
 
     fn queued(&self) -> usize {
         self.queued.load(Ordering::Relaxed)
+    }
+
+    fn dropped_messages(&self) -> u64 {
+        self.dropped_messages.load(Ordering::Relaxed)
+    }
+
+    fn dropped_bytes(&self) -> u64 {
+        self.dropped_bytes.load(Ordering::Relaxed)
+    }
+
+    fn record_drop(&self, len: usize) {
+        self.dropped_messages.fetch_add(1, Ordering::Relaxed);
+        self.dropped_bytes.fetch_add(len as u64, Ordering::Relaxed);
     }
 
     /// Reserves `len` bytes, or `None` when that would exceed the budget.
@@ -375,6 +443,32 @@ mod tests {
         drop(rx.try_recv().unwrap());
         assert_eq!(tx.queued_bytes(), 0);
         tx.try_send(message(100)).unwrap();
+    }
+
+    #[test]
+    fn drops_are_counted_on_both_bounds() {
+        // Sizing the budgets against real traffic depends on these counters, so a rejection by
+        // either bound must be visible.
+        let (tx, _rx) = gossip_queue(1, 100);
+        assert_eq!(tx.dropped_messages(), 0);
+
+        tx.try_send(message(10)).unwrap();
+
+        // Rejected by the byte budget.
+        tx.try_send(message(200)).unwrap_err();
+        assert_eq!(tx.dropped_messages(), 1);
+        assert_eq!(tx.dropped_bytes(), 200);
+
+        // Rejected by the message count, which is already at its limit of one.
+        tx.try_send(message(1)).unwrap_err();
+        assert_eq!(tx.dropped_messages(), 2);
+        assert_eq!(tx.dropped_bytes(), 201);
+
+        assert_eq!(
+            tx.queued_bytes(),
+            10,
+            "rejections must not disturb the admitted message"
+        );
     }
 
     #[test]

--- a/networking/core/src/message_mode.rs
+++ b/networking/core/src/message_mode.rs
@@ -1,7 +1,13 @@
 //   Copyright 2023 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use std::collections::HashMap;
+use std::{
+    collections::HashMap,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+};
 
 use libp2p::{PeerId, gossipsub};
 use tokio::sync::mpsc;
@@ -16,12 +22,16 @@ pub enum GossipSendError {
     InvalidToken(String),
     #[error("Inbound gossip channel closed")]
     InboundGossipChannelClosed,
-}
-
-impl From<mpsc::error::SendError<GossipMessage>> for GossipSendError {
-    fn from(_: mpsc::error::SendError<GossipMessage>) -> Self {
-        Self::InboundGossipChannelClosed
-    }
+    #[error(
+        "Inbound gossip queue for topic {topic} is full ({queued_messages} messages, {queued_bytes} bytes queued); \
+         dropped a {len} byte message"
+    )]
+    QueueFull {
+        topic: String,
+        queued_messages: usize,
+        queued_bytes: usize,
+        len: usize,
+    },
 }
 
 /// An inbound gossipsub message, carrying the identifiers needed to report its validation verdict.
@@ -38,19 +48,140 @@ pub struct GossipMessage {
     pub propagation_source: PeerId,
     pub message_id: gossipsub::MessageId,
     pub message: gossipsub::Message,
+    /// Holds this message's reservation against its topic queue's byte budget for as long as it is
+    /// queued, releasing it when the message is dropped by the consumer. `None` until the message
+    /// is admitted to a queue.
+    _queue_permit: Option<QueuePermit>,
 }
 
 impl GossipMessage {
+    pub fn new(
+        source: PeerId,
+        propagation_source: PeerId,
+        message_id: gossipsub::MessageId,
+        message: gossipsub::Message,
+    ) -> Self {
+        Self {
+            source,
+            propagation_source,
+            message_id,
+            message,
+            _queue_permit: None,
+        }
+    }
+
     /// The pair identifying this message to [`crate::NetworkingService::report_gossip_validation`].
     pub fn validation_key(&self) -> (gossipsub::MessageId, PeerId) {
         (self.message_id.clone(), self.propagation_source)
+    }
+
+    fn with_queue_permit(mut self, permit: QueuePermit) -> Self {
+        self._queue_permit = Some(permit);
+        self
+    }
+}
+
+/// Sender half of a bounded inbound gossip queue for one topic.
+///
+/// Bounds the queue by total size as well as message count. A count alone cannot do the job: every
+/// topic admits messages up to the swarm's `gossip_sub_max_message_size`, so a count low enough to
+/// bound worst-case memory is far too low for ordinary traffic, while a count high enough for
+/// ordinary traffic admits that many maximum-size messages. Sizing by bytes is simultaneously
+/// generous for real traffic (small messages, so many of them fit) and tight against a flood of
+/// maximum-size ones.
+///
+/// Admission never blocks the networking worker: one worker task serves every topic, so waiting for
+/// capacity on one topic would stall the others, consensus included. A message that does not fit is
+/// rejected, and the worker reports `Ignore` for it — a full queue is this node's condition, not
+/// misbehaviour by the peer that sent it, so it must not count against that peer's score.
+#[derive(Debug, Clone)]
+pub struct GossipQueueSender {
+    tx: mpsc::Sender<GossipMessage>,
+    queued_bytes: Arc<AtomicUsize>,
+    max_queued_bytes: usize,
+}
+
+/// Creates a bounded inbound gossip queue for a single topic.
+pub fn gossip_queue(
+    max_queued_messages: usize,
+    max_queued_bytes: usize,
+) -> (GossipQueueSender, mpsc::Receiver<GossipMessage>) {
+    let (tx, rx) = mpsc::channel(max_queued_messages);
+    (
+        GossipQueueSender {
+            tx,
+            queued_bytes: Arc::new(AtomicUsize::new(0)),
+            max_queued_bytes,
+        },
+        rx,
+    )
+}
+
+impl GossipQueueSender {
+    /// Bytes currently held by queued messages.
+    pub fn queued_bytes(&self) -> usize {
+        self.queued_bytes.load(Ordering::Relaxed)
+    }
+
+    /// Messages currently queued.
+    pub fn queued_messages(&self) -> usize {
+        self.tx.max_capacity() - self.tx.capacity()
+    }
+
+    fn try_send(&self, msg: GossipMessage) -> Result<(), GossipSendError> {
+        let len = msg.message.data.len();
+        let full = |msg: &GossipMessage| GossipSendError::QueueFull {
+            topic: msg.message.topic.to_string(),
+            queued_messages: self.queued_messages(),
+            queued_bytes: self.queued_bytes(),
+            len,
+        };
+
+        let Some(permit) = self.reserve(len) else {
+            return Err(full(&msg));
+        };
+
+        match self.tx.try_send(msg.with_queue_permit(permit)) {
+            Ok(()) => Ok(()),
+            // The rejected message carries its permit, so the reservation is released as it drops.
+            Err(mpsc::error::TrySendError::Full(msg)) => Err(full(&msg)),
+            Err(mpsc::error::TrySendError::Closed(_)) => Err(GossipSendError::InboundGossipChannelClosed),
+        }
+    }
+
+    /// Reserves `len` bytes of this queue's budget, or `None` when that would exceed it. The
+    /// reservation is released when the returned permit drops, i.e. once the consumer is done with
+    /// the message it travels with.
+    fn reserve(&self, len: usize) -> Option<QueuePermit> {
+        let previous = self.queued_bytes.fetch_add(len, Ordering::AcqRel);
+        if previous.saturating_add(len) > self.max_queued_bytes {
+            self.queued_bytes.fetch_sub(len, Ordering::AcqRel);
+            return None;
+        }
+        Some(QueuePermit {
+            queued_bytes: self.queued_bytes.clone(),
+            len,
+        })
+    }
+}
+
+/// Releases a queued message's share of its topic queue's byte budget when dropped.
+#[derive(Debug)]
+struct QueuePermit {
+    queued_bytes: Arc<AtomicUsize>,
+    len: usize,
+}
+
+impl Drop for QueuePermit {
+    fn drop(&mut self) {
+        self.queued_bytes.fetch_sub(self.len, Ordering::AcqRel);
     }
 }
 
 pub enum MessagingMode<TMsg: MessageSpec> {
     Enabled {
         tx_messages: mpsc::UnboundedSender<(PeerId, TMsg::Message)>,
-        tx_gossip_messages_by_topic: HashMap<String, mpsc::UnboundedSender<GossipMessage>>,
+        tx_gossip_messages_by_topic: HashMap<String, GossipQueueSender>,
     },
     Disabled,
 }
@@ -82,13 +213,74 @@ impl<TMsg: MessageSpec> MessagingMode<TMsg> {
             // Topics may be a bare prefix (single global topic, e.g. "consensus") or a prefixed topic
             // (e.g. "transactions-0-15"). Route on the prefix before the first delimiter, falling back to the
             // whole topic when there is no delimiter.
-            let topic = msg.message.topic.as_str();
-            let prefix = topic.split_once(TOPIC_DELIMITER).map_or(topic, |(prefix, _)| prefix);
-            let tx_gossip_messages = tx_gossip_messages_by_topic
-                .get(prefix)
-                .ok_or_else(|| GossipSendError::InvalidToken(topic.to_string()))?;
-            tx_gossip_messages.send(msg)?;
+            let queue = {
+                let topic = msg.message.topic.as_str();
+                let prefix = topic.split_once(TOPIC_DELIMITER).map_or(topic, |(prefix, _)| prefix);
+                tx_gossip_messages_by_topic
+                    .get(prefix)
+                    .ok_or_else(|| GossipSendError::InvalidToken(topic.to_string()))?
+            };
+            queue.try_send(msg)?;
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn message(len: usize) -> GossipMessage {
+        GossipMessage::new(
+            PeerId::random(),
+            PeerId::random(),
+            gossipsub::MessageId::new(b"id"),
+            gossipsub::Message {
+                source: None,
+                data: vec![0u8; len],
+                sequence_number: None,
+                topic: gossipsub::IdentTopic::new("test").hash(),
+            },
+        )
+    }
+
+    #[test]
+    fn admits_messages_until_the_byte_budget_is_reached() {
+        let (tx, _rx) = gossip_queue(16, 100);
+
+        tx.try_send(message(60)).unwrap();
+        assert_eq!(tx.queued_bytes(), 60);
+
+        let err = tx.try_send(message(60)).unwrap_err();
+        assert!(matches!(err, GossipSendError::QueueFull { .. }));
+        assert_eq!(tx.queued_bytes(), 60, "a rejected message must not hold budget");
+
+        tx.try_send(message(40)).unwrap();
+        assert_eq!(tx.queued_bytes(), 100, "a message that exactly fits is admitted");
+    }
+
+    #[test]
+    fn budget_is_released_once_a_message_is_consumed() {
+        let (tx, mut rx) = gossip_queue(16, 100);
+        tx.try_send(message(100)).unwrap();
+
+        let err = tx.try_send(message(1)).unwrap_err();
+        assert!(matches!(err, GossipSendError::QueueFull { .. }));
+
+        drop(rx.try_recv().unwrap());
+        assert_eq!(tx.queued_bytes(), 0);
+        tx.try_send(message(100)).unwrap();
+    }
+
+    #[test]
+    fn message_count_is_bounded_independently_of_size() {
+        // A flood of tiny messages carries per-message overhead the byte budget does not see.
+        let (tx, _rx) = gossip_queue(2, 1024 * 1024);
+        tx.try_send(message(1)).unwrap();
+        tx.try_send(message(1)).unwrap();
+
+        let err = tx.try_send(message(1)).unwrap_err();
+        assert!(matches!(err, GossipSendError::QueueFull { .. }));
+        assert_eq!(tx.queued_bytes(), 2, "the rejected message released its reservation");
     }
 }

--- a/networking/core/src/worker.rs
+++ b/networking/core/src/worker.rs
@@ -758,12 +758,12 @@ where
         // report `Ignore` here rather than leaving the message pinned in the validation cache.
         let topic = message.topic.clone();
         let len = message.data.len();
-        if let Err(e) = self.messaging_mode.send_gossip_message(GossipMessage {
+        if let Err(e) = self.messaging_mode.send_gossip_message(GossipMessage::new(
             source,
             propagation_source,
-            message_id: message_id.clone(),
+            message_id.clone(),
             message,
-        }) {
+        )) {
             warn!(target: LOG_TARGET, "📢 Gossipsub message failed to be handled: {}", e);
             self.report_gossip_validation(
                 &message_id,

--- a/networking/core/src/worker.rs
+++ b/networking/core/src/worker.rs
@@ -666,7 +666,9 @@ where
                 length,
             }) => {
                 info!(target: LOG_TARGET, "📧 Rx Messaging: peer {peer_id} ({length} bytes)");
-                let _ignore = self.messaging_mode.send_message(peer_id, message);
+                if let Err(e) = self.messaging_mode.send_message(peer_id, message, length) {
+                    warn!(target: LOG_TARGET, "📧 Inbound message dropped: {e}");
+                }
             },
             Messaging(event) => {
                 debug!(target: LOG_TARGET, "ℹ️ Messaging event: {:?}", event);


### PR DESCRIPTION
## Motivation

Three unbounded inbound queues, all drained serially by their consumers, so any arrival rate above the drain rate grows them without limit.

**Transaction gossip.** The mempool runs full validation on each transaction before taking the next from its `tokio::select!` loop. Growth happens *before* validation: no valid signature, no shard involvement and no fee are needed, only arrival. Nothing bounded it — `num_pending` is measured and forwarded to consensus, but only to decide whether to propose immediately, so it is a scheduling hint rather than backpressure.

**Consensus gossip.** Carries `HotStuffMessage`s between shard groups, including block-sized foreign proposals, and feeds a 10-deep *blocking* channel into consensus — so this queue absorbs real bursts rather than sitting idle.

**Direct consensus messaging.** Carries intra-committee `HotStuffMessage`s. Reaching it requires an established connection rather than a topic publish, so it is harder to flood, but it is equally liveness-critical.

Separately, the mempool's **seen-transaction set** was unbounded: `MEM_MAX_TRANSACTIONS_DEDUP_ALLOC` only called `shrink_to` on spare *capacity* after removals; length was never bounded, so the set grew with the unfinalized backlog.

## Changes

**Bounded queues** for all three paths, each bounded by total queued bytes as well as message count. The byte reservation is held by an RAII permit that travels with the message and is released when the consumer drops it — including when admission itself rejects, so a refused message never leaks budget. Accounting is shared via `QueueAccounting`; direct messages are carried as `InboundMessage` so a reservation can travel with them as it does for gossip. Direct messaging charges the wire size reported by the messaging layer, since the decoded message is not measurable at the admission point.

Bytes rather than count because messages range from small votes to block-sized proposals, and gossip topics admit up to the transmit limit: a count low enough to bound worst-case memory is far too low for ordinary traffic, while a count high enough for ordinary traffic admits that many maximum-size messages. The count bound remains as a secondary guard against per-message overhead from a flood of tiny messages.

Admission never blocks. One worker task serves every topic, so waiting for capacity on one would stall the others. For gossip, a message that does not fit is rejected and the worker reports `Ignore` — a full queue is this node's condition, not misbehaviour by the sender, so it must not count against that peer's score. This reuses the verdict path from #2362, so a dropped message is resolved rather than left pinned in gossipsub's validation cache.

Budgets are configurable, defaulting to **128 MiB** transaction gossip, **256 MiB** consensus gossip, **128 MiB** direct messaging. All `#[serde(default)]`, so existing config files continue to load. Consensus is budgeted above transactions because it tolerates loss far less well: a dropped transaction can be re-requested via `TransactionSource::Requested`, whereas a dropped proposal or vote can cost a view.

**Bounded seen-transaction cache.** `SeenTransactions` holds ids in two generations rather than a set alongside an eviction queue. A queue would store every id a second time, and exact eviction order is worth less than that memory when a miss is only a database read — `transaction_exists` falls through to the state store, so forgetting an id costs one extra read and nothing else. Inserts land in the current generation; when it fills, it becomes the previous generation and the older one is dropped wholesale. Lookups check both, so an id is remembered for between `capacity / 2` and `capacity` subsequent inserts rather than exactly `capacity` — that looser retention is the trade for roughly halving the footprint.

The previous doc comment claimed ~32 MiB, which was wrong on both counts: each id was stored twice, and hash tables allocate in powers of two, so 1M ids needed 2,097,152 buckets (~69 MiB) plus ~33 MiB of queue.

**Metrics.** `InboundQueueCollector` exports queue depth, budget and drop totals, reading the queues on each scrape rather than maintaining parallel gauges (mirroring `EpochManagerCollector`). All are labelled `queue`, with values `transaction_gossip`, `consensus_gossip`, `consensus_messaging`, and present only with the `metrics` feature:

| Metric | Type | Meaning |
|---|---|---|
| `inbound_queue_queued_bytes` | gauge | Bytes currently held by messages awaiting processing |
| `inbound_queue_max_queued_bytes` | gauge | Byte budget this queue admits up to before dropping |
| `inbound_queue_queued_messages` | gauge | Messages currently awaiting processing |
| `inbound_queue_dropped_messages_total` | counter | Messages discarded because the queue was full |
| `inbound_queue_dropped_bytes_total` | counter | Bytes discarded because the queue was full |

Depth against budget is what the budgets should be sized against — the defaults here are estimates, and `queued_bytes / max_queued_bytes` under load is what should replace them. Any non-zero drop counter means traffic is being discarded and either the budget or the drain rate behind it needs attention. Drop counters are plain atomics in the networking crate (which keeps no prometheus dependency) and are maintained unconditionally rather than behind the feature: they are two relaxed adds on a path that has already decided to discard a message, and a queue whose drops are invisible cannot be sized against real traffic.

## Effect on local submission and stress testing

Local submissions are unaffected. They arrive over `MempoolRequest::SubmitTransaction`, which is already a size-1 request/reply channel and backpressures its caller rather than dropping. `transaction_submitter` uses this path, so its own ingestion is unchanged. At ordinary transaction sizes the 128 MiB gossip budget holds a backlog in the hundreds of thousands before anything is dropped.

## Verification

- New tests: byte-budget admission, release-on-consume, the independent count bound, drop accounting on both bounds, and wire-size accounting for direct messages (`message_mode`); generation rotation, duplicates not consuming capacity, removal from either generation, and total retention staying within capacity (`mempool::service`); exported metric names and labels (`inbound_queue_metrics`). All deterministic — no timing assertions.
- `cargo check --workspace --all-targets` clean on default and `metrics` features, `cargo +nightly-2025-12-05 fmt --all` applied, `tari_networking` and `tari_validator_node` suites green.
