### PR TITLE
fix(engine): scope the free-compute credit to the fee intent

### DIFF
--- a/crates/engine/src/runtime/tracker.rs
+++ b/crates/engine/src/runtime/tracker.rs
@@ -107,18 +107,27 @@ impl<TStore: StateReader> StateTracker<TStore> {
     /// no payment-funded bound applies (WASM execution is not priced, or this is a dry run) — only
     /// the per-transaction hard cap then constrains compute.
     ///
-    /// The allowance is the points the fees paid can cover plus [`limits::FREE_COMPUTE_GRACE_POINTS`]
-    /// of credit, so a transaction can run its fee-sourcing instructions before it pays while a
-    /// transaction that never pays cannot consume more than the grace.
+    /// Within the fee intent the allowance is the points the fees paid can cover plus
+    /// [`limits::FREE_COMPUTE_GRACE_POINTS`] of credit, so a transaction can run its fee-sourcing
+    /// instructions before it pays, while a transaction that never pays cannot consume more than the
+    /// grace. Past the fee checkpoint the credit no longer applies: the transaction has paid what its
+    /// fee intent charged, and the compute it may still run is funded by that payment alone.
     pub fn wasm_point_allowance(&self) -> Option<u64> {
         let rate = self.wasm_metering_rate;
+        // The credit exists only so a transaction can source its fee before paying. Taking the fee
+        // checkpoint is precisely the point at which that need has been met, so the credit ends there.
+        let is_fee_intent = self.fee_checkpoint.is_none();
         self.read_with(|state| {
             let fee_state = state.fee_state();
             if fee_state.is_dry_run() {
                 return None;
             }
             let funded = rate.points_funded_by(fee_state.total_payments())?;
-            Some(funded.saturating_add(limits::FREE_COMPUTE_GRACE_POINTS))
+            if is_fee_intent {
+                Some(funded.saturating_add(limits::FREE_COMPUTE_GRACE_POINTS))
+            } else {
+                Some(funded)
+            }
         })
     }
 

--- a/crates/engine/tests/compute_fee_budget.rs
+++ b/crates/engine/tests/compute_fee_budget.rs
@@ -83,12 +83,12 @@ fn assert_insufficient_fees(reason: &RejectReason) {
     );
 }
 
-/// A transaction that pays only a tiny fee cannot run more than the grace of compute, even though the
-/// call is well under the per-transaction hard cap and would otherwise succeed. The fee intent still
-/// commits and the whole payment is collected — the validator is paid for the grace compute it ran,
-/// and only the compute beyond the payment is the (bounded) absorbed loss.
+/// A transaction that pays only a tiny fee cannot run more compute than that fee funds, even though
+/// the call is well under the per-transaction hard cap and would otherwise succeed. The fee intent
+/// still commits and the whole payment is collected, and because the credit does not extend past the
+/// fee checkpoint the validator is paid for every point it ran — there is no absorbed loss.
 #[test]
-fn underpaid_compute_is_capped_at_grace() {
+fn underpaid_compute_is_capped_at_what_the_payment_funds() {
     const FEE_PAYMENT: u64 = 1_000_000;
 
     let Harness {
@@ -124,10 +124,42 @@ fn underpaid_compute_is_capped_at_grace() {
         0,
         "nothing is refunded when compute exceeds the payment"
     );
-    assert!(
-        fee_receipt.unpaid_debt() > 0,
-        "compute charged beyond the payment is the bounded, absorbed loss",
+    assert_eq!(
+        fee_receipt.unpaid_debt(),
+        0,
+        "the allowance is exactly what the payment funds, so no compute runs unpaid",
     );
+}
+
+/// The credit is scoped to the fee intent. A call sized within the grace — and which therefore
+/// succeeds inside a fee intent, per `fee_intent_may_spend_compute_within_grace_before_paying` —
+/// still traps when it runs in the main instructions of a transaction whose payment does not fund
+/// it. Without this scoping every transaction would carry `FREE_COMPUTE_GRACE_POINTS` of compute it
+/// never pays for, on top of what it bought.
+#[test]
+fn grace_does_not_extend_past_the_fee_checkpoint() {
+    const FEE_PAYMENT: u64 = 1_000_000;
+    // The payment must fund materially less than the call needs, so the credit is what the call
+    // would otherwise be leaning on.
+    const _: () = assert!(BELOW_GRACE_POINTS > FEE_PAYMENT * 2);
+
+    let Harness {
+        mut test,
+        bench,
+        account,
+        owner,
+        key,
+        per_round,
+    } = setup();
+
+    let rounds = BELOW_GRACE_POINTS / per_round;
+    let tx = Transaction::builder_localnet()
+        .pay_fee_from_component(account, FEE_PAYMENT)
+        .call_function(bench, "bench_div_u64", args![rounds])
+        .build_and_seal(&key);
+
+    let result = test.try_execute(tx, vec![owner]).unwrap();
+    assert_insufficient_fees(result.expect_failure());
 }
 
 /// Paying more fees raises the compute allowance: the same call that fails when underpaid commits

--- a/crates/engine/tests/fees.rs
+++ b/crates/engine/tests/fees.rs
@@ -206,7 +206,8 @@ fn fail_partial_paid_fees() {
     test.enable_fees();
 
     // Must cover the fee section's own cost (so the fee instructions succeed) yet stay smaller
-    // than the full transaction's fee (so InsufficientFeesPaid is triggered on commit).
+    // than the full transaction's fee, so the main instructions exhaust the compute the payment
+    // funds and trap.
     const FEE_PAID: u64 = 100;
 
     let result = test.execute_expect_commit(
@@ -235,7 +236,7 @@ fn fail_partial_paid_fees() {
     );
     let reason = result.expect_failure();
     assert!(
-        matches!(reason, RejectReason::InsufficientFeesPaid(_)),
+        matches!(reason, RejectReason::ExecutionFailure(msg) if msg.contains("Insufficient fees")),
         "actual reason: {reason}"
     );
 

--- a/crates/engine/tests/native_compute_budget.rs
+++ b/crates/engine/tests/native_compute_budget.rs
@@ -195,9 +195,13 @@ fn in_flight_wasm_counts_toward_the_native_allowance() {
     let grind_points = FREE_COMPUTE_GRACE_POINTS - native_points / 2;
     let rounds = grind_points / per_round;
 
+    // Runs in the fee intent, which is where the credit applies — the main instructions are funded by
+    // the payment alone and would trap on the WASM grind long before the native charge.
     let reason = test.execute_expect_failure(
         Transaction::builder_localnet()
-            .call_method(faucet, "burn_compute_then_transfer", args![rounds, transfer.statement])
+            .with_fee_instructions_builder(|builder| {
+                builder.call_method(faucet, "burn_compute_then_transfer", args![rounds, transfer.statement])
+            })
             .build_and_seal(test.secret_key()),
         vec![],
     );

--- a/crates/engine_types/src/limits.rs
+++ b/crates/engine_types/src/limits.rs
@@ -44,6 +44,12 @@ pub const MAX_WASM_POINTS_PER_TRANSACTION: u64 = 100_000_000;
 /// can extract from a validator. Payments raise the allowance above this value proportionally to
 /// the WASM fee rate.
 ///
+/// The credit applies to the fee intent only. Sourcing a fee is the whole reason a transaction may
+/// run anything before paying, so once the fee checkpoint is taken the credit ends and the remaining
+/// instructions are funded by the payment alone (`StateTracker::wasm_point_allowance`). Extending it
+/// past the checkpoint would hand every transaction this many points of compute it never pays for,
+/// on top of what it bought.
+///
 /// Sized at ~3x the most expensive legitimate fee-sourcing flow: paying a fee from stealth UTXOs
 /// (one transfer: fixed cost + 1 stealth change output + up to 64 dust inputs ≈ 10.8M points at
 /// the calibrated native prices below — fees are TARI, which has no view key, so the flow prices


### PR DESCRIPTION
## Motivation

`FREE_COMPUTE_GRACE_POINTS` exists for one reason, stated in its own doc comment: a transaction sources its fee inside the fee intent — a withdraw, a claim-burn, an AMM swap to TARI, a stealth transfer — and only then calls `pay_fee`, so it must be allowed to run some compute on credit.

`StateTracker::wasm_point_allowance` added it unconditionally:

```rust
let funded = rate.points_funded_by(fee_state.total_payments())?;
Some(funded.saturating_add(limits::FREE_COMPUTE_GRACE_POINTS))
```

That allowance governs the whole transaction, so the credit also funded the main instructions. A transaction could commit a trivial `max_fee`, pass `checkpoint_fee_intent()`, and then run up to 32M metering points in its main body — work the validator performs and then absorbs when the transaction fails to pay at commit.

Against the 4.5e9 per-block point budget that is ~140 transactions to consume a block's entire compute, each paying only its weight and storage fees.

Past the checkpoint the credit has no justification: the transaction has paid what its fee intent charged, so the compute it may still run should be funded by that payment. The checkpoint is already recorded on the tracker (`fee_checkpoint`), so gating on it is one condition.

## Changes

- `wasm_point_allowance` adds the credit only while `fee_checkpoint.is_none()`. Past the checkpoint the allowance is `points_funded_by(total_payments())` alone.
- Doc updates on `FREE_COMPUTE_GRACE_POINTS` and `wasm_point_allowance` recording the scope.

Nothing else moves: dry runs still short-circuit to `None` (so fee estimation is unchanged), and with fees disabled `points_funded_by` returns `None` before the new branch is reached.

## Behaviour changes

- A transaction whose payment does not fund its main instructions traps **during execution** instead of running on credit and failing at commit. It stops sooner, having done less work.
- Compute underpayment surfaces as an execution failure rather than `RejectReason::InsufficientFeesPaid`. This matches how the fee intent already reports the same condition (`InsufficientFeesForCompute` / `InsufficientFeesForNativeExecution` predate this change). The commit-time variant stays reachable for non-compute charges and stays covered by `fees.rs`.
- `max_fee` must now cover the transaction's compute, with no 32M cushion behind it. In practice that cushion was ~200x a typical transaction's compute — an AMM swap is ~143k points — so callers that set `max_fee` from a dry-run estimate, or use the usual 500–2000 µT, are unaffected.

Consensus-affecting, since it changes which transactions trap. Belongs in a testnet-reset batch alongside #2350.

## Verification

- `underpaid_compute_is_capped_at_what_the_payment_funds` (renamed from `..._at_grace`) now asserts **zero** unpaid debt where it previously asserted a positive one — with the credit scoped, the allowance is exactly what the payment funds and the validator absorbs nothing.
- New `grace_does_not_extend_past_the_fee_checkpoint`: a call sized within the grace — which still succeeds inside a fee intent, per the existing `fee_intent_may_spend_compute_within_grace_before_paying` — traps in the main instructions when the payment does not fund it.
- `in_flight_wasm_counts_toward_the_native_allowance` moves its scenario into the fee intent, which is where the credit it exercises now lives. The property it guards (in-flight WASM is visible to a mid-invocation native charge) is unchanged.
- `tari_engine` suite green (300 tests), workspace sweep green (1673 tests, `not package(integration_tests)`), `cargo lints clippy --all-targets` clean on the touched crates, `cargo +nightly-2025-12-05 fmt --all` applied.

Note for reviewers: `tari_engine` has a pre-existing parallel-execution flake — `spend_script`, `shenanigans` and `template_upgrade` tests fail nondeterministically under high test-thread counts and pass in isolation. None of them call `enable_fees()`, so `wasm_point_allowance` returns `None` before reaching any code this PR touches. Unrelated, but worth a separate look.
