### PR TITLE
feat(storage): prune finalized transaction records in epoch GC

### DIFF
--- a/applications/tari_validator_node/src/bootstrap.rs
+++ b/applications/tari_validator_node/src/bootstrap.rs
@@ -250,7 +250,9 @@ pub async fn spawn_services(
     let state_store = ValidatorNodeStateStore::open(
         &config.validator_node.state_db_path,
         // TODO: just enable it always for now, later make it configurable and default to true for testnets
-        DatabaseOptions::default().with_debugging_data(true),
+        DatabaseOptions::default()
+            .with_debugging_data(true)
+            .with_prune_transaction_history(!config.validator_node.keep_transaction_history),
     )?;
 
     state_store.with_write_tx(|tx| migrations::migrate(tx, config.network, &consensus_constants))?;

--- a/applications/tari_validator_node/src/config.rs
+++ b/applications/tari_validator_node/src/config.rs
@@ -101,6 +101,12 @@ pub struct ValidatorNodeConfig {
     /// The (optional) sidechain to run this on. Identifies this chain for validator-node and
     /// template registration filtering, block-header validation, and L1 burn-claim binding.
     pub sidechain_id: Option<RistrettoPublicKey>,
+    /// Retain the full transaction history instead of pruning finalized transaction records once
+    /// they age out of the epoch retention window. Chain state (committed effects and transaction
+    /// receipts) is retained regardless; this only controls the node-local transaction payloads,
+    /// results and finalized markers used for queries and history.
+    #[serde(default)]
+    pub keep_transaction_history: bool,
     /// The path to store layer-one transactions.
     pub layer_one_transaction_path: PathBuf,
     /// Consensus configuration
@@ -191,6 +197,7 @@ impl Default for ValidatorNodeConfig {
             fee_claim_public_key: RistrettoPublicKey::default(),
             dont_create_id: false,
             sidechain_id: None,
+            keep_transaction_history: false,
             layer_one_transaction_path: PathBuf::from("data/layer_one_transactions"),
             consensus: ConsensusConfig::default(),
             max_transaction_gossip_queue_bytes: default_max_transaction_gossip_queue_bytes(),

--- a/crates/consensus/src/hotstuff/on_ready_to_vote_on_local_block.rs
+++ b/crates/consensus/src/hotstuff/on_ready_to_vote_on_local_block.rs
@@ -1763,7 +1763,7 @@ where TConsensusSpec: ConsensusSpec
                 .with_iterations(finalized_transactions.len());
             // Remove locks for finalized transactions
             SubstateRecord::unlock_all(tx, finalized_transactions.iter().map(|t| t.id()))?;
-            TransactionRecord::finalize_all(tx, &finalized_transactions)?;
+            TransactionRecord::finalize_all(tx, block.epoch(), &finalized_transactions)?;
 
             debug!(
                 target: LOG_TARGET,

--- a/crates/state_store_rocksdb/src/codecs/prefixed.rs
+++ b/crates/state_store_rocksdb/src/codecs/prefixed.rs
@@ -56,6 +56,7 @@ pub enum KeyPrefix {
     StateTreeShardVersion = 42,
     ValidatorNodeEpochStats = 43,
     RollbackHistory = 44,
+    FinalizedTransactionEpochIndex = 45,
 }
 
 impl KeyPrefix {

--- a/crates/state_store_rocksdb/src/column_families/finalized_transaction.rs
+++ b/crates/state_store_rocksdb/src/column_families/finalized_transaction.rs
@@ -3,14 +3,15 @@
 
 use minicbor::{CborLen, Decode, Encode};
 use serde::{Deserialize, Serialize};
+use tari_ootle_common_types::Epoch;
 use tari_ootle_storage::time::PrimitiveDateTime;
 use tari_ootle_transaction::TransactionId;
 
 use crate::{
-    codecs::{DefaultCodec, KeyPrefix, TransactionIdCodec},
+    codecs::{DefaultCodec, EpochCodec, KeyPrefix, TransactionIdCodec, UnitCodec},
     column_families::cf_names,
     prefixed,
-    traits::Cf,
+    traits::{Cf, QueryCf},
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize, Encode, Decode, CborLen)]
@@ -19,6 +20,12 @@ pub struct FinalizedTransactionLinkData {
     #[n(0)]
     #[cbor(with = "tari_bor::adapters::serde_bridge")]
     pub finalized_at: PrimitiveDateTime,
+    /// The epoch of the block that finalized the transaction. Keyed into [`EpochIndex`] so epoch GC
+    /// can prune finalized transaction bookkeeping by age.
+    #[n(1)]
+    #[cbor(default)]
+    #[serde(default)]
+    pub epoch: Epoch,
 }
 
 prefixed!(FinalizedTransactionLinkPrefix, KeyPrefix::FinalizedTransactionLinks);
@@ -35,4 +42,35 @@ impl Cf for FinalizedTransactionLinkCf {
     fn name() -> &'static str {
         cf_names::TRANSACTIONS
     }
+}
+
+prefixed!(
+    FinalizedTransactionEpochIndexPrefix,
+    KeyPrefix::FinalizedTransactionEpochIndex
+);
+
+/// Index of finalized transaction ids by the epoch they finalized in, used by epoch GC to prune
+/// transaction bookkeeping by age. Exactly one entry exists per finalized id — re-finalizing an id
+/// (a previously aborted transaction sequenced again) moves its entry to the latest epoch.
+pub struct EpochIndex;
+
+impl Cf for EpochIndex {
+    type Key = (Epoch, TransactionId);
+    type KeyCodec = (EpochCodec, TransactionIdCodec);
+    type Prefix = FinalizedTransactionEpochIndexPrefix;
+    type Value = ();
+    type ValueCodec = UnitCodec;
+
+    fn name() -> &'static str {
+        cf_names::TRANSACTIONS
+    }
+}
+
+/// Used to range-query [`EpochIndex`] up to a prune epoch.
+pub struct ByEpochQuery;
+
+impl QueryCf for ByEpochQuery {
+    type Cf = EpochIndex;
+    type Key = Epoch;
+    type KeyCodec = EpochCodec;
 }

--- a/crates/state_store_rocksdb/src/options.rs
+++ b/crates/state_store_rocksdb/src/options.rs
@@ -16,6 +16,13 @@ pub struct DatabaseOptions {
     /// Whether to store additional debugging data in the database. This may increase storage requirements and slow
     /// down some operations, so it should only be enabled for debugging purposes.
     pub debugging_data: bool,
+    /// Whether epoch GC prunes finalized transaction bookkeeping (payloads, results and finalized
+    /// markers) once it ages past `epoch_history_length`. Disable to retain the full transaction
+    /// history (an archival node). Chain state — committed effects and transaction receipts — is
+    /// retained regardless, so consensus behaviour is identical either way. The epoch index that
+    /// drives pruning is always maintained, so pruning can be enabled later and will still remove
+    /// history accumulated while it was disabled.
+    pub prune_transaction_history: bool,
 }
 
 impl DatabaseOptions {
@@ -43,6 +50,13 @@ impl DatabaseOptions {
         self.epoch_history_length = epoch_history_length;
         self
     }
+
+    /// Whether epoch GC prunes finalized transaction bookkeeping once it ages past
+    /// `epoch_history_length`. Disable to retain the full transaction history (an archival node).
+    pub fn with_prune_transaction_history(mut self, prune_transaction_history: bool) -> Self {
+        self.prune_transaction_history = prune_transaction_history;
+        self
+    }
 }
 
 impl Default for DatabaseOptions {
@@ -51,6 +65,7 @@ impl Default for DatabaseOptions {
             state_history_length: 100,
             epoch_history_length: 1,
             debugging_data: false,
+            prune_transaction_history: true,
         }
     }
 }

--- a/crates/state_store_rocksdb/src/writer.rs
+++ b/crates/state_store_rocksdb/src/writer.rs
@@ -122,6 +122,7 @@ use crate::{
         epoch_checkpoint::EpochCheckpointCf,
         evicted_node,
         evicted_node::{EvictedNodeCf, EvictedNodeData},
+        finalized_transaction,
         finalized_transaction::{FinalizedTransactionLinkCf, FinalizedTransactionLinkData},
         foreign_parked_blocks,
         foreign_parked_blocks::ForeignParkedBlockCf,
@@ -662,19 +663,33 @@ impl<'tx, TAddr: NodeAddressable + 'tx> StateStoreWriteTransaction for RocksDbSt
 
     fn transactions_finalize_all<'a, I: IntoIterator<Item = &'a TransactionPoolRecord>>(
         &mut self,
+        epoch: Epoch,
         transactions: I,
     ) -> Result<(), StorageError> {
         const OPERATION: &str = "transactions_finalize_all";
 
         let finalized_cf = self.db().cf(FinalizedTransactionLinkCf)?;
+        let epoch_index_cf = self.db().cf(finalized_transaction::EpochIndex)?;
         let exec_query = self.db().cf(block_transaction_execution::ByTransactionIdQuery)?;
         let exec_index_cf = self.db().cf(block_transaction_execution::BlockIndex)?;
 
         let iter = transactions.into_iter();
         // Add transactions to finalized CF
-        let data = FinalizedTransactionLinkData { finalized_at: now() };
+        let data = FinalizedTransactionLinkData {
+            finalized_at: now(),
+            epoch,
+        };
         for transaction in iter {
+            // The epoch index holds exactly one entry per id: a re-finalized id (a previously
+            // aborted transaction sequenced again) moves to the epoch it last finalized in, so the
+            // GC horizon applies to the latest attempt.
+            if let Some(prev) = finalized_cf.get(transaction.id(), OPERATION).optional()? &&
+                prev.epoch != epoch
+            {
+                epoch_index_cf.delete(&(prev.epoch, *transaction.id()), OPERATION)?;
+            }
             finalized_cf.put(transaction.id(), &data, OPERATION)?;
+            epoch_index_cf.put(&(epoch, *transaction.id()), &(), OPERATION)?;
 
             // Delete from block index which is used for querying pending executions
             let iter = exec_query.query_prefix_range_key_iterator(Ordering::default(), transaction.id());
@@ -690,7 +705,15 @@ impl<'tx, TAddr: NodeAddressable + 'tx> StateStoreWriteTransaction for RocksDbSt
     fn transactions_finalized_remove(&mut self, tx_id: &TransactionId) -> Result<(), StorageError> {
         const OPERATION: &str = "transactions_finalized_remove";
 
-        self.db().cf(FinalizedTransactionLinkCf)?.delete(tx_id, OPERATION)?;
+        let finalized_cf = self.db().cf(FinalizedTransactionLinkCf)?;
+        // The epoch index entry must go with the link, otherwise epoch GC would later delete the
+        // payload of an id that has been re-sequenced and is live again.
+        if let Some(link) = finalized_cf.get(tx_id, OPERATION).optional()? {
+            self.db()
+                .cf(finalized_transaction::EpochIndex)?
+                .delete(&(link.epoch, *tx_id), OPERATION)?;
+        }
+        finalized_cf.delete(tx_id, OPERATION)?;
 
         let exec_cf = self.db().cf(BlockTransactionExecutionCf)?;
         let exec_query = self.db().cf(block_transaction_execution::ByTransactionIdQuery)?;
@@ -1778,6 +1801,9 @@ impl<'tx, TAddr: NodeAddressable + 'tx> StateStoreWriteTransaction for RocksDbSt
         cleanup::cleanup_blocks_for_epoch(&db, prune_epoch)?;
         cleanup::cleanup_qcs_for_epoch(&db, prune_epoch)?;
         cleanup::foreign_proposals_for_epoch(&db, prune_epoch)?;
+        if self.options.prune_transaction_history {
+            cleanup::cleanup_finalized_transactions_for_epoch(&db, prune_epoch)?;
+        }
 
         Ok(())
     }
@@ -1935,6 +1961,54 @@ mod cleanup {
         info!(
             target: LOG_TARGET,
             "Cleaned up {} blocks for ..{}",
+            count,
+            up_to_epoch
+        );
+
+        Ok(())
+    }
+
+    /// Prunes finalized transaction bookkeeping — the payload, finalized link, recorded executions
+    /// and the epoch-index entry — for everything finalized up to and including `up_to_epoch`.
+    ///
+    /// Only bookkeeping is removed: a commit's effects and its receipt substate are synced state and
+    /// remain, so committed ids stay refused via the receipt-existence check after their records are
+    /// gone. The prune horizon matches block retention, so a transaction's payload outlives every
+    /// retained block that references it.
+    pub fn cleanup_finalized_transactions_for_epoch(
+        db: &DbWriteContext<'_>,
+        up_to_epoch: Epoch,
+    ) -> Result<(), StorageError> {
+        const OPERATION: &str = "cleanup::cleanup_finalized_transactions_for_epoch";
+        let up_to_epoch = up_to_epoch + Epoch(1); // Make it inclusive
+        let tx_cf = db.cf(TransactionCf)?;
+        let link_cf = db.cf(FinalizedTransactionLinkCf)?;
+        let epoch_index_cf = db.cf(finalized_transaction::EpochIndex)?;
+        let exec_cf = db.cf(BlockTransactionExecutionCf)?;
+        let exec_query = db.cf(block_transaction_execution::ByTransactionIdQuery)?;
+        let exec_index_cf = db.cf(block_transaction_execution::BlockIndex)?;
+
+        let query = db.cf(finalized_transaction::ByEpochQuery)?;
+        let iter = query.query_range_key_iterator(Ordering::Ascending, Epoch::zero()..up_to_epoch);
+
+        let mut count = 0usize;
+        for result in iter {
+            let (epoch, tx_id) = result?;
+            tx_cf.delete(&tx_id, OPERATION)?;
+            link_cf.delete(&tx_id, OPERATION)?;
+            let exec_iter = exec_query.query_prefix_range_key_iterator(Ordering::default(), &tx_id);
+            for result in exec_iter {
+                let (tx_id, block_id, height) = result?;
+                exec_cf.delete(&(tx_id, block_id, height), OPERATION)?;
+                exec_index_cf.delete(&(block_id, tx_id, height), OPERATION)?;
+            }
+            epoch_index_cf.delete(&(epoch, tx_id), OPERATION)?;
+            count += 1;
+        }
+
+        info!(
+            target: LOG_TARGET,
+            "Cleaned up {} finalized transactions for ..{}",
             count,
             up_to_epoch
         );

--- a/crates/state_store_rocksdb/tests/transactions.rs
+++ b/crates/state_store_rocksdb/tests/transactions.rs
@@ -412,7 +412,7 @@ mod transaction_execution_operations {
             .unwrap();
         let transactions = tx.transaction_pool_get_all(1000).unwrap();
         assert_eq!(transactions.len(), 1);
-        tx.transactions_finalize_all(transactions.iter()).unwrap();
+        tx.transactions_finalize_all(Epoch(1), transactions.iter()).unwrap();
 
         let rec = tx.transactions_get(tx1.id()).unwrap();
         assert!(rec.is_finalized(&*tx).unwrap(), "Transaction should be finalized");
@@ -495,6 +495,130 @@ mod transaction_execution_operations {
             matches!(res, Err(StorageError::NotFound { .. })),
             "orphan-branch execution must not be reused, got {res:?}"
         );
+
+        tx.rollback().unwrap();
+    }
+}
+
+mod finalized_transaction_gc {
+    use super::*;
+
+    fn insert_transaction(tx: &mut impl StateStoreWriteTransaction) -> TransactionRecord {
+        let rec = TransactionRecord::new(
+            Transaction::builder_localnet()
+                .add_instruction(Instruction::DropAllProofsInWorkspace)
+                .add_input(SubstateRequirement::new(create_random_substate_id(), Some(0)))
+                .build_and_seal(&PrivateKey::default()),
+        );
+        tx.transactions_insert(&rec).unwrap();
+        rec
+    }
+
+    #[test]
+    fn epoch_gc_prunes_finalized_transactions_rocksdb() {
+        let (db, _tmp) = create_rocksdb();
+        epoch_gc_prunes_finalized_transactions(db);
+    }
+
+    fn epoch_gc_prunes_finalized_transactions(db: impl StateStore) {
+        let mut tx = db.create_write_tx().unwrap();
+
+        let chain = create_chain(10);
+        commit_chain(&mut tx, &chain);
+
+        let tx1 = insert_transaction(&mut tx);
+        tx.transaction_pool_insert_new(*tx1.id(), Decision::Commit, &Evidence::empty(), true, false, None, 0)
+            .unwrap();
+        let pool = tx.transaction_pool_get_all(1000).unwrap();
+        tx.transactions_finalize_all(Epoch(1), pool.iter()).unwrap();
+        assert!(tx.transactions_exists(tx1.id()).unwrap());
+        assert!(TransactionRecord::is_record_finalized(&*tx, tx1.id()).unwrap());
+
+        // epoch_history_length is 1 (default options): cleaning at epoch 1 prunes ..=0, which keeps
+        // bookkeeping finalized in epoch 1.
+        tx.epoch_cleanup(Epoch(1)).unwrap();
+        assert!(tx.transactions_exists(tx1.id()).unwrap());
+        assert!(TransactionRecord::is_record_finalized(&*tx, tx1.id()).unwrap());
+
+        // Cleaning at epoch 2 prunes ..=1: payload, finalized link and executions all go.
+        tx.epoch_cleanup(Epoch(2)).unwrap();
+        assert!(!tx.transactions_exists(tx1.id()).unwrap());
+        assert!(!TransactionRecord::is_record_finalized(&*tx, tx1.id()).unwrap());
+        assert!(tx.finalized_transaction_execution_get(tx1.id()).is_err());
+
+        tx.rollback().unwrap();
+    }
+
+    #[test]
+    fn archival_node_keeps_transaction_history_rocksdb() {
+        use helpers::create_rocksdb_with_opts;
+        use tari_state_store_rocksdb::DatabaseOptions;
+
+        let (db, _tmp) = create_rocksdb_with_opts(DatabaseOptions::default().with_prune_transaction_history(false));
+        let mut tx = db.create_write_tx().unwrap();
+
+        let chain = create_chain(10);
+        commit_chain(&mut tx, &chain);
+
+        let tx1 = insert_transaction(&mut tx);
+        tx.transaction_pool_insert_new(*tx1.id(), Decision::Commit, &Evidence::empty(), true, false, None, 0)
+            .unwrap();
+        let pool = tx.transaction_pool_get_all(1000).unwrap();
+        tx.transactions_finalize_all(Epoch(1), pool.iter()).unwrap();
+
+        tx.epoch_cleanup(Epoch(10)).unwrap();
+        assert!(tx.transactions_exists(tx1.id()).unwrap());
+        assert!(TransactionRecord::is_record_finalized(&*tx, tx1.id()).unwrap());
+
+        tx.rollback().unwrap();
+    }
+
+    #[test]
+    fn refinalized_transaction_ages_from_its_latest_epoch_rocksdb() {
+        let (db, _tmp) = create_rocksdb();
+        refinalized_transaction_ages_from_its_latest_epoch(db);
+    }
+
+    /// The epoch index must hold exactly one entry per id, keyed to the latest finalization: a
+    /// stale entry from an earlier finalization (or one left behind by
+    /// `transactions_finalized_remove`) would let epoch GC delete the bookkeeping of a transaction
+    /// that finalized recently. Survival across the earlier epochs' cleanup is the proof that the
+    /// stale entries are gone.
+    fn refinalized_transaction_ages_from_its_latest_epoch(db: impl StateStore) {
+        let mut tx = db.create_write_tx().unwrap();
+
+        let chain = create_chain(10);
+        commit_chain(&mut tx, &chain);
+
+        let tx1 = insert_transaction(&mut tx);
+        tx.transaction_pool_insert_new(*tx1.id(), Decision::Commit, &Evidence::empty(), true, false, None, 0)
+            .unwrap();
+        let pool = tx.transaction_pool_get_all(1000).unwrap();
+
+        // Finalized in epoch 1, then finalized again in epoch 5: the index entry moves.
+        tx.transactions_finalize_all(Epoch(1), pool.iter()).unwrap();
+        tx.transactions_finalize_all(Epoch(5), pool.iter()).unwrap();
+        tx.epoch_cleanup(Epoch(2)).unwrap();
+        assert!(
+            tx.transactions_exists(tx1.id()).unwrap(),
+            "an id re-finalized in a later epoch must not age out from its earlier epoch"
+        );
+        assert!(TransactionRecord::is_record_finalized(&*tx, tx1.id()).unwrap());
+
+        // Resurrected (as consensus does for an aborted id) and finalized again in epoch 7.
+        tx.transactions_finalized_remove(tx1.id()).unwrap();
+        assert!(!TransactionRecord::is_record_finalized(&*tx, tx1.id()).unwrap());
+        tx.transactions_finalize_all(Epoch(7), pool.iter()).unwrap();
+        tx.epoch_cleanup(Epoch(6)).unwrap();
+        assert!(
+            tx.transactions_exists(tx1.id()).unwrap(),
+            "a resurrected id must not age out from the epoch of the removed finalization"
+        );
+
+        // It ages out from its latest finalization epoch.
+        tx.epoch_cleanup(Epoch(8)).unwrap();
+        assert!(!tx.transactions_exists(tx1.id()).unwrap());
+        assert!(!TransactionRecord::is_record_finalized(&*tx, tx1.id()).unwrap());
 
         tx.rollback().unwrap();
     }

--- a/crates/storage/src/consensus_models/transaction.rs
+++ b/crates/storage/src/consensus_models/transaction.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
 use tari_consensus_types::Decision;
 use tari_engine_types::substate::SubstateId;
 use tari_ootle_common_types::{
+    Epoch,
     NumPreshards,
     ToSubstateAddress,
     committee::CommitteeInfo,
@@ -252,13 +253,13 @@ impl TransactionRecord {
         tx.substates_exists_any_version(&receipt_id)
     }
 
-    pub fn finalize_all<'a, TTx, I>(tx: &mut TTx, transactions: I) -> Result<(), StorageError>
+    pub fn finalize_all<'a, TTx, I>(tx: &mut TTx, epoch: Epoch, transactions: I) -> Result<(), StorageError>
     where
         TTx: StateStoreWriteTransaction + Deref,
         TTx::Target: StateStoreReadTransaction,
         I: IntoIterator<Item = &'a TransactionPoolRecord>,
     {
-        tx.transactions_finalize_all(transactions)
+        tx.transactions_finalize_all(epoch, transactions)
     }
 
     pub fn has_all_required_input_pledges<TTx: StateStoreReadTransaction>(

--- a/crates/storage/src/state_store/mod.rs
+++ b/crates/storage/src/state_store/mod.rs
@@ -448,7 +448,7 @@ pub trait StateStoreWriteTransaction {
     fn transactions_finalize_all<'a, I: IntoIterator<Item = &'a TransactionPoolRecord>>(
         &mut self,
         epoch: Epoch,
-        transaction: I,
+        transactions: I,
     ) -> Result<(), StorageError>;
 
     /// Forgets the node-local finalized bookkeeping for a transaction: the finalized marker and all

--- a/crates/storage/src/state_store/mod.rs
+++ b/crates/storage/src/state_store/mod.rs
@@ -442,8 +442,12 @@ pub trait StateStoreWriteTransaction {
     // -------------------------------- Transaction -------------------------------- //
     fn transactions_insert(&mut self, transaction: &TransactionRecord) -> Result<(), StorageError>;
 
+    /// Marks the given transactions as finalized in the epoch of the finalizing block. The epoch is
+    /// recorded so that epoch GC can prune finalized transaction bookkeeping once it ages out of the
+    /// retained window.
     fn transactions_finalize_all<'a, I: IntoIterator<Item = &'a TransactionPoolRecord>>(
         &mut self,
+        epoch: Epoch,
         transaction: I,
     ) -> Result<(), StorageError>;
 


### PR DESCRIPTION
## Motivation
Transaction records were never garbage collected: the payload, finalized marker and recorded executions of every transaction a node ever finalized accumulated for the life of its database. With committed-id dedup now backed by the receipt substate rather than local records (#2381), this bookkeeping is a node-local cache and can safely age out — a freshly pruned node answers dedup questions identically to one that remembers everything.

## Changes
- Finalization records the epoch of the finalizing block (`FinalizedTransactionLinkData.epoch`, `#[cbor(default)]` for existing rows) and keys it into a new `finalized_transaction::EpochIndex` CF (`(Epoch, TransactionId) → ()`). `transactions_finalize_all` now takes the finalizing block's epoch.
- `cleanup_finalized_transactions_for_epoch` runs in `epoch_cleanup`, range-deleting the payload, finalized link, recorded executions and index entry for everything finalized at or before the prune epoch. The horizon shares `epoch_history_length` with block retention, so a transaction's payload outlives every retained block that references it (catch-up sync keeps serving).
- The index holds exactly one entry per id, keyed to the latest finalization: re-finalizing an id (a previously aborted transaction sequenced again, per #2381) moves the entry, and `transactions_finalized_remove` removes it together with the link. A stale entry from an earlier attempt would let GC delete the bookkeeping of a transaction that is live again or recently finalized.
- Pruning is per-operator policy, not protocol: consensus dedup never reads these records (committed ids are refused via receipt existence), so retention uniformity across the committee is not required. `DatabaseOptions::prune_transaction_history` (default `true`) gates the cleanup, exposed as `validator_node.keep_transaction_history` (`#[serde(default)]`) for archival operators who want full transaction history. Chain state — committed effects and receipts — is retained regardless. The epoch index is maintained even while pruning is disabled, so enabling it later reclaims history accumulated while it was off.

## Verification
- New store-level tests in `state_store_rocksdb/tests/transactions.rs` (`finalized_transaction_gc` module):
  - `epoch_gc_prunes_finalized_transactions` — bookkeeping survives cleanup inside the retention window and is fully removed once it ages out.
  - `refinalized_transaction_ages_from_its_latest_epoch` — an id re-finalized in a later epoch (including via `transactions_finalized_remove` resurrection) must not age out from an earlier epoch; survival across the earlier epochs' cleanup proves stale index entries are removed.
  - `archival_node_keeps_transaction_history` — with `prune_transaction_history` disabled, cleanup retains all transaction bookkeeping.
- Full `tari_state_store_rocksdb` suite green (55/55) and full `consensus_tests` suite green (65/65, exercises the new finalize signature end-to-end), both release.
- `cargo lints clippy --all-targets` clean on touched crates; `cargo +nightly-2025-12-05 fmt --all` applied.

## Deployment notes
Node-local only: no wire, state or consensus change. Existing databases work unchanged — pre-existing finalized rows decode with epoch 0 and have no index entry, so they are not pruned by the index-driven cleanup; they simply remain, as before.