### PR TITLE
chore(wallet): remove unimplemented encrypted config API

### DIFF
--- a/crates/wallet/sdk/src/apis/config.rs
+++ b/crates/wallet/sdk/src/apis/config.rs
@@ -47,17 +47,6 @@ impl<'a, TStore: WalletStore> ConfigApi<'a, TStore> {
         Ok(record.value)
     }
 
-    pub fn get_decrypted<T: DeserializeOwned>(
-        &self,
-        key: ConfigKey,
-        _decryption_key: impl AsRef<[u8]>,
-    ) -> Result<T, ConfigApiError> {
-        let mut tx = self.store.create_read_tx()?;
-        let record = tx.config_get(key.as_key_str())?;
-        // TODO: decryption if record.is_encrypted
-        Ok(record.value)
-    }
-
     pub fn exists(&self, key: ConfigKey) -> Result<bool, ConfigApiError> {
         let mut tx = self.store.create_read_tx()?;
         let exists = tx.config_exists(key.as_key_str())?;
@@ -65,27 +54,8 @@ impl<'a, TStore: WalletStore> ConfigApi<'a, TStore> {
     }
 
     pub fn set<T: Serialize + ?Sized>(&self, key: ConfigKey, value: &T) -> Result<(), ConfigApiError> {
-        self.set_opts(key, value, false)
-    }
-
-    pub fn set_encrypted<T: Serialize + ?Sized>(
-        &self,
-        key: ConfigKey,
-        value: &T,
-        _encryption_key: impl AsRef<[u8]>,
-    ) -> Result<(), ConfigApiError> {
-        // TODO: encrypt
-        self.set_opts(key, value, true)
-    }
-
-    fn set_opts<T: Serialize + ?Sized>(
-        &self,
-        key: ConfigKey,
-        value: &T,
-        is_encrypted: bool,
-    ) -> Result<(), ConfigApiError> {
         let mut tx = self.store.create_write_tx()?;
-        tx.config_set(key.as_key_str(), value, is_encrypted)?;
+        tx.config_set(key.as_key_str(), value, false)?;
         tx.commit()?;
         Ok(())
     }


### PR DESCRIPTION
## Description

`ConfigApi::set_encrypted` accepted an encryption key, ignored it, wrote the value in **plaintext**, and set `is_encrypted = true`. `get_decrypted` likewise ignored its key and returned the raw record. Both were TODO stubs.

Neither had a call site, so there is no exposure today — but they were a loaded gun: the next caller storing a secret through that API would have got plaintext at rest behind a column asserting the opposite.

This removes both and folds the now single-caller `set_opts` into `set`. The `is_encrypted` column and the guard in `get` are kept as a defensive check against a manual DB edit or a future writer.

## Why remove rather than implement

No `ConfigKey` currently holds a secret. `CipherSeed` is already enciphered under the OS keyring password before it reaches the config store; the rest (`Network`, `IndexerUrl`, `RecoveryNeeded`, `KeyringPasswordEntryKey`, `AdvancedUiFeatures`, `ClaimedAccounts`) are non-sensitive.

Implementing the stubs now would also have baked in two problems worth avoiding:

- `impl AsRef<[u8]>` is the wrong parameter type — no `SafePassword`, no zeroization, and no distinction between a password and a derived key.
- `ConfigApi` cannot source the keyring password itself. `PasswordManagerApi` already depends on `ConfigApi` (it reads `KeyringPasswordEntryKey` through it), so the reverse direction is a cycle; and `Network`, `KeyringPasswordEntryKey` and `CipherSeed` are all read during bootstrap before any key material exists, so they are structurally un-encryptable.

If encrypted config is needed later it can be reintroduced against a real requirement, taking a `SafePassword` and deriving a subkey once at SDK init rather than running Argon2id (46 MiB) per KV access.

## Test plan

- [x] `cargo check -p tari_ootle_wallet_sdk --all-targets`
- [x] No remaining references to the removed methods anywhere in the workspace