### PR TITLE
feat(walletd): support cross-origin JS clients with API-key auth

### DIFF
--- a/clients/javascript/wallet_daemon_client/README.md
+++ b/clients/javascript/wallet_daemon_client/README.md
@@ -2,4 +2,51 @@
 
 ## Overview
 
-Client library for interacting with the Tari Ootle Wallet Daemon via JSON-RPC. 
+Client library for interacting with the Tari Ootle Wallet Daemon via JSON-RPC.
+
+## Authentication
+
+The daemon accepts two kinds of bearer credential, and which one you can use depends on where your code runs.
+
+### Same-origin browser callers — session tokens
+
+A page served by the daemon itself authenticates with `auth.request`, which returns a short-lived JWT and sets an
+HttpOnly, `SameSite=Strict` refresh cookie. With `setReauthenticationEnabled(true)`, an expired JWT is refreshed
+transparently via `auth.refresh`.
+
+```ts
+const client = WalletDaemonClient.usingFetchTransport(WALLET_JRPC_URL);
+const token = await client.authRequest(permissions, credentials);
+client.setToken(token);
+```
+
+`auth.refresh` is authorised by the cookie alone — the bearer token is not consulted. Because the cookie is HttpOnly
+and `SameSite=Strict`, only a same-origin caller can hold a refreshable session.
+
+### Cross-origin callers — API keys
+
+Browser extensions, other hosts, and non-browser tooling cannot obtain the refresh cookie and so cannot hold a
+session. Authenticate with an API key instead: it is validated against the daemon's `api_keys` table on every call,
+with no `auth.request` round-trip and nothing to refresh.
+
+```ts
+const client = WalletDaemonClient.usingFetchTransport(WALLET_JRPC_URL);
+client.authenticateWithApiKey(apiKey);
+client.setReauthenticationEnabled(false);
+```
+
+A 401 from an API key is final — the key is revoked, expired, or lacks the permission the method requires.
+
+Keys are minted with `auth.create_api_key`, which requires an interactive Admin session; an API key cannot mint
+further keys. Scope each key to the narrowest permission set that works — a client that only proposes transactions
+for a human to approve needs `TransactionRequests(Create)` and not `Transfer` or `Transactions(Create)`.
+
+The daemon only serves cross-origin callers when its CORS configuration permits the origin.
+
+### Transport cookie policy
+
+`FetchRpcTransport` sends cookies according to its `credentials` option, which defaults to `"same-origin"`:
+
+```ts
+WalletDaemonClient.usingFetchTransport(url, { credentials: "include" });
+```

--- a/clients/javascript/wallet_daemon_client/package.json
+++ b/clients/javascript/wallet_daemon_client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tari-project/wallet_jrpc_client",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "description": "Tari wallet JSON-RPC client library",
   "homepage": "https://github.com/tari-project/tari-ootle#readme",
   "bugs": {

--- a/clients/javascript/wallet_daemon_client/src/index.ts
+++ b/clients/javascript/wallet_daemon_client/src/index.ts
@@ -143,17 +143,29 @@ import type {
   AddressBookDeleteRequest,
   AddressBookDeleteResponse,
 } from "@tari-project/ootle-ts-bindings";
-import { FetchRpcTransport, RpcErrorResponse, RpcResponse, RpcTransport } from "./transports";
+import { FetchRpcTransport, FetchRpcTransportOptions, RpcErrorResponse, RpcResponse, RpcTransport } from "./transports";
 
 export * as transports from "./transports";
 
 export { substateIdToString, stringToSubstateId, rejectReasonToString };
+
+/**
+ * Prefix the daemon puts on every API key it mints. A bearer carrying it is
+ * resolved against the api_keys table rather than decoded as a JWT.
+ */
+const API_KEY_PREFIX = "tw_";
+
+/** True if `token` is an API key rather than a session JWT. */
+export function isApiKey(token: string): boolean {
+  return token.startsWith(API_KEY_PREFIX);
+}
 
 export class WalletDaemonClient<T extends RpcTransport = FetchRpcTransport> {
   private token: string | null;
   private transport: T;
   private id: number;
   private reauthEnabled: boolean = true;
+  private hasWarnedApiKeyReauth: boolean = false;
 
   constructor(transport: T) {
     this.token = null;
@@ -165,12 +177,13 @@ export class WalletDaemonClient<T extends RpcTransport = FetchRpcTransport> {
     return new WalletDaemonClient(transport);
   }
 
-  public static usingFetchTransport(url: string): WalletDaemonClient {
-    return WalletDaemonClient.new(FetchRpcTransport.new(url));
+  public static usingFetchTransport(url: string, options?: FetchRpcTransportOptions): WalletDaemonClient {
+    return WalletDaemonClient.new(FetchRpcTransport.new(url, options));
   }
 
   public setReauthenticationEnabled(enabled: boolean) {
     this.reauthEnabled = enabled;
+    this.warnIfApiKeyReauth();
   }
 
   public isAuthenticated() {
@@ -179,6 +192,32 @@ export class WalletDaemonClient<T extends RpcTransport = FetchRpcTransport> {
 
   public setToken(token: string) {
     this.token = token;
+    this.warnIfApiKeyReauth();
+  }
+
+  private clearToken() {
+    this.token = null;
+    this.hasWarnedApiKeyReauth = false;
+  }
+
+  /**
+   * Reauthentication is inert for an API key: the key is validated against the
+   * api_keys table on every call rather than expiring into a refreshable
+   * session, and `auth.refresh` consumes the login cookie that an API-key
+   * holder never receives. Warn once so a 401 from a revoked or under-scoped
+   * key isn't mistaken for a refresh that failed.
+   *
+   * Called from both setters so the warning fires whichever order they run in.
+   */
+  private warnIfApiKeyReauth() {
+    if (this.hasWarnedApiKeyReauth || !this.reauthEnabled || !this.token || !isApiKey(this.token)) {
+      return;
+    }
+    this.hasWarnedApiKeyReauth = true;
+    console.warn(
+      "WalletDaemonClient: reauthentication is enabled but the credential is an API key. API keys cannot be " +
+        "refreshed; a 401 means the key is revoked, expired, or lacks the required permission.",
+    );
   }
 
   public getToken(): string | null {
@@ -565,10 +604,20 @@ export class WalletDaemonClient<T extends RpcTransport = FetchRpcTransport> {
       // Refresh failed with 401. No point in trying it again
       if (method.startsWith("auth.")) {
         console.warn("Token refresh failed");
-        this.token = null;
+        this.clearToken();
+        throw origError;
+      }
+      // An API key has no refresh grant behind it, so a 401 is final. The key
+      // is the caller's configured credential rather than a stale access
+      // token, so it is kept for the caller to revoke or replace.
+      if (this.token && isApiKey(this.token)) {
         throw origError;
       }
       const id = this.id++;
+      // `auth.refresh` is authorised by the HttpOnly refresh cookie set at
+      // login, never by the bearer token, so this call deliberately carries no
+      // token. It only succeeds for a same-origin browser caller whose
+      // transport sends cookies.
       const refreshResp = (await this.transport.sendRequest<any>({
         method: "auth.refresh",
         jsonrpc: "2.0",
@@ -578,7 +627,7 @@ export class WalletDaemonClient<T extends RpcTransport = FetchRpcTransport> {
 
       if (refreshResp.error) {
         console.debug("Refresh resp", refreshResp);
-        this.token = null;
+        this.clearToken();
         // Throw the original 401 error instead of the refresh error
         throw origError;
       }

--- a/clients/javascript/wallet_daemon_client/src/transports/fetch.ts
+++ b/clients/javascript/wallet_daemon_client/src/transports/fetch.ts
@@ -5,15 +5,31 @@
 
 import { RpcRequest, RpcResponse, RpcTransport, RpcTransportOptions } from "./index";
 
+export interface FetchRpcTransportOptions {
+  /**
+   * Cookie policy applied to every request this transport makes, matching the
+   * `credentials` option of `fetch`. Defaults to `"same-origin"`.
+   *
+   * The daemon's refresh grant lives in an HttpOnly, `SameSite=Strict` cookie
+   * issued by `auth.request`, so only a same-origin browser caller can hold a
+   * refreshable session. A cross-origin caller — a browser extension, or a
+   * page served from another host — cannot obtain that cookie under any
+   * setting here, and must authenticate with an API key instead.
+   */
+  credentials?: RequestCredentials;
+}
+
 export default class FetchRpcTransport implements RpcTransport {
   private url: string;
+  private credentials: RequestCredentials;
 
-  constructor(url: string) {
+  constructor(url: string, options?: FetchRpcTransportOptions) {
     this.url = url;
+    this.credentials = options?.credentials ?? "same-origin";
   }
 
-  static new(url: string) {
-    return new FetchRpcTransport(url);
+  static new(url: string, options?: FetchRpcTransportOptions) {
+    return new FetchRpcTransport(url, options);
   }
 
   async sendRequest<T>(data: RpcRequest, options?: RpcTransportOptions): Promise<RpcResponse<T>> {
@@ -37,6 +53,7 @@ export default class FetchRpcTransport implements RpcTransport {
       method: "POST",
       body: JSON.stringify(data),
       headers,
+      credentials: this.credentials,
       signal,
     });
     if (timeoutId) {

--- a/clients/javascript/wallet_daemon_client/src/transports/index.ts
+++ b/clients/javascript/wallet_daemon_client/src/transports/index.ts
@@ -6,6 +6,7 @@
 import FetchRpcTransport from "./fetch";
 
 export { FetchRpcTransport };
+export type { FetchRpcTransportOptions } from "./fetch";
 
 export interface RpcTransport {
   sendRequest<T>(request: RpcRequest, options?: RpcTransportOptions): Promise<RpcResponse<T>>;


### PR DESCRIPTION
## Summary

The JS wallet client assumes a same-origin browser caller throughout. Two places bake that in:

- `FetchRpcTransport` calls `fetch()` with no `credentials` option, so cookie policy is whatever the platform default happens to be.
- `sendRequest`'s 401 path always attempts `auth.refresh`, regardless of what kind of credential the client is holding.

`auth.refresh` is authorised solely by the HttpOnly, `SameSite=Strict` refresh cookie set at login — `handle_token_refresh` takes the bearer as `_token` and never reads it. A cross-origin caller (a browser extension, or a page on another host) cannot obtain that cookie, so it cannot hold a refreshable session and must authenticate with an API key instead. API keys are resolved against the `api_keys` table on every call and have nothing to refresh.

That distinction was invisible at the client API, so a cross-origin caller's only symptom was an opaque `Unauthorized: No refresh token` (see #2375, which read that error as a missing bearer header).

## Changes

- **`FetchRpcTransport` takes a `credentials` option**, defaulting to `"same-origin"` — the previous effective behaviour, now stated rather than inherited. Scoped to the transport rather than to individual calls, so one request cannot silently differ from its peers in cookie policy.
- **A 401 on an API key skips refresh** and surfaces the original error, which is the accurate one: the key is revoked, expired, or lacks the required permission. The key is retained rather than cleared — it is the caller's configured credential, not a stale access token.
- **Enabling reauthentication while holding an API key warns once**, fired from both `setToken` and `setReauthenticationEnabled` so the combination is reported whichever order they are called in.
- **Exported `isApiKey(token)`** so callers can branch on credential kind without duplicating the `tw_` prefix.
- **README documents both authentication paths**, their origin constraints, and the recommendation to scope a proposal-only client to `TransactionRequests(Create)` rather than `Transfer`.

All additions are optional parameters; existing callers are unaffected and same-origin behaviour is unchanged.

## Test plan

- [x] `npx tsc --project tsconfig.prod.json` passes
- [x] `npx prettier --check` passes on the changed sources and README
- [x] `npx tsc --noEmit` passes in `applications/tari_walletd/web_ui`, the in-tree consumer
- [ ] The package has no test harness, so the behavioural changes are not covered by an automated test

## Notes

This is the client half of better extension support. The daemon-side pieces — an explicit CORS origin allowlist in place of the current permissive/off toggle, a pairing flow so a key never has to be copy-pasted into an extension, and origin-bound keys — are not included here and are worth tracking separately.