### PR TITLE
ci: least-privilege test results publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -326,14 +326,3 @@ jobs:
         with:
           name: cucumber-log-artifacts
           path: ${{ github.workspace }}/integration_tests/tests/temp/cucumber_*/*.log
-
-  # needed for test results
-  event_file:
-    runs-on: [ ubuntu-latest ]
-
-    steps:
-      - name: Upload
-        uses: actions/upload-artifact@v7
-        with:
-          name: Event File
-          path: ${{ github.event_path }}

--- a/.github/workflows/test_results.yml
+++ b/.github/workflows/test_results.yml
@@ -3,7 +3,7 @@ name: Test Results for CI
 
 on:
   workflow_run:
-    workflows: ["CI", "PR"]
+    workflows: ["CI"]
     types:
       - completed
 
@@ -18,33 +18,29 @@ jobs:
     permissions:
       checks: write
 
-      # needed unless run with comment_mode: off
-      pull-requests: write
-
-      # required by download step to access artifacts API
+      # required by the download step to access the artifacts API of the triggering run
       actions: read
 
     steps:
-      - name: Download and Extract Artifacts
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-        run: |
-          mkdir -p artifacts && cd artifacts
-          
-          artifacts_url=${{ github.event.workflow_run.artifacts_url }}
-          
-          gh api --paginate "$artifacts_url" -q '.artifacts[] | [.name, .archive_download_url] | @tsv' | while read artifact
-          do
-            IFS=$'\t' read name url <<< "$artifact"
-            gh api $url > "$name.zip"
-            unzip -d "$name" "$name.zip"
-          done
+      # Only the JUnit XML artifacts are needed. Everything else the CI run uploads
+      # (cucumber logs, and anything a fork PR adds to ci.yml) stays out of this job.
+      - name: Download test result artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          pattern: "{test-results-*,cucumber-test-results}"
+          path: artifacts
 
+      # `event_name` and `event_file` must both stay unset. The action classifies a run as
+      # an unprivileged fork run when an event name of `pull_request` arrives without an
+      # event file, and silently skips publishing the check run. Omitting the event name
+      # leaves it as `workflow_run`, which is the trusted context this job actually runs in.
+      # `commit` is honoured on its own, so the head SHA does not depend on the event payload.
       - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3  # v2.24.0
         with:
           commit: ${{ github.event.workflow_run.head_sha }}
-          event_file: artifacts/Event File/event.json
-          check_name: "Test Results (${{ github.event.workflow_run.name || github.event_name }})"
-          event_name: ${{ github.event.workflow_run.event }}
+          check_name: "Test Results (${{ github.event.workflow_run.name }})"
+          comment_mode: "off"
           files: "artifacts/**/*.xml"


### PR DESCRIPTION
## Description

`test_results.yml` runs on `workflow_run`, which means it executes in the trusted base-repo context — with write scopes — while consuming artifacts produced by the PR job that triggered it. For a fork PR those artifacts are attacker-controlled. This tightens both what the job trusts and what it is able to do.

Changes:

- **Replace the `gh api` + `unzip` loop with `actions/download-artifact`.** The loop extracted fork-controlled zips into the workspace, which by that point also holds the already-downloaded action code for the next step. It relied on `unzip` rejecting `../` entries to stay safe.
- **Filter to the JUnit XML artifacts.** Previously every artifact the CI run uploaded was downloaded, including the cucumber logs — and anything else a PR adds to `ci.yml`.
- **Stop reading the Event File artifact.** It was uploaded by the triggering run and passed to the publish action as event metadata, which the action uses for PR association. `commit` is taken from `github.event.workflow_run.head_sha` in trusted context and is honoured on its own. The upload job is removed from `ci.yml` as nothing consumes it now.
- **Drop `pull-requests: write`** via `comment_mode: off`. The job keeps `checks: write` + `actions: read`.
- **Pin both actions by SHA**, consistent with the other workflows. `download-artifact` reuses the v8.0.1 pin already used in `ffi_libs.yml`.
- **Trigger on `CI` only.** The other listed workflow, `PR` (`pr_title.yml`), uploads no artifacts, so every title edit started a run with nothing to publish.

## Behaviour change

Test results are no longer posted as a PR comment — the check run carries them. That is the trade for dropping `pull-requests: write`.

## Note on the `event_name` input

`event_name` is deliberately left unset, and this is load-bearing. The action classifies a run as an unprivileged fork run when an event name of `pull_request` arrives with no event file, and then skips publishing the check run with only an info-level log. Leaving it unset keeps it at `workflow_run`, which is the context this job genuinely runs in. Dropping `event_file` while keeping `event_name` would have silently stopped test results from being reported.

## Test plan

- [ ] CI run on this PR publishes a "Test Results (CI)" check run against the head commit
- [ ] Check run includes results from all three `test-results-*` shards and `cucumber-test-results`
- [ ] Confirm on a failing-test branch that results still publish when the CI run concludes `failure`
