### PR TITLE
feat(engine): cap stealth transfers in the fee intent

### DIFF
--- a/crates/engine/src/runtime/error.rs
+++ b/crates/engine/src/runtime/error.rs
@@ -411,6 +411,11 @@ pub enum ArgumentValidationError {
     MaxStealthInputsExceeded { max_inputs: usize, actual_inputs: usize },
     #[error("Maximum number of stealth transfers per transaction exceeded: max {max_transfers}")]
     MaxStealthTransfersPerTransactionExceeded { max_transfers: usize },
+    #[error(
+        "Maximum number of stealth transfers in the fee intent exceeded: max {max_transfers}. Perform further \
+         transfers in the main intent."
+    )]
+    MaxFeeIntentStealthTransfersExceeded { max_transfers: usize },
     #[error("Maximum total stealth outputs per transaction exceeded: max {max_outputs}, got at least {actual_outputs}")]
     MaxStealthOutputsPerTransactionExceeded { max_outputs: usize, actual_outputs: usize },
     #[error("Maximum total stealth inputs per transaction exceeded: max {max_inputs}, got at least {actual_inputs}")]

--- a/crates/engine/src/runtime/impl.rs
+++ b/crates/engine/src/runtime/impl.rs
@@ -3764,6 +3764,11 @@ where
         // only creation-time invariant is that an output is spendable by at least one path (`spend_key` or
         // `condition_root` is `Some`), enforced by `validate_stealth_outputs_statement` during execution.
 
+        // The fee intent runs on free-compute credit, so the transfers it may perform are capped. Checked first, so
+        // an over-cap fee intent is rejected before any substate read, charge or crypto. Both the `StealthTransfer`
+        // instruction and a template's `ResourceManager::stealth_transfer` reach here, so neither route escapes it.
+        self.tracker.account_fee_intent_stealth_transfer()?;
+
         // The whole statement's native verification cost is charged against the payment-funded
         // allowance before any of it runs (the authorisation pass below included), so a transaction
         // that will not pay traps here without extracting the crypto work. The resource peek is a

--- a/crates/engine/src/runtime/tracker.rs
+++ b/crates/engine/src/runtime/tracker.rs
@@ -53,6 +53,7 @@ use crate::{
     fees::WasmMeteringRate,
     runtime::{
         RuntimeError,
+        error::ArgumentValidationError,
         locking::LockedSubstate,
         scope::{CallScope, PushCallFrame},
         working_state::WorkingState,
@@ -69,6 +70,10 @@ pub struct StateTracker<TStore> {
     fee_checkpoint: Option<WorkingState<TStore>>,
     transaction_weight: TransactionWeight,
     wasm_metering_rate: WasmMeteringRate,
+    /// Stealth transfers performed so far in the fee intent. Lives here rather than in `WorkingState` because the fee
+    /// intent is delimited by `fee_checkpoint`, and because the checkpoint clones the working state — a count held
+    /// there would be duplicated into the clone.
+    fee_intent_stealth_transfers: usize,
 }
 
 impl<TStore: StateReader> StateTracker<TStore> {
@@ -95,6 +100,7 @@ impl<TStore: StateReader> StateTracker<TStore> {
             fee_checkpoint: None,
             transaction_weight,
             wasm_metering_rate,
+            fee_intent_stealth_transfers: 0,
         }
     }
 
@@ -505,6 +511,26 @@ impl<TStore: StateReader> StateTracker<TStore> {
 
     pub(super) fn is_fee_intent_checkpointed(&self) -> bool {
         self.fee_checkpoint.is_some()
+    }
+
+    /// Accounts one more stealth transfer against [`limits::StealthLimits::max_fee_intent_transfers`]; a no-op once
+    /// the fee intent is over. Called before the transfer's native cost is charged and before any of its crypto runs,
+    /// so an over-cap fee intent is rejected without the work being performed.
+    ///
+    /// Counts every transfer the fee intent performs, whether from a `StealthTransfer` instruction or from a template
+    /// calling `ResourceManager::stealth_transfer` — both reach this through `RuntimeInterfaceImpl::stealth_transfer`.
+    /// Counting instructions alone would leave the WASM route uncapped, and so make the more expensive route the way
+    /// to exceed the limit.
+    pub(super) fn account_fee_intent_stealth_transfer(&mut self) -> Result<(), RuntimeError> {
+        if self.is_fee_intent_checkpointed() {
+            return Ok(());
+        }
+        let max_transfers = limits::STEALTH_LIMITS.max_fee_intent_transfers;
+        if self.fee_intent_stealth_transfers + 1 > max_transfers {
+            return Err(ArgumentValidationError::MaxFeeIntentStealthTransfersExceeded { max_transfers }.into());
+        }
+        self.fee_intent_stealth_transfers += 1;
+        Ok(())
     }
 }
 

--- a/crates/engine/src/runtime/validation.rs
+++ b/crates/engine/src/runtime/validation.rs
@@ -153,6 +153,8 @@ mod tests {
         max_witness_data_len: 4096,
         max_inclusion_proof_len: 32,
         max_transfers_per_transaction: 2,
+        // Enforced by `StateTracker`, not by this accumulator.
+        max_fee_intent_transfers: 1,
         max_total_inputs_per_transaction: 3,
         max_total_outputs_per_transaction: 2,
     };

--- a/crates/engine/tests/stealth.rs
+++ b/crates/engine/tests/stealth.rs
@@ -131,6 +131,107 @@ fn basic_transfer() {
     assert!(utxos[0].output().is_some());
 }
 
+/// Two independent transfers, both valid on their own, for the fee-intent cap tests. Each spends a different minted
+/// UTXO, so the first completes and only the cap can stop the second.
+fn two_transfers(mint: &StealthSecretTransferData) -> (StealthSecretTransferData, StealthSecretTransferData) {
+    let first = stealth::generate_transfer_data(
+        [MaskAndValue {
+            mask: mint.output_masks[0].clone(),
+            value: 100,
+        }],
+        0u64,
+        Some(100),
+        0,
+    );
+    let second = stealth::generate_transfer_data(
+        [MaskAndValue {
+            mask: mint.output_masks[1].clone(),
+            value: 1000,
+        }],
+        0u64,
+        Some(1000),
+        0,
+    );
+    (first, second)
+}
+
+const FEE_INTENT_CAP_REASON: &str = "Maximum number of stealth transfers in the fee intent exceeded";
+
+/// The fee intent runs on free-compute credit, so it may perform only one stealth transfer.
+#[test]
+fn fee_intent_rejects_a_second_stealth_transfer() {
+    let mut test = TemplateTest::new(CRATE_PATH, TEMPLATE_PATHS);
+    let mint = stealth::generate_mint_statement(vec![100, 1000], 0u64, None);
+    let (_faucet, faucet_resx) = setup(&mut test, &mint, None);
+    let (first, second) = two_transfers(&mint);
+
+    let reason = test.execute_expect_failure(
+        Transaction::builder_localnet()
+            .with_fee_instructions_builder(|builder| {
+                builder
+                    .stealth_transfer(faucet_resx, first.statement)
+                    .stealth_transfer(faucet_resx, second.statement)
+            })
+            .finish()
+            .add_signer(&test.to_public_key_bytes(), &mint.output_masks[0])
+            .add_signer(&test.to_public_key_bytes(), &mint.output_masks[1])
+            .seal(test.secret_key()),
+        vec![],
+    );
+
+    assert_reject_reason(reason, FEE_INTENT_CAP_REASON);
+}
+
+/// The cap counts transfers *performed*, so routing the second through a template does not evade it. Were only
+/// `StealthTransfer` instructions counted, the WASM route — which costs an invocation and a host call on top of the
+/// same verification — would be the way to exceed the limit.
+#[test]
+fn fee_intent_counts_a_stealth_transfer_performed_from_wasm() {
+    let mut test = TemplateTest::new(CRATE_PATH, TEMPLATE_PATHS);
+    let mint = stealth::generate_mint_statement(vec![100, 1000], 0u64, None);
+    let (_faucet, faucet_resx) = setup(&mut test, &mint, None);
+    let template_addr = test.get_template_address(TEMPLATE_NAME);
+    let (first, second) = two_transfers(&mint);
+
+    let reason = test.execute_expect_failure(
+        Transaction::builder_localnet()
+            .with_fee_instructions_builder(|builder| {
+                builder.stealth_transfer(faucet_resx, first.statement).call_function(
+                    template_addr,
+                    "static_programmatic_transfer",
+                    args![faucet_resx, second.statement],
+                )
+            })
+            .finish()
+            .add_signer(&test.to_public_key_bytes(), &mint.output_masks[0])
+            .add_signer(&test.to_public_key_bytes(), &mint.output_masks[1])
+            .seal(test.secret_key()),
+        vec![],
+    );
+
+    assert_reject_reason(reason, FEE_INTENT_CAP_REASON);
+}
+
+/// The cap is scoped to the fee intent: the main intent may perform further transfers, funded by the fee just paid.
+#[test]
+fn main_intent_may_transfer_after_the_fee_intent_has() {
+    let mut test = TemplateTest::new(CRATE_PATH, TEMPLATE_PATHS);
+    let mint = stealth::generate_mint_statement(vec![100, 1000], 0u64, None);
+    let (_faucet, faucet_resx) = setup(&mut test, &mint, None);
+    let (first, second) = two_transfers(&mint);
+
+    test.execute_expect_success(
+        Transaction::builder_localnet()
+            .with_fee_instructions_builder(|builder| builder.stealth_transfer(faucet_resx, first.statement))
+            .stealth_transfer(faucet_resx, second.statement)
+            .finish()
+            .add_signer(&test.to_public_key_bytes(), &mint.output_masks[0])
+            .add_signer(&test.to_public_key_bytes(), &mint.output_masks[1])
+            .seal(test.secret_key()),
+        vec![],
+    );
+}
+
 #[test]
 fn programmatic_transfer() {
     let mut test = TemplateTest::new(CRATE_PATH, TEMPLATE_PATHS);

--- a/crates/engine_types/src/limits.rs
+++ b/crates/engine_types/src/limits.rs
@@ -175,6 +175,19 @@ pub struct StealthLimits {
     pub max_inclusion_proof_len: usize,
     /// Maximum number of stealth transfers across a whole transaction.
     pub max_transfers_per_transaction: usize,
+    /// Maximum number of stealth transfers the fee intent may perform.
+    ///
+    /// The fee intent runs on [`FREE_COMPUTE_GRACE_POINTS`] of credit before any payment, so whatever it contains is
+    /// the transaction's free-execution surface. Sourcing a fee needs one transfer statement — inputs producing the
+    /// revealed fee amount plus a stealth change output — so one is what the fee intent gets. Further transfers
+    /// belong in the main intent, where the fee just paid funds them.
+    ///
+    /// Counts transfers *performed*, not `StealthTransfer` instructions: a template calling
+    /// `ResourceManager::stealth_transfer` counts the same, since both routes reach
+    /// `RuntimeInterfaceImpl::stealth_transfer`. Counting instructions alone would leave the WASM route uncapped and
+    /// so make the costlier route — a WASM invocation and host call on top of the same verification — the way to
+    /// exceed this limit.
+    pub max_fee_intent_transfers: usize,
     /// Maximum total stealth inputs across a whole transaction.
     pub max_total_inputs_per_transaction: usize,
     /// Maximum total stealth outputs across a whole transaction.
@@ -195,6 +208,7 @@ pub const STEALTH_LIMITS: StealthLimits = StealthLimits {
     max_witness_data_len: 4096,
     max_inclusion_proof_len: 32,
     max_transfers_per_transaction: 64,
+    max_fee_intent_transfers: 1,
     max_total_inputs_per_transaction: 1024,
     max_total_outputs_per_transaction: 256,
 };

--- a/crates/transaction_validation/src/stealth_limits.rs
+++ b/crates/transaction_validation/src/stealth_limits.rs
@@ -17,6 +17,10 @@ const LOG_TARGET: &str = "tari::ootle::mempool::validators::stealth_limits";
 /// proposing leader past the block time. The engine enforces the same per-transfer and per-transaction caps during
 /// execution; this mirrors them to reject doomed transactions at ingress, before they are gossiped, stored and
 /// executed.
+///
+/// `max_fee_intent_transfers` is mirrored here too, over the fee instructions alone. The engine counts transfers a
+/// template performs as well, which an instruction count cannot see, so this catches the common case at ingress while
+/// the engine remains authoritative.
 #[derive(Debug, Clone, Default)]
 pub struct StealthTransactionLimitsValidator;
 
@@ -32,10 +36,16 @@ impl Validator<Transaction> for StealthTransactionLimitsValidator {
 
     fn validate(&self, _context: &(), transaction: &Transaction) -> Result<(), Self::Error> {
         let mut transfers = 0usize;
+        let mut fee_intent_transfers = 0usize;
         let mut inputs = 0usize;
         let mut outputs = 0usize;
 
-        for instruction in transaction.instructions().iter().chain(transaction.fee_instructions()) {
+        for (is_fee_intent, instruction) in transaction
+            .fee_instructions()
+            .iter()
+            .map(|i| (true, i))
+            .chain(transaction.instructions().iter().map(|i| (false, i)))
+        {
             if let Instruction::StealthTransfer { statement, .. } = instruction {
                 let transfer_inputs = statement.inputs_statement.inputs.len();
                 let transfer_outputs = statement.outputs_statement.outputs.len();
@@ -54,11 +64,20 @@ impl Validator<Transaction> for StealthTransactionLimitsValidator {
                     transaction,
                 )?;
                 transfers += 1;
+                if is_fee_intent {
+                    fee_intent_transfers += 1;
+                }
                 inputs += transfer_inputs;
                 outputs += transfer_outputs;
             }
         }
 
+        self.check(
+            "fee intent transfers",
+            fee_intent_transfers,
+            STEALTH_LIMITS.max_fee_intent_transfers,
+            transaction,
+        )?;
         self.check(
             "transfers",
             transfers,
@@ -157,21 +176,31 @@ mod tests {
         stmt
     }
 
-    fn tx_with_stealth_transfers(statements: Vec<StealthTransferStatement>) -> Transaction {
-        let instructions = statements
+    fn transfer_instructions(statements: Vec<StealthTransferStatement>) -> Vec<Instruction> {
+        statements
             .into_iter()
             .map(|statement| Instruction::StealthTransfer {
                 resource_address_ref: ResourceAddressRef::from(0u16),
                 statement,
                 revealed_input_bucket: None,
             })
-            .collect();
+            .collect()
+    }
+
+    fn tx_with_stealth_transfers(statements: Vec<StealthTransferStatement>) -> Transaction {
+        tx_with_intents(vec![], statements)
+    }
+
+    fn tx_with_intents(
+        fee_statements: Vec<StealthTransferStatement>,
+        main_statements: Vec<StealthTransferStatement>,
+    ) -> Transaction {
         Transaction::new(
             UnsealedTransactionV1::new(
                 UnsignedTransactionV1::new(
                     Network::LocalNet.as_byte(),
-                    vec![],
-                    instructions,
+                    transfer_instructions(fee_statements),
+                    transfer_instructions(main_statements),
                     IndexSet::new(),
                     None,
                     None,
@@ -233,6 +262,28 @@ mod tests {
         assert!(matches!(
             err,
             TransactionValidationError::ExceedsStealthTransactionLimit { limit: "transfers", .. }
+        ));
+    }
+
+    /// One fee-sourcing transfer is admitted, and the cap applies to the fee intent alone — the main intent may carry
+    /// as many transfers as the per-transaction caps allow.
+    #[test]
+    fn admits_one_fee_intent_transfer_alongside_several_main_intent_transfers() {
+        let tx = tx_with_intents(vec![statement(16, 1)], (0..8).map(|_| statement(4, 2)).collect());
+        StealthTransactionLimitsValidator::new().validate(&(), &tx).unwrap();
+    }
+
+    #[test]
+    fn rejects_a_second_fee_intent_transfer() {
+        let n = STEALTH_LIMITS.max_fee_intent_transfers + 1;
+        let tx = tx_with_intents((0..n).map(|_| statement(1, 1)).collect(), vec![]);
+        let err = StealthTransactionLimitsValidator::new().validate(&(), &tx).unwrap_err();
+        assert!(matches!(
+            err,
+            TransactionValidationError::ExceedsStealthTransactionLimit {
+                limit: "fee intent transfers",
+                ..
+            }
         ));
     }
 


### PR DESCRIPTION
## Description

Caps the fee intent at one stealth transfer (`STEALTH_LIMITS.max_fee_intent_transfers = 1`).

Since #2364 the free-compute credit applies only inside the fee intent, so the fee intent *is* the transaction's entire free-execution surface. Sourcing a fee needs one transfer statement — inputs producing the revealed fee amount plus a stealth change output — so that is what it gets. Further transfers belong in the main intent, where the fee just paid funds them.

Until now the limit was emergent rather than stated. At 32M grace the fee intent admitted about four outputs (`2.1M + 4×6M + 64×42k = 28.8M`); a fifth reached 34.8M and trapped mid-execution as an out-of-gas error. This replaces that with an explicit rule that can be rejected at ingress, before a doomed transaction is gossiped, stored and executed.

### The cap counts transfers performed, not instructions

`ResourceManager::stealth_transfer` is public template-lib API, so a template can perform a stealth transfer that no instruction count can see. Both routes converge — `ResourceAction::StealthTransfer` in `resource_invoke` calls the same `RuntimeInterfaceImpl::stealth_transfer` the instruction path uses — so a single check in the engine covers both.

Counting instructions alone would not merely leave the WASM route uncovered; it would make that route the *cheaper* way to exceed the limit, since a WASM invocation and host call sit on top of identical verification. A rule that steers traffic to the more expensive path is worse than no rule. The mempool validator mirrors the instruction case so the common shape is still rejected early, with the engine authoritative.

The check runs first in `stealth_transfer`, ahead of the resource read, the native charge and `verify_input_authorizations`, so an over-cap fee intent is rejected without performing any of that work.

### What this does not do

**It does not reduce free compute.** `FREE_COMPUTE_GRACE_POINTS` is unchanged at 32M and remains what bounds unpaid work — for every transfer regardless of origin. The de-facto four-output ceiling in the fee intent is unchanged.

This is worth stating plainly because the surrounding work (#2364, #2369, #2370) has been about tightening execution cost, and this change is not that. An attacker denied a second transfer can still extract the full grace using one transfer, or a WASM grind loop; the ceiling is set by the grace alone. What this adds is an explicit, enforceable rule where there was an implicit trap.

### Sizing, for reference

Fee-intent cost is `2.1M (statement) + K × 6M (outputs) + inputs`, with `PER_OUTPUT` dominating:

| fee-intent outputs | native | grace needed |
|---:|---:|---:|
| 1 | 10.8M | ~12M |
| 2 | 16.8M | ~18M |
| 4 (today's de-facto ceiling) | 28.8M | ~30M |
| 8 (per-statement max) | 52.8M | ~54M |

Reducing the grace would mean tightening the output count too, which is a separate product decision about whether bundling transfers into the fee intent is a flow worth supporting. Not attempted here.

## Motivation and Context

The fee intent is where a transaction runs on credit. Leaving its size to emerge from the grace means the failure mode is an out-of-gas trap partway through execution, after the transaction has been gossiped and stored, with an error that does not explain what to do about it. An explicit cap fails at ingress with a message that points at the main intent.

## How Has This Been Tested?

- `fee_intent_rejects_a_second_stealth_transfer` — two `StealthTransfer` instructions in the fee intent.
- `fee_intent_counts_a_stealth_transfer_performed_from_wasm` — one instruction transfer plus a `static_programmatic_transfer` template call. It can only produce the cap error by reaching the host call, so it does not pass vacuously.
- `main_intent_may_transfer_after_the_fee_intent_has` — negative control; fails if the counter does not stop at the fee checkpoint.
- Mempool validator unit tests for the fee-intent tally and for main-intent transfers not counting against it.
- 327/327 pass across `tari_engine` and `tari_ootle_transaction_validation`; workspace `cargo check --all-targets` and clippy clean.

Verified against every in-tree fee-intent builder — the wallet SDK stealth transfer API, claim burn, validator fee claims, and the ootle-rs examples all produce at most one transfer. Note `ootle-rs/examples/stealth_transfer.rs` puts a two-output third-party payment in the fee intent; that is unaffected, since the cap is on transfers rather than outputs.

## Breaking Changes

- [ ] None
- [ ] Requires data directory to be deleted
- [x] Other

Consensus-affecting: it changes which transactions execute successfully, so it needs to ride a testnet-reset batch.
