### PR TITLE
fix(indexer): bound how long a cached substate serves as the latest version

### DIFF
--- a/applications/tari_indexer/src/bootstrap.rs
+++ b/applications/tari_indexer/src/bootstrap.rs
@@ -45,6 +45,7 @@ use tari_epoch_oracles::{
     store::EpochOracleStore,
 };
 use tari_indexer_client::event::{IndexerEvent, TransactionEvent};
+use tari_indexer_lib::substate_versions::SubstateVersionTracker;
 use tari_networking::{MessagingMode, NetworkingHandle, RelayCircuitLimits, RelayReservationLimits, SwarmConfig};
 use tari_ootle_app_utilities::{
     claim_burn_proof_verifier::KnowledgeProofVerifier,
@@ -200,6 +201,10 @@ pub async fn spawn_services(
     #[cfg(feature = "metrics")]
     let network_state_metrics = network_state_sync::NetworkStateMetrics::register(metrics_registry);
 
+    // Shared between the state sync (which records committed substate versions) and the substate
+    // manager (which uses them to tell a superseded cache entry from a current one).
+    let substate_versions = Arc::new(SubstateVersionTracker::new());
+
     network_state_sync::NetworkWideStateSync::new(
         epoch_manager.clone(),
         networking.clone(),
@@ -212,6 +217,7 @@ pub async fn spawn_services(
         event_notifier.clone(),
         transaction_event_notifier.clone(),
         validator_status.clone(),
+        substate_versions.clone(),
         #[cfg(feature = "metrics")]
         network_state_metrics,
         #[cfg(feature = "metrics")]
@@ -227,7 +233,9 @@ pub async fn spawn_services(
         epoch_manager.clone(),
         validator_node_client_factory.clone(),
         substate_cache,
+        substate_versions,
     )
+    .with_latest_version_ttl(config.indexer.latest_substate_cache_ttl)
     .with_substate_proof_verification(config.indexer.verify_substate_proofs);
     #[cfg(feature = "metrics")]
     let substate_manager = substate_manager.with_metrics(metrics_registry);

--- a/applications/tari_indexer/src/config.rs
+++ b/applications/tari_indexer/src/config.rs
@@ -124,6 +124,13 @@ pub struct IndexerConfig {
     /// A shorter TTL reduces the chance of stale fee estimates.
     #[serde(with = "serializers::seconds")]
     pub dry_run_cache_ttl: Duration,
+    /// How long a cached substate may be served as the latest version of that substate, bounding how
+    /// far behind the chain a version served to a client can be. Raising it trades a wider window for
+    /// pinning an already-spent input version against fewer validator round trips on hot substates;
+    /// lowering it does the reverse. Requests for a specific version are unaffected: those answers are
+    /// immutable.
+    #[serde(default = "default_latest_substate_cache_ttl", with = "serializers::seconds")]
+    pub latest_substate_cache_ttl: Duration,
     /// The event filtering configuration
     pub event_filters: Vec<EventFilter>,
     /// Template addresses to watch for component creation/update events.
@@ -143,6 +150,10 @@ pub struct IndexerConfig {
 
 fn default_verify_substate_proofs() -> bool {
     true
+}
+
+fn default_latest_substate_cache_ttl() -> Duration {
+    Duration::from_secs(2)
 }
 
 fn default_watched_templates() -> Vec<TemplateAddress> {
@@ -166,6 +177,7 @@ impl Default for IndexerConfig {
             state_scanning_interval: Duration::from_secs(60),
             sidechain_id: None,
             dry_run_cache_ttl: Duration::from_secs(10),
+            latest_substate_cache_ttl: default_latest_substate_cache_ttl(),
             event_filters: vec![],
             watched_templates: default_watched_templates(),
             verify_substate_proofs: default_verify_substate_proofs(),

--- a/applications/tari_indexer/src/config.rs
+++ b/applications/tari_indexer/src/config.rs
@@ -124,11 +124,9 @@ pub struct IndexerConfig {
     /// A shorter TTL reduces the chance of stale fee estimates.
     #[serde(with = "serializers::seconds")]
     pub dry_run_cache_ttl: Duration,
-    /// How long a cached substate may be served as the latest version of that substate, bounding how
-    /// far behind the chain a version served to a client can be. Raising it trades a wider window for
-    /// pinning an already-spent input version against fewer validator round trips on hot substates;
-    /// lowering it does the reverse. Requests for a specific version are unaffected: those answers are
-    /// immutable.
+    /// How long a cached substate may be served as the latest version of that substate. Raising it
+    /// trades a wider window for handing out an already-spent input version against fewer validator
+    /// round trips on hot substates. Requests for a specific version are unaffected.
     #[serde(default = "default_latest_substate_cache_ttl", with = "serializers::seconds")]
     pub latest_substate_cache_ttl: Duration,
     /// The event filtering configuration

--- a/applications/tari_indexer/src/network_state_sync/worker.rs
+++ b/applications/tari_indexer/src/network_state_sync/worker.rs
@@ -4,6 +4,7 @@
 use std::{
     collections::{HashMap, HashSet},
     pin::pin,
+    sync::Arc,
 };
 
 use futures::StreamExt;
@@ -17,6 +18,7 @@ use tari_engine_types::{
 };
 use tari_epoch_manager::{EpochManagerEvent, EpochManagerReader, service::EpochManagerHandle};
 use tari_indexer_client::event::{IndexerEvent, NewEpochEvent, TransactionEvent, TransactionFinalizedEvent};
+use tari_indexer_lib::substate_versions::SubstateVersionTracker;
 use tari_networking::NetworkingHandle;
 use tari_ootle_common_types::{
     Epoch,
@@ -83,6 +85,7 @@ pub struct NetworkWideStateSync {
     notify: Notify<IndexerEvent>,
     transaction_event_notify: Notify<TransactionEvent>,
     validator_status: ValidatorStatusMonitor,
+    substate_versions: Arc<SubstateVersionTracker>,
     #[cfg(feature = "metrics")]
     metrics: NetworkStateMetrics,
     #[cfg(feature = "metrics")]
@@ -98,6 +101,7 @@ impl NetworkWideStateSync {
         notify: Notify<IndexerEvent>,
         transaction_event_notify: Notify<TransactionEvent>,
         validator_status: ValidatorStatusMonitor,
+        substate_versions: Arc<SubstateVersionTracker>,
         #[cfg(feature = "metrics")] metrics: NetworkStateMetrics,
         #[cfg(feature = "metrics")] consensus_constants: ConsensusConstants,
     ) -> Self {
@@ -110,6 +114,7 @@ impl NetworkWideStateSync {
             notify,
             transaction_event_notify,
             validator_status,
+            substate_versions,
             #[cfg(feature = "metrics")]
             metrics,
             #[cfg(feature = "metrics")]
@@ -626,6 +631,15 @@ impl NetworkWideStateSync {
             let updates = std::mem::take(update_buf);
             let utxos = std::mem::take(utxos_buf);
             let transactions = std::mem::take(transactions_buf);
+
+            // A committed receipt names every substate the transaction upped, and upping a substate is
+            // the point at which its previous version goes down. This is the substate cache's only
+            // signal that an entry it holds has been superseded.
+            for (_, receipt) in &transactions {
+                for up in &receipt.diff_summary().upped {
+                    self.substate_versions.record_up(&up.substate_id, up.version);
+                }
+            }
             let validator_fee_pools = std::mem::take(validator_fee_pools_buf);
             let template_catalogue = std::mem::take(template_catalogue_buf);
 

--- a/applications/tari_indexer/src/network_state_sync/worker.rs
+++ b/applications/tari_indexer/src/network_state_sync/worker.rs
@@ -635,11 +635,12 @@ impl NetworkWideStateSync {
             // A committed receipt names every substate the transaction upped, and upping a substate is
             // the point at which its previous version goes down. This is the substate cache's only
             // signal that an entry it holds has been superseded.
-            for (_, receipt) in &transactions {
-                for up in &receipt.diff_summary().upped {
-                    self.substate_versions.record_up(&up.substate_id, up.version);
-                }
-            }
+            self.substate_versions.record_up_all(
+                transactions
+                    .iter()
+                    .flat_map(|(_, receipt)| receipt.diff_summary().upped.iter())
+                    .map(|up| (&up.substate_id, up.version)),
+            );
             let validator_fee_pools = std::mem::take(validator_fee_pools_buf);
             let template_catalogue = std::mem::take(template_catalogue_buf);
 

--- a/applications/tari_indexer/src/network_state_sync/worker.rs
+++ b/applications/tari_indexer/src/network_state_sync/worker.rs
@@ -632,9 +632,8 @@ impl NetworkWideStateSync {
             let utxos = std::mem::take(utxos_buf);
             let transactions = std::mem::take(transactions_buf);
 
-            // A committed receipt names every substate the transaction upped, and upping a substate is
-            // the point at which its previous version goes down. This is the substate cache's only
-            // signal that an entry it holds has been superseded.
+            // Upping a substate is the point at which its previous version goes down, so this is the
+            // substate cache's only signal that an entry it holds has been superseded.
             self.substate_versions.record_up_all(
                 transactions
                     .iter()

--- a/applications/tari_indexer/src/substate_manager.rs
+++ b/applications/tari_indexer/src/substate_manager.rs
@@ -38,6 +38,7 @@ use tari_indexer_client::types::{ListSubstateItem, NonFungibleSubstate, UtxoStat
 use tari_indexer_lib::{
     cached_substate_manager::{CachedSubstateManager, TrustedRootStore},
     error::IndexerError,
+    substate_versions::SubstateVersionTracker,
 };
 use tari_ootle_common_types::{
     Epoch,
@@ -124,6 +125,7 @@ impl SubstateManager {
         epoch_manager: EpochManagerHandle<PeerAddress>,
         validator_node_client_factory: TariValidatorNodeRpcClientFactory,
         substate_cache: SubstateFileCache,
+        substate_versions: Arc<SubstateVersionTracker>,
     ) -> Self {
         // Consulted only when proof verification is enabled (the dry-run manager has it off, so its
         // copy is inert). Lets a read skip re-validating a served commit proof when its root is
@@ -135,6 +137,7 @@ impl SubstateManager {
             epoch_manager.clone(),
             validator_node_client_factory.clone(),
             substate_cache,
+            substate_versions,
         )
         .with_trusted_root_store(trusted_root_store);
 
@@ -146,6 +149,11 @@ impl SubstateManager {
 
     pub fn with_cache_ttl(mut self, ttl: Duration) -> Self {
         self.cache_manager = self.cache_manager.with_cache_ttl(ttl);
+        self
+    }
+
+    pub fn with_latest_version_ttl(mut self, ttl: Duration) -> Self {
+        self.cache_manager = self.cache_manager.with_latest_version_ttl(ttl);
         self
     }
 

--- a/crates/indexer_lib/src/cached_substate_manager.rs
+++ b/crates/indexer_lib/src/cached_substate_manager.rs
@@ -58,11 +58,19 @@ use tari_validator_node_rpc::client::{
 use crate::{
     error::IndexerError,
     substate_cache::{SubstateCache, SubstateCacheEntry, SubstateCacheEntryRef},
+    substate_versions::SubstateVersionTracker,
 };
 
 const LOG_TARGET: &str = "tari::indexer::scanner";
 
 const DEFAULT_CACHE_TTL: Duration = Duration::from_secs(300);
+
+/// How long a cached value may be served as the latest version of its substate. Bounds how far
+/// behind the chain a version handed out as "latest" can be, and so how often a wallet pins an input
+/// version that consensus has already spent. Short enough that the window is comparable to the
+/// unavoidable one between submitting a transaction and it committing, long enough that a hot
+/// substate costs at most one committee round trip per window rather than one per request.
+const DEFAULT_LATEST_VERSION_TTL: Duration = Duration::from_secs(2);
 
 /// A store of committee-validated shard-group state merkle roots that the read path consults to
 /// avoid re-validating a served commit proof's QC chain when its root is already trusted.
@@ -94,7 +102,18 @@ pub struct CachedSubstateManager<TEpochManager, TVnClient, TSubstateCache> {
     committee_provider: TEpochManager,
     validator_node_client_factory: TVnClient,
     substate_cache: TSubstateCache,
+    /// Bounds how long an entry may answer for the exact version it holds. The value at a given
+    /// version never changes, so what this covers is the entry's verdict on whether that version is
+    /// up. It is also the backstop for what [`SubstateVersionTracker`] cannot reach: that signal is
+    /// capacity bounded, lags the chain by a state-sync interval, and starts empty after a restart
+    /// while the on-disk cache does not.
     cache_ttl: Duration,
+    /// How long an entry may answer a request for the *latest* version of its substate, which is a
+    /// claim the chain invalidates without touching the entry. See [`DEFAULT_LATEST_VERSION_TTL`].
+    latest_version_ttl: Duration,
+    /// Records the newest committed version of recently-updated substates, so a cache entry that has
+    /// since been spent is not served. See [`SubstateVersionTracker`].
+    substate_versions: Arc<SubstateVersionTracker>,
     /// When set, substates fetched from a validator must come with a proof that verifies against the
     /// shard group committee, or they are rejected (fail-closed). The negative `DoesNotExist` case
     /// is not provable and is left to the existing f+1 agreement.
@@ -117,12 +136,15 @@ where
         committee_provider: TEpochManager,
         validator_node_client_factory: TVnClient,
         substate_cache: TSubstateCache,
+        substate_versions: Arc<SubstateVersionTracker>,
     ) -> Self {
         Self {
             committee_provider,
             validator_node_client_factory,
             substate_cache,
             cache_ttl: DEFAULT_CACHE_TTL,
+            latest_version_ttl: DEFAULT_LATEST_VERSION_TTL,
+            substate_versions,
             verify_substate_proofs: false,
             trusted_root_store: None,
             #[cfg(feature = "metrics")]
@@ -133,6 +155,17 @@ where
     pub fn with_cache_ttl(mut self, ttl: Duration) -> Self {
         self.cache_ttl = ttl;
         self
+    }
+
+    pub fn with_latest_version_ttl(mut self, ttl: Duration) -> Self {
+        self.latest_version_ttl = ttl;
+        self
+    }
+
+    /// An entry that has aged out for exact-version reads cannot still be current, so the latest-version
+    /// window can never outlast the entry itself however the two are configured.
+    fn latest_version_ttl(&self) -> Duration {
+        self.latest_version_ttl.min(self.cache_ttl)
     }
 
     pub fn with_substate_proof_verification(mut self, enabled: bool) -> Self {
@@ -174,42 +207,45 @@ where
             // enabled) is never served while verification is on: refetch so it can be replaced with
             // a proven copy.
             if entry.verified || !self.verify_substate_proofs {
-                if let Some(version) = specific_version {
-                    if entry.version == version {
-                        debug!(target: LOG_TARGET, "Substate cache hit for {} with version {}", entry.version, substate_id);
-                        #[cfg(feature = "metrics")]
-                        self.metrics.as_ref().inspect(|m| m.inc_cache_hits());
-                        return Ok(SubstateLookupResult {
-                            result: entry.substate_result,
-                            verified: entry.verified,
-                        });
-                    }
-                } else {
-                    let now = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH)?.as_secs();
-                    let is_stale = now.saturating_sub(entry.cached_at) > self.cache_ttl.as_secs();
-                    // A cached `Down` result means the substate has advanced past `entry.version`. An
-                    // unversioned lookup asks for the *latest* version, so a `Down` entry can never
-                    // satisfy it: refetch from the committee (which always returns the latest Up for an
-                    // unversioned request) to discover the new version. Serving the stale `Down`
-                    // surfaces as a spurious "input substate is down" error — e.g. dry-running a
-                    // transaction whose unversioned inputs include a frequently-updated substate such as
-                    // a swap pool reserve.
-                    let is_down = matches!(entry.substate_result, SubstateResult::Down { .. });
-                    if is_stale {
-                        debug!(target: LOG_TARGET, "Cached substate {} is stale. Fetching fresh copy.", substate_id);
-                    } else if is_down {
-                        debug!(target: LOG_TARGET, "Cached substate {} is down at v{}. Fetching latest version.", substate_id, entry.version);
-                    } else {
-                        debug!(target: LOG_TARGET, "Substate cache hit for {} with version {}", substate_id, entry.version);
-                        #[cfg(feature = "metrics")]
-                        self.metrics.as_ref().inspect(|m| m.inc_cache_hits());
-                        return Ok(SubstateLookupResult {
-                            result: entry.substate_result.clone(),
-                            verified: entry.verified,
-                        });
-                    }
+                let now = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH)?.as_secs();
+                let age = now.saturating_sub(entry.cached_at);
+                let is_up = matches!(entry.substate_result, SubstateResult::Up { .. });
+                // An entry's verdict on whether its version is up can be falsified by a later commit
+                // without anything touching the entry. The signal lags the chain by a state-sync
+                // interval, so it retires long-lived entries rather than keeping the latest-version
+                // window honest - that is the TTL's job.
+                let is_superseded = self.substate_versions.is_superseded(substate_id, entry.version);
+
+                let is_servable = !is_superseded &&
+                    match specific_version {
+                        // The value at a version never changes, but whether that version is still up
+                        // does, so an entry answers for its own version only for as long as the TTL.
+                        Some(version) => entry.version == version && age <= self.cache_ttl.as_secs(),
+                        // "The latest version of id" moves under the entry every time the substate is
+                        // spent, and nothing rewrites the entry at that moment, so this claim is only good
+                        // for as long as the freshness window. A `Down` entry can never be the latest.
+                        None => is_up && age <= self.latest_version_ttl().as_secs(),
+                    };
+
+                if is_servable {
+                    debug!(target: LOG_TARGET, "Substate cache hit for {} with version {}", substate_id, entry.version);
+                    #[cfg(feature = "metrics")]
+                    self.metrics.as_ref().inspect(|m| m.inc_cache_hits());
+                    return Ok(SubstateLookupResult {
+                        result: entry.substate_result,
+                        verified: entry.verified,
+                    });
                 }
 
+                debug!(
+                    target: LOG_TARGET,
+                    "Cached substate {} at v{} (age {}s) cannot answer a request for v{} (superseded: {}). Fetching from committee.",
+                    substate_id,
+                    entry.version,
+                    age,
+                    specific_version.display(),
+                    is_superseded,
+                );
                 cached_version = Some(entry.version);
             }
         }

--- a/crates/indexer_lib/src/cached_substate_manager.rs
+++ b/crates/indexer_lib/src/cached_substate_manager.rs
@@ -65,11 +65,9 @@ const LOG_TARGET: &str = "tari::indexer::scanner";
 
 const DEFAULT_CACHE_TTL: Duration = Duration::from_secs(300);
 
-/// How long a cached value may be served as the latest version of its substate. Bounds how far
-/// behind the chain a version handed out as "latest" can be, and so how often a wallet pins an input
-/// version that consensus has already spent. Short enough that the window is comparable to the
-/// unavoidable one between submitting a transaction and it committing, long enough that a hot
-/// substate costs at most one committee round trip per window rather than one per request.
+/// How long a cached value may be served as the latest version of its substate: the window in which a
+/// wallet can be handed a version consensus has already spent. Comparable to the unavoidable gap
+/// between submitting a transaction and it committing, below which a fresher indexer buys nothing.
 const DEFAULT_LATEST_VERSION_TTL: Duration = Duration::from_secs(2);
 
 /// A store of committee-validated shard-group state merkle roots that the read path consults to
@@ -102,17 +100,13 @@ pub struct CachedSubstateManager<TEpochManager, TVnClient, TSubstateCache> {
     committee_provider: TEpochManager,
     validator_node_client_factory: TVnClient,
     substate_cache: TSubstateCache,
-    /// Bounds how long an entry may answer for the exact version it holds. The value at a given
-    /// version never changes, so what this covers is the entry's verdict on whether that version is
-    /// up. It is also the backstop for what [`SubstateVersionTracker`] cannot reach: that signal is
-    /// capacity bounded, lags the chain by a state-sync interval, and starts empty after a restart
-    /// while the on-disk cache does not.
+    /// Bounds how long an entry may answer for the exact version it holds - specifically its verdict
+    /// on whether that version is still up, since the value itself never changes. Backstops
+    /// [`SubstateVersionTracker`], which is capacity bounded, lags by a sync interval, and is empty
+    /// after a restart while the on-disk cache is not.
     cache_ttl: Duration,
-    /// How long an entry may answer a request for the *latest* version of its substate, which is a
-    /// claim the chain invalidates without touching the entry. See [`DEFAULT_LATEST_VERSION_TTL`].
+    /// See [`DEFAULT_LATEST_VERSION_TTL`].
     latest_version_ttl: Duration,
-    /// Records the newest committed version of recently-updated substates, so a cache entry that has
-    /// since been spent is not served. See [`SubstateVersionTracker`].
     substate_versions: Arc<SubstateVersionTracker>,
     /// When set, substates fetched from a validator must come with a proof that verifies against the
     /// shard group committee, or they are rejected (fail-closed). The negative `DoesNotExist` case
@@ -162,8 +156,7 @@ where
         self
     }
 
-    /// An entry that has aged out for exact-version reads cannot still be current, so the latest-version
-    /// window can never outlast the entry itself however the two are configured.
+    /// Clamped: an entry that has aged out for exact-version reads cannot still be the latest.
     fn latest_version_ttl(&self) -> Duration {
         self.latest_version_ttl.min(self.cache_ttl)
     }
@@ -210,20 +203,14 @@ where
                 let now = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH)?.as_secs();
                 let age = now.saturating_sub(entry.cached_at);
                 let is_up = matches!(entry.substate_result, SubstateResult::Up { .. });
-                // An entry's verdict on whether its version is up can be falsified by a later commit
-                // without anything touching the entry. The signal lags the chain by a state-sync
-                // interval, so it retires long-lived entries rather than keeping the latest-version
-                // window honest - that is the TTL's job.
+                // Lags the chain by a sync interval, so it retires long-lived entries rather than
+                // policing the latest-version window - that is the TTL's job.
                 let is_superseded = self.substate_versions.is_superseded(substate_id, entry.version);
 
                 let is_servable = !is_superseded &&
                     match specific_version {
-                        // The value at a version never changes, but whether that version is still up
-                        // does, so an entry answers for its own version only for as long as the TTL.
                         Some(version) => entry.version == version && age <= self.cache_ttl.as_secs(),
-                        // "The latest version of id" moves under the entry every time the substate is
-                        // spent, and nothing rewrites the entry at that moment, so this claim is only good
-                        // for as long as the freshness window. A `Down` entry can never be the latest.
+                        // A `Down` entry can never be the latest version.
                         None => is_up && age <= self.latest_version_ttl().as_secs(),
                     };
 

--- a/crates/indexer_lib/src/lib.rs
+++ b/crates/indexer_lib/src/lib.rs
@@ -5,6 +5,7 @@ pub mod cached_substate_manager;
 pub mod error;
 pub mod substate_cache;
 pub mod substate_decoder;
+pub mod substate_versions;
 
 #[cfg(feature = "metrics")]
 mod metrics;

--- a/crates/indexer_lib/src/substate_versions.rs
+++ b/crates/indexer_lib/src/substate_versions.rs
@@ -1,0 +1,135 @@
+//   Copyright 2026 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+use std::{collections::HashMap, mem, sync::Mutex};
+
+use tari_engine_types::substate::SubstateId;
+
+/// Number of substate IDs held per generation. Two generations are kept, so the tracker remembers
+/// between `CAPACITY` and `2 * CAPACITY` of the most recently updated substates.
+const CAPACITY_PER_GENERATION: usize = 50_000;
+
+/// The newest version of each recently-updated substate, as observed from committed transaction
+/// receipts.
+///
+/// A substate cache entry records the version that was current when it was written, and nothing
+/// touches that entry when the substate is later spent, so an entry cannot on its own distinguish
+/// "current" from "superseded". This tracker supplies that missing signal: a committed receipt names
+/// every substate the transaction upped, which is exactly the point at which the previous version of
+/// each went down.
+///
+/// Capacity is bounded, so this is a positive signal only: [`Self::is_superseded`] returning `false`
+/// means "not known to be superseded", never "current".
+#[derive(Debug)]
+pub struct SubstateVersionTracker {
+    inner: Mutex<Generations>,
+    capacity_per_generation: usize,
+}
+
+#[derive(Debug, Default)]
+struct Generations {
+    current: HashMap<SubstateId, u32>,
+    previous: HashMap<SubstateId, u32>,
+}
+
+impl SubstateVersionTracker {
+    pub fn new() -> Self {
+        Self::with_capacity(CAPACITY_PER_GENERATION)
+    }
+
+    pub fn with_capacity(capacity_per_generation: usize) -> Self {
+        Self {
+            inner: Mutex::new(Generations::default()),
+            capacity_per_generation: capacity_per_generation.max(1),
+        }
+    }
+
+    /// Records that `substate_id` reached `version`, implying every lower version of it is down.
+    pub fn record_up(&self, substate_id: &SubstateId, version: u32) {
+        let mut inner = self.lock();
+        if let Some(recorded) = inner.current.get_mut(substate_id) {
+            *recorded = (*recorded).max(version);
+            return;
+        }
+        inner.current.insert(substate_id.clone(), version);
+
+        // Roll generations rather than evicting individually: a substate that is still being updated
+        // is re-recorded into the new generation on its next commit, while everything untouched ages
+        // out. Lookups continue to hit the previous generation until it is dropped in turn.
+        if inner.current.len() > self.capacity_per_generation {
+            inner.previous = mem::take(&mut inner.current);
+        }
+    }
+
+    /// True if a version newer than `version` of `substate_id` is known to have been committed.
+    pub fn is_superseded(&self, substate_id: &SubstateId, version: u32) -> bool {
+        let inner = self.lock();
+        let current = inner.current.get(substate_id).copied();
+        let previous = inner.previous.get(substate_id).copied();
+        current.max(previous).is_some_and(|latest| latest > version)
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, Generations> {
+        // The guarded state is a plain map with no invariants to uphold across a panic, so a poisoned
+        // lock is recovered rather than propagated.
+        self.inner.lock().unwrap_or_else(|e| e.into_inner())
+    }
+}
+
+impl Default for SubstateVersionTracker {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn component(n: u8) -> SubstateId {
+        format!("component_{:064x}", n).parse().unwrap()
+    }
+
+    #[test]
+    fn unknown_substate_is_not_superseded() {
+        let tracker = SubstateVersionTracker::new();
+        assert!(!tracker.is_superseded(&component(1), 0));
+    }
+
+    #[test]
+    fn only_older_versions_are_superseded() {
+        let tracker = SubstateVersionTracker::new();
+        tracker.record_up(&component(1), 5);
+        assert!(tracker.is_superseded(&component(1), 4));
+        assert!(!tracker.is_superseded(&component(1), 5));
+        assert!(!tracker.is_superseded(&component(1), 6));
+    }
+
+    #[test]
+    fn out_of_order_records_keep_the_newest_version() {
+        let tracker = SubstateVersionTracker::new();
+        tracker.record_up(&component(1), 5);
+        tracker.record_up(&component(1), 3);
+        assert!(tracker.is_superseded(&component(1), 4));
+    }
+
+    #[test]
+    fn previous_generation_is_still_consulted() {
+        let tracker = SubstateVersionTracker::with_capacity(2);
+        tracker.record_up(&component(1), 5);
+        for i in 2..=5 {
+            tracker.record_up(&component(i), 1);
+        }
+        assert!(tracker.is_superseded(&component(1), 4));
+    }
+
+    #[test]
+    fn updated_substates_survive_generation_rolls() {
+        let tracker = SubstateVersionTracker::with_capacity(2);
+        for round in 1..=10u8 {
+            tracker.record_up(&component(1), u32::from(round));
+            tracker.record_up(&component(round + 1), 1);
+        }
+        assert!(tracker.is_superseded(&component(1), 9));
+    }
+}

--- a/crates/indexer_lib/src/substate_versions.rs
+++ b/crates/indexer_lib/src/substate_versions.rs
@@ -9,25 +9,18 @@ use std::{
 
 use tari_engine_types::substate::SubstateId;
 
-/// Number of substate IDs held per generation. Two generations are kept, so the tracker remembers
-/// between one and two times this many of the most recently updated substates.
+/// Substate IDs held per generation. Two are kept, so the tracker remembers between one and two times
+/// this many of the most recently updated substates.
 const CAPACITY_PER_GENERATION: usize = 50_000;
 
-/// The newest version of each recently-updated substate, as observed from committed transaction
-/// receipts.
+/// The newest version of each recently-updated substate, taken from committed transaction receipts.
 ///
-/// A substate cache entry records the version that was current when it was written, and nothing
-/// touches that entry when the substate is later spent, so an entry cannot on its own distinguish
-/// "current" from "superseded". This tracker supplies that missing signal: a committed receipt names
-/// every substate the transaction upped, which is exactly the point at which the previous version of
-/// each went down.
-///
-/// Capacity is bounded, so this is a positive signal only: [`Self::is_superseded`] returning `false`
-/// means "not known to be superseded", never "current".
+/// A substate cache entry holds the version that was current when it was written and is not touched
+/// when that version is later spent, so it cannot tell "current" from "superseded" on its own. This
+/// supplies that signal. Capacity is bounded, so it is positive-only: [`Self::is_superseded`]
+/// returning `false` means "not known to be superseded", never "current".
 #[derive(Debug)]
 pub struct SubstateVersionTracker {
-    // Lookups happen on every cache read and writes only when a sync round commits, so readers must
-    // not serialize against each other.
     inner: RwLock<Generations>,
     capacity_per_generation: usize,
 }
@@ -55,9 +48,8 @@ impl SubstateVersionTracker {
         self.record_up_all(std::iter::once((substate_id, version)));
     }
 
-    /// Records a batch of upped substates under a single acquisition of the write lock. Callers record
-    /// one committed batch at a time, and taking the lock per substate would put the writer in
-    /// contention with every concurrent lookup for the length of that batch.
+    /// Batched form of [`Self::record_up`], taking the write lock once for the whole batch rather than
+    /// contending with concurrent lookups on every substate.
     pub fn record_up_all<'a, I>(&self, ups: I)
     where I: IntoIterator<Item = (&'a SubstateId, u32)> {
         let mut inner = self.write();
@@ -68,10 +60,8 @@ impl SubstateVersionTracker {
             }
             inner.current.insert(substate_id.clone(), version);
 
-            // Roll generations rather than evicting individually: a substate that is still being
-            // updated is re-recorded into the new generation on its next commit, while everything
-            // untouched ages out. Lookups continue to hit the previous generation until it is dropped
-            // in turn.
+            // Rolling rather than evicting individually keeps substates that are still being updated:
+            // they are re-recorded into the new generation on their next commit.
             if inner.current.len() > self.capacity_per_generation {
                 inner.previous = mem::take(&mut inner.current);
             }
@@ -86,8 +76,8 @@ impl SubstateVersionTracker {
         current.max(previous).is_some_and(|latest| latest > version)
     }
 
-    // The guarded state is a plain map with no invariants to uphold across a panic, so a poisoned lock
-    // is recovered rather than propagated.
+    // Poisoning is recovered from rather than propagated: the maps hold no invariant a panic could
+    // break.
 
     fn read(&self) -> RwLockReadGuard<'_, Generations> {
         self.inner.read().unwrap_or_else(|e| e.into_inner())

--- a/crates/indexer_lib/src/substate_versions.rs
+++ b/crates/indexer_lib/src/substate_versions.rs
@@ -6,7 +6,7 @@ use std::{collections::HashMap, mem, sync::Mutex};
 use tari_engine_types::substate::SubstateId;
 
 /// Number of substate IDs held per generation. Two generations are kept, so the tracker remembers
-/// between `CAPACITY` and `2 * CAPACITY` of the most recently updated substates.
+/// between one and two times this many of the most recently updated substates.
 const CAPACITY_PER_GENERATION: usize = 50_000;
 
 /// The newest version of each recently-updated substate, as observed from committed transaction

--- a/crates/indexer_lib/src/substate_versions.rs
+++ b/crates/indexer_lib/src/substate_versions.rs
@@ -1,13 +1,21 @@
 //   Copyright 2026 The Tari Project
 //   SPDX-License-Identifier: BSD-3-Clause
 
-use std::{collections::HashMap, mem, sync::Mutex};
+use std::{
+    collections::HashMap,
+    mem,
+    sync::{RwLock, RwLockReadGuard, RwLockWriteGuard},
+};
 
 use tari_engine_types::substate::SubstateId;
 
 /// Number of substate IDs held per generation. Two generations are kept, so the tracker remembers
 /// between one and two times this many of the most recently updated substates.
 const CAPACITY_PER_GENERATION: usize = 50_000;
+
+/// Substates recorded per acquisition of the write lock. Bounds how long a single batch can hold off
+/// readers, which matters because a batch is as large as a sync round's worth of commits.
+const WRITE_CHUNK: usize = 1024;
 
 /// The newest version of each recently-updated substate, as observed from committed transaction
 /// receipts.
@@ -22,7 +30,9 @@ const CAPACITY_PER_GENERATION: usize = 50_000;
 /// means "not known to be superseded", never "current".
 #[derive(Debug)]
 pub struct SubstateVersionTracker {
-    inner: Mutex<Generations>,
+    // Lookups happen on every cache read and writes only when a sync round commits, so readers must
+    // not serialize against each other.
+    inner: RwLock<Generations>,
     capacity_per_generation: usize,
 }
 
@@ -39,40 +49,59 @@ impl SubstateVersionTracker {
 
     pub fn with_capacity(capacity_per_generation: usize) -> Self {
         Self {
-            inner: Mutex::new(Generations::default()),
+            inner: RwLock::new(Generations::default()),
             capacity_per_generation: capacity_per_generation.max(1),
         }
     }
 
     /// Records that `substate_id` reached `version`, implying every lower version of it is down.
     pub fn record_up(&self, substate_id: &SubstateId, version: u32) {
-        let mut inner = self.lock();
-        if let Some(recorded) = inner.current.get_mut(substate_id) {
-            *recorded = (*recorded).max(version);
-            return;
-        }
-        inner.current.insert(substate_id.clone(), version);
+        self.record_up_all(std::iter::once((substate_id, version)));
+    }
 
-        // Roll generations rather than evicting individually: a substate that is still being updated
-        // is re-recorded into the new generation on its next commit, while everything untouched ages
-        // out. Lookups continue to hit the previous generation until it is dropped in turn.
-        if inner.current.len() > self.capacity_per_generation {
-            inner.previous = mem::take(&mut inner.current);
+    /// Records a batch of upped substates under as few acquisitions of the write lock as [`WRITE_CHUNK`]
+    /// allows. Callers have a whole commit batch to record, and taking the lock per substate would put
+    /// the writer in contention with every concurrent lookup for the length of that batch.
+    pub fn record_up_all<'a, I>(&self, ups: I)
+    where I: IntoIterator<Item = (&'a SubstateId, u32)> {
+        let mut ups = ups.into_iter().peekable();
+        while ups.peek().is_some() {
+            let mut inner = self.write();
+            for (substate_id, version) in ups.by_ref().take(WRITE_CHUNK) {
+                if let Some(recorded) = inner.current.get_mut(substate_id) {
+                    *recorded = (*recorded).max(version);
+                    continue;
+                }
+                inner.current.insert(substate_id.clone(), version);
+
+                // Roll generations rather than evicting individually: a substate that is still being
+                // updated is re-recorded into the new generation on its next commit, while everything
+                // untouched ages out. Lookups continue to hit the previous generation until it is
+                // dropped in turn.
+                if inner.current.len() > self.capacity_per_generation {
+                    inner.previous = mem::take(&mut inner.current);
+                }
+            }
         }
     }
 
     /// True if a version newer than `version` of `substate_id` is known to have been committed.
     pub fn is_superseded(&self, substate_id: &SubstateId, version: u32) -> bool {
-        let inner = self.lock();
+        let inner = self.read();
         let current = inner.current.get(substate_id).copied();
         let previous = inner.previous.get(substate_id).copied();
         current.max(previous).is_some_and(|latest| latest > version)
     }
 
-    fn lock(&self) -> std::sync::MutexGuard<'_, Generations> {
-        // The guarded state is a plain map with no invariants to uphold across a panic, so a poisoned
-        // lock is recovered rather than propagated.
-        self.inner.lock().unwrap_or_else(|e| e.into_inner())
+    // The guarded state is a plain map with no invariants to uphold across a panic, so a poisoned lock
+    // is recovered rather than propagated.
+
+    fn read(&self) -> RwLockReadGuard<'_, Generations> {
+        self.inner.read().unwrap_or_else(|e| e.into_inner())
+    }
+
+    fn write(&self) -> RwLockWriteGuard<'_, Generations> {
+        self.inner.write().unwrap_or_else(|e| e.into_inner())
     }
 }
 
@@ -121,6 +150,20 @@ mod tests {
             tracker.record_up(&component(i), 1);
         }
         assert!(tracker.is_superseded(&component(1), 4));
+    }
+
+    #[test]
+    fn batch_spanning_write_chunks_records_every_substate() {
+        let tracker = SubstateVersionTracker::new();
+        let ids = (0..=u8::MAX).map(component).collect::<Vec<_>>();
+        let batch = std::iter::repeat_n(ids.iter(), WRITE_CHUNK / ids.len() + 2)
+            .flatten()
+            .map(|id| (id, 7));
+        tracker.record_up_all(batch);
+        for id in &ids {
+            assert!(tracker.is_superseded(id, 6));
+            assert!(!tracker.is_superseded(id, 7));
+        }
     }
 
     #[test]

--- a/crates/indexer_lib/src/substate_versions.rs
+++ b/crates/indexer_lib/src/substate_versions.rs
@@ -13,10 +13,6 @@ use tari_engine_types::substate::SubstateId;
 /// between one and two times this many of the most recently updated substates.
 const CAPACITY_PER_GENERATION: usize = 50_000;
 
-/// Substates recorded per acquisition of the write lock. Bounds how long a single batch can hold off
-/// readers, which matters because a batch is as large as a sync round's worth of commits.
-const WRITE_CHUNK: usize = 1024;
-
 /// The newest version of each recently-updated substate, as observed from committed transaction
 /// receipts.
 ///
@@ -59,28 +55,25 @@ impl SubstateVersionTracker {
         self.record_up_all(std::iter::once((substate_id, version)));
     }
 
-    /// Records a batch of upped substates under as few acquisitions of the write lock as [`WRITE_CHUNK`]
-    /// allows. Callers have a whole commit batch to record, and taking the lock per substate would put
-    /// the writer in contention with every concurrent lookup for the length of that batch.
+    /// Records a batch of upped substates under a single acquisition of the write lock. Callers record
+    /// one committed batch at a time, and taking the lock per substate would put the writer in
+    /// contention with every concurrent lookup for the length of that batch.
     pub fn record_up_all<'a, I>(&self, ups: I)
     where I: IntoIterator<Item = (&'a SubstateId, u32)> {
-        let mut ups = ups.into_iter().peekable();
-        while ups.peek().is_some() {
-            let mut inner = self.write();
-            for (substate_id, version) in ups.by_ref().take(WRITE_CHUNK) {
-                if let Some(recorded) = inner.current.get_mut(substate_id) {
-                    *recorded = (*recorded).max(version);
-                    continue;
-                }
-                inner.current.insert(substate_id.clone(), version);
+        let mut inner = self.write();
+        for (substate_id, version) in ups {
+            if let Some(recorded) = inner.current.get_mut(substate_id) {
+                *recorded = (*recorded).max(version);
+                continue;
+            }
+            inner.current.insert(substate_id.clone(), version);
 
-                // Roll generations rather than evicting individually: a substate that is still being
-                // updated is re-recorded into the new generation on its next commit, while everything
-                // untouched ages out. Lookups continue to hit the previous generation until it is
-                // dropped in turn.
-                if inner.current.len() > self.capacity_per_generation {
-                    inner.previous = mem::take(&mut inner.current);
-                }
+            // Roll generations rather than evicting individually: a substate that is still being
+            // updated is re-recorded into the new generation on its next commit, while everything
+            // untouched ages out. Lookups continue to hit the previous generation until it is dropped
+            // in turn.
+            if inner.current.len() > self.capacity_per_generation {
+                inner.previous = mem::take(&mut inner.current);
             }
         }
     }
@@ -153,12 +146,11 @@ mod tests {
     }
 
     #[test]
-    fn batch_spanning_write_chunks_records_every_substate() {
+    fn batch_records_every_substate_at_its_newest_version() {
         let tracker = SubstateVersionTracker::new();
         let ids = (0..=u8::MAX).map(component).collect::<Vec<_>>();
-        let batch = std::iter::repeat_n(ids.iter(), WRITE_CHUNK / ids.len() + 2)
-            .flatten()
-            .map(|id| (id, 7));
+        // Every id appears twice, newest first, so the batch covers the duplicate-within-a-batch path.
+        let batch = ids.iter().map(|id| (id, 7)).chain(ids.iter().map(|id| (id, 3)));
         tracker.record_up_all(batch);
         for id in &ids {
             assert!(tracker.is_superseded(id, 6));


### PR DESCRIPTION
## Problem

The substate cache is keyed by substate ID and holds whatever version was current when the entry was written. Nothing rewrites that entry when the version is later spent, so an unversioned lookup — "give me the latest version of X" — was answered from cache for the full 300s TTL. A wallet resolving versioned inputs pinned the stale version and consensus rejected the transaction with `Substate ... is DOWN`.

Seen on testnet: a faucet claim committed at 12:42:19 took `vault_0102030000..0001` to v9, and the indexer went on serving v8 to every claim for the next three minutes.

| time | tx | vault | result |
|---|---|---|---|
| 12:42:19 | `33bf939e81` | 8 | OK — spends v8 |
| 12:42:39 | `2fbcf90e77` | 8 | rejected, v8 DOWN |
| 12:43:31 | `61348c6d6a` | 8 | rejected |
| 12:44:15 | `438294a08e` | 8 | rejected |
| 12:45:36 | `0ec9c03236` | 9 | OK |

## Fix

A cache entry answers two questions with different lifetimes. The value at `(id, version)` never changes, so exact-version reads stay on `cache_ttl`. "The latest version of `id`" moves under the entry every time the substate is spent, so it gets its own window — `latest_substate_cache_ttl`, default **2s**. That sits at or below the unavoidable gap between submitting a transaction and it committing, below which a fresher indexer buys nothing.

Caching is kept rather than always fetching from the committee: a hot substate still costs at most one round trip per window instead of one per request.

Committed transaction receipts already name every substate a transaction upped, and the indexer already ingests them, so the state sync records those versions and the cache refuses an entry older than one it has seen. That signal is capacity bounded, lags by a state-sync interval and starts empty after a restart, so it retires long-lived entries rather than governing the latest-version window.

## Notes

- `latest_substate_cache_ttl` is defaulted, so existing config files still parse under `deny_unknown_fields`.
- Does not address the other staleness source behind the same symptom: walletd pinning versions from its own local store, which only advances when the previous transaction finalizes. That needs `detect_inputs_use_unversioned: true` (the default) client-side.
- No request coalescing — concurrent lookups of an uncached substate still fan out one fetch each. Pre-existing, deferred.