### PR TITLE
feat(p2p): score peers on invalid gossip deliveries

### DIFF
--- a/applications/tari_validator_node/src/bootstrap.rs
+++ b/applications/tari_validator_node/src/bootstrap.rs
@@ -217,6 +217,12 @@ pub async fn spawn_services(
                 user_agent: format!("/tari/validator/{}", env!("CARGO_PKG_VERSION")),
                 enable_mdns: config.validator_node.p2p.enable_mdns,
                 enable_relay: config.validator_node.p2p.enable_relay,
+                // Both topics report a `Reject` verdict for messages that fail to decode or fail
+                // validation, so both can score the peers that send them.
+                gossip_sub_scored_topics: vec![
+                    mempool::TOPIC_PREFIX.to_string(),
+                    consensus_gossip::TOPIC_PREFIX.to_string(),
+                ],
                 // TODO: allow node operator to configure
                 relay_circuit_limits: RelayCircuitLimits::high(),
                 relay_reservation_limits: RelayReservationLimits::high(),

--- a/applications/tari_validator_node/src/p2p/services/mempool/service.rs
+++ b/applications/tari_validator_node/src/p2p/services/mempool/service.rs
@@ -270,10 +270,15 @@ where
         // in its validation cache for a few heartbeats. A transaction we are not involved in is
         // still accepted — other shard groups need it.
         if let Some(validation) = gossip_validation {
-            let acceptance = if validation_result.is_ok() {
-                MessageAcceptance::Accept
-            } else {
-                MessageAcceptance::Reject
+            // Only a failure the sender is responsible for is rejected back to the mesh, since
+            // rejection counts against their peer score. A transaction we consider invalid because
+            // of our own view of runtime state — a template we have not synced — or because of our
+            // own storage health is withheld without penalty: a peer that is ahead of us, or our
+            // own failing database, must not graylist honest peers.
+            let acceptance = match &validation_result {
+                Ok(_) => MessageAcceptance::Accept,
+                Err(err) if err.is_sender_fault() => MessageAcceptance::Reject,
+                Err(_) => MessageAcceptance::Ignore,
             };
             self.gossip.report(validation, acceptance).await;
         }

--- a/crates/transaction_validation/src/error.rs
+++ b/crates/transaction_validation/src/error.rs
@@ -77,3 +77,121 @@ pub enum TransactionValidationError {
         actual: usize,
     },
 }
+
+impl TransactionValidationError {
+    /// Whether this failure is attributable to whoever sent us the transaction.
+    ///
+    /// A transaction arriving over gossip is rejected back to the mesh when it is, and merely
+    /// ignored when it is not: rejection counts against the sending peer's score and can graylist
+    /// it, so it must be reserved for failures that peer is responsible for.
+    ///
+    /// The distinction is whether the verdict could differ between two honest nodes. Structural
+    /// failures — malformed, wrong network, over a cap, bad signature — are properties of the
+    /// transaction itself and every node agrees on them. Failures that depend on this node's view
+    /// of runtime state, or on this node's own health, do not: a transaction referencing a template
+    /// we have not synced yet is valid to a peer that has, and a database error is our problem
+    /// entirely. Penalising a peer for either would let lagging or unhealthy nodes graylist honest
+    /// ones, and a node with a failing store would graylist everything it talks to.
+    ///
+    /// Matched exhaustively so that a new variant has to make this choice deliberately.
+    pub fn is_sender_fault(&self) -> bool {
+        match self {
+            // Ours, not theirs: local storage, pool and networking failures say nothing about the
+            // transaction.
+            Self::StorageError(_) |
+            Self::TransactionPoolError(_) |
+            Self::TemplateLookupError { .. } |
+            Self::NetworkingError(_) => false,
+
+            // Depends on this node's view of runtime state, which legitimately lags behind a peer's.
+            Self::TemplateNotFound { .. } |
+            Self::OutputSubstateExists { .. } |
+            Self::ValidatorFeeClaimEpochInvalid { .. } |
+            Self::CurrentEpochLessThanMinimum { .. } |
+            Self::CurrentEpochGreaterThanMaximum { .. } => false,
+
+            // Properties of the transaction itself, on which every node agrees.
+            Self::NoFeeInstructions { .. } |
+            Self::InvalidSignature |
+            Self::NoMainSigner { .. } |
+            Self::TransactionNotSigned { .. } |
+            Self::UnknownNetwork { .. } |
+            Self::NetworkMismatch { .. } |
+            Self::ContainsPayFeeInstruction { .. } |
+            Self::DryRunNotAllowed |
+            Self::TransactionExceedsMaxWeight { .. } |
+            Self::ExceedsStealthTransactionLimit { .. } |
+            Self::TooManyPublishTemplateInstructions { .. } |
+            Self::TooManySignatures { .. } => true,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tx_id() -> TransactionId {
+        TransactionId::new([1; 32])
+    }
+
+    /// A peer that is ahead of us, or our own unhealthy node, must not be able to graylist honest
+    /// peers. These are the failures where our verdict can differ from another honest node's.
+    #[test]
+    fn node_local_failures_are_not_blamed_on_the_sender() {
+        let node_local = [
+            TransactionValidationError::TemplateNotFound {
+                address: TemplateAddress::from_array([1; 32]),
+            },
+            TransactionValidationError::TemplateLookupError {
+                source: anyhow::anyhow!("db unavailable"),
+            },
+            TransactionValidationError::OutputSubstateExists {
+                transaction_id: tx_id(),
+            },
+            TransactionValidationError::CurrentEpochLessThanMinimum {
+                current_epoch: Epoch(1),
+                min_epoch: Epoch(2),
+            },
+            TransactionValidationError::CurrentEpochGreaterThanMaximum {
+                current_epoch: Epoch(3),
+                max_epoch: Epoch(2),
+            },
+        ];
+        for err in node_local {
+            assert!(!err.is_sender_fault(), "must not penalise the sender for: {err}");
+        }
+    }
+
+    /// Properties of the transaction itself: every honest node reaches the same verdict, so the
+    /// peer that sent it is answerable for it.
+    #[test]
+    fn structural_failures_are_blamed_on_the_sender() {
+        let structural = [
+            TransactionValidationError::InvalidSignature,
+            TransactionValidationError::NoMainSigner {
+                transaction_id: tx_id(),
+            },
+            TransactionValidationError::NoFeeInstructions {
+                transaction_id: tx_id(),
+            },
+            TransactionValidationError::ContainsPayFeeInstruction {
+                transaction_id: tx_id(),
+            },
+            TransactionValidationError::DryRunNotAllowed,
+            TransactionValidationError::TransactionExceedsMaxWeight {
+                transaction_id: tx_id(),
+                weight: 2,
+                max_weight: 1,
+            },
+            TransactionValidationError::TooManySignatures {
+                transaction_id: tx_id(),
+                max: 1,
+                actual: 2,
+            },
+        ];
+        for err in structural {
+            assert!(err.is_sender_fault(), "must penalise the sender for: {err}");
+        }
+    }
+}

--- a/networking/swarm/src/behaviour.rs
+++ b/networking/swarm/src/behaviour.rs
@@ -259,8 +259,14 @@ fn noise_prologue() -> Vec<u8> {
 /// per window, which on a quiet network is every honest peer. Scoring liveness that way would
 /// punish peers for the network being idle, so they are disabled rather than tuned.
 ///
-/// P6 (IP colocation) is disabled because sharing an address is normal here — a local swarm runs
-/// every validator on one host — so it is not evidence of misbehaviour.
+/// P6 (IP colocation) is omitted. It exists to make Sybil identities cost IP addresses, which
+/// matters where identity is free; here consensus participation is gated by validator registration
+/// on the base layer, so how an operator distributes their nodes says nothing about whether they
+/// are one entity or many. Penalising colocation would tax honest deployments — a local swarm on
+/// one host, nodes sharing a NAT egress address — for no signal. Its residual value is bounding
+/// eclipse of the gossip mesh, which is accepted: that degrades propagation but not consensus
+/// safety, since intra-committee traffic uses direct messaging to peers drawn from the registered
+/// set rather than from mesh selection.
 ///
 /// That leaves P4 carrying the signal the application actually produces: a `Reject` verdict from
 /// `report_gossip_validation`, reported for messages that fail to decode or fail validation. The

--- a/networking/swarm/src/behaviour.rs
+++ b/networking/swarm/src/behaviour.rs
@@ -97,11 +97,18 @@ where
                 .build()
                 .unwrap();
 
-            let gossipsub = gossipsub::Behaviour::new(
+            let mut gossipsub = gossipsub::Behaviour::new(
                 gossipsub::MessageAuthenticity::Signed(keypair.clone()),
                 gossipsub_config,
             )
             .unwrap();
+
+            if !config.gossip_sub_scored_topics.is_empty() {
+                let (params, thresholds) = peer_score_params(&config.gossip_sub_scored_topics);
+                // Only fails if the parameters are invalid or scoring is already active, both of
+                // which are constructed here.
+                gossipsub.with_peer_score(params, thresholds).unwrap();
+            }
 
             // Ping
             let ping = ping::Behaviour::new(config.ping);
@@ -239,4 +246,50 @@ fn noise_config(keypair: &Keypair) -> Result<noise::Config, noise::Error> {
 fn noise_prologue() -> Vec<u8> {
     const PROLOGUE: &str = "tari-digital-asset-network";
     PROLOGUE.as_bytes().to_vec()
+}
+
+/// Peer-scoring parameters for the topics in [`Config::gossip_sub_scored_topics`].
+///
+/// Deliberately narrow: of gossipsub's seven scoring parameters only P4 (invalid message
+/// deliveries) and P7 (protocol-level misbehaviour) are enabled.
+///
+/// P1–P3b score *delivery rates* — how long a peer has been in the mesh, how often it delivers a
+/// message first, whether it meets a delivery quota. Their defaults assume a busy topic:
+/// `mesh_message_deliveries_threshold` of 20 penalises any peer delivering fewer than 20 messages
+/// per window, which on a quiet network is every honest peer. Scoring liveness that way would
+/// punish peers for the network being idle, so they are disabled rather than tuned.
+///
+/// P6 (IP colocation) is disabled because sharing an address is normal here — a local swarm runs
+/// every validator on one host — so it is not evidence of misbehaviour.
+///
+/// That leaves P4 carrying the signal the application actually produces: a `Reject` verdict from
+/// `report_gossip_validation`, reported for messages that fail to decode or fail validation. The
+/// penalty is the square of a decaying counter, so occasional invalid messages (version skew, an
+/// epoch-boundary race) are forgiven within seconds, while a sustained flood accumulates. At these
+/// weights a peer must sustain roughly twenty invalid messages per second to be graylisted.
+///
+/// The thresholds are libp2p's defaults. Scoring too aggressively partitions a network by
+/// graylisting honest peers, which is a far worse failure than scoring too leniently — so this
+/// starts permissive, and should be tightened against observed behaviour rather than guessed at.
+fn peer_score_params(topics: &[String]) -> (gossipsub::PeerScoreParams, gossipsub::PeerScoreThresholds) {
+    let topic_params = gossipsub::TopicScoreParams {
+        topic_weight: 1.0,
+        time_in_mesh_weight: 0.0,
+        first_message_deliveries_weight: 0.0,
+        mesh_message_deliveries_weight: 0.0,
+        mesh_failure_penalty_weight: 0.0,
+        invalid_message_deliveries_weight: -1.0,
+        ..Default::default()
+    };
+
+    let params = gossipsub::PeerScoreParams {
+        topics: topics
+            .iter()
+            .map(|topic| (gossipsub::IdentTopic::new(topic).hash(), topic_params.clone()))
+            .collect(),
+        ip_colocation_factor_weight: 0.0,
+        ..Default::default()
+    };
+
+    (params, gossipsub::PeerScoreThresholds::default())
 }

--- a/networking/swarm/src/config.rs
+++ b/networking/swarm/src/config.rs
@@ -23,6 +23,12 @@ pub struct Config {
     pub relay_reservation_limits: RelayReservationLimits,
     pub identify_interval: Duration,
     pub gossip_sub_max_message_size: usize,
+    /// Gossipsub topics on which peers are scored for delivering invalid messages. Empty disables
+    /// peer scoring entirely.
+    ///
+    /// Only topics named here contribute to a peer's score, so a topic left out is one where
+    /// invalid deliveries cost the sender nothing. Names are topic strings, matched exactly.
+    pub gossip_sub_scored_topics: Vec<String>,
     pub rendezvous_server_enabled: bool,
 }
 
@@ -43,6 +49,7 @@ impl Default for Config {
             // This is the default for identify
             identify_interval: Duration::from_secs(5 * 60),
             gossip_sub_max_message_size: 2 * 1024 * 1024,
+            gossip_sub_scored_topics: Vec::new(),
             rendezvous_server_enabled: false,
         }
     }


### PR DESCRIPTION
## Motivation

#2362 plumbed validation verdicts back to gossipsub so invalid messages are withheld from the mesh rather than relayed on the application's behalf. But `gossipsub::Behaviour` is constructed without peer scoring, so every `Reject` was computed and then discarded — a peer flooding invalid messages remained indistinguishable from an honest one, and being withheld cost it nothing.

This connects those verdicts to a consequence, and fixes a misclassification that only becomes harmful once they have one.

## Only reject what the sender is answerable for

The mempool reported `Reject` for *any* validation failure. That was harmless while nothing consumed the verdict; with scoring on, it graylists the sender. Not every failure is the sender's fault:

- `before_execute_validator` ends with `TemplateExistsValidator` (`bootstrap.rs`), so a transaction referencing a template this node has not synced yet fails here while being perfectly valid to a peer that has it. The peer is ahead of us, not misbehaving.
- That validator also reads the store, so `StorageError` / `TemplateLookupError` land in the same branch. A node with a failing database would reject everything and graylist every peer it talks to — a self-inflicted partition.

`TransactionValidationError::is_sender_fault` now distinguishes properties of the transaction itself, on which every honest node agrees, from failures that depend on this node's view of runtime state or on its own health. Only the former is rejected; the latter is ignored, which withholds the message from the mesh without penalising anyone. The match is exhaustive, so a new variant has to make the choice deliberately.

This is the same structural-versus-contextual split already documented on `create_structural_transaction_validator`, which notes that those validations "cannot false-reject".

## Scoring parameters

Deliberately narrow. Of gossipsub's seven parameters, only P4 and P7 are enabled.

**P1–P3b are disabled.** They score delivery *rates* — time in mesh, first-delivery frequency, whether a peer meets a delivery quota. Their defaults assume a busy topic: `mesh_message_deliveries_threshold` of 20 penalises any peer delivering fewer than 20 messages per window, which on a quiet network is every honest peer. Scoring liveness that way punishes peers for the network being idle, so they are switched off rather than tuned to current traffic levels.

**P4 (invalid message deliveries) carries the signal**, at `topic_weight: 1.0` and `invalid_message_deliveries_weight: -1.0`, with libp2p's default thresholds. The penalty is the square of a counter decaying at 0.3 per second, giving two paths to the −80 graylist threshold:

- a **burst** of ~9 invalid messages within one second
- a **sustained** rate of ~21 invalid messages per second (steady state `c = 0.43k`)

Occasional invalid messages decay away within seconds without approaching the threshold.

**P6 (IP colocation) is not used.** It exists to make Sybil identities cost IP addresses, which matters where identity is free. Here consensus participation is gated by validator registration on the base layer, so how an operator distributes their nodes says nothing about whether they are one entity or many — a different adversary model from a permissionless network. Scoring it would tax honest deployments (a local swarm on one host, nodes sharing a NAT egress address) for no signal.

Its residual value is bounding eclipse of the gossip mesh, and that is knowingly accepted: eclipse degrades propagation but not consensus safety, since intra-committee traffic uses direct messaging to peers drawn from the registered set rather than from mesh selection, and transactions have a `TransactionSource::Requested` recovery path.

**P7 (protocol-level misbehaviour)** keeps its default: re-grafting before the prune backoff, and not following up on IWANT.

Scoring is opt-in per topic via `Config::gossip_sub_scored_topics`; an empty list disables it, so nothing changes for the indexer or any other swarm user that does not set it.

## On the posture

These weights are permissive on purpose. Over-aggressive scoring partitions a network by graylisting honest peers; under-scoring's worst case is the behaviour we have today. The asymmetry argues for starting loose and tightening against observed data.

Graylisting also only suppresses gossip. The indexer forwards transactions over validator-node RPC rather than gossip, so a wallet submitting an invalid transaction through it cannot affect the indexer's score.

## Known gap

There is no visibility into peer scores — nothing exports how many peers are graylisted or the score distribution, so if these weights do start affecting honest peers it would show up as symptoms rather than metrics. gossipsub offers `Behaviour::new_with_metrics` and a `peer_score()` accessor; wiring those up is worth a follow-up before the thresholds are tightened.

A related follow-up: `app_specific_weight` defaults to 10.0 but `set_application_score` is never called, so P5 contributes nothing. That is the hook for encoding what the application knows that the network layer cannot see — assigning registered validators a positive score would express the actual trust boundary directly, rather than inferring it from network behaviour alone.

## Verification

- New tests cover the fault classification in both directions: node-local failures (template not synced, lookup error, epoch range) are not blamed on the sender, and structural ones (bad signature, no fee instructions, over-weight, too many signatures) are.
- `cargo check --workspace --all-targets` clean, `cargo +nightly-2025-12-05 fmt --all` applied. The scoring parameters are validated by gossipsub itself at construction (`PeerScoreParams::validate` / `PeerScoreThresholds::validate`).
