### PR TITLE
Fix WalletDaemonClient not sending the token on auth.refresh

### DIFF
--- a/clients/javascript/wallet_daemon_client/src/index.ts
+++ b/clients/javascript/wallet_daemon_client/src/index.ts
@@ -569,12 +569,15 @@ export class WalletDaemonClient<T extends RpcTransport = FetchRpcTransport> {
         throw origError;
       }
       const id = this.id++;
-      const refreshResp = (await this.transport.sendRequest<any>({
-        method: "auth.refresh",
-        jsonrpc: "2.0",
-        id,
-        params: {},
-      })) as RpcResponse<AuthLoginResponse>;
+      const refreshResp = (await this.transport.sendRequest<any>(
+        {
+          method: "auth.refresh",
+          jsonrpc: "2.0",
+          id,
+          params: {},
+        },
+        { token: this.token, timeout_millis: null },
+      )) as RpcResponse<AuthLoginResponse>;
 
       if (refreshResp.error) {
         console.debug("Refresh resp", refreshResp);


### PR DESCRIPTION
## Summary

`WalletDaemonClient.sendRequest()`'s 401 auto-refresh path calls `this.transport.sendRequest({...})` with only the request payload, omitting the `{ token: this.token, timeout_millis: null }` options argument every other call site in this method passes. `FetchRpcTransport.sendRequest()` only attaches an `Authorization: Bearer <token>` header `if (options?.token)`, so the `auth.refresh` request goes out with no token at all — the server has nothing to look up a session from, and refresh unconditionally fails with `Unauthorized: No refresh token`, even when the refresh grant itself is still valid.

Net effect: once an access token expires, every subsequent call from that client permanently fails with a 401 instead of transparently refreshing and retrying, defeating the entire point of `setReauthenticationEnabled(true)`.

## Fix

Pass the same `{ token: this.token, timeout_millis: null }` options object to the `auth.refresh` call that every other `transport.sendRequest` call in this method already uses.

## Verification

Reproduced and confirmed the fix against a live `tari_ootle_walletd` (esmeralda) from a small Node script using this client directly:

- **Before**: connecting with an expired/invalid token → `auth.refresh` request → daemon logs `Refresh resp { error: { code: 401, message: "...Unauthorized: No refresh token" } }` → client throws the original 401.
- **After**: same scenario → refresh succeeds, returns a new token, and the original request is retried and succeeds.

This surfaced while building a Chrome extension wallet that relays to `tari_ootle_walletd` via this client — a daemon connection that had been running for a while (tokens expire after 5 minutes per this repo's own `CLAUDE.md`) became permanently unusable on the very next call, with no way to recover short of a brand new `auth.request`.

## Test plan

- [x] `npx prettier --check` passes on the changed file (matches existing formatting)
- [x] Manually verified end-to-end against a running `tari_ootle_walletd` as described above
- [ ] No existing automated test coverage for this client to extend — happy to add one if there's a preferred harness/mocking approach for this package