### PR TITLE
fix(docs): restore Reference sidebar group for Starlight v0.39+

### DIFF
--- a/applications/tari_validator_node/src/inbound_queue_metrics.rs
+++ b/applications/tari_validator_node/src/inbound_queue_metrics.rs
@@ -34,6 +34,9 @@ struct QueueReading {
     dropped_bytes: u64,
 }
 
+/// A metric family: its name, its help text, and how to pull its value out of a [`QueueReading`].
+type MetricFamily = (&'static str, &'static str, fn(&QueueReading) -> Reading);
+
 /// Reports depth, budget and drop totals for every inbound queue, labelled by `queue`.
 pub struct InboundQueueCollector {
     transaction_gossip: GossipQueueSender,
@@ -98,7 +101,7 @@ impl Collector for InboundQueueCollector {
         // Units are carried in the metric names rather than passed to the encoder, which would
         // append them a second time; counter names omit `_total`, which prometheus-client appends
         // itself. Both match `EpochManagerCollector`.
-        let families: [(&str, &str, fn(&QueueReading) -> Reading); 5] = [
+        let families: [MetricFamily; 5] = [
             (
                 "queued_bytes",
                 "Bytes currently held by messages awaiting processing",

--- a/docs/developer-docs/astro.config.mjs
+++ b/docs/developer-docs/astro.config.mjs
@@ -47,7 +47,7 @@ export default defineConfig({
         },
         {
           label: "Reference",
-          autogenerate: { directory: "reference" },
+          items: [{ autogenerate: { directory: "reference" } }],
         },
         { label: "For Bots", link: "/llms.txt", attrs: { target: "_blank" } },
       ],


### PR DESCRIPTION
## Description

The developer-docs build has been failing since #2365 bumped `@astrojs/starlight` (to `^0.41.3`):

```
[AstroUserError] Invalid config passed to starlight integration
  Found an `autogenerate` object with a `label`. Support for autogenerated sidebar
  groups was removed in Starlight v0.39.0.
```

Starlight v0.39.0 dropped support for pairing a `label` directly with `autogenerate` on a sidebar entry. The replacement form is a normal group whose `items` array contains the autogenerate config, which is what this applies to the "Reference" group.

Also bundles a small unrelated cleanup: the inbound-queue metric family tuple is factored into a `MetricFamily` type alias, clearing a pre-existing `clippy::type_complexity` warning in `tari_validator_node`.

## Motivation and Context

Docs deploys are currently broken on `development`.

## How Has This Been Tested?

- `npm ci && npm run build` in `docs/developer-docs/` — build completes, and both autogenerated Reference pages (`/reference/api-overview/`, `/reference/types/`) are emitted, so the sidebar group still picks up the directory.
- `cargo clippy -p tari_validator_node --all-targets` — the `type_complexity` warning is gone.

## What process can a PR reviewer use to test or verify this change?

Run the docs build from `docs/developer-docs/` and confirm the Reference section still lists every page under `src/content/docs/reference/`.

## Breaking Changes

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other