### PR TITLE
feat(consensus): allow previously aborted transactions to be resequenced, dedup on commit only

### DIFF
--- a/applications/tari_validator_node/src/p2p/services/mempool/service.rs
+++ b/applications/tari_validator_node/src/p2p/services/mempool/service.rs
@@ -25,11 +25,12 @@ use std::{collections::HashSet, fmt::Display, mem};
 use libp2p::gossipsub::MessageAcceptance;
 use log::*;
 use tari_consensus::hotstuff::HotstuffEvent;
+use tari_engine_types::substate::SubstateId;
 use tari_epoch_manager::{EpochManagerReader, service::EpochManagerHandle};
 use tari_networking::{GossipMessage, NetworkingHandle};
 use tari_ootle_common_types::optional::Optional;
 use tari_ootle_p2p::{NewTransactionMessage, PeerAddress, TariMessage, TariMessagingSpec};
-use tari_ootle_storage::{StateStore, StateStoreReadTransaction, consensus_models::TransactionRecord};
+use tari_ootle_storage::{StateStore, StateStoreReadTransaction, StorageError, consensus_models::TransactionRecord};
 use tari_ootle_transaction::{Transaction, TransactionId};
 use tari_ootle_transaction_validation::{TransactionValidationError, Validator};
 use tokio::sync::{broadcast, mpsc, oneshot};
@@ -355,7 +356,27 @@ where
                 );
                 return Ok(true);
             }
-            TransactionRecord::exists(tx, id)
+            if TransactionRecord::exists(tx, id)? {
+                return Ok(true);
+            }
+            // A commit outlives the local records: the transaction's receipt substate proves the id
+            // has committed even when the records were pruned. Best-effort — a node that does not
+            // host the receipt's shard (or is behind on sync) simply never finds it and the
+            // consensus gate makes the authoritative refusal.
+            let receipt_id = SubstateId::TransactionReceipt((*id).into());
+            if tx
+                .substates_get_max_version_for_substate(&receipt_id)
+                .optional()?
+                .is_some()
+            {
+                debug!(
+                    target: LOG_TARGET,
+                    "🎱 Transaction {} has a receipt in state and has already committed. Ignoring",
+                    id
+                );
+                return Ok(true);
+            }
+            Ok::<_, StorageError>(false)
         })?;
 
         if transaction_exists {

--- a/applications/tari_validator_node/src/p2p/services/mempool/service.rs
+++ b/applications/tari_validator_node/src/p2p/services/mempool/service.rs
@@ -25,7 +25,6 @@ use std::{collections::HashSet, fmt::Display, mem};
 use libp2p::gossipsub::MessageAcceptance;
 use log::*;
 use tari_consensus::hotstuff::HotstuffEvent;
-use tari_engine_types::substate::SubstateId;
 use tari_epoch_manager::{EpochManagerReader, service::EpochManagerHandle};
 use tari_networking::{GossipMessage, NetworkingHandle};
 use tari_ootle_common_types::optional::Optional;
@@ -363,12 +362,7 @@ where
             // has committed even when the records were pruned. Best-effort — a node that does not
             // host the receipt's shard (or is behind on sync) simply never finds it and the
             // consensus gate makes the authoritative refusal.
-            let receipt_id = SubstateId::TransactionReceipt((*id).into());
-            if tx
-                .substates_get_max_version_for_substate(&receipt_id)
-                .optional()?
-                .is_some()
-            {
+            if TransactionRecord::receipt_exists(tx, id)? {
                 debug!(
                     target: LOG_TARGET,
                     "🎱 Transaction {} has a receipt in state and has already committed. Ignoring",

--- a/crates/consensus/src/hotstuff/on_receive_new_transaction.rs
+++ b/crates/consensus/src/hotstuff/on_receive_new_transaction.rs
@@ -3,11 +3,9 @@
 
 use log::*;
 use tari_consensus_types::Decision;
-use tari_engine_types::substate::SubstateId;
-use tari_ootle_common_types::{Epoch, committee::CommitteeInfo, optional::Optional};
+use tari_ootle_common_types::{Epoch, committee::CommitteeInfo};
 use tari_ootle_storage::{
     StateStore,
-    StateStoreReadTransaction,
     consensus_models::{TransactionPool, TransactionRecord},
 };
 use tari_ootle_transaction::TransactionId;
@@ -186,20 +184,12 @@ where TConsensusSpec: ConsensusSpec
             None => {},
         }
 
-        // The local records are only a cache: every commit writes a TransactionReceipt substate at an
-        // address derived from the transaction id, so the receipt's existence in synced state proves
-        // the id has committed even when this node's records no longer (or never) knew it — freshly
-        // synced nodes included. Only nodes whose committee includes the receipt's shard can check
-        // this, and that group is always involved because the receipt is a known output of every
-        // transaction; other shard groups fall back to their local records and rely on the receipt's
-        // home group refusing the replay.
-        let receipt_id = SubstateId::TransactionReceipt(rec.to_receipt_id());
-        if local_committee_info.includes_substate_id(&receipt_id) &&
-            (**tx)
-                .substates_get_max_version_for_substate(&receipt_id)
-                .optional()?
-                .is_some()
-        {
+        // The local records are only a cache: the receipt's existence in synced state proves the id
+        // has committed even when this node's records no longer (or never) knew it — freshly synced
+        // nodes included. The receipt's shard group is always involved because the receipt is a
+        // known output of every transaction; shard groups that do not host it never observe the
+        // receipt and rely on the receipt's home group refusing the replay.
+        if TransactionRecord::receipt_exists(&**tx, rec.id())? {
             warn!(
                 target: LOG_TARGET,
                 "Transaction {} has a receipt in state and has therefore already committed. Consensus will ignore it.",

--- a/crates/consensus/src/hotstuff/on_receive_new_transaction.rs
+++ b/crates/consensus/src/hotstuff/on_receive_new_transaction.rs
@@ -162,27 +162,26 @@ where TConsensusSpec: ConsensusSpec
         // rather than on finalization keeps the outcome identical on every node regardless of what
         // its local records remember, so a proposal containing a previously-aborted id can never
         // split votes.
-        if rec.is_finalized(&**tx)? {
-            match TransactionRecord::get_finalized_decision(&**tx, rec.id())? {
-                Some(decision) if decision.is_commit() => {
-                    warn!(
-                        target: LOG_TARGET, "Transaction {} is already committed. Consensus will ignore it.", rec.id()
-                    );
-                    return Ok(None);
-                },
-                _ => {
-                    info!(
-                        target: LOG_TARGET,
-                        "🔄 Transaction {} was previously finalized as aborted. Removing the previous attempt and \
-                         sequencing it again.",
-                        rec.id()
-                    );
-                    // The aborted attempt's bookkeeping must not survive into the new lifecycle,
-                    // otherwise the stale execution could be returned as this id's finalized result
-                    // after the new attempt finalizes.
-                    TransactionRecord::remove_finalized(tx, rec.id())?;
-                },
-            }
+        match TransactionRecord::get_finalized_decision(&**tx, rec.id())? {
+            Some(decision) if decision.is_commit() => {
+                warn!(
+                    target: LOG_TARGET, "Transaction {} is already committed. Consensus will ignore it.", rec.id()
+                );
+                return Ok(None);
+            },
+            Some(_) => {
+                info!(
+                    target: LOG_TARGET,
+                    "🔄 Transaction {} was previously finalized as aborted. Removing the previous attempt and \
+                     sequencing it again.",
+                    rec.id()
+                );
+                // The aborted attempt's bookkeeping must not survive into the new lifecycle,
+                // otherwise the stale execution could be returned as this id's finalized result
+                // after the new attempt finalizes.
+                TransactionRecord::remove_finalized(tx, rec.id())?;
+            },
+            None => {},
         }
 
         // Mempool-originated transactions have already passed full validation; their structural properties are

--- a/crates/consensus/src/hotstuff/on_receive_new_transaction.rs
+++ b/crates/consensus/src/hotstuff/on_receive_new_transaction.rs
@@ -155,13 +155,34 @@ where TConsensusSpec: ConsensusSpec
             return Ok(None);
         }
 
-        // Edge case: a validator sends a transaction that is already finalized as a missing transaction or via
-        // propagation
+        // Consensus refuses to re-sequence an id only once it has committed: a commit consumes the id
+        // permanently (its effects, including fee payment, are in state). An abort is a circumstance,
+        // not a verdict — it commits nothing, so the same transaction may be sequenced again and
+        // either commit under current conditions or abort again. Deciding this on the commit decision
+        // rather than on finalization keeps the outcome identical on every node regardless of what
+        // its local records remember, so a proposal containing a previously-aborted id can never
+        // split votes.
         if rec.is_finalized(&**tx)? {
-            warn!(
-                target: LOG_TARGET, "Transaction {} is already finalized. Consensus will ignore it.", rec.id()
-            );
-            return Ok(None);
+            match TransactionRecord::get_finalized_decision(&**tx, rec.id())? {
+                Some(decision) if decision.is_commit() => {
+                    warn!(
+                        target: LOG_TARGET, "Transaction {} is already committed. Consensus will ignore it.", rec.id()
+                    );
+                    return Ok(None);
+                },
+                _ => {
+                    info!(
+                        target: LOG_TARGET,
+                        "🔄 Transaction {} was previously finalized as aborted. Removing the previous attempt and \
+                         sequencing it again.",
+                        rec.id()
+                    );
+                    // The aborted attempt's bookkeeping must not survive into the new lifecycle,
+                    // otherwise the stale execution could be returned as this id's finalized result
+                    // after the new attempt finalizes.
+                    TransactionRecord::remove_finalized(tx, rec.id())?;
+                },
+            }
         }
 
         // Mempool-originated transactions have already passed full validation; their structural properties are

--- a/crates/consensus/src/hotstuff/on_receive_new_transaction.rs
+++ b/crates/consensus/src/hotstuff/on_receive_new_transaction.rs
@@ -3,9 +3,11 @@
 
 use log::*;
 use tari_consensus_types::Decision;
-use tari_ootle_common_types::{Epoch, committee::CommitteeInfo};
+use tari_engine_types::substate::SubstateId;
+use tari_ootle_common_types::{Epoch, committee::CommitteeInfo, optional::Optional};
 use tari_ootle_storage::{
     StateStore,
+    StateStoreReadTransaction,
     consensus_models::{TransactionPool, TransactionRecord},
 };
 use tari_ootle_transaction::TransactionId;
@@ -182,6 +184,28 @@ where TConsensusSpec: ConsensusSpec
                 TransactionRecord::remove_finalized(tx, rec.id())?;
             },
             None => {},
+        }
+
+        // The local records are only a cache: every commit writes a TransactionReceipt substate at an
+        // address derived from the transaction id, so the receipt's existence in synced state proves
+        // the id has committed even when this node's records no longer (or never) knew it — freshly
+        // synced nodes included. Only nodes whose committee includes the receipt's shard can check
+        // this, and that group is always involved because the receipt is a known output of every
+        // transaction; other shard groups fall back to their local records and rely on the receipt's
+        // home group refusing the replay.
+        let receipt_id = SubstateId::TransactionReceipt(rec.to_receipt_id());
+        if local_committee_info.includes_substate_id(&receipt_id) &&
+            (**tx)
+                .substates_get_max_version_for_substate(&receipt_id)
+                .optional()?
+                .is_some()
+        {
+            warn!(
+                target: LOG_TARGET,
+                "Transaction {} has a receipt in state and has therefore already committed. Consensus will ignore it.",
+                rec.id()
+            );
+            return Ok(None);
         }
 
         // Mempool-originated transactions have already passed full validation; their structural properties are

--- a/crates/consensus_tests/src/consensus.rs
+++ b/crates/consensus_tests/src/consensus.rs
@@ -178,6 +178,130 @@ async fn single_transaction_abort() {
     test.assert_clean_shutdown().await;
 }
 
+/// An abort commits no state, so consensus must accept the identical transaction again and give it a
+/// full lifecycle: the resubmission may commit if conditions have changed.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn single_transaction_abort_then_resubmit_is_sequenced_again() {
+    setup_logger();
+    let mut test = Test::builder().add_committee(0, vec!["1"]).start().await;
+    let (tx1, inputs, new_outputs) = test
+        .send_transaction_to_all(Decision::Abort(AbortReason::ExecutionFailure), 1, 1, 1)
+        .await;
+    test.start_epoch(Epoch(1)).await;
+
+    loop {
+        test.on_block_committed().await;
+
+        if test.is_transaction_pool_empty() {
+            break;
+        }
+        let leaf = test.get_validator(&TestAddress::new("1")).get_leaf_block();
+        if leaf.height >= NodeHeight(10) {
+            panic!("Transaction not finalized after {} blocks", leaf.height);
+        }
+    }
+
+    test.assert_all_validators_have_decision(tx1.id(), Decision::Abort(AbortReason::ExecutionFailure))
+        .await;
+    test.assert_all_validators_did_not_commit(tx1.id());
+
+    // Resubmit the identical transaction; this time execution commits.
+    test.create_execution_at_destination_for_transaction(
+        TestVnDestination::All,
+        &tx1,
+        Decision::Commit,
+        1,
+        inputs
+            .iter()
+            .map(|input| (input.substate_id().clone(), SubstateLockType::Write))
+            .collect(),
+        new_outputs,
+    );
+    test.send_transaction_to_destination(TestVnDestination::All, tx1.clone())
+        .await;
+
+    loop {
+        test.on_block_committed().await;
+
+        if test.is_transaction_pool_empty() {
+            break;
+        }
+        let leaf = test.get_validator(&TestAddress::new("1")).get_leaf_block();
+        if leaf.height >= NodeHeight(20) {
+            panic!("Resubmitted transaction not finalized after {} blocks", leaf.height);
+        }
+    }
+
+    test.stop();
+    test.assert_all_validators_committed(tx1.id());
+    test.assert_all_validators_have_decision(tx1.id(), Decision::Commit)
+        .await;
+
+    test.assert_clean_shutdown().await;
+}
+
+/// A commit consumes the transaction id permanently: resubmitting a committed transaction must be
+/// ignored. The resubmission's execution spec is set to abort so that, if consensus wrongly gave the
+/// id a new lifecycle, the finalized decision would visibly change and fail the final assertion.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn resubmitted_committed_transaction_is_ignored() {
+    setup_logger();
+    let mut test = Test::builder().add_committee(0, vec!["1"]).start().await;
+    let (tx1, inputs, _) = test.send_transaction_to_all(Decision::Commit, 1, 1, 1).await;
+    test.start_epoch(Epoch(1)).await;
+
+    loop {
+        test.on_block_committed().await;
+
+        if test.is_transaction_pool_empty() {
+            break;
+        }
+        let leaf = test.get_validator(&TestAddress::new("1")).get_leaf_block();
+        if leaf.height >= NodeHeight(10) {
+            panic!("Transaction not finalized after {} blocks", leaf.height);
+        }
+    }
+
+    test.assert_all_validators_committed(tx1.id());
+
+    test.create_execution_at_destination_for_transaction(
+        TestVnDestination::All,
+        &tx1,
+        Decision::Abort(AbortReason::ExecutionFailure),
+        1,
+        inputs
+            .iter()
+            .map(|input| (input.substate_id().clone(), SubstateLockType::Write))
+            .collect(),
+        vec![],
+    );
+    test.send_transaction_to_destination(TestVnDestination::All, tx1.clone())
+        .await;
+
+    // A subsequent transaction on the same channel guarantees the resubmission has been processed by
+    // the time the pool drains.
+    let (tx2, _, _) = test.send_transaction_to_all(Decision::Commit, 1, 1, 1).await;
+
+    loop {
+        test.on_block_committed().await;
+
+        if test.is_transaction_pool_empty() {
+            break;
+        }
+        let leaf = test.get_validator(&TestAddress::new("1")).get_leaf_block();
+        if leaf.height >= NodeHeight(20) {
+            panic!("Not all transactions finalized after {} blocks", leaf.height);
+        }
+    }
+
+    test.stop();
+    test.assert_all_validators_committed(tx2.id());
+    test.assert_all_validators_have_decision(tx1.id(), Decision::Commit)
+        .await;
+
+    test.assert_clean_shutdown().await;
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn propose_blocks_with_queued_up_transactions_until_all_committed() {
     setup_logger();

--- a/crates/consensus_tests/src/consensus.rs
+++ b/crates/consensus_tests/src/consensus.rs
@@ -38,6 +38,7 @@ use tari_ootle_common_types::{
 use tari_ootle_storage::{
     StateStore,
     StateStoreReadTransaction,
+    StateStoreWriteTransaction,
     consensus_models::{Block, Command, SubstateRecord, TransactionRecord},
 };
 use tari_ootle_transaction::{Transaction, args};
@@ -298,6 +299,83 @@ async fn resubmitted_committed_transaction_is_ignored() {
     test.assert_all_validators_committed(tx2.id());
     test.assert_all_validators_have_decision(tx1.id(), Decision::Commit)
         .await;
+
+    test.assert_clean_shutdown().await;
+}
+
+/// The receipt substate is the durable proof of commit: even when a node's finalized records are
+/// gone (pruned by GC, or a freshly synced node that never had them), a resubmitted committed
+/// transaction must still be refused because its receipt exists in synced state.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn resubmitted_committed_transaction_is_ignored_after_records_pruned() {
+    setup_logger();
+    let mut test = Test::builder().add_committee(0, vec!["1"]).start().await;
+    let (tx1, inputs, _) = test.send_transaction_to_all(Decision::Commit, 1, 1, 1).await;
+    test.start_epoch(Epoch(1)).await;
+
+    loop {
+        test.on_block_committed().await;
+
+        if test.is_transaction_pool_empty() {
+            break;
+        }
+        let leaf = test.get_validator(&TestAddress::new("1")).get_leaf_block();
+        if leaf.height >= NodeHeight(10) {
+            panic!("Transaction not finalized after {} blocks", leaf.height);
+        }
+    }
+
+    test.assert_all_validators_committed(tx1.id());
+
+    // Forget the finalized bookkeeping, as record GC would.
+    test.get_validator(&TestAddress::new("1"))
+        .state_store
+        .with_write_tx(|tx| tx.transactions_finalized_remove(tx1.id()))
+        .unwrap();
+
+    // Tripwire: if consensus wrongly gave the id a new lifecycle, it would finalize as an abort and
+    // the final assertion would see a finalized record reappear.
+    test.create_execution_at_destination_for_transaction(
+        TestVnDestination::All,
+        &tx1,
+        Decision::Abort(AbortReason::ExecutionFailure),
+        1,
+        inputs
+            .iter()
+            .map(|input| (input.substate_id().clone(), SubstateLockType::Write))
+            .collect(),
+        vec![],
+    );
+    test.send_transaction_to_destination(TestVnDestination::All, tx1.clone())
+        .await;
+
+    // A subsequent transaction on the same channel guarantees the resubmission has been processed by
+    // the time the pool drains.
+    let (tx2, _, _) = test.send_transaction_to_all(Decision::Commit, 1, 1, 1).await;
+
+    loop {
+        test.on_block_committed().await;
+
+        if test.is_transaction_pool_empty() {
+            break;
+        }
+        let leaf = test.get_validator(&TestAddress::new("1")).get_leaf_block();
+        if leaf.height >= NodeHeight(20) {
+            panic!("Not all transactions finalized after {} blocks", leaf.height);
+        }
+    }
+
+    test.stop();
+    test.assert_all_validators_committed(tx2.id());
+    let finalized = test
+        .get_validator(&TestAddress::new("1"))
+        .state_store
+        .with_read_tx(|tx| TransactionRecord::is_record_finalized(tx, tx1.id()))
+        .unwrap();
+    assert!(
+        !finalized,
+        "resubmitted committed transaction was re-sequenced despite its receipt existing in state"
+    );
 
     test.assert_clean_shutdown().await;
 }

--- a/crates/state_store_rocksdb/src/reader.rs
+++ b/crates/state_store_rocksdb/src/reader.rs
@@ -1475,6 +1475,12 @@ impl<'tx, TAddr: NodeAddressable + Serialize + DeserializeOwned + 'tx, R: RocksR
         Ok((data.version, data.is_up))
     }
 
+    fn substates_exists_any_version(&self, substate_id: &SubstateId) -> Result<bool, StorageError> {
+        const OPERATION: &str = "substates_exists_any_version";
+        let exists = self.db().cf(substate::HeadIndex)?.exists(substate_id, OPERATION)?;
+        Ok(exists)
+    }
+
     fn substates_any_exist<'a, I>(&self, substates: I) -> Result<bool, StorageError>
     where I: IntoIterator<Item = VersionedSubstateIdRef<'a>> {
         const OPERATION: &str = "substates_any_exist";

--- a/crates/state_store_rocksdb/src/writer.rs
+++ b/crates/state_store_rocksdb/src/writer.rs
@@ -687,6 +687,27 @@ impl<'tx, TAddr: NodeAddressable + 'tx> StateStoreWriteTransaction for RocksDbSt
         Ok(())
     }
 
+    fn transactions_finalized_remove(&mut self, tx_id: &TransactionId) -> Result<(), StorageError> {
+        const OPERATION: &str = "transactions_finalized_remove";
+
+        self.db().cf(FinalizedTransactionLinkCf)?.delete(tx_id, OPERATION)?;
+
+        let exec_cf = self.db().cf(BlockTransactionExecutionCf)?;
+        let exec_query = self.db().cf(block_transaction_execution::ByTransactionIdQuery)?;
+        let exec_index_cf = self.db().cf(block_transaction_execution::BlockIndex)?;
+
+        let iter = exec_query.query_prefix_range_key_iterator(Ordering::default(), tx_id);
+        for result in iter {
+            let (tx_id, block_id, height) = result?;
+            exec_cf.delete(&(tx_id, block_id, height), OPERATION)?;
+            // The block index entry is removed at finalize, but executions recorded by proposals
+            // still in flight at that point may have index entries remaining.
+            exec_index_cf.delete(&(block_id, tx_id, height), OPERATION)?;
+        }
+
+        Ok(())
+    }
+
     fn block_transaction_executions_insert_or_ignore(
         &mut self,
         transaction_execution: &BlockTransactionExecution,

--- a/crates/storage/src/consensus_models/transaction.rs
+++ b/crates/storage/src/consensus_models/transaction.rs
@@ -10,6 +10,7 @@ use log::*;
 use minicbor::{CborLen, Decode, Encode};
 use serde::{Deserialize, Serialize};
 use tari_consensus_types::Decision;
+use tari_engine_types::substate::SubstateId;
 use tari_ootle_common_types::{
     NumPreshards,
     ToSubstateAddress,
@@ -235,6 +236,19 @@ impl TransactionRecord {
         transaction_id: &TransactionId,
     ) -> Result<(), StorageError> {
         tx.transactions_finalized_remove(transaction_id)
+    }
+
+    /// Returns true if this transaction's receipt substate exists in state. Every commit — including
+    /// a fee-only commit — writes the receipt at an address derived from the transaction id, so its
+    /// existence is the durable, synced proof that the id has committed, independent of local
+    /// transaction records. Only nodes hosting the receipt's shard can observe it; on any other node
+    /// this returns false.
+    pub fn receipt_exists<TTx: StateStoreReadTransaction>(
+        tx: &TTx,
+        transaction_id: &TransactionId,
+    ) -> Result<bool, StorageError> {
+        let receipt_id = SubstateId::TransactionReceipt((*transaction_id).into());
+        tx.substates_exists_any_version(&receipt_id)
     }
 
     pub fn finalize_all<'a, TTx, I>(tx: &mut TTx, transactions: I) -> Result<(), StorageError>

--- a/crates/storage/src/consensus_models/transaction.rs
+++ b/crates/storage/src/consensus_models/transaction.rs
@@ -217,9 +217,10 @@ impl TransactionRecord {
         Ok(time.is_some())
     }
 
-    /// Returns the decision of the finalized execution, or `None` if the transaction has not been
-    /// finalized. A finalized marker without a recorded execution also returns `None`: a commit
-    /// always records the execution it committed, so such a record cannot represent a commit.
+    /// Returns the decision of the finalized execution held in this node's records, or `None` when
+    /// the records hold none — either the transaction was never finalized here, or its bookkeeping
+    /// has since been removed. This reports only what the local records prove; proof of commit that
+    /// survives record removal is the receipt substate (see [`Self::receipt_exists`]).
     pub fn get_finalized_decision<TTx: StateStoreReadTransaction>(
         tx: &TTx,
         transaction_id: &TransactionId,
@@ -228,9 +229,9 @@ impl TransactionRecord {
         Ok(maybe_execution.map(|execution| execution.decision()))
     }
 
-    /// Removes the finalized marker and recorded executions for this id so consensus can sequence
-    /// the transaction again. Must only be called for transactions finalized with an abort: an
-    /// abort commits no state, so its bookkeeping can be discarded without inconsistency.
+    /// Forgets the node-local finalized bookkeeping for this id (marker and recorded executions),
+    /// making it appear unsequenced to this node's records. Never reverts committed state; see
+    /// [`StateStoreWriteTransaction::transactions_finalized_remove`].
     pub fn remove_finalized<TTx: StateStoreWriteTransaction>(
         tx: &mut TTx,
         transaction_id: &TransactionId,

--- a/crates/storage/src/consensus_models/transaction.rs
+++ b/crates/storage/src/consensus_models/transaction.rs
@@ -9,6 +9,7 @@ use std::{
 use log::*;
 use minicbor::{CborLen, Decode, Encode};
 use serde::{Deserialize, Serialize};
+use tari_consensus_types::Decision;
 use tari_ootle_common_types::{
     NumPreshards,
     ToSubstateAddress,
@@ -213,6 +214,27 @@ impl TransactionRecord {
             .finalized_transaction_execution_get_finalized_time(transaction_id)
             .optional()?;
         Ok(time.is_some())
+    }
+
+    /// Returns the decision of the finalized execution, or `None` if the transaction has not been
+    /// finalized. A finalized marker without a recorded execution also returns `None`: a commit
+    /// always records the execution it committed, so such a record cannot represent a commit.
+    pub fn get_finalized_decision<TTx: StateStoreReadTransaction>(
+        tx: &TTx,
+        transaction_id: &TransactionId,
+    ) -> Result<Option<Decision>, StorageError> {
+        let maybe_execution = tx.finalized_transaction_execution_get(transaction_id).optional()?;
+        Ok(maybe_execution.map(|execution| execution.decision()))
+    }
+
+    /// Removes the finalized marker and recorded executions for this id so consensus can sequence
+    /// the transaction again. Must only be called for transactions finalized with an abort: an
+    /// abort commits no state, so its bookkeeping can be discarded without inconsistency.
+    pub fn remove_finalized<TTx: StateStoreWriteTransaction>(
+        tx: &mut TTx,
+        transaction_id: &TransactionId,
+    ) -> Result<(), StorageError> {
+        tx.transactions_finalized_remove(transaction_id)
     }
 
     pub fn finalize_all<'a, TTx, I>(tx: &mut TTx, transactions: I) -> Result<(), StorageError>

--- a/crates/storage/src/state_store/mod.rs
+++ b/crates/storage/src/state_store/mod.rs
@@ -443,6 +443,12 @@ pub trait StateStoreWriteTransaction {
         transaction: I,
     ) -> Result<(), StorageError>;
 
+    /// Removes the finalized marker and all recorded executions for a transaction, returning it to
+    /// an unsequenced state so that consensus can process the same transaction id through a fresh
+    /// lifecycle. Only valid for transactions finalized with an abort decision: an abort commits no
+    /// state, so discarding its bookkeeping leaves the store consistent.
+    fn transactions_finalized_remove(&mut self, tx_id: &TransactionId) -> Result<(), StorageError>;
+
     // -------------------------------- Transaction Executions -------------------------------- //
 
     fn block_transaction_executions_insert_or_ignore(

--- a/crates/storage/src/state_store/mod.rs
+++ b/crates/storage/src/state_store/mod.rs
@@ -268,6 +268,10 @@ pub trait StateStoreReadTransaction: Sized {
     fn substates_any_exist<'a, I>(&self, substates: I) -> Result<bool, StorageError>
     where I: IntoIterator<Item = VersionedSubstateIdRef<'a>>;
 
+    /// Returns true if any version of the given substate id exists, up or down. A pure key-existence
+    /// check — cheaper than fetching the head version when the caller does not need it.
+    fn substates_exists_any_version(&self, substate_id: &SubstateId) -> Result<bool, StorageError>;
+
     /// Returns an iterator of all substates in the given shard, starting from the given state version (inclusive).
     /// It returns substates, ordered by state version however, the ordering within state versions is by the node key,
     /// meaning it is essentially random. WARNING: do not use this as it only works when all stale state tree nodes

--- a/crates/storage/src/state_store/mod.rs
+++ b/crates/storage/src/state_store/mod.rs
@@ -447,10 +447,12 @@ pub trait StateStoreWriteTransaction {
         transaction: I,
     ) -> Result<(), StorageError>;
 
-    /// Removes the finalized marker and all recorded executions for a transaction, returning it to
-    /// an unsequenced state so that consensus can process the same transaction id through a fresh
-    /// lifecycle. Only valid for transactions finalized with an abort decision: an abort commits no
-    /// state, so discarding its bookkeeping leaves the store consistent.
+    /// Forgets the node-local finalized bookkeeping for a transaction: the finalized marker and all
+    /// recorded executions. This never reverts committed state — a commit's effects, fees and
+    /// receipt substate live in synced state — it only makes the id appear unsequenced to this
+    /// node's records. Used to give an aborted transaction a fresh lifecycle, and by record GC to
+    /// prune old bookkeeping; committed ids remain refused via the receipt-existence check, which
+    /// does not depend on these records.
     fn transactions_finalized_remove(&mut self, tx_id: &TransactionId) -> Result<(), StorageError>;
 
     // -------------------------------- Transaction Executions -------------------------------- //


### PR DESCRIPTION
## Motivation
The consensus new-transaction gate refused any *finalized* transaction id. Finalization records are node-local — never synced, never GC'd — so a freshly synced (or checkpoint-joined) node has no record of a past abort. Whether a resubmitted transaction was blocked therefore depended on which node received it: a fresh node would sequence and propose it while nodes that remembered the abort refused to admit it via the missing-transactions path, leaving the proposal parked until leader timeout. A memory-dependent vote split — i.e., a liveness bug that recurs each time the fresh node leads.

The underlying principle of the fix: anything feeding the vote path must not depend on node-local memory. A commit is the only durable, state-backed fact about a transaction id; an abort commits nothing and is a circumstance, not a verdict.

## Changes
- `on_receive_new_transaction`: consensus ignores a resubmitted id only when its finalized decision is a commit. `AcceptFeeRejectRest` (failed-but-fee-paid) maps to `Decision::Commit`, so fee-paying failures remain non-replayable and a fee payer can never be billed twice. A finalized abort is re-admitted: the previous attempt's bookkeeping is removed and the transaction gets a fresh lifecycle — it either commits under current conditions or aborts again, identically on every node. Applies to both entry points (own mempool and requested missing transactions — the path that parked blocks).
- **Receipt-existence backstop**: local finalized records are only a cache, so the gate additionally refuses any id whose `TransactionReceipt` substate exists in synced state. Every commit — including a fee-only `AcceptFeeRejectRest` — writes the receipt at an address derived from the transaction id, and the receipt's shard group is always involved because the receipt is a known output of every transaction. This makes committed-id dedup identical on every synced node regardless of local record retention (freshly synced nodes included), and unblocks pruning transaction records in epoch GC as a follow-up. Shard groups that do not host the receipt fall back to their local records and rely on the receipt's home group refusing the replay.
- New `StateStoreWriteTransaction::transactions_finalized_remove` (+ RocksDB impl): deletes the finalized-link entry and all recorded block executions for the id. Required because `finalized_transaction_execution_get` returns an arbitrary execution row for the id; without the purge a later commit could report the stale aborted execution as its finalized result. All other per-transaction bookkeeping (pool record, substate locks, foreign pledges, lock conflicts) is already cleaned at finalization.
- New `TransactionRecord::get_finalized_decision` / `TransactionRecord::remove_finalized` model helpers.
- The mempool's `transaction_exists` also gains the receipt lookup as a best-effort edge filter: a node hosting the receipt's shard drops a committed-id replay before any gossip or consensus work. A node that doesn't host the shard (or is behind on sync) never finds the substate and falls through — the consensus gate makes the authoritative refusal.
- Deliberately unchanged: the mempool's strict record-based dedup (still drops any id it has a record for, so known resubmissions die at the first hop without re-execution) and the `foreign_proposal_processor` finalized check (single resurrection entry point — a lagging foreign proposal from an aborted attempt must not resurrect a transaction on its own).

## Deployment notes
Not consensus-breaking in the data sense: no wire, state, or id format change. It is a voting-behavior change, so all validators should upgrade together; during a mixed-version window a resubmitted aborted id reproduces today's behavior (no worse). Independent of the stable-transaction-id change (#2352) and of mandatory max_epoch.

## Verification
- Three end-to-end harness tests in `consensus_tests` (run on the real RocksDB store):
  - `single_transaction_abort_then_resubmit_is_sequenced_again` — abort finalizes; identical bytes resubmitted; second attempt commits.
  - `resubmitted_committed_transaction_is_ignored` — after a commit, the resubmission's execution spec is set to abort as a tripwire: if consensus wrongly gave the id a new lifecycle the finalized decision would visibly change; it stays Commit.
  - `resubmitted_committed_transaction_is_ignored_after_records_pruned` — the finalized records are removed after the commit (as record GC would), then the resubmission must still be refused via the receipt. Mutation-verified: with the receipt check disabled this test fails.
- Full `consensus_tests` suite green: 65/65 (release).
- `cargo lints clippy --all-targets` clean on touched crates; `cargo +nightly-2025-12-05 fmt --all` applied.
